### PR TITLE
ci(publish-npm): install jsonschema for discovery manifest lint

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -49,7 +49,12 @@ jobs:
           python-version: '3.12'
 
       - name: Install Python scanner deps
-        run: pip install pyyaml
+        # jsonschema is required by scripts/lint_discovery_manifest.py to
+        # validate dist/discovery/discovery-manifest.json against
+        # docs/contracts/discovery-manifest.schema.json. Mirrors
+        # consistency.yml; missing here caused the 3.0.0 tag publish to
+        # fail on the discovery-manifest step.
+        run: pip install pyyaml jsonschema
 
       - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
         run: npm install -g npm@latest


### PR DESCRIPTION
## Why

Tag `3.0.0` pushed cleanly, but the `Publish to npm` workflow failed at the **Build discovery manifest** step:

```
error: jsonschema not installed (pip install jsonschema)
```

`scripts/lint_discovery_manifest.py` validates `dist/discovery/discovery-manifest.json` against `docs/contracts/discovery-manifest.schema.json` using the `jsonschema` library. The publish workflow only installs `pyyaml`, so the strict-lint step blows up before publish can run.

## Fix

Add `jsonschema` to the same `pip install` line. Mirrors:

- `.github/workflows/consistency.yml` (already installs jsonschema for the same script)
- Commit `3448273` — the equivalent fix for `tests.yml` (explain-trace schema validation)

## Follow-up

After merge: `gh workflow run publish-npm.yml -f tag=3.0.0` to publish `@event4u/agent-config@3.0.0` to npm via OIDC.

Failed run: https://github.com/event4u-app/agent-config/actions/runs/26209995957
