### PR TITLE
fix(install): reaping catches pre-inventory tagged orphans

### DIFF
--- a/agents/roadmaps/archive/road-to-reaping-catches-pre-inventory-orphans.md
+++ b/agents/roadmaps/archive/road-to-reaping-catches-pre-inventory-orphans.md
@@ -1,0 +1,110 @@
+---
+complexity: lightweight
+status: completed
+---
+
+# Roadmap: Reaping catches pre-inventory tagged orphans
+
+> Goal: make global-deploy stale-reaping **self-healing** — a
+> package-tagged `.md` orphan must be deleted on the next global deploy
+> regardless of inventory history, not only on the one first-run window
+> when the tool is absent from `deployed-files.json`.
+>
+> Shipped together with the implementation in this PR; archived complete.
+
+## Context — the bug
+
+`install.py` (call site `src/scripts/install.py`) picked **one** reaping
+path per tool, mutually exclusively:
+
+```python
+if tool_id in inventory.get("tools", {}):
+    reaped = inv_mod.reap_stale(...)          # diff vs PREVIOUS inventory only
+else:
+    reaped = inv_mod.bootstrap_reap_tagged(...)  # tag-based, FIRST-run only
+```
+
+Consequence: once a tool is recorded in the inventory, the tag-based
+sweep never runs again, and `reap_stale` only deletes files that were in
+the *prior* inventory. A package-tagged file deployed by a
+**pre-inventory** installer version — never recorded in any inventory and
+surviving the single bootstrap window — rots forever.
+
+Observed 2026-06-13 on a v6.0.0 global install (3 tagged orphans the
+6.0.0 upgrade left under `~/.claude/`):
+
+- `commands/create-pr.md` (v6 rename → `pr/create`)
+- `commands/create-pr/description-only.md` (→ `pr/create/description-only`)
+- `rules/augment-source-of-truth.md` (v6 rename → `source-of-truth`, PR #427)
+
+Each carries the `package:` tag, sits under a deploy dest-sub, and is
+absent from the current bundle — provably ours and provably stale — yet
+both reaping paths skipped them. Affects every consumer who upgraded
+from a pre-inventory version.
+
+## Fix shape
+
+The tag-based sweep is the only path with ownership proof independent of
+inventory history (the injected `package:` tag). Run it on **every**
+deploy, in addition to `reap_stale`, and union the deletions. Untagged
+user files stay untouched. Idempotent: after the first always-run pass
+the orphans are gone, so subsequent deploys find nothing.
+
+## Phase 1 — always-run the tag sweep
+
+- [x] In `src/scripts/install.py`, replace the exclusive `if/else` with:
+  run `reap_stale` when the tool has an inventory entry, **and
+  unconditionally** run the tag sweep; union + dedup the two deleted-path
+  lists.
+- [x] Inline comment at the call site stating the tag sweep is no longer
+  first-run-only and documenting the unlink-before-rglob ordering so it is
+  not "optimised" back.
+- [x] Confirmed no double-delete hazard: `reap_stale` unlinks first, the
+  tag sweep's `rglob` cannot re-find an already-deleted path.
+
+## Phase 2 — rename for honesty
+
+- [x] Renamed `bootstrap_reap_tagged` → `reap_tagged_orphans` in
+  `src/scripts/_lib/global_deploy_inventory.py`; docstring rewritten
+  (drops "first-run" framing, states it runs every deploy).
+- [x] Updated the call site in `src/scripts/install.py` and all references
+  in `tests/test_global_deploy_inventory.py`.
+- [x] `grep -rn bootstrap_reap_tagged src/ tests/` → zero stale references.
+
+## Phase 3 — regression test
+
+- [x] Added `test_deploy_reaps_tagged_orphan_absent_from_recorded_inventory`
+  reproducing the miss (tool with an inventory entry whose `files` omits a
+  tagged on-disk orphan → must be reaped; untagged sibling survives).
+  Verified RED under restored old behaviour, GREEN with the fix.
+- [x] Added `test_reap_tagged_orphans_is_idempotent` (second pass deletes
+  nothing, raises nothing).
+- [x] `python3 -m pytest tests/test_global_deploy_inventory.py -q` → green.
+
+## Phase 4 — surfacing
+
+- [x] `agent-config doctor`: added read-only `stale-orphans` check
+  (`src/scripts/_cli/cmd_doctor.py`) scanning recorded anchors for
+  `package:`-tagged `.md` files absent from the inventory; reports the
+  count + remedy, deletes nothing. Registered in `CHECK_IDS` +
+  `GLOBAL_CHECK_IDS` + both runner dicts.
+- [x] Added `stale-orphans` doctor tests (no-inventory → ok, tagged orphan
+  → warn, clean → ok). `pytest tests/test_cmd_doctor.py` → green.
+
+## Acceptance criteria
+
+- [x] Tag-based reaping runs on every global deploy; a pre-inventory
+  tagged orphan is deleted on the next `agent-config global` without
+  manual intervention.
+- [x] Union/dedup of `reap_stale` + tag sweep — no double-delete, no
+  untagged user file touched.
+- [x] Regression + idempotency tests pass.
+- [x] `doctor` surfaces residual tagged orphans without deleting them.
+
+## Out of scope
+
+- Marketplace-plugin drift (`~/.claude/plugins/…`) — a separate channel
+  npm/install.py does not own; `doctor` already surfaces binary↔plugin
+  version drift.
+- `event4u/agent-memory` pinning `@event4u/agent-config@1.11.0` via
+  `github:…#main` — separate dependency-hygiene issue.

--- a/src/scripts/_cli/cmd_doctor.py
+++ b/src/scripts/_cli/cmd_doctor.py
@@ -18,7 +18,7 @@ Drift categories (manifest ↔ filesystem):
   here; files without frontmatter are skipped (P5.1 contract).
 
 Health checks (see :data:`CHECK_IDS`):
-scope · manifest-integrity · lockfile-freshness · bridge-drift ·
+scope · stale-orphans · manifest-integrity · lockfile-freshness · bridge-drift ·
 mcp-mode · mcp-beta-readiness · offline-readiness · python-runtime ·
 tier-usage-readiness · council-cli · unsupported-combos ·
 wizard-state.
@@ -450,6 +450,7 @@ def _foreign_records(
 CHECK_IDS = (
     "scope",
     "global-binary",
+    "stale-orphans",
     "manifest-integrity",
     "lockfile-freshness",
     "bridge-drift",
@@ -473,6 +474,7 @@ CHECK_IDS = (
 GLOBAL_CHECK_IDS: frozenset[str] = frozenset({
     "scope",
     "global-binary",
+    "stale-orphans",
     "mcp-mode",
     "mcp-beta-readiness",
     "offline-readiness",
@@ -750,6 +752,81 @@ def _check_offline_readiness() -> dict[str, Any]:
         "id": "offline-readiness", "status": "ok",
         "message": "verified-offline install entrypoint present",
         "remedy": "",
+    }
+
+
+def _check_stale_orphans() -> dict[str, Any]:
+    """Surface package-tagged files on disk that the global-deploy inventory
+    no longer tracks — leftovers from a pre-inventory installer or a
+    since-removed / renamed artefact (e.g. ``create-pr`` → ``pr/create``).
+
+    Read-only: counts candidates per recorded anchor, never deletes. The
+    remedy is a global redeploy, whose always-run tag sweep
+    (``reap_tagged_orphans``) reconciles them. Scans only the package-owned
+    subtrees the inventory recorded (not the whole anchor), and counts a
+    file only when it carries this package's ``package:`` tag — user-authored
+    files in shared anchors never register.
+    """
+    try:  # package-style import (installed package / pytest)
+        from scripts._lib import global_deploy_inventory as gdi
+    except ImportError:  # pragma: no cover — script-style sys.path fallback
+        from _lib import global_deploy_inventory as gdi  # type: ignore[no-redef]
+
+    tools = gdi.load_inventory().get("tools", {})
+    if not isinstance(tools, dict) or not tools:
+        return {
+            "id": "stale-orphans", "status": "ok",
+            "message": "no global-deploy inventory yet — nothing to reconcile",
+            "remedy": "",
+        }
+    orphan_count = 0
+    sample: list[str] = []
+    for tool_id, entry in sorted(tools.items()):
+        if not isinstance(entry, dict):
+            continue
+        anchor_raw = entry.get("anchor")
+        recorded = entry.get("files")
+        if not isinstance(anchor_raw, str) or not isinstance(recorded, list):
+            continue
+        anchor = Path(anchor_raw).expanduser()
+        if not anchor.is_dir():
+            continue
+        recorded_set = {r for r in recorded if isinstance(r, str)}
+        # Bound the scan to the top-level subtrees the package actually owns.
+        owned_roots = {r.split("/", 1)[0] for r in recorded_set if "/" in r}
+        for root_name in sorted(owned_roots):
+            root = anchor / root_name
+            if not root.is_dir():
+                continue
+            for md in root.rglob("*.md"):
+                if md.is_dir():
+                    continue
+                try:
+                    rel = md.relative_to(anchor).as_posix()
+                except ValueError:
+                    continue
+                if rel in recorded_set:
+                    continue
+                tag = _read_inline_package_tag(md)
+                if isinstance(tag, _Sentinel) or tag != PACKAGE_TAG_ID:
+                    continue
+                orphan_count += 1
+                if len(sample) < 5:
+                    sample.append(f"{tool_id}:{rel}")
+    if orphan_count == 0:
+        return {
+            "id": "stale-orphans", "status": "ok",
+            "message": "no stale package-tagged files under recorded anchors",
+            "remedy": "",
+        }
+    return {
+        "id": "stale-orphans", "status": "warn",
+        "message": (
+            f"{orphan_count} stale package-tagged file(s) not tracked by the "
+            f"deploy inventory (e.g. {', '.join(sample)})"
+        ),
+        "remedy": "run `agent-config global` to reap them "
+                  "(the tag sweep reconciles on every deploy)",
     }
 
 
@@ -1179,6 +1256,7 @@ def _run_checks(
     runners: dict[str, Any] = {
         "scope": lambda: _check_scope(project_root),
         "global-binary": lambda: _check_global_binary(project_root),
+        "stale-orphans": _check_stale_orphans,
         "manifest-integrity": lambda: _check_manifest_integrity(manifest),
         "lockfile-freshness": lambda: _check_lockfile_freshness(manifest),
         "bridge-drift": lambda: _check_bridge_drift(
@@ -1257,6 +1335,7 @@ def _run_checks_no_manifest(
     runners: dict[str, Any] = {
         "scope": lambda: _check_scope(project_root),
         "global-binary": lambda: _check_global_binary(project_root),
+        "stale-orphans": _check_stale_orphans,
         "manifest-integrity": lambda: _skipped_manifest_check("manifest-integrity"),
         "lockfile-freshness": lambda: _skipped_manifest_check("lockfile-freshness"),
         "bridge-drift": lambda: _check_bridge_drift_no_manifest(bridge_present),

--- a/src/scripts/_lib/global_deploy_inventory.py
+++ b/src/scripts/_lib/global_deploy_inventory.py
@@ -191,20 +191,30 @@ def reap_stale(
     return deleted
 
 
-def bootstrap_reap_tagged(
+def reap_tagged_orphans(
     anchor: Path,
     dest_subs: list[str],
     current_files: set[str],
     package_tag: str,
 ) -> list[Path]:
-    """First-run reaping for PRE-inventory installs (marker-based ownership).
+    """Marker-based reaping of package-tagged orphans — runs EVERY deploy.
 
-    Existing installs in the wild predate the inventory sidecar, so
-    :func:`reap_stale` has nothing to diff against on the first upgraded
-    deploy — the legacy mess (renamed skills, retired command-as-skill
-    entries, the 2026-05-13 colon-named shapes) would rot forever. Every
-    deployed ``.md`` however carries the injected ``package:`` frontmatter
-    tag (install P5.1), which is exactly the ownership proof reaping needs.
+    This is the self-healing reaping path, complementary to
+    :func:`reap_stale` (which can only diff against the *previous*
+    inventory). It is the **only** path with ownership proof independent
+    of inventory history: every deployed ``.md`` carries the injected
+    ``package:`` frontmatter tag (install P5.1), so a tagged file absent
+    from the current bundle is provably our orphan regardless of whether
+    any inventory ever recorded it.
+
+    Why it must run every deploy, not just on first-run: an install that
+    predates the inventory sidecar never recorded its files, so once a
+    tool *does* get an inventory entry, :func:`reap_stale` has no record
+    of those legacy files to diff against — they would rot forever (the
+    renamed skills, retired command-as-skill entries, 2026-05-13
+    colon-named shapes, and post-6.0.0 command renames like
+    ``create-pr`` → ``pr/create``). Running this sweep unconditionally
+    closes that gap; it is idempotent (a clean tree yields no deletions).
 
     Deletes ``.md`` files under ``<anchor>/<dest_sub>`` that (a) carry
     ``package: <package_tag>`` in their frontmatter and (b) are not in the

--- a/src/scripts/install.py
+++ b/src/scripts/install.py
@@ -3424,19 +3424,28 @@ def _deploy_global_content(
         # partial copy can never trigger deletions.
         inv_mod = _inventory_mod()
         inventory = inv_mod.load_inventory()
+        reaped: list = []
+        # Inventory-diff path: deletes files THIS anchor recorded in a prior
+        # deploy that the current bundle dropped. Covers every file type, but
+        # only what a previous inventory actually recorded.
         if tool_id in inventory.get("tools", {}):
-            reaped = inv_mod.reap_stale(
+            reaped += inv_mod.reap_stale(
                 tool_id, anchor, current_files, inventory,
             )
-        else:
-            # First deploy after the upgrade — no inventory to diff against.
-            # Fall back to marker-based ownership: every previously deployed
-            # .md carries the injected `package:` tag (P5.1), so tagged
-            # orphans under the plan's destinations are provably ours.
-            reaped = inv_mod.bootstrap_reap_tagged(
-                anchor, [dest_sub for _, dest_sub in plan],
-                current_files, PACKAGE_TAG_ID,
-            )
+        # Tag-based sweep: runs on EVERY deploy, not just first-run. It is the
+        # only path that catches package-tagged `.md` orphans the inventory
+        # diff cannot see — files deployed by a pre-inventory installer (never
+        # recorded), or surviving a since-replaced inventory (e.g. post-6.0.0
+        # command renames like create-pr → pr/create). Ownership proof is the
+        # injected `package:` tag (P5.1), so untagged user files in shared
+        # anchors are never touched. Idempotent: a clean tree yields nothing.
+        # Order matters: reap_stale unlinks first, so this rglob cannot
+        # re-find an already-deleted path — do not reorder these two.
+        reaped += inv_mod.reap_tagged_orphans(
+            anchor, [dest_sub for _, dest_sub in plan],
+            current_files, PACKAGE_TAG_ID,
+        )
+        reaped = sorted(set(reaped))
         # Record the UNexpanded anchor (`~/.agents/`) so the inventory stays
         # byte-identical across homes (GUI/CLI parity) and home relocations.
         inv_mod.record_deploy(tool_id, anchor_raw, current_files, inventory)

--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -430,6 +430,54 @@ def test_check_scope_standalone(
     assert "standalone" in scope["message"]
 
 
+def _seed_inventory(tmp_path: Path, monkeypatch, anchor: Path,
+                    recorded: list[str]) -> None:
+    from scripts._lib import global_deploy_inventory as gdi
+    inv_file = tmp_path / "deployed-files.json"
+    monkeypatch.setenv(gdi.INVENTORY_ENV, str(inv_file))
+    inv = gdi.record_deploy("tooltest", str(anchor), set(recorded), {})
+    gdi.save_inventory(inv, inv_file)
+
+
+def _write_tagged_md(path: Path, name: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nname: {name}\npackage: {cmd_doctor.PACKAGE_TAG_ID}\n---\n\nx\n",
+        encoding="utf-8",
+    )
+
+
+def test_stale_orphans_ok_when_no_inventory(monkeypatch, tmp_path) -> None:
+    from scripts._lib import global_deploy_inventory as gdi
+    monkeypatch.setenv(gdi.INVENTORY_ENV, str(tmp_path / "missing.json"))
+    result = cmd_doctor._check_stale_orphans()
+    assert result["status"] == "ok"
+
+
+def test_stale_orphans_warns_on_tagged_orphan(monkeypatch, tmp_path) -> None:
+    anchor = tmp_path / "anchor"
+    _write_tagged_md(anchor / "commands" / "pr" / "create.md", "create")     # recorded
+    _write_tagged_md(anchor / "commands" / "create-pr.md", "create-pr")       # orphan
+    # User-authored, untagged — must not register.
+    (anchor / "commands").mkdir(parents=True, exist_ok=True)
+    (anchor / "commands" / "mine.md").write_text(
+        "---\nname: mine\n---\n\nx\n", encoding="utf-8")
+    _seed_inventory(tmp_path, monkeypatch, anchor, ["commands/pr/create.md"])
+
+    result = cmd_doctor._check_stale_orphans()
+    assert result["status"] == "warn"
+    assert "create-pr.md" in result["message"]
+    assert "agent-config global" in result["remedy"]
+
+
+def test_stale_orphans_ok_when_clean(monkeypatch, tmp_path) -> None:
+    anchor = tmp_path / "anchor"
+    _write_tagged_md(anchor / "commands" / "pr" / "create.md", "create")
+    _seed_inventory(tmp_path, monkeypatch, anchor, ["commands/pr/create.md"])
+    result = cmd_doctor._check_stale_orphans()
+    assert result["status"] == "ok"
+
+
 def test_check_lockfile_freshness_drift(
     tmp_path: Path, capsys: pytest.CaptureFixture,
 ) -> None:

--- a/tests/test_global_deploy_inventory.py
+++ b/tests/test_global_deploy_inventory.py
@@ -226,7 +226,7 @@ def test_two_deploy_cycle_reaps_renamed_skill(tmp_path):
     assert (anchor / "skills" / "agents-review" / "SKILL.md").exists()
 
 
-# --- bootstrap_reap_tagged (pre-inventory installs) ----------------------
+# --- reap_tagged_orphans (marker-based, runs every deploy) ---------------
 
 TAG = "event4u/agent-config"
 
@@ -238,7 +238,7 @@ def _tagged_md(path: Path, name: str) -> None:
     )
 
 
-def test_bootstrap_reaps_tagged_orphans_only(tmp_path):
+def test_reap_tagged_orphans_only(tmp_path):
     anchor = tmp_path / "anchor"
     # Tagged orphan (e.g. retired 2026-05-13 command-as-skill entry).
     _tagged_md(anchor / "skills" / "dto-creator" / "SKILL.md", "dto-creator")
@@ -251,7 +251,7 @@ def test_bootstrap_reaps_tagged_orphans_only(tmp_path):
     # Untagged loose file — must survive.
     (anchor / "skills" / "notes.md").write_text("plain", encoding="utf-8")
 
-    deleted = inv.bootstrap_reap_tagged(
+    deleted = inv.reap_tagged_orphans(
         anchor, ["skills"], {"skills/kept/SKILL.md"}, TAG,
     )
 
@@ -262,13 +262,26 @@ def test_bootstrap_reaps_tagged_orphans_only(tmp_path):
     assert (anchor / "skills" / "notes.md").exists()
 
 
-def test_bootstrap_ignores_missing_dest_and_other_tags(tmp_path):
+def test_reap_tagged_orphans_is_idempotent(tmp_path):
+    # Second pass over an already-clean tree deletes nothing and raises
+    # nothing — the always-run sweep must be safe to repeat every deploy.
+    anchor = tmp_path / "anchor"
+    _tagged_md(anchor / "skills" / "kept" / "SKILL.md", "kept")
+    current = {"skills/kept/SKILL.md"}
+    first = inv.reap_tagged_orphans(anchor, ["skills"], current, TAG)
+    second = inv.reap_tagged_orphans(anchor, ["skills"], current, TAG)
+    assert first == []
+    assert second == []
+    assert (anchor / "skills" / "kept" / "SKILL.md").exists()
+
+
+def test_reap_tagged_orphans_ignores_missing_dest_and_other_tags(tmp_path):
     anchor = tmp_path / "anchor"
     _tagged_md(anchor / "skills" / "foreign" / "SKILL.md", "foreign")
     (anchor / "skills" / "foreign" / "SKILL.md").write_text(
         "---\nname: foreign\npackage: someone/else\n---\n\nbody\n",
         encoding="utf-8")
-    deleted = inv.bootstrap_reap_tagged(
+    deleted = inv.reap_tagged_orphans(
         anchor, ["skills", "rules"], set(), TAG,
     )
     assert deleted == []
@@ -355,6 +368,60 @@ def test_deploy_global_content_bootstrap_reaps_pre_inventory_orphans(
         "pre-inventory tagged orphan must be bootstrap-reaped on first run"
     assert (anchor / "skills" / "user-own" / "SKILL.md").exists()
     assert (anchor / "skills" / "current" / "SKILL.md").exists()
+
+
+def test_deploy_reaps_tagged_orphan_absent_from_recorded_inventory(
+        tmp_path, monkeypatch):
+    """Regression: a package-tagged orphan that no inventory ever recorded
+    (a pre-inventory deploy leftover, or a post-6.0.0 rename like
+    create-pr -> pr/create) must be reaped on redeploy.
+
+    The old code reaped via the inventory diff ONLY once a tool had an
+    entry, and ran the tag sweep ONLY when the tool was absent from the
+    inventory. So a tagged orphan that the recorded inventory never knew
+    about rotted forever. The always-run tag sweep closes that gap.
+    """
+    import install  # noqa: WPS433 — sys.path prepared at module top
+
+    pkg = tmp_path / "pkg"
+    (pkg / "dist/agent-src/skills/current").mkdir(parents=True)
+    (pkg / "dist/agent-src/skills/current/SKILL.md").write_text(
+        "---\nname: current\n---\n\nbody\n", encoding="utf-8")
+    anchor = tmp_path / "anchor"
+    monkeypatch.setenv(inv.INVENTORY_ENV, str(tmp_path / "inv.json"))
+    monkeypatch.setitem(
+        install.USER_SCOPE_PATHS, "tooltest", str(anchor))
+    monkeypatch.setitem(
+        install.GLOBAL_DEPLOY_SOURCES, "tooltest",
+        [("dist/agent-src/skills", "skills")],
+    )
+
+    # First deploy: establishes an inventory entry for tooltest.
+    install._deploy_global_content(
+        {"tooltest"}, True, pkg, tmp_path / "installed.lock",
+    )
+    assert (anchor / "skills" / "current" / "SKILL.md").exists()
+
+    # Simulate a pre-inventory tagged orphan the recorded inventory never
+    # knew about (deployed by an installer predating the sidecar).
+    _tagged_md(anchor / "skills" / "create-pr" / "SKILL.md", "create-pr")
+    # User-authored neighbour must survive.
+    (anchor / "skills" / "user-own").mkdir(parents=True)
+    (anchor / "skills" / "user-own" / "SKILL.md").write_text(
+        "---\nname: user-own\n---\n\nmine\n", encoding="utf-8")
+
+    # Redeploy: tooltest already has an inventory entry, so reap_stale alone
+    # (the old behaviour) would NOT see this orphan. The always-run tag
+    # sweep must.
+    results = install._deploy_global_content(
+        {"tooltest"}, True, pkg, tmp_path / "installed.lock",
+    )
+    assert results["tooltest"][2] == "deployed"
+    assert not (anchor / "skills" / "create-pr").exists(), \
+        "tagged orphan absent from recorded inventory must be reaped"
+    assert (anchor / "skills" / "current" / "SKILL.md").exists()
+    assert (anchor / "skills" / "user-own" / "SKILL.md").exists(), \
+        "user-authored entry in the shared anchor must survive"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Global-deploy stale-reaping picked **one** path per tool, mutually exclusively (`src/scripts/install.py`):

- `reap_stale` — only when the tool already has an inventory entry; only deletes files recorded in the *previous* inventory.
- `bootstrap_reap_tagged` — only when the tool is **absent** from the inventory (first run).

So once a tool is recorded, the tag-based sweep never runs again, and a package-tagged file deployed by a **pre-inventory** installer — never recorded in any inventory — rots forever.

Observed 2026-06-13 on a v6.0.0 global install: three tagged orphans left under `~/.claude/` after `npx … upgrade`:

- `commands/create-pr.md` → renamed to `pr/create` in v6
- `commands/create-pr/description-only.md` → `pr/create/description-only`
- `rules/augment-source-of-truth.md` → `source-of-truth` (PR #427)

Each carries the `package:` tag, sits under a deploy dest-sub, is absent from the current bundle — provably ours and provably stale — yet both reaping paths skipped them. Affects every consumer upgraded from a pre-inventory version.

## Fix

Run the tag-based sweep on **every** deploy *in addition to* `reap_stale`, and union the deletions. Ownership proof stays the injected `package:` tag, so untagged user files in shared anchors are never touched. Idempotent: a clean tree yields no deletions.

- `bootstrap_reap_tagged` → **`reap_tagged_orphans`** (the name no longer lies); docstring rewritten.
- Call site unions `reap_stale` + tag sweep, deduped; comment documents the unlink-before-rglob ordering.
- New **`doctor` `stale-orphans` check** (read-only) surfaces residual tagged orphans + remedy; never deletes.

## Tests

- `test_deploy_reaps_tagged_orphan_absent_from_recorded_inventory` — reproduces the exact miss; verified **RED** under restored old behaviour, **GREEN** with the fix.
- `test_reap_tagged_orphans_is_idempotent` — second pass deletes nothing, raises nothing.
- `stale-orphans` doctor tests: no-inventory → ok, tagged orphan → warn, clean → ok.
- `pytest -k "deploy or inventory or doctor or reap"` → **101 passed**.

## Out of scope

- Marketplace-plugin drift (`~/.claude/plugins/…`) — a separate channel npm/install.py does not own; `doctor` already surfaces binary↔plugin version drift.
- `event4u/agent-memory` pinning `@event4u/agent-config@1.11.0` via `github:…#main` — separate dependency-hygiene issue.
