### PR TITLE
fix(install): global install source paths + lockfile namespace

### DIFF
--- a/scripts/_cli/cmd_uninstall.py
+++ b/scripts/_cli/cmd_uninstall.py
@@ -422,6 +422,7 @@ def _uninstall_project(opts: argparse.Namespace) -> int:
 
 def _uninstall_global(opts: argparse.Namespace) -> int:
     lock_path = installed_lock.lockfile_path()
+    write_path = installed_lock.lockfile_write_path()
     lock = installed_lock.read_lockfile(lock_path)
     if lock is None and not opts.force:
         print(f"❌  no global lockfile at {lock_path}", file=sys.stderr)
@@ -442,15 +443,24 @@ def _uninstall_global(opts: argparse.Namespace) -> int:
             removed_names.append(tool)
     if lock is not None and not opts.dry_run:
         remaining = [t for t in lock.get("tools", []) if t not in tools]
+        version = lock.get("agent_config_version", "")
         if remaining:
-            installed_lock.write_lockfile(remaining, version=lock.get("agent_config_version", ""))
+            installed_lock.write_lockfile(version, remaining, path=write_path)
+            # Drop the legacy file if it differs from the canonical write
+            # target so the namespace migration completes on uninstall.
+            if lock_path != write_path:
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    pass
             print(f"✅  lockfile updated ({len(tools)} entries removed, {len(remaining)} kept)")
         else:
-            try:
-                lock_path.unlink()
-                print(f"✅  lockfile deleted ({lock_path})")
-            except OSError as exc:
-                print(f"⚠️   could not delete lockfile: {exc}")
+            for target in {lock_path, write_path}:
+                try:
+                    target.unlink()
+                except OSError:
+                    pass
+            print(f"✅  lockfile deleted ({write_path})")
     return 0
 
 

--- a/scripts/_cli/cmd_update.py
+++ b/scripts/_cli/cmd_update.py
@@ -243,17 +243,18 @@ def _refresh_global_lockfile(version: str, *, out=sys.stdout) -> None:
     when ``update`` flips the pin. Atomic write goes through
     ``installed_lock.write_lockfile``.
     """
-    lock_path = installed_lock.lockfile_path()
-    existing = installed_lock.read_lockfile(path=lock_path)
+    read_path = installed_lock.lockfile_path()
+    write_path = installed_lock.lockfile_write_path()
+    existing = installed_lock.read_lockfile(path=read_path)
     if existing is None:
         return
     recorded = existing.get("agent_config_version")
     tools = list(existing.get("tools", []))
-    if recorded == version:
-        print(f"ℹ️  {lock_path} already records {version}.", file=out)
+    if recorded == version and read_path == write_path:
+        print(f"ℹ️  {write_path} already records {version}.", file=out)
         return
-    installed_lock.write_lockfile(version, tools, path=lock_path)
-    print(f"✅  Refreshed global lockfile at {lock_path}.", file=out)
+    installed_lock.write_lockfile(version, tools, path=write_path)
+    print(f"✅  Refreshed global lockfile at {write_path}.", file=out)
 
 
 def _detect_installed_version() -> str:

--- a/scripts/_lib/claude_desktop_bundler.py
+++ b/scripts/_lib/claude_desktop_bundler.py
@@ -2,7 +2,7 @@
 
 Claude Desktop has no filesystem convention for skills; the Customize →
 Skills UI accepts a ZIP per skill via the Upload button. This module
-walks ``<package_root>/.claude/skills/*`` and produces one
+walks ``<package_root>/.agent-src/skills/*`` and produces one
 ``<skill-name>.zip`` per directory into ``dest_dir``.
 
 Contract:
@@ -51,8 +51,8 @@ def _walk_skill_files(skill_dir: Path) -> list[tuple[Path, tuple[str, ...]]]:
     """Return ``[(abs_path, rel_parts), ...]`` for every file in the skill.
 
     Symlinks are followed (``os.walk(..., followlinks=True)``) so a
