### PR TITLE
feat(mcp): Cloudflare-hosted MCP — roadmap + Phases 1–6 (MVP-1)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,17 +6,17 @@
 
 ## Overall
 
-**0 / 141 steps done · 0%**
+**3 / 141 steps done · 2%**
 
 ```text
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0%
+█░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   2%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-cloudflare-mcp-hosting.md](roadmaps/road-to-cloudflare-mcp-hosting.md) | 7 | 28 | 25 | 0 | 0 | 3 | ░░░░░░░░░░ 0% |
+| 1 | [road-to-cloudflare-mcp-hosting.md](roadmaps/road-to-cloudflare-mcp-hosting.md) | 7 | 28 | 22 | 3 | 0 | 3 | █░░░░░░░░░ 12% |
 | 2 | [road-to-distribution-and-adoption.md](roadmaps/road-to-distribution-and-adoption.md) | 4 | 13 | 13 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-gtm-and-growth.md](roadmaps/road-to-gtm-and-growth.md) | 1 | 26 | 26 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-money-strategy-ops.md](roadmaps/road-to-money-strategy-ops.md) | 1 | 31 | 31 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
@@ -29,11 +29,11 @@
 
 ### [road-to-cloudflare-mcp-hosting.md](roadmaps/road-to-cloudflare-mcp-hosting.md)
 
-**Road to Cloudflare-hosted MCP** — 0 / 25 done (0%)
+**Road to Cloudflare-hosted MCP** — 3 / 25 done (12%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | A0-cloud contract | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | A0-cloud contract | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 2 | TS Worker scaffold (read-only) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 3 | Content sync (R2) | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 4 | Release auto-deploy pipeline | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-cloudflare-mcp-hosting.md
+++ b/agents/roadmaps/road-to-cloudflare-mcp-hosting.md
@@ -65,16 +65,16 @@ no consumer code execution surface · single deployment per release.
 
 ## Phase 1 — A0-cloud contract
 
-- [ ] **1.1** Write `docs/contracts/mcp-cloud-scope.md` with: Worker
+- [x] **1.1** Write `docs/contracts/mcp-cloud-scope.md` with: Worker
   invariants (allowlisted origins, no DO writes outside `releases/`,
   no `subrequest` to consumer infra), R2-key shape (`releases/v<X.Y.Z>-<sha>/`),
   immutability guarantee per versioned URL, cache-TTL policy (1h
   pinned, 5min `latest`), deprecated-tool stub contract, MVP-2 wake-up
   triggers.
-- [ ] **1.2** Amend `docs/contracts/mcp-phase-1-scope.md` with a
+- [x] **1.2** Amend `docs/contracts/mcp-phase-1-scope.md` with a
   one-line Phase-7 pointer to `mcp-cloud-scope.md`. Phase-1 contract
   retains local-stdio ownership; cloud doc owns hosted.
-- [ ] **1.3** Cross-link from `mcp-request-signing § Appendix` to
+- [x] **1.3** Cross-link from `mcp-request-signing § Appendix` to
   the cloud contract (the Worker is the bridge that appendix
   describes).
 

--- a/docs/contracts/mcp-cloud-scope.md
+++ b/docs/contracts/mcp-cloud-scope.md
@@ -1,0 +1,168 @@
+---
+stability: experimental
+---
+
+# MCP Server — Cloud Scope (A0-cloud Hard Contract)
+
+> **Status:** Active · covers `workers/mcp/` (TypeScript Cloudflare
+> Worker bridge) per
+> [`road-to-cloudflare-mcp-hosting.md`](../../agents/roadmaps/road-to-cloudflare-mcp-hosting.md)
+> Phases 1–5 (MVP-1). Extends — does **not** supersede —
+> [`mcp-phase-1-scope.md`](mcp-phase-1-scope.md), which retains
+> exclusive ownership of `scripts/mcp_server/` (local stdio).
+> **Stability:** experimental — not linked from README, AGENTS.md, or
+> `docs/architecture.md`. Internal index reference only per `STABILITY.md`.
+
+## Purpose
+
+Locks the **execution-safety boundary** for the hosted MCP Worker. Any
+code under `workers/mcp/` must satisfy this contract verbatim. The
+local stdio kernel and the hosted Worker are two distinct surfaces; a
+deviation in one is **not** authorized by a precedent in the other.
+
+The Worker IS the bridge described in
+[`mcp-request-signing § Appendix`](../guidelines/agent-infra/mcp-request-signing.md#appendix--http-bridge-stdio-kernel-pattern-reference)
+— but with two material differences from the appendix pattern: (1) no
+spawned stdio child (content is read from a release-pinned R2 blob,
+not a sub-process), and (2) no HMAC for MVP-1 (content is OSS and
+read-only; the appendix pattern's `verifyRequest` is deferred to MVP-2
+alongside auth).
+
+## In-scope (MVP-1)
+
+- **Transport:** HTTP + SSE (Cloudflare Worker `fetch` handler). The
+  local stdio kernel is out-of-scope for this contract and stays
+  governed by `mcp-phase-1-scope.md`.
+- **MCP primitives:** `prompts/list` + `prompts/get` + `resources/list`
+  + `resources/read` — read-only, parity with the local stdio surface.
+- **Source data:** release-pinned content blob in R2 under the key
+  shape `releases/v<X.Y.Z>-<sha>/` (immutable per release). The blob
+  bundles `.agent-src/skills/<name>/SKILL.md`,
+  `.agent-src/commands/**/*.md`, and `docs/guidelines/` (the same
+  projection the local kernel reads). Never reads `.agent-src.uncompressed/`.
+- **Identity surface:** `serverInfo.version` reads from a Worker-
+  bundled constant, `_meta.packageVersion` reads from a
+  `wrangler.toml` env var, `_meta.skillSetSignature` reads from a
+  **prebaked manifest JSON** shipped with the content blob. The
+  Worker never computes the signature at runtime.
+- **URL shape:** two pinned shapes only —
+  `mcp.<host>/v<X.Y.Z>/sse` (immutable, cache TTL 1 h) and
+  `mcp.<host>/latest/sse` (pointer, cache TTL 5 min). The `latest`
+  pointer is repointed atomically by the release pipeline after a
+  green smoke run; pre-smoke failures leave it on the previous
+  release.
+- **Pagination + hot-reload parity:** `prompts/list` paginates with
+  `nextCursor` the same way the stdio kernel does; the Worker has no
+  hot-reload because the content blob is immutable per release —
+  the **release** is the cache-bust event.
+- **Deprecated tool stubs:** `tools/list` returns exactly two entries,
+  `lint_skills` and `chat_history_append`, both with
+  `deprecated: true` and a description pointing to the local stdio
+  server. `tools/call` against either returns `isError=true` with a
+  message naming the local-stdio successor. No other tool name is
+  reachable.
+
+## Out-of-scope (MVP-1)
+
+- **Tool execution.** `lint_skills` and `chat_history_append` are
+  exposed as deprecated stubs only — no TS port, no FS access, no
+  shell, no Python runtime in the Worker. Restoration is the
+  Phase-7-DEFERRED block of the roadmap, gated on a real consumer ask
+  plus a multi-tenant security review.
+- **`.agent-settings.yml` exposure.** Consumer-machine config, never
+  surfaced as a resource. The Worker has no access to consumer FS at
+  any layer.
+- **Agent memory** — separate MCP server, different roadmap.
+- **Chat history persistence** — the local kernel writes to
+  `agents/.agent-chat-history`; the Worker has no equivalent. Listed
+  as a deprecated stub per above.
+- **Authentication / multi-tenancy.** MVP-1 is open (OSS content,
+  read-only). Bearer / CF Access / HMAC moves to MVP-2 alongside
+  tool restoration.
+- **Network egress from the Worker** beyond an **explicit subrequest
+  allowlist** — see invariants below.
+
+## A0-cloud invariants
+
+The Worker code must satisfy all of:
+
+1. **Origin allowlist** — `fetch()` calls from the Worker are limited
+   to R2 (content read) and an explicit observability sink (optional).
+   No calls to consumer infrastructure, no calls to upstream LLM
+   APIs, no calls to `api.github.com`, no DNS-based egress. Enforced
+   in `wrangler.toml` via Worker-level network policies.
+2. **R2 write boundary** — the Worker never writes to R2. The release
+   pipeline writes under `releases/v<X.Y.Z>-<sha>/` and atomically
+   repoints `releases/latest.txt`; the Worker only reads.
+3. **Per-versioned-URL immutability** — for any
+   `mcp.<host>/v<X.Y.Z>/sse`, the response body is deterministic for
+   the lifetime of the deployment. Patch fixes ship a new version key;
+   the existing key is never rewritten. R2 eventual consistency is
+   handled by the unique-key-per-release shape.
+4. **Cache-TTL policy** — pinned URLs cache at the edge for 1 h
+   (safe because immutable); `latest` caches for 5 min (bounded
+   staleness window after a repoint). No client may rely on `latest`
+   for reproducibility — that is what the pinned URL is for.
+5. **Prebaked signature** — `skillSetSignature` is computed once by
+   the release pipeline against the worktree at the tag and stored in
+   `releases/v<X.Y.Z>-<sha>/manifest.json`. The Worker reads, never
+   computes. Any signature drift at runtime is a contract violation.
+6. **No consumer code execution.** No `eval`, no dynamic import of
+   content, no shelling out, no spawning a runtime. The Worker is a
+   read-and-route function.
+7. **Single deployment per release.** One `wrangler deploy` per tag.
+   Concurrent deployments are not supported; the release pipeline
+   serializes through `release: published` + `workflow_dispatch`
+   hotfix paths.
+
+## Deprecated tool stub contract
+
+`tools/list` returns:
+
+```json
+[
+  {
+    "name": "lint_skills",
+    "description": "Deprecated on hosted MCP — use the local stdio server (scripts/mcp_server/) which retains this tool. See road-to-cloudflare-mcp-hosting Phase 7 for restoration triggers.",
+    "deprecated": true
+  },
+  {
+    "name": "chat_history_append",
+    "description": "Deprecated on hosted MCP — filesystem-bound, local-only. Use the local stdio server.",
+    "deprecated": true
+  }
+]
+```
+
+`tools/call` against either name returns `isError=true` with the same
+deprecation message. No other tool name is reachable.
+
+## MVP-2 wake-up triggers
+
+The Phase-7 deferred items in the roadmap (tool restoration, history
+persistence, auth) wake up only when **all** of these fire:
+
+- A named consumer (internal or external) requests hosted lint or
+  history.
+- A security review has approved the validation layer for
+  `lint_skills` (URI regex allowlist, size limits, timeout,
+  concurrency cap).
+- An auth model has been selected (bearer vs. CF Access vs. HMAC).
+- The server stability label has been promoted from *experimental*
+  to *beta*.
+
+## Revision policy
+
+This contract is **experimental** — breaking changes are allowed in
+any release with a CHANGELOG note. Promotion to `beta` requires at
+least one shipped client connecting to the hosted endpoint end-to-end
+without a contract amendment.
+
+## See also
+
+- [`mcp-phase-1-scope.md`](mcp-phase-1-scope.md) — local-stdio kernel
+  contract (sibling, not parent).
+- [`STABILITY.md`](../../STABILITY.md) — stability policy for
+  `docs/contracts/`.
+- [`mcp-request-signing § Appendix`](../guidelines/agent-infra/mcp-request-signing.md#appendix--http-bridge-stdio-kernel-pattern-reference)
+  — bridge pattern reference (the Worker is a flavor of this).

--- a/docs/contracts/mcp-phase-1-scope.md
+++ b/docs/contracts/mcp-phase-1-scope.md
@@ -6,9 +6,12 @@ stability: experimental
 
 > **Status:** Active · covers Phase 1 (A1–A7) + Phase 2 (B1–B5) +
 > Phase 3 (C1–C4) + Phase 4 (D1–D4) + Phase 6 F1/F3 of
-> `road-to-mcp-server.md`. Phase 6 F2 (SSE transport) is deferred to
-> [`road-to-mcp-distribution.md`](../../agents/roadmaps/road-to-mcp-distribution.md)
-> and remains out of scope here.
+> `road-to-mcp-server.md`. Phase 6 F2 (SSE transport) is owned by
+> [`mcp-cloud-scope.md`](mcp-cloud-scope.md) — the hosted Cloudflare
+> Worker bridge per
+> [`road-to-cloudflare-mcp-hosting.md`](../../agents/roadmaps/road-to-cloudflare-mcp-hosting.md)
+> — and remains out of scope here. This contract retains exclusive
+> ownership of `scripts/mcp_server/` (local stdio).
 > **Stability:** experimental — not linked from README, AGENTS.md, or
 > `docs/architecture.md`. Internal index reference only per `STABILITY.md`.
 
@@ -187,4 +190,8 @@ prompts end-to-end without a contract amendment.
 
 ## See also
 
+- [`mcp-cloud-scope.md`](mcp-cloud-scope.md) — hosted Worker contract
+  (sibling, not child). Extends the bridge pattern from
+  [`mcp-request-signing § Appendix`](../guidelines/agent-infra/mcp-request-signing.md#appendix--http-bridge-stdio-kernel-pattern-reference)
+  for multi-tenant SSE.
 - [`STABILITY.md`](STABILITY.md) — stability policy for `docs/contracts/`.

--- a/docs/guidelines/agent-infra/mcp-request-signing.md
+++ b/docs/guidelines/agent-infra/mcp-request-signing.md
@@ -194,3 +194,8 @@ out-of-scope until a consumer surfaces a tenancy requirement.
   starts here; the upstream link is the authoritative source.
 - `road-to-ruflo-adoption.md` **P2.1** — landed this appendix; full
   bridge fork stays out-of-scope unless the dual trigger fires.
+- [`road-to-cloudflare-mcp-hosting.md`](../../../agents/roadmaps/road-to-cloudflare-mcp-hosting.md)
+  **Phase 2** — operationalizes this pattern as a TypeScript Cloudflare
+  Worker (no spawned stdio child; R2 blob replaces the child process).
+  Contract: [`mcp-cloud-scope.md`](../../contracts/mcp-cloud-scope.md).
+  HMAC `verifyRequest` is deferred to MVP-2 alongside auth.


### PR DESCRIPTION
## Summary

Phase 1 of [`road-to-cloudflare-mcp-hosting.md`](../blob/docs/mcp-cloud-scope/agents/roadmaps/road-to-cloudflare-mcp-hosting.md) — the contract gate before any Worker code lands.

**Stacked on #89** (the roadmap PR). Merge order: #89 first, then this. If #89 merges to `main`, this PR's base will need to be retargeted to `main`.

## What this PR does

### 1.1 — New `docs/contracts/mcp-cloud-scope.md` (168 lines)

Sibling contract to `mcp-phase-1-scope.md` — owns the `workers/mcp/` surface. Not a child, not a supersedure: the local stdio kernel and hosted Worker are two distinct surfaces governed by separate contracts.

**A0-cloud invariants** (7 hard rules):

1. Origin allowlist — `fetch()` limited to R2 + optional observability sink. No consumer-infra calls, no upstream LLM calls, no `api.github.com`.
2. R2 write boundary — Worker reads only; pipeline writes under `releases/v<X.Y.Z>-<sha>/` and atomically repoints `releases/latest.txt`.
3. Per-versioned-URL immutability — pinned URL response is deterministic for deployment lifetime.
4. Cache-TTL policy — 1 h pinned, 5 min `latest`.
5. Prebaked signature — `skillSetSignature` computed once by pipeline, stored in `manifest.json`. Worker reads, never computes.
6. No consumer code execution — no `eval`, no dynamic import, no shell, no spawned runtime.
7. Single deployment per release — serialized through `release: published` + `workflow_dispatch` hotfix.

**Deprecated tool stub contract** — `tools/list` returns exactly two entries (`lint_skills`, `chat_history_append`) both with `deprecated: true` and a description pointing to the local stdio server. `tools/call` against either returns `isError=true`. No other tool name is reachable.

**MVP-2 wake-up triggers** — Phase 7 restoration (tool execution, history persistence, auth) gates on all four firing: named consumer ask · security review of validation layer · auth model selected · stability label promoted to *beta*.

### 1.2 — `mcp-phase-1-scope.md` status header repointed

The stale `road-to-mcp-distribution.md` reference (the roadmap is archived in #89) is replaced by a pointer to `mcp-cloud-scope.md` as the owner of Phase 6 F2 (SSE). Local-stdio ownership of `scripts/mcp_server/` is now stated explicitly. New `See also` bullet links the cloud sibling.

### 1.3 — `mcp-request-signing § Appendix` Citation hooks

New bullet pointing to `road-to-cloudflare-mcp-hosting.md` Phase 2 and `mcp-cloud-scope.md`. Notes two material deviations from the appendix pattern: no spawned stdio child (R2 blob replaces it), HMAC `verifyRequest` deferred to MVP-2.

## Roadmap progress

- Phase 1: 3/3 done ✅
- Cloudflare roadmap: 3/25 open steps (12%) · 25 open + 3 deferred
- Overall: 3/141 across 6 open roadmaps

## Files

- `docs/contracts/mcp-cloud-scope.md` — new (168 lines)
- `docs/contracts/mcp-phase-1-scope.md` — header + See also (+10/-3)
- `docs/guidelines/agent-infra/mcp-request-signing.md` — Citation hooks (+5/-0)
- `agents/roadmaps/road-to-cloudflare-mcp-hosting.md` — three checkboxes flipped
- `agents/roadmaps-progress.md` — regenerated

## What this PR does NOT do

- No code under `workers/` — pure contract artefact. Phase 2 (TS Worker scaffold) is the next PR.
- No change to `scripts/mcp_server/` (local stdio kernel) — unchanged.
- No change to `.agent-settings.yml` semantics.

## Test plan

- [x] Marketplace check passes (`marketplace.json`).
- [x] Pre-push portability check passes.
- [x] Progress regen shows 3/141.
- [ ] Manual reviewer pass on the 7 invariants + the local/hosted ownership split.
