### PR TITLE
feat(py2ts): phase 8 — tools/ adapters (4) + adr/regenerate_index + score_ev (6 twins)

### DIFF
--- a/src/scripts/adr/regenerate_index.ts
+++ b/src/scripts/adr/regenerate_index.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env tsx
+/**
+ * Regenerate INDEX.md for an ADR directory. Parses ADR-*.md frontmatter
+ * (adr/status/date/decision/supersedes), writes INDEX.md, splits legacy
+ * non-numbered ADRs into an Unnumbered table, hard-fails on duplicate
+ * numbers, filename/frontmatter mismatch, or broken supersedes links.
+ *
+ * TypeScript twin of `src/scripts/adr/regenerate_index.py` (ADR-094, Phase 8).
+ * The CLI contract is mirrored EXACTLY — `--dir` (default `docs/adr/`),
+ * `--check`, exit codes (0 / 1 / 2), the stdout/stderr split, byte-identical
+ * messages, AND byte-identical generated `INDEX.md`. No behaviour changes —
+ * latent Python quirks replicated.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// ^ADR-(\d{3})-([a-z0-9-]+)\.md$
+const NAMED = /^ADR-(\d{3})-([a-z0-9-]+)\.md$/;
+// ^---\n(.*?)\n---  (DOTALL)
+const FM = /^---\n([\s\S]*?)\n---/;
+// ^([a-z_]+):\s*(.+?)\s*$  (MULTILINE)
+const FIELD = /^([a-z_]+):[ \t]*(.+?)[ \t]*$/gm;
+const HEAD = '| # | Title | Status | Date | Supersedes |\n|---|---|---|---|---|';
+
+type Meta = Record<string, string>;
+interface Row extends Meta {
+    // Numbered rows carry num/slug/path; legacy rows carry path (+ meta).
+    [k: string]: string;
+}
+
+/** Mirror Python `str.strip(" \"'")` — strip listed chars from both ends. */
+function _stripChars(s: string, chars: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && chars.includes(s[start] as string)) {
+        start += 1;
+    }
+    while (end > start && chars.includes(s[end - 1] as string)) {
+        end -= 1;
+    }
+    return s.slice(start, end);
+}
+
+/** Mirror Python `str.title()`: cap first letter of each alphabetic run, lower the rest. */
+function _title(s: string): string {
+    let out = '';
+    let prevIsCased = false;
+    for (const ch of s) {
+        const isCased = /[A-Za-z]/.test(ch);
+        if (isCased) {
+            out += prevIsCased ? ch.toLowerCase() : ch.toUpperCase();
+        } else {
+            out += ch;
+        }
+        prevIsCased = isCased;
+    }
+    return out;
+}
+
+/** Mirror Python `str.lstrip("0")` — drop leading "0" chars. */
+function _lstripZeros(s: string): string {
+    let i = 0;
+    while (i < s.length && s[i] === '0') {
+        i += 1;
+    }
+    return s.slice(i);
+}
+
+/** Mirror Python `str.zfill(3)` — left-pad with "0" to width 3. */
+function _zfill3(s: string): string {
+    return s.length >= 3 ? s : '0'.repeat(3 - s.length) + s;
+}
+
+/**
+ * Mirror Python `str(PurePosixPath(x))`: collapse `//`, drop `.` segments,
+ * strip the trailing slash, keep a single leading slash for absolute paths,
+ * and render the empty path as `.`. Used so the `adr-dir not found:` /
+ * `stale:` / `wrote` messages embed the path exactly as pathlib does.
+ */
+function _pyPathStr(x: string): string {
+    const absolute = x.startsWith('/');
+    const parts = x.split('/').filter((p) => p !== '' && p !== '.');
+    const body = parts.join('/');
+    if (absolute) {
+        return `/${body}`;
+    }
+    return body === '' ? '.' : body;
+}
+
+/** Mirror Python `Path(d) / "INDEX.md"` rendered via str(). */
+function _pyPathJoin(d: string, child: string): string {
+    const base = _pyPathStr(d);
+    return base === '.' ? child : `${base}/${child}`;
+}
+
+/** Mirror `fm(t)` — parse the leading `---` frontmatter block into a dict. */
+function fm(t: string): Meta {
+    const m = FM.exec(t);
+    if (!m) {
+        return {};
+    }
+    const out: Meta = {};
+    const body = m[1] as string;
+    FIELD.lastIndex = 0;
+    let f: RegExpExecArray | null;
+    while ((f = FIELD.exec(body)) !== null) {
+        const k = f[1] as string;
+        const v = f[2] as string;
+        out[k] = _stripChars(v, ' "\'');
+    }
+    return out;
+}
+
+/** `sorted(d.glob("ADR-*.md"))` — flat children matching ADR-*.md, lexically sorted. */
+function _globAdrSorted(d: string): string[] {
+    let names: string[];
+    try {
+        names = fs.readdirSync(d);
+    } catch {
+        return [];
+    }
+    const out = names
+        .filter((n) => n.startsWith('ADR-') && n.endsWith('.md'))
+        .map((n) => path.join(d, n));
+    out.sort();
+    return out;
+}
+
+/** Mirror `scan(d)` — returns [numbered, legacy, errors]. */
+export function scan(d: string): [Row[], Row[], string[]] {
+    const num: Row[] = [];
+    const leg: Row[] = [];
+    const errs: string[] = [];
+    const seen: Record<string, string> = {};
+    for (const p of _globAdrSorted(d)) {
+        const name = path.basename(p);
+        if (name === 'INDEX.md') {
+            continue;
+        }
+        const meta = fm(fs.readFileSync(p, 'utf-8'));
+        const m = NAMED.exec(name);
+        if (!m) {
+            leg.push({ path: name, ...meta });
+            continue;
+        }
+        const n = m[1] as string;
+        if (meta.adr !== undefined && meta.adr !== '' && _lstripZeros(meta.adr) !== _lstripZeros(n)) {
+            errs.push(`${name}: adr=${meta.adr} != filename ${n}`);
+        }
+        if (n in seen) {
+            errs.push(`ADR-${n} duplicate: ${name} and ${seen[n]}`);
+        }
+        seen[n] = name;
+        num.push({ num: n, slug: m[2] as string, path: name, ...meta });
+    }
+    const nums = new Set(num.map((r) => r.num as string));
+    for (const r of num) {
+        const s = r.supersedes ?? '—';
+        if (s && s !== '—') {
+            const t = _zfill3(_lstripZeros(s.replaceAll('ADR-', '')));
+            if (!nums.has(t)) {
+                errs.push(`${r.path}: supersedes ADR-${t} not found`);
+            }
+        }
+    }
+    return [num, leg, errs];
+}
+
+/** Mirror `row(r)`. */
+export function row(r: Row): string {
+    const decision = r.decision ?? r.slug ?? '—';
+    const title = _title(decision.replaceAll('-', ' '));
+    const label = 'num' in r ? `ADR-${r.num}` : (r.path as string).slice(0, -3);
+    return (
+        `| [${label}](${r.path}) | ${title} | ${r.status ?? '—'} ` +
+        `| ${r.date ?? '—'} | ${r.supersedes ?? '—'} |`
+    );
+}
+
+/** Mirror `render(num, leg)`. */
+export function render(num: Row[], leg: Row[]): string {
+    const out = [
+        '# ADR Index',
+        '',
+        '_Auto-generated by `scripts/adr/regenerate_index.py`. Do not edit._',
+        '',
+    ];
+    if (num.length === 0 && leg.length === 0) {
+        return [...out, 'No ADRs yet.', ''].join('\n');
+    }
+    out.push(HEAD, ...num.map(row));
+    if (leg.length > 0) {
+        out.push('', '## Unnumbered (legacy)', '', HEAD, ...leg.map(row));
+    }
+    return [...out, ''].join('\n');
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let dirArg = 'docs/adr/';
+    let check = false;
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i] as string;
+        if (a === '--check') {
+            check = true;
+        } else if (a === '--dir') {
+            dirArg = (argv[i + 1] as string) ?? dirArg;
+            i += 1;
+        } else if (a.startsWith('--dir=')) {
+            dirArg = a.slice('--dir='.length);
+        }
+    }
+    const d = dirArg;
+    let isDir = false;
+    try {
+        isDir = fs.statSync(d).isDirectory();
+    } catch {
+        isDir = false;
+    }
+    if (!isDir) {
+        process.stderr.write(`adr-dir not found: ${_pyPathStr(d)}\n`);
+        return 2;
+    }
+    const [num, leg, errs] = scan(d);
+    for (const e of errs) {
+        process.stderr.write(`error: ${e}\n`);
+    }
+    if (errs.length > 0) {
+        return 2;
+    }
+    const rendered = render(num, leg);
+    const idx = _pyPathJoin(d, 'INDEX.md');
+    if (check) {
+        let cur = '';
+        try {
+            cur = fs.readFileSync(idx, 'utf-8');
+        } catch {
+            cur = '';
+        }
+        if (cur !== rendered) {
+            process.stderr.write(`stale: ${idx}\n`);
+            return 1;
+        }
+        return 0;
+    }
+    fs.writeFileSync(idx, rendered, 'utf-8');
+    process.stdout.write(`wrote ${idx} (${num.length} numbered, ${leg.length} legacy)\n`);
+    return 0;
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    process.exitCode = main();
+}

