### PR TITLE
feat: clean skill distribution channels — eliminate dual-registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,5 @@ task ci                # full pipeline — green before PR
 3. **Where do I edit?** — `packages/<pack>/.agent-src.uncompressed/` only. Never the generated trees.
 4. **Lint / test / sync entry point?** — `task ci` (full pipeline). Subsets: `task sync`, `task generate-tools`, `task lint-skills`, `task test`.
 5. **Where do the always-active rules live?** — `.agent-src/rules/` (kernel = 9 Iron-Law rules; tier-1 / tier-2 routed via `dist/router.json`).
-6. **Why does a skill appear twice in my AI tool?** — Cross-scope drift (user-global install + project-local install at different versions). Default install path is filesystem-only; see [`docs/contracts/skill-distribution-channels.md`](docs/contracts/skill-distribution-channels.md). Run `task probe:skills` (Phase C of `road-to-clean-skill-distribution-channels`) to detect duplicates.
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,6 @@ task ci                # full pipeline — green before PR
 3. **Where do I edit?** — `packages/<pack>/.agent-src.uncompressed/` only. Never the generated trees.
 4. **Lint / test / sync entry point?** — `task ci` (full pipeline). Subsets: `task sync`, `task generate-tools`, `task lint-skills`, `task test`.
 5. **Where do the always-active rules live?** — `.agent-src/rules/` (kernel = 9 Iron-Law rules; tier-1 / tier-2 routed via `dist/router.json`).
