### PR TITLE
fix(council): resolve REPO_ROOT from the project, not the package dir

### DIFF
--- a/scripts/council_cli.py
+++ b/scripts/council_cli.py
@@ -19,14 +19,27 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 try:  # invocation-agnostic import (repo-root-on-path vs scripts-on-path)
-    from scripts._lib.agent_settings import project_settings_path
+    from scripts._lib.agent_settings import (
+        project_settings_path, resolve_project_root,
+    )
 except ModuleNotFoundError:  # pragma: no cover
-    from _lib.agent_settings import project_settings_path
+    from _lib.agent_settings import (
+        project_settings_path, resolve_project_root,
+    )
 from typing import Any
 
 import yaml
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+# `PACKAGE_ROOT` is where `scripts.ai_council.*` lives — fixed relative to
+# this file, used only for the import path below. `REPO_ROOT` is the project
+# the council operates on: when invoked via the global `agent-config`
+# wrapper from a consumer project it is that project (anchor-walked from
+# CWD, or pinned via AGENT_CONFIG_PROJECT_ROOT / --root), NOT the package
+# install dir. Hardcoding the package dir here was the bug — settings and
+# `.ai-council.yml` were then read from the package (which has neither), so
+# `council:*` always refused with `ai_council.enabled is false`.
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT, _ = resolve_project_root(None)
 SETTINGS_FILE = project_settings_path(REPO_ROOT)
 AI_COUNCIL_FILE = REPO_ROOT / "agents" / "settings" / ".ai-council.yml"
 
@@ -64,7 +77,7 @@ def _validate_council_output_path(
         ) from exc
     return p
 
-sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(PACKAGE_ROOT))
 
 from scripts.ai_council.bundler import (  # noqa: E402
     BundleTooLarge, bundle_prompt, bundle_roadmap,

--- a/tests/ai_council/test_cli.py
+++ b/tests/ai_council/test_cli.py
@@ -1391,3 +1391,36 @@ def test_decision_replay_settings_lens_override_redacts() -> None:
     }
     _, include_args = council_cli._decision_replay_settings(ai_cfg, "analysis")
     assert include_args is False
+
+
+def test_repo_root_follows_consumer_cwd_not_package(tmp_path: Path) -> None:
+    """Regression: council_cli must read settings from the project it is
+
+    invoked in, not from the package dir where the script lives. Pinning
+    REPO_ROOT to ``Path(__file__).parents[1]`` made ``council:*`` always
+    refuse with ``ai_council.enabled is false`` when run via the global
+    ``agent-config`` wrapper from a consumer project.
+    """
+    import os
+    import subprocess
+
+    package_root = Path(council_cli.__file__).resolve().parents[1]
+    consumer = tmp_path / "consumer"
+    (consumer / "agents" / "settings").mkdir(parents=True)
+    (consumer / "agents" / "settings" / ".agent-settings.yml").write_text(
+        "ai_council:\n  enabled: true\n", encoding="utf-8",
+    )
+    probe = (
+        "import council_cli as m;"
+        "print(m.REPO_ROOT);print(m.PACKAGE_ROOT)"
+    )
+    env = {**os.environ, "PYTHONPATH": str(package_root / "scripts")}
+    proc = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=consumer, env=env, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout.splitlines()
+    repo_root, pkg_root = Path(out[0]).resolve(), Path(out[1]).resolve()
+    assert repo_root == consumer.resolve()       # follows the consumer CWD
+    assert pkg_root == package_root.resolve()     # import base stays fixed


### PR DESCRIPTION
## Problem

`scripts/council_cli.py` hardcoded `REPO_ROOT = Path(__file__).resolve().parents[1]` — the **package install dir**. The global `agent-config council:*` wrapper (`scripts/_dispatch.bash:782`) execs this script from the package, so `SETTINGS_FILE` and `agents/settings/.ai-council.yml` were always looked up *inside the package*, which carries no council config.

Result: every `council:*` invocation from a consumer project refused with `ai_council.enabled is false`, regardless of the consumer's actual settings. A real CLI bug, not a misconfiguration.

## Fix

Split the two roles `REPO_ROOT` was conflating:

- **`PACKAGE_ROOT`** (`Path(__file__).parents[1]`) — used only for the `scripts.ai_council.*` import path (`sys.path.insert`).
- **`REPO_ROOT`** — now from the repo's canonical `resolve_project_root()` helper, which anchor-walks from CWD or honors `AGENT_CONFIG_PROJECT_ROOT` / `--root`. Settings + `.ai-council.yml` are now read from the project the council actually runs in, matching every other `cmd_*` in `_dispatch.bash`.

No dispatch change needed — `exec` preserves CWD, so the resolver lands on the consumer project.

## Verification

- `py_compile` clean.
- Functional proof: from a temp consumer dir, `REPO_ROOT` → consumer project, `PACKAGE_ROOT` → package, settings read from consumer.
- New regression test `test_repo_root_follows_consumer_cwd_not_package`.
- `tests/ai_council/` full suite: **747 passed**; council CLI / doctor / quota suites: **101 passed**.
- No external code consumes `council_cli.REPO_ROOT`.