### PR TITLE
feat(lint): enforce context_spine slot citation in skill bodies

### DIFF
--- a/.agent-src.uncompressed/skills/customer-research/SKILL.md
+++ b/.agent-src.uncompressed/skills/customer-research/SKILL.md
@@ -5,7 +5,7 @@ status: active
 tier: senior
 source: package
 domain: product
-context_spine: [product, team]
+context_spine: [product]
 ---
 
 # customer-research

--- a/.agent-src/skills/customer-research/SKILL.md
+++ b/.agent-src/skills/customer-research/SKILL.md
@@ -5,7 +5,7 @@ status: active
 tier: senior
 source: package
 domain: product
-context_spine: [product, team]
+context_spine: [product]
 ---
 
 # customer-research

--- a/.compression-hashes.json
+++ b/.compression-hashes.json
@@ -235,7 +235,7 @@
   "skills/conventional-commits-writing/SKILL.md": "136e6ef8d24579edd632697112034626c9c8cf1f32fa3f90303c73dcc8d45fad",
   "skills/copilot-agents-optimization/SKILL.md": "516d6990f170c9970108b504ad0439321677d1095a3b660728945c8bdd98a905",
   "skills/copilot-config/SKILL.md": "c84e8fe50998982eca3e16e052c7a6c97cf503f9dee96a2ffe91979a04f22d54",
-  "skills/customer-research/SKILL.md": "a6b8cfd947c62ed048b6e1b1938778b0ffa085ba00a2bc7aa4541ba5daa522df",
+  "skills/customer-research/SKILL.md": "749bdb3980edadec11367b0dd69f26425053aaed11e1090b13a44d164dd469bc",
   "skills/dashboard-design/SKILL.md": "ccff6fea86475be546abf47319fe6f6dabb1062e13799058d510ec41c1b330cc",
   "skills/data-flow-mapper/SKILL.md": "37172a1011677f613e7813524b3cacb349418616fc67993053c46b5798a1ed1c",
   "skills/database/SKILL.md": "056f6c66aaa75c6c24ee784c41c0f5277f372318bb9de983a7da865b45ce139a",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,6 +63,7 @@ tasks:
       - task: check-portability
       - task: check-examples-shape
       - task: lint-roadmap-complexity
+      - task: lint-context-spine-usage
       - task: check-public-links
       - task: check-public-catalog-links
       - task: check-command-count

