### PR TITLE
fix(release): cap PR body to GitHub limit + guard empty resume commit

### DIFF
--- a/src/scripts/release.py
+++ b/src/scripts/release.py
@@ -75,6 +75,31 @@ MAIN_BRANCH = "main"
 REMOTE = "origin"
 REPO_SLUG = "event4u-app/agent-config"
 
+# GitHub rejects bodies over these limits with a GraphQL "Body is too
+# long" error. The full entry always lands in CHANGELOG.md (committed in
+# the PR diff and attached to the tag), so an oversized body is capped
+# with a pointer rather than failing the release — a major bump can
+# render hundreds of commit bullets, well past the 65 536 PR-body limit.
+GH_PR_BODY_LIMIT = 65_536        # createPullRequest mutation hard limit
+GH_RELEASE_NOTES_LIMIT = 125_000  # release-notes body limit
+
+
+def _cap_body(text: str, limit: int, *, full_ref: str) -> str:
+    """Return ``text`` unchanged when within ``limit`` chars; otherwise
+    truncate at the last line boundary that fits and append a pointer to
+    ``full_ref`` so nothing is silently lost."""
+    if len(text) <= limit:
+        return text
+    notice = (
+        f"\n\n> _Changelog truncated to fit GitHub's "
+        f"{limit:,}-character body limit — full entry in {full_ref}._"
+    )
+    head = text[: limit - len(notice)]
+    nl = head.rfind("\n")
+    if nl > 0:
+        head = head[:nl]
+    return head + notice
+
 # Conventional Commit types and how they map into CHANGELOG sections.
 # Order in this tuple determines order in the rendered entry.
 SECTIONS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
@@ -757,14 +782,22 @@ def execute(
         if resume and last_msg == f"release: {plan.target}" and not porcelain:
             _step(3, total, f"Last commit already `release: {plan.target}` and tree clean — skip")
         else:
-            _step(3, total, f"Commit `release: {plan.target}`")
             # `git add -A` stages the three primary bump files AND every
             # regenerated derived file (src/packs/*/pack.yaml + README.md,
             # dist/agent-src/, .augment/, tool projections). Listing them
             # explicitly would silently drift the moment a new generated
             # tree is added.
             run("git", "add", "-A")
-            run("git", "commit", "-m", f"release: {plan.target}")
+            # On resume the bump + era-split may already be committed (the
+            # era-split lands its own commit, so `last_msg` above no longer
+            # equals "release: X" and the skip guard misses). If nothing is
+            # staged, the release content is already in history — skipping
+            # beats failing `git commit` on an empty index.
+            if git("diff", "--cached", "--name-only", capture=True).strip():
+                _step(3, total, f"Commit `release: {plan.target}`")
+                run("git", "commit", "-m", f"release: {plan.target}")
+            else:
+                _step(3, total, "Release content already committed — skip empty commit")
 
     # ─── 4. push ────────────────────────────────────────────────────────────
     if pr_merged:
@@ -782,9 +815,14 @@ def execute(
         _step(5, total, f"PR already open: {pr_info.get('url')}")
     else:
         _step(5, total, "Open pull request")
+        pr_changelog = _cap_body(
+            plan.changelog_body,
+            GH_PR_BODY_LIMIT - 200,  # leave room for the prefix + footer
+            full_ref="`CHANGELOG.md` in this PR",
+        )
         pr_body = (
             f"Release {plan.target}.\n\n"
-            f"{plan.changelog_body}\n\n"
+            f"{pr_changelog}\n\n"
             "Created by `scripts/release.py`."
         )
         run(
@@ -835,7 +873,11 @@ def execute(
         _step(9, total, f"GitHub Release {plan.target} already exists — skip")
     else:
         _step(9, total, "Create GitHub Release (triggers publish-npm on the tag)")
-        notes = plan.changelog_body or f"Release {plan.target}"
+        notes = _cap_body(
+            plan.changelog_body or f"Release {plan.target}",
+            GH_RELEASE_NOTES_LIMIT,
+            full_ref="`CHANGELOG.md`",
+        )
         run(
             "gh", "release", "create", plan.target,
             "--title", plan.target,

--- a/src/scripts/update_counts.py
+++ b/src/scripts/update_counts.py
@@ -80,8 +80,10 @@ TARGETS: list[tuple[str, list[tuple[str, str]]]] = [
     (
         "README.md",
         [
-            (r"(Browse all )(\d+)( commands\])", "commands"),
-            (r"(package \(rules \+ )(\d+)( skills)", "skills"),
+            # Browse-content line: `… [all NNN commands](…)`. Raw file
+            # count (the hero `Commands-N` badge carries the *active*
+            # count and is owned by check_command_count_messaging.py).
+            (r"(\[all )(\d+)( commands\])", "commands"),
             # Hero badges: shields.io URLs `Skills-NNN-<color>` etc.
             # Format: https://img.shields.io/badge/<Label>-<N>-<hex>?style=flat-square
             (r"(/badge/Skills-)(\d+)(-)", "skills"),
@@ -106,7 +108,10 @@ TARGETS: list[tuple[str, list[tuple[str, str]]]] = [
         "docs/getting-started.md",
         [
             (r"(automatically by )(\d+)( rules)", "rules"),
-            (r"(Browse all )(\d+)( commands\])", "commands"),
+            # NOTE: the "Browse all N active commands" line here carries the
+            # *active* command count and is owned by
+            # check_command_count_messaging.py — intentionally not synced
+            # from this raw-file-count script (avoids double-ownership).
         ],
     ),
     (


### PR DESCRIPTION
## Summary

Three release-tooling fixes that unblock the 6.0.0 release (and any future major bump).

## Fixes

1. **GraphQL "Body is too long" on `gh pr create`** — a major release renders hundreds of commit bullets (~66 k chars), past GitHub's 65 536 PR-body limit. `_cap_body()` now truncates the PR body and release notes to the respective GitHub limits with a pointer to `CHANGELOG.md` (the full entry is in the PR diff + tag anyway).
2. **Empty-commit crash on `--resume`** — the era-split lands its own commit, so step 3's skip-guard (`last_msg == "release: X"`) misses and `git commit` ran on an empty index → crash. Step 3 now skips when nothing is staged.
3. **Stale count-sync patterns** (`update_counts.py`) — README line is `[all N commands]` (was `Browse all N commands]`); dropped the dead `package (rules + N skills)` pattern and the getting-started `active commands` pattern (owned by `check_command_count_messaging.py`). Clears the `pattern missed` warnings.

## Scope

`src/scripts/release.py` + `src/scripts/update_counts.py` only. No behavioural change to released content.