### PR TITLE
ci: add workflow_dispatch release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+# Dispatched release pipeline: bump versions, commit, tag, publish in one
+# atomic run. Replaces the manual "run task release:bump → commit → tag →
+# push" sequence, which was error-prone (tagging before bumping leaves the
+# tag on a commit whose package.json still carries the previous version,
+# which in turn fails release-guard.yml).
+#
+# Trigger: workflow_dispatch with a stable-semver version input.
+# Release Guard still runs on the pushed tag as a belt-and-suspenders check.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (stable semver, e.g. 1.9.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump, tag, publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce dispatch from main
+        if: github.ref_name != 'main'
+        run: |
+          echo "::error::This workflow must be dispatched from 'main' (selected: '${{ github.ref_name }}')."
+          exit 1
+
+      - name: Validate version format
+        run: |
+          v="${{ inputs.version }}"
+          if ! echo "$v" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version '$v' must be stable semver (X.Y.Z). Pre-release suffixes are not supported."
+            exit 1
+          fi
+
+      - name: Check out main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify tag does not exist on remote
+        run: |
+          v="${{ inputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$v" >/dev/null; then
+            echo "::error::Tag '$v' already exists on origin. Pick a new version or delete the tag first."
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Task
+        uses: arduino/setup-task@v2
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump versions
+        run: task release:bump -- "${{ inputs.version }}"
+
+      - name: Push bump commit to main
+        run: git push origin main
+
+      - name: Tag and push
+        run: |
+          v="${{ inputs.version }}"
+          git tag "$v"
+          git push origin "$v"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          v="${{ inputs.version }}"
+          gh release create "$v" \
+            --title "$v" \
+            --generate-notes \
+            --verify-tag
+
+      - name: Job summary
+        if: always()
+        run: |
+          v="${{ inputs.version }}"
+          sha="$(git rev-parse HEAD)"
+          short="${sha:0:7}"
+          repo="${{ github.repository }}"
+          {
+            echo "## Release ${v}"
+            echo
+            if [ "${{ job.status }}" = "success" ]; then
+              echo "✅  Published"
+            else
+              echo "❌  Failed (see logs)"
+            fi
+            echo
+            echo "- Tag: [\`${v}\`](https://github.com/${repo}/releases/tag/${v})"
+            echo "- Commit: [\`${short}\`](https://github.com/${repo}/commit/${sha})"
+            echo "- Release Guard re-runs on the pushed tag as independent verification."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The 1.9.0 tag was pushed before `task release:bump` ran, so the tagged commit still carried `package.json = 1.8.0` and `marketplace.json = 1.8.0`. The existing [Release Guard](https://github.com/event4u-app/agent-config/blob/main/.github/workflows/release-guard.yml) caught it — as designed — but only after the bad tag was already live, requiring a tag rewrite to recover ([run 24829378271](https://github.com/event4u-app/agent-config/actions/runs/24829378271)).

The manual flow (`task release:bump → commit → push main → git tag → git push`) has two ordering failure modes:

1. Forget the bump step entirely → tag lands on the previous-version commit.
2. Tag and push before the bump commit is on `origin/main` → tag points to the wrong commit.

Both classes disappear if a single dispatched workflow performs all four steps atomically.

## What

New workflow `.github/workflows/release.yml`:

- Trigger: `workflow_dispatch` with required `version` input
- Validates stable-semver format (`X.Y.Z`, no pre-release suffixes per decision in chat)
- Enforces dispatch from `main`
- Refuses to run if the tag already exists on `origin`
- Sets up Python 3.12, Node 20, Task (matches patterns in existing workflows)
- Configures `github-actions[bot]` identity
- Runs `task release:bump -- <version>` → commit, push `main`, tag, push tag
- Creates the GitHub Release with `gh release create --generate-notes --verify-tag`
- Emits a job summary with links to the tag + commit

## Interaction with Release Guard

`release-guard.yml` stays unchanged and still runs on every tag push. It's now a redundancy layer — the dispatched flow shouldn't be able to produce a mismatch, but if someone ever tags manually (or the dispatched flow is bypassed), the guard catches it.

## Usage

```
gh workflow run release.yml -f version=X.Y.Z
```

or via the Actions UI → Release → Run workflow.

The existing `task release:bump` stays in place as a local fallback.

## Testing

- `python3 -c 'import yaml; yaml.safe_load(open(...))'` — valid YAML
- `task ci` — 0 failures (288 skills lint pass, 104 warnings on pre-existing unrelated skills)
- End-to-end run can only be exercised after merge (workflow must exist on `main` to dispatch); the first real release via this workflow will validate the happy path

## Out of scope

- Pre-release tags (`-rc.1`, `-beta.1`) — explicitly excluded per chat decision; can be added later behind the same workflow if needed
- Documentation update in `AGENTS.md` / README — deferred; the `workflow_dispatch` UI input is self-describing, happy to add a short "Releasing" section in a follow-up if preferred
- Retiring `task release:bump` — kept as local fallback


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author