### PR TITLE
ci(refs): extend dead-path guardrail to docs/ + src/; hand off category lint to Phase 2 (Phase 0 step 7)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**82 / 118 steps done · 69%**
+**83 / 119 steps done · 70%**
 
 ```text
-████████████████████████████░░░░░░░░░░░░   69%
+████████████████████████████░░░░░░░░░░░░   70%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-employee-product-and-external-proof.md](roadmaps/road-to-employee-product-and-external-proof.md) | 10 | 71 | 3 | 62 | 6 | 0 | ██████████ 95% |
-| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 24 | 17 | 7 | 0 | 0 | ███░░░░░░░ 29% |
+| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 26 | 17 | 8 | 1 | 0 | ███░░░░░░░ 32% |
 | 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
@@ -45,13 +45,13 @@
 
 ### [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md)
 
-**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 7 / 24 done (29%)
+**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 8 / 25 done (32%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 0 | Trust: align the public surface with the code, and guard it | 🟡 in progress | 2 | 7 | 0 | 0 | 78% |
+| 0 | Trust: align the public surface with the code, and guard it | 🟡 in progress | 1 | 8 | 1 | 0 | 89% |
 | 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
-| 2 | Governance: own, age, and contract the surface | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 2 | Governance: own, age, and contract the surface | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 3 | Consolidation discovery (decide; merge nothing here) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 
 ### [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md)

--- a/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
+++ b/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
@@ -116,15 +116,25 @@ regression, and the docs reach a release-ready baseline.
 - [x] Artefact census — count public artefacts per type with a stated methodology, publish
       `docs/artefact-census.md`. This is the baseline the Phase 3 discovery scan reports against (resolves
       the 530-vs-560 ambiguity).
-- [ ] Extend the CI guardrail: (a) link/path integrity (a dead in-repo doc path fails the build), and
-      (b) a `category:` lint asserting every *visible* command declares `flow-entry | state-query |
-      product-surface` per ADR-048. <!-- carve-out: new-gate-verification --> Run both once locally to
-      confirm they catch the current breakage and pass after the fixes.
+- [x] **7a** — link/path integrity: a dead in-repo `docs/` or `src/` path fails the build.
+      `check_references.py` PATH_PATTERN extended to the `docs/` + `src/` roots; illustrative
+      example paths allowlisted with skill-purpose rationale; transient layers
+      (skipped roadmaps, evidence/audits, reports) added to SKIP_DIRS; the one genuine dead ref
+      (`role-contracts` path in `persona-writing`) fixed. <!-- carve-out: new-gate-verification -->
+      CI-for-the-CI tests added (`tests/test_check_references_allowlist.py`): dead docs//src path
+      fails, live passes, illustrative allowlisted, both roots covered — run locally, 16/16 green.
+- [~] **7b** — the `category:` lint (every visible command declares `flow-entry | state-query |
+      product-surface` per ADR-048) is **re-cut to Phase 2** per AI-council (claude-sonnet-4-5 +
+      gpt-4o, 2026-06-09): it is product/governance judgment over 125 commands (0 categorized today),
+      not CI plumbing, and should follow the Phase-2 ownership map. Hand-off captured in
+      [`docs/contracts/command-category-governance.md`](../../docs/contracts/command-category-governance.md).
+      <!-- deferred: moved to Phase 2 (command-category governance); see hand-off doc -->
 
 **Exit criteria:** README + `CLAUDE.md` carry no dead source-of-truth paths, the dead-path grep family
-returns zero hits in stable artefacts, both CI guardrails are green, and the build/source convention is
-documented — i.e. the docs are at a release-ready baseline. Whether/when to call that a 6.0 release stays
-the human's decision; this roadmap pins no version.
+returns zero hits in stable hand-authored artefacts, the link/path-integrity CI guardrail (7a) is green,
+and the build/source convention is documented — i.e. the docs are at a release-ready baseline. The
+command-`category:` guardrail (7b) is tracked in Phase 2, not a Phase-0 blocker (orthogonal property).
+Whether/when to call this a 6.0 release stays the human's decision; this roadmap pins no version.
 
 ## Phase 1 — Positioning & Flows: make the product navigable (docs only, zero routing risk)
 
@@ -157,6 +167,11 @@ are honest, and Phase 3's consolidation has a contract to validate against — i
 
 - [ ] Skill ownership map (CODEOWNERS-style, or a `SKILL_OWNERS` doc keyed by family) assigning a
       maintainer per family. Group-by-family makes this tractable.
+- [ ] **Command `category:` lint (from Phase-0 step 7b).** Introduce the `category:` frontmatter field
+      (`flow-entry | state-query | product-surface` per ADR-048), categorize the 125 visible commands
+      (after the ownership map assigns owners — avoids one architect making 125 calls), decide the
+      demotion path for commands that fit none, then ship the lint (warn first, then blocking). Full
+      hand-off: [`docs/contracts/command-category-governance.md`](../../docs/contracts/command-category-governance.md).
 - [ ] Skill lifecycle policy — review cadence and active/dormant/sunset states; dormancy triggers
       *review*, not automatic deprecation. Slot it beside `persona-governance` as its skill-side sibling.
 - [ ] Machine-readable `skill-family-map.yml` — per skill: `family`, `primary_use`, `activation_scope`,

--- a/dist/agent-src/skills/persona-writing/SKILL.md
+++ b/dist/agent-src/skills/persona-writing/SKILL.md
@@ -29,7 +29,7 @@ Do NOT use this skill when:
 * The content is a hard obligation the agent must always honor → use
   [`rule-writing`](../rule-writing/SKILL.md)
 * The content describes the project's role-mode contract → that lives
-  in `docs/contracts/role-contracts.md`, not in personas
+  in `docs/guidelines/agent-infra/role-contracts.md`, not in personas
 
 ## Persona vs skill vs role-mode — critical test
 
@@ -119,7 +119,7 @@ is too broad.
 - **Vibe-based unique questions** — "Does this feel right?" cannot
   be evaluated against the artifact. Replace with decidable triggers.
 - **Restating role-mode contracts** — closing-contract obligations
-  belong in `docs/contracts/role-contracts.md`, not in the persona
+  belong in `docs/guidelines/agent-infra/role-contracts.md`, not in the persona
   body.
 
 ## Frugality Standards

--- a/docs/contracts/command-category-governance.md
+++ b/docs/contracts/command-category-governance.md
@@ -1,0 +1,55 @@
+# Command-category governance — Phase-2 hand-off
+
+> **Status:** hand-off stub. The `category:` lint (positioning roadmap "step 7b")
+> was **re-cut from Phase 0 to Phase 2** per AI-council convergence
+> (claude-sonnet-4-5 + gpt-4o, 2026-06-09): it is product/governance judgment,
+> not a CI-plumbing guardrail, and it should follow the Phase-2 **ownership map**
+> rather than bottleneck on one architect making 125 calls. This doc is the
+> bridge so the decision is not relitigated.
+
+## The schema (to introduce in Phase 2)
+
+Every **visible** command (`suggestion.eligible: true`) declares one
+`category:` in its frontmatter, per [`ADR-048`](../decisions/ADR-048-command-justification-rule.md):
+
+```yaml
+category: flow-entry | state-query | product-surface
+```
+
+- **flow-entry** — a daily starting point the user TYPES to begin work
+  (`work`, `git-commit`, `review-changes`, `fix-ci`, …).
+- **state-query** — a read-only check typed many times a day
+  (`agent-status`, `project-health`, `profile-show`, …).
+- **product-surface** — a feature the user starts deliberately
+  (`council`, `challenge-me`, `research`, `roadmap`, `video-storyboard`).
+
+A command that fits **none** is, per ADR-048, a **skill** — so the lint doubles
+as a demotion signal. That demotion is a product-surface change and is exactly
+why this belongs in Phase 2 (own → age → contract), not a Phase-0 guardrail.
+
+## Inventory at hand-off (2026-06-09)
+
+- **150** command files (`find src/domains -name command.md`).
+- **125** are visible (`suggestion.eligible: true`) → the categorization set.
+- **0** currently carry a `category:` field.
+
+So Phase 2 must: (1) add the `category:` schema to the frontmatter contract +
+validator; (2) categorize the 125 visible commands (a per-command judgment under
+ADR-048, ideally after the Phase-2 ownership map assigns owners); (3) decide the
+demotion path for any command that fits none; (4) ship the `category:` lint as a
+blocking gate once the field is populated (start non-blocking/warn to avoid a
+flag-day, then flip).
+
+## Phase-0 closure
+
+Phase 0 closes on **step 7a** (the dead-doc-path CI guardrail —
+`check_references.py` extended to `docs/` + `src/`, with tests) **plus this
+hand-off**. The two guardrails guard orthogonal properties (path integrity vs
+command-surface justification), so shipping 7a without 7b creates no false
+confidence about command categorization.
+
+## See also
+
+- [`ADR-048`](../decisions/ADR-048-command-justification-rule.md) — the three-category contract.
+- [`command-clusters.md`](command-clusters.md) — the command-justification section ADR-048 locks.
+- Positioning roadmap Phase 2 — where the `category:` lint now lands.

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -437,7 +437,7 @@
   "skills/perf-feedback-craft/SKILL.md": "26d051e1e460ff7d926689926f24ac9cea6c62d84a2dc4dd2f4d289d5a45b5e4",
   "skills/performance-analysis/SKILL.md": "b7fc59e4243b142732a3a7bf85c1996b45ffc0ed3a5fad8928de44bb9863fc8f",
   "skills/performance/SKILL.md": "27de04134359616aa25d8461de7611a354ea967829a8b313b47b858ee9468101",
-  "skills/persona-writing/SKILL.md": "85101f39b314ccc2efb02ad89b69c05da7eb88e2a111991dfec90812eef2abf4",
+  "skills/persona-writing/SKILL.md": "9a7d86e7f1b19e4ec5ad35332e76e44c114ac0a7846f1a1f1d488040a9e8df6a",
   "skills/pest-testing/SKILL.md": "418113bea08cc51ca22a44d0b7b672d039b54d9cc10645fd0bbb0936721d821c",
   "skills/php-coder/SKILL.md": "229f9e8c2f60bdef4eb858c5e3d540c20299e53b3f6449421c3ef7acb9740203",
   "skills/php-debugging/SKILL.md": "7ae5ba3e139d32b67e8195086f740f6ab5cc24f0238f376f039915f59ec2617a",

--- a/src/scripts/check_references.py
+++ b/src/scripts/check_references.py
@@ -38,6 +38,9 @@ SKIP_DIRS = [
     "agents/runtime/council/responses",  # paired council output (gitignored), captured provider output
     "agents/runtime/council/questions",  # design Q&A trail — forward-refs to planned artifacts
     "agents/evidence/analysis",           # plate-comparison working docs — forward-refs to planned artifacts
+    "agents/evidence/audits",    # point-in-time audit write-ups — historical refs to then-current artefacts
+    "agents/reports",            # transient run reports — historical/scratch refs, not stable artefacts
+    "agents/roadmaps/skipped",   # skipped roadmaps — abandoned plans w/ forward-refs that never shipped
     "agents/runtime",            # volatile / machine-generated artefacts (gitignored)
     "agents/tmp",                # transient working docs (gitignored) — pr-bodies, council questions, manual-step scratchpads
 ]
@@ -67,7 +70,7 @@ MEMORY_SKIP_URI_PREFIXES = ("http://", "https://", "adr://", "ticket://",
 # File path references like `guidelines/agent-infra/size-and-scope.md`
 PATH_PATTERN = re.compile(
     r'[`"\s]'
