### PR TITLE
sync: main → python2ts (5 commits) + lint_empty_roadmaps twin + check_references SKIP_DIRS parity

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
       - task: check-examples-shape
       - task: lint-roadmap-complexity
       - task: lint-roadmap-ci-steps
+      - task: lint-empty-roadmaps
       - task: lint-commit-subjects
       - task: lint-discovery-vocab
       - task: lint-profile-overlay-set-only
@@ -219,6 +220,7 @@ tasks:
       - task: check-examples-shape
       - task: lint-roadmap-complexity
       - task: lint-roadmap-ci-steps
+      - task: lint-empty-roadmaps
       - task: lint-commit-subjects
       - task: lint-discovery-vocab
       - task: lint-profile-overlay-set-only

--- a/agents/roadmaps/road-to-security-pillar.md
+++ b/agents/roadmaps/road-to-security-pillar.md
@@ -20,7 +20,7 @@ status: ready
 >
 > **Provenance:** competitor input ("Source S" below) is anonymised per
 > `source-confidentiality`; full names/URLs + the research dossier live untracked
-> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards
+> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards <!-- ref-ignore --> <!-- agents/.harvest-local/ is a deliberate gitignored evidence store (source-confidentiality); the path cannot resolve in CI -->
 > (OWASP) are named directly; attack classes are described generically.
 
 ## Goal

--- a/agents/roadmaps/road-to-security-pillar.md
+++ b/agents/roadmaps/road-to-security-pillar.md
@@ -20,7 +20,7 @@ status: ready
 >
 > **Provenance:** competitor input ("Source S" below) is anonymised per
 > `source-confidentiality`; full names/URLs + the research dossier live untracked
-> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards <!-- ref-ignore --> <!-- agents/.harvest-local/ is a deliberate gitignored evidence store (source-confidentiality); the path cannot resolve in CI -->
+> in `agents/.harvest-local/security-pillar-evidence.md`. Public standards
 > (OWASP) are named directly; attack classes are described generically.
 
 ## Goal

--- a/src/scripts/check_references.py
+++ b/src/scripts/check_references.py
@@ -43,6 +43,7 @@ SKIP_DIRS = [
     "agents/roadmaps/skipped",   # skipped roadmaps — abandoned plans w/ forward-refs that never shipped
     "agents/runtime",            # volatile / machine-generated artefacts (gitignored)
     "agents/tmp",                # transient working docs (gitignored) — pr-bodies, council questions, manual-step scratchpads
+    "agents/.harvest-local",     # deliberate gitignored evidence store (source-confidentiality) — refs to it can never resolve in CI
 ]
 
 # Per-file opt-out marker. When present in the first 10 lines of a .md

--- a/src/scripts/check_references.ts
+++ b/src/scripts/check_references.ts
@@ -58,6 +58,7 @@ const SKIP_DIRS = [
     'agents/roadmaps/skipped', // skipped roadmaps — abandoned plans w/ forward-refs that never shipped
     'agents/runtime', // volatile / machine-generated artefacts (gitignored)
     'agents/tmp', // transient working docs (gitignored) — pr-bodies, council questions, manual-step scratchpads
+    'agents/.harvest-local', // deliberate gitignored evidence store (source-confidentiality) — refs to it can never resolve in CI
 ];
 
 // Per-file opt-out marker. When present in the first 10 lines of a .md

--- a/src/scripts/install-hooks.sh
+++ b/src/scripts/install-hooks.sh
@@ -89,6 +89,17 @@ if git diff --cached --name-only | grep -qE '^agents/roadmaps(-progress\.md|/)';
         echo "   To bypass for an unrelated WIP commit: git commit --no-verify"
         exit 1
     fi
+
+    # Empty-roadmap backstop — refuse 0-byte / whitespace-only roadmap files.
+    # An external "chore: add uncomitted roadmaps" auto-commit has twice staged
+    # 0-byte placeholders; this gate stops the class from landing.
+    if ! python3 src/scripts/lint_empty_roadmaps.py --quiet; then
+        echo ""
+        echo "❌  Commit blocked — empty (0-byte / whitespace-only) roadmap file staged."
+        python3 src/scripts/lint_empty_roadmaps.py || true
+        echo "   To bypass for an unrelated WIP commit: git commit --no-verify"
+        exit 1
+    fi
 fi
 
 # Phase-0 pack gates (road-to-6.0.0-D) — pack.yaml schema + dependency/DAG +

