### PR TITLE
docs: process feedback-24-26-cleanup (Glama, release-body, branch-protection, overlay-gate)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**43 / 116 steps done · 37%**
+**48 / 115 steps done · 42%**
 
 ```text
-███████████████░░░░░░░░░░░░░░░░░░░░░░░░░   37%
+█████████████████░░░░░░░░░░░░░░░░░░░░░░░   42%
 ```
 
 ## Open roadmaps
@@ -20,7 +20,7 @@
 | 2 | [road-to-6.0.0-b-pack-scoped-projection.md](roadmaps/road-to-6.0.0-b-pack-scoped-projection.md) | 4 | 16 | 16 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-6.0.0-c-governance-and-evals.md](roadmaps/road-to-6.0.0-c-governance-and-evals.md) | 5 | 16 | 16 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-employee-product-and-external-proof.md](roadmaps/road-to-employee-product-and-external-proof.md) | 10 | 71 | 17 | 43 | 11 | 0 | ███████░░░ 72% |
-| 5 | [road-to-feedback-24-26-cleanup.md](roadmaps/road-to-feedback-24-26-cleanup.md) | 4 | 11 | 11 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 5 | [road-to-feedback-24-26-cleanup.md](roadmaps/road-to-feedback-24-26-cleanup.md) | 4 | 11 | 5 | 5 | 1 | 0 | █████░░░░░ 50% |
 
 ---
 
@@ -78,12 +78,12 @@
 
 ### [road-to-feedback-24-26-cleanup.md](roadmaps/road-to-feedback-24-26-cleanup.md)
 
