### PR TITLE
feat(claude-desktop): bundle commands as desktop skills

### DIFF
--- a/scripts/_lib/claude_desktop_bundler.py
+++ b/scripts/_lib/claude_desktop_bundler.py
@@ -3,20 +3,32 @@
 Claude Desktop has no filesystem convention for skills; the Customize →
 Skills UI accepts a ZIP per skill via the Upload button. This module
 walks ``<package_root>/.agent-src/skills/*`` and produces one
-``<skill-name>.zip`` per directory into ``dest_dir``.
+``<skill-name>.zip`` per directory into ``dest_dir``. It additionally
+walks ``<package_root>/.agent-src/commands/`` and produces one
+``<command-slug>.zip`` per command ``.md`` file so Claude Desktop sees
+the same surface that Claude Code exposes via the ``.claude/skills/``
+symlink wrapper layer.
 
 Contract:
 
 - Each ZIP contains ``SKILL.md`` plus every sibling file under the same
   directory (recursive). Symlinks are dereferenced so the ZIP is
   self-contained.
+- Command bundles wrap a single ``.agent-src/commands/<path>.md`` file
+  as ``SKILL.md`` inside the ZIP. Nested commands flatten to
+  ``<cluster>-<leaf>`` slugs (e.g. ``council/default.md`` →
+  ``council-default.zip``) to mirror ``compress.py``.
 - Exclusions: ``.git*``, ``__pycache__``, ``*.pyc`` — matched on the
   basename of any path component.
 - A skill folder without a ``SKILL.md`` is skipped (defensive: avoids
   shipping Claude-Code orchestrator stubs that don't follow the
   Anthropic skill schema).
+- Command files named ``AGENTS.md`` are skipped (cluster authoring docs,
+  not invocable commands).
+- A command slug that collides with an existing skill name is skipped —
+  the real skill bundle wins, matching ``compress.generate_claude_commands``.
 - Writes are atomic via tempfile → ``os.replace``.
-- Idempotent: each ZIP gets a sibling ``<skill-name>.sha256`` recording
+- Idempotent: each ZIP gets a sibling ``<slug>.sha256`` recording
   the manifest digest. If the recomputed digest matches the recorded
   one, the existing ZIP is left untouched (unless ``force=True``).
 """
@@ -141,6 +153,82 @@ def build_skill_bundles(
         digest = _manifest_digest(files)
         zip_path = dest_dir / f"{skill_name}.zip"
         digest_path = dest_dir / f"{skill_name}.sha256"
+        recorded = digest_path.read_text(encoding="utf-8").strip() if digest_path.exists() else ""
+        if not force and recorded == digest and zip_path.exists():
+            continue
+        _atomic_write_zip(zip_path, files)
+        digest_path.write_text(digest + "\n", encoding="utf-8")
+        written.append(zip_path)
+    return written
+
+
+def _command_slug(source_file: Path, commands_root: Path) -> str:
+    """Return the flat slug for a command source file.
+
+    Mirrors ``scripts/compress.py::_command_slug``: top-level commands
+    keep their stem (``commit.md`` → ``commit``); nested commands flatten
+    the relative path with ``-`` (``council/default.md`` →
+    ``council-default``).
+    """
+    rel = source_file.relative_to(commands_root)
+    return "-".join(rel.with_suffix("").parts)
+
+
+def _iter_command_files(commands_root: Path) -> Iterable[Path]:
+    """Yield every command ``.md`` file under ``commands_root`` (recursive).
+
+    Skips ``AGENTS.md`` cluster authoring docs, matching
+    ``scripts/compress.py::_iter_commands``.
+    """
+    for source_file in sorted(commands_root.rglob("*.md")):
+        if source_file.name == "AGENTS.md":
+            continue
+        yield source_file
+
+
+def build_command_bundles(
+    package_root: Path,
+    dest_dir: Path,
+    force: bool = False,
+    curation: Optional[list[str]] = None,
+) -> list[Path]:
+    """Build per-command ZIPs under ``dest_dir``.
+
+    Each ZIP contains a single ``SKILL.md`` whose bytes are the source
+    command ``.md`` file — same wrapping pattern that
+    ``compress.generate_claude_commands`` uses for Claude Code via
+    ``.claude/skills/<slug>/SKILL.md`` symlinks.
+
+    Slugs that collide with an existing skill folder under
+    ``<package_root>/.agent-src/skills/`` are skipped so the real skill
+    bundle wins.
+
+    Returns the list of ZIP paths that were (re-)written this call. ZIPs
+    skipped because their content digest matched the existing sidecar
+    are not in the returned list (but remain on disk).
+
+    ``curation`` optionally restricts the build to the given command
+    slugs; ``None`` bundles every command file.
+    """
+    commands_root = package_root / ".agent-src" / "commands"
+    if not commands_root.is_dir():
+        return []
+    skills_root = package_root / ".agent-src" / "skills"
+    skill_names: set[str] = set()
+    if skills_root.is_dir():
+        skill_names = {entry.name for entry in skills_root.iterdir() if entry.is_dir()}
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for source_file in _iter_command_files(commands_root):
+        slug = _command_slug(source_file, commands_root)
+        if slug in skill_names:
+            continue
+        if curation is not None and slug not in curation:
+            continue
+        files = [(source_file.resolve(), ("SKILL.md",))]
+        digest = _manifest_digest(files)
+        zip_path = dest_dir / f"{slug}.zip"
+        digest_path = dest_dir / f"{slug}.sha256"
         recorded = digest_path.read_text(encoding="utf-8").strip() if digest_path.exists() else ""
         if not force and recorded == digest and zip_path.exists():
             continue

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -2888,6 +2888,7 @@ def _deploy_claude_desktop(
     bundler = _load_claude_desktop_bundler_module()
     bundles_dir = _claude_desktop_bundles_dir()
     bundler.build_skill_bundles(package_root, bundles_dir, force=force)
+    bundler.build_command_bundles(package_root, bundles_dir, force=force)
     # Count total existing ZIPs (idempotent runs may not rewrite any).
     bundle_count = sum(1 for _ in bundles_dir.glob("*.zip")) if bundles_dir.is_dir() else 0
     _, _, marker_paths = _write_claude_desktop_marker(

--- a/tests/test_claude_desktop_bundler.py
+++ b/tests/test_claude_desktop_bundler.py
@@ -160,3 +160,136 @@ def test_curation_restricts_to_named_skills(tmp_path: Path) -> None:
     bundle_names = sorted(p.name for p in written)
     assert bundle_names == ["alpha.zip", "gamma.zip"]
     assert not (dest / "beta.zip").exists()
+
+
+def _make_command(
+    package_root: Path,
+    rel_path: str,
+    *,
+    body: str = "# command\n",
+) -> Path:
+    """Create a fake command file under ``<package_root>/.agent-src/commands/``."""
+    target = package_root / ".agent-src" / "commands" / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def test_command_bundle_generated_for_top_level_command(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_command(pkg, "commit.md", body="# /commit\n\nDo the commit thing.\n")
+    dest = tmp_path / "bundles"
+
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    zip_path = dest / "commit.zip"
+    assert written == [zip_path]
+    assert zip_path.exists()
+    assert (dest / "commit.sha256").exists()
+    with zipfile.ZipFile(zip_path) as zf:
+        names = sorted(zf.namelist())
+        assert names == ["SKILL.md"]
+        assert zf.read("SKILL.md").decode("utf-8") == "# /commit\n\nDo the commit thing.\n"
+
+
+def test_nested_command_flattens_slug(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_command(pkg, "council/default.md", body="# council default\n")
+    _make_command(pkg, "council/pr.md", body="# council pr\n")
+    dest = tmp_path / "bundles"
+
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    names = sorted(p.name for p in written)
+    assert names == ["council-default.zip", "council-pr.zip"]
+
+
+def test_command_skips_cluster_agents_md(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_command(pkg, "council/AGENTS.md", body="# cluster doc\n")
+    _make_command(pkg, "council/default.md", body="# default\n")
+    dest = tmp_path / "bundles"
+
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    assert [p.name for p in written] == ["council-default.zip"]
+    assert not (dest / "council-AGENTS.zip").exists()
+
+
+def test_command_skipped_when_skill_with_same_name_exists(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_skill(pkg, "compress", skill_md="# real skill\n")
+    _make_command(pkg, "compress.md", body="# command shadow\n")
+    _make_command(pkg, "research.md", body="# research\n")
+    dest = tmp_path / "bundles"
+
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    names = sorted(p.name for p in written)
+    assert names == ["research.zip"]
+    assert not (dest / "compress.zip").exists()
+
+
+def test_command_bundle_idempotent_second_call(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_command(pkg, "stable.md")
+    dest = tmp_path / "bundles"
+
+    first = claude_desktop_bundler.build_command_bundles(pkg, dest)
+    mtime_first = (dest / "stable.zip").stat().st_mtime_ns
+    second = claude_desktop_bundler.build_command_bundles(pkg, dest)
+    mtime_second = (dest / "stable.zip").stat().st_mtime_ns
+
+    assert len(first) == 1
+    assert second == []
+    assert mtime_first == mtime_second
+
+
+def test_command_force_rewrites_unchanged_bundle(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_command(pkg, "force-me.md")
+    dest = tmp_path / "bundles"
+    claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest, force=True)
+    assert written == [dest / "force-me.zip"]
+
+
+def test_command_content_change_rewrites_bundle(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    source = _make_command(pkg, "evolving.md", body="# v1\n")
+    dest = tmp_path / "bundles"
+    claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    source.write_text("# v2\n", encoding="utf-8")
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest)
+
+    assert written == [dest / "evolving.zip"]
+    with zipfile.ZipFile(dest / "evolving.zip") as zf:
+        assert zf.read("SKILL.md").decode("utf-8") == "# v2\n"
+
+
+def test_command_missing_dir_returns_empty(tmp_path: Path) -> None:
+    pkg = tmp_path / "empty-pkg"
+    pkg.mkdir()
+    dest = tmp_path / "bundles"
+
+    written = claude_desktop_bundler.build_command_bundles(pkg, dest)
+    assert written == []
+    assert not dest.exists() or not any(dest.iterdir())
+
+
+def test_command_curation_restricts_to_named_slugs(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    _make_command(pkg, "alpha.md")
+    _make_command(pkg, "beta.md")
+    _make_command(pkg, "gamma.md")
+    dest = tmp_path / "bundles"
+
+    written = claude_desktop_bundler.build_command_bundles(
+        pkg, dest, curation=["alpha", "gamma"]
+    )
+
+    names = sorted(p.name for p in written)
+    assert names == ["alpha.zip", "gamma.zip"]
+    assert not (dest / "beta.zip").exists()


### PR DESCRIPTION
## Summary

Extend the Claude Desktop bundler to wrap every `.agent-src/commands/*.md` file as a Skills-UI ZIP, mirroring how `compress.generate_claude_commands` exposes commands to Claude Code via `.claude/skills/<slug>/SKILL.md` symlinks. Closes the Desktop side of command/skill parity.

## What changed

| File | Change |
|---|---|
| `scripts/_lib/claude_desktop_bundler.py` | New `build_command_bundles()`, `_command_slug()`, `_iter_command_files()` |
| `scripts/install.py` | `_deploy_claude_desktop()` now invokes both skill and command bundlers |
| `tests/test_claude_desktop_bundler.py` | 9 new tests covering the command-bundle contract |

## Bundle behavior

- Top-level commands keep their stem: `commit.md` -> `commit.zip` with `SKILL.md` inside.
- Nested commands flatten with hyphens: `council/default.md` -> `council-default.zip`.
- `AGENTS.md` cluster authoring docs are skipped (matches `_iter_commands` in compress.py).
- Same-name collision: a real skill folder wins; the command is skipped silently.
- Idempotent via `.sha256` sidecar; `force=True` rebuilds.
- Curation list optional.

## Verification

| Check | Result |
|---|---|
| Targeted bundler tests | 17 passed |
| Install + lockfile + namespace tests | 171 passed |
| Full suite | 3118 passed, 412 skipped |
| Live smoke against this repo's .agent-src/ | 174 skill ZIPs + 102 command ZIPs = 276 total |

The 276 number matches `compress.generate_claude_commands` exactly (106 commands minus 4 same-name skill collisions = 102).

## Caveats (accepted)

Per user decision: bundle all commands regardless of `disable-model-invocation: true` or local-CLI dependencies. Commands that require `git`/`gh`/`task` will produce instructional output in Claude Desktop rather than executing — falls back to the rules layer as designed.

## Release shape

Feature, not a fix -> minor bump (`2.5.0`) after merge.
