### PR TITLE
feat(profile): profile-overlay explain envelope — why is the surface different? (observability Phase 2)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**41 / 67 steps done · 61%**
+**46 / 68 steps done · 68%**
 
 ```text
-████████████████████████░░░░░░░░░░░░░░░░   61%
+███████████████████████████░░░░░░░░░░░░░   68%
 ```
 
 ## Open roadmaps
@@ -18,7 +18,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-external-proof-upgrade.md](roadmaps/road-to-external-proof-upgrade.md) | 3 | 12 | 12 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 2 | [road-to-positioning-consistency-and-skill-governance.md](roadmaps/road-to-positioning-consistency-and-skill-governance.md) | 4 | 30 | 2 | 24 | 4 | 0 | █████████░ 92% |
-| 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 10 | 6 | 4 | 0 | 0 | ████░░░░░░ 40% |
+| 3 | [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md) | 3 | 11 | 2 | 9 | 0 | 0 | ████████░░ 82% |
 | 4 | [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md) | 4 | 12 | 4 | 8 | 0 | 0 | ███████░░░ 67% |
 | 5 | [road-to-video-provider-multiplexers.md](roadmaps/road-to-video-provider-multiplexers.md) | 3 | 7 | 2 | 5 | 0 | 0 | ███████░░░ 71% |
 
@@ -49,12 +49,12 @@
 
 ### [road-to-session-profile-observability.md](roadmaps/road-to-session-profile-observability.md)
 
