### PR TITLE
feat(py2ts): phase 8 — runtime_dispatcher + chat_history (dedup tools.ts) + tests.yml node prep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,21 @@ jobs:
         # tests actually run instead of skipping (ADR-062 must-have #1).
         run: pip install pytest pytest-xdist pyyaml jsonschema cryptography
 
+      # py2ts (ADR-094): the bootstrap + dispatcher + ci-summary steps below
+      # invoke `./scripts-run`, which execs `tsx` whenever the target's `.ts`
+      # twin exists. condense / runtime_dispatcher / ci_summary are already
+      # ported, so this job needs node + node_modules — without it the
+      # scripts-run calls fail (exec tsx: no node_modules) once these twins
+      # reach main. (No-op on a tree where the targets are still .py: the
+      # scripts-run python fast-path skips tsx entirely.)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install node deps (for scripts-run tsx targets)
+        run: npm ci
+
       - name: Bootstrap generated projection (.augment/, .cursor/, …)
         # The Phase-2.4 install_global tests deploy content from
         # `.augment/rules`, `.cursor/rules`, etc. into a fake user-scope

--- a/src/scripts/chat_history.ts
+++ b/src/scripts/chat_history.ts
@@ -1,0 +1,2301 @@
+// Persistent chat-history log for crash recovery.
+//
+// TypeScript twin of `src/scripts/chat_history.py` (ADR-094 — Python→TS
+// migration). Public API mirrors the Python module exactly (snake_case kept
+// deliberately) so callers — including the MCP tools layer
+// (`src/scripts/mcp_server/tools.ts`) — depend on one source of truth.
+//
+// Maintains `agents/runtime/.agent-chat-history` — a JSONL file whose
+// first line is a header (schema version, started timestamp, cadence
+// frequency) and whose remaining lines are append-only entries (user
+// messages, phases, tool calls, questions, answers, decisions, commits).
+//
+// Sessions are identified per-entry via the `s` field — a deterministic
+// 16-char prefix derived from the platform's `session_id`. Multiple
+// sessions coexist in one file; each entry self-identifies. No ownership
+// layer, no sidecar, no auto-adopt — every hook invocation simply appends
+// with its own session tag.
+//
+// File path defaults to `agents/runtime/.agent-chat-history` (relative to CWD)
+// and can be overridden via `$AGENT_CHAT_HISTORY_FILE` (used by tests).
+//
+// Byte-parity contract: every on-disk JSONL line is rendered with the
+// Python `json.dumps(obj, ensure_ascii=False)` separators (`", "` / `": "`,
+// non-ASCII kept verbatim, integer-valued floats via the PyFloat marker).
+// `status`/`read`/`sessions --json` emit `json.dumps(..., indent=2,
+// ensure_ascii=False)`. The CLI mirrors argparse exit codes (0 ok, 2 bad
+// args) and the exercised argparse error/usage strings.
+//
+// Usage:
+//     ./scripts-run src/scripts/chat_history init [--freq per_phase]
+//     ./scripts-run src/scripts/chat_history append --type phase --json '{...}'
+//     ./scripts-run src/scripts/chat_history status
+//     ./scripts-run src/scripts/chat_history reset --entries-json '[...]' [--freq per_phase]
+//     ./scripts-run src/scripts/chat_history prepend --entries-json '[...]'
+//     ./scripts-run src/scripts/chat_history read [--last N | --all] [--session <id>]
+//     ./scripts-run src/scripts/chat_history sessions [--limit N] [--json]
+//     ./scripts-run src/scripts/chat_history prune-sessions [--max N] [--dry-run]
+//     ./scripts-run src/scripts/chat_history clear
+//     ./scripts-run src/scripts/chat_history rotate --max-kb 256 --mode rotate
+
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { load_agent_settings } from './_lib/agent_settings.js';
+
+export const DEFAULT_FILE = 'agents/runtime/.agent-chat-history';
+export const DEFAULT_SETTINGS_FILE = '.agent-settings.yml';
+export const SCHEMA_VERSION = 4;
+export const DEFAULT_MAX_SESSIONS = 5;
+export const VALID_FREQS: ReadonlySet<string> = new Set(['per_turn', 'per_phase', 'per_tool']);
+export const VALID_OVERFLOW: ReadonlySet<string> = new Set(['rotate', 'condense']);
+
+// Replay-mode signal — when set, every write to the on-disk transcript
+// is a no-op. Honoured per `docs/contracts/hook-architecture-v1.md`
+// § Replay mode so fixture dispatches never mutate real session state.
+export const REPLAY_ENV_VAR = 'AGENT_CONFIG_REPLAY';
+
+function _is_replay_mode(): boolean {
+    return (process.env[REPLAY_ENV_VAR] ?? '').trim() === '1';
+}
+
+const _WS_RE = /\s+/g;
+export const SESSION_ID_LEN = 16;
+export const SESSION_ID_UNKNOWN = '<unknown>';
+export const SESSION_ID_LEGACY = '<legacy>';
+// Sentinel for entries without an `agent` field — legacy rows or
+// direct `append` calls that bypassed the platform-hook surface.
+export const AGENT_UNKNOWN = '<unknown>';
+
+// Per-entry-type text-length caps. 0 = full text, no whitespace collapse,
+// verbatim. N > 0 = collapse whitespace then slice to N chars and append a
+// "… [+K chars]" suffix so the log self-reports truncation. Overridable via
+// chat_history.text_limits.{user,agent,tool,phase} in .agent-settings.yml.
+export const DEFAULT_TEXT_LIMITS: Readonly<Record<string, number>> = {
+    user: 0,
+    agent: 5000,
+    tool: 200,
+    phase: 200,
+};
+
+// Exit codes for the CLI. Distinct codes let shell callers branch on state.
+export const EXIT_OK = 0;
+export const EXIT_BAD_ARGS = 2;
+
+export type Entry = Record<string, unknown>;
+
+// ---------------------------------------------------------------------
+// Python-faithful JSON serialization (json.dumps parity)
+// ---------------------------------------------------------------------
+
+/**
+ * Marker for a Python `float` so json.dumps renders integer-valued floats as
+ * `0.0`, not `0`. JS has no int/float distinction; this preserves
+ * `round()` outputs (e.g. `size_kb`) byte-for-byte.
+ */
+class PyFloat {
+    constructor(readonly value: number) {}
+}
+
+function _isPlainObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v) && !(v instanceof PyFloat);
+}
+
+/** Render a string the way CPython does with `ensure_ascii=False`. */
+function _pyJsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            case '\b':
+                out += '\\b';
+                break;
+            case '\f':
+                out += '\\f';
+                break;
+            default:
+                if (code < 0x20) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    // ensure_ascii=False — keep everything >= 0x20 verbatim.
+                    out += ch;
+                }
+        }
+    }
+    return out + '"';
+}
+
+function _pyJsonNum(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+function _pyJsonFloat(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return Number.isInteger(n) ? `${n}.0` : String(n);
+}
+
+function _pyJsonScalar(value: unknown): string | null {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (value instanceof PyFloat) {
+        return _pyJsonFloat(value.value);
+    }
+    if (typeof value === 'number') {
+        return _pyJsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _pyJsonStr(value);
+    }
+    return null;
+}
+
+/** Mirror `json.dumps(obj, ensure_ascii=False)` — compact, default separators `", "` / `": "`. */
+function _pyDumps(value: unknown): string {
+    const scalar = _pyJsonScalar(value);
+    if (scalar !== null) {
+        return scalar;
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => _pyDumps(v)).join(', ')}]`;
+    }
+    if (_isPlainObject(value)) {
+        const keys = Object.keys(value);
+        const parts = keys.map((k) => `${_pyJsonStr(k)}: ${_pyDumps(value[k])}`);
+        return `{${parts.join(', ')}}`;
+    }
+    return _pyJsonStr(String(value));
+}
+
+/** Mirror `json.dumps(obj, ensure_ascii=False, indent=2)`. */
+function _pyDumpsIndent2(value: unknown, depth = 0): string {
+    const scalar = _pyJsonScalar(value);
+    if (scalar !== null) {
+        return scalar;
+    }
+    const pad = ' '.repeat(2 * (depth + 1));
+    const closePad = ' '.repeat(2 * depth);
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _pyDumpsIndent2(v, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (_isPlainObject(value)) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map(
+            (k) => `${pad}${_pyJsonStr(k)}: ${_pyDumpsIndent2(value[k], depth + 1)}`,
+        );
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _pyJsonStr(String(value));
+}
+
+// ---------------------------------------------------------------------
+// Small Python-shim helpers
+// ---------------------------------------------------------------------
+
+/** Mirror Python `str.strip()` over the ASCII + common Unicode whitespace set. */
+function _strip(s: string): string {
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/** Code-point count, mirroring Python `len(str)`. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+/** Code-point slice `s[:n]`, mirroring Python string slicing. */
+function _pySliceTo(s: string, n: number): string {
+    if (n <= 0) {
+        return '';
+    }
+    let out = '';
+    let i = 0;
+    for (const ch of s) {
+        if (i >= n) {
+            break;
+        }
+        out += ch;
+        i += 1;
+    }
+    return out;
+}
+
+/** Left-justify to `width` with spaces — mirror Python `str.ljust`. */
+function _ljust(s: string, width: number): string {
+    const pad = width - _pyLen(s);
+    return pad > 0 ? s + ' '.repeat(pad) : s;
+}
+
+/** Mirror Python `int(x)` over the values that reach it here (int-or-float numerics). */
+function _pyIntFromAny(value: unknown): number {
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+    }
+    if (typeof value === 'string') {
+        const parsed = Number.parseInt(value, 10);
+        return Number.isNaN(parsed) ? 0 : parsed;
+    }
+    return 0;
+}
+
+/** Mirror Python `round(value, ndigits)` (banker's rounding). */
+function _pyRound(value: number, ndigits = 0): number {
+    if (!Number.isFinite(value)) {
+        return value;
+    }
+    const factor = 10 ** ndigits;
+    const scaled = value * factor;
+    const floor = Math.floor(scaled);
+    const diff = scaled - floor;
+    let rounded: number;
+    const EPS = 1e-9;
+    if (Math.abs(diff - 0.5) < EPS) {
+        // Round half to even.
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    return rounded / factor;
+}
+
+// ---------------------------------------------------------------------
+// File-path resolution + timestamp
+// ---------------------------------------------------------------------
+
+export function file_path(): string {
+    return process.env.AGENT_CHAT_HISTORY_FILE || DEFAULT_FILE;
+}
+
+function _now(): string {
+    // Python: datetime.now(utc).isoformat(timespec="seconds") → "...+00:00".
+    return new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00');
+}
+
+export function fingerprint(value: string): string {
+    const normalized = _strip((value || '').replace(_WS_RE, ' '));
+    return createHash('sha256').update(normalized, 'utf-8').digest('hex');
+}
+
+export function derive_session_tag(session_id: string): string {
+    if (!session_id) {
+        return SESSION_ID_UNKNOWN;
+    }
+    return fingerprint(session_id).slice(0, SESSION_ID_LEN);
+}
+
+function _isFile(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+function _statSize(p: string): number {
+    try {
+        return fs.statSync(p).size;
+    } catch {
+        return -1;
+    }
+}
+
+// ---------------------------------------------------------------------
+// Preview / summary helpers
+// ---------------------------------------------------------------------
+
+function _preview(msg: string, n = 80): string {
+    const flat = _strip((msg || '').replace(_WS_RE, ' '));
+    return _pySliceTo(flat, n);
+}
+
+function _extract_text(obj: Entry): string {
+    let text = obj.text;
+    if (typeof text !== 'string' || !text) {
+        const payload = obj.payload;
+        if (_isPlainObject(payload)) {
+            text = payload.text;
+        }
+    }
+    return typeof text === 'string' ? text : '';
+}
+
+function _summarize_session(head: Entry[], tail: Entry[], total: number, n = 60): string {
+    const seen = new Set<Entry>();
+    const sample: Entry[] = [];
+    for (const e of [...head, ...tail]) {
+        if (seen.has(e)) {
+            continue;
+        }
+        seen.add(e);
+        sample.push(e);
+    }
+
+    const user_texts = sample
+        .filter((e) => e.t === 'user' && _extract_text(e))
+        .map((e) => _extract_text(e));
+    if (user_texts.length > 0) {
+        const first = _preview(user_texts[0] as string, n);
+        if (user_texts.length > 1 && user_texts[user_texts.length - 1] !== user_texts[0]) {
+            const last = _preview(user_texts[user_texts.length - 1] as string, n);
+            return `${first} → ${last}`;
+        }
+        return first;
+    }
+
+    // Counter.most_common() order: by count desc, insertion order for ties.
+    const counts = new Map<string, number>();
+    for (const e of sample) {
+        const k = typeof e.t === 'string' ? e.t : '?';
+        counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+    const ordered = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    const mix = ordered.map(([k, v]) => `${k}×${v}`).join(' ');
+    return `(${total} entries — no user prompts; t-mix: ${mix})`;
+}
+
+function _session_tag_enabled(): boolean {
+    return (process.env.AGENT_CHAT_HISTORY_SESSION_TAG ?? 'true').trim().toLowerCase() !== 'false';
+}
+
+function _readLines(p: string): string[] {
+    // Mirror Python readlines() / readline semantics on \n-delimited files.
+    const raw = fs.readFileSync(p, 'utf-8');
+    if (raw === '') {
+        return [];
+    }
+    const parts = raw.split('\n');
+    // Python readlines keeps the trailing-newline split shape: a file ending
+    // in "\n" yields no extra empty final element to iterate meaningfully —
+    // but split('\n') on "a\n" gives ['a','']. We keep the empty tail so the
+    // downstream `.strip() == ''` skip matches, and so index 0 is the header.
+    return parts;
+}
+
+function _last_body_session_id(p?: string | null): string {
+    const target = p ?? file_path();
+    if (!_isFile(target) || _statSize(target) === 0) {
+        return SESSION_ID_UNKNOWN;
+    }
+    let lines: string[];
+    try {
+        lines = _readLines(target);
+    } catch {
+        return SESSION_ID_UNKNOWN;
+    }
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = _strip(lines[i] ?? '');
+        if (!line) {
+            continue;
+        }
+        let obj: unknown;
+        try {
+            obj = JSON.parse(line);
+        } catch {
+            continue;
+        }
+        if (!_isPlainObject(obj) || obj.t === 'header') {
+            continue;
+        }
+        const sid = obj.s;
+        if (typeof sid === 'string' && sid) {
+            return sid;
+        }
+    }
+    return SESSION_ID_UNKNOWN;
+}
+
+// ---------------------------------------------------------------------
+// Header read / build / init / migrate
+// ---------------------------------------------------------------------
+
+export function read_header(p?: string | null): Entry | null {
+    const target = p ?? file_path();
+    if (!_isFile(target) || _statSize(target) === 0) {
+        return null;
+    }
+    let first: string;
+    try {
+        const raw = fs.readFileSync(target, 'utf-8');
+        // Python readline() → up to first '\n'.
+        first = _strip(raw.split('\n', 1)[0] ?? '');
+    } catch {
+        return null;
+    }
+    if (!first) {
+        return null;
+    }
+    try {
+        const obj = JSON.parse(first) as unknown;
+        if (!(_isPlainObject(obj) && obj.t === 'header')) {
+            return null;
+        }
+        return obj;
+    } catch {
+        return null;
+    }
+}
+
+function _build_header(freq: string): Entry {
+    return { t: 'header', v: SCHEMA_VERSION, started: _now(), freq };
+}
+
+export function init(freq = 'per_phase', options: { path?: string | null } = {}): Entry {
+    if (!VALID_FREQS.has(freq)) {
+        throw new ValueError(`freq must be one of ${_pyReprSortedList(VALID_FREQS)}`);
+    }
+    const target = options.path ?? file_path();
+    const header = _build_header(freq);
+    if (_is_replay_mode()) {
+        return header;
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, _pyDumps(header) + '\n', { encoding: 'utf-8' });
+    return header;
+}
+
+export function migrate_header(
+    p?: string | null,
+    options: { freq?: string | null } = {},
+): Entry | null {
+    const target = p ?? file_path();
+    const existing = read_header(target);
+    if (existing === null) {
+        return null;
+    }
+    let current_v: number;
+    try {
+        current_v = _pyIntFromAny(existing.v ?? 0);
+    } catch {
+        current_v = 0;
+    }
+    if (current_v >= SCHEMA_VERSION) {
+        return null;
+    }
+    let chosen_freq = options.freq || (typeof existing.freq === 'string' ? existing.freq : '') || 'per_phase';
+    if (!VALID_FREQS.has(chosen_freq)) {
+        chosen_freq = 'per_phase';
+    }
+    const new_header = _build_header(chosen_freq);
+    if (typeof existing.started === 'string') {
+        new_header.started = existing.started;
+    }
+    const raw = fs.readFileSync(target, 'utf-8');
+    // splitlines() drops the trailing newline; rebuild it on write.
+    const lines = _pySplitlines(raw);
+    if (lines.length === 0) {
+        return null;
+    }
+    lines[0] = _pyDumps(new_header);
+    _atomic_write_text(target, lines.join('\n') + '\n');
+    return new_header;
+}
+
+/** Mirror Python str.splitlines() for the subset of separators used here (\n, \r, \r\n). */
+function _pySplitlines(text: string): string[] {
+    if (text === '') {
+        return [];
+    }
+    const out: string[] = [];
+    let cur = '';
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (ch === '\n') {
+            out.push(cur);
+            cur = '';
+        } else if (ch === '\r') {
+            out.push(cur);
+            cur = '';
+            if (text[i + 1] === '\n') {
+                i += 1;
+            }
+        } else {
+            cur += ch;
+        }
+    }
+    if (cur !== '') {
+        out.push(cur);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------
+// append / atomic write / normalize / reset / prepend / clear
+// ---------------------------------------------------------------------
+
+export function append(
+    entry: Entry,
+    options: { path?: string | null | undefined; session?: string | null | undefined } = {},
+): void {
+    if (!_isPlainObject(entry) || !entry.t) {
+        throw new ValueError("entry must be a dict with non-empty 't' key");
+    }
+    if (entry.t === 'header') {
+        throw new ValueError('use init() to write the header, not append()');
+    }
+    const target = options.path ?? file_path();
+    if (!('ts' in entry)) {
+        entry.ts = _now();
+    }
+    const session = options.session;
+    if (session !== undefined && session !== null) {
+        entry.s = session;
+    } else if (!('s' in entry) && _session_tag_enabled()) {
+        entry.s = _last_body_session_id(target);
+    }
+    if (_is_replay_mode()) {
+        return;
+    }
+    fs.appendFileSync(target, _pyDumps(entry) + '\n', { encoding: 'utf-8' });
+}
+
+function _atomic_write_text(target: string, text: string): void {
+    if (_is_replay_mode()) {
+        return;
+    }
+    const suffix = path.extname(target);
+    const uniq = `${process.pid}.${createHash('sha256')
+        .update(`${process.pid}:${Date.now()}:${Math.random()}`)
+        .digest('hex')
+        .slice(0, 8)}`;
+    const tmp = target.slice(0, target.length - suffix.length) + `${suffix}.${uniq}.tmp`;
+    try {
+        fs.writeFileSync(tmp, text, { encoding: 'utf-8' });
+        fs.renameSync(tmp, target);
+    } catch (exc) {
+        try {
+            fs.unlinkSync(tmp);
+        } catch {
+            /* ignore */
+        }
+        throw exc;
+    }
+}
+
+function _normalize_entries(entries: Entry[]): Entry[] {
+    const out: Entry[] = [];
+    for (const raw of entries || []) {
+        if (!_isPlainObject(raw) || !raw.t) {
+            throw new ValueError("each entry must be a dict with non-empty 't' key");
+        }
+        if (raw.t === 'header') {
+            throw new ValueError('entries must not contain headers');
+        }
+        const e: Entry = { ...raw };
+        if (!('ts' in e)) {
+            e.ts = _now();
+        }
+        out.push(e);
+    }
+    return out;
+}
+
+export function reset_with_entries(
+    entries: Entry[],
+    freq = 'per_phase',
+    options: { path?: string | null } = {},
+): Entry {
+    if (!VALID_FREQS.has(freq)) {
+        throw new ValueError(`freq must be one of ${_pyReprSortedList(VALID_FREQS)}`);
+    }
+    const target = options.path ?? file_path();
+    const header = _build_header(freq);
+    const body = _normalize_entries(entries);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const lines = [_pyDumps(header), ...body.map((e) => _pyDumps(e))];
+    _atomic_write_text(target, lines.join('\n') + '\n');
+    return header;
+}
+
+export function prepend_entries(entries: Entry[], options: { path?: string | null } = {}): number {
+    const target = options.path ?? file_path();
+    if (!_isFile(target)) {
+        throw new FileNotFoundError(`no file at ${target}`);
+    }
+    const existing = _readLinesKeepNewline(target);
+    if (existing.length === 0) {
+        throw new ValueError(`empty file at ${target}`);
+    }
+    const header_line = existing[0] as string;
+    const body = existing.slice(1);
+    const new_lines = _normalize_entries(entries).map((e) => _pyDumps(e) + '\n');
+    _atomic_write_text(target, header_line + new_lines.join('') + body.join(''));
+    return new_lines.length;
+}
+
+/** Mirror Python readlines() — keep the trailing "\n" on each line. */
+function _readLinesKeepNewline(p: string): string[] {
+    const raw = fs.readFileSync(p, 'utf-8');
+    if (raw === '') {
+        return [];
+    }
+    const out: string[] = [];
+    let start = 0;
+    for (let i = 0; i < raw.length; i++) {
+        if (raw[i] === '\n') {
+            out.push(raw.slice(start, i + 1));
+            start = i + 1;
+        }
+    }
+    if (start < raw.length) {
+        out.push(raw.slice(start));
+    }
+    return out;
+}
+
+export function clear(options: { path?: string | null } = {}): void {
+    if (_is_replay_mode()) {
+        return;
+    }
+    const target = options.path ?? file_path();
+    if (fs.existsSync(target)) {
+        fs.unlinkSync(target);
+    }
+}
+
+// ---------------------------------------------------------------------
+// read_entries / read_entries_for_current / list_sessions / status
+// ---------------------------------------------------------------------
+
+export function read_entries(
+    options: {
+        last?: number | null | undefined;
+        path?: string | null | undefined;
+        session?: string | null | undefined;
+        agent?: string | null | undefined;
+    } = {},
+): Entry[] {
+    const target = options.path ?? file_path();
+    const last = options.last ?? null;
+    const session = options.session ?? null;
+    const agent = options.agent ?? null;
+    if (!_isFile(target)) {
+        return [];
+    }
+    let entries: Entry[] = [];
+    const lines = _readLines(target);
+    for (let i = 0; i < lines.length; i++) {
+        const line = _strip(lines[i] ?? '');
+        if (!line) {
+            continue;
+        }
+        let obj: unknown;
+        try {
+            obj = JSON.parse(line);
+        } catch {
+            continue;
+        }
+        if (i === 0 && _isPlainObject(obj) && obj.t === 'header') {
+            continue;
+        }
+        if (_isPlainObject(obj)) {
+            entries.push(obj);
+        }
+    }
+    if (session !== null) {
+        entries = entries.filter((e) => e.s === session);
+    }
+    if (agent !== null) {
+        if (agent === AGENT_UNKNOWN) {
+            entries = entries.filter((e) => !e.agent);
+        } else {
+            entries = entries.filter((e) => e.agent === agent);
+        }
+    }
+    if (last !== null && last >= 0) {
+        entries = entries.slice(entries.length - last);
+    }
+    return entries;
+}
+
+export function read_entries_for_current(
+    options: { path?: string | null; last?: number | null } = {},
+): Entry[] {
+    const target = options.path ?? file_path();
+    const last = options.last ?? null;
+    const kill = (process.env.AGENT_CHAT_HISTORY_SESSION_FILTER ?? 'true').trim().toLowerCase();
+    if (kill === 'false') {
+        return read_entries({ last, path: target, session: null });
+    }
+    return read_entries({ last, path: target, session: _last_body_session_id(target) });
+}
+
+interface SessionBucket extends Entry {
+    id: string;
+    count: number;
+    first_ts: string | null;
+    last_ts: string | null;
+    preview: string;
+    agents: string[];
+    summary?: string;
+    _head?: Entry[];
+    _tail?: Entry[];
+    _preview_from?: string;
+}
+
+export function list_sessions(
+    options: { path?: string | null; summary?: boolean } = {},
+): Entry[] {
+    const target = options.path ?? file_path();
+    const summary = options.summary ?? false;
+    const buckets = new Map<string, SessionBucket>();
+
+    const _bucket = (sid: string): SessionBucket => {
+        let b = buckets.get(sid);
+        if (b === undefined) {
+            b = { id: sid, count: 0, first_ts: null, last_ts: null, preview: '', agents: [] };
+            if (summary) {
+                b._head = [];
+                b._tail = [];
+            }
+            buckets.set(sid, b);
+        }
+        return b;
+    };
+
+    if (_isFile(target)) {
+        const lines = _readLines(target);
+        for (let i = 0; i < lines.length; i++) {
+            const line = _strip(lines[i] ?? '');
+            if (!line) {
+                continue;
+            }
+            let obj: unknown;
+            try {
+                obj = JSON.parse(line);
+            } catch {
+                continue;
+            }
+            if (!_isPlainObject(obj)) {
+                continue;
+            }
+            if (i === 0 && obj.t === 'header') {
+                continue;
+            }
+            const rawSid = obj.s;
+            const sid = typeof rawSid === 'string' && rawSid ? rawSid : SESSION_ID_LEGACY;
+            const b = _bucket(sid);
+            b.count += 1;
+            const agent = typeof obj.agent === 'string' ? obj.agent : null;
+            const tag = agent ? agent : AGENT_UNKNOWN;
+            if (!b.agents.includes(tag)) {
+                b.agents.push(tag);
+            }
+            const ts = obj.ts;
+            if (typeof ts === 'string' && ts) {
+                if (b.first_ts === null || ts < b.first_ts) {
+                    b.first_ts = ts;
+                }
+                if (b.last_ts === null || ts > b.last_ts) {
+                    b.last_ts = ts;
+                }
+            }
+            if (summary) {
+                if ((b._head as Entry[]).length < 5) {
+                    (b._head as Entry[]).push(obj);
+                }
+                const tail = b._tail as Entry[];
+                tail.push(obj);
+                if (tail.length > 5) {
+                    tail.shift();
+                }
+            }
+            if (!b.preview || b._preview_from !== 'user') {
+                if (obj.t === 'user') {
+                    const payload = _isPlainObject(obj.payload) ? obj.payload : {};
+                    const text = (obj.text || payload.text || '') as unknown;
+                    if (typeof text === 'string' && text) {
+                        b.preview = _preview(text);
+                        b._preview_from = 'user';
+                    }
+                } else if (!b.preview) {
+                    const text = (obj.text || '') as unknown;
+                    if (typeof text === 'string' && text) {
+                        b.preview = _preview(text);
+                        b._preview_from = 'any';
+                    }
+                }
+            }
+        }
+    }
+
+    const out: SessionBucket[] = [];
+    for (const b of buckets.values()) {
+        delete b._preview_from;
+        b.agents = [...b.agents].sort(_pyStrCompare);
+        if (summary) {
+            const head = (b._head as Entry[]) ?? [];
+            const tail = (b._tail as Entry[]) ?? [];
+            delete b._head;
+            delete b._tail;
+            b.summary = _summarize_session(head, tail, b.count);
+        }
+        out.push(b);
+    }
+    out.sort((a, b) => _pyStrCompare(b.last_ts || '', a.last_ts || ''));
+    return out;
+}
+
+export function status(options: { path?: string | null } = {}): Entry {
+    const target = options.path ?? file_path();
+    if (!_isFile(target)) {
+        return { exists: false, path: target };
+    }
+    const header = read_header(target);
+    let entry_count = 0;
+    const per_agent = new Map<string, number>();
+    const lines = _readLines(target);
+    for (let i = 0; i < lines.length; i++) {
+        const line = _strip(lines[i] ?? '');
+        if (!line) {
+            continue;
+        }
+        let obj: unknown;
+        try {
+            obj = JSON.parse(line);
+        } catch {
+            continue;
+        }
+        if (!_isPlainObject(obj)) {
+            continue;
+        }
+        if (i === 0 && obj.t === 'header') {
+            continue;
+        }
+        entry_count += 1;
+        const agent = typeof obj.agent === 'string' ? obj.agent : null;
+        const tag = agent ? agent : AGENT_UNKNOWN;
+        per_agent.set(tag, (per_agent.get(tag) ?? 0) + 1);
+    }
+    const size = _statSize(target);
+    const sortedAgents = [...per_agent.entries()].sort((a, b) => _pyStrCompare(a[0], b[0]));
+    const per_agent_obj: Record<string, number> = {};
+    for (const [k, v] of sortedAgents) {
+        per_agent_obj[k] = v;
+    }
+    const agents = { total: per_agent.size, per_agent: per_agent_obj };
+    return {
+        exists: true,
+        path: target,
+        size_bytes: size,
+        size_kb: new PyFloat(_pyRound(size / 1024, 1)),
+        entries: entry_count,
+        header,
+        agents,
+    };
+}
+
+/** Mirror Python string comparison (by Unicode code point, lexicographic). */
+function _pyStrCompare(a: string, b: string): number {
+    if (a < b) {
+        return -1;
+    }
+    if (a > b) {
+        return 1;
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------
+// Settings access
+// ---------------------------------------------------------------------
+
+function _load_chat_history_section(settings_path: string): Record<string, unknown> | null {
+    const data = load_agent_settings({ project_path: settings_path });
+    const section = (data as Record<string, unknown>).chat_history;
+    return _isPlainObject(section) ? section : null;
+}
+
+function _read_chat_history_enabled(settings_path: string): boolean {
+    const section = _load_chat_history_section(settings_path);
+    if (section === null) {
+        return false;
+    }
+    return _pyBool(section.enabled ?? false);
+}
+
+function _pyBool(v: unknown): boolean {
+    if (v === null || v === undefined || v === false) {
+        return false;
+    }
+    if (v === true) {
+        return true;
+    }
+    if (typeof v === 'number') {
+        return v !== 0;
+    }
+    if (typeof v === 'string') {
+        return v.length > 0;
+    }
+    if (Array.isArray(v)) {
+        return v.length > 0;
+    }
+    if (_isPlainObject(v)) {
+        return Object.keys(v).length > 0;
+    }
+    return true;
+}
+
+// Hook events that the platform-hook wrapper accepts.
+export const VALID_HOOK_EVENTS: readonly string[] = [
+    'session_start',
+    'session_end',
+    'user_prompt',
+    'agent_response',
+    'tool_use',
+    'phase',
+    'stop',
+];
+const VALID_HOOK_EVENTS_SET = new Set(VALID_HOOK_EVENTS);
+
+export const HOOK_EVENT_ENTRY_TYPE: Readonly<Record<string, string>> = {
+    user_prompt: 'user',
+    agent_response: 'agent',
+    tool_use: 'tool',
+    phase: 'phase',
+    stop: 'agent',
+    session_end: 'phase',
+};
+
+export const CADENCE_EVENTS: Readonly<Record<string, ReadonlySet<string>>> = {
+    per_turn: new Set(['stop', 'agent_response', 'user_prompt']),
+    per_phase: new Set(['phase', 'stop', 'user_prompt']),
+    per_tool: new Set(['tool_use']),
+};
+
+export const PLATFORM_EVENT_MAP: Readonly<Record<string, Record<string, string>>> = {
+    claude: {
+        SessionStart: 'session_start',
+        UserPromptSubmit: 'user_prompt',
+        PostToolUse: 'tool_use',
+        Stop: 'stop',
+        SessionEnd: 'session_end',
+        PreCompact: 'phase',
+    },
+    cowork: {
+        SessionStart: 'session_start',
+        UserPromptSubmit: 'user_prompt',
+        PostToolUse: 'tool_use',
+        Stop: 'stop',
+        SessionEnd: 'session_end',
+        PreCompact: 'phase',
+    },
+    augment: {
+        SessionStart: 'session_start',
+        Stop: 'stop',
+        PostToolUse: 'tool_use',
+        SessionEnd: 'session_end',
+    },
+    cursor: {
+        sessionStart: 'session_start',
+        sessionEnd: 'session_end',
+        afterAgentResponse: 'agent_response',
+        stop: 'stop',
+        postToolUse: 'tool_use',
+        beforeSubmitPrompt: 'user_prompt',
+    },
+    cline: {
+        TaskStart: 'session_start',
+        TaskComplete: 'session_end',
+        UserPromptSubmit: 'user_prompt',
+        PostToolUse: 'tool_use',
+    },
+    windsurf: {
+        pre_user_prompt: 'user_prompt',
+        post_cascade_response: 'agent_response',
+        post_cascade_response_with_transcript: 'agent_response',
+        post_setup_worktree: 'phase',
+    },
+    gemini: {
+        SessionStart: 'session_start',
+        AfterAgent: 'agent_response',
+        AfterTool: 'tool_use',
+        SessionEnd: 'session_end',
+    },
+    generic: Object.fromEntries(VALID_HOOK_EVENTS.map((ev) => [ev, ev])),
+};
+export const VALID_PLATFORMS: readonly string[] = Object.keys(PLATFORM_EVENT_MAP);
+
+function _read_chat_history_frequency(settings_path: string): string {
+    const section = _load_chat_history_section(settings_path);
+    if (section === null) {
+        return 'per_phase';
+    }
+    const val = String(section.frequency ?? 'per_phase').toLowerCase();
+    return VALID_FREQS.has(val) ? val : 'per_phase';
+}
+
+function _read_chat_history_max_sessions(settings_path: string): number {
+    const section = _load_chat_history_section(settings_path);
+    if (section === null) {
+        return DEFAULT_MAX_SESSIONS;
+    }
+    const rawN = section.max_sessions ?? DEFAULT_MAX_SESSIONS;
+    let n: number;
+    if (typeof rawN === 'number' && Number.isFinite(rawN)) {
+        n = Math.trunc(rawN);
+    } else if (typeof rawN === 'string') {
+        const parsed = Number.parseInt(rawN, 10);
+        if (Number.isNaN(parsed)) {
+            return DEFAULT_MAX_SESSIONS;
+        }
+        n = parsed;
+    } else {
+        return DEFAULT_MAX_SESSIONS;
+    }
+    return Math.max(1, n);
+}
+
+function _read_text_limits(settings_path: string): Record<string, number> {
+    const out: Record<string, number> = { ...DEFAULT_TEXT_LIMITS };
+    const section = _load_chat_history_section(settings_path);
+    if (section === null) {
+        return out;
+    }
+    const overrides = section.text_limits;
+    if (!_isPlainObject(overrides)) {
+        return out;
+    }
+    for (const [kind, val] of Object.entries(overrides)) {
+        let n: number;
+        if (typeof val === 'number' && Number.isFinite(val)) {
+            n = Math.trunc(val);
+        } else if (typeof val === 'string') {
+            const parsed = Number.parseInt(val, 10);
+            if (Number.isNaN(parsed)) {
+                continue;
+            }
+            n = parsed;
+        } else {
+            continue;
+        }
+        out[kind] = Math.max(0, n);
+    }
+    return out;
+}
+
+function _apply_text_limit(text: string, kind: string, limits: Record<string, number>): string {
+    if (!text) {
+        return '';
+    }
+    const n = limits[kind] ?? DEFAULT_TEXT_LIMITS[kind] ?? 0;
+    if (n <= 0) {
+        return text;
+    }
+    const flat = _strip(text.replace(_WS_RE, ' '));
+    if (_pyLen(flat) <= n) {
+        return flat;
+    }
+    return `${_pySliceTo(flat, n)} … [+${_pyLen(flat) - n} chars]`;
+}
+
+// ---------------------------------------------------------------------
+// prune_sessions / overflow_handle
+// ---------------------------------------------------------------------
+
+export function prune_sessions(
+    max_sessions = DEFAULT_MAX_SESSIONS,
+    options: { path?: string | null } = {},
+): Entry {
+    if (max_sessions < 1) {
+        max_sessions = 1;
+    }
+    const target = options.path ?? file_path();
+    if (!_isFile(target)) {
+        return { action: 'noop', kept_sessions: 0, dropped_sessions: 0, dropped_entries: 0 };
+    }
+    const lines = _readLinesKeepNewline(target);
+    if (lines.length <= 1) {
+        return { action: 'noop', kept_sessions: 0, dropped_sessions: 0, dropped_entries: 0 };
+    }
+    const header_line = lines[0] as string;
+    const body = lines.slice(1);
+    const last_pos = new Map<string, number>();
+    const parsed: Array<[string, string]> = [];
+    for (let idx = 0; idx < body.length; idx++) {
+        const line = body[idx] as string;
+        const stripped = _strip(line);
+        if (!stripped) {
+            continue;
+        }
+        let obj: unknown;
+        try {
+            obj = JSON.parse(stripped);
+        } catch {
+            parsed.push([SESSION_ID_LEGACY, line]);
+            last_pos.set(SESSION_ID_LEGACY, idx);
+            continue;
+        }
+        if (!_isPlainObject(obj)) {
+            continue;
+        }
+        const sid = typeof obj.s === 'string' ? obj.s : SESSION_ID_LEGACY;
+        parsed.push([sid, line]);
+        last_pos.set(sid, idx);
+    }
+    if (last_pos.size <= max_sessions) {
+        return {
+            action: 'noop',
+            kept_sessions: last_pos.size,
+            dropped_sessions: 0,
+            dropped_entries: 0,
+        };
+    }
+    const ranked = [...last_pos.entries()].sort((a, b) => b[1] - a[1]);
+    const keep_set = new Set(ranked.slice(0, max_sessions).map(([sid]) => sid));
+    const drop_set = new Set(ranked.slice(max_sessions).map(([sid]) => sid));
+    const kept_lines = parsed.filter(([sid]) => keep_set.has(sid)).map(([, line]) => line);
+    const dropped_entries = parsed.length - kept_lines.length;
+    _atomic_write_text(target, header_line + kept_lines.join(''));
+    return {
+        action: 'pruned',
+        kept_sessions: keep_set.size,
+        dropped_sessions: drop_set.size,
+        dropped_entries,
+    };
+}
+
+export function overflow_handle(
+    max_kb: number,
+    mode = 'rotate',
+    options: { path?: string | null } = {},
+): Entry {
+    if (!VALID_OVERFLOW.has(mode)) {
+        throw new ValueError(`mode must be one of ${_pyReprSortedList(VALID_OVERFLOW)}`);
+    }
+    const target = options.path ?? file_path();
+    if (!_isFile(target) || _statSize(target) <= max_kb * 1024) {
+        return { action: 'noop', kept: null, dropped: 0 };
+    }
+    const lines = _readLinesKeepNewline(target);
+    if (lines.length === 0) {
+        return { action: 'noop', kept: 0, dropped: 0 };
+    }
+    const header_line = lines[0] as string;
+    const entries = lines.slice(1);
+    if (mode === 'rotate') {
+        const budget = max_kb * 1024 - Buffer.byteLength(header_line, 'utf-8');
+        const kept: string[] = [];
+        let total = 0;
+        for (let i = entries.length - 1; i >= 0; i--) {
+            const line = entries[i] as string;
+            const size = Buffer.byteLength(line, 'utf-8');
+            if (total + size > budget) {
+                break;
+            }
+            kept.push(line);
+            total += size;
+        }
+        kept.reverse();
+        const dropped = entries.length - kept.length;
+        _atomic_write_text(target, header_line + kept.join(''));
+        return { action: 'rotate', kept: kept.length, dropped };
+    }
+    const marker: Entry = {
+        t: 'needs_condense',
+        ts: _now(),
+        reason: `file exceeded ${max_kb} KB, condense-mode requested`,
+    };
+    append(marker, { path: target });
+    return { action: 'condense_marked', kept: entries.length, dropped: 0 };
+}
+
+// ---------------------------------------------------------------------
+// hook_append / hook_dispatch + per-platform extractors
+// ---------------------------------------------------------------------
+
+export function hook_append(
+    event: string,
+    options: {
+        session_id?: string | null | undefined;
+        payload?: Entry | null | undefined;
+        path?: string | null | undefined;
+        settings_path?: string | null | undefined;
+        dry_run?: boolean | undefined;
+    } = {},
+): Entry {
+    if (!VALID_HOOK_EVENTS_SET.has(event)) {
+        throw new ValueError(`event must be one of ${_pyReprSortedListArr(VALID_HOOK_EVENTS)}`);
+    }
+    const dry_run = options.dry_run ?? false;
+    const sp = options.settings_path ?? DEFAULT_SETTINGS_FILE;
+    if (!_read_chat_history_enabled(sp)) {
+        const out: Entry = { action: 'disabled', event };
+        if (dry_run) {
+            out.dry_run = true;
+        }
+        return out;
+    }
+    const target = options.path ?? file_path();
+    const payload = options.payload ?? {};
+    const session_id = options.session_id ?? null;
+    const s_tag = session_id ? derive_session_tag(session_id) : SESSION_ID_UNKNOWN;
+
+    const prior_s = _isFile(target) ? _last_body_session_id(target) : SESSION_ID_UNKNOWN;
+    const is_new_session =
+        s_tag !== SESSION_ID_UNKNOWN && prior_s !== SESSION_ID_UNKNOWN && prior_s !== s_tag;
+    if (is_new_session) {
+        process.stderr.write(
+            `chat-history session_rotation event=${event} prior_s=${prior_s} new_s=${s_tag}\n`,
+        );
+    }
+
+    if (!dry_run) {
+        if (!_isFile(target) || read_header(target) === null) {
+            const freq = _read_chat_history_frequency(sp);
+            init(freq, { path: target });
+        } else {
+            migrate_header(target, { freq: _read_chat_history_frequency(sp) });
+        }
+    }
+
+    const _maybe_prune = (): void => {
+        if (dry_run || !is_new_session) {
+            return;
+        }
+        const max_n = _read_chat_history_max_sessions(sp);
+        try {
+            prune_sessions(max_n, { path: target });
+        } catch (exc) {
+            process.stderr.write(`chat-history prune_failed: ${_excStr(exc)}\n`);
+        }
+    };
+
+    if (event === 'session_start') {
+        _maybe_prune();
+        const action = 'session_start_noop';
+        const out: Entry = { action: dry_run ? 'dry_run' : action, event, s: s_tag };
+        if (dry_run) {
+            out.would_action = action;
+            out.dry_run = true;
+        }
+        return out;
+    }
+    if (event === 'session_end') {
+        _maybe_prune();
+        const action = 'session_end_noop';
+        const out: Entry = { action: dry_run ? 'dry_run' : action, event, s: s_tag };
+        if (dry_run) {
+            out.would_action = action;
+            out.dry_run = true;
+        }
+        return out;
+    }
+
+    const freq = _read_chat_history_frequency(sp);
+    if (!(CADENCE_EVENTS[freq] ?? new Set<string>()).has(event)) {
+        const out: Entry = { action: 'skipped_cadence', event, frequency: freq };
+        if (dry_run) {
+            out.dry_run = true;
+        }
+        return out;
+    }
+
+    const entry_type = HOOK_EVENT_ENTRY_TYPE[event] ?? 'agent';
+    const limits = _read_text_limits(sp);
+    const entry: Entry = { t: entry_type };
+    const text = String((payload as Entry).text ?? '');
+    if (text) {
+        const sliced = _apply_text_limit(text, entry_type, limits);
+        if (sliced) {
+            entry.text = sliced;
+        }
+    }
+    if (event === 'tool_use') {
+        const tool = (payload as Entry).tool;
+        if (tool) {
+            entry.tool = String(tool);
+        }
+    }
+    for (const k of ['agent', 'source', 'phase', 'decision']) {
+        const v = (payload as Entry)[k];
+        if (v) {
+            entry[k] = String(v);
+        }
+    }
+    if (dry_run) {
+        const preview: Entry = { ...entry };
+        preview.s = s_tag;
+        return {
+            action: 'dry_run',
+            would_action: 'appended',
+            event,
+            type: entry_type,
+            s: s_tag,
+            entry_preview: preview,
+            dry_run: true,
+        };
+    }
+    append(entry, { path: target, session: s_tag });
+    _maybe_prune();
+    return { action: 'appended', event, type: entry_type, s: s_tag };
+}
+
+function _extract_augment_conversation(payload: Entry): [string, string] {
+    const conv = payload.conversation;
+    if (!_isPlainObject(conv)) {
+        return ['', ''];
+    }
+    const user = conv.userPrompt;
+    const agent = conv.agentTextResponse;
+    const user_s = typeof user === 'string' ? _strip(user) : '';
+    const agent_s = typeof agent === 'string' ? _strip(agent) : '';
+    return [user_s, agent_s];
+}
+
+function _extract_claude_transcript_response(transcript_path: string): string {
+    if (!transcript_path) {
+        return '';
+    }
+    if (!_isFile(transcript_path)) {
+        return '';
+    }
+    let last_text = '';
+    let lines: string[];
+    try {
+        lines = _readLines(transcript_path);
+    } catch {
+        return '';
+    }
+    for (const rawLine of lines) {
+        const line = _strip(rawLine);
+        if (!line) {
+            continue;
+        }
+        let obj: unknown;
+        try {
+            obj = JSON.parse(line);
+        } catch {
+            continue;
+        }
+        if (!_isPlainObject(obj)) {
+            continue;
+        }
+        if (obj.type !== 'assistant') {
+            continue;
+        }
+        const msg = obj.message;
+        if (!_isPlainObject(msg)) {
+            continue;
+        }
+        const content = msg.content;
+        if (typeof content === 'string') {
+            last_text = content;
+        } else if (Array.isArray(content)) {
+            const parts: string[] = [];
+            for (const blk of content) {
+                if (_isPlainObject(blk) && blk.type === 'text') {
+                    const t = blk.text ?? '';
+                    if (typeof t === 'string') {
+                        parts.push(t);
+                    }
+                }
+            }
+            if (parts.length > 0) {
+                last_text = parts.join('\n');
+            }
+        }
+    }
+    return _strip(last_text);
+}
+
+function _extract_cursor_text(payload: Entry, event: string | null): string {
+    if (event === 'stop' || event === 'agent_response') {
+        const tp = payload.transcript_path ?? payload.transcriptPath;
+        if (typeof tp === 'string') {
+            const txt = _extract_claude_transcript_response(tp);
+            if (txt) {
+                return txt;
+            }
+        }
+    }
+    return '';
+}
+
+function _extract_cline_text(payload: Entry, event: string | null): string {
+    if (event === 'user_prompt') {
+        const v = payload.prompt ?? payload.userPrompt;
+        if (typeof v === 'string' && _strip(v)) {
+            return _strip(v);
+        }
+    }
+    return '';
+}
+
+function _extract_gemini_text(payload: Entry, event: string | null): string {
+    if (event === 'agent_response' || event === 'stop') {
+        const v = payload.prompt_response ?? payload.promptResponse;
+        if (typeof v === 'string' && _strip(v)) {
+            return _strip(v);
+        }
+        const tp = payload.transcript_path ?? payload.transcriptPath;
+        if (typeof tp === 'string') {
+            const txt = _extract_claude_transcript_response(tp);
+            if (txt) {
+                return txt;
+            }
+        }
+    }
+    return '';
+}
+
+function _extract_windsurf_text(payload: Entry, event: string | null): string {
+    if (event === 'agent_response' || event === 'stop') {
+        const info = payload.tool_info ?? payload.toolInfo;
+        if (_isPlainObject(info)) {
+            const v = info.response ?? info.text;
+            if (typeof v === 'string' && _strip(v)) {
+                return _strip(v);
+            }
+        }
+        const tp = payload.transcript_path ?? payload.transcriptPath;
+        if (typeof tp === 'string') {
+            const txt = _extract_claude_transcript_response(tp);
+            if (txt) {
+                return txt;
+            }
+        }
+    }
+    return '';
+}
+
+function _extract_hook_text(
+    payload: Entry,
+    options: { platform?: string | null; event?: string | null } = {},
+): string {
+    const platform = options.platform ?? null;
+    const event = options.event ?? null;
+    if (platform === 'augment') {
+        const [user, agent] = _extract_augment_conversation(payload);
+        if (event === 'user_prompt' && user) {
+            return user;
+        }
+        if ((event === 'stop' || event === 'agent_response') && agent) {
+            return agent;
+        }
+        if (agent) {
+            return agent;
+        }
+        if (user) {
+            return user;
+        }
+    }
+    if ((platform === 'claude' || platform === 'cowork') && (event === 'stop' || event === 'agent_response')) {
+        const tp = payload.transcript_path ?? payload.transcriptPath;
+        if (typeof tp === 'string') {
+            const txt = _extract_claude_transcript_response(tp);
+            if (txt) {
+                return txt;
+            }
+        }
+    }
+    if (platform === 'cursor') {
+        const txt = _extract_cursor_text(payload, event);
+        if (txt) {
+            return txt;
+        }
+    }
+    if (platform === 'cline') {
+        const txt = _extract_cline_text(payload, event);
+        if (txt) {
+            return txt;
+        }
+    }
+    if (platform === 'gemini') {
+        const txt = _extract_gemini_text(payload, event);
+        if (txt) {
+            return txt;
+        }
+    }
+    if (platform === 'windsurf') {
+        const txt = _extract_windsurf_text(payload, event);
+        if (txt) {
+            return txt;
+        }
+    }
+    for (const key of [
+        'prompt',
+        'user_prompt',
+        'first_user_msg',
+        'firstUserMsg',
+        'userMessage',
+        'user_message',
+        'text',
+        'response',
+        'message',
+        'content',
+    ]) {
+        const v = payload[key];
+        if (typeof v === 'string' && _strip(v)) {
+            return _strip(v);
+        }
+    }
+    const tr = payload.tool_response ?? payload.toolResponse;
+    if (_isPlainObject(tr)) {
+        for (const key of ['output', 'stdout', 'result', 'text']) {
+            const v = tr[key];
+            if (typeof v === 'string' && _strip(v)) {
+                return _strip(v);
+            }
+        }
+    }
+    return '';
+}
+
+function _extract_hook_tool(payload: Entry): string {
+    for (const key of ['tool_name', 'toolName', 'tool']) {
+        const v = payload[key];
+        if (typeof v === 'string' && _strip(v)) {
+            return _strip(v);
+        }
+    }
+    return '';
+}
+
+function _extract_hook_event(payload: Entry): string {
+    for (const key of ['hook_event_name', 'event', 'eventName', 'event_name']) {
+        const v = payload[key];
+        if (typeof v === 'string' && _strip(v)) {
+            return _strip(v);
+        }
+    }
+    return '';
+}
+
+function _extract_session_id(payload: Entry): string {
+    for (const key of ['session_id', 'sessionId', 'task_id', 'taskId', 'conversation_id', 'conversationId']) {
+        const v = payload[key];
+        if (typeof v === 'string' && _strip(v)) {
+            return _strip(v);
+        }
+    }
+    return '';
+}
+
+export function hook_dispatch(
+    platform: string,
+    raw_json: string,
+    options: {
+        event_override?: string | null;
+        path?: string | null;
+        settings_path?: string | null;
+        dry_run?: boolean;
+    } = {},
+): Entry {
+    if (!(platform in PLATFORM_EVENT_MAP)) {
+        throw new ValueError(
+            `unknown platform: ${_pyRepr(platform)}; expected one of ${_pyReprSortedListArr(VALID_PLATFORMS)}`,
+        );
+    }
+    const event_override = options.event_override ?? null;
+    const dry_run = options.dry_run ?? false;
+    const raw = _strip(raw_json || '');
+    let payload: Entry;
+    if (!raw) {
+        payload = {};
+    } else {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(raw);
+        } catch (exc) {
+            throw new ValueError(`invalid JSON on stdin: ${_excStr(exc)}`);
+        }
+        if (!_isPlainObject(parsed)) {
+            throw new ValueError('stdin JSON must decode to an object');
+        }
+        payload = parsed;
+    }
+
+    let envelope_event = '';
+    if (['schema_version', 'platform', 'event', 'payload'].every((k) => k in payload)) {
+        envelope_event = _strip(
+            String((payload.native_event as unknown) || (payload.event as unknown) || ''),
+        );
+        const inner = payload.payload;
+        payload = _isPlainObject(inner) ? inner : {};
+    }
+
+    const raw_event = _strip(
+        String(event_override || envelope_event || _extract_hook_event(payload) || ''),
+    );
+    const event = (PLATFORM_EVENT_MAP[platform] as Record<string, string>)[raw_event];
+    if (!event) {
+        return { action: 'skipped_unmapped_event', platform, raw_event };
+    }
+
+    const text = _extract_hook_text(payload, { platform, event });
+    const tool = _extract_hook_tool(payload);
+    const session_id = _extract_session_id(payload);
+
+    let augment_user_prompt = '';
+    if (platform === 'augment' && event === 'stop') {
+        const [u] = _extract_augment_conversation(payload);
+        augment_user_prompt = u;
+    }
+
+    const hook_payload: Entry = {
+        source: `hook:${platform}:${raw_event}`,
+        agent: platform,
+    };
+    if (text && event !== 'session_start') {
+        hook_payload.text = text;
+    }
+    if (tool) {
+        hook_payload.tool = tool;
+    }
+
+    if (augment_user_prompt) {
+        hook_append('user_prompt', {
+            session_id,
+            payload: {
+                text: augment_user_prompt,
+                source: `hook:${platform}:${raw_event}:user`,
+                agent: platform,
+            },
+            path: options.path,
+            settings_path: options.settings_path,
+            dry_run,
+        });
+    }
+
+    return hook_append(event, {
+        session_id,
+        payload: hook_payload,
+        path: options.path,
+        settings_path: options.settings_path,
+        dry_run,
+    });
+}
+
+// ---------------------------------------------------------------------
+// Errors mirroring Python exceptions
+// ---------------------------------------------------------------------
+
+/** Mirror Python's `ValueError`. */
+export class ValueError extends Error {}
+/** Mirror Python's `FileNotFoundError`. */
+export class FileNotFoundError extends Error {}
+
+function _excStr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+/** Mirror Python `repr(str)` for simple single-quoted strings (sufficient for the choices used here). */
+function _pyRepr(s: string): string {
+    if (!s.includes("'") || s.includes('"')) {
+        return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return `'${s}'`;
+}
+
+function _pyReprSortedList(set: ReadonlySet<string>): string {
+    const items = [...set].sort(_pyStrCompare);
+    return `[${items.map((i) => _pyRepr(i)).join(', ')}]`;
+}
+
+function _pyReprSortedListArr(arr: readonly string[]): string {
+    const items = [...arr].sort(_pyStrCompare);
+    return `[${items.map((i) => _pyRepr(i)).join(', ')}]`;
+}
+
+// ---------------------------------------------------------------------
+// CLI — argparse-faithful for the exercised surface
+// ---------------------------------------------------------------------
+
+const PROG = 'chat_history.py';
+const SUBCMDS = [
+    'init',
+    'append',
+    'status',
+    'reset',
+    'prune-sessions',
+    'prepend',
+    'clear',
+    'read',
+    'sessions',
+    'rotate',
+    'hook-append',
+    'hook-dispatch',
+];
+
+function _print(line: string): void {
+    process.stdout.write(line + '\n');
+}
+
+function _eprint(line: string): void {
+    process.stderr.write(line + '\n');
+}
+
+/** argparse top-level usage block (80-col wrap, deterministic). */
+const _TOP_USAGE =
+    `usage: ${PROG} [-h]\n` +
+    `                       {${SUBCMDS.join(',')}}\n` +
+    `                       ...\n`;
+
+function _argError(usage: string, prog: string, message: string): number {
+    process.stderr.write(usage);
+    process.stderr.write(`${prog}: error: ${message}\n`);
+    return EXIT_BAD_ARGS;
+}
+
+function _cmd_init(argv: string[]): number {
+    let freq = 'per_phase';
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--freq') {
+            freq = (argv[i + 1] as string) ?? freq;
+            i += 1;
+        } else if (a.startsWith('--freq=')) {
+            freq = a.slice('--freq='.length);
+        }
+    }
+    if (!VALID_FREQS.has(freq)) {
+        return _argError(
+            `usage: ${PROG} init [-h] [--freq {per_phase,per_tool,per_turn}]\n`,
+            `${PROG} init`,
+            `argument --freq: invalid choice: ${_pyRepr(freq)} (choose from 'per_phase', 'per_tool', 'per_turn')`,
+        );
+    }
+    const h = init(freq);
+    _print(_pyDumps(h));
+    return 0;
+}
+
+function _cmd_hook_append(argv: string[]): number {
+    let event: string | null = null;
+    let session_id: string | null = null;
+    let payloadRaw: string | null = null;
+    let settings: string | null = null;
+    let dry_run = false;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--event') {
+            event = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--event=')) {
+            event = a.slice('--event='.length);
+        } else if (a === '--session-id') {
+            session_id = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--session-id=')) {
+            session_id = a.slice('--session-id='.length);
+        } else if (a === '--payload') {
+            payloadRaw = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--payload=')) {
+            payloadRaw = a.slice('--payload='.length);
+        } else if (a === '--settings') {
+            settings = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--settings=')) {
+            settings = a.slice('--settings='.length);
+        } else if (a === '--dry-run') {
+            dry_run = true;
+        }
+    }
+    // argparse: --event is required + choices-validated before the handler.
+    const _hookAppendUsage =
+        `usage: ${PROG} hook-append [-h] --event\n` +
+        `                                {agent_response,phase,session_end,session_start,stop,tool_use,user_prompt}\n` +
+        `                                [--session-id SESSION_ID]\n` +
+        `                                [--payload PAYLOAD] [--settings SETTINGS]\n` +
+        `                                [--dry-run]\n`;
+    if (event === null) {
+        return _argError(_hookAppendUsage, `${PROG} hook-append`, 'the following arguments are required: --event');
+    }
+    if (!VALID_HOOK_EVENTS_SET.has(event)) {
+        const choices = [...VALID_HOOK_EVENTS].sort(_pyStrCompare).map((c) => _pyRepr(c)).join(', ');
+        return _argError(
+            _hookAppendUsage,
+            `${PROG} hook-append`,
+            `argument --event: invalid choice: ${_pyRepr(event)} (choose from ${choices})`,
+        );
+    }
+    let payload: Entry = {};
+    if (payloadRaw) {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(payloadRaw);
+        } catch (exc) {
+            _eprint(`error: --payload must be valid JSON: ${_excStr(exc)}`);
+            return EXIT_BAD_ARGS;
+        }
+        if (!_isPlainObject(parsed)) {
+            _eprint('error: --payload must decode to a JSON object');
+            return EXIT_BAD_ARGS;
+        }
+        payload = parsed;
+    }
+    try {
+        const result = hook_append(event, {
+            session_id,
+            payload,
+            settings_path: settings,
+            dry_run,
+        });
+        _print(_pyDumps(result));
+    } catch (exc) {
+        if (exc instanceof ValueError) {
+            _eprint(`error: ${exc.message}`);
+            return EXIT_BAD_ARGS;
+        }
+        throw exc;
+    }
+    return EXIT_OK;
+}
+
+function _cmd_hook_dispatch(argv: string[]): number {
+    let platform: string | null = null;
+    let event: string | null = null;
+    let settings: string | null = null;
+    let dry_run = false;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--platform') {
+            platform = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--platform=')) {
+            platform = a.slice('--platform='.length);
+        } else if (a === '--event') {
+            event = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--event=')) {
+            event = a.slice('--event='.length);
+        } else if (a === '--settings') {
+            settings = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--settings=')) {
+            settings = a.slice('--settings='.length);
+        } else if (a === '--dry-run') {
+            dry_run = true;
+        }
+    }
+    // argparse: --platform is required + choices-validated before the handler.
+    const _hookDispatchUsage =
+        `usage: ${PROG} hook-dispatch [-h] --platform\n` +
+        `                                     {augment,claude,cline,cowork,cursor,gemini,generic,windsurf}\n` +
+        `                                     [--event EVENT] [--settings SETTINGS]\n` +
+        `                                     [--dry-run]\n`;
+    if (platform === null) {
+        return _argError(
+            _hookDispatchUsage,
+            `${PROG} hook-dispatch`,
+            'the following arguments are required: --platform',
+        );
+    }
+    if (!(platform in PLATFORM_EVENT_MAP)) {
+        const choices = [...VALID_PLATFORMS].sort(_pyStrCompare).map((c) => _pyRepr(c)).join(', ');
+        return _argError(
+            _hookDispatchUsage,
+            `${PROG} hook-dispatch`,
+            `argument --platform: invalid choice: ${_pyRepr(platform)} (choose from ${choices})`,
+        );
+    }
+    const raw = _readStdin();
+    try {
+        const result = hook_dispatch(platform, raw, {
+            event_override: event,
+            settings_path: settings,
+            dry_run,
+        });
+        _print(_pyDumps(result));
+    } catch (exc) {
+        if (exc instanceof ValueError) {
+            _eprint(`error: ${exc.message}`);
+            return EXIT_BAD_ARGS;
+        }
+        throw exc;
+    }
+    return EXIT_OK;
+}
+
+function _cmd_append(argv: string[]): number {
+    let type_: string | null = null;
+    let jsonRaw: string | null = null;
+    let session_id: string | null = null;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--type') {
+            type_ = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--type=')) {
+            type_ = a.slice('--type='.length);
+        } else if (a === '--json') {
+            jsonRaw = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--json=')) {
+            jsonRaw = a.slice('--json='.length);
+        } else if (a === '--session-id') {
+            session_id = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--session-id=')) {
+            session_id = a.slice('--session-id='.length);
+        }
+    }
+    const entry: Entry = jsonRaw ? (JSON.parse(jsonRaw) as Entry) : {};
+    if (!('t' in entry)) {
+        entry.t = type_;
+    }
+    if (!entry.t) {
+        _eprint("error: --type or a 't' key in --json is required");
+        return EXIT_BAD_ARGS;
+    }
+    const session = session_id ? derive_session_tag(session_id) : null;
+    append(entry, { session });
+    return EXIT_OK;
+}
+
+function _cmd_status(): number {
+    _print(_pyDumpsIndent2(status()));
+    return 0;
+}
+
+function _loadEntriesArg(entriesJson: string | null, entriesStdin: boolean): Entry[] {
+    const raw = entriesStdin ? _readStdin() : entriesJson || '[]';
+    let data: unknown;
+    try {
+        data = JSON.parse(raw);
+    } catch (exc) {
+        throw new ValueError(`invalid JSON for entries: ${_excStr(exc)}`);
+    }
+    if (!Array.isArray(data)) {
+        throw new ValueError('entries must be a JSON array');
+    }
+    return data as Entry[];
+}
+
+function _cmd_reset(argv: string[]): number {
+    let freq = 'per_phase';
+    let entriesJson: string | null = null;
+    let entriesStdin = false;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--freq') {
+            freq = (argv[++i] as string) ?? freq;
+        } else if (a.startsWith('--freq=')) {
+            freq = a.slice('--freq='.length);
+        } else if (a === '--entries-json') {
+            entriesJson = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--entries-json=')) {
+            entriesJson = a.slice('--entries-json='.length);
+        } else if (a === '--entries-stdin') {
+            entriesStdin = true;
+        }
+    }
+    if (!VALID_FREQS.has(freq)) {
+        return _argError(
+            `usage: ${PROG} reset [-h] [--freq {per_phase,per_tool,per_turn}]\n` +
+                `                            (--entries-json ENTRIES_JSON | --entries-stdin)\n`,
+            `${PROG} reset`,
+            `argument --freq: invalid choice: ${_pyRepr(freq)} (choose from 'per_phase', 'per_tool', 'per_turn')`,
+        );
+    }
+    if (entriesJson === null && !entriesStdin) {
+        return _argError(
+            `usage: ${PROG} reset [-h] [--freq {per_phase,per_tool,per_turn}]\n` +
+                `                            (--entries-json ENTRIES_JSON | --entries-stdin)\n`,
+            `${PROG} reset`,
+            'one of the arguments --entries-json --entries-stdin is required',
+        );
+    }
+    const entries = _loadEntriesArg(entriesJson, entriesStdin);
+    const h = reset_with_entries(entries, freq);
+    _print(_pyDumps(h));
+    return 0;
+}
+
+function _cmd_prune_sessions(argv: string[]): number {
+    let maxSessions: number | null = null;
+    let settings: string | null = null;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--max-sessions') {
+            maxSessions = _pyIntFromAny((argv[++i] as string) ?? '');
+        } else if (a.startsWith('--max-sessions=')) {
+            maxSessions = _pyIntFromAny(a.slice('--max-sessions='.length));
+        } else if (a === '--settings') {
+            settings = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--settings=')) {
+            settings = a.slice('--settings='.length);
+        }
+    }
+    let max_n: number;
+    if (maxSessions !== null) {
+        max_n = Math.max(1, maxSessions);
+    } else {
+        const sp = settings ?? DEFAULT_SETTINGS_FILE;
+        max_n = _read_chat_history_max_sessions(sp);
+    }
+    const result = prune_sessions(max_n);
+    _print(_pyDumps(result));
+    return EXIT_OK;
+}
+
+function _cmd_prepend(argv: string[]): number {
+    let entriesJson: string | null = null;
+    let entriesStdin = false;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--entries-json') {
+            entriesJson = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--entries-json=')) {
+            entriesJson = a.slice('--entries-json='.length);
+        } else if (a === '--entries-stdin') {
+            entriesStdin = true;
+        }
+    }
+    if (entriesJson === null && !entriesStdin) {
+        return _argError(
+            `usage: ${PROG} prepend [-h] (--entries-json ENTRIES_JSON | --entries-stdin)\n`,
+            `${PROG} prepend`,
+            'one of the arguments --entries-json --entries-stdin is required',
+        );
+    }
+    const entries = _loadEntriesArg(entriesJson, entriesStdin);
+    const n = prepend_entries(entries);
+    _print(_pyDumps({ prepended: n }));
+    return 0;
+}
+
+function _cmd_clear(): number {
+    clear();
+    return 0;
+}
+
+function _cmd_read(argv: string[]): number {
+    let last = 5;
+    let lastSeen = false;
+    let all = false;
+    let session: string | null = null;
+    let agent: string | null = null;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--last') {
+            last = _pyIntFromAny((argv[++i] as string) ?? '');
+            lastSeen = true;
+        } else if (a.startsWith('--last=')) {
+            last = _pyIntFromAny(a.slice('--last='.length));
+            lastSeen = true;
+        } else if (a === '--all') {
+            all = true;
+        } else if (a === '--session') {
+            session = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--session=')) {
+            session = a.slice('--session='.length);
+        } else if (a === '--agent') {
+            agent = (argv[++i] as string) ?? null;
+        } else if (a.startsWith('--agent=')) {
+            agent = a.slice('--agent='.length);
+        }
+    }
+    if (lastSeen && all) {
+        return _argError(
+            `usage: ${PROG} read [-h] [--last LAST | --all] [--session SESSION]\n` +
+                `                            [--agent AGENT]\n`,
+            `${PROG} read`,
+            'argument --all: not allowed with argument --last',
+        );
+    }
+    const lastArg = all ? null : last;
+    let entries: Entry[];
+    if (all) {
+        entries = read_entries({ last: lastArg, session: null, agent });
+    } else if (session !== null) {
+        entries = read_entries({ last: lastArg, session, agent });
+    } else if (agent !== null) {
+        const sid = _last_body_session_id(file_path());
+        entries = read_entries({ last: lastArg, session: sid, agent });
+    } else {
+        entries = read_entries_for_current({ last: lastArg });
+    }
+    _print(_pyDumpsIndent2(entries));
+    return 0;
+}
+
+function _cmd_sessions(argv: string[]): number {
+    let limit = 20;
+    let includeEmpty = false;
+    let json = false;
+    let summary = false;
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--limit') {
+            limit = _pyIntFromAny((argv[++i] as string) ?? '');
+        } else if (a.startsWith('--limit=')) {
+            limit = _pyIntFromAny(a.slice('--limit='.length));
+        } else if (a === '--include-empty') {
+            includeEmpty = true;
+        } else if (a === '--json') {
+            json = true;
+        } else if (a === '--summary') {
+            summary = true;
+        }
+    }
+    let sessions = list_sessions({ summary }) as SessionBucket[];
+    if (!includeEmpty) {
+        sessions = sessions.filter((s) => s.count > 0);
+    }
+    sessions = sessions.slice(0, limit);
+    if (json) {
+        _print(_pyDumpsIndent2(sessions));
+        return 0;
+    }
+    if (sessions.length === 0) {
+        _print('(no sessions)');
+        return 0;
+    }
+    const lastCol = summary ? 'SUMMARY' : 'PREVIEW';
+    const rows: string[][] = [['ID', 'COUNT', 'AGENTS', 'LAST_TS', lastCol]];
+    for (const s of sessions) {
+        const lastVal = summary ? s.summary : s.preview;
+        const agentsVal = (s.agents || []).join(',') || '-';
+        rows.push([s.id, String(s.count), agentsVal, s.last_ts || '-', lastVal || '-']);
+    }
+    const widths: number[] = [];
+    for (let i = 0; i < 5; i++) {
+        widths.push(Math.max(...rows.map((r) => _pyLen(r[i] as string))));
+    }
+    for (let i = 0; i < rows.length; i++) {
+        const r = rows[i] as string[];
+        const line = r.map((c, j) => _ljust(c, widths[j] as number)).join('  ');
+        _print(line);
+        if (i === 0) {
+            _print(widths.map((w) => '-'.repeat(w)).join('  '));
+        }
+    }
+    return 0;
+}
+
+function _cmd_rotate(argv: string[]): number {
+    let maxKb = 256;
+    let mode = 'rotate';
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--max-kb') {
+            maxKb = _pyIntFromAny((argv[++i] as string) ?? '');
+        } else if (a.startsWith('--max-kb=')) {
+            maxKb = _pyIntFromAny(a.slice('--max-kb='.length));
+        } else if (a === '--mode') {
+            mode = (argv[++i] as string) ?? mode;
+        } else if (a.startsWith('--mode=')) {
+            mode = a.slice('--mode='.length);
+        }
+    }
+    if (!VALID_OVERFLOW.has(mode)) {
+        return _argError(
+            `usage: ${PROG} rotate [-h] [--max-kb MAX_KB]\n` +
+                `                              [--mode {condense,rotate}]\n`,
+            `${PROG} rotate`,
+            `argument --mode: invalid choice: ${_pyRepr(mode)} (choose from 'condense', 'rotate')`,
+        );
+    }
+    const result = overflow_handle(maxKb, mode);
+    _print(_pyDumps(result));
+    return 0;
+}
+
+function _readStdin(): string {
+    try {
+        return fs.readFileSync(0, 'utf-8');
+    } catch {
+        return '';
+    }
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    const cmd = argv[0];
+    if (cmd === undefined) {
+        return _argError(_TOP_USAGE, PROG, 'the following arguments are required: cmd');
+    }
+    if (!SUBCMDS.includes(cmd)) {
+        const choices = SUBCMDS.map((c) => _pyRepr(c)).join(', ');
+        return _argError(
+            _TOP_USAGE,
+            PROG,
+            `argument cmd: invalid choice: ${_pyRepr(cmd)} (choose from ${choices})`,
+        );
+    }
+    const rest = argv.slice(1);
+    switch (cmd) {
+        case 'init':
+            return _cmd_init(rest);
+        case 'append':
+            return _cmd_append(rest);
+        case 'status':
+            return _cmd_status();
+        case 'reset':
+            return _cmd_reset(rest);
+        case 'prune-sessions':
+            return _cmd_prune_sessions(rest);
+        case 'prepend':
+            return _cmd_prepend(rest);
+        case 'clear':
+            return _cmd_clear();
+        case 'read':
+            return _cmd_read(rest);
+        case 'sessions':
+            return _cmd_sessions(rest);
+        case 'rotate':
+            return _cmd_rotate(rest);
+        case 'hook-append':
+            return _cmd_hook_append(rest);
+        case 'hook-dispatch':
+            return _cmd_hook_dispatch(rest);
+        default:
+            return EXIT_BAD_ARGS;
+    }
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    try {
+        process.exitCode = main();
+    } catch (exc) {
+        if (exc instanceof ValueError || exc instanceof FileNotFoundError) {
+            // Python would surface an uncaught traceback (exit 1); mirror the
+            // non-zero exit. The message goes to stderr like a traceback tail.
+            process.stderr.write(`${exc.constructor.name}: ${exc.message}\n`);
+            process.exitCode = 1;
+        } else {
+            throw exc;
+        }
+    }
+}

--- a/src/scripts/mcp_server/tools.ts
+++ b/src/scripts/mcp_server/tools.ts
@@ -34,6 +34,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import {
+    SCHEMA_VERSION as _CH_SCHEMA_VERSION,
+    append as _chAppendImpl,
+    init as _chInitImpl,
+    read_entries as _chReadEntriesImpl,
+    read_header as _chReadHeaderImpl,
+} from '../chat_history.js';
+import {
     type CatalogEntry,
     install_hint as _catalog_install_hint,
     load_catalog,
@@ -161,119 +168,21 @@ function _validateInTreePath(raw: string | null | undefined, consumerRoot: strin
 }
 
 // ---------------------------------------------------------------------
-// Minimal chat-history surface — faithful inline port of the five
-// functions tools.py lazily imports from scripts/chat_history.py
-// (SCHEMA_VERSION, init, append, read_header, read_entries). There is no
-// chat_history.ts twin yet; a .ts cannot import a .py, so the subset the
-// handlers depend on lives here. Behaviour mirrors the Python source
-// byte-for-byte on the JSONL it writes (ensure_ascii=False, trailing
-// newline, ISO-8601 second-precision `ts`).
+// Minimal chat-history surface — the five functions tools.py lazily
+// imports from scripts/chat_history.py (SCHEMA_VERSION, init, append,
+// read_header, read_entries) now come from the chat_history.ts twin
+// (the canonical single source of truth, byte-for-byte with the Python
+// writer: ensure_ascii=False default separators, trailing newline,
+// ISO-8601 second-precision `ts`). These thin shims keep the handler
+// call sites unchanged while delegating to the twin.
 // ---------------------------------------------------------------------
 
-const _CH_SCHEMA_VERSION = 4;
-const _CH_WS_RE = /\s+/g;
-
-/** ISO-8601 UTC, seconds precision — mirror Python `datetime.now(utc).isoformat(timespec="seconds")`. */
-function _chNow(): string {
-    // Python emits e.g. "2026-06-13T00:00:00+00:00"; replicate the +00:00 offset.
-    return new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00');
-}
-
-/** Mirror Python `json.dumps(obj, ensure_ascii=False)` for a flat entry/header dict. */
-function _chDumps(obj: Record<string, unknown>): string {
-    return JSON.stringify(obj);
-}
-
 function _chReadHeader(target: string): Record<string, unknown> | null {
-    let stat: fs.Stats;
-    try {
-        stat = fs.statSync(target);
-    } catch {
-        return null;
-    }
-    if (!stat.isFile() || stat.size === 0) {
-        return null;
-    }
-    let first: string;
-    try {
-        const raw = fs.readFileSync(target, 'utf-8');
-        first = raw.split('\n', 1)[0]?.trim() ?? '';
-    } catch {
-        return null;
-    }
-    if (!first) {
-        return null;
-    }
-    try {
-        const obj = JSON.parse(first) as unknown;
-        if (
-            obj === null ||
-            typeof obj !== 'object' ||
-            Array.isArray(obj) ||
-            (obj as Record<string, unknown>).t !== 'header'
-        ) {
-            return null;
-        }
-        return obj as Record<string, unknown>;
-    } catch {
-        return null;
-    }
-}
-
-function _chBuildHeader(freq: string): Record<string, unknown> {
-    return { t: 'header', v: _CH_SCHEMA_VERSION, started: _chNow(), freq };
+    return _chReadHeaderImpl(target);
 }
 
 function _chInit(target: string, freq = 'per_phase'): Record<string, unknown> {
-    const header = _chBuildHeader(freq);
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-    fs.writeFileSync(target, _chDumps(header) + '\n', { encoding: 'utf-8' });
-    return header;
-}
-
-/** Most recent body entry's `s`, or "<unknown>". Mirrors `_last_body_session_id`. */
-function _chLastBodySessionId(target: string): string {
-    const UNKNOWN = '<unknown>';
-    let stat: fs.Stats;
-    try {
-        stat = fs.statSync(target);
-    } catch {
-        return UNKNOWN;
-    }
-    if (!stat.isFile() || stat.size === 0) {
-        return UNKNOWN;
-    }
-    let lines: string[];
-    try {
-        lines = fs.readFileSync(target, 'utf-8').split('\n');
-    } catch {
-        return UNKNOWN;
-    }
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = (lines[i] ?? '').trim();
-        if (!line) {
-            continue;
-        }
-        let obj: unknown;
-        try {
-            obj = JSON.parse(line);
-        } catch {
-            continue;
-        }
-        if (
-            obj === null ||
-            typeof obj !== 'object' ||
-            Array.isArray(obj) ||
-            (obj as Record<string, unknown>).t === 'header'
-        ) {
-            continue;
-        }
-        const sid = (obj as Record<string, unknown>).s;
-        if (typeof sid === 'string' && sid) {
-            return sid;
-        }
-    }
-    return UNKNOWN;
+    return _chInitImpl(freq, { path: target });
 }
 
 function _chAppend(
@@ -281,21 +190,7 @@ function _chAppend(
     target: string,
     session: string | null | undefined,
 ): void {
-    if (entry === null || typeof entry !== 'object' || !entry.t) {
-        throw new Error("entry must be a dict with non-empty 't' key");
-    }
-    if (entry.t === 'header') {
-        throw new Error('use init() to write the header, not append()');
-    }
-    if (entry.ts === undefined) {
-        entry.ts = _chNow();
-    }
-    if (session !== null && session !== undefined) {
-        entry.s = session;
-    } else if (!('s' in entry)) {
-        entry.s = _chLastBodySessionId(target);
-    }
-    fs.appendFileSync(target, _chDumps(entry) + '\n', { encoding: 'utf-8' });
+    _chAppendImpl(entry, { path: target, session });
 }
 
 /** Mirror `read_entries(last, path, session)` (the subset the read handler uses). */
@@ -304,48 +199,7 @@ function _chReadEntries(
     last: number | null | undefined,
     session: string | null | undefined,
 ): Record<string, unknown>[] {
-    let stat: fs.Stats;
-    try {
-        stat = fs.statSync(target);
-    } catch {
-        return [];
-    }
-    if (!stat.isFile()) {
-        return [];
-    }
-    let entries: Record<string, unknown>[] = [];
-    const rawLines = fs.readFileSync(target, 'utf-8').split('\n');
-    for (let i = 0; i < rawLines.length; i++) {
-        const line = (rawLines[i] ?? '').trim();
-        if (!line) {
-            continue;
-        }
-        let obj: unknown;
-        try {
-            obj = JSON.parse(line);
-        } catch {
-            continue;
-        }
-        if (
-            i === 0 &&
-            obj !== null &&
-            typeof obj === 'object' &&
-            !Array.isArray(obj) &&
-            (obj as Record<string, unknown>).t === 'header'
-        ) {
-            continue;
-        }
-        if (obj !== null && typeof obj === 'object' && !Array.isArray(obj)) {
-            entries.push(obj as Record<string, unknown>);
-        }
-    }
-    if (session !== null && session !== undefined) {
-        entries = entries.filter((e) => e.s === session);
-    }
-    if (last !== null && last !== undefined && last >= 0) {
-        entries = entries.slice(entries.length - last);
-    }
-    return entries;
+    return _chReadEntriesImpl({ path: target, last, session });
 }
 
 // ---------------------------------------------------------------------

--- a/src/scripts/runtime_dispatcher.ts
+++ b/src/scripts/runtime_dispatcher.ts
@@ -1,0 +1,584 @@
+#!/usr/bin/env tsx
+/**
+ * Runtime Dispatcher — resolves execution type and drives real handler execution.
+ *
+ * TypeScript twin of `src/scripts/runtime_dispatcher.py` (ADR-094). Mirrors the
+ * Python public surface and CLI contract EXACTLY — `ExecutionRequest`,
+ * `DispatchResult`, `dispatch`, `run`, the `resolve` / `run` subcommands, the
+ * legacy flat `--skill` flag, `--format text|json`, `--root`, `--cwd`,
+ * `--output`, exit codes, and byte-identical stdout/stderr (including
+ * `json.dumps(..., indent=2)` output). No behaviour changes.
+ *
+ * Two modes:
+ *
+ * - resolve (default): produce a structured execution request, enforce safety,
+ *   return dispatch metadata. No side effects.
+ * - run: dispatch the skill, then hand it to the matching runtime handler to
+ *   actually execute. Returns a typed ExecutionResult.
+ *
+ * Usage:
+ *     tsx scripts/runtime_dispatcher.ts --skill NAME [--format text|json]
+ *     tsx scripts/runtime_dispatcher.ts resolve --skill NAME
+ *     tsx scripts/runtime_dispatcher.ts run --skill NAME [--cwd PATH] [--output FILE]
+ *
+ * `run --output FILE` persists the ExecutionResult as JSON to FILE. CI uses
+ * this to feed `scripts/ci_summary`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { SkillRuntime, build_registry } from './runtime_registry.js';
+import { ExecutionResult, HandlerError, execute_shell } from './runtime_handler.js';
+import { resolve_level } from './_lib/script_output.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+
+/** Structured execution request produced by the dispatcher. */
+export class ExecutionRequest {
+    readonly skill_name: string;
+
+    readonly execution_type: string;
+
+    readonly handler: string;
+
+    readonly timeout_seconds: number;
+
+    readonly safety_mode: string | null;
+
+    readonly allowed_tools: string[];
+
+    readonly status: string; // "ready", "blocked", "not_found"
+
+    readonly reason: string | null;
+
+    constructor(args: {
+        skill_name: string;
+        execution_type: string;
+        handler: string;
+        timeout_seconds: number;
+        safety_mode: string | null;
+        allowed_tools: string[];
+        status: string;
+        reason: string | null;
+    }) {
+        this.skill_name = args.skill_name;
+        this.execution_type = args.execution_type;
+        this.handler = args.handler;
+        this.timeout_seconds = args.timeout_seconds;
+        this.safety_mode = args.safety_mode;
+        this.allowed_tools = args.allowed_tools;
+        this.status = args.status;
+        this.reason = args.reason;
+    }
+
+    get is_ready(): boolean {
+        return this.status === 'ready';
+    }
+
+    /** Mirror `dataclasses.asdict(self)` — field order, properties excluded. */
+    asdict(): Record<string, unknown> {
+        return {
+            skill_name: this.skill_name,
+            execution_type: this.execution_type,
+            handler: this.handler,
+            timeout_seconds: this.timeout_seconds,
+            safety_mode: this.safety_mode,
+            allowed_tools: this.allowed_tools,
+            status: this.status,
+            reason: this.reason,
+        };
+    }
+}
+
+/** Result of dispatching a skill for execution. */
+export class DispatchResult {
+    readonly request: ExecutionRequest;
+
+    readonly warnings: string[];
+
+    constructor(args: { request: ExecutionRequest; warnings: string[] }) {
+        this.request = args.request;
+        this.warnings = args.warnings;
+    }
+
+    /** Mirror `dataclasses.asdict(self)` — recursive on the nested request. */
+    asdict(): Record<string, unknown> {
+        return {
+            request: this.request.asdict(),
+            warnings: this.warnings,
+        };
+    }
+}
+
+/** Resolve and validate a skill for execution. */
+export function dispatch(skillName: string, registry: SkillRuntime[]): DispatchResult {
+    const warnings: string[] = [];
+
+    // Find skill in registry
+    const matches = registry.filter((s) => s.name === skillName);
+    if (matches.length === 0) {
+        return new DispatchResult({
+            request: new ExecutionRequest({
+                skill_name: skillName,
+                execution_type: 'unknown',
+                handler: 'none',
+                timeout_seconds: 0,
+                safety_mode: null,
+                allowed_tools: [],
+                status: 'not_found',
+                reason: `Skill '${skillName}' not found in runtime registry`,
+            }),
+            warnings: [],
+        });
+    }
+
+    const skill = matches[0] as SkillRuntime;
+
+    // Manual skills cannot be dispatched
+    if (skill.execution_type === 'manual') {
+        return new DispatchResult({
+            request: new ExecutionRequest({
+                skill_name: skill.name,
+                execution_type: skill.execution_type,
+                handler: skill.handler,
+                timeout_seconds: skill.timeout_seconds,
+                safety_mode: skill.safety_mode,
+                allowed_tools: skill.allowed_tools,
+                status: 'blocked',
+                reason: 'Manual skills cannot be dispatched for execution',
+            }),
+            warnings: [],
+        });
+    }
+
+    // Automated skills must pass safety checks
+    if (skill.is_automated) {
+        if (skill.handler === 'none') {
+            return new DispatchResult({
+                request: new ExecutionRequest({
+                    skill_name: skill.name,
+                    execution_type: skill.execution_type,
+                    handler: skill.handler,
+                    timeout_seconds: skill.timeout_seconds,
+                    safety_mode: skill.safety_mode,
+                    allowed_tools: skill.allowed_tools,
+                    status: 'blocked',
+                    reason: 'Automated skill has no handler',
+                }),
+                warnings: [],
+            });
+        }
+        if (skill.safety_mode !== 'strict') {
+            return new DispatchResult({
+                request: new ExecutionRequest({
+                    skill_name: skill.name,
+                    execution_type: skill.execution_type,
+                    handler: skill.handler,
+                    timeout_seconds: skill.timeout_seconds,
+                    safety_mode: skill.safety_mode,
+                    allowed_tools: skill.allowed_tools,
+                    status: 'blocked',
+                    reason: 'Automated skill requires safety_mode: strict',
+                }),
+                warnings: [],
+            });
+        }
+    }
+
+    // Assisted/automated skill is ready
+    if (skill.execution_type === 'assisted') {
+        warnings.push('Assisted execution requires human confirmation before action');
+    }
+
+    return new DispatchResult({
+        request: new ExecutionRequest({
+            skill_name: skill.name,
+            execution_type: skill.execution_type,
+            handler: skill.handler,
+            timeout_seconds: skill.timeout_seconds,
+            safety_mode: skill.safety_mode,
+            allowed_tools: skill.allowed_tools,
+            status: 'ready',
+            reason: null,
+        }),
+        warnings,
+    });
+}
+
+/** Dispatch and execute a skill. Raises HandlerError on structural issues. */
+export function run(skillName: string, registry: SkillRuntime[], cwd: string): ExecutionResult {
+    const dispatchResult = dispatch(skillName, registry);
+    const req = dispatchResult.request;
+    if (!req.is_ready) {
+        throw new HandlerError(
+            `Skill '${skillName}' is not ready to run: ` +
+                `${req.status} — ${req.reason || 'no reason given'}`,
+        );
+    }
+
+    const skill = registry.find((s) => s.name === skillName) as SkillRuntime;
+    if (skill.handler === 'shell' || skill.handler === 'php' || skill.handler === 'node') {
+        return execute_shell(skill, cwd);
+    }
+    throw new HandlerError(
+        `Handler '${skill.handler}' has no executor yet — ` +
+            `only 'shell' is implemented in this phase`,
+    );
+}
+
+/** Mirror `dataclasses.asdict(ExecutionResult)` — field order, properties excluded. */
+function _executionResultAsdict(result: ExecutionResult): Record<string, unknown> {
+    return {
+        skill_name: result.skill_name,
+        handler: result.handler,
+        command: result.command,
+        cwd: result.cwd,
+        exit_code: result.exit_code,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        duration_ms: result.duration_ms,
+        status: result.status,
+        timed_out: result.timed_out,
+        error: result.error,
+        artifacts: result.artifacts,
+    };
+}
+
+// --- json.dumps(indent=2) emulation (ensure_ascii=True, NO sort_keys) -------
+
+type Json = null | boolean | number | string | Json[] | { [k: string]: Json };
+
+function _pyJsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (code < 0x20) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else if (code < 0x7f) {
+            out += ch;
+        } else if (code <= 0xffff) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            const c = code - 0x10000;
+            const hi = 0xd800 + (c >> 10);
+            const lo = 0xdc00 + (c & 0x3ff);
+            out += `\\u${hi.toString(16).padStart(4, '0')}\\u${lo.toString(16).padStart(4, '0')}`;
+        }
+    }
+    return out + '"';
+}
+
+function pyJsonDumpsIndent2(obj: Json, level = 0): string {
+    if (obj === null || obj === undefined) {
+        return 'null';
+    }
+    if (typeof obj === 'number') {
+        return String(obj);
+    }
+    if (typeof obj === 'string') {
+        return _pyJsonStr(obj);
+    }
+    if (obj === true) {
+        return 'true';
+    }
+    if (obj === false) {
+        return 'false';
+    }
+    if (Array.isArray(obj)) {
+        if (obj.length === 0) {
+            return '[]';
+        }
+        const pad = ' '.repeat(2 * (level + 1));
+        const closePad = ' '.repeat(2 * level);
+        return `[\n${obj.map((v) => pad + pyJsonDumpsIndent2(v, level + 1)).join(',\n')}\n${closePad}]`;
+    }
+    const keys = Object.keys(obj as Record<string, Json>);
+    if (keys.length === 0) {
+        return '{}';
+    }
+    const pad = ' '.repeat(2 * (level + 1));
+    const closePad = ' '.repeat(2 * level);
+    const parts = keys.map(
+        (k) => `${pad}${_pyJsonStr(k)}: ${pyJsonDumpsIndent2((obj as Record<string, Json>)[k] as Json, level + 1)}`,
+    );
+    return `{\n${parts.join(',\n')}\n${closePad}}`;
+}
+
+function _printDispatch(result: DispatchResult, fmt: string): void {
+    if (fmt === 'json') {
+        process.stdout.write(`${pyJsonDumpsIndent2(result.asdict() as Json)}\n`);
+        return;
+    }
+    const req = result.request;
+    process.stdout.write(`Skill: ${req.skill_name}\n`);
+    process.stdout.write(`Status: ${req.status}\n`);
+    if (req.reason) {
+        process.stdout.write(`Reason: ${req.reason}\n`);
+    }
+    if (req.is_ready) {
+        process.stdout.write(`Type: ${req.execution_type}\n`);
+        process.stdout.write(`Handler: ${req.handler}\n`);
+        process.stdout.write(`Timeout: ${req.timeout_seconds}s\n`);
+        const tools = req.allowed_tools.length > 0 ? req.allowed_tools.join(', ') : 'none';
+        process.stdout.write(`Tools: ${tools}\n`);
+    }
+    for (const w of result.warnings) {
+        process.stdout.write(`WARNING: ${w}\n`);
+    }
+}
+
+// Python str.strip() whitespace set: ASCII \t\n\v\f\r space, the C1/info
+// separators \x1c-\x1f, NEL \x85, NBSP \xa0, plus the Unicode
+// space-separator (Zs), line-separator, and paragraph-separator classes.
+const _PY_RSTRIP_RE =
+    /[\t\n\v\f\r \x1c\x1d\x1e\x1f\x85\xa0\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000]+$/u;
+
+/** Mirror Python `str.rstrip()` — strip trailing Python-whitespace. */
+function _pyRstrip(s: string): string {
+    return s.replace(_PY_RSTRIP_RE, '');
+}
+
+function _printExecution(result: ExecutionResult, fmt: string): void {
+    if (fmt === 'json') {
+        process.stdout.write(`${pyJsonDumpsIndent2(_executionResultAsdict(result) as Json)}\n`);
+        return;
+    }
+    const level = resolve_level();
+    if (level === 'silent' && result.is_success) {
+        return;
+    }
+    if (level === 'minimal' && result.is_success) {
+        const marker = result.is_success ? '✅' : '❌';
+        process.stdout.write(
+            `${marker}  ${result.skill_name} · ${result.handler} · ` +
+                `exit=${result.exit_code} (${result.duration_ms}ms)\n`,
+        );
+        return;
+    }
+    process.stdout.write(`Skill: ${result.skill_name}\n`);
+    process.stdout.write(`Handler: ${result.handler}\n`);
+    process.stdout.write(`Command: ${result.command.join(' ')}\n`);
+    process.stdout.write(`Cwd: ${result.cwd}\n`);
+    process.stdout.write(`Status: ${result.status}\n`);
+    process.stdout.write(`Exit code: ${result.exit_code}\n`);
+    process.stdout.write(`Duration: ${result.duration_ms}ms\n`);
+    if (result.error) {
+        process.stdout.write(`Error: ${result.error}\n`);
+    }
+    if (result.stdout) {
+        process.stdout.write('--- stdout ---\n');
+        process.stdout.write(`${_pyRstrip(result.stdout)}\n`);
+    }
+    if (result.stderr) {
+        process.stdout.write('--- stderr ---\n');
+        process.stdout.write(`${_pyRstrip(result.stderr)}\n`);
+    }
+}
+
+// --- argparse emulation ------------------------------------------------------
+
+const PROG = 'runtime_dispatcher';
+
+const _TOP_USAGE =
+    `usage: ${PROG} [-h] [--skill SKILL] [--root ROOT]\n` +
+    `                             [--format {text,json}]\n` +
+    `                             {resolve,run} ...\n`;
+
+interface Args {
+    action: string | null;
+    skill: string | null;
+    root: string;
+    cwd: string | null;
+    format: 'text' | 'json';
+    output: string | null;
+}
+
+/** Emit a top-level argparse error to stderr and exit 2. */
+function _topError(message: string): never {
+    process.stderr.write(_TOP_USAGE);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    process.exitCode = 2;
+    throw new _ArgExit();
+}
+
+/** Emit a subparser argparse error to stderr and exit 2. */
+function _subError(action: string, usage: string, message: string): never {
+    process.stderr.write(usage);
+    process.stderr.write(`${PROG} ${action}: error: ${message}\n`);
+    process.exitCode = 2;
+    throw new _ArgExit();
+}
+
+/** Sentinel thrown to unwind the call stack after an argparse-style exit. */
+class _ArgExit extends Error {}
+
+const _RESOLVE_USAGE =
+    `usage: ${PROG} resolve [-h] --skill SKILL [--root ROOT]\n` +
+    `                                     [--format {text,json}]\n`;
+
+const _RUN_USAGE =
+    `usage: ${PROG} run [-h] --skill SKILL [--root ROOT] [--cwd CWD]\n` +
+    `                                 [--format {text,json}] [--output OUTPUT]\n`;
+
+function _parseFormat(action: string | null, usage: string, value: string | undefined): 'text' | 'json' {
+    if (value !== 'text' && value !== 'json') {
+        const choice = value === undefined ? 'None' : `'${value}'`;
+        const msg = `argument --format: invalid choice: ${choice} (choose from 'text', 'json')`;
+        if (action === null) {
+            _topError(msg);
+        }
+        _subError(action, usage, msg);
+    }
+    return value;
+}
+
+/** Mirror argparse parsing — flat flags + `resolve` / `run` subcommands. */
+function parseArgs(argv: string[]): Args {
+    const out: Args = { action: null, skill: null, root: '.', cwd: null, format: 'text', output: null };
+
+    // Determine whether the first positional token selects a subcommand.
+    let i = 0;
+    let action: string | null = null;
+    let usage = _TOP_USAGE;
+    if (argv.length > 0 && !(argv[0] as string).startsWith('-')) {
+        const first = argv[0] as string;
+        if (first !== 'resolve' && first !== 'run') {
+            _topError(
+                `argument {resolve,run}: invalid choice: '${first}' (choose from 'resolve', 'run')`,
+            );
+        }
+        action = first;
+        out.action = first;
+        usage = first === 'resolve' ? _RESOLVE_USAGE : _RUN_USAGE;
+        i = 1;
+    }
+
+    const valueOf = (a: string, eqPrefix: string): string | undefined => {
+        if (a.startsWith(eqPrefix)) {
+            return a.slice(eqPrefix.length);
+        }
+        const next = argv[(i += 1)];
+        return next;
+    };
+    const errFn = (msg: string): never => (action === null ? _topError(msg) : _subError(action, usage, msg));
+
+    for (; i < argv.length; i += 1) {
+        const a = argv[i] as string;
+        if (a === '--skill' || a.startsWith('--skill=')) {
+            const v = valueOf(a, '--skill=');
+            if (v === undefined) {
+                errFn('argument --skill: expected one argument');
+            }
+            out.skill = v as string;
+        } else if (a === '--root' || a.startsWith('--root=')) {
+            const v = valueOf(a, '--root=');
+            if (v === undefined) {
+                errFn('argument --root: expected one argument');
+            }
+            out.root = v as string;
+        } else if (a === '--cwd' || a.startsWith('--cwd=')) {
+            if (action !== 'run') {
+                errFn(`unrecognized arguments: ${a}`);
+            }
+            const v = valueOf(a, '--cwd=');
+            if (v === undefined) {
+                errFn('argument --cwd: expected one argument');
+            }
+            out.cwd = v as string;
+        } else if (a === '--output' || a.startsWith('--output=')) {
+            if (action !== 'run') {
+                errFn(`unrecognized arguments: ${a}`);
+            }
+            const v = valueOf(a, '--output=');
+            if (v === undefined) {
+                errFn('argument --output: expected one argument');
+            }
+            out.output = v as string;
+        } else if (a === '--format' || a.startsWith('--format=')) {
+            const v = a.startsWith('--format=') ? a.slice('--format='.length) : argv[(i += 1)];
+            out.format = _parseFormat(action, usage, v);
+        } else {
+            errFn(`unrecognized arguments: ${a}`);
+        }
+    }
+
+    // resolve / run subparsers mark --skill required.
+    if (action === 'resolve' && out.skill === null) {
+        _subError('resolve', _RESOLVE_USAGE, 'the following arguments are required: --skill');
+    }
+    if (action === 'run' && out.skill === null) {
+        _subError('run', _RUN_USAGE, 'the following arguments are required: --skill');
+    }
+
+    return out;
+}
+
+export function main(argv: string[]): number {
+    const args = parseArgs(argv);
+
+    const action = args.action ?? 'resolve';
+    if (action === 'resolve' && !args.skill) {
+        _topError('--skill is required for resolve');
+    }
+
+    const registry = build_registry(args.root);
+
+    if (action === 'run') {
+        const cwd = args.cwd !== null ? args.cwd : args.root;
+        let result: ExecutionResult;
+        try {
+            result = run(args.skill as string, registry, cwd);
+        } catch (exc) {
+            if (exc instanceof HandlerError) {
+                process.stderr.write(`HandlerError: ${exc.message}\n`);
+                return 2;
+            }
+            throw exc;
+        }
+        _printExecution(result, args.format);
+        const output = args.output;
+        if (output !== null) {
+            fs.mkdirSync(path.dirname(output), { recursive: true });
+            fs.writeFileSync(
+                output,
+                `${pyJsonDumpsIndent2(_executionResultAsdict(result) as Json)}\n`,
+                { encoding: 'utf-8' },
+            );
+        }
+        return result.is_success ? 0 : 1;
+    }
+
+    const result = dispatch(args.skill as string, registry);
+    _printDispatch(result, args.format);
+    return result.request.is_ready || result.request.status === 'blocked' ? 0 : 1;
+}
+
+const _isCliEntry =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_isCliEntry || process.argv[1] === _HERE) {
+    try {
+        process.exitCode = main(process.argv.slice(2));
+    } catch (err) {
+        if (!(err instanceof _ArgExit)) {
+            throw err;
+        }
+        // process.exitCode already set to 2 by the argparse-style error path.
+    }
+}

--- a/tests/scripts/chat_history.test.ts
+++ b/tests/scripts/chat_history.test.ts
@@ -1,0 +1,617 @@
+// Tests for src/scripts/chat_history.ts (py2ts, ADR-094).
+//
+// No pytest suite exists for chat_history.py, so this is a differential
+// (golden-parity) suite that runs python3 vs tsx on identical fixtures and
+// asserts byte-identical stdout + stderr + exit code AND byte-identical
+// written history files. Wall-clock fields (`ts`, `started`) are the only
+// genuinely non-deterministic tokens; they are normalised with an inline
+// regex before the file comparison.
+//
+// Two layers:
+//   1. Subprocess golden parity (python3 PY_SCRIPT vs tsx TS_SCRIPT) for the
+//      settings-independent CLI surface — init / append / status / read /
+//      sessions / reset / prepend / prune-sessions / rotate / clear, plus
+//      the argparse error/usage strings. COLUMNS=80 pins argparse wrapping.
+//   2. In-process parity for the five functions the MCP tools layer consumes
+//      (SCHEMA_VERSION, init, append, read_header, read_entries) and for the
+//      settings-dependent hook surface (hook_append / hook_dispatch). These
+//      run the TS function against the python3 module via a `-c` inline and
+//      compare structured output. They run in-process because the
+//      settings-dependent path needs `require('yaml')`, which resolves inside
+//      vitest but NOT inside a bare tsx ESM subprocess (a pre-existing
+//      `agent_settings.ts` constraint — see report). The CLI subprocess layer
+//      therefore covers only settings-independent commands.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as ch from '../../src/scripts/chat_history.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'chat_history.py');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'chat_history.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'chat-hist-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+interface RunResult {
+    status: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Run python3 chat_history.py with $AGENT_CHAT_HISTORY_FILE pinned + COLUMNS=80. */
+function runPy(file: string, args: string[], stdin = ''): RunResult {
+    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
+        encoding: 'utf8',
+        cwd: REPO_ROOT,
+        input: stdin,
+        env: { ...process.env, AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' },
+        maxBuffer: 64 * 1024 * 1024,
+    });
+    return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+/** Run tsx chat_history.ts with $AGENT_CHAT_HISTORY_FILE pinned + COLUMNS=80. */
+function runTs(file: string, args: string[], stdin = ''): RunResult {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        encoding: 'utf8',
+        cwd: REPO_ROOT,
+        input: stdin,
+        env: { ...process.env, AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' },
+        maxBuffer: 64 * 1024 * 1024,
+    });
+    return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+/** Normalise the two wall-clock fields so file/stdout comparisons stay deterministic. */
+function normTs(text: string): string {
+    return text
+        .replace(/"ts": "[^"]*"/g, '"ts": "TS"')
+        .replace(/"started": "[^"]*"/g, '"started": "TS"');
+}
+
+/** Read the on-disk JSONL (or "" when absent). */
+function readFile(p: string): string {
+    return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : '';
+}
+
+/** Run an identical op sequence against a fresh py-file and a fresh ts-file. */
+function seqBoth(ops: string[][]): { pyFile: string; tsFile: string } {
+    const pyFile = path.join(mkTmp(), '.agent-chat-history');
+    const tsFile = path.join(mkTmp(), '.agent-chat-history');
+    for (const args of ops) {
+        runPy(pyFile, args);
+    }
+    for (const args of ops) {
+        runTs(tsFile, args);
+    }
+    return { pyFile, tsFile };
+}
+
+// ---------------------------------------------------------------------
+// Layer 1 — subprocess golden parity (settings-independent CLI surface)
+// ---------------------------------------------------------------------
+
+describe.runIf(hasPython3())('chat_history — CLI golden parity (python3 vs tsx)', () => {
+    it('init writes a byte-identical header (stdout + file)', () => {
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(pyFile, ['init', '--freq', 'per_phase']);
+        const ts = runTs(tsFile, ['init', '--freq', 'per_phase']);
+        expect(ts.status).toBe(py.status);
+        expect(normTs(ts.stdout)).toBe(normTs(py.stdout));
+        expect(ts.stderr).toBe(py.stderr);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('append writes byte-identical body for a multi-session sequence', () => {
+        const ops = [
+            ['init', '--freq', 'per_phase'],
+            ['append', '--type', 'user', '--json', '{"text":"first  prompt","agent":"claude"}', '--session-id', 'sessA'],
+            ['append', '--type', 'tool', '--json', '{"tool":"Bash","text":"ls"}', '--session-id', 'sessA'],
+            ['append', '--type', 'phase', '--json', '{"text":"unicode café ☕ 日本語 🎉"}', '--session-id', 'sessB'],
+        ];
+        const { pyFile, tsFile } = seqBoth(ops);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('read / status / sessions on a deterministic fixture are byte-identical', () => {
+        // Seed both copies with identical, fixed-`ts` bytes so the read-only
+        // commands carry zero wall-clock nondeterminism (timestamp ties in
+        // last_ts then sort identically in both impls).
+        const body =
+            '{"t": "header", "v": 4, "started": "2026-01-01T00:00:00+00:00", "freq": "per_phase"}\n' +
+            '{"text": "first  prompt", "agent": "claude", "t": "user", "ts": "2026-01-01T00:00:01+00:00", "s": "AAAA"}\n' +
+            '{"tool": "Bash", "text": "ls", "t": "tool", "ts": "2026-01-01T00:00:01+00:00", "s": "AAAA"}\n' +
+            '{"text": "unicode café ☕ 日本語 🎉", "t": "phase", "ts": "2026-01-01T00:00:02+00:00", "s": "BBBB"}\n';
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        fs.writeFileSync(pyFile, body);
+        fs.writeFileSync(tsFile, body);
+
+        for (const readArgs of [
+            ['read'],
+            ['read', '--all'],
+            ['read', '--last', '2', '--all'],
+            ['status'],
+            ['sessions'],
+            ['sessions', '--json'],
+            ['sessions', '--summary'],
+        ]) {
+            const py = runPy(pyFile, readArgs);
+            const ts = runTs(tsFile, readArgs);
+            // status / sessions --json embed the file path — normalise it.
+            const pyOut = normTs(py.stdout).split(pyFile).join('FILE');
+            const tsOut = normTs(ts.stdout).split(tsFile).join('FILE');
+            expect(ts.status, `status for ${readArgs.join(' ')}`).toBe(py.status);
+            expect(tsOut, `stdout for ${readArgs.join(' ')}`).toBe(pyOut);
+            expect(ts.stderr, `stderr for ${readArgs.join(' ')}`).toBe(py.stderr);
+        }
+    });
+
+    it('read --agent filter matches', () => {
+        const { pyFile, tsFile } = seqBoth([
+            ['init'],
+            ['append', '--type', 'user', '--json', '{"text":"a","agent":"claude"}', '--session-id', 'sessA'],
+            ['append', '--type', 'tool', '--json', '{"tool":"x"}', '--session-id', 'sessA'],
+        ]);
+        const py = runPy(pyFile, ['read', '--all', '--agent', 'claude']);
+        const ts = runTs(tsFile, ['read', '--all', '--agent', 'claude']);
+        expect(ts.status).toBe(py.status);
+        expect(normTs(ts.stdout)).toBe(normTs(py.stdout));
+    });
+
+    it('read --session filter (computed tag) matches', () => {
+        const tag = ch.derive_session_tag('sessA');
+        const { pyFile, tsFile } = seqBoth([
+            ['init'],
+            ['append', '--type', 'user', '--json', '{"text":"a"}', '--session-id', 'sessA'],
+            ['append', '--type', 'user', '--json', '{"text":"b"}', '--session-id', 'sessB'],
+        ]);
+        const py = runPy(pyFile, ['read', '--all', '--session', tag]);
+        const ts = runTs(tsFile, ['read', '--all', '--session', tag]);
+        expect(normTs(ts.stdout)).toBe(normTs(py.stdout));
+    });
+
+    it('reset writes a byte-identical file', () => {
+        const entries = '[{"t":"user","text":"a","s":"S1"},{"t":"phase","text":"b","s":"S2"}]';
+        const { pyFile, tsFile } = seqBoth([['reset', '--entries-json', entries, '--freq', 'per_turn']]);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('reset --entries-stdin matches (stdin path)', () => {
+        const entries = '[{"t":"user","text":"x","s":"S1"}]';
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(pyFile, ['reset', '--entries-stdin'], entries);
+        const ts = runTs(tsFile, ['reset', '--entries-stdin'], entries);
+        expect(ts.status).toBe(py.status);
+        expect(normTs(ts.stdout)).toBe(normTs(py.stdout));
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('prepend inserts after the header, byte-identical', () => {
+        const ops = [
+            ['reset', '--entries-json', '[{"t":"user","text":"newest","s":"S1"}]'],
+            ['prepend', '--entries-json', '[{"t":"phase","text":"older"}]'],
+        ];
+        const { pyFile, tsFile } = seqBoth(ops);
+        const py = runPy(pyFile, ['read', '--all']);
+        const ts = runTs(tsFile, ['read', '--all']);
+        expect(normTs(ts.stdout)).toBe(normTs(py.stdout));
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('prune-sessions --max-sessions trims the oldest session, byte-identical', () => {
+        const ops = [
+            ['reset', '--entries-json', '[{"t":"a","text":"1","s":"S1"},{"t":"b","text":"2","s":"S2"},{"t":"c","text":"3","s":"S3"}]'],
+            ['prune-sessions', '--max-sessions', '2'],
+        ];
+        const { pyFile, tsFile } = seqBoth(ops);
+        const py = runPy(pyFile, ['prune-sessions', '--max-sessions', '2']);
+        const ts = runTs(tsFile, ['prune-sessions', '--max-sessions', '2']);
+        // The prune was already applied in seqBoth; this re-run is a noop and
+        // should report identically.
+        expect(ts.stdout).toBe(py.stdout);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('rotate (mode rotate) drops oldest entries, byte-identical', () => {
+        const big = 'x'.repeat(300);
+        const entries = `[{"t":"a","text":"${big}","s":"S"},{"t":"b","text":"${big}","s":"S"},{"t":"c","text":"${big}","s":"S"}]`;
+        const { pyFile, tsFile } = seqBoth([
+            ['reset', '--entries-json', entries],
+            ['rotate', '--max-kb', '1'],
+        ]);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('rotate --mode condense appends the marker, byte-identical', () => {
+        const big = 'y'.repeat(300);
+        const entries = `[{"t":"a","text":"${big}"},{"t":"b","text":"${big}"}]`;
+        const { pyFile, tsFile } = seqBoth([
+            ['reset', '--entries-json', entries],
+            ['rotate', '--max-kb', '0', '--mode', 'condense'],
+        ]);
+        const py = runPy(pyFile, ['rotate', '--max-kb', '0', '--mode', 'condense']);
+        const ts = runTs(tsFile, ['rotate', '--max-kb', '0', '--mode', 'condense']);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('rotate noop on a small file', () => {
+        const { pyFile, tsFile } = seqBoth([['init']]);
+        const py = runPy(pyFile, ['rotate', '--max-kb', '256']);
+        const ts = runTs(tsFile, ['rotate', '--max-kb', '256']);
+        expect(ts.stdout).toBe(py.stdout);
+    });
+
+    it('clear deletes the file', () => {
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        runPy(pyFile, ['init']);
+        runTs(tsFile, ['init']);
+        const py = runPy(pyFile, ['clear']);
+        const ts = runTs(tsFile, ['clear']);
+        expect(ts.status).toBe(py.status);
+        expect(fs.existsSync(tsFile)).toBe(fs.existsSync(pyFile));
+        expect(fs.existsSync(tsFile)).toBe(false);
+    });
+
+    it('status on a missing file (path token normalised)', () => {
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(pyFile, ['status']);
+        const ts = runTs(tsFile, ['status']);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout.split(tsFile).join('FILE')).toBe(py.stdout.split(pyFile).join('FILE'));
+    });
+
+    it('sessions on an empty (no-body) file', () => {
+        const { pyFile, tsFile } = seqBoth([['init']]);
+        const py = runPy(pyFile, ['sessions']);
+        const ts = runTs(tsFile, ['sessions']);
+        expect(ts.stdout).toBe(py.stdout);
+    });
+
+    // ---- error / argparse paths --------------------------------------
+
+    it('no subcommand → usage + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, []);
+        const ts = runTs(f, []);
+        expect(ts.status).toBe(2);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stdout).toBe(py.stdout);
+    });
+
+    it('invalid subcommand → usage + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, ['bogus']);
+        const ts = runTs(f, ['bogus']);
+        expect(ts.status).toBe(2);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('init --freq invalid choice → usage + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, ['init', '--freq', 'nope']);
+        const ts = runTs(f, ['init', '--freq', 'nope']);
+        expect(ts.status).toBe(2);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('read --last with --all → mutually-exclusive error + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, ['read', '--last', '1', '--all']);
+        const ts = runTs(f, ['read', '--last', '1', '--all']);
+        expect(ts.status).toBe(2);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('rotate --mode invalid choice → usage + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, ['rotate', '--mode', 'nope']);
+        const ts = runTs(f, ['rotate', '--mode', 'nope']);
+        expect(ts.status).toBe(2);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('append with neither --type nor a t key → error + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, ['append', '--json', '{"text":"x"}']);
+        const ts = runTs(f, ['append', '--json', '{"text":"x"}']);
+        expect(ts.status).toBe(2);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    // ---- legacy chat-history filename fallbacks ----------------------
+    // The default file path is agents/runtime/.agent-chat-history but the CLI
+    // honours any $AGENT_CHAT_HISTORY_FILE; legacy installs used
+    // agents/.agent-chat-history or .agent-chat-history. The behaviour is
+    // identical regardless of which path the env var points at — verify the
+    // flat legacy filename and a v3-style header are both read identically.
+    it('reads a flat legacy .agent-chat-history identically', () => {
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        const body =
+            '{"t": "header", "v": 4, "started": "2026-01-01T00:00:00+00:00", "freq": "per_phase"}\n' +
+            '{"t": "user", "text": "legacy", "s": "S1", "ts": "2026-01-01T00:00:01+00:00"}\n';
+        const pyFile = path.join(pyDir, '.agent-chat-history');
+        const tsFile = path.join(tsDir, '.agent-chat-history');
+        fs.writeFileSync(pyFile, body);
+        fs.writeFileSync(tsFile, body);
+        const py = runPy(pyFile, ['read', '--all']);
+        const ts = runTs(tsFile, ['read', '--all']);
+        expect(ts.stdout).toBe(py.stdout);
+    });
+
+    it('migrates a stale v3 header in place on hook init path-independent read', () => {
+        // read does not migrate; this asserts a v3 header is still read by
+        // read_header parity (forward-compatible).
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        const body =
+            '{"t": "header", "v": 3, "started": "2026-01-01T00:00:00+00:00", "freq": "per_phase", "fp": "abc"}\n' +
+            '{"t": "phase", "text": "x", "s": "S1", "ts": "2026-01-01T00:00:01+00:00"}\n';
+        const pyFile = path.join(pyDir, '.agent-chat-history');
+        const tsFile = path.join(tsDir, '.agent-chat-history');
+        fs.writeFileSync(pyFile, body);
+        fs.writeFileSync(tsFile, body);
+        const py = runPy(pyFile, ['status']);
+        const ts = runTs(tsFile, ['status']);
+        expect(ts.stdout.split(tsFile).join('FILE')).toBe(py.stdout.split(pyFile).join('FILE'));
+    });
+
+    // ---- hook with no settings (settings-independent: disabled / unmapped)
+    it('hook-append with a missing settings file → disabled (no write)', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const missing = path.join(mkTmp(), 'nope.yml');
+        const py = runPy(f, ['hook-append', '--event', 'phase', '--session-id', 'S1', '--payload', '{"text":"x"}', '--settings', missing]);
+        const ts = runTs(f, ['hook-append', '--event', 'phase', '--session-id', 'S1', '--payload', '{"text":"x"}', '--settings', missing]);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(fs.existsSync(f)).toBe(false);
+    });
+
+    it('hook-dispatch unmapped event → skipped_unmapped_event', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const missing = path.join(mkTmp(), 'nope.yml');
+        const stdin = '{"hook_event_name":"Weird"}';
+        const py = runPy(f, ['hook-dispatch', '--platform', 'claude', '--settings', missing], stdin);
+        const ts = runTs(f, ['hook-dispatch', '--platform', 'claude', '--settings', missing], stdin);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+    });
+
+    it('hook-dispatch unknown platform → error + exit 2', () => {
+        const f = path.join(mkTmp(), '.agent-chat-history');
+        const py = runPy(f, ['hook-dispatch', '--platform', 'bogus'], '{}');
+        const ts = runTs(f, ['hook-dispatch', '--platform', 'bogus'], '{}');
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Layer 2 — in-process parity for the five tools-consumed functions
+// ---------------------------------------------------------------------
+
+/** Run a python3 chat_history snippet with src/ on PYTHONPATH; return stdout. */
+function pyInline(code: string, file: string): { status: number; stdout: string; stderr: string } {
+    const r = spawnSync('python3', ['-c', code], {
+        encoding: 'utf8',
+        cwd: REPO_ROOT,
+        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), AGENT_CHAT_HISTORY_FILE: file },
+        maxBuffer: 64 * 1024 * 1024,
+    });
+    return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe.runIf(hasPython3())('chat_history — in-process function parity (tools.ts surface)', () => {
+    it('SCHEMA_VERSION matches', () => {
+        const py = pyInline('from scripts.chat_history import SCHEMA_VERSION; print(SCHEMA_VERSION)', '/dev/null');
+        expect(String(ch.SCHEMA_VERSION)).toBe(py.stdout.trim());
+    });
+
+    it('init + append write a byte-identical JSONL vs the python writer', () => {
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+
+        // TS path (the five functions tools.ts consumes).
+        ch.init('per_phase', { path: tsFile });
+        ch.append({ t: 'note', text: 'real entry' }, { path: tsFile, session: 'abc1234567890def' });
+
+        // Python path — identical ops.
+        pyInline(
+            'from scripts.chat_history import init, append;' +
+                `init(path=__import__("pathlib").Path(${JSON.stringify(pyFile)}));` +
+                `append({"t":"note","text":"real entry"}, path=__import__("pathlib").Path(${JSON.stringify(pyFile)}), session="abc1234567890def")`,
+            pyFile,
+        );
+
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('read_header parses the header dict identically', () => {
+        const file = path.join(mkTmp(), '.agent-chat-history');
+        fs.writeFileSync(
+            file,
+            '{"t": "header", "v": 4, "started": "2026-01-01T00:00:00+00:00", "freq": "per_phase"}\n' +
+                '{"t": "phase", "text": "x", "s": "S1", "ts": "2026-01-01T00:00:01+00:00"}\n',
+        );
+        const tsHeader = ch.read_header(file);
+        const py = pyInline(
+            'import json; from scripts.chat_history import read_header;' +
+                `print(json.dumps(read_header(__import__("pathlib").Path(${JSON.stringify(file)})), sort_keys=True))`,
+            file,
+        );
+        // Compare structurally (key order is irrelevant for the dict identity).
+        expect(JSON.parse(py.stdout.trim())).toEqual(tsHeader);
+    });
+
+    it('read_entries (last/session filters) matches the python reader', () => {
+        const file = path.join(mkTmp(), '.agent-chat-history');
+        fs.writeFileSync(
+            file,
+            '{"t": "header", "v": 4, "started": "2026-01-01T00:00:00+00:00", "freq": "per_phase"}\n' +
+                '{"t": "phase", "s": "AAAA", "text": "row-1", "ts": "2026-01-01T00:00:01+00:00"}\n' +
+                '{"t": "tool", "s": "AAAA", "text": "row-2", "ts": "2026-01-01T00:00:01+00:00"}\n' +
+                '{"t": "phase", "s": "BBBB", "text": "row-3", "ts": "2026-01-01T00:00:01+00:00"}\n',
+        );
+        for (const [last, session] of [
+            [null, null],
+            [2, null],
+            [null, 'AAAA'],
+            [1, 'AAAA'],
+        ] as Array<[number | null, string | null]>) {
+            const tsEntries = ch.read_entries({ last, path: file, session });
+            const py = pyInline(
+                'import json; from scripts.chat_history import read_entries;' +
+                    `print(json.dumps(read_entries(last=${last === null ? 'None' : last}, ` +
+                    `path=__import__("pathlib").Path(${JSON.stringify(file)}), ` +
+                    `session=${session === null ? 'None' : JSON.stringify(session)}), sort_keys=True))`,
+                file,
+            );
+            expect(JSON.parse(py.stdout.trim())).toEqual(tsEntries);
+        }
+    });
+
+    it('append raises for a header entry type (ValueError parity)', () => {
+        const file = path.join(mkTmp(), '.agent-chat-history');
+        expect(() => ch.append({ t: 'header' }, { path: file })).toThrow(/use init/);
+    });
+});
+
+// ---------------------------------------------------------------------
+// Layer 2b — settings-dependent hook surface (in-process; needs yaml)
+// ---------------------------------------------------------------------
+
+describe.runIf(hasPython3())('chat_history — hook_append / hook_dispatch parity (settings-enabled)', () => {
+    function writeSettings(dir: string, body: string): string {
+        const p = path.join(dir, '.agent-settings.yml');
+        fs.writeFileSync(p, body);
+        return p;
+    }
+
+    it('hook_append per_phase appends + writes byte-identical body', () => {
+        const dir = mkTmp();
+        const settings = writeSettings(dir, 'chat_history:\n  enabled: true\n  frequency: per_phase\n');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+
+        const tsResult = ch.hook_append('phase', {
+            session_id: 'S1',
+            payload: { text: 'phase text', agent: 'claude' },
+            path: tsFile,
+            settings_path: settings,
+        });
+        const py = pyInline(
+            'import json; from pathlib import Path; from scripts.chat_history import hook_append;' +
+                `print(json.dumps(hook_append("phase", session_id="S1", payload={"text":"phase text","agent":"claude"}, ` +
+                `path=Path(${JSON.stringify(pyFile)}), settings_path=Path(${JSON.stringify(settings)})), sort_keys=True))`,
+            pyFile,
+        );
+        expect(JSON.parse(py.stdout.trim())).toEqual(tsResult);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+
+    it('hook_append tool_use under per_phase → skipped_cadence', () => {
+        const dir = mkTmp();
+        const settings = writeSettings(dir, 'chat_history:\n  enabled: true\n  frequency: per_phase\n');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsResult = ch.hook_append('tool_use', {
+            session_id: 'S1',
+            payload: { text: 'x', tool: 'Bash' },
+            path: tsFile,
+            settings_path: settings,
+        });
+        const py = pyInline(
+            'import json; from pathlib import Path; from scripts.chat_history import hook_append;' +
+                `print(json.dumps(hook_append("tool_use", session_id="S1", payload={"text":"x","tool":"Bash"}, ` +
+                `path=Path(${JSON.stringify(pyFile)}), settings_path=Path(${JSON.stringify(settings)})), sort_keys=True))`,
+            pyFile,
+        );
+        expect(JSON.parse(py.stdout.trim())).toEqual(tsResult);
+    });
+
+    it('hook_append dry_run resolves the entry_preview identically', () => {
+        const dir = mkTmp();
+        const settings = writeSettings(
+            dir,
+            'chat_history:\n  enabled: true\n  frequency: per_phase\n  text_limits:\n    phase: 8\n',
+        );
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const tsResult = ch.hook_append('phase', {
+            session_id: 'S1',
+            payload: { text: 'this is a long phase body' },
+            path: tsFile,
+            settings_path: settings,
+            dry_run: true,
+        });
+        const py = pyInline(
+            'import json; from pathlib import Path; from scripts.chat_history import hook_append;' +
+                `print(json.dumps(hook_append("phase", session_id="S1", payload={"text":"this is a long phase body"}, ` +
+                `path=Path(${JSON.stringify(tsFile)}), settings_path=Path(${JSON.stringify(settings)}), dry_run=True), sort_keys=True))`,
+            tsFile,
+        );
+        expect(JSON.parse(py.stdout.trim())).toEqual(tsResult);
+        expect(fs.existsSync(tsFile)).toBe(false);
+    });
+
+    it('hook_dispatch (claude PostToolUse) writes byte-identical body', () => {
+        const dir = mkTmp();
+        const settings = writeSettings(dir, 'chat_history:\n  enabled: true\n  frequency: per_tool\n');
+        const tsFile = path.join(mkTmp(), '.agent-chat-history');
+        const pyFile = path.join(mkTmp(), '.agent-chat-history');
+        const payload = JSON.stringify({
+            hook_event_name: 'PostToolUse',
+            session_id: 'S9',
+            tool_name: 'Bash',
+            tool_response: { output: 'done' },
+        });
+        const tsResult = ch.hook_dispatch('claude', payload, { path: tsFile, settings_path: settings });
+        const py = pyInline(
+            'import json,sys; from pathlib import Path; from scripts.chat_history import hook_dispatch;' +
+                `print(json.dumps(hook_dispatch("claude", ${JSON.stringify(payload)}, ` +
+                `path=Path(${JSON.stringify(pyFile)}), settings_path=Path(${JSON.stringify(settings)})), sort_keys=True))`,
+            pyFile,
+        );
+        expect(JSON.parse(py.stdout.trim())).toEqual(tsResult);
+        expect(normTs(readFile(tsFile))).toBe(normTs(readFile(pyFile)));
+    });
+});

--- a/tests/scripts/runtime_dispatcher.test.ts
+++ b/tests/scripts/runtime_dispatcher.test.ts
@@ -1,0 +1,286 @@
+// Tests for src/scripts/runtime_dispatcher.ts — TypeScript twin of
+// src/scripts/runtime_dispatcher.py (ADR-094, py2ts).
+//
+// Two layers:
+//   1. Pure unit tests of `dispatch` (the pure resolution function) — mirrors
+//      tests/test_runtime_dispatcher.py 1:1 (not_found / manual / assisted /
+//      automated-ready / automated-no-handler / automated-no-safety / tools /
+//      timeout passthrough).
+//   2. Golden parity (python3 vs tsx via spawnSync) on the real CLI surface:
+//      - resolve (flat + subcommand) in text + json → byte-identical
+//        stdout/stderr/exit.
+//      - run --output JSON → byte-identical after the one inherently
+//        non-deterministic field (`duration_ms`, wall-clock) is normalized to 0
+//        on both sides; reason inlined below.
+//      - HandlerError paths (not-ready skills) → byte-identical
+//        stdout/stderr/exit.
+//      - argparse-style error paths → exit 2 + non-empty stderr only.
+//        argparse usage/error prose embeds `prog` (`runtime_dispatcher.py` for
+//        the original, `runtime_dispatcher` for the twin per the established
+//        py2ts stem convention) and varies across CPython versions, so the
+//        migration contract for those is channel + exit code, not byte prose.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { SkillRuntime } from '../../src/scripts/runtime_registry.js';
+import { dispatch } from '../../src/scripts/runtime_dispatcher.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+const PY = path.join(REPO_ROOT, 'src', 'scripts', 'runtime_dispatcher.py');
+const TS = path.join(REPO_ROOT, 'src', 'scripts', 'runtime_dispatcher.ts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+function runPy(args: string[]): SpawnSyncReturns<string> {
+    return spawnSync('python3', [PY, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+function runTs(args: string[]): SpawnSyncReturns<string> {
+    return spawnSync(TSX_BIN, [TS, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
+}
+
+function skill(args: {
+    name: string;
+    exec_type?: string;
+    handler?: string;
+    safety_mode?: string | null;
+    allowed_tools?: string[];
+    timeout_seconds?: number;
+}): SkillRuntime {
+    return new SkillRuntime({
+        name: args.name,
+        path: `/skills/${args.name}/SKILL.md`,
+        description: `Test ${args.name}`,
+        execution_type: args.exec_type ?? 'manual',
+        handler: args.handler ?? 'none',
+        timeout_seconds: args.timeout_seconds ?? 30,
+        safety_mode: args.safety_mode ?? null,
+        allowed_tools: args.allowed_tools ?? [],
+    });
+}
+
+// --- Layer 1: pure `dispatch` (1:1 with test_runtime_dispatcher.py) ----------
+
+describe('runtime_dispatcher — dispatch (pure)', () => {
+    it('test_dispatch_not_found', () => {
+        const result = dispatch('nonexistent', []);
+        expect(result.request.status).toBe('not_found');
+        expect(result.request.is_ready).toBe(false);
+    });
+
+    it('test_dispatch_manual_blocked', () => {
+        const result = dispatch('manual-skill', [skill({ name: 'manual-skill', exec_type: 'manual' })]);
+        expect(result.request.status).toBe('blocked');
+        expect(result.request.reason ?? '').toContain('Manual');
+    });
+
+    it('test_dispatch_assisted_ready', () => {
+        const result = dispatch('assist', [
+            skill({ name: 'assist', exec_type: 'assisted', handler: 'internal' }),
+        ]);
+        expect(result.request.status).toBe('ready');
+        expect(result.request.is_ready).toBe(true);
+        expect(result.request.execution_type).toBe('assisted');
+        expect(result.warnings.some((w) => w.toLowerCase().includes('confirmation'))).toBe(true);
+    });
+
+    it('test_dispatch_automated_ready', () => {
+        const result = dispatch('auto', [
+            skill({ name: 'auto', exec_type: 'automated', handler: 'shell', safety_mode: 'strict' }),
+        ]);
+        expect(result.request.status).toBe('ready');
+        expect(result.request.is_ready).toBe(true);
+        expect(result.request.execution_type).toBe('automated');
+    });
+
+    it('test_dispatch_automated_no_handler_blocked', () => {
+        const result = dispatch('bad-auto', [
+            skill({ name: 'bad-auto', exec_type: 'automated', handler: 'none', safety_mode: 'strict' }),
+        ]);
+        expect(result.request.status).toBe('blocked');
+        expect((result.request.reason ?? '').toLowerCase()).toContain('handler');
+    });
+
+    it('test_dispatch_automated_no_safety_blocked', () => {
+        const result = dispatch('bad-safety', [
+            skill({ name: 'bad-safety', exec_type: 'automated', handler: 'shell', safety_mode: null }),
+        ]);
+        expect(result.request.status).toBe('blocked');
+        expect((result.request.reason ?? '').toLowerCase()).toContain('safety_mode');
+    });
+
+    it('test_dispatch_automated_with_tools', () => {
+        const result = dispatch('tooled', [
+            skill({
+                name: 'tooled',
+                exec_type: 'automated',
+                handler: 'internal',
+                safety_mode: 'strict',
+                allowed_tools: ['github', 'jira'],
+            }),
+        ]);
+        expect(result.request.is_ready).toBe(true);
+        expect(result.request.allowed_tools).toEqual(['github', 'jira']);
+    });
+
+    it('test_dispatch_returns_correct_timeout', () => {
+        const result = dispatch('timed', [
+            skill({ name: 'timed', exec_type: 'assisted', handler: 'shell', timeout_seconds: 120 }),
+        ]);
+        expect(result.request.timeout_seconds).toBe(120);
+    });
+
+    it('asdict mirrors dataclasses.asdict — request nested, properties excluded', () => {
+        const result = dispatch('nope', []);
+        const d = result.asdict() as { request: Record<string, unknown>; warnings: unknown[] };
+        // Field order + keys mirror the dataclass exactly (no `is_ready`).
+        expect(Object.keys(d)).toEqual(['request', 'warnings']);
+        expect(Object.keys(d.request)).toEqual([
+            'skill_name',
+            'execution_type',
+            'handler',
+            'timeout_seconds',
+            'safety_mode',
+            'allowed_tools',
+            'status',
+            'reason',
+        ]);
+        expect(d.warnings).toEqual([]);
+    });
+});
+
+// --- Layer 2: golden parity (python3 vs tsx) ---------------------------------
+
+describe.skipIf(!py3)('runtime_dispatcher — golden parity, deterministic paths', () => {
+    function bothEqual(args: string[]): void {
+        const p = runPy(args);
+        const t = runTs(args);
+        expect(t.stdout).toBe(p.stdout);
+        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toBe(p.status);
+    }
+
+    it('resolve --skill <real> --format json → identical', () => {
+        bothEqual(['resolve', '--skill', 'lint-skills', '--root', '.', '--format', 'json']);
+    });
+
+    it('resolve --skill <real> --format text → identical', () => {
+        bothEqual(['resolve', '--skill', 'lint-skills', '--root', '.', '--format', 'text']);
+    });
+
+    it('flat --skill <real> (no subcommand, defaults to resolve) → identical', () => {
+        bothEqual(['--skill', 'lint-skills', '--root', '.', '--format', 'json']);
+    });
+
+    it('resolve --skill <not-found> --format json → identical (exit 1)', () => {
+        const p = runPy(['resolve', '--skill', '__no_such_skill__', '--root', '.', '--format', 'json']);
+        const t = runTs(['resolve', '--skill', '__no_such_skill__', '--root', '.', '--format', 'json']);
+        expect(t.stdout).toBe(p.stdout);
+        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toBe(p.status);
+        expect(t.status).toBe(1);
+    });
+
+    it('resolve --skill <not-found> --format text → identical (exit 1)', () => {
+        bothEqual(['resolve', '--skill', '__no_such_skill__', '--root', '.', '--format', 'text']);
+    });
+
+    it('run --skill <not-found> → identical HandlerError (exit 2)', () => {
+        const p = runPy(['run', '--skill', '__no_such_skill__', '--root', '.']);
+        const t = runTs(['run', '--skill', '__no_such_skill__', '--root', '.']);
+        expect(t.stdout).toBe(p.stdout);
+        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toBe(p.status);
+        expect(t.status).toBe(2);
+    });
+});
+
+describe.skipIf(!py3)('runtime_dispatcher — golden parity, run --output (duration normalized)', () => {
+    // `run` shells out a real skill; its ExecutionResult carries `duration_ms`
+    // (wall-clock) and possibly skill-dependent stdout/stderr. We normalize the
+    // single non-deterministic field (`duration_ms` → 0) on both the printed
+    // JSON and the persisted --output JSON, then assert byte parity on the rest.
+    function normalize(jsonText: string): string {
+        const obj = JSON.parse(jsonText) as Record<string, unknown>;
+        obj.duration_ms = 0;
+        return JSON.stringify(obj, null, 2);
+    }
+
+    it('run --skill check-refs --output FILE --format json → identical (duration zeroed)', () => {
+        const args = (out: string): string[] => [
+            'run',
+            '--skill',
+            'check-refs',
+            '--root',
+            '.',
+            '--output',
+            out,
+            '--format',
+            'json',
+        ];
+        const p = runPy(args('/tmp/rd_py_out.json'));
+        const t = runTs(args('/tmp/rd_ts_out.json'));
+        expect(t.status).toBe(p.status);
+        // Printed JSON (stdout) parity after normalizing duration.
+        expect(normalize(t.stdout)).toBe(normalize(p.stdout));
+        // Persisted --output JSON parity after normalizing duration.
+        expect(normalize(fs.readFileSync('/tmp/rd_ts_out.json', 'utf8'))).toBe(
+            normalize(fs.readFileSync('/tmp/rd_py_out.json', 'utf8')),
+        );
+        // The persisted file ends with a trailing newline on both sides.
+        expect(fs.readFileSync('/tmp/rd_ts_out.json', 'utf8').endsWith('\n')).toBe(true);
+        fs.rmSync('/tmp/rd_py_out.json', { force: true });
+        fs.rmSync('/tmp/rd_ts_out.json', { force: true });
+    });
+});
+
+describe.skipIf(!py3)('runtime_dispatcher — argparse error paths (exit + channel only)', () => {
+    // argparse usage/error prose embeds `prog` and differs across CPython
+    // versions; the migration contract here is exit 2 + non-empty stderr.
+    function exit2Both(args: string[]): void {
+        const p = runPy(args);
+        const t = runTs(args);
+        expect(t.status).toBe(2);
+        expect(p.status).toBe(2);
+        expect(t.stderr.length).toBeGreaterThan(0);
+        expect(p.stderr.length).toBeGreaterThan(0);
+        expect(t.stdout).toBe('');
+        expect(p.stdout).toBe('');
+    }
+
+    it('no args (defaults to resolve, --skill missing) → exit 2', () => {
+        exit2Both([]);
+    });
+
+    it('resolve subcommand without --skill → exit 2', () => {
+        exit2Both(['resolve']);
+    });
+
+    it('run subcommand without --skill → exit 2', () => {
+        exit2Both(['run']);
+    });
+
+    it('unrecognized flag → exit 2', () => {
+        exit2Both(['--bogus']);
+    });
+
+    it('invalid --format choice → exit 2', () => {
+        exit2Both(['resolve', '--skill', 'x', '--format', 'bad']);
+    });
+
+    it('invalid subcommand → exit 2', () => {
+        exit2Both(['frobnicate']);
+    });
+});


### PR DESCRIPTION
Ports two Phase-8 scripts to byte-identical TS twins + reconciles a duplicated inline port + prepares a workflow for the eventual main merge. Targets `python2ts`. `.py` originals stay until the Phase 12 sweep.

## Twins
- **`runtime_dispatcher`** (276 LOC) — dataclasses + `resolve|run` CLI + legacy flags + exit 0/1/2; reuses the ported `runtime_registry.ts` + `runtime_handler.ts`. 22 golden-parity tests.
- **`chat_history`** (1799 → 2301 LOC) — full public surface + 12-subcommand CLI; imports the ported `_lib/agent_settings.ts`. 35 golden-parity tests.

## Reconciliation — `mcp_server/tools.ts` dedup
`tools.ts` carried a ~190-line inline copy of the 5 chat-history functions it lazily used. Swapped it to import from the canonical `chat_history.ts` twin (single source of truth) and **fixed a latent byte-divergence in the bargain**: the old inline writer used bare `JSON.stringify` (compact) while Python's `json.dumps(ensure_ascii=False)` uses `', '`/`': '` separators — the MCP-written JSONL is now byte-identical to the Python writer. The mcp_server tools/server/foundation suites stay green (55/55).

## CI prep — `tests.yml` python-tests gets node + npm ci
`python-tests` invokes `./scripts-run` for `condense` / `runtime_dispatcher` / `ci_summary`. `scripts-run` execs `tsx` whenever a target's `.ts` twin exists — those three are now ported, so the job needs node + node_modules **once the twins reach main**. Without it the scripts-run calls fail (no node_modules). Harmless until then (on a still-`.py` tree the scripts-run python fast-path skips tsx).

> ⚠️ `tests.yml` triggers on `main`/`master` only — **not** on `python2ts` PRs — so this workflow change is **not exercised by this PR's CI**; it takes effect (and is validated) at the eventual `python2ts → main` merge. This was already latent for `condense`/`ci_summary` (ported earlier); runtime_dispatcher adds another call, so the fix lands now. Flagging explicitly for review.

## Known pre-existing issue (not fixed here — minimal-safe-diff)
`_lib/agent_settings.ts::_read_yaml` uses a bare `require('yaml')` which is `undefined` in a bare-tsx ESM **subprocess** (works in-process under vitest). So `tsx chat_history.ts hook-append --settings <enabled.yml>` as a subprocess reads settings as disabled. Pre-existing in `agent_settings.ts`, left untouched. chat_history's settings-dependent parity is covered in-process; settings-independent paths via subprocess. MCP `tools.ts` consumers never touch settings. Worth a follow-up.

## Verification
`tsc` clean · phase-gate passes · 155/155 across runtime_dispatcher + chat_history + the full mcp_server suite (post-dedup) · legacy-literal ts==py==0. Migration-gates 4-shard run validates on this PR's CI.