### PR TITLE
test(install): regression coverage for the reaping-orphan gap (follow-up to #499)

### DIFF
--- a/tests/test_cmd_doctor.py
+++ b/tests/test_cmd_doctor.py
@@ -478,6 +478,36 @@ def test_stale_orphans_ok_when_clean(monkeypatch, tmp_path) -> None:
     assert result["status"] == "ok"
 
 
+def test_doctor_pipeline_surfaces_stale_orphans(
+    monkeypatch, tmp_path: Path, capsys: pytest.CaptureFixture,
+) -> None:
+    """End-to-end through ``main`` (--check + --json): the registered
+    ``stale-orphans`` check must report ``warn`` when a tagged orphan sits
+    under a recorded anchor. Locks the runner-dict wiring, not just the
+    bare check function.
+    """
+    anchor = tmp_path / "anchor"
+    _write_tagged_md(anchor / "commands" / "pr" / "create.md", "create")
+    _write_tagged_md(anchor / "commands" / "create-pr.md", "create-pr")  # orphan
+    _seed_inventory(tmp_path, monkeypatch, anchor, ["commands/pr/create.md"])
+
+    # Global-only consumer (bridge marker, no lockfile) so the no-manifest
+    # path runs the global checks — stale-orphans among them.
+    project = tmp_path / "proj"
+    (project / "agents").mkdir(parents=True)
+    (project / "agents" / ".event4u-bridge.yml").write_text(
+        "schema: 1\n", encoding="utf-8")
+
+    cmd_doctor.main([
+        f"--project={project}", "--check", "stale-orphans", "--json",
+    ])
+    payload = json.loads(capsys.readouterr().out)
+    check = {c["id"]: c for c in payload["checks"]}["stale-orphans"]
+    assert check["status"] == "warn"
+    assert "create-pr.md" in check["message"]
+    assert "agent-config global" in check["remedy"]
+
+
 def test_check_lockfile_freshness_drift(
     tmp_path: Path, capsys: pytest.CaptureFixture,
 ) -> None:

--- a/tests/test_global_deploy_inventory.py
+++ b/tests/test_global_deploy_inventory.py
@@ -9,6 +9,7 @@ Run: python3 -m pytest tests/test_global_deploy_inventory.py -q
 """
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -422,6 +423,111 @@ def test_deploy_reaps_tagged_orphan_absent_from_recorded_inventory(
     assert (anchor / "skills" / "current" / "SKILL.md").exists()
     assert (anchor / "skills" / "user-own" / "SKILL.md").exists(), \
         "user-authored entry in the shared anchor must survive"
+
+
+def test_deploy_reaps_both_inventory_and_tagged_orphans_in_one_pass(
+        tmp_path, monkeypatch):
+    """Union proof: one redeploy must reap BOTH an inventory-recorded file
+    the bundle dropped (``reap_stale`` path) AND a pre-inventory tagged
+    orphan the inventory never knew (``reap_tagged_orphans`` path).
+
+    Guards against a regression to the old exclusive ``if/else`` that ran
+    only one of the two paths per deploy.
+    """
+    import install  # noqa: WPS433 — sys.path prepared at module top
+
+    pkg = tmp_path / "pkg"
+    (pkg / "dist/agent-src/skills/keep").mkdir(parents=True)
+    (pkg / "dist/agent-src/skills/keep/SKILL.md").write_text(
+        "---\nname: keep\n---\n\nbody\n", encoding="utf-8")
+    (pkg / "dist/agent-src/skills/drop-me").mkdir(parents=True)
+    (pkg / "dist/agent-src/skills/drop-me/SKILL.md").write_text(
+        "---\nname: drop-me\n---\n\nbody\n", encoding="utf-8")
+    anchor = tmp_path / "anchor"
+    monkeypatch.setenv(inv.INVENTORY_ENV, str(tmp_path / "inv.json"))
+    monkeypatch.setitem(install.USER_SCOPE_PATHS, "tooltest", str(anchor))
+    monkeypatch.setitem(
+        install.GLOBAL_DEPLOY_SOURCES, "tooltest",
+        [("dist/agent-src/skills", "skills")],
+    )
+
+    # First deploy records keep + drop-me in the inventory.
+    install._deploy_global_content(
+        {"tooltest"}, True, pkg, tmp_path / "lock",
+    )
+    assert (anchor / "skills" / "drop-me" / "SKILL.md").exists()
+
+    # The bundle drops drop-me (a reap_stale target — it was recorded) ...
+    shutil.rmtree(pkg / "dist/agent-src/skills/drop-me")
+    # ... and a pre-inventory tagged orphan appears that no inventory ever
+    # recorded (a reap_tagged_orphans target).
+    _tagged_md(anchor / "skills" / "ghost" / "SKILL.md", "ghost")
+
+    install._deploy_global_content(
+        {"tooltest"}, True, pkg, tmp_path / "lock",
+    )
+    assert not (anchor / "skills" / "drop-me").exists(), \
+        "inventory-recorded drop must be reaped (reap_stale path)"
+    assert not (anchor / "skills" / "ghost").exists(), \
+        "pre-inventory tagged orphan must be reaped (reap_tagged_orphans path)"
+    assert (anchor / "skills" / "keep" / "SKILL.md").exists()
+
+
+def test_deploy_real_bundle_reaps_planted_orphan_and_is_idempotent(
+        tmp_path, monkeypatch):
+    """End-to-end against the REAL dist bundle: deploy actual
+    rules+commands+personas, plant a package-tagged orphan under a deployed
+    root, redeploy, and assert the orphan is reaped while real shipped files
+    survive — then a third pass is a clean no-op.
+
+    Catches packaging / deploy-plan regressions the synthetic tests cannot.
+    Bounded and fast (~0.2s for ~280 files) so it never blocks CI.
+    """
+    import install  # noqa: WPS433 — sys.path prepared at module top
+
+    repo_root = Path(__file__).resolve().parent.parent
+    if not (repo_root / "dist" / "agent-src" / "rules").is_dir():
+        pytest.skip("dist/agent-src bundle not built in this checkout")
+
+    anchor = tmp_path / "anchor"
+    monkeypatch.setenv(inv.INVENTORY_ENV, str(tmp_path / "inv.json"))
+    monkeypatch.setitem(install.USER_SCOPE_PATHS, "bundletest", str(anchor))
+    monkeypatch.setitem(
+        install.GLOBAL_DEPLOY_SOURCES, "bundletest",
+        [
+            ("dist/agent-src/rules", "rules"),
+            ("dist/agent-src/commands", "commands"),
+            ("dist/agent-src/personas", "personas"),
+        ],
+    )
+
+    install._deploy_global_content(
+        {"bundletest"}, True, repo_root, tmp_path / "lock",
+    )
+    real_files = list((anchor / "rules").glob("*.md"))
+    assert real_files, "real bundle should deploy rule files"
+    sentinel = real_files[0]
+
+    # Plant a package-tagged orphan under a deployed root (simulates a
+    # renamed/removed artefact from a prior version, e.g. create-pr).
+    orphan = anchor / "commands" / "__removed_in_next_version__.md"
+    orphan.write_text(
+        f"---\nname: gone\npackage: {install.PACKAGE_TAG_ID}\n---\n\nx\n",
+        encoding="utf-8",
+    )
+
+    install._deploy_global_content(
+        {"bundletest"}, True, repo_root, tmp_path / "lock",
+    )
+    assert not orphan.exists(), \
+        "planted tagged orphan must be reaped on redeploy of the real bundle"
+    assert sentinel.exists(), "real shipped file must survive reaping"
+
+    # Idempotent third pass: nothing left to reap, no error raised.
+    install._deploy_global_content(
+        {"bundletest"}, True, repo_root, tmp_path / "lock",
+    )
+    assert sentinel.exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Follow-up to #499

Adds regression coverage so the pre-inventory-orphan reaping gap (fixed in #499) cannot recur silently. #499 already shipped the core regression + idempotency + doctor unit tests; this PR adds the three broader guards requested after merge.

## What's added

- **Union proof** (`test_deploy_reaps_both_inventory_and_tagged_orphans_in_one_pass`) — one redeploy must reap **both** an inventory-recorded drop (`reap_stale` path) **and** a pre-inventory tagged orphan (`reap_tagged_orphans` path). Directly guards against a revert to the old exclusive `if/else` that ran only one path.
- **Real-bundle E2E** (`test_deploy_real_bundle_reaps_planted_orphan_and_is_idempotent`) — deploys the **actual** `dist/agent-src` rules+commands+personas to a temp anchor, plants a package-tagged orphan, redeploys → orphan reaped, real shipped files survive, third pass is a clean no-op. Catches packaging/deploy-plan regressions the synthetic tests miss. Skips cleanly if the bundle isn't built.
- **Doctor pipeline** (`test_doctor_pipeline_surfaces_stale_orphans`) — `main(--check stale-orphans --json)` reports `warn`, locking the runner-dict registration end-to-end (not just the bare check function).

## Speed

Bounded by design — the real-bundle deploy is ~0.2s for ~280 files. Both test files together: **52 passed in ~5.5s**. No long CI block.

## Base note

The three fix commits from #499 are already in `main` (merge commit 764611e4), so this PR's diff is the two test files only (+136 lines).