-**Session-Profile Observability for Employees — make "which profile, what changed, why" legible without a CLI** — 4 / 10 done (40%)
+**Session-Profile Observability for Employees — make "which profile, what changed, why" legible without a CLI** — 9 / 11 done (82%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Plain-language profile surface (read the existing state, say it in human words) | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 2 | Profile-overlay explain envelope ("why is the agent behaving differently?") | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 2 | Profile-overlay explain envelope ("why is the agent behaving differently?") | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 3 | Overlay-integrity guard + employee task-type gap audit | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
 ### [road-to-video-foundation-validation.md](roadmaps/road-to-video-foundation-validation.md)

--- a/agents/roadmaps/road-to-session-profile-observability.md
+++ b/agents/roadmaps/road-to-session-profile-observability.md
@@ -113,19 +113,21 @@ one plain-language reply — over the **existing** `session_profiles.py` state, 
 Goal: `/why` answers the profile question, not just the memory/trust question — in plain language, over a
 new envelope rendered by the **existing** plain renderer, template-based only.
 
-- [ ] Author the `profile-overlay` explain-envelope shape in `docs/contracts/explain-modes.md` (a new
+- [x] Author the `profile-overlay` explain-envelope shape in `docs/contracts/explain-modes.md` (a new
       `envelope_type` alongside `explain-v1`) — fields: active profile, activated seed tokens, expanded
       pack closure, counts surfaced/hidden, staleness age, and the deterministic "what this changed"
       delta. **Trust boundary (council amendment):** the renderer is a pure template over these fields; it
       never calls an LLM to generate the explanation and never reads beyond the overlay state it is given.
-- [ ] Implement the renderer path — `workspace_explain.py` (or a sibling `profile_explain.py` if the
+- [x] Implement the renderer path — `workspace_explain.py` (or a sibling `profile_explain.py` if the
       shared module would couple awkwardly) renders the `profile-overlay` envelope in plain mode by
       default, `--mode technical` for the engineering-lead view, reusing the explain-modes plumbing and the
       4-band/3-band convention. Build the envelope from `session_profiles.py show|surface` output.
-- [ ] Wire `/why profile` (or extend `/why` to detect "why is the surface different / why these
+- [x] Wire `/why profile` (or extend `/why` to detect "why is the surface different / why these
       commands") to emit the `profile-overlay` plain render. One question per turn if the intent is
       ambiguous (memory-explain vs profile-explain), per `ask-when-uncertain`.
-- [ ] Coverage — `tests/` golden cases for the `profile-overlay` renderer: no overlay, single overlay,
+      <!-- done: wired as `session_profiles explain --mode plain|technical` (a script subcommand) + agent-intent routing documented in explain-modes.md § profile-overlay — same model as /why for memory. Deliberately NOT a new top-level command verb (that needs an ADR-041 verb addition; the /why intent routes to the explain subcommand, no new surface). -->
+- [x] **(renderer detail)** Built `src/scripts/config/profile_explain.py` (sibling to session_profiles, not a shared workspace module — the workspace one doesn't exist post-`src/` move and would couple awkwardly).
+- [x] Coverage — `tests/` golden cases for the `profile-overlay` renderer: no overlay, single overlay,
       multi-pack overlay, stale overlay, and a missing-field placeholder (renderer never throws). Run the
       targeted test once locally. <!-- carve-out: new-gate-verification -->
 

--- a/docs/contracts/explain-modes.md
+++ b/docs/contracts/explain-modes.md
@@ -142,6 +142,43 @@ one with a glossary override. ≥ 90 % branch on the renderer module.
 - `/why` finds no `mem://` markers → renders "This reply did not
   cite any stored memory entries." No error.
 
+## `profile-overlay` envelope (session-profile observability)
+
+A second `envelope_type` alongside `explain-v1`, answering **"why is the surface
+different / why these commands?"** over the session-profile overlay — not the
+memory/trust question. Built by `scripts/config/profile_explain.build_profile_envelope`
+from `session_profiles show|surface` state; rendered by
+`render_profile_overlay(envelope, mode)`.
+
+Fields:
+
+| field | meaning |
+|---|---|
+| `active` | the effective active pack set (the persisted overlay) |
+| `commands_shown` / `skills_shown` | surfaced counts |
+| `hidden_total` | items hidden behind inactive packs |
+| `delta.hidden_behind_inactive_packs` | the deterministic "what changed vs the full surface" |
+| `persists_across_sessions` | staleness as **persistence** (the overlay has no timestamp) |
+
+**Trust boundary (council amendment):** the renderer is a **pure template** over
+these fields — it **never calls an LLM** and **never reads beyond the overlay
+state** it is handed. `build_profile_envelope` is the only state read;
+`render_profile_overlay` is a pure function (golden-tested,
+`tests/test_profile_explain.py`). Missing fields render a placeholder; the
+renderer never throws.
+
+**Not fields** (not persisted, so deliberately absent — same honesty as the
+plain status surface): the seed-token-vs-closure split (the overlay stores the
+effective set, no request log) and a staleness **age-in-days** (no timestamp).
+An age render is a separate, overlay-semantics-touching change.
+
+**`/why profile` routing.** Same model as `/why` for memory: the agent
+recognises a "why is the surface different / why aren't these commands showing"
+intent and renders the `profile-overlay` plain view
+(`session_profiles explain --mode plain`; `--mode technical` for an engineering
+lead). One question per turn if the intent is ambiguous between memory-explain and
+profile-explain (`ask-when-uncertain`).
+
 ## Cross-references
 
 - ADR: [`ADR-026`](../decisions/ADR-026-explain-mode-translation.md).

--- a/src/scripts/config/profile_explain.py
+++ b/src/scripts/config/profile_explain.py
@@ -1,0 +1,89 @@
+"""profile_explain — the `profile-overlay` explain envelope + renderer.
+
+Phase 2 of road-to-session-profile-observability: answer "why is the agent
+behaving differently / why is the surface different?" over the session-profile
+overlay, in plain language by default (`technical` for an engineering lead).
+
+Trust boundary (AI-council amendment): the renderer is a **pure template** over
+the envelope fields — it NEVER calls an LLM and NEVER reads beyond the overlay
+state it is handed. `build_profile_envelope` is the only place that reads state;
+`render_profile_overlay` is a pure function of the envelope (golden-testable).
+
+Reuses the explain-modes two-views-over-one-envelope convention
+(`docs/contracts/explain-modes.md`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ENVELOPE_TYPE = "profile-overlay"
+
+
+def build_profile_envelope(
+    active_packs: list[str],
+    commands_shown: int,
+    skills_shown: int,
+    hidden_total: int,
+) -> dict[str, Any]:
+    """Build the `profile-overlay` envelope from the `show`/`surface` state.
+
+    Only the persisted overlay state is available, so seed-vs-closure split and
+    staleness-age-in-days are intentionally NOT fields (the overlay stores the
+    effective pack set, no request log, no timestamp — see the contract). The
+    overlay set is reported as the effective `active_packs`; staleness is
+    persistence, not an age.
+    """
+    return {
+        "envelope_type": ENVELOPE_TYPE,
+        "active": list(active_packs),
+        "commands_shown": commands_shown,
+        "skills_shown": skills_shown,
+        "hidden_total": hidden_total,
+        # deterministic "what changed vs the full surface"
+        "delta": {"hidden_behind_inactive_packs": hidden_total},
+        # staleness = persistence (no timestamp in the overlay)
+        "persists_across_sessions": bool(active_packs),
+    }
+
+
+def _g(env: dict[str, Any], key: str, default: Any) -> Any:
+    """Missing-field-tolerant getter — the renderer never throws on a partial
+    envelope (a missing field renders a placeholder, per the coverage spec)."""
+    v = env.get(key, default)
+    return default if v is None else v
+
+
+def render_profile_overlay(envelope: dict[str, Any], mode: str = "plain") -> str:
+    """Pure render of the `profile-overlay` envelope. `plain` (default) for a
+    non-technical employee; `technical` for an engineering lead. Never raises on
+    a partial envelope."""
+    active = _g(envelope, "active", [])
+    cmds = _g(envelope, "commands_shown", "?")
+    skills = _g(envelope, "skills_shown", "?")
+    hidden = _g(envelope, "hidden_total", "?")
+
+    if not active:
+        if mode == "technical":
+            return "profile-overlay: none active — full surface (no filtering)."
+        return (
+            "Nothing is filtered — no profile is active, so you see every command "
+            "and skill. The agent isn't hiding anything."
+        )
+
+    names = ", ".join(active) if isinstance(active, list) else str(active)
+    if mode == "technical":
+        return "\n".join([
+            f"profile-overlay: active=[{names}]",
+            f"  surfaced: commands={cmds} skills={skills}",
+            f"  hidden:   {hidden} (behind inactive packs)",
+            "  delta:    surface = full ∖ (artefacts whose packs ∉ active)",
+            "  staleness: persists across sessions (overlay has no timestamp)",
+        ])
+    return "\n".join([
+        f"Why the surface looks different: a profile is active ({names}).",
+        f"It shows you {cmds} commands and {skills} skills, and hides {hidden} "
+        "behind packs you haven't turned on — that's why some commands aren't visible.",
+        "Nothing is broken; the overlay just narrows the surface to this profile.",
+        "It stays this way across sessions until you run `/profile deactivate`.",
+    ])

--- a/src/scripts/config/session_profiles.py
+++ b/src/scripts/config/session_profiles.py
@@ -41,6 +41,7 @@ except Exception:  # pragma: no cover - yaml is a hard dep in practice
     yaml = None  # type: ignore
 
 from scripts._lib import agent_settings
+from scripts.config import profile_explain
 
 # --- Paths -----------------------------------------------------------------
 
@@ -434,6 +435,10 @@ def main(argv: list[str] | None = None) -> int:
     p_surf = sub.add_parser("surface", parents=[common], help="list shown/hidden artefacts")
     p_surf.add_argument("--category", choices=["command", "skill"], default=None)
     sub.add_parser("stale-notice", parents=[common], help="emit session_start staleness notice if any")
+    p_exp = sub.add_parser("explain", parents=[common],
+                           help="explain WHY the surface is different (the profile-overlay envelope)")
+    p_exp.add_argument("--mode", choices=["plain", "technical"], default="plain",
+                       help="plain (default, employee) or technical (engineering lead)")
 
     args = ap.parse_args(argv)
     root = _repo_root(args.root)
@@ -488,6 +493,19 @@ def main(argv: list[str] | None = None) -> int:
                     print(f"active packs: {', '.join(active)}")
                     print(f"surfaced: {cmds_shown} commands, {skills_shown} skills "
                           f"({len(surf.hidden)} hidden behind inactive packs)")
+            return 0
+
+        if args.cmd == "explain":
+            active = read_overlay(root)
+            surf = compute_surface(root, active=active)
+            cmds_shown = sum(1 for a in surf.shown if a["category"] == "command")
+            skills_shown = sum(1 for a in surf.shown if a["category"] == "skill")
+            env = profile_explain.build_profile_envelope(
+                active, cmds_shown, skills_shown, len(surf.hidden))
+            if args.json:
+                print(json.dumps(env))
+            else:
+                print(profile_explain.render_profile_overlay(env, mode=args.mode))
             return 0
 
         if args.cmd == "surface":

--- a/tests/test_profile_explain.py
+++ b/tests/test_profile_explain.py
@@ -1,0 +1,68 @@
+"""Goldens for the `profile-overlay` explain renderer (Phase 2,
+road-to-session-profile-observability).
+
+render_profile_overlay is a PURE template over the envelope — never an LLM, never
+reads beyond the envelope. These pin plain + technical renders and prove the
+renderer never throws on a partial/missing-field envelope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from scripts.config import profile_explain as pe  # noqa: E402
+
+
+def test_envelope_shape():
+    env = pe.build_profile_envelope(["engineering-base"], 40, 60, 167)
+    assert env["envelope_type"] == "profile-overlay"
+    assert env["active"] == ["engineering-base"]
+    assert env["delta"]["hidden_behind_inactive_packs"] == 167
+    assert env["persists_across_sessions"] is True
+    # no seed/closure split and no staleness-age — not persisted, must be absent
+    assert "staleness_days" not in env
+    assert "seed_tokens" not in env
+
+
+def test_no_overlay_plain():
+    out = pe.render_profile_overlay(pe.build_profile_envelope([], 150, 227, 0))
+    assert "Nothing is filtered" in out
+    assert "no profile is active" in out
+
+
+def test_single_overlay_plain():
+    out = pe.render_profile_overlay(pe.build_profile_envelope(["engineering-base"], 40, 60, 167))
+    assert "a profile is active (engineering-base)" in out
+    assert "40 commands and 60 skills" in out
+    assert "hides 167" in out
+    assert "/profile deactivate" in out
+    assert "days" not in out  # staleness is persistence, not an age
+
+
+def test_multi_overlay_joins_names():
+    out = pe.render_profile_overlay(
+        pe.build_profile_envelope(["finance-basic", "finance-advanced"], 12, 20, 300))
+    assert "(finance-basic, finance-advanced)" in out
+
+
+def test_technical_mode():
+    out = pe.render_profile_overlay(
+        pe.build_profile_envelope(["ops-people"], 30, 50, 100), mode="technical")
+    assert out.startswith("profile-overlay: active=[ops-people]")
+    assert "surfaced: commands=30 skills=50" in out
+    assert "hidden:   100" in out
+
+
+def test_partial_envelope_never_throws():
+    # missing-field placeholder — renderer must not raise
+    for env in ({}, {"active": ["x"]}, {"active": [], "commands_shown": None}):
+        out = pe.render_profile_overlay(env)
+        assert isinstance(out, str) and out
+
+
+def test_render_is_deterministic():
+    a = pe.render_profile_overlay(pe.build_profile_envelope(["x"], 1, 2, 3))
+    b = pe.render_profile_overlay(pe.build_profile_envelope(["x"], 1, 2, 3))
+    assert a == b


### PR DESCRIPTION
## What

`road-to-session-profile-observability` **Phase 2** — `/why` answers the **profile**
question ("why is the surface different / why aren't these commands showing?"), not
just memory/trust, in plain language over the existing overlay state.

- **`src/scripts/config/profile_explain.py`** — the `profile-overlay` envelope
  (`build_profile_envelope`) + a **pure template** renderer
  (`render_profile_overlay`): **plain** by default, **technical** for an
  engineering lead. **Never calls an LLM**, never reads beyond the overlay state,
  **never throws** on a partial envelope (council trust-boundary amendment).
- **`session_profiles.py`** — `explain [--mode plain|technical]` subcommand builds
  the envelope from `show|surface` state and renders it.
- **`/why` wiring** — documented in `explain-modes.md § profile-overlay` as
  **agent-intent routing** (same model as `/why` for memory) → `session_profiles
  explain`. **Deliberately not a new top-level command verb** (that needs an
  ADR-041 verb addition); the intent routes to the explain subcommand — no new
  surface, no scope creep.
- **`explain-modes.md`** — the `profile-overlay` `envelope_type` (fields + trust
  boundary + the not-persisted honesty: no seed/closure split, no age-in-days,
  same as the Phase-1 plain surface).
- **`tests/test_profile_explain.py`** — 7 goldens (no overlay, single, multi,
  technical, partial-never-throws, deterministic). **30/30 green** with
  session_profiles.

## Note

Built `profile_explain.py` as a **sibling** — the shared workspace explain module
the roadmap mentioned doesn't exist post-`src/` move and would couple awkwardly
(the roadmap explicitly allowed this fallback).

## Verification

`check-refs` ✅ · `validate_frontmatter` (0 failing) ✅ · `check-md-language` ✅ ·
tests 30/30 ✅.

## Roadmap

Phase 2 → all steps `[x]`. **Phase 3** (overlay-integrity guard + employee
task-type gap audit) is the last phase. No version pinned.
