### PR TITLE
docs(mcp): add per-client setup guide for hosted Remote MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ curl https://agent-config-mcp.event4u.workers.dev
 # → { "ok": true, "name": "agent-config-mcp", "release_key": "v…", … }
 ```
 
-Read-only, identity-stable per release. Client config snippets and URL
-shapes (latest vs. pinned `/v<X.Y.Z>`) live in
+Read-only, identity-stable per release. Per-client setup snippets
+(Claude Desktop, Claude Code, Cursor, Zed, Continue) —
+[`docs/setup/mcp-client-config.md`](docs/setup/mcp-client-config.md).
+URL shapes (latest vs. pinned `/v<X.Y.Z>`) —
 [`docs/setup/mcp-cloud-endpoints.md`](docs/setup/mcp-cloud-endpoints.md).
 Operator setup (account, R2, secrets) — [`docs/setup/mcp-cloud-setup.md`](docs/setup/mcp-cloud-setup.md).
 Experimental — A0-cloud contract in [`docs/contracts/mcp-cloud-scope.md`](docs/contracts/mcp-cloud-scope.md).

--- a/docs/setup/mcp-client-config.md
+++ b/docs/setup/mcp-client-config.md
@@ -1,0 +1,134 @@
+# MCP Client Config — Remote agent-config
+
+Connect any MCP-capable client to the hosted `agent-config-mcp` Worker
+at `https://agent-config-mcp.event4u.workers.dev`. Read-only,
+identity-stable per release, no auth.
+
+For URL shapes (latest vs. pinned `/v<X.Y.Z>`) see
+[`mcp-cloud-endpoints.md`](mcp-cloud-endpoints.md). For operator
+setup of your own deployment see [`mcp-cloud-setup.md`](mcp-cloud-setup.md).
+
+## Transport note
+
+The Worker speaks JSON-RPC over HTTP POST. Clients that support
+HTTP transport natively (Claude Code, Cursor) talk to it directly.
+Clients that only support stdio (Claude Desktop, Zed) need the
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge from
+npm — invoked via `npx`, no install required.
+
+## Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "agent-config": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://agent-config-mcp.event4u.workers.dev"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The connector appears in the dropdown.
+
+Newer builds also support **Settings → Connectors → Add Custom
+Connector** with the URL directly — no `mcp-remote` wrapper needed.
+
+## Claude Code
+
+Native HTTP transport — one command:
+
+```bash
+claude mcp add --transport http agent-config https://agent-config-mcp.event4u.workers.dev
+```
+
+Verify:
+
+```bash
+claude mcp list
+```
+
+## Cursor
+
+`~/.cursor/mcp.json` (global) or `<repo>/.cursor/mcp.json`
+(project-local):
+
+```json
+{
+  "mcpServers": {
+    "agent-config": {
+      "url": "https://agent-config-mcp.event4u.workers.dev"
+    }
+  }
+}
+```
+
+Reload Cursor (`Cmd+Shift+P → Reload Window`).
+
+## Zed
+
+`~/.config/zed/settings.json`:
+
+```json
+{
+  "context_servers": {
+    "agent-config": {
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://agent-config-mcp.event4u.workers.dev"]
+    }
+  }
+}
+```
+
+Zed has no native remote-MCP transport yet, so the `mcp-remote`
+bridge is required.
+
+## Continue
+
+`~/.continue/config.yaml` (or `<repo>/.continue/config.yaml`):
+
+```yaml
+mcpServers:
+  - name: agent-config
+    command: npx
+    args: ["-y", "mcp-remote", "https://agent-config-mcp.event4u.workers.dev"]
+```
+
+## Verify
+
+After reload, every client should:
+
+1. List `agent-config` under connectors / tools with a release-key
+   matching the live deploy. Probe the endpoint to see the current
+   release:
+
+   ```bash
+   curl https://agent-config-mcp.event4u.workers.dev
+   # → { "ok": true, "release_key": "v…", "signature": "…", … }
+   ```
+
+2. Expose skill + command prompts under URIs like `skill://…` and
+   `command://…`.
+3. Expose rule + guideline + context resources under `rule://…`,
+   `guideline://…`, `context://…`.
+
+If the client shows the connector but no prompts / resources,
+re-probe the URL — a 5xx from the Worker indicates the deploy is
+mid-roll, retry after a minute.
+
+## Local stdio alternative
+
+If you have the repo cloned and prefer running the MCP server
+locally (faster startup, no network), the stdio kernel under
+`scripts/mcp_server/` is the same wire surface. Setup:
+`task mcp:setup`, run details in [`../mcp-server.md`](../mcp-server.md).
+
+## See also
+
+- URL shapes & DNS — [`mcp-cloud-endpoints.md`](mcp-cloud-endpoints.md)
+- Operator setup (your own deploy) — [`mcp-cloud-setup.md`](mcp-cloud-setup.md)
+- A0-cloud contract — [`../contracts/mcp-cloud-scope.md`](../contracts/mcp-cloud-scope.md)

