### PR TITLE
fix(refs): exempt gitignored agents/.harvest-local in check_references (replace #513 band-aid)

### DIFF
--- a/agents/roadmaps/road-to-security-pillar.md
+++ b/agents/roadmaps/road-to-security-pillar.md
@@ -20,7 +20,7 @@ status: ready
 >
 > **Provenance:** competitor input ("Source S" below) is anonymised per
 > `source-confidentiality`; full names/URLs + the research dossier live untracked
-> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards <!-- ref-ignore --> <!-- agents/.harvest-local/ is a deliberate gitignored evidence store (source-confidentiality); the path cannot resolve in CI -->
+> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards
 > (OWASP) are named directly; attack classes are described generically.
 
 ## Goal

--- a/src/scripts/check_references.py
+++ b/src/scripts/check_references.py
@@ -43,6 +43,7 @@ SKIP_DIRS = [
     "agents/roadmaps/skipped",   # skipped roadmaps — abandoned plans w/ forward-refs that never shipped
     "agents/runtime",            # volatile / machine-generated artefacts (gitignored)
     "agents/tmp",                # transient working docs (gitignored) — pr-bodies, council questions, manual-step scratchpads
+    "agents/.harvest-local",     # deliberate gitignored evidence store (source-confidentiality) — refs to it can never resolve in CI
 ]
 
 # Per-file opt-out marker. When present in the first 10 lines of a .md


### PR DESCRIPTION
## Root-cause fix — replaces the per-line band-aid from #513

#513 silenced the `check_references.py` failure on `road-to-security-pillar.md:23` (ref to the gitignored `agents/.harvest-local/security-pillar-evidence.md`) with a per-line `<!-- ref-ignore -->` marker. That treats the symptom — **every** future roadmap that references the harvest store would need its own marker.

This fixes the cause: `agents/.harvest-local` is a deliberate, gitignored evidence store (source-confidentiality), exactly like the sibling gitignored stores `agents/runtime` and `agents/tmp` that are already in `check_references.py`'s `SKIP_DIRS`. Add it there — the resolver already skips references whose target starts with a `SKIP_DIRS` entry — and restore the security-pillar roadmap line clean (band-aid removed).

## Diff

- `src/scripts/check_references.py`: `+ "agents/.harvest-local"` in `SKIP_DIRS`.
- `agents/roadmaps/road-to-security-pillar.md`: drop the now-unnecessary `<!-- ref-ignore -->` marker.

## Verification

- `python3 src/scripts/check_references.py` → exit 0 **with no marker** (proves the systemic skip works).
- `pytest -k 'reference or check_ref'` → 75 passed, 8 skipped — no regression.
