### PR TITLE
fix: Zed-compliant skill names (colon → hyphen) + installer stale reaping

### DIFF
--- a/src/scripts/_lib/global_deploy_inventory.py
+++ b/src/scripts/_lib/global_deploy_inventory.py
@@ -191,6 +191,75 @@ def reap_stale(
     return deleted
 
 
+def bootstrap_reap_tagged(
+    anchor: Path,
+    dest_subs: list[str],
+    current_files: set[str],
+    package_tag: str,
+) -> list[Path]:
+    """First-run reaping for PRE-inventory installs (marker-based ownership).
+
+    Existing installs in the wild predate the inventory sidecar, so
+    :func:`reap_stale` has nothing to diff against on the first upgraded
+    deploy — the legacy mess (renamed skills, retired command-as-skill
+    entries, the 2026-05-13 colon-named shapes) would rot forever. Every
+    deployed ``.md`` however carries the injected ``package:`` frontmatter
+    tag (install P5.1), which is exactly the ownership proof reaping needs.
+
+    Deletes ``.md`` files under ``<anchor>/<dest_sub>`` that (a) carry
+    ``package: <package_tag>`` in their frontmatter and (b) are not in the
+    current expected file set; then prunes empty directories. Untagged
+    files (user-authored skills in shared anchors) are never touched.
+    Returns the absolute paths deleted.
+    """
+    anchor_resolved = anchor.expanduser().resolve()
+    deleted: list[Path] = []
+    prune_candidates: set[Path] = set()
+    needle = f"package: {package_tag}"
+    for dest_sub in dest_subs:
+        root = anchor_resolved / dest_sub if dest_sub else anchor_resolved
+        if not root.is_dir():
+            continue
+        for md in root.rglob("*.md"):
+            if md.is_dir():
+                continue
+            rel = md.relative_to(anchor_resolved).as_posix()
+            if rel in current_files:
+                continue
+            try:
+                md.parent.resolve().relative_to(anchor_resolved)
+            except ValueError:
+                continue
+            try:
+                head = md.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            if not head.startswith("---"):
+                continue
+            end = head.find("\n---", 3)
+            block = head[: end if end != -1 else len(head)]
+            if not any(
+                line.strip() == needle for line in block.splitlines()
+            ):
+                continue
+            try:
+                md.unlink()
+            except OSError:
+                continue
+            deleted.append(md)
+            prune_candidates.add(md.parent)
+    for start in sorted(prune_candidates, key=lambda p: len(p.parts),
+                        reverse=True):
+        node = start
+        while node != anchor_resolved and anchor_resolved in node.parents:
+            try:
+                node.rmdir()  # only succeeds when empty
+            except OSError:
+                break
+            node = node.parent
+    return deleted
+
+
 def record_deploy(
     tool_id: str,
     anchor: "Path | str",

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -3424,7 +3424,19 @@ def _deploy_global_content(
         # partial copy can never trigger deletions.
         inv_mod = _inventory_mod()
         inventory = inv_mod.load_inventory()
-        reaped = inv_mod.reap_stale(tool_id, anchor, current_files, inventory)
+        if tool_id in inventory.get("tools", {}):
+            reaped = inv_mod.reap_stale(
+                tool_id, anchor, current_files, inventory,
+            )
+        else:
+            # First deploy after the upgrade — no inventory to diff against.
+            # Fall back to marker-based ownership: every previously deployed
+            # .md carries the injected `package:` tag (P5.1), so tagged
+            # orphans under the plan's destinations are provably ours.
+            reaped = inv_mod.bootstrap_reap_tagged(
+                anchor, [dest_sub for _, dest_sub in plan],
+                current_files, PACKAGE_TAG_ID,
+            )
         # Record the UNexpanded anchor (`~/.agents/`) so the inventory stays
         # byte-identical across homes (GUI/CLI parity) and home relocations.
         inv_mod.record_deploy(tool_id, anchor_raw, current_files, inventory)

--- a/tests/test_global_deploy_inventory.py
+++ b/tests/test_global_deploy_inventory.py
@@ -226,6 +226,55 @@ def test_two_deploy_cycle_reaps_renamed_skill(tmp_path):
     assert (anchor / "skills" / "agents-review" / "SKILL.md").exists()
 
 
+# --- bootstrap_reap_tagged (pre-inventory installs) ----------------------
+
+TAG = "event4u/agent-config"
+
+
+def _tagged_md(path: Path, name: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nname: {name}\npackage: {TAG}\n---\n\nbody\n", encoding="utf-8",
+    )
+
+
+def test_bootstrap_reaps_tagged_orphans_only(tmp_path):
+    anchor = tmp_path / "anchor"
+    # Tagged orphan (e.g. retired 2026-05-13 command-as-skill entry).
+    _tagged_md(anchor / "skills" / "dto-creator" / "SKILL.md", "dto-creator")
+    # Tagged file still shipped by the current bundle.
+    _tagged_md(anchor / "skills" / "kept" / "SKILL.md", "kept")
+    # User-authored skill: no package tag — must survive.
+    (anchor / "skills" / "my-zed-skill").mkdir(parents=True)
+    (anchor / "skills" / "my-zed-skill" / "SKILL.md").write_text(
+        "---\nname: my-zed-skill\n---\n\nmine\n", encoding="utf-8")
+    # Untagged loose file — must survive.
+    (anchor / "skills" / "notes.md").write_text("plain", encoding="utf-8")
+
+    deleted = inv.bootstrap_reap_tagged(
+        anchor, ["skills"], {"skills/kept/SKILL.md"}, TAG,
+    )
+
+    assert [p.parent.name for p in deleted] == ["dto-creator"]
+    assert not (anchor / "skills" / "dto-creator").exists()
+    assert (anchor / "skills" / "kept" / "SKILL.md").exists()
+    assert (anchor / "skills" / "my-zed-skill" / "SKILL.md").exists()
+    assert (anchor / "skills" / "notes.md").exists()
+
+
+def test_bootstrap_ignores_missing_dest_and_other_tags(tmp_path):
+    anchor = tmp_path / "anchor"
+    _tagged_md(anchor / "skills" / "foreign" / "SKILL.md", "foreign")
+    (anchor / "skills" / "foreign" / "SKILL.md").write_text(
+        "---\nname: foreign\npackage: someone/else\n---\n\nbody\n",
+        encoding="utf-8")
+    deleted = inv.bootstrap_reap_tagged(
+        anchor, ["skills", "rules"], set(), TAG,
+    )
+    assert deleted == []
+    assert (anchor / "skills" / "foreign" / "SKILL.md").exists()
+
+
 # --- integration: install._deploy_global_content reaps via inventory -----
 
 
@@ -273,6 +322,39 @@ def test_deploy_global_content_reaps_stale_entries(tmp_path, monkeypatch):
     assert (anchor / "skills" / "new-skill" / "SKILL.md").exists()
     assert (anchor / "skills" / "user-own" / "SKILL.md").exists(), \
         "user-authored entry in the shared anchor must survive"
+
+
+def test_deploy_global_content_bootstrap_reaps_pre_inventory_orphans(
+        tmp_path, monkeypatch):
+    import install  # noqa: WPS433 — sys.path prepared at module top
+
+    pkg = tmp_path / "pkg"
+    (pkg / "dist/agent-src/skills/current").mkdir(parents=True)
+    (pkg / "dist/agent-src/skills/current/SKILL.md").write_text(
+        "---\nname: current\n---\n\nbody\n", encoding="utf-8")
+    anchor = tmp_path / "anchor"
+    # Pre-inventory legacy state: tagged orphan + user-authored neighbour.
+    _tagged_md(anchor / "skills" / "dto-creator" / "SKILL.md", "dto-creator")
+    (anchor / "skills" / "user-own").mkdir(parents=True)
+    (anchor / "skills" / "user-own" / "SKILL.md").write_text(
+        "---\nname: user-own\n---\n\nmine\n", encoding="utf-8")
+
+    monkeypatch.setenv(inv.INVENTORY_ENV, str(tmp_path / "inv.json"))
+    monkeypatch.setitem(
+        install.USER_SCOPE_PATHS, "tooltest", str(anchor))
+    monkeypatch.setitem(
+        install.GLOBAL_DEPLOY_SOURCES, "tooltest",
+        [("dist/agent-src/skills", "skills")],
+    )
+
+    results = install._deploy_global_content(
+        {"tooltest"}, True, pkg, tmp_path / "installed.lock",
+    )
+    assert results["tooltest"][2] == "deployed"
+    assert not (anchor / "skills" / "dto-creator").exists(), \
+        "pre-inventory tagged orphan must be bootstrap-reaped on first run"
+    assert (anchor / "skills" / "user-own" / "SKILL.md").exists()
+    assert (anchor / "skills" / "current" / "SKILL.md").exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Supersedes #471 (closed; branch was recreated by the follow-up push).

## Problem

Zed rejects projected skill entries with **"Skill name must contain only lowercase letters, numbers, and hyphens"** and **"Invalid YAML frontmatter"**. Three root causes:

1. Command sources carried colon-namespaced `name:` frontmatter (`council:default`, `fix:ci`, …) that leaked into every skill-shaped projection. The Agent Skills spec (which Zed enforces verbatim) requires `^[a-z0-9]+(-[a-z0-9]+)*$` and `name` == folder name.
2. The global installer never deletes anything from its deploy anchors, so renamed/removed package skills rot in place — 100+ leftovers from the 2026-05-13 deploy shape sat in `~/.agents/skills/` (Zed's discovery dir, shared with user-authored skills), some with invalid YAML frontmatter (`dto-creator`, `migration-creator`, `check-current-md`).
3. Existing installs predate any inventory, so a purely inventory-based reaper would never clean the legacy mess.

## Changes

- **Rename (87 files):** every `src/domains/**/command.md` `name:` is now the canonical path-derived hyphen slug (`_lib.agent_src.command_slug`); the 8 cluster heads' `routes_to:` lists follow. Claude Code's `/cluster:sub` invocation is path-derived and unaffected.
- **Schema:** `command.schema.json` forbids colons in `name`/`routes_to` (≤64 chars, Agent-Skills shape). `replaces` keeps colon forms deliberately — they are legitimate historical aliases.
- **New CI gate:** `task lint-skill-names` fails when a command name diverges from its slug or a skill name violates the spec / its directory name.
- **Consumers:** `lint_command_verbs` reads the verb from `sub:` frontmatter; MCP wire names follow the slugs (`command.fix-ci`, legacy `:`→`.` kept as tolerance shim); `pack_mcp_content._repo_root()` repaired (pointed at `src/` since the `scripts/`→`src/scripts/` move and packed zero URIs) and `content.json` regenerated.
- **Installer stale reaping:** new sidecar `~/.event4u/agent-config/deployed-files.json` records per tool the anchor (unexpanded, home-portable) and deployed file set. Re-installs delete exactly the previously-recorded paths the current bundle no longer ships — never user files, never directories, never outside the anchor, never after a failed deploy postcheck.
- **Bootstrap reaping (pre-inventory installs):** when a tool has no inventory entry yet, the deploy falls back to marker-based ownership — `.md` files under the plan's destinations carrying the injected `package: event4u/agent-config` tag (P5.1) that are absent from the current bundle are reaped, then empty dirs pruned. Untagged (user-authored) files are never touched.

## Verification

- `validate_frontmatter` 330/0 · `check_condensation` 0 errors · hashes in sync
- `lint-skill-names` (negative-tested), `lint-command-verbs`, `lint-command-routing`, `lint-namespace-collisions`, `check-refs`, `check-index`, `check-md-language`, `lint-marketplace`, discovery lint — all green
- pytest: 5364 passed (18 new inventory/reaping tests incl. GUI/CLI parity + bootstrap integration; `test_modern_editor_formats` and `test_refine_ticket_detect` fail pre-existing on a pristine worktree, unrelated)
- Worker `tsc --noEmit` green; generated `.claude/skills`: 0 colon names, 0 dir/name mismatches
- CI on the first 4 commits was fully green on #471 (48 pass / 4 expected skips) before the branch recreation