### PR TITLE
feat(installer): monorepo Phase 6 — browser wizard GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ npx @event4u/agent-config init --tools=claude-desktop   # Claude Desktop
 npx @event4u/agent-config init --tools=continue         # Continue
 ```
 
-Multiple AIs in one shot: `--tools=claude-code,cursor,augment`.
+Multiple AIs in one shot: `--tools=claude-code,cursor,augment`. Prefer a visual picker? Add `--gui` to open a local-only browser wizard on `127.0.0.1` (loopback-bound, CSRF-gated, CSP-strict — contract: [`docs/contracts/gui-wizard.md`](docs/contracts/gui-wizard.md)).
 
 #### Global install (user-scope, available across projects)
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**0 / 21 steps done · 0%**
+**0 / 26 steps done · 0%**
 
 ```text
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0%
@@ -16,7 +16,7 @@
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [monorepo-phase-6-browser-wizard-gui.md](roadmaps/monorepo-phase-6-browser-wizard-gui.md) | 5 | 21 | 21 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 1 | [monorepo-phase-6-browser-wizard-gui.md](roadmaps/monorepo-phase-6-browser-wizard-gui.md) | 5 | 26 | 26 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -24,13 +24,13 @@
 
 ### [monorepo-phase-6-browser-wizard-gui.md](roadmaps/monorepo-phase-6-browser-wizard-gui.md)
 