--- a/src/scripts/prediction-pool/score_ev.ts
+++ b/src/scripts/prediction-pool/score_ev.ts
@@ -1,0 +1,546 @@
+#!/usr/bin/env tsx
+/**
+ * Exact-score EV optimiser for prediction-pool-optimizer.
+ *
+ * TypeScript twin of `src/scripts/prediction-pool/score_ev.py` (ADR-094,
+ * Phase 8). The CLI contract is mirrored EXACTLY — the positional `matches`
+ * JSON file, `--lh` / `--la` / `--exact` / `--diff` / `--tendency` /
+ * `--max-tip` / `--top` / `--json`, exit codes, the stdout/stderr split, and
+ * byte-identical text AND `--json` output. No behaviour changes.
+ *
+ * Float parity: `round(x, 3)` uses CPython half-to-even (pyRound from _lib);
+ * JSON renders every Python `float` via the PyFloat marker so integer-valued
+ * floats keep the `.0` suffix (`0.0`, not `0`); text uses Python `str(float)`
+ * and `f"{x:.3f}"` semantics. The Poisson grid is a pure deterministic
+ * computation (no RNG) — its sibling sims poisson_sim / pool_winsim DO use
+ * RNG and are out of scope.
+ *
+ * Original module docstring (verbatim):
+ *
+ * Honest replacement for eyeballing the favourite — given each side's expected
+ * goals (lambda) and the pool's scoring rule, this builds the full Poisson
+ * score grid and computes the expected points of EVERY candidate tip, then
+ * prints the EV-maximizing scoreline. It exists to kill two recurring failure
+ * modes:
+ *
+ *   1. Hallucinated high scorelines (4:2, 1:4, 3:2 ...). Under any partial-points
+ *      rule these are almost never EV-max for a moderate favourite — the points
+ *      live in the tendency and goal-difference tiers, not the exact high score.
+ *   2. Under-tipped draws. A correctly-tipped draw banks the goal-difference
+ *      tier on every draw scoreline, so a 1:1 can beat a 1:0 in a close game.
+ *      The grid surfaces this; intuition does not.
+ *
+ * The scoring model (configurable points per tier):
+ *
+ *     exact result  → --exact     (default 4)
+ *     goal diff      → --diff      (default 3)   # same difference, not exact; draw-on-draw lands here
+ *     tendency       → --tendency  (default 2)   # same W/D/L sign only
+ *     else           → 0
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { pyRound } from '../_lib/value_ladder.js';
+
+const MAX_GOALS = 12; // truncation of the Poisson grid; tail beyond this is negligible
+
+/** Marker for a Python `float` so JSON renders integer-valued floats as `0.0`, not `0`. */
+class PyFloat {
+    constructor(readonly value: number) {}
+}
+
+/** Mirror Python `str(float(x))` — integer-valued floats keep the `.0` suffix. */
+function pyFloatStr(x: number): string {
+    if (!Number.isFinite(x)) {
+        if (Number.isNaN(x)) {
+            return 'nan';
+        }
+        return x > 0 ? 'inf' : '-inf';
+    }
+    return Number.isInteger(x) ? `${x}.0` : String(x);
+}
+
+/** Mirror Python `f"{x:.3f}"` — fixed 3 decimals, round-half-to-even on the exact value. */
+function pyFixed3(x: number): string {
+    if (!Number.isFinite(x)) {
+        return String(x);
+    }
+    const neg = x < 0 || Object.is(x, -0);
+    const abs = Math.abs(x);
+    const factor = 1000;
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    const tol = Math.max(Math.abs(scaled), 1) * 2 ** -40;
+    let rounded: number;
+    if (Math.abs(frac - 0.5) <= tol) {
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    let intStr = String(rounded);
+    if (intStr.length <= 3) {
+        intStr = '0'.repeat(3 - intStr.length + 1) + intStr;
+    }
+    const whole = intStr.slice(0, intStr.length - 3);
+    const dec = intStr.slice(intStr.length - 3);
+    const result = `${whole}.${dec}`;
+    return neg ? `-${result}` : result;
+}
+
+/** Mirror Python `f"{s:>5}"` — right-justify a string in a field of width 5. */
+function rjust5(s: string): string {
+    return s.length >= 5 ? s : ' '.repeat(5 - s.length) + s;
+}
+
+/** Mirror Python `math.factorial(k)` for the small k this grid uses (exact in a double up to 12!). */
+function factorial(k: number): number {
+    let r = 1;
+    for (let i = 2; i <= k; i += 1) {
+        r *= i;
+    }
+    return r;
+}
+
+function _pois_pmf(k: number, rate: number): number {
+    if (rate <= 0) {
+        return k === 0 ? 1.0 : 0.0;
+    }
+    return (Math.exp(-rate) * rate ** k) / factorial(k);
+}
+
+function _sign(x: number): number {
+    return (x > 0 ? 1 : 0) - (x < 0 ? 1 : 0);
+}
+
+/** Points a tip (th:ta) earns against an actual result (ah:aa). */
+function _score(
+    th: number,
+    ta: number,
+    ah: number,
+    aa: number,
+    pts_exact: number,
+    pts_diff: number,
+    pts_tend: number,
+): number {
+    if (th === ah && ta === aa) {
+        return pts_exact;
+    }
+    if (th - ta === ah - aa) {
+        return pts_diff;
+    }
+    if (_sign(th - ta) === _sign(ah - aa)) {
+        return pts_tend;
+    }
+    return 0.0;
+}
+
+/** Joint probability of every actual scoreline up to max_goals. */
+function grid(lh: number, la: number, max_goals: number = MAX_GOALS): number[][] {
+    const ph: number[] = [];
+    const pa: number[] = [];
+    for (let k = 0; k <= max_goals; k += 1) {
+        ph.push(_pois_pmf(k, lh));
+        pa.push(_pois_pmf(k, la));
+    }
+    const g: number[][] = [];
+    for (let h = 0; h <= max_goals; h += 1) {
+        const rowVals: number[] = [];
+        for (let a = 0; a <= max_goals; a += 1) {
+            rowVals.push((ph[h] as number) * (pa[a] as number));
+        }
+        g.push(rowVals);
+    }
+    return g;
+}
+
+type EvRow = [number, number, number];
+
+/** EV (expected points) of every candidate tip up to max_tip goals/side. */
+function ev_table(
+    lh: number,
+    la: number,
+    pts_exact: number,
+    pts_diff: number,
+    pts_tend: number,
+    max_tip = 6,
+    max_goals: number = MAX_GOALS,
+): [EvRow[], number[][]] {
+    const g = grid(lh, la, max_goals);
+    const rows: EvRow[] = [];
+    for (let th = 0; th <= max_tip; th += 1) {
+        for (let ta = 0; ta <= max_tip; ta += 1) {
+            let ev = 0.0;
+            for (let ah = 0; ah <= max_goals; ah += 1) {
+                for (let aa = 0; aa <= max_goals; aa += 1) {
+                    const p = (g[ah] as number[])[aa] as number;
+                    if (p <= 0) {
+                        continue;
+                    }
+                    const s = _score(th, ta, ah, aa, pts_exact, pts_diff, pts_tend);
+                    if (s) {
+                        ev += p * s;
+                    }
+                }
+            }
+            rows.push([th, ta, ev]);
+        }
+    }
+    // Python `rows.sort(key=lambda r: r[2], reverse=True)` — stable descending.
+    rows.sort((rowA, rowB) => rowB[2] - rowA[2]);
+    return [rows, g];
+}
+
+function _modal(g: number[][]): [number, number, number] {
+    let best: [number, number, number] = [0, 0, 0.0];
+    for (let h = 0; h < g.length; h += 1) {
+        const gRow = g[h] as number[];
+        for (let a = 0; a < gRow.length; a += 1) {
+            if ((gRow[a] as number) > best[2]) {
+                best = [h, a, gRow[a] as number];
+            }
+        }
+    }
+    return best;
+}
+
+function _p_draw(g: number[][]): number {
+    let total = 0.0;
+    for (let i = 0; i < g.length; i += 1) {
+        total += (g[i] as number[])[i] as number;
+    }
+    return total;
+}
+
+interface RankedEntry {
+    tip: string;
+    ev: PyFloat;
+}
+
+interface Analysis {
+    lambda: PyFloat[];
+    rule: { exact: PyFloat; diff: PyFloat; tendency: PyFloat };
+    ev_max: { tip: string; ev: PyFloat };
+    modal_result: { score: string; prob: PyFloat };
+    p_draw: PyFloat;
+    ranked: RankedEntry[];
+    match?: string;
+}
+
+function analyse(
+    lh: number,
+    la: number,
+    pts_exact: number,
+    pts_diff: number,
+    pts_tend: number,
+    max_tip = 6,
+    top = 6,
+): Analysis {
+    const [rows, g] = ev_table(lh, la, pts_exact, pts_diff, pts_tend, max_tip);
+    const [mh, ma, mp] = _modal(g);
+    const first = rows[0] as EvRow;
+    return {
+        lambda: [new PyFloat(lh), new PyFloat(la)],
+        rule: { exact: new PyFloat(pts_exact), diff: new PyFloat(pts_diff), tendency: new PyFloat(pts_tend) },
+        ev_max: { tip: `${first[0]}:${first[1]}`, ev: new PyFloat(pyRound(first[2], 3)) },
+        modal_result: { score: `${mh}:${ma}`, prob: new PyFloat(pyRound(mp, 3)) },
+        p_draw: new PyFloat(pyRound(_p_draw(g), 3)),
+        ranked: rows.slice(0, top).map(([h, a, ev]) => ({ tip: `${h}:${a}`, ev: new PyFloat(pyRound(ev, 3)) })),
+    };
+}
+
+function _print_one(name: string | null, res: Analysis): void {
+    if (name) {
+        process.stdout.write(`\n## ${name}\n`);
+    }
+    const [lh, la] = res.lambda;
+    const r = res.rule;
+    process.stdout.write(
+        `lambda ${pyFloatStr((lh as PyFloat).value)}:${pyFloatStr((la as PyFloat).value)}  ` +
+            `rule exact=${pyFloatStr(r.exact.value)} diff=${pyFloatStr(r.diff.value)} tendency=${pyFloatStr(r.tendency.value)}\n`,
+    );
+    process.stdout.write(`EV-max tip : ${res.ev_max.tip}  (EV ${pyFloatStr(res.ev_max.ev.value)})\n`);
+    process.stdout.write(
+        `modal score: ${res.modal_result.score}  (P ${pyFloatStr(res.modal_result.prob.value)})  ` +
+            `P(draw) ${pyFloatStr(res.p_draw.value)}\n`,
+    );
+    process.stdout.write('ranked by EV:\n');
+    for (const rowEntry of res.ranked) {
+        const flag = rowEntry.tip === res.ev_max.tip ? '  <- EV-max' : '';
+        process.stdout.write(`  ${rjust5(rowEntry.tip)}  EV ${pyFixed3(rowEntry.ev.value)}${flag}\n`);
+    }
+}
+
+// --- JSON (json.dumps(out, indent=2)) parity --------------------------------
+
+function _jsonDumps(value: unknown, indent: number): string {
+    return _escapeNonAscii(_dumpsIndent(value, indent, 0));
+}
+
+function _dumpsIndent(value: unknown, indent: number, depth: number): string {
+    const pad = ' '.repeat(indent * (depth + 1));
+    const closePad = ' '.repeat(indent * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStr(value);
+    }
+    if (value instanceof PyFloat) {
+        return _jsonFloat(value.value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumpsIndent(v, indent, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0) {
+        return '{}';
+    }
+    const items = keys.map((k) => `${pad}${_jsonStr(k)}: ${_dumpsIndent(obj[k], indent, depth + 1)}`);
+    return `{\n${items.join(',\n')}\n${closePad}}`;
+}
+
+/** Render a Python float — integer-valued floats keep a `.0` suffix (repr(float)). */
+function _jsonFloat(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return Number.isInteger(n) ? `${n}.0` : String(n);
+}
+
+function _jsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            default: {
+                const code = ch.codePointAt(0) ?? 0;
+                if (code < 0x20) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+            }
+        }
+    }
+    return `${out}"`;
+}
+
+/** json.dumps default ensure_ascii=True — escape any non-ASCII to \uXXXX. */
+function _escapeNonAscii(s: string): string {
+    let out = '';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) ?? 0;
+        if (code > 0x7f) {
+            if (code > 0xffff) {
+                const high = 0xd800 + ((code - 0x10000) >> 10);
+                const low = 0xdc00 + ((code - 0x10000) & 0x3ff);
+                out += `\\u${high.toString(16).padStart(4, '0')}\\u${low.toString(16).padStart(4, '0')}`;
+            } else {
+                out += `\\u${code.toString(16).padStart(4, '0')}`;
+            }
+        } else {
+            out += ch;
+        }
+    }
+    return out;
+}
+
+// --- argparse-equivalent CLI ------------------------------------------------
+
+const USAGE =
+    'usage: score_ev.py [-h] [--lh LH] [--la LA] [--exact EXACT] [--diff DIFF]\n' +
+    '                   [--tendency TENDENCY] [--max-tip MAX_TIP] [--top TOP]\n' +
+    '                   [--json]\n' +
+    '                   [matches]\n';
+
+interface Args {
+    matches: string | null;
+    lh: number | null;
+    la: number | null;
+    exact: number;
+    diff: number;
+    tendency: number;
+    max_tip: number;
+    top: number;
+    json: boolean;
+}
+
+class ArgError extends Error {}
+
+function _apError(msg: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`score_ev.py: error: ${msg}\n`);
+    process.exitCode = 2;
+    throw new ArgError(msg);
+}
+
+/** Mirror `float(x)` / `int(x)` parsing with argparse's invalid-value error. */
+function _parseFloatArg(name: string, raw: string): number {
+    const v = Number(raw);
+    if (raw.trim() === '' || Number.isNaN(v)) {
+        _apError(`argument ${name}: invalid float value: '${raw}'`);
+    }
+    return v;
+}
+
+function _parseIntArg(name: string, raw: string): number {
+    if (!/^[+-]?\d+$/.test(raw.trim())) {
+        _apError(`argument ${name}: invalid int value: '${raw}'`);
+    }
+    return parseInt(raw, 10);
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        matches: null,
+        lh: null,
+        la: null,
+        exact: 4.0,
+        diff: 3.0,
+        tendency: 2.0,
+        max_tip: 6,
+        top: 6,
+        json: false,
+    };
+    const positionals: string[] = [];
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i] as string;
+        const takeValue = (flag: string): string => {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                return a.slice(eq + 1);
+            }
+            i += 1;
+            if (i >= argv.length) {
+                _apError(`argument ${flag}: expected one argument`);
+            }
+            return argv[i] as string;
+        };
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(USAGE);
+            process.exitCode = 0;
+            throw new ArgError('help');
+        } else if (a === '--lh' || a.startsWith('--lh=')) {
+            args.lh = _parseFloatArg('--lh', takeValue('--lh'));
+        } else if (a === '--la' || a.startsWith('--la=')) {
+            args.la = _parseFloatArg('--la', takeValue('--la'));
+        } else if (a === '--exact' || a.startsWith('--exact=')) {
+            args.exact = _parseFloatArg('--exact', takeValue('--exact'));
+        } else if (a === '--diff' || a.startsWith('--diff=')) {
+            args.diff = _parseFloatArg('--diff', takeValue('--diff'));
+        } else if (a === '--tendency' || a.startsWith('--tendency=')) {
+            args.tendency = _parseFloatArg('--tendency', takeValue('--tendency'));
+        } else if (a === '--max-tip' || a.startsWith('--max-tip=')) {
+            args.max_tip = _parseIntArg('--max-tip', takeValue('--max-tip'));
+        } else if (a === '--top' || a.startsWith('--top=')) {
+            args.top = _parseIntArg('--top', takeValue('--top'));
+        } else if (a === '--json') {
+            args.json = true;
+        } else if (a.startsWith('-') && a !== '-') {
+            _apError(`unrecognized arguments: ${a}`);
+        } else {
+            positionals.push(a);
+        }
+    }
+    if (positionals.length > 1) {
+        _apError(`unrecognized arguments: ${positionals.slice(1).join(' ')}`);
+    }
+    if (positionals.length === 1) {
+        args.matches = positionals[0] as string;
+    }
+    return args;
+}
+
+interface MatchSpec {
+    match?: string;
+    lh: number | string;
+    la: number | string;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgError) {
+            return process.exitCode === undefined ? 0 : (process.exitCode as number);
+        }
+        throw e;
+    }
+
+    const jobs: Array<[string | null, number, number]> = [];
+    if (args.matches) {
+        const data = JSON.parse(fs.readFileSync(args.matches, 'utf-8')) as MatchSpec[];
+        for (const m of data) {
+            jobs.push([m.match ?? null, Number(m.lh), Number(m.la)]);
+        }
+    } else if (args.lh !== null && args.la !== null) {
+        jobs.push([null, args.lh, args.la]);
+    } else {
+        _apError('provide either a matches JSON file or --lh and --la');
+    }
+
+    const out: Analysis[] = [];
+    for (const [name, lh, la] of jobs) {
+        const res = analyse(lh, la, args.exact, args.diff, args.tendency, args.max_tip, args.top);
+        if (name) {
+            res.match = name;
+        }
+        out.push(res);
+        if (!args.json) {
+            _print_one(name, res);
+        }
+    }
+
+    if (args.json) {
+        process.stdout.write(`${_jsonDumps(out, 2)}\n`);
+    }
+    return 0;
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    try {
+        const rc = main();
+        if (process.exitCode === undefined) {
+            process.exitCode = rc;
+        }
+    } catch (e) {
+        if (!(e instanceof ArgError)) {
+            throw e;
+        }
+    }
+}