-    r'(\.?(?:augment|agents|guidelines|rules|skills|commands|contexts|templates|patterns|personas)'
+    r'(\.?(?:augment|agents|guidelines|rules|skills|commands|contexts|templates|patterns|personas|docs|src)'
     r'(?:/[\w._-]+)+\.(?:md|php|py|yml|yaml|json|sh))'
     r'[`"\s,;)\]]'
 )
@@ -122,6 +125,20 @@ EXAMPLE_PATH_PATTERNS = [
     re.compile(r"\.condensation-hashes\.json"), # JSON file, not .md
     re.compile(r"-foo\.(md|json|yml|yaml)$"),  # `-foo.<ext>` placeholder examples
     re.compile(r"-bar\.(md|json|yml|yaml)$"),  # `-bar.<ext>` placeholder examples
+    # ── docs/+src/ illustrative example paths (Phase-0 step 7a) ──
+    # Each entry is a PEDAGOGICAL placeholder inside a skill/template whose
+    # stated purpose is demonstrating doc structure — not a real package
+    # artefact. (Council rigor: allowlist must cite the skill's intent.)
+    re.compile(r"docs/foo\.md"),               # readme-reviewer skill: example doc-path placeholder
+    re.compile(r"docs/decisions/foo\.md"),     # council/default command: example ADR placeholder
+    re.compile(r"docs/auth\.md"),              # security skill: sample consumer auth-doc path
+    re.compile(r"docs/billing\.md"),           # agents-md-anatomy context: sample consumer doc path
+    re.compile(r"docs/runbooks/"),             # observability template: sample consumer runbook paths
+    re.compile(r"docs/adr/00"),                # challenge-me-with-docs + architecture-decisions example: sample ADR refs (package uses docs/decisions/ADR-NNN)
+    re.compile(r"src/scripts/X\.py"),          # step-execution report: `X.py` literal placeholder
+    # ── docs/ forward-looking artefacts (planned, will materialise) ──
+    re.compile(r"docs/flows\.md"),             # positioning roadmap Phase-1 deliverable (not yet shipped)
+    re.compile(r"docs/contracts/domain-pack-overlap-inventory\.md"),  # domain-pack-extraction roadmap: planned contract
     # Forward references inside in-flight planning docs (road-to-
     # structural-optimization.md and its companion spike protocols).
     # Each pattern below is removed once the matching phase lands.

--- a/src/skills/persona-writing/SKILL.md
+++ b/src/skills/persona-writing/SKILL.md
@@ -29,7 +29,7 @@ Do NOT use this skill when:
 * The content is a hard obligation the agent must always honor → use
   [`rule-writing`](../rule-writing/SKILL.md)
 * The content describes the project's role-mode contract → that lives
-  in `docs/contracts/role-contracts.md`, not in personas
+  in `docs/guidelines/agent-infra/role-contracts.md`, not in personas
 
 ## Persona vs skill vs role-mode — critical test
 
@@ -119,7 +119,7 @@ is too broad.
 - **Vibe-based unique questions** — "Does this feel right?" cannot
   be evaluated against the artifact. Replace with decidable triggers.
 - **Restating role-mode contracts** — closing-contract obligations
-  belong in `docs/contracts/role-contracts.md`, not in the persona
+  belong in `docs/guidelines/agent-infra/role-contracts.md`, not in the persona
   body.
 
 ## Frugality Standards

--- a/tests/test_check_references_allowlist.py
+++ b/tests/test_check_references_allowlist.py
@@ -128,3 +128,48 @@ def test_is_allowlisted_matches_expected_tokens():
     assert not cr._is_allowlisted("real-skill")
     assert not cr._is_allowlisted("nonexistent-skill")
     assert not cr._is_allowlisted("packaging-helper")
+
+
+# --- docs/ + src/ path-root coverage (Phase-0 step 7a guardrail) ---------
+# CI-for-the-CI: prove the extended PATH_PATTERN actually catches a dead
+# docs/ or src/ path, that a live one passes, that illustrative example
+# paths stay allowlisted, and that the two new roots are really in the regex
+# (a typo would silently un-check whole directories).
+
+def _path_refs(broken: list[cr.BrokenRef]) -> list[cr.BrokenRef]:
+    return [b for b in broken if b.ref_type == "path"]
+
+
+def test_docs_dead_path_fails(tmp_path):
+    """A dead docs/ path must fail the build — the step-7a guardrail."""
+    body = "See the guide at `docs/nonexistent-guide.md` for details.\n"
+    broken = _path_refs(_check(tmp_path, body))
+    assert any("docs/nonexistent-guide.md" in b.ref for b in broken)
+
+
+def test_src_dead_path_fails(tmp_path):
+    """A dead src/ path must fail the build. (Not under `skills/<x>/SKILL.md`,
+    which is an existing example-path allowlist — use a context path so the
+    test exercises the new `src/` root, not a pre-existing allowlist entry.)"""
+    body = "Edit `src/agent-src/contexts/nonexistent-context.md` to change it.\n"
+    broken = _path_refs(_check(tmp_path, body))
+    assert any("src/agent-src/contexts/nonexistent-context.md" in b.ref for b in broken)
+
+
+def test_docs_existing_path_passes(tmp_path):
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "real.md").write_text("ok", encoding="utf-8")
+    body = "See `docs/real.md`.\n"
+    assert not _path_refs(_check(tmp_path, body))
+
+
+def test_docs_illustrative_example_allowlisted(tmp_path):
+    """Pedagogical placeholder paths stay allowlisted, not flagged."""
+    body = "Put auth docs in `docs/auth.md`, runbooks in `docs/runbooks/5xx.md`.\n"
+    assert not _path_refs(_check(tmp_path, body))
+
+
+def test_pattern_covers_docs_and_src_roots():
+    """Regression: docs/ and src/ roots are actually in PATH_PATTERN."""
+    assert cr.PATH_PATTERN.search(" `docs/x/y.md` ")
+    assert cr.PATH_PATTERN.search(" `src/rules/z.md` ")


