### PR TITLE
fix: allow --global installs from agent-config source repo

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -230,17 +230,18 @@ if [[ -z "$TARGET_DIR" ]]; then
 fi
 
 # Source-repo guard: refuse to install into the agent-config dev tree itself.
-# Mirrors packages/create-agent-config/src/install.js — defense-in-depth so a
-# direct `bash scripts/install` from inside the source checkout (without the
-# Node wrapper) cannot corrupt .augment/ symlinks. Override for self-tests:
+# Defense-in-depth so a direct `bash scripts/install` from inside the source
+# checkout cannot corrupt .augment/ symlinks. Skipped for --global because
+# global installs only write to user-scope paths (~/.config/agent-config/,
+# ~/.claude/, …) and never touch the source tree. Override for self-tests:
 # AGENT_CONFIG_ALLOW_SELF_INSTALL=1.
-if [[ "${AGENT_CONFIG_ALLOW_SELF_INSTALL:-0}" != "1" ]]; then
+if ! $GLOBAL && [[ "${AGENT_CONFIG_ALLOW_SELF_INSTALL:-0}" != "1" ]]; then
     self_marker=""
     if [[ -d "$TARGET_DIR/.agent-src.uncompressed" ]]; then
         self_marker=".agent-src.uncompressed/"
     elif [[ -f "$TARGET_DIR/package.json" ]] && \
