### PR TITLE
fix(install): restrict augment to project scope to prevent char-limit overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,13 @@ npx @event4u/agent-config init --tools=cursor --global        # → ~/.cursor/
 ```
 
 Per-AI scope support varies — Claude Desktop, for example, is
-global-only (no project-local discovery on macOS), while Roo Code and
-Continue.dev are project-local. The Supported Tools table below
-documents per-AI scope. Incompatible combinations (e.g.
-`--tools=roocode --global` or `--tools=claude-desktop` without
-`--global`) are rejected with a directive error; `--tools=all`
+global-only (no project-local discovery on macOS), while Augment Code
+is project-only (`~/.augment/rules/` loads on every workspace and the
+full rule set exceeds Augment's 49,512-char workspace-guidelines
+limit — see [`ADR-007 § Amendment 2026-05-13`](docs/decisions/ADR-007-agent-discovery-scopes.md#amendment-2026-05-13--augment-downgraded-to-scopeproject-only)).
+The Supported Tools table below documents per-AI scope. Incompatible
+combinations (e.g. `--tools=augment --global` or `--tools=claude-desktop`
+without `--global`) are rejected with a directive error; `--tools=all`
 silently filters to the scope's compatible subset.
 
 ### For individual use (optional)

--- a/docs/decisions/ADR-007-agent-discovery-scopes.md
+++ b/docs/decisions/ADR-007-agent-discovery-scopes.md
@@ -290,3 +290,33 @@ Out of scope for this ADR. Sequencing target for a separate roadmap:
 - Prior latent global code: `scripts/install.py` (~280 LOC, never
   reachable from npx entry).
 - Related rule: [`non-destructive-by-default`](../../.augment/rules/non-destructive-by-default.md) — Hard Floor on overwrite of user's existing `~/.claude/CLAUDE.md`.
+
+## Amendment 2026-05-13 — Augment downgraded to scope=project-only
+
+`SCOPE_SUPPORT["augment"]` flipped from `"both"` to `"project"`; the
+`augment` entry in `GLOBAL_DEPLOY_SOURCES` is removed.
+
+**Empirical trigger.** A global install of the standard rule set
+(`~/.augment/rules/` = 9 `always` + 48 `auto` + 4 `manual` = 61 files,
+138 557 chars total) lights up Augment's workspace UI with
+"Total rules and workspace guidelines (155 149 chars) exceeds the
+limit of 49 512 characters" on the first session. The kernel-+-router
+design (`docs/contracts/kernel-membership.md`,
+`docs/contracts/rule-router.md`) assumes Augment counts only the
+description-stub for `type: auto` rules; the actual UI measurement
+counts the full body of every file under `~/.augment/rules/`.
+
+**Decision.** Reject global Augment installs at `_validate_scope()`:
+- `--tools=augment --global` → hard reject (remediation: drop --global).
+- `--tools=all --global` → silent filter; `augment` drops out.
+- `--tools=augment --project` / default → unchanged.
+
+Updated matrix row (§ Verified per-agent discovery matrix):
+
+| Agent | User-scope (global) | Project-scope | Precedence |
+|---|---|---|---|
+| Augment Code | _not supported (scope=project-only)_ | `.augment/{rules,commands,skills,…}` + `AGENTS.md` | project only |
+
+D1 (Install scope: global is the default) still holds for the rest of
+the matrix — `~/.augment/` is removed from the global-default anchor
+list. Project installs are unchanged.

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -2023,7 +2023,13 @@ SCOPE_SUPPORT = {
     "cline":          "both",
     "gemini-cli":     "both",
     "copilot":        "both",
-    "augment":        "both",
+    # `augment` is project-only: `~/.augment/rules/` loads on every project
+    # the developer opens, and Augment counts the full body of every rule
+    # file against its 49,512-char workspace-guidelines limit (not just the
+    # description stub for `type: auto` rules). A global install of the 48
+    # auto-rules deterministically exceeds the limit across every workspace.
+    # Project scope keeps `.augment/rules/` per-repo where it belongs.
+    "augment":        "project",
     "aider":          "both",
     "codex":          "both",
     # Phase 2.4: roocode / kilocode lifted to "both" — global deploys
@@ -2109,14 +2115,12 @@ _CLAUDE_SKILL_BUNDLE: list[tuple[str, str]] = [
 ]
 GLOBAL_DEPLOY_SOURCES: dict[str, list[tuple[str, str]]] = {
     "claude-code": _CLAUDE_SKILL_BUNDLE,
-    "augment": [
-        (".agent-src/rules",     "rules"),
-        (".agent-src/skills",    "skills"),
-        (".agent-src/commands",  "commands"),
-        (".agent-src/contexts",  "contexts"),
-        (".agent-src/personas",  "personas"),
-        (".agent-src/templates", "templates"),
-    ],
+    # `augment` is intentionally absent: scope=project-only per
+    # SCOPE_SUPPORT. `~/.augment/rules/` would load on every workspace
+    # and Augment counts the full body of every rule file against its
+    # 49,512-char workspace-guidelines limit — the 48 auto-rules alone
+    # exceed it. Project-scope deploy (via scripts/install.sh) keeps
+    # `.augment/` per-repo where the budget is manageable.
     "cursor": [
         (".agent-src/rules",    "rules"),
         (".agent-src/commands", "commands"),

--- a/tests/test_install_py.py
+++ b/tests/test_install_py.py
@@ -210,6 +210,15 @@ class TestValidateScope(SilentTest):
             with self.assertRaises(SystemExit):
                 install._validate_scope({"qoder"}, "project", was_all=False)
 
+    def test_augment_rejects_global(self) -> None:
+        # Augment is project-only: `~/.augment/rules/` loads on every
+        # workspace and the 48 auto-rules exceed Augment's 49,512-char
+        # workspace-guidelines limit. Explicit `--tools=augment --global`
+        # must hard-reject with a remediation hint.
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                install._validate_scope({"augment"}, "global", was_all=False)
+
     def test_all_silent_filters_global_only_under_project(self) -> None:
         result = install._validate_scope(
             {"claude-desktop", "jetbrains", "claude-code", "cursor"},
@@ -218,6 +227,17 @@ class TestValidateScope(SilentTest):
         )
         self.assertNotIn("claude-desktop", result)
         self.assertNotIn("jetbrains", result)
+        self.assertIn("claude-code", result)
+        self.assertIn("cursor", result)
+
+    def test_all_silent_filters_augment_under_global(self) -> None:
+        # `--tools=all --global` must drop `augment` silently (project-only).
+        result = install._validate_scope(
+            {"augment", "claude-code", "cursor"},
+            "global",
+            was_all=True,
+        )
+        self.assertNotIn("augment", result)
         self.assertIn("claude-code", result)
         self.assertIn("cursor", result)
 

--- a/tests/test_installed_lock.py
+++ b/tests/test_installed_lock.py
@@ -195,14 +195,21 @@ def test_install_global_deploys_claude_code_content(
     assert skills, "expected at least one skill in ~/.claude/skills/"
 
 
-def test_install_global_deploys_augment_content(
+def test_install_global_does_not_deploy_augment(
     isolated_lock: Path, tmp_path: Path
 ) -> None:
+    # ADR-007 Amendment 2026-05-13: Augment is project-only. A global
+    # install must not populate `~/.augment/rules/` (would load on every
+    # workspace and exceed Augment's 49,512-char workspace-guidelines
+    # limit). `_validate_scope` rejects `--tools=augment --global` at the
+    # CLI gate; install_global() is defensive — augment has no
+    # GLOBAL_DEPLOY_SOURCES entry, so the deploy is a no-op.
     rc = _silent_install_global(["augment"])
     assert rc == 0
     home = tmp_path / "home"
-    assert (home / ".augment" / "rules").is_dir()
-    assert list((home / ".augment" / "rules").glob("*.md"))
+    assert not (home / ".augment" / "rules").exists(), (
+        "augment is project-only; global deploy must not create ~/.augment/rules/"
+    )
 
 
 def test_install_global_writes_claude_desktop_marker(


### PR DESCRIPTION
## Why

Augment's workspace-guidelines limit is **49,512 characters** and applies to the full body of every file in `~/.augment/rules/` — not just the description stubs that `scripts/measure_augment_budget.py` assumes.

A global install populating `~/.augment/rules/` blows the budget on every workspace. Observed on a real machine after `agent-config install --global`:

| type | count | chars |
|---|---:|---:|
| `always` (kernel) | 9 | 27 465 |
| `auto` | 48 | **107 053** |
| `manual` | 4 | 4 039 |
| **TOTAL** | **61** | **138 557** |

Limit: **49 512** → **89 045 chars over budget** on every workspace.

## What

- `scripts/install.py`: `SCOPE_SUPPORT['augment'] = 'project'`; drop augment from `GLOBAL_DEPLOY_SOURCES`. `_validate_scope` now rejects `--tools=augment --global` and silently filters augment from `--tools=all` under `--global` (matches the codex/aider pattern).
- `tests/test_install_py.py`: add `test_augment_rejects_global` and `test_all_silent_filters_augment_under_global`.
- `tests/test_installed_lock.py`: flip the prior augment-deploys-globally test to assert `install_global({'augment'})` is a no-op for the user-scope tree.
- `docs/decisions/ADR-007-agent-discovery-scopes.md`: Amendment 2026-05-13 documents the char-limit trigger and the scope downgrade.
- `README.md`: clarify augment is project-only.

## Test

- `python3 -m pytest tests/ -q` → **3120 passed, 412 skipped** (no regressions; includes the two new scope tests and the flipped lockfile test).
- `task sync && task generate-tools` → counts in sync, no drift.
- Pre-existing failure unrelated to this change: `tests/test_install_orchestrator.sh::test_source_repo_guard_allows_global_install` fails on a clean `main` checkout with foreign-file pollution in `~/.claude/rules/`. Verified by `git stash` on the same branch.

## Migration

Users who previously ran `agent-config install --global --tools=augment` (or `--tools=all --global` with augment included) should:

1. Remove `~/.augment/` to clear the over-budget content.
2. Re-run the install in their **project** directory: `agent-config install --tools=augment`.

The project-scope `.augment/` payload remains unchanged.