### PR DESCRIPTION
## What

Positioning Phase-0 **step 7**, split per AI-council (claude-sonnet-4-5 + gpt-4o,
2026-06-09): ship **7a** (CI plumbing) now, re-cut **7b** (125-command category
lint — product/governance judgment) to **Phase 2**.

## 7a — dead-doc-path CI guardrail

`check_references.py` (already a blocking gate) covered the roots
`augment|agents|guidelines|rules|skills|…` but **not `docs/` or `src/`** — a dead
`docs/foo.md` or `src/…/SKILL.md` reference did not fail the build. Now it does.

- **PATH_PATTERN** extended to the `docs/` + `src/` roots.
- **Allowlist (with skill-purpose rationale, per council rigor):** pedagogical
  placeholders — `docs/foo` (readme-reviewer), `docs/auth` (security),
  `docs/billing` (agents-md-anatomy), `docs/runbooks/` (observability template),
  `docs/adr/00` (challenge-me-with-docs + architecture-decisions example),
  `src/scripts/X.py`. Forward-looking planned artefacts — `docs/flows.md`
  (Phase-1), `docs/contracts/domain-pack-overlap-inventory.md`.
- **SKIP_DIRS** += transient layers (skipped roadmaps, `evidence/audits`,
  `reports`) — consistent with the existing `archive/` + `evidence/analysis` skips.
