### PR TITLE
docs(governance): review-lens schema + Creative Pack boundary (Phase 2)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**91 / 119 steps done · 76%**
+**93 / 119 steps done · 78%**
 
 ```text
-██████████████████████████████░░░░░░░░░░   76%
+███████████████████████████████░░░░░░░░░   78%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-employee-product-and-external-proof.md](roadmaps/road-to-employee-product-and-external-proof.md) | 10 | 71 | 3 | 62 | 6 | 0 | ██████████ 95% |
-| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 27 | 9 | 16 | 2 | 0 | ██████░░░░ 64% |
+| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 27 | 7 | 18 | 2 | 0 | ███████░░░ 72% |
 | 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
@@ -45,13 +45,13 @@
 
 ### [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md)
 
-**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 16 / 25 done (64%)
+**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 18 / 25 done (72%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Trust: align the public surface with the code, and guard it | 🟡 in progress | 1 | 8 | 1 | 0 | 89% |
 | 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 2 | Governance: own, age, and contract the surface | 🟡 in progress | 4 | 2 | 1 | 0 | 33% |
+| 2 | Governance: own, age, and contract the surface | 🟡 in progress | 2 | 4 | 1 | 0 | 67% |
 | 3 | Consolidation discovery (decide; merge nothing here) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 
 ### [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md)

--- a/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
+++ b/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
@@ -187,11 +187,11 @@ are honest, and Phase 3's consolidation has a contract to validate against — i
       scaffolding consumed as input by the Phase 3 scan. No renames in this step.
       <!-- done (base fields): docs/contracts/skill-family-map.yml — 227 skills × {family, primary_use, activation_scope}, generated + reproducible. overlaps_with + candidate_for_* are intentionally ABSENT — they are Phase-3 discovery conclusions, not Phase-2 metadata (AI-council 2026-06-09; Single-Source-of-Truth rule in docs/governance.md). Phase 3 populates them. -->
 - [ ] **(Phase 3 feeder)** Populate `skill-family-map.yml`'s `overlaps_with` + `candidate_for_{merge,lens,internal}` as outputs of the Phase-3 consolidation scan.
-- [ ] Review-lens routing schema — define the metadata a review "lens" carries (context, constraints,
+- [x] Review-lens routing schema — define the metadata a review "lens" carries (context, constraints,
       delegation rules) and which review skills are true entry skills vs lenses dispatched by
       `/review-changes`. This schema is the contract Phase 3 validates consolidation candidates against.
       Proposal/schema only — no skill merged here.
-- [ ] Video-pack boundary contract (`docs/`) — "Creative Pack is optional": (a) user-facing video
+- [x] Video-pack boundary contract (`docs/`) — "Creative Pack is optional": (a) user-facing video
       artefacts, (b) internal/provider-specific ones, (c) a compatibility matrix of which profiles/flows
       work without the Creative Pack, which degrade gracefully, which break. Keeps video a bounded
       Creator pack, not core identity.

--- a/docs/contracts/creative-pack-boundary.md
+++ b/docs/contracts/creative-pack-boundary.md
@@ -1,0 +1,58 @@
+# Creative Pack boundary — video is an optional pack, not core identity
+
+The `ai-video` (Creative) pack is a **bounded, optional** capability: a first-class
+part of the **content creator** experience, never the package's core identity.
+This contract draws the boundary so omitting the pack degrades nothing in the
+engineering / strategy / finance experiences. (`ai-video` ships
+`trust_level_default: experimental`, 10 artefacts.)
+
+## (a) User-facing video artefacts
+
+Surfaced only when the pack is active (the `content_creator` profile, or an
+explicit enable):
+
+- **Commands:** `/video:from-script` · `/video:storyboard` · `/video:scene` ·
+  `/video:stitch` · `/video:from-song` · `/image:create` · `/image:analyse` · `/image:verify`.
+- **Skills:** `video-director` · `character-consistency` · `motion-choreographer` ·
+  `scene-expander` · `song-to-script` · `pixar-storyteller` · `image-creator` ·
+  `image-analyser` (+ `prediction-pool-optimizer`).
+
+## (b) Internal / provider-specific artefacts
+
+Not user-facing; they implement the pipeline and stay inside the pack boundary:
+
+- Provider adapters under `src/scripts/ai-video/adapters/` (openai-images,
+  gemini-veo, kling, higgsfield, sora) + the adapter contract.
+- `provider-lifecycle-discipline` rule + `agents/templates/.ai-video.xml.example`
+  (provider tiers, `<default-video-provider>`).
+- `AIV_DRYRUN=true` cost-safety default; the media-governance policy layer
+  (`agents/settings/policies/media/`) and the `media-sync-ground-truth` /
+  `media-governance-routing` rules.
+
+## (c) Compatibility matrix — what works without the Creative Pack
+
+| Profile | Creative Pack | Without it |
+|---|---|---|
+| `content_creator` | **active** | full video surface |
+| `developer` · `agency` · `ops` · `finance` · `founder` | not included | **no change** — video was never projected |
+
+| Flow | Depends on Creative Pack? |
+|---|---|
+| discovery · implementation · review · delivery | **No** — the four work-flows are engineering journeys; none reference a video command or skill |
+
+**What breaks without it:** nothing in the core surface. The `/video:*` and
+`/image:*` commands are simply absent (graceful — projection-time filtering never
+writes them); no rule, flow, or non-creator profile depends on an `ai-video`
+artefact. The media-governance policy layer is referenced by routing rules that
+stay inert unless a media surface fires, so it does not break either.
+
+**Conclusion:** the Creative Pack is cleanly severable. It enriches the
+`content_creator` experience and is invisible everywhere else — keeping video a
+bounded Creator capability, not the package's identity.
+
+## See also
+
+- [`src/domains/ai-video/pack.yaml`](../../src/domains/ai-video/pack.yaml) — the generated pack manifest (span + trust level).
+- [`profiles.md`](../profiles.md) · [`experiences/content_creator.md`](../experiences/content_creator.md) — where the pack surfaces.
+- [`provider-lifecycle-discipline`](../../src/rules/provider-lifecycle-discipline.md) — the provider-tier rule inside the boundary.
+- ADR-040 — projection-time filtering (the mechanism that makes a pack optional).

--- a/docs/contracts/review-lens-schema.md
+++ b/docs/contracts/review-lens-schema.md
@@ -1,0 +1,59 @@
+# Review-lens routing schema
+
+Defines what a review **lens** is, the metadata it carries, and which review
+skills are **entry skills** (invoked directly / by task) vs **dispatched lenses**
+(run only under an orchestrator). This is the contract the Phase-3 consolidation
+scan validates merge candidates against — **proposal/schema only; no skill is
+merged here.**
+
+## Lens vs entry skill
+
+```
+A LENS IS DISPATCHED, NEVER A FRONT DOOR.
+AN ENTRY SKILL IS INVOKED; A LENS IS ORCHESTRATED.
+DO NOT MERGE ACROSS THE LINE.
+```
+
+- **Entry review skill** — a reviewer the user (or a task) invokes directly. It
+  produces a standalone verdict and may itself orchestrate. Examples:
+  `code-review` (also the `/review-changes` consolidator), `adversarial-review`,
+  `authz-review`, `design-review`, `privacy-review`, `receiving-code-review`,
+  `requesting-code-review`, `skill-reviewer`.
+- **Dispatched lens** — a specialized reviewer that runs **only** under an
+  orchestrator (`/review-changes` dispatches five, each on the same diff +
+  context, independently, then consolidates). Examples: `judge-bug-hunter`,
+  `judge-security-auditor`, `judge-test-coverage`, `judge-code-quality`,
+  `architecture-review-lens`.
+- **Router** — picks reviewers by path + risk, dispatches nothing itself:
+  `review-routing`.
+
+## Schema — the metadata a lens carries
+
+| Field | Meaning |
+|---|---|
+| `id` | the lens skill slug (`judge-bug-hunter`, `architecture-review-lens`, …) |
+| `scope` | the single dimension it reviews (correctness · security · test-coverage · quality · architecture) |
+| `constraints` | what it MUST flag and what it must NOT (stay in its lane — a bug lens does not opine on style) |
+| `dispatched_by` | the orchestrator that runs it (`/review-changes`; `/judge` for solo/steps) |
+| `runs` | `independently` — same diff + task context, no cross-talk between lenses |
+| `consolidated_by` | who merges the verdicts (`code-review` for `/review-changes`) |
+| `verdict_shape` | findings list with severity; no merge/ship decision (the human decides) |
+
+## The dispatch contract (what Phase 3 validates against)
+
+1. A **lens never becomes a front door** — it has no standalone command and is
+   not in a profile's `commands_hint`. Merging a lens into an entry skill (or
+   promoting it to a command) breaks the orchestrated-review model.
+2. A **lens stays single-scope** — consolidation must not fuse two lenses into
+   one multi-scope reviewer (that re-creates the monolith `/review-changes` was
+   built to decompose).
+3. An **entry skill may absorb another entry skill** only when both are
+   user-invoked and their scopes genuinely overlap — but never absorb a lens.
+4. The **consolidator** (`code-review`) is load-bearing — it is the entry skill
+   that both stands alone and merges lens verdicts; it is not a merge candidate.
+
+## See also
+
+- [`/review-changes`](../../src/domains/engineering-base/review-changes/command.md) — the five-judge dispatcher.
+- [`skill-family-map.yml`](skill-family-map.yml) — `family: review-judging` carries these skills; Phase 3 reads `candidate_*` against this contract.
+- [`governance.md`](../governance.md) — the lifecycle + Single-Source-of-Truth rules these skills age under.


### PR DESCRIPTION
## What

Positioning **Phase 2** — the two remaining tractable governance items (proposal/
schema only; no skill merged, no pack changed).

### Review-lens routing schema — `docs/contracts/review-lens-schema.md`

The **lens-vs-entry-skill** contract:

- **Dispatched lenses** (run only under an orchestrator): `judge-bug-hunter`,
  `judge-security-auditor`, `judge-test-coverage`, `judge-code-quality`,
  `architecture-review-lens` — the five `/review-changes` dispatches.
- **Entry skills** (invoked directly): `code-review` (also the consolidator),
  `adversarial-review`, `authz-review`, `design-review`, `privacy-review`, …
- **Router**: `review-routing`.

Plus the metadata a lens carries (`scope`, `constraints`, `dispatched_by`,
`runs: independently`, `consolidated_by`, `verdict_shape`) and the **four
dispatch-contract rules** Phase 3 validates consolidation candidates against
(a lens never becomes a front door; lenses stay single-scope; etc.).

### Creative Pack boundary — `docs/contracts/creative-pack-boundary.md`

"Creative Pack is optional": (a) user-facing video/image artefacts, (b) internal/
provider-specific ones, (c) a **compatibility matrix** proving the four flows +
the five non-creator profiles work unchanged without `ai-video` — projection-time
filtering simply omits it; nothing core depends on it. Video stays a bounded
Creator pack, not the package's identity.

## Phase 2 status

The **"ship now"** set is complete (lifecycle policy + family-map spine in #436;
review-lens schema + video-pack boundary here). Remaining Phase-2 items are
**council-deferred**: ownership map (`[~]`, until a 2nd maintainer),
command-category lint (`[ ]`, Phase 2b/3), `skill-family-map` `candidate_*`
(`[ ]`, Phase 3).

## Verification

`check-refs` ✅ (all `src/` + `docs/` links resolve) · `check-md-language` ✅.

No version pinned.
