### PR TITLE
fix(mcp): send bearer auth in post-deploy smoke probe

### DIFF
--- a/.github/workflows/deploy-mcp-worker.yml
+++ b/.github/workflows/deploy-mcp-worker.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Post-deploy smoke
         env:
           MCP_WORKER_URL: https://agent-config-mcp.${{ secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}.workers.dev
+          MCP_SMOKE_TOKEN: ${{ secrets.MCP_SMOKE_TOKEN }}
         run: npx tsx test/dev-smoke.ts
         working-directory: internal/workers/mcp
 

--- a/internal/workers/mcp/test/dev-smoke.ts
+++ b/internal/workers/mcp/test/dev-smoke.ts
@@ -12,6 +12,10 @@
  */
 
 const BASE_URL = process.env.MCP_WORKER_URL ?? "http://127.0.0.1:8787";
+// Optional bearer token — when the deployed Worker has the `MCP-Token`
+// secret set, every POST must carry `Authorization: Bearer <token>`.
+// Provided to CI via the `MCP_SMOKE_TOKEN` repo secret; unset locally → no auth.
+const AUTH_TOKEN = process.env.MCP_SMOKE_TOKEN;
 
 type Probe = { name: string; method: string; params?: unknown };
 
@@ -33,7 +37,10 @@ type JsonRpcResp = {
 async function rpc(probe: Probe, id: number): Promise<JsonRpcResp> {
   const res = await fetch(BASE_URL, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      ...(AUTH_TOKEN ? { authorization: `Bearer ${AUTH_TOKEN}` } : {}),
+    },
     body: JSON.stringify({
       jsonrpc: "2.0",
       id,


### PR DESCRIPTION
## What
Restore green post-deploy smoke for the **intentionally gated** MCP worker.

The worker enforces `Authorization: Bearer <MCP-Token>` when the `MCP-Token`
secret is set on Cloudflare (deliberate access limit). The post-deploy smoke
probe (`internal/workers/mcp/test/dev-smoke.ts`) sent no Authorization header →
5/5 probes returned HTTP 401 (documented in
`agents/evidence/audits/2026-05-ci-triage/02-deployment-failures.md` Finding 2;
masked for the last days by the `condenselevel` packer crash, now fixed).

## Fix
- `dev-smoke.ts`: read `MCP_SMOKE_TOKEN` from env; when present, send
  `Authorization: Bearer <token>`. Unset locally → no auth (unchanged dev flow).
- `deploy-mcp-worker.yml`: wire `MCP_SMOKE_TOKEN: ${{ secrets.MCP_SMOKE_TOKEN }}`
  into the Post-deploy smoke step.

## Operator action required (same value on both sides)
The bearer token must match the worker's `MCP-Token`:
- Repo secret `MCP_SMOKE_TOKEN` — **set** (this PR consumes it).
- Worker secret `MCP-Token` — operator sets the **same value** via
  `task mcp:cloud:secret-put` (Cloudflare). Forward-compatible: unset on both →
  public, set on both → gated.
