### PR TITLE
fix(rules): make production-branch commits a Hard-Floor opt-in (kernel)

### DIFF
--- a/.agent-src/rules/non-destructive-by-default.md
+++ b/.agent-src/rules/non-destructive-by-default.md
@@ -1,7 +1,7 @@
 ---
 type: "always"
 tier: "safety-floor"
-description: "Agent is never destructive — Hard Floor always asks for prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; verify the branch before every commit; no autonomy or roadmap bypass"
+description: "Hard Floor: agent asks before prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions/infra commits; verify branch before each commit; no autonomy or roadmap bypass"
 alwaysApply: true
 load_context:
   - ../contexts/authority/destructive-mechanics.md

--- a/.agent-src/rules/non-destructive-by-default.md
+++ b/.agent-src/rules/non-destructive-by-default.md
@@ -1,7 +1,7 @@
 ---
 type: "always"
 tier: "safety-floor"
-description: "Agent is never destructive — Hard Floor always asks for prod-trunk merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; no autonomy or roadmap bypass"
+description: "Agent is never destructive — Hard Floor always asks for prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; verify the branch before every commit; no autonomy or roadmap bypass"
 alwaysApply: true
 load_context:
   - ../contexts/authority/destructive-mechanics.md
@@ -28,6 +28,7 @@ Triggers below require explicit user confirmation **on this turn** — not from 
 | Trigger | Examples |
 |---|---|
 | **Production-branch merge** | `main`, `master`, `prod`, `production`, `release/*`, or any branch the project marks as deployment trunk |
+| **Commit on a production branch** | any `git commit` while `HEAD` is on a prod trunk (set above). **Verify branch before every commit** — `main` is opt-in only, never inferred from a prior turn or a merged PR that left the repo on `main` |
 | **Deploy / release** | `terraform apply` on prod, `kubectl apply` on prod, deploy scripts, release commands, tag pushes that trigger CI deployment |
 | **Push to remote** | any `git push` (also covered by [`scope-control`](scope-control.md), restated so the floor never weakens) |
 | **Production data / infra** | prod DB writes / migrations, prod config, secrets rotation, IAM / role / policy, DNS, anything in a `prod`-scoped path or pipeline |

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -257,7 +257,7 @@
   "rules/no-decorative-emojis-in-git-surfaces.md": "3a4ab41703d085c1005eca56b170b2806bfe71a610a337d6392d5d4fc407a14d",
   "rules/no-pr-progress-comments.md": "bbee2f8dc467fa6585b8532f1ae8137fe23bf97b870cece21f19cda4a4d19710",
   "rules/no-roadmap-references.md": "0437e7a3c0ae1dac97123c4cb68e4294f229335086c3d6326b442411141f497c",
-  "rules/non-destructive-by-default.md": "fdadd4fee8250469f71dc10591b9c0944717f2300893f4033c41eaaacf70819e",
+  "rules/non-destructive-by-default.md": "a795cb369d6fbe58cb33fb2d94f61e70dd91995961174b7ab3dd47dbd9f48158",
   "rules/onboarding-gate.md": "7a9bc16eca723333ef94be6eb14939bfbe88060d0c412b45f9924d554ba73527",
   "rules/package-ci-checks.md": "84136bd72c75b0af93fa05067d9b3b232ea879e971bc3de8e6219774c65c54c7",
   "rules/persona-governance.md": "71bc204364e028ac6c29b5d7fe77dbc18a631b3934187ef06951244b46b3872b",

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -257,7 +257,7 @@
   "rules/no-decorative-emojis-in-git-surfaces.md": "3a4ab41703d085c1005eca56b170b2806bfe71a610a337d6392d5d4fc407a14d",
   "rules/no-pr-progress-comments.md": "bbee2f8dc467fa6585b8532f1ae8137fe23bf97b870cece21f19cda4a4d19710",
   "rules/no-roadmap-references.md": "0437e7a3c0ae1dac97123c4cb68e4294f229335086c3d6326b442411141f497c",
-  "rules/non-destructive-by-default.md": "a795cb369d6fbe58cb33fb2d94f61e70dd91995961174b7ab3dd47dbd9f48158",
+  "rules/non-destructive-by-default.md": "821b304719f9af40bc88aa7e9401b8ef1167132410404649acf895152c266ebc",
   "rules/onboarding-gate.md": "7a9bc16eca723333ef94be6eb14939bfbe88060d0c412b45f9924d554ba73527",
   "rules/package-ci-checks.md": "84136bd72c75b0af93fa05067d9b3b232ea879e971bc3de8e6219774c65c54c7",
   "rules/persona-governance.md": "71bc204364e028ac6c29b5d7fe77dbc18a631b3934187ef06951244b46b3872b",

--- a/packages/core/.agent-src.uncondensed/rules/non-destructive-by-default.md
+++ b/packages/core/.agent-src.uncondensed/rules/non-destructive-by-default.md
@@ -1,7 +1,7 @@
 ---
 type: "always"
 tier: "safety-floor"
-description: "Agent is never destructive — Hard Floor always asks for prod-trunk merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; no autonomy or roadmap bypass"
+description: "Agent is never destructive — Hard Floor always asks for prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; verify the branch before every commit; no autonomy or roadmap bypass"
 alwaysApply: true
 load_context:
   - contexts/authority/destructive-mechanics.md
@@ -28,6 +28,7 @@ Triggers below require explicit user confirmation **on this turn** — not from 
 | Trigger | Examples |
 |---|---|
 | **Production-branch merge** | `main`, `master`, `prod`, `production`, `release/*`, or any branch the project marks as deployment trunk |
