### PR TITLE
docs(mcp): MCP registries & cross-tool install reference (ADR-086 follow-up)

### DIFF
--- a/docs/decisions/ADR-086-read-only-cross-agent-mcp-discovery-helper.md
+++ b/docs/decisions/ADR-086-read-only-cross-agent-mcp-discovery-helper.md
@@ -45,10 +45,16 @@ both registries are queryable read-only with **no API key** — official
 `GET glama.ai/api/mcp/v1/servers?first=&after=` (200; resolves ADR-086's open
 "does Glama need a key?" question — it does not).
 
-**Follow-up recommendations (not actioned by the closing roadmap — net-new / external
-scope):** contribute Augment support to `smithery-ai/cli` (`VALID_CLIENTS`); optionally
-ship a registry coverage-matrix doc (official / Glama / Smithery) to capture the
-registry-agnostic value cheaply.
+**Follow-up — resolved 2026-06-11 (AI council, claude-sonnet-4-5 + gpt-4o, design
+mode; split → tie-break → converged C-only):** the surviving value is captured as a
+reference doc, [`docs/mcp-registries.md`](../mcp-registries.md) — the three-registry
+comparison plus a per-agent install path (Smithery covers 5/6; Augment via manual
+Import-from-JSON). An automated **Smithery → Augment** contribution is **deferred, not
+filed**: Augment's writable surface is undocumented/nested and there is no demand
+signal, so a PR or issue would externalise risk for zero proven benefit. Reopen only
+if all three hold: ≥ 3 independent user requests, Augment documents its `settings.json`
+MCP schema as stable, and the Smithery maintainers pre-approve the approach (mirrored
+in the doc footer).
 
 **Reopen criteria:** 5+ demand responses citing a concrete need Smithery cannot serve,
 OR Smithery registry-locks / declines Augment support / shuts down. Any reopen is a new

--- a/docs/mcp-registries.md
+++ b/docs/mcp-registries.md
@@ -1,0 +1,94 @@
+# MCP registries & cross-tool install landscape
+
+> Reference material. Where to *discover* MCP servers, what each registry gives
+> you, and how to install one into each agent today — without our own tooling.
+>
+> Background: we evaluated building a read-only cross-agent MCP discovery helper
+> (`ADR-086`) and decided **not to** — existing tooling already covers it. This
+> doc captures the surviving value: the registry comparison and the per-agent
+> manual install path. See [`docs/mcp.md`](mcp.md) for generating *your own*
+> `mcp.json` across tools.
+
+## The three registries (verified 2026-06-11)
+
+| Dimension | Official registry | Glama | Smithery |
+|---|---|---|---|
+| Role | Vendor-neutral **catalog** (discovery spec) | Catalog **superset** + quality/safety scoring | Catalog **+ installer** |
+| Canonical shape | `server.json` | Own schema (maps to `server.json` fields) | Own schema |
+| Approx. scale | Hundreds+ (paginated, growing) | ~32k servers | Own index |
+| Writes client config? | **No** (discovery only) | **No** (discovery only) | **Yes** — `smithery install X --client <c>` |
+| API auth | **None** — public read | **None** — public read | n/a (CLI) |
+| Query endpoint | `GET registry.modelcontextprotocol.io/v0/servers?search=&limit=&cursor=` | `GET glama.ai/api/mcp/v1/servers?first=&after=` | `smithery` CLI / site |
+
+Both catalog APIs were live-checked: each returns `200` with **no API key**. The
+official registry returns `{servers:[{server:<server.json>,_meta:…}],metadata:{nextCursor,count}}`;
+Glama returns `{pageInfo:{endCursor,hasNextPage},servers:[{id,name,namespace,slug,
+description,environmentVariablesJsonSchema,repository,spdxLicense,tools,url}]}`.
+
+> Glama's quality/safety **score is a popularity/heuristic signal, not a verified
+> security property** — treat it as a hint, never a guarantee.
+
+## Installing a discovered server per agent
+
+For most agents, **Smithery already writes the config for you** (the read-write
+path — harder than discovery). Its CLI (`smithery-ai/cli`, `src/config/clients.ts`
+`VALID_CLIENTS`, verified 2026-06-11) configures 23 clients, including:
+
+`smithery install <server> --client <client>` where `<client>` ∈ **claude** (Desktop),
+**claude-code**, **cursor**, **windsurf**, **cline**, **vscode** / **vscode-insiders**
+(Copilot), plus codex, gemini-cli, zed, goose, kiro, trae, and others.
+
+That covers Claude Code, Cursor, Windsurf, Cline, and VS Code/Copilot. **Augment is
+the gap** — it is not in Smithery's client list, so install it manually (below).
+
+## Augment — manual MCP install (no tooling needed)
+
+Augment supports the **standard `mcpServers` object map** via its built-in
+**Import from JSON** (Augment Settings Panel → gear icon → Import from JSON).
+Paste, for a stdio server:
+
+```json
+{
+  "mcpServers": {
+    "<server-name>": {
+      "command": "npx",
+      "args": ["-y", "<package>"]
+    }
+  }
+}
+```
+
+…or for a remote server:
+
+```json
+{
+  "mcpServers": {
+    "<server-name>": {
+      "url": "https://example.com/mcp",
+      "type": "sse"
+    }
+  }
+}
+```
+
+Secret env vars get their own section in the Settings Panel — paste placeholders,
+fill in the real value there; never commit a real secret. Augment also offers
+**Easy MCP** (one-click) for common servers, and the JetBrains plugin manages MCP
+through its own settings UI.
+
+> Why no automated Augment writer? Augment's only file-writable surface is VS Code
+> `settings.json` under the nested key `augment.advanced.mcpServers` (an array of
+> `{name, command, args}`), which the official docs do not commit to as a stable
+> contract. Smithery's writer targets flat, dedicated config files, so it cannot
+> safely write Augment's nested/shared surface. Manual Import-from-JSON is the
+> supported path today.
+
+## Reopen criteria — automated Augment install
+
+Reconsidered (e.g. native Smithery support or our own writer) only if **all** hold:
+
+1. ≥ 3 users independently request automated Smithery → Augment install.
+2. Augment documents the `settings.json` MCP schema as a **stable** contract.
+3. The Smithery maintainers pre-approve the integration approach.
+
+Until then this stays manual by design (`ADR-086`, AI-council convergence 2026-06-11).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -138,6 +138,9 @@ secret tool you already use into the process environment before you run
 
 ## Related
 
