### PR TITLE
fix(kernel): repoint iron_law_sha to packages/core layout (Iron-Law SHA gate was broken)

### DIFF
--- a/scripts/iron_law_sha.py
+++ b/scripts/iron_law_sha.py
@@ -26,7 +26,15 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-RULES_DIR = REPO_ROOT / ".agent-src.uncondensed" / "rules"
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from _lib.agent_src import artefact_roots  # noqa: E402
+
+# Pre-monorepo this was REPO_ROOT/.agent-src.uncondensed/rules. Post-move
+# (ADR-017) the source rules live under packages/*/.agent-src.uncondensed/rules.
+# Resolve the same way measure_rule_budget does (multi-root aware) so the
+# Iron-Law SHA gate keeps working against the current layout.
+def _rules_dirs() -> list[Path]:
+    return [root / "rules" for root in artefact_roots() if (root / "rules").is_dir()]
 
 # Locked kernel set — kept in sync with measure_rule_budget.KERNEL_RULES.
 KERNEL_RULES = (
@@ -58,10 +66,11 @@ def iron_law_sha(text: str) -> str:
 
 
 def rule_sha(rule_id: str) -> str:
-    path = RULES_DIR / f"{rule_id}.md"
-    if not path.exists():
-        raise FileNotFoundError(path)
-    return iron_law_sha(path.read_text(encoding="utf-8"))
+    for rules_dir in _rules_dirs():
+        path = rules_dir / f"{rule_id}.md"
+        if path.exists():
+            return iron_law_sha(path.read_text(encoding="utf-8"))
+    raise FileNotFoundError(f"{rule_id}.md not found under any artefact root's rules/")
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## What

`scripts/iron_law_sha.py` — the Iron-Law fence-SHA verifier, the gate for kernel-rule edits — hardcoded `REPO_ROOT/.agent-src.uncondensed/rules`, which no longer exists post-monorepo (ADR-017). Every `--all-kernel` run crashed with `FileNotFoundError`. It is **not wired into CI**, so the breakage went unnoticed (main stayed green).

## Fix

Resolve kernel rules via `artefact_roots()` (multi-root, same helper `measure_rule_budget` uses). One-line-class path repoint; no behaviour change beyond making the tool runnable.

## Verified

- `python3 scripts/iron_law_sha.py --all-kernel` runs and emits all 9 kernel SHAs.
- `agent-authority` reproduces its canonical empty-fence hash `e3b0c44298fc1c14…` from `kernel-membership.md § 2` → the resolution + hashing are correct.
- 34 kernel/iron-law tests pass.

## Why it matters

The kernel-budget soak track (trimming `commit-policy` / `scope-control`) requires this gate green before a kernel-rule edit — it was silently unusable.

Pre-existing note (not this PR): `commit-policy`'s current SHA differs from the § 2 baseline because the rule grew since that pilot snapshot (2354→2879 chars). To re-baseline when the soak track trims it.