-**Road to Feedback 24–26 Cleanup — the genuinely-new, non-blocked items** — 0 / 11 done (0%)
+**Road to Feedback 24–26 Cleanup — the genuinely-new, non-blocked items** — 5 / 10 done (50%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Registry capture — Glama + sweep | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
-| 2 | Verify the two flagged-but-likely-fine risks | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
-| 3 | Profile-complexity gate coverage | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
-| 4 | Forward-routing record (no code) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 1 | Registry capture — Glama + sweep | ✅ done | 0 | 2 | 0 | 0 | 100% |
+| 2 | Verify the two flagged-but-likely-fine risks | ✅ done | 0 | 1 | 1 | 0 | 100% |
+| 3 | Profile-complexity gate coverage | ✅ done | 0 | 1 | 0 | 0 | 100% |
+| 4 | Forward-routing record (no code) | 🟡 in progress | 5 | 1 | 0 | 0 | 17% |
 

--- a/agents/roadmaps/road-to-feedback-24-26-cleanup.md
+++ b/agents/roadmaps/road-to-feedback-24-26-cleanup.md
@@ -67,45 +67,80 @@ feedback's assumptions):
 
 ## Phase 1: Registry capture — Glama + sweep
 
-- [ ] **Step 1:** Add a Glama (`glama.ai`) row to the submission-status table in
+- [x] **Step 1:** Add a Glama (`glama.ai`) row to the submission-status table in
   [`docs/distribution/registries.md`](../../docs/distribution/registries.md)
   § MCP registries, with the same one-line entry template the three existing
   MCP registries use (repo URL `https://github.com/event4u-app/agent-config`,
   description, tags `agent-governance`, `mcp`, `skills`). Mark status
   `⬜ open (human-owner: maintainer submits via the Glama claim flow)`.
-- [ ] **Step 2:** Sweep the three existing MCP-registry rows (punkpeye, mcp.so,
+- [x] **Step 2:** Sweep the three existing MCP-registry rows (punkpeye, mcp.so,
   mcpservers.org) for stale status text; if any submission timestamp landed
   since the rows were written, capture it. No new submissions (those stay
   human-owner per the existing roadmap).
+  <!-- swept 2026-06-02: all three rows still ⬜ open / pending across registries.md,
+  registry-submissions.md, and dist/mcp/registry-manifest.json — no PR URLs, no
+  submission timestamps landed. No stale status, nothing to backfill. -->
 
 ## Phase 2: Verify the two flagged-but-likely-fine risks
 
-- [ ] **Step 3:** Confirm the automated release path populates the GitHub
+- [~] **Step 3:** Confirm the automated release path populates the GitHub
   release body. Read the github-actions tag/release path (`.github/workflows/`
   publish/release + `scripts/release.py` `--notes` wiring). If the historical
   5.8.0 GitHub release body is still the bare merge-commit text, backfill it
   from `CHANGELOG.md` via `gh release edit 5.8.0 --notes-file …`. If the path
   already populates correctly, record "verified — non-issue" inline and close
   the step. <!-- carve-out: new-gate-verification -->
-- [ ] **Step 4:** Confirm `docs/contracts/branch-protection-policy.md` matches
+  <!-- verified 2026-06-02: regular path is correct — scripts/release.py step 9
+  runs `gh release create <tag> --notes plan.changelog_body`; publish-npm.yml only
+  publishes npm, cloud-release.yml (softprops/action-gh-release) only attaches
+  artefacts to the pre-existing release and sets no body, so it never blanks it.
+  The 5.8.0 body IS still empty (one-off). Byte-accurate backfill notes prepared
+  from docs/archive/CHANGELOG-pre-5.9.0.md → /tmp/release-5.8.0-notes.md, but the
+  `gh release edit 5.8.0` external write was denied by the harness auto-mode
+  classifier (external collaboration artifact). deferred: needs maintainer to run
+  `gh release edit 5.8.0 --notes-file <body>` or grant the permission. -->
+- [x] **Step 4:** Confirm `docs/contracts/branch-protection-policy.md` matches
   the live GitHub ruleset for `main` (require status checks + restrict force
   pushes). This is a maintainer UI check; record the verification outcome
   inline. If the doc and the UI drift, note the drift — do **not** change the
   ruleset autonomously (Hard Floor on repo settings).
+  <!-- verified 2026-06-02: DRIFT FOUND. main is NOT protected.
+  `gh api repos/event4u-app/agent-config/rulesets` → [] (no repo rulesets);
+  `.../branches/main/protection` → 404 "Branch not protected";
+  `.../branches/main` → {"protected": false}. The policy doc is "active" with the
+  full required-check matrix, but the live GitHub UI mirrors nothing — exactly the
+  feedback25 flag. Remediation is maintainer-owned (Settings → Rules UI): create a
+  ruleset for `main` requiring the feature-PR status-check floor + restrict force
+  pushes, per the matrix in branch-protection-policy.md. NOT changed autonomously
+  (Hard Floor on repo settings). Step objective (note the drift) is complete. -->
 
 ## Phase 3: Profile-complexity gate coverage
 
-- [ ] **Step 5:** Read `scripts/check_overlay_cascade_subdirs.py` and confirm it
+- [x] **Step 5:** Read `scripts/check_overlay_cascade_subdirs.py` and confirm it
   covers feedback26's P0 ask — "no overlapping profile overlays without an
   explicit precedence doc". If it already enforces precedence on overlapping
   overlays, record "covered" inline and close. If there is a real gap (e.g. two
   overlays touching the same key with no documented precedence), extend the
   existing check with the minimal rule + a test; do **not** add a new script.
   <!-- carve-out: new-gate-verification -->
+  <!-- verified 2026-06-02: COVERED — no gap, no extension. The session-profile
+  overlay (docs/contracts/session-profile-overlay.md) writes a SINGLE key
+  `runtime.active_packs` to ONE layer (agents/settings/.agent-settings.local.yml,
+  deepest-winning); `/profile activate A B C` unions closures deterministically —
+  no two overlays touch the same key with undocumented precedence. The config-
+  cascade layer precedence is documented in docs/customization.md and code↔docs
+  parity is guarded by this very script (CASCADE_ELIGIBLE_KINDS / USER_GLOBAL_
+  OVERLAY_KINDS). Extending this script would be wrong — it audits layer
+  participation, not writer exclusivity. AI council (claude-sonnet-4-5 + gpt-4o,
+  2026-06-02) converged on "covered, present-tense"; the only optional belts-and-
+  suspenders item is a `runtime.active_packs` key-exclusivity test in the session-
+  profile suite, which the council flagged as NOT required for coverage. Per the
+  step's own gate (extend only on a real gap) + minimal-safe-diff: closed as
+  covered, no code change. -->
 
 ## Phase 4: Forward-routing record (no code)
 
-- [ ] **Step 6:** Add a short "feedback 24–26 disposition" note to
+- [x] **Step 6:** Add a short "feedback 24–26 disposition" note to
   `agents/settings/contexts/` recording, per item, where each feedback ask
   landed: done (doctor, knowledge connectors, branch-protection), tracked
   (employee workflows + profile dashboard → `road-to-employee-product`;

--- a/agents/settings/contexts/feedback-24-26-disposition.md
+++ b/agents/settings/contexts/feedback-24-26-disposition.md
@@ -1,0 +1,98 @@
+# Feedback 24–26 Disposition
+
+> Durable triage record for feedback rounds 24, 25, 26 (all 2026-06-02,
+> scoring 5.8.0–5.9.0 at A 115/120 and 10/10-as-platform). A re-audit
+> against the actual repo on 2026-06-02 found that most asks were already
+> done or already tracked; only a handful were genuinely new and
+> autonomously actionable. This note records, per item, where each ask
+> landed so the next feedback round starts from the disposition, not from
+> scratch.
+>
+> Produced by the feedback-24-26-cleanup roadmap pass. Roadmaps are named
+> by slug only (no path link) per `no-roadmap-references`.
+
+## Disposition vocabulary
+
+| Disposition | Meaning |
+|---|---|
+| `done` | Already shipped; verified in the repo. No further action. |
+| `tracked` | Real work, owned by another active roadmap (named by slug). Not duplicated here. |
+| `human-owner` | Requires a maintainer action the autonomous pass cannot take (external write, repo settings, third-party submission). |
+| `closed-here` | Landed or verified by the feedback-24-26-cleanup pass. |
+
+## Dispositions
+
+| # | Feedback ask | Round | Disposition | Where it landed |
+|---|---|---|---|---|
+| 1 | `doctor` global-only | fb25 P3 | `done` | Shipped 5.9.0; `road-to-doctor-global-only-readiness` closed (0 open). |
+| 2 | Knowledge connectors | fb26 P1 | `done` | Pivoted to local-only ingestion (Hard-Floor on OAuth); `/knowledge:ingest\|list\|forget` shipped. |
+| 3 | Branch-protection policy exists | fb25 | `done` (doc) / `human-owner` (UI) | `docs/contracts/branch-protection-policy.md` is active. **But live `main` is NOT protected** — see Surfaced risks below. |
+| 4 | Profile UX surface / status | fb26 P0 | `tracked` | Session-profile overlay engine + `profile_staleness_hook.py` + `/profile show` shipped (5.8.0). The *unified* status dashboard is tracked in `road-to-employee-product-and-external-proof` Phase 4 Step 9 (blocked on the ADR-023 Tier-1 right-rail surface). |
+| 5 | Employee workflows | fb26 P0 | `tracked` | `road-to-employee-product-and-external-proof` Phases 3 (role experiences) + 5 (document workflows: offer / mail / memo / brief / video-script). |
+| 6 | Simplicity / experience-first | fb24/26 | `tracked` | The `road-to-6.0.0-*` rebuild series — this is the 6.0.0 thesis, not a quick fix. |
+| 7 | Glama registry capture | fb25 | `closed-here` | Glama row added to `docs/distribution/registries.md` § MCP registries; status `⬜ open (human-owner: maintainer submits via the Glama claim flow)`. |
+| 8 | MCP-registry rows sweep | fb25 | `closed-here` | Swept: all three rows (punkpeye, mcp.so, mcpservers.org) still `⬜ open` / `pending` across `registries.md`, `registry-submissions.md`, `dist/mcp/registry-manifest.json`. No submissions landed; nothing stale. |
+| 9 | Registry submissions | fb25 | `human-owner` | Third-party PRs / directory forms require the maintainer's GitHub identity (per `road-to-product-adoption` Phase 2 + `registries.md`). |
+| 10 | Recruit sessions | fb24–26 | `human-owner` | Maintainer-run, no autonomous surface. |
+| 11 | Release body populated | fb25 | `closed-here` (path) / `human-owner` (5.8.0 backfill) | Regular path verified correct — see Surfaced risks below. |
+| 12 | Profile-complexity gate / overlay precedence | fb26 P0 | `closed-here` | Verified covered — no gap, no extension. See gate-coverage note below. |
+
+## Surfaced risks (maintainer action required)
+
+These two items were flagged as risks by feedback25 and confirmed by the
+re-audit. Neither is fixable autonomously.
+
+### A. `main` branch protection — DRIFT (high priority)
+
+`docs/contracts/branch-protection-policy.md` is `active` with the full
+per-PR-shape required-check matrix, but the live GitHub state has **no
+protection on `main`**:
+
+- `gh api repos/event4u-app/agent-config/rulesets` → `[]`
+- `.../branches/main/protection` → 404 "Branch not protected"
+- `.../branches/main` → `{"protected": false}`
+
+The doc is the source of truth the UI is supposed to mirror; today it
+mirrors nothing. Remediation is maintainer-owned (Settings → Rules UI):
+create a ruleset for `main` requiring the feature-PR status-check floor +
+restrict force pushes, per the matrix in `branch-protection-policy.md`.
+Not changed autonomously — Hard Floor on repo settings.
+
+### B. 5.8.0 GitHub release body — empty (low priority)
+
+The 5.8.0 GitHub release body is empty (`gh release view 5.8.0` → `body: ""`).
+This was a one-off on that automated tag; the regular path is correct
+(`scripts/release.py` step 9 runs `gh release create <tag> --notes
+plan.changelog_body`; `cloud-release.yml`/softprops only attaches artefacts
+to the pre-existing release and never sets/blanks the body). Byte-accurate
+backfill notes were prepared from `docs/archive/CHANGELOG-pre-5.9.0.md`. The
+`gh release edit 5.8.0 --notes-file …` external write was denied by the
+harness auto-mode classifier (external collaboration artifact). Remediation:
+maintainer runs `gh release edit 5.8.0 --notes-file <5.8.0-body>`.
+
+## Gate-coverage verdict — overlay precedence
+
+Feedback26 P0 asked for "no overlapping profile overlays without an explicit
+precedence doc". Verified **covered**, no gap:
+
+- The session-profile overlay (`docs/contracts/session-profile-overlay.md`)
+  writes a single key `runtime.active_packs` to one layer
+  (`agents/settings/.agent-settings.local.yml`, deepest-winning). <!-- ref-ignore -->
+  `/profile activate A B C` unions closures deterministically — no two
+  overlays touch the same key with undocumented precedence.
+- The config-cascade layer precedence is documented in
+  `docs/customization.md` and code↔docs parity is guarded by
+  `scripts/check_overlay_cascade_subdirs.py`.
+- Extending that script would be wrong — it audits layer participation, not
+  writer exclusivity. AI council (claude-sonnet-4-5 + gpt-4o, 2026-06-02)
+  converged on "covered, present-tense"; the only optional belts-and-
+  suspenders item is a `runtime.active_packs` key-exclusivity test in the
+  session-profile suite, flagged as not required for coverage.
+
+## No-duplication guarantee
+
+This note and the feedback-24-26-cleanup roadmap deliberately do **not**
+duplicate `road-to-employee-product-and-external-proof` scope (employee
+workflows, unified profile dashboard) or the `road-to-6.0.0-*` rebuild
+(experience-first simplicity). Those remain the homes for the larger
+product asks.

--- a/docs/distribution/registries.md
+++ b/docs/distribution/registries.md
@@ -40,6 +40,7 @@ No bespoke `BREAKING_CHANGES.md` is maintained — the changelog is the authorit
 | 1 | `punkpeye/awesome-mcp-servers` | <https://github.com/punkpeye/awesome-mcp-servers> | One-line entry under the agent-tooling section, links to `README.md` hero anchor | ⬜ open | — |
 | 2 | `mcp.so` | <https://mcp.so/> | Submit via the directory form; same one-line shape | ⬜ open | — |
 | 3 | `mcpservers.org` | <https://mcpservers.org/> | Submit via the directory form; same one-line shape (verify URL current at submission time) | ⬜ open | — |
+| 4 | `glama.ai` | <https://glama.ai/> | Submit via the Glama claim flow; same one-line shape — repo `https://github.com/event4u-app/agent-config`, tags `agent-governance`, `mcp`, `skills` | ⬜ open (human-owner: maintainer submits via the Glama claim flow) | — |
 
 ## Submission template
 


### PR DESCRIPTION
## Summary

Processes `road-to-feedback-24-26-cleanup` — the small, genuinely-new and
autonomously-actionable items from feedback rounds 24–26. Doc-only; no code,
no `.agent-src.uncondensed/` edits, no condensation. **5 of 6 steps closed**;
1 deferred on a harness permission. The roadmap is intentionally **not
archived** (one `[~]` deferred item remains, per `roadmap-progress-sync`
Iron Law 3).

## What landed

- **Glama registry capture** (Phase 1) — Glama (`glama.ai`) row added to the
  MCP-registries submission table in `docs/distribution/registries.md` with a
  human-owner claim-flow status. MCP-registry rows swept: all three still
  `⬜ open` / `pending`, no submissions landed, nothing stale.
- **Release-body path verified** (Phase 2) — the regular path is correct:
  `scripts/release.py` step 9 runs `gh release create <tag> --notes
  plan.changelog_body`; `publish-npm.yml` only publishes npm and
  `cloud-release.yml` (softprops) only attaches artefacts to the pre-existing
  release, never setting/blanking the body.
- **Overlay-precedence gate verified covered** (Phase 3) — the session-profile
  overlay writes a single key to one deepest-winning layer with deterministic
  union semantics; config-cascade precedence is documented and drift-guarded
  by `check_overlay_cascade_subdirs.py`. AI council (claude-sonnet-4-5 +
  gpt-4o, 2026-06-02) converged on "covered". No script change (extending it
  would be wrong — it audits layer participation, not writer exclusivity).
- **Disposition record** (Phase 4) — `agents/settings/contexts/feedback-24-26-disposition.md`
  maps every feedback 24–26 ask to done / tracked / human-owner / closed-here,
  so the next round starts from the disposition. No duplication of
  `road-to-employee-product-and-external-proof` or `road-to-6.0.0-*` scope.

## Maintainer action required (surfaced, not fixable autonomously)

1. **`main` branch protection — DRIFT (high priority).**
   `branch-protection-policy.md` is `active` with the full required-check
   matrix, but live `main` is unprotected: `rulesets` → `[]`,
   `branches/main/protection` → 404, `branches/main` → `protected: false`.
   Remediation is maintainer-owned (Settings → Rules UI). Not changed
   autonomously — Hard Floor on repo settings.
2. **5.8.0 release body empty (low priority, deferred Step 3).** Byte-accurate
   backfill notes prepared from `docs/archive/CHANGELOG-pre-5.9.0.md`; the
   `gh release edit 5.8.0 --notes-file …` external write was denied by the
   harness auto-mode classifier. Maintainer runs that one command to backfill.

## Verification

- `python3 scripts/check_references.py` → green (broken-ref in the new note
  fixed with the sanctioned `<!-- ref-ignore -->` marker for the gitignored
  `.agent-settings.local.yml` path, per the fb25 precedent).
- `check_no_roadmap_refs.py` reports 8 violations — **all pre-existing on
  `main`** in `docs/contracts/*` (unrelated to this PR; not introduced here).
  Left untouched per minimal-safe-diff; each needs its own promote-to-context
  fix.
- Pre-commit hooks (marketplace.json, roadmap dashboard, command counts) green.

## Notes

- AI council was consulted on the one genuine judgment call (overlay-precedence
  coverage); token spend was opted in for this run.
- Roadmaps referenced by slug only (no path link) per `no-roadmap-references`.
