### PR TITLE
release: 2.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Shared agent configuration \u2014 skills for AI coding tools (Claude Code, Augment, Cursor, Cline, Windsurf, Gemini CLI).",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "keywords": [
       "agent-config",
       "skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,14 @@ our recommendation order, not its support status.
   users" tension without removing any path that an existing user
   might rely on.
 
+## [2.6.1](https://github.com/event4u-app/agent-config/compare/2.6.0...2.6.1) (2026-05-13)
+
+### Chores
+
+* **gitignore:** add /agents/state/ to consumer template ([80449c4](https://github.com/event4u-app/agent-config/commit/80449c4fa13ca847f8af925d4b7e472658c60aef))
+
+Tests: 3530 (+0 since 2.6.0)
+
 ## [2.6.0](https://github.com/event4u-app/agent-config/compare/2.4.1...2.6.0) (2026-05-13)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@event4u/agent-config",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "Shared agent configuration \u2014 skills, rules, commands, guidelines, and templates for AI coding tools",
     "license": "MIT",
     "private": false,


### PR DESCRIPTION
Release 2.6.1.

### Chores

* **gitignore:** add /agents/state/ to consumer template ([80449c4](https://github.com/event4u-app/agent-config/commit/80449c4fa13ca847f8af925d4b7e472658c60aef))

Tests: 3530 (+0 since 2.6.0)

Created by `scripts/release.py`.