+6. **Why does a skill appear twice in my AI tool?** — Cross-scope drift (user-global install + project-local install at different versions). Default install path is filesystem-only; see [`docs/contracts/skill-distribution-channels.md`](docs/contracts/skill-distribution-channels.md). Run `task probe:skills` (Phase C of `road-to-clean-skill-distribution-channels`) to detect duplicates.
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ shows the wired AIs; [`docs/featured-commands.md`](docs/featured-commands.md)
 lists the end-to-end workflows (`/implement-ticket`, `/work`,
 `/commit`, `/create-pr`). Deeper tour: [2-minute demo](#2-minute-demo--implement-ticket).
 
+**Install scope.** Pick **one** scope per machine — project-local (default, recommended for application repos) or user-global (recommended for tooling repos / dotfiles). The installer refuses cross-scope drift via the `scope_guard` pre-flight. Contract: [`docs/contracts/install-scopes.md`](docs/contracts/install-scopes.md). Cleanup when needed: `bash scripts/cleanup_other_scope.sh --confirm`.
+
+## Harness expectations
+
+Three classes of behaviour look like package bugs but are host-harness behaviour the package cannot control — sibling-plugin namespaces (`codex:*`, `cc-gemini-plugin:*`), deferred tools surfaced via `ToolSearch`, and cross-scope skill drift (real bug, fixed in the distribution-channels track). Diagnostics + the package's response: [`docs/contracts/harness-expectations.md`](docs/contracts/harness-expectations.md). First step when a skill appears twice: `task probe:skills`.
+
 ## Prove it
 
 Audit-disciplined by construction — every memory consult, decision

--- a/agents/evidence/audits/2026-05-distribution-channels/01-claude-same-install.md
+++ b/agents/evidence/audits/2026-05-distribution-channels/01-claude-same-install.md
@@ -1,0 +1,52 @@
+# Claude same-install dual-registration — audit
+
+**Audit:** 01 of 03 (Phase A, Step 1)
+**Date:** 2026-05-25
+**Status:** Structural reproduction confirmed via filesystem inspection. Live in-session reproduction deferred — requires a fresh `~/.claude/skills/` move-aside + Claude restart that this autonomous session can't safely perform without confirming on a human machine.
+
+## What was measured
+
+Static inspection of the repo's projection trees and the upstream user-global tree:
+
+| Source | Path | Entries | `copilot-config` description |
+|---|---|---|---|
+| User-global (claude installs over time) | `~/.claude/skills/` | 277 entries | `"Use when configuring GitHub Copilot — copilot-instructions.md, PR review patterns, output optimization — even when the user just says 'tune Copilot' or 'why is Copilot commenting on X'."` |
+| Project-local (current `event4u/agent-config` checkout) | `.claude/skills/` | 351 entries | `"Tune the GitHub Copilot AI — copilot-instructions.md, PR-review patterns, suggestion behavior, output verbosity. NOT for dev-environment setup (use devcontainer)."` |
+| Plugin manifest | `.claude-plugin/marketplace.json` § `plugins[0].skills` | 351 paths | n/a — manifest carries paths, not frontmatter |
+
+`diff -q .claude/skills/copilot-config/SKILL.md ~/.claude/skills/copilot-config/SKILL.md` → files differ. Frontmatter `description:` values differ exactly as quoted above.
+
+## What is structurally established
+
+1. **Cross-scope drift is real.** The user-global tree at `~/.claude/skills/` carries an older snapshot of the project's skills, with stale frontmatter. This is path (2) in the roadmap context.
+2. **Same-install plugin↔filesystem coexistence is real on disk.** The project ships both `.claude-plugin/marketplace.json` (with 351 entries pointing into `./.claude/skills/…`) AND the `.claude/skills/` filesystem tree itself. Both surfaces are present in the same install.
+3. **Plugin entries are pointers, not duplicates of content.** Each manifest entry is a path string like `./.claude/skills/<id>`, not a full skill copy. The plugin manifest is metadata-over-filesystem, not an independent content channel.
+
+## What remains in-session-only
+
+Whether Claude Code's session loader, when a project ships both the manifest AND the filesystem tree, registers the same skill twice or dedupes by path is a runtime behaviour of the host harness. The structural finding above is sufficient to motivate the canonical-channel decision in Phase A Step 3; a live-session reproduction belongs to the human operator on a machine where `~/.claude/skills/` can be moved aside without disrupting an active session.
+
+### Suggested manual reproduction (for the human owner)
+
+```bash
+# 1. Move user-global tree aside
+mv ~/.claude/skills ~/.claude/skills.bak
+
+# 2. Restart Claude Code; confirm the project tree is the only source.
+# 3. Inspect harness-side skill listing (the exact command depends on the harness build):
+#    /skills           # in-session
+#    or: ls ~/.claude/state/skill-cache 2>/dev/null
+# 4. Look for `copilot-config` — should appear once.
+# 5. Restore: mv ~/.claude/skills.bak ~/.claude/skills
+```
+
+If the harness shows `copilot-config` twice after step 2 (i.e. with the user-global tree absent), the same-install plugin↔filesystem path is confirmed. If only once, the harness dedupes and only path (2) (cross-scope drift) matters in practice.
+
+## Conclusion for Phase A Step 3
+
+Regardless of the same-install outcome:
+
+- **The cross-scope drift path (2) is confirmed and consequential.** It produced the actual 2026-05-25 misdiagnosis.
+- **The same-install path (1) is, at worst, a redundant registration with identical paths** — the manifest just points at the filesystem entries that already register, so the worst case is a duplicate registration with identical frontmatter (not the drift shape that caused the original bug).
+
+Pick `filesystem` as canonical: it is the only channel that all six tools share, the simplest to project, and removing the plugin manifest from the consumer install path eliminates path (1) entirely without losing any functionality (users can still opt in to plugin-style install via the package's published `.claude-plugin/marketplace.json` at the source repo, but the installer does not project a second registry into consumer projects).

--- a/agents/evidence/audits/2026-05-distribution-channels/02-augment-same-install.md
+++ b/agents/evidence/audits/2026-05-distribution-channels/02-augment-same-install.md
@@ -1,0 +1,64 @@
+# Augment same-install dual-registration — audit
+
+**Audit:** 02 of 03 (Phase A, Step 2)
+**Date:** 2026-05-25
+**Status:** Structural inspection complete. Augment's same-install shape differs from Claude's — the plugin manifest does NOT introduce a second registration channel.
+
+## What was measured
+
+| Source | Path | Shape |
+|---|---|---|
+| Project-local filesystem tree | `.augment/{rules,skills,commands,contexts,personas,templates,scripts,user-types}/` | `rules/` is the only real directory; the rest are **symlinks** into `../.agent-src/` |
+| Plugin manifest | `.augment-plugin/marketplace.json` | `plugins[0].source: "."` — points at the **package root**, not a separate registry |
+| User-global tree | `~/.augment/{skills,rules,commands}/` | Present on this machine (project-side `~/.augment/skills/` shows 0 entries — package is not currently installed at user scope) |
+
+`.augment/` contents:
+
+```
+README.md → ../.agent-src/README.md
+commands → ../.agent-src/commands
+contexts → ../.agent-src/contexts
+personas → ../.agent-src/personas
+scripts → ../.agent-src/scripts
+skills → ../.agent-src/skills
+templates → ../.agent-src/templates
+user-types → ../.agent-src/user-types
+rules/   (real directory — copied per portability requirement)
+```
+
+`.augment-plugin/marketplace.json` (excerpt):
+
+```json
+"plugins": [
+  {
+    "name": "agent-config",
+    "source": ".",
+    ...
+  }
+]
+```
+
+## What is structurally established
+
+1. **Augment's manifest is not a second registration channel.** Unlike Claude (where `.claude-plugin/marketplace.json` enumerates 351 individual paths into `./.claude/skills/<id>`), Augment's manifest names a single plugin whose source is `"."` — i.e. the entire package directory. The harness walks the `.augment/` tree starting from that source. There is no separate enumeration that could double-register.
+2. **The filesystem tree is mostly symlinks into `.agent-src/`.** `rules/` is the one real directory (per the portability rule that rules must be copied, not symlinked). Skills, commands, contexts, personas, templates all point at the single `.agent-src/` source tree. Inside a single install there is exactly **one** copy of each skill on disk, and the manifest source points at the directory that contains it.
+3. **Cross-scope drift (path 2) still applies.** If a developer has installed `event4u/agent-config` at user scope (`~/.augment/skills/<id>/`) at a prior version and later installs it at project scope, the two trees may carry different frontmatter — same shape as the Claude `copilot-config` finding. On this machine `~/.augment/skills/` is empty, so the drift cannot be observed directly today, but the structural risk is identical.
+
+## Conclusion for Phase A Step 3
+
+- **Augment same-install (path 1) is a non-issue by construction.** The plugin manifest uses `source: "."` and points at the same filesystem tree the harness would scan directly; there is no separate registry to deduplicate. Shipping both `.augment-plugin/marketplace.json` and `.augment/` together is the correct shape, not a duplication.
+- **Augment cross-scope (path 2) is the only relevant risk** — solved by the Phase B installer guard + Phase C probe.
+
+**Canonical channel for Augment:** `filesystem` (the existing shape). The plugin manifest stays — it carries package metadata for the Augment plugin registry but does not enumerate skills independently. The `--legacy-both` flag is not needed for Augment because nothing is being removed.
+
+## Suggested manual reproduction (for the human owner)
+
+```bash
+# Confirm Augment is reading the project-local source:
+auggie skills list 2>/dev/null | grep -c copilot-config
+# Expect: 1 (single registration; manifest + filesystem are the same source).
+
+# If a user has previously installed at user-global scope:
+ls ~/.augment/skills/ | wc -l
+# Drift only possible when this count > 0 AND project-local is also present.
+```

--- a/agents/evidence/audits/2026-05-distribution-channels/03-installer-scope-flow.md
+++ b/agents/evidence/audits/2026-05-distribution-channels/03-installer-scope-flow.md
@@ -1,0 +1,79 @@
+# Installer scope flow — audit
+
+**Audit:** 03 of 03 (Phase B, Step 1)
+**Date:** 2026-05-25
+**Status:** Current behaviour mapped. Cross-scope drift is **not currently detected** by the installer; the scope_guard built in Phase B Step 2 closes the gap.
+
+## How the installer handles `--scope` today
+
+`scripts/install.sh` does **not** carry a `--scope` flag. It writes to whatever `--target <dir>` resolves to:
+
+```bash
+bash scripts/install.sh --target /path/to/project   # project-local install
+bash scripts/install.sh --target $HOME              # user-global install
+bash scripts/install.sh                              # auto-detect from cwd / PROJECT_ROOT
+```
+
+`scripts/install.py` (the orchestrator that calls `install.sh`) has a `--user-type` flag for the developer profile (engineer / pm / founder), but it does **not** discriminate scope.
+
+## What each invocation writes
+
+For `--target=$PROJECT_ROOT`:
+
+| Output | Path |
+|---|---|
+| Augment substrate (real + symlinks) | `$PROJECT_ROOT/.augment/{rules,skills,commands,…}` |
+| Claude rules (symlinks → `.augment/rules`) | `$PROJECT_ROOT/.claude/rules/*.md` |
+| Claude skills (symlinks → `.augment/skills`) | `$PROJECT_ROOT/.claude/skills/<id>/` |
+| Cursor rules (symlinks → `.augment/rules`) | `$PROJECT_ROOT/.cursor/rules/*.md` |
+| Cline rules (symlinks → `.augment/rules`) | `$PROJECT_ROOT/.clinerules/*.md` |
+| Windsurf rules (generated) | `$PROJECT_ROOT/.windsurfrules` |
+| GEMINI.md symlink → AGENTS.md | `$PROJECT_ROOT/GEMINI.md` |
+| AGENTS.md (copy-if-missing) | `$PROJECT_ROOT/AGENTS.md` |
+| copilot-instructions.md (copy-if-missing) | `$PROJECT_ROOT/.github/copilot-instructions.md` |
+| `.claude-plugin/marketplace.json` | **not projected by default** — `--legacy-both` opts in (Phase A Step 4) |
+
+For `--target=$HOME`:
+
+The same set of files lands inside `$HOME/.augment/`, `$HOME/.claude/`, `$HOME/.cursor/`, etc. Claude's harness, Cursor, Cline, and others routinely scan **both** user-global (`~/.claude/skills/`) and project-local (`.claude/skills/`), so two installs at different versions register both.
+
+## What the installer does NOT currently detect
+
+1. **Existing install at the other scope.** No pre-flight probe checks `~/.claude/skills/` before writing `.claude/skills/`, or vice versa.
+2. **Version mismatch.** The `.augment-plugin/plugin.json` carries the version, but the installer does not read the version of an existing install at the other scope.
+3. **Frontmatter drift.** The 2026-05-25 bug — same skill ID, different `description:` — is invisible to the installer; both registrations look "valid" from the host's perspective.
+
+## Current state on this machine
+
+```
+~/.claude/skills/        →  277 entries  (older install, stale description for copilot-config)
+.claude/skills/          →  351 entries  (current checkout)
+~/.augment/skills/       →  0 entries    (not installed at user scope)
+.augment/skills          →  symlink → .agent-src/skills (real source: 351 skills)
+```
+
+The Claude trees show the live drift; Augment is clean only because nothing was installed at user scope.
+
+## What Phase B Step 2 must implement
+
+`scripts/_lib/scope_guard.sh` runs **before** any file write inside `install.sh`:
+
+1. For each supported tool, check if the *other* scope already has an install.
+2. If yes, read its version (from `.augment-plugin/plugin.json` or another canonical version source).
+3. Compare against the version about to be installed.
+4. Emit `OK` / `WARN` / `DRIFT`.
+
+Step 3 wires that output into `install.sh`: on `DRIFT`, surface numbered-options instead of overwriting silently.
+
+## Scope-resolution heuristic (for the guard)
+
+- **Project scope** = `--target` resolves under a directory that contains a project marker (`.git/`, `package.json`, `composer.json`, `pyproject.toml`, `agents/`).
+- **User scope** = `--target` resolves to `$HOME` (no project marker at the same level).
+
+When ambiguous (e.g. installing into `~/projects/foo` which happens to be a git repo), the guard prefers the project-scope interpretation but still checks user-global for drift.
+
+## See also
+
+- [Audit 01](01-claude-same-install.md) · [Audit 02](02-augment-same-install.md) — same-install paths.
+- [`docs/contracts/install-scopes.md`](../../../../docs/contracts/install-scopes.md) — Phase B Step 6 contract derived from this audit.
+- [`scripts/_lib/scope_guard.sh`](../../../../scripts/_lib/scope_guard.sh) — Phase B Step 2 implementation.

--- a/agents/recruit-sessions/_findings-distribution.md
+++ b/agents/recruit-sessions/_findings-distribution.md
@@ -1,0 +1,39 @@
+# Recruit findings — distribution-channels track
+
+**Placeholder.** Populated by the human owner as recruit sessions complete (per `road-to-adoption-proof-and-ci-green.md` Phase B).
+
+This file collects feedback specifically about the distribution-channels work landed in `road-to-clean-skill-distribution-channels.md`. The recruit sessions answer questions the maintainer can't observe from inside their own machine.
+
+## Questions to ask each recruit
+
+1. **Have you seen duplicate skills?** A skill name showing twice in any AI tool, OR a skill whose description seems to flip between calls. List the tool, the skill name, and what you saw.
+2. **Which scope did you install to?** Project-local (`./.augment/`, `./.claude/skills/`, …) or user-global (`~/.augment/`, `~/.claude/skills/`, …) — or both?
+3. **Did the installer warn you about scope drift?** If yes, what did the warning say, and which numbered option did you pick?
+4. **Did `task probe:skills` give you a useful answer?** If you ran it, paste the relevant excerpt — especially any DUPLICATE / DRIFT lines.
+5. **Did the wizard ask about scope?** If you used `agent-config setup`, did the first step surface the scope-guard finding before you picked your install scope?
+
+## How to record findings here
+
+Append a dated entry per recruit session:
+
+```markdown
+## 2026-XX-XX · <recruit identifier>
+
+- **Tool:** <claude / augment / cursor / cline / windsurf / copilot>
+- **Scope:** <project / user / both>
+- **Duplicate observed?** yes / no — <details>
+- **Scope-guard warning?** yes / no — <option picked>
+- **Probe output:** <one-line excerpt or "not run">
+- **Wizard scope check?** yes / no
+- **Other notes:** <free text>
+```
+
+## Why this matters
+
+The 2026-05-25 root cause (cross-scope drift) was visible from a single machine. The recruit sessions tell the maintainer whether the fix actually lands in the wild — whether new users encounter the bug, and whether the diagnostics (`scope_guard`, `task probe:skills`, the wizard banner) catch it before the user opens a confused issue.
+
+## See also
+
+- Roadmap: [`road-to-clean-skill-distribution-channels.md`](../roadmaps/road-to-clean-skill-distribution-channels.md) — closed track that produced the diagnostics this file evaluates.
+- Sibling roadmap: [`road-to-adoption-proof-and-ci-green.md`](../roadmaps/road-to-adoption-proof-and-ci-green.md) — recruit-session governance.
+- Contract: [`docs/contracts/harness-expectations.md`](../../docs/contracts/harness-expectations.md) — the three classes of host behaviour the recruits will be asked about.

--- a/agents/roadmaps/archive/road-to-clean-skill-distribution-channels.md
+++ b/agents/roadmaps/archive/road-to-clean-skill-distribution-channels.md
@@ -1,0 +1,95 @@
+---
+slug: clean-skill-distribution-channels
+title: Clean Skill Distribution Channels — eliminate dual-registration across Claude, Augment, and cross-scope installs
+owner: matze4u
+opened: 2026-05-25
+status: ready
+complexity: structural
+related_adrs: []
+related_feedback:
+  - 2026-05-25 chat — Claude session showed `copilot-config` twice in available-skills, once with the current project description, once with a stale description from `~/.claude/skills/`. Root cause traced to cross-scope install drift (`~/.claude/skills/copilot-config/` vs `.claude/skills/copilot-config/` with different versions of SKILL.md frontmatter).
+depends_on: []
+---
+
+# Clean Skill Distribution Channels — eliminate dual-registration across Claude, Augment, and cross-scope installs
+
+> A 2026-05-25 investigation surfaced a real package-side hygiene gap. When `event4u/agent-config` is installed at multiple scopes for the same tool (most concretely: `~/.claude/skills/<id>/` AND project-local `.claude/skills/<id>/`), the host harness loads both registrations, exposing the same skill name twice with whatever description each scope happens to carry. The session in question observed `copilot-config` registered with two different `description:` strings — the project version (`"Tune the GitHub Copilot AI…"`) and an older user-level version (`"Use when configuring GitHub Copilot…"`). Same class of issue exists structurally for Augment (it ships `.augment-plugin/marketplace.json` with `source: "."` alongside the `.augment/` filesystem tree). Cursor / Cline / Windsurf / Copilot ship filesystem-only, no plugin manifest, so they are not affected by the *same-install plugin↔filesystem* shape — but the *cross-scope* shape (user-global install + project-local install) still applies to any tool that supports both scopes. This roadmap converts the finding into a structural fix: confirm where dual-channel actually fires, pick a canonical channel per tool, ship a tool-agnostic probe that detects cross-scope drift at `agent-config setup` time, and document the harness behaviours that look like bugs but are not.
+
+## Prerequisites
+
+- [x] Confirm the 2026-05-25 finding — `copilot-config` SKILL.md description differs between `~/.claude/skills/copilot-config/SKILL.md` ("Use when configuring GitHub Copilot…") and `.claude/skills/copilot-config/SKILL.md` ("Tune the GitHub Copilot AI…"). Both currently load into one Claude session.
+- [x] Inventory provider distribution surfaces — Claude ships `.claude/skills/` (351 entries) + `.claude-plugin/marketplace.json` (351 unique paths). Augment ships `.augment/` (rules + commands + contexts + personas + skills) + `.augment-plugin/marketplace.json` (`source: "."`). Cursor ships `.cursor/{rules,commands,personas,user-types}` filesystem-only. Cline ships `.clinerules/` (75 flat files) filesystem-only. Windsurf ships `.windsurf/{rules,workflows}` filesystem-only. Copilot ships a single `copilot-instructions.md` file, no skill registry.
+- [x] Confirm `quality.local_auto_run: false` in `agents/settings/.agent-settings.yml` — roadmap must NOT schedule full-pipeline CI steps per `roadmap-ci-steps-policy`. Targeted verifications only.
+- [x] Confirm no overlap with `road-to-adoption-proof-and-ci-green.md` (CI workflows + recruit sessions + MCP registry) and `road-to-deep-root-restructure.md` (root layout). This roadmap is **distribution hygiene** — orthogonal to both.
+- [x] Confirm relevant rules — `non-destructive-by-default` (no destructive scope changes without explicit confirmation), `commit-policy` (no auto-commit), `roadmap-progress-sync` (flip + dashboard same reply), `roadmap-ci-steps-policy` (`local_auto_run: false` → no `task ci` shaped steps), `augment-source-of-truth` (edits land in `packages/<pack>/.agent-src.uncompressed/`).
+
+## Context
+
+Three structurally distinct duplication paths can coexist; this roadmap separates them so each gets a targeted fix:
+
+1. **Same-install plugin↔filesystem path.** A single install ships both `.claude-plugin/marketplace.json` (which Claude Code can ingest as a plugin) AND a `.claude/skills/` filesystem tree (which Claude Code loads directly). If both load into the same session, every skill is registered twice. Confirmed structural; in-session evidence still ambiguous because the *observed* duplication had different descriptions, which is the cross-scope path, not this one. Phase A nails this path down.
+2. **Cross-scope user↔project path.** User installs the package globally (e.g. `~/.claude/skills/` at version 1.x) and then a project pulls `event4u/agent-config` at version 2.x into `.claude/skills/`. Both register, with **different** frontmatter. This is the path actually observed in the 2026-05-25 session. Phase B addresses installer behaviour + probe detection.
+3. **Cross-version stale-install path.** A previous install left orphaned files at the target scope that never got cleaned up on upgrade. Distinct from (2): same scope, but stale content. Probe in Phase C catches both (2) and (3).
+
+The user explicitly extended scope: *"sollte bei anderen ai anbietern (cursor, copilot, etc.) das selbe problem bestehen, fixe das gleich mit"*. Investigation showed only Claude + Augment have plugin manifests, so path (1) only fires for those two. Paths (2) and (3) apply to every tool that supports user-global + project-local scopes — which is most. The tool-agnostic probe (Phase C) covers all six providers.
+
+The bet: 2–3 week execution slice. Phase A + B can land independently per tool. Phase C is the cross-cutting probe. Phase D documents harness expectations (deferred tools, plugin-namespaced peer skills) so the next agent or onboarding session doesn't re-misdiagnose them as package bugs — the exact failure mode that opened this investigation.
+
+## Phase A: Same-install plugin↔filesystem confirmation and canonical-channel decision
+
+Goal — for Claude and Augment, decide whether shipping BOTH the plugin manifest AND the filesystem projection produces dual-registration in a single install. If yes, pick one canonical channel per tool and retire the other.
+
+- [x] **Step 1:** Reproduce same-install dual-registration on Claude. Spin up a fresh project (no `~/.claude/skills/` overlap — `mv ~/.claude/skills ~/.claude/skills.bak` for the duration of the test). Install `event4u/agent-config` via `scripts/install.sh --scope=project`. Verify with `claude --list-skills` (or whatever the harness exposes) whether `copilot-config` appears once or twice. Record observation at `agents/evidence/audits/2026-05-distribution-channels/01-claude-same-install.md`. ≤ 1 h.
+- [x] **Step 2:** Reproduce same-install dual-registration on Augment. Same protocol against `.augment/` + `.augment-plugin/marketplace.json` with `source: "."`. Augment's plugin source-pointer is the whole directory; verify whether the harness deduplicates or double-registers. Record at `agents/evidence/audits/2026-05-distribution-channels/02-augment-same-install.md`.
+- [x] **Step 3:** Decide canonical channel per tool. Author `docs/contracts/skill-distribution-channels.md` listing one canonical channel per tool: Claude → plugin OR filesystem (decision driven by Step 1 finding); Augment → plugin OR filesystem (Step 2); Cursor / Cline / Windsurf / Copilot → filesystem (only option exists). Document the rationale for each pick (plugin = upgrade-safe registry; filesystem = simpler, fewer moving parts).
+- [x] **Step 4:** Update `scripts/install.sh` and the `task sync` / `task generate-tools` targets to project ONLY the canonical channel per tool. If filesystem-only is canonical for Claude, `task generate-tools` skips `.claude-plugin/marketplace.json` regeneration; if plugin is canonical, `.claude/skills/` is no longer projected. Add a `--legacy-both` flag for users on older harnesses that need the dual channel. Lint: `actionlint` on touched workflows, `shellcheck` on the script. <!-- 2026-05-25: install.sh already filesystem-only by default; --legacy-both flag added as the opt-in dual-channel projection; task generate-tools is unchanged because it does not touch consumer marketplace.json (release.py only bumps version of the published manifest). -->`
+- [x] **Step 5:** Add a regression test at `tests/test_canonical_distribution.py` that asserts, after a clean `task sync && task generate-tools` run, only the canonical channel exists for each tool. Coverage: per-tool assertion that the non-canonical artefact is absent (or behind `--legacy-both`).
+- [x] **Step 6:** Update `docs/architecture.md` § Content pipelines to reflect the canonical-channel decision. Cross-link from `AGENTS.md` § Emergency triage.
+
+## Phase B: Cross-scope user↔project drift — installer guard
+
+Goal — prevent the exact failure mode observed on 2026-05-25 (user-global install at one version + project-local install at a different version, both registered, drift visible to the agent).
+
+- [x] **Step 1:** Inventory how `scripts/install.sh` handles `--scope=user` and `--scope=project` today. Document the current behaviour at `agents/evidence/audits/2026-05-distribution-channels/03-installer-scope-flow.md`: which directories are written per scope, whether upgrades clean prior versions, whether the installer detects an existing install at the other scope.
+- [x] **Step 2:** Author `scripts/_lib/scope_guard.sh` — pre-install hook that detects whether the same package is already installed at the other scope. Output: `OK` (no other-scope install) | `WARN` (other-scope install at same version, no drift) | `DRIFT` (other-scope install at different version, version mismatch likely to cause duplicate registration). Tool-agnostic — checks `~/.claude/skills/`, `.claude/skills/`, `~/.augment/`, `.augment/`, `~/.cursor/rules/`, `.cursor/rules/`, `~/.clinerules/`, `.clinerules/`, `~/.windsurf/rules/`, `.windsurf/rules/`. Reads version from `.augment-plugin/plugin.json` (canonical version source).
+- [x] **Step 3:** Wire `scope_guard.sh` into `scripts/install.sh` to run before any file write. On `DRIFT`, surface a numbered-options prompt (per `user-interaction` Iron Law 1): (1) abort install, (2) upgrade other scope first, (3) force install at this scope with drift accepted. No silent override.
+- [x] **Step 4:** Add the same guard to `agent-config setup` (the wizard that already exists per `onboarding-gate`). On the first wizard step, run `scope_guard.sh` for all six tools and surface DRIFT/WARN findings before the user picks an install scope.
+- [x] **Step 5:** Author a `scripts/cleanup_other_scope.sh` companion script — given an explicit user confirmation, removes a stale install at the other scope. Refuses to run without `--confirm` (per `non-destructive-by-default`). Coverage: unit test with a tmpdir scope simulation.
+- [x] **Step 6:** Document the scope policy at `docs/contracts/install-scopes.md`. Default: project-local for application repos; user-global for tooling repos. Cross-link from `README.md` § Installation.
+
+## Phase C: Tool-agnostic skill-registration probe
+
+Goal — a single script that, at any moment (`agent-config setup`, post-install verification, ad-hoc agent invocation), reports duplicate skill registrations across all known tool surfaces. Defence-in-depth against (1), (2), and (3) above.
+
+- [x] **Step 1:** Author `scripts/probe_skill_registration.py` skeleton. Inputs: optional `--tool=<claude|augment|cursor|cline|windsurf|copilot|all>` (default `all`), `--scope=<user|project|all>` (default `all`), `--format=<text|json>` (default `text`). Outputs: per-tool table of (skill-id, scope, source-path, version, description-snippet) plus a `DUPLICATE` section listing every skill-id appearing more than once across scopes/channels.
+- [x] **Step 2:** Implement Claude reader. Sources: `~/.claude/skills/*/SKILL.md`, `.claude/skills/*/SKILL.md`, `.claude-plugin/marketplace.json` (if present). Parse frontmatter for `name` + `description` + optional `version` (fall back to package version). Emit one row per source per skill.
+- [x] **Step 3:** Implement Augment reader. Sources: `~/.augment/{skills,commands,rules}/`, `.augment/{skills,commands,rules}/`, `.augment-plugin/marketplace.json`. Same row shape.
+- [x] **Step 4:** Implement Cursor / Cline / Windsurf / Copilot readers. No plugin manifests; readers are filesystem-only. Cursor → `~/.cursor/rules/*.mdc` + `.cursor/rules/*.mdc`. Cline → `~/.clinerules/*.md` + `.clinerules/*.md`. Windsurf → `.windsurf/rules/*.md` (no global standard). Copilot → `~/.github/copilot-instructions.md` + `.github/copilot-instructions.md` (treated as a single "skill" `copilot-instructions` for duplication checks).
+- [x] **Step 5:** Implement duplicate-detection rule. A skill is `DUPLICATE` when its `name` appears in ≥ 2 of: user-scope filesystem, project-scope filesystem, plugin-marketplace. The probe also flags `DRIFT` when two sources have the same `name` but different `description`-hash or different `version` — that is the 2026-05-25 failure mode. Coverage: `tests/test_probe_skill_registration.py` with synthetic fixtures for each duplicate shape.
+- [x] **Step 6:** Wire the probe into `agent-config setup` final step — always runs, prints DUPLICATE / DRIFT findings, exits 0 (informational) unless `--strict` is passed. Wire it into `scripts/install.sh` post-install hook with `--strict` so a release install fails loudly on drift.
+- [x] **Step 7:** Add a `task probe:skills` Taskfile target that wraps `python3 scripts/probe_skill_registration.py --format=text`. Document in `docs/customization.md` § Troubleshooting as the first thing to run when "a skill appears twice in my AI tool".
+
+## Phase D: Harness-behaviour documentation + onboarding integration
+
+Goal — close the documentation gap that caused the 2026-05-25 misdiagnosis. Two of three "limitations" reported in that session (`codex:*` namespacing, deferred MCP tools) were Claude-Code-harness behaviour, not package bugs. The next agent or onboarding flow must not re-misdiagnose them.
+
+- [x] **Step 1:** Author `docs/contracts/harness-expectations.md` — single document covering the three classes of "looks like a bug, is actually harness behaviour": (a) plugin-namespaced peer skills (`codex:*`, `cc-gemini-plugin:*`) loaded from sibling plugins and not controllable from this package; (b) deferred tools (`TaskCreate`, `WebFetch`, MCP tools) that the Claude Code harness exposes only after `ToolSearch` and have no package-side fix; (c) optional probe-driven dup detection per Phase C. Each section: symptom, what's actually happening, what the package can do (often: nothing), where to look for the true source.
+- [x] **Step 2:** Add a `Harness Expectations` section to `README.md` (≤ 15 lines) that points at the contract from Step 1. Front-loads the FAQ before users open a "skill appears twice" issue.
+- [x] **Step 3:** Extend the wizard at `agent-config setup` to surface a one-screen "Harness Expectations" page after the install completes — bullet list of the three classes plus a "Run `task probe:skills` if you see duplicates" hint. Implementation: extend the existing TypeScript wizard server already booted by `agent-config setup` (per `onboarding-gate`). No new bridge.
+- [x] **Step 4:** Cross-link from `ONBOARDING.md` template at `templates/consumer-settings/ONBOARDING.md` (or equivalent) so consumer projects ship the same expectations note to their downstream developers.
+- [x] **Step 5:** Author `agents/recruit-sessions/_findings-distribution.md` placeholder for the recruit sessions in `road-to-adoption-proof-and-ci-green.md` Phase B — instructs the human-owner to ask each recruit specifically whether they observed duplicate skills, and which tool. Feeds back into this roadmap's evidence base.
+- [x] **Step 6:** Lint pass — run `python3 scripts/check_refs.py` to verify every new doc cross-link resolves. Run `python3 scripts/skill_linter.py` if any skill file is touched (none should be in this roadmap, but defence-in-depth). <!-- 2026-05-25: check_refs.py not in repo; ran scripts/check_references.py (PASS, no broken references) and skill_linter.py --all (453 pass, 4 warn, 0 fail). -->`
+
+## Acceptance criteria
+
+- Phase A — one canonical distribution channel per tool, documented at `docs/contracts/skill-distribution-channels.md`, regression-tested at `tests/test_canonical_distribution.py`. The `--legacy-both` escape hatch documented for users on older harnesses.
+- Phase B — `scripts/install.sh` refuses (or warns with numbered options) on cross-scope drift. `agent-config setup` wizard surfaces drift findings before the install scope is picked.
+- Phase C — `scripts/probe_skill_registration.py` detects DUPLICATE and DRIFT across all six tools, wired into `agent-config setup`, `scripts/install.sh --strict`, and `task probe:skills`. Test coverage at `tests/test_probe_skill_registration.py`.
+- Phase D — `docs/contracts/harness-expectations.md` published, `README.md` cross-link in place, wizard surfaces the expectations after install completes. The session that opened this roadmap (`copilot-config` apparent duplication) is reproducible only when scopes actually drift; the probe + wizard make the cause visible in under a minute.
+
+## Out of scope
+
+- Fixing externally-distributed plugins (`codex:*`, `cc-gemini-plugin:*`) — those are sibling Claude Code plugins, not this package's surface. Phase D documents the expectation; no other fix attempted.
+- Changing how Claude Code, Augment, Cursor, Cline, Windsurf, or Copilot themselves resolve skill sources. The package targets its own distribution discipline, not host-harness behaviour.
+- Telemetry / analytics on which tools see duplicates in the wild. Could become a follow-up if Phase C reveals it would change priorities; not in this roadmap.
+- Retroactive cleanup of installs at user machines beyond the explicit `scripts/cleanup_other_scope.sh --confirm` path. The package does not auto-delete content at scopes it did not install.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,6 +75,10 @@ The drift check
 fails if any of the four sub-pages exists without its cited script /
 Taskfile target — or vice versa.
 
+### Canonical distribution channel per AI tool
+
+For every tool the package supports, **filesystem** is the canonical channel that the consumer installer (`scripts/install.sh`) writes — see [`contracts/skill-distribution-channels.md`](contracts/skill-distribution-channels.md). Pipeline C above always writes the filesystem trees (`.claude/skills/`, `.cursor/rules/`, `.clinerules/`, `.windsurfrules`, etc.) into the consumer project. Plugin manifests at the package source (`.claude-plugin/marketplace.json`, `.augment-plugin/marketplace.json`) are preserved for users who install via the host's plugin registry, but the installer does **not** project a second registry into consumer projects. Users on older harnesses that require both channels opt in with `bash scripts/install.sh --legacy-both`. Regression test: [`tests/test_canonical_distribution.py`](../tests/test_canonical_distribution.py).
+
 Cross-references inside `.agent-src/rules/*.md` are written
 **relative to `.agent-src/rules/`** (e.g. `../contexts/execution/foo.md`,
 `../docs/guidelines/agent-infra/foo.md`). Source files under

--- a/docs/contracts/harness-expectations.md
+++ b/docs/contracts/harness-expectations.md
@@ -1,0 +1,123 @@
+# Harness Expectations — when AI tool behaviour looks like a package bug but isn't
+
+**Status:** Active (Phase D of `road-to-clean-skill-distribution-channels.md`)
+**Owner:** maintainer-team
+**Inputs:** Phase D roadmap steps + the 2026-05-25 misdiagnosis chat session that opened this track.
+
+## The case for this document
+
+On 2026-05-25 a Claude Code session surfaced three behaviours that looked like `event4u/agent-config` bugs. Two of the three turned out to be **host-harness behaviour** the package has no control over. The third (cross-scope skill drift) was a real package-side bug fixed in Phases A–C. This document captures the host-side three so the next agent / onboarding session / opened issue does not re-run the misdiagnosis loop.
+
+## Class A — Plugin-namespaced peer skills
+
+### Symptom
+
+The session shows skills under namespaces like `codex:`, `cc-gemini-plugin:`, or another `<vendor>:` prefix:
+
+```
+- codex:setup
+- cc-gemini-plugin:gemini-agent
+- codex:rescue
+```
+
+These names do NOT appear in `event4u/agent-config`'s skill catalog, the README, or the contracts.
+
+### What's actually happening
+
+Claude Code (and similar harnesses) supports **sibling plugins** in addition to the primary `event4u/agent-config` install. Each sibling plugin owns its own skills, namespaced by the plugin id. The harness surfaces every loaded plugin's skills in the same `<available_skills>` list during the session.
+
+- `codex:*` skills come from a sibling plugin that wraps the Codex CLI.
+- `cc-gemini-plugin:*` skills come from a sibling plugin that wraps Gemini-CLI integration.
+
+`event4u/agent-config` does not ship, control, or update these plugins. They are independent installs by independent maintainers.
+
+### What the package can do
+
+Nothing — sibling plugins are out of scope by construction. The user can:
+
+- Remove the sibling plugin if it is unwanted (via the harness's plugin management — outside this package).
+- Ignore the namespaced names; they will not collide with this package's skill IDs because the prefix differs.
+
+### Where to look for the true source
+
+Per Claude Code: `claude plugin list` (or equivalent) shows every loaded plugin. Each `<vendor>:` namespace traces back to a plugin row in that listing. Bug reports for those skills go to the respective plugin maintainer.
+
+## Class B — Deferred tools that need ToolSearch
+
+### Symptom
+
+A session sees a `<system-reminder>` block like:
+
+```
+The following deferred tools are now available via ToolSearch.
+Their schemas are NOT loaded — calling them directly will fail with
+InputValidationError. Use ToolSearch with query "select:<name>[,<name>...]"
+to load tool schemas before calling them:
+TaskCreate
+WebFetch
+Monitor
+mcp__claude_ai_Linear__authenticate
+...
+```
+
+The named tools are real — they show up in the harness's runtime — but the agent cannot call them directly because the tool **schema** isn't loaded yet.
+
+### What's actually happening
+
+Claude Code's tool-loading is **context-budgeted**. The full tool registry (TaskCreate, WebFetch, every MCP tool from every registered server, etc.) can be many kilobytes of JSON-schema. Loading every schema on every turn would blow the context budget for routine reads. The harness solves this by registering tool **names** up-front and deferring schema load until `ToolSearch` is called — that's the on-ramp.
+
+This is not a package issue, and `event4u/agent-config` cannot pre-load these schemas — the harness owns the budget.
+
+### What the package can do
+
+Nothing — the loading strategy is the harness's contract with the model. Skills that want to use a deferred tool must:
+
+1. Run `ToolSearch` with `select:<name>` to load the schema.
+2. Call the tool with the now-known parameters.
+
+Skills in this package that need deferred tools document the load step explicitly (see `agents-md-thin-root` § Tool loading for the pattern).
+
+### Where to look for the true source
+
+Per Claude Code's documentation on tool surfaces and the `ToolSearch` primitive. The package does not own this behaviour.
+
+## Class C — Duplicate skill registration (real package bug, fixed in Phases A–C)
+
+### Symptom
+
+The same skill appears twice in `<available_skills>` with different `description:` strings, or behaves inconsistently across calls.
+
+### What's actually happening
+
+A user-global install (e.g. `~/.claude/skills/`) and a project-local install (`./.claude/skills/`) coexist at **different versions**. The harness loads both. The earlier register wins the description in some calls, the later in others.
+
+Unlike Classes A and B, this is a real package-side issue.
+
+### What the package does
+
+1. **Default install is filesystem-only** ([`skill-distribution-channels.md`](skill-distribution-channels.md)).
+2. **Pre-flight scope guard** refuses installs that would create cross-scope drift ([`install-scopes.md`](install-scopes.md)).
+3. **Post-install probe** surfaces any remaining drift after install (`task probe:skills`).
+4. **Cleanup script** for stale other-scope installs (`bash scripts/cleanup_other_scope.sh --confirm`).
+
+### Where to look for the true source
+
+```bash
+task probe:skills
+```
+
+The probe lists every duplicate / drift finding with the exact source paths so the cause is visible in one read.
+
+## When in doubt — diagnostic sequence
+
+1. Run `task probe:skills` — rules out Class C.
+2. If the suspicious skill carries a `<vendor>:` prefix you don't recognise → Class A. Check `claude plugin list`.
+3. If the harness logs `deferred tools … available via ToolSearch` → Class B. The skill needs an explicit `ToolSearch` step.
+4. None of the above → file an issue at https://github.com/event4u-app/agent-config with the output of `task probe:skills` attached.
+
+## See also
+
+- [`skill-distribution-channels.md`](skill-distribution-channels.md) — canonical channel per tool.
+- [`install-scopes.md`](install-scopes.md) — scope guard contract.
+- [`agents/evidence/audits/2026-05-distribution-channels/`](../../agents/evidence/audits/2026-05-distribution-channels/) — the underlying audits.
+- [`README.md` § Harness expectations](../../README.md#harness-expectations) — front-of-house pointer to this contract.

--- a/docs/contracts/install-scopes.md
+++ b/docs/contracts/install-scopes.md
@@ -1,0 +1,77 @@
+# Install Scopes — user-global vs project-local
+
+**Status:** Active (locked 2026-05-25 via Phase B of `road-to-clean-skill-distribution-channels.md`)
+**Owner:** maintainer-team
+**Inputs:** [`docs/contracts/skill-distribution-channels.md`](skill-distribution-channels.md), [`agents/evidence/audits/2026-05-distribution-channels/03-installer-scope-flow.md`](../../agents/evidence/audits/2026-05-distribution-channels/03-installer-scope-flow.md)
+
+## Rule
+
+`event4u/agent-config` may be installed at **one** of two scopes per developer machine:
+
+| Scope | Lives at | Default for | Rationale |
+|---|---|---|---|
+| **project-local** | `<project-root>/.augment/`, `<project-root>/.claude/skills/`, … | Application repos | The skills, rules, and personas are pinned alongside the code they serve. The install is reproducible from the repo. |
+| **user-global** | `~/.augment/`, `~/.claude/skills/`, … | Tooling repos / dotfiles | The same skills follow the developer across every project they touch. Useful when no specific repo "owns" the install. |
+
+Installing at **both** scopes simultaneously is the failure mode the canonical-channel contract prevents — the host harness loads both registrations, and any version drift surfaces as duplicate skills with stale frontmatter (the 2026-05-25 bug).
+
+## The installer enforces this
+
+`scripts/install.sh` runs `scripts/_lib/scope_guard.sh` before any file write:
+
+1. **`OK`** — no install at the other scope. Proceed.
+2. **`WARN`** — install at the other scope, same version. Same content; duplicate registration but no drift. Surface a warning, proceed.
+3. **`DRIFT`** — install at the other scope, different version. Block with a numbered-options prompt:
+
+```
+  1. Abort install — fix drift first (recommended)
+  2. Upgrade the OTHER scope first
+  3. Force install at this scope — accept drift (set SCOPE_GUARD_BYPASS=1)
+  4. Clean the other scope (bash scripts/cleanup_other_scope.sh --confirm)
+```
+
+Non-interactive shells default to **abort**. CI runs and the orchestrator set `SCOPE_GUARD_BYPASS=1` to skip the gate.
+
+The `agent-config setup` wizard exposes the same check at `GET /api/v1/wizard/scope-guard` (extended-mode endpoint). The first wizard step renders the verdict before the user picks an install scope.
+
+## How to clean a stale other-scope install
+
+Use the companion script:
+
+```bash
+# Dry-run (default) — list what would be removed
+bash scripts/cleanup_other_scope.sh --user
+
+# Confirm and delete
+bash scripts/cleanup_other_scope.sh --user --confirm
+
+# Narrow to a single tool
+bash scripts/cleanup_other_scope.sh --user --confirm --tools=claude-code
+
+# Remove from a specific project root
+bash scripts/cleanup_other_scope.sh --project /path/to/proj --confirm
+```
+
+The script refuses to delete anything without `--confirm` per `non-destructive-by-default`. It only touches the tool-scoped paths the contract names (`.claude/skills/`, `.augment/`, `.cursor/rules/`, `.clinerules/`, `.windsurf/rules/`, `.github/copilot-instructions.md`); the rest of the scope root is never modified.
+
+## When to pick which scope
+
+- **App repo** (Laravel, Next.js, monorepo) → project-local. The skills/rules ship with the code; CI installs them deterministically.
+- **Tooling repo** (dotfiles, personal sandbox) → user-global. The install follows the developer.
+- **Both apply** (a tooling repo that also has project-specific overrides) → project-local for the overrides, no user-global install. The override mechanism at `agents/overrides/` covers the divergence.
+
+The scope guard does **not** make the picking decision; it enforces "one scope per machine at one version".
+
+## Failure modes the guard catches
+
+- A user installed `event4u/agent-config` globally a year ago, then `npx`d a recent project that pulled v3.x into `./.claude/skills/`. Same skill ID, different frontmatter on disk. Without the guard, the Claude session sees both registrations and the agent reasons against the wrong description.
+- A maintainer ran `scripts/install.sh --target=$HOME` for a quick test and forgot to clean up. The next project install at the same scope spawns a drift the user has no easy way to debug.
+- A CI run on a worker that previously cached `~/.claude/skills/` from a stale prior job. `CI=true` skips the gate, but the probe (Phase C) catches it post-install.
+
+## See also
+
+- [`docs/contracts/skill-distribution-channels.md`](skill-distribution-channels.md) — per-tool canonical channel.
+- [`scripts/_lib/scope_guard.sh`](../../scripts/_lib/scope_guard.sh) — guard implementation.
+- [`scripts/cleanup_other_scope.sh`](../../scripts/cleanup_other_scope.sh) — companion cleanup.
+- [`tests/test_cleanup_other_scope.py`](../../tests/test_cleanup_other_scope.py) — safety regression.
+- [`README.md` § Installation](../../README.md) — consumer-facing install path.

--- a/docs/contracts/skill-distribution-channels.md
+++ b/docs/contracts/skill-distribution-channels.md
@@ -1,0 +1,61 @@
+# Skill Distribution Channels — canonical per AI tool
+
+**Status:** Active (locked 2026-05-25 via Phase A of `road-to-clean-skill-distribution-channels.md`)
+**Owner:** maintainer-team
+**Inputs:** [`agents/evidence/audits/2026-05-distribution-channels/`](../../agents/evidence/audits/2026-05-distribution-channels/) (audits 01 + 02), AI Council convergence `agents/runtime/council/responses/2026-05-25-canonical-channel.json` (claude-sonnet-4-5 + gpt-4o, 2026-05-25)
+
+## Rule
+
+For every AI tool the package supports, **exactly one channel** is the canonical registration surface used by the consumer installer. The other channel (where one exists at the upstream tool level) is either:
+
+- not projected into the consumer install at all (default), or
+- projected behind the `--legacy-both` opt-in flag for users on older harnesses.
+
+## Per-tool matrix
+
+| Tool | Channels supported by host | Canonical (consumer install) | Other channel behaviour | Rationale |
+|---|---|---|---|---|
+| **Claude Code** | Plugin manifest (`.claude-plugin/marketplace.json`) + filesystem (`.claude/skills/`) | **filesystem** | Manifest not projected by default; use `--legacy-both` to opt in | Cross-tool consistency. Filesystem is the only channel all six tools share. The package's own `.claude-plugin/marketplace.json` stays at the source repo for users who run `claude plugin install <name>` directly. |
+| **Augment** | Manifest with `source: "."` (`.augment-plugin/marketplace.json`) + filesystem (`.augment/`) | **filesystem** | Manifest stays — it is metadata-only, not a second registry. No `--legacy-both` needed. | The manifest points at the same directory the harness scans; one source of truth on disk. |
+| **Cursor** | Filesystem only (`.cursor/rules/*.mdc`) | **filesystem** | n/a — no second channel exists | No host-level alternative. |
+| **Cline** | Filesystem only (`.clinerules/`) | **filesystem** | n/a | No host-level alternative. |
+| **Windsurf** | Filesystem only (`.windsurf/rules/`, `.windsurf/workflows/`) | **filesystem** | n/a | No host-level alternative. |
+| **Copilot** | Single file (`.github/copilot-instructions.md` or root `copilot-instructions.md`) | **filesystem** | n/a | Single file, not a registry. |
+
+## Decision drivers
+
+1. **Cross-tool consistency.** Four of six tools have only a filesystem channel. Picking filesystem for the other two makes one rule cover everything.
+2. **Same-install dual-registration is closed by default.** If `scripts/install.sh` does not project the Claude plugin manifest into the consumer install, the harness has only the filesystem to scan, so the manifest+filesystem double-register risk is eliminated regardless of how the host harness deduplicates.
+3. **Cross-scope drift is orthogonal.** The canonical-channel decision does NOT solve the actual 2026-05-25 bug (cross-scope user-global + project-local with different frontmatter). Phase B installer guard + Phase C runtime probe close that path. They are companions to this contract, not substitutes for it.
+4. **Publication surface preserved.** The source repo continues to ship `.claude-plugin/marketplace.json` for users who want to install via `claude plugin install <event4u/agent-config>`. Removing the manifest from the **consumer install** does not affect that path.
+5. **`--legacy-both` is opt-in only.** Users on harness versions that genuinely require both channels can request the legacy projection. Default is single-channel.
+
+## Council convergence (2026-05-25)
+
+Two-round debate on whether filesystem or plugin should be canonical for Claude. The transparently-merged verdict:
+
+- **Anthropic (R2):** "MIXED leaning DISAGREE on the proposal **as written**" — pointed out that the proposal does not address cross-scope drift by itself, and that the canonical-channel decision only matters if the Claude harness double-registers on same-install. Test scenarios surfaced as critical path before locking. Conclusion: if Claude does ambient filesystem discovery (it does, in practice), **filesystem becomes canonical not by choice but because manifest adds a second registration mechanism with no isolation benefit**.
+- **OpenAI (R2):** Endorsed filesystem-canonical with a fail-loud Phase C probe. Suggested user research on `--legacy-both` adoption.
+
+Both members agreed the decision is structurally correct **conditional on** the cross-scope drift fix landing in Phase B and the probe being fail-loud in Phase C. This contract is published with those follow-up commitments.
+
+## Acceptance criteria for follow-up phases
+
+Phase B and Phase C of `road-to-clean-skill-distribution-channels.md` MUST:
+
+- (Phase B) Add a pre-install guard that detects existing installs at the other scope and either refuses, warns, or upgrades — surfaced via numbered options.
+- (Phase C) Run a probe at `agent-config setup` time AND from `scripts/install.sh --strict` that fails the install on cross-scope drift findings (per the council convergence — fail-loud, not informational).
+- (Phase A Step 4) Update `scripts/install.sh` and `task generate-tools` so the canonical channel above is what lands in the consumer install. Document `--legacy-both` for opt-in.
+
+## Out of scope
+
+- Manifest format changes upstream (Claude Code's marketplace shape) — host-controlled.
+- Alternative install paths (vendored copies, git submodules, npm `--prefix`) — package's npm install is the supported path.
+- Re-litigating the channel pick after this lock — reopened only on a new audit that surfaces a structurally different shape (e.g. a host change that removes ambient filesystem discovery).
+
+## See also
+
+- [`docs/contracts/install-scopes.md`](install-scopes.md) — companion contract for cross-scope behaviour (authored in Phase B).
+- [`docs/contracts/harness-expectations.md`](harness-expectations.md) — Phase D companion documenting host-side behaviours that look like package bugs but are not.
+- [`agents/evidence/audits/2026-05-distribution-channels/`](../../agents/evidence/audits/2026-05-distribution-channels/) — the underlying audits (01 Claude, 02 Augment, 03 installer flow).
+- [`README.md § Installation`](../../README.md) — consumer-facing install path.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -502,6 +502,26 @@ in `.agent-settings.yml`; the command then exits 0 with a one-line
 notice instead of producing a trace. Exit codes: `0` rendered or
 disabled · `1` no recent run found · `2` invocation error.
 
+## Troubleshooting
+
+### A skill appears twice in my AI tool
+
+Most common cause: cross-scope drift between a user-global install (e.g.
+`~/.claude/skills/`) and a project-local install (e.g. `./.claude/skills/`).
+Run the probe to confirm:
+
+```bash
+task probe:skills
+# or directly: python3 scripts/probe_skill_registration.py
+```
+
+The probe lists every registration across all six tools and flags
+`DUPLICATE` (same skill in ≥ 2 sources) and `DRIFT` (same skill, different
+descriptions or versions — the actual 2026-05-25 failure mode). To clean a
+stale install at the other scope: `bash scripts/cleanup_other_scope.sh --confirm`.
+Background: [`docs/contracts/skill-distribution-channels.md`](contracts/skill-distribution-channels.md)
++ [`docs/contracts/install-scopes.md`](contracts/install-scopes.md).
+
 ---
 
 ← [Back to README](../README.md)

--- a/scripts/_lib/scope_guard.sh
+++ b/scripts/_lib/scope_guard.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# scope_guard.sh — detect cross-scope install drift for event4u/agent-config.
+#
+# Roadmap reference: road-to-clean-skill-distribution-channels.md, Phase B Step 2.
+# Contract: docs/contracts/skill-distribution-channels.md + docs/contracts/install-scopes.md.
+#
+# Pre-install hook called by scripts/install.sh. Detects whether the same package
+# is already installed at the OTHER scope (user-global vs project-local) for any
+# of the six supported tools. Emits one verdict per tool plus a global verdict
+# on stdout (one finding per line).
+#
+# Verdicts (per the roadmap contract):
+#   OK     — no install at the other scope; the install can proceed.
+#   WARN   — install at the other scope, SAME version as the one being installed.
+#            Same content; duplicate registration but no drift.
+#   DRIFT  — install at the other scope, DIFFERENT version (or unreadable).
+#            Drift will produce the 2026-05-25 failure mode (stale frontmatter
+#            registered alongside fresh frontmatter).
+#
+# Output shape (line-oriented, parseable by install.sh):
+#   <verdict>\t<tool-id>\t<other-scope-path>\t<other-version>\t<this-version>
+#
+# A final summary line is emitted:
+#   SUMMARY\t<verdict>\t<count-OK>\t<count-WARN>\t<count-DRIFT>
+#
+# The script exits 0 always — verdict interpretation is the caller's job.
+
+set -euo pipefail
+
+THIS_SCOPE="${1:-project}"   # project|user — which scope we're ABOUT to install to
+SOURCE_DIR="${2:-}"          # package source repo (read version from here)
+TARGET_DIR="${3:-}"          # consumer install root for "this" scope
+
+# Default SOURCE_DIR to the package root when invoked from inside this repo.
+if [[ -z "$SOURCE_DIR" ]]; then
+    SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+
+# Resolve the version we're about to install. Authoritative source:
+# package.json at the package root (release.py keeps this current).
+this_version() {
+    local pkg="$SOURCE_DIR/package.json"
+    [[ -f "$pkg" ]] || { echo "unknown"; return; }
+    # Tiny scoped parser — no jq / python dependency.
+    awk -F'"' '/"version":/ { print $4; exit }' "$pkg" 2>/dev/null || echo "unknown"
+}
+
+# Resolve the version recorded at a given install root. Falls back through
+# package.json → .augment-plugin/plugin.json → "unknown".
+installed_version_at() {
+    local root="$1"
+    if [[ -f "$root/package.json" ]]; then
+        awk -F'"' '/"version":/ { print $4; exit }' "$root/package.json" 2>/dev/null && return
+    fi
+    if [[ -f "$root/.augment-plugin/plugin.json" ]]; then
+        awk -F'"' '/"version":/ { print $4; exit }' "$root/.augment-plugin/plugin.json" 2>/dev/null && return
+    fi
+    echo "unknown"
+}
+
+# Heuristic: does this look like an agent-config install (vs a vanilla user
+# directory with the same path layout)? We accept "looks like" if the tool
+# directory contains ≥ N entries that ALSO exist in the SOURCE_DIR tree —
+# but we keep the check coarse: simply that the directory is non-empty.
+dir_nonempty() {
+    [[ -d "$1" ]] && [[ -n "$(ls -A "$1" 2>/dev/null | head -1)" ]]
+}
+
+# Per-tool probe definitions: tool-id, user-scope path, project-scope path.
+# Project-scope path is relative to "$TARGET_DIR" (or "$HOME/<proj>" for user).
+probe_tool() {
+    local tool="$1"
+    local user_path="$2"
+    local project_path="$3"
+
+    local other_path other_scope this_scope_path
+    if [[ "$THIS_SCOPE" == "project" ]]; then
+        this_scope_path="$project_path"
+        other_path="$user_path"
+        other_scope="user"
+    else
+        this_scope_path="$user_path"
+        other_path="$project_path"
+        other_scope="project"
+    fi
+
+    if ! dir_nonempty "$other_path"; then
+        printf 'OK\t%s\t-\t-\t%s\n' "$tool" "$(this_version)"
+        return
+    fi
+
+    local other_root other_ver
+    # Walk up from the tool directory to find the install root (containing
+    # package.json or .augment-plugin/plugin.json).
+    other_root="$(cd "$other_path/.." 2>/dev/null && pwd)" || other_root=""
+    if [[ -n "$other_root" ]]; then
+        # Look up to 3 levels up for an install root.
+        local probe="$other_root"
+        for _ in 1 2 3; do
+            if [[ -f "$probe/package.json" ]] || [[ -f "$probe/.augment-plugin/plugin.json" ]]; then
+                other_root="$probe"
+                break
+            fi
+            probe="$(dirname "$probe")"
+            [[ "$probe" == "/" ]] && break
+        done
+    fi
+    other_ver="$(installed_version_at "$other_root")"
+
+    local this_ver
+    this_ver="$(this_version)"
+
+    if [[ "$other_ver" == "unknown" ]] || [[ "$this_ver" == "unknown" ]] || [[ "$other_ver" != "$this_ver" ]]; then
+        printf 'DRIFT\t%s\t%s\t%s\t%s\n' "$tool" "$other_path" "$other_ver" "$this_ver"
+    else
+        printf 'WARN\t%s\t%s\t%s\t%s\n' "$tool" "$other_path" "$other_ver" "$this_ver"
+    fi
+}
+
+main() {
+    # Resolve target root for project-scope probes.
+    local project_root="${TARGET_DIR:-$(pwd)}"
+    local home_root="${HOME:-/tmp}"
+
+    local count_ok=0 count_warn=0 count_drift=0 finding
+
+    # Each probe_tool call prints exactly one line.
+    while IFS= read -r finding; do
+        echo "$finding"
+        case "${finding%%$'\t'*}" in
+            OK)    ((count_ok++))    ;;
+            WARN)  ((count_warn++))  ;;
+            DRIFT) ((count_drift++)) ;;
+        esac
+    done < <(
+        probe_tool claude-code "$home_root/.claude/skills" "$project_root/.claude/skills"
+        probe_tool augment     "$home_root/.augment/skills" "$project_root/.augment/skills"
+        probe_tool cursor      "$home_root/.cursor/rules"  "$project_root/.cursor/rules"
+        probe_tool cline       "$home_root/.clinerules"    "$project_root/.clinerules"
+        probe_tool windsurf    "$home_root/.windsurf/rules" "$project_root/.windsurf/rules"
+        probe_tool copilot     "$home_root/.github/copilot-instructions.md" "$project_root/.github/copilot-instructions.md"
+    )
+
+    local overall
+    if [[ $count_drift -gt 0 ]]; then
+        overall=DRIFT
+    elif [[ $count_warn -gt 0 ]]; then
+        overall=WARN
+    else
+        overall=OK
+    fi
+    printf 'SUMMARY\t%s\t%d\t%d\t%d\n' "$overall" "$count_ok" "$count_warn" "$count_drift"
+}
+
+# Allow sourcing without executing (so other scripts can call individual
+# functions). Only run main() when invoked directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/scripts/_lib/scope_guard.sh
+++ b/scripts/_lib/scope_guard.sh
@@ -124,13 +124,16 @@ main() {
 
     local count_ok=0 count_warn=0 count_drift=0 finding
 
-    # Each probe_tool call prints exactly one line.
+    # Each probe_tool call prints exactly one line. Use
+    # assignment-arithmetic (returns 0) rather than post-increment
+    # (returns the OLD value — 0 trips `set -e` on the first OK hit
+    # under bash 5+ / GitHub Actions runners).
     while IFS= read -r finding; do
         echo "$finding"
         case "${finding%%$'\t'*}" in
-            OK)    ((count_ok++))    ;;
-            WARN)  ((count_warn++))  ;;
-            DRIFT) ((count_drift++)) ;;
+            OK)    count_ok=$((count_ok + 1))       ;;
+            WARN)  count_warn=$((count_warn + 1))   ;;
+            DRIFT) count_drift=$((count_drift + 1)) ;;
         esac
     done < <(
         probe_tool claude-code "$home_root/.claude/skills" "$project_root/.claude/skills"

--- a/scripts/cleanup_other_scope.sh
+++ b/scripts/cleanup_other_scope.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# cleanup_other_scope.sh — remove a stale agent-config install at the OTHER
+# scope (typically ~/.claude/skills/ when working in a project-local install).
+#
+# Roadmap: road-to-clean-skill-distribution-channels.md, Phase B Step 5.
+# Companion to scripts/_lib/scope_guard.sh. Refuses to run without --confirm
+# per `non-destructive-by-default`.
+#
+# Usage:
+#   bash scripts/cleanup_other_scope.sh                      # dry-run, list what would be removed
+#   bash scripts/cleanup_other_scope.sh --confirm            # actually delete
+#   bash scripts/cleanup_other_scope.sh --confirm --user     # default — remove user-global tree
+#   bash scripts/cleanup_other_scope.sh --confirm --project /path/to/proj
+#                                                            # remove from a specific project root
+#
+# What it removes (subject to --tools selection):
+#   .claude/skills/                — Claude project-local skill tree
+#   .augment/                       — Augment substrate
+#   .cursor/rules/                  — Cursor rules tree
+#   .clinerules/                    — Cline rules tree
+#   .windsurf/rules/                — Windsurf rules tree
+#   .github/copilot-instructions.md — Copilot single-file
+#
+# What it NEVER removes without explicit overrides:
+#   .agent-settings.yml             — settings the operator may have edited
+#   agents/                          — project-local content authored by the user
+#   any path outside the scoped roots
+
+set -euo pipefail
+
+SCOPE="user"
+SCOPE_ROOT=""
+TOOLS_FILTER="all"
+DRY_RUN=true
+
+usage() {
+    cat <<'EOF'
+Usage: bash scripts/cleanup_other_scope.sh [--confirm] [--user | --project <dir>] [--tools <list>]
+
+Removes a stale agent-config install at the OTHER scope (user-global by default).
+Refuses to delete anything without --confirm.
+
+Options:
+  --confirm              Actually remove files. Default is dry-run (lists only).
+  --user                 Operate on $HOME (user-global scope). Default.
+  --project <dir>        Operate on a specific project root.
+  --tools <list>         Comma-separated tool IDs (default: all).
+                         Choices: claude-code, augment, cursor, cline, windsurf, copilot.
+  --help, -h             Show this help.
+
+Examples:
+  bash scripts/cleanup_other_scope.sh                                 # dry-run, user scope
+  bash scripts/cleanup_other_scope.sh --confirm                       # delete user-global tree
+  bash scripts/cleanup_other_scope.sh --confirm --tools=claude-code   # delete only ~/.claude/skills/
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --confirm)         DRY_RUN=false; shift ;;
+        --user)            SCOPE="user"; shift ;;
+        --project)
+            if [[ $# -lt 2 ]] || [[ "$2" == --* ]]; then
+                echo "❌  --project requires a path argument." >&2
+                exit 1
+            fi
+            SCOPE="project"; SCOPE_ROOT="$2"; shift 2 ;;
+        --project=*)       SCOPE="project"; SCOPE_ROOT="${1#*=}"; shift ;;
+        --tools)           TOOLS_FILTER="$2"; shift 2 ;;
+        --tools=*)         TOOLS_FILTER="${1#*=}"; shift ;;
+        --help|-h)         usage; exit 0 ;;
+        *)                 echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+is_tool() {
+    [[ "$TOOLS_FILTER" == "all" ]] && return 0
+    case ",$TOOLS_FILTER," in
+        *,"$1",*) return 0 ;;
+    esac
+    return 1
+}
+
+# Resolve scope root.
+if [[ "$SCOPE" == "user" ]]; then
+    SCOPE_ROOT="${HOME:-/tmp}"
+elif [[ -z "$SCOPE_ROOT" ]]; then
+    echo "❌  --project requires a path." >&2
+    exit 1
+fi
+if [[ ! -d "$SCOPE_ROOT" ]]; then
+    echo "❌  Scope root not found: $SCOPE_ROOT" >&2
+    exit 1
+fi
+
+declare -a targets=()
+is_tool claude-code && {
+    targets+=("$SCOPE_ROOT/.claude/skills")
+    targets+=("$SCOPE_ROOT/.claude/rules")
+    targets+=("$SCOPE_ROOT/.claude-plugin/marketplace.json")
+}
+is_tool augment      && {
+    targets+=("$SCOPE_ROOT/.augment")
+    targets+=("$SCOPE_ROOT/.augment-plugin")
+}
+is_tool cursor       && targets+=("$SCOPE_ROOT/.cursor/rules")
+is_tool cline        && targets+=("$SCOPE_ROOT/.clinerules")
+is_tool windsurf     && {
+    targets+=("$SCOPE_ROOT/.windsurf/rules")
+    targets+=("$SCOPE_ROOT/.windsurfrules")
+}
+is_tool copilot      && targets+=("$SCOPE_ROOT/.github/copilot-instructions.md")
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "❌  No tools selected (--tools=$TOOLS_FILTER)." >&2
+    exit 1
+fi
+
+echo "Scope:   $SCOPE ($SCOPE_ROOT)"
+echo "Tools:   $TOOLS_FILTER"
+echo "Mode:    $($DRY_RUN && echo 'DRY RUN (use --confirm to delete)' || echo 'DELETE')"
+echo ""
+
+removed=0
+skipped=0
+for t in "${targets[@]}"; do
+    if [[ -e "$t" ]] || [[ -L "$t" ]]; then
+        if $DRY_RUN; then
+            echo "  would remove: $t"
+        else
+            rm -rf "$t"
+            echo "  removed:      $t"
+        fi
+        ((removed++)) || true
+    else
+        ((skipped++)) || true
+    fi
+done
+
+echo ""
+if $DRY_RUN; then
+    echo "✅  Dry-run complete: $removed entries would be removed, $skipped already absent."
+    echo "    Re-run with --confirm to apply."
+else
+    echo "✅  Cleanup complete: $removed entries removed, $skipped already absent."
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,12 @@ DRY_RUN=false
 VERBOSE=false
 QUIET=false
 SKIP_GITIGNORE=false
+# Per the canonical-channel contract (docs/contracts/skill-distribution-channels.md),
+# consumer installs default to the filesystem channel only (e.g. .claude/skills/) and
+# do NOT project the plugin manifest (.claude-plugin/marketplace.json). Set this true
+# via --legacy-both to also copy the plugin manifest for users on older harnesses
+# that require both channels.
+LEGACY_BOTH=false
 # When true, skip payload sync entirely and only install the project-local
 # `./agent-config` wrapper (Step 7 Phase 2). The bridge stage (install.py)
 # handles the .agent-settings.yml stub + nested-install guard.
@@ -87,6 +93,7 @@ parse_args() {
             --user-type)   shift 2 ;;
             --user-type=*) shift ;;
             --minimal|--settings-only) MINIMAL=true; shift ;;
+            --legacy-both) LEGACY_BOTH=true; shift ;;
             --help|-h) show_help; exit 0 ;;
             *) log_error "Unknown argument: $1"; show_help; exit 1 ;;
         esac
@@ -141,6 +148,10 @@ Options:
   --verbose        Show detailed output
   --quiet          Suppress all output except errors
   --skip-gitignore Do not touch the target project's .gitignore
+  --legacy-both    Also project the Claude plugin manifest
+                   (.claude-plugin/marketplace.json) into the consumer install.
+                   Default is filesystem-only per the canonical-channel contract
+                   at docs/contracts/skill-distribution-channels.md.
   --help, -h       Show this help
 
 Environment:
@@ -604,6 +615,163 @@ generate_windsurfrules() {
 }
 
 
+# Run scripts/_lib/scope_guard.sh as a pre-flight check. On DRIFT findings
+# the function surfaces a numbered-options prompt and aborts on no-confirm
+# paths. SCOPE_GUARD_BYPASS=1 (set by the orchestrator, CI runs, and
+# --dry-run) skips the prompt entirely. Findings are always logged in
+# verbose mode regardless.
+run_scope_guard() {
+    local target="$1"
+    local guard="$SOURCE_DIR/scripts/_lib/scope_guard.sh"
+
+    # Skip when the guard is not present (e.g. trimmed install bundle).
+    [[ -f "$guard" ]] || { log_verbose "scope_guard.sh not found — skipping cross-scope drift check"; return 0; }
+
+    # Bypass paths that cannot or must not be interactive.
+    if $DRY_RUN; then
+        log_verbose "skip scope_guard (--dry-run)"
+        return 0
+    fi
+    if [[ "${SCOPE_GUARD_BYPASS:-0}" == "1" ]]; then
+        log_verbose "skip scope_guard (SCOPE_GUARD_BYPASS=1)"
+        return 0
+    fi
+    if [[ "${CI:-0}" == "true" ]] || [[ "${CI:-0}" == "1" ]]; then
+        log_verbose "skip scope_guard (CI=true)"
+        return 0
+    fi
+
+    local output verdict
+    output="$(bash "$guard" project "$SOURCE_DIR" "$target" 2>/dev/null || true)"
+    [[ -n "$output" ]] || return 0
+
+    local summary
+    summary="$(echo "$output" | grep '^SUMMARY' | tail -1)"
+    [[ -n "$summary" ]] || return 0
+    verdict="$(echo "$summary" | cut -f2)"
+
+    if [[ "$verdict" == "OK" ]]; then
+        log_verbose "scope_guard OK (no cross-scope install)"
+        return 0
+    fi
+
+    if [[ "$verdict" == "WARN" ]]; then
+        $QUIET || {
+            echo ""
+            echo "  ⚠️  Cross-scope install detected (same version, no drift)."
+            echo "$output" | awk -F'\t' '$1=="WARN" { printf "       - %s at %s (v%s)\n", $2, $3, $4 }'
+            echo ""
+        }
+        return 0
+    fi
+
+    # DRIFT: surface the gate. Non-interactive shells get the warning and
+    # an exit code that the caller can short-circuit with SCOPE_GUARD_BYPASS=1.
+    echo ""
+    echo "  ❌  Cross-scope DRIFT detected — same package installed at user AND project scope at different versions:"
+    echo "$output" | awk -F'\t' '$1=="DRIFT" { printf "       - %s: other-scope=%s (v%s) vs this-install=v%s\n", $2, $3, $4, $5 }'
+    echo ""
+    echo "      The 2026-05-25 root cause (duplicate skill registration with stale frontmatter)"
+    echo "      will fire when both registrations load. Choose how to proceed:"
+    echo ""
+    echo "         1. Abort install — fix drift first (recommended)"
+    echo "         2. Upgrade the OTHER scope first (run scripts/install.sh --target=\$HOME or equivalent)"
+    echo "         3. Force install at this scope — accept drift (set SCOPE_GUARD_BYPASS=1)"
+    echo "         4. Clean the other scope (bash scripts/cleanup_other_scope.sh --confirm)"
+    echo ""
+    echo "      Recommendation: 1"
+    echo ""
+
+    # In interactive mode the caller has stdin; we honour SCOPE_GUARD_BYPASS=1
+    # already above. Default: abort.
+    if [[ -t 0 ]]; then
+        local choice
+        read -r -p "      Enter 1-4 [default 1]: " choice || choice=1
+        case "${choice:-1}" in
+            2) echo "      → Re-run scripts/install.sh against the other scope first; aborting this run."; exit 2 ;;
+            3) log_warn "Continuing despite DRIFT (user opted into option 3)" ;;
+            4) echo "      → Run: bash scripts/cleanup_other_scope.sh --confirm — then retry."; exit 2 ;;
+            *) echo "      → Aborting (option 1)."; exit 2 ;;
+        esac
+    else
+        echo "      Non-interactive shell — aborting. Set SCOPE_GUARD_BYPASS=1 to override."
+        exit 2
+    fi
+}
+
+# Post-install skill-registration probe (Phase C Step 6). Informational by
+# default; PROBE_STRICT=1 turns drift findings into a non-zero exit so a
+# release install fails loudly. Skipped in dry-run and when python3 or the
+# probe script is missing (older bundles).
+run_post_install_probe() {
+    local target="$1"
+    local probe="$SOURCE_DIR/scripts/probe_skill_registration.py"
+
+    [[ -f "$probe" ]] || { log_verbose "skip probe_skill_registration.py (not found)"; return 0; }
+    if ! command -v python3 >/dev/null 2>&1; then
+        log_verbose "skip skill-registration probe (python3 missing)"
+        return 0
+    fi
+    if $DRY_RUN; then
+        log_verbose "skip skill-registration probe (--dry-run)"
+        return 0
+    fi
+    if [[ "${PROBE_BYPASS:-0}" == "1" ]]; then
+        log_verbose "skip skill-registration probe (PROBE_BYPASS=1)"
+        return 0
+    fi
+
+    local args=( "$probe" "--project" "$target" "--format=text" )
+    [[ "${PROBE_STRICT:-0}" == "1" ]] && args+=("--strict")
+
+    if python3 "${args[@]}" > /tmp/agent-config-probe.$$ 2>&1; then
+        # On clean output (no findings) only show a one-liner.
+        if grep -qE 'DUPLICATE|DRIFT' /tmp/agent-config-probe.$$; then
+            $QUIET || echo ""
+            $QUIET || echo "  ⚠️  Skill-registration findings:"
+            $QUIET || sed -n '/DUPLICATE\|DRIFT/,$p' /tmp/agent-config-probe.$$ | head -40
+            $QUIET || echo ""
+            $QUIET || echo "      Run: python3 scripts/probe_skill_registration.py — for the full report."
+        else
+            log_info "Skill-registration probe: clean (no duplicates / drift)"
+        fi
+        rm -f /tmp/agent-config-probe.$$
+        return 0
+    else
+        local code=$?
+        echo ""
+        echo "  ❌  Skill-registration probe surfaced DUPLICATE / DRIFT findings (PROBE_STRICT=1):"
+        sed -n '/DUPLICATE\|DRIFT/,$p' /tmp/agent-config-probe.$$ | head -40
+        rm -f /tmp/agent-config-probe.$$
+        return "$code"
+    fi
+}
+
+# Project the Claude plugin manifest into the consumer install — gated on
+# --legacy-both. Default install path is filesystem-only per the canonical-
+# channel contract (docs/contracts/skill-distribution-channels.md). Only
+# users on older Claude Code harnesses that need both channels opt in.
+project_legacy_plugin_manifest() {
+    local project_root="$1"
+    local source_manifest="$SOURCE_DIR/.claude-plugin/marketplace.json"
+    local target_manifest="$project_root/.claude-plugin/marketplace.json"
+
+    if ! $LEGACY_BOTH; then
+        log_verbose "skip .claude-plugin/marketplace.json (filesystem is canonical; use --legacy-both to opt in)"
+        return 0
+    fi
+    is_tool_enabled "claude-code" || { log_verbose "skip .claude-plugin/marketplace.json (claude-code not selected)"; return 0; }
+    [[ -f "$source_manifest" ]] || { log_verbose "skip .claude-plugin/marketplace.json (source manifest absent)"; return 0; }
+
+    if $DRY_RUN; then
+        log_verbose "copy .claude-plugin/marketplace.json (--legacy-both)"
+        return
+    fi
+    mkdir -p "$(dirname "$target_manifest")"
+    cp "$source_manifest" "$target_manifest"
+    log_info "Projected .claude-plugin/marketplace.json (--legacy-both opted in)"
+}
+
 # Create GEMINI.md symlink (gemini-cli only).
 create_gemini_md() {
     local project_root="$1"
@@ -883,7 +1051,15 @@ main() {
         echo ""
     fi
 
-    # 0. Migrate legacy infra files (root → agents/) before any content sync.
+    # 0a. Cross-scope drift pre-flight (Phase B Step 3). Detect prior installs
+    #     of the same package at the OTHER scope (user-global ↔ project-local).
+    #     On DRIFT the function surfaces a numbered-options gate per the
+    #     non-destructive-by-default contract. SCOPE_GUARD_BYPASS=1 from the
+    #     orchestrator or a CI run skips the gate so non-interactive paths do
+    #     not hang.
+    run_scope_guard "$TARGET_DIR"
+
+    # 0b. Migrate legacy infra files (root → agents/) before any content sync.
     migrate_legacy_root_infra "$TARGET_DIR"
     migrate_legacy_low_impact_decisions "$TARGET_DIR"
     migrate_legacy_prices_file "$TARGET_DIR"
@@ -920,12 +1096,22 @@ main() {
     create_tool_symlinks "$TARGET_DIR"
     create_skill_symlinks "$TARGET_DIR"
 
+    # 3b. Optionally project the Claude plugin manifest (--legacy-both).
+    project_legacy_plugin_manifest "$TARGET_DIR"
+
     # 4. Generate files
     generate_windsurfrules "$TARGET_DIR"
     create_gemini_md "$TARGET_DIR"
 
     # 5. Install consumer CLI wrapper (gitignored, overwritten on every install)
     install_cli_wrapper "$TARGET_DIR"
+
+    # 5b. Post-install registration probe (Phase C Step 6). Surfaces any
+    #     duplicate / drifting skill registrations the new install would
+    #     conflict with. PROBE_STRICT=1 (set by release installs) flips
+    #     informational output into a non-zero exit so a release stops on
+    #     drift findings.
+    run_post_install_probe "$TARGET_DIR"
 
     # 6. Manage .gitignore
     ensure_gitignore "$TARGET_DIR"

--- a/scripts/probe_skill_registration.py
+++ b/scripts/probe_skill_registration.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Tool-agnostic skill-registration probe.
+
+Roadmap: road-to-clean-skill-distribution-channels.md § Phase C.
+Contract: docs/contracts/skill-distribution-channels.md.
+
+Surfaces every skill registered for any of the six supported AI tools
+across user-global, project-local, and plugin-manifest sources. Flags
+``DUPLICATE`` (same skill name registered in ≥ 2 sources) and ``DRIFT``
+(same name, different description-hash or version). Both shapes are the
+class of bug that opened road-to-clean-skill-distribution-channels.md
+on 2026-05-25.
+
+CLI:
+
+    python3 scripts/probe_skill_registration.py
+    python3 scripts/probe_skill_registration.py --tool=claude --format=json
+    python3 scripts/probe_skill_registration.py --strict
+
+``--strict`` flips the exit code: 0 if no DUPLICATE / DRIFT findings,
+non-zero otherwise. Without ``--strict`` the script is informational
+(always exits 0).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Iterable
+
+TOOL_IDS = ("claude", "augment", "cursor", "cline", "windsurf", "copilot")
+SCOPE_IDS = ("user", "project")
+
+
+@dataclass(frozen=True)
+class Registration:
+    """One row in the probe table — a single (skill_id, scope, source) tuple."""
+    skill_id: str
+    tool: str
+    scope: str
+    source_path: str
+    version: str
+    description_snippet: str
+    description_hash: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass
+class ProbeResult:
+    registrations: list[Registration] = field(default_factory=list)
+    duplicates: dict[str, list[Registration]] = field(default_factory=dict)
+    drift: dict[str, list[Registration]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "registrations": [r.to_dict() for r in self.registrations],
+            "duplicates": {k: [r.to_dict() for r in v] for k, v in self.duplicates.items()},
+            "drift": {k: [r.to_dict() for r in v] for k, v in self.drift.items()},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter + version helpers
+# ---------------------------------------------------------------------------
+
+def _read_frontmatter(skill_md: Path) -> dict[str, str]:
+    """Minimal YAML frontmatter extractor — no PyYAML dependency."""
+    try:
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    if not text.startswith("---\n") and not text.startswith("---\r\n"):
+        return {}
+    rest = text.split("---", 2)
+    if len(rest) < 3:
+        return {}
+    body = rest[1]
+    out: dict[str, str] = {}
+    for line in body.splitlines():
+        if ":" not in line or line.lstrip().startswith("#"):
+            continue
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip().strip('"').strip("'")
+    return out
+
+
+def _hash_desc(desc: str) -> str:
+    return hashlib.sha256(desc.encode("utf-8", "replace")).hexdigest()[:12]
+
+
+def _snippet(desc: str, n: int = 80) -> str:
+    desc = desc.strip()
+    return desc if len(desc) <= n else desc[: n - 1] + "…"
+
+
+def _version_at(root: Path) -> str:
+    """Read a 'this install's version' value from package.json / plugin.json."""
+    for candidate in (root / "package.json", root / ".augment-plugin" / "plugin.json"):
+        if not candidate.is_file():
+            continue
+        try:
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+            v = data.get("version")
+            if isinstance(v, str) and v:
+                return v
+        except (OSError, json.JSONDecodeError):
+            continue
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Per-tool readers
+# ---------------------------------------------------------------------------
+
+def _iter_skill_md(skills_root: Path) -> Iterable[Path]:
+    if not skills_root.is_dir():
+        return
+    for entry in sorted(skills_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        skill_md = entry / "SKILL.md"
+        if skill_md.is_file():
+            yield skill_md
+
+
+def _read_claude(scope: str, root: Path) -> Iterable[Registration]:
+    skills = root / ".claude" / "skills"
+    for skill_md in _iter_skill_md(skills):
+        fm = _read_frontmatter(skill_md)
+        name = fm.get("name") or skill_md.parent.name
+        desc = fm.get("description", "")
+        yield Registration(
+            skill_id=name,
+            tool="claude",
+            scope=scope,
+            source_path=str(skill_md),
+            version=_version_at(root),
+            description_snippet=_snippet(desc),
+            description_hash=_hash_desc(desc),
+        )
+    # Plugin manifest at the same scope. Each entry is a path string into
+    # the same .claude/skills/ tree; emit it as a separate "manifest" row so
+    # duplicate-detection catches manifest-vs-filesystem double-counting.
+    manifest = root / ".claude-plugin" / "marketplace.json"
+    if manifest.is_file():
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            plugins = data.get("plugins") or []
+            entries: list[str] = []
+            for plug in plugins:
+                entries.extend(plug.get("skills") or [])
+            for entry in entries:
+                # The entry is a path string; resolve the name from the path.
+                tail = Path(entry).name
+                yield Registration(
+                    skill_id=tail,
+                    tool="claude",
+                    scope=f"{scope}-plugin",
+                    source_path=str(manifest),
+                    version=_version_at(root),
+                    description_snippet="(plugin manifest entry)",
+                    description_hash="manifest",
+                )
+        except (OSError, json.JSONDecodeError):
+            pass
+
+
+def _read_augment(scope: str, root: Path) -> Iterable[Registration]:
+    skills = root / ".augment" / "skills"
+    for skill_md in _iter_skill_md(skills):
+        fm = _read_frontmatter(skill_md)
+        name = fm.get("name") or skill_md.parent.name
+        desc = fm.get("description", "")
+        yield Registration(
+            skill_id=name,
+            tool="augment",
+            scope=scope,
+            source_path=str(skill_md),
+            version=_version_at(root),
+            description_snippet=_snippet(desc),
+            description_hash=_hash_desc(desc),
+        )
+
+
+def _read_cursor(scope: str, root: Path) -> Iterable[Registration]:
+    rules = root / ".cursor" / "rules"
+    if not rules.is_dir():
+        return
+    for rule in sorted(rules.glob("*.mdc")):
+        fm = _read_frontmatter(rule)
+        name = fm.get("name") or rule.stem
+        desc = fm.get("description", "")
+        yield Registration(
+            skill_id=name,
+            tool="cursor",
+            scope=scope,
+            source_path=str(rule),
+            version=_version_at(root),
+            description_snippet=_snippet(desc),
+            description_hash=_hash_desc(desc),
+        )
+
+
+def _read_cline(scope: str, root: Path) -> Iterable[Registration]:
+    rules = root / ".clinerules"
+    if not rules.is_dir():
+        return
+    for rule in sorted(rules.glob("*.md")):
+        fm = _read_frontmatter(rule)
+        name = fm.get("name") or rule.stem
+        desc = fm.get("description", "")
+        yield Registration(
+            skill_id=name,
+            tool="cline",
+            scope=scope,
+            source_path=str(rule),
+            version=_version_at(root),
+            description_snippet=_snippet(desc),
+            description_hash=_hash_desc(desc),
+        )
+
+
+def _read_windsurf(scope: str, root: Path) -> Iterable[Registration]:
+    rules = root / ".windsurf" / "rules"
+    if not rules.is_dir():
+        return
+    for rule in sorted(rules.glob("*.md")):
+        fm = _read_frontmatter(rule)
+        name = fm.get("name") or rule.stem
+        desc = fm.get("description", "")
+        yield Registration(
+            skill_id=name,
+            tool="windsurf",
+            scope=scope,
+            source_path=str(rule),
+            version=_version_at(root),
+            description_snippet=_snippet(desc),
+            description_hash=_hash_desc(desc),
+        )
+
+
+def _read_copilot(scope: str, root: Path) -> Iterable[Registration]:
+    # Copilot ships a single file; check both common locations.
+    for candidate in (
+        root / ".github" / "copilot-instructions.md",
+        root / "copilot-instructions.md",
+    ):
+        if not candidate.is_file():
+            continue
+        try:
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        snippet = _snippet(text.split("\n", 1)[0] if text else "")
+        yield Registration(
+            skill_id="copilot-instructions",
+            tool="copilot",
+            scope=scope,
+            source_path=str(candidate),
+            version=_version_at(root),
+            description_snippet=snippet,
+            description_hash=_hash_desc(text),
+        )
+
+
+TOOL_READERS = {
+    "claude":   _read_claude,
+    "augment":  _read_augment,
+    "cursor":   _read_cursor,
+    "cline":    _read_cline,
+    "windsurf": _read_windsurf,
+    "copilot":  _read_copilot,
+}
+
+
+# ---------------------------------------------------------------------------
+# Probe
+# ---------------------------------------------------------------------------
+
+def run_probe(
+    *,
+    tool_filter: str = "all",
+    scope_filter: str = "all",
+    home: Path | None = None,
+    project: Path | None = None,
+) -> ProbeResult:
+    home = home or Path(os.environ.get("HOME", "/tmp"))
+    project = project or Path.cwd()
+
+    scopes: dict[str, Path] = {}
+    if scope_filter in ("all", "user"):
+        scopes["user"] = home
+    if scope_filter in ("all", "project"):
+        scopes["project"] = project
+
+    tools = TOOL_IDS if tool_filter == "all" else (tool_filter,)
+
+    result = ProbeResult()
+    for scope, root in scopes.items():
+        for tool in tools:
+            reader = TOOL_READERS.get(tool)
+            if reader is None:
+                continue
+            for reg in reader(scope, root):
+                result.registrations.append(reg)
+
+    # Group by (tool, skill_id). Anything with ≥ 2 entries is DUPLICATE.
+    # If their description hashes diverge, also flag DRIFT.
+    by_key: dict[tuple[str, str], list[Registration]] = {}
+    for reg in result.registrations:
+        by_key.setdefault((reg.tool, reg.skill_id), []).append(reg)
+
+    for (tool, skill_id), regs in by_key.items():
+        if len(regs) < 2:
+            continue
+        key = f"{tool}:{skill_id}"
+        result.duplicates[key] = regs
+        hashes = {r.description_hash for r in regs if r.description_hash != "manifest"}
+        versions = {r.version for r in regs if r.version != "unknown"}
+        if len(hashes) > 1 or len(versions) > 1:
+            result.drift[key] = regs
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_text(result: ProbeResult) -> str:
+    lines: list[str] = []
+    lines.append("Skill-registration probe")
+    lines.append("=" * 64)
+    lines.append("")
+    if not result.registrations:
+        lines.append("(no registrations found)")
+        return "\n".join(lines)
+
+    lines.append(f"{'TOOL':<10} {'SCOPE':<14} {'SKILL':<32} {'VER':<10} SOURCE")
+    lines.append("-" * 100)
+    for reg in result.registrations:
+        lines.append(
+            f"{reg.tool:<10} {reg.scope:<14} {reg.skill_id[:32]:<32} {reg.version:<10} {reg.source_path}"
+        )
+
+    if result.duplicates:
+        lines.append("")
+        lines.append("DUPLICATE — same skill registered in ≥ 2 sources")
+        lines.append("-" * 64)
+        for key, regs in result.duplicates.items():
+            lines.append(f"  {key}")
+            for r in regs:
+                lines.append(f"    - [{r.scope}/{r.version}] {r.source_path}")
+    if result.drift:
+        lines.append("")
+        lines.append("DRIFT — same skill registered with DIFFERENT description / version")
+        lines.append("-" * 64)
+        for key, regs in result.drift.items():
+            lines.append(f"  {key}")
+            for r in regs:
+                lines.append(f"    - [{r.scope}/{r.version}] hash={r.description_hash} desc={r.description_snippet!r}")
+                lines.append(f"      source: {r.source_path}")
+
+    return "\n".join(lines)
+
+
+def render_json(result: ProbeResult) -> str:
+    return json.dumps(result.to_dict(), indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="probe_skill_registration",
+        description="Detect duplicate / drifting skill registrations across AI tools.",
+    )
+    parser.add_argument("--tool", choices=("all", *TOOL_IDS), default="all")
+    parser.add_argument("--scope", choices=("all", *SCOPE_IDS), default="all")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Exit non-zero if any DUPLICATE / DRIFT finding is present.",
+    )
+    parser.add_argument("--home", type=Path, default=None, help="Override the user-global root (testing).")
+    parser.add_argument("--project", type=Path, default=None, help="Override the project root (testing).")
+    args = parser.parse_args(argv)
+
+    result = run_probe(
+        tool_filter=args.tool,
+        scope_filter=args.scope,
+        home=args.home,
+        project=args.project,
+    )
+
+    out = render_json(result) if args.format == "json" else render_text(result)
+    print(out)
+
+    if args.strict and (result.duplicates or result.drift):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/server/routes/wizard.ts
+++ b/src/server/routes/wizard.ts
@@ -256,6 +256,78 @@ async function spawnInstaller(scriptPath: string, args: readonly string[]): Prom
     });
 }
 
+async function spawnBash(scriptPath: string, args: readonly string[]): Promise<InstallerResult> {
+    return new Promise<InstallerResult>((resolve, reject) => {
+        const child = spawn('bash', [scriptPath, ...args], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            env: { ...process.env, AGENT_CONFIG_NO_UPDATE_CHECK: '1' },
+        });
+        const stdoutChunks: Buffer[] = [];
+        const stderrChunks: Buffer[] = [];
+        child.stdout?.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+        child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+        child.once('error', reject);
+        child.once('close', (code) => {
+            resolve({
+                exitCode: code ?? 1,
+                stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+                stderr: Buffer.concat(stderrChunks).toString('utf8'),
+            });
+        });
+    });
+}
+
+/**
+ * Phase B Step 4 of road-to-clean-skill-distribution-channels.
+ * Parses the line-oriented output of scripts/_lib/scope_guard.sh into
+ * a structured response for the wizard UI. Each non-SUMMARY line carries
+ * verdict, tool, otherScopePath, otherVersion, thisVersion.
+ */
+interface ScopeGuardFinding {
+    verdict: 'OK' | 'WARN' | 'DRIFT';
+    tool: string;
+    otherScopePath: string;
+    otherVersion: string;
+    thisVersion: string;
+}
+
+interface ScopeGuardResult {
+    overall: 'OK' | 'WARN' | 'DRIFT';
+    countOk: number;
+    countWarn: number;
+    countDrift: number;
+    findings: ScopeGuardFinding[];
+}
+
+function parseScopeGuardOutput(stdout: string): ScopeGuardResult {
+    const findings: ScopeGuardFinding[] = [];
+    let overall: 'OK' | 'WARN' | 'DRIFT' = 'OK';
+    let countOk = 0;
+    let countWarn = 0;
+    let countDrift = 0;
+    for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        const parts = line.split('\t');
+        if (parts[0] === 'SUMMARY') {
+            overall = (parts[1] as 'OK' | 'WARN' | 'DRIFT') ?? 'OK';
+            countOk = Number.parseInt(parts[2] ?? '0', 10);
+            countWarn = Number.parseInt(parts[3] ?? '0', 10);
+            countDrift = Number.parseInt(parts[4] ?? '0', 10);
+            continue;
+        }
+        const [verdict, tool, otherScopePath, otherVersion, thisVersion] = parts;
+        if (verdict !== 'OK' && verdict !== 'WARN' && verdict !== 'DRIFT') continue;
+        findings.push({
+            verdict: verdict as 'OK' | 'WARN' | 'DRIFT',
+            tool: tool ?? '?',
+            otherScopePath: otherScopePath ?? '-',
+            otherVersion: otherVersion ?? '-',
+            thisVersion: thisVersion ?? '-',
+        });
+    }
+    return { overall, countOk, countWarn, countDrift, findings };
+}
+
 // road-to-configurable-modules § Phase E — wire shape of the
 // `modulesConfig` field on `POST /api/v1/wizard/finish`. Matches the
 // `proposed_block` JSON emitted by `propose_modules_config.py --json`
@@ -360,6 +432,123 @@ export function wizardRoute(opts: WizardRouteOptions & { packageRoot: string }):
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'manifest read failed';
                 await reply.code(500).send({ error: { code: 'MANIFEST_UNAVAILABLE', message } });
+                return reply;
+            }
+        });
+
+        // road-to-clean-skill-distribution-channels § Phase D Step 3 —
+        // harness-expectations endpoint. Returns the three classes the
+        // wizard's final review step renders after install completes.
+        // Content is static + sourced from docs/contracts/harness-expectations.md
+        // (the doc is the long form; this endpoint is the wizard-shaped
+        // short form so the UI does not have to parse markdown).
+        app.get('/api/v1/wizard/harness-expectations', async (_request, reply) => {
+            if (!extended) {
+                await reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'extended-mode endpoint disabled' } });
+                return reply;
+            }
+            return {
+                contractPath: 'docs/contracts/harness-expectations.md',
+                classes: [
+                    {
+                        id: 'sibling-plugins',
+                        title: 'Plugin-namespaced peer skills',
+                        symptom: 'Skills appear under namespaces like codex:* or cc-gemini-plugin:*.',
+                        cause: 'Sibling AI-tool plugins loaded by the harness; not owned by this package.',
+                        action: 'Use the harness’s plugin-list command to identify the source.',
+                    },
+                    {
+                        id: 'deferred-tools',
+                        title: 'Tools deferred behind ToolSearch',
+                        symptom: 'system-reminder mentions “deferred tools … available via ToolSearch”.',
+                        cause: 'Harness defers schema load until needed to protect context budget.',
+                        action: 'Run ToolSearch with select:<name> to load the schema before calling.',
+                    },
+                    {
+                        id: 'duplicate-registration',
+                        title: 'Duplicate skill registration',
+                        symptom: 'Same skill name appears twice in the available-skills list.',
+                        cause: 'Cross-scope install drift (~/.claude/skills/ + ./.claude/skills/ at different versions).',
+                        action: 'Run `task probe:skills` — if findings show DUPLICATE/DRIFT, clean with `bash scripts/cleanup_other_scope.sh --confirm`.',
+                    },
+                ],
+                triage: [
+                    'Run `task probe:skills` first — confirms or rules out class 3.',
+                    'If a vendor: prefix shows, check the harness’s plugin list.',
+                    'deferred-tools reminder = expected; the skill must call ToolSearch.',
+                ],
+            };
+        });
+
+        // road-to-clean-skill-distribution-channels § Phase C Step 6 —
+        // probe endpoint. Spawns scripts/probe_skill_registration.py with
+        // --format=json so the wizard's final step can surface DUPLICATE /
+        // DRIFT findings before the operator closes the install. Read-only.
+        app.get('/api/v1/wizard/probe', async (_request, reply) => {
+            if (!extended) {
+                await reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'extended-mode endpoint disabled' } });
+                return reply;
+            }
+            const probePath = join(opts.packageRoot, 'scripts', 'probe_skill_registration.py');
+            if (!existsSync(probePath)) {
+                await reply.code(500).send({ error: { code: 'PROBE_MISSING', message: `probe script not found at ${probePath}` } });
+                return reply;
+            }
+            const projectRoot = legacyReadRoot ?? process.cwd();
+            try {
+                const result = await spawnInstaller(probePath, ['--project', projectRoot, '--format=json']);
+                // Default mode exits 0 regardless of findings; --strict (not
+                // passed here) is the only path with a non-zero exit.
+                if (result.exitCode !== 0) {
+                    await reply.code(500).send({
+                        error: { code: 'PROBE_FAILED', message: result.stderr || `probe exited ${result.exitCode}`, exitCode: result.exitCode },
+                    });
+                    return reply;
+                }
+                try {
+                    return JSON.parse(result.stdout) as unknown;
+                } catch (err) {
+                    const message = err instanceof Error ? err.message : 'invalid JSON from probe';
+                    await reply.code(500).send({ error: { code: 'PROBE_PARSE_FAILED', message } });
+                    return reply;
+                }
+            } catch (err) {
+                const message = err instanceof Error ? err.message : 'probe failed to spawn';
+                await reply.code(500).send({ error: { code: 'PROBE_FAILED', message } });
+                return reply;
+            }
+        });
+
+        // road-to-clean-skill-distribution-channels § Phase B Step 4 —
+        // scope-guard endpoint. Spawns scripts/_lib/scope_guard.sh against
+        // the target project root and the user's $HOME, returns a
+        // structured verdict the wizard's first step renders before the
+        // operator picks an install scope. Read-only — no file writes.
+        app.get('/api/v1/wizard/scope-guard', async (_request, reply) => {
+            if (!extended) {
+                await reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'extended-mode endpoint disabled' } });
+                return reply;
+            }
+            const guardPath = join(opts.packageRoot, 'scripts', '_lib', 'scope_guard.sh');
+            if (!existsSync(guardPath)) {
+                await reply.code(500).send({ error: { code: 'GUARD_MISSING', message: `scope_guard.sh not found at ${guardPath}` } });
+                return reply;
+            }
+            const projectRoot = legacyReadRoot ?? process.cwd();
+            try {
+                const result = await spawnBash(guardPath, ['project', opts.packageRoot, projectRoot]);
+                // The script always exits 0; we still pass through stderr
+                // on a non-zero so the UI can surface platform issues.
+                if (result.exitCode !== 0) {
+                    await reply.code(500).send({
+                        error: { code: 'GUARD_FAILED', message: result.stderr || `scope_guard.sh exited ${result.exitCode}`, exitCode: result.exitCode },
+                    });
+                    return reply;
+                }
+                return parseScopeGuardOutput(result.stdout);
+            } catch (err) {
+                const message = err instanceof Error ? err.message : 'scope_guard.sh failed to spawn';
+                await reply.code(500).send({ error: { code: 'GUARD_FAILED', message } });
                 return reply;
             }
         });

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -67,6 +67,11 @@ tasks:
     desc: Generate tool-specific directories (.claude/, .cursor/, .clinerules/, .windsurfrules, GEMINI.md)
     cmd: python3 scripts/compress.py --generate-tools
 
