### PR TITLE
feat: conversation thread view + arbitrary continuation (ADR-083, PR-2/2)

### DIFF
--- a/src/ui/pages/WorkspacePage.tsx
+++ b/src/ui/pages/WorkspacePage.tsx
@@ -82,6 +82,13 @@ interface SessionMeta {
     started_at: string;
 }
 
+// One record from a session JSONL log (ADR-083 thread view).
+interface SessionRecord {
+    ts: string;
+    kind: string;
+    data: Record<string, unknown>;
+}
+
 interface KnowledgeChunk {
     id: string;
     source: string;
@@ -159,13 +166,17 @@ const openTask = signal<string | null>(null);
 const formInputs = signal<Record<string, string>>({});
 const launching = signal(false);
 const launchResult = signal<LaunchResult | null>(null);
-const showFullTurn = signal(false);
 // Follow-up continuation (ADR-076 GUI, closes the ADR-076 v1 debt): the
 // in-flight follow-up prompt + busy flag for the active session.
 const followupText = signal('');
 const continuing = signal(false);
 const sessionGone = signal(false);     // 410: host session expired (ADR-080/081)
 const lastLaunch = signal<{ role: string; task: string; inputs: Record<string, string> } | null>(null);
+// One current-session model (ADR-083): the thread + the follow-up box key off
+// this id, set by a launch OR by selecting a past session from the strip.
+const currentSessionId = signal<string | null>(null);
+const thread = signal<SessionRecord[]>([]);
+const expandedTurns = signal<Set<number>>(new Set());
 
 const DRIVE_HOST = 'claude-code';      // v0: single hard-coded tier-1 host (council)
 const TURN_COLLAPSE_CHARS = 2000;      // collapse long turns behind "Show full"
@@ -213,10 +224,32 @@ async function loadTasks(slug: string, fallback: RoleTask[]): Promise<void> {
     }
 }
 
