### PR TITLE
fix(wizard): make voice_sample optional so setup can save

### DIFF
--- a/docs/contracts/agent-user-schema.md
+++ b/docs/contracts/agent-user-schema.md
@@ -30,7 +30,7 @@ role:                      # required — unordered list of role labels; ≥ 1 e
   - engineer
 style:
   pace: "pragmatic"        # pragmatic | thorough | rapid
-voice_sample: |            # required — one paste of the user's typical writing
+voice_sample: |            # optional — one paste of the user's typical writing
   Mach das einfach. Wenn unklar, frag im Council.
 last_updated: "2026-05-15" # YYYY-MM-DD — bumped on every accepted change
 ---
@@ -57,7 +57,7 @@ enforced by `/agents user accept` and `/agents user update`.
 | `language` | yes | Primary language; the agent mirrors per [`language-and-tone`](../../.agent-src/rules/language-and-tone.md). |
 | `role` | yes | Unordered list of role labels (≥ 1). Drives reviewer-voice selection and persona pairing. Seeded enum mirrors `SEED_PROFILE_IDS`; additional free-form entries accepted. |
 | `style.pace` | yes | `pragmatic` (default), `thorough` (more verification), or `rapid` (shorter replies). |
-| `voice_sample` | yes | One representative paste — anchors mirror-back and tone calibration. |
+| `voice_sample` | no | Optional representative paste — sharpens mirror-back and tone calibration when present; may be empty. The setup wizard never blocks a save on it. |
 | `last_updated` | yes | ISO date, bumped on every accept. |
 
 ## Explicit exclusions

--- a/src/shared/userMd/schema.ts
+++ b/src/shared/userMd/schema.ts
@@ -38,11 +38,14 @@ export const userIdentitySchema = z.object({
         // informally ("Du"). Only `pace` remains tunable.
         pace: z.enum(['rapid', 'pragmatic', 'thorough']),
     }),
+    // Optional — a writing sample sharpens tone mirroring but is not
+    // required to save an identity (the setup wizard must not block on it).
+    // Empty string is allowed; the hard cap still applies when present.
     voice_sample: z
         .string()
         .trim()
-        .min(1, 'voice_sample is required')
-        .max(USER_IDENTITY_VOICE_SAMPLE_MAX_CHARS, 'voice_sample exceeds hard cap'),
+        .max(USER_IDENTITY_VOICE_SAMPLE_MAX_CHARS, 'voice_sample exceeds hard cap')
+        .default(''),
     last_updated: isoDate,
     notes: z
         .string()

--- a/tests/shared/userMd/schema.test.ts
+++ b/tests/shared/userMd/schema.test.ts
@@ -74,6 +74,21 @@ describe('userIdentitySchema — strict v1 contract', () => {
             expect(messages).toMatch(/voice_sample/);
         }
     });
+
+    // voice_sample is optional (the setup wizard must not block a save on a
+    // missing writing sample). Empty or omitted both resolve to `''`.
+    it('accepts an empty voice_sample', () => {
+        const result = userIdentitySchema.safeParse(validIdentity({ voice_sample: '' }));
+        expect(result.success).toBe(true);
+    });
+
+    it('defaults a missing voice_sample to empty string', () => {
+        const obj = validIdentity();
+        delete (obj as Record<string, unknown>).voice_sample;
+        const result = userIdentitySchema.safeParse(obj);
+        expect(result.success).toBe(true);
+        if (result.success) expect(result.data.voice_sample).toBe('');
+    });
 });
 
 describe('userIdentitySchema — required-field enforcement', () => {


### PR DESCRIPTION
## Summary

Fixes a hard block in the setup wizard: on the Review step in non-draft
mode you could see **"Some fields need attention before saving."** with
the Finish button stuck, and no way to save.

**Root cause:** the welcome step pre-fills name + language; selecting a
role makes `finish()` POST an identity. But `userIdentitySchema` required
`voice_sample` (`min(1)`), and the user may never have filled a writing
sample → `POST /api/v1/wizard/finish` returned 422 VALIDATION →
"needs attention" + blocked save.

**Fix:** `voice_sample` is a tone-mirroring aid, not a prerequisite for an
identity. It is now optional — empty string allowed, defaults to `''`,
hard cap still enforced when present. The wizard never blocks a save on
it. Contract (`docs/contracts/agent-user-schema.md`) updated to mark it
optional.

Regression tests added: empty and omitted `voice_sample` both validate.

## Test plan
- [ ] CI `Node Tests` (ESLint + tsc + vitest) green
- [ ] CI `Python Tests` green
- [ ] Manual: `agent-config setup` → pick a role, leave voice sample empty → Review step saves without "needs attention"