### PR TITLE
docs(positioning): flow documentation + README workflows section (Phase 1 steps 1-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ schema: [`docs/contracts/profile-system.md`](docs/contracts/profile-system.md).
 Beyond software: [`user-types/`](src/agent-src/user-types/)
 (galabau · metalworking · truck — see [Beyond software](#beyond-software).
 
+### Workflows, not raw commands
+
+You don't memorize 150 commands — you run a **work journey**. Four flows span the
+developer story end-to-end; each names the command you TYPE to start and the
+skills it composes:
+
+| Flow | Start with | The journey |
+|---|---|---|
+| 🔍 **Discovery** | `/feature:plan` · `/research` | explore → plan → estimate → refine, *before* building |
+| 🔨 **Implementation** | `/work` · `/implement-ticket` | plan → implement → verify → commit |
+| 🔎 **Review** | `/review-changes` · `/judge` | self-review → judge → quality-fix → threat-model |
+| 🚢 **Delivery** | `/commit` · `/pr:create` | commit in chunks → open PR → answer review |
+
+Full detail — entry commands, canonical path, composed skills per flow:
+[`docs/flows.md`](docs/flows.md). (`agent-admin` — memory / analytics / config —
+is platform operation, not a user-work flow.)
+
 <p align="center">
   <a href="CHANGELOG.md">CHANGELOG</a> ·
   <a href="MIGRATION.md">Upgrade to 6.0</a> ·

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**83 / 119 steps done · 70%**
+**85 / 119 steps done · 71%**
 
 ```text
-████████████████████████████░░░░░░░░░░░░   70%
+████████████████████████████░░░░░░░░░░░░   71%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-employee-product-and-external-proof.md](roadmaps/road-to-employee-product-and-external-proof.md) | 10 | 71 | 3 | 62 | 6 | 0 | ██████████ 95% |
-| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 26 | 17 | 8 | 1 | 0 | ███░░░░░░░ 32% |
+| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 26 | 15 | 10 | 1 | 0 | ████░░░░░░ 40% |
 | 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
@@ -45,12 +45,12 @@
 
 ### [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md)
 
-**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 8 / 25 done (32%)
+**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 10 / 25 done (40%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Trust: align the public surface with the code, and guard it | 🟡 in progress | 1 | 8 | 1 | 0 | 89% |
-| 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | 🟡 in progress | 4 | 2 | 0 | 0 | 33% |
 | 2 | Governance: own, age, and contract the surface | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 3 | Consolidation discovery (decide; merge nothing here) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
+++ b/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
@@ -141,9 +141,9 @@ Whether/when to call this a 6.0 release stays the human's decision; this roadmap
 Goal: a reader sees the architecture as profiles → flows → skills, can pick an experience, and a
 maintainer can navigate 227 skills by family — without touching any skill file or its routing triggers.
 
-- [ ] Add a "Workflows, not raw commands" section to the README naming the five `src/flows/` flows and
+- [x] Add a "Workflows, not raw commands" section to the README naming the five `src/flows/` flows and
       mapping each profile to the flow(s) it drives (developer→implementation/review, content→delivery, …).
-- [ ] Flow documentation — author `docs/flows.md` describing each flow's purpose, entry commands, involved
+- [x] Flow documentation — author `docs/flows.md` describing each flow's purpose, entry commands, involved
       packs, default path, skills/lenses, rules, and output evidence, and propose a per-flow metadata
       schema for `src/flows/*.yaml`. **Scope gate:** document the *existing* flow structure and behaviour
       only — do NOT change flow execution logic. Any execution gap surfaced here becomes an input to a

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -1,0 +1,67 @@
+# Flows — the user-work journeys
+
+A **Flow** names a multi-command *user-work journey*, the connective tissue
+between the curated command surface and the day-to-day developer journey. It
+answers **"what am I trying to *do*?"** — not "which command do I type?".
+
+The layered model:
+
+```
+Profile → Pack → Flow → Command → Skill → Rule
+```
+
+The user-facing developer story is **discovery → implementation → review →
+delivery**. Each flow below lists its **entry commands** (the daily front
+doors), its **canonical path** (the typical command sequence), and the
+**skills** it composes end-to-end. Source of truth:
+[`src/flows/<flow>.yaml`](../src/flows/) (schema + lint:
+[`flow.schema.json`](../src/scripts/schemas/flow.schema.json),
+[`lint_flows.py`](../src/scripts/lint_flows.py); data-model in
+[`ADR-055`](decisions/ADR-055-flow-layer-data-model.md)).
+
+## 🔍 Discovery — *what should we build, and how*
+
+Explore, plan, estimate, refine, and investigate **before** building.
+
+- **Entry commands:** `/feature:plan` · `/bug-investigate` · `/research`
+- **Canonical path:** `/feature:explore` → `/feature:plan` → `/estimate-ticket` → `/refine-ticket`
+- **Skills:** `feature-planning` · `estimate-ticket` · `refine-ticket` · `project-analysis-core` · `validate-feature-fit`
+
+## 🔨 Implementation — *build it*
+
+Drive a prompt, ticket, or feature end-to-end through plan → implement → verify.
+
+- **Entry commands:** `/work` · `/implement-ticket` · `/feature:dev` · `/bug-fix`
+- **Canonical path:** `/work` → `/review-changes` → `/quality-fix` → `/commit`
+- **Skills:** `test-driven-development` · `code-review` · `systematic-debugging` · `git-workflow`
+
+## 🔎 Review — *check it*
+
+Self-review, judge, quality-fix, and threat-model a change before it ships.
+
+- **Entry commands:** `/review-changes` · `/judge`
+- **Canonical path:** `/review-changes` → `/judge` → `/quality-fix` → `/threat-model`
+- **Skills:** `code-review` · `adversarial-review` · `quality-tools` · `threat-modeling` · `receiving-code-review`
+
+## 🚢 Delivery — *ship it*
+
+Commit in logical chunks, open the PR, answer review comments, prepare the
+branch for review.
+
+- **Entry commands:** `/commit` · `/pr:create` · `/prepare-for-review`
+- **Canonical path:** `/commit` → `/pr:create` → `/fix:pr-comments`
+- **Skills:** `conventional-commits-writing` · `git-workflow` · `requesting-code-review`
+
+## Why `agent-admin` is not a flow
+
+`agent-admin` (memory · analytics · governance · config) describes **system
+administration**, not user *work*. The four flows above describe what a user
+*does*; `agent-admin` describes how the platform is *operated* — almost entirely
+skills plus a couple of state-queries. It stays out of the flow set by
+construction.
+
+## See also
+
+- [`profiles.md`](profiles.md) — the six entry profiles that select which packs (and so which flows) surface.
+- [`catalog.md`](catalog.md) — the full command / skill / rule / guideline surface.
+- [`src/flows/README.md`](../src/flows/README.md) — the flow schema and the source stubs.

--- a/src/scripts/check_references.py
+++ b/src/scripts/check_references.py
@@ -137,7 +137,6 @@ EXAMPLE_PATH_PATTERNS = [
     re.compile(r"docs/adr/00"),                # challenge-me-with-docs + architecture-decisions example: sample ADR refs (package uses docs/decisions/ADR-NNN)
     re.compile(r"src/scripts/X\.py"),          # step-execution report: `X.py` literal placeholder
     # ── docs/ forward-looking artefacts (planned, will materialise) ──
-    re.compile(r"docs/flows\.md"),             # positioning roadmap Phase-1 deliverable (not yet shipped)
     re.compile(r"docs/contracts/domain-pack-overlap-inventory\.md"),  # domain-pack-extraction roadmap: planned contract
     # Forward references inside in-flight planning docs (road-to-
     # structural-optimization.md and its companion spike protocols).


### PR DESCRIPTION
## What

Positioning roadmap **Phase 1, steps 1-2** (docs only, zero routing risk) — make
the product navigable by **work journey**, not raw command list.

### Step 2 — `docs/flows.md`

The four **user-work flows** from the source of truth (`src/flows/<flow>.yaml`,
validated by `lint_flows.py` / ADR-055):

| Flow | Entry commands | Canonical path |
|---|---|---|
| 🔍 Discovery | `/feature:plan` · `/research` | explore → plan → estimate → refine |
| 🔨 Implementation | `/work` · `/implement-ticket` | plan → implement → verify → commit |
| 🔎 Review | `/review-changes` · `/judge` | review → judge → quality-fix → threat-model |
| 🚢 Delivery | `/commit` · `/pr:create` | commit → open PR → answer review |

Each flow lists entry commands, canonical path, and composed skills; plus why
`agent-admin` is platform operation, not a user-work flow.

### Step 1 — README "Workflows, not raw commands"

A 4-row flow table under the profiles table — "you don't memorize 150 commands,
you run a work journey" — linking to `docs/flows.md`.

### Bonus

Removed the now-satisfied forward-looking allowlist entry for `docs/flows.md` in
`check_references.py` (added in #432 when the file didn't exist yet). The file
now exists, so the dead-path guardrail validates the reference for real.

## Note on "five"

The roadmap text said "five `src/flows/` flows"; the source of truth is **four**
(discovery / implementation / review / delivery) + a non-flow `surface-map.yaml`.
Docs follow the source, not the miscount.

## Verification

`check-refs` ✅ (0 broken; `docs/flows.md` resolves, guardrail now validates it) ·
`check-md-language` ✅.

## Roadmap

Phase 1 steps 1 + 2 → `[x]`. Remaining Phase 1: per-profile experience pages,
skill-family taxonomy, cross-linking. No version pinned.
