### PR TITLE
fix(wizard): voice_sample optional + drop AI Council step from setup

### DIFF
--- a/docs/contracts/agent-user-schema.md
+++ b/docs/contracts/agent-user-schema.md
@@ -30,7 +30,7 @@ role:                      # required — unordered list of role labels; ≥ 1 e
   - engineer
 style:
   pace: "pragmatic"        # pragmatic | thorough | rapid
-voice_sample: |            # required — one paste of the user's typical writing
+voice_sample: |            # optional — one paste of the user's typical writing
   Mach das einfach. Wenn unklar, frag im Council.
 last_updated: "2026-05-15" # YYYY-MM-DD — bumped on every accepted change
 ---
@@ -57,7 +57,7 @@ enforced by `/agents user accept` and `/agents user update`.
 | `language` | yes | Primary language; the agent mirrors per [`language-and-tone`](../../.agent-src/rules/language-and-tone.md). |
 | `role` | yes | Unordered list of role labels (≥ 1). Drives reviewer-voice selection and persona pairing. Seeded enum mirrors `SEED_PROFILE_IDS`; additional free-form entries accepted. |
 | `style.pace` | yes | `pragmatic` (default), `thorough` (more verification), or `rapid` (shorter replies). |
-| `voice_sample` | yes | One representative paste — anchors mirror-back and tone calibration. |
+| `voice_sample` | no | Optional representative paste — sharpens mirror-back and tone calibration when present; may be empty. The setup wizard never blocks a save on it. |
 | `last_updated` | yes | ISO date, bumped on every accept. |
 
 ## Explicit exclusions