--- a/src/scripts/lint_empty_roadmaps.py
+++ b/src/scripts/lint_empty_roadmaps.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Hard-Gate linter: no empty roadmap files under ``agents/roadmaps/``.
+
+A roadmap ``.md`` that is 0 bytes (or only whitespace) is never valid — it
+carries no goal, no phases, no content. Empty roadmaps have been introduced
+twice by an external ``chore: add uncomitted roadmaps`` auto-commit that
+staged 0-byte placeholders (2026-06-13: ``road-to-6.0.0-final-readiness.md``
+and ``road-to-reaping-catches-pre-inventory-orphans.md``). The local
+pre-commit dashboard check did not catch them — the dashboard generator
+silently skips empty files — and the commits bypassed it anyway. This linter
+is the authoritative backstop: it fails CI (and the pre-commit hook) so an
+empty roadmap can never reach ``main`` again, regardless of how it was staged.
+
+Scope: every ``*.md`` under ``agents/roadmaps/`` (active, ``archive/``,
+``skipped/``, ``stubs/``, ``later/``) — empty is invalid everywhere. The
+``.gitkeep`` placeholders are not ``.md`` and are ignored.
+
+Cap: ≤ 120 LOC, stdlib only. Hooked into ``task ci`` / ``task ci-fast`` via
+``task lint-empty-roadmaps`` and into the pre-commit hook.
+
+Exit codes: 0 = clean, 1 = at least one empty roadmap found.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+QUIET = "--quiet" in sys.argv
+
+ROADMAP_DIR = Path("agents/roadmaps")
+
+
+def _repo_root() -> Path:
+    """Walk up from CWD until a dir containing ``agents/roadmaps`` is found."""
+    here = Path.cwd()
+    for candidate in (here, *here.parents):
+        if (candidate / ROADMAP_DIR).is_dir():
+            return candidate
+    return here
+
+
+def find_empty_roadmaps(root: Path) -> list[Path]:
+    base = root / ROADMAP_DIR
+    if not base.is_dir():
+        return []
+    empties: list[Path] = []
+    for md in sorted(base.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # Unreadable / binary -> not an empty-text file; leave to other gates.
+            continue
+        if text.strip() == "":
+            empties.append(md.relative_to(root))
+    return empties
+
+
+def main() -> int:
+    root = _repo_root()
+    empties = find_empty_roadmaps(root)
+
+    if not empties:
+        if not QUIET:
+            print("✅  lint-empty-roadmaps: no empty roadmap files.")
+        return 0
+
+    print("❌  lint-empty-roadmaps: empty (0-byte / whitespace-only) roadmap file(s):")
+    for rel in empties:
+        print(f"      {rel}")
+    print()
+    print("   A roadmap with no content is invalid. Either:")
+    print("     • restore the intended content, or")
+    print("     • delete the file (if its content lives in agents/roadmaps/archive/).")
+    print("   Empty roadmap stubs are usually an artefact of an auto-commit that")
+    print("   staged a 0-byte placeholder — remove it; do not commit it.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scripts/lint_empty_roadmaps.ts
+++ b/src/scripts/lint_empty_roadmaps.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Hard-Gate linter: no empty roadmap files under `agents/roadmaps/`.
+ *
+ * TypeScript twin of `src/scripts/lint_empty_roadmaps.py` (ADR-094 migration).
+ * Byte-identical CLI contract: same stdout, same exit codes (0 = clean,
+ * 1 = at least one empty roadmap). `--quiet` is a bare argv membership check
+ * (computed at import, NOT argparse), mirroring the Python original.
+ *
+ * A roadmap `.md` that is 0 bytes (or only whitespace) is never valid — it
+ * carries no goal, no phases, no content. Scope: every `*.md` under
+ * `agents/roadmaps/` (active, `archive/`, `skipped/`, `stubs/`, `later/`).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+/** Mirror `QUIET = "--quiet" in sys.argv` (computed at import). */
+const QUIET = process.argv.slice(2).includes('--quiet');
+
+const ROADMAP_DIR = path.join('agents', 'roadmaps');
+
+const _HERE = path.resolve(fileURLToPath(import.meta.url));
+
+/** Walk up from CWD until a dir containing `agents/roadmaps` is found. */
+function _repo_root(): string {
+    const here = process.cwd();
+    const chain = [here];
+    let cur = here;
+    while (true) {
+        const parent = path.dirname(cur);
+        if (parent === cur) break;
+        chain.push(parent);
+        cur = parent;
+    }
+    for (const candidate of chain) {
+        try {
+            if (fs.statSync(path.join(candidate, ROADMAP_DIR)).isDirectory()) {
+                return candidate;
+            }
+        } catch {
+            // not a dir / does not exist — keep walking
+        }
+    }
+    return here;
+}
+
+/** `Path.is_dir()` following symlinks, never throwing. */
+function _isDir(p: string): boolean {
+    try {
+        return fs.statSync(p).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Mirror `sorted(base.rglob("*.md"))` — every descendant `*.md`, sorted by the
+ * POSIX path-string key Python's `pathlib.Path` ordering uses (follows
+ * directory symlinks, as `rglob` does).
+ */
+function _rglobMdSorted(base: string): string[] {
+    const out: string[] = [];
+    const walk = (dir: string): void => {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const ent of entries) {
+            const full = path.join(dir, ent.name);
+            if (ent.name.endsWith('.md')) {
+                out.push(full);
+            }
+            if (ent.isDirectory() || (ent.isSymbolicLink() && _isDir(full))) {
+                walk(full);
+            }
+        }
+    };
+    walk(base);
+    return out.sort();
+}
+
+// Python `str.strip()` (no args) strips every character for which
+// `str.isspace()` is true: ASCII whitespace + the C0 separators \x1c-\x1f +
+// NEL \x85 + the Unicode whitespace set. Match that exact class so a
+// "whitespace-only" file is detected identically to the Python original.
+const _PY_WS = /[\t\n\v\f\r \u001c\u001d\u001e\u001f\u0085\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]/g;
+
+function _toPosix(target: string, root: string): string {
+    return path.relative(root, target).split(path.sep).join('/');
+}
+
+function find_empty_roadmaps(root: string): string[] {
+    const base = path.join(root, ROADMAP_DIR);
+    if (!_isDir(base)) {
+        return [];
+    }
+    const empties: string[] = [];
+    for (const md of _rglobMdSorted(base)) {
+        let text: string;
+        try {
+            text = fs.readFileSync(md, 'utf-8');
+        } catch {
+            // Unreadable / binary -> not an empty-text file; leave to other gates.
+            continue;
+        }
+        if (text.replace(_PY_WS, '') === '') {
+            empties.push(_toPosix(md, root));
+        }
+    }
+    return empties;
+}
+
+function main(): number {
+    const root = _repo_root();
+    const empties = find_empty_roadmaps(root);
+
+    if (empties.length === 0) {
+        if (!QUIET) {
+            console.log('✅  lint-empty-roadmaps: no empty roadmap files.');
+        }
+        return 0;
+    }
+
+    console.log('❌  lint-empty-roadmaps: empty (0-byte / whitespace-only) roadmap file(s):');
+    for (const rel of empties) {
+        console.log(`      ${rel}`);
+    }
+    console.log('');
+    console.log('   A roadmap with no content is invalid. Either:');
+    console.log('     • restore the intended content, or');
+    console.log('     • delete the file (if its content lives in agents/roadmaps/archive/).');
+    console.log('   Empty roadmap stubs are usually an artefact of an auto-commit that');
+    console.log('   staged a 0-byte placeholder — remove it; do not commit it.');
+    return 1;
+}
+
+const _isCliEntry =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_isCliEntry || process.argv[1] === _HERE) {
+    process.exitCode = main();
+}
+
+export { QUIET, find_empty_roadmaps, main };

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -374,6 +374,11 @@ tasks:
     desc: Forbid full-pipeline CI steps (task ci / make test / npm run check) in roadmaps when quality.local_auto_run=false (roadmap-ci-steps-policy rule)
     cmd: python3 src/scripts/lint_roadmap_ci_steps.py {{.QUIET_FLAG}}
 
+  lint-empty-roadmaps:
+    silent: true
+    desc: Reject empty (0-byte / whitespace-only) roadmap files under agents/roadmaps/ — backstop against auto-commit 0-byte stubs
+    cmd: python3 src/scripts/lint_empty_roadmaps.py {{.QUIET_FLAG}}
+
   lint-commit-subjects:
     silent: true
     desc: Reject sloppy commit subjects (< 10 chars after Conventional-Commits prefix, or blocklist tokens wip/leftover/temp/tmp/fixup) feeding the auto-generated changelog (ADR-033 + road-to-distribution-identity Phase 3)

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -374,6 +374,11 @@ tasks:
     desc: Forbid full-pipeline CI steps (task ci / make test / npm run check) in roadmaps when quality.local_auto_run=false (roadmap-ci-steps-policy rule)
     cmd: ./scripts-run src/scripts/lint_roadmap_ci_steps {{.QUIET_FLAG}}
 
+  lint-empty-roadmaps:
+    silent: true
+    desc: Reject empty (0-byte / whitespace-only) roadmap files under agents/roadmaps/ — backstop against auto-commit 0-byte stubs
+    cmd: python3 src/scripts/lint_empty_roadmaps.py {{.QUIET_FLAG}}
+
   lint-commit-subjects:
     silent: true
     desc: Reject sloppy commit subjects (< 10 chars after Conventional-Commits prefix, or blocklist tokens wip/leftover/temp/tmp/fixup) feeding the auto-generated changelog (ADR-033 + road-to-distribution-identity Phase 3)

--- a/tests/scripts/lint_empty_roadmaps.test.ts
+++ b/tests/scripts/lint_empty_roadmaps.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Golden-parity tests for `src/scripts/lint_empty_roadmaps.ts`.
+ *
+ * The TS twin and the Python original (`lint_empty_roadmaps.py`) produce
+ * byte-identical stdout + exit code on:
+ *   1. the REAL repo tree (clean — no empty roadmaps),
+ *   2. a tmp fixture carrying empty / whitespace-only / valid roadmaps across
+ *      active + archive/ + skipped/ subdirs (exercises the rglob, the sorted
+ *      relative-path listing, the whitespace-only detection, and the exit-1
+ *      multi-line guidance block),
+ *   3. `--quiet` (suppresses the clean-case line only).
+ *
+ * Skips when python3 is unavailable.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'lint_empty_roadmaps.py');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'lint_empty_roadmaps.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+function runPy(cwd: string, args: string[] = []) {
+    return spawnSync('python3', [PY_SCRIPT, ...args], { cwd, encoding: 'utf8' });
+}
+function runTs(cwd: string, args: string[] = []) {
+    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd, encoding: 'utf8' });
+}
+
+describe.skipIf(!py3)('lint_empty_roadmaps — golden parity (python3 vs tsx)', () => {
+    it('clean real repo: byte-identical stdout + exit 0', () => {
+        const py = runPy(REPO_ROOT);
+        const ts = runTs(REPO_ROOT);
+        expect(ts.stderr).toBe('');
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.status).toBe(py.status);
+    });
+
+    it('clean real repo --quiet: empty stdout + exit 0 on both', () => {
+        const py = runPy(REPO_ROOT, ['--quiet']);
+        const ts = runTs(REPO_ROOT, ['--quiet']);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stdout).toBe('');
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(0);
+    });
+});
+
+describe.skipIf(!py3)('lint_empty_roadmaps — golden parity (tmp fixture with empties)', () => {
+    let work: string;
+
+    beforeEach(() => {
+        work = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-empty-roadmaps-'));
+        const rm = path.join(work, 'agents', 'roadmaps');
+        fs.mkdirSync(path.join(rm, 'archive'), { recursive: true });
+        fs.mkdirSync(path.join(rm, 'skipped'), { recursive: true });
+        // valid roadmap (has content) — must NOT be flagged
+        fs.writeFileSync(path.join(rm, 'road-to-valid.md'), '# Goal\n\nReal content.\n');
+        // 0-byte empty — flagged
+        fs.writeFileSync(path.join(rm, 'road-to-empty.md'), '');
+        // whitespace-only (spaces, tabs, newlines) — flagged
+        fs.writeFileSync(path.join(rm, 'archive', 'road-to-whitespace.md'), '   \n\t\n  \n');
+        // valid in a nested dir
+        fs.writeFileSync(path.join(rm, 'skipped', 'road-to-skipped.md'), 'content\n');
+        // a non-.md file that is empty — IGNORED (only *.md counts)
+        fs.writeFileSync(path.join(rm, '.gitkeep'), '');
+    });
+    afterEach(() => {
+        fs.rmSync(work, { recursive: true, force: true });
+    });
+
+    it('flags empty + whitespace-only roadmaps: byte-identical stdout + exit 1', () => {
+        const py = runPy(work);
+        const ts = runTs(work);
+        expect(ts.stderr).toBe('');
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(1);
+    });
+
+    it('--quiet still reports empties (quiet only silences the clean line): identical', () => {
+        const py = runPy(work, ['--quiet']);
+        const ts = runTs(work, ['--quiet']);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(1);
+    });
+});

