### PR TITLE
fix(lint): skip router_routes_to_missing for trust.level: core rules

### DIFF
--- a/scripts/skill_linter.py
+++ b/scripts/skill_linter.py
@@ -975,6 +975,30 @@ def extract_frontmatter(text: str) -> Optional[str]:
     return match.group(1) if match else None
 
 
+def _parse_trust_level(frontmatter: str) -> Optional[str]:
+    """Parse `trust.level:` from the nested `trust:` mapping in frontmatter.
+
+    Returns the level string (e.g. ``"core"``, ``"advisory"``) or ``None``
+    if absent. Stdlib-only — mirrors the line-walking approach of
+    ``_parse_yaml_list`` so the linter stays pyyaml-free.
+    """
+    lines = frontmatter.splitlines()
+    in_block = False
+    for line in lines:
+        if not in_block:
+            if line.startswith("trust:"):
+                rhs = line[len("trust:"):].strip()
+                if rhs == "":
+                    in_block = True
+            continue
+        if line.startswith("  level:"):
+            return line[len("  level:"):].strip().strip('"').strip("'")
+        if line.startswith("  "):
+            continue
+        break
+    return None
+
+
 def _parse_yaml_list(frontmatter: str, key: str) -> Optional[list]:
     """Parse a simple top-level YAML list `key:` from frontmatter.
 
@@ -1029,6 +1053,10 @@ def lint_router_frontmatter(rule_id: str, frontmatter: str,
     Lenient checks (info-level until Phase 4 migrations land): non-kernel
     rules without `triggers:` / `routes_to:` get an informational note,
     not an error — the existing description-matching path still works.
+
+    Trust-tier carve-out: rules with ``trust.level: core`` are exempt from
+    the ``router_routes_to_missing`` migration hint — they are authoritative
+    by design and their body legitimately lives inline.
     """
     issues: List[Issue] = []
     triggers = _parse_yaml_list(frontmatter, "triggers")
@@ -1069,9 +1097,15 @@ def lint_router_frontmatter(rule_id: str, frontmatter: str,
                     f"triggers[{idx}] key '{k}' not in allowed set ({allowed})"))
 
     if routes_to is None:
-        issues.append(Issue("info", "router_routes_to_missing",
-            "Non-kernel rule has no routes_to: — body should migrate to skill / "
-            "guideline in Phase 4"))
+        # Trust-tier carve-out: rules pinned at trust.level: core are
+        # authoritative — their body IS the behavior and may legitimately
+        # live inline without a routes_to: delegation. The Phase 4
+        # migration hint applies only to lower-trust rules.
+        trust_level = _parse_trust_level(frontmatter)
+        if trust_level != "core":
+            issues.append(Issue("info", "router_routes_to_missing",
+                "Non-kernel rule has no routes_to: — body should migrate to skill / "
+                "guideline in Phase 4"))
     else:
         repo_root = Path(__file__).resolve().parent.parent
         for idx, item in enumerate(routes_to):

--- a/tests/test_skill_linter.py
+++ b/tests/test_skill_linter.py
@@ -2612,3 +2612,67 @@ The pushed commit hash.
     )
     result = lint_file(path)
     assert any(i.code == "missing_inspect_step" for i in result.issues)
