### PR TITLE
feat: integrate agent-memory MCP server + harden recommendation rule

### DIFF
--- a/.agent-src.uncompressed/rules/user-interaction.md
+++ b/.agent-src.uncompressed/rules/user-interaction.md
@@ -25,30 +25,76 @@ The user should be able to reply with just a number (e.g., `1`) instead of typin
 - **Every question with choices** must use numbered options — no exceptions.
 - **Keep options short** — one line each, with a brief explanation after the dash.
 - **Always include a "skip" or "no change" option** when applicable.
-- **Default/recommended option** can be marked: `1. Do X (recommended)`.
+- **Always state a recommendation** — see iron law below.
 - **Use the user's language** for the question and options.
 - **Accept both** the number and a natural language answer (e.g., "1" or "the first one").
 
+### Iron Law — ALWAYS recommend
+
+```
+EVERY numbered-option question MUST state which option the agent recommends and WHY.
+"Egal, was bevorzugst Du?" / "no preference" is NEVER an acceptable agent stance.
+```
+
+The user is asking the agent because the agent has read the code, the
+contracts, the trade-offs. Refusing to take a position dumps that work
+back on the user. Take the position; be wrong out loud if needed.
+
+**Format:**
+
+- Mark the recommended option inline: `1. Do X — short explanation (recommended)`.
+- After the option block, state **WHY** in 1–3 sentences: the trade-off
+  that tips the balance, plus the **caveat** that would flip it.
+- If the agent genuinely cannot pick (rare — true 50/50 with missing
+  data), say what data would break the tie and ask for that instead.
+
+**Example:**
+
+```
+> 1. Hybrid contract — keys + query (recommended)
+> 2. Key-based — extend the package
+> 3. Semantic — change all call sites
+
+I recommend 1: solves the acute consult-flow without a cross-repo PR,
+and the file-fallback stays trivial. Caveat — if hit-rate on the
+concat-shim turns out poor in practice, escalate to 2.
+```
+
+**What does NOT count as a recommendation:**
+
+- "Both work" / "either is fine" / "depends on what you prefer"
+- Listing pros and cons without picking
+- "I'd lean towards X" without a reason
+- Hiding behind "you know the project better" (the agent just researched it)
+
 ### Examples
 
-**Binary choice:**
+**Binary choice (with recommendation):**
 ```
-> 1. Interactive — ask before each comment
+> 1. Interactive — ask before each comment (recommended)
 > 2. Automatic — handle all independently
+
+I recommend 1: the comments touch security-sensitive code, so a wrong
+auto-fix is more expensive than the friction of approving each one.
+Switch to 2 if the comments turn out to be pure formatting.
 ```
 
-**Multiple choice with skip:**
+**Multiple choice with skip (with recommendation):**
 ```
-> 1. Fix the code
+> 1. Fix the code (recommended)
 > 2. Fix the test
 > 3. Skip
+
+I recommend 1: the test is asserting the documented behavior; the
+production code drifted from the contract. Pick 2 only if the contract
+itself is wrong.
 ```
 
-**Confirmation with context:**
+**Confirmation with context (recommendation implicit in framing):**
 ```
 > Found PR #1399 on branch `chore/refactor-agent-setup-2`.
 >
-> 1. Yes, that's the right PR
+> 1. Yes, that's the right PR (recommended — branch matches)
 > 2. No, different PR — I'll provide the URL
 ```
 

--- a/.agent-src.uncompressed/scripts/update_roadmap_progress.py
+++ b/.agent-src.uncompressed/scripts/update_roadmap_progress.py
@@ -19,6 +19,12 @@ Percentage = done / (done + open). Deferred and cancelled do not count towards
 Invocation (from project root):
   python3 .augment/scripts/update_roadmap_progress.py              # rewrite
   python3 .augment/scripts/update_roadmap_progress.py --check      # CI: exit 1 if stale
+
+`--check` mode also fails when a roadmap reaches `count_open == 0` but is
+still under `agents/roadmaps/` instead of `agents/roadmaps/archive/` —
+backstopping the `roadmap-progress-sync` rule's "completion = archival,
+same response" requirement. The write path emits the same finding as a
+warning on stderr and still regenerates the dashboard.
 """
 
 from __future__ import annotations
@@ -176,6 +182,15 @@ def collect(roadmap_root: Path) -> list[RoadmapStats]:
     return results
 
 
+def unarchived_complete(roadmaps: list[RoadmapStats]) -> list[RoadmapStats]:
+    # A roadmap is complete when every active checkbox is done and at least
+    # one active checkbox exists. The `roadmap-progress-sync` rule mandates
+    # that such a roadmap be moved to `agents/roadmaps/archive/` in the
+    # same response that closes its last open item; `collect()` already
+    # excludes that directory, so anything left here is unarchived.
+    return [r for r in roadmaps if r.total_active > 0 and r.open_ == 0]
+
+
 def render(roadmaps: list[RoadmapStats]) -> str:
     total_done = sum(r.done for r in roadmaps)
     total_active = sum(r.total_active for r in roadmaps)
@@ -241,12 +256,22 @@ def main() -> int:
     roadmaps = collect(roadmap_root)
     new_text = render(roadmaps)
     current = target.read_text(encoding="utf-8") if target.exists() else ""
+    complete = unarchived_complete(roadmaps)
     if args.check:
-        if current != new_text:
+        stale = current != new_text
+        if stale:
             print(f"❌  {target.relative_to(args.repo_root)} is stale. "
                   f"Run `python3 .augment/scripts/update_roadmap_progress.py` "
                   f"to regenerate (or `task roadmap-progress` in Taskfile "
                   f"projects).", file=sys.stderr)
+        if complete:
+            print("❌  Completed roadmaps are still in `agents/roadmaps/` — "
+                  "move them to `agents/roadmaps/archive/` (per the "
+                  "`roadmap-progress-sync` rule):", file=sys.stderr)
+            for r in complete:
+                print(f"      - {r.rel}  ({r.done}/{r.total_active} done)",
+                      file=sys.stderr)
+        if stale or complete:
             return 1
         print(f"✅  {target.relative_to(args.repo_root)} is up to date.")
         return 0
@@ -254,6 +279,11 @@ def main() -> int:
     print(f"✅  Wrote {target.relative_to(args.repo_root)} · "
           f"{len(roadmaps)} roadmap(s) · "
           f"{sum(r.done for r in roadmaps)}/{sum(r.total_active for r in roadmaps)} steps done.")
+    if complete:
+        print("⚠️   Completed roadmaps not yet archived — move to "
+              "`agents/roadmaps/archive/`:", file=sys.stderr)
+        for r in complete:
+            print(f"      - {r.rel}", file=sys.stderr)
     return 0
 
 

--- a/.agent-src.uncompressed/templates/github-workflows/roadmap-progress-check.yml
+++ b/.agent-src.uncompressed/templates/github-workflows/roadmap-progress-check.yml
@@ -1,0 +1,63 @@
+# Roadmap Progress Check — template shipped by agent-config
+#
+# Copy this file to `.github/workflows/roadmap-progress-check.yml` in the
+# consumer project. It fails CI when `agents/roadmaps-progress.md` is
+# stale relative to the source roadmaps under `agents/roadmaps/`.
+#
+# This is the last-line defence behind the `roadmap-progress-sync` rule
+# and the optional pre-commit hook (see `./agent-config hooks:install`).
+# A green check here proves the dashboard reflects reality on every PR
+# that touches roadmaps.
+#
+# Prerequisites:
+#   - `.augment/scripts/update_roadmap_progress.py` installed by
+#     `task install` (or `./agent-config install`).
+#   - At least one file exists under `agents/roadmaps/` — absence
+#     short-circuits the check with a passing exit (consumer projects
+#     that haven't adopted roadmaps stay green).
+#
+# This workflow is intentionally narrow: it only runs when relevant
+# files change, so it adds zero overhead to unrelated PRs.
+
+name: Roadmap Progress Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agents/roadmaps/**"
+      - "agents/roadmaps-progress.md"
+      - ".augment/scripts/update_roadmap_progress.py"
+  pull_request:
+    paths:
+      - "agents/roadmaps/**"
+      - "agents/roadmaps-progress.md"
+      - ".augment/scripts/update_roadmap_progress.py"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Verify roadmaps-progress.md is fresh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run roadmap progress check
+        run: python3 .augment/scripts/update_roadmap_progress.py --check
+
+      - name: Remediation hint on failure
+        if: failure()
+        run: |
+          echo "::error::roadmaps-progress.md is stale."
+          echo "Regenerate locally with one of:"
+          echo "  ./agent-config roadmap:progress"
+          echo "  task roadmap-progress"
+          echo "  python3 .augment/scripts/update_roadmap_progress.py"
+          echo "Then commit and push the updated agents/roadmaps-progress.md."

--- a/.agent-src.uncompressed/templates/hooks/pre-commit-roadmap-progress
+++ b/.agent-src.uncompressed/templates/hooks/pre-commit-roadmap-progress
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pre-commit hook: roadmap progress dashboard sync (event4u/agent-config)
+#
+# Installed by `./agent-config hooks:install`. Aborts the commit if
+# `agents/roadmaps-progress.md` is out of date relative to staged
+# changes under `agents/roadmaps/`. Exits silently when no roadmap
+# files are staged — zero overhead on unrelated commits.
+#
+# To run manually:
+#   ./agent-config roadmap:progress-check
+#
+# To uninstall:
+#   rm .git/hooks/pre-commit
+set -e
+
+# Only act on commits that touch roadmap content.
+staged="$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)"
+case "$staged" in
+  *agents/roadmaps/*.md*|*agents/roadmaps-progress.md*|*.augment/scripts/update_roadmap_progress.py*)
+    : ;;
+  *)
+    exit 0 ;;
+esac
+
+# Resolve the script — prefer the consumer-shipped path, fall back to
+# the source-of-truth copy when run from inside the package itself.
+script=""
+for cand in \
+  ".augment/scripts/update_roadmap_progress.py" \
+  ".agent-src/scripts/update_roadmap_progress.py" \
+  ".agent-src.uncompressed/scripts/update_roadmap_progress.py"; do
+  if [ -f "$cand" ]; then
+    script="$cand"
+    break
+  fi
+done
+
+if [ -z "$script" ]; then
+  echo "⚠️  pre-commit-roadmap-progress: update_roadmap_progress.py not found." >&2
+  echo "    Run \`task install\` (or \`./agent-config install\`) and retry." >&2
+  echo "    Skipping check — letting commit through." >&2
+  exit 0
+fi
+
+if ! python3 "$script" --check >/dev/null 2>&1; then
+  echo "❌  agents/roadmaps-progress.md is stale relative to your staged changes." >&2
+  echo "" >&2
+  echo "    Regenerate the dashboard with one of:" >&2
+  echo "      ./agent-config roadmap:progress" >&2
+  echo "      task roadmap-progress" >&2
+  echo "      python3 $script" >&2
+  echo "" >&2
+  echo "    Then \`git add agents/roadmaps-progress.md\` and retry the commit." >&2
+  echo "" >&2
+  echo "    To bypass once (NOT recommended):" >&2
+  echo "      git commit --no-verify" >&2
+  exit 1
+fi
+
+exit 0

--- a/.agent-src.uncompressed/templates/scripts/memory_lookup.py
+++ b/.agent-src.uncompressed/templates/scripts/memory_lookup.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
-"""File-based retrieval for the `absent` path.
+"""Hybrid retrieval — file-first with optional package augmentation.
 
 Implements the shared `retrieve(types, keys, limit)` abstraction used
 by skills. Reads YAML under `agents/memory/<type>/` (curated, hand-
 reviewed) and JSONL under `agents/memory/intake/*.jsonl` (agent-written,
 append-only, supersede-chain aware).
 
-The returned shape is identical to the `present`-path adapter over the
-`@event4u/agent-memory` API, so skills stay backend-agnostic.
+When the `@event4u/agent-memory` package is present (see
+`scripts/memory_status.py`), callers can pass the result of
+:func:`package_operational_provider` to route additional retrieval
+through the package's semantic CLI. Repo entries always win on
+conflict — see `_apply_conflict_rule`.
 
 Usage:
     python3 scripts/memory_lookup.py --types domain-invariants,ownership \\
         --key "app/Http/Controllers/Foo" --limit 5
     python3 scripts/memory_lookup.py --types incident-learnings --format json
+    python3 scripts/memory_lookup.py --types ownership --key billing --auto
 
-    from scripts.memory_lookup import retrieve
-    hits = retrieve(types=["ownership"], keys=["app/Http"], limit=3)
+    from scripts.memory_lookup import retrieve, package_operational_provider
+    hits = retrieve(
+        types=["ownership"], keys=["app/Http"], limit=3,
+        operational_provider=package_operational_provider(),
+    )
 """
 
 from __future__ import annotations
@@ -23,10 +30,12 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import os
+import subprocess
 import sys
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Optional, Union
 
 MEMORY_ROOT = Path("agents/memory")
 INTAKE_ROOT = MEMORY_ROOT / "intake"
@@ -45,13 +54,45 @@ CURATED_TYPES = {
 class Hit:
     id: str
     type: str
-    source: str            # "curated" or "intake"
-    path: str              # file that produced the hit
+    source: str            # "curated" | "intake" | "operational"
+    path: str              # file (or logical locator) that produced the hit
     score: float           # naive, content-match based [0..1]
     entry: dict = field(default_factory=dict)
 
     def as_dict(self) -> dict:
         return asdict(self)
+
+
+@dataclass
+class Shadow:
+    """An operational entry suppressed by the conflict rule."""
+    id: str
+    type: str
+    reason: str                    # "same-id" | "repo-deprecated"
+    operational_path: str          # where the suppressed entry came from
+    repo_path: str                 # repo entry that shadowed it
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class RetrievalResult:
+    """Full retrieval payload with conflict-rule observability."""
+    hits: list
+    shadows: list = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "hits": [h.as_dict() for h in self.hits],
+            "shadows": [s.as_dict() for s in self.shadows],
+        }
+
+
+# An operational provider returns repo-shaped Hit objects with
+# source="operational". Backend adapters (e.g. @event4u/agent-memory)
+# are expected to translate their native payload into this shape.
+OperationalProvider = Callable[[list[str], list[str]], Iterable[Hit]]
 
 
 def _load_yaml(path: Path):
@@ -152,19 +193,195 @@ def _score(entry: dict, keys: list[str]) -> float:
     return best
 
 
