### PR TITLE
chore(docs): strip 9 roadmap-file references from stable artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ task mcp:cloud:secret-put    # opt in to bearer-auth (recommended for private de
 |---|---|---|
 | **Single-user workspace** | ✅ today | `npx @event4u/agent-config init` — single machine, single user; no remote sync |
 | **Small team (3–10 people)** | ✅ today | Shared `agents/overrides/` Git repo + shared NAS for knowledge — no code change, no new server. Recipe: [`docs/deploy/small-team-recipe.md`](docs/deploy/small-team-recipe.md) |
-| **Organization mode** (SSO · central policy · team context · internal connectors) | ⏸ not started | Tracked under [`agents/roadmaps/stubs/`](agents/roadmaps/stubs/README.md); each stub gated on a recruited customer + funded audit + maintainer ADR. Posture rationale: [`docs/deploy/team-deployment-posture.md`](docs/deploy/team-deployment-posture.md) |
+| **Organization mode** (SSO · central policy · team context · internal connectors) | ⏸ not started | Each shape gated on a recruited customer + funded audit + maintainer ADR. Posture rationale: [`docs/deploy/team-deployment-posture.md`](docs/deploy/team-deployment-posture.md) |
 
-The Hard Floor on organization-mode features (SSO, central policy, OAuth connectors, team-context) is preserved by design — they stay cancelled in the archived [`road-to-internal-ai-os-deployment.md`](agents/roadmaps/archive/road-to-internal-ai-os-deployment.md) until a real first customer + funded security audit lifts them. The small-team recipe is the supported path in the meantime.
+The Hard Floor on organization-mode features (SSO, central policy, OAuth connectors, team-context) is preserved by design — they stay cancelled until a real first customer + funded security audit lifts them. The small-team recipe is the supported path in the meantime.
 
 ### Optional: persistent agent memory
 

--- a/docs/contracts/at-rest-encryption.md
+++ b/docs/contracts/at-rest-encryption.md
@@ -1,7 +1,7 @@
 # At-Rest Encryption Contract
 
-> **Status** · v0 / design · 2026-05-24. Phase 8 of
-> [`road-to-employee-product-and-external-proof.md`](../../agents/roadmaps/road-to-employee-product-and-external-proof.md).
+> **Status** · v0 / design · 2026-05-24. Phase 8 of the
+> employee-product workstream.
 > Single-user, single-machine encryption for the three workspace
 > stores added in Phases 4 / 5 / 7. Does **not** touch the existing
 > `agents/memory/` store — that gets a separate decision.

--- a/docs/contracts/daily-workspace.md
+++ b/docs/contracts/daily-workspace.md
@@ -1,8 +1,7 @@
 # Daily Workspace Surface Contract
 
 > **Status** · v0 / design · 2026-05-24. Surface contract for the daily
-> workspace introduced in Phase 4 of
-> [`road-to-employee-product-and-external-proof.md`](../../agents/roadmaps/road-to-employee-product-and-external-proof.md).
+> workspace introduced as Phase 4 of the employee-product workstream.
 > Governed by ADRs [`022`](../decisions/ADR-022-daily-workspace-decomposition.md) ·
 > [`023`](../decisions/ADR-023-host-agent-protocol.md) ·
 > [`024`](../decisions/ADR-024-workspace-v0-feature-floor.md) ·

--- a/docs/contracts/explain-modes.md
+++ b/docs/contracts/explain-modes.md
@@ -1,7 +1,7 @@
 # Explain Modes Contract
 
-> **Status** · v0 / design · 2026-05-24. Phase 6 of
-> [`road-to-employee-product-and-external-proof.md`](../../agents/roadmaps/road-to-employee-product-and-external-proof.md).
+> **Status** · v0 / design · 2026-05-24. Phase 6 of the
+> employee-product workstream.
 > Governed by [`ADR-026`](../decisions/ADR-026-explain-mode-translation.md).
 > Translates the existing engineer-shaped `explain-v1` envelope into a
 > role-aware plain surface, without changing the underlying data.

--- a/docs/contracts/local-analytics.md
+++ b/docs/contracts/local-analytics.md
@@ -1,7 +1,7 @@
 # Local Analytics Contract
 