--- a/src/server/routes/wizard.ts
+++ b/src/server/routes/wizard.ts
@@ -117,12 +117,12 @@ const AI_COUNCIL_KEY_INSTALL: Readonly<Record<string, string>> = {
 const LEGACY_USER_MD_REL = '.agent-user.md';
 const LEGACY_SETTINGS_REL = '.agent-settings.yml';
 // Step count mirrors the UI's `getWizardSteps` plan in `src/ui/wizard/steps.ts`.
-// Bump in lockstep. Default flow = welcome + 8 core steps (editor, personality,
-// cost, roadmap-quality, memory, ai-council, user-md, review) → 9. Extended
-// mode adds the install-only lead (ai-tools + roles + packs) and appends the
-// project `modules` step just before review → 13.
-const DEFAULT_TOTAL_STEPS = 9;
-const EXTENDED_TOTAL_STEPS = 13;
+// Bump in lockstep. Default flow = welcome + 7 core steps (editor, personality,
+// cost, roadmap-quality, memory, user-md, review) → 8. Extended mode prepends
+// the install-only lead (ai-tools + roles + packs) → 11. AI Council lives on
+// its own top-level surface (not a wizard step); modules on the Projekt surface.
+const DEFAULT_TOTAL_STEPS = 8;
+const EXTENDED_TOTAL_STEPS = 11;
 
 /**
  * Discovery-manifest path. Resolved from the package root the server

--- a/src/shared/userMd/schema.ts
+++ b/src/shared/userMd/schema.ts
@@ -38,11 +38,14 @@ export const userIdentitySchema = z.object({
         // informally ("Du"). Only `pace` remains tunable.
         pace: z.enum(['rapid', 'pragmatic', 'thorough']),
     }),
+    // Optional — a writing sample sharpens tone mirroring but is not
+    // required to save an identity (the setup wizard must not block on it).
+    // Empty string is allowed; the hard cap still applies when present.
     voice_sample: z
         .string()
         .trim()
-        .min(1, 'voice_sample is required')
-        .max(USER_IDENTITY_VOICE_SAMPLE_MAX_CHARS, 'voice_sample exceeds hard cap'),
+        .max(USER_IDENTITY_VOICE_SAMPLE_MAX_CHARS, 'voice_sample exceeds hard cap')
+        .default(''),
     last_updated: isoDate,
     notes: z
         .string()

--- a/src/ui/pages/WizardPage.tsx
+++ b/src/ui/pages/WizardPage.tsx
@@ -32,14 +32,6 @@ import { ContinueScreen } from '../wizard/ContinueScreen.js';
 import { BackupScreen } from '../wizard/BackupScreen.js';
 import {
     activeTotalSteps,
-    aiCouncilConfig,
-    aiCouncilKeyInstall,
-    aiCouncilKeyPresence,
-    aiCouncilLoaded,
-    aiCouncilProviders,
-    type AiCouncilClassMode,
-    type AiCouncilMode,
-    type AiCouncilState,
     banner,
     clampStep,
     continueAcknowledged,
@@ -264,9 +256,6 @@ async function loadAll(): Promise<void> {
         }
         if (resumed.id === 'identity') {
             void loadRtkDetectionOnce();
-        }
-        if (resumed.kind === 'aiCouncil') {
-            void loadAiCouncilOnce();
         }
         if (resumed.kind === 'review') {
             void refreshDiff();
@@ -499,32 +488,6 @@ async function loadRtkDetectionOnce(): Promise<void> {
     }
 }
 
-interface AiCouncilGetResponse {
-    config: AiCouncilState;
-    providers?: string[];
-    keyPresence?: Record<string, boolean>;
-    keyInstall?: Record<string, string>;
-}
-
-/**
- * Load the AI-council config subset once per session (Phase 8). On failure
- * (extended-mode 404 / read error) the config stays null and the step renders
- * an explanatory note instead of controls.
- */
-async function loadAiCouncilOnce(): Promise<void> {
-    if (aiCouncilLoaded.value) return;
-    aiCouncilLoaded.value = true;
-    try {
-        const res = await apiFetch<AiCouncilGetResponse>('/api/v1/wizard/ai-council');
-        aiCouncilConfig.value = res.config;
-        aiCouncilProviders.value = res.providers ?? [];
-        aiCouncilKeyPresence.value = res.keyPresence ?? {};
-        aiCouncilKeyInstall.value = res.keyInstall ?? {};
-    } catch {
-        // Leave aiCouncilConfig null; the step shows a "config unavailable" note.
-    }
-}
-
 
 async function persistStep(nextIndex: number, partial: Record<string, JsonValue>): Promise<void> {
     try {
@@ -598,9 +561,6 @@ async function goTo(nextIndex: number): Promise<void> {
     }
     if (next.id === 'identity') {
         void loadRtkDetectionOnce();
-    }
-    if (next.kind === 'aiCouncil') {
-        void loadAiCouncilOnce();
     }
     if (next.kind === 'review') {
         void refreshDiff();
@@ -791,22 +751,7 @@ async function finish(): Promise<void> {
                 applyCopy = ` Installer bridge failed: ${message}. Settings were saved; re-run the wizard to retry the install plan.`;
             }
         }
-        // road-to-wizard-ux-improvements § Phase 8 — persist the AI-council
-        // config (scalar subset) into .ai-council.yml. Best-effort: settings
-        // are already committed, so a failure surfaces as a soft warning.
-        let councilCopy = '';
-        if (extendedSteps.value && aiCouncilConfig.value !== null) {
-            try {
-                await apiFetch('/api/v1/wizard/ai-council', { method: 'POST', body: aiCouncilConfig.value });
-                councilCopy = ' AI Council saved.';
-            } catch (err) {
-                const message = err instanceof ApiCallError
-                    ? topLevelCopy(err.body.error ?? { code: 'UNKNOWN', message: err.message })
-                    : err instanceof Error ? err.message : String(err);
-                councilCopy = ` AI Council save failed: ${message}.`;
-            }
-        }
-        banner.value = { message: `${finishCopy}${applyCopy}${councilCopy} ${closeHint}`, tone: 'success' };
+        banner.value = { message: `${finishCopy}${applyCopy} ${closeHint}`, tone: 'success' };
         // Drop wizard state on success — server unlinks; mirror locally.
         stepIndex.value = clampStep(activeTotalSteps() - 1);
         // Refresh initialSettings to match the just-written state so a
@@ -1207,149 +1152,6 @@ function RtkRow(): preact.JSX.Element {
     );
 }
 
-/**
- * AI Council step (Phase 8). Edits the wizard-controlled scalar subset of
- * `.ai-council.yml` held in `aiCouncilConfig`; finish() persists it via POST.
- * Deep/locked knobs (advisors, model_ladder, high_impact/user_required classes)
- * are intentionally not editable here.
- */
-function AiCouncilStepBody(): preact.JSX.Element {
-    const cfg = aiCouncilConfig.value;
-    if (cfg === null) {
-        return (
-            <div class="ac-wizard-step-stub">
-                <p class="ac-banner">
-                    AI Council config is unavailable (extended-mode only, or
-                    <code> .ai-council.yml </code> could not be read). Configure
-                    it later by editing <code>agents/settings/.ai-council.yml</code>.
-                </p>
-            </div>
-        );
-    }
-    const providers = aiCouncilProviders.value;
-    const keyPresence = aiCouncilKeyPresence.value;
-    const keyInstall = aiCouncilKeyInstall.value;
-    const update = (patch: Partial<AiCouncilState>): void => {
-        aiCouncilConfig.value = { ...cfg, ...patch };
-    };
-    const updateMember = (p: string, patch: Partial<{ enabled: boolean; participateLowImpact: boolean }>): void => {
-        const cur = cfg.members[p] ?? { enabled: false, participateLowImpact: false };
-        aiCouncilConfig.value = { ...cfg, members: { ...cfg.members, [p]: { ...cur, ...patch } } };
-    };
-    return (
-        <div class="ac-wizard-step-stub ac-council">
-            <label class="ac-council__master">
-                <input
-                    type="checkbox"
-                    checked={cfg.enabled}
-                    onChange={(e): void => { update({ enabled: (e.currentTarget as HTMLInputElement).checked }); }}
-                />
-                {' '}Enable the AI Council (external second-opinion network)
-            </label>
-            <fieldset class="ac-council__section" disabled={!cfg.enabled}>
-                <div class="ac-field">
-                    <label class="ac-field__label">Transport mode (default for all members)</label>
-                    <select
-                        class="ac-input"
-                        value={cfg.defaultMode}
-                        onChange={(e): void => { update({ defaultMode: (e.currentTarget as HTMLSelectElement).value as AiCouncilMode }); }}
-                    >
-                        <option value="manual">manual — copy &amp; paste (free, no key)</option>
-                        <option value="api">api — stored key, per-token billing</option>
-                        <option value="cli">cli — subscription auth (flat-rate)</option>
-                    </select>
-                </div>
-                <div class="ac-field">
-                    <label class="ac-field__label">Debate rounds (minimum)</label>
-                    <input
-                        class="ac-input"
-                        type="number"
-                        min="1"
-                        value={cfg.minRounds}
-                        onInput={(e): void => { update({ minRounds: Math.max(1, Number.parseInt((e.currentTarget as HTMLInputElement).value, 10) || 1) }); }}
-                    />
-                </div>
-                <div class="ac-field">
-                    <label class="ac-field__label">Cost budget — max total USD per invocation</label>
-                    <input
-                        class="ac-input"
-                        type="number"
-                        min="0"
-                        step="0.5"
-                        value={cfg.maxTotalUsd}
-                        onInput={(e): void => { update({ maxTotalUsd: Math.max(0, Number.parseFloat((e.currentTarget as HTMLInputElement).value) || 0) }); }}
-                    />
-                </div>
-                <h3 class="ac-council__h">Members</h3>
-                <ul class="ac-wizard__tool-list">
-                    {providers.map((p) => {
-                        const m = cfg.members[p] ?? { enabled: false, participateLowImpact: false };
-                        const hasKey = keyPresence[p] === true;
-                        const installCmd = keyInstall[p];
-                        return (
-                            <li key={p} class="ac-pack-tile">
-                                <div class="ac-pack-tile__head">
-                                    <label class="ac-pack-tile__head" style="flex:1;">
-                                        <input
-                                            type="checkbox"
-                                            checked={m.enabled}
-                                            onChange={(e): void => { updateMember(p, { enabled: (e.currentTarget as HTMLInputElement).checked }); }}
-                                        />
-                                        <span class="ac-pack-tile__title">{p}</span>
-                                    </label>
-                                    <span class={`ac-badge ${hasKey ? 'ac-badge--installed' : 'ac-badge--missing'}`}>
-                                        {hasKey ? 'key present' : 'no key'}
-                                    </span>
-                                </div>
-                                <label class="ac-pack-tile__child">
-                                    <input
-                                        type="checkbox"
-                                        checked={m.participateLowImpact}
-                                        disabled={!m.enabled}
-                                        onChange={(e): void => { updateMember(p, { participateLowImpact: (e.currentTarget as HTMLInputElement).checked }); }}
-                                    />
-                                    <span>low-impact fast-path</span>
-                                </label>
-                                {!hasKey
-                                    ? (
-                                        <p class="ac-field__description">
-                                            {installCmd !== undefined
-                                                ? <>Add a key — run in a terminal: <code>{installCmd}</code></>
-                                                : <>No installer; set <code>api_key_ref: env:{p.toUpperCase()}_API_KEY</code> and export that variable.</>}
-                                        </p>
-                                    )
-                                    : null}
-                            </li>
-                        );
-                    })}
-                </ul>
-                <h3 class="ac-council__h">Impact routing</h3>
-                {(['trivial', 'low_impact', 'medium_impact'] as const).map((cls) => (
-                    <div class="ac-field" key={cls}>
-                        <label class="ac-field__label">{cls}</label>
-                        <select
-                            class="ac-input"
-                            value={cfg.decision[cls] ?? 'agent'}
-                            onChange={(e): void => {
-                                const mode = (e.currentTarget as HTMLSelectElement).value as AiCouncilClassMode;
-                                aiCouncilConfig.value = { ...cfg, decision: { ...cfg.decision, [cls]: mode } };
-                            }}
-                        >
-                            <option value="agent">agent — the agent decides</option>
-                            <option value="council">council — poll the council</option>
-                            <option value="user">user — always ask you</option>
-                        </select>
-                    </div>
-                ))}
-                <p class="ac-field__description">
-                    <code>high_impact</code> and <code>user_required</code> are
-                    locked to “user” (Iron Law) and not editable here.
-                </p>
-            </fieldset>
-        </div>
-    );
-}
-
 function StepBody(): preact.JSX.Element | null {
     const step = stepAt(stepIndex.value, { extended: extendedSteps.value });
     // road-to-unified-setup § B5 — hard-stop continue-screen between the
@@ -1412,9 +1214,6 @@ function StepBody(): preact.JSX.Element | null {
     }
     if (step.kind === 'packs') {
         return <PacksStepBody />;
-    }
-    if (step.kind === 'aiCouncil') {
-        return <AiCouncilStepBody />;
     }
 
     // review

--- a/src/ui/wizard/steps.ts
+++ b/src/ui/wizard/steps.ts
@@ -10,7 +10,7 @@
  * `/onboard` chat skill was removed in the wizard-takeover pivot.
  */
 
-export type WizardStepKind = 'form' | 'userMd' | 'review' | 'welcome' | 'aiTools' | 'roles' | 'packs' | 'aiCouncil';
+export type WizardStepKind = 'form' | 'userMd' | 'review' | 'welcome' | 'aiTools' | 'roles' | 'packs';
 
 export interface WizardStep {
     /** Stable id used for state-machine routing and tests. */
@@ -141,13 +141,6 @@ const CORE_WIZARD_STEPS: readonly WizardStep[] = [
             'memory.review_threshold',
             'memory.redact_patterns',
         ],
-    },
-    {
-        id: 'ai-council',
-        title: 'AI Council',
-        navLabel: 'AI Council',
-        subtitle: 'External second-opinion network. Enable members, pick transport + rounds + budget + impact routing, add provider keys. Writes .ai-council.yml.',
-        kind: 'aiCouncil',
     },
     {
         id: 'user-md',

--- a/tests/server/wizard.initialStep.test.ts
+++ b/tests/server/wizard.initialStep.test.ts
@@ -26,7 +26,7 @@ describe('wizard initialStep (B0 dispatch)', () => {
 
     afterEach(async () => { await ctx.cleanup(); });
 
-    it('install mode lands on Step 1 (index 0) with 13 total steps', async () => {
+    it('install mode lands on Step 1 (index 0) with 11 total steps', async () => {
         ctx = await bootTestApp({ port: 41610, extendedSteps: true, initialStep: 0 });
         const res = await ctx.app.inject({
             method: 'GET',
@@ -36,12 +36,12 @@ describe('wizard initialStep (B0 dispatch)', () => {
         expect(res.statusCode).toBe(200);
         const body = res.json() as StateBody;
         expect(body.step).toBe(0);
-        expect(body.totalSteps).toBe(13);
+        expect(body.totalSteps).toBe(11);
         expect(body.extendedSteps).toBe(true);
         expect(body.startedAt).toBeNull();
     });
 
-    it('setup mode lands on the first settings step (index 4) with 13 total steps', async () => {
+    it('setup mode lands on the first settings step (index 4) with 11 total steps', async () => {
         ctx = await bootTestApp({ port: 41611, extendedSteps: true, initialStep: 4 });
         const res = await ctx.app.inject({
             method: 'GET',
@@ -51,12 +51,12 @@ describe('wizard initialStep (B0 dispatch)', () => {
         expect(res.statusCode).toBe(200);
         const body = res.json() as StateBody;
         expect(body.step).toBe(4);
-        expect(body.totalSteps).toBe(13);
+        expect(body.totalSteps).toBe(11);
         expect(body.extendedSteps).toBe(true);
         expect(body.startedAt).toBeNull();
     });
 
-    it('non-extended setup falls back to the 7-step flow at index 0', async () => {
+    it('non-extended setup falls back to the 8-step flow at index 0', async () => {
         ctx = await bootTestApp({ port: 41612, extendedSteps: false, initialStep: 0 });
         const res = await ctx.app.inject({
             method: 'GET',
@@ -66,7 +66,7 @@ describe('wizard initialStep (B0 dispatch)', () => {
         expect(res.statusCode).toBe(200);
         const body = res.json() as StateBody;
         expect(body.step).toBe(0);
-        expect(body.totalSteps).toBe(9);
+        expect(body.totalSteps).toBe(8);
         expect(body.extendedSteps).toBe(false);
     });
 
@@ -78,8 +78,8 @@ describe('wizard initialStep (B0 dispatch)', () => {
             headers: authHeaders(ctx.token, ctx.host),
         });
         const body = res.json() as StateBody;
-        expect(body.step).toBe(12);
-        expect(body.totalSteps).toBe(13);
+        expect(body.step).toBe(10);
+        expect(body.totalSteps).toBe(11);
     });
 
     it('clamps a negative initialStep to 0', async () => {

--- a/tests/server/wizard.state.test.ts
+++ b/tests/server/wizard.state.test.ts
@@ -1,7 +1,7 @@
 /**
  * Phase 1.6 acceptance: wizard state + finish routes.
  *
- *   GET  /api/v1/wizard/state    → starts at step 0, totalSteps default 7,
+ *   GET  /api/v1/wizard/state    → starts at step 0, totalSteps default 8,
  *                                  resumes prior partial after POST.
  *   POST /api/v1/wizard/state    → validates step; rejects negative.
  *   POST /api/v1/wizard/finish   → 2PC dual-write of settings + user-md;
@@ -32,7 +32,7 @@ describe('wizard state + finish', () => {
         expect(res.statusCode).toBe(200);
         const body = res.json() as StateBody;
         expect(body.step).toBe(0);
-        expect(body.totalSteps).toBe(9);
+        expect(body.totalSteps).toBe(8);
         expect(body.partial).toEqual({});
         expect(body.startedAt).toBeNull();
     });

--- a/tests/shared/userMd/schema.test.ts
+++ b/tests/shared/userMd/schema.test.ts
@@ -74,6 +74,21 @@ describe('userIdentitySchema — strict v1 contract', () => {
             expect(messages).toMatch(/voice_sample/);
         }
     });
+
+    // voice_sample is optional (the setup wizard must not block a save on a
+    // missing writing sample). Empty or omitted both resolve to `''`.
+    it('accepts an empty voice_sample', () => {
+        const result = userIdentitySchema.safeParse(validIdentity({ voice_sample: '' }));
+        expect(result.success).toBe(true);
+    });
+
+    it('defaults a missing voice_sample to empty string', () => {
+        const obj = validIdentity();
+        delete (obj as Record<string, unknown>).voice_sample;
+        const result = userIdentitySchema.safeParse(obj);
+        expect(result.success).toBe(true);
+        if (result.success) expect(result.data.voice_sample).toBe('');
+    });
 });
 
 describe('userIdentitySchema — required-field enforcement', () => {


### PR DESCRIPTION
## Summary

Two setup-wizard fixes found while testing the wizard in non-draft mode.

### 1. `voice_sample` optional — unblocks save (fix)
On the Review step you could hit **"Some fields need attention before
saving."** with the Finish button stuck: the welcome step pre-fills
name/language, picking a role makes `finish()` POST an identity, but
`userIdentitySchema` required `voice_sample` (`min(1)`) → 422 VALIDATION
with no way to proceed. voice_sample is a tone-mirroring aid, not a
prerequisite — it is now optional (empty allowed, hard cap kept).
Contract (`agent-user-schema.md`) updated. Regression tests added.

### 2. Drop the AI Council step from setup (feat)
AI Council configuration is reached as its own top-level surface, so it
no longer needs a wizard step. Removed the `aiCouncil` step + form +
load/persist wiring + dispatch. The `/api/v1/wizard/ai-council`
endpoints and state signals stay as the foundation for the Council
surface.

Step counts updated in lockstep: core 8→7 → default flow **8**,
extended flow **11** (welcome + ai-tools/roles/packs lead + 7 core).
Also corrects a stale extended-count left from the earlier modules-step
removal. initialStep/state tests updated.

Verified: ESLint, `tsc --noEmit`, vite build, full vitest (62 files /
419 tests) green.

## Note
Supersedes #268 (which carried only the voice_sample fix — included here).

## Test plan
- [ ] CI Node Tests + Python Tests green
- [ ] Manual: `agent-config setup` → no AI Council step; pick a role, leave voice sample empty → Review saves without "needs attention"