### PR TITLE
chore(gitignore): add /agents/state/ to consumer template

### DIFF
--- a/config/gitignore-block.txt
+++ b/config/gitignore-block.txt
@@ -36,3 +36,8 @@
 /agents/council-questions/
 /agents/council-responses/
 /agents/council-sessions/
+
+# Agent config — Tier 1 hook runtime state (context-hygiene.json,
+# onboarding-gate.json). Written by SessionStart / PostToolUse hooks
+# on Augment + Claude Code; regenerated on demand, never commit.
+/agents/state/


### PR DESCRIPTION
## Why

Tier-1 hook runtime state (`context-hygiene.json`, `onboarding-gate.json`) is written by `SessionStart` / `PostToolUse` hooks on Augment + Claude Code and regenerated on demand. The package's own `.gitignore` already ignores `/agents/state/` (line 147), but the consumer template at `config/gitignore-block.txt` was missing the entry — so consumer projects would accidentally commit hook state on first run.

## What

- `config/gitignore-block.txt`: append `/agents/state/` with a short comment block explaining the origin (Tier 1 hook runtime state).

## Test

- `python3 -m pytest tests/test_sync_gitignore.py -q` → **26 passed**.
- `task sync` clean, no drift.

## Migration

Consumer projects pick up the new entry on the next `/sync-gitignore` (or installer run). Append-only — existing user-added lines inside the managed block are preserved.