### PR TITLE
feat(ai-video): promote fal, replicate, kling experimental -> stable

### DIFF
--- a/agents/reports/human-owner-todo.md
+++ b/agents/reports/human-owner-todo.md
@@ -114,11 +114,11 @@ manifests `verified:true` with trace refs, ~$2–4 total. Bonus: the Kling direc
 adapter got real keypair/JWT auth (AccessKey+SecretKey) and a live trace.
 Roadmap archived.
 
-One open maintainer call (NOT blocking):
-
-- [ ] **Lifecycle promotions** — `fal` (3/3), `replicate` (3/3), `kling` (1/1)
-  all have live traces and stay `experimental` until your tier flip. Tell the
-  agent which to promote to `stable` (gemini-veo already is).
+- [x] **Lifecycle promotions** — ✅ done 2026-06-10 (maintainer-authorized):
+  `fal`, `replicate`, `kling` promoted `experimental → stable` (all sync
+  points: adapter headers + template + operator config). All four wired
+  video adapters now run `stable`; only the ADR-056 leftovers (`sora`,
+  `openai-images`, `higgsfield`) remain `experimental`.
 
 ---
 

--- a/agents/templates/.ai-video.xml.example
+++ b/agents/templates/.ai-video.xml.example
@@ -80,7 +80,7 @@
   </provider>
 
   <provider id="kling" kind="video">
-    <lifecycle>experimental</lifecycle>
+    <lifecycle>stable</lifecycle>
     <access-key>kling-access-REPLACE-ME</access-key>
     <secret-key>kling-secret-REPLACE-ME</secret-key>
     <endpoint>https://api.klingai.com/v1</endpoint>
@@ -118,7 +118,7 @@
   <!-- ============================================================ -->
 
   <provider id="fal" kind="video">
-    <lifecycle>experimental</lifecycle>
+    <lifecycle>stable</lifecycle>
     <enabled>true</enabled>
     <api-key>fal-REPLACE-ME</api-key>
     <endpoint>https://queue.fal.run</endpoint>
@@ -132,7 +132,7 @@
   </provider>
 
   <provider id="replicate" kind="video">
-    <lifecycle>experimental</lifecycle>
+    <lifecycle>stable</lifecycle>
     <enabled>true</enabled>
     <api-key>r8_REPLACE-ME</api-key>
     <endpoint>https://api.replicate.com/v1</endpoint>

--- a/src/scripts/ai-video/adapters/fal.sh
+++ b/src/scripts/ai-video/adapters/fal.sh
@@ -8,10 +8,12 @@
 # lib/model-capabilities/fal.json and are surfaced via
 # `capability --model <id>`.
 #
-# Lifecycle: experimental — structural shape conformant; no maintainer
-# real-API smoke trace captured yet. See docs/contracts/provider-lifecycle.md
-# for promotion criteria. The agent must surface this tier and ask
-# before defaulting to this adapter.
+# Lifecycle: stable — promoted 2026-06-10 (maintainer-authorized): 3/3 live
+# renders succeeded — ltx-2 (6.1s, native audio confirmed), wan-2.2 (5.0s),
+# hunyuan (5.4s; ~14.5min render). Manifest entries carry verified:true +
+# smoke_trace refs; raw traces are local-only operator evidence
+# (agents/reference/ai-video/smoke-traces/, gitignored).
+# See docs/contracts/provider-lifecycle.md for tier semantics.
 # Encoder note: provider-specific prompt grammar comes from the
 #   motion-choreographer encoder table; the scene blueprint stays
 #   provider-agnostic (see adapter-contract.md § Blueprint → provider translation).

--- a/src/scripts/ai-video/adapters/kling.sh
+++ b/src/scripts/ai-video/adapters/kling.sh
@@ -6,10 +6,12 @@
 # / ambient at stitch time. Max duration is model-dependent; clip-time
 # clamping happens in motion-choreographer (it tunes the prompt to fit).
 #
-# Lifecycle: experimental — live submit/poll/fetch wired (JWT keypair
-# auth); maintainer real-API smoke trace pending. See
-# docs/contracts/provider-lifecycle.md for promotion criteria. The agent
-# must surface this tier and ask before defaulting to this adapter.
+# Lifecycle: stable — promoted 2026-06-10 (maintainer-authorized): live
+# round-trip validated 1/1 (5.04s h264 720p, video-only as expected,
+# ~$1.40 kling-v2-master 5s std; ~2.3min render). JWT keypair auth
+# reference-verified. Raw trace is local-only operator evidence
+# (agents/reference/ai-video/smoke-traces/, gitignored).
+# See docs/contracts/provider-lifecycle.md for tier semantics.
 #
 # Auth: Kling has NO single API token. The console issues an
 # AccessKey + SecretKey pair (<access-key>/<secret-key> in

--- a/src/scripts/ai-video/adapters/replicate.sh
+++ b/src/scripts/ai-video/adapters/replicate.sh
@@ -26,10 +26,13 @@
 # agents/.ai-video.xml. Kill-switch: <enabled>false</enabled> on the
 # provider block refuses every network subcommand.
 #
-# Lifecycle: experimental — structural shape conformant; no maintainer
-# real-API smoke trace captured yet. See docs/contracts/provider-lifecycle.md
-# for promotion criteria. The agent must surface this tier and ask
-# before defaulting to this adapter.
+# Lifecycle: stable — promoted 2026-06-10 (maintainer-authorized): 3/3 live
+# renders succeeded — wan-2.2-fast (official route), ltx-video + hunyuan
+# (version route). Manifest entries carry verified:true + smoke_trace refs;
+# raw traces are local-only operator evidence
+# (agents/reference/ai-video/smoke-traces/, gitignored). Caveat: under $5
+# account credit the create rate drops to 6/min, burst 1.
+# See docs/contracts/provider-lifecycle.md for tier semantics.
 # Encoder note: provider-specific prompt grammar comes from the
 #   motion-choreographer encoder table; the scene blueprint stays
 #   provider-agnostic (see adapter-contract.md § Blueprint → provider translation).


### PR DESCRIPTION
## Summary

Maintainer-authorized lifecycle promotions (2026-06-10), follow-up to #457. All evidence per `provider-lifecycle-discipline`:

| Adapter | Evidence | Tier |
|---|---|---|
| `fal` | 3/3 live renders — ltx-2 (native audio confirmed), wan-2.2, hunyuan (~14.5 min render) | experimental → **stable** |
| `replicate` | 3/3 live renders — wan-2.2-fast (official route), ltx-video + hunyuan (version route) | experimental → **stable** |
| `kling` | 1/1 live render — 5.04s h264 720p, JWT keypair auth reference-verified | experimental → **stable** |

With `gemini-veo` (promoted in #457), **all four wired video adapters now run `stable`**. Only the ADR-056 leftovers (`sora`, `openai-images`, `higgsfield`) stay `experimental`.

### Sync points flipped together (per `provider-lifecycle-discipline`)

- Adapter `Lifecycle:` headers — now carry the validation summary + operational caveats inline (replicate: create-rate throttle under $5 credit; raw traces stay local-only gitignored operator evidence)
- `agents/templates/.ai-video.xml.example` `<lifecycle>` tags
- Operator's local `agents/.ai-video.xml` (gitignored, flipped in the same session)

### Verification

- `tests/test_ai_video_{trust_boundary,adapter_contract,model_capabilities}.py`: **116 passed** (fresh, this branch)
- `smoke-trace.sh` dry-run reports `tier=stable` for all four adapters
- Template XML parses clean