### PR TITLE
docs(mcp): A0-cloud invariant 8 + content.json stub clarity

### DIFF
--- a/docs/contracts/mcp-cloud-scope.md
+++ b/docs/contracts/mcp-cloud-scope.md
@@ -112,6 +112,22 @@ The Worker code must satisfy all of:
    Concurrent deployments are not supported; the release pipeline
    serializes through `release: published` + `workflow_dispatch`
    hotfix paths.
+8. **Ingress protection = edge cache + platform rate limit.** MVP-1
+   is auth-less by design; the public surface is shielded by two
+   layers Cloudflare provides without code: (a) edge caching per
+   invariant 4 (1 h on pinned URLs, 5 min on `latest`) absorbs
+   read-loop traffic before it reaches the Worker, and (b)
+   Cloudflare's account-level anti-abuse + DDoS shielding caps
+   per-IP burst on `*.workers.dev`. These two together **are** the
+   MVP-1 auth surrogate. **Promotion triggers** — any of these
+   flips HMAC (currently MVP-2 §Out-of-scope) from deferred to
+   active before the wake-up triggers below would otherwise fire:
+   sustained 429 spikes from origin (cache miss storm), Workers
+   request-cost line item exceeding the free-tier budget for two
+   consecutive billing periods, or a CVE-class abuse report
+   against the endpoint. A per-Worker `[[unsafe.bindings]]`
+   rate-limiter in `wrangler.toml` is **not** configured in MVP-1
+   — adding one is a contract amendment, not a free hand.
 
 ## Deprecated tool stub contract
 

--- a/workers/mcp/content.json
+++ b/workers/mcp/content.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "DEV STUB — packer (scripts/pack_mcp_content.py) overwrites this entire file at deploy time. Zero URIs + sentinel signature '000000000000' are expected here on a clean checkout. See workers/mcp/README.md.",
   "schema_version": 1,
   "uris": {},
   "manifest": {


### PR DESCRIPTION
Two follow-up fixes for gaps surfaced during PR #91 review.

## Changes

### 1 · `docs/contracts/mcp-cloud-scope.md` — new invariant 8

MVP-1 ships auth-less by design. The contract documented HMAC as deferred to MVP-2 but did not explicitly name the **ingress protection** that stands in for it. Invariant 8 now does:

- Edge cache per invariant 4 (1 h pinned, 5 min `latest`) absorbs read-loop traffic before it reaches the Worker.
- Cloudflare account-level anti-abuse + DDoS shielding caps per-IP burst on `*.workers.dev`.
- **These two together ARE the MVP-1 auth surrogate** — not an accident, a documented design.

Three **promotion triggers** flip HMAC from deferred to active ahead of the existing wake-up block:

1. Sustained 429 spikes from origin (cache-miss storm).
2. Workers request-cost line item exceeds free-tier budget for two consecutive billing periods.
3. CVE-class abuse report against the endpoint.

A per-Worker `[[unsafe.bindings]]` rate-limiter in `wrangler.toml` is **not** configured in MVP-1 — adding one is a contract amendment, not a free hand.

### 2 · `workers/mcp/content.json` — explanatory `_comment` key

The committed `content.json` is a zero-URI stub (sentinel signature `000000000000`). On a fresh checkout it looks broken; `workers/mcp/README.md` documents this but the file itself was silent. The `_comment` key now names what it is.

Safe by construction:

- `scripts/pack_mcp_content.py` rebuilds the blob from scratch via `write_bytes`, so production bundles never carry `_comment`.
- `assertContentBlob` validates required fields only and ignores extras.
- TS import infers the wider JSON type; the runtime assertion narrows to `ContentBlob`. `tsc --noEmit` is green.

## Verification

| Check | Result |
|---|---|
| `python3 -c "json.load(open(...))"` on `content.json` | ✅ valid |
| `tsc --noEmit` in `workers/mcp/` | ✅ no errors |
| German chars in changed files | ✅ none |
| Portability pre-push | ✅ passed |

## Out of scope

- Changing actual rate-limit configuration (would be a contract amendment per invariant 8).
- Re-running parity smoke or `wrangler dev` — schema is unchanged, packer overwrites the file at deploy, Worker boot path is identical.
- Reopening / re-targeting PR #91 — already merged.