### PR TITLE
fix(ci): guard against empty (0-byte) roadmap files

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
       - task: check-examples-shape
       - task: lint-roadmap-complexity
       - task: lint-roadmap-ci-steps
+      - task: lint-empty-roadmaps
       - task: lint-commit-subjects
       - task: lint-discovery-vocab
       - task: lint-profile-overlay-set-only
@@ -219,6 +220,7 @@ tasks:
       - task: check-examples-shape
       - task: lint-roadmap-complexity
       - task: lint-roadmap-ci-steps
+      - task: lint-empty-roadmaps
       - task: lint-commit-subjects
       - task: lint-discovery-vocab
       - task: lint-profile-overlay-set-only

--- a/agents/roadmaps/road-to-security-pillar.md
+++ b/agents/roadmaps/road-to-security-pillar.md
@@ -20,7 +20,7 @@ status: ready
 >
 > **Provenance:** competitor input ("Source S" below) is anonymised per
 > `source-confidentiality`; full names/URLs + the research dossier live untracked
-> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards
+> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards <!-- ref-ignore --> <!-- agents/.harvest-local/ is a deliberate gitignored evidence store (source-confidentiality); the path cannot resolve in CI -->
 > (OWASP) are named directly; attack classes are described generically.
 
 ## Goal

--- a/src/scripts/install-hooks.sh
+++ b/src/scripts/install-hooks.sh
@@ -89,6 +89,17 @@ if git diff --cached --name-only | grep -qE '^agents/roadmaps(-progress\.md|/)';
         echo "   To bypass for an unrelated WIP commit: git commit --no-verify"
         exit 1
     fi
+
+    # Empty-roadmap backstop — refuse 0-byte / whitespace-only roadmap files.
+    # An external "chore: add uncomitted roadmaps" auto-commit has twice staged
+    # 0-byte placeholders; this gate stops the class from landing.
+    if ! python3 src/scripts/lint_empty_roadmaps.py --quiet; then
+        echo ""
+        echo "❌  Commit blocked — empty (0-byte / whitespace-only) roadmap file staged."
+        python3 src/scripts/lint_empty_roadmaps.py || true
+        echo "   To bypass for an unrelated WIP commit: git commit --no-verify"
+        exit 1
+    fi
 fi
 
 # Phase-0 pack gates (road-to-6.0.0-D) — pack.yaml schema + dependency/DAG +

