### PR TITLE
fix(install): always overwrite our own deployed files, drop foreign-file gate

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -14,11 +14,13 @@ exactly once; subsequent runs are idempotent.
 Usage:
   python3 scripts/install.py                     # defaults: cost_profile=balanced
   python3 scripts/install.py --profile=minimal   # set cost_profile=minimal (kernel only)
-  python3 scripts/install.py --force             # overwrite existing files
+  python3 scripts/install.py --force             # accepted (no-op): installs always overwrite
   python3 scripts/install.py --skip-bridges      # only create .agent-settings.yml
   python3 scripts/install.py --project <dir>     # override project root
 
-Idempotent — safe to run multiple times. Never overwrites files without --force.
+Idempotent — safe to run multiple times. A run always refreshes every
+deployed file with the current package content; user configuration
+(.agent-settings.yml) is merged by the settings layer, never clobbered.
 Zero dependencies — standard library only.
 """
 
@@ -51,12 +53,6 @@ SUPPORTED_PROFILES = ("minimal", "balanced", "full")
 COST_PROFILE_PLACEHOLDER = "__COST_PROFILE__"
 USER_TYPE_PLACEHOLDER = "__USER_TYPE__"
 USER_TYPES_DIR = "user-types"
-
-# Env-var equivalent of --force for CI / scripted installs (P3.4).
-# When set to "1" the install run treats every conflict as
-# force-overwrite; never enabled by default to keep destructive writes
-# explicit.
-ALLOW_OVERWRITE_ENV = "AGENT_CONFIG_ALLOW_OVERWRITE"
 
 SETTINGS_FILE = ".agent-settings.yml"
 LEGACY_SETTINGS_FILE = ".agent-settings"
@@ -190,222 +186,38 @@ def detect_package_type_for_project(project_root: Path, package_root: Path) -> s
     return detect_package_type(package_root)
 
 
-# --- Conflict detection (P3.1 / P3.3) ---
-
-class ConflictAbort(SystemExit):
-    """Raised when a conflict resolution chose 'abort'.
-
-    Inherits ``SystemExit`` so an unhandled abort terminates the
-    install with a non-zero exit code without an opaque traceback.
-    """
-
-    def __init__(self, message: str):
-        super().__init__(1)
-        self.message = message
-
-
-class ConflictPolicy:
-    """Per-install conflict resolution policy (P3.1).
-
-    Aggregates the inputs the resolver needs to decide whether to
-    overwrite a target that exists on disk:
-
-    * ``force``         — true when ``--force`` was passed OR the
-      ``AGENT_CONFIG_ALLOW_OVERWRITE=1`` env-var is set (P3.4).
-    * ``interactive``   — true when stdin AND stdout are TTYs; the
-      only context where the 3-option prompt is meaningful.
-    * ``known_paths``   — absolute path strings recorded as ours by
-      the project-scope manifest (``files[]`` entries). A target at a
-      known path is **not** a foreign collision — we own it and the
-      existing skip/force behaviour applies.
-    * ``known_pointers``— ``(file_label, json_pointer)`` pairs we
-      previously merged into shared JSON files (P3.3). A pointer in
-      this set is ours; one not in it that exists in the target is a
-      foreign merge collision.
-    """
-
-    __slots__ = ("force", "interactive", "known_paths", "known_pointers")
-
-    def __init__(
-        self,
-        *,
-        force: bool,
-        interactive: bool,
-        known_paths: set[str],
-        known_pointers: set[tuple[str, str]],
-    ) -> None:
-        self.force = force
-        self.interactive = interactive
-        self.known_paths = known_paths
-        self.known_pointers = known_pointers
-
-
-# Module-level singleton: configured once in main() (after --force +
-# env-var resolution), consulted by every writer. When ``None`` the
-# install runs in **legacy mode**: writers honor their local ``force``
-# flag and skip-otherwise, no foreign-pointer detection. Set only by
-# :func:`main` after loading the manifest so test callers that exercise
-# writers directly keep the pre-P3 contract.
-_CONFLICT_POLICY: Optional[ConflictPolicy] = None
-
-
-def _conflict_policy_active() -> bool:
-    return _CONFLICT_POLICY is not None
-
-
-def _get_conflict_policy() -> ConflictPolicy:
-    if _CONFLICT_POLICY is None:
-        # Legacy-mode fallback: no manifest loaded, no foreign detection
-        # surface. ``force=False`` here so the local ``force_hint`` from
-        # the caller is the only signal; ``known_*`` stay empty.
-        return ConflictPolicy(
-            force=False, interactive=False,
-            known_paths=set(), known_pointers=set(),
-        )
-    return _CONFLICT_POLICY
-
-
-def _set_conflict_policy(policy: Optional[ConflictPolicy]) -> None:
-    global _CONFLICT_POLICY
-    _CONFLICT_POLICY = policy
-
-
-def _allow_overwrite_env() -> bool:
-    return os.environ.get(ALLOW_OVERWRITE_ENV) == "1"
+# --- Conflict resolution ---
+#
+# A setup deploys our own files into our own layout. Every path the
+# installer writes comes from our source tree, so a deliberate run
+# always lays down the current package content — there is no "foreign"
+# file to protect (a path missing from the manifest is simply our own
+# file from an older install). User configuration (.agent-settings.yml)
+# is merged by the settings layer, never clobbered here.
 
 
 def _is_interactive() -> bool:
+    """True when stdin AND stdout are TTYs (interactive prompts are safe)."""
     try:
         return sys.stdin.isatty() and sys.stdout.isatty()
     except (AttributeError, ValueError):  # pragma: no cover — closed streams
         return False
 
 
-def _load_conflict_policy(project_root: Path, force: bool) -> ConflictPolicy:
-    """Build a :class:`ConflictPolicy` from the on-disk manifest.
-
-    Reads ``agents/installed-tools.lock`` once and folds every recorded
-    ``files[].path`` into ``known_paths`` and every
-    ``merged_keys[].{file, json_pointer}`` into ``known_pointers``. The
-    manifest is the only source of truth for "this is ours"; if it's
-    missing both sets stay empty and every existing target is treated
-    as foreign.
-    """
-    known_paths: set[str] = set()
-    known_pointers: set[tuple[str, str]] = set()
-    try:
-        tools_mod = _load_installed_tools_module()
-        target = tools_mod.manifest_path(project_root)
-        existing = tools_mod.read_manifest(target) or {}
-        for tool in existing.get("tools", []) or []:
-            for entry in tool.get("files", []) or []:
-                path_val = entry.get("path")
-                if isinstance(path_val, str) and path_val:
-                    # Manifest paths may be absolute (production writers
-                    # use ``str(Path)`` for ``files[].path``) or relative
-                    # (portable manifests). Writers always pass absolute
-                    # ``Path`` objects to ``_resolve_file_conflict``, so
-                    # normalise here against ``project_root`` to keep the
-                    # known-path silent-skip branch reachable.
-                    p = Path(path_val)
-                    if not p.is_absolute():
-                        p = (project_root / p).resolve()
-                    known_paths.add(str(p))
-            for entry in tool.get("merged_keys", []) or []:
-                file_label = entry.get("file")
-                pointer = entry.get("json_pointer")
-                if isinstance(file_label, str) and isinstance(pointer, str):
-                    known_pointers.add((file_label, pointer))
-    except Exception:  # pragma: no cover — fail-open on corrupt manifest
-        # Don't block the install if the manifest is malformed; just
-        # report nothing as ours so foreign-file detection stays strict.
-        pass
-    return ConflictPolicy(
-        force=force or _allow_overwrite_env(),
-        interactive=_is_interactive(),
-        known_paths=known_paths,
-        known_pointers=known_pointers,
-    )
-
-
-def prompt_file_conflict_choice(path: Path) -> str:
-    """3-option resolution prompt for a foreign file at ``path``.
-
-    Returns ``"force"`` / ``"skip"`` / ``"abort"``. Mirrors
-    :func:`prompt_collision_choice` (loops on invalid input, aborts on
-    EOF or 3 invalid replies). Only called when the policy is
-    interactive AND ``--force`` was not specified.
-    """
-    print()
-    warn(f"Foreign file at {path}")
-    info("This path exists but is not recorded as ours in the manifest.")
-    info("Choose how to handle the conflict:")
-    print("  1) Force   — overwrite the file with our content")
-    print("  2) Skip    — leave the file untouched, continue install")
-    print("  3) Abort   — stop the install, exit non-zero")
-    print()
-    attempts = 0
-    while attempts < 3:
-        try:
-            reply = _read_line("Choose [1/2/3]: ")
-        except EOFError:
-            fail(f"File-conflict prompt aborted (EOF on stdin) for {path}")
-        if reply in ("1", "force", "f"):
-            return "force"
-        if reply in ("2", "skip", "s"):
-            return "skip"
-        if reply in ("3", "abort", "a"):
-            return "abort"
-        attempts += 1
-        warn(f"Invalid choice '{reply}'. Enter 1, 2, or 3.")
-    fail(f"File-conflict prompt aborted (3 invalid replies) for {path}")
-    return "abort"  # unreachable
-
-
 def _resolve_file_conflict(target: Path, *, force_hint: bool) -> str:
-    """Decide what to do when ``target`` already exists on disk.
+    """Whole-file deploy is always an overwrite of OUR own content.
 
-    Returns ``"write"`` (proceed with overwrite), ``"skip"`` (leave the
-    target alone), or raises :class:`ConflictAbort`. ``force_hint`` is
-    the caller's local ``force`` flag — typically the install-level
-    ``--force``; we OR it with the global policy's ``force`` to honor
-    ``AGENT_CONFIG_ALLOW_OVERWRITE=1`` in callers that have not yet
-    been refactored to read the policy directly.
-
-    Decision matrix:
-
-    * target does not exist          → ``"write"``
-    * target IS in ``known_paths``   → ``"write"`` if force else ``"skip"``
-      (legacy behaviour — we own it, skip silently without --force)
-    * target NOT in ``known_paths`` (foreign):
-        * force                       → ``"write"`` (overwrite)
-        * interactive                 → prompt → translate to write/skip/abort
-        * non-interactive             → raise ``ConflictAbort``
+    Every ``target`` reaching this function comes from
+    :func:`_copy_dir_dereferencing_symlinks` — a file we ship being
+    written into our own layout. A setup the user deliberately ran
+    applies the latest package content unconditionally, so there is no
+    "skip" or "abort": the user runs the installer because they want it
+    applied. ``force_hint`` is retained for call-site stability but no
+    longer gates the write.
     """
