### PR TITLE
fix(repo): untrack stray node_modules symlink (fixes ERR_MODULE_NOT_FOUND commander)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,14 @@
 
 # Dependencies
 /vendor/
-/node_modules/
+# No trailing slash: matches the node_modules *directory* AND a stray
+# `node_modules` *symlink* (mode 120000). A `node_modules/` (dir-only)
+# pattern let a self-referential symlink slip into the tree once
+# (committed in 54de5a85, broke local `node dist/cli/...`).
+/node_modules
 # Unanchored — nested node_modules (workspaces, sub-packages) must
-# never enter the tree. Root /node_modules/ stays for clarity.
-node_modules/
+# never enter the tree, dir or symlink.
+node_modules
 # pnpm — repo uses npm (package-lock.json). Stray pnpm-lock.yaml from
 # accidental `pnpm install` runs must never enter the tree.
 pnpm-lock.yaml

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/mathiasberg/projects/galawork/galawork-packages/event4u/agent-config/node_modules


### PR DESCRIPTION
## The bug

`node_modules` was committed to the repo as a **symlink** (git mode `120000`) pointing to the committer's absolute path — a self-loop:

```
node_modules -> /Users/mathiasberg/projects/.../agent-config/node_modules
```

Introduced in `54de5a85` (PR #507). It slipped past `.gitignore` because the ignore patterns used a **trailing slash** (`node_modules/` = directories only), which does not match a symlink named `node_modules`.

**Effect:** every clone/checkout gets a broken self-loop symlink instead of a real `node_modules`. CI survived because `npm ci` removes + reinstalls `node_modules`, but **local / direct `node` invocations got the broken symlink**:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'commander'
  imported from .../dist/cli/agent-config.js
```

## Fix

- `git rm --cached node_modules` — untrack the symlink blob.
- `.gitignore` — drop the trailing slash (`/node_modules` + `node_modules`) so **both** the directory and a stray symlink are ignored, with a comment explaining why.

## Verification

- `git check-ignore node_modules` matches both a symlink and a real dir.
- Locally (after `rm node_modules && npm ci`): `node dist/cli/agent-config.js --version` → `6.0.0`, `commander` resolves.

Consumers who already pulled the bad symlink: `rm node_modules && npm ci` restores a real install.