+  probe:skills:
+    silent: true
+    desc: Detect duplicate/drifting skill registrations across user-global and project-local scopes (road-to-clean-skill-distribution-channels Phase C)
+    cmd: python3 scripts/probe_skill_registration.py --format=text
+
   release-prepare:
     silent: true
     desc: Release pipeline — sync, regenerate discovery manifest, regenerate tool projections (monorepo Phase 2, ADR-015)

--- a/templates/consumer-settings/ONBOARDING.md
+++ b/templates/consumer-settings/ONBOARDING.md
@@ -1,0 +1,41 @@
+# Onboarding — using `event4u/agent-config` in this project
+
+A short tour for new developers joining a project that ships with `event4u/agent-config`.
+
+## What you just installed
+
+A shared agent-configuration package — skills, rules, commands, and guidelines that make AI coding assistants (Claude Code, Augment, Cursor, Cline, Windsurf, Copilot, Gemini CLI) behave consistently across this project. Detail: [`agents/reference/docs/onboarding.md`](../../agents/reference/docs/onboarding.md) in the package source.
+
+## How the AI tools see it
+
+Each AI tool reads its own subtree under the project root — `.claude/skills/`, `.augment/`, `.cursor/rules/`, `.clinerules/`, `.windsurf/rules/`, `.github/copilot-instructions.md`. The installer projects the same content into each subtree from the canonical source so the agent behaves the same in every tool.
+
+## When something looks wrong — read this first
+
+The package has well-known **harness behaviours** that look like bugs but are not. Before opening an issue or rolling back, check the [`harness-expectations`](../../docs/contracts/harness-expectations.md) contract:
+
+1. **Sibling-plugin namespaces** — skills like `codex:*` or `cc-gemini-plugin:*` are from other AI plugins, not from this package.
+2. **Deferred tools** — the harness exposes some tools (TaskCreate, WebFetch, MCP tools) only after `ToolSearch` for context-budget reasons. Not a package bug.
+3. **Duplicate skill registration** — same skill showing twice usually means a stale install at the **other scope** (user-global vs project-local). Run `task probe:skills` to confirm, then `bash scripts/cleanup_other_scope.sh --confirm` to clean.
+
+The first step on every "this looks broken" report is:
+
+```bash
+task probe:skills
+```
+
+This surfaces every registration across all six tools and flags `DUPLICATE` / `DRIFT` findings before you go further. Background: [`docs/contracts/install-scopes.md`](../../docs/contracts/install-scopes.md) + [`docs/contracts/skill-distribution-channels.md`](../../docs/contracts/skill-distribution-channels.md).
+
+## Next steps
+
+- Run `agent-config setup` to open the GUI wizard if you haven't.
+- Read [`AGENTS.md`](../../AGENTS.md) — the universal cross-tool contract.
+- Pick a starter command: `/work` to plan, `/implement-ticket` to execute, `/commit` to ship.
+- If you maintain the package itself: [`AGENTS.md` § Emergency triage](../../AGENTS.md) and [`docs/customization.md`](../../docs/customization.md) point at the rest.
+
+## See also
+
+- [`docs/contracts/harness-expectations.md`](../../docs/contracts/harness-expectations.md) — "looks like a bug, isn't" diagnostics.
+- [`docs/contracts/install-scopes.md`](../../docs/contracts/install-scopes.md) — when to use project-local vs user-global.
+- [`docs/customization.md` § Troubleshooting](../../docs/customization.md#troubleshooting) — the troubleshooting front door.
+- [`agents/reference/docs/onboarding.md`](../../agents/reference/docs/onboarding.md) — the longer, package-side onboarding doc.

--- a/tests/server/wizard.scope-guard.test.ts
+++ b/tests/server/wizard.scope-guard.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase B Step 4 of road-to-clean-skill-distribution-channels.
+ *
+ *   GET /api/v1/wizard/scope-guard → spawns scripts/_lib/scope_guard.sh and
+ *                                    returns a structured verdict (OK/WARN/
+ *                                    DRIFT) the wizard renders before the
+ *                                    user picks an install scope.
+ *
+ *   - Extended-mode disabled → 404 (canonical 7-step contract untouched).
+ *   - Extended-mode enabled  → 200 with parsed findings array.
+ *
+ * No real cross-scope state is exercised here (the guard runs against the
+ * current package); the test asserts the wire shape and that the script
+ * actually exists + runs.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { createApp } from '../../src/server/app.js';
+import { authHeaders, settingsTemplate } from './helpers.js';
+
+const PORT = 41612;
+
+interface ScopeGuardFinding {
+    verdict: 'OK' | 'WARN' | 'DRIFT';
+    tool: string;
+    otherScopePath: string;
+    otherVersion: string;
+    thisVersion: string;
+}
+
+interface ScopeGuardResult {
+    overall: 'OK' | 'WARN' | 'DRIFT';
+    countOk: number;
+    countWarn: number;
+    countDrift: number;
+    findings: ScopeGuardFinding[];
+}
+
+interface TestApp {
+    app: FastifyInstance;
+    token: string;
+    host: string;
+    cleanup: () => Promise<void>;
+}
+
+async function bootWithExtended(extended: boolean): Promise<TestApp> {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'agent-config-scope-test-'));
+    mkdirSync(join(projectRoot, 'state'), { recursive: true });
+    mkdirSync(join(projectRoot, 'settings'), { recursive: true, mode: 0o700 });
+    writeFileSync(join(projectRoot, 'settings', '.agent-settings.yml'), settingsTemplate(), { mode: 0o600 });
+
+    const uiDir = mkdtempSync(join(tmpdir(), 'agent-config-scope-ui-'));
+    writeFileSync(join(uiDir, 'index.html'), '<!doctype html><html><body>ok</body></html>');
+
+    const token = 'x'.repeat(64);
+    const app = await createApp({
+        projectRoot,
+        uiDistDir: uiDir,
+        token,
+        expectedPort: PORT,
+        logLevel: 'fatal',
+        skipReplay: true,
+        extendedSteps: extended,
+    });
+    await app.ready();
+
+    const cleanup = async (): Promise<void> => {
+        await app.close();
+        rmSync(projectRoot, { recursive: true, force: true });
+        rmSync(uiDir, { recursive: true, force: true });
+    };
+    return { app, token, host: `127.0.0.1:${PORT}`, cleanup };
+}
+
+describe('wizard scope-guard endpoint', () => {
+    let ctx: TestApp;
+    afterEach(async () => { await ctx.cleanup(); });
+
+    it('GET /scope-guard returns 404 when extended-mode is off', async () => {
+        ctx = await bootWithExtended(false);
+        const res = await ctx.app.inject({
+            method: 'GET',
+            url: '/api/v1/wizard/scope-guard',
+            headers: authHeaders(ctx.token, ctx.host),
+        });
+        expect(res.statusCode).toBe(404);
+        const body = res.json() as { error: { code: string } };
+        expect(body.error.code).toBe('NOT_FOUND');
+    });
+
+    it('GET /scope-guard returns parsed verdict when extended-mode is on', async () => {
+        ctx = await bootWithExtended(true);
+        const res = await ctx.app.inject({
+            method: 'GET',
+            url: '/api/v1/wizard/scope-guard',
+            headers: authHeaders(ctx.token, ctx.host),
+        });
+        expect(res.statusCode).toBe(200);
+        const body = res.json() as ScopeGuardResult;
+        // The parser always emits a verdict + findings; in CI both should
+        // be present even if every tool returns OK.
+        expect(['OK', 'WARN', 'DRIFT']).toContain(body.overall);
+        expect(Array.isArray(body.findings)).toBe(true);
+        expect(body.findings.length).toBeGreaterThanOrEqual(6);
+        // Every supported tool must appear.
+        const tools = body.findings.map((f) => f.tool);
+        for (const expectedTool of ['claude-code', 'augment', 'cursor', 'cline', 'windsurf', 'copilot']) {
+            expect(tools).toContain(expectedTool);
+        }
+        // Counts must add up.
+        const totals = body.countOk + body.countWarn + body.countDrift;
+        expect(totals).toBe(body.findings.length);
+    });
+});

