### PR TITLE
fix: correct gzip kwarg in pack_mcp_content (condenselevel -> compresslevel)

### DIFF
--- a/scripts/pack_mcp_content.py
+++ b/scripts/pack_mcp_content.py
@@ -237,7 +237,7 @@ def pack(root: Path, out_dir: Path) -> dict[str, Any]:
     # R2 archival copy hashes deterministically.
     with open(out_dir / "content.json.gz", "wb") as raw:
         with gzip.GzipFile(
-            fileobj=raw, mode="wb", condenselevel=9, mtime=0
+            fileobj=raw, mode="wb", compresslevel=9, mtime=0
         ) as gz:
             gz.write(payload_bytes)
     (out_dir / "manifest.json").write_text(


### PR DESCRIPTION
## What
`scripts/pack_mcp_content.py` passed a non-existent `condenselevel=9` kwarg to
`gzip.GzipFile(...)`, raising `TypeError: GzipFile.__init__() got an unexpected
keyword argument 'condenselevel'`. This failed the **deploy-mcp-worker** job on
every release-triggered run (e.g. tag `5.6.0`).

## Fix
One-word correction to the real gzip parameter: `condenselevel` → `compresslevel`.
Verified `gzip.GzipFile(..., compresslevel=9, mtime=0)` works.
