### PR TITLE
fix(roadmaps): restore competitive-borrow v6 work + drop empty reaping stub

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**1 / 113 steps done · 1%**
+**2 / 116 steps done · 2%**
 
 ```text
-░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   1%
+█░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   2%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-6.0.0-final-readiness.md](roadmaps/road-to-6.0.0-final-readiness.md) | 6 | 17 | 17 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 2 | [road-to-competitive-borrow.md](roadmaps/road-to-competitive-borrow.md) | 4 | 30 | 20 | 1 | 4 | 5 | ░░░░░░░░░░ 5% |
+| 2 | [road-to-competitive-borrow.md](roadmaps/road-to-competitive-borrow.md) | 4 | 35 | 22 | 2 | 4 | 7 | █░░░░░░░░░ 8% |
 | 3 | [road-to-greenfield-scaffold.md](roadmaps/road-to-greenfield-scaffold.md) | 4 | 21 | 21 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-image-brand-typography.md](roadmaps/road-to-image-brand-typography.md) | 4 | 47 | 47 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 5 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 7 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
@@ -41,14 +41,14 @@
 
 ### [road-to-competitive-borrow.md](roadmaps/road-to-competitive-borrow.md)
 
-**Competitive Borrow** — 1 / 21 done (5%)
+**Competitive Borrow** — 2 / 24 done (8%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Reality check (do NOT build these — already shipped) | ✅ done | 0 | 1 | 0 | 0 | 100% |
-| 1 | Adopt-now plate (4 units + 1 rolling docs task) | ⬜ not started | 16 | 0 | 0 | 0 | 0% |
+| 1 | Adopt-now plate (4 units + 1 rolling docs task) | ⬜ not started | 18 | 0 | 0 | 0 | 0% |
 | 2 | out-of-horizon (deferred-with-trigger) | ⏭️ skipped | 0 | 0 | 4 | 0 | 0% |
-| 3 | Dropped (reject reason; not carried forward) | ⬜ not started | 4 | 0 | 0 | 5 | 0% |
+| 3 | Dropped (reject reason; not carried forward) | 🟡 in progress | 4 | 1 | 0 | 7 | 20% |
 
 ### [road-to-greenfield-scaffold.md](roadmaps/road-to-greenfield-scaffold.md)
 

--- a/agents/roadmaps/road-to-competitive-borrow.md
+++ b/agents/roadmaps/road-to-competitive-borrow.md
@@ -17,13 +17,22 @@ rule (real links retained as `ENC1:` tokens in § Provenance):
 
 ## Goal
 
-Decide, with evidence and a four-lens council, which mechanics from three
-external agent-suites are worth borrowing — and reject the large fraction
-agent-config **already ships** or that would be cargo-culting a competitor's
-surface. Honest finding: the adoption gap (this package ≈7 stars vs the
-sources' very large counts) is **distribution + visible value + narrative**,
-not engineering substance. Most high-value moves make an *existing* strength
-visible; only a few are net-new.
+Achieve competitive-borrow parity **within the 5-unit plate cap** by (1)
+surfacing the differentiators v6 already shipped, (2) executing the
+high-leverage P1 borrows, and (3) gating P2 items on demand triggers. The
+adoption gap (this package ≈7 stars vs the sources' very large counts) is
+**external visibility, not feature delivery** — v6 shipped three mechanics the
+sources are not known to match (pointer-level uninstall, pack-scoped
+projection, a portability guard), yet all three are invisible in a README scan.
+Decide, with evidence and a council, which *remaining* mechanics are worth
+borrowing and reject the large fraction agent-config **already ships** or that
+would cargo-cult a source's surface.
+
+> **Differentiator grading (council, 2026-06-13).** "Shipped" is CONFIRMED
+> against `src/` (file paths in Phase 0). "Differentiator vs the sources" is
+> **INFERRED** from the sources' write-ups, not from a code audit of their
+> repos — so it stays a claim pending the P1.0 validation gate, never asserted
+> as fact in user-facing copy until validated.
 
 ---
 
@@ -34,7 +43,7 @@ Verified against `src/` (capability audit, 2026-06-13):
 
 | Borrow claim | Verdict | Evidence |
 |---|---|---|
-| "No `uninstall` command" | **FALSE — shipped** | `src/scripts/_cli/cmd_uninstall.py` (two-phase, `--purge`, subtracts JSON keys); delegated from `src/cli/registry.ts`. The reader only checked `src/cli/commands/`. |
+| "No `uninstall` command" | **FALSE — shipped, finer-grained than Source A** | `src/scripts/_cli/cmd_uninstall.py` (two-phase, `--purge`); ownership tracked at **JSON-pointer** level via `src/scripts/_lib/json_pointers.py` (named-key pointers + SHA-256 `value_hash` array discriminator) — subtracts only its own keys from a shared host config without touching a neighbour tool's entries. Source A's install-state tracks at *file* level; this is the harder, finer case. The reader only checked `src/cli/commands/`. |
 | "Build a reversible install / transaction log" | **Shipped** | `src/install/txlog.ts` — append-only JSONL, `kind: write\|skip\|abort\|rollback`, per-file sha256, rotation. |
 | "Add install-state per target" | **Shipped** | `installed-tools.lock` + global `installed.lock`. |
 | "Add plan/apply/doctor/drift lifecycle" | **Shipped** | `plan.ts` + `atomic.ts`; `cmd_doctor.py`; `cmd_validate.py`; `cmd_prune.py`. |
@@ -42,8 +51,10 @@ Verified against `src/` (capability audit, 2026-06-13):
 | "Declarative install manifests + packs" | **Equivalent shipped** | 15 packs (`src/packs/*/pack.yaml`) with `requires`/`suggests`/`trust_level_default`/`dependencies`. |
 | "Docs-from-manifest to stop README drift" | **Shipped** | `generate_catalog.py` / `generate_index.py`; `lint-readme-jargon` gate. |
 | "Typed agent/skill schema + linter" | **Shipped** | schemas in `src/scripts/schemas/`; `skill_linter.py`. |
+| "Lean / scoped install (not a 500-artifact dump)" | **Shipped (CONFIRMED) — differentiator vs sources (INFERRED)** | Pack-scoped projection, ADR-040 (accepted, v6): the projector writes only the active profile/pack's artifacts, not all ~150 commands / ~223 skills. Sources are not known to project a scoped subset — claim pending the P1.0 validation gate. |
+| "Portability / source-confidentiality governance" | **Shipped (CONFIRMED) — differentiator vs sources (INFERRED)** | `src/scripts/check_portability.py` (CI): forbids project/customer/team-specific refs in the condensed output ("must work in any project"). No source is known to enforce this — claim pending the P1.0 validation gate. |
 
-- [x] Reality check complete — 8 borrow items confirmed already shipped, excluded from the plate.
+- [x] Reality check complete — 10 items confirmed already shipped, excluded from the plate (8 from the original audit + scoped projection + portability guard surfaced by the post-v6 re-read).
 
 **Skeptical flags carried into the council:** the sources' star counts are
 extraordinary for individual-maintainer repos and possibly inflated — no
@@ -61,6 +72,22 @@ provable misreading, so the whole list got per-item source verification.
 ### P1.0 — README / profile above-fold narrative pass (rolling, not a slot)
 
 - [ ] Drive `lint-readme-jargon` above-fold hits to **0** (currently 2).
+- [ ] Surface the **three shipped differentiators** above the fold, one line each:
+      - pointer-level uninstall — "removes only its own keys from a shared host
+        config (JSON-pointer + SHA-256), never a neighbour tool's entries";
+      - pack-scoped projection — "installs the active pack only, not a
+        500-artifact dump";
+      - portability guard — "CI-enforced source confidentiality; works in any
+        project".
+- [ ] **Validation gate (council guardrail — blocking before any hero copy
+      ships).** By P1 midpoint, validate the two INFERRED differentiator claims
+      (scoped projection, portability guard) against the sources. Because the
+      roadmap is **source-anonymous**, the audit evidence lives in the gitignored
+      harvest-evidence store — never in this file or the README; the README
+      cites only "validation: confirmed `<date>`" with no source disclosed.
+      **Failure protocol:** if a claim is disproved — (1) pull it from the README
+      hero immediately, (2) downgrade its Phase 0 row to "parity achieved (not a
+      differentiator)", (3) log the correction in § Acceptance.
 - [ ] Render the **existing role-level taglines** (`lint_role_experiences.py`,
       WorkspacePage) in profile/catalog pages — do **not** add a per-skill
       `tagline` field (227 strings + a locked `additionalProperties:false`
@@ -126,13 +153,19 @@ Promote the existing **report** to a guard-railed **gate**.
 > Glyph `[~]` = deferred-with-trigger, not abandoned.
 
 - [~] **P2.1 — Readiness-audit funnel (the strategic bet).**
-  - **Trigger.** Either ≥3 distinct user/issue requests for "is my repo ready /
-    what should I install" scoring, OR a measured first-touch drop-off after
-    P1.4 + P1.0 ship that a funnel would plausibly fix.
+  - **Trigger (quantified, council guardrail — falsifiable).** Any one of:
+    (a) **3+ distinct users/issues** asking "is my repo ready / what should I
+    install" with the same root need; OR (b) a source ships a readiness-check
+    equivalent AND it draws public adoption; OR (c) **10+ inbound validation
+    questions** after P1.0 + P1.4 ship that a pre-flight funnel would resolve.
   - **Shape.** An `agent-config audit` command that *runs the existing*
     `project-analyzer`/`project-health` skills, maps findings onto the
     profile/pack recommendation already in the wizard's `auto-detect`, and emits
     a shareable one-screen summary + "run setup with profile X". No new rubric.
+    A **queryable run-state + `status` handoff** (Source A's observability lead)
+    folds in here as this command's output store — **not a separate adoption
+    unit** (telemetry primitives in `engagement.py` already exist; the gap is a
+    queryable surface, which this funnel provides).
   - **Sunset.** Never fork a standalone maturity-rubric catalog — the skills
     *are* the rubric items.
   - **Owner / cadence.** Plate owner; reviewed each plate.
@@ -181,6 +214,12 @@ Promote the existing **report** to a guard-railed **gate**.
 - [-] **Declarative install-manifest rewrite** — already have declarative pack
   manifests + plan/apply; a shape-for-shape rewrite is churn.
 - [-] **Visible uninstall / txlog / converter pipeline** — already shipped (Phase 0).
+- [-] **Queryable observability state-store as a *standalone* borrow** — folds
+  into P2.1 as that command's output store; adopting it separately double-counts
+  effort and burns a slot (council, 2026-06-13).
+- [-] **"Six-majors-in-eight-weeks" cadence / instability note in the README** —
+  speculative (no user feedback, metric, or issue cites the perception); would
+  consume hero real estate the three differentiators need (council, 2026-06-13).
 
 ---
 
@@ -201,8 +240,30 @@ critical-skeptic) scored each candidate; synthesis + tie-break:
 - Consensus DROP: parity **gate**; consensus ADOPT: capability matrix
   (generated), anti-dup gate (guard-railed).
 
-Re-run the real `/council:analysis` on this file once council keys are
-configured, to confirm the substitute-panel dispositions.
+### v6 refresh — live two-member council (2026-06-13, deep)
+
+Done — the real run the four-lens panel asked for. Live keys
+(claude-sonnet-4-5 + gpt-4o, analysis lens, deep) scored the post-v6.0.0
+reviewer pass. Convergence:
+
+- **ADOPT** — strengthen Phase 0 (pointer-level uninstall + scoped projection +
+  portability guard); rewrite the Goal (the old "only distribution gap" wording
+  contradicts Phase 0 once it lists shipped differentiators — internal-
+  consistency repair, not narrative); surface the three differentiators above
+  the README fold.
+- **REJECT** — queryable state-store as a *standalone* unit (it is P2.1's
+  implementation detail); the "six-majors = instability" cadence note
+  (speculative, no cited signal, displaces differentiator messaging).
+- **Guardrails (both members):** the two new differentiator claims are
+  **INFERRED** from the sources' write-ups, not code-audited — gate them behind
+  the P1.0 validation step with a disprove-and-downgrade failure protocol; keep
+  the audit evidence **source-anonymous** (gitignored store; README cites only
+  "validated `<date>`"); quantify the P2.1 triggers so "deferred-with-trigger"
+  stays falsifiable.
+- **Sharpest catch (claude-sonnet-4-5):** the validation gate and source-
+  anonymity collide — competitor code citations cannot live in a source-
+  anonymous doc, so the evidence goes to the gitignored harvest store, never
+  this file. This guardrail is now baked into the P1.0 validation step.
 
 ---
 
@@ -212,18 +273,28 @@ configured, to confirm the substitute-panel dispositions.
 - [ ] Each shipped P1 unit lands with verification evidence (linter green for
       P1.1; eval stub for P1.2; drift-check for P1.3; validation-fails-on-bad-
       recipe test for P1.4).
+- [ ] **P1.0 validation gate cleared** — both INFERRED differentiator claims
+      validated (or disproved + downgraded per the failure protocol) before any
+      hero copy ships; evidence stored source-anonymously; correction logged
+      here if a claim fell.
 - [ ] P2 deferred items reviewed at the next plate boundary; any fired trigger
-      promotes to adopt-now (consumes a slot).
-- [ ] Real `/council:analysis` re-run recorded once council keys exist.
+      (per the quantified P2.1 criteria) promotes to adopt-now (consumes a slot).
+- [x] Live council re-run recorded (claude-sonnet-4-5 + gpt-4o, deep,
+      2026-06-13) — dispositions folded into Goal / Phase 0 / P1.0 / P2.1 /
+      Phase 3 above. Supersedes the four-lens substitute panel.
 
 ## Provenance
 
 - Feedback inputs: local harvest evidence (gitignored), cross-read against the
-  package's own `src/` capability audit (2026-06-13). 8 borrow items confirmed
-  already shipped; 8 genuine gaps identified.
+  package's own `src/` capability audit (2026-06-13), plus a post-v6.0.0
+  reviewer pass verified against `src/` (`json_pointers.py`, ADR-040,
+  `check_portability.py`, ADR-086 = rejected). 10 borrow items confirmed already
+  shipped; the genuine gaps drive Phase 1 / Phase 2.
 - Source identities (recoverable by the maintainer via
   `src/scripts/_lib/link_crypto.py decrypt`):
   - Source A — `ENC1:0VGF0oQGy1++2LZ7J08eq/9/u/4CHfXgmsKIKkpiyYxtsdKB3sjHIcD8pqFzRWyw3Mc3Q/THxUjU+YEWQUpfGBlGssQPglkM98w62uaxZmt08UIe1BWr5YFKHPmk62I=`
   - Source B — `ENC1:pMcCJPiF4aJk2EXmSEXNhWnyOwffE7bD6egqIdQS8qH56ex8qkyT8oS+6o6+D1XQp6G6fQX3MBYGWY5hqS/G3AW7doi3nW/NK1f1fGZzRAx8aOhjoL/MPuB1lCT4iZDnq3rdfK0OF4wK03eJvA==`
   - Source C — `ENC1:MksmcIO40Qxua7Fuzw4iXID96m1+jteECu4f9TuUby2lWE3osfaoHNhyyyU6fdU0Fj6ZXh1tAHAjPDC+jV3hG+xms0Q8Bg5upQd5z73kk/Vos4bL4r2mfz65txi8wsGPHcS0LKveFe6kGnkfuIH5TQ==`
-- Council: four-lens adversarial panel; syntheses + tie-breaks in § Council notes.
+- Council: live two-member run (claude-sonnet-4-5 + gpt-4o, deep, 2026-06-13)
+  plus the earlier four-lens substitute panel; syntheses + tie-breaks in
+  § Council notes.


### PR DESCRIPTION
A `chore: add uncomitted roadmaps` auto-commit on main emptied two roadmap files. This restores the remaining loss and removes the broken stub.

## What was lost / fixed

| Roadmap | State on main | This PR |
|---|---|---|
| `road-to-6.0.0-final-readiness.md` | already restored upstream (PR #510) | untouched |
| `road-to-competitive-borrow.md` | reverted to pre-v6 version | re-applies the v6 council pass |
| `road-to-reaping-catches-…md` | empty 0-byte top-level stub | removed (completed roadmap preserved in `archive/`) |

## competitive-borrow v6 pass (re-applied)

Driven by a live two-member council (claude-sonnet-4-5 + gpt-4o, deep, 2026-06-13), all claims verified against `src/`:

- Phase 0: pointer-level uninstall (`json_pointers.py`), pack-scoped projection (ADR-040), portability guard (`check_portability.py`) added as shipped (CONFIRMED) / differentiator-vs-sources (INFERRED) rows.
- Goal rewrite (parity within the 5-unit cap; bottleneck = external visibility).
- P1.0 validation gate with disprove-and-downgrade + source-anonymity guardrail.
- Quantified, falsifiable P2.1 triggers; observability state-store folded into P2.1 (not a new unit).

## Notes

- Dashboard regenerated.
- Reaping content is intact in `agents/roadmaps/archive/` (`status: completed`); only the spurious empty top-level duplicate is removed.
- 6.0.0-final-readiness is deliberately untouched — already correct on main.
