### PR TITLE
docs(readme): reduce above-fold jargon 9 → 2 hits (lint-readme-jargon green)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,7 @@ shows the wired AIs; [`docs/featured-commands.md`](docs/featured-commands.md)
 lists the end-to-end workflows (`/implement-ticket`, `/work`,
 `/commit`, `/create-pr`). Deeper tour: [2-minute demo](#2-minute-demo--implement-ticket).
 
-**Install scope.** Pick **one** scope per machine — project-local (default, recommended for application repos) or user-global (recommended for tooling repos / dotfiles). The installer refuses cross-scope drift via the `scope_guard` pre-flight. Contract: [`docs/contracts/install-scopes.md`](docs/contracts/install-scopes.md). Cleanup when needed: `bash scripts/cleanup_other_scope.sh --confirm`.
-
-## Harness expectations
-
-Three classes of behaviour look like package bugs but are host-harness behaviour the package cannot control — sibling-plugin namespaces (`codex:*`, `cc-gemini-plugin:*`), deferred tools surfaced via `ToolSearch`, and cross-scope skill drift (real bug, fixed in the distribution-channels track). Diagnostics + the package's response: [`docs/contracts/harness-expectations.md`](docs/contracts/harness-expectations.md). First step when a skill appears twice: `task probe:skills`.
+**Install scope.** Pick **one** scope per machine — project-local (default, recommended for application repos) or user-global (recommended for tooling repos / dotfiles). The installer refuses a second, conflicting scope via the `scope_guard` pre-flight. Details: [`docs/contracts/install-scopes.md`](docs/contracts/install-scopes.md). Cleanup when needed: `bash scripts/cleanup_other_scope.sh --confirm`.
 
 ## Prove it
 
@@ -303,6 +299,10 @@ npm install --save-dev @event4u/agent-memory
 → [Memory contract](docs/contracts/agent-memory-contract.md) · [Built-in MCP server](docs/mcp-server.md) (experimental)
 
 ---
+
+## Harness expectations
+
+Three classes of install/runtime behaviour look like package bugs but are host-harness behaviour the package cannot control — sibling-plugin namespaces (`codex:*`, `cc-gemini-plugin:*`), deferred tools surfaced via `ToolSearch`, and cross-scope skill drift (real bug, fixed in the distribution-channels track). Diagnostics + the package's response: [`docs/contracts/harness-expectations.md`](docs/contracts/harness-expectations.md). First step when a skill appears twice: `task probe:skills`.
 
 ## Supported tools
 


### PR DESCRIPTION
## Summary

Closes #383. The local gate `lint-readme-jargon` was red on main: 9 watchlist hits above the fold (lines 1–120), limit 3. The PR #379 council converged on deferring to a README-voice PR — role-first rewrite or section reorder below the fold, brand-voice review required. This is that PR.

### Changes

1. **`## Harness expectations` moved below the fold** (now directly in front of `## Supported tools`) — the section is maintainer-diagnostic ('looks like a bug but is host behaviour') and accounted for 5 of the 9 hits. A council-suggested anchoring phrase ('install/runtime behaviour') keeps mid-page readers oriented.
2. **Install-scope sentence rewritten role-first** — 'refuses cross-scope drift' → 'refuses a second, conflicting scope'; 'Contract:' → 'Details:' (−2 hits).

Above-fold hits: **9 → 2** (limit 3). The remaining 2 are the ADR-033 reference in the distribution sub-line (link text + href), kept deliberately — the decision-record citation is load-bearing.

### Brand-voice review (issue requirement)

Council (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2026-06-09, pr lens): **APPROVE / APPROVE-WITH-TWEAKS.** Applied the one non-blocking tweak (anchoring phrase). The other suggestion (re-wording the scope sentence around 'install') was explicitly rejected in council round 2 — it would shift the subject away from 'scope'.

### Verification

- `task lint-readme-jargon` → exit 0
- `task check-refs` → no broken references (the `#harness-expectations` deep-link from `docs/contracts/harness-expectations.md` still resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)