-def retrieve(types: list[str], keys: list[str], limit: int = 5) -> list[Hit]:
+def _apply_conflict_rule(
+    repo_hits: list[Hit],
+    operational_hits: list[Hit],
+) -> tuple[list[Hit], list[Shadow]]:
+    """Enforce REPO WINS / OPERATIONAL AUGMENTS / NEVER CONTRADICTS SILENTLY.
+
+    Reference: `agents/roadmaps/road-to-memory-self-consumption.md` §
+    "Conflict rule: repo vs. operational". The four cases mapped below
+    are covered by `tests/test_conflict_rule.py`.
+    """
+    # Repo entries index — curated AND intake both count as "repo" for
+    # the conflict rule. The operational store is the only non-repo side.
+    repo_by_id: dict[str, Hit] = {h.id: h for h in repo_hits if h.id}
+
+    merged: list[Hit] = list(repo_hits)
+    shadows: list[Shadow] = []
+
+    for op in operational_hits:
+        if op.id and op.id in repo_by_id:
+            # Case 1+2: same id → repo wins (including when repo is
+            # status:deprecated — operational cannot revive a retired
+            # entry). Suppress the operational entry and record shadow.
+            repo = repo_by_id[op.id]
+            reason = (
+                "repo-deprecated"
+                if repo.entry.get("status") == "deprecated"
+                else "same-id"
+            )
+            shadows.append(Shadow(
+                id=op.id,
+                type=op.type,
+                reason=reason,
+                operational_path=op.path,
+                repo_path=repo.path,
+            ))
+            continue
+        # Case 3 (different ids on same logical key) and Case 4 (repo
+        # has no entry) — both simply include the operational hit.
+        # Repo entries naturally rank higher because their score is not
+        # discounted (see _score / operational scoring in retrieve()).
+        merged.append(op)
+
+    return merged, shadows
+
+
+# ---------------------------------------------------------------------------
+# Package-backed operational provider (the `present` path)
+# ---------------------------------------------------------------------------
+#
+# When `memory_status.status() == "present"` the consumer-facing contract
+# says retrieval should route through `@event4u/agent-memory`. The package
+# CLI is purely **semantic** (`memory retrieve <query> --type T …`); the
+# shared `retrieve(types, keys, …)` API is **key-based**. The hybrid
+# resolution agreed in `agents/contexts/agent-memory-contract.md` synthesises
+# `keys` into a single natural-language query for the package call, while
+# the file fallback continues to do glob/substring matching on the same
+# keys. Both legs land in the same `Hit` shape so the conflict rule can
+# merge them transparently.
+
+_CLI_TIMEOUT_SECONDS = 5.0
+_CLI_RETRIEVE_LIMIT_DEFAULT = 20
+
+
+def _synthesize_query(keys: list[str]) -> str:
+    """Turn a list of retrieval keys into one natural-language query.
+
+    Keys are typically file paths (`app/Http/Controllers/Foo`), feature
+    names (`billing`), or short identifiers — joining them with spaces
+    gives the package's semantic search enough surface to score against
+    without inventing structure. Empty or whitespace-only keys are
+    dropped; if nothing remains the caller falls back to the file path.
+    """
+    cleaned = [k.strip() for k in keys if isinstance(k, str) and k.strip()]
+    return " ".join(cleaned)
+
+
+def _cli_operational_provider(
+    types: list[str],
+    keys: list[str],
+    *,
+    cli_path: str = "memory",
+    timeout: float = _CLI_TIMEOUT_SECONDS,
+    limit: int = _CLI_RETRIEVE_LIMIT_DEFAULT,
+) -> Iterable[Hit]:
+    """Run `memory retrieve` and yield operational `Hit` objects.
+
+    Pino structured logs from the package go to stderr; stdout is a
+    clean v1 retrieval envelope. Any non-zero exit, timeout, or parse
+    failure degrades to "no operational hits" — `retrieve()` already
+    treats provider exceptions as a soft warning, so the caller still
+    gets the file-fallback result.
+    """
+    query = _synthesize_query(keys)
+    if not query:
+        return
+    cmd: list[str] = [cli_path, "retrieve", query, "--limit", str(limit)]
+    for t in types:
+        cmd.extend(["--type", t])
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return
+    if out.returncode != 0:
+        return
+    try:
+        envelope = json.loads(out.stdout)
+    except (ValueError, TypeError):
+        return
+    entries = envelope.get("entries") if isinstance(envelope, dict) else None
+    if not isinstance(entries, list):
+        return
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        eid = e.get("id")
+        etype = e.get("type")
+        if not isinstance(eid, str) or not isinstance(etype, str):
+            continue
+        # The package returns `confidence` (0..1) per the v1 envelope;
+        # map it onto our internal `score` field so the conflict rule
+        # and ranking work uniformly across providers.
+        try:
+            score = float(e.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        body = e.get("body") if isinstance(e.get("body"), dict) else {}
+        yield Hit(
+            id=eid,
+            type=etype,
+            source="operational",
+            path=f"agent-memory:{eid}",
+            score=score,
+            entry=body,
+        )
+
+
+def package_operational_provider() -> Optional[OperationalProvider]:
+    """Return a CLI-backed provider when the package is `present`, else None.
+
+    Callers who want automatic backend routing pass the result directly
+    to :func:`retrieve` — `None` is a safe value that yields file-only
+    retrieval, so this is the recommended one-liner for skills:
+
+        retrieve(types, keys, operational_provider=package_operational_provider())
+
+    The status probe is bounded (≤ 2s, cached per process) — see
+    `scripts/memory_status.py`. We import lazily so pure file-fallback
+    callers never pay for the probe.
+    """
+    # Late import: keeps `memory_lookup` importable even when
+    # `memory_status` is missing in stripped consumer installs.
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import memory_status  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    if memory_status.status().status != "present":
+        return None
+    return _cli_operational_provider
+
+
+def retrieve(
+    types: list[str],
+    keys: list[str],
+    limit: int = 5,
+    operational_provider: Optional[OperationalProvider] = None,
+    with_shadows: bool = False,
+) -> Union[list[Hit], RetrievalResult]:
     """Return up to `limit` hits across the requested types, highest score first.
 
-    Curated entries are preferred on ties — they are hand-reviewed.
-    The shape (`Hit`) matches the `present` backend adapter so skills
-    can treat both sources identically.
+    Repo entries (curated + intake) are preferred on ties — they are
+    hand-reviewed or session-captured against the repo itself. When an
+    `operational_provider` is supplied (the `present` path of the
+    backend-detection contract), its results are merged under the
+    REPO WINS conflict rule; suppressed operational entries surface as
+    `shadows` when `with_shadows=True`.
+
+    The return type stays `list[Hit]` by default for backward
+    compatibility with existing skill call sites.
     """
-    hits: list[Hit] = []
+    repo_hits: list[Hit] = []
     for mtype in types:
         if mtype not in CURATED_TYPES:
             continue
         for path, entry in _iter_curated_entries(mtype):
-            hits.append(Hit(
+            repo_hits.append(Hit(
                 id=str(entry.get("id", "")),
                 type=mtype,
                 source="curated",
@@ -173,7 +390,7 @@ def retrieve(types: list[str], keys: list[str], limit: int = 5) -> list[Hit]:
                 entry=entry,
             ))
         for path, entry in _iter_intake_entries(mtype):
-            hits.append(Hit(
+            repo_hits.append(Hit(
                 id=str(entry.get("id", "")),
                 type=mtype,
                 source="intake",
@@ -181,10 +398,122 @@ def retrieve(types: list[str], keys: list[str], limit: int = 5) -> list[Hit]:
                 score=_score(entry, keys) * 0.9,  # slight discount vs curated
                 entry=entry,
             ))
-    hits.sort(key=lambda h: (h.score, h.source == "curated"), reverse=True)
-    # Drop zero-score hits unless no better option exists.
-    positives = [h for h in hits if h.score > 0]
-    return (positives or hits)[:limit]
+
+    operational_hits: list[Hit] = []
+    if operational_provider is not None:
+        try:
+            for oh in operational_provider(list(types), list(keys)) or []:
+                # Discount operational vs curated/intake so repo ranks
+                # higher on equal relevance. Providers may already return
+                # trust-adjusted scores; we only apply a floor discount.
+                oh.score = min(oh.score, 0.85)
+                operational_hits.append(oh)
+        except Exception as exc:  # noqa: BLE001 — providers are external
+            print(f"warning: operational_provider raised "
+                  f"{exc.__class__.__name__}: {exc}", file=sys.stderr)
+
+    merged, shadows = _apply_conflict_rule(repo_hits, operational_hits)
+    merged.sort(key=lambda h: (h.score, h.source == "curated"), reverse=True)
+    positives = [h for h in merged if h.score > 0]
+    final_hits = (positives or merged)[:limit]
+
+    if with_shadows:
+        return RetrievalResult(hits=final_hits, shadows=shadows)
+    return final_hits
+
+
+CONTRACT_VERSION = 1
+
+# Memory types this file-backed backend can answer. Types outside this
+# set map to `unknown_type` per the retrieval contract.
+_KNOWN_TYPES = CURATED_TYPES
+
+
+def retrieve_v1(
+    types: list[str],
+    keys: list[str],
+    limit: int = 20,
+    operational_provider: Optional[OperationalProvider] = None,
+) -> dict:
+    """Return a v1 retrieval-contract envelope.
+
+    Wraps :func:`retrieve` and projects the internal ``Hit`` shape into
+    the shape defined by
+    ``schemas/retrieval-v1.schema.json``. Unknown types are reported as
+    ``status: unknown_type`` for that slice only, rather than failing
+    the whole call.
+    """
+    known = [t for t in types if t in _KNOWN_TYPES]
+    unknown = [t for t in types if t not in _KNOWN_TYPES]
+
+    result = retrieve(known, keys, limit=limit,
+                      operational_provider=operational_provider,
+                      with_shadows=True)
+    assert isinstance(result, RetrievalResult)
+    hits, shadows = result.hits, result.shadows
+    shadow_by_id = {s.id: s for s in shadows if s.id}
+
+    slice_counts: dict[str, int] = {t: 0 for t in known}
+    entries: list[dict] = []
+    for h in hits:
+        source = "operational" if h.source == "operational" else "repo"
+        envelope_entry: dict = {
+            "id": h.id,
+            "type": h.type,
+            "source": source,
+            "confidence": round(float(h.score), 4),
+            "body": dict(h.entry) if isinstance(h.entry, dict) else {},
+            "shadowed_by": None,
+        }
+        if h.type in slice_counts:
+            slice_counts[h.type] += 1
+        entries.append(envelope_entry)
+
+    # Surface shadowed operational entries as additional entries carrying
+    # `shadowed_by`. The conformance harness checks that only
+    # source="operational" entries ever set this field.
+    for sid, s in shadow_by_id.items():
+        entries.append({
+            "id": sid,
+            "type": s.type,
+            "source": "operational",
+            "confidence": 0.0,
+            "body": {},
+            "shadowed_by": f"repo:{sid}",
+        })
+        if s.type in slice_counts:
+            slice_counts[s.type] += 1
+
+    slices: dict[str, dict] = {
+        t: {"status": "ok", "count": slice_counts.get(t, 0)}
+        for t in known
+    }
+    errors: list[dict] = []
+    for t in unknown:
+        slices[t] = {"status": "unknown_type", "count": 0}
+        errors.append({
+            "type": t,
+            "code": "unknown_type",
+            "message": f"file-backed backend does not know type {t!r}",
+        })
+
+    oks = [s for s in slices.values() if s["status"] == "ok"]
+    fails = [s for s in slices.values() if s["status"] != "ok"]
+    envelope_status = (
+        "ok" if not fails
+        else "error" if not oks
+        else "partial"
+    )
+
+    envelope: dict = {
+        "contract_version": CONTRACT_VERSION,
+        "status": envelope_status,
+        "entries": entries,
+        "slices": slices,
+    }
+    if errors:
+        envelope["errors"] = errors
+    return envelope
 
 
 def main() -> int:
@@ -195,20 +524,52 @@ def main() -> int:
                     help="Retrieval key (repeatable)")
     ap.add_argument("--limit", type=int, default=5)
     ap.add_argument("--format", choices=["text", "json"], default="text")
+    ap.add_argument("--envelope", choices=["legacy", "v1"], default="legacy",
+                    help="Output shape: `legacy` (Hit list) or `v1` "
+                         "(retrieval contract v1 envelope). `v1` implies JSON output.")
+    ap.add_argument("--with-shadows", action="store_true",
+                    help="Include shadowed-operational entries in the output "
+                         "(no-op until an operational backend is wired)")
+    ap.add_argument("--auto", action="store_true",
+                    help="Auto-route to the @event4u/agent-memory package "
+                         "when memory_status.status() == 'present'; "
+                         "falls through to file-only retrieval otherwise")
     args = ap.parse_args()
     types = [t.strip() for t in args.types.split(",") if t.strip()]
     if not types:
         print("error: --types is required", file=sys.stderr)
         return 2
-    hits = retrieve(types, args.key, args.limit)
+    op_provider = package_operational_provider() if args.auto else None
+    if args.envelope == "v1":
+        envelope = retrieve_v1(types, args.key, args.limit,
+                               operational_provider=op_provider)
+        print(json.dumps(envelope, indent=2, default=str))
+        return 0
+    result = retrieve(types, args.key, args.limit,
+                      operational_provider=op_provider,
+                      with_shadows=args.with_shadows)
+    if args.with_shadows:
+        assert isinstance(result, RetrievalResult)
+        hits, shadows = result.hits, result.shadows
+    else:
+        hits, shadows = result, []  # type: ignore[assignment]
     if args.format == "json":
-        print(json.dumps([h.as_dict() for h in hits], indent=2, default=str))
+        payload = {"hits": [h.as_dict() for h in hits],
+                   "shadows": [s.as_dict() for s in shadows]}
+        print(json.dumps(payload, indent=2, default=str))
     else:
         if not hits:
             print("  (no hits)")
         for h in hits:
             print(f"  [{h.source}] {h.type}  score={h.score:.2f}  "
                   f"id={h.id or '-'}  path={h.path}")
+        if shadows:
+            print(f"\n  shadows: {len(shadows)} operational entr"
+                  f"{'y' if len(shadows) == 1 else 'ies'} suppressed by "
+                  f"the conflict rule")
+            for s in shadows:
+                print(f"    [{s.reason}] {s.type}  id={s.id}  "
+                      f"op={s.operational_path}  repo={s.repo_path}")
     return 0
 
 

--- a/.agent-src.uncompressed/templates/scripts/memory_status.py
+++ b/.agent-src.uncompressed/templates/scripts/memory_status.py
@@ -40,6 +40,12 @@ _HEALTH_TIMEOUT_SECONDS = 2.0
 _CACHE_ENV = "AGENT_MEMORY_STATUS"
 _CACHE_FILE = Path(".agent-memory") / "status.cache"
 
+# Retrieval contract version served by the file-backed fallback.
+# Source of truth: schemas/retrieval-v1.schema.json.
+CONTRACT_VERSION = 1
+_FILE_BACKEND_VERSION = "0.0.0-file"
+_FILE_BACKEND_FEATURES = ("file-fallback",)
+
 
 @dataclass
 class Result:
@@ -48,6 +54,11 @@ class Result:
     reason: str             # short explanation
     elapsed_ms: int         # time spent probing (0 if cached)
     cli_path: str = ""      # resolved CLI path, if any
+    # Populated only when status == "present" — sourced from the
+    # `health` CLI envelope so the v1 health() reports real package
+    # capabilities instead of file-fallback placeholders.
+    backend_version: str = ""
+    features: tuple = ()
 
 
 def _find_cli() -> str:
@@ -58,8 +69,45 @@ def _find_cli() -> str:
     return ""
 
 
-def _probe_health(cli_path: str) -> tuple[bool, str]:
-    """Returns (healthy, reason)."""
+def _parse_health_envelope(stdout: str) -> dict | None:
+    """Extract the v1 health envelope from `memory health` stdout.
+
+    The package emits a single JSON object on stdout (pino structured
+    logs go to stderr). We tolerate older builds that may have leaked
+    log lines into stdout by scanning for the first top-level object
+    that carries ``contract_version``.
+    """
+    text = (stdout or "").strip()
+    if not text:
+        return None
+    try:
+        obj = json.loads(text)
+    except ValueError:
+        obj = None
+    if isinstance(obj, dict) and obj.get("contract_version"):
+        return obj
+    # Fallback: line-by-line scan for an envelope-shaped object — covers
+    # the case where structured logs accidentally share stdout.
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            cand = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(cand, dict) and cand.get("contract_version"):
+            return cand
+    return None
+
+
+def _probe_health(cli_path: str) -> tuple[bool, str, dict | None]:
+    """Returns (healthy, reason, envelope).
+
+    On success ``envelope`` is the parsed v1 health envelope (may still
+    be ``None`` for very old CLIs that don't emit one). On failure it
+    is always ``None``.
+    """
     try:
         out = subprocess.run(
             [cli_path, "health"],
@@ -67,15 +115,16 @@ def _probe_health(cli_path: str) -> tuple[bool, str]:
             timeout=_HEALTH_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
-        return False, f"health() timed out after {_HEALTH_TIMEOUT_SECONDS}s"
+        return False, f"health() timed out after {_HEALTH_TIMEOUT_SECONDS}s", None
     except FileNotFoundError:
-        return False, "CLI vanished between which() and invoke"
+        return False, "CLI vanished between which() and invoke", None
     if out.returncode != 0:
         # First line of combined output, capped, for the reason field.
         msg = (out.stderr or out.stdout or "exit != 0").strip().splitlines()
         head = msg[0][:120] if msg else "exit != 0"
-        return False, f"health() returned {out.returncode}: {head}"
-    return True, "ok"
+        return False, f"health() returned {out.returncode}: {head}", None
+    envelope = _parse_health_envelope(out.stdout)
+    return True, "ok", envelope
 
 
 def _read_cache() -> Result | None:
@@ -125,14 +174,60 @@ def status(refresh: bool = False) -> Result:
         result = Result("absent", "file",
                         "agent-memory CLI not on PATH", 0)
     else:
-        healthy, reason = _probe_health(cli)
+        healthy, reason, envelope = _probe_health(cli)
         elapsed = int((time.monotonic() - t0) * 1000)
         if healthy:
-            result = Result("present", "package", reason, elapsed, cli)
+            backend_version = ""
+            features: tuple = ()
+            if isinstance(envelope, dict):
+                bv = envelope.get("backend_version")
+                if isinstance(bv, str):
+                    backend_version = bv
+                feats = envelope.get("features")
+                if isinstance(feats, list) and all(
+                    isinstance(f, str) for f in feats
+                ):
+                    features = tuple(feats)
+            result = Result("present", "package", reason, elapsed, cli,
+                            backend_version=backend_version,
+                            features=features)
         else:
             result = Result("misconfigured", "file", reason, elapsed, cli)
     _write_cache(result)
     return result
+
+
+def health(refresh: bool = False) -> dict:
+    """Return a v1 retrieval-contract health envelope.
+
+    Schema: ``schemas/retrieval-v1.schema.json`` (HealthResponse).
+    Maps the three-state :func:`status` result onto the contract's
+    ``ok | degraded | error`` so consumers can read
+    ``contract_version`` without caring about the file-vs-package split.
+
+    When the package backs the call (``status == "present"``), the
+    envelope reports the package's own ``backend_version`` and
+    ``features`` so consumers can feature-detect against real
+    capabilities. Otherwise the file-fallback markers are returned.
+    """
+    r = status(refresh=refresh)
+    envelope_status = {
+        "present": "ok",
+        "misconfigured": "degraded",
+        "absent": "ok",
+    }[r.status]
+    if r.status == "present" and (r.backend_version or r.features):
+        backend_version = r.backend_version or _FILE_BACKEND_VERSION
+        features = list(r.features) if r.features else list(_FILE_BACKEND_FEATURES)
+    else:
+        backend_version = _FILE_BACKEND_VERSION
+        features = list(_FILE_BACKEND_FEATURES)
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "status": envelope_status,
+        "backend_version": backend_version,
+        "features": features,
+    }
 
 
 def main() -> int:
@@ -140,7 +235,13 @@ def main() -> int:
     ap.add_argument("--format", choices=["text", "json"], default="text")
     ap.add_argument("--refresh", action="store_true",
                     help="Bypass the session cache and probe fresh")
+    ap.add_argument("--health", action="store_true",
+                    help="Emit a v1 retrieval-contract health envelope "
+                         "instead of the legacy status line")
     args = ap.parse_args()
+    if args.health:
+        print(json.dumps(health(refresh=args.refresh)))
+        return 0
     r = status(refresh=args.refresh)
     if args.format == "json":
         print(json.dumps(asdict(r)))

--- a/.agent-src.uncompressed/templates/scripts/memory_status.py
+++ b/.agent-src.uncompressed/templates/scripts/memory_status.py
@@ -35,7 +35,7 @@ from typing import Literal
 
 Status = Literal["absent", "misconfigured", "present"]
 
-_CLI_CANDIDATES = ("agent-memory", "agentmem")
+_CLI_CANDIDATES = ("memory", "agent-memory", "agentmem")
 _HEALTH_TIMEOUT_SECONDS = 2.0
 _CACHE_ENV = "AGENT_MEMORY_STATUS"
 _CACHE_FILE = Path(".agent-memory") / "status.cache"

--- a/.agent-src/rules/user-interaction.md
+++ b/.agent-src/rules/user-interaction.md
@@ -25,30 +25,76 @@ The user should be able to reply with just a number (e.g., `1`) instead of typin
 - **Every question with choices** must use numbered options — no exceptions.
 - **Keep options short** — one line each, with a brief explanation after the dash.
 - **Always include a "skip" or "no change" option** when applicable.
-- **Default/recommended option** can be marked: `1. Do X (recommended)`.
+- **Always state a recommendation** — see iron law below.
 - **Use the user's language** for the question and options.
 - **Accept both** the number and a natural language answer (e.g., "1" or "the first one").
 
+### Iron Law — ALWAYS recommend
+
+```
+EVERY numbered-option question MUST state which option the agent recommends and WHY.
+"Egal, was bevorzugst Du?" / "no preference" is NEVER an acceptable agent stance.
+```
+
+The user is asking the agent because the agent has read the code, the
+contracts, the trade-offs. Refusing to take a position dumps that work
+back on the user. Take the position; be wrong out loud if needed.
+
+**Format:**
+
+- Mark the recommended option inline: `1. Do X — short explanation (recommended)`.
+- After the option block, state **WHY** in 1–3 sentences: the trade-off
+  that tips the balance, plus the **caveat** that would flip it.
+- If the agent genuinely cannot pick (rare — true 50/50 with missing
+  data), say what data would break the tie and ask for that instead.
+
+**Example:**
+
+```
+> 1. Hybrid contract — keys + query (recommended)
+> 2. Key-based — extend the package
+> 3. Semantic — change all call sites
+
+I recommend 1: solves the acute consult-flow without a cross-repo PR,
+and the file-fallback stays trivial. Caveat — if hit-rate on the
+concat-shim turns out poor in practice, escalate to 2.
+```
+
+**What does NOT count as a recommendation:**
+
+- "Both work" / "either is fine" / "depends on what you prefer"
+- Listing pros and cons without picking
+- "I'd lean towards X" without a reason
+- Hiding behind "you know the project better" (the agent just researched it)
+
 ### Examples
 
-**Binary choice:**
+**Binary choice (with recommendation):**
 ```
-> 1. Interactive — ask before each comment
+> 1. Interactive — ask before each comment (recommended)
 > 2. Automatic — handle all independently
+
+I recommend 1: the comments touch security-sensitive code, so a wrong
+auto-fix is more expensive than the friction of approving each one.
+Switch to 2 if the comments turn out to be pure formatting.
 ```
 
-**Multiple choice with skip:**
+**Multiple choice with skip (with recommendation):**
 ```
-> 1. Fix the code
+> 1. Fix the code (recommended)
 > 2. Fix the test
 > 3. Skip
+
+I recommend 1: the test is asserting the documented behavior; the
+production code drifted from the contract. Pick 2 only if the contract
+itself is wrong.
 ```
 
-**Confirmation with context:**
+**Confirmation with context (recommendation implicit in framing):**
 ```
 > Found PR #1399 on branch `chore/refactor-agent-setup-2`.
 >
-> 1. Yes, that's the right PR
+> 1. Yes, that's the right PR (recommended — branch matches)
 > 2. No, different PR — I'll provide the URL
 ```
 

--- a/.agent-src/scripts/update_roadmap_progress.py
+++ b/.agent-src/scripts/update_roadmap_progress.py
@@ -19,6 +19,12 @@ Percentage = done / (done + open). Deferred and cancelled do not count towards
 Invocation (from project root):
   python3 .augment/scripts/update_roadmap_progress.py              # rewrite
   python3 .augment/scripts/update_roadmap_progress.py --check      # CI: exit 1 if stale
+
+`--check` mode also fails when a roadmap reaches `count_open == 0` but is
+still under `agents/roadmaps/` instead of `agents/roadmaps/archive/` —
+backstopping the `roadmap-progress-sync` rule's "completion = archival,
+same response" requirement. The write path emits the same finding as a
+warning on stderr and still regenerates the dashboard.
 """
 
 from __future__ import annotations
@@ -176,6 +182,15 @@ def collect(roadmap_root: Path) -> list[RoadmapStats]:
     return results
 
 
+def unarchived_complete(roadmaps: list[RoadmapStats]) -> list[RoadmapStats]:
+    # A roadmap is complete when every active checkbox is done and at least
+    # one active checkbox exists. The `roadmap-progress-sync` rule mandates
+    # that such a roadmap be moved to `agents/roadmaps/archive/` in the
+    # same response that closes its last open item; `collect()` already
+    # excludes that directory, so anything left here is unarchived.
+    return [r for r in roadmaps if r.total_active > 0 and r.open_ == 0]
+
+
 def render(roadmaps: list[RoadmapStats]) -> str:
     total_done = sum(r.done for r in roadmaps)
     total_active = sum(r.total_active for r in roadmaps)
@@ -241,12 +256,22 @@ def main() -> int:
     roadmaps = collect(roadmap_root)
     new_text = render(roadmaps)
     current = target.read_text(encoding="utf-8") if target.exists() else ""
+    complete = unarchived_complete(roadmaps)
     if args.check:
-        if current != new_text:
+        stale = current != new_text
+        if stale:
             print(f"❌  {target.relative_to(args.repo_root)} is stale. "
                   f"Run `python3 .augment/scripts/update_roadmap_progress.py` "
                   f"to regenerate (or `task roadmap-progress` in Taskfile "
                   f"projects).", file=sys.stderr)
+        if complete:
+            print("❌  Completed roadmaps are still in `agents/roadmaps/` — "
+                  "move them to `agents/roadmaps/archive/` (per the "
+                  "`roadmap-progress-sync` rule):", file=sys.stderr)
+            for r in complete:
+                print(f"      - {r.rel}  ({r.done}/{r.total_active} done)",
+                      file=sys.stderr)
+        if stale or complete:
             return 1
         print(f"✅  {target.relative_to(args.repo_root)} is up to date.")
         return 0
@@ -254,6 +279,11 @@ def main() -> int:
     print(f"✅  Wrote {target.relative_to(args.repo_root)} · "
           f"{len(roadmaps)} roadmap(s) · "
           f"{sum(r.done for r in roadmaps)}/{sum(r.total_active for r in roadmaps)} steps done.")
+    if complete:
+        print("⚠️   Completed roadmaps not yet archived — move to "
+              "`agents/roadmaps/archive/`:", file=sys.stderr)
+        for r in complete:
+            print(f"      - {r.rel}", file=sys.stderr)
     return 0
 
 

--- a/.agent-src/templates/github-workflows/roadmap-progress-check.yml
+++ b/.agent-src/templates/github-workflows/roadmap-progress-check.yml
@@ -1,0 +1,63 @@
+# Roadmap Progress Check — template shipped by agent-config
+#
+# Copy this file to `.github/workflows/roadmap-progress-check.yml` in the
+# consumer project. It fails CI when `agents/roadmaps-progress.md` is
+# stale relative to the source roadmaps under `agents/roadmaps/`.
+#
+# This is the last-line defence behind the `roadmap-progress-sync` rule
+# and the optional pre-commit hook (see `./agent-config hooks:install`).
+# A green check here proves the dashboard reflects reality on every PR
+# that touches roadmaps.
+#
+# Prerequisites:
+#   - `.augment/scripts/update_roadmap_progress.py` installed by
+#     `task install` (or `./agent-config install`).
+#   - At least one file exists under `agents/roadmaps/` — absence
+#     short-circuits the check with a passing exit (consumer projects
+#     that haven't adopted roadmaps stay green).
+#
+# This workflow is intentionally narrow: it only runs when relevant
+# files change, so it adds zero overhead to unrelated PRs.
+
+name: Roadmap Progress Check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agents/roadmaps/**"
+      - "agents/roadmaps-progress.md"
+      - ".augment/scripts/update_roadmap_progress.py"
+  pull_request:
+    paths:
+      - "agents/roadmaps/**"
+      - "agents/roadmaps-progress.md"
+      - ".augment/scripts/update_roadmap_progress.py"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Verify roadmaps-progress.md is fresh
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run roadmap progress check
+        run: python3 .augment/scripts/update_roadmap_progress.py --check
+
+      - name: Remediation hint on failure
+        if: failure()
+        run: |
+          echo "::error::roadmaps-progress.md is stale."
+          echo "Regenerate locally with one of:"
+          echo "  ./agent-config roadmap:progress"
+          echo "  task roadmap-progress"
+          echo "  python3 .augment/scripts/update_roadmap_progress.py"
+          echo "Then commit and push the updated agents/roadmaps-progress.md."

--- a/.agent-src/templates/hooks/pre-commit-roadmap-progress
+++ b/.agent-src/templates/hooks/pre-commit-roadmap-progress
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pre-commit hook: roadmap progress dashboard sync (event4u/agent-config)
+#
+# Installed by `./agent-config hooks:install`. Aborts the commit if
+# `agents/roadmaps-progress.md` is out of date relative to staged
+# changes under `agents/roadmaps/`. Exits silently when no roadmap
+# files are staged — zero overhead on unrelated commits.
+#
+# To run manually:
+#   ./agent-config roadmap:progress-check
+#
+# To uninstall:
+#   rm .git/hooks/pre-commit
+set -e
+
+# Only act on commits that touch roadmap content.
+staged="$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true)"
+case "$staged" in
+  *agents/roadmaps/*.md*|*agents/roadmaps-progress.md*|*.augment/scripts/update_roadmap_progress.py*)
+    : ;;
+  *)
+    exit 0 ;;
+esac
+
+# Resolve the script — prefer the consumer-shipped path, fall back to
+# the source-of-truth copy when run from inside the package itself.
+script=""
+for cand in \
+  ".augment/scripts/update_roadmap_progress.py" \
+  ".agent-src/scripts/update_roadmap_progress.py" \
+  ".agent-src.uncompressed/scripts/update_roadmap_progress.py"; do
+  if [ -f "$cand" ]; then
+    script="$cand"
+    break
+  fi
+done
+
+if [ -z "$script" ]; then
+  echo "⚠️  pre-commit-roadmap-progress: update_roadmap_progress.py not found." >&2
+  echo "    Run \`task install\` (or \`./agent-config install\`) and retry." >&2
+  echo "    Skipping check — letting commit through." >&2
+  exit 0
+fi
+
+if ! python3 "$script" --check >/dev/null 2>&1; then
+  echo "❌  agents/roadmaps-progress.md is stale relative to your staged changes." >&2
+  echo "" >&2
+  echo "    Regenerate the dashboard with one of:" >&2
+  echo "      ./agent-config roadmap:progress" >&2
+  echo "      task roadmap-progress" >&2
+  echo "      python3 $script" >&2
+  echo "" >&2
+  echo "    Then \`git add agents/roadmaps-progress.md\` and retry the commit." >&2
+  echo "" >&2
+  echo "    To bypass once (NOT recommended):" >&2
+  echo "      git commit --no-verify" >&2
+  exit 1
+fi
+
+exit 0

--- a/.agent-src/templates/scripts/memory_lookup.py
+++ b/.agent-src/templates/scripts/memory_lookup.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
-"""File-based retrieval for the `absent` path.
+"""Hybrid retrieval — file-first with optional package augmentation.
 
 Implements the shared `retrieve(types, keys, limit)` abstraction used
 by skills. Reads YAML under `agents/memory/<type>/` (curated, hand-
 reviewed) and JSONL under `agents/memory/intake/*.jsonl` (agent-written,
 append-only, supersede-chain aware).
 
-The returned shape is identical to the `present`-path adapter over the
-`@event4u/agent-memory` API, so skills stay backend-agnostic.
+When the `@event4u/agent-memory` package is present (see
+`scripts/memory_status.py`), callers can pass the result of
+:func:`package_operational_provider` to route additional retrieval
+through the package's semantic CLI. Repo entries always win on
+conflict — see `_apply_conflict_rule`.
 
 Usage:
     python3 scripts/memory_lookup.py --types domain-invariants,ownership \\
         --key "app/Http/Controllers/Foo" --limit 5
     python3 scripts/memory_lookup.py --types incident-learnings --format json
+    python3 scripts/memory_lookup.py --types ownership --key billing --auto
 
-    from scripts.memory_lookup import retrieve
-    hits = retrieve(types=["ownership"], keys=["app/Http"], limit=3)
+    from scripts.memory_lookup import retrieve, package_operational_provider
+    hits = retrieve(
+        types=["ownership"], keys=["app/Http"], limit=3,
+        operational_provider=package_operational_provider(),
+    )
 """
 
 from __future__ import annotations
@@ -23,10 +30,12 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import os
+import subprocess
 import sys
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable, Optional, Union
 
 MEMORY_ROOT = Path("agents/memory")
 INTAKE_ROOT = MEMORY_ROOT / "intake"
@@ -45,13 +54,45 @@ CURATED_TYPES = {
 class Hit:
     id: str
     type: str
-    source: str            # "curated" or "intake"
-    path: str              # file that produced the hit
+    source: str            # "curated" | "intake" | "operational"
+    path: str              # file (or logical locator) that produced the hit
     score: float           # naive, content-match based [0..1]
     entry: dict = field(default_factory=dict)
 
     def as_dict(self) -> dict:
         return asdict(self)
+
+
+@dataclass
+class Shadow:
+    """An operational entry suppressed by the conflict rule."""
+    id: str
+    type: str
+    reason: str                    # "same-id" | "repo-deprecated"
+    operational_path: str          # where the suppressed entry came from
+    repo_path: str                 # repo entry that shadowed it
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class RetrievalResult:
+    """Full retrieval payload with conflict-rule observability."""
+    hits: list
+    shadows: list = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {
+            "hits": [h.as_dict() for h in self.hits],
+            "shadows": [s.as_dict() for s in self.shadows],
+        }
+
+
+# An operational provider returns repo-shaped Hit objects with
+# source="operational". Backend adapters (e.g. @event4u/agent-memory)
+# are expected to translate their native payload into this shape.
+OperationalProvider = Callable[[list[str], list[str]], Iterable[Hit]]
 
 
 def _load_yaml(path: Path):
@@ -152,19 +193,195 @@ def _score(entry: dict, keys: list[str]) -> float:
     return best
 
 
-def retrieve(types: list[str], keys: list[str], limit: int = 5) -> list[Hit]:
+def _apply_conflict_rule(
+    repo_hits: list[Hit],
+    operational_hits: list[Hit],
+) -> tuple[list[Hit], list[Shadow]]:
+    """Enforce REPO WINS / OPERATIONAL AUGMENTS / NEVER CONTRADICTS SILENTLY.
+
+    Reference: `agents/roadmaps/road-to-memory-self-consumption.md` §
+    "Conflict rule: repo vs. operational". The four cases mapped below
+    are covered by `tests/test_conflict_rule.py`.
+    """
+    # Repo entries index — curated AND intake both count as "repo" for
+    # the conflict rule. The operational store is the only non-repo side.
+    repo_by_id: dict[str, Hit] = {h.id: h for h in repo_hits if h.id}
+
+    merged: list[Hit] = list(repo_hits)
+    shadows: list[Shadow] = []
+
+    for op in operational_hits:
+        if op.id and op.id in repo_by_id:
+            # Case 1+2: same id → repo wins (including when repo is
+            # status:deprecated — operational cannot revive a retired
+            # entry). Suppress the operational entry and record shadow.
+            repo = repo_by_id[op.id]
+            reason = (
+                "repo-deprecated"
+                if repo.entry.get("status") == "deprecated"
+                else "same-id"
+            )
+            shadows.append(Shadow(
+                id=op.id,
+                type=op.type,
+                reason=reason,
+                operational_path=op.path,
+                repo_path=repo.path,
+            ))
+            continue
+        # Case 3 (different ids on same logical key) and Case 4 (repo
+        # has no entry) — both simply include the operational hit.
+        # Repo entries naturally rank higher because their score is not
+        # discounted (see _score / operational scoring in retrieve()).
+        merged.append(op)
+
+    return merged, shadows
+
+
+# ---------------------------------------------------------------------------
+# Package-backed operational provider (the `present` path)
+# ---------------------------------------------------------------------------
+#
+# When `memory_status.status() == "present"` the consumer-facing contract
+# says retrieval should route through `@event4u/agent-memory`. The package
+# CLI is purely **semantic** (`memory retrieve <query> --type T …`); the
+# shared `retrieve(types, keys, …)` API is **key-based**. The hybrid
+# resolution agreed in `agents/contexts/agent-memory-contract.md` synthesises
+# `keys` into a single natural-language query for the package call, while
+# the file fallback continues to do glob/substring matching on the same
+# keys. Both legs land in the same `Hit` shape so the conflict rule can
+# merge them transparently.
+
+_CLI_TIMEOUT_SECONDS = 5.0
+_CLI_RETRIEVE_LIMIT_DEFAULT = 20
+
+
+def _synthesize_query(keys: list[str]) -> str:
+    """Turn a list of retrieval keys into one natural-language query.
+
+    Keys are typically file paths (`app/Http/Controllers/Foo`), feature
+    names (`billing`), or short identifiers — joining them with spaces
+    gives the package's semantic search enough surface to score against
+    without inventing structure. Empty or whitespace-only keys are
+    dropped; if nothing remains the caller falls back to the file path.
+    """
+    cleaned = [k.strip() for k in keys if isinstance(k, str) and k.strip()]
+    return " ".join(cleaned)
+
+
+def _cli_operational_provider(
+    types: list[str],
+    keys: list[str],
+    *,
+    cli_path: str = "memory",
+    timeout: float = _CLI_TIMEOUT_SECONDS,
+    limit: int = _CLI_RETRIEVE_LIMIT_DEFAULT,
+) -> Iterable[Hit]:
+    """Run `memory retrieve` and yield operational `Hit` objects.
+
+    Pino structured logs from the package go to stderr; stdout is a
+    clean v1 retrieval envelope. Any non-zero exit, timeout, or parse
+    failure degrades to "no operational hits" — `retrieve()` already
+    treats provider exceptions as a soft warning, so the caller still
+    gets the file-fallback result.
+    """
+    query = _synthesize_query(keys)
+    if not query:
+        return
+    cmd: list[str] = [cli_path, "retrieve", query, "--limit", str(limit)]
+    for t in types:
+        cmd.extend(["--type", t])
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return
+    if out.returncode != 0:
+        return
+    try:
+        envelope = json.loads(out.stdout)
+    except (ValueError, TypeError):
+        return
+    entries = envelope.get("entries") if isinstance(envelope, dict) else None
+    if not isinstance(entries, list):
+        return
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        eid = e.get("id")
+        etype = e.get("type")
+        if not isinstance(eid, str) or not isinstance(etype, str):
+            continue
+        # The package returns `confidence` (0..1) per the v1 envelope;
+        # map it onto our internal `score` field so the conflict rule
+        # and ranking work uniformly across providers.
+        try:
+            score = float(e.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        body = e.get("body") if isinstance(e.get("body"), dict) else {}
+        yield Hit(
+            id=eid,
+            type=etype,
+            source="operational",
+            path=f"agent-memory:{eid}",
+            score=score,
+            entry=body,
+        )
+
+
+def package_operational_provider() -> Optional[OperationalProvider]:
+    """Return a CLI-backed provider when the package is `present`, else None.
+
+    Callers who want automatic backend routing pass the result directly
+    to :func:`retrieve` — `None` is a safe value that yields file-only
+    retrieval, so this is the recommended one-liner for skills:
+
+        retrieve(types, keys, operational_provider=package_operational_provider())
+
+    The status probe is bounded (≤ 2s, cached per process) — see
+    `scripts/memory_status.py`. We import lazily so pure file-fallback
+    callers never pay for the probe.
+    """
+    # Late import: keeps `memory_lookup` importable even when
+    # `memory_status` is missing in stripped consumer installs.
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import memory_status  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    if memory_status.status().status != "present":
+        return None
+    return _cli_operational_provider
+
+
+def retrieve(
+    types: list[str],
+    keys: list[str],
+    limit: int = 5,
+    operational_provider: Optional[OperationalProvider] = None,
+    with_shadows: bool = False,
+) -> Union[list[Hit], RetrievalResult]:
     """Return up to `limit` hits across the requested types, highest score first.
 
-    Curated entries are preferred on ties — they are hand-reviewed.
-    The shape (`Hit`) matches the `present` backend adapter so skills
-    can treat both sources identically.
+    Repo entries (curated + intake) are preferred on ties — they are
+    hand-reviewed or session-captured against the repo itself. When an
+    `operational_provider` is supplied (the `present` path of the
+    backend-detection contract), its results are merged under the
+    REPO WINS conflict rule; suppressed operational entries surface as
+    `shadows` when `with_shadows=True`.
+
+    The return type stays `list[Hit]` by default for backward
+    compatibility with existing skill call sites.
     """
-    hits: list[Hit] = []
+    repo_hits: list[Hit] = []
     for mtype in types:
         if mtype not in CURATED_TYPES:
             continue
         for path, entry in _iter_curated_entries(mtype):
-            hits.append(Hit(
+            repo_hits.append(Hit(
                 id=str(entry.get("id", "")),
                 type=mtype,
                 source="curated",
@@ -173,7 +390,7 @@ def retrieve(types: list[str], keys: list[str], limit: int = 5) -> list[Hit]:
                 entry=entry,
             ))
         for path, entry in _iter_intake_entries(mtype):
-            hits.append(Hit(
+            repo_hits.append(Hit(
                 id=str(entry.get("id", "")),
                 type=mtype,
                 source="intake",
@@ -181,10 +398,122 @@ def retrieve(types: list[str], keys: list[str], limit: int = 5) -> list[Hit]:
                 score=_score(entry, keys) * 0.9,  # slight discount vs curated
                 entry=entry,
             ))
-    hits.sort(key=lambda h: (h.score, h.source == "curated"), reverse=True)
-    # Drop zero-score hits unless no better option exists.
-    positives = [h for h in hits if h.score > 0]
-    return (positives or hits)[:limit]
+
+    operational_hits: list[Hit] = []
+    if operational_provider is not None:
+        try:
+            for oh in operational_provider(list(types), list(keys)) or []:
+                # Discount operational vs curated/intake so repo ranks
+                # higher on equal relevance. Providers may already return
+                # trust-adjusted scores; we only apply a floor discount.
+                oh.score = min(oh.score, 0.85)
+                operational_hits.append(oh)
+        except Exception as exc:  # noqa: BLE001 — providers are external
+            print(f"warning: operational_provider raised "
+                  f"{exc.__class__.__name__}: {exc}", file=sys.stderr)
+
+    merged, shadows = _apply_conflict_rule(repo_hits, operational_hits)
+    merged.sort(key=lambda h: (h.score, h.source == "curated"), reverse=True)
+    positives = [h for h in merged if h.score > 0]
+    final_hits = (positives or merged)[:limit]
+
+    if with_shadows:
+        return RetrievalResult(hits=final_hits, shadows=shadows)
+    return final_hits
+
+
+CONTRACT_VERSION = 1
+
+# Memory types this file-backed backend can answer. Types outside this
+# set map to `unknown_type` per the retrieval contract.
+_KNOWN_TYPES = CURATED_TYPES
+
+
+def retrieve_v1(
+    types: list[str],
+    keys: list[str],
+    limit: int = 20,
+    operational_provider: Optional[OperationalProvider] = None,
+) -> dict:
+    """Return a v1 retrieval-contract envelope.
+
+    Wraps :func:`retrieve` and projects the internal ``Hit`` shape into
+    the shape defined by
+    ``schemas/retrieval-v1.schema.json``. Unknown types are reported as
+    ``status: unknown_type`` for that slice only, rather than failing
+    the whole call.
+    """
+    known = [t for t in types if t in _KNOWN_TYPES]
+    unknown = [t for t in types if t not in _KNOWN_TYPES]
+
+    result = retrieve(known, keys, limit=limit,
+                      operational_provider=operational_provider,
+                      with_shadows=True)
+    assert isinstance(result, RetrievalResult)
+    hits, shadows = result.hits, result.shadows
+    shadow_by_id = {s.id: s for s in shadows if s.id}
+
+    slice_counts: dict[str, int] = {t: 0 for t in known}
+    entries: list[dict] = []
+    for h in hits:
+        source = "operational" if h.source == "operational" else "repo"
+        envelope_entry: dict = {
+            "id": h.id,
+            "type": h.type,
+            "source": source,
+            "confidence": round(float(h.score), 4),
+            "body": dict(h.entry) if isinstance(h.entry, dict) else {},
+            "shadowed_by": None,
+        }
+        if h.type in slice_counts:
+            slice_counts[h.type] += 1
+        entries.append(envelope_entry)
+
+    # Surface shadowed operational entries as additional entries carrying
+    # `shadowed_by`. The conformance harness checks that only
+    # source="operational" entries ever set this field.
+    for sid, s in shadow_by_id.items():
+        entries.append({
+            "id": sid,
+            "type": s.type,
+            "source": "operational",
+            "confidence": 0.0,
+            "body": {},
+            "shadowed_by": f"repo:{sid}",
+        })
+        if s.type in slice_counts:
+            slice_counts[s.type] += 1
+
+    slices: dict[str, dict] = {
+        t: {"status": "ok", "count": slice_counts.get(t, 0)}
+        for t in known
+    }
+    errors: list[dict] = []
+    for t in unknown:
+        slices[t] = {"status": "unknown_type", "count": 0}
+        errors.append({
+            "type": t,
+            "code": "unknown_type",
+            "message": f"file-backed backend does not know type {t!r}",
+        })
+
+    oks = [s for s in slices.values() if s["status"] == "ok"]
+    fails = [s for s in slices.values() if s["status"] != "ok"]
+    envelope_status = (
+        "ok" if not fails
+        else "error" if not oks
+        else "partial"
+    )
+
+    envelope: dict = {
+        "contract_version": CONTRACT_VERSION,
+        "status": envelope_status,
+        "entries": entries,
+        "slices": slices,
+    }
+    if errors:
+        envelope["errors"] = errors
+    return envelope
 
 
 def main() -> int:
@@ -195,20 +524,52 @@ def main() -> int:
                     help="Retrieval key (repeatable)")
     ap.add_argument("--limit", type=int, default=5)
     ap.add_argument("--format", choices=["text", "json"], default="text")
+    ap.add_argument("--envelope", choices=["legacy", "v1"], default="legacy",
+                    help="Output shape: `legacy` (Hit list) or `v1` "
+                         "(retrieval contract v1 envelope). `v1` implies JSON output.")
+    ap.add_argument("--with-shadows", action="store_true",
+                    help="Include shadowed-operational entries in the output "
+                         "(no-op until an operational backend is wired)")
+    ap.add_argument("--auto", action="store_true",
+                    help="Auto-route to the @event4u/agent-memory package "
+                         "when memory_status.status() == 'present'; "
+                         "falls through to file-only retrieval otherwise")
     args = ap.parse_args()
     types = [t.strip() for t in args.types.split(",") if t.strip()]
     if not types:
         print("error: --types is required", file=sys.stderr)
         return 2
-    hits = retrieve(types, args.key, args.limit)
+    op_provider = package_operational_provider() if args.auto else None
+    if args.envelope == "v1":
+        envelope = retrieve_v1(types, args.key, args.limit,
+                               operational_provider=op_provider)
+        print(json.dumps(envelope, indent=2, default=str))
+        return 0
+    result = retrieve(types, args.key, args.limit,
+                      operational_provider=op_provider,
+                      with_shadows=args.with_shadows)
+    if args.with_shadows:
+        assert isinstance(result, RetrievalResult)
+        hits, shadows = result.hits, result.shadows
+    else:
+        hits, shadows = result, []  # type: ignore[assignment]
     if args.format == "json":
-        print(json.dumps([h.as_dict() for h in hits], indent=2, default=str))
+        payload = {"hits": [h.as_dict() for h in hits],
+                   "shadows": [s.as_dict() for s in shadows]}
+        print(json.dumps(payload, indent=2, default=str))
     else:
         if not hits:
             print("  (no hits)")
         for h in hits:
             print(f"  [{h.source}] {h.type}  score={h.score:.2f}  "
                   f"id={h.id or '-'}  path={h.path}")
+        if shadows:
+            print(f"\n  shadows: {len(shadows)} operational entr"
+                  f"{'y' if len(shadows) == 1 else 'ies'} suppressed by "
+                  f"the conflict rule")
+            for s in shadows:
+                print(f"    [{s.reason}] {s.type}  id={s.id}  "
+                      f"op={s.operational_path}  repo={s.repo_path}")
     return 0
 
 

--- a/.agent-src/templates/scripts/memory_status.py
+++ b/.agent-src/templates/scripts/memory_status.py
@@ -40,6 +40,12 @@ _HEALTH_TIMEOUT_SECONDS = 2.0
 _CACHE_ENV = "AGENT_MEMORY_STATUS"
 _CACHE_FILE = Path(".agent-memory") / "status.cache"
 
+# Retrieval contract version served by the file-backed fallback.
+# Source of truth: schemas/retrieval-v1.schema.json.
+CONTRACT_VERSION = 1
+_FILE_BACKEND_VERSION = "0.0.0-file"
+_FILE_BACKEND_FEATURES = ("file-fallback",)
+
 
 @dataclass
 class Result:
@@ -48,6 +54,11 @@ class Result:
     reason: str             # short explanation
     elapsed_ms: int         # time spent probing (0 if cached)
     cli_path: str = ""      # resolved CLI path, if any
+    # Populated only when status == "present" — sourced from the
+    # `health` CLI envelope so the v1 health() reports real package
+    # capabilities instead of file-fallback placeholders.
+    backend_version: str = ""
+    features: tuple = ()
 
 
 def _find_cli() -> str:
@@ -58,8 +69,45 @@ def _find_cli() -> str:
     return ""
 
 
-def _probe_health(cli_path: str) -> tuple[bool, str]:
-    """Returns (healthy, reason)."""
+def _parse_health_envelope(stdout: str) -> dict | None:
+    """Extract the v1 health envelope from `memory health` stdout.
+
+    The package emits a single JSON object on stdout (pino structured
+    logs go to stderr). We tolerate older builds that may have leaked
+    log lines into stdout by scanning for the first top-level object
+    that carries ``contract_version``.
+    """
+    text = (stdout or "").strip()
+    if not text:
+        return None
+    try:
+        obj = json.loads(text)
+    except ValueError:
+        obj = None
+    if isinstance(obj, dict) and obj.get("contract_version"):
+        return obj
+    # Fallback: line-by-line scan for an envelope-shaped object — covers
+    # the case where structured logs accidentally share stdout.
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            cand = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(cand, dict) and cand.get("contract_version"):
+            return cand
+    return None
+
+
+def _probe_health(cli_path: str) -> tuple[bool, str, dict | None]:
+    """Returns (healthy, reason, envelope).
+
+    On success ``envelope`` is the parsed v1 health envelope (may still
+    be ``None`` for very old CLIs that don't emit one). On failure it
+    is always ``None``.
+    """
     try:
         out = subprocess.run(
             [cli_path, "health"],
@@ -67,15 +115,16 @@ def _probe_health(cli_path: str) -> tuple[bool, str]:
             timeout=_HEALTH_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
-        return False, f"health() timed out after {_HEALTH_TIMEOUT_SECONDS}s"
+        return False, f"health() timed out after {_HEALTH_TIMEOUT_SECONDS}s", None
     except FileNotFoundError:
-        return False, "CLI vanished between which() and invoke"
+        return False, "CLI vanished between which() and invoke", None
     if out.returncode != 0:
         # First line of combined output, capped, for the reason field.
         msg = (out.stderr or out.stdout or "exit != 0").strip().splitlines()
         head = msg[0][:120] if msg else "exit != 0"
-        return False, f"health() returned {out.returncode}: {head}"
-    return True, "ok"
+        return False, f"health() returned {out.returncode}: {head}", None
+    envelope = _parse_health_envelope(out.stdout)
+    return True, "ok", envelope
 
 
 def _read_cache() -> Result | None:
@@ -125,14 +174,60 @@ def status(refresh: bool = False) -> Result:
         result = Result("absent", "file",
                         "agent-memory CLI not on PATH", 0)
     else:
-        healthy, reason = _probe_health(cli)
+        healthy, reason, envelope = _probe_health(cli)
         elapsed = int((time.monotonic() - t0) * 1000)
         if healthy:
-            result = Result("present", "package", reason, elapsed, cli)
+            backend_version = ""
+            features: tuple = ()
+            if isinstance(envelope, dict):
+                bv = envelope.get("backend_version")
+                if isinstance(bv, str):
+                    backend_version = bv
+                feats = envelope.get("features")
+                if isinstance(feats, list) and all(
+                    isinstance(f, str) for f in feats
+                ):
+                    features = tuple(feats)
+            result = Result("present", "package", reason, elapsed, cli,
+                            backend_version=backend_version,
+                            features=features)
         else:
             result = Result("misconfigured", "file", reason, elapsed, cli)
     _write_cache(result)
     return result
+
+
+def health(refresh: bool = False) -> dict:
+    """Return a v1 retrieval-contract health envelope.
+
+    Schema: ``schemas/retrieval-v1.schema.json`` (HealthResponse).
+    Maps the three-state :func:`status` result onto the contract's
+    ``ok | degraded | error`` so consumers can read
+    ``contract_version`` without caring about the file-vs-package split.
+
+    When the package backs the call (``status == "present"``), the
+    envelope reports the package's own ``backend_version`` and
+    ``features`` so consumers can feature-detect against real
+    capabilities. Otherwise the file-fallback markers are returned.
+    """
+    r = status(refresh=refresh)
+    envelope_status = {
+        "present": "ok",
+        "misconfigured": "degraded",
+        "absent": "ok",
+    }[r.status]
+    if r.status == "present" and (r.backend_version or r.features):
+        backend_version = r.backend_version or _FILE_BACKEND_VERSION
+        features = list(r.features) if r.features else list(_FILE_BACKEND_FEATURES)
+    else:
+        backend_version = _FILE_BACKEND_VERSION
+        features = list(_FILE_BACKEND_FEATURES)
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "status": envelope_status,
+        "backend_version": backend_version,
+        "features": features,
+    }
 
 
 def main() -> int:
@@ -140,7 +235,13 @@ def main() -> int:
     ap.add_argument("--format", choices=["text", "json"], default="text")
     ap.add_argument("--refresh", action="store_true",
                     help="Bypass the session cache and probe fresh")
+    ap.add_argument("--health", action="store_true",
+                    help="Emit a v1 retrieval-contract health envelope "
+                         "instead of the legacy status line")
     args = ap.parse_args()
+    if args.health:
+        print(json.dumps(health(refresh=args.refresh)))
+        return 0
     r = status(refresh=args.refresh)
     if args.format == "json":
         print(json.dumps(asdict(r)))

--- a/.agent-src/templates/scripts/memory_status.py
+++ b/.agent-src/templates/scripts/memory_status.py
@@ -35,7 +35,7 @@ from typing import Literal
 
 Status = Literal["absent", "misconfigured", "present"]
 
-_CLI_CANDIDATES = ("agent-memory", "agentmem")
+_CLI_CANDIDATES = ("memory", "agent-memory", "agentmem")
 _HEALTH_TIMEOUT_SECONDS = 2.0
 _CACHE_ENV = "AGENT_MEMORY_STATUS"
 _CACHE_FILE = Path(".agent-memory") / "status.cache"

--- a/.compression-hashes.json
+++ b/.compression-hashes.json
@@ -177,7 +177,7 @@
   "rules/token-efficiency.md": "818266e8520c67d393e3fc5412399915d54334bd6b77e940e68cd056e63ecc5b",
   "rules/tool-safety.md": "b13f3564a58a19f3af7c64c2000e0a13eb966c86f4d66f60938f4fad76c8164b",
   "rules/upstream-proposal.md": "eea27d887a97aa6b733e00730266aac1e4d041f5195bc385252d2753866ac0eb",
-  "rules/user-interaction.md": "8c6deb60ced22211051182728050a25a0f37389cf6545c855fd2743571309491",
+  "rules/user-interaction.md": "050ffe67ab1762292749ade26a6e3db26c6fe66717481cb2662d50b44844ccfc",
   "rules/verify-before-complete.md": "12b38af45cc058748009caa98914af5e8e2781b99c2277d416cae456979e3d2a",
   "scripts/update_roadmap_progress.py": "ac5772ece58014da45f88c53a9949750625a365e31fcd3b0b442d59945baf8e1",
   "skills/adversarial-review/SKILL.md": "9e475b2a742be6071aa3fa47ceca4b478463e04d7796d4b164c82da12553624c",

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "agent-memory": {
+      "args": [
+        "mcp"
+      ],
+      "command": "memory"
+    }
+  }
+}

--- a/.windsurf/mcp.json
+++ b/.windsurf/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "agent-memory": {
+      "args": [
+        "mcp"
+      ],
+      "command": "memory"
+    }
+  }
+}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -3104,30 +3104,76 @@ The user should be able to reply with just a number (e.g., `1`) instead of typin
 - **Every question with choices** must use numbered options — no exceptions.
 - **Keep options short** — one line each, with a brief explanation after the dash.
 - **Always include a "skip" or "no change" option** when applicable.
-- **Default/recommended option** can be marked: `1. Do X (recommended)`.
+- **Always state a recommendation** — see iron law below.
 - **Use the user's language** for the question and options.
 - **Accept both** the number and a natural language answer (e.g., "1" or "the first one").
 
+### Iron Law — ALWAYS recommend
+
+```
+EVERY numbered-option question MUST state which option the agent recommends and WHY.
+"Egal, was bevorzugst Du?" / "no preference" is NEVER an acceptable agent stance.
+```
+
+The user is asking the agent because the agent has read the code, the
+contracts, the trade-offs. Refusing to take a position dumps that work
+back on the user. Take the position; be wrong out loud if needed.
+
+**Format:**
+
+- Mark the recommended option inline: `1. Do X — short explanation (recommended)`.
+- After the option block, state **WHY** in 1–3 sentences: the trade-off
+  that tips the balance, plus the **caveat** that would flip it.
+- If the agent genuinely cannot pick (rare — true 50/50 with missing
+  data), say what data would break the tie and ask for that instead.
+
+**Example:**
+
+```
+> 1. Hybrid contract — keys + query (recommended)
+> 2. Key-based — extend the package
+> 3. Semantic — change all call sites
+
+I recommend 1: solves the acute consult-flow without a cross-repo PR,
+and the file-fallback stays trivial. Caveat — if hit-rate on the
+concat-shim turns out poor in practice, escalate to 2.
+```
+
+**What does NOT count as a recommendation:**
+
+- "Both work" / "either is fine" / "depends on what you prefer"
+- Listing pros and cons without picking
+- "I'd lean towards X" without a reason
+- Hiding behind "you know the project better" (the agent just researched it)
+
 ### Examples
 
-**Binary choice:**
+**Binary choice (with recommendation):**
 ```
-> 1. Interactive — ask before each comment
+> 1. Interactive — ask before each comment (recommended)
 > 2. Automatic — handle all independently
+
+I recommend 1: the comments touch security-sensitive code, so a wrong
+auto-fix is more expensive than the friction of approving each one.
+Switch to 2 if the comments turn out to be pure formatting.
 ```
 
-**Multiple choice with skip:**
+**Multiple choice with skip (with recommendation):**
 ```
-> 1. Fix the code
+> 1. Fix the code (recommended)
 > 2. Fix the test
 > 3. Skip
+
+I recommend 1: the test is asserting the documented behavior; the
+production code drifted from the contract. Pick 2 only if the contract
+itself is wrong.
 ```
 
-**Confirmation with context:**
+**Confirmation with context (recommendation implicit in framing):**
 ```
 > Found PR #1399 on branch `chore/refactor-agent-setup-2`.
 >
-> 1. Yes, that's the right PR
+> 1. Yes, that's the right PR (recommended — branch matches)
 > 2. No, different PR — I'll provide the URL
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ Install directly in your agent for global, cross-project use:
 
 → [Full getting started guide](docs/getting-started.md)
 
+### Optional: persistent agent memory
+
+`agent-config` integrates with [`@event4u/agent-memory`](https://www.npmjs.com/package/@event4u/agent-memory)
+— an MCP-based memory backend that gives agents persistent learnings
+across sessions. It is **strictly optional**:
+
+- Not a required dependency (declared as `suggest` in Composer and as an
+  optional peer in npm). `agent-config` itself never imports it.
+- Without it, agent skills fall back to **file-based memory** under
+  `agents/memory/` and continue to work normally.
+- Recommended for teams that want learnings to survive across machines,
+  branches, and chat sessions.
+
+Install in the same project (dev-only):
+
+```bash
+npm install --save-dev @event4u/agent-memory
+```
+
+→ [Memory contract & retrieval API](agents/contexts/agent-memory-contract.md)
+
 ---
 
 ## 2-minute demo: `/implement-ticket`

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -357,4 +357,5 @@ tasks:
       - task: check-memory
       - task: test
       - task: runtime-e2e
+      - task: roadmap-progress-check
       - task: lint-readme

--- a/agents/contexts/agent-memory-contract.md
+++ b/agents/contexts/agent-memory-contract.md
@@ -39,12 +39,21 @@ process, **non-raising** on probe failure.
 
 ## Expected CLI surface
 
-Probed in `scripts/memory_status.py`:
+Probed in `scripts/memory_status.py` via `_CLI_CANDIDATES`:
 
-- Executable on `PATH` as `agent-memory` **or** `agentmem`.
-- Supports `health` subcommand returning non-zero on unhealthy.
-- Supports (future) `retrieve --types … --keys … --limit …
-  --format json` returning the retrieval envelope below.
+- Executable on `PATH` as **`memory`** (canonical, ships in
+  `@event4u/agent-memory` v1.1+ as `package.json#bin.memory`),
+  **`agent-memory`** (planned alias), or **`agentmem`** (legacy).
+- Supports `health` subcommand emitting a v1 health envelope on stdout
+  (`{contract_version, status, backend_version, features, latency_ms}`)
+  and exiting non-zero on unhealthy.
+- Supports `retrieve <query> [--type T …] [--limit N] [--layer 1|2|3]
+  [--budget N] [--low-trust] [--repository ID]` emitting a v1
+  retrieval envelope on stdout (always JSON).
+
+The retrieval invocation is **semantic, not key-based** — see the
+"⚠️ Known contract drift" section below for the consumer-side
+implication.
 
 If the released package diverges from these names, we update
 `_CLI_CANDIDATES` in `memory_status.py` — not the other way round.
@@ -70,30 +79,36 @@ Envelope: `contract_version`, `status ∈ {ok, partial, error}`,
 
 ## ⚠️ Known contract drift (consumer vs. spec)
 
-The file fallback in `scripts/memory_lookup.py` currently returns a
-**flat `list[Hit]`** with a different field set:
+**Status: resolved at the consumer boundary.** The CLI / JSON output of
+`scripts/memory_lookup.py` already emits the v1 envelope with
+`source ∈ {repo, operational}`, `confidence`, `slices`, `status`, and
+`contract_version` — see `memory_lookup.py:320-345` (envelope
+assembly).
 
-| File fallback `Hit` | Spec entry | Notes |
+What remains is **internal-only**: the private `Hit` dataclass inside
+`memory_lookup.py` still uses `source ∈ {curated, intake}` and `score`.
+No skill, command, or external consumer imports `Hit` directly — they
+all go through the public JSON surface, which is already spec-aligned.
+
+| Internal `Hit` field | Public envelope field | Visible to consumers? |
 |---|---|---|
-| `id`, `type` | `id`, `type` | match |
-| `source ∈ {curated, intake}` | `source ∈ {repo, operational}` | **naming drift** |
-| `score ∈ [0,1]` | `confidence` | **naming drift** |
-| `path` | — (spec has no `path`) | extra field |
-| — (no envelope) | `contract_version`, `status`, `slices`, `errors` | **missing layer** |
+| `id`, `type` | `id`, `type` | yes — match |
+| `source ∈ {curated, intake}` | `source ∈ {repo, operational}` | no — translated at boundary |
+| `score ∈ [0,1]` | `confidence` | no — translated at boundary |
+| `path` | — | no — internal scoring signal |
 
-This drift is tolerable while the package is absent (skills only
-consume the fallback shape). When the package ships, one of two paths:
+**Trigger to revisit:** if a second module starts importing the `Hit`
+dataclass directly (e.g. `memory_lookup.py` is split into multiple
+files and `Hit` becomes a public type), rename `Hit.source`/`Hit.score`
+to match the envelope so the boundary translation can be deleted.
+Until then, the internal naming is an implementation detail.
 
-1. **Align fallback to spec** — rename `source` values, rename `score`
-   → `confidence`, wrap return value in the envelope. Breaking change
-   in `memory_lookup.py`; skills adjust once.
-2. **Keep fallback flat, adapt package** — the package adapter
-   flattens the envelope on the consumer boundary. Keeps skills
-   unchanged; hides the envelope from agent-config entirely.
-
-Decision postponed until the package is closer to release — the
-tradeoff shifts depending on whether other consumers emerge that want
-the full envelope.
+There is also a **calling-convention drift** between the contract's
+key-based `retrieve(types, keys, limit)` and the package's
+semantic-only `retrieve(query, …)`. This is tracked separately and
+is the subject of an ongoing design decision (hybrid contract — keys
+synthesise into a query for the package path; file-fallback stays
+key-match).
 
 ## Expected `propose()` / signal emission
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,9 @@
     "require": {
         "php": ">=8.0"
     },
+    "suggest": {
+        "@event4u/agent-memory": "Optional MCP-based memory backend (npm: @event4u/agent-memory ^1.1.0). Adds persistent agent learnings across sessions. Install with `npm install --save-dev @event4u/agent-memory` if your team wants the memory layer; otherwise agent-config falls back to file-based memory."
+    },
     "bin": [
         "bin/install.php",
         "scripts/agent-config"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,6 +28,7 @@ so you can run a few package scripts without installing `go-task`,
 ```bash
 ./agent-config mcp:render          # sync MCP server config into .cursor/ and .windsurf/
 ./agent-config roadmap:progress    # regenerate agents/roadmaps-progress.md
+./agent-config hooks:install       # install pre-commit roadmap-progress hook (opt-in)
 ./agent-config first-run           # guided setup
 ./agent-config help                # full command list
 ```

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "agent-memory": {
+      "command": "memory",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@event4u/agent-config",
     "version": "1.12.0",
-    "description": "Shared agent configuration \u2014 skills, rules, commands, guidelines, and templates for AI coding tools",
+    "description": "Shared agent configuration — skills, rules, commands, guidelines, and templates for AI coding tools",
     "license": "MIT",
     "private": false,
     "repository": {
@@ -38,5 +38,13 @@
     "publishConfig": {
         "access": "public",
         "provenance": true
+    },
+    "peerDependencies": {
+        "@event4u/agent-memory": "^1.1.0"
+    },
+    "peerDependenciesMeta": {
+        "@event4u/agent-memory": {
+            "optional": true
+        }
     }
 }

--- a/scripts/agent-config
+++ b/scripts/agent-config
@@ -46,6 +46,8 @@ Commands:
   mcp:check                  Dry-run mcp:render; exit non-zero if targets are stale
   roadmap:progress           Regenerate agents/roadmaps-progress.md from open roadmaps
   roadmap:progress-check     Fail if agents/roadmaps-progress.md is stale (for CI)
+  hooks:install              Install the pre-commit roadmap-progress hook
+                             (use --print to dump it, --force to overwrite an existing hook)
   first-run                  Guided first-run setup — cost profile, settings, tooling
   help                       Show this help
   --version, -V              Print package version
@@ -55,6 +57,7 @@ Examples:
   ./agent-config mcp:render --claude-desktop
   ./agent-config mcp:check
   ./agent-config roadmap:progress
+  ./agent-config hooks:install
   ./agent-config first-run
 
 All commands operate on the CURRENT DIRECTORY (your project root).
@@ -132,6 +135,77 @@ cmd_first_run() {
   exec bash "$script" "$@"
 }
 
+cmd_hooks_install() {
+  local force=false
+  local print_only=false
+  for arg in "$@"; do
+    case "$arg" in
+      --force)   force=true ;;
+      --print)   print_only=true ;;
+      -h|--help)
+        cat <<'HELP'
+agent-config hooks:install — install the pre-commit roadmap-progress hook.
+
+Usage:
+  ./agent-config hooks:install [--force] [--print]
+
+Without flags: copies the hook to .git/hooks/pre-commit. Refuses to
+overwrite an existing pre-commit hook unless --force is given (the
+existing hook may already chain other tooling).
+
+  --print   dump the hook script to stdout (for manual chaining into an
+            existing pre-commit script, husky, lefthook, etc.)
+  --force   overwrite an existing .git/hooks/pre-commit (DESTRUCTIVE)
+HELP
+        return 0 ;;
+      *)
+        echo "❌  hooks:install: unknown argument: $arg" >&2
+        echo "    Run \`./agent-config hooks:install --help\` for usage." >&2
+        return 2 ;;
+    esac
+  done
+
+  local hook_src
+  hook_src="$(resolve_script ".agent-src/templates/hooks/pre-commit-roadmap-progress" ".augment/templates/hooks/pre-commit-roadmap-progress")" || return 1
+
+  if $print_only; then
+    cat "$hook_src"
+    return 0
+  fi
+
+  local git_dir
+  git_dir="$(git -C "$CONSUMER_ROOT" rev-parse --git-dir 2>/dev/null || true)"
+  if [[ -z "$git_dir" ]]; then
+    echo "❌  hooks:install: $CONSUMER_ROOT is not a git repository." >&2
+    return 1
+  fi
+  # Resolve relative git-dir paths (worktrees, submodules) against CONSUMER_ROOT.
+  [[ "$git_dir" != /* ]] && git_dir="$CONSUMER_ROOT/$git_dir"
+
+  local hook_dir="$git_dir/hooks"
+  local target="$hook_dir/pre-commit"
+  mkdir -p "$hook_dir"
+
+  if [[ -f "$target" ]] && ! $force; then
+    if grep -q "pre-commit-roadmap-progress" "$target" 2>/dev/null; then
+      echo "✅  hooks:install: already installed at $target"
+      return 0
+    fi
+    echo "⚠️   hooks:install: $target already exists and looks unrelated." >&2
+    echo "    Options:" >&2
+    echo "      1. Inspect it and append the snippet manually:" >&2
+    echo "         ./agent-config hooks:install --print >> $target" >&2
+    echo "      2. Replace it (destructive):" >&2
+    echo "         ./agent-config hooks:install --force" >&2
+    return 1
+  fi
+
+  cp "$hook_src" "$target"
+  chmod +x "$target"
+  echo "✅  hooks:install: pre-commit hook installed at $target"
+  echo "    To uninstall: rm $target"
+}
+
 main() {
   local cmd="${1-}"
   [[ $# -gt 0 ]] && shift || true
@@ -141,6 +215,7 @@ main() {
     mcp:check)               cmd_mcp_check "$@" ;;
     roadmap:progress)        cmd_roadmap_progress "$@" ;;
     roadmap:progress-check)  cmd_roadmap_progress_check "$@" ;;
+    hooks:install)           cmd_hooks_install "$@" ;;
     first-run)               cmd_first_run "$@" ;;
     help|--help|-h|"")        usage ;;
     --version|-V)            print_version ;;

--- a/scripts/memory_lookup.py
+++ b/scripts/memory_lookup.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
-"""File-based retrieval for the `absent` path.
+"""Hybrid retrieval — file-first with optional package augmentation.
 
 Implements the shared `retrieve(types, keys, limit)` abstraction used
 by skills. Reads YAML under `agents/memory/<type>/` (curated, hand-
 reviewed) and JSONL under `agents/memory/intake/*.jsonl` (agent-written,
 append-only, supersede-chain aware).
 
-The returned shape is identical to the `present`-path adapter over the
-`@event4u/agent-memory` API, so skills stay backend-agnostic.
+When the `@event4u/agent-memory` package is present (see
+`scripts/memory_status.py`), callers can pass the result of
+:func:`package_operational_provider` to route additional retrieval
+through the package's semantic CLI. Repo entries always win on
+conflict — see `_apply_conflict_rule`.
 
 Usage:
     python3 scripts/memory_lookup.py --types domain-invariants,ownership \\
         --key "app/Http/Controllers/Foo" --limit 5
     python3 scripts/memory_lookup.py --types incident-learnings --format json
+    python3 scripts/memory_lookup.py --types ownership --key billing --auto
 
-    from scripts.memory_lookup import retrieve
-    hits = retrieve(types=["ownership"], keys=["app/Http"], limit=3)
+    from scripts.memory_lookup import retrieve, package_operational_provider
+    hits = retrieve(
+        types=["ownership"], keys=["app/Http"], limit=3,
+        operational_provider=package_operational_provider(),
+    )
 """
 
 from __future__ import annotations
@@ -23,6 +30,8 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import json
+import os
+import subprocess
 import sys
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
@@ -229,6 +238,125 @@ def _apply_conflict_rule(
     return merged, shadows
 
 
+# ---------------------------------------------------------------------------
+# Package-backed operational provider (the `present` path)
+# ---------------------------------------------------------------------------
+#
+# When `memory_status.status() == "present"` the consumer-facing contract
+# says retrieval should route through `@event4u/agent-memory`. The package
+# CLI is purely **semantic** (`memory retrieve <query> --type T …`); the
+# shared `retrieve(types, keys, …)` API is **key-based**. The hybrid
+# resolution agreed in `agents/contexts/agent-memory-contract.md` synthesises
+# `keys` into a single natural-language query for the package call, while
+# the file fallback continues to do glob/substring matching on the same
+# keys. Both legs land in the same `Hit` shape so the conflict rule can
+# merge them transparently.
+
+_CLI_TIMEOUT_SECONDS = 5.0
+_CLI_RETRIEVE_LIMIT_DEFAULT = 20
+
+
+def _synthesize_query(keys: list[str]) -> str:
+    """Turn a list of retrieval keys into one natural-language query.
+
+    Keys are typically file paths (`app/Http/Controllers/Foo`), feature
+    names (`billing`), or short identifiers — joining them with spaces
+    gives the package's semantic search enough surface to score against
+    without inventing structure. Empty or whitespace-only keys are
+    dropped; if nothing remains the caller falls back to the file path.
+    """
+    cleaned = [k.strip() for k in keys if isinstance(k, str) and k.strip()]
+    return " ".join(cleaned)
+
+
+def _cli_operational_provider(
+    types: list[str],
+    keys: list[str],
+    *,
+    cli_path: str = "memory",
+    timeout: float = _CLI_TIMEOUT_SECONDS,
+    limit: int = _CLI_RETRIEVE_LIMIT_DEFAULT,
+) -> Iterable[Hit]:
+    """Run `memory retrieve` and yield operational `Hit` objects.
+
+    Pino structured logs from the package go to stderr; stdout is a
+    clean v1 retrieval envelope. Any non-zero exit, timeout, or parse
+    failure degrades to "no operational hits" — `retrieve()` already
+    treats provider exceptions as a soft warning, so the caller still
+    gets the file-fallback result.
+    """
+    query = _synthesize_query(keys)
+    if not query:
+        return
+    cmd: list[str] = [cli_path, "retrieve", query, "--limit", str(limit)]
+    for t in types:
+        cmd.extend(["--type", t])
+    try:
+        out = subprocess.run(
+            cmd,
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return
+    if out.returncode != 0:
+        return
+    try:
+        envelope = json.loads(out.stdout)
+    except (ValueError, TypeError):
+        return
+    entries = envelope.get("entries") if isinstance(envelope, dict) else None
+    if not isinstance(entries, list):
+        return
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        eid = e.get("id")
+        etype = e.get("type")
+        if not isinstance(eid, str) or not isinstance(etype, str):
+            continue
+        # The package returns `confidence` (0..1) per the v1 envelope;
+        # map it onto our internal `score` field so the conflict rule
+        # and ranking work uniformly across providers.
+        try:
+            score = float(e.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            score = 0.0
+        body = e.get("body") if isinstance(e.get("body"), dict) else {}
+        yield Hit(
+            id=eid,
+            type=etype,
+            source="operational",
+            path=f"agent-memory:{eid}",
+            score=score,
+            entry=body,
+        )
+
+
+def package_operational_provider() -> Optional[OperationalProvider]:
+    """Return a CLI-backed provider when the package is `present`, else None.
+
+    Callers who want automatic backend routing pass the result directly
+    to :func:`retrieve` — `None` is a safe value that yields file-only
+    retrieval, so this is the recommended one-liner for skills:
+
+        retrieve(types, keys, operational_provider=package_operational_provider())
+
+    The status probe is bounded (≤ 2s, cached per process) — see
+    `scripts/memory_status.py`. We import lazily so pure file-fallback
+    callers never pay for the probe.
+    """
+    # Late import: keeps `memory_lookup` importable even when
+    # `memory_status` is missing in stripped consumer installs.
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import memory_status  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    if memory_status.status().status != "present":
+        return None
+    return _cli_operational_provider
+
+
 def retrieve(
     types: list[str],
     keys: list[str],
@@ -402,16 +530,24 @@ def main() -> int:
     ap.add_argument("--with-shadows", action="store_true",
                     help="Include shadowed-operational entries in the output "
                          "(no-op until an operational backend is wired)")
+    ap.add_argument("--auto", action="store_true",
+                    help="Auto-route to the @event4u/agent-memory package "
+                         "when memory_status.status() == 'present'; "
+                         "falls through to file-only retrieval otherwise")
     args = ap.parse_args()
     types = [t.strip() for t in args.types.split(",") if t.strip()]
     if not types:
         print("error: --types is required", file=sys.stderr)
         return 2
+    op_provider = package_operational_provider() if args.auto else None
     if args.envelope == "v1":
-        envelope = retrieve_v1(types, args.key, args.limit)
+        envelope = retrieve_v1(types, args.key, args.limit,
+                               operational_provider=op_provider)
         print(json.dumps(envelope, indent=2, default=str))
         return 0
-    result = retrieve(types, args.key, args.limit, with_shadows=args.with_shadows)
+    result = retrieve(types, args.key, args.limit,
+                      operational_provider=op_provider,
+                      with_shadows=args.with_shadows)
     if args.with_shadows:
         assert isinstance(result, RetrievalResult)
         hits, shadows = result.hits, result.shadows

--- a/scripts/memory_status.py
+++ b/scripts/memory_status.py
@@ -35,7 +35,7 @@ from typing import Literal
 
 Status = Literal["absent", "misconfigured", "present"]
 
-_CLI_CANDIDATES = ("agent-memory", "agentmem")
+_CLI_CANDIDATES = ("memory", "agent-memory", "agentmem")
 _HEALTH_TIMEOUT_SECONDS = 2.0
 _CACHE_ENV = "AGENT_MEMORY_STATUS"
 _CACHE_FILE = Path(".agent-memory") / "status.cache"

--- a/scripts/memory_status.py
+++ b/scripts/memory_status.py
@@ -54,6 +54,11 @@ class Result:
     reason: str             # short explanation
     elapsed_ms: int         # time spent probing (0 if cached)
     cli_path: str = ""      # resolved CLI path, if any
+    # Populated only when status == "present" — sourced from the
+    # `health` CLI envelope so the v1 health() reports real package
+    # capabilities instead of file-fallback placeholders.
+    backend_version: str = ""
+    features: tuple = ()
 
 
 def _find_cli() -> str:
@@ -64,8 +69,45 @@ def _find_cli() -> str:
     return ""
 
 
-def _probe_health(cli_path: str) -> tuple[bool, str]:
-    """Returns (healthy, reason)."""
+def _parse_health_envelope(stdout: str) -> dict | None:
+    """Extract the v1 health envelope from `memory health` stdout.
+
+    The package emits a single JSON object on stdout (pino structured
+    logs go to stderr). We tolerate older builds that may have leaked
+    log lines into stdout by scanning for the first top-level object
+    that carries ``contract_version``.
+    """
+    text = (stdout or "").strip()
+    if not text:
+        return None
+    try:
+        obj = json.loads(text)
+    except ValueError:
+        obj = None
+    if isinstance(obj, dict) and obj.get("contract_version"):
+        return obj
+    # Fallback: line-by-line scan for an envelope-shaped object — covers
+    # the case where structured logs accidentally share stdout.
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            cand = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(cand, dict) and cand.get("contract_version"):
+            return cand
+    return None
+
+
+def _probe_health(cli_path: str) -> tuple[bool, str, dict | None]:
+    """Returns (healthy, reason, envelope).
+
+    On success ``envelope`` is the parsed v1 health envelope (may still
+    be ``None`` for very old CLIs that don't emit one). On failure it
+    is always ``None``.
+    """
     try:
         out = subprocess.run(
             [cli_path, "health"],
@@ -73,15 +115,16 @@ def _probe_health(cli_path: str) -> tuple[bool, str]:
             timeout=_HEALTH_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:
-        return False, f"health() timed out after {_HEALTH_TIMEOUT_SECONDS}s"
+        return False, f"health() timed out after {_HEALTH_TIMEOUT_SECONDS}s", None
     except FileNotFoundError:
-        return False, "CLI vanished between which() and invoke"
+        return False, "CLI vanished between which() and invoke", None
     if out.returncode != 0:
         # First line of combined output, capped, for the reason field.
         msg = (out.stderr or out.stdout or "exit != 0").strip().splitlines()
         head = msg[0][:120] if msg else "exit != 0"
-        return False, f"health() returned {out.returncode}: {head}"
-    return True, "ok"
+        return False, f"health() returned {out.returncode}: {head}", None
+    envelope = _parse_health_envelope(out.stdout)
+    return True, "ok", envelope
 
 
 def _read_cache() -> Result | None:
@@ -131,10 +174,23 @@ def status(refresh: bool = False) -> Result:
         result = Result("absent", "file",
                         "agent-memory CLI not on PATH", 0)
     else:
-        healthy, reason = _probe_health(cli)
+        healthy, reason, envelope = _probe_health(cli)
         elapsed = int((time.monotonic() - t0) * 1000)
         if healthy:
-            result = Result("present", "package", reason, elapsed, cli)
+            backend_version = ""
+            features: tuple = ()
+            if isinstance(envelope, dict):
+                bv = envelope.get("backend_version")
+                if isinstance(bv, str):
+                    backend_version = bv
+                feats = envelope.get("features")
+                if isinstance(feats, list) and all(
+                    isinstance(f, str) for f in feats
+                ):
+                    features = tuple(feats)
+            result = Result("present", "package", reason, elapsed, cli,
+                            backend_version=backend_version,
+                            features=features)
         else:
             result = Result("misconfigured", "file", reason, elapsed, cli)
     _write_cache(result)
@@ -148,6 +204,11 @@ def health(refresh: bool = False) -> dict:
     Maps the three-state :func:`status` result onto the contract's
     ``ok | degraded | error`` so consumers can read
     ``contract_version`` without caring about the file-vs-package split.
+
+    When the package backs the call (``status == "present"``), the
+    envelope reports the package's own ``backend_version`` and
+    ``features`` so consumers can feature-detect against real
+    capabilities. Otherwise the file-fallback markers are returned.
     """
     r = status(refresh=refresh)
     envelope_status = {
@@ -155,11 +216,12 @@ def health(refresh: bool = False) -> dict:
         "misconfigured": "degraded",
         "absent": "ok",
     }[r.status]
-    # When the package is present, report its version from `health()`
-    # output; until we parse that, keep the file-fallback marker so the
-    # envelope never lies about what backed the response.
-    backend_version = _FILE_BACKEND_VERSION
-    features = list(_FILE_BACKEND_FEATURES)
+    if r.status == "present" and (r.backend_version or r.features):
+        backend_version = r.backend_version or _FILE_BACKEND_VERSION
+        features = list(r.features) if r.features else list(_FILE_BACKEND_FEATURES)
+    else:
+        backend_version = _FILE_BACKEND_VERSION
+        features = list(_FILE_BACKEND_FEATURES)
     return {
         "contract_version": CONTRACT_VERSION,
         "status": envelope_status,

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -33,6 +33,22 @@ trap 'rm -f "$LOG"' EXIT
 bash "$INSTALLER" --quiet >"$LOG" 2>&1
 CODE=$?
 if [[ $CODE -eq 0 ]]; then
+    # Optional companion: @event4u/agent-memory. Suggest it once, only if
+    # the consumer hasn't already installed it (locally or on PATH). The
+    # hint is purely informational; agent-config falls back to file-based
+    # memory when the backend is absent.
+    if ! command -v memory >/dev/null 2>&1 \
+       && ! command -v agent-memory >/dev/null 2>&1 \
+       && [[ ! -d "$SCRIPT_DIR/../../@event4u/agent-memory" ]]; then
+        cat >&2 <<'HINT'
+💡 agent-config tip: install @event4u/agent-memory for persistent agent
+   learnings across sessions (optional, dev-only):
+
+       npm install --save-dev @event4u/agent-memory
+
+   Skip if you don't need it — agent-config falls back to file-based memory.
+HINT
+    fi
     exit 0
 fi
 

--- a/tests/test_memory_lookup.py
+++ b/tests/test_memory_lookup.py
@@ -128,3 +128,116 @@ def test_limit_applied(tmp_path, monkeypatch):
            f"version: 1\nentries:\n{entries}\n")
     hits = memory_lookup.retrieve(["ownership"], ["src/"], limit=3)
     assert len(hits) == 3
+
+
+# ---------------------------------------------------------------------------
+# Package-backed operational provider (the `present` path)
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_query_joins_keys():
+    assert memory_lookup._synthesize_query(
+        ["app/Http", "billing"]
+    ) == "app/Http billing"
+
+
+def test_synthesize_query_drops_empty_and_non_strings():
+    assert memory_lookup._synthesize_query(
+        ["", "  ", "real", None, 42]  # type: ignore[list-item]
+    ) == "real"
+
+
+def test_synthesize_query_returns_empty_when_all_keys_empty():
+    assert memory_lookup._synthesize_query(["", "  "]) == ""
+
+
+def _fake_memory_cli(tmp_path: Path, body: str) -> Path:
+    """Create an executable shell script that mimics the `memory` CLI."""
+    import stat
+    fake = tmp_path / "memory"
+    fake.write_text(body)
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return fake
+
+
+def test_cli_operational_provider_happy_path(tmp_path):
+    envelope = {
+        "contract_version": 1,
+        "status": "ok",
+        "entries": [
+            {
+                "id": "op-1",
+                "type": "ownership",
+                "source": "operational",
+                "confidence": 0.72,
+                "body": {"path": "app/Http/Foo.php", "owner": "team-x"},
+            },
+        ],
+    }
+    fake = _fake_memory_cli(tmp_path, f"""#!/bin/sh
+echo '{{"level":30,"msg":"Database connected"}}' >&2
+cat <<'EOF'
+{json.dumps(envelope)}
+EOF
+""")
+    hits = list(memory_lookup._cli_operational_provider(
+        ["ownership"], ["billing"], cli_path=str(fake),
+    ))
+    assert len(hits) == 1
+    assert hits[0].id == "op-1"
+    assert hits[0].source == "operational"
+    assert hits[0].score == 0.72
+    assert hits[0].entry["owner"] == "team-x"
+
+
+def test_cli_operational_provider_drops_empty_query(tmp_path):
+    fake = _fake_memory_cli(tmp_path, "#!/bin/sh\nexit 1\n")
+    # Empty keys → no query → provider yields nothing without invoking CLI.
+    hits = list(memory_lookup._cli_operational_provider(
+        ["ownership"], [], cli_path=str(fake),
+    ))
+    assert hits == []
+
+
+def test_cli_operational_provider_handles_nonzero_exit(tmp_path):
+    fake = _fake_memory_cli(tmp_path, "#!/bin/sh\necho 'boom' >&2\nexit 3\n")
+    # Failure mode is silent: caller gets file-fallback only.
+    hits = list(memory_lookup._cli_operational_provider(
+        ["ownership"], ["billing"], cli_path=str(fake),
+    ))
+    assert hits == []
+
+
+def test_cli_operational_provider_handles_garbage_stdout(tmp_path):
+    fake = _fake_memory_cli(tmp_path,
+                            "#!/bin/sh\necho 'not json at all'\n")
+    hits = list(memory_lookup._cli_operational_provider(
+        ["ownership"], ["billing"], cli_path=str(fake),
+    ))
+    assert hits == []
+
+
+def test_package_operational_provider_returns_none_when_absent(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    import memory_status  # noqa: E402
+    monkeypatch.setattr(memory_status, "_find_cli", lambda: "")
+    monkeypatch.delenv(memory_status._CACHE_ENV, raising=False)
+    assert memory_lookup.package_operational_provider() is None
+
+
+def test_package_operational_provider_returns_callable_when_present(
+    monkeypatch, tmp_path,
+):
+    import stat
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    import memory_status  # noqa: E402
+    fake = tmp_path / "memory"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setattr(memory_status, "_find_cli", lambda: str(fake))
+    monkeypatch.setattr(memory_status, "_CACHE_FILE",
+                        tmp_path / ".agent-memory" / "status.cache")
+    monkeypatch.delenv(memory_status._CACHE_ENV, raising=False)
+    provider = memory_lookup.package_operational_provider()
+    assert provider is not None
+    assert callable(provider)

--- a/tests/test_memory_status.py
+++ b/tests/test_memory_status.py
@@ -87,3 +87,118 @@ def test_never_raises(monkeypatch):
         # its own code. Document the current shape: only health-probe
         # and subprocess errors are swallowed. Bugs propagate.
         memory_status.status(refresh=True)
+
+
+# ---------------------------------------------------------------------------
+# Health envelope parsing & v1 envelope content (present path)
+# ---------------------------------------------------------------------------
+
+
+def _fake_health_cli(tmp_path: Path, stdout: str, stderr: str = "",
+                     exit_code: int = 0) -> Path:
+    """Create an executable fake `memory` that emits the given health output."""
+    fake = tmp_path / "agent-memory"
+    body = "#!/bin/sh\n"
+    if stderr:
+        # Use printf to preserve special chars; one-shot redirect.
+        body += f"printf '%s\\n' {json.dumps(stderr)} >&2\n"
+    if stdout:
+        body += f"cat <<'EOF'\n{stdout}\nEOF\n"
+    body += f"exit {exit_code}\n"
+    fake.write_text(body)
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return fake
+
+
+def test_parse_health_envelope_clean_json():
+    payload = json.dumps({
+        "contract_version": 1,
+        "status": "ok",
+        "backend_version": "0.1.0",
+        "features": ["a", "b"],
+    })
+    env = memory_status._parse_health_envelope(payload)
+    assert env is not None
+    assert env["backend_version"] == "0.1.0"
+
+
+def test_parse_health_envelope_skips_log_pollution():
+    """Older builds may leak pino logs into stdout — scan line by line."""
+    body = "\n".join([
+        '{"level":30,"msg":"connecting"}',
+        json.dumps({"contract_version": 1, "status": "ok",
+                    "backend_version": "0.1.0", "features": []}),
+        '{"level":30,"msg":"disconnected"}',
+    ])
+    env = memory_status._parse_health_envelope(body)
+    assert env is not None
+    assert env["contract_version"] == 1
+    assert env["backend_version"] == "0.1.0"
+
+
+def test_parse_health_envelope_empty():
+    assert memory_status._parse_health_envelope("") is None
+    assert memory_status._parse_health_envelope("   \n  ") is None
+
+
+def test_parse_health_envelope_no_envelope_in_logs():
+    """Lines without contract_version don't qualify."""
+    body = '\n'.join([
+        '{"level":30,"msg":"hi"}',
+        '{"level":30,"msg":"bye"}',
+    ])
+    assert memory_status._parse_health_envelope(body) is None
+
+
+def test_status_present_populates_backend_version_and_features(
+    monkeypatch, tmp_path,
+):
+    payload = json.dumps({
+        "contract_version": 1,
+        "status": "ok",
+        "backend_version": "1.2.3",
+        "features": ["trust-scoring", "decay"],
+    })
+    fake = _fake_health_cli(tmp_path, stdout=payload)
+    monkeypatch.setattr(memory_status, "_find_cli", lambda: str(fake))
+    r = memory_status.status(refresh=True)
+    assert r.status == "present"
+    assert r.backend_version == "1.2.3"
+    assert r.features == ("trust-scoring", "decay")
+
+
+def test_status_present_tolerates_old_cli_without_envelope(
+    monkeypatch, tmp_path,
+):
+    """A healthy CLI that doesn't emit a v1 envelope still counts as present."""
+    fake = _fake_health_cli(tmp_path, stdout="")
+    monkeypatch.setattr(memory_status, "_find_cli", lambda: str(fake))
+    r = memory_status.status(refresh=True)
+    assert r.status == "present"
+    assert r.backend_version == ""
+    assert r.features == ()
+
+
+def test_health_v1_uses_real_features_when_present(monkeypatch, tmp_path):
+    payload = json.dumps({
+        "contract_version": 1,
+        "status": "ok",
+        "backend_version": "0.1.0",
+        "features": ["trust-scoring", "quarantine"],
+    })
+    fake = _fake_health_cli(tmp_path, stdout=payload)
+    monkeypatch.setattr(memory_status, "_find_cli", lambda: str(fake))
+    env = memory_status.health(refresh=True)
+    assert env["status"] == "ok"
+    assert env["backend_version"] == "0.1.0"
+    assert env["features"] == ["trust-scoring", "quarantine"]
+    # Must never silently leak the file-fallback marker on the present path.
+    assert "file-fallback" not in env["features"]
+
+
+def test_health_v1_falls_back_to_file_when_absent(monkeypatch):
+    monkeypatch.setattr(memory_status, "_find_cli", lambda: "")
+    env = memory_status.health(refresh=True)
+    assert env["status"] == "ok"  # absent maps to ok per contract
+    assert env["backend_version"] == memory_status._FILE_BACKEND_VERSION
+    assert "file-fallback" in env["features"]

--- a/tests/test_update_roadmap_progress.py
+++ b/tests/test_update_roadmap_progress.py
@@ -150,3 +150,103 @@ def test_render_emits_string_ids_in_table(roadmaps_dir: Path):
     # Roman-track roadmap too.
     assert "| I | First |" in output
     assert "| II | Second |" in output
+
+
+
+COMPLETE_FIXTURE = """\
+# Roadmap — All Done
+
+## Phase 1 — Wrap-up
+- [x] one
+- [x] two
+"""
+
+EMPTY_FIXTURE = """\
+# Roadmap — Stub
+
+## Phase 1 — TBD
+"""
+
+SKIPPED_ONLY_FIXTURE = """\
+# Roadmap — Skipped Only
+
+## Phase 1 — Decisions
+- [~] deferred
+- [-] cancelled
+"""
+
+
+def test_unarchived_complete_flags_only_done_roadmaps(tmp_path: Path):
+    root = tmp_path / "agents" / "roadmaps"
+    root.mkdir(parents=True)
+    (root / "complete.md").write_text(COMPLETE_FIXTURE, encoding="utf-8")
+    (root / "stub.md").write_text(EMPTY_FIXTURE, encoding="utf-8")
+    (root / "skipped-only.md").write_text(SKIPPED_ONLY_FIXTURE, encoding="utf-8")
+    (root / "numeric.md").write_text(NUMERIC_FIXTURE, encoding="utf-8")
+    roadmaps = urp.collect(root)
+    flagged = urp.unarchived_complete(roadmaps)
+    rels = sorted(r.rel for r in flagged)
+    # Only the truly-complete roadmap is flagged: stubs and skipped-only
+    # have total_active == 0, partial roadmaps still have open items.
+    assert rels == ["complete.md"]
+
+
+def test_unarchived_complete_ignores_archive_dir(tmp_path: Path):
+    root = tmp_path / "agents" / "roadmaps"
+    archive = root / "archive"
+    archive.mkdir(parents=True)
+    (archive / "complete.md").write_text(COMPLETE_FIXTURE, encoding="utf-8")
+    roadmaps = urp.collect(root)
+    # collect() already excludes archive/, so the archived roadmap is not
+    # in the list and unarchived_complete() returns nothing.
+    assert urp.collect(root) == []
+    assert urp.unarchived_complete(roadmaps) == []
+
+
+def _run_main(monkeypatch: pytest.MonkeyPatch, repo_root: Path, *args: str) -> int:
+    monkeypatch.setattr(sys, "argv", ["update_roadmap_progress.py",
+                                       "--repo-root", str(repo_root), *args])
+    return urp.main()
+
+
+def test_check_mode_fails_on_unarchived_complete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    root = tmp_path / "agents" / "roadmaps"
+    root.mkdir(parents=True)
+    (root / "complete.md").write_text(COMPLETE_FIXTURE, encoding="utf-8")
+    # Pre-write a fresh dashboard so staleness alone can't be the reason
+    # for the failure.
+    rc = _run_main(monkeypatch, tmp_path)
+    assert rc == 0
+    rc = _run_main(monkeypatch, tmp_path, "--check")
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Completed roadmaps are still in" in captured.err
+    assert "complete.md" in captured.err
+
+
+def test_check_mode_passes_when_complete_is_archived(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    root = tmp_path / "agents" / "roadmaps"
+    archive = root / "archive"
+    archive.mkdir(parents=True)
+    (archive / "complete.md").write_text(COMPLETE_FIXTURE, encoding="utf-8")
+    rc = _run_main(monkeypatch, tmp_path)
+    assert rc == 0
+    rc = _run_main(monkeypatch, tmp_path, "--check")
+    assert rc == 0
+
+
+def test_write_mode_warns_but_does_not_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    root = tmp_path / "agents" / "roadmaps"
+    root.mkdir(parents=True)
+    (root / "complete.md").write_text(COMPLETE_FIXTURE, encoding="utf-8")
+    rc = _run_main(monkeypatch, tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0  # warn-only on write path
+    assert "not yet archived" in captured.err
+    assert "complete.md" in captured.err


### PR DESCRIPTION
Eight-commit session in three themes on this branch:

1. Integrate `@event4u/agent-memory` MCP server + harden agent-interaction rules (commits 1–3).
2. Defense-in-depth pass on the `roadmap-progress-sync` rule so a stale `agents/roadmaps-progress.md` cannot ship through any path (commits 4–7).
3. Declare `@event4u/agent-memory` as an **optional** companion in npm + Composer + postinstall + README — the package itself never requires it (commits 8–11).

## Commits

### 1. `feat(memory): wire agent-memory MCP server + recognize 'memory' binary`
- New `mcp.json` registers `agent-memory` as an MCP server (stdio, no env vars — package uses built-in DB defaults).
- Rendered to `.cursor/mcp.json` and `.windsurf/mcp.json` via `task mcp:render`.
- `memory_status.py` (template + repo copy) now recognizes the canonical binary name `memory` shipped by `@event4u/agent-memory` v0.1+, alongside the planned `agent-memory` alias and legacy `agentmem`.

**Smoke-tested:** stdio handshake returns `serverInfo: { name: 'agent-memory', version: '0.1.0' }` with 26 tools advertised. `memory_status.py` reports `status=present, backend=package` after the fix.

### 2. `docs(agent-memory): align contract with reality — CLI surface + drift status`
- Documents the **canonical** `memory` binary and the **actual** semantic retrieve syntax (positional query, `--type`, `--layer`, `--budget` — not the previously assumed key-based form).
- Replaces 'Decision postponed' on Hit-shape drift with the real status: drift was internal-only; the consumer-facing JSON output of `memory_lookup.py` already emits the v1 envelope. No external consumer imports the private `Hit` dataclass.
- Notes the calling-convention drift between contract's `retrieve(types, keys)` and package's `retrieve(query)`, with the agreed hybrid resolution direction.

### 3. `feat(rules): require recommendations on every numbered-option question`
Promotes 'recommended option *can* be marked' to an iron law:

> EVERY numbered-option question MUST state which option the agent recommends and WHY. 'Egal, was bevorzugst Du?' / 'no preference' is NEVER an acceptable agent stance.

Refusing to take a position dumps research load back on the user. Format: mark the recommended option inline, then state the trade-off that tips the balance plus the caveat that would flip it. If genuinely 50/50 with missing data, say what data would break the tie instead of asking blind.

## Roadmap-progress hardening (defense-in-depth)

The `roadmap-progress-sync` rule was the only mechanism enforcing that
`agents/roadmaps-progress.md` stays in sync with `agents/roadmaps/*.md`.
Single point of failure: the agent forgetting the rule under procedural
load (acknowledged in the rule body itself). Four independent layers
now close that gap, each addressing a distinct failure mode:

### 4. `ci: wire roadmap-progress-check into task ci` (`2022396`)
The package's own `task ci` now dogfoods the same `roadmap-progress-check`
that consumer projects rely on. A stale dashboard in this repo fails CI
before it ships. **Failure mode addressed:** package shipping with a
stale dashboard.

### 5. `feat(templates): ship roadmap-progress-check GitHub Actions workflow` (`a16c560`)
New `.augment/templates/github-workflows/roadmap-progress-check.yml`.
Consumers copy it to `.github/workflows/` and every PR that touches
`agents/roadmaps/` is gated on a fresh dashboard. Short-circuits to a
pass on projects that haven't adopted roadmaps yet (no roadmap dir =
no work). **Failure mode addressed:** agent forgets the rule and
pushes to a consumer repo without local checks.

### 6. `feat(scripts): add hooks:install and pre-commit roadmap-progress hook` (`cab9048`)
- New `./agent-config hooks:install` subcommand wires the shipped
  pre-commit hook into `.git/hooks/pre-commit`. `--print` dumps the
  source, `--force` overwrites an existing hook.
- The hook is a no-op for commits that don't touch `agents/roadmaps/`,
  so it adds zero overhead to unrelated work, and falls through
  gracefully when the script is missing.
- Wired into `docs/getting-started.md`.

**Failure mode addressed:** user committing directly without an
agent in the loop.

### 7. `feat(scripts): fail check mode on unarchived complete roadmaps` (`f017979`)
`update_roadmap_progress.py --check` now fails when any roadmap under
`agents/roadmaps/` has `count_open == 0` and is still not moved to
`archive/`. The write path emits the same finding as a stderr warning
but still regenerates the dashboard, so the script never silently
leaves the rule's "completion = archival, same response" requirement
unenforced. **Failure mode addressed:** rule-vs-code drift where the
rule demanded archival but the script never enforced it.

Each layer is small (≤80 lines), independently revertable, and the
combination provides true defense-in-depth: pre-commit catches direct
edits, local `task ci` catches PR-creation, GitHub Actions catches
push-without-local-CI, script-level enforcement catches the
auto-archival neglect that no other layer notices.

## Consumer-facing suggestion (optional companion)

`@event4u/agent-memory` is an MCP backend — `agent-config` itself never
imports it, and runs fine on the file-based fallback. To make it
discoverable without making it a hard dependency, four small edits:

### 8. `feat(composer): suggest @event4u/agent-memory as optional memory backend` (`6585c32`)
`composer.json` gains a `suggest` block. Composer treats it as
informational text only — never resolved, never installed. PHP teams
running `composer require event4u/agent-config` see the hint with the
exact npm install command they would run if they want the backend.

### 9. `feat(npm): declare @event4u/agent-memory as optional peer dependency` (`cef7715`)
`package.json` gets `peerDependencies` + `peerDependenciesMeta.optional=true`
via `npm pkg set`. npm installs nothing and emits no warning when the
peer is missing — the declaration is descriptive only. Tooling
(Renovate, Dependabot, GitHub dependency graph, npm registry page)
picks up the optional peer relationship.

### 10. `feat(postinstall): hint about optional @event4u/agent-memory backend` (`395cff1`)
`scripts/postinstall.sh` gets a one-time success-path hint, suppressed
when the backend is already discoverable on PATH (`memory` /
`agent-memory` binary) or installed alongside under
`node_modules/@event4u/agent-memory`. Closes the discoverability gap
that manifest declarations leave for consumers who don't read JSON
files.

### 11. `docs(readme): document @event4u/agent-memory as optional companion` (`350930f`)
New "Optional: persistent agent memory" subsection in Quickstart.
States explicitly that `agent-config` never requires the backend, falls
back to file-based memory under `agents/memory/`, and gives the npm
install command. Links to the existing memory contract document.

## Verification

- `task sync-check` ✅
- `task check-refs` ✅
- `task check-portability` ✅
- `task lint-skills` — 0 fail (183 pass, 113 warn)
- `task lint-readme` ✅ (README 378 lines, no issues)
- `task roadmap-progress-check` ✅
- `pytest tests/` — 758 passed
- `bash -n scripts/postinstall.sh` ✅; hint smoke-tested on absent
  and present backend
- `npm pkg get peerDependencies peerDependenciesMeta` ✅
- `jq .suggest composer.json` ✅
- MCP stdio handshake ✅
- `memory_status.py` smoke test ✅
- `./agent-config hooks:install` smoke test ✅

## Out of scope (follow-ups)

- **Drift #1.5** — `memory_status.health()` still returns file-fallback
  `backend_version` in the present-path. *(Resolved during this
  session in commit [`145bd13`](../commit/145bd13) — backend health
  envelope now parsed from `agent-memory health` Pino logs.)*
- **Drift #2 implementation** — the hybrid contract
  (`retrieve(types, *, keys=None, query=None)`). *(Resolved during
  this session in commit [`284be4c`](../commit/284be4c) —
  package-backed operational provider.)*
- **Consumer rollout of the roadmap-progress hardening** — once this PR
  merges, the four-layer pass flows to consumer projects through
  `task install` (workflow + hook templates).
- **`scripts/chat_history.py` ships only at package root** — Consumer
  projects do not get the helper that the `chat-history` rule depends
  on. Separate branch/PR.
