### PR TITLE
feat(character-consistency): per-subject-class token matrix for non-humanoid locks

### DIFF
--- a/dist/agent-src/skills/character-consistency/SKILL.md
+++ b/dist/agent-src/skills/character-consistency/SKILL.md
@@ -39,9 +39,10 @@ install:
 Do NOT use when:
 
 - One-shot scene with no recurring character — overhead is wasted.
-- The "character" is an object or environment, not a person /
-  creature — use a `style.json` lock pattern in the project's notes
-  instead.
+- The "character" is an environment or set (a place, not an
+  entity) — use a `style.json` lock pattern in the project's notes
+  instead. Recurring creatures, vehicles, and hero objects DO get a
+  real lock — pick the matching `subject_class` below.
 
 ## Procedure
 
@@ -63,6 +64,7 @@ the lock.
 {
   "id": "kebab-case-id",
   "name": "Display Name",
+  "subject_class": "humanoid | creature | vehicle | abstract | object",
   "silhouette": "one-line read of the body shape from 30m",
   "palette": ["#hex1", "#hex2", "#hex3"],
   "wardrobe": "garment list, materials, era",
@@ -72,6 +74,48 @@ the lock.
   "face": "age band, skin tone, hair (length / color / texture), distinguishing marks",
   "voice_note": "timbre + cadence for native-audio adapters; null if N/A",
   "reference_frame": "scenes/<id>/frames/<n>.png or null",
+  "version": 1
+}
+```
+
+#### Subject-class token matrix
+
+Field NAMES are fixed (downstream consumers extract them verbatim);
+their SEMANTICS shift per `subject_class`. Missing `subject_class` →
+`humanoid` (back-compat with existing locks). The blueprint layer
+stays subject-agnostic on purpose — it only consumes the rendered
+SUBJECT string; class semantics live here, in the one file the
+drafting agent reads.
+
+| Field | humanoid | creature | vehicle | abstract | object |
+|---|---|---|---|---|---|
+| `silhouette` | body shape from 30m | body shape + locomotion read | hull/body outline | dominant form | outline + scale cue |
+| `wardrobe` | garments, materials, era | integument: fur / scales / skin texture + markings | body panels, livery, decals, wear | motif / texture field | surface finish, material, wear |
+| `signature_prop` | the object that travels with them | anatomical signature (horn, tail tuft, scar) | hood ornament / aerial / charm | recurring sub-form | defining attachment or mark |
+| `posture_default` | how they stand | gait + resting stance | stance / ride attitude | motion signature | resting pose / orientation |
+| `eye_behavior` | blink rhythm, glance habit | eye/ear behavior | lighting signature (headlights, dash glow) | pulse / emission rhythm | highlight + reflection behavior |
+| `face` | age band, skin, hair, marks | head anatomy (muzzle, eyes, dentition) | front fascia (grille, lights) | focal form | defining front / face side |
+| `voice_note` | timbre + cadence | vocalization | engine / motion sound | sound signature | interaction sound |
+
+Universal slots (`id`, `name`, `palette`, `reference_frame`,
+`version`) keep one meaning across all classes.
+
+Worked example — `creature`:
+
+```json
+{
+  "id": "moor-wyrm",
+  "name": "Moor Wyrm",
+  "subject_class": "creature",
+  "silhouette": "low six-limbed serpentine bulk, head held below shoulder line",
+  "palette": ["#2e4a3f", "#c9b458", "#1a1a1a"],
+  "wardrobe": "moss-green plated scales, gold-flecked underbelly, mud-matted ridge fur",
+  "signature_prop": "broken left tusk capped with a brass ring",
+  "posture_default": "coiled low, weight on forelimbs, tail tip always moving",
+  "eye_behavior": "slow horizontal nictitating blink; ears flatten before lunges",
+  "face": "blunt muzzle, four-nostril ridge, amber eyes with horizontal pupils",
+  "voice_note": "sub-bass rumble with clicking overtones; null if scenes are scored only",
+  "reference_frame": null,
   "version": 1
 }
 ```
@@ -90,8 +134,12 @@ the lock.
 
 1. JSON parses (`jq . characters/<id>.json` exits 0).
 2. All mandatory fields present and non-empty.
-3. Palette has ≥ 2 and ≤ 5 hex values.
-4. Downstream skills cite this file by path, never paraphrase its
+3. `subject_class` (when present) is one of `humanoid | creature |
+   vehicle | abstract | object`; each field reads per the matrix row
+   for that class — a creature lock with a garment list in `wardrobe`
+   is a drafting error, not a style choice.
+4. Palette has ≥ 2 and ≤ 5 hex values.
+5. Downstream skills cite this file by path, never paraphrase its
    contents.
 
 ## Output format
@@ -105,6 +153,9 @@ the lock.
 
 ## Gotcha
 
+- A non-humanoid lock without `subject_class` reads as humanoid
+  downstream — the lock is structurally weaker and nobody can tell.
+  Always set the class for non-humanoid subjects.
 - The model wants to "improve" identity tokens on each scene —
   this is the silent drift failure. Tokens are immutable until a
   revision note bumps `version`.

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -317,7 +317,7 @@
   "skills/bug-analyzer/SKILL.md": "c3364ad6ad6a883db8da9fdecafa1f6650ea1340f850ce98a3691171b41c309d",
   "skills/build-buy-partner/SKILL.md": "bb84bdd998be659cc73bd979c3f386ad680a2d5d2c7fb0672fda7b9f1783375b",
   "skills/canvas-design/SKILL.md": "1c1434a3c9b4b8c4df2727a663c1635d106640072cba79bb9cebb41dc2391736",
-  "skills/character-consistency/SKILL.md": "11a3b7eb04c2bf77c00ed40507b16daf626a8f32a7e4010947b6f6b430927eaa",
+  "skills/character-consistency/SKILL.md": "798c57680e31df74fa0c6faaa094ff8985016039524913bd76bf3a7e5bb215e6",
   "skills/check-refs/SKILL.md": "4260a020a5159016e016e4513487d4cd9cb09dec7824d37a6dcc143ae3987059",
   "skills/churn-prevention/SKILL.md": "091612ab5f27a799695198a2c7173d79db7e7779d7f4964e51b2ae32050d556a",
   "skills/code-refactoring/SKILL.md": "6b6eec64cad38d1fb5678efec7bc79fabfa0f2158713c8cff32742088bdd9196",

--- a/src/skills/character-consistency/SKILL.md
+++ b/src/skills/character-consistency/SKILL.md
@@ -39,9 +39,10 @@ install:
 Do NOT use when:
 
 - One-shot scene with no recurring character — overhead is wasted.
-- The "character" is an object or environment, not a person /
-  creature — use a `style.json` lock pattern in the project's notes
-  instead.
+- The "character" is an environment or set (a place, not an
+  entity) — use a `style.json` lock pattern in the project's notes
+  instead. Recurring creatures, vehicles, and hero objects DO get a
+  real lock — pick the matching `subject_class` below.
 
 ## Procedure
 
@@ -63,6 +64,7 @@ the lock.
 {
   "id": "kebab-case-id",
   "name": "Display Name",
+  "subject_class": "humanoid | creature | vehicle | abstract | object",
   "silhouette": "one-line read of the body shape from 30m",
   "palette": ["#hex1", "#hex2", "#hex3"],
   "wardrobe": "garment list, materials, era",
@@ -72,6 +74,48 @@ the lock.
   "face": "age band, skin tone, hair (length / color / texture), distinguishing marks",
   "voice_note": "timbre + cadence for native-audio adapters; null if N/A",
   "reference_frame": "scenes/<id>/frames/<n>.png or null",
+  "version": 1
+}
+```
+
+#### Subject-class token matrix
+
+Field NAMES are fixed (downstream consumers extract them verbatim);
+their SEMANTICS shift per `subject_class`. Missing `subject_class` →
+`humanoid` (back-compat with existing locks). The blueprint layer
+stays subject-agnostic on purpose — it only consumes the rendered
+SUBJECT string; class semantics live here, in the one file the
+drafting agent reads.
+
+| Field | humanoid | creature | vehicle | abstract | object |
+|---|---|---|---|---|---|
+| `silhouette` | body shape from 30m | body shape + locomotion read | hull/body outline | dominant form | outline + scale cue |
+| `wardrobe` | garments, materials, era | integument: fur / scales / skin texture + markings | body panels, livery, decals, wear | motif / texture field | surface finish, material, wear |
+| `signature_prop` | the object that travels with them | anatomical signature (horn, tail tuft, scar) | hood ornament / aerial / charm | recurring sub-form | defining attachment or mark |
+| `posture_default` | how they stand | gait + resting stance | stance / ride attitude | motion signature | resting pose / orientation |
+| `eye_behavior` | blink rhythm, glance habit | eye/ear behavior | lighting signature (headlights, dash glow) | pulse / emission rhythm | highlight + reflection behavior |
+| `face` | age band, skin, hair, marks | head anatomy (muzzle, eyes, dentition) | front fascia (grille, lights) | focal form | defining front / face side |
+| `voice_note` | timbre + cadence | vocalization | engine / motion sound | sound signature | interaction sound |
+
+Universal slots (`id`, `name`, `palette`, `reference_frame`,
+`version`) keep one meaning across all classes.
+
+Worked example — `creature`:
+
+```json
+{
+  "id": "moor-wyrm",
+  "name": "Moor Wyrm",
+  "subject_class": "creature",
+  "silhouette": "low six-limbed serpentine bulk, head held below shoulder line",
+  "palette": ["#2e4a3f", "#c9b458", "#1a1a1a"],
+  "wardrobe": "moss-green plated scales, gold-flecked underbelly, mud-matted ridge fur",
+  "signature_prop": "broken left tusk capped with a brass ring",
+  "posture_default": "coiled low, weight on forelimbs, tail tip always moving",
+  "eye_behavior": "slow horizontal nictitating blink; ears flatten before lunges",
+  "face": "blunt muzzle, four-nostril ridge, amber eyes with horizontal pupils",
+  "voice_note": "sub-bass rumble with clicking overtones; null if scenes are scored only",
+  "reference_frame": null,
   "version": 1
 }
 ```