--- a/tests/test_lint_empty_roadmaps.py
+++ b/tests/test_lint_empty_roadmaps.py
@@ -1,0 +1,62 @@
+"""Tests for ``src/scripts/lint_empty_roadmaps.py``.
+
+Covers the empty-roadmap backstop: 0-byte and whitespace-only ``.md`` files
+under ``agents/roadmaps/`` (active + nested ``archive/`` etc.) are detected,
+files with real content are not, and a missing roadmaps dir is a clean pass.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src" / "scripts"))
+
+import lint_empty_roadmaps as mod  # noqa: E402
+
+
+def _mk(root: Path, rel: str, content: str) -> Path:
+    p = root / "agents" / "roadmaps" / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_zero_byte_roadmap_is_flagged(tmp_path: Path):
+    _mk(tmp_path, "road-to-x.md", "")
+    empties = mod.find_empty_roadmaps(tmp_path)
+    assert [str(p) for p in empties] == ["agents/roadmaps/road-to-x.md"]
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\n\n", "\t\n  \n"])
+def test_whitespace_only_roadmap_is_flagged(tmp_path: Path, blank: str):
+    _mk(tmp_path, "road-to-blank.md", blank)
+    empties = mod.find_empty_roadmaps(tmp_path)
+    assert len(empties) == 1
+
+
+def test_roadmap_with_content_is_not_flagged(tmp_path: Path):
+    _mk(tmp_path, "road-to-real.md", "---\nstatus: ready\n---\n\n# Goal\n\nDo X.\n")
+    assert mod.find_empty_roadmaps(tmp_path) == []
+
+
+def test_nested_archive_empty_is_flagged(tmp_path: Path):
+    _mk(tmp_path, "archive/old.md", "")
+    _mk(tmp_path, "road-to-real.md", "# Real\n\nbody\n")
+    empties = [str(p) for p in mod.find_empty_roadmaps(tmp_path)]
+    assert "agents/roadmaps/archive/old.md" in empties
+    assert "agents/roadmaps/road-to-real.md" not in empties
+
+
+def test_missing_roadmaps_dir_is_clean(tmp_path: Path):
+    assert mod.find_empty_roadmaps(tmp_path) == []
+
+
+def test_main_exit_codes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    _mk(tmp_path, "road-to-ok.md", "# ok\n\nbody\n")
+    assert mod.main() == 0
+    _mk(tmp_path, "road-to-empty.md", "")
+    assert mod.main() == 1


### PR DESCRIPTION
Brings `python2ts` current with `origin/main` (5 commits). Clean merge — no conflicts, no condensation-hash drift, content in sync.

## No-loss twin reconciliation (main changed/added scripts)

- **`check_references.py`** added `agents/.harvest-local` to `SKIP_DIRS` — main's checker-level fix for the #512 broken-ref the *previous* sync worked around with a per-line `<!-- ref-ignore -->`. Mirrored the same entry into **`check_references.ts`** so py↔ts golden parity holds (26/26). The earlier ref-ignore marker stays as harmless belt-and-suspenders.
- **NEW `lint_empty_roadmaps.py`** → ported **`lint_empty_roadmaps.ts`** (rglob `*.md` under `agents/roadmaps`, pathlib-sorted relative paths, Python `str.strip()` whitespace-set emptiness detection, byte-identical multi-line exit-1 guidance). 4 golden-parity tests (clean real tree + tmp fixture with empty / whitespace-only / valid roadmaps across active/archive/skipped, + `--quiet`). legacy-literal ts==py==0.

## Verification

`tsc` clean · phase-gate passes · content + condensation hashes in sync · `lint_empty_roadmaps` 4/4 · `check_references` 26/26. Full 4-shard run validates on this PR's CI.