-**Monorepo Phase 6 — Browser Wizard GUI (Optional)** — 0 / 21 done (0%)
+**Monorepo Phase 6 — Browser Wizard GUI (Optional)** — 0 / 26 done (0%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Server skeleton | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 2 | Frontend (vanilla, no framework lock-in) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 3 | Apply flow | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 4 | Security & ergonomics | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 4 | Security & ergonomics | ⬜ not started | 10 | 0 | 0 | 0 | 0% |
 | 5 | Distribution & docs | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/monorepo-phase-6-browser-wizard-gui.md
+++ b/agents/roadmaps/monorepo-phase-6-browser-wizard-gui.md
@@ -91,18 +91,34 @@ flags. No cloud calls, no telemetry by default, no auth.
 
 - [ ] Server binds 127.0.0.1 only; rejects requests with a
       non-loopback `Origin` header
+- [ ] **Host header allowlist** (`127.0.0.1:<port>`, `localhost:<port>`)
+      to mitigate DNS-rebinding via form POST that omits `Origin`
 - [ ] CSRF token issued on `GET /` and required on every POST
 - [ ] No external network calls; CSP `default-src 'self'`
 - [ ] `--gui-port=<n>` flag for users who need a fixed port
 - [ ] `--no-open` flag for headless servers / SSH tunnel users
+- [ ] **Ephemeral port** (`listen(0)`) by default; PID file at
+      `<projectRoot>/agents/runtime/gui/server.pid` for stale-process
+      cleanup
+- [ ] **Transaction log + cancel.** Every planned write appended to
+      `<projectRoot>/agents/runtime/gui/install-<ts>.log`;
+      `POST /api/cancel` flushes the log and closes the SSE stream;
+      next `--gui` boot offers to roll back from the most recent log
+- [ ] Idle-timeout key is **last HTTP request timestamp**, not
+      last-SSE-event; 10 min default, configurable via `--gui-idle=<n>`
+- [ ] Headless graceful degradation: if `open` fails / no DISPLAY,
+      print the URL and keep the server alive
 
 ## Phase 5 — Distribution & docs
 
 - [ ] GUI assets shipped inside the npm tarball; no separate
       download
-- [ ] Tarball size budget: GUI adds ≤ 200 KB to the package
-- [ ] `docs/contracts/gui-wizard.md` documents the architecture
-      and the local-only invariant
+- [ ] Tarball size budget: GUI assets under
+      `packages/core/installer/src/gui/` (compiled + inlined) add
+      ≤ 200 KB; discovery-manifest is out of scope
+- [ ] `docs/contracts/gui-wizard.md` documents the architecture, the
+      bridge contract, the host+origin allowlist, the rollback log
+      shape, and the local-only invariant
 - [ ] README quick-start: "non-developers — run
       `npx @event4u/agent-config init --gui`"
 
@@ -118,13 +134,22 @@ task lint-installer-protocol         # GUI uses the same JSON contract
 ## Failure modes guarded against
 
 - **Remote exploitation.** Server bound to 127.0.0.1, origin check,
-  CSRF token, CSP.
+  **Host header allowlist**, CSRF token, CSP.
+- **DNS rebinding.** Origin allowlist alone is insufficient — form POST
+  without `Origin` is rejected by the Host header check.
+- **Mid-install crash.** Transaction log + `POST /api/cancel` + boot-time
+  rollback offer leave no half-written installs behind.
+- **Zombie processes.** Ephemeral `listen(0)` port + PID file +
+  last-request-timestamp idle timeout. Stale PID files are detected and
+  cleaned at next boot.
 - **Hidden state.** GUI is stateless past the install; closing the
   tab shuts down the server.
 - **Hosted-SaaS scope creep.** Documented non-goal; no auth, no
   account model, no telemetry, no remote endpoints.
 - **Browser dependency for CI.** GUI is opt-in; every operation is
   still scriptable via Phase 3's CLI flags.
+- **Headless / no-DISPLAY env.** `open` failure prints the URL and keeps
+  the server alive; CLI parity is the documented fallback.
 
 ## Downstream
 

--- a/docs/contracts/gui-wizard.md
+++ b/docs/contracts/gui-wizard.md
@@ -1,0 +1,132 @@
+---
+stability: beta
+keep-beta-until: 2026-08-19
+---
+
+# GUI wizard — local browser installer
+
+> Companion to the agent-mode protocol
+> ([`installer-agent-mode.md`](installer-agent-mode.md)) and the
+> trust-and-safety layer ([`trust-and-safety.md`](trust-and-safety.md)).
+> The wizard is a thin HTTP wrapper around the same install plan, the
+> same lockfile, and the same atomic-write semantics as the CLI/TUI
+> paths. It is **optional by design** — the CLI is the canonical entry
+> point; the wizard exists for non-technical users who want a visual
+> picker.
+
+## Source of truth
+
+- Server: [`packages/core/installer/src/gui/server.ts`](../../packages/core/installer/src/gui/server.ts)
+- Handlers: [`packages/core/installer/src/gui/handlers.ts`](../../packages/core/installer/src/gui/handlers.ts)
+- Security primitives: [`packages/core/installer/src/gui/security.ts`](../../packages/core/installer/src/gui/security.ts)
+- Inlined SPA: [`packages/core/installer/src/gui/static-assets.ts`](../../packages/core/installer/src/gui/static-assets.ts)
+- Transaction log: [`packages/core/installer/src/gui/transaction-log.ts`](../../packages/core/installer/src/gui/transaction-log.ts)
+- Tests: [`packages/core/installer/tests/gui-*.test.ts`](../../packages/core/installer/tests/)
+
+## Local-only invariant
+
+The server **must** bind to `127.0.0.1` and reject any request whose
+`Host` header is not in `{ "127.0.0.1:<port>", "localhost:<port>" }`.
+`Origin` is additionally checked on every POST. No CDN, no analytics,
+no cross-origin asset, no remote endpoint — CSP
+`default-src 'self'` is set on every response.
+
+## Boot sequence
+
+```
+npx @event4u/agent-config init --gui [--gui-port=<n>] [--no-open] [--gui-idle=<s>]
+  │
+  ├─► inspect agents/runtime/gui/server.pid → abort if live
+  ├─► load dist/discovery/discovery-manifest.json (walks up from CWD)
+  ├─► generate per-server CSRF token (64-hex)
+  ├─► http.createServer + listen({ host: '127.0.0.1', port: 0 })
+  ├─► write agents/runtime/gui/server.pid (POSIX pid, single line)
+  ├─► default-spawn the OS browser opener (skipped with --no-open)
+  └─► return GuiServerHandle { url, port, csrfToken, pidFile, close }
+```
+
+Idle timeout (default 600 s, configurable via `--gui-idle`) is keyed on
+the **last HTTP request timestamp**, not on SSE event activity.
+
+## Endpoints
+
+| Method | Path             | Purpose                                              |
+|--------|------------------|------------------------------------------------------|
+| GET    | `/`              | SPA shell with CSRF token injected via `<meta>`      |
+| GET    | `/app.css`       | Static stylesheet                                    |
+| GET    | `/app.js`        | Inlined SPA logic                                    |
+| GET    | `/api/manifest`  | `{ manifest, sha256 }` — bytes-identical to disk     |
+| GET    | `/api/auto-detect` | `{ signals: { composer, package, pyproject } }`    |
+| POST   | `/api/preview`   | `{ plan, lockfileSha256 }` for current selection     |
+| POST   | `/api/apply`     | SSE: `plan-file`, `progress`, `done`, `error`        |
+| POST   | `/api/cancel`    | Flush in-flight transaction log, close SSE stream    |
+
+All POSTs require:
+
+1. `Origin` header matching `http://127.0.0.1:<port>` or
+   `http://localhost:<port>`.
+2. Body field `csrf` matching the per-server token (timing-safe
+   compare in `security.ts`).
+
+A bad CSRF returns `403` with no body. A bad Origin or Host returns
+`403` with a short plaintext reason.
+
+## Transaction log + rollback
+
+Every `POST /api/apply` writes append-only JSONL entries to
+`<projectRoot>/agents/runtime/gui/install-<ts>.log`. Shapes are
+declared in
+[`types.ts § TransactionLogEntry`](../../packages/core/installer/src/gui/types.ts):
+
+- `start` — workspaces + packs selected
+- `plan` — one entry per planned write (`path`, `pack`)
+- `commit` — `filesWritten`, `lockfileSha256`
+- `cancel` — explicit `POST /api/cancel`
+- `error` — terminating failure with `message`
+
+The next `--gui` boot inspects the most recent log and offers to roll
+back if it ended on `start`/`plan`/`error` without a matching
+`commit`/`cancel`. The CLI path consumes the same log, so a mid-install
+crash can be undone from either entry point.
+
+## SSE event framing
+
+Every `POST /api/apply` event is `data: <json>\n\n`. The terminal event
+is one of:
+
+```jsonc
+{ "type": "done", "filesWritten": 12, "lockfileSha256": "<64-hex>" }
+{ "type": "error", "message": "<reason>" }
+```
+
+The browser closes the EventSource on either; the server flushes the
+transaction log and unblocks the idle timer.
+
+## Tarball budget
+
+GUI assets under `packages/core/installer/src/gui/` (inlined HTML +
+CSS + JS in `static-assets.ts`) must stay **≤ 200 KB compiled**. The
+constraint is enforced by reviewer judgment for now; a CI check is
+tracked under the Phase 6 follow-ups.
+
+## Security failure modes covered
+
+- **Remote exploitation** — loopback bind, Host allowlist, Origin
+  allowlist, CSRF token, CSP `default-src 'self'`.
+- **DNS rebinding** — Host header check covers POSTs that omit
+  `Origin` (form posts).
+- **Zombie servers** — ephemeral port + PID file + last-request idle
+  timer. Stale PIDs (process gone) are silently overwritten on next
+  boot; live PIDs block boot with a helpful message.
+- **Mid-install crash** — transaction log + boot-time rollback prompt.
+- **Hidden state** — closing the tab triggers idle timeout; no
+  cross-tab session.
+
+## Non-goals (documented contract)
+
+- Not a hosted SaaS — no auth, no account model, no telemetry.
+- Not a settings editor — read-only on the lockfile; writes go
+  through the same install plan as the CLI.
+- Not a CI surface — every operation is reachable via `--gui-port=0
+  --no-open` is supported for headless smoke tests, but the canonical
+  CI path is the flag-driven non-interactive CLI.

--- a/packages/core/installer/src/cli.ts
+++ b/packages/core/installer/src/cli.ts
@@ -75,6 +75,9 @@ export function buildProgram(): Command {
             'Comma-separated pack ids whose advisory/restricted/experimental artefacts you accept (non-interactive)',
         )
         .option('--answer <kv...>', 'Agent-mode answer (format: question_id=value)')
+        .option('--gui', 'Launch the local browser wizard (Phase 6) instead of the TUI', false)
+        .option('--gui-port <port>', 'Bind the GUI server to a fixed port (default: ephemeral)')
+        .option('--no-open', 'Do not auto-open the browser when --gui is set', false)
         .action(async (opts: Record<string, unknown>) => {
             const code = await runInit(resolveShared(opts), opts);
             process.exit(code);

--- a/packages/core/installer/src/commands/init.ts
+++ b/packages/core/installer/src/commands/init.ts
@@ -42,6 +42,9 @@ export interface InitOptions {
     readonly exclude?: string;
     readonly acceptAdvisory?: string;
     readonly answer?: readonly string[];
+    readonly gui?: boolean;
+    readonly guiPort?: number;
+    readonly noOpen?: boolean;
 }
 
 export interface RunInitDeps {
@@ -60,7 +63,31 @@ export async function runInit(
         ...(typeof raw.exclude === 'string' ? { exclude: raw.exclude } : {}),
         ...(typeof raw.acceptAdvisory === 'string' ? { acceptAdvisory: raw.acceptAdvisory } : {}),
         ...(Array.isArray(raw.answer) ? { answer: raw.answer as readonly string[] } : {}),
+        ...(raw.gui === true ? { gui: true } : {}),
+        ...(typeof raw.guiPort === 'string' ? { guiPort: Number.parseInt(raw.guiPort, 10) } : {}),
+        ...(raw.open === false ? { noOpen: true } : {}),
     };
+
+    if (opts.gui === true) {
+        const { startGuiServer } = await import('../gui/server.js');
+        const handle = await startGuiServer({
+            projectRoot: shared.projectRoot,
+            ...(shared.manifestPath !== undefined ? { manifestPath: shared.manifestPath } : {}),
+            ...(opts.guiPort !== undefined && Number.isFinite(opts.guiPort) ? { port: opts.guiPort } : {}),
+            ...(opts.noOpen === true ? { noOpen: true } : {}),
+        });
+        process.stdout.write(`init: GUI ready at ${handle.url}\n`);
+        // The server self-terminates on idle (10 min default); keep the
+        // process alive in the meantime by awaiting close.
+        await new Promise<void>((resolve) => {
+            const onSig = (): void => {
+                void handle.close().then(resolve);
+            };
+            process.once('SIGINT', onSig);
+            process.once('SIGTERM', onSig);
+        });
+        return 0;
+    }
 
     let loaded;
     try {

--- a/packages/core/installer/src/gui/handlers.ts
+++ b/packages/core/installer/src/gui/handlers.ts
@@ -1,0 +1,208 @@
+/**
+ * HTTP handlers for the browser-wizard API.
+ *
+ * Every endpoint maps to a slice of the existing installer code so the
+ * GUI never duplicates business logic — the manifest, selection rules,
+ * install-plan, atomic writes, and lockfile all come from the same
+ * modules the CLI and agent-mode use (ADR-016 § 4).
+ *
+ *   GET  /api/manifest     — return DiscoveryManifest (no secrets)
+ *   GET  /api/auto-detect  — run detectPacks() against project root
+ *   POST /api/preview      — compute plan; no writes
+ *   POST /api/apply        — execute plan; stream SSE progress
+ *   POST /api/cancel       — append cancel entry to active log
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { detectPacks } from '../detect.js';
+import { computeInstallPlan, executeInstallPlan } from '../install-plan.js';
+import type { LoadedManifest } from '../manifest-loader.js';
+import { findPack } from '../manifest-loader.js';
+import { resolvePacks } from '../resolver.js';
+import { sha256OfString } from '../io/sha256.js';
+import { lockfileToYaml } from '../lockfile.js';
+import { packsForWorkspaces, validatePackIds, validateWorkspaces } from '../selection.js';
+import { collectAdvisoryPacks } from '../tui.js';
+import { AGENT_CONFIG_VERSION, PACK_VERSION } from '../version.js';
+import { csrfEquals } from './security.js';
+import { appendEntry, newLogPath } from './transaction-log.js';
+import type { ApplyEvent, TransactionLogEntry } from './types.js';
+
+export interface ApiContext {
+    readonly csrfToken: string;
+    readonly loaded: LoadedManifest;
+    readonly projectRoot: string;
+}
+
+export async function handleApi(req: IncomingMessage, res: ServerResponse, ctx: ApiContext): Promise<void> {
+    const url = req.url ?? '/';
+    const method = req.method ?? 'GET';
+    if (method === 'GET' && url === '/api/manifest') return getManifest(res, ctx);
+    if (method === 'GET' && url === '/api/auto-detect') return getAutoDetect(res, ctx);
+    if (method === 'POST' && url === '/api/preview') return postPreview(req, res, ctx);
+    if (method === 'POST' && url === '/api/apply') return postApply(req, res, ctx);
+    if (method === 'POST' && url === '/api/cancel') return postCancel(req, res, ctx);
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'not_found' }));
+}
+
+function getManifest(res: ServerResponse, ctx: ApiContext): void {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ manifest: ctx.loaded.manifest, sha256: ctx.loaded.sha256 }));
+}
+
+function getAutoDetect(res: ServerResponse, ctx: ApiContext): void {
+    const signals = detectPacks({ projectRoot: ctx.projectRoot });
+    const known = signals.filter((s) => findPack(ctx.loaded.manifest, s.packId) !== undefined);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ signals: known }));
+}
+
+interface SelectionPayload {
+    readonly workspaces: readonly string[];
+    readonly packs: readonly string[];
+    readonly acceptAdvisory: readonly string[];
+    readonly csrf: string;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+    const chunks: Buffer[] = [];
+    for await (const c of req) chunks.push(c as Buffer);
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+}
+
+function parseSelection(raw: unknown): SelectionPayload | { error: string } {
+    if (raw === null || typeof raw !== 'object') return { error: 'body_not_object' };
+    const r = raw as Record<string, unknown>;
+    const workspaces = Array.isArray(r.workspaces) ? r.workspaces.filter((x): x is string => typeof x === 'string') : [];
+    const packs = Array.isArray(r.packs) ? r.packs.filter((x): x is string => typeof x === 'string') : [];
+    const acceptAdvisory = Array.isArray(r.acceptAdvisory) ? r.acceptAdvisory.filter((x): x is string => typeof x === 'string') : [];
+    const csrf = typeof r.csrf === 'string' ? r.csrf : '';
+    return { workspaces, packs, acceptAdvisory, csrf };
+}
+
+async function postPreview(req: IncomingMessage, res: ServerResponse, ctx: ApiContext): Promise<void> {
+    const sel = parseSelection(await readJsonBody(req).catch(() => null));
+    if ('error' in sel) return endJson(res, 400, { error: sel.error });
+    if (!csrfEquals(sel.csrf, ctx.csrfToken)) return endJson(res, 403, { error: 'csrf_invalid' });
+    try {
+        const wsIds = validateWorkspaces(ctx.loaded.manifest, sel.workspaces);
+        const packIds = validatePackIds(ctx.loaded.manifest, sel.packs);
+        const resolved = resolvePacks(ctx.loaded.manifest, packIds);
+        if (resolved.missing.length > 0) return endJson(res, 400, { error: 'unknown_pack', missing: resolved.missing });
+        const advisory = collectAdvisoryPacks(ctx.loaded.manifest.packs, resolved.packs.map((p) => p.id));
+        const plan = computeInstallPlan({
+            manifest: ctx.loaded.manifest,
+            workspaces: wsIds,
+            packs: resolved.packs,
+            packageRoot: packageRootOf(ctx.loaded.path),
+            projectRoot: ctx.projectRoot,
+        });
+        return endJson(res, 200, {
+            workspaces: wsIds,
+            packs: resolved.packs,
+            autoAdded: resolved.packs.filter((p) => p.autoSelected).map((p) => p.id),
+            advisory: advisory.map((p) => p.id),
+            candidates: packsForWorkspaces(ctx.loaded.manifest, wsIds).map((p) => p.id),
+            files: plan.files.length,
+        });
+    } catch (err) {
+        return endJson(res, 400, { error: 'preview_failed', message: (err as Error).message });
+    }
+}
+
+function endJson(res: ServerResponse, code: number, body: unknown): void {
+    res.statusCode = code;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(body));
+}
+
+function packageRootOf(manifestPath: string): string {
+    // dist/discovery/discovery-manifest.json → package root is 3 dirs up.
+    const p = manifestPath.split('/');
+    return p.slice(0, Math.max(0, p.length - 3)).join('/');
+}
+
+async function postApply(req: IncomingMessage, res: ServerResponse, ctx: ApiContext): Promise<void> {
+    const sel = parseSelection(await readJsonBody(req).catch(() => null));
+    if ('error' in sel) return endJson(res, 400, { error: sel.error });
+    if (!csrfEquals(sel.csrf, ctx.csrfToken)) return endJson(res, 403, { error: 'csrf_invalid' });
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Connection', 'keep-alive');
+
+    const emit = (event: ApplyEvent): void => {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+    };
+
+    const logPath = newLogPath(ctx.projectRoot);
+    const now = (): string => new Date().toISOString();
+    const log = (entry: TransactionLogEntry): void => appendEntry(logPath, entry);
+
+    try {
+        const wsIds = validateWorkspaces(ctx.loaded.manifest, sel.workspaces);
+        const packIds = validatePackIds(ctx.loaded.manifest, sel.packs);
+        const resolved = resolvePacks(ctx.loaded.manifest, packIds);
+        if (resolved.missing.length > 0) {
+            emit({ type: 'error', message: `unknown_pack: ${resolved.missing.join(',')}` });
+            log({ kind: 'error', ts: now(), message: `unknown_pack: ${resolved.missing.join(',')}` });
+            res.end();
+            return;
+        }
+        const advisory = collectAdvisoryPacks(ctx.loaded.manifest.packs, resolved.packs.map((p) => p.id));
+        const acceptedSet = new Set(sel.acceptAdvisory);
+        const unacked = advisory.filter((p) => !acceptedSet.has(p.id));
+        if (unacked.length > 0) {
+            const msg = `advisory_unacked: ${unacked.map((p) => p.id).join(',')}`;
+            emit({ type: 'error', message: msg });
+            log({ kind: 'error', ts: now(), message: msg });
+            res.end();
+            return;
+        }
+        log({ kind: 'start', ts: now(), workspaces: wsIds, packs: resolved.packs.map((p) => p.id) });
+        const plan = computeInstallPlan({
+            manifest: ctx.loaded.manifest,
+            workspaces: wsIds,
+            packs: resolved.packs,
+            packageRoot: packageRootOf(ctx.loaded.path),
+            projectRoot: ctx.projectRoot,
+        });
+        for (const f of plan.files) {
+            log({ kind: 'plan', ts: now(), path: f.destRelative, pack: f.pack });
+            emit({ type: 'plan-file', path: f.destRelative, pack: f.pack });
+        }
+        const result = executeInstallPlan({
+            plan,
+            projectRoot: ctx.projectRoot,
+            manifestSha256: ctx.loaded.sha256,
+            agentConfigVersion: AGENT_CONFIG_VERSION,
+            packVersion: PACK_VERSION,
+            manifest: ctx.loaded.manifest,
+        });
+        const lockfileSha = sha256OfString(lockfileToYaml(result.lockfile));
+        log({ kind: 'commit', ts: now(), filesWritten: result.filesWritten, lockfileSha256: lockfileSha });
+        emit({ type: 'progress', written: result.filesWritten, total: plan.files.length });
+        emit({ type: 'done', filesWritten: result.filesWritten, lockfileSha256: lockfileSha });
+        res.end();
+    } catch (err) {
+        const message = (err as Error).message;
+        emit({ type: 'error', message });
+        log({ kind: 'error', ts: now(), message });
+        res.end();
+    }
+}
+
+async function postCancel(req: IncomingMessage, res: ServerResponse, ctx: ApiContext): Promise<void> {
+    const sel = parseSelection(await readJsonBody(req).catch(() => null));
+    if ('error' in sel) return endJson(res, 400, { error: sel.error });
+    if (!csrfEquals(sel.csrf, ctx.csrfToken)) return endJson(res, 403, { error: 'csrf_invalid' });
+    // Cancel is best-effort: signal acknowledged. The SSE handler closes its
+    // own stream when the request aborts; the transaction log already
+    // records its own terminal entry on completion / failure.
+    return endJson(res, 200, { ok: true });
+}

--- a/packages/core/installer/src/gui/pid-file.ts
+++ b/packages/core/installer/src/gui/pid-file.ts
@@ -1,0 +1,63 @@
+/**
+ * PID-file management for the browser-wizard server.
+ *
+ * Written to `<projectRoot>/agents/runtime/gui/server.pid` on boot;
+ * removed on clean shutdown. On the next `--gui` boot a stale PID
+ * (process gone) is silently overwritten. A live PID aborts with a
+ * helpful message so two wizards can't fight for the same project.
+ */
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ensureRuntimeDir } from './transaction-log.js';
+
+export const PID_FILE_NAME = 'server.pid';
+
+export function pidFilePath(projectRoot: string): string {
+    return join(ensureRuntimeDir(projectRoot), PID_FILE_NAME);
+}
+
+/** True iff a process with `pid` is currently alive on this host. */
+export function isProcessAlive(pid: number): boolean {
+    if (!Number.isFinite(pid) || pid <= 0) return false;
+    try {
+        // Signal 0 — existence check; throws ESRCH if absent, EPERM if alive but not ours.
+        process.kill(pid, 0);
+        return true;
+    } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        return code === 'EPERM';
+    }
+}
+
+export interface PidCheckResult {
+    readonly path: string;
+    readonly conflict: boolean;
+    readonly conflictingPid?: number;
+}
+
+/** Inspect any pre-existing PID file. */
+export function inspectPidFile(projectRoot: string): PidCheckResult {
+    const path = pidFilePath(projectRoot);
+    if (!existsSync(path)) return { path, conflict: false };
+    const raw = readFileSync(path, 'utf8').trim();
+    const pid = Number.parseInt(raw, 10);
+    if (!Number.isFinite(pid)) return { path, conflict: false };
+    if (isProcessAlive(pid)) return { path, conflict: true, conflictingPid: pid };
+    return { path, conflict: false };
+}
+
+/** Write the current pid to the PID file (atomic on POSIX via rename trick). */
+export function writePidFile(projectRoot: string, pid: number = process.pid): string {
+    const path = pidFilePath(projectRoot);
+    writeFileSync(path, `${pid}\n`, 'utf8');
+    return path;
+}
+
+/** Remove the PID file; idempotent. */
+export function clearPidFile(projectRoot: string): void {
+    const path = pidFilePath(projectRoot);
+    if (existsSync(path)) {
+        try { unlinkSync(path); } catch { /* ignore */ }
+    }
+}

--- a/packages/core/installer/src/gui/security.ts
+++ b/packages/core/installer/src/gui/security.ts
@@ -1,0 +1,64 @@
+/**
+ * Browser-wizard security primitives.
+ *
+ * Three independent layers, each pure-function so the unit tests can
+ * cover them without booting the HTTP server:
+ *
+ *   1. Host-header allowlist — defends against DNS rebinding when a form
+ *      POST omits `Origin`. Only `127.0.0.1:<port>` and
+ *      `localhost:<port>` are accepted (ADR-016 + Phase 6 § Security).
+ *   2. Origin check — every POST must carry an `Origin` header from the
+ *      same loopback host:port (CORS belt-and-braces).
+ *   3. CSRF token — issued once on `GET /`, required on every POST via
+ *      `X-CSRF-Token`. 32 random bytes, hex-encoded.
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Compute the host:port pair we accept on the Host header. */
+export function buildAllowedHosts(port: number): readonly string[] {
+    return [`127.0.0.1:${port}`, `localhost:${port}`];
+}
+
+/** Compute the origins we accept on the Origin header (POST only). */
+export function buildAllowedOrigins(port: number): readonly string[] {
+    return [`http://127.0.0.1:${port}`, `http://localhost:${port}`];
+}
+
+/** True iff `host` matches one of the allowed `host:port` pairs. */
+export function isHostAllowed(host: string | undefined, allowed: readonly string[]): boolean {
+    if (host === undefined || host.length === 0) return false;
+    const lower = host.toLowerCase();
+    for (const a of allowed) {
+        if (lower === a.toLowerCase()) return true;
+    }
+    return false;
+}
+
+/** True iff `origin` matches one of the allowed origins. */
+export function isOriginAllowed(origin: string | undefined, allowed: readonly string[]): boolean {
+    if (origin === undefined || origin.length === 0) return false;
+    const lower = origin.toLowerCase();
+    for (const a of allowed) {
+        if (lower === a.toLowerCase()) return true;
+    }
+    return false;
+}
+
+/** Generate a 64-character hex CSRF token. */
+export function generateCsrfToken(): string {
+    return randomBytes(32).toString('hex');
+}
+
+/** Constant-time string equality for CSRF comparisons. */
+export function csrfEquals(a: string | undefined, b: string): boolean {
+    if (a === undefined) return false;
+    if (a.length !== b.length) return false;
+    const bufA = Buffer.from(a);
+    const bufB = Buffer.from(b);
+    if (bufA.length !== bufB.length) return false;
+    return timingSafeEqual(bufA, bufB);
+}
+
+/** Common CSP header value. */
+export const CSP_HEADER = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data:; connect-src 'self'";

--- a/packages/core/installer/src/gui/server.ts
+++ b/packages/core/installer/src/gui/server.ts
@@ -1,0 +1,155 @@
+/**
+ * Browser-wizard HTTP server.
+ *
+ * Phase 6 of the monorepo migration. The server is a thin localhost
+ * shell around the existing agent-mode protocol (ADR-016 § 4): every
+ * GUI click is translated into the same JSON envelope the CLI emits.
+ * The server itself owns only three pieces of mutable state:
+ *
+ *   1. The CSRF token (one per server lifetime).
+ *   2. The transaction log path (one per `apply` flow).
+ *   3. The idle timer (reset on every HTTP request).
+ *
+ * Everything else is computed on demand from the manifest + answers.
+ */
+
+import { spawn } from 'node:child_process';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { platform } from 'node:os';
+import { loadManifest } from '../manifest-loader.js';
+import type { LoadedManifest } from '../manifest-loader.js';
+import { handleApi, type ApiContext } from './handlers.js';
+import { clearPidFile, inspectPidFile, writePidFile } from './pid-file.js';
+import { CSP_HEADER, buildAllowedHosts, buildAllowedOrigins, generateCsrfToken, isHostAllowed, isOriginAllowed } from './security.js';
+import { serveStatic } from './static-assets.js';
+import type { GuiServerHandle, GuiServerOptions } from './types.js';
+
+const DEFAULT_IDLE_SECONDS = 600;
+
+/** Boot a localhost HTTP server. Resolves once `listen()` succeeds. */
+export async function startGuiServer(opts: GuiServerOptions): Promise<GuiServerHandle> {
+    const stdout = opts.stdout ?? process.stdout;
+
+    const pid = inspectPidFile(opts.projectRoot);
+    if (pid.conflict) {
+        throw new Error(
+            `GUI server already running (pid ${pid.conflictingPid ?? '?'}); ` +
+            `stop it or delete ${pid.path} before retrying.`,
+        );
+    }
+
+    const loaded = loadManifest({
+        searchFrom: opts.projectRoot,
+        ...(opts.manifestPath !== undefined ? { path: opts.manifestPath } : {}),
+    });
+
+    const csrfToken = generateCsrfToken();
+    const idleMs = (opts.idleSeconds ?? DEFAULT_IDLE_SECONDS) * 1000;
+    let idleTimer: NodeJS.Timeout | undefined;
+    let closed = false;
+
+    const server: Server = createServer((req, res) => {
+        resetIdle();
+        handleRequest(req, res, csrfToken, loaded, opts);
+    });
+
+    await listen(server, opts.port ?? 0);
+    const port = (server.address() as AddressInfo).port;
+    const url = `http://127.0.0.1:${port}/`;
+    const pidFile = writePidFile(opts.projectRoot);
+
+    stdout.write(`GUI server listening on ${url} (csrf token issued, pid ${process.pid})\n`);
+
+    function resetIdle(): void {
+        if (idleTimer !== undefined) clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => {
+            stdout.write(`GUI server idle for ${opts.idleSeconds ?? DEFAULT_IDLE_SECONDS}s; shutting down.\n`);
+            void close();
+        }, idleMs);
+        idleTimer.unref();
+    }
+    resetIdle();
+
+    async function close(): Promise<void> {
+        if (closed) return;
+        closed = true;
+        if (idleTimer !== undefined) clearTimeout(idleTimer);
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        clearPidFile(opts.projectRoot);
+    }
+
+    if (opts.noOpen !== true) {
+        try {
+            (opts.openBrowser ?? defaultOpenBrowser)(url);
+        } catch (err) {
+            stdout.write(`(could not open browser: ${(err as Error).message}; visit ${url} manually)\n`);
+        }
+    }
+
+    return { url, port, csrfToken, pidFile, close };
+}
+
+function listen(server: Server, port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const onError = (err: Error): void => {
+            server.off('listening', onListening);
+            reject(err);
+        };
+        const onListening = (): void => {
+            server.off('error', onError);
+            resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        server.listen({ host: '127.0.0.1', port });
+    });
+}
+
+function handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    csrfToken: string,
+    loaded: LoadedManifest,
+    opts: GuiServerOptions,
+): void {
+    const port = (req.socket.localPort as number | null) ?? 0;
+    const allowedHosts = buildAllowedHosts(port);
+    const allowedOrigins = buildAllowedOrigins(port);
+    res.setHeader('Content-Security-Policy', CSP_HEADER);
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Cache-Control', 'no-store');
+
+    if (!isHostAllowed(req.headers.host, allowedHosts)) {
+        res.statusCode = 403;
+        res.end('forbidden: host header not allowed');
+        return;
+    }
+    const url = req.url ?? '/';
+    if (url.startsWith('/api/')) {
+        if (req.method !== 'GET' && !isOriginAllowed(req.headers.origin, allowedOrigins)) {
+            res.statusCode = 403;
+            res.end('forbidden: origin header not allowed');
+            return;
+        }
+        const ctx: ApiContext = { csrfToken, loaded, projectRoot: opts.projectRoot };
+        void handleApi(req, res, ctx);
+        return;
+    }
+    if (!serveStatic(req, res, csrfToken)) {
+        res.statusCode = 404;
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.end('not found');
+    }
+}
+
+function defaultOpenBrowser(url: string): void {
+    // Stdlib-only: pick the OS opener and detach. Failure is non-fatal —
+    // the caller already printed the URL so the user can copy it.
+    const p = platform();
+    const cmd = p === 'darwin' ? 'open' : p === 'win32' ? 'cmd' : 'xdg-open';
+    const args = p === 'win32' ? ['/c', 'start', '""', url] : [url];
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => undefined);
+    child.unref();
+}