+| **Commit on a production branch** | any `git commit` while `HEAD` is on a prod trunk (set above). **Verify branch before every commit** — `main` is opt-in only, never inferred from a prior turn or a merged PR that left the repo on `main` |
 | **Deploy / release** | `terraform apply` on prod, `kubectl apply` on prod, deploy scripts, release commands, tag pushes that trigger CI deployment |
 | **Push to remote** | any `git push` (also covered by [`scope-control`](scope-control.md), restated so the floor never weakens) |
 | **Production data / infra** | prod DB writes / migrations, prod config, secrets rotation, IAM / role / policy, DNS, anything in a `prod`-scoped path or pipeline |

--- a/packages/core/.agent-src.uncondensed/rules/non-destructive-by-default.md
+++ b/packages/core/.agent-src.uncondensed/rules/non-destructive-by-default.md
@@ -1,7 +1,7 @@
 ---
 type: "always"
 tier: "safety-floor"
-description: "Agent is never destructive — Hard Floor always asks for prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; verify the branch before every commit; no autonomy or roadmap bypass"
+description: "Hard Floor: agent asks before prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions/infra commits; verify branch before each commit; no autonomy or roadmap bypass"
 alwaysApply: true
 load_context:
   - contexts/authority/destructive-mechanics.md

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -248,7 +248,7 @@ Core framework-neutral artefacts.
 - **`no-decorative-emojis-in-git-surfaces`** — Generating PR/issue/commit titles or PR/issue comments — forbids decorative emojis; allowed in PR/issue descriptions + commit bodies only when matched by an in-artifact legend
 - **`no-pr-progress-comments`** — Posting comments on an open PR — refuses unsolicited progress / status / CI-fix narration unless personal.pr_progress_comments is true
 - **`no-roadmap-references`** — Linking transient files (agents/roadmaps/, agents/runtime/council/*/) from a stable artifact — both layers expire; promote findings
-- **`non-destructive-by-default`** — Agent is never destructive — Hard Floor always asks for prod-trunk merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; no autonomy or roadmap bypass
+- **`non-destructive-by-default`** — Agent is never destructive — Hard Floor always asks for prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; verify the branch before every commit; no autonomy or roadmap bypass
 - **`onboarding-gate`** — First turn — if onboarding.onboarded is false in .agent-settings.yml, instruct dev to run `agent-config setup` before any request
 - **`package-ci-checks`** — Before pushing to remote or creating a PR in the agent-config package — run all CI checks locally first
 - **`persona-governance`** — Creating/editing/proposing personas — enforce per-domain cap (≤ 2 specialists), ≥ 1 skill citation, deprecation path

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -248,7 +248,7 @@ Core framework-neutral artefacts.
 - **`no-decorative-emojis-in-git-surfaces`** — Generating PR/issue/commit titles or PR/issue comments — forbids decorative emojis; allowed in PR/issue descriptions + commit bodies only when matched by an in-artifact legend
 - **`no-pr-progress-comments`** — Posting comments on an open PR — refuses unsolicited progress / status / CI-fix narration unless personal.pr_progress_comments is true
 - **`no-roadmap-references`** — Linking transient files (agents/roadmaps/, agents/runtime/council/*/) from a stable artifact — both layers expire; promote findings
-- **`non-destructive-by-default`** — Agent is never destructive — Hard Floor always asks for prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions, and bulk-deletion/infra commits; verify the branch before every commit; no autonomy or roadmap bypass
+- **`non-destructive-by-default`** — Hard Floor: agent asks before prod-trunk commits/merges, deploys, pushes, prod data/infra, bulk deletions/infra commits; verify branch before each commit; no autonomy or roadmap bypass
 - **`onboarding-gate`** — First turn — if onboarding.onboarded is false in .agent-settings.yml, instruct dev to run `agent-config setup` before any request
 - **`package-ci-checks`** — Before pushing to remote or creating a PR in the agent-config package — run all CI checks locally first
 - **`persona-governance`** — Creating/editing/proposing personas — enforce per-domain cap (≤ 2 specialists), ≥ 1 skill citation, deprecation path


### PR DESCRIPTION
## What

Hardens the `non-destructive-by-default` kernel rule so the agent **never commits to a production branch without an explicit this-turn opt-in**.

## Why — a real incident this session

PR #318 was merged, which left the local repo checked out on `main`. On the next task the agent committed value-dashboard work and pushed it **directly to `main`** without re-verifying the branch — a Hard-Floor violation. The rule covered prod-branch *merges* and *pushes* but did not explicitly gate prod-branch *commits*, and nothing mandated a branch check before committing.

## Change

`non-destructive-by-default.md` (kernel rule) gains:

- A Hard-Floor trigger row **"Commit on a production branch"** — any `git commit` while `HEAD` is on a prod trunk (`main` / `master` / `prod` / `production` / `release/*`) requires explicit this-turn opt-in, **never inferred from a prior turn or a merged PR that left the repo on `main`**.
- A standing mandate: **verify the current branch before every commit**.
- Description updated to match.

## Verification

- Iron-Law fence unchanged — `scripts/iron_law_sha.py --all-kernel` green (SHA `17e6ed8b…`).
- Kernel budget: `measure_rule_budget --kernel-budget-check` → **25,998 / 26,000 chars, pass** (tight; the new row was trimmed to fit by referencing the prod-trunk set already listed in the merge row).
- Condensed output + `packages/core/README.md` regenerated; tool projections (`.cursor` / `.windsurf` / `.clinerules`) are gitignored and regenerate from `.agent-src/`.
- `bash scripts/condense.sh --check` green; `check_condensation.py` zero errors.

## Scope

Kernel-rule edit → its own PR, slow-rollout per `scope-control § kernel-rule-edits`. Diff is the single rule + its derived condensed/README/hash — no other rules touched.
