### PR TITLE
docs(stability): align public surface with stability markers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,12 @@ task ci                # full pipeline — green before PR
 
 ## Pointers
 
-- **Package self-orientation** — identity, four-wing cognition map, repo layout, tech stack, key-rules table, telemetry, command-suggester: [`docs/contracts/package-self-orientation.md`](docs/contracts/package-self-orientation.md).
-- **Kernel + Router** — 9 always-loaded Iron-Law rules, tier-1 / tier-2 routing, cost profiles, per-rule char caps enforced by `task lint-rule-budget`: [`kernel-membership`](docs/contracts/kernel-membership.md) + [`rule-router`](docs/contracts/rule-router.md).
+- **Package self-orientation** (beta) — identity, four-wing cognition map, repo layout, tech stack, key-rules table, telemetry, command-suggester: [`docs/contracts/package-self-orientation.md`](docs/contracts/package-self-orientation.md).
+- **Kernel + Router** (beta) — 9 always-loaded Iron-Law rules, tier-1 / tier-2 routing, cost profiles, per-rule char caps enforced by `task lint-rule-budget`: [`kernel-membership`](docs/contracts/kernel-membership.md) + [`rule-router`](docs/contracts/rule-router.md).
 - **Multi-tool projection** — Augment, Claude Code, Cursor, Cline, Windsurf, Gemini CLI, Claude.ai bundle pipeline that ships from `.agent-src/` to consumer surfaces: [`docs/architecture.md`](docs/architecture.md#cloud-bundle-pipeline).
 - **Editing this repo** — Iron-Law rules (portability, source-of-truth, skill-quality) and the Thin-Root contract (caps · pointer-ratio · triage block) governing AGENTS.md: [`augment-portability`](.agent-src/rules/augment-portability.md), [`augment-source-of-truth`](.agent-src/rules/augment-source-of-truth.md), [`skill-quality`](.agent-src/rules/skill-quality.md), [`agents-md-thin-root`](.agent-src/skills/agents-md-thin-root/SKILL.md).
-- **Consumer story + architecture deep-dive** — what the package does for installers and how it ships: [`README.md`](README.md), [`docs/architecture.md`](docs/architecture.md).
-- **Personas** — 11 review-lens cast (6 core · 5 specialist), `personas:` vs `/mode` axes, citation map, override pattern: [`docs/personas.md`](docs/personas.md), schema [`docs/contracts/persona-schema.md`](docs/contracts/persona-schema.md).
+- **Consumer story + architecture deep-dive** — install story + ship pipeline: [`README.md`](README.md), [`docs/architecture.md`](docs/architecture.md).
+- **Personas** — 11 review-lens cast (6 core · 5 specialist), `personas:` vs `/mode` axes, citation map, override pattern: [`docs/personas.md`](docs/personas.md), schema [`docs/contracts/persona-schema.md`](docs/contracts/persona-schema.md) (beta).
 
 ## Emergency triage — read this when nothing else is reachable
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Read-only, identity-stable per release. Client config snippets and URL
 shapes (latest vs. pinned `/v<X.Y.Z>`) live in
 [`docs/setup/mcp-cloud-endpoints.md`](docs/setup/mcp-cloud-endpoints.md).
 Operator setup (account, R2, secrets) — [`docs/setup/mcp-cloud-setup.md`](docs/setup/mcp-cloud-setup.md).
-Experimental — A0-cloud contract in [`docs/contracts/mcp-cloud-scope.md`](docs/contracts/mcp-cloud-scope.md).
+Experimental — A0-cloud contract lives at `docs/contracts/mcp-cloud-scope.md` (internal reference only per `STABILITY.md`).
 
 ### Optional: persistent agent memory
 


### PR DESCRIPTION
## Why

`task ci` was failing on `main` due to pre-existing `check-public-links` violations — unrelated to in-flight feature work. This unblocks the next PR (P1 of `road-to-portable-dev-preferences`).

## What

- **README.md:115** — unlink experimental `mcp-cloud-scope` contract. Public surface MUST NOT link to `stability: experimental` contracts (per `STABILITY.md` and enforced by `scripts/check_public_links.py`). Path reference kept as plain text, intent preserved.
- **AGENTS.md:19/20/24** — add `(beta)` markers to four links into `stability: beta` contracts (`package-self-orientation`, `kernel-membership`, `rule-router`, `persona-schema`).
- **AGENTS.md:23** — tightened description ("install story + ship pipeline") to stay under the 3000-char Thin-Root cap after the `(beta)` insertions (3020 → 2996).

## Verification

- `task check-public-links` → ✅ clean (38 contracts scanned, 3 public files clean)
- `task lint-agents-md` → ✅ 2996 chars (under 3000 FAIL cap; soft warn at 2800)
- `task ci` → ✅ green end-to-end (1m 55s, 2681 tests passed, 0 errors)

## Diff stats

5 insertions / 5 deletions, two files, no code touched.