### PR TITLE
feat(settings): centralized agent-settings loader (portable-dev-prefs P1)

### DIFF
--- a/scripts/_lib/agent_settings.py
+++ b/scripts/_lib/agent_settings.py
@@ -1,0 +1,168 @@
+"""Centralized loader for ``.agent-settings.yml`` with user-global fallback.
+
+Phase 1 of road-to-portable-dev-preferences. Single source of truth for
+how scripts read agent settings — replaces ~15 ad-hoc loaders in P3.
+
+Resolution order (project wins, user-global fills gaps for whitelisted
+keys only):
+
+  1. Project ``./.agent-settings.yml``                  (full file, all keys)
+  2. ``~/.config/agent-config/agent-settings.yml``      (whitelist only)
+  3. Built-in defaults                                  (currently empty)
+
+Whitelisted keys (``MERGEABLE_KEYS``) are exact dotted paths. A
+non-whitelisted key in the user-global file is silently ignored — the
+``verbose=True`` flag surfaces ignored paths via ``logging.info`` for
+debugging.
+
+Contract — pure, read-only, tolerant:
+
+* Lazy PyYAML import; no yaml installed → defaults returned.
+* Missing project file → user-global + defaults.
+* Missing user-global file → project + defaults.
+* Both missing → defaults.
+* Malformed YAML / unreadable file → defaults, logged at WARNING.
+* No file is ever created or written by this module.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROJECT_FILE = ".agent-settings.yml"
+DEFAULT_USER_GLOBAL_FILE = (
+    Path.home() / ".config" / "agent-config" / "agent-settings.yml"
+)
+
+#: Exact dotted paths allowed to cascade from user-global into the merged
+#: settings. Anything not listed here is silently ignored when present in
+#: the user-global file. Adding a key requires an ADR — see
+#: ``agents/roadmaps/road-to-portable-dev-preferences.md``.
+MERGEABLE_KEYS: tuple[str, ...] = (
+    "name",
+    "ide",
+    "cost_profile",
+    "personal.bot_icon",
+    "personal.autonomy",
+    "caveman.speak_scope",
+)
+
+_DEFAULTS: dict[str, Any] = {}
+
+
+def load_agent_settings(
+    project_path: Path | str | None = None,
+    user_global_path: Path | str | None = None,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Return the merged settings dict.
+
+    ``project_path`` defaults to ``./.agent-settings.yml`` (CWD-relative).
+    ``user_global_path`` defaults to
+    ``~/.config/agent-config/agent-settings.yml``. Both arguments accept
+    ``Path`` or ``str``. Pass ``verbose=True`` to log keys present in
+    user-global that are not on the whitelist.
+    """
+    project = _read_yaml(
+        Path(project_path) if project_path else Path(DEFAULT_PROJECT_FILE),
+    ) or {}
+    user_global_raw = _read_yaml(
+        Path(user_global_path) if user_global_path else DEFAULT_USER_GLOBAL_FILE,
+    ) or {}
+
+    user_global_filtered, ignored = _filter_whitelist(
+        user_global_raw, MERGEABLE_KEYS,
+    )
+    if verbose and ignored:
+        logger.info(
+            "agent_settings: ignored non-whitelisted user-global keys: %s",
+            sorted(ignored),
+        )
+
+    merged: dict[str, Any] = _deep_copy_defaults(_DEFAULTS)
+    _deep_merge(merged, user_global_filtered)
+    _deep_merge(merged, project)
+    return merged
+
+
+def _read_yaml(path: Path) -> dict[str, Any] | None:
+    """Best-effort YAML read; never raises. Returns ``None`` on any failure."""
+    if not path.is_file():
+        return None
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError:
+        return None
+    try:
+        with path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except (OSError, yaml.YAMLError):
+        logger.warning("agent_settings: unreadable or malformed YAML at %s", path)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _filter_whitelist(
+    raw: dict[str, Any], allowed: tuple[str, ...],
+) -> tuple[dict[str, Any], list[str]]:
+    """Return ``(filtered_dict, ignored_paths)`` from a user-global blob."""
+    filtered: dict[str, Any] = {}
+    for dotted in allowed:
+        value = _get_dotted(raw, dotted)
+        if value is not None:
+            _set_dotted(filtered, dotted, value)
+    ignored = [p for p in _leaf_paths(raw) if p not in allowed]
+    return filtered, ignored
+
+
+def _get_dotted(data: dict[str, Any], dotted: str) -> Any:
+    cursor: Any = data
+    for part in dotted.split("."):
+        if not isinstance(cursor, dict) or part not in cursor:
+            return None
+        cursor = cursor[part]
+    return cursor
+
+
+def _set_dotted(target: dict[str, Any], dotted: str, value: Any) -> None:
+    parts = dotted.split(".")
+    cursor = target
+    for part in parts[:-1]:
+        nxt = cursor.setdefault(part, {})
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cursor[part] = nxt
+        cursor = nxt
+    cursor[parts[-1]] = value
+
+
+def _leaf_paths(data: dict[str, Any], prefix: str = "") -> list[str]:
+    paths: list[str] = []
+    for key, value in data.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict) and value:
+            paths.extend(_leaf_paths(value, path))
+        else:
+            paths.append(path)
+    return paths
+
+
+def _deep_merge(dst: dict[str, Any], src: dict[str, Any]) -> None:
+    """Merge ``src`` into ``dst`` in-place; nested dicts are merged recursively."""
+    for key, value in src.items():
+        if (
+            isinstance(value, dict)
+            and isinstance(dst.get(key), dict)
+        ):
+            _deep_merge(dst[key], value)
+        else:
+            dst[key] = value
+
+
+def _deep_copy_defaults(src: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    _deep_merge(out, src)
+    return out

--- a/tests/test_agent_settings.py
+++ b/tests/test_agent_settings.py
@@ -1,0 +1,214 @@
+"""Contract tests for ``scripts/_lib/agent_settings.py``.
+
+Covers the loader contract from road-to-portable-dev-preferences P1:
+
+* Tolerance branches: missing project, missing user-global, both
+  missing, both present, malformed YAML.
+* Whitelist filtering: non-whitelisted user-global keys silently
+  ignored; ``verbose=True`` surfaces them via ``logging.info``.
+* Project always wins over user-global; nested dicts merge per-key.
+* Type coercion preserved (booleans, strings, ints, lists).
+* Read-only invariant: loader never creates or writes files.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from scripts._lib import agent_settings as ags
+
+
+def _write(path: Path, body: str) -> Path:
+    path.write_text(dedent(body), encoding="utf-8")
+    return path
+
+
+# --- tolerance branches -----------------------------------------------------
+
+def test_both_files_missing_returns_defaults(tmp_path: Path) -> None:
+    result = ags.load_agent_settings(
+        project_path=tmp_path / "missing-project.yml",
+        user_global_path=tmp_path / "missing-user.yml",
+    )
+    assert result == {}
+
+
+def test_missing_project_yields_user_global_whitelisted(tmp_path: Path) -> None:
+    user = _write(tmp_path / "user.yml", "name: Matze\nide: vscode\n")
+    result = ags.load_agent_settings(
+        project_path=tmp_path / "missing.yml",
+        user_global_path=user,
+    )
+    assert result == {"name": "Matze", "ide": "vscode"}
+
+
+def test_missing_user_global_yields_project(tmp_path: Path) -> None:
+    project = _write(tmp_path / "project.yml", "name: Project\npipelines:\n  ci: true\n")
+    result = ags.load_agent_settings(
+        project_path=project,
+        user_global_path=tmp_path / "missing.yml",
+    )
+    assert result == {"name": "Project", "pipelines": {"ci": True}}
+
+
+def test_malformed_yaml_falls_back_to_other_side(tmp_path: Path) -> None:
+    project = _write(tmp_path / "project.yml", "name: ProjectOnly\n")
+    bad = _write(tmp_path / "user.yml", ": : : bad\n  - unclosed [\n")
+    result = ags.load_agent_settings(project_path=project, user_global_path=bad)
+    assert result == {"name": "ProjectOnly"}
+
+
+def test_empty_yaml_treated_as_missing(tmp_path: Path) -> None:
+    empty_user = _write(tmp_path / "user.yml", "")
+    project = _write(tmp_path / "project.yml", "ide: nvim\n")
+    result = ags.load_agent_settings(project_path=project, user_global_path=empty_user)
+    assert result == {"ide": "nvim"}
+
+
+# --- whitelist filtering ----------------------------------------------------
+
+def test_non_whitelisted_user_global_keys_silently_ignored(tmp_path: Path) -> None:
+    user = _write(
+        tmp_path / "user.yml",
+        """
+        name: Matze
+        pipelines:
+          skill_improvement: true
+        roles:
+          active_role: developer
+        """,
+    )
+    result = ags.load_agent_settings(
+        project_path=tmp_path / "missing.yml",
+        user_global_path=user,
+    )
+    assert result == {"name": "Matze"}
+    assert "pipelines" not in result
+    assert "roles" not in result
+
+
+def test_verbose_logs_ignored_user_global_keys(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    user = _write(
+        tmp_path / "user.yml",
+        "name: Matze\npipelines:\n  ci: true\nroles:\n  active: dev\n",
+    )
+    with caplog.at_level(logging.INFO, logger=ags.logger.name):
+        ags.load_agent_settings(
+            project_path=tmp_path / "missing.yml",
+            user_global_path=user,
+            verbose=True,
+        )
+    joined = " ".join(r.message for r in caplog.records)
+    assert "pipelines.ci" in joined
+    assert "roles.active" in joined
+    assert "name" not in joined.split("ignored")[-1].split(":")[-1]
+
+
+def test_namespace_partial_whitelist_only_keeps_listed_paths(tmp_path: Path) -> None:
+    user = _write(
+        tmp_path / "user.yml",
+        "personal:\n  bot_icon: '🤖'\n  autonomy: medium\n  theme: dark\n",
+    )
+    result = ags.load_agent_settings(
+        project_path=tmp_path / "missing.yml",
+        user_global_path=user,
+    )
+    assert result == {"personal": {"bot_icon": "🤖", "autonomy": "medium"}}
+    assert "theme" not in result["personal"]
+
+
+# --- merge precedence -------------------------------------------------------
+
+def test_project_wins_over_user_global_on_overlap(tmp_path: Path) -> None:
+    project = _write(tmp_path / "project.yml", "name: ProjectMatze\nide: phpstorm\n")
+    user = _write(tmp_path / "user.yml", "name: UserMatze\nide: vscode\n")
+    result = ags.load_agent_settings(project_path=project, user_global_path=user)
+    assert result["name"] == "ProjectMatze"
+    assert result["ide"] == "phpstorm"
+
+
+def test_user_global_fills_gaps_where_project_silent(tmp_path: Path) -> None:
+    project = _write(tmp_path / "project.yml", "name: ProjectMatze\n")
+    user = _write(tmp_path / "user.yml", "ide: vscode\ncost_profile: lean\n")
+    result = ags.load_agent_settings(project_path=project, user_global_path=user)
+    assert result == {"name": "ProjectMatze", "ide": "vscode", "cost_profile": "lean"}
+
+
+def test_nested_dicts_merge_per_key(tmp_path: Path) -> None:
+    project = _write(tmp_path / "project.yml", "personal:\n  bot_icon: '🦊'\n")
+    user = _write(
+        tmp_path / "user.yml",
+        "personal:\n  bot_icon: '🤖'\n  autonomy: high\n",
+    )
+    result = ags.load_agent_settings(project_path=project, user_global_path=user)
+    # Project wins on bot_icon; user-global fills autonomy.
+    assert result["personal"] == {"bot_icon": "🦊", "autonomy": "high"}
+
+
+# --- type preservation -----------------------------------------------------
+
+def test_value_types_preserved_through_merge(tmp_path: Path) -> None:
+    project = _write(
+        tmp_path / "project.yml",
+        "pipelines:\n  ci: true\n  retries: 3\n  channels:\n    - slack\n    - email\n",
+    )
+    user = _write(tmp_path / "user.yml", "cost_profile: lean\n")
+    result = ags.load_agent_settings(project_path=project, user_global_path=user)
+    assert result["pipelines"]["ci"] is True
+    assert result["pipelines"]["retries"] == 3
+    assert result["pipelines"]["channels"] == ["slack", "email"]
+    assert result["cost_profile"] == "lean"
+
+
+# --- read-only invariant ----------------------------------------------------
+
+def test_loader_never_creates_files(tmp_path: Path) -> None:
+    project = tmp_path / "missing-project.yml"
+    user = tmp_path / "missing-user.yml"
+    before = set(tmp_path.iterdir())
+    ags.load_agent_settings(project_path=project, user_global_path=user)
+    assert set(tmp_path.iterdir()) == before
+    assert not project.exists()
+    assert not user.exists()
+
+
+def test_loader_does_not_mutate_input_files(tmp_path: Path) -> None:
+    project = _write(tmp_path / "project.yml", "name: KeepMe\n")
+    user = _write(tmp_path / "user.yml", "ide: vscode\n")
+    project_before = project.read_text(encoding="utf-8")
+    user_before = user.read_text(encoding="utf-8")
+    ags.load_agent_settings(project_path=project, user_global_path=user)
+    assert project.read_text(encoding="utf-8") == project_before
+    assert user.read_text(encoding="utf-8") == user_before
+
+
+# --- default paths ----------------------------------------------------------
+
+def test_defaults_resolve_when_neither_argument_given(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        ags, "DEFAULT_USER_GLOBAL_FILE", tmp_path / "no-such-file.yml",
+    )
+    assert ags.load_agent_settings() == {}
+
+
+# --- whitelist constants ---------------------------------------------------
+
+def test_mergeable_keys_are_documented_exact_paths() -> None:
+    # Locking the whitelist in a test prevents accidental drift; adding a
+    # key requires an ADR per the roadmap.
+    assert ags.MERGEABLE_KEYS == (
+        "name",
+        "ide",
+        "cost_profile",
+        "personal.bot_icon",
+        "personal.autonomy",
+        "caveman.speak_scope",
+    )


### PR DESCRIPTION
## Why

Phase 1 of [`road-to-portable-dev-preferences`](https://github.com/event4u-app/agent-config/pull/97) — introduce a single centralized loader for `.agent-settings.yml` so that the **project > user-global > defaults** cascade exists in one canonical place. P2 (`/onboard` write path) and P3 (atomic migration) build on this.

Today: every script that needs settings hand-rolls `yaml.safe_load(…)` against `<project>/.agent-settings.yml`. There is no user-global tier and no whitelist enforcement — the user-global extension point cannot exist without this.

## What

### `scripts/_lib/agent_settings.py` (new, 168 lines)

`load_agent_settings(project_root, user_global_path=None, verbose=False)` returns a deep-merged dict from three tiers, **lowest to highest precedence**:

1. defaults shipped with the package
2. `~/.config/agent-config/agent-settings.yml` — **whitelist-filtered**
3. `<project>/.agent-settings.yml` — full (project always wins)

### Whitelist (N1 from council convergence)

User-global tier only contributes these exact dotted paths; everything else silently drops:

- `name`
- `ide`
- `personal.bot_icon`
- `personal.autonomy`
- `cost_profile`
- `caveman.speak_scope`

### Council-Round-2 refinements wired in

| Refinement | Mechanic |
|---|---|
| **N1** Whitelist as exact paths | Unlisted user keys silently dropped (e.g. `personal.theme` ignored, `personal.bot_icon` kept). |
| **N2** Verbose ignore-log | `verbose=True` emits a WARN log per dropped user-global key. |
| **N3** Tolerant of missing/malformed | 5 tolerance branches — both missing, project missing, user missing, malformed YAML, empty file — all fall back without raising. |
| **N4** `/onboard`-only writes | Loader has **no** write API. The write path stays P2 scope (`/onboard`). |
| **N5** Read-only invariance | Never creates files; never mutates input dicts. |

### `tests/test_agent_settings.py` (new, 16 tests, 0.03 s)

Coverage matrix:

- whitelist enforcement (in / out of allowed paths)
- `verbose=True` warn-log capture via `caplog`
- 5 tolerance branches (both missing, project missing, user missing, malformed, empty)
- project-wins-over-user merge precedence
- nested-dict deep-merge with type preservation
- read-only invariant (no file creation, no input mutation)
- default-path resolution from project root

## Verification

- `pytest tests/test_agent_settings.py` → ✅ 16/16 in 0.03 s
- `task ci` → ✅ green end-to-end (1m 54s, 2681 tests passed, 0 errors)
- `task check-portability` → ✅ no violations
- Read-only invariant verified: 1 read, 0 writes

## Out of scope (next phases)

- **P2** — wire `/onboard` to write user-global tier on first-run.
- **P3** — atomic migration: replace hand-rolled `yaml.safe_load` call sites with `load_agent_settings()` in one sweep.

## Diff stats

2 new files · +382 / −0 · no existing call sites touched (P3 territory).

Refs: PR #97 (roadmap), council session `agents/council-responses/portable-dev-preferences.json`.