### PR TITLE
fix(wizard): make role optional so setup can save without a role pick

### DIFF
--- a/docs/contracts/agent-user-schema.md
+++ b/docs/contracts/agent-user-schema.md
@@ -25,7 +25,7 @@ version: 1
 identity:
   name: "Matze"            # required — how the user wants to be addressed (full name or shorthand)
 language: "de"             # required — BCP-47-ish primary language ("de", "en", "fr", ...)
-role:                      # required — unordered list of role labels; ≥ 1 entry
+role:                      # optional — unordered list of role labels (may be empty)
   - founder
   - engineer
 style:
@@ -55,7 +55,7 @@ enforced by `/agents user accept` and `/agents user update`.
 | `version` | yes | Schema version. v1 is the only valid value today. |
 | `identity.name` | yes | How the agent addresses the user (full name or shorthand — user's choice). |
 | `language` | yes | Primary language; the agent mirrors per [`language-and-tone`](../../.agent-src/rules/language-and-tone.md). |
-| `role` | yes | Unordered list of role labels (≥ 1). Drives reviewer-voice selection and persona pairing. Seeded enum mirrors `SEED_PROFILE_IDS`; additional free-form entries accepted. |
+| `role` | no | Unordered list of role labels (may be empty). Drives reviewer-voice selection and persona pairing when populated. Seeded enum mirrors `SEED_PROFILE_IDS`; additional free-form entries accepted; each present entry must be non-empty. The setup wizard never blocks a save on it. |
 | `style.pace` | yes | `pragmatic` (default), `thorough` (more verification), or `rapid` (shorter replies). |
 | `voice_sample` | no | Optional representative paste — sharpens mirror-back and tone calibration when present; may be empty. The setup wizard never blocks a save on it. |
 | `last_updated` | yes | ISO date, bumped on every accept. |

--- a/src/shared/userMd/formAdapter.ts
+++ b/src/shared/userMd/formAdapter.ts
@@ -28,7 +28,7 @@ export function defaultIdentity(): UserIdentity {
         version: 1,
         identity: { name: '' },
         language: 'en',
-        role: [''],
+        role: [],
         style: { pace: 'pragmatic' },
         voice_sample: '',
         last_updated: '1970-01-01',
@@ -48,9 +48,11 @@ function pickPace(value: unknown): UserIdentity['style']['pace'] {
 }
 
 function pickRoles(value: unknown): string[] {
-    if (!Array.isArray(value)) return [''];
-    const filtered = value.filter((v): v is string => typeof v === 'string');
-    return filtered.length === 0 ? [''] : filtered;
+    if (!Array.isArray(value)) return [];
+    // Drop empty-string entries — an empty role entry is meaningless and
+    // would fail the schema's per-entry min(1). Returning `[]` is allowed
+    // (role is optional; the wizard must not block setup on a role pick).
+    return value.filter((v): v is string => typeof v === 'string' && v.trim() !== '');
 }
 
 function pickNotes(value: unknown): string | undefined {

--- a/src/shared/userMd/schema.ts
+++ b/src/shared/userMd/schema.ts
@@ -30,9 +30,12 @@ export const userIdentitySchema = z.object({
         name: z.string().trim().min(1, 'identity.name is required'),
     }),
     language: z.string().trim().min(2, 'language must be a non-empty code'),
+    // Optional — picking ≥1 role sharpens reviewer-voice selection and
+    // persona pairing, but the setup wizard must not block a save on it.
+    // Empty array is allowed; each present entry must be non-empty.
     role: z
         .array(z.string().trim().min(1, 'role entries must be non-empty'))
-        .min(1, 'role must list at least one entry'),
+        .default([]),
     style: z.object({
         // Formality is not configurable — the agent always addresses the user
         // informally ("Du"). Only `pace` remains tunable.

--- a/tests/shared/userMd/schema.test.ts
+++ b/tests/shared/userMd/schema.test.ts
@@ -89,6 +89,30 @@ describe('userIdentitySchema — strict v1 contract', () => {
         expect(result.success).toBe(true);
         if (result.success) expect(result.data.voice_sample).toBe('');
     });
+
+    // role is optional (the setup wizard must not block a save on a role pick).
+    // Empty array is allowed; each present entry must be non-empty.
+    it('accepts an empty role array', () => {
+        const result = userIdentitySchema.safeParse(validIdentity({ role: [] }));
+        expect(result.success).toBe(true);
+    });
+
+    it('defaults a missing role to empty array', () => {
+        const obj = validIdentity();
+        delete (obj as Record<string, unknown>).role;
+        const result = userIdentitySchema.safeParse(obj);
+        expect(result.success).toBe(true);
+        if (result.success) expect(result.data.role).toEqual([]);
+    });
+
+    it('still rejects role entries that are empty strings', () => {
+        const result = userIdentitySchema.safeParse(validIdentity({ role: [''] }));
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            const messages = result.error.issues.map((i) => i.message).join(' | ');
+            expect(messages).toMatch(/role entries must be non-empty/);
+        }
+    });
 });
 
 describe('userIdentitySchema — required-field enforcement', () => {
@@ -110,15 +134,6 @@ describe('userIdentitySchema — required-field enforcement', () => {
         if (!result.success) {
             const paths = result.error.issues.map((i) => i.path.join('.'));
             expect(paths.some((p) => p.includes('identity.name'))).toBe(true);
-        }
-    });
-
-    it('rejects empty role list', () => {
-        const result = userIdentitySchema.safeParse(validIdentity({ role: [] }));
-        expect(result.success).toBe(false);
-        if (!result.success) {
-            const messages = result.error.issues.map((i) => i.message).join(' | ');
-            expect(messages).toMatch(/role/);
         }
     });
 

--- a/tests/ui/UserMdPanel.test.tsx
+++ b/tests/ui/UserMdPanel.test.tsx
@@ -133,7 +133,7 @@ describe('UserMdPanel', () => {
             expect(putIdentity.version).toBe(1);
             expect((putIdentity.identity as { name: string }).name).toBe('');
             expect(putIdentity.language).toBe('en');
-            expect(putIdentity.role).toEqual(['']);
+            expect(putIdentity.role).toEqual([]);
             expect(putIdentity.last_updated).toBe('1970-01-01');
         } finally {
             mock.restore();


### PR DESCRIPTION
## Summary

Second-order 422 on `POST /api/v1/wizard/finish`, surfaced after #269
landed: setup still couldn't save in the welcome-only flow.

**Root cause:** `defaultIdentity()` seeded `role: ['']` (one empty-string
entry). The welcome step makes `userMdChanged=true`, so `finish()` sends
the seed identity even when the user didn't pick a role in the roles
step — and the per-entry `min(1)` on `role` rejected the empty string →
422 "Some fields need attention" → Finish stuck.

**Fix:** same pattern + same product call as the `voice_sample` fix:
`role` is meaningful for reviewer-voice routing but the setup wizard
must never block a save on it. Schema relaxes the array's `min(1)` to
allow an empty list (each present entry still must be non-empty).
`defaultIdentity` seeds `role: []`. `pickRoles` drops empty-string
entries instead of synthesising one. Contract (`agent-user-schema.md`)
marks `role` optional.

Regression tests: empty array accepted; missing role defaults to `[]`;
empty-string entry still rejected. Stale "rejects empty role list" test
removed; UserMdPanel first-write assertion updated to `[]`.

Verified: ESLint, `tsc --noEmit`, vite build, full vitest (62 files /
**421 tests**) green.

## Test plan
- [ ] CI Node Tests + Python Tests green
- [ ] Manual: `agent-config setup` → welcome (name) → DON'T pick a role → Review saves without "needs attention"