### PR TITLE
fix(init): open the browser wizard when the GUI is usable

### DIFF
--- a/docs/contracts/gui-wizard.md
+++ b/docs/contracts/gui-wizard.md
@@ -41,23 +41,30 @@ no cross-origin asset, no remote endpoint — CSP
 ## Boot sequence
 
 ```
-agent-config install   (or `setup`, or `init` → scripts/install.py → spawns
-                        `node dist/cli/agent-config.js install --no-open`)
+agent-config install   (or `setup`, or `init` when the GUI is usable)
   │
   ├─► pick a free loopback port; mint a per-server bearer/CSRF token
   ├─► Fastify listen({ host: '127.0.0.1', port })
   ├─► print `WIZARD_READY <url>` on stdout (url carries `?token=…` + `#/…`)
   ├─► open the OS browser at <url>   (skipped with --no-open / headless)
-  └─► serve until Ctrl-C
+  └─► serve until the user finishes (Finish → install) or Ctrl-C
 ```
 
-`init` is the consumer entry point: it delegates to `scripts/install.py`,
-which — on a TTY with a display and no `--no-ui` / `CI` / explicit
-`--tools=` — spawns the `install` subcommand with `--no-open` and waits for
-the `WIZARD_READY <url>` handshake (progressive 10/20/40/80 s budget) before
-printing the URL banner. Headless / CI / `--no-ui` / explicit `--tools=`
-installs run the non-interactive `install.py` path directly and never boot
-the GUI.
+`init` is the consumer entry point and the install **front-end**: the TS CLI
+(`src/cli/initRouting.ts → shouldInitLaunchGui`) opens the browser wizard
+directly (via `runUiServe`, install mode) whenever it can actually be used —
+interactive TTY, a display, and no CLI-mode flag. There is no CLI tool-picker
+in that path; the wizard collects the tool/pack/settings selection and its
+Finish drives the **whole** install through `POST /api/v1/wizard/apply` →
+`scripts/install.py --apply-payload` (one installer).
+
+`init` falls back to the non-interactive bash CLI install (`scripts/install` →
+`install.py`) — and never boots the GUI — when any of these hold: `CI` set,
+`AGENT_CONFIG_NO_UI` set, stdin/stdout not a TTY, a headless host (SSH / Linux
+without `DISPLAY`), or a CLI-mode flag (`--no-ui` / `--tools` / `--ai` /
+`--yes` / `--quiet` / `--dry-run` / `--minimal` / `--settings-only` /
+`--list-tools`). `install.py`'s own tail-launch (`_wizard_spawn`, matching the
+`WIZARD_READY <url>` handshake) remains for direct `python3 install.py` runs.
 
 ### `WIZARD_READY` stdout contract
 

--- a/src/cli/agent-config.ts
+++ b/src/cli/agent-config.ts
@@ -20,6 +20,7 @@ import { delegateToBash } from './bash/runBash.js';
 import { runVersions } from './commands/versions.js';
 import { runDoctorShell } from './commands/doctorShell.js';
 import { runUiServe } from './commands/uiServe.js';
+import { shouldInitLaunchGui, buildInitGuiOptions } from './initRouting.js';
 import { runSettings } from './commands/settings.js';
 import { runWorkspacesLs } from './commands/workspaces.js';
 import { runPacksLs } from './commands/packs.js';
@@ -266,6 +267,15 @@ async function main(argv: readonly string[]): Promise<number> {
     if (head !== undefined && native.includes(head)) {
         await program.parseAsync(['node', 'agent-config', ...argv]);
         return 0;
+    }
+
+    // `init` is the install front-end: when the browser wizard can actually be
+    // used (interactive TTY, display, no CLI-mode flags), open it and let it
+    // drive the install via /api/v1/wizard/apply → install.py --apply-payload —
+    // no CLI tool-picker, one installer. Otherwise fall through to the bash CLI
+    // install (road-to-single-install-source-of-truth § Phase 4 follow-up).
+    if (head === 'init' && shouldInitLaunchGui(argv.slice(1))) {
+        return runUiServe(buildInitGuiOptions(argv.slice(1)));
     }
 
     // Everything else forwards to the Bash dispatcher verbatim.

--- a/src/cli/commands/uiServe.ts
+++ b/src/cli/commands/uiServe.ts
@@ -65,7 +65,7 @@ export interface UiServeOptions {
     wizardMode?: 'install' | 'setup';
 }
 
-function isHeadless(): boolean {
+export function isHeadless(): boolean {
     if (process.env['SSH_CONNECTION']) return true;
     if (process.platform === 'linux' && !process.env['DISPLAY']) return true;
     return false;

--- a/src/cli/initRouting.ts
+++ b/src/cli/initRouting.ts
@@ -1,0 +1,88 @@
+/**
+ * `init` install-front-end routing (road-to-single-install-source-of-truth
+ * § Phase 4 follow-up).
+ *
+ * `init` is the consumer install entry point. When the browser wizard can
+ * actually be used, `init` opens it and lets it drive the whole install via
+ * `/api/v1/wizard/apply` → `scripts/install.py --apply-payload` — no CLI
+ * tool-picker, one installer. Otherwise `init` falls back to the bash CLI
+ * install. These pure helpers make that decision (and the GUI option mapping)
+ * unit-testable, separate from the self-executing CLI entry point.
+ */
+
+import { isHeadless, type runUiServe } from './commands/uiServe.js';
+
+/**
+ * Whether `init` should open the browser wizard instead of the non-interactive
+ * CLI install. Returns false (→ delegate to the bash CLI install) when ANY of
+ * these hold:
+ *   - CI env set, or AGENT_CONFIG_NO_UI set
+ *   - stdin/stdout is not a TTY (piped / curl|bash)
+ *   - headless host (SSH / Linux without DISPLAY)
+ *   - a CLI-mode flag is present (--no-ui / --tools / --ai / --yes / --quiet /
+ *     --dry-run / --minimal / --settings-only / --list-tools) — the caller
+ *     already knows what to install and doesn't want the picker.
+ *
+ * `rest` is argv without the leading `init` token.
+ */
+export function shouldInitLaunchGui(rest: readonly string[]): boolean {
+    const ci = (process.env['CI'] ?? '').trim();
+    if (ci && ci !== '0') return false;
+    const envNoUi = (process.env['AGENT_CONFIG_NO_UI'] ?? '').trim();
+    if (envNoUi && envNoUi !== '0') return false;
+    if (process.stdin.isTTY !== true || process.stdout.isTTY !== true) return false;
+    if (isHeadless()) return false;
+    const cliSignals = new Set([
+        '--no-ui', '--tools', '--ai', '--yes', '-y', '--quiet', '-q',
+        '--dry-run', '--minimal', '--settings-only', '--list-tools',
+    ]);
+    for (const arg of rest) {
+        const flag = arg.split('=', 1)[0];
+        if (flag !== undefined && cliSignals.has(flag)) return false;
+    }
+    return true;
+}
+
+/**
+ * Translate the GUI-compatible subset of `init` flags into `runUiServe`
+ * options. Lands on the install wizard (Step 1 / AI tools). `rest` is argv
+ * without the leading `init` token.
+ */
+export function buildInitGuiOptions(rest: readonly string[]): Parameters<typeof runUiServe>[0] {
+    const forwarded: Parameters<typeof runUiServe>[0] = {
+        initialRoute: '/wizard',
+        extendedSteps: true,
+        initialStep: 0,
+        wizardMode: 'install',
+    };
+    for (let i = 0; i < rest.length; i += 1) {
+        const arg = rest[i];
+        if (arg === undefined) continue;
+        if (arg === '--no-open') {
+            forwarded.open = false;
+        } else if (arg === '--allow-headless') {
+            forwarded.allowHeadless = true;
+        } else if (arg === '--port' || arg === '--project-root' || arg === '--ui-dist') {
+            const value = rest[i + 1];
+            if (value !== undefined) {
+                i += 1;
+                if (arg === '--port') {
+                    const n = Number.parseInt(value, 10);
+                    if (!Number.isNaN(n)) forwarded.port = n;
+                } else if (arg === '--project-root') {
+                    forwarded.projectRoot = value;
+                } else {
+                    forwarded.uiDist = value;
+                }
+            }
+        } else if (arg.startsWith('--port=')) {
+            const n = Number.parseInt(arg.slice('--port='.length), 10);
+            if (!Number.isNaN(n)) forwarded.port = n;
+        } else if (arg.startsWith('--project-root=')) {
+            forwarded.projectRoot = arg.slice('--project-root='.length);
+        } else if (arg.startsWith('--ui-dist=')) {
+            forwarded.uiDist = arg.slice('--ui-dist='.length);
+        }
+    }
+    return forwarded;
+}

--- a/tests/cli/init-gui-routing.test.ts
+++ b/tests/cli/init-gui-routing.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for `init` install-front-end routing
+ * (road-to-single-install-source-of-truth § Phase 4 follow-up).
+ *
+ * `shouldInitLaunchGui` decides GUI vs bash-CLI install; `buildInitGuiOptions`
+ * maps the GUI-compatible flag subset onto `runUiServe` options.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `isHeadless` reads SSH/DISPLAY env — mock it so the GUI-capable baseline is
+// deterministic on Linux CI runners (which have no DISPLAY).
+vi.mock('../../src/cli/commands/uiServe.js', () => ({
+    isHeadless: vi.fn(() => false),
+    runUiServe: vi.fn(),
+}));
+
+import { shouldInitLaunchGui, buildInitGuiOptions } from '../../src/cli/initRouting.js';
+import { isHeadless } from '../../src/cli/commands/uiServe.js';
+
+const headlessMock = vi.mocked(isHeadless);
+
+describe('shouldInitLaunchGui', () => {
+    let stdinTTY: boolean | undefined;
+    let stdoutTTY: boolean | undefined;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+        // GUI-capable baseline: interactive TTY, no CI / NO_UI, not headless.
+        stdinTTY = process.stdin.isTTY;
+        stdoutTTY = process.stdout.isTTY;
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+        for (const key of ['CI', 'AGENT_CONFIG_NO_UI']) {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        }
+        headlessMock.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: stdinTTY, configurable: true });
+        Object.defineProperty(process.stdout, 'isTTY', { value: stdoutTTY, configurable: true });
+        for (const key of ['CI', 'AGENT_CONFIG_NO_UI']) {
+            if (savedEnv[key] === undefined) delete process.env[key];
+            else process.env[key] = savedEnv[key];
+        }
+        vi.clearAllMocks();
+    });
+
+    it('launches the GUI for a bare interactive init', () => {
+        expect(shouldInitLaunchGui([])).toBe(true);
+    });
+
+    it('falls back to CLI when CI is set', () => {
+        process.env['CI'] = 'true';
+        expect(shouldInitLaunchGui([])).toBe(false);
+    });
+
+    it('CI=0 does not count as CI', () => {
+        process.env['CI'] = '0';
+        expect(shouldInitLaunchGui([])).toBe(true);
+    });
+
+    it('falls back to CLI when AGENT_CONFIG_NO_UI is set', () => {
+        process.env['AGENT_CONFIG_NO_UI'] = '1';
+        expect(shouldInitLaunchGui([])).toBe(false);
+    });
+
+    it('falls back to CLI when stdout is not a TTY', () => {
+        Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+        expect(shouldInitLaunchGui([])).toBe(false);
+    });
+
+    it('falls back to CLI on a headless host', () => {
+        headlessMock.mockReturnValue(true);
+        expect(shouldInitLaunchGui([])).toBe(false);
+    });
+
+    it.each([
+        ['--no-ui'],
+        ['--tools', 'cursor'],
+        ['--tools=cursor'],
+        ['--ai', 'cursor'],
+        ['--yes'],
+        ['-y'],
+        ['--quiet'],
+        ['--dry-run'],
+        ['--minimal'],
+        ['--settings-only'],
+        ['--list-tools'],
+    ])('falls back to CLI when a CLI-mode flag is present: %s', (...flags) => {
+        expect(shouldInitLaunchGui(flags)).toBe(false);
+    });
+
+    it('launches the GUI when only GUI-compatible flags are present', () => {
+        expect(shouldInitLaunchGui(['--no-open', '--port', '5050', '--global'])).toBe(true);
+    });
+});
+
+describe('buildInitGuiOptions', () => {
+    it('defaults to the install-wizard route', () => {
+        expect(buildInitGuiOptions([])).toMatchObject({
+            initialRoute: '/wizard',
+            extendedSteps: true,
+            initialStep: 0,
+            wizardMode: 'install',
+        });
+    });
+
+    it('maps --no-open to open:false', () => {
+        expect(buildInitGuiOptions(['--no-open']).open).toBe(false);
+    });
+
+    it('parses --port (space and = forms)', () => {
+        expect(buildInitGuiOptions(['--port', '5050']).port).toBe(5050);
+        expect(buildInitGuiOptions(['--port=6060']).port).toBe(6060);
+    });
+
+    it('ignores a non-numeric --port', () => {
+        expect(buildInitGuiOptions(['--port', 'abc']).port).toBeUndefined();
+    });
+
+    it('parses --project-root and --allow-headless', () => {
+        const opts = buildInitGuiOptions(['--project-root', '/tmp/proj', '--allow-headless']);
+        expect(opts.projectRoot).toBe('/tmp/proj');
+        expect(opts.allowHeadless).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Closes the Phase-4 gap from #254: `npx … init` on a normal terminal showed a
**CLI tool-picker** and never opened the browser wizard — the opposite of the
roadmap goal ("init opens the GUI when a display is available; skip CLI tool
questions").

**Root cause.** `init` delegated unconditionally to the bash CLI install. That
ran its own interactive tool-picker (`scripts/install` → `prompt_tools`) and
then passed `--tools=<picked>` to `install.py` — which the Phase-4 gate read as
"explicit `--tools` → suppress GUI". So the GUI was blocked twice.

**Fix (Option 2 — GUI is the front-end).** The TS CLI now intercepts `init`:
when the wizard can actually be used (interactive TTY, a display, no CLI-mode
flag, no `CI`/`--no-ui`), it opens the browser wizard directly via `runUiServe`
(install mode) — **no CLI tool-picker**. The wizard's Finish drives the whole
install through `POST /api/v1/wizard/apply` → `scripts/install.py
--apply-payload` (one installer, no double-install). Every headless / `--no-ui`
/ `CI` / explicit-flag case delegates to the bash CLI install **unchanged**.

## Changes

- `src/cli/initRouting.ts` (new): `shouldInitLaunchGui` (GUI-vs-CLI decision) +
  `buildInitGuiOptions` (flag → `runUiServe` mapping). Pure + unit-testable,
  kept out of the self-executing entry point.
- `src/cli/agent-config.ts`: intercept `init` before the bash-delegate fallback.
- `src/cli/commands/uiServe.ts`: export `isHeadless` for the routing gate.
- `tests/cli/init-gui-routing.test.ts` (new): 23 cases.
- `docs/contracts/gui-wizard.md`: boot sequence updated.

## Routing matrix

| Condition | `init` behavior |
|---|---|
| Interactive TTY + display + no flags | **Open browser wizard** (GUI drives install) |
| `CI` / `AGENT_CONFIG_NO_UI` / non-TTY / headless | bash CLI install |
| `--no-ui` / `--tools` / `--ai` / `--yes` / `--quiet` / `--dry-run` / `--minimal` / `--settings-only` / `--list-tools` | bash CLI install |
| GUI-compatible flags (`--no-open` / `--port` / `--project-root`) | GUI, flags forwarded |

## Test plan

- [x] `npm run lint:ts` + `typecheck` + `build` (cli + ui) green
- [x] `npm run test:ts` — 403 passed (incl. 23 new routing tests)
- [x] `node scripts/prepack-check.mjs` OK

## Note

The live browser-open + full wizard→apply round-trip needs a display, so it's
not runnable in the headless dev env; the routing decision + option mapping are
unit-covered, and the GUI→`/wizard/apply`→`install.py --apply-payload` chain is
the same path #254's parity test already validated.