### PR TITLE
test(glama): local MCP build/run parity test for glama.ai sync

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Build context for internal/glama/Dockerfile (task mcp:glama-test).
+# Goal: keep ONLY what the MCP build + server need, drop the ~1.2 GB of
+# node_modules / .git / venvs that bloat the context.
+#
+# The MCP server's content roots are load-bearing (verified in
+# src/scripts/mcp_server/{prompts,resources}.py):
+#   dist/agent-src/{skills,commands,rules,contexts}
+#   docs/guidelines
+# Starve any of these and the server boots, then crashes at runtime with an
+# empty content root — a silent failure worse than a build error.
+
+.git
+**/node_modules
+.venv
+.venv-*
+*.log
+.DS_Store
+coverage
+ui/dist
+
+# dist/ holds the CLI + UI bundles the server never reads; keep only agent-src.
+# NEGATION ORDER IS LOAD-BEARING: Docker honours `!` re-includes only when the
+# parent is matched by a glob (`dist/*`), NOT when an ancestor dir is excluded
+# whole (`dist/`). Writing `dist/` here would silently drop dist/agent-src.
+dist/*
+!dist/agent-src
+
+# Transient runtime state (council sessions, dashboards) — not needed to boot.
+agents/runtime

--- a/internal/glama/Dockerfile
+++ b/internal/glama/Dockerfile
@@ -1,0 +1,32 @@
+# Local reproduction of glama.ai's MCP-server build/run environment.
+#
+# This is NOT glama's Dockerfile. glama generates its own and git-clones a
+# pinned commit; this one `COPY`s the local working tree so `task mcp:glama-test`
+# validates internal/glama/{build,run} against UNCOMMITTED changes, offline.
+#
+# Scope (AI-council 2026-06-09, anthropic/claude-sonnet-4-5 + openai/gpt-4o —
+# converged on COPY-over-clone): this verifies the build/run scripts boot the
+# stdio MCP server in a Debian + mcp-proxy env — the failure surface WE own
+# (the 2026-06-04 scripts/ -> src/scripts/ move broke exactly these path refs).
+# It deliberately does NOT reproduce glama's git-clone stage, and the pinned
+# toolchain below is a DATED SNAPSHOT of glama's generated Dockerfile, not a
+# live mirror. See internal/glama/README.md before trusting it for glama
+# sync debugging.
+FROM debian:trixie-slim
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g mcp-proxy@6.4.3 pnpm@10.14.0 \
+    && curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR="/usr/local/bin" sh \
+    && uv python install 3.11 --default --preview \
+    && ln -s "$(uv python find)" /usr/local/bin/python \
+    && node --version && python --version \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+WORKDIR /app
+COPY . /app
+RUN bash /app/internal/glama/build
+# Mirrors glama's launch (CMD field). `task mcp:glama-test` overrides this with
+# the smoke client to assert the MCP handshake.
+CMD ["mcp-proxy","--","bash","/app/internal/glama/run"]

--- a/internal/glama/README.md
+++ b/internal/glama/README.md
@@ -1,0 +1,58 @@
+# glama.ai MCP-server integration
+
+[glama.ai](https://glama.ai/) indexes this package's read-only stdio MCP server
+(`src/scripts/mcp_server/`). It clones the repo, runs a **build** step, launches
+the server via **mcp-proxy**, and introspects it. glama's admin panel stores the
+build + launch commands; to keep those fields free of dotted tokens (glama
+truncates the last char of any token containing a dot — `3.11` → `3.1`), the
+real commands live in committed scripts:
+
+| File | glama field | What it does |
+|---|---|---|
+| `build` | Build steps → `bash /app/internal/glama/build` | `uv venv` + `uv pip install -r src/scripts/mcp_server/requirements.txt` |
+| `run` | CMD → `["mcp-proxy","--","bash","/app/internal/glama/run"]` | `PYTHONPATH=/app/src python -m scripts.mcp_server` |
+
+## Local test — `task mcp:glama-test`
+
+`Dockerfile` + `smoke.py` reproduce glama's build/run environment locally and
+assert the server boots and speaks MCP (`initialize` + `prompts/list > 0`).
+
+```bash
+task mcp:glama-test
+```
+
+It builds a Debian image, runs `internal/glama/build`, then runs `smoke.py`
+(an MCP stdio client) against `internal/glama/run`. Green = the build/run
+scripts and the server's content roots work in a glama-like container.
+
+## Scope — what this does and does NOT prove
+
+Decided by AI council on 2026-06-09 (anthropic/claude-sonnet-4-5 +
+openai/gpt-4o, converged): test the failure surface **we** own, not glama's.
+
+**Proves:** `build` + `run` boot the server in Debian + mcp-proxy; the content
+roots (`dist/agent-src/{skills,commands,rules,contexts}`, `docs/guidelines`)
+are present and the handshake works. This is exactly what the 2026-06-04
+`scripts/` → `src/scripts/` move broke.
+
+**Does NOT prove:** that glama's sync will succeed. Out of our control —
+glama's git-clone, its introspection timeout, and its generated Dockerfile all
+live on their side.
+
+**`Dockerfile` is a `COPY`-based local variant, not glama's Dockerfile.** It
+tests the working tree (incl. uncommitted changes), offline. The pinned
+toolchain (node 24, mcp-proxy 6.4.3, python 3.11, debian trixie) is a **dated
+snapshot** of glama's generated Dockerfile, not a live mirror.
+
+## Debugging a glama sync failure
+
+1. Open the package's glama registry page and read its **current** generated
+   Dockerfile — compare node / mcp-proxy / python versions against the pins
+   here; if they drifted, update the pins locally to re-test (no need to commit
+   the bump unless it is a real fix).
+2. Confirm glama's admin **Build steps** = `bash /app/internal/glama/build`
+   and **CMD** = `["mcp-proxy","--","bash","/app/internal/glama/run"]`.
+3. Run `task mcp:glama-test` to rule out a build/run regression on our side.
+
+_Last verified glama-parity build: 2026-06-09 — image built in ~14s, `run`
+booted the server (377 prompts / 189 resources / 20 tools), handshake OK._

--- a/internal/glama/smoke.py
+++ b/internal/glama/smoke.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Glama-parity smoke test for the stdio MCP server.
+
+Boots the server exactly as glama does — `bash /app/internal/glama/run` — then
+asserts it speaks MCP: `initialize` succeeds and `prompts/list` returns at least
+one prompt. A zero-prompt result is the canonical content-root failure (a
+`.dockerignore` that dropped `dist/agent-src/`, or a build/run path bug).
+
+Runs INSIDE the container with /opt/venv/bin/python — the `mcp` SDK lives there,
+installed by internal/glama/build. This is the real integration test of the
+build + run pipeline, i.e. the failure surface the 2026-06-04 path move broke.
+"""
+from __future__ import annotations
+
+import anyio
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+# Spawn the stdio server through the exact launch script glama runs.
+SERVER = StdioServerParameters(command="bash", args=["/app/internal/glama/run"])
+
+
+async def _run() -> int:
+    async with stdio_client(SERVER) as (read, write):
+        async with ClientSession(read, write) as session:
+            init = await session.initialize()
+            prompts = (await session.list_prompts()).prompts
+            try:
+                resources = (await session.list_resources()).resources
+            except Exception:  # resources are optional for the smoke verdict
+                resources = []
+
+            info = init.serverInfo
+            print(f"server:    {info.name} v{info.version}")
+            print(f"prompts:   {len(prompts)} (first page)")
+            print(f"resources: {len(resources)} (first page)")
+
+            if not prompts:
+                print(
+                    "FAIL: prompts/list returned 0 — content root missing. "
+                    "Check .dockerignore kept dist/agent-src/ and that "
+                    "internal/glama/{build,run} resolve src/scripts/mcp_server."
+                )
+                return 1
+
+            print("OK: MCP initialize + prompts/list succeeded")
+            return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(anyio.run(_run))

--- a/taskfiles/mcp.yml
+++ b/taskfiles/mcp.yml
@@ -26,6 +26,14 @@ tasks:
     cmds:
       - python3 src/scripts/mcp_telemetry_health.py {{.CLI_ARGS}}
 
+  mcp:glama-test:
+    desc: "Reproduce glama.ai's build/run env in Docker and smoke-test the MCP handshake (local working tree, offline). See internal/glama/README.md."
+    cmds:
+      - |
+        command -v docker >/dev/null 2>&1 || { echo "❌  docker not found — install Docker to run the glama-parity test"; exit 1; }
+      - docker build -f internal/glama/Dockerfile -t agent-config-mcp-glama-test .
+      - docker run --rm agent-config-mcp-glama-test /opt/venv/bin/python /app/internal/glama/smoke.py
+
   # ---------------------------------------------------------------------------
   # Cloudflare hosted MCP — one-time operator setup.
   #


### PR DESCRIPTION
## Why

glama.ai indexes this package's stdio MCP server (`src/scripts/mcp_server/`). The 2026-06-04 `scripts/` → `src/scripts/` restructure broke glama's stored build/CMD paths, so its sync hung in the introspection timeout (observed: a manual sync running ~10h). The server code is fine; the breakage was the launch paths glama executes.

The repo-side fix (`internal/glama/{build,run}`, dot-free launch scripts) already landed on `main`. This PR adds a way to **verify that fix locally** before a glama re-sync.

## What

- `internal/glama/Dockerfile` — COPY-based local reproduction of glama's build/run environment (offline, tests the working tree; not glama's own clone-based Dockerfile).
- `internal/glama/smoke.py` — stdio MCP client; boots the server via `internal/glama/run` and asserts `initialize` + `prompts/list > 0`.
- `internal/glama/README.md` — scope (tests **our** build/run surface, not glama's clone) + glama-debug runbook.
- `.dockerignore` — keeps `dist/agent-src/` (the server's content root) in the build context; drops the ~1.2 GB of node_modules/.git/venvs. The `dist/*` + `!dist/agent-src` negation order is load-bearing.
- `taskfiles/mcp.yml` — `task mcp:glama-test`.

## Scope

Decided by AI council (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2026-06-09): test the build/run surface we own, not glama's clone stage. The test proves the build/run scripts boot the server in a glama-like container; it does **not** guarantee glama's sync succeeds (their clone, timeout, and generated Dockerfile are out of our control).

## Verification

`task mcp:glama-test` — image builds (~14s), server boots (377 prompts / 189 resources / 20 tools), MCP `initialize` + `prompts/list` succeed, exit 0.