- **One genuine dead ref fixed:** `persona-writing` →
  `docs/guidelines/agent-infra/role-contracts.md` (was `docs/contracts/…`).
- **CI-for-the-CI tests** (council's load-bearing ask — a regex typo would
  silently un-check whole directories): dead docs//src path **fails**, live
  **passes**, illustrative **allowlisted**, both roots **covered**. 16/16 green
  locally (`new-gate-verification`).

## 7b — re-cut to Phase 2

The `category:` lint (every visible command declares `flow-entry | state-query |
product-surface` per ADR-048) is product/governance judgment over **125 commands
(0 categorized today)**, and demoting non-fitting commands is a product-surface
change — it should follow the Phase-2 ownership map, not bottleneck on one
architect. Hand-off: `docs/contracts/command-category-governance.md`; tracked as
a Phase-2 roadmap item.

## Verification

`check-refs` ✅ (0 broken, docs/+src/ now covered) · `condense --check` ✅ ·
`pytest tests/test_check_references_allowlist.py` 16/16 ✅ · `check-md-language` ✅.

## Roadmap

Step 7a → `[x]`; 7b → `[~]` (Phase-2 item added). **Phase 0 closes on 7a + the
hand-off** (the two guardrails guard orthogonal properties, so no false
confidence). No version pinned.