--- a/src/scripts/tools/adapter_errors.ts
+++ b/src/scripts/tools/adapter_errors.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared error types for tool adapters.
+ *
+ * TypeScript twin of `src/scripts/tools/adapter_errors.py` (ADR-094 —
+ * Python→TS migration, Phase 1 / tools adapter cluster). Public API mirrors
+ * the Python module exactly (snake_case kept deliberately — fidelity over TS
+ * idiom): the `AdapterErrorType` string enum, the `AdapterError` value shape
+ * with its `is_retryable` property, and `classify_http_error`'s status-code →
+ * error-type mapping. No behaviour changes.
+ */
+
+/** Categorized adapter errors (mirrors the `AdapterErrorType` str-Enum). */
+export enum AdapterErrorType {
+    AUTH_FAILURE = 'auth_failure',
+    NOT_FOUND = 'not_found',
+    RATE_LIMIT = 'rate_limit',
+    TIMEOUT = 'timeout',
+    NETWORK = 'network',
+    VALIDATION = 'validation',
+    UNKNOWN = 'unknown',
+}
+
+/**
+ * Structured adapter error (mirrors the `AdapterError` dataclass).
+ *
+ * Construct via `makeAdapterError` to keep the same field defaults as the
+ * Python dataclass (`status_code` / `retry_after` default to null).
+ */
+export interface AdapterError {
+    adapter: string;
+    action: string;
+    error_type: AdapterErrorType;
+    message: string;
+    status_code: number | null;
+    retry_after: number | null;
+}
+
+/** Build an `AdapterError` with Python dataclass defaults. */
+export function makeAdapterError(args: {
+    adapter: string;
+    action: string;
+    error_type: AdapterErrorType;
+    message: string;
+    status_code?: number | null;
+    retry_after?: number | null;
+}): AdapterError {
+    return {
+        adapter: args.adapter,
+        action: args.action,
+        error_type: args.error_type,
+        message: args.message,
+        status_code: args.status_code ?? null,
+        retry_after: args.retry_after ?? null,
+    };
+}
+
+/** Whether this error can be retried (mirrors the `is_retryable` property). */
+export function is_retryable(error: AdapterError): boolean {
+    return (
+        error.error_type === AdapterErrorType.RATE_LIMIT ||
+        error.error_type === AdapterErrorType.TIMEOUT ||
+        error.error_type === AdapterErrorType.NETWORK
+    );
+}
+
+/** Classify an HTTP error into a structured AdapterError. */
+export function classify_http_error(
+    adapter: string,
+    action: string,
+    status_code: number,
+    message: string,
+): AdapterError {
+    let error_type: AdapterErrorType;
+    if (status_code === 401 || status_code === 403) {
+        error_type = AdapterErrorType.AUTH_FAILURE;
+    } else if (status_code === 404) {
+        error_type = AdapterErrorType.NOT_FOUND;
+    } else if (status_code === 429) {
+        error_type = AdapterErrorType.RATE_LIMIT;
+    } else if (status_code >= 500) {
+        error_type = AdapterErrorType.NETWORK;
+    } else {
+        error_type = AdapterErrorType.UNKNOWN;
+    }
+
+    return makeAdapterError({
+        adapter,
+        action,
+        error_type,
+        message,
+        status_code,
+    });
+}

--- a/src/scripts/tools/base_adapter.ts
+++ b/src/scripts/tools/base_adapter.ts
@@ -1,0 +1,147 @@
+/**
+ * Base Tool Adapter — abstract contract for tool integrations.
+ *
+ * All tool adapters must:
+ * 1. Extend BaseToolAdapter
+ * 2. Define supported_actions
+ * 3. Implement execute_action
+ * 4. Implement check_auth
+ *
+ * No real API calls are made by the base — adapters return structured results.
+ *
+ * TypeScript twin of `src/scripts/tools/base_adapter.py` (ADR-094 — Python→TS
+ * migration, Phase 1 / tools adapter cluster). Public API mirrors the Python
+ * module exactly (snake_case kept deliberately — fidelity over TS idiom):
+ * the `ToolAction` / `ToolResult` value shapes, `ToolResult.to_dict()` with
+ * Python-truthiness key omission (empty `data` / `error` dropped), and the
+ * `validate_action` / `safe_execute` flow on the abstract base. No behaviour
+ * changes.
+ */
+
+/** Arbitrary JSON-ish param / data map (mirrors `Dict[str, Any]`). */
+export type ParamDict = Record<string, unknown>;
+
+/** Plain-object shape returned by `ToolResult.to_dict()`. */
+export type ToolResultDict = {
+    tool: string;
+    action: string;
+    success: boolean;
+    data?: ParamDict;
+    error?: string;
+};
+
+/**
+ * Python truthiness for the values `to_dict` gates on (dict / str).
+ * `null`/`undefined`, `false`, `0`, empty string, empty array, and empty
+ * object are falsy; everything else truthy — exactly like Python `if value`.
+ */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'string') return value.length > 0;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Structured representation of a tool action request (mirrors `ToolAction`). */
+export class ToolAction {
+    tool_name: string;
+    action: string;
+    params: ParamDict;
+
+    constructor(args: { tool_name: string; action: string; params: ParamDict }) {
+        this.tool_name = args.tool_name;
+        this.action = args.action;
+        this.params = args.params;
+    }
+}
+
+/** Structured result from a tool action (mirrors the `ToolResult` dataclass). */
+export class ToolResult {
+    tool_name: string;
+    action: string;
+    success: boolean;
+    data: ParamDict | null;
+    error: string | null;
+
+    constructor(args: {
+        tool_name: string;
+        action: string;
+        success: boolean;
+        data?: ParamDict | null;
+        error?: string | null;
+    }) {
+        this.tool_name = args.tool_name;
+        this.action = args.action;
+        this.success = args.success;
+        this.data = args.data ?? null;
+        this.error = args.error ?? null;
+    }
+
+    to_dict(): ToolResultDict {
+        const result: ToolResultDict = {
+            tool: this.tool_name,
+            action: this.action,
+            success: this.success,
+        };
+        if (_pyTruthy(this.data)) {
+            result.data = this.data as ParamDict;
+        }
+        if (_pyTruthy(this.error)) {
+            result.error = this.error as string;
+        }
+        return result;
+    }
+}
+
+/**
+ * Python `sorted(set[str])` — ascending codepoint order, like the .py default.
+ */
+function _sorted(values: Iterable<string>): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Abstract base for tool adapters (mirrors the `BaseToolAdapter` ABC). */
+export abstract class BaseToolAdapter {
+    /** Tool name (must match registry entry). */
+    abstract get name(): string;
+
+    /** Set of supported action names. */
+    abstract get supported_actions(): ReadonlySet<string>;
+
+    /** Check if authentication is available. Does NOT make API calls. */
+    abstract check_auth(): boolean;
+
+    /** Execute a tool action. Returns structured result. */
+    abstract execute_action(action: ToolAction): ToolResult;
+
+    /** Validate an action before execution. Returns error message or null. */
+    validate_action(action: ToolAction): string | null {
+        if (action.tool_name !== this.name) {
+            return `Action tool '${action.tool_name}' does not match adapter '${this.name}'`;
+        }
+        if (!this.supported_actions.has(action.action)) {
+            return (
+                `Action '${action.action}' not supported by '${this.name}'; ` +
+                `valid: ${_sorted(this.supported_actions).join(', ')}`
+            );
+        }
+        return null;
+    }
+
+    /** Validate and execute an action safely. */
+    safe_execute(action: ToolAction): ToolResult {
+        const error = this.validate_action(action);
+        if (error) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: action.action,
+                success: false,
+                error,
+            });
+        }
+        return this.execute_action(action);
+    }
+}

