### PR TITLE
feat(workspace): re-cipher encrypt-at-rest to AES-256-GCM (ADR-062 Part A)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,8 +154,10 @@ jobs:
         # cores (`-n auto`); pyyaml is a runtime dep of the memory
         # tooling (check_memory / check_proposal / memory_lookup) that
         # the tests invoke via subprocess; jsonschema validates the
-        # ExplainTrace v1 payload via scripts/lint_explain_trace.py.
-        run: pip install pytest pytest-xdist pyyaml jsonschema
+        # ExplainTrace v1 payload via scripts/lint_explain_trace.py;
+        # cryptography lets the workspace_crypto AES-256-GCM round-trip
+        # tests actually run instead of skipping (ADR-062 must-have #1).
+        run: pip install pytest pytest-xdist pyyaml jsonschema cryptography
 
       - name: Bootstrap generated projection (.augment/, .cursor/, …)
         # The Phase-2.4 install_global tests deploy content from

--- a/src/cli/python/workspace_crypto.py
+++ b/src/cli/python/workspace_crypto.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python3
 """Workspace encryption-at-rest — Phase 8 of ``road-to-employee-product``.
 
-Implements ``docs/contracts/at-rest-encryption.md``. Local-only AES-256-GCM
-via Fernet (cryptography lib), master key wrapped in the OS keyring.
+Implements ``docs/contracts/at-rest-encryption.md``. Local-only
+**AES-256-GCM** with the contract's ``AC1\\0`` envelope; master key wrapped
+in the OS keyring. Cipher choice + architecture locked in
+``docs/decisions/ADR-062-encrypt-at-rest-store-architecture.md`` (Part A:
+the prior Fernet implementation drifted from the spec — this aligns the code
+to the contract so the same envelope is byte-reproducible in Node's
+``node:crypto`` for the later Python-authoritative store wiring).
 
 The feature is **opt-in** via ``.agent-settings.yml → workspace.encrypt_at_rest``.
-When disabled, every public function short-circuits and writes plaintext.
+When disabled, callers write plaintext; ``decrypt_bytes`` passes plaintext
+through unchanged (no magic prefix), so reads stay back-compatible.
 
 Encryption and keyring libraries are imported lazily — when the feature flag
 is off (the default), this module loads without any optional deps.
+
+Envelope (per the contract):
+
+    | 4 bytes  | magic    "AC1\\0"  (0x41 0x43 0x31 0x00)
+    | 1 byte   | version  0x01
+    | 12 bytes | GCM nonce
+    | 16 bytes | GCM auth tag
+    | N bytes  | ciphertext
 
 CLI::
 
@@ -22,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import binascii
 import json
 import os
 import secrets
@@ -34,7 +49,13 @@ KEYRING_USER = "master-key"
 ENV_OVERRIDE_KEY = "AGENT_CONFIG_WORKSPACE_KEY"
 ENV_FORCE_DISABLE = "AGENT_CONFIG_NO_ENCRYPTION"
 
-MAGIC = b"E4U-WSv1\n"
+# Envelope constants (docs/contracts/at-rest-encryption.md).
+MAGIC = b"AC1\x00"
+VERSION = 1
+_NONCE_LEN = 12
+_TAG_LEN = 16
+_KEY_LEN = 32
+_HEADER_LEN = len(MAGIC) + 1  # magic + version byte
 
 
 def is_enabled(settings_path: Path | None = None) -> bool:
@@ -62,23 +83,46 @@ def is_enabled(settings_path: Path | None = None) -> bool:
     return False
 
 
-def _load_fernet():
+def _load_aesgcm():
     try:
-        from cryptography.fernet import Fernet  # type: ignore[import-not-found]
+        from cryptography.hazmat.primitives.ciphers.aead import (  # type: ignore[import-not-found]
+            AESGCM,
+        )
     except ImportError as err:
         raise RuntimeError(
             "workspace_crypto: install the 'cryptography' package to use encryption"
         ) from err
-    return Fernet
+    return AESGCM
+
+
+def _coerce_key(material: bytes) -> bytes:
+    """Accept a raw 32-byte key or its base64 encoding; return raw 32 bytes."""
+    if len(material) == _KEY_LEN:
+        return material
+    try:
+        decoded = base64.b64decode(material, validate=True)
+    except (ValueError, binascii.Error) as err:
+        raise ValueError(
+            "workspace_crypto: master key is not 32 bytes or valid base64"
+        ) from err
+    if len(decoded) != _KEY_LEN:
+        raise ValueError(
+            f"workspace_crypto: master key must be {_KEY_LEN} bytes, got {len(decoded)}"
+        )
+    return decoded
+
+
+def _generate_key_b64() -> str:
+    return base64.b64encode(secrets.token_bytes(_KEY_LEN)).decode("ascii")
 
 
 def _get_or_create_master_key(*, override: str | None = None) -> bytes:
-    """Resolve the master key. Order: env override → OS keyring → generate."""
+    """Resolve the 32-byte master key. Order: override → env → keyring → file."""
     if override is not None:
-        return override.encode("ascii")
+        return _coerce_key(override.encode("ascii"))
     env_key = os.environ.get(ENV_OVERRIDE_KEY)
     if env_key:
-        return env_key.encode("ascii")
+        return _coerce_key(env_key.encode("ascii"))
     try:
         import keyring  # type: ignore[import-not-found]
     except ImportError:
@@ -86,41 +130,49 @@ def _get_or_create_master_key(*, override: str | None = None) -> bytes:
     if keyring is not None:
         existing = keyring.get_password(KEYRING_SERVICE, KEYRING_USER)
         if existing:
-            return existing.encode("ascii")
-        Fernet = _load_fernet()
-        key = Fernet.generate_key()
-        keyring.set_password(KEYRING_SERVICE, KEYRING_USER, key.decode("ascii"))
-        return key
+            return _coerce_key(existing.encode("ascii"))
+        key_b64 = _generate_key_b64()
+        keyring.set_password(KEYRING_SERVICE, KEYRING_USER, key_b64)
+        return _coerce_key(key_b64.encode("ascii"))
     # No keyring backend: fall back to a file under the workspace home,
     # mode 0o600. Documented in the contract as the recovery path.
     WORKSPACE_HOME.mkdir(parents=True, exist_ok=True)
     keyfile = WORKSPACE_HOME / ".master-key"
     if keyfile.exists():
-        return keyfile.read_bytes().strip()
-    Fernet = _load_fernet()
-    key = Fernet.generate_key()
-    keyfile.write_bytes(key)
+        return _coerce_key(keyfile.read_bytes().strip())
+    key_b64 = _generate_key_b64()
+    keyfile.write_bytes(key_b64.encode("ascii"))
     try:
         os.chmod(keyfile, 0o600)
     except OSError:
         pass
-    return key
+    return _coerce_key(key_b64.encode("ascii"))
 
 
 def encrypt_bytes(payload: bytes, *, key: bytes | None = None) -> bytes:
-    Fernet = _load_fernet()
-    k = key or _get_or_create_master_key()
-    token = Fernet(k).encrypt(payload)
-    return MAGIC + token
+    """AES-256-GCM encrypt. ``key`` is 32 raw bytes (or base64); None → master."""
+    AESGCM = _load_aesgcm()
+    k = _coerce_key(key) if key is not None else _get_or_create_master_key()
+    nonce = secrets.token_bytes(_NONCE_LEN)
+    ct_with_tag = AESGCM(k).encrypt(nonce, payload, None)
+    ciphertext, tag = ct_with_tag[:-_TAG_LEN], ct_with_tag[-_TAG_LEN:]
+    return MAGIC + bytes([VERSION]) + nonce + tag + ciphertext
 
 
 def decrypt_bytes(payload: bytes, *, key: bytes | None = None) -> bytes:
     if not payload.startswith(MAGIC):
         # Plaintext payload — feature flag was off at write time.
         return payload
-    Fernet = _load_fernet()
-    k = key or _get_or_create_master_key()
-    return Fernet(k).decrypt(payload[len(MAGIC):])
+    version = payload[len(MAGIC)]
+    if version != VERSION:
+        raise ValueError(f"workspace_crypto: unsupported envelope version {version}")
+    body = payload[_HEADER_LEN:]
+    nonce = body[:_NONCE_LEN]
+    tag = body[_NONCE_LEN:_NONCE_LEN + _TAG_LEN]
+    ciphertext = body[_NONCE_LEN + _TAG_LEN:]
+    AESGCM = _load_aesgcm()
+    k = _coerce_key(key) if key is not None else _get_or_create_master_key()
+    return AESGCM(k).decrypt(nonce, ciphertext + tag, None)
 
 
 def encrypt_file(src: Path, dst: Path, *, key: bytes | None = None) -> None:
@@ -134,21 +186,20 @@ def decrypt_file(src: Path, dst: Path, *, key: bytes | None = None) -> None:
 
 
 def rotate_key() -> bytes:
-    """Generate a new master key and replace the keyring entry. Returns the new key."""
-    Fernet = _load_fernet()
-    new_key = Fernet.generate_key()
+    """Generate a new master key, replace the keyring/keyfile entry. Returns raw key."""
+    key_b64 = _generate_key_b64()
     try:
         import keyring  # type: ignore[import-not-found]
-        keyring.set_password(KEYRING_SERVICE, KEYRING_USER, new_key.decode("ascii"))
+        keyring.set_password(KEYRING_SERVICE, KEYRING_USER, key_b64)
     except ImportError:
         keyfile = WORKSPACE_HOME / ".master-key"
         WORKSPACE_HOME.mkdir(parents=True, exist_ok=True)
-        keyfile.write_bytes(new_key)
+        keyfile.write_bytes(key_b64.encode("ascii"))
         try:
             os.chmod(keyfile, 0o600)
         except OSError:
             pass
-    return new_key
+    return _coerce_key(key_b64.encode("ascii"))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_workspace_crypto.py
+++ b/tests/test_workspace_crypto.py
@@ -78,29 +78,64 @@ def test_decrypt_passes_through_plaintext(mod):
     assert mod.decrypt_bytes(payload, key=b"unused") == payload
 
 
+def _key(mod):
+    """A raw 32-byte AES-256-GCM key (no keyring lookup)."""
+    import os
+    return os.urandom(mod._KEY_LEN)
+
+
 @pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
 def test_round_trip_bytes(mod):
-    from cryptography.fernet import Fernet
-    key = Fernet.generate_key()
+    key = _key(mod)
     blob = mod.encrypt_bytes(b"hello world", key=key)
     assert blob.startswith(mod.MAGIC)
+    assert blob[len(mod.MAGIC)] == mod.VERSION
     assert mod.decrypt_bytes(blob, key=key) == b"hello world"
 
 
 @pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_envelope_shape(mod):
+    """Magic + version + 12-byte nonce + 16-byte tag precede ciphertext."""
+    blob = mod.encrypt_bytes(b"x", key=_key(mod))
+    assert blob[:4] == b"AC1\x00"
+    assert len(blob) >= 5 + 12 + 16 + 1  # header + nonce + tag + >=1 ct byte
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_wrong_key_raises(mod):
+    blob = mod.encrypt_bytes(b"secret", key=_key(mod))
+    with pytest.raises(Exception):  # cryptography InvalidTag
+        mod.decrypt_bytes(blob, key=_key(mod))
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_unknown_version_rejected(mod):
+    key = _key(mod)
+    blob = bytearray(mod.encrypt_bytes(b"secret", key=key))
+    blob[len(mod.MAGIC)] = 0xFF  # corrupt the version byte
+    with pytest.raises(ValueError, match="version"):
+        mod.decrypt_bytes(bytes(blob), key=key)
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
 def test_round_trip_file(mod, tmp_path):
-    from cryptography.fernet import Fernet
-    key = Fernet.generate_key()
+    key = _key(mod)
     src = tmp_path / "in.txt"
     src.write_bytes(b"top secret")
     enc = tmp_path / "out.enc"
     dec = tmp_path / "out.txt"
-
-    # Encrypt without keyring/cryptography lookup: pass key explicitly via
-    # encrypt_bytes, write file ourselves to bypass keyring requirement.
     enc.write_bytes(mod.encrypt_bytes(src.read_bytes(), key=key))
     dec.write_bytes(mod.decrypt_bytes(enc.read_bytes(), key=key))
     assert dec.read_bytes() == b"top secret"
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_key_accepts_base64_and_raw(mod):
+    """A base64-encoded 32-byte key decrypts a blob made with the raw key."""
+    import base64
+    raw = _key(mod)
+    blob = mod.encrypt_bytes(b"data", key=raw)
+    assert mod.decrypt_bytes(blob, key=base64.b64encode(raw)) == b"data"
 
 
 def test_missing_cryptography_raises_clean_error(mod, monkeypatch):
@@ -108,15 +143,24 @@ def test_missing_cryptography_raises_clean_error(mod, monkeypatch):
     real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "cryptography.fernet":
+        if name.startswith("cryptography"):
             raise ImportError("simulated missing")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr("builtins.__import__", fake_import)
     with pytest.raises(RuntimeError, match="cryptography"):
-        mod._load_fernet()
+        mod._load_aesgcm()
 
 
 def test_env_override_key_used(mod, monkeypatch):
-    monkeypatch.setenv("AGENT_CONFIG_WORKSPACE_KEY", "ZmFrZS1rZXk=")
-    assert mod._get_or_create_master_key() == b"ZmFrZS1rZXk="
+    import base64
+    import os
+    raw = os.urandom(mod._KEY_LEN)
+    monkeypatch.setenv("AGENT_CONFIG_WORKSPACE_KEY", base64.b64encode(raw).decode("ascii"))
+    assert mod._get_or_create_master_key() == raw
+
+
+def test_env_override_rejects_bad_length(mod, monkeypatch):
+    monkeypatch.setenv("AGENT_CONFIG_WORKSPACE_KEY", "ZmFrZS1rZXk=")  # 8 bytes
+    with pytest.raises(ValueError, match="32 bytes"):
+        mod._get_or_create_master_key()


### PR DESCRIPTION
## What

**Part A of ADR-062** — the contained, verifiable half of the encrypt-at-rest work. No GUI changes; the Python-authoritative store wiring is the separate Part B.

The shipped `workspace_crypto.py` used **Fernet** (AES-128-CBC+HMAC), drifting from `docs/contracts/at-rest-encryption.md`, which specifies **AES-256-GCM** with the `AC1\0` envelope. ADR-062 decided to align the code to the contract so the same envelope is byte-reproducible in Node's `node:crypto` for Part B.

**Safe to re-cipher now:** the flag is **default-OFF** and no field data is encrypted yet — nothing to migrate.

## Changes

- **AES-256-GCM** via `cryptography`'s `AESGCM`. Envelope: magic `AC1\0` + version byte + 12-byte nonce + 16-byte tag + ciphertext. Unknown versions → clear `ValueError`.
- Master key is now **32 raw bytes** (base64 in keyring/keyfile/env); `_coerce_key` accepts raw-32 or base64. Public API unchanged (`encrypt_bytes`/`decrypt_bytes`/`encrypt_file`/`decrypt_file`; plaintext pass-through on read for back-compat).
- **ADR-062 must-have #1**: `cryptography` added to the CI test job so the round-trip tests **run instead of skip** — they were never exercised in CI before (a latent `verify-before-complete` gap on a security primitive). New cases: envelope-shape, wrong-key (InvalidTag), unknown-version, base64-key acceptance, bad-key-length.

## Verification

Installed `cryptography` into the local `.venv` (gitignored, not committed) to actually exercise the cipher:

```
tests/test_workspace_crypto.py … 14 passed in 0.41s   (round-trips RUN, 0 skips)
```

Broader workspace suite (crypto + secrets + documents + sessions + analytics): 72 passed, 1 skipped (unrelated pandoc real-render).

## Not in this PR (Part B — awaits the dedicated refactor)

Python-authoritative store access (Node stops reading the files directly), concurrency-safe migration, key rotation, kill-switch, cross-runtime integration test. Tracked in ADR-062's must-have checklist. Flag stays default-OFF.

Depends on the ADR landing: [#393](https://github.com/event4u-app/agent-config/pull/393).