### PR TITLE
fix(ci): allow CHANGELOG era archive in release-PR shape allowlist

### DIFF
--- a/docs/contracts/release-pr-gating.md
+++ b/docs/contracts/release-pr-gating.md
@@ -7,7 +7,8 @@
 > avg **413 s** (3-OS × 2-Node matrix), `Tests` avg **218 s** (Linux + macOS
 > + Windows). Both trigger on `package.json`. Release PRs (`release/X.Y.Z`)
 > only touch `package.json`, `CHANGELOG.md`, `marketplace.json`,
-> `packages/*/pack.yaml`, `packages/*/README.md` — verified against PR #238
+> `packages/*/pack.yaml`, `packages/*/README.md`, and the CHANGELOG era
+> archive `docs/archive/CHANGELOG-pre-*.md` — verified against PR #238
 > (3.3.0). They cannot regress install or runtime behaviour by construction.
 
 ## Release-PR shape
@@ -23,6 +24,10 @@ hold:
    - `.claude-plugin/marketplace.json`
    - `packages/*/pack.yaml`
    - `packages/*/README.md`
+   - `docs/archive/CHANGELOG-pre-*.md` — emitted by `scripts/release.py`'s
+     automatic CHANGELOG era split (see `docs/contracts/CHANGELOG-conventions.md`
+     § Era splits) when the current era crosses its line cap on an
+     era-boundary release.
 
 Both predicates are enforced by `scripts/check_release_pr_shape.py`
 (stdlib-only, ≤ 150 LOC). The script exits 0 when both hold; non-zero with

--- a/scripts/check_release_pr_shape.py
+++ b/scripts/check_release_pr_shape.py
@@ -9,6 +9,7 @@ and asserts every changed file matches the version-bump allowlist:
   * `.claude-plugin/marketplace.json`
   * `packages/*/pack.yaml`
   * `packages/*/README.md`
+  * `docs/archive/CHANGELOG-pre-*.md`
 
 Exit codes:
 
@@ -40,6 +41,12 @@ ALLOWLIST_GLOBS = (
     ".claude-plugin/marketplace.json",
     "packages/*/pack.yaml",
     "packages/*/README.md",
+    # `scripts/release.py` auto-splits the CHANGELOG era before bumping
+    # (perform_split / plan_split in `_lib/changelog_eras.py`) whenever the
+    # current era body crosses CURRENT_ERA_BODY_CAP. The split emits a new
+    # `docs/archive/CHANGELOG-pre-X.Y.Z.md` — part of the release surface,
+    # so the shape gate must allow it. Test-enforced by test_changelog_eras.
+    "docs/archive/CHANGELOG-pre-*.md",
 )
 
 

--- a/tests/test_check_release_pr_shape.py
+++ b/tests/test_check_release_pr_shape.py
@@ -113,12 +113,46 @@ def test_pack_readme_only_passes(capsys: pytest.CaptureFixture[str]) -> None:
     assert code == 0
 
 
+def test_era_archive_release_passes(capsys: pytest.CaptureFixture[str]) -> None:
+    """An era-boundary release emits docs/archive/CHANGELOG-pre-X.Y.Z.md.
+
+    `scripts/release.py` auto-splits the CHANGELOG era before bumping, so the
+    archive file is part of the release surface and must be shape-clean.
+    Regression guard for the 5.4.0 release where the shape gate rejected the
+    release-script's own output (allowlist drift).
+    """
+    files = [
+        "package.json",
+        "CHANGELOG.md",
+        ".claude-plugin/marketplace.json",
+        "packages/core/pack.yaml",
+        "packages/core/README.md",
+        "docs/archive/CHANGELOG-pre-5.4.0.md",
+    ]
+    code, out = _check(files, capsys)
+    assert code == 0
+    assert "SHAPE-CLEAN" in out
+
+
+def test_unrelated_archive_file_fails(capsys: pytest.CaptureFixture[str]) -> None:
+    """Only the CHANGELOG era archive is allowed under docs/archive/."""
+    files = [
+        "package.json",
+        "docs/archive/some-other-doc.md",  # ← not a CHANGELOG era archive
+    ]
+    code, out = _check(files, capsys)
+    assert code == 1
+    assert "OUT-OF-SHAPE: docs/archive/some-other-doc.md" in out
+
+
 def test_matches_helper_rejects_unrelated_paths() -> None:
     """Spot-check the matcher: random project paths must not slip through."""
     assert not shape._matches("scripts/install.py")
     assert not shape._matches("tests/test_condense.py")
     assert not shape._matches(".github/workflows/tests.yml")
     assert not shape._matches("packages/core/installer/foo.ts")
+    assert not shape._matches("docs/archive/some-other-doc.md")
     assert shape._matches("package.json")
     assert shape._matches("packages/core/pack.yaml")
     assert shape._matches("packages/core/README.md")
+    assert shape._matches("docs/archive/CHANGELOG-pre-5.4.0.md")


### PR DESCRIPTION
## Problem

The 5.4.0 release PR (#297) fails its own **fail-closed** "Release-PR shape detector":

```
OUT-OF-SHAPE: docs/archive/CHANGELOG-pre-5.4.0.md
```

`scripts/release.py` auto-splits the CHANGELOG era before bumping (`perform_split` / `plan_split` in `_lib/changelog_eras.py`) whenever the current era body crosses `CURRENT_ERA_BODY_CAP` — emitting a new `docs/archive/CHANGELOG-pre-X.Y.Z.md`. The split is **test-enforced** by `tests/test_changelog_eras.py`. But `scripts/check_release_pr_shape.py`'s allowlist never included that path, so an era-boundary release PR fails the shape gate against the release script's **own output**. Allowlist drift between `release.py` and `check_release_pr_shape.py`.

## Fix

- Add `docs/archive/CHANGELOG-pre-*.md` to `ALLOWLIST_GLOBS`.
- Document it in `docs/contracts/release-pr-gating.md` (both allowlist listings).
- Two regression tests: era archive passes; unrelated `docs/archive/*` still fails.

`scripts/print_required_checks.py` reuses `shape._matches`, so the required-check classifier picks up the new entry with no further change.

## Verification

- `python3 -m pytest tests/test_check_release_pr_shape.py -q` → 11 passed.
- `gh pr diff 297 --name-only | python3 scripts/check_release_pr_shape.py --files -` → `SHAPE-CLEAN: 40 file(s)`.

Once merged, PR #297's shape detector re-runs from the updated merge-ref and passes — unblocking the 5.4.0 release with no change to the release branch.