### PR TITLE
release: 3.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Shared agent configuration \u2014 skills for AI coding tools (Claude Code, Augment, Cursor, Cline, Windsurf, Gemini CLI).",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "keywords": [
       "agent-config",
       "skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -738,6 +738,48 @@ our recommendation order, not its support status.
 > that forces a new era split (`# Era: 3.3.x`, etc.) — see
 > [`docs/contracts/CHANGELOG-conventions.md § Era splits`](docs/contracts/CHANGELOG-conventions.md).
 
+## [3.2.0](https://github.com/event4u-app/agent-config/compare/3.1.1...3.2.0) (2026-05-25)
+
+### Features
+
+* **workspace:** GUI bridge + Workspace tab for Phases 4-8 backends ([6911b56](https://github.com/event4u-app/agent-config/commit/6911b56d1e474dace4a250d077ed93f628b029be))
+* **workspace:** backend Python modules for Phases 5/6/7/8 ([c890fde](https://github.com/event4u-app/agent-config/commit/c890fde556b24e6b69409a4f0f647cace3779320))
+* **memory:** wire knowledge namespace into hybrid retrieval ([a65ae2c](https://github.com/event4u-app/agent-config/commit/a65ae2c117ac10aff78ac711316b441d2ee2f42c))
+* **knowledge:** implement local knowledge ingestion module ([d842ba3](https://github.com/event4u-app/agent-config/commit/d842ba350f325293f0faafe4698b8bbbe77033f8))
+* **knowledge:** add /knowledge command cluster source files ([9023c17](https://github.com/event4u-app/agent-config/commit/9023c17049ea42769537919df5ca10db1cc785e7))
+* **roadmap:** land road-to-employee-product-and-external-proof + consumer docs ([b2901ad](https://github.com/event4u-app/agent-config/commit/b2901ad516a6bb209b7fadae884563025a090e4d))
+* **roles:** scaffold consultant, content-creator, galabau experiences ([55384df](https://github.com/event4u-app/agent-config/commit/55384df486cba24288f38275435d151c5c7b8762))
+
+### Bug Fixes
+
+* **knowledge:** use agent-config-maintainer workspace per discovery vocabulary ([75f78ab](https://github.com/event4u-app/agent-config/commit/75f78ab2999ed5fbc261aecf9fadd692588a2498))
+* **check-refs:** mark forward-refs to recruit-sessions with ref-ignore ([147909b](https://github.com/event4u-app/agent-config/commit/147909b4428492ad8332959635573a1ab419d865))
+
+### Documentation
+
+* **roadmap:** mark Phases 4-8 backend complete + regen progress dashboard ([38b82f9](https://github.com/event4u-app/agent-config/commit/38b82f9928d57c9c7cfabd0b75f3c1284b6e2dcb))
+* **roadmap:** mark Phase 2 done + sync command counts ([4089810](https://github.com/event4u-app/agent-config/commit/4089810f2123a0838e318fb442e975f6f60faf00))
+* **knowledge:** add user guide and update contract for impl reality ([9fbea43](https://github.com/event4u-app/agent-config/commit/9fbea43033471e2daf2ef91342212a3480e24f93))
+* **deploy:** add team-deployment-posture + small-team-recipe + stubs ([0892317](https://github.com/event4u-app/agent-config/commit/08923177dbd62346456a4992b8ab06e0442fb0cf))
+* **contracts:** add 8 contracts for Daily Workspace + role experience ([34f882c](https://github.com/event4u-app/agent-config/commit/34f882c815fa2366956f2f454534bd9f18f79e04))
+* **adr:** add ADR-022..026 for Daily Workspace architecture ([034eb99](https://github.com/event4u-app/agent-config/commit/034eb99569fcf388099b059ae5e8fb0537d902e3))
+
+### CI
+
+* **visibility:** drop push-trigger ghost-runs from drift workflows ([1704683](https://github.com/event4u-app/agent-config/commit/1704683ff0f08985e750b7cb6c8555812f349914))
+
+### Chores
+
+* **gitignore:** ignore pnpm-lock.yaml (repo uses npm) ([088fae6](https://github.com/event4u-app/agent-config/commit/088fae6ef8377200185826c31ea8adc0b97573f4))
+* **counts:** sync command count to 136 (analytics cluster added) ([1d56496](https://github.com/event4u-app/agent-config/commit/1d564962bd57aedc6d4ff2ae6b757e45e8a63e2c))
+* **release:** bump agent_config_version in templates to match package.json 3.1.1 ([4864332](https://github.com/event4u-app/agent-config/commit/4864332804fe9979a4f94cb053cdd13c7473ac40))
+* **sync:** regenerate index + catalog for analytics commands ([77cb4fa](https://github.com/event4u-app/agent-config/commit/77cb4fa41d8b2773e7f5ece27f385d7b42862f5f))
+* **sync:** regenerate compressed analytics commands + Claude skill stubs ([41728c4](https://github.com/event4u-app/agent-config/commit/41728c4400c8cabaa8966d2708fbb4f3cef64adb))
+* **knowledge:** regenerate projections + manifests for /knowledge cluster ([f4c5a26](https://github.com/event4u-app/agent-config/commit/f4c5a26bffef0a25918bdde42131354c9dd5295d))
+* **discovery:** add agent-skills and cinematic-ai-video to topics ([5c01d5e](https://github.com/event4u-app/agent-config/commit/5c01d5e152bda559aefd48fd8220f2a3cbd90249))
+
+Tests: 4929 (+90 since 3.1.1)
+
 # Era: pre-3.2.0 — archived
 
 > All entries from `3.1.0` and `3.1.1` live in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@event4u/agent-config",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "description": "Universal AI Agent OS \u2014 audited skills, governance rules, commands, and templates for AI coding tools (Claude Code, Cursor, Windsurf, Copilot).",
     "license": "MIT",
     "private": false,

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -3,7 +3,7 @@
 # cloud
 
 - **id**: `cloud`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: —
 - **requires**: —
 - **artefacts**: 0

--- a/packages/cloud/pack.yaml
+++ b/packages/cloud/pack.yaml
@@ -6,4 +6,4 @@ label: cloud
 owner: []
 requires: []
 trust_level_default: core
-version: 3.1.1
+version: 3.2.0

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@
 Core framework-neutral artefacts.
 
 - **id**: `core`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: agent-config-maintainer
 - **requires**: —
 - **artefacts**: 364

--- a/packages/core/pack.yaml
+++ b/packages/core/pack.yaml
@@ -7,4 +7,4 @@ owner:
 - agent-config-maintainer
 requires: []
 trust_level_default: core
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-ai-video/README.md
+++ b/packages/pack-ai-video/README.md
@@ -5,7 +5,7 @@
 AI video pipeline (per ADR-011, the only heavyweight domain).
 
 - **id**: `ai-video`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: small-business
 - **requires**: —
 - **artefacts**: 6

--- a/packages/pack-ai-video/pack.yaml
+++ b/packages/pack-ai-video/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - small-business
 requires: []
 trust_level_default: experimental
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-finance-advanced/README.md
+++ b/packages/pack-finance-advanced/README.md
@@ -5,7 +5,7 @@
 DCF, scenario modelling, comp banding.
 
 - **id**: `finance-advanced`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: finance
 - **requires**: finance-basic
 - **artefacts**: 2

--- a/packages/pack-finance-advanced/pack.yaml
+++ b/packages/pack-finance-advanced/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - finance-basic
 trust_level_default: core
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-finance-basic/README.md
+++ b/packages/pack-finance-basic/README.md
@@ -5,7 +5,7 @@
 Cashflow, runway, basic forecasting.
 
 - **id**: `finance-basic`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: finance, founder
 - **requires**: —
 - **artefacts**: 4

--- a/packages/pack-finance-basic/pack.yaml
+++ b/packages/pack-finance-basic/pack.yaml
@@ -12,4 +12,4 @@ owner:
 - founder
 requires: []
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-founder-strategy/README.md
+++ b/packages/pack-founder-strategy/README.md
@@ -5,7 +5,7 @@
 Vision, fundraising narrative, competitive moat.
 
 - **id**: `founder-strategy`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: founder
 - **requires**: —
 - **artefacts**: 8

--- a/packages/pack-founder-strategy/pack.yaml
+++ b/packages/pack-founder-strategy/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - founder
 requires: []
 trust_level_default: core
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-gtm-marketing/README.md
+++ b/packages/pack-gtm-marketing/README.md
@@ -5,7 +5,7 @@
 Positioning, messaging, editorial, content funnel.
 
 - **id**: `gtm-marketing`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: gtm, founder
 - **requires**: —
 - **artefacts**: 8

--- a/packages/pack-gtm-marketing/pack.yaml
+++ b/packages/pack-gtm-marketing/pack.yaml
@@ -8,4 +8,4 @@ owner:
 - founder
 requires: []
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-gtm-sales/README.md
+++ b/packages/pack-gtm-sales/README.md
@@ -5,7 +5,7 @@
 Pipeline, MEDDIC, forecast accuracy.
 
 - **id**: `gtm-sales`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: gtm
 - **requires**: —
 - **artefacts**: 4

--- a/packages/pack-gtm-sales/pack.yaml
+++ b/packages/pack-gtm-sales/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - gtm
 requires: []
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-laravel/README.md
+++ b/packages/pack-laravel/README.md
@@ -5,7 +5,7 @@
 Laravel framework patterns; depends on PHP at the artefact level.
 
 - **id**: `laravel`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: php, engineering-base
 - **artefacts**: 25

--- a/packages/pack-laravel/pack.yaml
+++ b/packages/pack-laravel/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - php
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-nextjs/README.md
+++ b/packages/pack-nextjs/README.md
@@ -5,7 +5,7 @@
 Next.js framework patterns.
 
 - **id**: `nextjs`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: react, typescript, engineering-base
 - **artefacts**: 2

--- a/packages/pack-nextjs/pack.yaml
+++ b/packages/pack-nextjs/pack.yaml
@@ -10,4 +10,4 @@ requires:
 - typescript
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-ops-people/README.md
+++ b/packages/pack-ops-people/README.md
@@ -5,7 +5,7 @@
 Hiring loops, onboarding programs, comp banding.
 
 - **id**: `ops-people`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: ops
 - **requires**: —
 - **artefacts**: 8

--- a/packages/pack-ops-people/pack.yaml
+++ b/packages/pack-ops-people/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - ops
 requires: []
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-php/README.md
+++ b/packages/pack-php/README.md
@@ -5,7 +5,7 @@
 PHP-language patterns (framework-free).
 
 - **id**: `php`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: engineering-base
 - **artefacts**: 6

--- a/packages/pack-php/pack.yaml
+++ b/packages/pack-php/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-product-basic/README.md
+++ b/packages/pack-product-basic/README.md
@@ -5,7 +5,7 @@
 Core PO/PM artefacts (ticket refinement, AC, estimation).
 
 - **id**: `product-basic`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: product
 - **requires**: —
 - **artefacts**: 9

--- a/packages/pack-product-basic/pack.yaml
+++ b/packages/pack-product-basic/pack.yaml
@@ -7,4 +7,4 @@ owner:
 - product
 requires: []
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-product-discovery/README.md
+++ b/packages/pack-product-discovery/README.md
@@ -5,7 +5,7 @@
 JTBD, interviews, VoC, hypothesis testing.
 
 - **id**: `product-discovery`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: product
 - **requires**: product-basic
 - **artefacts**: 4

--- a/packages/pack-product-discovery/pack.yaml
+++ b/packages/pack-product-discovery/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - product-basic
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-python/README.md
+++ b/packages/pack-python/README.md
@@ -5,7 +5,7 @@
 Python-language patterns.
 
 - **id**: `python`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: engineering-base
 - **artefacts**: 1

--- a/packages/pack-python/pack.yaml
+++ b/packages/pack-python/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-react/README.md
+++ b/packages/pack-react/README.md
@@ -5,7 +5,7 @@
 React framework patterns.
 
 - **id**: `react`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: javascript, engineering-base
 - **artefacts**: 3

--- a/packages/pack-react/pack.yaml
+++ b/packages/pack-react/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - javascript
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-symfony/README.md
+++ b/packages/pack-symfony/README.md
@@ -5,7 +5,7 @@
 Symfony framework patterns; depends on PHP at the artefact level.
 
 - **id**: `symfony`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: php, engineering-base
 - **artefacts**: 3

--- a/packages/pack-symfony/pack.yaml
+++ b/packages/pack-symfony/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - php
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0

--- a/packages/pack-typescript/README.md
+++ b/packages/pack-typescript/README.md
@@ -5,7 +5,7 @@
 TypeScript-language patterns.
 
 - **id**: `typescript`
-- **version**: `3.1.1`
+- **version**: `3.2.0`
 - **owner**: engineering
 - **requires**: javascript, engineering-base
 - **artefacts**: 1

--- a/packages/pack-typescript/pack.yaml
+++ b/packages/pack-typescript/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - javascript
 - engineering-base
 trust_level_default: professional
-version: 3.1.1
+version: 3.2.0


### PR DESCRIPTION
Release 3.2.0.

### Features

* **workspace:** GUI bridge + Workspace tab for Phases 4-8 backends ([6911b56](https://github.com/event4u-app/agent-config/commit/6911b56d1e474dace4a250d077ed93f628b029be))
* **workspace:** backend Python modules for Phases 5/6/7/8 ([c890fde](https://github.com/event4u-app/agent-config/commit/c890fde556b24e6b69409a4f0f647cace3779320))
* **memory:** wire knowledge namespace into hybrid retrieval ([a65ae2c](https://github.com/event4u-app/agent-config/commit/a65ae2c117ac10aff78ac711316b441d2ee2f42c))
* **knowledge:** implement local knowledge ingestion module ([d842ba3](https://github.com/event4u-app/agent-config/commit/d842ba350f325293f0faafe4698b8bbbe77033f8))
* **knowledge:** add /knowledge command cluster source files ([9023c17](https://github.com/event4u-app/agent-config/commit/9023c17049ea42769537919df5ca10db1cc785e7))
* **roadmap:** land road-to-employee-product-and-external-proof + consumer docs ([b2901ad](https://github.com/event4u-app/agent-config/commit/b2901ad516a6bb209b7fadae884563025a090e4d))
* **roles:** scaffold consultant, content-creator, galabau experiences ([55384df](https://github.com/event4u-app/agent-config/commit/55384df486cba24288f38275435d151c5c7b8762))

### Bug Fixes

* **knowledge:** use agent-config-maintainer workspace per discovery vocabulary ([75f78ab](https://github.com/event4u-app/agent-config/commit/75f78ab2999ed5fbc261aecf9fadd692588a2498))
* **check-refs:** mark forward-refs to recruit-sessions with ref-ignore ([147909b](https://github.com/event4u-app/agent-config/commit/147909b4428492ad8332959635573a1ab419d865))

### Documentation

* **roadmap:** mark Phases 4-8 backend complete + regen progress dashboard ([38b82f9](https://github.com/event4u-app/agent-config/commit/38b82f9928d57c9c7cfabd0b75f3c1284b6e2dcb))
* **roadmap:** mark Phase 2 done + sync command counts ([4089810](https://github.com/event4u-app/agent-config/commit/4089810f2123a0838e318fb442e975f6f60faf00))
* **knowledge:** add user guide and update contract for impl reality ([9fbea43](https://github.com/event4u-app/agent-config/commit/9fbea43033471e2daf2ef91342212a3480e24f93))
* **deploy:** add team-deployment-posture + small-team-recipe + stubs ([0892317](https://github.com/event4u-app/agent-config/commit/08923177dbd62346456a4992b8ab06e0442fb0cf))
* **contracts:** add 8 contracts for Daily Workspace + role experience ([34f882c](https://github.com/event4u-app/agent-config/commit/34f882c815fa2366956f2f454534bd9f18f79e04))
* **adr:** add ADR-022..026 for Daily Workspace architecture ([034eb99](https://github.com/event4u-app/agent-config/commit/034eb99569fcf388099b059ae5e8fb0537d902e3))

### CI

* **visibility:** drop push-trigger ghost-runs from drift workflows ([1704683](https://github.com/event4u-app/agent-config/commit/1704683ff0f08985e750b7cb6c8555812f349914))

### Chores

* **gitignore:** ignore pnpm-lock.yaml (repo uses npm) ([088fae6](https://github.com/event4u-app/agent-config/commit/088fae6ef8377200185826c31ea8adc0b97573f4))
* **counts:** sync command count to 136 (analytics cluster added) ([1d56496](https://github.com/event4u-app/agent-config/commit/1d564962bd57aedc6d4ff2ae6b757e45e8a63e2c))
* **release:** bump agent_config_version in templates to match package.json 3.1.1 ([4864332](https://github.com/event4u-app/agent-config/commit/4864332804fe9979a4f94cb053cdd13c7473ac40))
* **sync:** regenerate index + catalog for analytics commands ([77cb4fa](https://github.com/event4u-app/agent-config/commit/77cb4fa41d8b2773e7f5ece27f385d7b42862f5f))
* **sync:** regenerate compressed analytics commands + Claude skill stubs ([41728c4](https://github.com/event4u-app/agent-config/commit/41728c4400c8cabaa8966d2708fbb4f3cef64adb))
* **knowledge:** regenerate projections + manifests for /knowledge cluster ([f4c5a26](https://github.com/event4u-app/agent-config/commit/f4c5a26bffef0a25918bdde42131354c9dd5295d))
* **discovery:** add agent-skills and cinematic-ai-video to topics ([5c01d5e](https://github.com/event4u-app/agent-config/commit/5c01d5e152bda559aefd48fd8220f2a3cbd90249))

Tests: 4929 (+90 since 3.1.1)

Created by `scripts/release.py`.