+// Load (or reload) a session's full log into the thread (ADR-083). Sets it as
+// the current session — the thread + follow-up box key off this id.
+async function loadThread(id: string): Promise<void> {
+    currentSessionId.value = id;
+    expandedTurns.value = new Set();
+    try {
+        const res = await apiFetch<{ id: string; log: SessionRecord[] }>(`/api/v1/workspace/sessions/${id}`);
+        thread.value = Array.isArray(res.log) ? res.log : [];
+    } catch {
+        thread.value = [];
+    }
+}
+
+// Open a past session from the strip (ADR-083) → it becomes the current
+// session; its thread renders and a follow-up continues it.
+async function openSession(id: string): Promise<void> {
+    launchBanner.value = null;
+    sessionGone.value = false;
+    followupText.value = '';
+    openTask.value = null;
+    await loadThread(id);
+}
+
 async function launch(role: string, task: string, inputs: Record<string, string>): Promise<void> {
     launchBanner.value = null;
     launching.value = true;
-    showFullTurn.value = false;
     followupText.value = '';        // a new launch starts a fresh conversation
     sessionGone.value = false;
     lastLaunch.value = { role, task, inputs };   // remembered for one-click re-launch on 410 (ADR-082)
@@ -228,6 +261,7 @@ async function launch(role: string, task: string, inputs: Record<string, string>
         launchResult.value = res;
         launchBanner.value = bannerFor(res);
         openTask.value = null;                 // collapse the form on a completed launch
+        await loadThread(res.id);              // the new session becomes current (ADR-083)
         const s = await apiFetch<{ sessions: SessionMeta[] }>('/api/v1/workspace/sessions?limit=20');
         sessions.value = s.sessions;
     } catch (err) {
@@ -249,7 +283,6 @@ async function continueTurn(sessionId: string, prompt: string): Promise<void> {
     if (prompt.trim() === '' || continuing.value) return;
     continuing.value = true;
     launchBanner.value = null;
-    showFullTurn.value = false;
     try {
         const res = await apiFetch<LaunchResult>(
             `/api/v1/workspace/sessions/${sessionId}/continue`,
@@ -258,6 +291,7 @@ async function continueTurn(sessionId: string, prompt: string): Promise<void> {
         launchResult.value = res;
         launchBanner.value = bannerFor(res);
         if (res.driven) followupText.value = '';     // clear only on a landed turn
+        await loadThread(sessionId);                 // re-render the thread with the new turn
         const s = await apiFetch<{ sessions: SessionMeta[] }>('/api/v1/workspace/sessions?limit=20');
         sessions.value = s.sessions;
     } catch (err) {
@@ -381,27 +415,67 @@ function TaskForm({ role, task }: { role: string; task: RoleTask }): preact.JSX.
 
 // The driven turn's assistant text (ADR-075). Long turns collapse behind a
 // "Show full" toggle so a 4k-token response can't break the layout chrome.
-function TurnResult(): preact.JSX.Element | null {
-    const r = launchResult.value;
-    if (r === null || !r.driven || r.turn === undefined) return null;
-    const text = r.turn.text ?? '';
-    const long = text.length > TURN_COLLAPSE_CHARS;
-    const shown = long && !showFullTurn.value ? `${text.slice(0, TURN_COLLAPSE_CHARS)}…` : text;
-    const usage = r.turn.usage;
+// One conversation turn rendered as a block (ADR-083). Assistant turns collapse
+// past the 2000-char limit, tracked per-record so a long thread stays readable.
+interface ThreadBlock { kind: 'task' | 'user' | 'assistant' | 'error'; text: string; meta?: string }
+
+function threadBlocks(records: SessionRecord[]): ThreadBlock[] {
+    const out: ThreadBlock[] = [];
+    for (const rec of records) {
+        const d = rec.data ?? {};
+        if (rec.kind === 'launcher.input') {
+            if (d['followup'] === true) {
+                out.push({ kind: 'user', text: typeof d['prompt'] === 'string' ? d['prompt'] : '' });
+            } else {
+                out.push({ kind: 'task', text: typeof d['task'] === 'string' ? d['task'] : '' });
+            }
+        } else if (rec.kind === 'host.turn') {
+            const usage = d['usage'] as { input_tokens?: number; output_tokens?: number } | null | undefined;
+            const meta = usage != null
+                ? `${typeof d['model'] === 'string' ? d['model'] : DRIVE_HOST} · in ${usage.input_tokens ?? 0} / out ${usage.output_tokens ?? 0} tokens`
+                : undefined;
+            out.push({ kind: 'assistant', text: typeof d['text'] === 'string' ? d['text'] : '', meta });
+        } else if (rec.kind === 'host.error') {
+            const ek = typeof d['error_kind'] === 'string' ? d['error_kind'] : 'error';
+            out.push({ kind: 'error', text: `${ek}: ${typeof d['error'] === 'string' ? d['error'] : ''}` });
+        }
+        // host.output / host.tool / inbox.handoff are not rendered as thread blocks in v0.
+    }
+    return out;
+}
+
+function ThreadView(): preact.JSX.Element | null {
+    if (currentSessionId.value === null) return null;
+    const blocks = threadBlocks(thread.value);
+    const hasTurn = thread.value.some((r) => r.kind === 'host.turn');
     return (
-        <section class="ac-workspace__turn" aria-label="Host turn result">
-            <h2 class="ac-workspace__heading">Result · {r.task}</h2>
-            <pre class="ac-workspace__turn-text">{shown}</pre>
-            {long ? (
-                <button type="button" class="ac-button" onClick={(): void => { showFullTurn.value = !showFullTurn.value; }}>
-                    {showFullTurn.value ? 'Show less' : 'Show full'}
-                </button>
-            ) : null}
-            {usage != null ? (
-                <p class="ac-workspace__turn-meta">
-                    {r.turn.model ?? DRIVE_HOST} · in {usage.input_tokens ?? 0} / out {usage.output_tokens ?? 0} tokens
-                </p>
-            ) : null}
+        <section class="ac-workspace__thread" aria-label="Conversation thread">
+            <h2 class="ac-workspace__heading">Conversation</h2>
+            {blocks.length === 0 ? (
+                <p class="ac-workspace__empty">No turns yet.</p>
+            ) : (
+                <ol class="ac-workspace__thread-list">
+                    {blocks.map((b, i) => {
+                        const long = b.kind === 'assistant' && b.text.length > TURN_COLLAPSE_CHARS;
+                        const open = expandedTurns.value.has(i);
+                        const shown = long && !open ? `${b.text.slice(0, TURN_COLLAPSE_CHARS)}…` : b.text;
+                        return (
+                            <li key={i} class={`ac-workspace__thread-block ac-workspace__thread-block--${b.kind}`}>
+                                <span class="ac-workspace__thread-role">{b.kind === 'task' ? 'Task' : b.kind === 'user' ? 'You' : b.kind === 'assistant' ? 'Host' : 'Error'}</span>
+                                <pre class="ac-workspace__thread-text">{shown}</pre>
+                                {long ? (
+                                    <button type="button" class="ac-button" onClick={(): void => {
+                                        const next = new Set(expandedTurns.value);
+                                        if (next.has(i)) { next.delete(i); } else { next.add(i); }
+                                        expandedTurns.value = next;
+                                    }}>{open ? 'Show less' : 'Show full'}</button>
+                                ) : null}
+                                {b.meta != null ? <p class="ac-workspace__turn-meta">{b.meta}</p> : null}
+                            </li>
+                        );
+                    })}
+                </ol>
+            )}
             {sessionGone.value ? (
                 <div class="ac-workspace__followup-gone" role="status">
                     <p>Host session expired.</p>
@@ -421,33 +495,33 @@ function TurnResult(): preact.JSX.Element | null {
                         <p>Pick a task above to start a new conversation.</p>
                     )}
                 </div>
-            ) : (
-            <form
-                class="ac-workspace__followup"
-                onSubmit={(e): void => {
-                    e.preventDefault();
-                    void continueTurn(r.id, followupText.value);
-                }}
-            >
-                <label class="ac-workspace__field">
-                    <span class="ac-workspace__field-label">Follow up</span>
-                    <textarea
-                        class="ac-workspace__field-input"
-                        placeholder="Continue this conversation — e.g. make it shorter"
-                        aria-label="Follow-up prompt"
-                        value={followupText.value}
-                        onInput={(e): void => { followupText.value = (e.target as HTMLTextAreaElement).value; }}
-                    />
-                </label>
-                <button
-                    type="submit"
-                    class="ac-button ac-button--primary"
-                    disabled={followupText.value.trim() === '' || continuing.value}
+            ) : hasTurn ? (
+                <form
+                    class="ac-workspace__followup"
+                    onSubmit={(e): void => {
+                        e.preventDefault();
+                        if (currentSessionId.value !== null) void continueTurn(currentSessionId.value, followupText.value);
+                    }}
                 >
-                    {continuing.value ? 'Continuing…' : 'Send follow-up'}
-                </button>
-            </form>
-            )}
+                    <label class="ac-workspace__field">
+                        <span class="ac-workspace__field-label">Follow up</span>
+                        <textarea
+                            class="ac-workspace__field-input"
+                            placeholder="Continue this conversation — e.g. make it shorter"
+                            aria-label="Follow-up prompt"
+                            value={followupText.value}
+                            onInput={(e): void => { followupText.value = (e.target as HTMLTextAreaElement).value; }}
+                        />
+                    </label>
+                    <button
+                        type="submit"
+                        class="ac-button ac-button--primary"
+                        disabled={followupText.value.trim() === '' || continuing.value}
+                    >
+                        {continuing.value ? 'Continuing…' : 'Send follow-up'}
+                    </button>
+                </form>
+            ) : null}
         </section>
     );
 }
@@ -473,6 +547,8 @@ function TaskPicker({ role }: { role: Role }): preact.JSX.Element {
                                         openTask.value = openTask.value === t.name ? null : t.name;
                                         formInputs.value = {};
                                         launchResult.value = null;
+                                        currentSessionId.value = null;   // clear the prior thread
+                                        thread.value = [];
                                     }}
                                 >
                                     {openTask.value === t.name ? 'Close' : 'Start session'}
@@ -514,9 +590,17 @@ function SessionStrip(): preact.JSX.Element {
                 <ul class="ac-workspace__session-list">
                     {sessions.value.map((s) => (
                         <li key={s.id} class="ac-workspace__session">
-                            <span class="ac-workspace__session-id">{s.id.slice(0, 16)}</span>
-                            <span class="ac-workspace__session-role">{s.role}</span>
-                            <span class="ac-workspace__session-task">{s.task}</span>
+                            <button
+                                type="button"
+                                class={`ac-workspace__session-open${currentSessionId.value === s.id ? ' ac-workspace__session-open--active' : ''}`}
+                                aria-label={`Open session ${s.task}`}
+                                aria-current={currentSessionId.value === s.id ? 'true' : undefined}
+                                onClick={(): void => { void openSession(s.id); }}
+                            >
+                                <span class="ac-workspace__session-id">{s.id.slice(0, 16)}</span>
+                                <span class="ac-workspace__session-role">{s.role}</span>
+                                <span class="ac-workspace__session-task">{s.task}</span>
+                            </button>
                         </li>
                     ))}
                 </ul>
@@ -740,7 +824,7 @@ export function WorkspacePage(): preact.JSX.Element {
                     {role !== null ? <TaskPicker role={role} /> : (
                         <p class="ac-workspace__empty">Pick a role on the left to see its first tasks.</p>
                     )}
-                    <TurnResult />
+                    <ThreadView />
                     <SessionStrip />
                 </main>
                 <aside class="ac-workspace__rail" aria-label="Knowledge and documents">

--- a/tests/ui/WorkspacePage.test.tsx
+++ b/tests/ui/WorkspacePage.test.tsx
@@ -31,6 +31,9 @@ interface FixtureOverrides {
 
 function installWorkspaceFetchMock(overrides: FixtureOverrides = {}): { calls: Call[]; restore: () => void } {
     const calls: Call[] = [];
+    // Stateful session log (ADR-083): launch/continue append records; the
+    // single-session GET returns them so ThreadView renders a real thread.
+    const sessionLog: Array<{ ts: string; kind: string; data: Record<string, unknown> }> = [];
     const original = global.fetch;
     global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
         const path = typeof url === 'string' ? url : url.toString();
@@ -88,6 +91,11 @@ function installWorkspaceFetchMock(overrides: FixtureOverrides = {}): { calls: C
             };
             return new Response(JSON.stringify(payload), { status: 200 });
         }
+        // Single session (thread) — must precede the list handler.
+        if (/\/api\/v1\/workspace\/sessions\/[^/?]+$/.test(path) && method === 'GET') {
+            const id = path.split('/')[5];
+            return new Response(JSON.stringify({ id, role: 'galabau', task: 'Offer drafting', log: sessionLog }), { status: 200 });
+        }
         if (path.startsWith('/api/v1/workspace/sessions') && method === 'GET') {
             const payload = overrides.sessions ?? {
                 sessions: [
@@ -129,24 +137,35 @@ function installWorkspaceFetchMock(overrides: FixtureOverrides = {}): { calls: C
             return new Response(JSON.stringify(payload), { status: 200 });
         }
         if (path === '/api/v1/workspace/launch' && method === 'POST') {
-            const ov = overrides.launch;
-            if (ov !== undefined) return new Response(JSON.stringify(ov.body), { status: ov.status });
             const reqBody = body as { role: string; task: string };
+            sessionLog.length = 0;   // a launch starts a fresh session log
+            sessionLog.push({ ts: 't', kind: 'launcher.input', data: { role: reqBody.role, task: reqBody.task } });
+            const ov = overrides.launch;
+            if (ov !== undefined) {
+                const ob = ov.body as { driven?: boolean; turn?: Record<string, unknown> };
+                if (ob.driven === true && ob.turn) sessionLog.push({ ts: 't', kind: 'host.turn', data: ob.turn });
+                return new Response(JSON.stringify(ov.body), { status: ov.status });
+            }
+            const turn = { text: 'Here is your drafted offer.', model: 'claude-code', usage: { input_tokens: 12, output_tokens: 40 } };
+            sessionLog.push({ ts: 't', kind: 'host.turn', data: turn });
             return new Response(JSON.stringify({
-                id: '20260525T130000Z-deadbeef',
-                role: reqBody.role,
-                task: reqBody.task,
-                driven: true,
-                turn: { text: 'Here is your drafted offer.', model: 'claude-code', usage: { input_tokens: 12, output_tokens: 40 } },
+                id: '20260525T130000Z-deadbeef', role: reqBody.role, task: reqBody.task, driven: true, turn,
             }), { status: 200 });
         }
         if (/\/api\/v1\/workspace\/sessions\/[^/]+\/continue$/.test(path) && method === 'POST') {
-            const ov = overrides.continueTurn;
-            if (ov !== undefined) return new Response(JSON.stringify(ov.body), { status: ov.status });
             const id = path.split('/')[5];
+            const reqBody = body as { prompt: string };
+            sessionLog.push({ ts: 't', kind: 'launcher.input', data: { prompt: reqBody.prompt, followup: true } });
+            const ov = overrides.continueTurn;
+            if (ov !== undefined) {
+                const ob = ov.body as { driven?: boolean; turn?: Record<string, unknown> };
+                if (ob.driven === true && ob.turn) sessionLog.push({ ts: 't', kind: 'host.turn', data: ob.turn });
+                return new Response(JSON.stringify(ov.body), { status: ov.status });
+            }
+            const turn = { text: 'Shorter offer.', model: 'claude-code', usage: { input_tokens: 8, output_tokens: 20 } };
+            sessionLog.push({ ts: 't', kind: 'host.turn', data: turn });
             return new Response(JSON.stringify({
-                id, role: 'galabau', task: 'Offer drafting', driven: true,
-                turn: { text: 'Shorter offer.', model: 'claude-code', usage: { input_tokens: 8, output_tokens: 20 } },
+                id, role: 'galabau', task: 'Offer drafting', driven: true, turn,
             }), { status: 200 });
         }
         return new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: path } }), { status: 404 });


### PR DESCRIPTION
## What

**PR 2 of 2** for ADR-083. The GUI now renders a full **conversation thread**
and lets the user **continue any past session** from the strip — not just view
the latest turn of the active one. Builds on PR-1 (#420, the follow-up-prompt
record).

## Design (ADR-083, one current-session model)

- A single `currentSessionId` drives both the thread and the follow-up box. A
  launch **or** clicking a session in the strip loads the full log via
  `GET /sessions/:id` and sets it current.
- **ThreadView** replaces the single-turn result: interleaved **Task / You /
  Host / Error** blocks; assistant turns collapse per-block past 2000 chars
  (per-record expand state, so a long thread stays readable).
- The follow-up box continues `currentSessionId`; a continuation reloads the
  thread in place (the new turn appends). 410 / re-launch affordance carry over.
- **Old sessions** (created before PR-1's recording) degrade gracefully — they
  show the opening task + assistant turns (reply-only), no crash.
- Session strip items are now buttons (`Open session …`), with the active one
  marked.

## Tests — `tests/ui/WorkspacePage.test.tsx` (20)

A **stateful mock** session log (launch/continue append; `GET /sessions/:id`
returns it) so the thread reflects real turns. All prior result-area tests
(drive, follow-up, 410, re-launch, health, host-picker) pass against the
ThreadView.

## Verification (fresh)

- `npx vitest run tests/ui/ tests/server/workspace.test.ts` → **117/117** ✅
- `npm run typecheck` ✅ · `npm run lint:ts` ✅ · `task check-refs` ✅ · `task check-md-language` ✅

## Result

The workspace is now a browseable, resumable conversation history: pick a host →
role → task → thread → follow up, or reopen any past session and continue it.
This closes the last substantive item of the Drive arc (ADR-069–083).