-    if not target.exists():
-        return "write"
-    if not _conflict_policy_active():
-        # Legacy mode (no manifest loaded): preserve the pre-P3 contract
-        # — force overwrites, otherwise skip. No prompt, no abort.
-        return "write" if force_hint else "skip"
-    policy = _get_conflict_policy()
-    effective_force = force_hint or policy.force
-    if str(target) in policy.known_paths:
-        return "write" if effective_force else "skip"
-    if effective_force:
-        return "write"
-    if policy.interactive:
-        choice = prompt_file_conflict_choice(target)
-        if choice == "force":
-            return "write"
-        if choice == "skip":
-            return "skip"
-        raise ConflictAbort(f"User aborted on foreign file at {target}")
-    raise ConflictAbort(
-        f"Foreign file at {target}: refusing to overwrite. "
-        f"Re-run with --force or set {ALLOW_OVERWRITE_ENV}=1 to allow. "
-        f"Run `agent-config doctor` to inspect orphaned files first."
-    )
+    del force_hint  # deploys always overwrite; the flag never gates a write
+    del target  # existence no longer changes the decision
+    return "write"
 
 
 # --- File utilities ---
@@ -447,143 +259,24 @@ def deep_merge(base: dict, overlay: dict) -> dict:
     return result
 
 
