### PR TITLE
ci: harden Task setup against transient CDN 504s

### DIFF
--- a/.github/actions/setup-task/action.yml
+++ b/.github/actions/setup-task/action.yml
@@ -1,0 +1,47 @@
+name: "Setup Task (resilient)"
+description: >-
+  Install go-task/task via arduino/setup-task, with a retrying
+  install-script fallback that survives transient CDN 504s on the
+  release download (the documented flake this action exists to absorb).
+
+inputs:
+  repo-token:
+    description: "GITHUB_TOKEN, forwarded to arduino/setup-task to avoid API rate limits."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # Happy path: the trusted action. continue-on-error so a transient
+    # download failure (HTTP 504 from the release CDN) does not fail the
+    # job outright — the fallback below takes over.
+    - id: action
+      uses: arduino/setup-task@v2
+      continue-on-error: true
+      with:
+        repo-token: ${{ inputs.repo-token }}
+
+    # Fallback: only runs when the action step failed. Retries the
+    # official install script (which itself uses --retry on the binary
+    # fetch) up to 3 times with backoff.
+    - name: Set up Task (fallback — retry transient download failures)
+      if: steps.action.outcome == 'failure'
+      shell: bash
+      run: |
+        set -euo pipefail
+        bindir="$HOME/.local/bin"
+        mkdir -p "$bindir"
+        for attempt in 1 2 3; do
+          if sh -c "$(curl --fail --silent --show-error --location \
+              --retry 5 --retry-all-errors https://taskfile.dev/install.sh)" \
+              -- -b "$bindir"; then
+            echo "$bindir" >> "$GITHUB_PATH"
+            "$bindir/task" --version
+            exit 0
+          fi
+          echo "task fallback install attempt ${attempt}/3 failed; retrying" >&2
+          sleep $(( attempt * 5 ))
+        done
+        echo "task install failed after arduino/setup-task + 3 fallback attempts" >&2
+        exit 1

--- a/.github/workflows/bench-drift.yml
+++ b/.github/workflows/bench-drift.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.12"
           cache: 'pip'
 
-      - uses: arduino/setup-task@v2
+      - uses: ./.github/actions/setup-task
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -62,7 +62,7 @@ jobs:
           cache: 'pip'
 
       - name: Set up Task
-        uses: arduino/setup-task@v2
+        uses: ./.github/actions/setup-task
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -69,7 +69,7 @@ jobs:
           cache: 'pip'
 
       - name: Set up Task
-        uses: arduino/setup-task@v2
+        uses: ./.github/actions/setup-task
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,7 +92,7 @@ jobs:
           cache: 'pip'
 
       - name: Set up Task
-        uses: arduino/setup-task@v2
+        uses: ./.github/actions/setup-task
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -192,7 +192,7 @@ jobs:
           cache: 'pip'
 
       - name: Set up Task
-        uses: arduino/setup-task@v2
+        uses: ./.github/actions/setup-task
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

`arduino/setup-task@v2` flaked **three times this week** with the same transient error during *Set up Task*:

```
Failed to download version v3.51.1: Error: Unexpected HTTP response: 504
```

It's a gateway timeout on the release CDN, not a code fault — it hit `skill-lint-per-pack` on three separate pushes (PR #390 once, PR #391 twice) and needed a manual rerun each time.

## Fix

A local composite action `.github/actions/setup-task` with a try-then-fallback shape:

- **Happy path unchanged** — still `arduino/setup-task@v2`, now `continue-on-error: true`.
- **Fallback fires only on its failure** — retries the official install script (`curl --retry 5 --retry-all-errors` + 3 attempts with backoff), appends the bindir to `GITHUB_PATH`, verifies `task --version`.

All five call sites — `bench-drift.yml`, `consistency.yml`, `skill-lint.yml` (×3) — now use `./.github/actions/setup-task`. `arduino/setup-task` lives only inside the composite.

## Why this shape

Near-zero blast radius: when the trusted action works (the normal case), nothing changes — the fallback only runs when the action already failed. No new third-party dependency; the fallback uses the official `taskfile.dev` install script with curl-level retry.

## Verification
- All workflow + action YAML parse (`yaml.safe_load`).
- Each `setup-task` step is preceded by `actions/checkout` in its job (required for a local composite action).
- No stale `arduino/setup-task` references remain in any workflow.