+- [`docs/mcp-registries.md`](mcp-registries.md) — where to *discover* MCP servers
+  (official registry / Glama / Smithery) and how to install one per agent, incl.
+  Augment's manual Import-from-JSON path.
 - [`.agent-src.uncondensed/skills/mcp/SKILL.md`](../.agent-src.uncondensed/skills/mcp/SKILL.md) — MCP server
   selection and usage patterns.
 - [`agents/roadmaps/archive/road-to-mcp.md`](../agents/roadmaps/archive/road-to-mcp.md) — archived roadmap that produced this feature.


### PR DESCRIPTION
## Summary

Follow-up to PR #465 (ADR-086 Phase-0 gate → **STOP**: don't build a cross-agent MCP
discovery helper). This ships the surviving value the council endorsed: a reference
doc capturing the MCP registry landscape and the per-agent manual install path.

Combines **both** post-gate follow-ups (originally "Option 1" Augment→Smithery and
"Option 2" coverage matrix) into one artifact, per the AI council
(claude-sonnet-4-5 + gpt-4o, design mode, 2026-06-11; split → tie-break →
**converged C-only**).

## Why no Smithery PR/issue (the "Option 1" resolution)

Fact-finding falsified the "one-edit add Augment to Smithery" premise: Augment's only
file-writable MCP surface is VS Code `settings.json` under the **nested** key
`augment.advanced.mcpServers` (array shape), which Smithery's writer (flat
`topLevelKey`, object-map only — all 23 clients verified) cannot express, and which
Augment's docs do not commit to as stable. With zero demand signal, filing a PR or
issue would externalise risk for no proven benefit. **Deferred with explicit reopen
criteria**, not abandoned silently.

## Changes

- **`docs/mcp-registries.md`** (new) — three-registry comparison (official / Glama /
  Smithery; both catalog APIs live-verified as no-auth), per-agent install path
  (Smithery covers 5/6 agents read-write; **Augment** via manual Import-from-JSON
  with snippet), and reopen criteria for automated Augment install.
- **`docs/mcp.md`** — linked the new doc from "Related".
- **ADR-086** — follow-up note updated to the C-only resolution.

## Verification

`check-refs` clean, `check-md-language` green, `check-portability` clean,
pre-commit hooks pass. Markdown-only.