--- a/src/scripts/lint_empty_roadmaps.py
+++ b/src/scripts/lint_empty_roadmaps.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Hard-Gate linter: no empty roadmap files under ``agents/roadmaps/``.
+
+A roadmap ``.md`` that is 0 bytes (or only whitespace) is never valid — it
+carries no goal, no phases, no content. Empty roadmaps have been introduced
+twice by an external ``chore: add uncomitted roadmaps`` auto-commit that
+staged 0-byte placeholders (2026-06-13: ``road-to-6.0.0-final-readiness.md``
+and ``road-to-reaping-catches-pre-inventory-orphans.md``). The local
+pre-commit dashboard check did not catch them — the dashboard generator
+silently skips empty files — and the commits bypassed it anyway. This linter
+is the authoritative backstop: it fails CI (and the pre-commit hook) so an
+empty roadmap can never reach ``main`` again, regardless of how it was staged.
+
+Scope: every ``*.md`` under ``agents/roadmaps/`` (active, ``archive/``,
+``skipped/``, ``stubs/``, ``later/``) — empty is invalid everywhere. The
+``.gitkeep`` placeholders are not ``.md`` and are ignored.
+
+Cap: ≤ 120 LOC, stdlib only. Hooked into ``task ci`` / ``task ci-fast`` via
+``task lint-empty-roadmaps`` and into the pre-commit hook.
+
+Exit codes: 0 = clean, 1 = at least one empty roadmap found.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+QUIET = "--quiet" in sys.argv
+
+ROADMAP_DIR = Path("agents/roadmaps")
+
+
+def _repo_root() -> Path:
+    """Walk up from CWD until a dir containing ``agents/roadmaps`` is found."""
+    here = Path.cwd()
+    for candidate in (here, *here.parents):
+        if (candidate / ROADMAP_DIR).is_dir():
+            return candidate
+    return here
+
+
+def find_empty_roadmaps(root: Path) -> list[Path]:
+    base = root / ROADMAP_DIR
+    if not base.is_dir():
+        return []
+    empties: list[Path] = []
+    for md in sorted(base.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # Unreadable / binary -> not an empty-text file; leave to other gates.
+            continue
+        if text.strip() == "":
+            empties.append(md.relative_to(root))
+    return empties
+
+
+def main() -> int:
+    root = _repo_root()
+    empties = find_empty_roadmaps(root)
+
+    if not empties:
+        if not QUIET:
+            print("✅  lint-empty-roadmaps: no empty roadmap files.")
+        return 0
+
+    print("❌  lint-empty-roadmaps: empty (0-byte / whitespace-only) roadmap file(s):")
+    for rel in empties:
+        print(f"      {rel}")
+    print()
+    print("   A roadmap with no content is invalid. Either:")
+    print("     • restore the intended content, or")
+    print("     • delete the file (if its content lives in agents/roadmaps/archive/).")
+    print("   Empty roadmap stubs are usually an artefact of an auto-commit that")
+    print("   staged a 0-byte placeholder — remove it; do not commit it.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -374,6 +374,11 @@ tasks:
     desc: Forbid full-pipeline CI steps (task ci / make test / npm run check) in roadmaps when quality.local_auto_run=false (roadmap-ci-steps-policy rule)
     cmd: python3 src/scripts/lint_roadmap_ci_steps.py {{.QUIET_FLAG}}
 
+  lint-empty-roadmaps:
+    silent: true
+    desc: Reject empty (0-byte / whitespace-only) roadmap files under agents/roadmaps/ — backstop against auto-commit 0-byte stubs
+    cmd: python3 src/scripts/lint_empty_roadmaps.py {{.QUIET_FLAG}}
+
   lint-commit-subjects:
     silent: true
     desc: Reject sloppy commit subjects (< 10 chars after Conventional-Commits prefix, or blocklist tokens wip/leftover/temp/tmp/fixup) feeding the auto-generated changelog (ADR-033 + road-to-distribution-identity Phase 3)

--- a/tests/test_lint_empty_roadmaps.py
+++ b/tests/test_lint_empty_roadmaps.py
@@ -1,0 +1,62 @@
+"""Tests for ``src/scripts/lint_empty_roadmaps.py``.
+
+Covers the empty-roadmap backstop: 0-byte and whitespace-only ``.md`` files
+under ``agents/roadmaps/`` (active + nested ``archive/`` etc.) are detected,
+files with real content are not, and a missing roadmaps dir is a clean pass.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src" / "scripts"))
+
+import lint_empty_roadmaps as mod  # noqa: E402
+
+
+def _mk(root: Path, rel: str, content: str) -> Path:
+    p = root / "agents" / "roadmaps" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_zero_byte_roadmap_is_flagged(tmp_path: Path):
+    _mk(tmp_path, "road-to-x.md", "")
+    empties = mod.find_empty_roadmaps(tmp_path)
+    assert [str(p) for p in empties] == ["agents/roadmaps/road-to-x.md"]
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n\n", "\t\n  \n"])
+def test_whitespace_only_roadmap_is_flagged(tmp_path: Path, blank: str):
+    _mk(tmp_path, "road-to-blank.md", blank)
+    empties = mod.find_empty_roadmaps(tmp_path)
+    assert len(empties) == 1
+
+
+def test_roadmap_with_content_is_not_flagged(tmp_path: Path):
+    _mk(tmp_path, "road-to-real.md", "---\nstatus: ready\n---\n\n# Goal\n\nDo X.\n")
+    assert mod.find_empty_roadmaps(tmp_path) == []
+
+
+def test_nested_archive_empty_is_flagged(tmp_path: Path):
+    _mk(tmp_path, "archive/old.md", "")
+    _mk(tmp_path, "road-to-real.md", "# Real\n\nbody\n")
+    empties = [str(p) for p in mod.find_empty_roadmaps(tmp_path)]
+    assert "agents/roadmaps/archive/old.md" in empties
+    assert "agents/roadmaps/road-to-real.md" not in empties
+
+
+def test_missing_roadmaps_dir_is_clean(tmp_path: Path):
+    assert mod.find_empty_roadmaps(tmp_path) == []
+
+
+def test_main_exit_codes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    _mk(tmp_path, "road-to-ok.md", "# ok\n\nbody\n")
+    assert mod.main() == 0
+    _mk(tmp_path, "road-to-empty.md", "")
+    assert mod.main() == 1


### PR DESCRIPTION
## Problem

An external `chore: add uncomitted roadmaps` auto-commit (made under the maintainer's git identity — **not** any in-repo hook, CI, or script; the message string appears nowhere in the tree) has **twice** staged 0-byte roadmap placeholders onto `main`, emptying:

- `road-to-6.0.0-final-readiness.md` (restored by #510)
- `road-to-reaping-catches-pre-inventory-orphans.md` (removed by #511, re-created again by a later auto-commit)

The existing pre-commit dashboard check never caught it — the dashboard generator silently skips empty files — and the auto-commit bypassed the hook regardless. No data was ever lost (content lived in the working tree / `archive/`), but the empty stubs kept reappearing.

## Fix — make the empty-stub class non-mergeable

| Layer | Change |
|---|---|
| Linter | `src/scripts/lint_empty_roadmaps.py` — fails on any 0-byte / whitespace-only `.md` under `agents/roadmaps/` (active + `archive/` + `skipped/` + `stubs/` + `later/`) |
| CI | wired into `task ci` + `task ci-strict` (via `taskfiles/ci-fast.yml` → `lint-empty-roadmaps`) — a PR with an empty roadmap fails CI **even when local hooks are bypassed** (the authoritative gate, since the bad commits bypassed local hooks) |
| Pre-commit | `install-hooks.sh` refuses the commit locally too, inside the existing roadmap-touch block |
| Tests | `tests/test_lint_empty_roadmaps.py` — 9 cases (0-byte, whitespace-only, nested archive, content-OK, missing dir, `main()` exit codes) |
| Cleanup | remove the lingering empty `road-to-reaping-catches` stub (completed content preserved in `archive/`) |

## Verification

- linter: fails on the stub (exit 1) → passes after removal (exit 0); `--quiet` clean.
- `task lint-empty-roadmaps` exit 0; appears in `task --list`.
- `pytest tests/test_lint_empty_roadmaps.py` → 9 passed.

## Scope note

The auto-commit itself is **external** to this repo (IDE/global tool/habit using the maintainer's identity) and cannot be fixed from here. This guard ensures its empty-stub output can no longer reach `main`. The maintainer should still track down the external source separately.

---

**Update (CI):** also folds a one-line fix for a pre-existing broken reference on `main` (from #512) — `road-to-security-pillar.md:23` linked the gitignored `agents/.harvest-local/security-pillar-evidence.md`, which `check_references.py` cannot resolve and which was reddening Python Tests + Sync-consistency. Added the documented `<!-- ref-ignore -->` per-line opt-out. Required for this PR's own CI to pass.
