### PR TITLE
chore(gitignore): ignore /agents/state/ in the synced template

### DIFF
--- a/config/gitignore-block.txt
+++ b/config/gitignore-block.txt
@@ -75,6 +75,13 @@
 # decision records in agents/decisions/.
 /agents/runtime/
 
+# Agent config — Tier 1 hook + wizard runtime state (machine-generated,
+# regenerated on demand, never committed). Holds the dispatcher lock,
+# per-rule hook state (context-hygiene, verify-before-complete,
+# minimal-safe-diff, onboarding-gate), and the GUI wizard resume snapshot.
+# Local-only per the Volatile Runtime policy.
+/agents/state/
+
 # Agent config — unified-setup wizard partial state (Roadmap R2 Phase 1).
 # Written by POST /api/v1/wizard/state between step transitions, deleted
 # on POST /api/v1/wizard/finish. Local-only crash-recovery aid.


### PR DESCRIPTION
## What

Add `/agents/state/` to `config/gitignore-block.txt` — the canonical block `scripts/sync_gitignore.py` syncs into consumer projects.

## Why

Tier 1 hooks write runtime state under `agents/state/` (dispatcher lock, `context-hygiene.json`, `verify-before-complete.json`, `minimal-safe-diff.json`, `onboarding-gate.json`), and the GUI wizard writes `wizard-state.json` there. The synced block already covered `/agents/runtime/` but not `/agents/state/`, so consumer installs left that directory tracked.

This repo's own `.gitignore` already ignored `agents/state/`; only the consumer-facing template lagged.

## Verification

- `python3 -m pytest tests/test_sync_gitignore.py` — 28 passed.