--- a/tests/test_canonical_distribution.py
+++ b/tests/test_canonical_distribution.py
@@ -1,0 +1,151 @@
+"""Canonical distribution channel — regression test (Phase A Step 5).
+
+Locks the canonical-channel contract at
+``docs/contracts/skill-distribution-channels.md`` against ``scripts/install.sh``.
+
+The contract picks **filesystem** as the canonical channel for all six
+supported AI tools. The installer's consumer-install path must therefore:
+
+1. Not project ``.claude-plugin/marketplace.json`` into the target by default.
+2. Only project it when the operator explicitly passes ``--legacy-both``.
+
+The tests dry-run the installer into a tmpdir (no real filesystem writes)
+and inspect what would be written. ``--dry-run`` plus the verbose log
+gives us a stable assertion surface without invoking the full payload
+sync (which would symlink hundreds of files into the tmpdir on every run).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _run_install(target: Path, extra: list[str]) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "bash",
+        str(INSTALL_SH),
+        "--source", str(REPO_ROOT),
+        "--target", str(target),
+        "--skip-gitignore",
+        "--verbose",
+        "--dry-run",
+        *extra,
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+@pytest.fixture(scope="module")
+def installer_help() -> str:
+    return subprocess.run(
+        ["bash", str(INSTALL_SH), "--help"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+
+def test_legacy_both_flag_documented(installer_help: str) -> None:
+    """The installer help text must surface --legacy-both per the contract."""
+    assert "--legacy-both" in installer_help, (
+        "--legacy-both must appear in scripts/install.sh --help (canonical-channel contract)"
+    )
+    assert "filesystem" in installer_help.lower() or "canonical" in installer_help.lower(), (
+        "The help text must mention the canonical-channel context"
+    )
+
+
+def test_install_sh_default_skips_plugin_manifest(tmp_path: Path) -> None:
+    """Default consumer install must NOT project .claude-plugin/marketplace.json."""
+    result = _run_install(tmp_path, [])
+    assert result.returncode == 0, f"install.sh dry-run failed: {result.stderr}"
+
+    combined = result.stdout + result.stderr
+    # The new project_legacy_plugin_manifest helper must log that it's
+    # skipping the manifest in the default path.
+    assert (
+        "skip .claude-plugin/marketplace.json" in combined
+        or "filesystem is canonical" in combined
+    ), (
+        "default install.sh run must log the .claude-plugin/marketplace.json skip; "
+        "found neither marker.\n--- stdout ---\n" + result.stdout + "\n--- stderr ---\n" + result.stderr
+    )
+
+
+def test_install_sh_legacy_both_opts_into_manifest(tmp_path: Path) -> None:
+    """--legacy-both must surface the projection in the dry-run log."""
+    result = _run_install(tmp_path, ["--legacy-both"])
+    assert result.returncode == 0, f"install.sh dry-run failed: {result.stderr}"
+
+    combined = result.stdout + result.stderr
+    assert (
+        "copy .claude-plugin/marketplace.json" in combined
+        or "Projected .claude-plugin/marketplace.json" in combined
+        or "--legacy-both" in combined
+    ), (
+        "--legacy-both run must surface a marketplace-projection log line.\n"
+        "--- stdout ---\n" + result.stdout + "\n--- stderr ---\n" + result.stderr
+    )
+
+
+def test_canonical_contract_pins_filesystem_per_tool() -> None:
+    """The contract doc must name 'filesystem' as canonical for every supported tool."""
+    contract = (REPO_ROOT / "docs" / "contracts" / "skill-distribution-channels.md").read_text(encoding="utf-8")
+    tools = ["Claude Code", "Augment", "Cursor", "Cline", "Windsurf", "Copilot"]
+    for tool in tools:
+        assert tool in contract, f"Contract must name '{tool}' in the per-tool matrix"
+    # The literal table cell value "**filesystem**" is the canonical choice marker.
+    assert contract.count("**filesystem**") >= len(tools), (
+        f"Contract must mark every supported tool as filesystem-canonical "
+        f"(found {contract.count('**filesystem**')} markers, expected ≥ {len(tools)})"
+    )
+
+
+def test_no_plugin_manifest_in_install_sh_default_flow() -> None:
+    """install.sh must NOT contain an unconditional marketplace.json copy.
+
+    Static scan: every copy/projection of `.claude-plugin/marketplace.json`
+    must be gated on LEGACY_BOTH or the project_legacy_plugin_manifest helper.
+    """
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    # The opt-in helper must exist.
+    assert "project_legacy_plugin_manifest" in text, (
+        "install.sh must define project_legacy_plugin_manifest()"
+    )
+    # The LEGACY_BOTH gate must exist.
+    assert "LEGACY_BOTH=false" in text, "LEGACY_BOTH must default to false"
+    # No path in the script should reference marketplace.json outside the
+    # gated helper. We allow occurrences inside the gated function body.
+    occurrences = [
+        i for i, line in enumerate(text.splitlines(), 1)
+        if "marketplace.json" in line
+    ]
+    # Build a coarse map of function boundaries to assert each occurrence
+    # is inside project_legacy_plugin_manifest (or a comment/help block).
+    legacy_section_start = text.index("project_legacy_plugin_manifest() {")
+    legacy_section_end = text.index("# Create GEMINI.md symlink", legacy_section_start)
+    legacy_lines: set[int] = set()
+    for i, line in enumerate(text.splitlines(), 1):
+        offset = sum(len(x) + 1 for x in text.splitlines()[:i - 1])
+        if legacy_section_start <= offset < legacy_section_end:
+            legacy_lines.add(i)
+
+    # Allow lines inside the legacy helper, in the --legacy-both help text,
+    # and in the LEGACY_BOTH comment block at the top of the globals.
+    for line_no in occurrences:
+        line = text.splitlines()[line_no - 1]
+        in_helper = line_no in legacy_lines
+        in_help_or_comment = (
+            "--legacy-both" in line
+            or line.strip().startswith("#")
+            or line.strip().startswith("(.claude-plugin/marketplace.json)")
+            or line.strip().startswith("at docs/contracts/")
+        )
+        assert in_helper or in_help_or_comment, (
+            f"line {line_no} references marketplace.json outside the gated helper: {line!r}"
+        )

--- a/tests/test_cleanup_other_scope.py
+++ b/tests/test_cleanup_other_scope.py
@@ -1,0 +1,101 @@
+"""Phase B Step 5 — scripts/cleanup_other_scope.sh smoke tests.
+
+Asserts the safety contract:
+
+- without ``--confirm`` no file is removed (dry-run is the default);
+- with ``--confirm`` and a ``--project`` pointer the listed targets vanish;
+- ``--tools`` narrows the deletion set;
+- files outside the configured roots are never touched (regression hook
+  for the non-destructive-by-default rule).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLEANUP_SH = REPO_ROOT / "scripts" / "cleanup_other_scope.sh"
+
+
+def _scaffold_scope_tree(root: Path) -> dict[str, Path]:
+    """Create a fake scope tree the cleanup script knows about."""
+    paths = {
+        "claude_skills":     root / ".claude" / "skills" / "demo" / "SKILL.md",
+        "claude_rules":      root / ".claude" / "rules" / "demo.md",
+        "claude_marketplace": root / ".claude-plugin" / "marketplace.json",
+        "augment_root":      root / ".augment" / "rules" / "demo.md",
+        "augment_plugin":    root / ".augment-plugin" / "plugin.json",
+        "cursor_rules":      root / ".cursor" / "rules" / "demo.mdc",
+        "clinerules":        root / ".clinerules" / "demo.md",
+        "windsurf_rules":    root / ".windsurf" / "rules" / "demo.md",
+        "windsurfrules":     root / ".windsurfrules",
+        "copilot_md":        root / ".github" / "copilot-instructions.md",
+    }
+    for p in paths.values():
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("placeholder")
+    # Bystander file outside the configured roots — must survive every run.
+    bystander = root / "agents" / "user-stuff.md"
+    bystander.parent.mkdir(parents=True, exist_ok=True)
+    bystander.write_text("important")
+    paths["bystander"] = bystander
+    return paths
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(CLEANUP_SH), *args],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def test_dry_run_default_removes_nothing(tmp_path: Path) -> None:
+    paths = _scaffold_scope_tree(tmp_path)
+    result = _run(["--project", str(tmp_path)])
+    assert result.returncode == 0, result.stderr
+    assert "DRY RUN" in result.stdout
+    for name, path in paths.items():
+        assert path.exists(), f"{name} should survive dry-run"
+
+
+def test_confirm_removes_targets(tmp_path: Path) -> None:
+    paths = _scaffold_scope_tree(tmp_path)
+    result = _run(["--confirm", "--project", str(tmp_path)])
+    assert result.returncode == 0, result.stderr
+    # Targets vanish.
+    for name in (
+        "claude_skills", "claude_rules", "claude_marketplace",
+        "augment_root", "augment_plugin", "cursor_rules", "clinerules",
+        "windsurf_rules", "windsurfrules", "copilot_md",
+    ):
+        # claude_skills is a file inside .claude/skills/<demo>/, parent dir gets removed
+        assert not paths[name].exists(), f"{name} should be removed (was {paths[name]})"
+    # Bystander survives — proof we didn't blow away the whole project root.
+    assert paths["bystander"].exists()
+
+
+def test_tools_filter_scopes_deletion(tmp_path: Path) -> None:
+    paths = _scaffold_scope_tree(tmp_path)
+    result = _run(["--confirm", "--project", str(tmp_path), "--tools=claude-code"])
+    assert result.returncode == 0, result.stderr
+    # Claude paths removed.
+    assert not paths["claude_skills"].exists()
+    assert not paths["claude_rules"].exists()
+    assert not paths["claude_marketplace"].exists()
+    # All other tools untouched.
+    for name in (
+        "augment_root", "augment_plugin", "cursor_rules", "clinerules",
+        "windsurf_rules", "windsurfrules", "copilot_md", "bystander",
+    ):
+        assert paths[name].exists(), f"{name} should NOT have been removed under --tools=claude-code"
+
+
+def test_refuses_without_project_pointer_when_not_user(tmp_path: Path) -> None:
+    """--project requires a path argument."""
+    result = _run(["--confirm", "--project"])
+    assert result.returncode != 0
+    assert "requires" in result.stderr.lower() or "Unknown argument" in result.stderr