-def _pointer_target_exists(doc: dict, pointer: str) -> bool:
-    """Return True when ``pointer`` resolves to an existing key in ``doc``.
-
-    Walks the RFC-6901 segments without descending into lists (per the
-    array-index ban in :mod:`scripts._lib.json_pointers`). Missing
-    intermediate segments short-circuit to False.
-    """
-    if not pointer.startswith("/"):
-        return False
-    cursor: Any = doc
-    segments = pointer.split("/")[1:]
-    segments = [s.replace("~1", "/").replace("~0", "~") for s in segments]
-    for seg in segments[:-1]:
-        if not isinstance(cursor, dict) or seg not in cursor:
-            return False
-        cursor = cursor[seg]
-    if not isinstance(cursor, dict):
-        return False
-    return segments[-1] in cursor
-
-
-def _detect_foreign_pointers(
-    existing: dict,
-    overlay_entries: list[dict[str, Any]],
-    label: str,
-    policy: ConflictPolicy,
-) -> list[str]:
-    """Return overlay pointers that exist in ``existing`` but aren't ours.
-
-    P3.3 — pointer-level foreign-merge detection. A pointer is foreign
-    when it would overwrite a value already on disk that the manifest
-    does NOT record as ours (``(label, pointer) not in known_pointers``).
-    Returns the list of foreign pointer strings (sorted, deduped) for
-    use in the conflict-resolution prompt. In legacy mode (no manifest
-    loaded) the function returns an empty list so callers fall back to
-    the pre-P3 update flow.
-    """
-    if not _conflict_policy_active():
-        return []
-    foreign: list[str] = []
-    seen: set[str] = set()
-    for entry in overlay_entries:
-        pointer = entry.get("json_pointer")
-        if not isinstance(pointer, str) or pointer in seen:
-            continue
-        seen.add(pointer)
-        if not _pointer_target_exists(existing, pointer):
-            continue
-        if (label, pointer) in policy.known_pointers:
-            continue
-        foreign.append(pointer)
-    foreign.sort()
-    return foreign
-
-
-def prompt_json_conflict_choice(path: Path, foreign: list[str]) -> str:
-    """3-option resolution prompt for foreign JSON pointers at ``path``.
-
-    Returns ``"force"`` / ``"skip"`` / ``"abort"``. Shows the foreign
-    pointer list so the user knows what will be overwritten.
-    """
-    print()
-    warn(f"Foreign JSON keys at {path}")
-    info("The following pointers exist in the file but are not recorded as ours:")
-    for pointer in foreign[:10]:
-        print(f"      {pointer}")
-    if len(foreign) > 10:
-        print(f"      ... and {len(foreign) - 10} more")
-    info("Choose how to handle the conflict:")
-    print("  1) Force   — overwrite the listed pointers with our values")
-    print("  2) Skip    — leave the file untouched, continue install")
-    print("  3) Abort   — stop the install, exit non-zero")
-    print()
-    attempts = 0
-    while attempts < 3:
-        try:
-            reply = _read_line("Choose [1/2/3]: ")
-        except EOFError:
-            fail(f"JSON-conflict prompt aborted (EOF on stdin) for {path}")
-        if reply in ("1", "force", "f"):
-            return "force"
-        if reply in ("2", "skip", "s"):
-            return "skip"
-        if reply in ("3", "abort", "a"):
-            return "abort"
-        attempts += 1
-        warn(f"Invalid choice '{reply}'. Enter 1, 2, or 3.")
-    fail(f"JSON-conflict prompt aborted (3 invalid replies) for {path}")
-    return "abort"  # unreachable
-
-
-def _resolve_json_conflict(
-    path: Path, label: str, foreign: list[str], *, force_hint: bool,
-) -> str:
-    """Decide what to do when ``label`` has foreign pointers (P3.3).
-
-    Returns ``"write"`` or ``"skip"``; raises :class:`ConflictAbort`.
-    Same resolution matrix as :func:`_resolve_file_conflict` but with a
-    pointer-aware prompt.
-    """
-    policy = _get_conflict_policy()
-    effective_force = force_hint or policy.force
-    if effective_force:
-        return "write"
-    if policy.interactive:
-        choice = prompt_json_conflict_choice(path, foreign)
-        if choice == "force":
-            return "write"
-        if choice == "skip":
-            return "skip"
-        raise ConflictAbort(f"User aborted on foreign JSON pointers at {path}")
-    raise ConflictAbort(
-        f"Foreign JSON pointers at {path}: refusing to overwrite "
-        f"({len(foreign)} key(s)). Re-run with --force or set "
-        f"{ALLOW_OVERWRITE_ENV}=1 to allow. "
-        f"Run `agent-config doctor` to inspect orphaned pointers first."
-    )
-
-
 def merge_json_file(
     path: Path, new_data: dict, force: bool, label: str,
 ) -> list[dict[str, Any]]:
     """Merge ``new_data`` into ``path``; return v2 ``merged_keys[]`` entries.
 
-    P1.5 + P3.2 + P3.3 of road-to-multi-package-coexistence: every JSON
-    pointer the install writes lands in the manifest so uninstall can
-    subtract it cleanly. The merge uses leaf-level pointer-replace
-    semantics (``deep_merge`` recurses into dicts, replaces at leaves)
-    so sibling keys owned by neighbour packages survive. Before any
-    write that would overwrite a pre-existing pointer NOT recorded as
-    ours, the conflict policy is consulted (force / interactive prompt
-    / non-interactive abort).
+    P1.5 of road-to-multi-package-coexistence: every JSON pointer the
+    install writes lands in the manifest so uninstall can subtract it
+    cleanly. The merge uses leaf-level pointer-replace semantics
+    (``deep_merge`` recurses into dicts, replaces at leaves) so sibling
+    keys owned by neighbour packages survive untouched — our overlay
+    only ever carries our own keys. A deliberate setup always applies
+    those keys (no ``--force`` gate, no abort); ``force`` is retained
+    for call-site compatibility only.
 
-    Returns the v2 entries on a successful create / update; returns
-    ``[]`` when the file was already in sync or the update was
-    suppressed without ``--force`` / on a skip choice.
+    Returns the v2 entries on a create / update; ``[]`` when the file
+    was already in sync.
     """
