### PR TITLE
feat(install): source-repo self-install guard + install:use-dev/release switch tasks

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -127,6 +127,18 @@ task dev:link                  # Symlink this repo as the global @event4u/agent-
 task dev:unlink                # Remove the global symlink
 ```
 
+**Switch the global install between dev and release** — one-shot toggles
+that flip BOTH the `agent-config` bin on PATH and the user-scope content:
+
+```bash
+task install:use-dev           # global = THIS working tree (npm link + dev-build content)
+task install:use-release       # global = latest npm release (npm i -g @latest + release content)
+```
+
+Run `install:use-dev` to test the working tree as the live global install,
+then `install:use-release` to switch back to the published version. They are
+symmetric — whichever you run last is the active global `agent-config`.
+
 **Typical flow:**
 
 1. In this repo: `task dev:link` — once. The `agent-config` bin on PATH

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -2162,6 +2162,41 @@ def _enforce_consumer_global_only(scope: str) -> None:
     )
 
 
+def _enforce_not_source_repo(scope: str, project_root: Path) -> None:
+    """Refuse a non-global install into the agent-config source repo.
+
+    Python-side mirror of the bash orchestrator's "Source-repo guard"
+    (``scripts/install``). The bash guard only covers the headless
+    ``init`` front door; the wizard reaches the apply engine directly via
+    ``install.py --apply-payload`` (and maintainers can call
+    ``python3 scripts/install.py``), so without this the GUI path could
+    write the ``.augment/`` / ``.claude/`` / ``.cursor/`` projection trees
+    back into the checkout. Both front doors converge on ``main()`` here, so
+    this is the single chokepoint that makes the floor uniform.
+
+    ``--global`` only writes user-scope paths and never the source tree, so
+    it is exempt. Unlike :func:`_enforce_consumer_global_only`, dev-mode does
+    NOT lift this guard — dogfooding bridges into the source tree is an
+    explicit action gated by its own ``AGENT_CONFIG_ALLOW_SELF_INSTALL=1``
+    override (same flag the bash guard honours).
+    """
+    if scope == "global":
+        return
+    if os.environ.get("AGENT_CONFIG_ALLOW_SELF_INSTALL") == "1":
+        return
+    is_source, signature = _is_agent_config_source_repo(project_root)
+    if not is_source:
+        return
+    fail(
+        "Refusing to install agent-config into its own source checkout "
+        f"(detected: {signature}). The source repo is global-only — a "
+        "project-scope install would recreate the .augment/ .claude/ .cursor/ "
+        "projection trees in the repo (double token cost). Run `task sync` to "
+        "regenerate them from .agent-src.uncondensed/ instead, or set "
+        "AGENT_CONFIG_ALLOW_SELF_INSTALL=1 to force."
+    )
+
+
 # --- road-to-global-only-install § Phase 2.2 — three-layer settings reader ---
 #
 # Merge order (per ADR-020 / D9):
@@ -4692,6 +4727,7 @@ def main(argv: list[str]) -> int:
     custom_path: Path | None = Path(opts.custom_path).resolve() if opts.custom_path else None
     scope = _resolve_scope(opts, detected, detect_reason, custom_path)
     _enforce_consumer_global_only(scope)
+    _enforce_not_source_repo(scope, detect_root)
 
     # Scope validation runs before filesystem / package detection so
     # --tools=X / --scope conflicts fail fast with a directive error

--- a/taskfiles/dev.yml
+++ b/taskfiles/dev.yml
@@ -87,4 +87,38 @@ tasks:
       - npm run build
       - node dist/cli/agent-config.js install --dry-run
 
+  install:use-dev:
+    desc: |
+      Switch the GLOBAL agent-config to THIS working tree (the dev package).
+      Points the `agent-config` bin on PATH at this repo (npm link) and
+      refreshes user-scope content (~/.claude, ~/.cursor, ~/.event4u, …) from
+      the freshly-built dev tree. Content comes from THIS repo's package root
+      (node dist/...). Switch back with `task install:use-release`.
+      Usage:
+      task install:use-dev
+    cmds:
+      - task: dev:link
+      - task: dev:install-global
+      - 'echo "→ GLOBAL agent-config now = DEV working tree ($(pwd))"'
+      - 'echo "  switch back to the published release: task install:use-release"'
+
+  install:use-release:
+    desc: |
+      Switch the GLOBAL agent-config to the latest published npm release.
+      Drops the dev symlink (npm unlink -g), installs
+      @event4u/agent-config@latest globally, and refreshes user-scope content
+      from it. Content comes from the GLOBAL release package (the `agent-config`
+      bin resolves to ~/ node_modules, not this repo). Switch back to the
+      working tree with `task install:use-dev`.
+      Usage:
+      task install:use-release
+    cmds:
+      - npm unlink -g @event4u/agent-config 2>/dev/null || true
+      - npm install -g @event4u/agent-config@latest
+      # `agent-config` now resolves to the global release bin → installs the
+      # RELEASE content (not this repo's). --allow-headless keeps it global.
+      - agent-config install --allow-headless
+      - 'echo "→ GLOBAL agent-config now = RELEASE @event4u/agent-config@$(npm view @event4u/agent-config version 2>/dev/null)"'
+      - 'echo "  switch back to the working tree: task install:use-dev"'
+
 

--- a/tests/test_install_scope_global_only.py
+++ b/tests/test_install_scope_global_only.py
@@ -58,6 +58,52 @@ class TestEnforceConsumerGlobalOnly(unittest.TestCase):
                     install._enforce_consumer_global_only("project")
 
 
+class TestEnforceNotSourceRepo(unittest.TestCase):
+    """`_enforce_not_source_repo` — refuse non-global install into the source repo.
+
+    Python-side mirror of the bash orchestrator's source-repo guard. Unlike
+    the consumer-floor above, dev-mode does NOT lift it; the dedicated
+    ``AGENT_CONFIG_ALLOW_SELF_INSTALL=1`` override does.
+    """
+
+    DUMMY_ROOT = Path("/tmp/agent-config-fake-root")
+
+    def _clean_env(self) -> Dict[str, str]:
+        drop = {"AGENT_CONFIG_DEV_MODE", "AGENT_CONFIG_ALLOW_SELF_INSTALL"}
+        return {k: v for k, v in install.os.environ.items() if k not in drop}
+
+    def test_global_scope_allowed_even_in_source_repo(self) -> None:
+        with mock.patch.object(install, "_is_agent_config_source_repo", return_value=(True, "package.json:name")):
+            with mock.patch.dict("os.environ", self._clean_env(), clear=True):
+                install._enforce_not_source_repo("global", self.DUMMY_ROOT)
+
+    def test_project_scope_in_consumer_dir_allowed(self) -> None:
+        with mock.patch.object(install, "_is_agent_config_source_repo", return_value=(False, "")):
+            with mock.patch.dict("os.environ", self._clean_env(), clear=True):
+                install._enforce_not_source_repo("project", self.DUMMY_ROOT)
+
+    def test_project_scope_in_source_repo_is_rejected(self) -> None:
+        with mock.patch.object(install, "_is_agent_config_source_repo", return_value=(True, "package.json:name")):
+            with mock.patch.dict("os.environ", self._clean_env(), clear=True):
+                with redirect_stderr(io.StringIO()) as buf:
+                    with self.assertRaises(SystemExit):
+                        install._enforce_not_source_repo("project", self.DUMMY_ROOT)
+                self.assertIn("source checkout", buf.getvalue())
+
+    def test_dev_mode_does_not_lift_source_repo_guard(self) -> None:
+        with mock.patch.object(install, "_is_agent_config_source_repo", return_value=(True, "package.json:name")):
+            with mock.patch.dict("os.environ", {"AGENT_CONFIG_DEV_MODE": "1"}):
+                install.os.environ.pop("AGENT_CONFIG_ALLOW_SELF_INSTALL", None)
+                with redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit):
+                        install._enforce_not_source_repo("project", self.DUMMY_ROOT)
+
+    def test_allow_self_install_override_lifts_guard(self) -> None:
+        with mock.patch.object(install, "_is_agent_config_source_repo", return_value=(True, "package.json:name")):
+            with mock.patch.dict("os.environ", {"AGENT_CONFIG_ALLOW_SELF_INSTALL": "1"}):
+                install._enforce_not_source_repo("project", self.DUMMY_ROOT)
+
+
 class TestGlobalPathConstants(unittest.TestCase):
     """Phase 2.1 — canonical global path constants."""
 


### PR DESCRIPTION
## What

Two related installer changes:

1. **Source-repo self-install guard** (`scripts/install.py`). The wizard apply path (`agent-config install` → `install.py --apply-payload`) and direct `python3 scripts/install.py` calls bypassed the bash orchestrator's existing source-repo guard, so a project-scope install could recreate the `.augment/` `.claude/` `.cursor/` projection trees inside the package checkout. New `_enforce_not_source_repo` mirrors the bash guard at the single `main()` chokepoint both front doors traverse.
   - `--global` is exempt (writes only user-scope, never the source tree).
   - Dev-mode does **not** lift it — dogfooding into the tree stays an explicit `AGENT_CONFIG_ALLOW_SELF_INSTALL=1` action (the same flag the bash guard already honors).
   - Reuses the existing `_is_agent_config_source_repo` detector.

2. **Global install switch tasks** (`taskfiles/dev.yml`). Two symmetric toggles to flip the global agent-config (bin on PATH + user-scope content) between the working tree and the latest npm release:
   - `task install:use-dev` → `npm link` + dev-build content (package root = repo)
   - `task install:use-release` → `npm i -g @latest` + release content (package root = `~/`)

## Why

Closes the project-install hole on the GUI/direct-Python paths uniformly across all install front doors, and gives maintainers a clean dev↔release switch for testing the working tree as the live global install.

## Verification

- `tests/test_install_scope_global_only.py` — 5 new regression tests for the guard; full file green (23 passed).
- Real path confirmed: `AGENT_CONFIG_DEV_MODE=1 python3 scripts/install.py --scope=project --tools=claude-code` → refused (exit 1) before any write; `--global` and `AGENT_CONFIG_ALLOW_SELF_INSTALL=1` pass.
- `task --list` shows both `install:use-*` tasks; YAML parses.

## Notes for the reviewer

- The `check-public-links` CI gate has **pre-existing** failures on `main` (missing `stability:` frontmatter in `AGENTS.md` / `docs/contracts/*`) — none of those files are in this diff. Not introduced by this PR.