### PR TITLE
docs(positioning): per-profile experience pages + cross-linking (Phase 1 steps 3,5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ schema: [`docs/contracts/profile-system.md`](docs/contracts/profile-system.md).
 Beyond software: [`user-types/`](src/agent-src/user-types/)
 (galabau · metalworking · truck — see [Beyond software](#beyond-software).
 
+**Per-profile experience pages** (who it's for · first tasks · packs + flows ·
+what is *not* loaded · examples):
+[developer](docs/experiences/developer.md) ·
+[content_creator](docs/experiences/content_creator.md) ·
+[founder](docs/experiences/founder.md) ·
+[agency](docs/experiences/agency.md) ·
+[finance](docs/experiences/finance.md) ·
+[ops](docs/experiences/ops.md).
+
 ### Workflows, not raw commands
 
 You don't memorize 150 commands — you run a **work journey**. Four flows span the

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**85 / 119 steps done · 71%**
+**87 / 119 steps done · 73%**
 
 ```text
-████████████████████████████░░░░░░░░░░░░   71%
+█████████████████████████████░░░░░░░░░░░   73%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-employee-product-and-external-proof.md](roadmaps/road-to-employee-product-and-external-proof.md) | 10 | 71 | 3 | 62 | 6 | 0 | ██████████ 95% |
-| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 26 | 15 | 10 | 1 | 0 | ████░░░░░░ 40% |
+| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 26 | 13 | 12 | 1 | 0 | █████░░░░░ 48% |
 | 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
@@ -45,12 +45,12 @@
 
 ### [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md)
 
-**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 10 / 25 done (40%)
+**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 12 / 25 done (48%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Trust: align the public surface with the code, and guard it | 🟡 in progress | 1 | 8 | 1 | 0 | 89% |
-| 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | 🟡 in progress | 4 | 2 | 0 | 0 | 33% |
+| 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | 🟡 in progress | 2 | 4 | 0 | 0 | 67% |
 | 2 | Governance: own, age, and contract the surface | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 3 | Consolidation discovery (decide; merge nothing here) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
+++ b/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
@@ -148,13 +148,13 @@ maintainer can navigate 227 skills by family — without touching any skill file
       schema for `src/flows/*.yaml`. **Scope gate:** document the *existing* flow structure and behaviour
       only — do NOT change flow execution logic. Any execution gap surfaced here becomes an input to a
       future roadmap, not in-phase work.
-- [ ] Per-profile experience landing pages — `docs/experiences/{developer,founder,content_creator,
+- [x] Per-profile experience landing pages — `docs/experiences/{developer,founder,content_creator,
       agency,finance,ops}.md`. Each page: who it's for · first 3 tasks · first commands · which packs
       activate · which flows apply · what is NOT loaded · examples. README links these instead of artefact lists.
 - [ ] Skill-family taxonomy doc (`docs/`) grouping the 227 skills into navigable families (engineering,
       review, architecture, testing, security, frontend, content, video, finance, strategy, operations,
       agent-admin, …). Navigation only — no file moves, no description edits, no merges.
-- [ ] Cross-link profile pages ↔ flows ↔ representative skills so the "experience" framing is walkable.
+- [x] Cross-link profile pages ↔ flows ↔ representative skills so the "experience" framing is walkable.
       Verify every new link resolves (`check-refs`).
 - [ ] Cross-reference note — record that the experience pages, flow docs, and taxonomy feed the active
       `road-to-employee-product-and-external-proof.md` workstream; coordinate timing, do not duplicate its

--- a/docs/experiences/agency.md
+++ b/docs/experiences/agency.md
@@ -1,0 +1,49 @@
+# 🏛 The `agency` experience
+
+> Set `profile.id: agency` (wizard, or `agent-config use --profile=agency`).
+> **Preset default: `strict`.**
+
+## Who it's for
+
+The multi-client delivery shop — refine a fuzzy client ask into an estimated,
+AC-tight ticket; turn a phase into a roadmap; ship per client without losing
+decision provenance.
+
+## First three tasks
+
+1. **Refine the client ask** — `/refine-ticket` rewrites the ticket and surfaces the top-5 risks.
+2. **Size and split** — `estimate-ticket` sizes and breaks the work down.
+3. **Anchor the trade-off** — `decision-record` writes an ADR before code starts.
+
+## First commands
+
+`/work` · `/implement-ticket` · `/refine-ticket` · `/feature` · `/roadmap`
+
+## Packs that activate
+
+`engineering-base` + `gtm-marketing` + `product-basic` + `ops-people`
+(+ `meta`, always on) — the broadest profile, for a shop that does delivery,
+positioning, and account work.
+
+## Flows that apply
+
+All four — [discovery → implementation → review → delivery](../flows.md) — run
+per client engagement. The `strict` preset keeps the gates tight across accounts.
+
+## What is NOT loaded
+
+No `finance-advanced`, no `ai-video`, no `founder-strategy`. Delivery-shop
+surface, not a CFO or studio one.
+
+## Example
+
+> *"Client wants 'a better dashboard' by next sprint."* → `/refine-ticket`
+> rewrites it AC-tight with top-5 risks; `estimate-ticket` splits it;
+> `decision-record` captures the charting-library trade-off before code.
+
+## See also
+
+[Profile (deep)](../profiles.md#profile-agency) ·
+[Role guide](../getting-started-by-role.md#consultant-advisory-freelance-fractional) ·
+[Flows](../flows.md) ·
+key skills: `refine-ticket` · `estimate-ticket` · `decision-record` · `doc-coauthoring` · `perf-feedback-craft`.

--- a/docs/experiences/content_creator.md
+++ b/docs/experiences/content_creator.md
@@ -1,0 +1,47 @@
+# ✍️ The `content_creator` experience
+
+> Set `profile.id: content_creator` (wizard, or
+> `agent-config use --profile=content_creator`). **Preset default: `balanced`.**
+
+## Who it's for
+
+Writers, ghostwriters, marketers — draft in someone else's voice, plan a quarter
+of content, ship a launch, render a cinematic AI video.
+
+## First three tasks
+
+1. **Write in a voice** — `/ghostwriter` against a public-figure voice profile, or `/post-as` for your own (`.agent-user.md`).
+2. **Lock the brand frame** — `voice-and-tone-design` + `messaging-architecture` before any copy ships.
+3. **Render a video** — `/video:from-script` drives script → character-locked image → motion+audio → render → stitch (`AIV_DRYRUN=true` cost-safety default).
+
+## First commands
+
+`/work` · `/post-as` · `/ghostwriter` · `/optimize-prompt` · `/video:from-script` · `/video:storyboard` · `/video:scene` · `/video:stitch`
+
+## Packs that activate
+
+`gtm-marketing` + `ai-video` (+ `meta`, always on).
+
+## Flows that apply
+
+[Discovery](../flows.md) drives content planning (editorial calendar, messaging).
+The engineering flows (implementation / review / delivery) do not apply — the work
+is pack-skill-driven (voice, messaging, video), not a code journey.
+
+## What is NOT loaded
+
+No `engineering-base` (no `/implement-ticket`, `/review-changes` code judges),
+no `finance-*`, no `founder-strategy`. The surface is content + video.
+
+## Example
+
+> *"Draft a launch post in our founder's voice."* → `/post-as:me` writes against
+> `.agent-user.md`; `voice-and-tone-design` + `messaging-architecture` hold the
+> brand frame; `release-comms` shapes the announcement.
+
+## See also
+
+[Profile (deep)](../profiles.md#profile-content_creator) ·
+[Role guide](../getting-started-by-role.md#creator-writer-marketer-indie-content-shop) ·
+[Flows](../flows.md) ·
+key skills: `voice-and-tone-design` · `messaging-architecture` · `editorial-calendar` · `release-comms` · `character-consistency`.

--- a/docs/experiences/developer.md
+++ b/docs/experiences/developer.md
@@ -1,0 +1,49 @@
+# 👩‍💻 The `developer` experience
+
+> Set `profile.id: developer` (the wizard's first question, or
+> `agent-config use --profile=developer`). **Preset default: `balanced`.**
+
+## Who it's for
+
+The IC engineer — implement a ticket end-to-end, fix CI red, self-review before
+the PR. Stack-aware across Laravel · Symfony · Next.js · React · Node.
+
+## First three tasks
+
+1. **Implement a ticket** — `/implement-ticket` refines it, plans, edits, tests, verifies.
+2. **Fix a red build** — `/fix:ci` reads the failure and drives it green.
+3. **Self-review the diff** — `/review-changes` dispatches five judges (bug, security, tests, quality, architecture).
+
+## First commands
+
+`/work` · `/implement-ticket` · `/review-changes` · `/fix` · `/commit`
+
+## Packs that activate
+
+`engineering-base` (+ `meta`, always on). Language/framework packs (laravel, php,
+react, …) overlay per session from the project's detected stack.
+
+## Flows that apply
+
+All four — this is the home profile for the developer journey:
+**[discovery](../flows.md) → implementation → review → delivery**.
+
+## What is NOT loaded
+
+No `gtm-marketing`, `ai-video`, `finance-*`, or `founder-strategy` packs — no
+ghostwriter, video, DCF, or fundraising surfaces. The profile stays focused on
+shipping code.
+
+## Example
+
+> *"Implement PROJ-412."* → `/implement-ticket` refines acceptance criteria,
+> plans the change, edits with `minimal-safe-diff`, runs the suite via
+> `test-driven-development`, and stops on fresh green evidence
+> (`verify-completion-evidence`) — then `/review-changes` before you open the PR.
+
+## See also
+
+[Profile (deep)](../profiles.md#profile-developer) ·
+[Role guide](../getting-started-by-role.md#developer-the-original-audience) ·
+[Flows](../flows.md) ·
+key skills: `developer-like-execution` · `verify-completion-evidence` · `minimal-safe-diff` · `systematic-debugging` · `test-driven-development`.

--- a/docs/experiences/finance.md
+++ b/docs/experiences/finance.md
@@ -1,0 +1,48 @@
+# 💼 The `finance` experience
+
+> Set `profile.id: finance` (wizard, or `agent-config use --profile=finance`).
+> **Preset default: `strict`.**
+
+## Who it's for
+
+The CFO / fractional finance / FP&A lead — build a DCF, stress-test the plan,
+frame the runway call. Every output carries the finance safety floor (no final
+invest/raise verdict; assumptions + sensitivity + confidence band).
+
+## First three tasks
+
+1. **Value it** — `dcf-modeling` walks WACC / terminal-value / 5-year-hold reasoning.
+2. **Cut the scenarios** — `scenario-modeling` produces base / upside / downside.
+3. **Frame the runway** — `runway-cognition` shapes the fundraise-vs-cut-vs-grow decision.
+
+## First commands
+
+`/work` · `/council` · `/challenge-me`
+
+## Packs that activate
+
+`finance-basic` + `finance-advanced` (+ `meta`, always on).
+
+## Flows that apply
+
+[Discovery](../flows.md)-style modeling and framing dominate. The engineering
+flows (implementation / review / delivery) do not apply — finance work is
+pack-skill-driven and gated by the `finance-safety-floor` rule.
+
+## What is NOT loaded
+
+No `engineering-base`, no `ai-video`, no `gtm-marketing`, no `founder-strategy`.
+Pure finance surface.
+
+## Example
+
+> *"What's our runway if growth halves?"* → `runway-cognition` frames the shape;
+> `scenario-modeling` cuts base/downside; output ends with the mandatory
+> *"Not investment advice — figures are model output, sensitivity stated"* footer.
+
+## See also
+
+[Profile (deep)](../profiles.md#profile-finance) ·
+[Role guide](../getting-started-by-role.md#finance--ops-cfo-controller-ops-lead-founder-finance) ·
+[Flows](../flows.md) ·
+key skills: `dcf-modeling` · `forecasting` · `scenario-modeling` · `unit-economics-modeling` · `runway-cognition`.

--- a/docs/experiences/founder.md
+++ b/docs/experiences/founder.md
@@ -1,0 +1,47 @@
+# 🚀 The `founder` experience
+
+> Set `profile.id: founder` (wizard, or `agent-config use --profile=founder`).
+> **Preset default: `fast`.**
+
+## Who it's for
+
+The solo / early-stage founder — sharpen a fuzzy idea, rank what to build, write
+the why-now slide, get a neutral second opinion.
+
+## First three tasks
+
+1. **Sharpen the idea** — `/challenge-me` runs a grill-style interview that turns a vague plan into a copyable pitch.
+2. **Rank the backlog** — `rice-prioritization` orders what to build next.
+3. **Get a second opinion** — `/council` polls external AIs for a neutral read on a plan or decision.
+
+## First commands
+
+`/work` · `/feature` · `/challenge-me` · `/council`
+
+## Packs that activate
+
+`founder-strategy` + `product-basic` + `finance-basic` (+ `meta`, always on).
+
+## Flows that apply
+
+[Discovery](../flows.md) is the home flow — idea → plan → estimate → refine.
+Implementation applies when the founder builds; review/delivery are light until
+there is a team. Strategy/finance work is pack-skill-driven.
+
+## What is NOT loaded
+
+No `engineering-base` by default (added per session if the founder codes), no
+`ai-video`, no `gtm-marketing`, no `finance-advanced`. Lean, fast-preset surface.
+
+## Example
+
+> *"Should we build the team-seats feature next?"* → `/challenge-me` interviews
+> to 95% confidence and emits a copyable pitch; `rice-prioritization` ranks it
+> against the backlog; `vision-articulation` frames the why-now.
+
+## See also
+
+[Profile (deep)](../profiles.md#profile-founder) ·
+[Role guide](../getting-started-by-role.md#founder-early-stage-operator-wearing-every-hat) ·
+[Flows](../flows.md) ·
+key skills: `rice-prioritization` · `vision-articulation` · `fundraising-narrative` · `runway-cognition`.

--- a/docs/experiences/ops.md
+++ b/docs/experiences/ops.md
@@ -1,0 +1,47 @@
+# 🛡 The `ops` experience
+
+> Set `profile.id: ops` (wizard, or `agent-config use --profile=ops`).
+> **Preset default: `strict`.**
+
+## Who it's for
+
+RevOps, support, SRE-adjacent — threat-model a change before it ships, command
+the incident when it breaks, build the dashboard that catches it next time.
+
+## First three tasks
+
+1. **Threat-model first** — `/threat-model` enumerates abuse cases and trust boundaries before the first line of code.
+2. **Command the incident** — `incident-commander` frames severity and the post-mortem.
+3. **Build the signal** — `dashboard-design` chooses the right RED / USE / Golden-Signal panel.
+
+## First commands
+
+`/work` · `/threat-model` · `/review-changes` · `/fix`
+
+## Packs that activate
+
+`engineering-base` + `founder-strategy` (+ `meta`, always on).
+
+## Flows that apply
+
+[Implementation](../flows.md), **review** (threat-model is the front door), and
+**delivery** apply; discovery is lighter. The `strict` preset keeps the
+security/quality gates tight.
+
+## What is NOT loaded
+
+No `ai-video`, no `gtm-marketing`, no `finance-*`. Engineering + reliability
+surface, not a studio or CFO one.
+
+## Example
+
+> *"We're adding a public webhook endpoint."* → `/threat-model` enumerates abuse
+> cases + trust boundaries first (per `security-sensitive-stop`); `/review-changes`
+> dispatches the security judge; `logging-monitoring` keeps PII out of the stream.
+
+## See also
+
+[Profile (deep)](../profiles.md#profile-ops) ·
+[Role guide](../getting-started-by-role.md#finance--ops-cfo-controller-ops-lead-founder-finance) ·
+[Flows](../flows.md) ·
+key skills: `incident-commander` · `dashboard-design` · `logging-monitoring` · `threat-modeling` · `launch-readiness`.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,6 +9,10 @@ and the exact commands and skills wired into the profile YAML at
 The summary table at the top of [`README.md`](../README.md) is the
 one-page index; the prose below is the deep version.
 
+→ Each profile's **experience page** (packs · flows · what is *not* loaded ·
+examples) lives under [`docs/experiences/`](experiences/); the multi-command
+**work journeys** those profiles run are in [`docs/flows.md`](flows.md).
+
 **Switching experience.** `agent-config setup` writes `profile.id` on first run
 (it is the wizard's first question). To switch later, run
 `agent-config use --profile=<id>` (one of `developer` · `content_creator` ·


### PR DESCRIPTION
## What

Positioning roadmap **Phase 1, steps 3 + 5** (docs only) — per-profile experience
pages + cross-linking so the "experience" framing is walkable.

### Step 3 — six experience pages (`docs/experiences/`)

One page per profile, sourced from `src/agent-src/profiles/<id>.yml`. Each carries
the step's required sections: **who it's for · first three tasks · first commands ·
which packs activate · which flows apply · what is NOT loaded · a worked example**
+ see-also.

| Page | Packs | Flows that apply |
|---|---|---|
| developer | engineering-base | all four |
| content_creator | gtm-marketing, ai-video | discovery (rest pack-driven) |
| founder | founder-strategy, product-basic, finance-basic | discovery (+ impl when building) |
| agency | engineering-base, gtm-marketing, product-basic, ops-people | all four |
| finance | finance-basic, finance-advanced | discovery-style modeling |
| ops | engineering-base, founder-strategy | implementation, review, delivery |

The "what is NOT loaded" section is the scoping-clarity payoff — each profile
states which packs/surfaces it deliberately omits.

### Step 5 — cross-linking (profile ↔ flows ↔ skills)

- README links the six experience pages under the profiles table.
- `docs/profiles.md` points to `docs/experiences/` + `docs/flows.md`.
- Each experience page links its deep profile, role guide, flows, and names its
  representative skills — the triangle is now walkable.

## Deferred (still `[ ]` in Phase 1)

- **Skill-family taxonomy** (227-skill bucketing) — its own PR.
- **Cross-reference note** — references the taxonomy; flipped once that lands.

## Verification

`check-refs` ✅ (every experience-page link resolves) · `check-md-language` ✅.

## Roadmap

Phase 1 steps 3 + 5 → `[x]`. No version pinned.
