### PR TITLE
fix(lint): regression report compared the current tree against itself

### DIFF
--- a/src/scripts/lint_regression.py
+++ b/src/scripts/lint_regression.py
@@ -26,15 +26,6 @@ from pathlib import Path
 
 def run_linter_json(ref: str | None, repo_root: Path) -> dict:
     """Run the linter and return parsed JSON. If ref is None, run on working tree."""
-    env_cmd = []
-    if ref:
-        # Run linter at a specific git ref using git stash + checkout
-        # Instead, use git show to avoid checkout — run on working tree after git stash
-        pass
-
-    cmd = [sys.executable, str(repo_root / "src" / "scripts" / "skill_linter.py"), "--all", "--format", "json",
-           "--repo-root", str(repo_root)]
-
     if ref:
         # Strategy: create a temp worktree at the ref, run linter there, clean up
         with tempfile.TemporaryDirectory(prefix="lint-baseline-") as tmpdir:
@@ -43,8 +34,25 @@ def run_linter_json(ref: str | None, repo_root: Path) -> dict:
                 capture_output=True, check=True
             )
             try:
+                # MUST be the baseline worktree's own copy of the linter:
+                # artefact discovery is anchored at the script's location
+                # (_lib/agent_src.py::ROOT = Path(__file__).parents[3]), NOT
+                # at --repo-root. Running the current branch's copy here
+                # linted the CURRENT tree a second time — with absolute
+                # display paths (relative_to(tmpdir) fails for them), so the
+                # two result sets shared zero keys and every repo-wide
+                # warning file surfaced as a "new file" on every PR
+                # (observed on PR #466).
+                baseline_linter = Path(tmpdir) / "src" / "scripts" / "skill_linter.py"
+                if not baseline_linter.is_file():
+                    # Pre-src-move baselines kept the linter under scripts/.
+                    baseline_linter = Path(tmpdir) / "scripts" / "skill_linter.py"
+                if not baseline_linter.is_file():
+                    print(f"Warning: no skill_linter.py in baseline '{ref}' — "
+                          f"baseline treated as empty.", file=sys.stderr)
+                    return {"results": [], "summary": {}}
                 result = subprocess.run(
-                    [sys.executable, str(repo_root / "src" / "scripts" / "skill_linter.py"),
+                    [sys.executable, str(baseline_linter),
                      "--all", "--format", "json", "--repo-root", tmpdir],
                     capture_output=True, text=True, cwd=tmpdir
                 )
@@ -55,6 +63,8 @@ def run_linter_json(ref: str | None, repo_root: Path) -> dict:
                     capture_output=True
                 )
     else:
+        cmd = [sys.executable, str(repo_root / "src" / "scripts" / "skill_linter.py"),
+               "--all", "--format", "json", "--repo-root", str(repo_root)]
         result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(repo_root))
         return json.loads(result.stdout) if result.stdout.strip() else {"results": [], "summary": {}}
 
@@ -214,6 +224,15 @@ def main() -> int:
 
     baseline_map = build_status_map(baseline_data)
     current_map = build_status_map(current_data)
+
+    # Sanity guard: two non-empty result sets that share not a single file
+    # mean the runs are not comparable (path-scheme mismatch, wrong tree, …).
+    # Reporting in that state would surface EVERY current issue as "new" —
+    # refuse instead of emitting a misleading report.
+    if baseline_map and current_map and not (set(baseline_map) & set(current_map)):
+        print("Error: baseline and current lint results share no files — "
+              "runs are not comparable; refusing to report.", file=sys.stderr)
+        return 2
 
     delta = compare(baseline_map, current_map)
 