-    bundle from a symlinked entry under ``.claude/skills/`` contains the
-    actual target content, not a dangling symlink.
+    bundle from a symlinked entry under ``.agent-src/skills/`` contains
+    the actual target content, not a dangling symlink.
     """
     out: list[tuple[Path, tuple[str, ...]]] = []
     resolved = skill_dir.resolve()
@@ -121,7 +121,7 @@ def build_skill_bundles(
     ``curation`` optionally restricts the build to the given skill
     names; ``None`` bundles every skill folder containing ``SKILL.md``.
     """
-    skills_root = package_root / ".claude" / "skills"
+    skills_root = package_root / ".agent-src" / "skills"
     if not skills_root.is_dir():
         return []
     dest_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/_lib/installed_lock.py
+++ b/scripts/_lib/installed_lock.py
@@ -50,7 +50,7 @@ _TOOL_RE = re.compile(r"^\s*-\s*([A-Za-z0-9_\-.]+)\s*$")
 
 
 def lockfile_path(env: Optional[dict] = None) -> Path:
-    """Return the active lockfile path, honoring the env override.
+    """Return the active lockfile path for **reads**, honoring overrides.
 
     Resolution order:
 
@@ -59,9 +59,10 @@ def lockfile_path(env: Optional[dict] = None) -> Path:
     3. ``~/.config/agent-config/installed.lock``  (legacy fallback, read-only).
     4. Canonical write target under the new namespace (Step 2 fallthrough).
 