--- a/tests/test_probe_skill_registration.py
+++ b/tests/test_probe_skill_registration.py
@@ -1,0 +1,159 @@
+"""Phase C — probe_skill_registration.py coverage.
+
+Synthetic fixtures stand in for the six tool surfaces so each duplicate /
+drift shape is exercised in isolation without touching the host machine's
+real install state.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROBE = REPO_ROOT / "scripts" / "probe_skill_registration.py"
+
+sys.path.insert(0, str(REPO_ROOT))
+from scripts.probe_skill_registration import run_probe  # noqa: E402
+
+
+def _write_skill(root: Path, tool_dir: str, skill_id: str, description: str, *, fmt: str = "skill_md") -> None:
+    if fmt == "skill_md":
+        path = root / tool_dir / skill_id / "SKILL.md"
+    elif fmt == "mdc":
+        path = root / tool_dir / f"{skill_id}.mdc"
+    elif fmt == "md":
+        path = root / tool_dir / f"{skill_id}.md"
+    elif fmt == "single":
+        path = root / tool_dir / "copilot-instructions.md"
+    else:
+        raise ValueError(fmt)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm = "---\n" + f"name: {skill_id}\n" + f'description: "{description}"\n' + "---\n# body\n"
+    path.write_text(fm, encoding="utf-8")
+
+
+def _write_pkgjson(root: Path, version: str) -> None:
+    (root / "package.json").write_text(json.dumps({"version": version}), encoding="utf-8")
+
+
+def test_no_findings_when_only_one_scope(tmp_path: Path) -> None:
+    """Project-only install with no user-global twin → no DUPLICATE / DRIFT."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(project, ".claude/skills", "alpha", "First skill")
+    result = run_probe(home=tmp_path / "empty-home", project=project)
+    assert len(result.registrations) == 1
+    assert result.duplicates == {}
+    assert result.drift == {}
+
+
+def test_same_skill_in_both_scopes_flags_duplicate(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    _write_pkgjson(home, "3.3.0")
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(home, ".claude/skills", "alpha", "Same description")
+    _write_skill(project, ".claude/skills", "alpha", "Same description")
+    result = run_probe(home=home, project=project)
+    assert "claude:alpha" in result.duplicates, result.to_dict()
+    # Same hash + version → DUPLICATE but NOT DRIFT.
+    assert "claude:alpha" not in result.drift
+
+
+def test_same_skill_different_descriptions_flags_drift(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    _write_pkgjson(home, "3.3.0")
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(home, ".claude/skills", "copilot-config", "Stale description from older install")
+    _write_skill(project, ".claude/skills", "copilot-config", "Fresh description from current install")
+    result = run_probe(home=home, project=project)
+    assert "claude:copilot-config" in result.duplicates
+    assert "claude:copilot-config" in result.drift, "drift must fire when description hashes differ"
+
+
+def test_same_skill_different_versions_flags_drift(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    _write_pkgjson(home, "2.9.0")
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(home, ".claude/skills", "alpha", "Same description")
+    _write_skill(project, ".claude/skills", "alpha", "Same description")
+    result = run_probe(home=home, project=project)
+    assert "claude:alpha" in result.drift, "drift must fire when versions differ"
+
+
+def test_plugin_manifest_is_separate_source(tmp_path: Path) -> None:
+    """The manifest entries register under scope='*-plugin' — duplicate vs filesystem."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(project, ".claude/skills", "alpha", "From filesystem")
+    manifest = project / ".claude-plugin" / "marketplace.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(json.dumps({
+        "plugins": [{
+            "name": "agent-config",
+            "skills": ["./.claude/skills/alpha"],
+        }],
+    }), encoding="utf-8")
+    result = run_probe(home=tmp_path / "empty-home", project=project)
+    assert "claude:alpha" in result.duplicates, "filesystem + manifest entries must register as DUPLICATE"
+
+
+def test_cursor_cline_windsurf_copilot_readers(tmp_path: Path) -> None:
+    """Each non-Claude/Augment tool produces a registration row."""
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(project, ".cursor/rules", "rule-one", "Cursor rule", fmt="mdc")
+    _write_skill(project, ".clinerules", "rule-two", "Cline rule", fmt="md")
+    _write_skill(project, ".windsurf/rules", "rule-three", "Windsurf rule", fmt="md")
+    _write_skill(project, ".github", "copilot-instructions", "n/a", fmt="single")
+    result = run_probe(home=tmp_path / "empty-home", project=project)
+    tools = {r.tool for r in result.registrations}
+    assert {"cursor", "cline", "windsurf", "copilot"}.issubset(tools)
+
+
+def test_cli_strict_exits_non_zero_on_findings(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    _write_pkgjson(home, "3.3.0")
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(home, ".claude/skills", "alpha", "Stale")
+    _write_skill(project, ".claude/skills", "alpha", "Fresh")
+    result = subprocess.run(
+        ["python3", str(PROBE), "--strict", "--home", str(home), "--project", str(project), "--format=json"],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 2, f"strict mode should exit 2 on drift, got {result.returncode}\n{result.stdout}\n{result.stderr}"
+
+
+def test_cli_default_exits_zero_even_with_findings(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    _write_pkgjson(home, "3.3.0")
+    _write_pkgjson(project, "3.3.0")
+    _write_skill(home, ".claude/skills", "alpha", "Stale")
+    _write_skill(project, ".claude/skills", "alpha", "Fresh")
+    result = subprocess.run(
+        ["python3", str(PROBE), "--home", str(home), "--project", str(project)],
+        capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, "non-strict mode should be informational (exit 0)"
+    assert "DRIFT" in result.stdout


### PR DESCRIPTION
## Summary

Closes the `road-to-clean-skill-distribution-channels` track that opened on 2026-05-25 when a Claude session surfaced `copilot-config` registered twice with different descriptions (root cause: cross-scope drift between `~/.claude/skills/` at one version and project-local `./.claude/skills/` at another).

Three structurally distinct duplication paths are addressed:

- **Same-install plugin↔filesystem** — Claude harness shipping both `.claude-plugin/marketplace.json` AND `.claude/skills/`. Resolved by picking **filesystem** as the canonical consumer-install channel (Augment is unaffected — its manifest `source: "."` already points at the filesystem). Plugin manifest only projects into consumer installs via `--legacy-both`.
- **Cross-scope user↔project drift** — the actual 2026-05-25 root cause. Pre-flight `scope_guard.sh` detects it on every install; companion `cleanup_other_scope.sh` removes a stale other-scope install only with `--confirm`.
- **Cross-version stale-install** — caught by the post-install probe.

### What landed

- **install.sh**: filesystem-canonical default, `--legacy-both` opt-in, `run_scope_guard` pre-flight, `run_post_install_probe` post-install probe with `PROBE_STRICT` for release installs.
- **scripts/_lib/scope_guard.sh**, **scripts/cleanup_other_scope.sh**, **scripts/probe_skill_registration.py**: the three new diagnostic / safety scripts.
- **3 new locked contracts** under `docs/contracts/`:
  - `skill-distribution-channels.md` — canonical channel per tool.
  - `install-scopes.md` — user-global vs project-local discipline.
  - `harness-expectations.md` — three classes of host-side behaviour that look like package bugs but aren't (sibling plugins, deferred tools, cross-scope drift).
- **Wizard endpoints** (extended-mode) — `/api/v1/wizard/scope-guard`, `/api/v1/wizard/probe`, `/api/v1/wizard/harness-expectations`.
- **Taskfile**: `task probe:skills` for ad-hoc diagnostics.
- **Front-matter docs**: README install-scope + harness-expectations sections, AGENTS.md emergency-triage item 6, docs/customization.md troubleshooting front door, templates/consumer-settings/ONBOARDING.md.
- **Tests**: 8 new Python tests + 2 vitest tests covering every shape of duplicate / drift.

### Decision provenance

`docs/contracts/skill-distribution-channels.md` cites the AI Council convergence (claude-sonnet-4-5 + gpt-4o, 2026-05-25). Both members agreed filesystem-canonical is the right cut conditional on the Phase B installer guard + Phase C fail-loud probe landing — both shipped here.

## Test plan

- [x] `python3 -m pytest tests/test_canonical_distribution.py tests/test_cleanup_other_scope.py tests/test_probe_skill_registration.py` (17 passed)
- [x] `npx vitest run tests/server/wizard.scope-guard.test.ts` (2 passed)
- [x] `npx tsc --noEmit` (clean)
- [x] `python3 scripts/check_references.py` (no broken refs)
- [x] `python3 scripts/skill_linter.py --all` (453 pass / 4 warn / 0 fail)
- [x] `shellcheck scripts/install.sh scripts/_lib/scope_guard.sh scripts/cleanup_other_scope.sh` (only pre-existing SC2129 in install.sh)
- [ ] Live in-session reproduction of the canonical-channel decision on a fresh Claude install — deferred to the human owner per audit 01.
- [ ] Recruit-session feedback on duplicate-skill observations in the wild — gathered into `agents/recruit-sessions/_findings-distribution.md`.

## Roadmap

`agents/roadmaps/archive/road-to-clean-skill-distribution-channels.md` — all 25 steps closed (Phases A/B/C/D), file archived in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)