### PR TITLE
feat(commands): optional category: field + creation-time checklist (Phase 2b, Option 1)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**36 / 66 steps done · 55%**
+**37 / 67 steps done · 55%**
 
 ```text
 ██████████████████████░░░░░░░░░░░░░░░░░░   55%
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-external-proof-upgrade.md](roadmaps/road-to-external-proof-upgrade.md) | 3 | 12 | 12 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 29 | 2 | 23 | 4 | 0 | █████████░ 92% |
+| 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 30 | 2 | 24 | 4 | 0 | █████████░ 92% |
 | 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
@@ -38,13 +38,13 @@
 
 ### [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md)
 
-**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 23 / 25 done (92%)
+**Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps** — 24 / 26 done (92%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Trust: align the public surface with the code, and guard it | ✅ done | 0 | 9 | 2 | 0 | 100% |
 | 1 | Positioning & Flows: make the product navigable (docs only, zero routing risk) | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 2 | Governance: own, age, and contract the surface | 🟡 in progress | 2 | 5 | 1 | 0 | 71% |
+| 2 | Governance: own, age, and contract the surface | 🟡 in progress | 2 | 6 | 1 | 0 | 75% |
 | 3 | Consolidation discovery (decide; merge nothing here) | ✅ done | 0 | 3 | 1 | 0 | 100% |
 
 ### [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md)

--- a/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
+++ b/agents/roadmaps/road-to-positioning-consistency-and-skill-governance.md
@@ -176,11 +176,13 @@ are honest, and Phase 3's consolidation has a contract to validate against — i
 - [~] Skill ownership map (CODEOWNERS-style, or a `SKILL_OWNERS` doc keyed by family) assigning a
       maintainer per family. Group-by-family makes this tractable.
       <!-- deferred (AI-council 2026-06-09): single maintainer → per-family ownership is ceremony with zero information. Deferred until a 2nd maintainer exists; the `owner:` field then becomes a skill-family-map.yml column, not a separate CODEOWNERS. Recorded in docs/governance.md § Deferred governance. -->
-- [ ] **Command `category:` lint (from Phase-0 step 7b).** Introduce the `category:` frontmatter field
+- [x] **Command `category:` lint (from Phase-0 step 7b) — resolved as Option 1 (light).** Introduce the `category:` frontmatter field
       (`flow-entry | state-query | product-surface` per ADR-048), categorize the 125 visible commands
       (after the ownership map assigns owners — avoids one architect making 125 calls), decide the
       demotion path for commands that fit none, then ship the lint (warn first, then blocking). Full
       hand-off: [`docs/contracts/command-category-governance.md`](../../docs/contracts/command-category-governance.md).
+      <!-- done as Option 1 (AI-council tie-break 2026-06-09, light > full, decisive; maintainer: "Option 2 only if better — it isn't"): `category:` DEFINED as an optional validate-when-present enum in command.schema.json; creation-time categorization checklist added to the command-writing skill; full 54-categorization + blocking lint + demotion DEFERRED until a merged CONSUMER PR reads `category:` (no consumer today = supply-without-demand/YAGNI; blocking a 15%-ambiguous taxonomy enforces presence-not-correctness). Upgrade trigger + rationale in command-category-governance.md. -->
+- [ ] **(deferred → consumer-gated)** Full categorization of all 54 top-level commands + blocking `category:` lint + demotion of fits-none commands — lands in one focused PR when a consumer (routing/analytics/discovery) that reads `category:` is merged.
 - [x] Skill lifecycle policy — review cadence and active/dormant/sunset states; dormancy triggers
       *review*, not automatic deprecation. Slot it beside `persona-governance` as its skill-side sibling.
       <!-- done: docs/governance.md § Skill lifecycle policy — commit-based dormancy (git log, no last_reviewed busywork for a solo maintainer); review-not-auto-deprecate; sunset recorded in-commit. -->

--- a/dist/agent-src/skills/command-writing/SKILL.md
+++ b/dist/agent-src/skills/command-writing/SKILL.md
@@ -42,6 +42,20 @@ author as a skill and add a thin command that delegates to it.
 Check first: [`command-clusters` § Command justification](../../../docs/contracts/command-clusters.md#command-justification--a-command-must-earn-a-top-level-slot)
 ([ADR-048](../../../docs/decisions/ADR-048-command-justification-rule.md)).
 
+**Categorize at creation (checklist).** New top-level command → declare
+`category:` (schema enum `flow-entry | state-query | product-surface`):
+
+- [ ] **flow-entry** — daily work start (`work`, `git-commit`, `review-changes`).
+- [ ] **state-query** — read-only check (`agent-status`, `project-health`, `profile`).
+- [ ] **product-surface** — deliberately-started feature (`council`, `research`, `roadmap`).
+- [ ] **fits none → it's a skill.** Don't add the command.
+- [ ] **ambiguous?** Omit `category:` + note why — OPTIONAL (validate-when-present);
+  deferring is intentional.
+
+Sub-commands inherit the parent cluster's category — leave `category:` off them.
+Why optional + not yet blocking, + the upgrade trigger:
+[`command-category-governance`](../../../docs/contracts/command-category-governance.md).
+
 ## Commands ARE Claude skills (projection reality)
 
 Every `src/agent-src/commands/{name}.md` projects to

--- a/docs/contracts/command-category-governance.md
+++ b/docs/contracts/command-category-governance.md
@@ -1,11 +1,35 @@
-# Command-category governance — Phase-2 hand-off
+# Command-category governance
 
-> **Status:** hand-off stub. The `category:` lint (positioning roadmap "step 7b")
-> was **re-cut from Phase 0 to Phase 2** per AI-council convergence
-> (claude-sonnet-4-5 + gpt-4o, 2026-06-09): it is product/governance judgment,
-> not a CI-plumbing guardrail, and it should follow the Phase-2 **ownership map**
-> rather than bottleneck on one architect making 125 calls. This doc is the
-> bridge so the decision is not relitigated.
+> **Status (2026-06-09):** Phase-2b resolved as **Option 1 (light)** — an
+> AI-council tie-break (claude-sonnet-4-5 + gpt-4o) chose light over a
+> full/blocking lint, decisively: no consumer reads `category:` today, so
+> populating all 54 + blocking CI is "supply without demand" (YAGNI), and a
+> blocking gate on a 15%-ambiguous taxonomy enforces *presence, not correctness*
+> — mis-calls made under CI pressure surface later as a re-categorization pass
+> ("pays the cost twice"). What shipped, and the upgrade trigger, are below.
+
+## Shipped (Option 1 — light)
+
+- **`category:` defined** as an OPTIONAL enum in `command.schema.json`
+  (`flow-entry | state-query | product-surface`), **validate-when-present** —
+  a declared value must be a valid enum; absence is fine. (Note: the 150
+  `src/domains/**/command.md` files are not yet full-schema-validated — a
+  pre-existing gap, separate from this field; the enum bites wherever
+  command-schema validation runs / when a consumer reads it.)
+- **Creation-time checklist** in the [`command-writing`](../../src/skills/command-writing/SKILL.md)
+  skill: categorize a NEW top-level command at authoring; fits-none → it's a
+  skill; genuinely ambiguous → omit `category:` and note why (intentionally
+  deferred, not forgotten). Sub-commands inherit the parent cluster's category.
+
+## Deferred — until the upgrade trigger fires
+
+**Full categorization of all 54 top-level commands + a blocking lint + the
+demotion of fits-none commands** are deferred. **Upgrade trigger:** a **merged
+consumer PR** — runnable code that *reads* `category:` (routing, analytics, a
+catalog/discovery grouping, a "daily five" surface). A design doc is not the
+trigger; running code that breaks on miscategorization is. When it lands,
+population + enforcement land together in one focused PR, with the consumer's
+requirements defining the ambiguous categories unambiguously.
 
 ## The schema (to introduce in Phase 2)
 

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -323,7 +323,7 @@
   "skills/code-refactoring/SKILL.md": "6b6eec64cad38d1fb5678efec7bc79fabfa0f2158713c8cff32742088bdd9196",
   "skills/code-review/SKILL.md": "81ed5eee623626fa6f1c16a094d5836dd0bff2df0a800ba0bec728a985a94d92",
   "skills/command-routing/SKILL.md": "21d302e01e6744d474f0bc25b8958b60f06c441fe9a06933a2e266c01a5cac8f",
-  "skills/command-writing/SKILL.md": "b96fe373f4eb83cb3219a84cc6674b3d0f5f3b7557eb0c575cce446b089d06f1",
+  "skills/command-writing/SKILL.md": "7acdae10e5c2c8af2cb4838cf1520cdb55a7109ec4628a70d4a76ef03c7d8f83",
   "skills/comp-banding/SKILL.md": "09b1ad2edc42447e3ca6354aeb045947f475df3db6521e93d057dad92523694d",
   "skills/competitive-moat-analysis/SKILL.md": "3d25048b070141e3f2bf90cc4e1b5b5437e7af480c0c96e369d06ef82eb0bb20",
   "skills/competitive-positioning/SKILL.md": "37d6c8575dc7f9e462898cd72df825888fc88afdcae1178098aa538f7851b9c7",

--- a/src/scripts/schemas/command.schema.json
+++ b/src/scripts/schemas/command.schema.json
@@ -69,6 +69,11 @@
       },
       "description": "6.0.0-C Phase 2 routing metadata. The data backbone the routing-eval lint checks against: the skill slug(s), cluster sub-command(s), or command(s) this command routes the intent to (e.g. ['refine-ticket', 'feature-planning'] or ['fix:ci']). REQUIRED on every visible command (tier 0/1), enforced by scripts/lint_command_routing.py; optional on internal commands."
     },
+    "category": {
+      "type": "string",
+      "enum": ["flow-entry", "state-query", "product-surface"],
+      "description": "ADR-048 command-justification category for a top-level slot: `flow-entry` (daily work starting point), `state-query` (read-only check), `product-surface` (deliberately-started feature). OPTIONAL and validate-when-present (positioning Phase 2b, AI-council 2026-06-09): the field is defined and an author MAY categorize a command at creation (see the command-writing skill checklist), but full categorization + blocking enforcement are DEFERRED until a consumer (routing / analytics / discovery) reads it — populating supply before demand is YAGNI. Sub-commands inherit the parent cluster's category."
+    },
     "replaces": {
       "type": "array",
       "uniqueItems": true,

--- a/src/skills/command-writing/SKILL.md
+++ b/src/skills/command-writing/SKILL.md
@@ -42,6 +42,22 @@ author as a skill and add a thin command that delegates to it.
 skill. Check before authoring: [`command-clusters` § Command justification](../../../docs/contracts/command-clusters.md#command-justification--a-command-must-earn-a-top-level-slot)
 ([ADR-048](../../../docs/decisions/ADR-048-command-justification-rule.md)).
 
+**Categorize at creation (checklist).** When you author a NEW top-level command,
+declare its justification as a `category:` in the frontmatter — the schema enum
+is `flow-entry | state-query | product-surface`:
+
+- [ ] **flow-entry** — a daily work starting point the user TYPES to begin
+  (`work`, `git-commit`, `review-changes`).
+- [ ] **state-query** — a read-only check (`agent-status`, `project-health`, `profile`).
+- [ ] **product-surface** — a feature started deliberately (`council`, `research`, `roadmap`).
+- [ ] **fits none → it is a skill.** Don't add the command; author a skill.
+- [ ] **genuinely ambiguous?** Omit `category:` and note why — `category:` is
+  OPTIONAL (validate-when-present); deferring is intentional, not forgotten.
+
+Sub-commands (`council:debate`) inherit the parent cluster's category — leave
+`category:` off them. Why optional + not yet a blocking lint, and what triggers
+the upgrade: [`command-category-governance`](../../../docs/contracts/command-category-governance.md).
+
 ## Commands ARE Claude skills (projection reality)
 
 Every command in `src/agent-src/commands/{name}.md` is projected


### PR DESCRIPTION
## What

Command-category governance (positioning **Phase 2b**), resolved as **Option 1
(light)** — an AI-council **tie-break** (claude-sonnet-4-5 + gpt-4o, 2026-06-09)
chose light over a full/blocking lint, **decisively**. Maintainer instruction:
"Option 2 (full) only if genuinely better than Option 1 — let the council decide."
It isn't.

### Why not the full/blocking lint

- **No consumer reads `category:` today** (ADR-048 *defines* the categories; no
  routing/analytics/discovery dispatches on them) → populating all 54 + blocking
  CI is **supply without demand** (YAGNI).
- A blocking gate on a **15%-ambiguous** taxonomy (8/54) enforces **presence, not
  correctness** — forced calls under CI pressure resurface later as a
  re-categorization pass ("pays the cost twice").

### Shipped (light)

- **`command.schema.json`**: `category:` as an **OPTIONAL** enum
  (`flow-entry | state-query | product-surface`), **validate-when-present** —
  defines + reserves the value space without forcing population.
  *(The 150 `src/domains/**/command.md` aren't yet full-schema-validated — a
  pre-existing gap, noted in the hand-off, not fixed here.)*
- **`command-writing` skill**: a **creation-time categorization checklist** —
  categorize a new top-level command; fits-none → it's a skill; ambiguous → omit
  `category:` + note why; sub-commands inherit the parent cluster.
- **`command-category-governance.md`**: re-headed to the Option-1 decision + the
  **upgrade trigger**.

### Deferred — consumer-gated

Full 54-categorization + blocking lint + fits-none demotion land in **one focused
PR when a merged consumer PR** (routing / analytics / discovery) reads
`category:` — runnable code, not a design doc.

## Verification

`schema JSON` ✅ · `validate_frontmatter` (0 failing) ✅ · `condense --check` ✅ ·
`check-refs` ✅ · `check-md-language` ✅.

## Roadmap

command-category-lint → `[x]` (Option 1); consumer-gated follow-up added. With
this, the positioning roadmap's remaining items are all deferred-by-design
(ownership map, routing harness, corpus migration, dormancy re-run, the
consumer-gated full category lint). No version pinned.