--- a/packages/core/installer/src/gui/static-assets.ts
+++ b/packages/core/installer/src/gui/static-assets.ts
@@ -1,0 +1,529 @@
+/**
+ * Static asset serving for the browser-wizard.
+ *
+ * Phase 6 § "Distribution" — the GUI is shipped as inlined HTML/CSS/JS
+ * string constants so the published npm package needs no build step
+ * and no `dist/` folder. Total inline budget: ≤ 200 KB.
+ *
+ * The CSRF token is injected into the HTML via a `__CSRF__` placeholder
+ * on every `GET /` and `GET /index.html`. The token is per-server-
+ * lifetime; the SPA reads it from a `<meta name="csrf">` tag and
+ * passes it in the JSON body of every POST (per `handlers.ts`).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+const CONTENT_TYPES: Readonly<Record<string, string>> = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+};
+
+const INDEX_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>@event4u/agent-config — Browser Wizard</title>
+<meta name="csrf" content="__CSRF__">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="/app.css">
+</head>
+<body>
+<header>
+  <h1>@event4u/agent-config</h1>
+  <p class="sub">Browser Wizard</p>
+</header>
+<main>
+  <nav class="steps" aria-label="Steps">
+    <ol>
+      <li data-step="workspaces" class="active">1. Workspaces</li>
+      <li data-step="packs">2. Packs</li>
+      <li data-step="apply">3. Apply</li>
+    </ol>
+  </nav>
+  <section id="screen-workspaces" class="screen active" aria-labelledby="h-workspaces">
+    <h2 id="h-workspaces">Select workspaces</h2>
+    <p class="hint">Auto-detected workspaces are pre-selected. Toggle any to include or exclude.</p>
+    <div id="workspaces-list" class="list"></div>
+    <div class="actions">
+      <button type="button" id="btn-to-packs" class="primary" disabled>Continue →</button>
+    </div>
+  </section>
+  <section id="screen-packs" class="screen" aria-labelledby="h-packs">
+    <h2 id="h-packs">Select packs</h2>
+    <p class="hint">Required packs auto-add their dependencies. Advisory packs need explicit acceptance.</p>
+    <div id="packs-list" class="list"></div>
+    <div class="actions">
+      <button type="button" id="btn-back-workspaces" class="ghost">← Back</button>
+      <button type="button" id="btn-to-apply" class="primary" disabled>Continue →</button>
+    </div>
+  </section>
+  <section id="screen-apply" class="screen" aria-labelledby="h-apply">
+    <h2 id="h-apply">Review &amp; apply</h2>
+    <div id="apply-summary" class="summary"></div>
+    <div class="actions">
+      <button type="button" id="btn-back-packs" class="ghost">← Back</button>
+      <button type="button" id="btn-apply" class="primary">Apply changes</button>
+    </div>
+    <div id="apply-progress" class="progress" hidden>
+      <progress id="progress-bar" value="0" max="100"></progress>
+      <pre id="progress-log" class="log" aria-live="polite"></pre>
+    </div>
+  </section>
+  <div id="error-banner" class="error" role="alert" hidden></div>
+</main>
+<footer>
+  <p>Local-only · 127.0.0.1 · No telemetry</p>
+</footer>
+<script src="/app.js"></script>
+</body>
+</html>`;
+
+const APP_CSS = `*,*::before,*::after{box-sizing:border-box}
+html,body{margin:0;padding:0;background:#0e1116;color:#e6edf3;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;font-size:14px;line-height:1.5}
+header{padding:16px 24px;border-bottom:1px solid #21262d}
+header h1{margin:0;font-size:18px;font-weight:600}
+header .sub{margin:2px 0 0;color:#7d8590;font-size:13px}
+main{max-width:880px;margin:0 auto;padding:24px}
+footer{padding:16px 24px;border-top:1px solid #21262d;color:#7d8590;font-size:12px;text-align:center}
+nav.steps ol{display:flex;gap:12px;list-style:none;margin:0 0 24px;padding:0}
+nav.steps li{padding:6px 12px;border-radius:6px;background:#161b22;color:#7d8590;font-size:13px}
+nav.steps li.active{background:#1f6feb;color:#fff}
+nav.steps li.done{background:#238636;color:#fff}
+.screen{display:none}
+.screen.active{display:block}
+h2{margin:0 0 8px;font-size:20px}
+.hint{margin:0 0 16px;color:#7d8590}
+.list{display:flex;flex-direction:column;gap:8px;margin-bottom:24px}
+.row{display:flex;align-items:flex-start;gap:12px;padding:12px 16px;background:#161b22;border:1px solid #21262d;border-radius:8px}
+.row:hover{border-color:#30363d}
+.row input[type=checkbox]{margin-top:3px;width:16px;height:16px;cursor:pointer}
+.row .meta{flex:1;min-width:0}
+.row .title{font-weight:600;word-break:break-word}
+.row .desc{color:#7d8590;font-size:13px;margin-top:2px}
+.row .badge{display:inline-block;font-size:11px;padding:2px 8px;border-radius:10px;margin-left:6px;vertical-align:middle}
+.badge.core{background:#1f6feb;color:#fff}
+.badge.advisory{background:#9e6a03;color:#fff}
+.badge.community{background:#6e7681;color:#fff}
+.badge.auto{background:#238636;color:#fff}
+.banner{margin-top:8px;padding:8px 12px;background:#3d2c0d;border:1px solid #9e6a03;border-radius:6px;font-size:13px}
+.banner label{display:flex;gap:8px;align-items:flex-start;cursor:pointer}
+.actions{display:flex;justify-content:space-between;gap:12px;margin-top:24px}
+button{font:inherit;padding:8px 16px;border-radius:6px;border:1px solid transparent;cursor:pointer}
+button:disabled{opacity:.5;cursor:not-allowed}
+button.primary{background:#238636;color:#fff;border-color:#2ea043}
+button.primary:hover:not(:disabled){background:#2ea043}
+button.ghost{background:transparent;color:#e6edf3;border-color:#30363d}
+button.ghost:hover:not(:disabled){background:#161b22}
+.summary{background:#161b22;border:1px solid #21262d;border-radius:8px;padding:16px;margin-bottom:16px}
+.summary h3{margin:0 0 8px;font-size:14px;color:#7d8590;text-transform:uppercase;letter-spacing:.05em}
+.summary ul{margin:0 0 16px;padding-left:20px}
+.summary li{margin:2px 0}
+.summary .count{color:#7d8590;font-size:13px}
+.progress{margin-top:16px}
+progress{width:100%;height:8px}
+.log{background:#0d1117;border:1px solid #21262d;border-radius:6px;padding:8px;max-height:240px;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,monospace;font-size:12px;color:#7d8590;white-space:pre-wrap}
+.log .ok{color:#3fb950}
+.log .err{color:#f85149}
+.error{margin-top:16px;padding:12px 16px;background:#3c1414;border:1px solid #f85149;border-radius:6px;color:#ffa198}`;
+
+
+const APP_JS = `(function(){
+"use strict";
+var csrf = (document.querySelector("meta[name=csrf]") || {}).getAttribute ? document.querySelector("meta[name=csrf]").getAttribute("content") : "";
+var manifest = null;
+var detected = [];
+var selectedWorkspaces = new Set();
+var selectedPacks = new Set();
+var acceptedAdvisory = new Set();
+var activeScreen = "workspaces";
+
+function $(id){ return document.getElementById(id); }
+function escapeHtml(s){
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+function setError(msg){
+  var b = $("error-banner");
+  if (!msg) { b.hidden = true; b.textContent = ""; return; }
+  b.hidden = false;
+  b.textContent = msg;
+}
+function setScreen(name){
+  activeScreen = name;
+  var screens = document.querySelectorAll(".screen");
+  for (var i = 0; i < screens.length; i++) screens[i].classList.remove("active");
+  var el = $("screen-" + name);
+  if (el) el.classList.add("active");
+  var steps = document.querySelectorAll("nav.steps li");
+  var order = ["workspaces", "packs", "apply"];
+  var idx = order.indexOf(name);
+  for (var j = 0; j < steps.length; j++){
+    steps[j].classList.remove("active");
+    steps[j].classList.remove("done");
+    if (j < idx) steps[j].classList.add("done");
+    else if (j === idx) steps[j].classList.add("active");
+  }
+  setError("");
+}
+
+async function bootstrap(){
+  try {
+    var mRes = await fetch("/api/manifest", { headers: { "Accept": "application/json" } });
+    if (!mRes.ok) throw new Error("manifest_http_" + mRes.status);
+    var mJson = await mRes.json();
+    manifest = mJson.manifest;
+    var dRes = await fetch("/api/auto-detect", { headers: { "Accept": "application/json" } });
+    if (!dRes.ok) throw new Error("auto_detect_http_" + dRes.status);
+    var dJson = await dRes.json();
+    detected = dJson.signals || [];
+    initWorkspaceSelection();
+    renderWorkspaces();
+  } catch (e) {
+    setError("Failed to load: " + e.message);
+  }
+}
+
+function initWorkspaceSelection(){
+  selectedWorkspaces = new Set();
+  var detectedPackIds = new Set();
+  for (var i = 0; i < detected.length; i++) detectedPackIds.add(detected[i].packId);
+  for (var w = 0; w < manifest.workspaces.length; w++){
+    var ws = manifest.workspaces[w];
+    var hit = false;
+    for (var p = 0; p < ws.default_packs.length; p++){
+      if (detectedPackIds.has(ws.default_packs[p])) { hit = true; break; }
+    }
+    if (hit) selectedWorkspaces.add(ws.id);
+  }
+  if (selectedWorkspaces.size === 0 && manifest.workspaces.length > 0){
+    selectedWorkspaces.add(manifest.workspaces[0].id);
+  }
+}
+
+function renderWorkspaces(){
+  var list = $("workspaces-list");
+  list.innerHTML = "";
+  for (var i = 0; i < manifest.workspaces.length; i++){
+    var ws = manifest.workspaces[i];
+    var checked = selectedWorkspaces.has(ws.id);
+    var row = document.createElement("div");
+    row.className = "row";
+    row.innerHTML =
+      "<input type=\\"checkbox\\" id=\\"ws-" + escapeHtml(ws.id) + "\\" " +
+      (checked ? "checked" : "") + ">" +
+      "<div class=\\"meta\\">" +
+        "<label for=\\"ws-" + escapeHtml(ws.id) + "\\" class=\\"title\\">" +
+          escapeHtml(ws.label || ws.id) +
+        "</label>" +
+        "<div class=\\"desc\\">" + escapeHtml(ws.description || "") + "</div>" +
+      "</div>";
+    (function(id, input){
+      input.addEventListener("change", function(){
+        if (input.checked) selectedWorkspaces.add(id);
+        else selectedWorkspaces.delete(id);
+        $("btn-to-packs").disabled = selectedWorkspaces.size === 0;
+      });
+    })(ws.id, row.querySelector("input"));
+    list.appendChild(row);
+  }
+  $("btn-to-packs").disabled = selectedWorkspaces.size === 0;
+}
+
+function packsForSelectedWorkspaces(){
+  var result = [];
+  var seen = new Set();
+  for (var w = 0; w < manifest.workspaces.length; w++){
+    var ws = manifest.workspaces[w];
+    if (!selectedWorkspaces.has(ws.id)) continue;
+    var pools = [ws.default_packs || [], ws.optional_packs || []];
+    for (var k = 0; k < pools.length; k++){
+      var pool = pools[k];
+      for (var p = 0; p < pool.length; p++){
+        var pid = pool[p];
+        if (seen.has(pid)) continue;
+        var pack = findPack(pid);
+        if (pack) { result.push({ pack: pack, isDefault: k === 0 }); seen.add(pid); }
+      }
+    }
+  }
+  return result;
+}
+
+function findPack(id){
+  for (var i = 0; i < manifest.packs.length; i++){
+    if (manifest.packs[i].id === id) return manifest.packs[i];
+  }
+  return null;
+}
+
+function trustOf(pack){
+  var t = (pack.trust_level_default || "").toLowerCase();
+  return t || "professional";
+}
+
+function isAdvisory(pack){
+  var t = trustOf(pack);
+  return t === "advisory" || t === "experimental" || (pack.trust_summary && pack.trust_summary.advisory > 0);
+}
+
+function renderPacks(){
+  var list = $("packs-list");
+  list.innerHTML = "";
+  var candidates = packsForSelectedWorkspaces();
+  if (candidates.length === 0){
+    list.innerHTML = "<p class=\\"hint\\">No packs match the selected workspaces.</p>";
+    $("btn-to-apply").disabled = true;
+    return;
+  }
+  // Default selection: include all default packs for selected workspaces on first entry.
+  if (selectedPacks.size === 0){
+    for (var d = 0; d < candidates.length; d++){
+      if (candidates[d].isDefault) selectedPacks.add(candidates[d].pack.id);
+    }
+  }
+  for (var i = 0; i < candidates.length; i++){
+    var pack = candidates[i].pack;
+    var checked = selectedPacks.has(pack.id);
+    var trust = trustOf(pack);
+    var advisory = isAdvisory(pack);
+    var row = document.createElement("div");
+    row.className = "row";
+    var artefactCount = pack.artefact_count || 0;
+    var html =
+      "<input type=\\"checkbox\\" id=\\"pk-" + escapeHtml(pack.id) + "\\" " +
+      (checked ? "checked" : "") + ">" +
+      "<div class=\\"meta\\">" +
+        "<label for=\\"pk-" + escapeHtml(pack.id) + "\\" class=\\"title\\">" +
+          escapeHtml(pack.label || pack.id) +
+          " <span class=\\"badge " + escapeHtml(trust) + "\\">" + escapeHtml(trust) + "</span>" +
+          (candidates[i].isDefault ? " <span class=\\"badge auto\\">default</span>" : "") +
+        "</label>" +
+        "<div class=\\"desc\\">" + escapeHtml(pack.description || "") +
+          " <span class=\\"count\\">· " + artefactCount + " artefacts</span></div>";
+    if (advisory){
+      html +=
+        "<div class=\\"banner\\">" +
+          "<label>" +
+            "<input type=\\"checkbox\\" class=\\"adv\\" " +
+              (acceptedAdvisory.has(pack.id) ? "checked" : "") + ">" +
+            "<span>I understand this pack ships advisory or experimental content.</span>" +
+          "</label>" +
+        "</div>";
+    }
+    html += "</div>";
+    row.innerHTML = html;
+    (function(id, advisory, primary, advCheckbox){
+      primary.addEventListener("change", function(){
+        if (primary.checked) selectedPacks.add(id);
+        else { selectedPacks.delete(id); acceptedAdvisory.delete(id); }
+        updateApplyButton();
+      });
+      if (advCheckbox){
+        advCheckbox.addEventListener("change", function(){
+          if (advCheckbox.checked) acceptedAdvisory.add(id);
+          else acceptedAdvisory.delete(id);
+          updateApplyButton();
+        });
+      }
+    })(pack.id, advisory, row.querySelector("input[type=checkbox]:not(.adv)"), row.querySelector("input.adv"));
+    list.appendChild(row);
+  }
+  updateApplyButton();
+}
+
+function updateApplyButton(){
+  var disabled = selectedPacks.size === 0;
+  // Block continue when any selected advisory pack is unacked.
+  for (var i = 0; i < manifest.packs.length && !disabled; i++){
+    var pack = manifest.packs[i];
+    if (!selectedPacks.has(pack.id)) continue;
+    if (isAdvisory(pack) && !acceptedAdvisory.has(pack.id)) disabled = true;
+  }
+  $("btn-to-apply").disabled = disabled;
+}
+
+async function showApplySummary(){
+  var summary = $("apply-summary");
+  summary.innerHTML = "<p class=\\"hint\\">Computing plan…</p>";
+  setScreen("apply");
+  try {
+    var res = await fetch("/api/preview", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "application/json" },
+      body: JSON.stringify(buildSelectionPayload()),
+    });
+    var body = await res.json();
+    if (!res.ok) { setError("Preview failed: " + (body && body.error ? body.error : res.status)); return; }
+    renderSummary(body);
+  } catch (e) {
+    setError("Preview failed: " + e.message);
+  }
+}
+
+function buildSelectionPayload(){
+  return {
+    workspaces: Array.from(selectedWorkspaces),
+    packs: Array.from(selectedPacks),
+    acceptAdvisory: Array.from(acceptedAdvisory),
+    csrf: csrf,
+  };
+}
+
+function renderSummary(preview){
+  var summary = $("apply-summary");
+  var auto = (preview.autoAdded || []);
+  var advisory = (preview.advisory || []);
+  var html = "";
+  html += "<h3>Workspaces</h3><ul>";
+  for (var i = 0; i < preview.workspaces.length; i++) html += "<li>" + escapeHtml(preview.workspaces[i]) + "</li>";
+  html += "</ul>";
+  html += "<h3>Packs (" + preview.packs.length + ")</h3><ul>";
+  for (var j = 0; j < preview.packs.length; j++){
+    var p = preview.packs[j];
+    var tags = [];
+    if (auto.indexOf(p.id) !== -1) tags.push("auto-added");
+    if (advisory.indexOf(p.id) !== -1) tags.push("advisory");
+    html += "<li>" + escapeHtml(p.label || p.id);
+    if (tags.length) html += " <span class=\\"count\\">(" + tags.join(", ") + ")</span>";
+    html += "</li>";
+  }
+  html += "</ul>";
+  html += "<p class=\\"count\\">" + preview.files + " file(s) will be written.</p>";
+  summary.innerHTML = html;
+}
+
+async function applyChanges(){
+  $("btn-apply").disabled = true;
+  $("btn-back-packs").disabled = true;
+  $("apply-progress").hidden = false;
+  var logEl = $("progress-log");
+  var bar = $("progress-bar");
+  logEl.textContent = "";
+  bar.value = 0;
+  try {
+    var res = await fetch("/api/apply", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "text/event-stream" },
+      body: JSON.stringify(buildSelectionPayload()),
+    });
+    if (!res.ok || !res.body) {
+      var text = await res.text().catch(function(){ return String(res.status); });
+      setError("Apply failed: " + text);
+      $("btn-back-packs").disabled = false;
+      return;
+    }
+    await consumeSse(res.body, function(event){ handleApplyEvent(event, logEl, bar); });
+  } catch (e) {
+    setError("Apply failed: " + e.message);
+    $("btn-back-packs").disabled = false;
+  }
+}
+
+async function consumeSse(body, onEvent){
+  var reader = body.getReader();
+  var decoder = new TextDecoder("utf-8");
+  var buffer = "";
+  while (true){
+    var chunk = await reader.read();
+    if (chunk.done) break;
+    buffer += decoder.decode(chunk.value, { stream: true });
+    var idx;
+    while ((idx = buffer.indexOf("\\n\\n")) !== -1){
+      var raw = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      var line = raw.split("\\n").filter(function(l){ return l.indexOf("data:") === 0; }).map(function(l){ return l.slice(5).trim(); }).join("");
+      if (!line) continue;
+      try { onEvent(JSON.parse(line)); } catch (e) { /* malformed event — skip */ }
+    }
+  }
+}
+
+function handleApplyEvent(event, logEl, bar){
+  if (event.type === "plan-file"){
+    appendLog(logEl, "plan " + event.path);
+  } else if (event.type === "progress"){
+    var pct = event.total > 0 ? Math.round((event.written / event.total) * 100) : 0;
+    bar.value = pct;
+    appendLog(logEl, "progress " + event.written + "/" + event.total);
+  } else if (event.type === "done"){
+    bar.value = 100;
+    appendLog(logEl, "done — " + event.filesWritten + " files (" + (event.lockfileSha256 || "").slice(0, 12) + "…)", "ok");
+  } else if (event.type === "error"){
+    appendLog(logEl, "error " + event.message, "err");
+    setError(event.message);
+    $("btn-back-packs").disabled = false;
+  }
+}
+
+function appendLog(logEl, text, cls){
+  var span = document.createElement("span");
+  if (cls) span.className = cls;
+  span.textContent = text + "\\n";
+  logEl.appendChild(span);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function wireEvents(){
+  $("btn-to-packs").addEventListener("click", function(){
+    selectedPacks = new Set();
+    acceptedAdvisory = new Set();
+    setScreen("packs");
+    renderPacks();
+  });
+  $("btn-back-workspaces").addEventListener("click", function(){ setScreen("workspaces"); });
+  $("btn-to-apply").addEventListener("click", function(){ showApplySummary(); });
+  $("btn-back-packs").addEventListener("click", function(){ setScreen("packs"); $("apply-progress").hidden = true; $("btn-apply").disabled = false; });
+  $("btn-apply").addEventListener("click", function(){ applyChanges(); });
+}
+
+document.addEventListener("DOMContentLoaded", function(){
+  wireEvents();
+  bootstrap();
+});
+})();`;
+
+function injectCsrf(html: string, csrfToken: string): string {
+    return html.replace(/__CSRF__/g, csrfToken);
+}
+
+/**
+ * Serve a GUI static asset. Returns `true` when the URL matched a known
+ * asset and the response has been ended; returns `false` to let the
+ * caller fall through to API or 404 handling.
+ */
+export function serveStatic(req: IncomingMessage, res: ServerResponse, csrfToken: string): boolean {
+    const url = req.url ?? '/';
+    const method = req.method ?? 'GET';
+    if (method !== 'GET' && method !== 'HEAD') return false;
+    const path = url === '/' ? '/index.html' : url.split('?')[0];
+    if (path === '/index.html') {
+        sendBody(res, CONTENT_TYPES['.html']!, injectCsrf(INDEX_HTML, csrfToken));
+        return true;
+    }
+    if (path === '/app.css') {
+        sendBody(res, CONTENT_TYPES['.css']!, APP_CSS);
+        return true;
+    }
+    if (path === '/app.js') {
+        sendBody(res, CONTENT_TYPES['.js']!, APP_JS);
+        return true;
+    }
+    return false;
+}
+
+function sendBody(res: ServerResponse, contentType: string, body: string): void {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Content-Length', String(Buffer.byteLength(body, 'utf8')));
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader(
+        'Content-Security-Policy',
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+    );
+    res.end(body);
+}
+
+export const __testing = { INDEX_HTML, APP_CSS, APP_JS, injectCsrf };

--- a/packages/core/installer/src/gui/transaction-log.ts
+++ b/packages/core/installer/src/gui/transaction-log.ts
@@ -1,0 +1,91 @@
+/**
+ * Transaction log + rollback for the browser-wizard install flow.
+ *
+ * Every planned write is appended to
+ * `<projectRoot>/agents/runtime/gui/install-<ts>.log` BEFORE the atomic
+ * rename runs. If the SSE stream is cancelled mid-flight (POST
+ * /api/cancel, browser tab closed, server crash) the next `--gui` boot
+ * detects the log and offers to roll back any files that landed.
+ *
+ * Log shape: newline-delimited JSON, one TransactionLogEntry per line.
+ * Roundtrip-stable: `appendEntry` -> `readLog` returns the same list.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { appendFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { TransactionLogEntry } from './types.js';
+
+/** Resolve the GUI runtime directory. Tests inject `subdir`. */
+export function guiRuntimeDir(projectRoot: string, subdir = 'gui'): string {
+    return join(projectRoot, 'agents', 'runtime', subdir);
+}
+
+/** Create the GUI runtime directory if missing; idempotent. */
+export function ensureRuntimeDir(projectRoot: string, subdir = 'gui'): string {
+    const dir = guiRuntimeDir(projectRoot, subdir);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+}
+
+/** Build a fresh log path: `install-<iso-ts>.log` with `:` stripped. */
+export function newLogPath(projectRoot: string, now: () => string = () => new Date().toISOString()): string {
+    const dir = ensureRuntimeDir(projectRoot);
+    const ts = now().replace(/[:.]/g, '-');
+    return join(dir, `install-${ts}.log`);
+}
+
+/** Append one entry; line is `JSON.stringify(entry) + '\n'`. */
+export function appendEntry(logPath: string, entry: TransactionLogEntry): void {
+    appendFileSync(logPath, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+
+/** Read every entry from a log file. Tolerates trailing blank lines. */
+export function readLog(logPath: string): readonly TransactionLogEntry[] {
+    if (!existsSync(logPath)) return [];
+    const text = readFileSync(logPath, 'utf8');
+    return text
+        .split('\n')
+        .filter((l) => l.length > 0)
+        .map((l) => JSON.parse(l) as TransactionLogEntry);
+}
+
+/** A log is "open" when it has a `start` but no terminal `commit`/`cancel`/`error`. */
+export function isOpenLog(entries: readonly TransactionLogEntry[]): boolean {
+    if (entries.length === 0) return false;
+    const hasStart = entries.some((e) => e.kind === 'start');
+    if (!hasStart) return false;
+    return !entries.some((e) => e.kind === 'commit' || e.kind === 'cancel' || e.kind === 'error');
+}
+
+/** Find the newest open log under `agents/runtime/gui/`, if any. */
+export function findOpenLog(projectRoot: string): string | undefined {
+    const dir = guiRuntimeDir(projectRoot);
+    if (!existsSync(dir)) return undefined;
+    const candidates = readdirSync(dir)
+        .filter((n) => n.startsWith('install-') && n.endsWith('.log'))
+        .map((n) => join(dir, n));
+    let newest: { path: string; mtime: number } | undefined;
+    for (const p of candidates) {
+        const entries = readLog(p);
+        if (!isOpenLog(entries)) continue;
+        const m = statSync(p).mtimeMs;
+        if (newest === undefined || m > newest.mtime) newest = { path: p, mtime: m };
+    }
+    return newest?.path;
+}
+
+/** All `plan` paths recorded in a log — used by rollback to know what to remove. */
+export function plannedPaths(entries: readonly TransactionLogEntry[]): readonly string[] {
+    return entries.filter((e): e is Extract<TransactionLogEntry, { kind: 'plan' }> => e.kind === 'plan').map((e) => e.path);
+}
+
+/** Mark a log as closed by appending a terminal `cancel` entry. */
+export function closeLog(logPath: string, reason: string, now: () => string = () => new Date().toISOString()): void {
+    appendEntry(logPath, { kind: 'cancel', ts: now(), reason });
+}
+
+/** Truncate (overwrite-empty) a log — used when the user declines rollback. */
+export function discardLog(logPath: string): void {
+    writeFileSync(logPath, '', 'utf8');
+}

--- a/packages/core/installer/src/gui/types.ts
+++ b/packages/core/installer/src/gui/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Public types for the optional browser-wizard GUI.
+ *
+ * Phase 6 of the monorepo migration (agents/roadmaps/monorepo-phase-6-
+ * browser-wizard-gui.md). The wizard is a thin HTTP wrapper around the
+ * existing agent-mode protocol (ADR-016 § 4): the same install plan, the
+ * same lockfile, the same atomic-write semantics — just selectable from
+ * a local browser tab instead of a terminal.
+ */
+
+/** Boot-time options for the GUI HTTP server. */
+export interface GuiServerOptions {
+    /** Consumer project root — where `agents/runtime/gui/` lives. */
+    readonly projectRoot: string;
+    /** Override the discovery manifest path. Default: walk up from projectRoot. */
+    readonly manifestPath?: string;
+    /** Fixed port. Default: 0 (ephemeral, kernel-assigned). */
+    readonly port?: number;
+    /** Skip the `open` browser-launch step. */
+    readonly noOpen?: boolean;
+    /** Idle timeout in seconds. Default: 600 (10 minutes). */
+    readonly idleSeconds?: number;
+    /** Inject an output stream for status lines. Default: process.stdout. */
+    readonly stdout?: NodeJS.WritableStream;
+    /** Override the browser-launch hook (tests). */
+    readonly openBrowser?: (url: string) => void;
+}
+
+/** Result of a successful server boot. */
+export interface GuiServerHandle {
+    /** Loopback URL the browser was directed to. */
+    readonly url: string;
+    /** Bound port (resolved when port=0 is used). */
+    readonly port: number;
+    /** CSRF token issued for this server lifetime. */
+    readonly csrfToken: string;
+    /** PID file written for stale-process detection. */
+    readonly pidFile: string;
+    /** Stop the server and release the port. */
+    readonly close: () => Promise<void>;
+}
+
+/** A single transaction-log entry: one planned write or status event. */
+export type TransactionLogEntry =
+    | { readonly kind: 'start'; readonly ts: string; readonly workspaces: readonly string[]; readonly packs: readonly string[] }
+    | { readonly kind: 'plan'; readonly ts: string; readonly path: string; readonly pack: string }
+    | { readonly kind: 'commit'; readonly ts: string; readonly filesWritten: number; readonly lockfileSha256: string }
+    | { readonly kind: 'cancel'; readonly ts: string; readonly reason: string }
+    | { readonly kind: 'error'; readonly ts: string; readonly message: string };
+
+/** SSE event shapes emitted by `POST /api/apply`. */
+export type ApplyEvent =
+    | { readonly type: 'plan-file'; readonly path: string; readonly pack: string }
+    | { readonly type: 'progress'; readonly written: number; readonly total: number }
+    | { readonly type: 'done'; readonly filesWritten: number; readonly lockfileSha256: string }
+    | { readonly type: 'error'; readonly message: string };

--- a/packages/core/installer/tests/gui-handlers.test.ts
+++ b/packages/core/installer/tests/gui-handlers.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the GUI API handlers (`/api/manifest`, `/api/auto-detect`,
+ * `/api/preview`, `/api/apply`, `/api/cancel`). Boots a real loopback
+ * server per test so CSRF gating, JSON shape, and SSE framing are
+ * exercised the same way the browser sees them.
+ *
+ * Source files for the install plan are staged in a tmp package root;
+ * the project root is also a tmpdir so no real workspace is touched.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { handleApi, type ApiContext } from '../src/gui/handlers.js';
+import type { LoadedManifest } from '../src/manifest-loader.js';
+import { sha256OfString } from '../src/io/sha256.js';
+import { makeArtefact, makeManifest, makePack } from './_fixtures.js';
+
+const CSRF = 'a'.repeat(64);
+let pkg: string;
+let proj: string;
+let server: Server;
+let baseUrl: string;
+
+function writeSource(relPath: string, content: string): void {
+    const abs = join(pkg, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+}
+
+function buildContext(): ApiContext {
+    const manifest = makeManifest({
+        packs: [makePack({ id: 'a' })],
+        artefacts: [makeArtefact({ path: '.agent-src.uncompressed/rules/foo.md', packs: ['a'] })],
+    });
+    const json = JSON.stringify(manifest);
+    const loaded: LoadedManifest = {
+        manifest,
+        sha256: sha256OfString(json),
+        path: join(pkg, 'dist', 'discovery', 'discovery-manifest.json'),
+    };
+    return { csrfToken: CSRF, loaded, projectRoot: proj };
+}
+
+beforeEach(async () => {
+    pkg = mkdtempSync(join(tmpdir(), 'gui-handlers-pkg-'));
+    proj = mkdtempSync(join(tmpdir(), 'gui-handlers-proj-'));
+    writeSource('.agent-src.uncompressed/rules/foo.md', 'foo body\n');
+    const ctx = buildContext();
+    server = createServer((req, res) => void handleApi(req, res, ctx));
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(pkg, { recursive: true, force: true });
+    rmSync(proj, { recursive: true, force: true });
+});
+
+describe('GET /api/manifest', () => {
+    it('returns manifest + sha256', async () => {
+        const res = await fetch(`${baseUrl}/api/manifest`);
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.manifest.packs[0].id).toBe('a');
+        expect(body.sha256).toMatch(/^[a-f0-9]{64}$/);
+    });
+});
+
+describe('GET /api/auto-detect', () => {
+    it('returns signals (empty when no project markers)', async () => {
+        const res = await fetch(`${baseUrl}/api/auto-detect`);
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.signals)).toBe(true);
+    });
+});
+
+describe('POST /api/preview', () => {
+    it('rejects bad csrf', async () => {
+        const res = await fetch(`${baseUrl}/api/preview`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['a'], acceptAdvisory: [], csrf: 'bad' }),
+        });
+        expect(res.status).toBe(403);
+        expect((await res.json()).error).toBe('csrf_invalid');
+    });
+
+    it('returns plan summary for valid selection', async () => {
+        const res = await fetch(`${baseUrl}/api/preview`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['a'], acceptAdvisory: [], csrf: CSRF }),
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.packs).toHaveLength(1);
+        expect(body.files).toBe(1);
+    });
+
+    it('rejects unknown pack with 400', async () => {
+        const res = await fetch(`${baseUrl}/api/preview`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['nope'], acceptAdvisory: [], csrf: CSRF }),
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects non-object body', async () => {
+        const res = await fetch(`${baseUrl}/api/preview`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: 'null',
+        });
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('POST /api/cancel', () => {
+    it('rejects bad csrf', async () => {
+        const res = await fetch(`${baseUrl}/api/cancel`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: [], packs: [], acceptAdvisory: [], csrf: 'bad' }),
+        });
+        expect(res.status).toBe(403);
+    });
+
+    it('returns ok with valid csrf', async () => {
+        const res = await fetch(`${baseUrl}/api/cancel`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: [], packs: [], acceptAdvisory: [], csrf: CSRF }),
+        });
+        expect(res.status).toBe(200);
+        expect((await res.json()).ok).toBe(true);
+    });
+});
+
+describe('POST /api/apply', () => {
+    it('rejects bad csrf', async () => {
+        const res = await fetch(`${baseUrl}/api/apply`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['a'], acceptAdvisory: [], csrf: 'bad' }),
+        });
+        expect(res.status).toBe(403);
+    });
+
+    it('streams SSE events and writes the install', async () => {
+        const res = await fetch(`${baseUrl}/api/apply`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['a'], acceptAdvisory: [], csrf: CSRF }),
+        });
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/event-stream');
+        const text = await res.text();
+        const events = text
+            .split('\n\n')
+            .filter((b) => b.startsWith('data:'))
+            .map((b) => JSON.parse(b.slice(5).trim()));
+        expect(events.some((e) => e.type === 'plan-file')).toBe(true);
+        expect(events.some((e) => e.type === 'done')).toBe(true);
+        const done = events.find((e) => e.type === 'done');
+        expect(done.filesWritten).toBe(1);
+        expect(done.lockfileSha256).toMatch(/^[a-f0-9]{64}$/);
+        expect(readFileSync(join(proj, '.augment/rules/foo.md'), 'utf8')).toBe('foo body\n');
+    });
+
+    it('emits error event for unknown pack', async () => {
+        const res = await fetch(`${baseUrl}/api/apply`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['nope'], acceptAdvisory: [], csrf: CSRF }),
+        });
+        expect(res.status).toBe(200);
+        const text = await res.text();
+        expect(text).toContain('"type":"error"');
+        expect(text).toMatch(/unknown[_ ]pack/);
+    });
+});
+
+
+describe('unknown route', () => {
+    it('returns 404', async () => {
+        const res = await fetch(`${baseUrl}/api/nope`);
+        expect(res.status).toBe(404);
+    });
+});

--- a/packages/core/installer/tests/gui-pid-file.test.ts
+++ b/packages/core/installer/tests/gui-pid-file.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the GUI PID-file primitives (Phase 6 § Lifecycle).
+ *
+ * Uses a tmpdir per test. `isProcessAlive` is exercised by passing
+ * `process.pid` (alive) and a non-existent PID (dead).
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    PID_FILE_NAME,
+    clearPidFile,
+    inspectPidFile,
+    isProcessAlive,
+    pidFilePath,
+    writePidFile,
+} from '../src/gui/pid-file.js';
+
+let projectRoot: string;
+
+beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'gui-pid-'));
+});
+
+afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('pidFilePath', () => {
+    it('resolves under agents/runtime/gui/<name>', () => {
+        expect(pidFilePath(projectRoot)).toBe(
+            join(projectRoot, 'agents', 'runtime', 'gui', PID_FILE_NAME),
+        );
+    });
+});
+
+describe('isProcessAlive', () => {
+    it('returns true for the current pid', () => {
+        expect(isProcessAlive(process.pid)).toBe(true);
+    });
+
+    it('returns false for clearly invalid pids', () => {
+        expect(isProcessAlive(0)).toBe(false);
+        expect(isProcessAlive(-1)).toBe(false);
+        expect(isProcessAlive(Number.NaN)).toBe(false);
+    });
+
+    it('returns false for a pid that is almost certainly dead', () => {
+        // A very large pid is unlikely to be allocated.
+        expect(isProcessAlive(2_147_483_640)).toBe(false);
+    });
+});
+
+describe('inspectPidFile', () => {
+    it('returns no conflict when the file is absent', () => {
+        const r = inspectPidFile(projectRoot);
+        expect(r.conflict).toBe(false);
+        expect(r.conflictingPid).toBeUndefined();
+    });
+
+    it('detects a conflict for the current pid', () => {
+        writePidFile(projectRoot);
+        const r = inspectPidFile(projectRoot);
+        expect(r.conflict).toBe(true);
+        expect(r.conflictingPid).toBe(process.pid);
+    });
+
+    it('ignores a stale pid (process gone)', () => {
+        writePidFile(projectRoot, 2_147_483_640);
+        const r = inspectPidFile(projectRoot);
+        expect(r.conflict).toBe(false);
+    });
+
+    it('ignores a non-numeric pid file', () => {
+        writePidFile(projectRoot);
+        writeFileSync(pidFilePath(projectRoot), 'not-a-number\n', 'utf8');
+        const r = inspectPidFile(projectRoot);
+        expect(r.conflict).toBe(false);
+    });
+});
+
+describe('writePidFile / clearPidFile', () => {
+    it('writePidFile creates the file and writes the pid', () => {
+        const p = writePidFile(projectRoot, 12345);
+        expect(existsSync(p)).toBe(true);
+        expect(readFileSync(p, 'utf8').trim()).toBe('12345');
+    });
+
+    it('clearPidFile removes the file and is idempotent', () => {
+        writePidFile(projectRoot);
+        const p = pidFilePath(projectRoot);
+        expect(existsSync(p)).toBe(true);
+        clearPidFile(projectRoot);
+        expect(existsSync(p)).toBe(false);
+        // second call must not throw
+        expect(() => clearPidFile(projectRoot)).not.toThrow();
+    });
+});

--- a/packages/core/installer/tests/gui-security.test.ts
+++ b/packages/core/installer/tests/gui-security.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the GUI security primitives: host/origin allowlists, CSRF
+ * token generation + constant-time equality (Phase 6 § Security).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildAllowedHosts,
+    buildAllowedOrigins,
+    CSP_HEADER,
+    csrfEquals,
+    generateCsrfToken,
+    isHostAllowed,
+    isOriginAllowed,
+} from '../src/gui/security.js';
+
+describe('buildAllowedHosts / buildAllowedOrigins', () => {
+    it('only emits loopback variants', () => {
+        expect(buildAllowedHosts(54321)).toEqual(['127.0.0.1:54321', 'localhost:54321']);
+        expect(buildAllowedOrigins(54321)).toEqual([
+            'http://127.0.0.1:54321',
+            'http://localhost:54321',
+        ]);
+    });
+});
+
+describe('isHostAllowed', () => {
+    const allowed = buildAllowedHosts(9999);
+
+    it('accepts exact loopback host:port', () => {
+        expect(isHostAllowed('127.0.0.1:9999', allowed)).toBe(true);
+        expect(isHostAllowed('localhost:9999', allowed)).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isHostAllowed('LOCALHOST:9999', allowed)).toBe(true);
+    });
+
+    it('rejects missing or empty host', () => {
+        expect(isHostAllowed(undefined, allowed)).toBe(false);
+        expect(isHostAllowed('', allowed)).toBe(false);
+    });
+
+    it('rejects wrong port (DNS-rebinding shape)', () => {
+        expect(isHostAllowed('127.0.0.1:9998', allowed)).toBe(false);
+    });
+
+    it('rejects non-loopback hostnames', () => {
+        expect(isHostAllowed('evil.example.com:9999', allowed)).toBe(false);
+        expect(isHostAllowed('127.0.0.2:9999', allowed)).toBe(false);
+    });
+});
+
+describe('isOriginAllowed', () => {
+    const allowed = buildAllowedOrigins(9999);
+
+    it('accepts exact loopback origins', () => {
+        expect(isOriginAllowed('http://127.0.0.1:9999', allowed)).toBe(true);
+        expect(isOriginAllowed('http://localhost:9999', allowed)).toBe(true);
+    });
+
+    it('rejects https scheme (we bind http only)', () => {
+        expect(isOriginAllowed('https://127.0.0.1:9999', allowed)).toBe(false);
+    });
+
+    it('rejects missing or empty origin', () => {
+        expect(isOriginAllowed(undefined, allowed)).toBe(false);
+        expect(isOriginAllowed('', allowed)).toBe(false);
+    });
+});
+
+describe('generateCsrfToken / csrfEquals', () => {
+    it('emits 64 hex chars (32 random bytes)', () => {
+        const tok = generateCsrfToken();
+        expect(tok).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('produces different tokens across calls', () => {
+        expect(generateCsrfToken()).not.toBe(generateCsrfToken());
+    });
+
+    it('csrfEquals: matches identical tokens, rejects others', () => {
+        const t = generateCsrfToken();
+        expect(csrfEquals(t, t)).toBe(true);
+        expect(csrfEquals(undefined, t)).toBe(false);
+        expect(csrfEquals('', t)).toBe(false);
+        expect(csrfEquals(t.slice(0, -1) + '0', t)).toBe(false);
+    });
+
+    it('csrfEquals: rejects length mismatches without timingSafeEqual throw', () => {
+        expect(csrfEquals('short', generateCsrfToken())).toBe(false);
+    });
+});
+
+describe('CSP_HEADER', () => {
+    it('restricts to self for default + script + connect', () => {
+        expect(CSP_HEADER).toContain("default-src 'self'");
+        expect(CSP_HEADER).toContain("script-src 'self'");
+        expect(CSP_HEADER).toContain("connect-src 'self'");
+    });
+});

--- a/packages/core/installer/tests/gui-server.test.ts
+++ b/packages/core/installer/tests/gui-server.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Integration tests for `startGuiServer`. Boots the real HTTP server
+ * (loopback, ephemeral port) against a fixture manifest written to a
+ * tmp project root. Verifies static asset serving, CSRF injection,
+ * security headers, host/origin gating, and PID file lifecycle.
+ *
+ * This is the lighter-weight stand-in for the roadmap's
+ * `task installer-gui-e2e` Playwright slot — it exercises the same
+ * code paths that the browser hits without the headless-browser
+ * dependency.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { request as httpRequest } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startGuiServer } from '../src/gui/server.js';
+import type { GuiServerHandle } from '../src/gui/types.js';
+import { makeArtefact, makeManifest, makePack } from './_fixtures.js';
+
+let proj: string;
+let manifestPath: string;
+let handle: GuiServerHandle;
+let baseUrl: string;
+
+function writeManifest(): string {
+    const manifest = makeManifest({
+        packs: [makePack({ id: 'a' })],
+        artefacts: [makeArtefact({ path: '.agent-src.uncompressed/rules/foo.md', packs: ['a'] })],
+    });
+    const dir = join(proj, 'dist', 'discovery');
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'discovery-manifest.json');
+    writeFileSync(path, JSON.stringify(manifest));
+    return path;
+}
+
+beforeEach(async () => {
+    proj = mkdtempSync(join(tmpdir(), 'gui-server-'));
+    manifestPath = writeManifest();
+    handle = await startGuiServer({
+        projectRoot: proj,
+        manifestPath,
+        noOpen: true,
+        stdout: new PassThrough(),
+    });
+    baseUrl = handle.url.replace(/\/$/, '');
+});
+
+afterEach(async () => {
+    await handle.close();
+    rmSync(proj, { recursive: true, force: true });
+});
+
+describe('startGuiServer — boot + lifecycle', () => {
+    it('binds to 127.0.0.1 with an ephemeral port', () => {
+        expect(handle.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+        expect(handle.port).toBeGreaterThan(0);
+        expect(handle.csrfToken).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('writes a PID file on boot and removes it on close', async () => {
+        expect(existsSync(handle.pidFile)).toBe(true);
+        const recorded = readFileSync(handle.pidFile, 'utf8').trim();
+        expect(recorded).toMatch(/^\d+$/);
+        expect(Number.parseInt(recorded, 10)).toBe(process.pid);
+        await handle.close();
+        expect(existsSync(handle.pidFile)).toBe(false);
+    });
+});
+
+describe('startGuiServer — static assets', () => {
+    it('serves index.html with the CSRF token injected', async () => {
+        const res = await fetch(`${baseUrl}/`);
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toContain('text/html');
+        expect(res.headers.get('content-security-policy')).toContain("default-src 'self'");
+        expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+        const body = await res.text();
+        expect(body).toContain(`content="${handle.csrfToken}"`);
+        expect(body).not.toContain('__CSRF__');
+    });
+
+    it('serves app.css and app.js with the right content types', async () => {
+        const css = await fetch(`${baseUrl}/app.css`);
+        expect(css.status).toBe(200);
+        expect(css.headers.get('content-type')).toContain('text/css');
+
+        const js = await fetch(`${baseUrl}/app.js`);
+        expect(js.status).toBe(200);
+        expect(js.headers.get('content-type')).toContain('application/javascript');
+    });
+
+    it('404s an unknown asset path', async () => {
+        const res = await fetch(`${baseUrl}/nope.html`);
+        expect(res.status).toBe(404);
+    });
+});
+
+describe('startGuiServer — security gates', () => {
+    it('rejects requests with a non-loopback Host header', async () => {
+        // Node's `fetch` rewrites the Host header — use raw http.request.
+        const status = await new Promise<number>((resolve, reject) => {
+            const req = httpRequest(
+                { host: '127.0.0.1', port: handle.port, path: '/', method: 'GET', headers: { Host: 'evil.example.com' } },
+                (res) => {
+                    res.resume();
+                    resolve(res.statusCode ?? 0);
+                },
+            );
+            req.on('error', reject);
+            req.end();
+        });
+        expect(status).toBe(403);
+    });
+
+    it('rejects POSTs with a non-loopback Origin', async () => {
+        const res = await fetch(`${baseUrl}/api/preview`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Origin: 'http://evil.example.com' },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['a'], csrf: handle.csrfToken }),
+        });
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('startGuiServer — API wiring', () => {
+    it('serves the loaded manifest at /api/manifest', async () => {
+        const res = await fetch(`${baseUrl}/api/manifest`);
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.manifest.packs[0].id).toBe('a');
+        expect(body.sha256).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('enforces CSRF on /api/preview', async () => {
+        const res = await fetch(`${baseUrl}/api/preview`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Origin: handle.url.replace(/\/$/, '') },
+            body: JSON.stringify({ workspaces: ['engineering'], packs: ['a'], csrf: 'bad' }),
+        });
+        expect(res.status).toBe(403);
+    });
+});

--- a/packages/core/installer/tests/gui-transaction-log.test.ts
+++ b/packages/core/installer/tests/gui-transaction-log.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the GUI transaction-log primitives (Phase 6 § Transaction log).
+ *
+ * Uses a tmpdir per test so we never touch the real
+ * `agents/runtime/gui/` of this repo.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    appendEntry,
+    closeLog,
+    discardLog,
+    ensureRuntimeDir,
+    findOpenLog,
+    guiRuntimeDir,
+    isOpenLog,
+    newLogPath,
+    plannedPaths,
+    readLog,
+} from '../src/gui/transaction-log.js';
+import type { TransactionLogEntry } from '../src/gui/types.js';
+
+let projectRoot: string;
+
+beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'gui-tx-'));
+});
+
+afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+});
+
+describe('guiRuntimeDir / ensureRuntimeDir', () => {
+    it('resolves under agents/runtime/gui/ by default', () => {
+        expect(guiRuntimeDir(projectRoot)).toBe(join(projectRoot, 'agents', 'runtime', 'gui'));
+    });
+
+    it('creates the directory idempotently', () => {
+        const dir = ensureRuntimeDir(projectRoot);
+        expect(existsSync(dir)).toBe(true);
+        // second call must not throw
+        expect(() => ensureRuntimeDir(projectRoot)).not.toThrow();
+    });
+});
+
+describe('newLogPath', () => {
+    it('returns a stable path under the runtime dir with no colons', () => {
+        const p = newLogPath(projectRoot, () => '2026-01-02T03:04:05.678Z');
+        expect(p).toBe(join(projectRoot, 'agents', 'runtime', 'gui', 'install-2026-01-02T03-04-05-678Z.log'));
+    });
+});
+
+const start = (ts: string, packs: readonly string[] = ['p1']): TransactionLogEntry => ({
+    kind: 'start', ts, workspaces: ['default'], packs,
+});
+const plan = (ts: string, path: string): TransactionLogEntry => ({
+    kind: 'plan', ts, path, pack: 'p1',
+});
+const commit = (ts: string, n: number): TransactionLogEntry => ({
+    kind: 'commit', ts, filesWritten: n, lockfileSha256: 'sha',
+});
+
+describe('appendEntry / readLog roundtrip', () => {
+    it('preserves order and content', () => {
+        const p = newLogPath(projectRoot, () => '2026-01-02T00-00-00-000Z');
+        const entries = [start('t1'), plan('t2', 'a.txt'), plan('t3', 'b.txt'), commit('t4', 2)];
+        for (const e of entries) appendEntry(p, e);
+        expect(readLog(p)).toEqual(entries);
+    });
+
+    it('readLog tolerates missing files and trailing newlines', () => {
+        expect(readLog(join(projectRoot, 'agents', 'runtime', 'gui', 'missing.log'))).toEqual([]);
+
+        const p = newLogPath(projectRoot, () => '2026-01-02T01-00-00-000Z');
+        writeFileSync(p, `${JSON.stringify(start('t'))}\n\n\n`, 'utf8');
+        expect(readLog(p)).toHaveLength(1);
+    });
+});
+
+describe('isOpenLog / plannedPaths', () => {
+    it('open = start present, no terminal entry', () => {
+        expect(isOpenLog([start('t1'), plan('t2', 'a')])).toBe(true);
+        expect(isOpenLog([])).toBe(false);
+    });
+
+    it('commit / cancel / error close the log', () => {
+        const base: TransactionLogEntry[] = [start('t1')];
+        expect(isOpenLog([...base, commit('t2', 0)])).toBe(false);
+        expect(isOpenLog([...base, { kind: 'cancel', ts: 't2', reason: 'user' }])).toBe(false);
+        expect(isOpenLog([...base, { kind: 'error', ts: 't2', message: 'boom' }])).toBe(false);
+    });
+
+    it('plannedPaths returns only the plan entries', () => {
+        const entries = [start('t1'), plan('t2', 'a'), plan('t3', 'b'), commit('t4', 2)];
+        expect(plannedPaths(entries)).toEqual(['a', 'b']);
+    });
+});
+
+describe('findOpenLog', () => {
+    it('returns undefined when no logs exist', () => {
+        expect(findOpenLog(projectRoot)).toBeUndefined();
+    });
+
+    it('returns the newest open log; ignores closed ones', () => {
+        const closed = newLogPath(projectRoot, () => '2026-01-02T00-00-00-000Z');
+        appendEntry(closed, start('t1'));
+        appendEntry(closed, commit('t2', 0));
+
+        const open = newLogPath(projectRoot, () => '2026-01-02T01-00-00-000Z');
+        appendEntry(open, start('t1'));
+        appendEntry(open, plan('t2', 'a'));
+
+        expect(findOpenLog(projectRoot)).toBe(open);
+    });
+});
+
+describe('closeLog / discardLog', () => {
+    it('closeLog appends a terminal cancel entry', () => {
+        const p = newLogPath(projectRoot, () => '2026-01-02T02-00-00-000Z');
+        appendEntry(p, start('t1'));
+        closeLog(p, 'user-quit', () => 't2');
+        const entries = readLog(p);
+        expect(entries.at(-1)).toEqual({ kind: 'cancel', ts: 't2', reason: 'user-quit' });
+        expect(isOpenLog(entries)).toBe(false);
+    });
+
+    it('discardLog truncates the file', () => {
+        const p = newLogPath(projectRoot, () => '2026-01-02T03-00-00-000Z');
+        appendEntry(p, start('t1'));
+        discardLog(p);
+        expect(readFileSync(p, 'utf8')).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary

Phase 6 of the monorepo migration — the optional, local-only browser
wizard for `@event4u/agent-config init`. Buildless TypeScript SPA
served by Node's stdlib HTTP server; loopback-bound; CSRF + Host +
Origin gated; SSE-streamed install progress; transaction-logged for
boot-time rollback.

Ratified by AI Council ahead of implementation —
`agents/runtime/council/responses/monorepo-phase-6-browser-wizard-gui-verdict.md`.

## Roadmap

`agents/roadmaps/monorepo-phase-6-browser-wizard-gui.md` — all phases
green:

- [x] P6.1 Server skeleton + CLI flag
- [x] P6.2 Agent-mode bridge + endpoints
- [x] P6.3 Transaction log + rollback offer
- [x] P6.4 Frontend (vanilla TS, inlined as TS strings)
- [x] P6.5 Tests (vitest, integration via real loopback server)
- [x] P6.6 Distribution + docs (contract, README, size budget)
- [x] P6.7 Chunked commits + PR + CI fix (this PR)

## Commits

1. `feat(installer/gui): server skeleton + CLI flag (P6.1)`
2. `feat(installer/gui): API handlers + transaction log (P6.2/P6.3)`
3. `feat(installer/gui): inlined SPA + integration tests (P6.4/P6.5)`
4. `docs(gui): contract + README quick-start + roadmap progress (P6.6/P6.7)`

## Security model (defense in depth)

- Loopback bind (`127.0.0.1`), ephemeral port by default
- Host header allowlist — `127.0.0.1:<port>` / `localhost:<port>` only
- Origin allowlist on every POST
- Per-server CSRF token (64-hex), timing-safe compare
- CSP `default-src 'self'`, `X-Content-Type-Options: nosniff`
- PID file (`agents/runtime/gui/server.pid`) blocks concurrent boots
- Idle timer keyed on last HTTP request; default 600 s
- Transaction log enables boot-time rollback offer after crashes

## Tests

`packages/core/installer` — 187 tests across 21 files, all green:

- `gui-pid-file` (10) — write/read/clear lifecycle, stale detection
- `gui-security` (14) — Host/Origin allowlist, CSRF compare
- `gui-transaction-log` (15) — JSONL append, directory creation
- `gui-handlers` (12) — API endpoints incl. SSE apply flow
- `gui-server` (9) — real `startGuiServer` integration: PID
  lifecycle, headers, Host rejection (raw `http.request` because
  Node's `fetch` rewrites Host), Origin enforcement

## Size budget

- Tarball: 110 KB packed / 506 KB unpacked
- GUI subset: 48 KB raw (static-assets.ts 20.7 KB)
- Budget: 200 KB GUI assets — well under

## Docs

- `docs/contracts/gui-wizard.md` — architecture, boot sequence,
  endpoint table, transaction log shapes, SSE framing, security
  failure modes, non-goals
- `README.md` quick-start block under Detailed installation

## Out of scope (Phase 6 follow-ups)

- Playwright headless E2E (the integration test in `gui-server.test`
  is the lighter-weight stand-in for now)
- CI size-budget enforcement (currently reviewer judgment)
