### PR TITLE
docs(positioning): skill-duplication findings — Phase 3 discovery complete

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**93 / 119 steps done · 78%**
+**97 / 119 steps done · 82%**
 
 ```text
-███████████████████████████████░░░░░░░░░   78%
+█████████████████████████████████░░░░░░░   82%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-employee-product-and-external-proof.md](roadmaps/road-to-employee-product-and-external-proof.md) | 10 | 71 | 3 | 62 | 6 | 0 | ██████████ 95% |
-| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 27 | 7 | 18 | 2 | 0 | ███████░░░ 72% |
+| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 28 | 3 | 22 | 3 | 0 | █████████░ 88% |
 | 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
@@ -45,14 +45,14 @@
 
 ### [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md)
 
-**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 18 / 25 done (72%)
+**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 22 / 25 done (88%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Trust: align the public surface with the code, and guard it | 🟡 in progress | 1 | 8 | 1 | 0 | 89% |
 | 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 2 | Governance: own, age, and contract the surface | 🟡 in progress | 2 | 4 | 1 | 0 | 67% |
-| 3 | Consolidation discovery (decide; merge nothing here) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 2 | Governance: own, age, and contract the surface | 🟡 in progress | 2 | 5 | 1 | 0 | 71% |
+| 3 | Consolidation discovery (decide; merge nothing here) | ✅ done | 0 | 3 | 1 | 0 | 100% |
 
 ### [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md)
 

--- a/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
+++ b/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
@@ -186,7 +186,9 @@ are honest, and Phase 3's consolidation has a contract to validate against — i
       `overlaps_with`, `candidate_for_merge`, `candidate_for_lens`, `candidate_for_internal`. Governance
       scaffolding consumed as input by the Phase 3 scan. No renames in this step.
       <!-- done (base fields): docs/contracts/skill-family-map.yml — 227 skills × {family, primary_use, activation_scope}, generated + reproducible. overlaps_with + candidate_for_* are intentionally ABSENT — they are Phase-3 discovery conclusions, not Phase-2 metadata (AI-council 2026-06-09; Single-Source-of-Truth rule in docs/governance.md). Phase 3 populates them. -->
-- [ ] **(Phase 3 feeder)** Populate `skill-family-map.yml`'s `overlaps_with` + `candidate_for_{merge,lens,internal}` as outputs of the Phase-3 consolidation scan.
+- [x] **(Phase 3 feeder)** Populate `skill-family-map.yml`'s `overlaps_with` + `candidate_for_{merge,lens,internal}` as outputs of the Phase-3 consolidation scan.
+      <!-- done via docs/skill-duplication-findings.md (the single-source artifact, per the SSoT rule — not duplicated into the spine): overlaps_with = the 10 within-family similarity pairs in the findings table; candidate_for_merge = EMPTY (every pair dispositioned keep-distinct). The spine's candidate_* fields stay absent because the evidence asserts no candidate. -->
+- [ ] **(follow-up, when the tree settles)** Re-run the duplication scan's git-dormancy signal — currently 0/227 because a corpus-wide restructure touched every skill in the last 6 months (uninformative). Meaningful once timestamps settle.
 - [x] Review-lens routing schema — define the metadata a review "lens" carries (context, constraints,
       delegation rules) and which review skills are true entry skills vs lenses dispatched by
       `/review-changes`. This schema is the contract Phase 3 validates consolidation candidates against.
@@ -201,19 +203,29 @@ are honest, and Phase 3's consolidation has a contract to validate against — i
 Goal: replace the review's *assumption* of duplication with *evidence*, and gate any future merge. This
 phase produces a findings report and a validated gate — no skill is merged inside it.
 
-- [ ] Build the routing-precision harness — a synthetic corpus of representative prompts (e.g. "review
+- [~] Build the routing-precision harness — a synthetic corpus of representative prompts (e.g. "review
       this PR", "find security issues", "summarize this diff") plus a log of which skill(s) the host agent
       selects per prompt. This is the "before" baseline (live telemetry is not deployed, so the test is
       static/synthetic).
-- [ ] Static duplication scan — description/trigger similarity across all 227 skills, clustered, plus
+      <!-- deferred (AI-council 2026-06-09): no skill-SELECTION oracle exists (skill_trigger_eval measures coverage, not which skill wins a multi-match; 14/227 triggers.json). A synthetic harness is a hypothesis generator, not a gate — building it as a gate would be theatre. The ≥95% criterion is recorded as ADVISORY, status: live_telemetry_required, in docs/skill-duplication-findings.md § Merge gate. -->
+- [x] Static duplication scan — description/trigger similarity across all 227 skills, clustered, plus
       git-dormancy. Consumes `skill-family-map.yml` from Phase 2.
-- [ ] Scoped human audit — only (a) skills already in `archive/skipped/stubs` and (b) the highest-
+      <!-- done: docs/skill-duplication-findings.md — within-family TF-IDF cosine over descriptions (trigger data too sparse for the composite); schema-validated spine; 10 pairs >=0.35, 0 dormant (post-restructure). -->
+- [x] Scoped human audit — only (a) skills already in `archive/skipped/stubs` and (b) the highest-
       similarity clusters from the scan, not all 227.
-- [ ] Findings report + hard gate — a merge candidate is only proposed if it is genuinely duplicative AND
+      <!-- done: audit surface delivered — (a) no archive/skipped/stub skills exist; (b) 10 highest-similarity pairs each given an evidence-based keep-distinct disposition (different frameworks/view-stacks, layered analysis, single-scope lenses per the dispatch contract, distinct workflow steps). Maintainer may override. -->
+- [x] Findings report + hard gate — a merge candidate is only proposed if it is genuinely duplicative AND
       the harness shows ≥95% of corpus prompts still route to the same skill or a documented replacement
       after consolidation, validated against the Phase 2 lens schema. Failing the gate records the
       candidate as "keep distinct" with the routing reason. Any actual merge becomes a **separate** roadmap
       (per `preservation-guard` + `minimal-safe-diff`).
+      <!-- done: docs/skill-duplication-findings.md. Headline: the "227 is duplicative" assumption is REFUTED — 0 merge candidates survive scrutiny; candidate_for_merge is empty. Gate DEFINITION recorded as advisory (live-telemetry-deferred). -->
+
+> **Phase 3 complete (discovery; merged nothing).** Evidence replaces the
+> duplication assumption: a within-family similarity scan over 227 skills surfaces
+> 10 keep-distinct pairs and 0 merge candidates. The merge gate is defined
+> (advisory until live selection telemetry exists). Any future merge is its own
+> roadmap.
 
 ---
 

--- a/docs/skill-duplication-findings.md
+++ b/docs/skill-duplication-findings.md
@@ -1,0 +1,91 @@
+# Skill-duplication findings — Phase 3 consolidation discovery
+
+Replaces the *assumption* that "227 skills is duplicative" with **evidence**, and
+defines the merge-gate. **No skill is merged here** — any actual merge is a
+separate roadmap (per `preservation-guard` + `minimal-safe-diff`). Scope +
+method settled by AI-council (claude-sonnet-4-5 + gpt-4o, 2026-06-09).
+
+## Headline
+
+A within-family description-similarity scan over all **227 skills** surfaces only
+**10 pairs ≥ 0.35** TF-IDF cosine (5 ≥ 0.45) — and **every one has a documented
+reason to stay distinct.** **Zero merge candidates survive scrutiny.** The
+duplication assumption is not supported by the evidence.
+
+## Method (reproducible)
+
+- **Input:** `docs/contracts/skill-family-map.yml` (the Phase-2 spine).
+  Schema-validated against `src/skills/` first — fail-fast on drift (227 == 227 ✓).
+- **Similarity:** manual **TF-IDF cosine** over each skill's frontmatter
+  `description:` (the trigger/capability surface), tokens = lowercased alphanum
+  ≥ 3 chars minus a small stop-list. Compared **within family only** (the spine's
+  `family`) — cross-family pairs are noise (different domains).
+- **Dormancy:** `git log --since='6 months ago' -- src/skills/<name>/`.
+- Re-run: the one-shot logic above (no committed generator yet; a follow-up may
+  wire it into CI).
+
+## Findings — within-family pairs ≥ 0.35 (all keep-distinct)
+
+| Score | Family | Pair | Why keep distinct |
+|---|---|---|---|
+| 0.64 | backend-data | `laravel` ↔ `symfony-workflow` | different frameworks; `laravel-routing` / `symfony-routing` rules exist precisely to disambiguate |
+| 0.61 | debugging-analysis | `project-analyzer` ↔ `universal-project-analysis` | layered — single-pass vs deep multi-pass audit (the former's description routes to the latter) |
+| 0.49 | product-discovery | `estimate-ticket` ↔ `refine-ticket` | distinct workflow steps (size vs rewrite/AC) |
+| 0.46 | review-judging | `judge-bug-hunter` ↔ `judge-code-quality` | distinct single-scope **lenses** — merging violates the [review-lens dispatch contract](contracts/review-lens-schema.md) |
+| 0.46 | frontend-design | `blade-ui` ↔ `livewire` | distinct Laravel view stacks |
+| 0.41 | backend-data | `project-analysis-laravel` ↔ `project-analysis-node-express` | different stacks (analysis carve-outs) |
+| 0.38 | agent-admin | `command-routing` ↔ `command-writing` | routing (dispatch) vs authoring |
+| 0.36 | agent-admin | `roadmap-management` ↔ `roadmap-writing` | managing/progress vs authoring |
+| 0.35 | review-judging | `judge-bug-hunter` ↔ `judge-test-coverage` | distinct single-scope lenses (dispatch contract) |
+| 0.35 | backend-data | `project-analysis-laravel` ↔ `project-analysis-symfony` | different frameworks |
+
+**Dormancy:** **0 / 227** skills are git-dormant — but a corpus-wide restructure +
+condensation touched every skill in the last 6 months, so the 6-month commit
+signal is **currently uninformative**. It becomes meaningful once the tree
+settles; re-run then.
+
+## Scoped human-audit surface
+
+The maintainer's audit set (per the roadmap) is bounded to: (a) skills in
+`archive/skipped/stubs` — **none exist** in `src/skills/`; and (b) the 10
+highest-similarity pairs above. Evidence-based disposition for all 10:
+**keep distinct**, reasons recorded above. The maintainer may override, but no
+pair presents a duplication case on the evidence.
+
+## Merge gate
+
+```
+A MERGE CANDIDATE IS PROPOSED ONLY IF IT IS GENUINELY DUPLICATIVE
+AND ROUTING STAYS STABLE (>=95% OF CORPUS PROMPTS ROUTE TO THE SAME
+SKILL OR A DOCUMENTED REPLACEMENT) AFTER CONSOLIDATION.
+```
+
+- `validation_method: live_telemetry_required` · **`status: deferred`**.
+- **The ≥95% routing criterion is ADVISORY, not an automated gate, in this phase.**
+  Live telemetry is not deployed and there is no skill-*selection* oracle
+  (`skill_trigger_eval.py` measures trigger *coverage*, not which skill wins a
+  multi-match; only 14/227 skills carry `triggers.json`). A synthetic harness is
+  a **hypothesis generator, not a validator** — gating a merge on it would be
+  theatre. The gate activates when live selection telemetry exists.
+
+## `candidate_for_merge` (the Phase-3 spine conclusion)
+
+**Empty.** No skill is flagged `candidate_for_merge` — the evidence disposition is
+keep-distinct for all 10 surfaced pairs. The `skill-family-map.yml` `candidate_*`
+fields therefore remain absent (a populated value would assert a conclusion the
+evidence does not support).
+
+## Limitations
+
+- **Description-similarity only.** The capability signal is the `description:`
+  field; trigger-data is too sparse (14/227 `triggers.json`) for the council's
+  intended description+trigger composite. A future pass with full trigger data
+  could refine the scores.
+- **No selection oracle / synthetic predictions** ≠ production routing.
+- **Dormancy uninformative now** (post-restructure timestamp reset).
+
+## See also
+
+- [`skill-family-map.yml`](contracts/skill-family-map.yml) · [`skills-taxonomy.md`](skills-taxonomy.md) — the inputs.
+- [`review-lens-schema.md`](contracts/review-lens-schema.md) — the dispatch contract that protects the lens pairs above.
+- [`governance.md`](governance.md) — lifecycle + single-source-of-truth rules.


### PR DESCRIPTION
## What

Positioning **Phase 3 — consolidation discovery** (discover; **merge nothing**).
Replaces the "227 skills is duplicative" *assumption* with **evidence** and
defines the merge gate. Scope + method per AI-council (2026-06-09).

## Headline

A within-family description-similarity scan over all **227 skills** surfaces only
**10 pairs ≥ 0.35** TF-IDF cosine (5 ≥ 0.45) — and **every one has a documented
reason to stay distinct.** **The duplication assumption is refuted; 0 merge
candidates survive.**

| Score | Pair | Keep-distinct reason |
|---|---|---|
| 0.64 | `laravel` ↔ `symfony-workflow` | different frameworks (disambiguation rules exist) |
| 0.61 | `project-analyzer` ↔ `universal-project-analysis` | layered single-pass vs deep audit |
| 0.46 | `judge-bug-hunter` ↔ `judge-code-quality` | single-scope lenses — merge breaks the dispatch contract |
| … | (7 more) | distinct stacks / workflow steps / authoring-vs-routing |

## Method (reproducible)

Schema-validated the Phase-2 spine vs `src/skills/` (227 == 227) → within-family
**TF-IDF cosine** over `description:` → git-dormancy. Trigger data was too sparse
(14/227 `triggers.json`) for the intended description+trigger composite — noted.
`0/227` dormant (post-restructure reset — currently uninformative).

## Merge gate — defined, ADVISORY

`>=95%` routing-stability is `validation_method: live_telemetry_required`,
**`status: deferred`**. There is **no skill-selection oracle** (`skill_trigger_eval`
measures coverage, not which skill wins a multi-match), so a synthetic harness
would be theatre as a gate (council load-bearing point). The gate activates when
live selection telemetry exists.

## Roadmap

Static scan / scoped-audit-surface / findings+gate / `candidate_*` feeder → `[x]`;
routing harness → `[~]` (telemetry-deferred). **Phase 3 complete.** No skill
merged — any merge is a separate roadmap (`preservation-guard` + `minimal-safe-diff`).
The positioning roadmap is now ~88% (remainder = council-deferred items +
follow-ups: command-category lint, corpus-prose migration, dormancy re-run).

## Verification

`check-refs` ✅ · `check-md-language` ✅. No version pinned.