-> **Status** · v0 / design · 2026-05-24. Phase 7 of
-> [`road-to-employee-product-and-external-proof.md`](../../agents/roadmaps/road-to-employee-product-and-external-proof.md).
+> **Status** · v0 / design · 2026-05-24. Phase 7 of the
+> employee-product workstream.
 > **Local-only.** Does NOT lift the Hard-Floor item from 3.1.0 — no
 > network egress, no remote Worker, no POST. Inertia of the prior
 > telemetry roadmap is preserved.

--- a/docs/contracts/local-knowledge-ingestion.md
+++ b/docs/contracts/local-knowledge-ingestion.md
@@ -7,7 +7,7 @@ keep-beta-until: 2026-08-24
 
 **Purpose.** Freeze the input shape, bounds, storage target, and redaction defaults for the single-user, local-only knowledge surface (`/knowledge:ingest`, `/knowledge:list`, `/knowledge:forget`) **before** any implementation lands. Closes the "Copy/Paste AI" complaint from feedback A without touching OAuth, multi-tenancy, or Hard-Floor connector territory.
 
-Last refreshed: 2026-05-24. Roadmap home: `agents/roadmaps/road-to-employee-product-and-external-proof.md` Phase 2.
+Last refreshed: 2026-05-24. Phase 2 of the employee-product workstream.
 
 ## What this doc is **not**
 

--- a/docs/contracts/role-experience.md
+++ b/docs/contracts/role-experience.md
@@ -7,7 +7,7 @@ keep-beta-until: 2026-08-24
 
 **Purpose.** Freeze the on-disk shape of a `role-experience` — the artefact that turns a non-developer persona (galabau owner, content creator, consultant, …) into a first-class entry point with three first tasks, a named prompt library, and a curated skill shortlist. Pins the interface **before** the launcher in Phase 4 reads it, so the launcher and the role authors can move independently.
 
-Last refreshed: 2026-05-24. Roadmap home: `agents/roadmaps/road-to-employee-product-and-external-proof.md` Phase 3.
+Last refreshed: 2026-05-24. Phase 3 of the employee-product workstream.
 
 ## What a role experience is
 

--- a/docs/contracts/workspace-documents.md
+++ b/docs/contracts/workspace-documents.md
@@ -1,7 +1,7 @@
 # Workspace Documents Contract
 
-> **Status** · v0 / design · 2026-05-24. Phase 5 of
-> [`road-to-employee-product-and-external-proof.md`](../../agents/roadmaps/road-to-employee-product-and-external-proof.md).
+> **Status** · v0 / design · 2026-05-24. Phase 5 of the
+> employee-product workstream.
 > Builds on the [`daily-workspace`](daily-workspace.md) surface and
 > the host-agent protocol from
 > [`ADR-023`](../decisions/ADR-023-host-agent-protocol.md). Documents


### PR DESCRIPTION
## What

Strips 9 roadmap-file references from stable artifacts (7 contracts + README) so `scripts/check_no_roadmap_refs.py` runs green on `main`.

## Why

The [`no-roadmap-references`](.agent-src.uncompressed/rules/no-roadmap-references.md) rule (Iron Law: *"NEVER LINK TO A SPECIFIC FILE IN agents/roadmaps/ FROM A STABLE ARTIFACT"*) was being violated by 9 stable artifacts that linked into transient roadmap files. The roadmap layer is archived / deleted as work completes — each link is a future rotten reference.

## How

**Pattern applied:** *"Inline first, link never"* (from the rule's failure-modes section). The phase number and workstream name are kept inline; the file path is removed. No new context file authored — the contracts already stand on their own with their ADR governance lines.

| File | Before | After |
|---|---|---|
| `docs/contracts/{daily-workspace, at-rest-encryption, explain-modes, local-analytics, workspace-documents}.md` | `Phase N of [road-to-employee-product-and-external-proof.md](...)` | `Phase N of the employee-product workstream` |
| `docs/contracts/{local-knowledge-ingestion, role-experience}.md` | ``Roadmap home: `agents/roadmaps/...md` Phase N`` | `Phase N of the employee-product workstream` |
| `README.md:230` | `Tracked under [agents/roadmaps/stubs/](...)` | (stub-marker link removed; gating clause retained) |
| `README.md:232` | `stay cancelled in the archived [road-to-internal-ai-os-deployment.md](...)` | `stay cancelled` |

## Verification

```
$ python3 scripts/check_no_roadmap_refs.py
✅  No roadmap-file references in stable artifacts.
```

## Risk

Zero — no behavioral changes, no API changes, no content rewrites beyond stripping link syntax and substituting the workstream name for the file path. ADR governance lines on each contract preserved.
