### PR TITLE
chore: ignore pnpm-lock.yaml (repo uses npm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Dependencies
 /vendor/
 /node_modules/
+# pnpm — repo uses npm (package-lock.json). Stray pnpm-lock.yaml from
+# accidental `pnpm install` runs must never enter the tree.
+pnpm-lock.yaml
 # Python virtualenv — used only for the live trigger-eval runner
 # (anthropic SDK). Never commit.
 /.venv/


### PR DESCRIPTION
Repo uses **npm** as the sole package manager — `package-lock.json` is committed at root and in `workers/mcp/` + `packages/cloud/telemetry-worker/`. No `packageManager` field, no `pnpm-workspace.yaml` → pnpm is not supported here.

A stray `pnpm-lock.yaml` (158 KB) appeared locally from an accidental `pnpm install` run. Two lockfiles in parallel would drift version resolution silently. This PR closes the gap.

## Change

- `.gitignore` — add `pnpm-lock.yaml` under the "Dependencies" block with a short comment explaining why.

## Verification

- `git check-ignore -v pnpm-lock.yaml` → ignored by the new rule.
- No tracked `pnpm-lock.yaml` exists; nothing to remove from history.
- Pre-push hook clean (.agent-src/ sync, command-count messaging in sync).