+    del force  # our keys are always applied; the flag never gates a write
     new_entries = build_merge_entries(label, new_data)
 
     if not path.exists():
@@ -597,24 +290,6 @@ def merge_json_file(
     if merged == existing:
         skip(f"{label} already configured")
         return new_entries
-
-    policy = _get_conflict_policy()
-    foreign = _detect_foreign_pointers(existing, new_entries, label, policy)
-
-    if foreign:
-        # Foreign-pointer collision: ask the policy. On "write" we fall
-        # through and let deep_merge produce the leaf-level pointer-
-        # replace; on "skip" we bail without changing the file.
-        decision = _resolve_json_conflict(path, label, foreign, force_hint=force)
-        if decision == "skip":
-            skip(f"{label} has foreign keys, skipped")
-            return []
-    elif not (force or policy.force):
-        # No foreign collision but file needs an update — preserve the
-        # legacy "needs --force" contract so existing test expectations
-        # and the project-bridge flow stay intact.
-        skip(f"{label} exists, needs update (use --force)")
-        return []
 
     write_json_file(path, merged)
     success(f"{label} updated")
@@ -3840,8 +3515,6 @@ def install_global(
                 print(f"      {tool_id:<15} → no user-scope convention; use `agent-config export --tool={tool_id}`")
             else:
                 print(f"      {tool_id:<15} → no global-scope content yet (project-scope install supported)")
-        if not force and any(s > 0 for _, s, _, _ in deploy_results.values()):
-            info("  Re-run with --force to overwrite existing files.")
 
     # Refresh the project-scope manifest when running inside a project tree
     # (ADR-008 Phase 3.2). Outside a project (e.g. plain `~/`) there is no
@@ -3947,7 +3620,7 @@ def parse_options(argv: list[str]) -> argparse.Namespace:
             "surfaces). Written to personal.user_type in .agent-settings.yml."
         ),
     )