--- a/tests/test_lint_regression.py
+++ b/tests/test_lint_regression.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lint_regression.py — the PR lint-regression report.
+
+Pins the PR #466 failure mode: the baseline run used the current branch's
+skill_linter.py, whose artefact discovery is anchored at the script location
+(_lib/agent_src.py::ROOT), not at --repo-root. The baseline therefore linted
+the CURRENT tree with absolute display paths, the two result sets shared zero
+file keys, and every repo-wide warning file was reported as a "new file with
+issues" on every PR — even PRs that touched no lintable file at all.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "src" / "scripts" / "lint_regression.py"
+
+sys.path.insert(0, str(REPO_ROOT / "src" / "scripts"))
+
+import lint_regression  # type: ignore  # noqa: E402
+
+
+class CompareTests(unittest.TestCase):
+    """Pure comparison logic — no git, no subprocess."""
+
+    def test_identical_maps_produce_empty_delta(self):
+        m = {"a.md": {"status": "pass_with_warnings", "codes": {"long_rule"}}}
+        delta = lint_regression.compare(m, m)
+        self.assertEqual(delta["regressions"], [])
+        self.assertEqual(delta["new_files"], [])
+        self.assertEqual(delta["improvements"], [])
+
+    def test_new_file_with_issues_is_reported(self):
+        base = {"a.md": {"status": "pass", "codes": set()}}
+        curr = {
+            "a.md": {"status": "pass", "codes": set()},
+            "b.md": {"status": "pass_with_warnings", "codes": {"long_rule"}},
+        }
+        delta = lint_regression.compare(base, curr)
+        self.assertEqual([nf["file"] for nf in delta["new_files"]], ["b.md"])
+
+    def test_new_clean_file_is_not_reported(self):
+        base = {}
+        curr = {"b.md": {"status": "pass", "codes": set()}}
+        delta = lint_regression.compare(base, curr)
+        self.assertEqual(delta["new_files"], [])
+
+    def test_status_downgrade_is_a_regression(self):
+        base = {"a.md": {"status": "pass", "codes": set()}}
+        curr = {"a.md": {"status": "pass_with_warnings", "codes": {"long_rule"}}}
+        delta = lint_regression.compare(base, curr)
+        self.assertEqual(len(delta["regressions"]), 1)
+        self.assertEqual(delta["regressions"][0]["new_codes"], ["long_rule"])
+
+    def test_status_upgrade_is_an_improvement(self):
+        base = {"a.md": {"status": "fail", "codes": {"missing_section"}}}
+        curr = {"a.md": {"status": "pass", "codes": set()}}
+        delta = lint_regression.compare(base, curr)
+        self.assertEqual(len(delta["improvements"]), 1)
+        self.assertEqual(delta["regressions"], [])
+
+    def test_removed_file_is_not_a_regression(self):
+        base = {"a.md": {"status": "pass_with_warnings", "codes": {"long_rule"}}}
+        delta = lint_regression.compare(base, {})
+        self.assertEqual(delta["regressions"], [])
+        self.assertEqual(delta["new_files"], [])
+
+
+class EndToEndTests(unittest.TestCase):
+    """Run the real script against --baseline HEAD.
+
+    The working tree's lintable .md files equal HEAD in CI checkouts and on
+    any branch where only code (not artefacts) changed, so the report must be
+    empty. Before the PR #466 fix this exact invocation reported every
+    repo-wide warning file as new.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        inside = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True, text=True,
+        )
+        if inside.returncode != 0 or inside.stdout.strip() != "true":
+            raise unittest.SkipTest("not a git checkout")
+
+        # Skip when lintable sources differ from HEAD — the comparison is
+        # then legitimately non-empty and asserts nothing about the tooling.
+        dirty = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "status", "--porcelain",
+             "src/skills", "src/rules", "src/agent-src"],
+            capture_output=True, text=True,
+        )
+        if dirty.stdout.strip():
+            raise unittest.SkipTest("lintable sources dirty vs HEAD")
+
+        cls.proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--baseline", "HEAD",
+             "--format", "json", "--repo-root", str(REPO_ROOT)],
+            capture_output=True, text=True,
+        )
+
+    def test_zero_diff_baseline_reports_nothing(self):
+        self.assertEqual(
+            self.proc.returncode, 0,
+            f"expected clean report, got rc={self.proc.returncode}:\n"
+            f"{self.proc.stdout}\n{self.proc.stderr}",
+        )
+        delta = json.loads(self.proc.stdout)
+        self.assertEqual(delta["regressions"], [], delta)
+        self.assertEqual(delta["new_files"], [], delta)
+
+    def test_baseline_results_are_comparable_not_disjoint(self):
+        # The disjoint-guard exits 2 with this message when baseline and
+        # current runs share no file keys — the PR #466 failure shape.
+        self.assertNotIn("share no files", self.proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The skill-lint sticky comment on PR #466 reported **7 "New files with issues"** — all of them pre-existing, none touched by that PR. The same report reproduces locally on a branch with zero diff vs `origin/main`.

## Root cause

`lint_regression.py` ran the **current branch's** `skill_linter.py` against the baseline worktree. But the linter's artefact discovery is anchored at the script's own location (`_lib/agent_src.py::ROOT = Path(__file__).parents[3]`), not at `--repo-root`. The "baseline" run therefore linted the **current tree a second time** — and emitted absolute display paths, because `relative_to(<baseline-worktree>)` fails for them. The two result sets shared zero file keys, so the comparison saw every current warning file as "new". The 7 listed files are simply every repo-wide `pass_with_warnings` file; they would appear on **every** PR.

## Fix

- The baseline run now invokes the **baseline worktree's own copy** of `skill_linter.py` (with a fallback to the pre-src-move `scripts/` location, then to an empty baseline + stderr warning). Discovery and display paths then both resolve inside the baseline tree, and the file keys are comparable.
- Sanity guard: if baseline and current results are both non-empty but share **no** file keys, the script aborts with exit 2 instead of emitting an everything-is-new report — this failure shape can never reach a PR comment again.
- New `tests/test_lint_regression.py`: unit coverage for `compare()` (new file / regression / improvement / removal) plus an e2e run against `--baseline HEAD` pinning the zero-diff-reports-nothing contract.

## Evidence (fresh local runs)

- Before fix, zero-diff branch: `⚠️ 7 New files with issues` (exact PR #466 report)
- After fix, zero-diff branch: `✅ No regressions detected`, exit 0
- Induced `long_rule` edit on `src/rules/tool-safety.md`: reported as exactly **1 regression** with the right codes, exit 1
- `tests/test_lint_regression.py`: 8/8 pass

## Live proof

The sticky `skill-lint-report` comment on **this** PR should now read "No regressions detected" — the 7 pre-existing warnings (`long_rule`, `router_routes_to_missing`, `weak_output_format`, …) stay out of it. Fixing those 7 files is a separate follow-up PR.