### PR TITLE
fix(coexistence): multi-package audit follow-ups — resume-uninstall, path normalisation, E2E coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # Agent Config — Governed Agent System
 
-> ⚠️ **Breaking change in vX.0** — `agent-config` now ships as an
-> **npx-only runtime**. `composer require` / `npm install --save-dev`
-> are gone, the `--global` symlink scheme is retired. Existing
-> consumers: run `npx @event4u/agent-config migrate`
-> ([guide](docs/migration/v1-to-v2.md)). New consumers: jump to
-> [Quickstart](#quickstart).
-
 > **agent-config is not a runtime, but it ships a deterministic orchestration contract / state machine for host agents.**
 
 Give your AI agents an audit-disciplined orchestration contract — testing, Git, CI, code review, and **120+ stack-aware skills** — with quality guardrails built in.

--- a/docs/contracts/installed-tools-lockfile.md
+++ b/docs/contracts/installed-tools-lockfile.md
@@ -64,7 +64,7 @@ tools:
 | `scope` | str | yes | `global` (user-home) or `project` (workspace bridge) |
 | `bridge_marker` | str | yes | absolute / `~`-prefixed for global; repo-relative for project |
 | `installed_at` | str | yes | ISO date; informational only |
-| `status` | str | no | `installed` (default when absent) or `uninstalling`; reserved for two-phase uninstall (P2.2) |
+| `status` | str | no | `installed` (default when absent) or `uninstalling`; two-phase uninstall (P2.2). A crashed uninstall leaves the entry in `uninstalling` — `agent-config prune --resume-uninstall` sweeps only those entries' `files[]` without touching healthy tools or unmanaged drift. |
 | `files` | list[obj] | no | content the installer deployed for this tool |
 | `merged_keys` | list[obj] | no | named keys this tool inserted into shared JSON files |
 

--- a/scripts/_cli/cmd_prune.py
+++ b/scripts/_cli/cmd_prune.py
@@ -26,6 +26,13 @@ hashed before deletion. A mismatch flags the file as **modified** —
 prune surfaces the path and skips removal so user / neighbour-tool
 edits to deployed content survive the prune sweep. Files without a
 recorded hash (bridges) skip the check and prune normally.
+
+Resume-uninstall (P2.2): ``--resume-uninstall`` narrows prune to the
+crash-recovery scope — only files belonging to tools with
+``status: uninstalling`` are surfaced. The legacy disk scan is skipped
+and healthy tools / unmanaged drift are untouched. Intended for
+re-running after an uninstall crashed mid-flight; no-op when no tool
+is in the ``uninstalling`` state.
 """
 from __future__ import annotations
 
@@ -93,7 +100,8 @@ def _sha256(path: Path) -> str | None:
         return None
 
 
-def _orphaned(project_root: Path, manifest: dict | None, declared: set[str]
+def _orphaned(project_root: Path, manifest: dict | None, declared: set[str],
+              *, resume_uninstall: bool = False,
               ) -> list[tuple[str, Path, str | None, str | None]]:
     """Return ``[(tool_id, target_path, kind, expected_sha256), …]``.
 
@@ -113,18 +121,25 @@ def _orphaned(project_root: Path, manifest: dict | None, declared: set[str]
 
     Paths already collected by the disk scan are deduplicated so the
     same orphan never appears twice.
+
+    ``resume_uninstall=True`` skips the legacy disk scan and the
+    healthy-tool branch entirely — only tools with
+    ``status == "uninstalling"`` contribute candidates. Used by
+    ``--resume-uninstall`` to scope crash recovery to half-removed
+    tools without touching unmanaged drift.
     """
     out: list[tuple[str, Path, str | None, str | None]] = []
     seen: set[Path] = set()
 
-    for tool_id, rel in PROJECT_BRIDGE_MARKERS.items():
-        if tool_id in declared:
-            continue
-        target = project_root / rel
-        if not target.exists():
-            continue
-        out.append((tool_id, target, None, None))
-        seen.add(target.resolve())
+    if not resume_uninstall:
+        for tool_id, rel in PROJECT_BRIDGE_MARKERS.items():
+            if tool_id in declared:
+                continue
+            target = project_root / rel
+            if not target.exists():
+                continue
+            out.append((tool_id, target, None, None))
+            seen.add(target.resolve())
 
     if manifest is None:
         return out
@@ -137,7 +152,10 @@ def _orphaned(project_root: Path, manifest: dict | None, declared: set[str]
             continue
         tool_id = str(tool.get("name", ""))
         status = tool.get("status", "installed")
-        if status == "installed" and tool_id in declared:
+        if resume_uninstall:
+            if status != "uninstalling":
+                continue
+        elif status == "installed" and tool_id in declared:
             continue
         for entry in files:
             kind = entry.get("kind")
@@ -207,6 +225,10 @@ def _parse(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--all-missing-lock", action="store_true",
                         help="treat a missing lockfile as 'no tools declared' "
                              "and prune every known marker (destructive)")
+    parser.add_argument("--resume-uninstall", action="store_true",
+                        help="only sweep files of tools left in "
+                             "status='uninstalling' (P2.2 crash recovery); "
+                             "skips the legacy disk scan and healthy tools")
     return parser.parse_args(argv)
 
 
@@ -270,7 +292,10 @@ def main(argv: list[str] | None = None) -> int:
         print("    pass --all-missing-lock to prune every known marker (destructive)",
               file=sys.stderr)
         return 1
-    candidates = _orphaned(project_root, manifest, declared)
+    candidates = _orphaned(
+        project_root, manifest, declared,
+        resume_uninstall=opts.resume_uninstall,
+    )
     results: list[tuple[str, Path, str, bool, str]] = []
     for tool_id, target, _kind, expected_sha in candidates:
         state, _actual = _classify(target, expected_sha)

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -252,8 +252,17 @@ def _load_conflict_policy(project_root: Path, force: bool) -> ConflictPolicy:
         for tool in existing.get("tools", []) or []:
             for entry in tool.get("files", []) or []:
                 path_val = entry.get("path")
-                if isinstance(path_val, str):
-                    known_paths.add(path_val)
+                if isinstance(path_val, str) and path_val:
+                    # Manifest paths may be absolute (production writers
+                    # use ``str(Path)`` for ``files[].path``) or relative
+                    # (portable manifests). Writers always pass absolute
+                    # ``Path`` objects to ``_resolve_file_conflict``, so
+                    # normalise here against ``project_root`` to keep the
+                    # known-path silent-skip branch reachable.
+                    p = Path(path_val)
+                    if not p.is_absolute():
+                        p = (project_root / p).resolve()
+                    known_paths.add(str(p))
             for entry in tool.get("merged_keys", []) or []:
                 file_label = entry.get("file")
                 pointer = entry.get("json_pointer")
@@ -346,7 +355,8 @@ def _resolve_file_conflict(target: Path, *, force_hint: bool) -> str:
         raise ConflictAbort(f"User aborted on foreign file at {target}")
     raise ConflictAbort(
         f"Foreign file at {target}: refusing to overwrite. "
-        f"Re-run with --force or set {ALLOW_OVERWRITE_ENV}=1 to allow."
+        f"Re-run with --force or set {ALLOW_OVERWRITE_ENV}=1 to allow. "
+        f"Run `agent-config doctor` to inspect orphaned files first."
     )
 
 
@@ -503,7 +513,8 @@ def _resolve_json_conflict(
     raise ConflictAbort(
         f"Foreign JSON pointers at {path}: refusing to overwrite "
         f"({len(foreign)} key(s)). Re-run with --force or set "
-        f"{ALLOW_OVERWRITE_ENV}=1 to allow."
+        f"{ALLOW_OVERWRITE_ENV}=1 to allow. "
+        f"Run `agent-config doctor` to inspect orphaned pointers first."
     )
 
 

--- a/tests/test_cmd_prune.py
+++ b/tests/test_cmd_prune.py
@@ -325,3 +325,114 @@ def test_v1_fallback_when_no_files_in_manifest(
     assert rc == 0
     assert (tmp_path / ".cursor" / "hooks.json").exists()
     assert not (tmp_path / ".windsurf" / "hooks.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# P2.2 — --resume-uninstall (crash recovery)
+# ---------------------------------------------------------------------------
+
+
+def test_resume_uninstall_only_touches_uninstalling_tools(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """--resume-uninstall sweeps only files of tools with status='uninstalling';
+    unmanaged drift (legacy disk scan) and undeclared markers are left alone."""
+    _touch(tmp_path, ".cursor/hooks.json")
+    _touch(tmp_path, ".roo/rules/agent-config.md")  # would be a disk-scan orphan
+    _write_manifest(tmp_path, [
+        _entry_v2(
+            "cursor", ".cursor/hooks.json",
+            status="uninstalling",
+            files=[{"path": ".cursor/hooks.json", "kind": "bridge", "sha256": None}],
+        ),
+    ])
+    rc = cmd_prune.main([f"--project={tmp_path}", "--resume-uninstall"])
+    assert rc == 0
+    # Half-uninstalled file: removed.
+    assert not (tmp_path / ".cursor" / "hooks.json").exists()
+    # Unmanaged drift: not touched.
+    assert (tmp_path / ".roo" / "rules" / "agent-config.md").exists()
+
+
+def test_resume_uninstall_leaves_healthy_tools_alone(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """A healthy v2 entry (status=installed) is invisible to --resume-uninstall
+    even when its tool is *not* in `declared` (e.g. removed from spec but not
+    yet uninstalled). Recovery must not silently complete a half-spec'd uninstall."""
+    _touch(tmp_path, ".cursor/hooks.json")
+    _write_manifest(tmp_path, [
+        _entry_v2(
+            "cursor", ".cursor/hooks.json",
+            files=[{"path": ".cursor/hooks.json", "kind": "bridge", "sha256": None}],
+        ),
+    ])
+    rc = cmd_prune.main([f"--project={tmp_path}", "--resume-uninstall"])
+    assert rc == 0
+    assert (tmp_path / ".cursor" / "hooks.json").exists()
+    out = capsys.readouterr().out
+    assert "no orphaned bridges" in out
+
+
+def test_resume_uninstall_no_op_when_nothing_uninstalling(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """No tool in uninstalling state → zero candidates, exit 0, even when
+    a legacy disk-scan would have flagged orphans."""
+    _write_manifest(tmp_path, [])  # nothing declared
+    _touch(tmp_path, ".roo/rules/agent-config.md")  # legacy disk-scan orphan
+    rc = cmd_prune.main([f"--project={tmp_path}", "--resume-uninstall"])
+    assert rc == 0
+    # Legacy disk scan is skipped under --resume-uninstall.
+    assert (tmp_path / ".roo" / "rules" / "agent-config.md").exists()
+    out = capsys.readouterr().out
+    assert "no orphaned bridges" in out
+
+
+def test_resume_uninstall_respects_drift_detection(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """Drift on a deployed file of an uninstalling tool is still surfaced as
+    modified and skipped — recovery never deletes user-edited content."""
+    _touch(tmp_path, ".augment/rules/r1.md")
+    _write_manifest(tmp_path, [
+        _entry_v2(
+            "augment", ".augment/PROJECT_MANAGED_BY_AGENT_CONFIG",
+            status="uninstalling",
+            files=[{"path": ".augment/rules/r1.md", "kind": "deployed",
+                    "sha256": "00" * 32}],
+        ),
+    ])
+    rc = cmd_prune.main([f"--project={tmp_path}", "--resume-uninstall"])
+    assert rc == 0
+    assert (tmp_path / ".augment" / "rules" / "r1.md").exists()
+    out = capsys.readouterr().out
+    assert "modified" in out
+    assert "skipped" in out
+
+
+def test_resume_uninstall_dry_run_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """--resume-uninstall composes with --dry-run --json: payload lists the
+    uninstalling tool's files, nothing else, and disk is untouched."""
+    _touch(tmp_path, ".cursor/hooks.json")
+    _touch(tmp_path, ".roo/rules/agent-config.md")
+    _write_manifest(tmp_path, [
+        _entry_v2(
+            "cursor", ".cursor/hooks.json",
+            status="uninstalling",
+            files=[{"path": ".cursor/hooks.json", "kind": "bridge", "sha256": None}],
+        ),
+    ])
+    rc = cmd_prune.main([
+        f"--project={tmp_path}",
+        "--resume-uninstall", "--dry-run", "--json",
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    paths = [o["path"] for o in payload["orphans"]]
+    assert paths == [".cursor/hooks.json"]
+    # Dry-run: both files still present.
+    assert (tmp_path / ".cursor" / "hooks.json").exists()
+    assert (tmp_path / ".roo" / "rules" / "agent-config.md").exists()

--- a/tests/test_e2e_multi_package_coexistence.py
+++ b/tests/test_e2e_multi_package_coexistence.py
@@ -124,3 +124,200 @@ def test_two_packages_coexist_then_one_uninstall_keeps_other_intact(
     assert out["missing"] == []
     assert out["modified"] == []
     assert out["tag_drift"] == []
+
+
+# ---------------------------------------------------------------------------
+# Shared-JSON-merge coexistence (P3.3 — merged_keys subtraction)
+# ---------------------------------------------------------------------------
+
+
+def test_two_packages_share_hooks_json_uninstall_preserves_neighbour_keys(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """Two packages each contribute a top-level key to .cursor/hooks.json
+    via ``merged_keys[]``. Uninstalling pkg-b removes only pkg-b's key
+    and leaves pkg-a's contribution intact; the file is preserved (not
+    deleted) because foreign keys survive subtraction."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    hooks_rel = ".cursor/hooks.json"
+
+    # Shared JSON: both packages own one top-level key each.
+    hooks_path = proj / hooks_rel
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    hooks_doc = {
+        "pkg-a-hook": {"command": "echo a"},
+        "pkg-b-hook": {"command": "echo b"},
+    }
+    hooks_path.write_text(json.dumps(hooks_doc, indent=2) + "\n", encoding="utf-8")
+
+    # Each tool registers its single pointer + the shared file as a
+    # "bridge" entry (existence-tracked). merged_keys carries the
+    # ownership claim that drives subtract_pointers on uninstall.
+    a_bridge_meta = {"path": hooks_rel, "kind": "bridge", "sha256": None}
+    b_bridge_meta = {"path": hooks_rel, "kind": "bridge", "sha256": None}
+
+    manifest_path = it.manifest_path(proj)
+    it.write_manifest(
+        manifest_path,
+        "2.1.0",
+        [
+            {
+                **_entry("pkg-a", [a_bridge_meta]),
+                "bridge_marker": hooks_rel,
+                "merged_keys": [
+                    {"file": hooks_rel, "json_pointer": "/pkg-a-hook"},
+                ],
+            },
+            {
+                **_entry("pkg-b", [b_bridge_meta]),
+                "bridge_marker": hooks_rel,
+                "merged_keys": [
+                    {"file": hooks_rel, "json_pointer": "/pkg-b-hook"},
+                ],
+            },
+        ],
+        deploy_roots=[".cursor"],
+    )
+
+    # Uninstall pkg-b — purge so JSON subtraction runs (no --force needed).
+    rc = cmd_uninstall.main([f"--project={proj}", "--tools=pkg-b"])
+    capsys.readouterr()
+    assert rc == 0
+
+    # Shared file still exists; pkg-a's key untouched, pkg-b's key gone.
+    assert hooks_path.exists(), "shared file deleted despite surviving foreign keys"
+    survived = json.loads(hooks_path.read_text(encoding="utf-8"))
+    assert "pkg-a-hook" in survived
+    assert survived["pkg-a-hook"] == {"command": "echo a"}
+    assert "pkg-b-hook" not in survived
+
+    # Manifest: only pkg-a remains in installed state.
+    state = it.read_manifest(manifest_path)
+    assert state is not None
+    healthy = {e["name"] for e in state.get("tools", [])
+               if e.get("status", "installed") == "installed"}
+    assert healthy == {"pkg-a"}
+
+
+def test_uninstalling_last_owner_of_shared_json_deletes_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """When the uninstall would empty the shared JSON document (no
+    foreign keys remain), the bridge file is deleted — there is nothing
+    for a neighbour to inherit."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    hooks_rel = ".cursor/hooks.json"
+
+    hooks_path = proj / hooks_rel
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    hooks_path.write_text(
+        json.dumps({"pkg-a-hook": {"command": "echo a"}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_path = it.manifest_path(proj)
+    it.write_manifest(
+        manifest_path,
+        "2.1.0",
+        [
+            {
+                **_entry("pkg-a", [{"path": hooks_rel, "kind": "bridge", "sha256": None}]),
+                "bridge_marker": hooks_rel,
+                "merged_keys": [
+                    {"file": hooks_rel, "json_pointer": "/pkg-a-hook"},
+                ],
+            },
+        ],
+        deploy_roots=[".cursor"],
+    )
+
+    rc = cmd_uninstall.main([f"--project={proj}", "--tools=pkg-a"])
+    capsys.readouterr()
+    assert rc == 0
+
+    assert not hooks_path.exists(), "sole-owner uninstall left empty JSON behind"
+
+
+# ---------------------------------------------------------------------------
+# Foreign-file conflict integration (P3.1 — manifest → policy → resolver)
+# ---------------------------------------------------------------------------
+
+
+def test_load_conflict_policy_from_manifest_then_resolver_aborts_on_foreign(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end conflict-detection chain.
+
+    Builds a real manifest, calls the live ``_load_conflict_policy`` to
+    derive the runtime policy, then proves that ``_resolve_file_conflict``
+    raises ``ConflictAbort`` with a remediation hint when a writer hits
+    a foreign file. The env-var escape hatch (``AGENT_CONFIG_ALLOW_OVERWRITE``)
+    is exercised in the same chain to verify it lifts the abort.
+
+    Path-keying: ``_load_conflict_policy`` normalises every manifest path
+    against ``project_root`` so writers passing absolute ``Path`` objects
+    hit the known-path silent-skip branch. The known-path assertion below
+    is the live regression test for that resolution.
+    """
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import install  # type: ignore
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    known_rel = ".augment/rules/a1.md"
+    foreign_rel = ".augment/rules/squatter.md"
+
+    known_path, known_meta = _write_file(proj, known_rel, b"ours\n")
+    foreign_path, _ = _write_file(proj, foreign_rel, b"someone else wrote this\n")
+
+    it.write_manifest(
+        it.manifest_path(proj),
+        "2.1.0",
+        [_entry("pkg-a", [known_meta])],
+        deploy_roots=[".augment"],
+    )
+
+    # Non-interactive: env clean, no policy carried over from a sibling
+    # test. The unconditional reset in ``finally`` protects subsequent
+    # tests if any assertion below blows up mid-chain.
+    monkeypatch.delenv(install.ALLOW_OVERWRITE_ENV, raising=False)
+    policy = install._load_conflict_policy(proj, force=False)
+    known_abs = str((proj / known_rel).resolve())
+    assert known_abs in policy.known_paths, (
+        "relative manifest path must be resolved against project_root so "
+        "writers passing absolute paths match the known-path branch"
+    )
+    assert not policy.force, "fresh load with no env should not be forced"
+
+    install._set_conflict_policy(policy)
+    try:
+        # Known path: legacy silent-skip semantics — we own it, no abort,
+        # no overwrite without --force. Proves the path-keying normalisation
+        # makes the branch reachable from the manifest → resolver chain.
+        assert (
+            install._resolve_file_conflict(known_path, force_hint=False) == "skip"
+        ), "known path must skip silently without --force"
+
+        # Foreign existing path: raise ConflictAbort with all remediation
+        # hooks (--force flag, env-var escape, doctor) surfaced in the message.
+        with pytest.raises(install.ConflictAbort) as excinfo:
+            install._resolve_file_conflict(foreign_path, force_hint=False)
+        # ConflictAbort is a SystemExit(1) subclass; the human-readable
+        # text lives on the ``message`` attribute, not ``.code``.
+        msg = excinfo.value.message
+        assert "--force" in msg, "abort message must point users at --force"
+        assert install.ALLOW_OVERWRITE_ENV in msg, (
+            "abort message must surface the env-var escape hatch"
+        )
+        assert "agent-config doctor" in msg, (
+            "abort message must point users at the doctor remediation path"
+        )
+
+        # Env-var override flips foreign → write through the same chain.
+        monkeypatch.setenv(install.ALLOW_OVERWRITE_ENV, "1")
+        install._set_conflict_policy(install._load_conflict_policy(proj, force=False))
+        assert install._resolve_file_conflict(foreign_path, force_hint=False) == "write"
+    finally:
+        install._set_conflict_policy(None)


### PR DESCRIPTION
## Context

Audit follow-up to the archived `road-to-multi-package-coexistence` roadmap (PR #121). Three gaps surfaced in the council review plus one path-normalisation bug uncovered while drafting the E2E test for the conflict-policy chain. Also drops a stale README banner that was carried in the same working-tree state.

## What

### 1. `feat(prune): add --resume-uninstall`

Focused crash-recovery flag for `agent-config prune`. Restricts the orphan sweep to tools whose manifest entry carries `status: 'uninstalling'` — i.e. uninstalls that crashed mid-flight. The full orphan-sweep behaviour stays the default. Makes the recovery promise from the roadmap discoverable via `prune --help` and gives a clean semantic for triaging half-deinstalled tools without touching the rest of the inventory.

### 2. `fix(install): normalise manifest paths`

`_load_conflict_policy` recorded `files[].path` strings as-is, but every writer passes an absolute `Path` to `_resolve_file_conflict`. Manifests with relative path entries (the portable form) never matched `policy.known_paths`, so the known-path silent-skip branch was unreachable in practice — every re-install of an existing tool fell into the foreign-file branch and demanded `--force`. Resolve relative entries against `project_root` so the match works for both formats.

### 3. `fix(install): doctor remediation hint`

The non-interactive `ConflictAbort` paths (file + JSON) now point users at `agent-config doctor` for triage in addition to the existing `--force` / `AGENT_CONFIG_ALLOW_OVERWRITE=1` escape hatches. A crashed install surfaces a discoverable next step instead of a dead end.

### 4. `test(e2e): shared JSON, sole-owner cleanup, conflict chain`

Three scenarios added to `test_e2e_multi_package_coexistence.py`:

- **Shared JSON merge** — two packages contribute keys to a shared `hooks.json`; uninstalling pkg-b leaves pkg-a's key intact and the file on disk.
- **Sole-owner cleanup** — last remaining owner uninstalls and the empty JSON file is removed instead of left as an orphan.
- **Foreign-file conflict chain** — build a real manifest, derive policy via `_load_conflict_policy`, then prove `_resolve_file_conflict` raises `ConflictAbort` with all three remediation hooks and that the env-var bypass lifts the abort through the same chain. Also asserts the known-path branch to regress the path-normalisation fix in commit 2.

### 5. `docs(readme): remove stale vX.0 breaking-change notice`

Drop the top-of-README banner so new readers see the product description first. The migration guide at `docs/migration/v1-to-v2.md` stays in place for the consumers it applies to.

## Test plan

- `pytest tests/test_cmd_prune.py tests/test_e2e_multi_package_coexistence.py tests/test_conflict_policy.py tests/test_install_*.py` — 168 passed.
- Full suite: `pytest -q` — **3078 passed, 412 skipped**.

## Files

- `scripts/_cli/cmd_prune.py` — `--resume-uninstall` flag + filter.
- `scripts/install.py` — path normalisation in `_load_conflict_policy`; doctor hint in `ConflictAbort` messages.
- `tests/test_cmd_prune.py` — 5 regression tests for the new flag.
- `tests/test_e2e_multi_package_coexistence.py` — 3 new scenarios.
- `docs/contracts/installed-tools-lockfile.md` — documents the focused recovery path.
- `README.md` — drop stale vX.0 breaking-change notice.

## Risk

Low. All changes are scoped to install / uninstall pipelines that already had test coverage. The path-normalisation fix is **strictly additive** — relative paths that previously didn't match still get their absolute form added; absolute paths in manifests keep working unchanged.