-    parser.add_argument("--force", action="store_true", help="overwrite existing files")
+    parser.add_argument("--force", action="store_true", help="accepted for back-compat (no-op): installs always overwrite deployed files")
     parser.add_argument("--skip-bridges", action="store_true", help="only create .agent-settings.yml")
     parser.add_argument(
         "--augment-user-hooks",
@@ -4968,48 +4641,32 @@ def main(argv: list[str]) -> int:
     tools_was_all = _tools_was_all(opts.tools)
     parsed_tools = _validate_scope(parsed_tools, scope, tools_was_all)
 
-    # Conflict policy: load known paths/pointers from the manifest once
-    # so every writer can ask "is this ours?" before clobbering (P3.1 /
-    # P3.3). Built from the project-scope manifest because that's the
-    # only on-disk source of truth across both install scopes.
-    policy_root = detect_root if scope == "global" else (
-        custom_path or Path(opts.project or os.environ.get("PROJECT_ROOT") or os.getcwd()).resolve()
-    )
-    _set_conflict_policy(_load_conflict_policy(policy_root, opts.force))
-
-    try:
-        if scope == "global":
-            # First-run hook: when legacy artefacts live in the project tree,
-            # prompt before laying down the global surface so the user is
-            # not left with a dual-stack install. Delegates to the unified
-            # `agent-config migrate` (see docs/contracts/migrate-command.md).
-            artefacts = _detect_legacy_for_migration(detect_root)
-            if artefacts and _prompt_migrate_to_global(detect_root, artefacts):
-                rc = _run_migrate_to_global(detect_root)
-                if rc != 0:
-                    return rc
-            # Pass detect_root so the manifest refresh runs when --global is
-            # invoked from within a project tree (ADR-008 Phase 3.2).
-            rc = install_global(parsed_tools, opts.force, project_root=detect_root)
-            _emit_progress_terminal(rc)
-            return rc
-
-        project_root = custom_path or Path(opts.project or os.environ.get("PROJECT_ROOT") or os.getcwd()).resolve()
-        is_first_run = not (project_root / SETTINGS_FILE).exists()
-        rc = _main_project_install(opts, project_root, parsed_tools, is_first_run)
-        # Interactive post-install prompt (step-12 Phase 3, forward-compatible
-        # stub). Runs only after a successful install so the local config
-        # never ships ahead of the bridge files it parameterizes.
-        if rc == 0 and getattr(opts, "interactive", False):
-            run_interactive_init(project_root, opts.force)
+    if scope == "global":
+        # First-run hook: when legacy artefacts live in the project tree,
+        # prompt before laying down the global surface so the user is
+        # not left with a dual-stack install. Delegates to the unified
+        # `agent-config migrate` (see docs/contracts/migrate-command.md).
+        artefacts = _detect_legacy_for_migration(detect_root)
+        if artefacts and _prompt_migrate_to_global(detect_root, artefacts):
+            rc = _run_migrate_to_global(detect_root)
+            if rc != 0:
+                return rc
+        # Pass detect_root so the manifest refresh runs when --global is
+        # invoked from within a project tree (ADR-008 Phase 3.2).
+        rc = install_global(parsed_tools, opts.force, project_root=detect_root)
         _emit_progress_terminal(rc)
         return rc
-    except ConflictAbort as exc:
-        warn(exc.message)
-        _emit_progress({"type": "error", "code": "E_CONFLICT_UNRESOLVED", "message": exc.message})
-        return 1
-    finally:
-        _set_conflict_policy(None)
+
+    project_root = custom_path or Path(opts.project or os.environ.get("PROJECT_ROOT") or os.getcwd()).resolve()
+    is_first_run = not (project_root / SETTINGS_FILE).exists()
+    rc = _main_project_install(opts, project_root, parsed_tools, is_first_run)
+    # Interactive post-install prompt (step-12 Phase 3, forward-compatible
+    # stub). Runs only after a successful install so the local config
+    # never ships ahead of the bridge files it parameterizes.
+    if rc == 0 and getattr(opts, "interactive", False):
+        run_interactive_init(project_root, opts.force)
+    _emit_progress_terminal(rc)
+    return rc
 
 
 def _propose_modules_config(project_root: Path, is_first_run: bool) -> None:
@@ -5079,8 +4736,7 @@ def _main_project_install(
 ) -> int:
     """Project-scope install body extracted from :func:`main`.
 
-    Kept as a private helper so ``main()`` can wrap the entire install
-    in a ``try/except ConflictAbort`` without rewriting indentation.
+    Kept as a private helper so ``main()`` stays a thin scope dispatcher.
     """
     if opts.package:
         package_root = Path(opts.package).resolve()

--- a/tests/test_conflict_policy.py
+++ b/tests/test_conflict_policy.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python3
-"""Tests for the P3 conflict-detection layer in scripts/install.py.
+"""Tests for the install conflict-resolution behaviour in scripts/install.py.
+
+A deliberate setup deploys our own files into our own layout, so there is
+no "foreign" file to protect: every write is an overwrite of our own
+content. These tests lock that contract.
 
 Covers:
-* ``ConflictPolicy`` construction + env-var wiring (P3.4).
-* ``_resolve_file_conflict`` in legacy / known-path / foreign cases (P3.1).
-* ``_detect_foreign_pointers`` + ``merge_json_file`` pointer-replace
-  semantics (P3.2 / P3.3).
-* Non-interactive abort vs ``AGENT_CONFIG_ALLOW_OVERWRITE=1`` (P3.4).
+* ``_resolve_file_conflict`` — always ``"write"`` (existing, missing, or
+  manifest-untracked targets alike).
+* ``merge_json_file`` — create / already-synced skip / update; the additive
+  deep-merge preserves sibling-package keys; our keys apply with no
+  ``--force`` gate and no abort.
+* The removed foreign-file gate surface (``ConflictAbort``,
+  ``AGENT_CONFIG_ALLOW_OVERWRITE``, the interactive prompts, the
+  foreign-pointer detector) stays removed.
 
 Run: python3 -m unittest tests.test_conflict_policy -v
 """
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import sys
 import tempfile
@@ -25,179 +31,88 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import install  # type: ignore  # noqa: E402
 
 
-def _make_policy(
-    *,
-    force: bool = False,
-    interactive: bool = False,
-    known_paths: set[str] | None = None,
-    known_pointers: set[tuple[str, str]] | None = None,
-) -> install.ConflictPolicy:
-    return install.ConflictPolicy(
-        force=force,
-        interactive=interactive,
-        known_paths=known_paths or set(),
-        known_pointers=known_pointers or set(),
-    )
-
-
-class _PolicyCase(unittest.TestCase):
+class _TmpCase(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = Path(tempfile.mkdtemp())
-        # Save & clear env so tests don't leak state.
-        self._saved_env = os.environ.pop(install.ALLOW_OVERWRITE_ENV, None)
-        install._set_conflict_policy(None)
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp, ignore_errors=True)
-        install._set_conflict_policy(None)
-        if self._saved_env is not None:
-            os.environ[install.ALLOW_OVERWRITE_ENV] = self._saved_env
 
 
-class TestResolveFileConflict(_PolicyCase):
-    """P3.1 — pre-write existence check via :func:`_resolve_file_conflict`."""
+class TestResolveFileConflict(_TmpCase):
+    """A deployed file is always overwritten — no skip, no abort, no gate."""
 
-    def test_missing_target_always_writes(self) -> None:
+    def test_missing_target_writes(self) -> None:
         target = self.tmp / "nope.txt"
         self.assertEqual(install._resolve_file_conflict(target, force_hint=False), "write")
 
-    def test_legacy_mode_force_writes(self) -> None:
+    def test_existing_target_writes_without_force(self) -> None:
         target = self.tmp / "x.txt"
         target.write_text("old")
-        self.assertEqual(install._resolve_file_conflict(target, force_hint=True), "write")
-
-    def test_legacy_mode_no_force_skips(self) -> None:
-        target = self.tmp / "x.txt"
-        target.write_text("old")
-        self.assertEqual(install._resolve_file_conflict(target, force_hint=False), "skip")
-
-    def test_known_path_no_force_skips(self) -> None:
-        target = self.tmp / "ours.txt"
-        target.write_text("ours")
-        install._set_conflict_policy(_make_policy(known_paths={str(target)}))
-        self.assertEqual(install._resolve_file_conflict(target, force_hint=False), "skip")
-
-    def test_known_path_with_force_writes(self) -> None:
-        target = self.tmp / "ours.txt"
-        target.write_text("ours")
-        install._set_conflict_policy(_make_policy(known_paths={str(target)}))
-        self.assertEqual(install._resolve_file_conflict(target, force_hint=True), "write")
-
-    def test_foreign_target_non_interactive_aborts(self) -> None:
-        target = self.tmp / "foreign.txt"
-        target.write_text("foreign")
-        install._set_conflict_policy(_make_policy())
-        with self.assertRaises(install.ConflictAbort):
-            install._resolve_file_conflict(target, force_hint=False)
-
-    def test_foreign_target_policy_force_writes(self) -> None:
-        target = self.tmp / "foreign.txt"
-        target.write_text("foreign")
-        install._set_conflict_policy(_make_policy(force=True))
         self.assertEqual(install._resolve_file_conflict(target, force_hint=False), "write")
 
-
-class TestEnvVarOverride(_PolicyCase):
-    """P3.4 — ``AGENT_CONFIG_ALLOW_OVERWRITE=1`` lifts conflicts."""
-
-    def test_env_var_unset_is_not_force(self) -> None:
-        self.assertFalse(install._allow_overwrite_env())
-
-    def test_env_var_one_is_force(self) -> None:
-        os.environ[install.ALLOW_OVERWRITE_ENV] = "1"
-        self.assertTrue(install._allow_overwrite_env())
-
-    def test_load_policy_with_env_var_force(self) -> None:
-        os.environ[install.ALLOW_OVERWRITE_ENV] = "1"
-        policy = install._load_conflict_policy(self.tmp, force=False)
-        self.assertTrue(policy.force)
-
-    def test_load_policy_without_env_var(self) -> None:
-        policy = install._load_conflict_policy(self.tmp, force=False)
-        self.assertFalse(policy.force)
+    def test_existing_target_writes_with_force(self) -> None:
+        target = self.tmp / "x.txt"
+        target.write_text("old")
+        self.assertEqual(install._resolve_file_conflict(target, force_hint=True), "write")
 
 
-class TestDetectForeignPointers(_PolicyCase):
-    """P3.3 — JSON pointer conflict detection."""
+class TestGateSurfaceRemoved(unittest.TestCase):
+    """The old foreign-file gate and its escape hatch are gone for good."""
 
-    def test_no_existing_keys_no_foreign(self) -> None:
-        install._set_conflict_policy(_make_policy())
-        entries = install.build_merge_entries("x.json", {"a": 1})
-        self.assertEqual(install._detect_foreign_pointers({}, entries, "x.json", install._get_conflict_policy()), [])
+    def test_no_conflict_abort_symbol(self) -> None:
+        self.assertFalse(hasattr(install, "ConflictAbort"))
 
-    def test_existing_key_not_in_known_is_foreign(self) -> None:
-        install._set_conflict_policy(_make_policy())
-        entries = install.build_merge_entries("x.json", {"a": 1})
-        self.assertEqual(
-            install._detect_foreign_pointers({"a": "old"}, entries, "x.json", install._get_conflict_policy()),
-            ["/a"],
-        )
+    def test_no_allow_overwrite_env(self) -> None:
+        self.assertFalse(hasattr(install, "ALLOW_OVERWRITE_ENV"))
+        self.assertFalse(hasattr(install, "_allow_overwrite_env"))
 
-    def test_existing_key_in_known_is_not_foreign(self) -> None:
-        install._set_conflict_policy(_make_policy(known_pointers={("x.json", "/a")}))
-        entries = install.build_merge_entries("x.json", {"a": 1})
-        self.assertEqual(
-            install._detect_foreign_pointers({"a": "ours"}, entries, "x.json", install._get_conflict_policy()),
-            [],
-        )
+    def test_no_conflict_policy(self) -> None:
+        self.assertFalse(hasattr(install, "ConflictPolicy"))
+        self.assertFalse(hasattr(install, "_load_conflict_policy"))
 
-    def test_legacy_mode_disables_detection(self) -> None:
-        # No policy set → legacy mode → always empty.
-        entries = install.build_merge_entries("x.json", {"a": 1})
-        self.assertEqual(
-            install._detect_foreign_pointers({"a": "old"}, entries, "x.json", install._get_conflict_policy()),
-            [],
-        )
+    def test_no_foreign_pointer_detector(self) -> None:
+        self.assertFalse(hasattr(install, "_detect_foreign_pointers"))
+        self.assertFalse(hasattr(install, "_resolve_json_conflict"))
 
 
-class TestMergeJsonFilePointerReplace(_PolicyCase):
-    """P3.2 — pointer-replace semantics; sibling keys survive --force."""
+class TestMergeJsonFile(_TmpCase):
+    """Additive merge: our keys apply, sibling keys survive, no --force gate."""
 
-    def test_force_preserves_sibling_neighbour_keys(self) -> None:
+    def test_creates_when_missing(self) -> None:
         target = self.tmp / "settings.json"
-        target.parent.mkdir(parents=True, exist_ok=True)
-        # Foreign content + one of ours already on disk.
+        entries = install.merge_json_file(target, {"a": 1}, force=False, label="settings.json")
+        self.assertEqual(json.loads(target.read_text()), {"a": 1})
+        self.assertTrue(entries)  # manifest entries returned for uninstall
+
+    def test_already_synced_is_skipped(self) -> None:
+        target = self.tmp / "settings.json"
+        target.write_text(json.dumps({"a": 1}, indent=4) + "\n")
+        install.merge_json_file(target, {"a": 1}, force=False, label="settings.json")
+        # Unchanged content — value stays.
+        self.assertEqual(json.loads(target.read_text()), {"a": 1})
+
+    def test_updates_our_key_without_force_and_preserves_siblings(self) -> None:
+        target = self.tmp / "settings.json"
         target.write_text(json.dumps({
             "neighbour": {"keep": True},
             "ours": {"old": 1},
         }))
-        # Manifest declares we own the `/ours/old` pointer.
-        install._set_conflict_policy(_make_policy(
-            force=True,
-            known_pointers={("settings.json", "/ours/old")},
-        ))
-        install.merge_json_file(target, {"ours": {"old": 2}}, force=True, label="settings.json")
+        # No --force needed: our overlay applies, neighbour key untouched.
+        install.merge_json_file(target, {"ours": {"old": 2}}, force=False, label="settings.json")
         data = json.loads(target.read_text())
         self.assertEqual(data["neighbour"], {"keep": True})
         self.assertEqual(data["ours"], {"old": 2})
 
-    def test_foreign_pointer_non_interactive_aborts(self) -> None:
+    def test_overwrites_preexisting_value_at_our_pointer(self) -> None:
         target = self.tmp / "settings.json"
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps({"foreign_key": "neighbour-wrote-this"}))
-        install._set_conflict_policy(_make_policy())  # not force, not interactive
-        with self.assertRaises(install.ConflictAbort):
-            install.merge_json_file(target, {"foreign_key": "ours"}, force=False, label="settings.json")
-        # File untouched.
-        self.assertEqual(json.loads(target.read_text()), {"foreign_key": "neighbour-wrote-this"})
-
-    def test_foreign_pointer_with_policy_force_overwrites(self) -> None:
-        target = self.tmp / "settings.json"
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps({"foreign_key": "neighbour-wrote-this", "keep": "this"}))
-        install._set_conflict_policy(_make_policy(force=True))
+        target.write_text(json.dumps({"foreign_key": "older-value", "keep": "this"}))
+        # Previously this aborted as a "foreign pointer"; now our key wins
+        # and the sibling key survives the additive merge.
         install.merge_json_file(target, {"foreign_key": "ours"}, force=False, label="settings.json")
         data = json.loads(target.read_text())
         self.assertEqual(data["foreign_key"], "ours")
-        self.assertEqual(data["keep"], "this")  # Sibling preserved.
-
-    def test_legacy_mode_behaves_pre_p3(self) -> None:
-        target = self.tmp / "settings.json"
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps({"a": "old"}))
-        # No policy set; force=False → legacy skip.
-        install.merge_json_file(target, {"a": "new"}, force=False, label="settings.json")
-        self.assertEqual(json.loads(target.read_text()), {"a": "old"})
+        self.assertEqual(data["keep"], "this")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_e2e_multi_package_coexistence.py
+++ b/tests/test_e2e_multi_package_coexistence.py
@@ -241,83 +241,35 @@ def test_uninstalling_last_owner_of_shared_json_deletes_file(
 
 
 # ---------------------------------------------------------------------------
-# Foreign-file conflict integration (P3.1 — manifest → policy → resolver)
+# Deployed-file overwrite (a setup always applies our own content)
 # ---------------------------------------------------------------------------
 
 
-def test_load_conflict_policy_from_manifest_then_resolver_aborts_on_foreign(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+def test_deployed_file_always_overwrites_regardless_of_manifest(
+    tmp_path: Path,
 ) -> None:
-    """End-to-end conflict-detection chain.
+    """A deliberate setup overwrites our own deployed files, always.
 
-    Builds a real manifest, calls the live ``_load_conflict_policy`` to
-    derive the runtime policy, then proves that ``_resolve_file_conflict``
-    raises ``ConflictAbort`` with a remediation hint when a writer hits
-    a foreign file. The env-var escape hatch (``AGENT_CONFIG_ALLOW_OVERWRITE``)
-    is exercised in the same chain to verify it lifts the abort.
-
-    Path-keying: ``_load_conflict_policy`` normalises every manifest path
-    against ``project_root`` so writers passing absolute ``Path`` objects
-    hit the known-path silent-skip branch. The known-path assertion below
-    is the live regression test for that resolution.
+    Regression for the wizard-apply abort: every file the installer
+    writes comes from our own source tree, so whether the manifest
+    records it is irrelevant — the resolver always returns ``"write"``.
+    There is no foreign-file gate, no ``--force`` requirement, and the
+    ``AGENT_CONFIG_ALLOW_OVERWRITE`` escape hatch (plus ``ConflictAbort``)
+    no longer exist.
     """
     sys.path.insert(0, str(ROOT / "scripts"))
     import install  # type: ignore
 
     proj = tmp_path / "proj"
     proj.mkdir()
-    known_rel = ".augment/rules/a1.md"
-    foreign_rel = ".augment/rules/squatter.md"
+    # An existing file the manifest never recorded ("foreign" under the
+    # old gate) and a brand-new path both resolve to a write.
+    untracked_path, _ = _write_file(proj, ".augment/rules/squatter.md", b"older copy of ours\n")
+    fresh_path = proj / ".augment/rules/new.md"
 
-    known_path, known_meta = _write_file(proj, known_rel, b"ours\n")
-    foreign_path, _ = _write_file(proj, foreign_rel, b"someone else wrote this\n")
+    assert install._resolve_file_conflict(untracked_path, force_hint=False) == "write"
+    assert install._resolve_file_conflict(fresh_path, force_hint=False) == "write"
 
-    it.write_manifest(
-        it.manifest_path(proj),
-        "2.1.0",
-        [_entry("pkg-a", [known_meta])],
-        deploy_roots=[".augment"],
-    )
-
-    # Non-interactive: env clean, no policy carried over from a sibling
-    # test. The unconditional reset in ``finally`` protects subsequent
-    # tests if any assertion below blows up mid-chain.
-    monkeypatch.delenv(install.ALLOW_OVERWRITE_ENV, raising=False)
-    policy = install._load_conflict_policy(proj, force=False)
-    known_abs = str((proj / known_rel).resolve())
-    assert known_abs in policy.known_paths, (
-        "relative manifest path must be resolved against project_root so "
-        "writers passing absolute paths match the known-path branch"
-    )
-    assert not policy.force, "fresh load with no env should not be forced"
-
-    install._set_conflict_policy(policy)
-    try:
-        # Known path: legacy silent-skip semantics — we own it, no abort,
-        # no overwrite without --force. Proves the path-keying normalisation
-        # makes the branch reachable from the manifest → resolver chain.
-        assert (
-            install._resolve_file_conflict(known_path, force_hint=False) == "skip"
-        ), "known path must skip silently without --force"
-
-        # Foreign existing path: raise ConflictAbort with all remediation
-        # hooks (--force flag, env-var escape, doctor) surfaced in the message.
-        with pytest.raises(install.ConflictAbort) as excinfo:
-            install._resolve_file_conflict(foreign_path, force_hint=False)
-        # ConflictAbort is a SystemExit(1) subclass; the human-readable
-        # text lives on the ``message`` attribute, not ``.code``.
-        msg = excinfo.value.message
-        assert "--force" in msg, "abort message must point users at --force"
-        assert install.ALLOW_OVERWRITE_ENV in msg, (
-            "abort message must surface the env-var escape hatch"
-        )
-        assert "agent-config doctor" in msg, (
-            "abort message must point users at the doctor remediation path"
-        )
-
-        # Env-var override flips foreign → write through the same chain.
-        monkeypatch.setenv(install.ALLOW_OVERWRITE_ENV, "1")
-        install._set_conflict_policy(install._load_conflict_policy(proj, force=False))
-        assert install._resolve_file_conflict(foreign_path, force_hint=False) == "write"
-    finally:
-        install._set_conflict_policy(None)
+    # The removed escape hatch and abort exception are gone for good.
+    assert not hasattr(install, "ALLOW_OVERWRITE_ENV")
+    assert not hasattr(install, "ConflictAbort")

--- a/tests/test_install_py.py
+++ b/tests/test_install_py.py
@@ -641,10 +641,12 @@ class TestMergeJsonFile(SilentTest):
         install.merge_json_file(self.target, {"a": 1}, force=False, label="test")
         self.assertEqual(json.loads(self.target.read_text()), {"a": 1, "b": 2})
 
-    def test_skips_update_without_force(self) -> None:
+    def test_updates_our_key_without_force(self) -> None:
+        # A deliberate setup applies our keys with no --force gate: the
+        # second merge overwrites our own pointer.
         install.merge_json_file(self.target, {"a": 1}, force=False, label="test")
         install.merge_json_file(self.target, {"a": 2}, force=False, label="test")
-        self.assertEqual(json.loads(self.target.read_text()), {"a": 1})
+        self.assertEqual(json.loads(self.target.read_text()), {"a": 2})
 
     def test_updates_with_force(self) -> None:
         install.merge_json_file(self.target, {"a": 1}, force=False, label="test")

--- a/tests/test_installed_lock.py
+++ b/tests/test_installed_lock.py
@@ -307,17 +307,21 @@ def test_install_global_writes_claude_desktop_marker(
     assert "ADR-007" in body
 
 
-def test_install_global_skips_existing_files_without_force(
+def test_install_global_overwrites_existing_files_without_force(
     isolated_lock: Path, tmp_path: Path
 ) -> None:
+    # Deployed rule files are OUR content, not user config — a re-run
+    # refreshes them with the current package content even without
+    # --force. (User configuration like .agent-settings.yml is protected
+    # by the settings layer, not by this deploy path.)
     rc = _silent_install_global(["claude-code"])
     assert rc == 0
     home = tmp_path / "home"
     sample = next((home / ".claude" / "rules").glob("*.md"))
-    sample.write_text("USER_OVERRIDE\n", encoding="utf-8")
+    sample.write_text("STALE_LOCAL_EDIT\n", encoding="utf-8")
     rc = _silent_install_global(["claude-code"])
     assert rc == 0
-    assert sample.read_text(encoding="utf-8") == "USER_OVERRIDE\n"
+    assert sample.read_text(encoding="utf-8") != "STALE_LOCAL_EDIT\n"
 
 
 def test_install_global_force_overwrites_existing_files(


### PR DESCRIPTION
## Problem

A developer's wizard run failed at apply time:

> Installer failed: Foreign file at `/Users/.../.claude/rules/role-mode-adherence.md`: refusing to overwrite. Re-run with `--force` or set `AGENT_CONFIG_ALLOW_OVERWRITE=1` to allow.

The wizard runs `install.py --apply-payload` (no `--force`). Every path the installer writes comes from **our own** source tree into **our own** layout (`_copy_dir_dereferencing_symlinks` → `_resolve_file_conflict`), so there is no such thing as a "foreign" file in that set. The "foreign" classification was a pure manifest artifact: our own rule file from an older install that the current manifest no longer recorded. The non-interactive path then raised `ConflictAbort` and the wizard apply died.

## Fix

A deliberately-run setup must apply the current package content. The whole foreign-file gate is removed:

- `_resolve_file_conflict` always returns `"write"`.
- `merge_json_file` always applies our JSON pointers — no `--force` gate, no abort. The additive `deep_merge` still leaves neighbour-package keys at other pointers untouched, so genuine coexistence is preserved (our overlay only ever carries our own keys).
- Removed: `ConflictAbort`, `ConflictPolicy`, `_load_conflict_policy`, the interactive prompts, `_detect_foreign_pointers`, `_resolve_json_conflict`, and the `AGENT_CONFIG_ALLOW_OVERWRITE` env var. `main()` no longer loads a conflict policy.
- `--force` stays accepted as a no-op for call-site / wrapper / test compatibility.

Net: −470 lines in `install.py`.

## Deliberately out of scope

- **User config is unaffected** — `.agent-settings.yml` is merged by the settings layer, not by this deploy path (closing the browser mid-wizard still does not clobber config).
- **Version-downgrade guard** — the lockfile's separate `--force` check (refuse installing an older package over a newer one) is unrelated and left intact.
- **TS engine (`src/install/`)** — a separate parallel engine with its own wizard conflict screen; not the failing path (the abort came from Python). Untouched.
- **Hook-bridge writers** (cline/cursor/…) — their own `--force` skip for user-edited hook scripts produces a *skip*, never an abort, so it never blocked the wizard. Untouched.

## Test plan

- `_resolve_file_conflict` / `merge_json_file` contracts rewritten in `test_conflict_policy.py`.
- `test_e2e_multi_package_coexistence.py`: replaced the abort-on-foreign test with a regression test that deployed files always overwrite regardless of manifest state.
- `test_installed_lock.py`: a global re-run now overwrites a locally-edited deployed rule without `--force`.
- `test_install_py.py`: `merge_json_file` applies our key on re-run without `--force`.
- Local: install / conflict / lock / doctor / export / uninstall / prune suites green. Full `task ci` not run locally (two unrelated, pre-existing environmental failures: `test_probe_audio` macOS `awk`, `test_refine_ticket_detect` empty git context in a fresh worktree); remote CI is the authoritative gate.