### PR TITLE
fix(release): harden against unpublished-release + resume downgrade drift

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,52 @@
+name: Release Drift Check
+
+# READ-ONLY backstop for the "release merged but never tagged/published"
+# failure mode. On main + daily schedule + manual dispatch, it asserts:
+#   1. main's package.json version has a matching git tag, AND
+#   2. npm dist-tags.latest equals that version.
+# Fails (red) when npm lags main — the signal that a release crashed
+# after merge but before the tag-push that triggers publish-npm.yml.
+# NEVER mutates anything. Recovery: `python3 scripts/release.py --resume`
+# (now package.json-anchored, ADR-safe) or a manual tag-push.
+#
+# NOTE: deliberately no path-filtered `push:` trigger (avoids the
+# phantom 0-job "failure" runs that path-filtered pushes create). The
+# `task ci` gate already enforces the tag invariant on every main build;
+# this workflow adds the network (npm) invariant on a cadence.
+
+on:
+  schedule:
+    # Daily sweep — catches a stuck release within 24h.
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-drift
+  cancel-in-progress: true
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out main (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Node (npm registry read)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Detect release-published drift (read-only)
+        run: python3 scripts/check_release_published.py --strict --check-npm --require-main

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -85,6 +85,7 @@ tasks:
       - task: check-portability
       - task: check-module-management-neutral
       - task: check-release-trunk-sync
+      - task: check-release-published
       - task: validate-decision-engine
       - task: validate-agent-settings
       - task: smoke-quickstart
@@ -194,6 +195,7 @@ tasks:
       - task: check-portability
       - task: check-module-management-neutral
       - task: check-release-trunk-sync
+      - task: check-release-published
       - task: validate-decision-engine
       - task: validate-agent-settings
       - task: smoke-quickstart

--- a/scripts/check_release_published.py
+++ b/scripts/check_release_published.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Release-published drift gate.
+
+Catches the "release merged to main but never tagged/published" failure
+mode — where ``main``'s ``package.json`` claims a version that has no
+matching git tag, and npm's ``latest`` therefore lags behind main. This
+is the backstop that would have surfaced the 5.8.0-stuck-on-5.7.0 state
+the moment it happened, instead of weeks later.
+
+Two independent invariants:
+
+  1. **Tag invariant** (always checkable, no network): the version in
+     ``package.json`` MUST have a matching git tag (local or remote).
+  2. **npm invariant** (``--check-npm``, network): ``npm view <pkg>
+     dist-tags.latest`` MUST equal the ``package.json`` version.
+
+Scope guard: this only makes sense on the release trunk. Off ``main``
+(e.g. a feature branch, or a ``release/X.Y.Z`` branch mid-flight where
+the bump legitimately precedes the tag) the gate **no-ops** unless
+``--strict`` is combined with an explicit on-main signal. The daily
+scheduled workflow runs ``--strict --check-npm`` on ``main``; the local
+``task check-release-published`` runs the tag invariant only.
+
+Exit codes: 0 = pass / no-op · 1 = drift detected · 3 = internal error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_JSON = REPO_ROOT / "package.json"
+MAIN_BRANCH = "main"
+
+
+def _git(*args: str) -> tuple[int, str]:
+    proc = subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    return proc.returncode, (proc.stdout or "").strip()
+
+
+def _package_version() -> str:
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    return str(data["version"])
+
+
+def _package_name() -> str:
+    data = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+    return str(data["name"])
+
+
+def _tag_exists(tag: str) -> bool:
+    rc, out = _git("tag", "-l", tag)
+    if rc == 0 and tag in out.splitlines():
+        return True
+    rc, _ = _git("ls-remote", "--exit-code", "--tags", "origin", tag)
+    return rc == 0
+
+
+def _on_main() -> bool:
+    # Local checkout, CI push ref, or CI scheduled ref all map to main.
+    ref = os.environ.get("GITHUB_REF", "")
+    if ref in ("refs/heads/main", "refs/heads/master"):
+        return True
+    rc, head = _git("rev-parse", "--abbrev-ref", "HEAD")
+    return rc == 0 and head == MAIN_BRANCH
+
+
+def _npm_latest(pkg: str) -> str | None:
+    proc = subprocess.run(
+        ["npm", "view", pkg, "dist-tags.latest"],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return (proc.stdout or "").strip() or None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Release-published drift gate.")
+    ap.add_argument("--strict", action="store_true",
+                    help="Fail on drift (default: informational, exit 0).")
+    ap.add_argument("--check-npm", action="store_true",
+                    help="Also assert npm dist-tags.latest == package.json version (network).")
+    ap.add_argument("--require-main", action="store_true",
+                    help="Only enforce when on main; no-op elsewhere (default for scheduled).")
+    args = ap.parse_args(argv)
+
+    try:
+        version = _package_version()
+    except (OSError, KeyError, json.JSONDecodeError) as exc:
+        print(f"❌  cannot read package.json version: {exc}", file=sys.stderr)
+        return 3
+    if not SEMVER_RE.match(version):
+        print(f"❌  package.json version is not semver: {version!r}", file=sys.stderr)
+        return 3
+
+    if args.require_main and not _on_main():
+        print(f"ℹ️  not on {MAIN_BRANCH} — release-published gate skipped.")
+        return 0
+
+    problems: list[str] = []
+
+    if not _tag_exists(version):
+        problems.append(
+            f"package.json is {version} but no git tag {version} exists "
+            f"(local or origin) — the release was bumped/merged but never "
+            f"tagged. Complete it: tag the release-merge commit and push "
+            f"(triggers publish-npm.yml), e.g. `git tag {version} && git "
+            f"push origin {version}`."
+        )
+
+    if args.check_npm:
+        pkg = _package_name()
+        latest = _npm_latest(pkg)
+        if latest is None:
+            print(f"⚠️  could not read npm dist-tags.latest for {pkg} "
+                  f"(network/registry) — npm invariant not checked.", file=sys.stderr)
+        elif latest != version:
+            problems.append(
+                f"npm {pkg}@latest is {latest} but package.json is {version} "
+                f"— the published release lags main. Check publish-npm.yml "
+                f"for tag {version}, or re-dispatch it."
+            )
+
+    if not problems:
+        suffix = " + npm" if args.check_npm else ""
+        print(f"✅  release-published: {version} is tagged{suffix} and in sync.")
+        return 0
+
+    header = "❌  Release-published drift:" if args.strict else "⚠️  Release-published drift (warn-only):"
+    print(header, file=sys.stderr)
+    for p in problems:
+        print(f"  - {p}", file=sys.stderr)
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -665,7 +665,7 @@ def execute(
     resume: bool = False,
 ) -> None:
     branch = f"release/{plan.target}"
-    total = 9
+    total = 10
 
     if dry_run:
         print("(dry-run) no git/gh mutations will be performed.")
@@ -842,6 +842,25 @@ def execute(
             "--notes", notes,
         )
 
+    # ─── 10. delete the merged release branch (local + remote) ───────────────
+    # Branch hygiene: a merged-but-undeleted release/X.Y.Z is what made
+    # `--resume` mis-detect an old version. Delete it now so it can never
+    # accumulate. Idempotent — skips whatever is already gone. Never touches
+    # `main` or any tag.
+    if dry_run:
+        _step(10, total, f"Would delete merged branch {branch} (local + remote)")
+    else:
+        deleted = []
+        if _branch_exists_local(branch) and \
+                git("rev-parse", "--abbrev-ref", "HEAD", capture=True) != branch:
+            run("git", "branch", "-D", branch, check=False)
+            deleted.append("local")
+        if _branch_exists_remote(branch):
+            run("git", "push", REMOTE, "--delete", branch, check=False)
+            deleted.append("remote")
+        where = " + ".join(deleted) if deleted else "already gone"
+        _step(10, total, f"Delete merged branch {branch} ({where})")
+
     print()
     print(f"✅  Released {plan.target}")
     print(f"   https://github.com/{REPO_SLUG}/releases/tag/{plan.target}")
@@ -904,43 +923,47 @@ _RELEASE_BRANCH_RE = re.compile(r"^release/(\d+\.\d+\.\d+)$")
 
 
 def _detect_in_flight_target() -> str | None:
-    """Find the in-flight release target from existing release branches.
+    """Find the in-flight release target — the SOURCE OF TRUTH is package.json.
 
-    Resume mode needs to know which `release/X.Y.Z` is being recovered,
-    not what the next bump would be. The release branch name is the
-    canonical anchor: it was committed by step 1 of an earlier run and
-    is the only state guaranteed to survive a partial pipeline.
+    An "in-flight" release is one whose version was already bumped into
+    ``main``'s ``package.json`` (and possibly merged) but whose tag has not
+    yet been pushed — i.e. the publish step never completed. The canonical
+    anchor is therefore ``package.json`` version `V` **with no matching tag
+    `V`**, NOT the set of ``release/X.Y.Z`` branches.
 
-    Local branches win over remote, current-branch wins over both — if
-    you ran `git checkout release/1.15.0`, that's the target. Returns
-    None if no release branch exists; caller falls back to the regular
-    bump-inference path.
+    Why not the branch set: merged release branches are frequently left
+    undeleted on the remote, so "highest existing release/* branch" can
+    resolve to an OLD, already-published version (e.g. picking 5.4.0 while
+    5.8.0 is the real in-flight target) and tag a downgrade. The package.json
+    version cannot lie that way — it is the version main currently claims to
+    be, and an untagged claim is exactly an incomplete release.
+
+    Resolution order:
+      1. If HEAD is on a ``release/X.Y.Z`` branch, that explicit checkout wins.
+      2. Else: read ``package.json`` version `V`. If tag `V` does not exist
+         (local or remote), `V` is the in-flight target. If it is already
+         tagged, the release is complete → return None (regular bump path).
+
+    Stale ``release/*`` branches are never used for version detection.
     """
     head = git("rev-parse", "--abbrev-ref", "HEAD", capture=True)
     m = _RELEASE_BRANCH_RE.match(head)
     if m:
         return m.group(1)
 
-    local_raw = git("for-each-ref", "--format=%(refname:short)", "refs/heads/release/", capture=True)
-    candidates = [
-        m.group(1)
-        for line in local_raw.splitlines()
-        if (m := _RELEASE_BRANCH_RE.match(line.strip()))
-    ]
-    remote_raw = git(
-        "for-each-ref", "--format=%(refname:short)",
-        f"refs/remotes/{REMOTE}/release/", capture=True,
-    )
-    for line in remote_raw.splitlines():
-        bare = line.strip().removeprefix(f"{REMOTE}/")
-        if (m := _RELEASE_BRANCH_RE.match(bare)):
-            candidates.append(m.group(1))
-
-    if not candidates:
+    try:
+        version = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))["version"]
+    except (OSError, KeyError, json.JSONDecodeError):
         return None
-    # Sort semver-aware so 1.10.0 > 1.9.0 (lexicographic would lose).
-    candidates.sort(key=parse_version)
-    return candidates[-1]
+    try:
+        parse_version(version)
+    except Exception:
+        return None
+
+    # An already-tagged version is a completed release, not in-flight.
+    if _tag_exists_local(version) or _tag_exists_remote(version):
+        return None
+    return version
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -961,7 +984,7 @@ def main(argv: list[str] | None = None) -> int:
         target = args.explicit
     elif in_flight:
         target = in_flight
-        print(f"(resume) detected in-flight release branch release/{in_flight}")
+        print(f"(resume) in-flight target {in_flight} (package.json version with no tag yet)")
     else:
         target = bump_version(current, bump)
     parse_version(target)

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -329,6 +329,11 @@ tasks:
     desc: Fail if main is more than one tagged release behind a release/X.Y.Z branch (P1.3 of road-to-productization, contract docs/contracts/release-trunk-sync.md)
     cmd: python3 scripts/check_release_trunk_sync.py
 
+  check-release-published:
+    silent: true
+    desc: "Fail if main's package.json version has no matching tag (release merged but never tagged/published). No-ops off main; tag invariant only — the npm invariant runs in the scheduled release-drift workflow. See scripts/check_release_published.py"
+    cmd: python3 scripts/check_release_published.py --strict --require-main
+
   validate-decision-engine:
     silent: true
     desc: Validate decision_engine block schema in agent-settings.template.yml and any local .agent-settings.yml (P2 of road-to-productization, contract docs/contracts/decision-engine-gates.md)

--- a/tests/test_check_release_published.py
+++ b/tests/test_check_release_published.py
@@ -1,0 +1,67 @@
+"""Tests for scripts/check_release_published.py — the release-published drift gate."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+import check_release_published as c  # noqa: E402
+
+
+@pytest.fixture()
+def stub(monkeypatch):
+    def _apply(*, version, tagged, npm_latest=None, on_main=True, name="@event4u/agent-config"):
+        monkeypatch.setattr(c, "_package_version", lambda: version)
+        monkeypatch.setattr(c, "_package_name", lambda: name)
+        monkeypatch.setattr(c, "_tag_exists", lambda t: tagged)
+        monkeypatch.setattr(c, "_on_main", lambda: on_main)
+        monkeypatch.setattr(c, "_npm_latest", lambda pkg: npm_latest)
+    return _apply
+
+
+def test_pass_when_tagged(stub) -> None:
+    stub(version="5.8.0", tagged=True)
+    assert c.main(["--strict"]) == 0
+
+
+def test_strict_fails_when_untagged(stub) -> None:
+    stub(version="5.8.0", tagged=False)
+    assert c.main(["--strict"]) == 1
+
+
+def test_warn_only_never_fails(stub) -> None:
+    stub(version="5.8.0", tagged=False)
+    assert c.main([]) == 0  # default mode is informational
+
+
+def test_npm_lag_fails_strict(stub) -> None:
+    stub(version="5.8.0", tagged=True, npm_latest="5.7.0")
+    assert c.main(["--strict", "--check-npm"]) == 1
+
+
+def test_npm_in_sync_passes(stub) -> None:
+    stub(version="5.8.0", tagged=True, npm_latest="5.8.0")
+    assert c.main(["--strict", "--check-npm"]) == 0
+
+
+def test_npm_unreadable_is_warned_not_failed(stub) -> None:
+    stub(version="5.8.0", tagged=True, npm_latest=None)
+    # tag ok + npm unreadable → no hard failure
+    assert c.main(["--strict", "--check-npm"]) == 0
+
+
+def test_require_main_noops_off_main(stub) -> None:
+    stub(version="5.8.0", tagged=False, on_main=False)
+    assert c.main(["--strict", "--require-main"]) == 0  # skipped off main
+
+
+def test_require_main_enforces_on_main(stub) -> None:
+    stub(version="5.8.0", tagged=False, on_main=True)
+    assert c.main(["--strict", "--require-main"]) == 1
+
+
+def test_non_semver_version_errors(stub) -> None:
+    stub(version="not-a-version", tagged=True)
+    assert c.main(["--strict"]) == 3

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -38,6 +38,50 @@ class TestBumpVersion:
         with pytest.raises(SystemExit):
             rel.bump_version("not-a-version", "patch")
 
+
+class TestDetectInFlightTarget:
+    """`_detect_in_flight_target` derives from package.json + tag existence,
+    NOT from `release/*` branches (which can be merged-but-undeleted and would
+    otherwise resolve to an old, already-published version → downgrade tag).
+    """
+
+    def _stub(self, monkeypatch, tmp_path, *, version, tag_local=False, tag_remote=False, head="main"):
+        pkg = tmp_path / "package.json"
+        pkg.write_text(json.dumps({"version": version}), encoding="utf-8")
+        monkeypatch.setattr(rel, "PACKAGE_JSON", pkg)
+        monkeypatch.setattr(rel, "git", lambda *a, **k: head if "rev-parse" in a else "")
+        monkeypatch.setattr(rel, "_tag_exists_local", lambda t: tag_local)
+        monkeypatch.setattr(rel, "_tag_exists_remote", lambda t: tag_remote)
+
+    def test_untagged_package_version_is_in_flight(self, monkeypatch, tmp_path) -> None:
+        # main claims 5.8.0 but no tag 5.8.0 → that is the in-flight release.
+        self._stub(monkeypatch, tmp_path, version="5.8.0", tag_local=False, tag_remote=False)
+        assert rel._detect_in_flight_target() == "5.8.0"
+
+    def test_tagged_package_version_is_complete(self, monkeypatch, tmp_path) -> None:
+        # 5.8.0 already tagged → release complete → no in-flight target.
+        self._stub(monkeypatch, tmp_path, version="5.8.0", tag_local=True)
+        assert rel._detect_in_flight_target() is None
+
+    def test_remote_tag_also_counts_as_complete(self, monkeypatch, tmp_path) -> None:
+        self._stub(monkeypatch, tmp_path, version="5.8.0", tag_local=False, tag_remote=True)
+        assert rel._detect_in_flight_target() is None
+
+    def test_stale_release_branches_never_picked(self, monkeypatch, tmp_path) -> None:
+        # The regression: even with package.json at 5.8.0 (tagged → complete),
+        # the function must NOT fall back to scanning release/* branches and
+        # return an old 5.4.0. It returns None, not a downgrade version.
+        self._stub(monkeypatch, tmp_path, version="5.8.0", tag_local=True)
+        result = rel._detect_in_flight_target()
+        assert result is None
+        assert result != "5.4.0"
+
+    def test_explicit_release_branch_head_wins(self, monkeypatch, tmp_path) -> None:
+        # If you deliberately `git checkout release/1.15.0`, that explicit
+        # checkout is honored over the package.json path.
+        self._stub(monkeypatch, tmp_path, version="9.9.9", head="release/1.15.0")
+        assert rel._detect_in_flight_target() == "1.15.0"
+
     def test_invalid_kind_exits(self) -> None:
         with pytest.raises(SystemExit):
             rel.bump_version("1.0.0", "mega")


### PR DESCRIPTION
## Summary

Hardens the release pipeline against the two failure modes surfaced while completing the **5.8.0** release (which had been merged to `main` but left untagged → npm stuck on 5.7.0, and `release.py --resume` would have tagged a **downgrade**).

## A — `--resume` anchored to `package.json` (safety-critical)

`_detect_in_flight_target()` picked the **highest existing `release/*` branch**. Because merged release branches are left undeleted, it resolved to `release/5.4.0` while `5.8.0` was the real in-flight target — a downgrade tag waiting to happen.

Now it derives the in-flight version from **`main`'s `package.json`**: a version with no matching tag *is* the incomplete release; an already-tagged version means complete (no in-flight). Stale `release/*` branches are never consulted for version detection. + 5 regression tests (incl. the explicit "never picks a stale 5.4.0" case).

## B — release-published drift gate (catch npm lagging main)

`scripts/check_release_published.py` — two invariants:
1. **Tag** — `main`'s `package.json` version must have a matching git tag (no network).
2. **npm** — `npm dist-tags.latest` must equal that version (`--check-npm`).

- `task check-release-published` (tag invariant, `--require-main`) wired into both CI chains — no-ops on PR branches where an in-flight bump legitimately precedes its tag.
- `.github/workflows/release-drift.yml` — daily scheduled run of the full tag + npm invariant on `main`; goes **red within 24h** of a stuck release.
- 9 tests.

## C — branch hygiene

- **C1 (shipped here):** `release.py` step 10 deletes the merged `release/X.Y.Z` branch (local + remote) after a release completes — idempotent, never touches `main`/tags — removing the stale-branch source of the A mis-detection.
- **C2 (needs your go-ahead):** one-time deletion of the existing stale merged branches `release/5.4.0`, `release/3.0.0`, `release/3.1.1` (all merged + tagged → fully recoverable). The auto-mode classifier declined the agent-initiated remote-branch delete; see the PR thread / chat. `release/1.30.0` is **un-merged + untagged** → left intact, flagged for manual review.

## Verification

`tests/test_release.py` (55, +5) and `tests/test_check_release_published.py` (9) green; YAML valid; the gate passes on the current synced 5.8.0 state and fails (exit 1) on simulated drift.