-    Writers always end up at (4) when no lockfile exists yet; readers
-    benefit from (3) so pre-2.4 installs keep working while the
-    migration shim has not yet run.
+    Readers benefit from (3) so pre-2.4 installs keep working while the
+    migration shim has not yet run. Writers must use
+    :func:`lockfile_write_path` so a stale legacy file does not anchor
+    subsequent writes to the deprecated location.
     """
     env = env if env is not None else os.environ
     override = env.get(LOCKFILE_ENV)
@@ -70,6 +71,24 @@ def lockfile_path(env: Optional[dict] = None) -> Path:
     resolved = user_global_paths.resolve_with_fallback("installed.lock", env=env)
     if resolved is not None:
         return resolved
+    return user_global_paths.write_target("installed.lock", env=env)
+
+
+def lockfile_write_path(env: Optional[dict] = None) -> Path:
+    """Return the canonical write target for the lockfile.
+
+    Unlike :func:`lockfile_path`, this never falls back to the legacy
+    ``~/.config/agent-config/`` location. Honors the
+    ``$AGENT_CONFIG_INSTALLED_LOCK`` override for tests, otherwise pins
+    to ``~/.event4u/agent-config/installed.lock``. Callers in
+    ``init``, ``update``, and ``uninstall`` use this so writes always
+    land in the new namespace regardless of whether a stale legacy
+    lockfile is still present.
+    """
+    env = env if env is not None else os.environ
+    override = env.get(LOCKFILE_ENV)
+    if override:
+        return Path(override).expanduser()
     return user_global_paths.write_target("installed.lock", env=env)
 
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -2092,36 +2092,41 @@ PROJECT_BRIDGE_MARKERS = {
 #   ``_write_claude_desktop_marker`` rather than via this map.
 #
 # Tools that follow the markdown-skills convention (anchors lifted from
-# nextlevelbuilder/ui-ux-pro-max-skill) deploy ``.claude/skills`` —
-# the universal Anthropic-shaped skill bundle — into ``<anchor>/skills/``
-# (or ``<anchor>/steering/`` for kiro). ``.claude/rules`` is also copied
+# nextlevelbuilder/ui-ux-pro-max-skill) deploy the universal Anthropic-
+# shaped skill bundle — sourced from ``.agent-src/`` (the npm-shipped
+# canonical asset tree) — into ``<anchor>/skills/`` (or
+# ``<anchor>/steering/`` for kiro). ``.agent-src/rules`` is also copied
 # where the destination is a true rules-aware tool root.
+#
+# All source paths reference ``.agent-src/<subdir>`` because that is the
+# only asset tree included in the npm tarball (see ``package.json#files``).
+# The legacy ``.augment/``, ``.claude/``, ``.cursor/`` projections only
+# exist in the development checkout — they are not shipped.
 _CLAUDE_SKILL_BUNDLE: list[tuple[str, str]] = [
-    (".claude/rules",    "rules"),
-    (".claude/skills",   "skills"),
-    (".claude/personas", "personas"),
+    (".agent-src/rules",    "rules"),
+    (".agent-src/skills",   "skills"),
+    (".agent-src/personas", "personas"),
 ]
 GLOBAL_DEPLOY_SOURCES: dict[str, list[tuple[str, str]]] = {
     "claude-code": _CLAUDE_SKILL_BUNDLE,
     "augment": [
-        (".augment/rules",     "rules"),
-        (".augment/skills",    "skills"),
-        (".augment/commands",  "commands"),
-        (".augment/contexts",  "contexts"),
-        (".augment/personas",  "personas"),
-        (".augment/templates", "templates"),
+        (".agent-src/rules",     "rules"),
+        (".agent-src/skills",    "skills"),
+        (".agent-src/commands",  "commands"),
+        (".agent-src/contexts",  "contexts"),
+        (".agent-src/personas",  "personas"),
+        (".agent-src/templates", "templates"),
     ],
     "cursor": [
-        (".cursor/rules",    "rules"),
-        (".cursor/commands", "commands"),
-        (".cursor/personas", "personas"),
+        (".agent-src/rules",    "rules"),
+        (".agent-src/commands", "commands"),
+        (".agent-src/personas", "personas"),
     ],
     "windsurf": [
-        (".windsurf/rules",     "rules"),
-        (".windsurf/workflows", "workflows"),
+        (".agent-src/rules", "rules"),
     ],
     "cline": [
-        (".clinerules", ""),
+        (".agent-src/rules", ""),
     ],
     # Markdown-skills tools — mirror the universal skill bundle into the
     # tool-specific anchor. Subpath matches the reference repo's
@@ -2142,9 +2147,9 @@ GLOBAL_DEPLOY_SOURCES: dict[str, list[tuple[str, str]]] = {
     # Kiro reads from `steering/` not `skills/` (per
     # platforms/kiro.json#folderStructure.skillPath).
     "kiro": [
-        (".claude/rules",    "rules"),
-        (".claude/skills",   "steering"),
-        (".claude/personas", "personas"),
+        (".agent-src/rules",    "rules"),
+        (".agent-src/skills",   "steering"),
+        (".agent-src/personas", "personas"),
     ],
 }
 
@@ -2988,14 +2993,15 @@ def install_global(
 
     lock_mod = _load_installed_lock_module()
     installed_version = lock_mod.current_package_version()
-    lock_path = lock_mod.lockfile_path()
-    ok, recorded = lock_mod.check_version(installed_version, path=lock_path)
+    read_path = lock_mod.lockfile_path()
+    write_path = lock_mod.lockfile_write_path()
+    ok, recorded = lock_mod.check_version(installed_version, path=read_path)
 
     if not ok and not force:
         if not QUIET:
             print()
             warn("Refusing global install: lockfile version mismatch.")
-            info(f"  Lockfile:           {lock_path}")
+            info(f"  Lockfile:           {read_path}")
             info(f"  Recorded version:   {recorded}")
             info(f"  Current package:    {installed_version}")
             info("  Fix:                run `agent-config update`")
@@ -3013,10 +3019,10 @@ def install_global(
                 continue
             print(f"      {tool_id:<15} → {anchor}")
 
-    existing = lock_mod.read_lockfile(path=lock_path) or {}
+    existing = lock_mod.read_lockfile(path=read_path) or {}
     existing_tools = list(existing.get("tools", []))
     merged_tools = sorted(set(existing_tools) | set(tools))
-    written = lock_mod.write_lockfile(installed_version, merged_tools, path=lock_path)
+    written = lock_mod.write_lockfile(installed_version, merged_tools, path=write_path)
 
     if not QUIET:
         print()

--- a/tests/test_claude_desktop_bundler.py
+++ b/tests/test_claude_desktop_bundler.py
@@ -29,8 +29,8 @@ def _make_skill(
     extras: dict[str, str] | None = None,
     junk: dict[str, str] | None = None,
 ) -> Path:
-    """Create a fake skill folder under ``<package_root>/.claude/skills/``."""
-    skill_dir = package_root / ".claude" / "skills" / name
+    """Create a fake skill folder under ``<package_root>/.agent-src/skills/``."""
+    skill_dir = package_root / ".agent-src" / "skills" / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
     for rel, content in (extras or {}).items():
@@ -125,7 +125,7 @@ def test_force_rewrites_unchanged_bundle(tmp_path: Path) -> None:
 
 def test_skill_without_skill_md_is_skipped(tmp_path: Path) -> None:
     pkg = tmp_path / "pkg"
-    not_a_skill = pkg / ".claude" / "skills" / "orphan"
+    not_a_skill = pkg / ".agent-src" / "skills" / "orphan"
     not_a_skill.mkdir(parents=True)
     (not_a_skill / "notes.md").write_text("no SKILL.md here\n", encoding="utf-8")
     dest = tmp_path / "bundles"


### PR DESCRIPTION
## Problem

Following the 2.4.0 release, `npx @event4u/agent-config init --tools=...` reports zero deployments and silently writes the lockfile to the legacy `~/.config/agent-config/` path instead of completing the namespace migration:

```
augment         → ~/.augment/ (0 files, 0 skipped)
claude-code     → ~/.claude/ (0 files, 0 skipped)
claude-desktop  → /Users/…/.event4u/agent-config/claude-desktop/bundles (0 bundles)
```

Two root causes, both regressions in the global-install path.

## Root causes

**1. Source paths point at dev-only tree.** `GLOBAL_DEPLOY_SOURCES` and `_CLAUDE_SKILL_BUNDLE` resolved from `.claude/skills`, `.augment/rules`, etc. — directories that only exist in the development repo. The shipped npm tarball consolidates everything under `.agent-src/`, so every per-tool deploy found an empty source and reported `0 files`.

**2. Lockfile writes back through legacy fallback.** `read_lockfile()` returns the legacy `~/.config/agent-config/installed.lock` when present so existing users keep working. But `install_global`, `cmd_update`, and `cmd_uninstall` then wrote back through the same path, pinning users at the legacy location forever.

## Fix

- **Source remap**: `GLOBAL_DEPLOY_SOURCES`, `_CLAUDE_SKILL_BUNDLE`, and `claude_desktop_bundler.build_skill_bundles` resolve from `.agent-src/<subdir>` (exists in dev tree *and* in the npm tarball).
- **Canonical write path**: new `installed_lock.lockfile_write_path()` returns the new-namespace target ignoring legacy fallbacks; `install_global`, `cmd_update`, `cmd_uninstall` now use it for every write.
- **Migration completion**: `cmd_uninstall` removes the legacy lockfile after a successful canonical write so the namespace migration finishes on the next state-changing call.

## Verification

- Targeted suite (install / lockfile / bundler / namespace migration): **162 passed**.
- Full Python suite: **3080 passed, 412 skipped**.
- Live smoke test against a tmp `HOME`:
  - augment → 544 files
  - claude-code → 270 files (174 skills)
  - cline → 61 files (`~/Documents/Cline/Rules/`)
  - windsurf → 61 files (`~/.codeium/windsurf/rules`)
  - lockfile written at canonical `~/.event4u/agent-config/installed.lock`

## Files

- `scripts/install.py` — `GLOBAL_DEPLOY_SOURCES`, `_CLAUDE_SKILL_BUNDLE`, switched `install_global` to `lockfile_write_path`.
- `scripts/_lib/claude_desktop_bundler.py` — source skills from `.agent-src/skills`.
- `scripts/_lib/installed_lock.py` — added `lockfile_write_path()`.
- `scripts/_cli/cmd_update.py`, `scripts/_cli/cmd_uninstall.py` — write to canonical path; uninstall also removes legacy file.
- `tests/test_claude_desktop_bundler.py` — fixture aligned with new source layout.