+
+
+def test_router_routes_to_missing_skipped_for_trust_core(tmp_path: Path) -> None:
+    """Rules pinned at `trust.level: core` skip the Phase 4 migration hint.
+
+    Trust-tier carve-out: a non-kernel rule that is nonetheless declared
+    authoritative (``trust.level: core``) may legitimately keep its body
+    inline without a ``routes_to:`` delegation. The linter must not emit
+    ``router_routes_to_missing`` for that shape.
+    """
+    path = write_file(
+        tmp_path,
+        ".agent-src.uncompressed/rules/trust-core-rule.md",
+        """---
+type: auto
+description: "Use when something specific happens — core-trust authoritative rule"
+triggers:
+  - keyword: "foo"
+trust:
+  level: core
+  confidence: high
+  human_review_required: false
+---
+
+# trust-core-rule
+
+```
+IRON LAW
+DO THE THING. ALWAYS.
+```
+
+Body lives inline because trust.level=core makes the rule authoritative.
+""",
+    )
+    result = lint_file(path)
+    assert not any(i.code == "router_routes_to_missing" for i in result.issues), \
+        [i.code for i in result.issues]
+
+
+def test_router_routes_to_missing_still_fires_without_trust_core(tmp_path: Path) -> None:
+    """Non-core rules still get the Phase 4 migration hint when routes_to: is absent."""
+    path = write_file(
+        tmp_path,
+        ".agent-src.uncompressed/rules/regular-auto-rule.md",
+        """---
+type: auto
+description: "Use when something specific happens — regular auto rule"
+triggers:
+  - keyword: "foo"
+trust:
+  level: advisory
+  confidence: medium
+  human_review_required: false
+---
+
+# regular-auto-rule
+
+Body that should migrate to a skill in Phase 4.
+""",
+    )
+    result = lint_file(path)
+    assert any(i.code == "router_routes_to_missing" for i in result.issues), \
+        [i.code for i in result.issues]
+


### PR DESCRIPTION
## Summary

Linter-Bug-Fix: `router_routes_to_missing` (info-level) feuerte fälschlich auf 4 Kernel-nahe Rules mit `trust.level: core`, deren Body legitim inline lebt. Trust-Tier-Carve-out im Linter sorgt jetzt dafür, dass diese Rules den Phase-4-Migration-Hint überspringen.

Teil 1 der Hybrid-Lösung aus dem Phase-5-Closeout (Option 3): Linter-False-Positives jetzt, struktureller Refactor (Iron-Law-Blocks + Command-Split) später nach Phase 6.

## Affected rules (before this PR they all triggered the info hint)

- `caveman-speak`
- `context-hygiene`
- `missing-tool-handling`
- `security-sensitive-stop`

Alle 4 Rules sind `trust.level: core` mit `confidence: high` und `install.removable: false` — Kernel-adjacent, authoritative, body-inline by design.

## Changes

- **`scripts/skill_linter.py`**
  - Neuer Helper `_parse_trust_level(frontmatter)` — stdlib-only, parst die verschachtelte `trust.level:`-Map analog zu `_parse_yaml_list`.
  - `lint_router_frontmatter`: vor dem `router_routes_to_missing`-Issue prüft jetzt `trust.level` und überspringt den Hint bei `core`.
  - Docstring aktualisiert.
- **`tests/test_skill_linter.py`** — 2 Regression-Tests:
  - `test_router_routes_to_missing_skipped_for_trust_core` — Carve-out greift.
  - `test_router_routes_to_missing_still_fires_without_trust_core` — Carve-out übersteuert nicht versehentlich `advisory`/`restricted`.

## Lint output before/after

```
core (before): 9 warnings = 4 router_routes_to_missing + 4 long_rule + 1 large_command
core  (after): 5 warnings = 4 long_rule + 1 large_command
```

Die 5 verbleibenden strukturellen Warnings sind bewusst nicht in diesem PR — sie gehören in einen fokussierten Refactor-PR nach Phase 6 (Iron-Law-Block-Einbau + Command-Split).

## Verification

- `pytest tests/test_skill_linter.py tests/test_lint_trust_coherence.py` → 111 passed.
- `task lint-pack PACK=core` → Summary: 348 pass, 5 warn, 0 fail.
- Alle anderen 14 Packs → 0 warn, 0 fail (kein Regression-Risk auf Non-Core).

## Out of scope (deferred)

Per Phase-5-Closeout-Plan Option 3:

- Iron-Law-Block-Einbau für die 4 `long_rule`-Treffer.
- Command-Split für `update-form-request-messages.md` (`large_command`).
- Beide Punkte → eigener Refactor-PR nach Phase 6.