--- a/docs/setup/mcp-client-config.md
+++ b/docs/setup/mcp-client-config.md
@@ -16,6 +16,24 @@ Clients that only support stdio (Claude Desktop, Zed) need the
 [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) bridge from
 npm — invoked via `npx`, no install required.
 
+## Where settings live — `.agent-settings.yml` vs. MCP config
+
+These are **two different files** for two different layers. Don't
+look for MCP server config inside `.agent-settings.yml`.
+
+| File | Where | Who reads it | Purpose |
+|---|---|---|---|
+| MCP client config (this page) | client-specific path per section above | the MCP client at startup | which MCP servers to talk to (name + URL / command) |
+| `.agent-settings.yml` | consumer project root (`<repo>/.agent-settings.yml`) | the agent at runtime (Claude / Cursor / …) | per-developer preferences: `name`, `ide`, `cost_profile`, `personal.autonomy`, `pipelines.skill_improvement`, `caveman.speak_scope`, … |
+
+The hosted MCP is **stateless** and **project-agnostic** — it serves
+the same skill / rule / command catalog to every client. Personalization
+happens agent-side after the MCP delivers its content blob; the Worker
+itself does not read `.agent-settings.yml`.
+
+First-time setup of `.agent-settings.yml` runs through `/onboard`;
+template drift is handled by `/sync-agent-settings`.
+
 ## Claude Desktop
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json`

--- a/docs/setup/mcp-cloud-endpoints.md
+++ b/docs/setup/mcp-cloud-endpoints.md
@@ -88,6 +88,7 @@ serving on `/latest/`.
 
 ## See also
 
+- Per-client config snippets: [`mcp-client-config.md`](mcp-client-config.md)
 - A0-cloud contract: `docs/contracts/mcp-cloud-scope.md`
 - R2 bootstrap: `docs/setup/mcp-r2-bootstrap.md`
 - Local stdio fallback: `scripts/mcp_server/` (unchanged)


### PR DESCRIPTION
## Why

PR #93 surfaced the hosted Remote MCP in the root README and added the
operator setup guide. The consumer-side counterpart was still missing —
"how do I wire Claude Desktop / Cursor / Zed to this URL?"

This PR adds the per-client setup page and cross-links it from the
existing entry points.

## What

New file: **`docs/setup/mcp-client-config.md`**

Five clients covered, each with a copy-paste config snippet:

| Client | Transport | Snippet kind |
|---|---|---|
| Claude Desktop | stdio via `npx mcp-remote` | JSON in `claude_desktop_config.json` |
| Claude Code | native HTTP | `claude mcp add --transport http …` |
| Cursor | native HTTP | JSON in `~/.cursor/mcp.json` |
| Zed | stdio via `npx mcp-remote` | JSON in Zed `settings.json` |
| Continue | stdio via `npx mcp-remote` | YAML in `~/.continue/config.yaml` |

Plus a transport-note section that explains *why* some clients need
the `mcp-remote` bridge (the Worker speaks JSON-RPC over HTTP POST,
no stdio).

## Cross-links

- Root `README.md` §"Remote MCP — zero install" now points at
  `mcp-client-config.md` *first* (consumer path), then endpoints +
  operator + contract.
- `docs/setup/mcp-cloud-endpoints.md` §"See also" links back to the
  new doc.

## Test plan

- [x] `task lint-skills` (via pre-push) — clean.
- [x] README portability + refs hooks — clean.
- [x] README under 750-line threshold (526 lines).
- [x] No new symbols or code paths — pure docs.

## Out of scope

- No new client *added* — `mcp-remote` is upstream from
  `geelen/mcp-remote`, just referenced via `npx -y mcp-remote`.
- No DNS / custom domain work — still tracked under Phase 5.2.
