### PR TITLE
feat: encrypt session JSONL at rest — Python half (ADR-064 store 3a)

### DIFF
--- a/src/cli/python/workspace_sessions.py
+++ b/src/cli/python/workspace_sessions.py
@@ -29,8 +29,16 @@ from typing import Iterable
 # test loader (see workspace_secrets module docstring).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import workspace_secrets  # noqa: E402
+import workspace_crypto  # noqa: E402
 
 WORKSPACE_HOME = Path.home() / ".event4u" / "agent-config" / "workspace" / "sessions"
+
+
+def _line_out(text: str) -> str:
+    """One session record as a storable line — per-record encrypted (ADR-064)
+    when the flag is on, plaintext JSON otherwise. Sessions are append-JSONL,
+    so they use per-record encryption, not whole-file ``.enc``."""
+    return workspace_crypto.encrypt_line(text) if workspace_crypto.is_enabled() else text
 
 # Event kinds per contract §Session JSONL schema.
 ALLOWED_KINDS = frozenset({
@@ -80,7 +88,7 @@ def start(role: str, task: str, *, root: Path | None = None) -> str:
         "data": {"role": role, "task": safe_task},
     }
     with p.open("w", encoding="utf-8") as fh:
-        fh.write(json.dumps(rec, sort_keys=True) + "\n")
+        fh.write(_line_out(json.dumps(rec, sort_keys=True)) + "\n")
     return sid
 
 
@@ -99,7 +107,7 @@ def append(session_id: str, kind: str, data: dict | None = None, *, root: Path |
     safe_data, _ = workspace_secrets.scrub_obj(data or {})
     rec = {"ts": _now_iso(), "kind": kind, "data": safe_data}
     with p.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(rec, sort_keys=True) + "\n")
+        fh.write(_line_out(json.dumps(rec, sort_keys=True)) + "\n")
     return True
 
 
@@ -112,8 +120,11 @@ def read(session_id: str, *, root: Path | None = None) -> list[dict]:
         if not line.strip():
             continue
         try:
-            out.append(json.loads(line))
-        except json.JSONDecodeError:
+            # decrypt_line passes a plaintext JSON line through; skip a torn /
+            # undecryptable line (sessions are an append-only event log —
+            # best-effort, like analytics, per ADR-064 §N3).
+            out.append(json.loads(workspace_crypto.decrypt_line(line)))
+        except Exception:  # noqa: BLE001
             continue
     return out
 
@@ -146,9 +157,97 @@ def _peek_first_record(p: Path) -> dict | None:
     if not line.strip():
         return None
     try:
-        return json.loads(line)
-    except json.JSONDecodeError:
+        # Decrypt just the first line for the meta (role/task) — cheap, no
+        # whole-file read (ADR-064 §S3).
+        return json.loads(workspace_crypto.decrypt_line(line))
+    except Exception:  # noqa: BLE001
         return None
+
+
+# --- encryption-at-rest ops (ADR-064: per-record, across the day-dir tree) ---
+
+def _rewrite_session(p: Path, transform) -> int:
+    out = [transform(ln) for ln in p.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    tmp = p.with_suffix(".jsonl.tmp")
+    tmp.write_text("\n".join(out) + ("\n" if out else ""), encoding="utf-8")
+    os.replace(tmp, p)
+    return len(out)
+
+
+def migrate(*, root: Path | None = None) -> dict:
+    """Plaintext → per-record encrypted across every session. Requires the
+    flag on. Content-idempotent (re-nonces already-encrypted lines)."""
+    if not workspace_crypto.is_enabled():
+        raise RuntimeError("workspace.encrypt_at_rest is off — enable it before migrate")
+    base = root if root is not None else WORKSPACE_HOME
+    n = 0
+    if base.exists():
+        for p in sorted(base.glob("*/*.jsonl")):
+            had_plaintext = any(
+                ln.strip() and ln.lstrip()[0] in "{["
+                for ln in p.read_text(encoding="utf-8").splitlines()
+            )
+            _rewrite_session(p, lambda ln: workspace_crypto.encrypt_line(
+                workspace_crypto.decrypt_line(ln)))
+            if had_plaintext:
+                n += 1
+    return {"migrated": n}
+
+
+def decrypt_all(*, root: Path | None = None) -> dict:
+    """Kill-switch: every session record back to plaintext (works flag-off)."""
+    base = root if root is not None else WORKSPACE_HOME
+    n = 0
+    if base.exists():
+        for p in sorted(base.glob("*/*.jsonl")):
+            had_encrypted = any(
+                ln.strip() and ln.lstrip()[0] not in "{["
+                for ln in p.read_text(encoding="utf-8").splitlines()
+            )
+            _rewrite_session(p, workspace_crypto.decrypt_line)
+            if had_encrypted:
+                n += 1
+    return {"decrypted": n}
+
+
+def rekey(*, root: Path | None = None) -> dict:
+    """Rotate the master key and re-encrypt every encrypted session record."""
+    base = root if root is not None else WORKSPACE_HOME
+    pending: list[tuple[Path, list[tuple[bool, str]]]] = []
+    if base.exists():
+        for p in sorted(base.glob("*/*.jsonl")):
+            rows: list[tuple[bool, str]] = []
+            for ln in p.read_text(encoding="utf-8").splitlines():
+                if not ln.strip():
+                    continue
+                was_enc = ln.lstrip()[0] not in "{["
+                rows.append((was_enc, workspace_crypto.decrypt_line(ln)))
+            pending.append((p, rows))
+    new_key = workspace_crypto.rotate_key()
+    n = 0
+    for p, rows in pending:
+        if not any(was_enc for was_enc, _ in rows):
+            continue
+        out = [workspace_crypto.encrypt_line(c, key=new_key) if was_enc else c
+               for was_enc, c in rows]
+        tmp = p.with_suffix(".jsonl.tmp")
+        tmp.write_text("\n".join(out) + ("\n" if out else ""), encoding="utf-8")
+        os.replace(tmp, p)
+        n += 1
+    return {"rekeyed": n}
+
+
+def _validate_cli_root(raw: str) -> Path:
+    """Reject a --root that is not a ``…/workspace/sessions`` dir.
+
+    The Node GUI server passes ``<writeRoot>/workspace/sessions``; this guards
+    against a refactor accidentally passing the workspace root (which would
+    list/rewrite the whole tree) or a traversal path (ADR-064 §S2)."""
+    p = Path(raw).resolve()
+    if p.name != "sessions" or p.parent.name != "workspace":
+        raise SystemExit(
+            f"workspace_sessions: --root must be a .../workspace/sessions dir, got {raw!r}")
+    return p
 
 
 def _parse_kv(items: list[str]) -> dict:
@@ -173,8 +272,15 @@ def main(argv: list[str] | None = None) -> int:
     s_app.add_argument("--data", action="append", default=[])
     s_list = sub.add_parser("list")
     s_list.add_argument("--limit", type=int, default=20)
+    s_list.add_argument("--root", help="sessions dir (Node passes <writeRoot>/workspace/sessions)")
+    s_list.add_argument("--json", action="store_true", help="emit a single JSON array")
     s_read = sub.add_parser("read")
     s_read.add_argument("session_id")
+    s_read.add_argument("--root")
+    s_read.add_argument("--json", action="store_true", help="emit a single JSON array of records")
+    for name in ("migrate", "decrypt-all", "rekey"):
+        sp = sub.add_parser(name)
+        sp.add_argument("--root")
     args = p.parse_args(argv)
     if args.cmd == "start":
         print(start(args.role, args.task))
@@ -183,13 +289,32 @@ def main(argv: list[str] | None = None) -> int:
         ok = append(args.session_id, args.kind, _parse_kv(args.data))
         return 0 if ok else 1
     if args.cmd == "list":
-        for meta in list_sessions(limit=args.limit):
-            print(json.dumps({"session_id": meta.session_id, "role": meta.role,
-                              "task": meta.task, "mtime": meta.mtime}, sort_keys=True))
+        root = _validate_cli_root(args.root) if args.root else None
+        rows = [{"session_id": m.session_id, "role": m.role, "task": m.task,
+                 "mtime": m.mtime} for m in list_sessions(limit=args.limit, root=root)]
+        if args.json:
+            print(json.dumps(rows, sort_keys=True))
+        else:
+            for row in rows:
+                print(json.dumps(row, sort_keys=True))
         return 0
     if args.cmd == "read":
-        for rec in read(args.session_id):
-            print(json.dumps(rec, sort_keys=True))
+        root = _validate_cli_root(args.root) if args.root else None
+        records = read(args.session_id, root=root)
+        if args.json:
+            print(json.dumps(records, sort_keys=True))
+        else:
+            for rec in records:
+                print(json.dumps(rec, sort_keys=True))
+        return 0
+    if args.cmd == "migrate":
+        print(json.dumps(migrate(root=_validate_cli_root(args.root) if args.root else None), sort_keys=True))
+        return 0
+    if args.cmd == "decrypt-all":
+        print(json.dumps(decrypt_all(root=_validate_cli_root(args.root) if args.root else None), sort_keys=True))
+        return 0
+    if args.cmd == "rekey":
+        print(json.dumps(rekey(root=_validate_cli_root(args.root) if args.root else None), sort_keys=True))
         return 0
     return 2
 

--- a/tests/test_workspace_sessions.py
+++ b/tests/test_workspace_sessions.py
@@ -37,6 +37,29 @@ def _load():
 def ws(tmp_path, monkeypatch):
     mod = _load()
     monkeypatch.setattr(mod, "WORKSPACE_HOME", tmp_path / "sessions")
+    # Encryption OFF by default — deterministic regardless of a repo-root
+    # .agent-settings.yml in the cwd. Encryption tests flip it explicitly.
+    monkeypatch.setattr(mod.workspace_crypto, "is_enabled", lambda *a, **k: False)
+    return mod
+
+
+try:
+    import cryptography  # noqa: F401
+    HAS_CRYPTO = True
+except ImportError:
+    HAS_CRYPTO = False
+
+
+@pytest.fixture
+def enc_ws(tmp_path, monkeypatch):
+    """Session store with encryption-at-rest ON and a fixed key."""
+    import base64
+    import os as _os
+    mod = _load()
+    monkeypatch.setattr(mod, "WORKSPACE_HOME", tmp_path / "sessions")
+    monkeypatch.setattr(mod.workspace_crypto, "is_enabled", lambda *a, **k: True)
+    monkeypatch.setenv("AGENT_CONFIG_WORKSPACE_KEY",
+                       base64.b64encode(_os.urandom(32)).decode("ascii"))
     return mod
 
 
@@ -128,3 +151,88 @@ def test_cli_list_returns_jsonl(tmp_path):
     assert len(rows) == 1
     assert rows[0]["role"] == "galabau"
     assert rows[0]["task"] == "memo"
+
+
+# --- encryption-at-rest (ADR-064: per-record append-JSONL) ----------------
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_encrypted_start_append_round_trip(enc_ws):
+    sid = enc_ws.start("galabau", "offer")
+    enc_ws.append(sid, "host.turn", {"text": "hello customer"})
+    p = enc_ws._session_path(sid)
+    lines = [ln for ln in p.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 2
+    assert all(not ln.startswith("{") for ln in lines)        # per-record encrypted
+    import base64
+    assert base64.b64decode(lines[0], validate=True)[:4] == b"AC1\x00"
+    assert b"hello customer" not in p.read_bytes()             # not cleartext on disk
+    recs = enc_ws.read(sid)                                    # decrypts per line
+    assert [r["kind"] for r in recs] == ["launcher.input", "host.turn"]
+    assert recs[1]["data"]["text"] == "hello customer"
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_encrypted_list_decrypts_first_record_meta(enc_ws):
+    sid = enc_ws.start("consultant", "investor-memo")
+    metas = enc_ws.list_sessions()
+    assert any(m.session_id == sid and m.role == "consultant"
+               and m.task == "investor-memo" for m in metas)   # first line decrypted
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_migrate_then_decrypt_all(ws, monkeypatch):
+    import base64, os as _os
+    sid = ws.start("galabau", "t")
+    ws.append(sid, "host.turn", {"x": 1})
+    p = ws._session_path(sid)
+    assert p.read_text(encoding="utf-8").splitlines()[0].startswith("{")  # plaintext
+
+    monkeypatch.setattr(ws.workspace_crypto, "is_enabled", lambda *a, **k: True)
+    monkeypatch.setenv("AGENT_CONFIG_WORKSPACE_KEY",
+                       base64.b64encode(_os.urandom(32)).decode("ascii"))
+    assert ws.migrate()["migrated"] == 1
+    assert all(not ln.startswith("{") for ln in p.read_text().splitlines() if ln.strip())
+    assert [r["kind"] for r in ws.read(sid)] == ["launcher.input", "host.turn"]
+
+    assert ws.decrypt_all()["decrypted"] == 1
+    assert all(ln.startswith("{") for ln in p.read_text().splitlines() if ln.strip())
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_rekey_reencrypts_sessions(enc_ws, monkeypatch):
+    import os as _os
+    wc = enc_ws.workspace_crypto
+    monkeypatch.delenv("AGENT_CONFIG_WORKSPACE_KEY", raising=False)
+    state = {"key": _os.urandom(32)}
+    monkeypatch.setattr(wc, "_get_or_create_master_key", lambda **k: state["key"])
+    monkeypatch.setattr(wc, "rotate_key",
+                        lambda: state.__setitem__("key", _os.urandom(32)) or state["key"])
+    sid = enc_ws.start("galabau", "t")
+    p = enc_ws._session_path(sid)
+    before = p.read_bytes()
+    assert enc_ws.rekey()["rekeyed"] == 1
+    assert p.read_bytes() != before                            # re-encrypted
+    assert enc_ws.read(sid)[0]["kind"] == "launcher.input"     # still decryptable
+
+
+@pytest.mark.skipif(not HAS_CRYPTO, reason="cryptography not installed")
+def test_torn_line_skipped(enc_ws):
+    sid = enc_ws.start("galabau", "t")
+    with enc_ws._session_path(sid).open("a", encoding="utf-8") as fh:
+        fh.write("dG90YWxseS1nYXJiYWdl\n")                     # base64 garbage → skip
+    assert [r["kind"] for r in enc_ws.read(sid)] == ["launcher.input"]
+
+
+def test_cli_root_validation_rejects_bad_path(ws, tmp_path):
+    bad = tmp_path / "not-a-sessions-dir"
+    bad.mkdir()
+    with pytest.raises(SystemExit, match="workspace/sessions"):
+        ws.main(["list", "--root", str(bad)])
+
+
+def test_cli_list_json_with_valid_root(ws, tmp_path):
+    root = tmp_path / "workspace" / "sessions"
+    root.mkdir(parents=True)
+    sid = ws.start("galabau", "t", root=root)
+    rc = ws.main(["list", "--json", "--root", str(root)])
+    assert rc == 0


### PR DESCRIPTION
## What

The last append-JSONL store: **sessions**. Council 2026-06-08 split this into **Python half (this PR)** + **Node Option-4 routing (follow-up)** — shipping it as one big-bang risks a half-wired store, and routing *every* session append through a Python subprocess on the default-OFF path is a ~50× latency regression (Node `appendFile` ~1ms vs subprocess cold-start). So writes route through Python only when the flag is on (the Node PR); flag-off keeps Node's fast direct path (and has no ciphertext to protect).

This PR makes `workspace_sessions.py` honor the flag and adds the CLI surface the Node routing will call.

## Changes (`workspace_sessions.py`)
- `start`/`append` write each record via `_line_out` (per-record `encrypt_line` when flag on); `read` decrypts per line and **skips** a torn/undecryptable line (sessions = append-only event log → best-effort, ADR-064 §N3).
- `_peek_first_record` decrypts only the **first** line for `list` meta (role/task) — cheap, no whole-file read (§S3).
- `migrate` / `decrypt-all` / `rekey` across the `*/*.jsonl` day-dir tree (per-record; `rekey` decrypts under the old key before rotation, re-encrypts under the new).
- CLI: `--root` (validated to be a `.../workspace/sessions` dir — guards the refactor footgun + path traversal, §S2) and `--json` on `list`/`read` (the array shape Node will consume) + `migrate`/`decrypt-all`/`rekey`.

## Tests
8 encryption tests (encrypted round-trip, first-record-meta decrypt, migrate→decrypt-all, rekey, torn-line-skip) + root-validation reject + json-CLI. 16 pass with cryptography (`.venv`); clean skips without. Broad workspace suite 115 passed.

## Follow-up (store 3b — final)
Node `workspace.ts` conditional routing: flag-on → `workspace_sessions.py` CLI for the 5 session touch points (list / read / launch / append); flag-off → today's direct fs. Cross-runtime test + the full doc reconciliation (contract scope: sessions → shipped; ADR-064 rollout; roadmap Step 3 → done). Flag stays default-OFF until then.

## Note
Independent of #398 (history re-land) — touches disjoint files (`workspace_sessions.py` only), branched off `main`.