### PR TITLE
ci(skill-lint): enforce rule tiers in CI + guard the tier/visibility wiring

### DIFF
--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -117,12 +117,18 @@ jobs:
       - name: Run skill linter (changed files only)
         run: python3 src/scripts/skill_linter.py --changed
 
-      - name: Validate command tier + visibility frontmatter
-        # ADR-090: lint_command_tiers is the sole enforcer of `visibility:`
-        # (presence, valid enum, tier/visibility consistency). It must run in
-        # CI on every PR — validate_frontmatter treats visibility as optional,
-        # so without this step a missing/invalid visibility would slip through.
-        run: task lint-command-tiers
+      - name: Validate command + rule tier/visibility frontmatter
+        # These two lints are the sole CI enforcers that every command declares
+        # a valid tier + visibility (ADR-090: presence, enum, tier/visibility
+        # consistency) and every rule declares a valid tier. They are otherwise
+        # only reachable via the local `task ci`/`ci-strict` meta-tasks, which
+        # no workflow invokes — and validate_frontmatter treats these fields as
+        # optional. Without this step a missing/invalid tier or visibility on a
+        # newly-created rule or command would slip through CI. The
+        # test_tier_visibility_ci_wired guard keeps this step from regressing.
+        run: |
+          task lint-command-tiers
+          task lint-rule-tiers
 
       - name: Generate lint reports (full repo, informational)
         if: always()

--- a/tests/test_tier_visibility_ci_wired.py
+++ b/tests/test_tier_visibility_ci_wired.py
@@ -1,0 +1,34 @@
+"""Guard: the tier/visibility enforcement lints must stay wired into CI.
+
+`lint_command_tiers.py` (ADR-090 — every command declares a valid `tier:` +
+`visibility:`, with the two consistent) and `lint_rule_tiers.py` (every rule
+declares a valid `tier:`) are the ONLY CI enforcers of those frontmatter
+fields. `validate_frontmatter` treats them as optional, and the lints
+otherwise live only in the local `task ci`/`ci-strict` meta-tasks that no
+workflow invokes — so they are run as an explicit step in the `skill-lint`
+workflow.
+
+This test fails if that wiring regresses (the step is renamed away or a lint is
+dropped). Without it, a newly-created rule or command missing a valid
+tier/visibility would silently pass CI — the exact gap ADR-090 closed.
+"""
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SKILL_LINT_WORKFLOW = REPO / ".github" / "workflows" / "skill-lint.yml"
+
+# The enforcement lints that MUST run on every PR, as Task targets.
+REQUIRED_CI_TASKS = ("task lint-command-tiers", "task lint-rule-tiers")
+
+
+def test_tier_visibility_lints_wired_in_skill_lint_ci() -> None:
+    assert SKILL_LINT_WORKFLOW.is_file(), f"missing workflow: {SKILL_LINT_WORKFLOW}"
+    text = SKILL_LINT_WORKFLOW.read_text(encoding="utf-8")
+    missing = [t for t in REQUIRED_CI_TASKS if t not in text]
+    assert not missing, (
+        "tier/visibility enforcement lints not wired into the skill-lint "
+        f"workflow: {missing}. They must run in CI on every PR (ADR-090) so a "
+        "new rule/command without a valid tier/visibility cannot slip through. "
+        "Re-add the step or update this guard if the wiring moved to another "
+        "PR-triggered workflow."
+    )


### PR DESCRIPTION
## Summary

Follow-up to #496. Closes the CI-enforcement gap for tier/visibility frontmatter and makes the wiring regression-proof.

- **Enforce rule tiers in CI too.** Adds `task lint-rule-tiers` alongside `task lint-command-tiers` in the `skill-lint` workflow. Both lints previously lived only in the local `task ci`/`ci-strict` meta-tasks, which no workflow invokes — so a rule (or command) created without a valid `tier:`/`visibility:` could pass CI. `validate_frontmatter` treats those fields as optional, so it does not cover the gap.
- **Guard the wiring.** Adds `tests/test_tier_visibility_ci_wired.py`, which fails if either lint is dropped from the workflow. This is the structural guarantee that future rules/commands keep being created under the tier/visibility principle — the enforcement cannot silently regress.

## Verification
`task lint-command-tiers` ✅ · `task lint-rule-tiers` ✅ (79 rules) · new guard test passes ✅ · negative check confirms the guard fails when a lint is unwired ✅ · workflow YAML parses ✅.
