### PR TITLE
release: 5.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Shared agent configuration \u2014 skills for AI coding tools (Claude Code, Augment, Cursor, Cline, Windsurf, Gemini CLI).",
-    "version": "5.8.0",
+    "version": "5.9.0",
     "keywords": [
       "agent-config",
       "skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -811,6 +811,23 @@ our recommendation order, not its support status.
 > that forces a new era split (`# Era: 5.5.x`, etc.) — see
 > [`docs/contracts/CHANGELOG-conventions.md § Era splits`](docs/contracts/CHANGELOG-conventions.md).
 
+## [5.9.0](https://github.com/event4u-app/agent-config/compare/5.8.0...5.9.0) (2026-06-02)
+
+### Features
+
+* **doctor:** runnable global-only report without a project lockfile ([4c4f20b](https://github.com/event4u-app/agent-config/commit/4c4f20b82eb472ff6b6d84ebac889832ce1329f0))
+* **ci:** release-published drift gate (catch npm lagging main) ([7f4e125](https://github.com/event4u-app/agent-config/commit/7f4e125dd48d0233d33ce8cbb219731a0b501497))
+
+### Bug Fixes
+
+* **release:** anchor --resume to package.json, auto-delete merged branch ([f2db736](https://github.com/event4u-app/agent-config/commit/f2db736c7259845fe204af1ffd293e7f5341a58d))
+
+### Chores
+
+* **roadmap:** close + archive doctor-global-only-readiness ([3d3aaf7](https://github.com/event4u-app/agent-config/commit/3d3aaf739464b9e6613175f352b09a153bdbec90))
+
+Tests: 5480 (+25 since 5.8.0)
+
 ## [5.8.0](https://github.com/event4u-app/agent-config/compare/5.7.0...5.8.0) (2026-06-02)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@event4u/agent-config",
-    "version": "5.8.0",
+    "version": "5.9.0",
     "description": "Universal AI Agent OS \u2014 audited skills, governance rules, commands, and templates for AI coding tools (Claude Code, Cursor, Windsurf, Copilot).",
     "license": "MIT",
     "private": false,

--- a/packages/cloud/README.md
+++ b/packages/cloud/README.md
@@ -3,7 +3,7 @@
 # cloud
 
 - **id**: `cloud`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: —
 - **requires**: —
 - **artefacts**: 0

--- a/packages/cloud/pack.yaml
+++ b/packages/cloud/pack.yaml
@@ -6,4 +6,4 @@ label: cloud
 owner: []
 requires: []
 trust_level_default: core
-version: 5.8.0
+version: 5.9.0

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@
 Core framework-neutral artefacts.
 
 - **id**: `core`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: agent-config-maintainer
 - **requires**: —
 - **artefacts**: 383

--- a/packages/core/pack.yaml
+++ b/packages/core/pack.yaml
@@ -7,4 +7,4 @@ owner:
 - agent-config-maintainer
 requires: []
 trust_level_default: core
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-ai-video/README.md
+++ b/packages/pack-ai-video/README.md
@@ -5,7 +5,7 @@
 AI video pipeline.
 
 - **id**: `ai-video`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: small-business
 - **requires**: —
 - **artefacts**: 9

--- a/packages/pack-ai-video/pack.yaml
+++ b/packages/pack-ai-video/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - small-business
 requires: []
 trust_level_default: experimental
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-finance-advanced/README.md
+++ b/packages/pack-finance-advanced/README.md
@@ -5,7 +5,7 @@
 DCF, scenario modelling, comp banding.
 
 - **id**: `finance-advanced`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: finance
 - **requires**: finance-basic
 - **artefacts**: 2

--- a/packages/pack-finance-advanced/pack.yaml
+++ b/packages/pack-finance-advanced/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - finance-basic
 trust_level_default: core
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-finance-basic/README.md
+++ b/packages/pack-finance-basic/README.md
@@ -5,7 +5,7 @@
 Cashflow, runway, basic forecasting.
 
 - **id**: `finance-basic`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: finance, founder
 - **requires**: —
 - **artefacts**: 4

--- a/packages/pack-finance-basic/pack.yaml
+++ b/packages/pack-finance-basic/pack.yaml
@@ -12,4 +12,4 @@ owner:
 - founder
 requires: []
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-founder-strategy/README.md
+++ b/packages/pack-founder-strategy/README.md
@@ -5,7 +5,7 @@
 Vision, fundraising narrative, competitive moat.
 
 - **id**: `founder-strategy`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: founder
 - **requires**: —
 - **artefacts**: 8

--- a/packages/pack-founder-strategy/pack.yaml
+++ b/packages/pack-founder-strategy/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - founder
 requires: []
 trust_level_default: core
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-fun/README.md
+++ b/packages/pack-fun/README.md
@@ -5,7 +5,7 @@
 Non-essential social/fun workflows (prediction-pool tips, etc.).
 
 - **id**: `fun`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: small-business
 - **requires**: —
 - **artefacts**: 2

--- a/packages/pack-fun/pack.yaml
+++ b/packages/pack-fun/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - small-business
 requires: []
 trust_level_default: experimental
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-gtm-marketing/README.md
+++ b/packages/pack-gtm-marketing/README.md
@@ -5,7 +5,7 @@
 Positioning, messaging, editorial, content funnel.
 
 - **id**: `gtm-marketing`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: gtm, founder
 - **requires**: —
 - **artefacts**: 8

--- a/packages/pack-gtm-marketing/pack.yaml
+++ b/packages/pack-gtm-marketing/pack.yaml
@@ -8,4 +8,4 @@ owner:
 - founder
 requires: []
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-gtm-sales/README.md
+++ b/packages/pack-gtm-sales/README.md
@@ -5,7 +5,7 @@
 Pipeline, MEDDIC, forecast accuracy.
 
 - **id**: `gtm-sales`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: gtm
 - **requires**: —
 - **artefacts**: 4

--- a/packages/pack-gtm-sales/pack.yaml
+++ b/packages/pack-gtm-sales/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - gtm
 requires: []
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-laravel/README.md
+++ b/packages/pack-laravel/README.md
@@ -5,7 +5,7 @@
 Laravel framework patterns; depends on PHP at the artefact level.
 
 - **id**: `laravel`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: php, engineering-base
 - **artefacts**: 25

--- a/packages/pack-laravel/pack.yaml
+++ b/packages/pack-laravel/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - php
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-nextjs/README.md
+++ b/packages/pack-nextjs/README.md
@@ -5,7 +5,7 @@
 Next.js framework patterns.
 
 - **id**: `nextjs`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: react, typescript, engineering-base
 - **artefacts**: 2

--- a/packages/pack-nextjs/pack.yaml
+++ b/packages/pack-nextjs/pack.yaml
@@ -10,4 +10,4 @@ requires:
 - typescript
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-ops-people/README.md
+++ b/packages/pack-ops-people/README.md
@@ -5,7 +5,7 @@
 Hiring loops, onboarding programs, comp banding.
 
 - **id**: `ops-people`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: ops
 - **requires**: —
 - **artefacts**: 8

--- a/packages/pack-ops-people/pack.yaml
+++ b/packages/pack-ops-people/pack.yaml
@@ -11,4 +11,4 @@ owner:
 - ops
 requires: []
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-php/README.md
+++ b/packages/pack-php/README.md
@@ -5,7 +5,7 @@
 PHP-language patterns (framework-free).
 
 - **id**: `php`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: engineering-base
 - **artefacts**: 6

--- a/packages/pack-php/pack.yaml
+++ b/packages/pack-php/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-product-basic/README.md
+++ b/packages/pack-product-basic/README.md
@@ -5,7 +5,7 @@
 Core PO/PM artefacts (ticket refinement, AC, estimation).
 
 - **id**: `product-basic`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: product
 - **requires**: engineering-base
 - **artefacts**: 9

--- a/packages/pack-product-basic/pack.yaml
+++ b/packages/pack-product-basic/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-product-discovery/README.md
+++ b/packages/pack-product-discovery/README.md
@@ -5,7 +5,7 @@
 JTBD, interviews, VoC, hypothesis testing.
 
 - **id**: `product-discovery`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: product
 - **requires**: product-basic
 - **artefacts**: 4

--- a/packages/pack-product-discovery/pack.yaml
+++ b/packages/pack-product-discovery/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - product-basic
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-python/README.md
+++ b/packages/pack-python/README.md
@@ -5,7 +5,7 @@
 Python-language patterns.
 
 - **id**: `python`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: engineering-base
 - **artefacts**: 1

--- a/packages/pack-python/pack.yaml
+++ b/packages/pack-python/pack.yaml
@@ -8,4 +8,4 @@ owner:
 requires:
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-react/README.md
+++ b/packages/pack-react/README.md
@@ -5,7 +5,7 @@
 React framework patterns.
 
 - **id**: `react`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: javascript, engineering-base
 - **artefacts**: 3

--- a/packages/pack-react/pack.yaml
+++ b/packages/pack-react/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - javascript
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-symfony/README.md
+++ b/packages/pack-symfony/README.md
@@ -5,7 +5,7 @@
 Symfony framework patterns; depends on PHP at the artefact level.
 
 - **id**: `symfony`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: php, engineering-base
 - **artefacts**: 3

--- a/packages/pack-symfony/pack.yaml
+++ b/packages/pack-symfony/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - php
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0

--- a/packages/pack-typescript/README.md
+++ b/packages/pack-typescript/README.md
@@ -5,7 +5,7 @@
 TypeScript-language patterns.
 
 - **id**: `typescript`
-- **version**: `5.8.0`
+- **version**: `5.9.0`
 - **owner**: engineering
 - **requires**: javascript, engineering-base
 - **artefacts**: 1

--- a/packages/pack-typescript/pack.yaml
+++ b/packages/pack-typescript/pack.yaml
@@ -9,4 +9,4 @@ requires:
 - javascript
 - engineering-base
 trust_level_default: professional
-version: 5.8.0
+version: 5.9.0


### PR DESCRIPTION
Release 5.9.0.

### Features

* **doctor:** runnable global-only report without a project lockfile ([4c4f20b](https://github.com/event4u-app/agent-config/commit/4c4f20b82eb472ff6b6d84ebac889832ce1329f0))
* **ci:** release-published drift gate (catch npm lagging main) ([7f4e125](https://github.com/event4u-app/agent-config/commit/7f4e125dd48d0233d33ce8cbb219731a0b501497))

### Bug Fixes

* **release:** anchor --resume to package.json, auto-delete merged branch ([f2db736](https://github.com/event4u-app/agent-config/commit/f2db736c7259845fe204af1ffd293e7f5341a58d))

### Chores

* **roadmap:** close + archive doctor-global-only-readiness ([3d3aaf7](https://github.com/event4u-app/agent-config/commit/3d3aaf739464b9e6613175f352b09a153bdbec90))

Tests: 5480 (+25 since 5.8.0)

Created by `scripts/release.py`.