### PR TITLE
chore(scripts): exclude stubs/ from roadmap candidate scan

### DIFF
--- a/.agent-src/scripts/update_roadmap_progress.py
+++ b/.agent-src/scripts/update_roadmap_progress.py
@@ -65,7 +65,7 @@ PHASE_RE = re.compile(
 TITLE_RE = re.compile(r"^#\s+(?:Roadmap:\s*)?(.+?)\s*$", re.MULTILINE)
 EXCLUDE_NAMES = {"template.md", "README.md", "progress.md", "roadmaps-progress.md"}
 EXCLUDE_PREFIXES = ("open-questions",)
-EXCLUDE_DIRS = {"archive", "skipped"}
+EXCLUDE_DIRS = {"archive", "skipped", "stubs"}
 
 # Frontmatter — minimal YAML block at the top of a roadmap. Used to hide
 # drafts (`status: draft`) from the dashboard. Anything else (no

--- a/packages/core/.agent-src.uncompressed/scripts/update_roadmap_progress.py
+++ b/packages/core/.agent-src.uncompressed/scripts/update_roadmap_progress.py
@@ -65,7 +65,7 @@ PHASE_RE = re.compile(
 TITLE_RE = re.compile(r"^#\s+(?:Roadmap:\s*)?(.+?)\s*$", re.MULTILINE)
 EXCLUDE_NAMES = {"template.md", "README.md", "progress.md", "roadmaps-progress.md"}
 EXCLUDE_PREFIXES = ("open-questions",)
-EXCLUDE_DIRS = {"archive", "skipped"}
+EXCLUDE_DIRS = {"archive", "skipped", "stubs"}
 
 # Frontmatter — minimal YAML block at the top of a roadmap. Used to hide
 # drafts (`status: draft`) from the dashboard. Anything else (no


### PR DESCRIPTION
## Why

`scripts/check_roadmap_trackable.py` reports four violations against the four stub roadmaps under `agents/roadmaps/stubs/`:

```
❌  agents/roadmaps/stubs/road-to-central-policy.md: no `## Phase <id>` heading …
❌  agents/roadmaps/stubs/road-to-internal-connectors.md: no `## Phase <id>` heading …
❌  agents/roadmaps/stubs/road-to-team-context.md: no `## Phase <id>` heading …
❌  agents/roadmaps/stubs/road-to-team-sso.md: no `## Phase <id>` heading …
```

These files **are** correctly authored as stubs — they intentionally have no `## Phase` headings because none of them is active work. `agents/roadmaps/stubs/README.md` (lines 17–21) documents this contract explicitly:

> The stubs live under `stubs/` (not `agents/roadmaps/*.md` directly) so they do not register with `task lint-roadmap-complexity` and do not appear on `agents/roadmaps-progress.md`. Promotion to active status moves the file up one directory …

The dashboard generator's `EXCLUDE_DIRS` set drifted from that contract — it had `{archive, skipped}` but not `stubs`. The trackability linter (which reuses the dashboard's `is_roadmap_candidate`) therefore scanned every stub as if it were active and produced four false-positive violations.

## Fix

One-line drift correction in the projected source:

```diff
- EXCLUDE_DIRS = {"archive", "skipped"}
+ EXCLUDE_DIRS = {"archive", "skipped", "stubs"}
```

Edit lives in `packages/core/.agent-src.uncompressed/scripts/update_roadmap_progress.py` (source of truth). Projected to `.agent-src/scripts/` via `task sync`. `.augment/scripts/` is a symlink to `.agent-src/scripts/` and picks up the change automatically.

## Verification

| Check | Before | After |
|---|---|---|
| `python3 scripts/check_roadmap_trackable.py` exit code | 1 (4 violations) | 0 (1 active roadmap clean) |
| `agents/roadmaps-progress.md` diff against `main` | n/a | 0 lines (stubs were already invisible — no Phase headings — so the dashboard never rendered them; this PR just stops the linter from flagging them) |
| `task sync` projection | n/a | clean |

No behavior change to the dashboard output. The linter stops flagging stubs that were never meant to be flagged.

## Why not add `status: draft` to each stub?

Considered. Rejected because:

1. Stubs are not drafts — they have their own lifecycle (cancelled-until-promoted, with explicit promotion criteria). Forcing them through the `draft` channel overloads a frontmatter key with two distinct meanings.
2. The README already documents the directory-level intent. The correct fix is to make the scanner honor that intent, not to add per-file workarounds.
3. One-line script change covers all four files at once and prevents the drift from re-occurring as new stubs are added.

## Related

- Found while validating the `docs/roadmap-changelog-era-auto-split` PR; surfaces as part of the in-flight conversation about a "Found Defect Policy" for pre-existing lint failures.
- Contract referenced: `agents/roadmaps/stubs/README.md`.
- Rule referenced in the linter output: `.augment/rules/roadmap-progress-sync.md` § "Iron Law — every active roadmap is trackable".