--- a/scripts/lint_context_spine_usage.py
+++ b/scripts/lint_context_spine_usage.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Context-spine usage linter.
+
+Closes the lint gap left after `scripts/schemas/skill.schema.json`
+gained the `context_spine` enum: a skill can declare
+`context_spine: [product]` in frontmatter without ever citing the
+slot in its body, and the schema check will not catch it.
+
+This linter enforces the author checklist in
+`docs/contracts/context-spine.md` § 6: for every slot declared in
+frontmatter, the skill body MUST cite the slot at least once.
+A citation is any of these tokens:
+
+  - the literal path `agents/context-spine/<slot>.md`
+  - the slot name in bold: ``**<slot>**``
+  - the slot name in inline code: `` `<slot>` ``
+
+Cap: ≤ 150 LOC, stdlib only. Hooked into `task ci` via
+`task lint-context-spine-usage`.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+QUIET = "--quiet" in sys.argv
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_GLOBS = (
+    ".agent-src.uncompressed/skills/**/SKILL.md",
+    ".agent-src/skills/**/SKILL.md",
+)
+VALID_SLOTS = ("product", "team", "repo")
+
+CONTEXT_SPINE_PAT = re.compile(
+    r"^context_spine:\s*\[([^\]]*)\]\s*$", re.MULTILINE
+)
+
+
+def _frontmatter_and_body(text: str) -> tuple[str, str]:
+    if not text.startswith("---\n"):
+        return "", text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return "", text
+    return text[4:end], text[end + 5 :]
+
+
+def _read_spine(fm: str) -> list[str] | None:
+    m = CONTEXT_SPINE_PAT.search(fm)
+    if m is None:
+        return None
+    raw = m.group(1).strip()
+    if not raw:
+        return []
+    return [s.strip().strip("'\"") for s in raw.split(",") if s.strip()]
+
+
+def _slot_cited(body: str, slot: str) -> bool:
+    """A slot is cited if any of three forms appears in the body."""
+    forms = (
+        f"agents/context-spine/{slot}.md",
+        f"**{slot}**",
+        f"`{slot}`",
+    )
+    return any(form in body for form in forms)
+
+
+def lint_skill(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    fm, body = _frontmatter_and_body(text)
+    if not fm:
+        return []
+    slots = _read_spine(fm)
+    if slots is None:
+        return []
+    problems: list[str] = []
+    for slot in slots:
+        if slot not in VALID_SLOTS:
+            problems.append(
+                f"unknown_context_spine_slot: '{slot}' "
+                f"(valid: {', '.join(VALID_SLOTS)})"
+            )
+            continue
+        if not _slot_cited(body, slot):
+            problems.append(
+                f"declared context_spine slot '{slot}' is never cited "
+                f"in the skill body — add `**{slot}**`, `` `{slot}` ``, "
+                f"or a link to `agents/context-spine/{slot}.md` "
+                f"(see docs/contracts/context-spine.md § 6)"
+            )
+    return problems
+
+
+def main() -> int:
+    skills: list[Path] = []
+    for pattern in SKILL_GLOBS:
+        skills.extend(sorted(REPO_ROOT.glob(pattern)))
+    if not skills:
+        print("❌  no SKILL.md files matched", file=sys.stderr)
+        return 1
+    failed = 0
+    declared = 0
+    for skill in skills:
+        rel = skill.relative_to(REPO_ROOT)
+        problems = lint_skill(skill)
+        text = skill.read_text(encoding="utf-8")
+        fm, _ = _frontmatter_and_body(text)
+        if fm and CONTEXT_SPINE_PAT.search(fm):
+            declared += 1
+        if problems:
+            failed += 1
+            print(f"❌  {rel}", file=sys.stderr)
+            for p in problems:
+                print(f"    - {p}", file=sys.stderr)
+    if failed:
+        print(
+            f"\n❌  {failed} skill(s) failed context-spine usage lint "
+            f"({declared} skill(s) declare a spine)",
+            file=sys.stderr,
+        )
+        return 1
+    if not QUIET:
+        print(
+            f"✅  {declared} skill(s) declare context_spine; "
+            f"all declared slots are cited in the body"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -126,6 +126,11 @@ tasks:
     desc: Enforce roadmap-complexity-standard contract on agents/roadmaps/*.md (Phase 5.2 of road-to-context-layer-maturity)
     cmd: python3 scripts/lint_roadmap_complexity.py {{.QUIET_FLAG}}
 
+  lint-context-spine-usage:
+    silent: true
+    desc: Verify every skill that declares context_spine cites each slot in its body (closes lint gap from 1.34.0)
+    cmd: python3 scripts/lint_context_spine_usage.py {{.QUIET_FLAG}}
+
   check-public-links:
     silent: true
     desc: Validate README/AGENTS.md/docs/architecture.md links into docs/contracts/ against stability frontmatter


### PR DESCRIPTION
## What

Closes the lint gap left after **1.34.0** added the `context_spine` enum
to `scripts/schemas/skill.schema.json`: a skill could declare
`context_spine: [product]` in frontmatter without ever citing the slot
in its body, and CI would not notice.

`scripts/lint_context_spine_usage.py` walks every `SKILL.md` under
`.agent-src.uncompressed/` and `.agent-src/`, parses `context_spine`,
and fails when a declared slot lacks a citation in one of three forms:

- `agents/context-spine/<slot>.md` (path)
- `**<slot>**` (bold)
- `` `<slot>` `` (inline code)

Per author checklist in `docs/contracts/context-spine.md` § 6.

## Why

External feedback (Claude review of #77):

> Die context_spine[]-Schema-Extension ist in skill.schema.json als Enum
> registriert — aber es gibt noch keine CI-Prüfung ob Skills die
> context_spine: [product] im Frontmatter haben, tatsächlich auch den
> entsprechenden Slot in ihrem Body lesen. Das ist ein Linter-Gap.

The new linter caught a real violation immediately:
`customer-research` declared `[product, team]` but only cited the
**product** slot. Fixed by dropping the unused `team` slot from the
frontmatter (release-comms legitimately uses both, untouched).

## Commits

1. **feat(lint)** — new linter `scripts/lint_context_spine_usage.py`
   (≤ 150 LOC, stdlib only) wired into `task ci` via
   `task lint-context-spine-usage`.
2. **fix(skill)** — drop `team` from `customer-research` `context_spine`
   (slot was declared but never cited).
3. **chore(sync)** — refresh compression hash for `customer-research`.

## Verification

```
task ci                                  → green (2606 tests pass)
task lint-context-spine-usage            → ✅ 4 skills declare context_spine; all slots cited
```

Smoke-tested against three fixtures: good (all slots cited), bad
(slot declared but uncited), unknown-slot. All three classes detected.

## Risk

Low. New linter, no existing-behaviour change. The single skill fix is
a 1-line frontmatter edit removing a slot the body never referenced.