--- a/src/scripts/tools/github_adapter.ts
+++ b/src/scripts/tools/github_adapter.ts
@@ -1,0 +1,228 @@
+/**
+ * GitHub Tool Adapter — read-only GitHub API interactions.
+ *
+ * Read-only actions use real API calls when GITHUB_TOKEN is available.
+ * Write actions remain scaffold-only (never auto-executed).
+ * Falls back to scaffold data when no token is present.
+ *
+ * TypeScript twin of `src/scripts/tools/github_adapter.py` (ADR-094 —
+ * Python→TS migration, Phase 1 / tools adapter cluster). Public API mirrors
+ * the Python module exactly (snake_case kept deliberately): the
+ * `read_pr` / `read_issue` / `list_files` / `read_commit` / `create_pr`
+ * dispatch, the GITHUB_TOKEN credential-from-env handling, the scaffold
+ * fallback shape, and the GitHub API request construction (URL, headers,
+ * method). The Python reference uses `urllib.request`; this twin builds the
+ * identical request and performs the fetch through `_httpGetJson` — a seam
+ * tests stub so no live network call is made (the no-token path scaffolds and
+ * never reaches HTTP, exactly like the original). No behaviour changes.
+ */
+import { spawnSync } from 'node:child_process';
+
+import { BaseToolAdapter, ToolAction, ToolResult } from './base_adapter.js';
+
+export const GITHUB_API = 'https://api.github.com';
+export const TIMEOUT_SECONDS = 15;
+
+/** Request shape mirroring `urllib.request.Request`. */
+export interface BuiltRequest {
+    url: string;
+    headers: Record<string, string>;
+    method: string;
+    timeout: number;
+}
+
+/** Adapter for GitHub API interactions. */
+export class GitHubAdapter extends BaseToolAdapter {
+    static readonly READ_ACTIONS: ReadonlySet<string> = new Set([
+        'read_pr',
+        'read_issue',
+        'list_files',
+        'read_commit',
+    ]);
+    static readonly WRITE_ACTIONS: ReadonlySet<string> = new Set(['create_pr']);
+
+    get name(): string {
+        return 'github';
+    }
+
+    get supported_actions(): ReadonlySet<string> {
+        return new Set([...GitHubAdapter.READ_ACTIONS, ...GitHubAdapter.WRITE_ACTIONS]);
+    }
+
+    check_auth(): boolean {
+        return Boolean(process.env.GITHUB_TOKEN);
+    }
+
+    protected get _token(): string | undefined {
+        return process.env.GITHUB_TOKEN || undefined;
+    }
+
+    /**
+     * Build the GitHub API request for `path` (mirrors the `urllib.Request`
+     * construction in `_api_get`). Exposed for parity tests.
+     */
+    _buildRequest(path: string): BuiltRequest {
+        const url = `${GITHUB_API}/${path.replace(/^\/+/, '')}`;
+        const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
+        if (this._token) {
+            headers.Authorization = `Bearer ${this._token}`;
+        }
+        return { url, headers, method: 'GET', timeout: TIMEOUT_SECONDS };
+    }
+
+    /**
+     * Perform the authenticated GET and decode JSON. Seam over the actual
+     * network call — never reached on the no-token / scaffold path. Default
+     * implementation mirrors `urlopen(...).read().decode()` + `json.loads`.
+     */
+    protected _httpGetJson(req: BuiltRequest): Record<string, unknown> {
+        const headerArgs: string[] = [];
+        for (const [k, v] of Object.entries(req.headers)) {
+            headerArgs.push('-H', `${k}: ${v}`);
+        }
+        const proc = spawnSync(
+            'curl',
+            ['-sS', '--fail', '--max-time', String(req.timeout), ...headerArgs, req.url],
+            { encoding: 'utf8' },
+        );
+        if (proc.status !== 0) {
+            throw new Error(proc.stderr || `request failed for ${req.url}`);
+        }
+        return JSON.parse(proc.stdout) as Record<string, unknown>;
+    }
+
+    private _api_get(path: string): Record<string, unknown> {
+        return this._httpGetJson(this._buildRequest(path));
+    }
+
+    execute_action(action: ToolAction): ToolResult {
+        const handlers: Record<string, ((a: ToolAction) => ToolResult) | undefined> = {
+            read_pr: (a) => this._read_pr(a),
+            read_issue: (a) => this._read_issue(a),
+            list_files: (a) => this._list_files(a),
+            read_commit: (a) => this._read_commit(a),
+            create_pr: (a) => this._create_pr(a),
+        };
+        const handler = handlers[action.action];
+
+        if (!handler) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: action.action,
+                success: false,
+                error: `Unsupported action: ${action.action}`,
+            });
+        }
+        return handler(action);
+    }
+
+    private _read_pr(action: ToolAction): ToolResult {
+        const owner = (action.params.owner as string | undefined) ?? '';
+        const repo = (action.params.repo as string | undefined) ?? '';
+        const number = (action.params.number as string | undefined) ?? '';
+        if (!(owner && repo && number) || !this._token) {
+            return this._scaffold('read_pr', action);
+        }
+        try {
+            const data = this._api_get(`repos/${owner}/${repo}/pulls/${number}`);
+            return new ToolResult({ tool_name: this.name, action: 'read_pr', success: true, data });
+        } catch (e) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_pr',
+                success: false,
+                error: String(e instanceof Error ? e.message : e),
+            });
+        }
+    }
+
+    private _read_issue(action: ToolAction): ToolResult {
+        const owner = (action.params.owner as string | undefined) ?? '';
+        const repo = (action.params.repo as string | undefined) ?? '';
+        const number = (action.params.number as string | undefined) ?? '';
+        if (!(owner && repo && number) || !this._token) {
+            return this._scaffold('read_issue', action);
+        }
+        try {
+            const data = this._api_get(`repos/${owner}/${repo}/issues/${number}`);
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_issue',
+                success: true,
+                data,
+            });
+        } catch (e) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_issue',
+                success: false,
+                error: String(e instanceof Error ? e.message : e),
+            });
+        }
+    }
+
+    private _list_files(action: ToolAction): ToolResult {
+        const owner = (action.params.owner as string | undefined) ?? '';
+        const repo = (action.params.repo as string | undefined) ?? '';
+        const number = (action.params.number as string | undefined) ?? '';
+        if (!(owner && repo && number) || !this._token) {
+            return this._scaffold('list_files', action);
+        }
+        try {
+            const data = this._api_get(`repos/${owner}/${repo}/pulls/${number}/files`);
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'list_files',
+                success: true,
+                data,
+            });
+        } catch (e) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'list_files',
+                success: false,
+                error: String(e instanceof Error ? e.message : e),
+            });
+        }
+    }
+
+    private _read_commit(action: ToolAction): ToolResult {
+        const owner = (action.params.owner as string | undefined) ?? '';
+        const repo = (action.params.repo as string | undefined) ?? '';
+        const sha = (action.params.sha as string | undefined) ?? '';
+        if (!(owner && repo && sha) || !this._token) {
+            return this._scaffold('read_commit', action);
+        }
+        try {
+            const data = this._api_get(`repos/${owner}/${repo}/commits/${sha}`);
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_commit',
+                success: true,
+                data,
+            });
+        } catch (e) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_commit',
+                success: false,
+                error: String(e instanceof Error ? e.message : e),
+            });
+        }
+    }
+
+    /** Write action — scaffold only, never auto-executed. */
+    private _create_pr(action: ToolAction): ToolResult {
+        return this._scaffold('create_pr', action);
+    }
+
+    /** Return scaffold data when no token or params are missing. */
+    private _scaffold(action_name: string, action: ToolAction): ToolResult {
+        return new ToolResult({
+            tool_name: this.name,
+            action: action_name,
+            success: true,
+            data: { scaffold: true, action: action_name, params: action.params },
+        });
+    }
+}

--- a/src/scripts/tools/jira_adapter.ts
+++ b/src/scripts/tools/jira_adapter.ts
@@ -1,0 +1,195 @@
+/**
+ * Jira Tool Adapter — read-only Jira API interactions.
+ *
+ * Read-only actions use real API calls when JIRA_API_TOKEN + JIRA_BASE_URL are
+ * set. Write actions remain scaffold-only (never auto-executed). Falls back to
+ * scaffold data when no credentials are present.
+ *
+ * TypeScript twin of `src/scripts/tools/jira_adapter.py` (ADR-094 — Python→TS
+ * migration, Phase 1 / tools adapter cluster). Public API mirrors the Python
+ * module exactly (snake_case kept deliberately): the
+ * `read_ticket` / `search_tickets` / `add_comment` / `transition_ticket`
+ * dispatch, the JIRA_API_TOKEN + JIRA_BASE_URL (+ optional JIRA_EMAIL)
+ * credential-from-env handling (basic-auth when email present, else bearer),
+ * the `_base_url` trailing-slash strip, the JQL space-encoding, the scaffold
+ * fallback shape, and the Jira API request construction (URL, headers,
+ * method). The Python reference uses `urllib.request`; this twin builds the
+ * identical request and performs the fetch through `_httpGetJson` — a seam
+ * tests stub so no live network call is made (the no-credentials path
+ * scaffolds and never reaches HTTP). No behaviour changes.
+ */
+import { spawnSync } from 'node:child_process';
+
+import { BaseToolAdapter, ToolAction, ToolResult } from './base_adapter.js';
+
+export const TIMEOUT_SECONDS = 15;
+
+/** Request shape mirroring `urllib.request.Request`. */
+export interface BuiltRequest {
+    url: string;
+    headers: Record<string, string>;
+    method: string;
+    timeout: number;
+}
+
+/** Adapter for Jira API interactions. */
+export class JiraAdapter extends BaseToolAdapter {
+    static readonly READ_ACTIONS: ReadonlySet<string> = new Set(['read_ticket', 'search_tickets']);
+    static readonly WRITE_ACTIONS: ReadonlySet<string> = new Set([
+        'add_comment',
+        'transition_ticket',
+    ]);
+
+    get name(): string {
+        return 'jira';
+    }
+
+    get supported_actions(): ReadonlySet<string> {
+        return new Set([...JiraAdapter.READ_ACTIONS, ...JiraAdapter.WRITE_ACTIONS]);
+    }
+
+    check_auth(): boolean {
+        return Boolean(this._token) && Boolean(this._base_url);
+    }
+
+    protected get _token(): string | undefined {
+        return process.env.JIRA_API_TOKEN || undefined;
+    }
+
+    protected get _base_url(): string | undefined {
+        const url = process.env.JIRA_BASE_URL ?? '';
+        return url ? url.replace(/\/+$/, '') : undefined;
+    }
+
+    protected get _email(): string | undefined {
+        return process.env.JIRA_EMAIL || undefined;
+    }
+
+    /**
+     * Build the Jira API request for `path` (mirrors the `urllib.Request`
+     * construction in `_api_get`). Exposed for parity tests.
+     */
+    _buildRequest(path: string): BuiltRequest {
+        const url = `${this._base_url}/rest/api/3/${path.replace(/^\/+/, '')}`;
+        const headers: Record<string, string> = { Accept: 'application/json' };
+        if (this._email && this._token) {
+            const creds = Buffer.from(`${this._email}:${this._token}`, 'utf8').toString('base64');
+            headers.Authorization = `Basic ${creds}`;
+        } else if (this._token) {
+            headers.Authorization = `Bearer ${this._token}`;
+        }
+        return { url, headers, method: 'GET', timeout: TIMEOUT_SECONDS };
+    }
+
+    /**
+     * Perform the authenticated GET and decode JSON. Seam over the actual
+     * network call — never reached on the no-credentials / scaffold path.
+     * Default implementation mirrors `urlopen(...).read().decode()` +
+     * `json.loads`.
+     */
+    protected _httpGetJson(req: BuiltRequest): Record<string, unknown> {
+        const headerArgs: string[] = [];
+        for (const [k, v] of Object.entries(req.headers)) {
+            headerArgs.push('-H', `${k}: ${v}`);
+        }
+        const proc = spawnSync(
+            'curl',
+            ['-sS', '--fail', '--max-time', String(req.timeout), ...headerArgs, req.url],
+            { encoding: 'utf8' },
+        );
+        if (proc.status !== 0) {
+            throw new Error(proc.stderr || `request failed for ${req.url}`);
+        }
+        return JSON.parse(proc.stdout) as Record<string, unknown>;
+    }
+
+    private _api_get(path: string): Record<string, unknown> {
+        return this._httpGetJson(this._buildRequest(path));
+    }
+
+    execute_action(action: ToolAction): ToolResult {
+        const handlers: Record<string, ((a: ToolAction) => ToolResult) | undefined> = {
+            read_ticket: (a) => this._read_ticket(a),
+            search_tickets: (a) => this._search_tickets(a),
+            add_comment: (a) => this._add_comment(a),
+            transition_ticket: (a) => this._transition_ticket(a),
+        };
+        const handler = handlers[action.action];
+
+        if (!handler) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: action.action,
+                success: false,
+                error: `Unsupported action: ${action.action}`,
+            });
+        }
+        return handler(action);
+    }
+
+    private _read_ticket(action: ToolAction): ToolResult {
+        const key = (action.params.key as string | undefined) ?? '';
+        if (!key || !this.check_auth()) {
+            return this._scaffold('read_ticket', action);
+        }
+        try {
+            const data = this._api_get(`issue/${key}`);
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_ticket',
+                success: true,
+                data,
+            });
+        } catch (e) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'read_ticket',
+                success: false,
+                error: String(e instanceof Error ? e.message : e),
+            });
+        }
+    }
+
+    private _search_tickets(action: ToolAction): ToolResult {
+        const jql = (action.params.jql as string | undefined) ?? '';
+        if (!jql || !this.check_auth()) {
+            return this._scaffold('search_tickets', action);
+        }
+        try {
+            const encoded_jql = jql.split(' ').join('%20');
+            const data = this._api_get(`search?jql=${encoded_jql}&maxResults=20`);
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'search_tickets',
+                success: true,
+                data,
+            });
+        } catch (e) {
+            return new ToolResult({
+                tool_name: this.name,
+                action: 'search_tickets',
+                success: false,
+                error: String(e instanceof Error ? e.message : e),
+            });
+        }
+    }
+
+    /** Write action — scaffold only. */
+    private _add_comment(action: ToolAction): ToolResult {
+        return this._scaffold('add_comment', action);
+    }
+
+    /** Write action — scaffold only. */
+    private _transition_ticket(action: ToolAction): ToolResult {
+        return this._scaffold('transition_ticket', action);
+    }
+
+    private _scaffold(action_name: string, action: ToolAction): ToolResult {
+        return new ToolResult({
+            tool_name: this.name,
+            action: action_name,
+            success: true,
+            data: { scaffold: true, action: action_name, params: action.params },
+        });
+    }
+}