@@ -90,8 +134,12 @@ the lock.
 
 1. JSON parses (`jq . characters/<id>.json` exits 0).
 2. All mandatory fields present and non-empty.
-3. Palette has ≥ 2 and ≤ 5 hex values.
-4. Downstream skills cite this file by path, never paraphrase its
+3. `subject_class` (when present) is one of `humanoid | creature |
+   vehicle | abstract | object`; each field reads per the matrix row
+   for that class — a creature lock with a garment list in `wardrobe`
+   is a drafting error, not a style choice.
+4. Palette has ≥ 2 and ≤ 5 hex values.
+5. Downstream skills cite this file by path, never paraphrase its
    contents.
 
 ## Output format
@@ -105,6 +153,9 @@ the lock.
 
 ## Gotcha
 
+- A non-humanoid lock without `subject_class` reads as humanoid
+  downstream — the lock is structurally weaker and nobody can tell.
+  Always set the class for non-humanoid subjects.
 - The model wants to "improve" identity tokens on each scene —
   this is the silent drift failure. Tokens are immutable until a
   revision note bumps `version`.


### PR DESCRIPTION
## Summary

Closes #178. The character-lock identity-token contract was written for humanoids; creatures, vehicles, abstracts, and hero objects inherited the same slots with no guidance — producing locks with empty/nonsense `wardrobe` fields that downstream skills could not distinguish from strong humanoid locks.