-         grep -qE '"name"[[:space:]]*:[[:space:]]*"@event4u/(create-)?agent-config"' "$TARGET_DIR/package.json" 2>/dev/null; then
-        self_marker='package.json::name === "@event4u/(create-)agent-config"'
+         grep -qE '"name"[[:space:]]*:[[:space:]]*"@event4u/agent-config"' "$TARGET_DIR/package.json" 2>/dev/null; then
+        self_marker='package.json::name === "@event4u/agent-config"'
     fi
     if [[ -n "$self_marker" ]]; then
         err "Refusing to install agent-config into its own source checkout."

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -2036,7 +2036,14 @@ def install_global(
     # Refresh the project-scope manifest when running inside a project tree
     # (ADR-008 Phase 3.2). Outside a project (e.g. plain `~/`) there is no
     # manifest to write and the global lockfile alone is the source of truth.
-    if project_root is not None and (project_root / SETTINGS_FILE).exists():
+    # Skipped inside the agent-config source repo (detected by
+    # `.agent-src.uncompressed/`) — maintainers dogfood with their own
+    # `.agent-settings.yml` and the manifest would be untracked noise.
+    if (
+        project_root is not None
+        and (project_root / SETTINGS_FILE).exists()
+        and not (project_root / ".agent-src.uncompressed").is_dir()
+    ):
         rc = _update_installed_tools_manifest(project_root, tools, "global", force)
         if rc != 0:
             return rc

--- a/tests/test_install_orchestrator.sh
+++ b/tests/test_install_orchestrator.sh
@@ -216,6 +216,57 @@ test_tools_combination_cursor_plus_windsurf() {
     teardown
 }
 
+# Source-repo guard — defense-in-depth so a project install into the
+# agent-config dev tree itself cannot corrupt .augment/ symlinks. The guard
+# is skipped for --global because user-scope installs never touch the source
+# tree, and bypassable via AGENT_CONFIG_ALLOW_SELF_INSTALL=1 for self-tests.
+test_source_repo_guard_blocks_project_install() {
+    setup
+    mkdir -p "$TMPDIR/.agent-src.uncompressed"
+    local out exit_code
+    out="$(bash "$INSTALL" --target "$TMPDIR" --quiet 2>&1)"; exit_code=$?
+    assert_true "guard: exit 2 on project install into source tree" test "$exit_code" -eq 2
+    assert_true "guard: 'Refusing' message printed" grep -q "Refusing to install agent-config" <<<"$out"
+    assert_false "guard: no .augment/ created in source tree" test -d "$TMPDIR/.augment"
+    teardown
+}
+
+test_source_repo_guard_allows_global_install() {
+    setup
+    mkdir -p "$TMPDIR/.agent-src.uncompressed"
+    local out exit_code
+    out="$(AGENT_CONFIG_INSTALLED_LOCK="$TMPDIR/installed.lock" \
+        bash "$INSTALL" --target "$TMPDIR" --global --tools=claude-code --quiet 2>&1)"; exit_code=$?
+    assert_true "guard: exit 0 on --global into source tree" test "$exit_code" -eq 0
+    assert_false "guard: no 'Refusing' message on --global" grep -q "Refusing to install agent-config" <<<"$out"
+    assert_true "guard: lockfile written to redirected path" test -f "$TMPDIR/installed.lock"
+    teardown
+}
+
+test_source_repo_guard_override_env_bypasses() {
+    setup
+    mkdir -p "$TMPDIR/.agent-src.uncompressed"
+    local out exit_code
+    out="$(AGENT_CONFIG_ALLOW_SELF_INSTALL=1 \
+        bash "$INSTALL" --target "$TMPDIR" --quiet 2>&1)"; exit_code=$?
+    assert_true "guard: exit 0 with AGENT_CONFIG_ALLOW_SELF_INSTALL=1" test "$exit_code" -eq 0
+    assert_false "guard: no 'Refusing' message with override" grep -q "Refusing to install agent-config" <<<"$out"
+    teardown
+}
+
+test_source_repo_guard_package_json_marker() {
+    setup
+    # No .agent-src.uncompressed/, but package.json declares the source name.
+    cat >"$TMPDIR/package.json" <<'JSON'
+{ "name": "@event4u/agent-config", "version": "0.0.0" }
+JSON
+    local out exit_code
+    out="$(bash "$INSTALL" --target "$TMPDIR" --quiet 2>&1)"; exit_code=$?
+    assert_true "guard: exit 2 on package.json name marker" test "$exit_code" -eq 2
+    assert_true "guard: 'package.json::name' in detected reason" grep -q 'package.json::name' <<<"$out"
+    teardown
+}
+
 # --- Runner ---
 TESTS=(
     test_full_run_creates_payload_and_bridges
@@ -235,6 +286,10 @@ TESTS=(
     test_tools_claude_code_only_excludes_others
     test_tools_all_matches_default
     test_tools_combination_cursor_plus_windsurf
+    test_source_repo_guard_blocks_project_install
+    test_source_repo_guard_allows_global_install
+    test_source_repo_guard_override_env_bypasses
+    test_source_repo_guard_package_json_marker
 )
 
 if [[ "${1:-}" == "--list" ]]; then


### PR DESCRIPTION
## Description

The source-repo guard in `scripts/install` was blocking **every** install when `.agent-src.uncompressed/` or the `@event4u/agent-config` package marker was detected. This refused legitimate maintainer workflows — most importantly `./agent-config global --tools=…` from the source checkout — even though `--global` installs only write to user-scope paths (`~/.config/agent-config/`, `~/.claude/`, …) and never touch the source tree.

This PR narrows the guard to project-scope installs and stops the global path from leaving a stray `agents/installed-tools.lock` behind in the dev tree.

- `scripts/install`: gate the guard behind `! $GLOBAL` so `--global` bypasses the refusal. `AGENT_CONFIG_ALLOW_SELF_INSTALL=1` remains the universal override. Stale comment/marker references to the removed `create-agent-config` wrapper were cleaned up in the same block.
- `scripts/install.py`: skip the ADR-008 project-manifest refresh when the target is the source repo itself (detected via `.agent-src.uncompressed/`), so `--global` from the source repo no longer drops a stray `agents/installed-tools.lock` into the dev tree.
- `tests/test_install_orchestrator.sh`: add 4 integration tests / 10 assertions.

## Type of change

- [ ] New skill/rule/command/guideline
- [ ] Update existing skill/rule/command/guideline
- [ ] Linter/tooling improvement
- [ ] Documentation
- [x] Bug fix

## Upstream Contribution Checklist

### Promotion Gate
- [x] Learning occurred 2+ times OR is clearly generalizable
- [x] Improves correctness, reliability, or consistency
- [x] Prevents a real, observed failure
- [x] No existing rule/skill/guideline already covers this
- [x] Update preferred over creation (checked existing first)

### Quality Gate
- [x] `task lint-skills` — 0 FAIL
- [x] `task lint-skills --pairs` — no orphaned or missing pairs
- [x] All existing tests pass

### Universality Gate
- [x] No project-specific assumptions (domain logic, local paths, FQDNs)
- [x] Benefits ALL consumers of the package, not just one project
- [x] Does not break or weaken existing guidance

### Completeness Gate
- [x] Both uncompressed + compressed versions present
- [x] Compressed preserves: triggers, validation, decisions, gotchas
- [x] Symlinks regenerated (`task generate-tools`)

_N/A: this PR only touches `scripts/` and `tests/`; no skill/rule/command bodies changed._

## Testing

- New tests added to `tests/test_install_orchestrator.sh`:
  - `test_source_repo_guard_blocks_project_install` — project install into source tree → exit 2 + `Refusing` message + no `.augment/` written.
  - `test_source_repo_guard_allows_global_install` — `--global` into source tree → exit 0, no `Refusing` message, lockfile written to the redirected path.
  - `test_source_repo_guard_override_env_bypasses` — `AGENT_CONFIG_ALLOW_SELF_INSTALL=1` bypasses the guard.
  - `test_source_repo_guard_package_json_marker` — `package.json::name == "@event4u/agent-config"` marker still trips the guard for project installs.
- Regression suites green locally:
  - `tests/test_install_orchestrator.sh` — 62 passed (52 existing + 10 new assertions).
  - `tests/test_install_py.py` — 110 passed.
  - `tests/test_installed_lock.py` — 16 passed.
  - `tests/test_installed_tools.py` — 10 passed.
- Manual check: `./agent-config global --tools=claude-code` from the source repo now exits 0 and does not create `agents/installed-tools.lock`; `./agent-config init` from the source repo still refuses as before.

## Notes

- `AGENT_CONFIG_ALLOW_SELF_INSTALL=1` is preserved as the universal escape hatch for genuine self-install testing.
- The manifest-refresh skip is keyed on `.agent-src.uncompressed/` only; consumer repos are unaffected because they never carry that directory.