### PR TITLE
fix(ci): grant contents:write to deploy-mcp-worker for release comment

### DIFF
--- a/.github/workflows/deploy-mcp-worker.yml
+++ b/.github/workflows/deploy-mcp-worker.yml
@@ -24,7 +24,7 @@ on:
         default: ""
 
 permissions:
-  contents: read
+  contents: write  # needed by "Comment on release" step to PATCH the release body
 
 concurrency:
   group: deploy-mcp-worker


### PR DESCRIPTION
## Why

The `deploy-mcp-worker` workflow shipped with `permissions: contents: read`, but the final **Comment on release** step uses `actions/github-script` to PATCH the release body with the MCP Worker deploy footer. That PATCH needs `contents: write`.

Result on the v1.38.0 release run ([job 75286021462](https://github.com/event4u-app/agent-config/actions/runs/25649916381/job/75286021462)):

```
RequestError [HttpError]: Resource not accessible by integration
  status: 403
  x-accepted-github-permissions: contents=write
```

## What

One-line scope bump:

```yaml
permissions:
  contents: write  # needed by "Comment on release" step to PATCH the release body
```

## Real-deploy impact — none

All deploy steps on the failed run **succeeded**:

| Step | Status |
|---|---|
| Pack content blob | ✅ |
| Upload archival copy to R2 | ✅ |
| Deploy Worker | ✅ |
| Post-deploy smoke | ✅ |
| Repoint `latest.txt` (after smoke) | ✅ |
| **Comment on release** | ❌ 403 (this PR fixes) |

Worker is live:

```
$ curl https://agent-config-mcp.event4u.workers.dev
{"ok":true,"name":"agent-config-mcp","release_key":"v1.38.0-25c71e3","package_version":"1.38.0","signature":"319bd3de10b0","schema_version":1}
```

## Test plan

- [x] YAML parses (pre-push portability hook clean)
- [ ] Next release-published trigger appends the footer cleanly — verified by the run, not by this PR

## Out of scope

- No other write surfaces (releases, packages, deployments) touched. Scope stays minimal — only `contents` is bumped because that's what the PATCH endpoint requires.