### Design (council-backed)

- **`subject_class: humanoid | creature | vehicle | abstract | object`** added to the lock JSON. Missing → `humanoid` (full back-compat).
- **Fixed field names, per-class semantics** — a token-slot matrix in the skill maps every slot per class (creature: `wardrobe` = integument, `posture_default` = gait, `face` = head anatomy, `voice_note` = vocalization; vehicle: body panels/livery, stance, lighting signature, front fascia, engine sound; etc.). Field names stay fixed because the consumers extract them verbatim: `test-pipeline.sh` jq-pulls `.silhouette/.palette/.wardrobe`, and downstream skills are LLM prompt-templaters.
- **Worked creature example** (`moor-wyrm`) in the skill body.
- **Carve-out fix**: only environments/sets route to the `style.json` pattern; recurring creatures/vehicles/objects now get a real lock (the old wording routed all non-persons away).
- **Blueprint layer stays subject-agnostic** (documented): it only consumes the rendered SUBJECT string; class semantics live in the one file the drafting agent reads.

### Council decision

Two sessions (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2026-06-09, design lens). Round 1 split A-with-guards vs B+ (per-class field names; argued from type-system enforcement). Tie-break under the real consumer constraint — there is no type system, consumers are LLM prose + one jq script — **converged unanimously on A-as-proposed**: one vocabulary + semantics matrix in the schema-defining file minimizes drift surface; per-class vocabularies without enforcement multiply desync points.

### Verification

- `skill_linter.py` → PASS (0 warn)
- `task check-refs` → green
- src/skills and dist/agent-src/skills edited in lockstep, condensation hash updated
- Pre-existing condensation drift on main (5 video/image command files) intentionally untouched — out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)