--- a/tests/scripts/adr_regenerate_index.test.ts
+++ b/tests/scripts/adr_regenerate_index.test.ts
@@ -1,0 +1,229 @@
+// Tests for src/scripts/adr/regenerate_index.ts (py2ts Phase 8).
+//
+// No pytest suite exists, so this is a focused differential suite over the
+// pure helpers (fm, scan duplicate/mismatch/supersedes detection, row
+// title-casing + label, render) plus a golden-parity layer that runs
+// python3 vs tsx and compares stdout + stderr + exit code byte-for-byte.
+//
+// The write path (--report) would overwrite the live docs/decisions/INDEX.md,
+// so the golden-parity layer copies the real ADR-*.md set into two throwaway
+// tmp dirs (one for python3, one for tsx) and asserts the generated INDEX.md
+// is byte-identical. The error paths (duplicate number, adr/filename
+// mismatch, dangling supersedes) and the empty-dir / not-found paths use
+// synthetic fixtures. Everything is deterministic — zero git drift; the live
+// tree is never written.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as rgi from '../../src/scripts/adr/regenerate_index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'adr', 'regenerate_index.ts');
+const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'adr', 'regenerate_index.py');
+const DECISIONS = path.join(REPO_ROOT, 'docs', 'decisions');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'adr-idx-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+/** Write a minimal ADR file with the given frontmatter fields. */
+function writeAdr(dir: string, name: string, fm: Record<string, string>): void {
+    const lines = Object.entries(fm).map(([k, v]) => `${k}: ${v}`);
+    fs.writeFileSync(path.join(dir, name), `---\n${lines.join('\n')}\n---\nbody\n`);
+}
+
+describe('regenerate_index — pure helpers', () => {
+    it('scan splits numbered vs legacy and parses frontmatter', () => {
+        const d = mkTmp();
+        writeAdr(d, 'ADR-001-first-thing.md', { adr: '1', status: 'accepted', date: '2026-01-01', decision: 'first-thing' });
+        fs.writeFileSync(path.join(d, 'ADR-legacy-note.md'), '---\nstatus: draft\n---\nbody\n');
+        const [num, leg, errs] = rgi.scan(d);
+        expect(errs).toEqual([]);
+        expect(num).toHaveLength(1);
+        expect(num[0]!.num).toBe('001');
+        expect(num[0]!.slug).toBe('first-thing');
+        expect(num[0]!.path).toBe('ADR-001-first-thing.md');
+        expect(num[0]!.status).toBe('accepted');
+        expect(leg).toHaveLength(1);
+        expect(leg[0]!.path).toBe('ADR-legacy-note.md');
+    });
+
+    it('scan skips INDEX.md and ignores non-ADR files', () => {
+        const d = mkTmp();
+        fs.writeFileSync(path.join(d, 'INDEX.md'), 'whatever');
+        fs.writeFileSync(path.join(d, 'README.md'), 'whatever');
+        writeAdr(d, 'ADR-002-x.md', { adr: '2', decision: 'x' });
+        const [num, leg] = rgi.scan(d);
+        expect(num).toHaveLength(1);
+        expect(leg).toHaveLength(0);
+    });
+
+    it('scan flags an adr/filename mismatch', () => {
+        const d = mkTmp();
+        writeAdr(d, 'ADR-008-mismatch.md', { adr: '7', decision: 'mismatch' });
+        const [, , errs] = rgi.scan(d);
+        expect(errs).toContain('ADR-008-mismatch.md: adr=7 != filename 008');
+    });
+
+    it('scan accepts a zero-padded adr matching the filename number', () => {
+        const d = mkTmp();
+        writeAdr(d, 'ADR-008-ok.md', { adr: '008', decision: 'ok' });
+        const [, , errs] = rgi.scan(d);
+        expect(errs).toEqual([]);
+    });
+
+    it('scan flags a duplicate number (second filename listed against the first)', () => {
+        const d = mkTmp();
+        writeAdr(d, 'ADR-005-first.md', { adr: '5', decision: 'first' });
+        writeAdr(d, 'ADR-005-second.md', { adr: '5', decision: 'second' });
+        const [, , errs] = rgi.scan(d);
+        expect(errs).toContain('ADR-005 duplicate: ADR-005-second.md and ADR-005-first.md');
+    });
+
+    it('scan flags a dangling supersedes link', () => {
+        const d = mkTmp();
+        writeAdr(d, 'ADR-009-dangling.md', { adr: '9', decision: 'dangling', supersedes: 'ADR-042' });
+        const [, , errs] = rgi.scan(d);
+        expect(errs).toContain('ADR-009-dangling.md: supersedes ADR-042 not found');
+    });
+
+    it('scan resolves a valid supersedes link (no error)', () => {
+        const d = mkTmp();
+        writeAdr(d, 'ADR-001-base.md', { adr: '1', decision: 'base' });
+        writeAdr(d, 'ADR-002-super.md', { adr: '2', decision: 'super', supersedes: 'ADR-001' });
+        const [, , errs] = rgi.scan(d);
+        expect(errs).toEqual([]);
+    });
+
+    it('row title-cases the decision and emits the ADR-NNN label', () => {
+        const out = rgi.row({ num: '001', slug: 'foo-bar', path: 'ADR-001-foo-bar.md', decision: 'python-to-ts-migration', status: 'accepted', date: '2026-01-01' });
+        expect(out).toBe('| [ADR-001](ADR-001-foo-bar.md) | Python To Ts Migration | accepted | 2026-01-01 | — |');
+    });
+
+    it('row falls back to the slug, then to dashes, when decision is absent', () => {
+        const out = rgi.row({ num: '003', slug: 'just-the-slug', path: 'ADR-003-just-the-slug.md' });
+        expect(out).toBe('| [ADR-003](ADR-003-just-the-slug.md) | Just The Slug | — | — | — |');
+    });
+
+    it('row for a legacy entry strips .md for the label and renders em-dash placeholders', () => {
+        const out = rgi.row({ path: 'ADR-rule-kernel.md' });
+        expect(out).toBe('| [ADR-rule-kernel](ADR-rule-kernel.md) | — | — | — | — |');
+    });
+
+    it('render emits the No-ADRs body when empty', () => {
+        expect(rgi.render([], [])).toBe(
+            '# ADR Index\n\n_Auto-generated by `scripts/adr/regenerate_index.py`. Do not edit._\n\nNo ADRs yet.\n',
+        );
+    });
+
+    it('render appends the Unnumbered (legacy) section only when legacy rows exist', () => {
+        const out = rgi.render(
+            [{ num: '001', slug: 'a', path: 'ADR-001-a.md', decision: 'a' }],
+            [{ path: 'ADR-legacy.md' }],
+        );
+        expect(out).toContain('## Unnumbered (legacy)');
+        const noLegacy = rgi.render([{ num: '001', slug: 'a', path: 'ADR-001-a.md', decision: 'a' }], []);
+        expect(noLegacy).not.toContain('## Unnumbered (legacy)');
+    });
+});
+
+describe.runIf(hasPython3())('regenerate_index — golden parity (python3 vs tsx)', () => {
+    it('--check matches on the real docs/decisions tree (read-only)', () => {
+        const args = ['--check', '--dir', DECISIONS];
+        const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('default dir (docs/adr/ missing) prints the same not-found message + exit 2', () => {
+        const py = spawnSync('python3', [PY_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('--report writes a byte-identical INDEX.md from the real ADR set', () => {
+        const real = fs
+            .readdirSync(DECISIONS)
+            .filter((n) => n.startsWith('ADR-') && n.endsWith('.md'));
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        for (const n of real) {
+            fs.copyFileSync(path.join(DECISIONS, n), path.join(pyDir, n));
+            fs.copyFileSync(path.join(DECISIONS, n), path.join(tsDir, n));
+        }
+        const py = spawnSync('python3', [PY_SCRIPT, '--dir', pyDir], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, '--dir', tsDir], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        // stdout embeds the dir path; normalise that one token, compare the rest.
+        expect(ts.stdout.replace(tsDir, 'DIR')).toBe(py.stdout.replace(pyDir, 'DIR'));
+        expect(ts.stderr).toBe(py.stderr);
+        const pyIdx = fs.readFileSync(path.join(pyDir, 'INDEX.md'), 'utf8');
+        const tsIdx = fs.readFileSync(path.join(tsDir, 'INDEX.md'), 'utf8');
+        expect(tsIdx).toBe(pyIdx);
+    });
+
+    it('--report on an empty dir writes the same No-ADRs INDEX.md', () => {
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        spawnSync('python3', [PY_SCRIPT, '--dir', pyDir], { encoding: 'utf8', cwd: REPO_ROOT });
+        spawnSync(TSX_BIN, [TS_SCRIPT, '--dir', tsDir], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(fs.readFileSync(path.join(tsDir, 'INDEX.md'), 'utf8')).toBe(
+            fs.readFileSync(path.join(pyDir, 'INDEX.md'), 'utf8'),
+        );
+    });
+
+    it('duplicate ADR number → byte-identical error + exit 2 (the orchestrator path)', () => {
+        const dir = mkTmp();
+        writeAdr(dir, 'ADR-005-first.md', { adr: '5', status: 'accepted', date: '2026-01-01', decision: 'first' });
+        writeAdr(dir, 'ADR-005-second.md', { adr: '5', status: 'draft', date: '2026-01-02', decision: 'second' });
+        const py = spawnSync('python3', [PY_SCRIPT, '--dir', dir], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, '--dir', dir], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(2);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toContain('ADR-005 duplicate');
+    });
+
+    it('adr/filename mismatch + dangling supersedes → byte-identical errors + exit 2', () => {
+        const dir = mkTmp();
+        writeAdr(dir, 'ADR-008-mismatch.md', { adr: '7', decision: 'mismatch' });
+        writeAdr(dir, 'ADR-009-dangling.md', { adr: '9', decision: 'dangling', supersedes: 'ADR-042' });
+        const py = spawnSync('python3', [PY_SCRIPT, '--dir', dir], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, '--dir', dir], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(2);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+});

--- a/tests/scripts/prediction-pool_score_ev.test.ts
+++ b/tests/scripts/prediction-pool_score_ev.test.ts
@@ -1,0 +1,118 @@
+// Tests for src/scripts/prediction-pool/score_ev.ts (py2ts Phase 8).
+//
+// No pytest suite exists, so this is a golden-parity suite that runs python3
+// vs tsx and asserts byte-identical stdout + stderr + exit code across the
+// text and --json output paths, single-lambda and JSON-batch inputs, and the
+// error paths.
+//
+// score_ev is a pure deterministic computation (Poisson grid, NO RNG — its
+// siblings poisson_sim / pool_winsim use RNG and are out of scope), so the
+// output is fully reproducible cross-runtime; nothing needs normalisation.
+//
+// The no-input argparse error wraps its usage block to the terminal width,
+// which is environment-dependent (lesson #8: argparse error PROSE is
+// Python-version / COLUMNS-dependent) — so the error case asserts exit code 2
+// and that the stable error LINE is present, not the full byte stream.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'score_ev.ts');
+const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'score_ev.py');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpFiles: string[] = [];
+function writeTmp(name: string, content: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'score-ev-'));
+    const p = path.join(d, name);
+    fs.writeFileSync(p, content);
+    tmpFiles.push(d);
+    return p;
+}
+afterEach(() => {
+    while (tmpFiles.length > 0) {
+        const d = tmpFiles.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+describe.runIf(hasPython3())('score_ev — golden parity (python3 vs tsx)', () => {
+    const cases: Array<{ label: string; args: string[] }> = [
+        { label: 'text — moderate favourite', args: ['--lh', '2.0', '--la', '0.7'] },
+        { label: 'text — kicktipp 2/3/5 underdog', args: ['--lh', '0.6', '--la', '2.1', '--tendency', '2', '--diff', '3', '--exact', '5'] },
+        { label: 'text — even draw-likely', args: ['--lh', '1.5', '--la', '1.5'] },
+        { label: 'text — zero rates', args: ['--lh', '0', '--la', '0'] },
+        { label: 'text — custom top + max-tip', args: ['--lh', '2.3', '--la', '1.1', '--top', '3', '--max-tip', '4'] },
+        { label: 'json — moderate favourite', args: ['--lh', '2.0', '--la', '0.7', '--json'] },
+        { label: 'json — kicktipp config', args: ['--lh', '0.6', '--la', '2.1', '--tendency', '2', '--diff', '3', '--exact', '5', '--json'] },
+        { label: 'json — fractional lambdas, top 2', args: ['--lh', '1.234', '--la', '0.876', '--top', '2', '--json'] },
+    ];
+    for (const { label, args } of cases) {
+        it(`byte-identical: ${label}`, () => {
+            const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+            const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+            expect(ts.status).toBe(py.status);
+            expect(ts.stdout).toBe(py.stdout);
+            expect(ts.stderr).toBe(py.stderr);
+        });
+    }
+
+    it('byte-identical: JSON batch input (text mode)', () => {
+        const matches = JSON.stringify([
+            { match: 'Senegal-Iraq', lh: 2.0, la: 0.7 },
+            { match: 'Qatar-Switzerland', lh: 0.6, la: 2.1 },
+        ]);
+        const file = writeTmp('m.json', matches);
+        const args = [file, '--tendency', '2', '--diff', '3', '--exact', '5'];
+        const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('byte-identical: JSON batch input (--json mode)', () => {
+        const matches = JSON.stringify([
+            { match: 'A-B', lh: 1.8, la: 1.1 },
+            { match: 'C-D', lh: 0.9, la: 0.9 },
+        ]);
+        const file = writeTmp('m.json', matches);
+        const args = [file, '--json'];
+        const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    // Error path: no input. argparse wraps the usage block to terminal width
+    // (env-dependent), so assert exit 2 + the stable error line, not the full
+    // byte stream.
+    it('no input → exit 2 with the same error line on stderr', () => {
+        const py = spawnSync('python3', [PY_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+        const ts = spawnSync(TSX_BIN, [TS_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+        expect(ts.status).toBe(2);
+        expect(py.status).toBe(2);
+        expect(ts.stdout).toBe('');
+        expect(py.stdout).toBe('');
+        const line = 'score_ev.py: error: provide either a matches JSON file or --lh and --la';
+        expect(ts.stderr).toContain(line);
+        expect(py.stderr).toContain(line);
+    });
+});

--- a/tests/scripts/tools/adapter_errors.test.ts
+++ b/tests/scripts/tools/adapter_errors.test.ts
@@ -1,0 +1,176 @@
+// Tests for src/scripts/tools/adapter_errors.ts (py2ts Phase 1 — tools cluster).
+//
+// Pure-unit parity for the AdapterErrorType enum values, the AdapterError
+// value shape + is_retryable predicate, and classify_http_error's status-code
+// → error-type mapping. Plus a golden-parity layer (python3 vs tsx) that drives
+// the same classify_http_error inputs through both languages and asserts the
+// JSON shapes (incl. is_retryable) are byte-identical. Output is fully
+// deterministic — no timestamps / measured fields.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    AdapterErrorType,
+    classify_http_error,
+    is_retryable,
+    makeAdapterError,
+} from '../../../src/scripts/tools/adapter_errors.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+describe('adapter_errors — pure unit', () => {
+    it('enum values mirror the Python str-Enum', () => {
+        expect(AdapterErrorType.AUTH_FAILURE).toBe('auth_failure');
+        expect(AdapterErrorType.NOT_FOUND).toBe('not_found');
+        expect(AdapterErrorType.RATE_LIMIT).toBe('rate_limit');
+        expect(AdapterErrorType.TIMEOUT).toBe('timeout');
+        expect(AdapterErrorType.NETWORK).toBe('network');
+        expect(AdapterErrorType.VALIDATION).toBe('validation');
+        expect(AdapterErrorType.UNKNOWN).toBe('unknown');
+    });
+
+    it('makeAdapterError defaults status_code / retry_after to null', () => {
+        const err = makeAdapterError({
+            adapter: 'github',
+            action: 'read_pr',
+            error_type: AdapterErrorType.VALIDATION,
+            message: 'bad',
+        });
+        expect(err.status_code).toBeNull();
+        expect(err.retry_after).toBeNull();
+    });
+
+    it('is_retryable: rate_limit / timeout / network are retryable', () => {
+        for (const t of [
+            AdapterErrorType.RATE_LIMIT,
+            AdapterErrorType.TIMEOUT,
+            AdapterErrorType.NETWORK,
+        ]) {
+            const err = makeAdapterError({
+                adapter: 'github',
+                action: 'x',
+                error_type: t,
+                message: 'm',
+            });
+            expect(is_retryable(err)).toBe(true);
+        }
+    });
+
+    it('is_retryable: auth / not_found / validation / unknown are not retryable', () => {
+        for (const t of [
+            AdapterErrorType.AUTH_FAILURE,
+            AdapterErrorType.NOT_FOUND,
+            AdapterErrorType.VALIDATION,
+            AdapterErrorType.UNKNOWN,
+        ]) {
+            const err = makeAdapterError({
+                adapter: 'github',
+                action: 'x',
+                error_type: t,
+                message: 'm',
+            });
+            expect(is_retryable(err)).toBe(false);
+        }
+    });
+
+    it('classify_http_error: status-code mapping', () => {
+        const cases: Array<[number, AdapterErrorType]> = [
+            [401, AdapterErrorType.AUTH_FAILURE],
+            [403, AdapterErrorType.AUTH_FAILURE],
+            [404, AdapterErrorType.NOT_FOUND],
+            [429, AdapterErrorType.RATE_LIMIT],
+            [500, AdapterErrorType.NETWORK],
+            [502, AdapterErrorType.NETWORK],
+            [400, AdapterErrorType.UNKNOWN],
+            [418, AdapterErrorType.UNKNOWN],
+            [301, AdapterErrorType.UNKNOWN],
+        ];
+        for (const [code, expected] of cases) {
+            const err = classify_http_error('github', 'read_pr', code, 'boom');
+            expect(err.error_type).toBe(expected);
+            expect(err.adapter).toBe('github');
+            expect(err.action).toBe('read_pr');
+            expect(err.message).toBe('boom');
+            expect(err.status_code).toBe(code);
+            expect(err.retry_after).toBeNull();
+        }
+    });
+});
+
+// --- Golden parity (python3 vs tsx) -----------------------------------------
+
+const PY_HARNESS = `
+import json, sys
+sys.path.insert(0, "src/scripts")
+from tools.adapter_errors import classify_http_error
+codes = [401, 403, 404, 429, 500, 502, 400, 418, 301]
+out = []
+for c in codes:
+    e = classify_http_error("github", "read_pr", c, "boom")
+    out.append({
+        "adapter": e.adapter,
+        "action": e.action,
+        "error_type": e.error_type.value,
+        "message": e.message,
+        "status_code": e.status_code,
+        "retry_after": e.retry_after,
+        "is_retryable": e.is_retryable,
+    })
+sys.stdout.write(json.dumps(out, indent=2, sort_keys=True))
+`;
+
+const TS_HARNESS = `
+import { classify_http_error, is_retryable } from "./src/scripts/tools/adapter_errors.ts";
+const codes = [401, 403, 404, 429, 500, 502, 400, 418, 301];
+const out = codes.map((c) => {
+    const e = classify_http_error("github", "read_pr", c, "boom");
+    return {
+        adapter: e.adapter,
+        action: e.action,
+        error_type: e.error_type,
+        message: e.message,
+        status_code: e.status_code,
+        retry_after: e.retry_after,
+        is_retryable: is_retryable(e),
+    };
+});
+// Mirror json.dumps(out, indent=2, sort_keys=True): sort object keys.
+function sortKeys(v: unknown): unknown {
+    if (Array.isArray(v)) return v.map(sortKeys);
+    if (v && typeof v === "object") {
+        const o = v as Record<string, unknown>;
+        const r: Record<string, unknown> = {};
+        for (const k of Object.keys(o).sort()) r[k] = sortKeys(o[k]);
+        return r;
+    }
+    return v;
+}
+process.stdout.write(JSON.stringify(sortKeys(out), null, 2));
+`;
+
+describe.skipIf(!py3)('adapter_errors — golden parity (python3 vs tsx)', () => {
+    it('classify_http_error JSON shapes are byte-identical', () => {
+        const p = spawnSync('python3', ['-c', PY_HARNESS], { cwd: REPO_ROOT, encoding: 'utf8' });
+        const t = spawnSync(TSX_BIN, ['--eval', TS_HARNESS], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+        });
+        expect(p.status).toBe(0);
+        expect(t.status).toBe(0);
+        expect(t.stdout).toBe(p.stdout);
+    });
+});

--- a/tests/scripts/tools/base_adapter.test.ts
+++ b/tests/scripts/tools/base_adapter.test.ts
@@ -1,0 +1,201 @@
+// Tests for src/scripts/tools/base_adapter.ts (py2ts Phase 1 — tools cluster).
+//
+// Pure-unit parity for ToolAction / ToolResult, ToolResult.to_dict() with
+// Python-truthiness key omission (empty data / error dropped), and the
+// validate_action / safe_execute flow on a concrete BaseToolAdapter subclass.
+// Plus a golden-parity layer (python3 vs tsx) over to_dict across the
+// success/error/empty-data permutations, asserting the JSON shapes are
+// byte-identical. Output is fully deterministic.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    BaseToolAdapter,
+    ToolAction,
+    ToolResult,
+} from '../../../src/scripts/tools/base_adapter.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+/** Minimal concrete adapter to exercise the abstract base. */
+class FakeAdapter extends BaseToolAdapter {
+    get name(): string {
+        return 'github';
+    }
+    get supported_actions(): ReadonlySet<string> {
+        return new Set(['read_pr', 'list_files', 'create_pr']);
+    }
+    check_auth(): boolean {
+        return false;
+    }
+    execute_action(action: ToolAction): ToolResult {
+        return new ToolResult({
+            tool_name: this.name,
+            action: action.action,
+            success: true,
+            data: { ran: true },
+        });
+    }
+}
+
+describe('base_adapter — pure unit', () => {
+    it('validate_action: wrong tool', () => {
+        const a = new FakeAdapter();
+        const err = a.validate_action(
+            new ToolAction({ tool_name: 'jira', action: 'read_pr', params: {} }),
+        );
+        expect(err).not.toBeNull();
+        expect(err!).toContain('does not match');
+    });
+
+    it('validate_action: unsupported action lists sorted valid actions', () => {
+        const a = new FakeAdapter();
+        const err = a.validate_action(
+            new ToolAction({ tool_name: 'github', action: 'delete_repo', params: {} }),
+        );
+        expect(err).not.toBeNull();
+        expect(err!).toContain('not supported');
+        // sorted(supported_actions) ascending: create_pr, list_files, read_pr
+        expect(err!).toContain('valid: create_pr, list_files, read_pr');
+    });
+
+    it('validate_action: valid → null', () => {
+        const a = new FakeAdapter();
+        expect(
+            a.validate_action(new ToolAction({ tool_name: 'github', action: 'read_pr', params: {} })),
+        ).toBeNull();
+    });
+
+    it('safe_execute: rejects invalid', () => {
+        const a = new FakeAdapter();
+        const r = a.safe_execute(
+            new ToolAction({ tool_name: 'github', action: 'delete_repo', params: {} }),
+        );
+        expect(r.success).toBe(false);
+        expect(r.error).not.toBeNull();
+    });
+
+    it('safe_execute: runs valid', () => {
+        const a = new FakeAdapter();
+        const r = a.safe_execute(
+            new ToolAction({ tool_name: 'github', action: 'read_pr', params: {} }),
+        );
+        expect(r.success).toBe(true);
+        expect(r.data).not.toBeNull();
+    });
+
+    it('to_dict: success with data omits error', () => {
+        const r = new ToolResult({
+            tool_name: 'github',
+            action: 'read_pr',
+            success: true,
+            data: { id: 1 },
+        });
+        const d = r.to_dict();
+        expect(d.success).toBe(true);
+        expect((d.data as Record<string, unknown>).id).toBe(1);
+        expect('error' in d).toBe(false);
+        // key order
+        expect(Object.keys(d)).toEqual(['tool', 'action', 'success', 'data']);
+    });
+
+    it('to_dict: error omits data', () => {
+        const r = new ToolResult({
+            tool_name: 'github',
+            action: 'read_pr',
+            success: false,
+            error: 'Not found',
+        });
+        const d = r.to_dict();
+        expect(d.success).toBe(false);
+        expect(d.error).toBe('Not found');
+        expect('data' in d).toBe(false);
+    });
+
+    it('to_dict: empty dict data is omitted (Python falsy)', () => {
+        const r = new ToolResult({
+            tool_name: 'github',
+            action: 'read_pr',
+            success: true,
+            data: {},
+        });
+        const d = r.to_dict();
+        expect('data' in d).toBe(false);
+    });
+
+    it('to_dict: empty-string error is omitted (Python falsy)', () => {
+        const r = new ToolResult({
+            tool_name: 'github',
+            action: 'read_pr',
+            success: false,
+            error: '',
+        });
+        const d = r.to_dict();
+        expect('error' in d).toBe(false);
+    });
+});
+
+// --- Golden parity (python3 vs tsx) -----------------------------------------
+
+const PY_HARNESS = `
+import json, sys
+sys.path.insert(0, "src/scripts")
+from tools.base_adapter import ToolResult
+cases = [
+    ToolResult(tool_name="github", action="read_pr", success=True, data={"id": 1}),
+    ToolResult(tool_name="github", action="read_pr", success=False, error="Not found"),
+    ToolResult(tool_name="jira", action="read_ticket", success=True),  # data/error None
+    ToolResult(tool_name="github", action="x", success=True, data={}),  # empty dict
+    ToolResult(tool_name="github", action="x", success=False, error=""),  # empty str
+    ToolResult(tool_name="github", action="y", success=True, data={"scaffold": True, "params": {"a": 1}}),
+]
+out = [c.to_dict() for c in cases]
+sys.stdout.write(json.dumps(out, indent=2, sort_keys=True))
+`;
+
+const TS_HARNESS = `
+import { ToolResult } from "./src/scripts/tools/base_adapter.ts";
+const cases = [
+    new ToolResult({ tool_name: "github", action: "read_pr", success: true, data: { id: 1 } }),
+    new ToolResult({ tool_name: "github", action: "read_pr", success: false, error: "Not found" }),
+    new ToolResult({ tool_name: "jira", action: "read_ticket", success: true }),
+    new ToolResult({ tool_name: "github", action: "x", success: true, data: {} }),
+    new ToolResult({ tool_name: "github", action: "x", success: false, error: "" }),
+    new ToolResult({ tool_name: "github", action: "y", success: true, data: { scaffold: true, params: { a: 1 } } }),
+];
+const out = cases.map((c) => c.to_dict());
+function sortKeys(v: unknown): unknown {
+    if (Array.isArray(v)) return v.map(sortKeys);
+    if (v && typeof v === "object") {
+        const o = v as Record<string, unknown>;
+        const r: Record<string, unknown> = {};
+        for (const k of Object.keys(o).sort()) r[k] = sortKeys(o[k]);
+        return r;
+    }
+    return v;
+}
+process.stdout.write(JSON.stringify(sortKeys(out), null, 2));
+`;
+
+describe.skipIf(!py3)('base_adapter — golden parity (python3 vs tsx)', () => {
+    it('to_dict JSON shapes are byte-identical across permutations', () => {
+        const p = spawnSync('python3', ['-c', PY_HARNESS], { cwd: REPO_ROOT, encoding: 'utf8' });
+        const t = spawnSync(TSX_BIN, ['--eval', TS_HARNESS], { cwd: REPO_ROOT, encoding: 'utf8' });
+        expect(p.status).toBe(0);
+        expect(t.status).toBe(0);
+        expect(t.stdout).toBe(p.stdout);
+    });
+});

--- a/tests/scripts/tools/tool_adapters.test.ts
+++ b/tests/scripts/tools/tool_adapters.test.ts
@@ -1,0 +1,331 @@
+// Tests for src/scripts/tools/github_adapter.ts + jira_adapter.ts
+// (py2ts Phase 1 — tools cluster).
+//
+// Ports tests/test_tool_adapters.py 1:1 (names, supported_actions, scaffold
+// dispatch, validate/safe_execute) plus:
+//   - request-construction parity (_buildRequest URL/headers/method) asserted
+//     directly (no live network — the no-credentials path scaffolds and never
+//     reaches HTTP, exactly like the Python original), and
+//   - a golden-parity layer (python3 vs tsx) over the scaffold dispatch +
+//     to_dict shapes, with a scrubbed env so the result is deterministic and
+//     no API call is ever attempted.
+//
+// All credential env vars are cleared in-process (beforeEach) and in the
+// spawned harness env so read actions deterministically take the scaffold
+// path regardless of the developer's shell.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ToolAction } from '../../../src/scripts/tools/base_adapter.js';
+import { GITHUB_API, GitHubAdapter } from '../../../src/scripts/tools/github_adapter.js';
+import { JiraAdapter } from '../../../src/scripts/tools/jira_adapter.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+const CRED_KEYS = [
+    'GITHUB_TOKEN',
+    'JIRA_API_TOKEN',
+    'JIRA_BASE_URL',
+    'JIRA_EMAIL',
+] as const;
+
+// Snapshot + clear credential env in-process so the scaffold path is
+// deterministic; restore afterward to avoid leaking into sibling suites.
+const _saved: Record<string, string | undefined> = {};
+beforeEach(() => {
+    for (const k of CRED_KEYS) {
+        _saved[k] = process.env[k];
+        delete process.env[k];
+    }
+});
+afterEach(() => {
+    for (const k of CRED_KEYS) {
+        if (_saved[k] === undefined) delete process.env[k];
+        else process.env[k] = _saved[k];
+    }
+});
+
+// --- Base / validate via GitHubAdapter (mirrors test_tool_adapters.py) ------
+
+describe('tool adapters — ported pytest suite', () => {
+    it('validate_action wrong tool', () => {
+        const a = new GitHubAdapter();
+        const err = a.validate_action(
+            new ToolAction({ tool_name: 'jira', action: 'read_pr', params: {} }),
+        );
+        expect(err).not.toBeNull();
+        expect(err!).toContain('does not match');
+    });
+
+    it('validate_action unsupported', () => {
+        const a = new GitHubAdapter();
+        const err = a.validate_action(
+            new ToolAction({ tool_name: 'github', action: 'delete_repo', params: {} }),
+        );
+        expect(err).not.toBeNull();
+        expect(err!).toContain('not supported');
+    });
+
+    it('validate_action valid', () => {
+        const a = new GitHubAdapter();
+        expect(
+            a.validate_action(
+                new ToolAction({ tool_name: 'github', action: 'read_pr', params: {} }),
+            ),
+        ).toBeNull();
+    });
+
+    it('safe_execute rejects invalid', () => {
+        const a = new GitHubAdapter();
+        const r = a.safe_execute(
+            new ToolAction({ tool_name: 'github', action: 'delete_repo', params: {} }),
+        );
+        expect(r.success).toBe(false);
+        expect(r.error).not.toBeNull();
+    });
+
+    it('safe_execute runs valid (scaffold)', () => {
+        const a = new GitHubAdapter();
+        const r = a.safe_execute(
+            new ToolAction({ tool_name: 'github', action: 'read_pr', params: { pr_number: 42 } }),
+        );
+        expect(r.success).toBe(true);
+        expect(r.data).not.toBeNull();
+    });
+
+    // GitHub
+    it('github name', () => {
+        expect(new GitHubAdapter().name).toBe('github');
+    });
+
+    it('github supported_actions', () => {
+        const actions = new GitHubAdapter().supported_actions;
+        expect(actions.has('read_pr')).toBe(true);
+        expect(actions.has('create_pr')).toBe(true);
+        expect(actions.has('list_files')).toBe(true);
+    });
+
+    it('github all actions scaffold', () => {
+        const a = new GitHubAdapter();
+        for (const action_name of a.supported_actions) {
+            const r = a.execute_action(
+                new ToolAction({ tool_name: 'github', action: action_name, params: { test: true } }),
+            );
+            expect(r.success, `Action ${action_name} failed`).toBe(true);
+            expect(r.data).not.toBeNull();
+            expect((r.data as Record<string, unknown>).scaffold).toBe(true);
+        }
+    });
+
+    // Jira
+    it('jira name', () => {
+        expect(new JiraAdapter().name).toBe('jira');
+    });
+
+    it('jira supported_actions', () => {
+        const actions = new JiraAdapter().supported_actions;
+        expect(actions.has('read_ticket')).toBe(true);
+        expect(actions.has('search_tickets')).toBe(true);
+        expect(actions.has('add_comment')).toBe(true);
+    });
+
+    it('jira all actions scaffold', () => {
+        const a = new JiraAdapter();
+        for (const action_name of a.supported_actions) {
+            const r = a.execute_action(
+                new ToolAction({ tool_name: 'jira', action: action_name, params: { test: true } }),
+            );
+            expect(r.success, `Action ${action_name} failed`).toBe(true);
+            expect(r.data).not.toBeNull();
+        }
+    });
+
+    it('github unsupported action via execute_action', () => {
+        const a = new GitHubAdapter();
+        const r = a.execute_action(
+            new ToolAction({ tool_name: 'github', action: 'no_such', params: {} }),
+        );
+        expect(r.success).toBe(false);
+        expect(r.error).toBe('Unsupported action: no_such');
+    });
+});
+
+// --- Request construction parity (no live network) --------------------------
+
+describe('request construction (no live network)', () => {
+    it('github _buildRequest: no token → no Authorization header', () => {
+        const a = new GitHubAdapter();
+        const req = a._buildRequest('/repos/o/r/pulls/1');
+        expect(req.url).toBe(`${GITHUB_API}/repos/o/r/pulls/1`);
+        expect(req.headers.Accept).toBe('application/vnd.github+json');
+        expect('Authorization' in req.headers).toBe(false);
+        expect(req.method).toBe('GET');
+        expect(req.timeout).toBe(15);
+    });
+
+    it('github _buildRequest: with token → Bearer header + lstrip leading slash', () => {
+        process.env.GITHUB_TOKEN = 'gh_tok';
+        const a = new GitHubAdapter();
+        const req = a._buildRequest('///repos/o/r/commits/abc');
+        expect(req.url).toBe(`${GITHUB_API}/repos/o/r/commits/abc`);
+        expect(req.headers.Authorization).toBe('Bearer gh_tok');
+    });
+
+    it('jira _buildRequest: email+token → Basic base64 + base-url slash strip', () => {
+        process.env.JIRA_BASE_URL = 'https://acme.atlassian.net//';
+        process.env.JIRA_API_TOKEN = 'tok';
+        process.env.JIRA_EMAIL = 'me@acme.io';
+        const a = new JiraAdapter();
+        const req = a._buildRequest('issue/ABC-1');
+        const expectedCreds = Buffer.from('me@acme.io:tok', 'utf8').toString('base64');
+        expect(req.url).toBe('https://acme.atlassian.net/rest/api/3/issue/ABC-1');
+        expect(req.headers.Authorization).toBe(`Basic ${expectedCreds}`);
+        expect(req.headers.Accept).toBe('application/json');
+    });
+
+    it('jira _buildRequest: token only → Bearer header', () => {
+        process.env.JIRA_BASE_URL = 'https://acme.atlassian.net';
+        process.env.JIRA_API_TOKEN = 'tok';
+        const a = new JiraAdapter();
+        const req = a._buildRequest('issue/ABC-1');
+        expect(req.headers.Authorization).toBe('Bearer tok');
+    });
+
+    it('jira search JQL space-encoding (all spaces → %20)', () => {
+        process.env.JIRA_BASE_URL = 'https://acme.atlassian.net';
+        process.env.JIRA_API_TOKEN = 'tok';
+        const a = new JiraAdapter();
+        // Stub the HTTP seam to capture the path instead of calling the network.
+        let capturedUrl = '';
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (a as any)._httpGetJson = (req: { url: string }) => {
+            capturedUrl = req.url;
+            return {};
+        };
+        const r = a.execute_action(
+            new ToolAction({
+                tool_name: 'jira',
+                action: 'search_tickets',
+                params: { jql: 'project = ABC AND status = Open' },
+            }),
+        );
+        expect(r.success).toBe(true);
+        expect(capturedUrl).toBe(
+            'https://acme.atlassian.net/rest/api/3/search?jql=project%20=%20ABC%20AND%20status%20=%20Open&maxResults=20',
+        );
+    });
+
+    it('github read_pr with token routes through HTTP seam, not scaffold', () => {
+        process.env.GITHUB_TOKEN = 'gh_tok';
+        const a = new GitHubAdapter();
+        let capturedUrl = '';
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (a as any)._httpGetJson = (req: { url: string }) => {
+            capturedUrl = req.url;
+            return { number: 7 };
+        };
+        const r = a.execute_action(
+            new ToolAction({
+                tool_name: 'github',
+                action: 'read_pr',
+                params: { owner: 'o', repo: 'r', number: '7' },
+            }),
+        );
+        expect(r.success).toBe(true);
+        expect(capturedUrl).toBe(`${GITHUB_API}/repos/o/r/pulls/7`);
+        expect((r.data as Record<string, unknown>).number).toBe(7);
+        // Not a scaffold result.
+        expect((r.data as Record<string, unknown>).scaffold).toBeUndefined();
+    });
+});
+
+// --- Golden parity (python3 vs tsx) — scaffold dispatch + to_dict -----------
+
+const PY_HARNESS = `
+import json, sys
+sys.path.insert(0, "src/scripts")
+from tools.github_adapter import GitHubAdapter
+from tools.jira_adapter import JiraAdapter
+from tools.base_adapter import ToolAction
+
+def run(adapter):
+    out = []
+    for action_name in sorted(adapter.supported_actions):
+        action = ToolAction(tool_name=adapter.name, action=action_name, params={"test": True, "b": "x"})
+        out.append(adapter.execute_action(action).to_dict())
+    # one validation rejection + one unsupported dispatch
+    bad = ToolAction(tool_name="other", action=sorted(adapter.supported_actions)[0], params={})
+    out.append(adapter.safe_execute(bad).to_dict())
+    unsup = ToolAction(tool_name=adapter.name, action="zzz_no_such", params={})
+    out.append(adapter.execute_action(unsup).to_dict())
+    return out
+
+result = {"github": run(GitHubAdapter()), "jira": run(JiraAdapter())}
+sys.stdout.write(json.dumps(result, indent=2, sort_keys=True))
+`;
+
+const TS_HARNESS = `
+import { GitHubAdapter } from "./src/scripts/tools/github_adapter.ts";
+import { JiraAdapter } from "./src/scripts/tools/jira_adapter.ts";
+import { ToolAction, BaseToolAdapter } from "./src/scripts/tools/base_adapter.ts";
+
+function run(adapter: BaseToolAdapter) {
+    const actions = [...adapter.supported_actions].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const out: unknown[] = [];
+    for (const action_name of actions) {
+        const action = new ToolAction({ tool_name: adapter.name, action: action_name, params: { test: true, b: "x" } });
+        out.push(adapter.execute_action(action).to_dict());
+    }
+    const bad = new ToolAction({ tool_name: "other", action: actions[0]!, params: {} });
+    out.push(adapter.safe_execute(bad).to_dict());
+    const unsup = new ToolAction({ tool_name: adapter.name, action: "zzz_no_such", params: {} });
+    out.push(adapter.execute_action(unsup).to_dict());
+    return out;
+}
+
+const result = { github: run(new GitHubAdapter()), jira: run(new JiraAdapter()) };
+function sortKeys(v: unknown): unknown {
+    if (Array.isArray(v)) return v.map(sortKeys);
+    if (v && typeof v === "object") {
+        const o = v as Record<string, unknown>;
+        const r: Record<string, unknown> = {};
+        for (const k of Object.keys(o).sort()) r[k] = sortKeys(o[k]);
+        return r;
+    }
+    return v;
+}
+process.stdout.write(JSON.stringify(sortKeys(result), null, 2));
+`;
+
+describe.skipIf(!py3)('tool adapters — golden parity (python3 vs tsx)', () => {
+    it('scaffold dispatch + to_dict are byte-identical', () => {
+        const scrubbedEnv = { ...process.env };
+        for (const k of CRED_KEYS) delete scrubbedEnv[k];
+        const p = spawnSync('python3', ['-c', PY_HARNESS], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+            env: scrubbedEnv,
+        });
+        const t = spawnSync(TSX_BIN, ['--eval', TS_HARNESS], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+            env: scrubbedEnv,
+        });
+        expect(p.status).toBe(0);
+        expect(t.status).toBe(0);
+        expect(t.stdout).toBe(p.stdout);
+    });
+});


### PR DESCRIPTION
Ports six self-contained Phase-8 scripts to byte-identical TypeScript twins. Targets `python2ts`. `.py` originals stay until the Phase 12 sweep.

## Twins

| Cluster | Files |
|---|---|
| `src/scripts/tools/` adapters | `adapter_errors`, `base_adapter`, `github_adapter`, `jira_adapter` |
| misc | `adr/regenerate_index`, `prediction-pool/score_ev` |

64 golden-parity / unit tests (tools 35, adr 18, score_ev 11). legacy-literal ts==py==0 for all six. tsc clean, phase-gate passes.

## Notes

- **tools adapters**: credentials read from `process.env` (no embedded secrets, per tool-safety). The credentialed HTTP path uses a sync `curl` subprocess (Node has no sync fetch) replaying the identical request shape; tests stub the seam and assert request-construction + response-handling parity — no live calls. Scaffold fallback when env unset.
- **adr/regenerate_index**: byte-identical `INDEX.md` incl. the duplicate-number / mismatch / dangling-supersedes error paths (the orchestrator relies on this after ADR changes).
- **score_ev**: EV scoring, no RNG — byte-exact (no float divergence). Its RNG siblings `poisson_sim`/`pool_winsim` use Python's seeded `random.Random` (Mersenne Twister) and are deferred to a dedicated wave (they need an MT19937 port for byte parity).

## Verification

`tsc` clean · phase-gate passes · 64/64 tests green locally · no node-less-workflow gap. Full 4-shard run validates on this PR's CI.