### PR TITLE
feat(py2ts): phase 8 — RNG wave (CPython MT19937 lib + poisson_sim + pool_winsim)

### DIFF
--- a/src/scripts/_lib/py_random.ts
+++ b/src/scripts/_lib/py_random.ts
@@ -1,0 +1,212 @@
+/**
+ * Bit-exact reproduction of CPython's `random.Random` (Mersenne Twister
+ * MT19937) — the subset the prediction-pool simulators need for
+ * byte-identical output.
+ *
+ * py2ts migration (ADR-094): the simulators `poisson_sim` and `pool_winsim`
+ * call `random.Random(seed)` and consume ONLY `rng.random()` and (poisson_sim)
+ * `rng.shuffle(...)`. Reproducing CPython's stream bit-for-bit is the only way
+ * those twins emit identical simulation output. This is a NEW library — there
+ * is no `py_random.py` source (the Python side is the stdlib `random` module),
+ * so the ADR-051 legacy-literal parity check does not apply to this file.
+ *
+ * Implementation notes:
+ *   - All word operations are 32-bit unsigned (`>>> 0` masks every result).
+ *   - The constant multiplies overflow 32 bits, so they use
+ *     `Math.imul(a, b) >>> 0` — plain `*` would lose the low 32 bits to FP.
+ *   - Integer seeding mirrors CPython's `random_seed`: `abs(n)` is split into
+ *     little-endian 32-bit words and fed to `init_by_array`. BigInt is used
+ *     ONLY for that split; the generator itself is pure uint32.
+ *
+ * Cross-checked against CPython directly (see tests/scripts/_lib/py_random.test.ts):
+ *   python3 -c "import random; r=random.Random(1); print([r.random() for _ in range(5)])"
+ *   python3 -c "import random; r=random.Random(7); l=list(range(10)); r.shuffle(l); print(l)"
+ */
+
+const N = 624;
+const M = 397;
+const MATRIX_A = 0x9908b0df;
+const UPPER_MASK = 0x80000000;
+const LOWER_MASK = 0x7fffffff;
+
+export class PyRandom {
+    private mt = new Uint32Array(N);
+    private mti = N + 1;
+
+    constructor(seed?: number | bigint) {
+        if (seed === undefined || seed === null) {
+            // CPython seeds from urandom/time when no seed is given. The
+            // simulators always pass an explicit (possibly null→default)
+            // seed; this branch exists only so `new PyRandom()` does not
+            // throw. Non-deterministic — never used in parity paths.
+            this.seedFromInt(BigInt(Date.now()));
+            return;
+        }
+        this.seedFromInt(typeof seed === 'bigint' ? seed : BigInt(Math.trunc(seed)));
+    }
+
+    /** CPython `init_genrand` — seed the state array from a single uint32. */
+    private init_genrand(s: number): void {
+        const mt = this.mt;
+        mt[0] = s >>> 0;
+        for (let i = 1; i < N; i += 1) {
+            const prev = mt[i - 1] as number;
+            mt[i] = (Math.imul(1812433253, (prev ^ (prev >>> 30)) >>> 0) + i) >>> 0;
+        }
+        this.mti = N;
+    }
+
+    /** CPython `init_by_array` — seed the state from an array of uint32 words. */
+    private init_by_array(key: number[]): void {
+        this.init_genrand(19650218);
+        const mt = this.mt;
+        const keyLength = key.length;
+        let i = 1;
+        let j = 0;
+        let k = Math.max(N, keyLength);
+        for (; k; k -= 1) {
+            const prev = mt[i - 1] as number;
+            mt[i] =
+                (((mt[i] as number) ^ Math.imul((prev ^ (prev >>> 30)) >>> 0, 1664525)) +
+                    (key[j] as number) +
+                    j) >>>
+                0;
+            i += 1;
+            j += 1;
+            if (i >= N) {
+                mt[0] = mt[N - 1] as number;
+                i = 1;
+            }
+            if (j >= keyLength) {
+                j = 0;
+            }
+        }
+        for (k = N - 1; k; k -= 1) {
+            const prev = mt[i - 1] as number;
+            mt[i] =
+                (((mt[i] as number) ^ Math.imul((prev ^ (prev >>> 30)) >>> 0, 1566083941)) - i) >>> 0;
+            i += 1;
+            if (i >= N) {
+                mt[0] = mt[N - 1] as number;
+                i = 1;
+            }
+        }
+        mt[0] = 0x80000000;
+    }
+
+    /**
+     * Mirror CPython `random_seed` for an integer argument: take `abs(n)`,
+     * split into little-endian 32-bit words, and feed `init_by_array`.
+     * For seed=0 the key is `[0]`; for seed=1 it is `[1]`.
+     */
+    private seedFromInt(n: bigint): void {
+        let v = n < 0n ? -n : n;
+        const key: number[] = [];
+        if (v === 0n) {
+            key.push(0);
+        } else {
+            while (v > 0n) {
+                key.push(Number(v & 0xffffffffn));
+                v >>= 32n;
+            }
+        }
+        this.init_by_array(key);
+    }
+
+    /** CPython `genrand_uint32` — one tempered 32-bit output word. */
+    private genrand_uint32(): number {
+        const mt = this.mt;
+        let y: number;
+        if (this.mti >= N) {
+            let kk: number;
+            const mag01 = [0, MATRIX_A];
+            for (kk = 0; kk < N - M; kk += 1) {
+                y = (((mt[kk] as number) & UPPER_MASK) | ((mt[kk + 1] as number) & LOWER_MASK)) >>> 0;
+                mt[kk] = ((mt[kk + M] as number) ^ (y >>> 1) ^ (mag01[y & 0x1] as number)) >>> 0;
+            }
+            for (; kk < N - 1; kk += 1) {
+                y = (((mt[kk] as number) & UPPER_MASK) | ((mt[kk + 1] as number) & LOWER_MASK)) >>> 0;
+                mt[kk] = ((mt[kk + (M - N)] as number) ^ (y >>> 1) ^ (mag01[y & 0x1] as number)) >>> 0;
+            }
+            y = (((mt[N - 1] as number) & UPPER_MASK) | ((mt[0] as number) & LOWER_MASK)) >>> 0;
+            mt[N - 1] = ((mt[M - 1] as number) ^ (y >>> 1) ^ (mag01[y & 0x1] as number)) >>> 0;
+            this.mti = 0;
+        }
+        y = mt[this.mti] as number;
+        this.mti += 1;
+        y ^= y >>> 11;
+        y ^= ((y << 7) >>> 0) & 0x9d2c5680;
+        y ^= ((y << 15) >>> 0) & 0xefc60000;
+        y ^= y >>> 18;
+        return y >>> 0;
+    }
+
+    /** CPython `random_random` (genrand_res53) — a float in [0, 1). */
+    random(): number {
+        const a = this.genrand_uint32() >>> 5;
+        const b = this.genrand_uint32() >>> 6;
+        return (a * 67108864.0 + b) * (1.0 / 9007199254740992.0);
+    }
+
+    /** CPython `getrandbits(k)` — k random bits as a non-negative integer. */
+    getrandbits(k: number): number | bigint {
+        if (k <= 0) {
+            throw new Error('number of bits must be greater than zero');
+        }
+        if (k <= 32) {
+            return this.genrand_uint32() >>> (32 - k);
+        }
+        // k > 32: assemble LSB-first in 32-bit chunks, as CPython does
+        // (each word holds the low `min(32, remaining)` bits).
+        let result = 0n;
+        let shift = 0n;
+        let remaining = k;
+        while (remaining > 0) {
+            const take = remaining > 32 ? 32 : remaining;
+            const word = this.genrand_uint32() >>> (32 - take);
+            result |= BigInt(word >>> 0) << shift;
+            shift += 32n;
+            remaining -= 32;
+        }
+        return result;
+    }
+
+    /** CPython `_randbelow_with_getrandbits` — uniform int in [0, n). */
+    _randbelow(n: number): number {
+        if (n <= 0) {
+            return 0;
+        }
+        const k = bitLength(n);
+        if (k <= 32) {
+            let r = this.genrand_uint32() >>> (32 - k);
+            while (r >= n) {
+                r = this.genrand_uint32() >>> (32 - k);
+            }
+            return r;
+        }
+        const bn = BigInt(n);
+        let r = this.getrandbits(k) as bigint;
+        while (r >= bn) {
+            r = this.getrandbits(k) as bigint;
+        }
+        return Number(r);
+    }
+
+    /** CPython `Random.shuffle` — in-place Fisher-Yates using `_randbelow`. */
+    shuffle<T>(x: T[]): void {
+        for (let i = x.length - 1; i > 0; i -= 1) {
+            const j = this._randbelow(i + 1);
+            const tmp = x[i] as T;
+            x[i] = x[j] as T;
+            x[j] = tmp;
+        }
+    }
+}
+
+/** Python `int.bit_length()` for a non-negative integer. */
+function bitLength(n: number): number {
+    if (n === 0) {
+        return 0;
+    }
+    return Math.abs(n).toString(2).length;
+}

--- a/src/scripts/prediction-pool/poisson_sim.ts
+++ b/src/scripts/prediction-pool/poisson_sim.ts
@@ -1,0 +1,537 @@
+#!/usr/bin/env tsx
+/**
+ * Poisson tournament simulator for prediction-pool-optimizer.
+ *
+ * TypeScript twin of `src/scripts/prediction-pool/poisson_sim.py` (ADR-094).
+ * The CLI contract is mirrored EXACTLY — the positional `config` JSON file,
+ * `--runs` / `--seed`, exit codes, the stdout/stderr split, and byte-identical
+ * output. No behaviour changes.
+ *
+ * RNG parity: `random.Random(seed)` is reproduced bit-for-bit by `PyRandom`
+ * (MT19937) in `../_lib/py_random.js`. The two consumers are `rng.random()`
+ * (Poisson draws + the group-table tiebreak) and `rng.shuffle()` (knockout
+ * seeding). The group-table sort consumes `rng.random()` once per group member
+ * in iteration order BEFORE sorting, matching CPython's `sorted(key=…)`
+ * single-key-evaluation order exactly.
+ *
+ * Float parity: JSON renders every Python `float` via the PyFloat marker so
+ * integer-valued floats keep the `.0` suffix (`seed` is rendered as a Python
+ * int or `null`; `advance_pct` / `title_pct` values via CPython `round(x, 2)`).
+ *
+ * Original module docstring (verbatim):
+ *
+ * Honest replacement for "I simulated 10,000 runs" — this actually runs them.
+ * Goals per match are drawn from a Poisson whose rate comes from each team's
+ * attack / defence strength; group stages are round-robin, then a single-
+ * elimination bracket runs over the qualifiers. Aggregates advancement and
+ * title probabilities over N runs.
+ *
+ * It is an APPROXIMATION, stated as such: real tournament bracket pairings
+ * (winner-of-A vs runner-up-of-B …) are format-specific. Provide an explicit
+ * `bracket` (list of name pairs per round, or "auto" for a random seed) to
+ * control this; the default "auto" randomly seeds qualifiers and is good
+ * enough for outright/advancement estimates, not for exact-pairing bonus
+ * questions.
+ *
+ * Input JSON shape:
+ * {
+ *   "base_goals": 1.35,                       # league-average goals per side
+ *   "teams": { "Germany": {"att": 1.3, "def": 0.8}, ... },   # att/def multipliers (1.0 = average)
+ *   "groups": [ ["Germany","Scotland","Hungary","Switzerland"], ... ],
+ *   "advance_per_group": 2,
+ *   "bracket": "auto"                          # or omit; "auto" = random seed of qualifiers
+ * }
+ *
+ * Usage:
+ *   python3 scripts/prediction-pool/poisson_sim.py teams.json --runs 20000 [--seed 1]
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { PyRandom } from '../_lib/py_random.js';
+
+/**
+ * CPython `round(value, ndigits)` — correct decimal rounding of the *exact*
+ * IEEE-754 value, half-to-even. Uses `toFixed(40)` (far beyond double
+ * precision) so a value that displays as an exact half at 17 sig digits but is
+ * truly just below/above (e.g. `31/800 = 0.03874999999999999972`) rounds the
+ * way CPython does. The value-ladder `pyRound` trusts `toPrecision(17)` and
+ * diverges on these simulation ratios, so this twin carries its own.
+ */
+function pyRound(value: number, ndigits: number): number {
+    if (!Number.isFinite(value) || value === 0) {
+        return value;
+    }
+    const sign = value < 0 ? -1 : 1;
+    const abs = Math.abs(value);
+    const str = abs.toFixed(40);
+    const [intPart, fracRaw = ''] = str.split('.');
+    let fracPart = fracRaw;
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keepFrac = fracPart.slice(0, ndigits);
+    const decider = fracPart.slice(ndigits);
+    let scaledInt = BigInt((intPart ?? '0') + keepFrac || '0');
+    const first = decider.charAt(0);
+    const restNonZero = /[1-9]/u.test(decider.slice(1));
+    let roundUp = false;
+    if (first > '5' || (first === '5' && restNonZero)) {
+        roundUp = true;
+    } else if (first === '5' && !restNonZero) {
+        roundUp = scaledInt % 2n === 1n;
+    }
+    if (roundUp) {
+        scaledInt += 1n;
+    }
+    const factor = 10 ** ndigits;
+    return (Number(scaledInt) / factor) * sign;
+}
+
+/** Marker for a Python `float` so JSON renders integer-valued floats as `0.0`, not `0`. */
+class PyFloat {
+    constructor(readonly value: number) {}
+}
+
+/** Marker for a Python `int` so JSON renders it without a `.0` suffix. */
+class PyInt {
+    constructor(readonly value: number) {}
+}
+
+interface TeamStats {
+    att?: number;
+    def?: number;
+}
+
+type TeamsMap = Record<string, TeamStats>;
+
+/** Knuth's algorithm — stdlib only, no numpy. */
+function _poisson(rate: number, rng: PyRandom): number {
+    if (rate <= 0) {
+        return 0;
+    }
+    const L = Math.exp(-rate);
+    let k = 0;
+    let p = 1.0;
+    for (;;) {
+        k += 1;
+        p *= rng.random();
+        if (p <= L) {
+            return k - 1;
+        }
+    }
+}
+
+function _rates(home: string, away: string, teams: TeamsMap, base: number): [number, number] {
+    const h = teams[home] ?? {};
+    const a = teams[away] ?? {};
+    const lam_h = base * (h.att ?? 1.0) * (a.def ?? 1.0);
+    const lam_a = base * (a.att ?? 1.0) * (h.def ?? 1.0);
+    return [lam_h, lam_a];
+}
+
+function _play(
+    home: string,
+    away: string,
+    teams: TeamsMap,
+    base: number,
+    rng: PyRandom,
+    allow_draw = true,
+): [number, number] {
+    const [lam_h, lam_a] = _rates(home, away, teams, base);
+    const gh = _poisson(lam_h, rng);
+    const ga = _poisson(lam_a, rng);
+    if (!allow_draw && gh === ga) {
+        // extra-time / penalties proxy: edge to the stronger attack, else coin flip
+        if (lam_h === lam_a) {
+            return rng.random() < 0.5 ? [gh + 1, ga] : [gh, ga + 1];
+        }
+        return lam_h > lam_a ? [gh + 1, ga] : [gh, ga + 1];
+    }
+    return [gh, ga];
+}
+
+function _group_table(group: string[], teams: TeamsMap, base: number, rng: PyRandom): string[] {
+    const pts: Record<string, number> = {};
+    const gd: Record<string, number> = {};
+    const gf: Record<string, number> = {};
+    const bump = (m: Record<string, number>, key: string, by: number): void => {
+        m[key] = (m[key] ?? 0) + by;
+    };
+    for (let i = 0; i < group.length; i += 1) {
+        for (let j = i + 1; j < group.length; j += 1) {
+            const gi = group[i] as string;
+            const gj = group[j] as string;
+            const [gh, ga] = _play(gi, gj, teams, base, rng);
+            bump(gd, gi, gh - ga);
+            bump(gd, gj, ga - gh);
+            bump(gf, gi, gh);
+            bump(gf, gj, ga);
+            if (gh > ga) {
+                bump(pts, gi, 3);
+            } else if (ga > gh) {
+                bump(pts, gj, 3);
+            } else {
+                bump(pts, gi, 1);
+                bump(pts, gj, 1);
+            }
+        }
+    }
+    // rank: points, then goal difference, then goals for, then random tiebreak.
+    // CPython `sorted(group, key=lambda t: (pts[t], gd[t], gf[t], rng.random()),
+    // reverse=True)` evaluates the key once per element in iteration order, so
+    // `rng.random()` is consumed in group order BEFORE the sort.
+    const keyed = group.map((t) => ({
+        t,
+        key: [pts[t] ?? 0, gd[t] ?? 0, gf[t] ?? 0, rng.random()] as [number, number, number, number],
+    }));
+    // reverse=True stable sort: descending tuple compare, ties keep original
+    // order (Array.prototype.sort is stable; comparator returns 0 on full ties).
+    keyed.sort((a, b) => {
+        for (let i = 0; i < 4; i += 1) {
+            const av = a.key[i] as number;
+            const bv = b.key[i] as number;
+            if (av < bv) {
+                return 1;
+            }
+            if (av > bv) {
+                return -1;
+            }
+        }
+        return 0;
+    });
+    return keyed.map((e) => e.t);
+}
+
+function _knockout(qualifiers: string[], teams: TeamsMap, base: number, rng: PyRandom): string | null {
+    let field: Array<string | null> = qualifiers.slice();
+    rng.shuffle(field);
+    // pad to a power of two with byes
+    while ((field.length & (field.length - 1)) !== 0) {
+        field.push(null);
+    }
+    while (field.length > 1) {
+        const nxt: Array<string | null> = [];
+        for (let i = 0; i < field.length; i += 2) {
+            const a = field[i] as string | null;
+            const b = field[i + 1] as string | null;
+            if (a === null) {
+                nxt.push(b);
+            } else if (b === null) {
+                nxt.push(a);
+            } else {
+                const [gh, ga] = _play(a, b, teams, base, rng, false);
+                nxt.push(gh > ga ? a : b);
+            }
+        }
+        field = nxt;
+    }
+    return field[0] ?? null;
+}
+
+interface Config {
+    base_goals?: number;
+    teams: TeamsMap;
+    groups?: string[][];
+    advance_per_group?: number;
+    bracket?: unknown;
+}
+
+interface SimResult {
+    runs: PyInt;
+    seed: PyInt | null;
+    advance_pct: Record<string, PyFloat>;
+    title_pct: Record<string, PyFloat>;
+}
+
+function simulate(cfg: Config, runs: number, seed: number | null): SimResult {
+    const rng = new PyRandom(seed === null ? undefined : seed);
+    const base = Number(cfg.base_goals ?? 1.35);
+    const teams = cfg.teams;
+    const groups = cfg.groups ?? [];
+    const adv = Math.trunc(Number(cfg.advance_per_group ?? 2));
+
+    // defaultdict(int) — insertion-ordered, like a Python dict.
+    const advanced: Record<string, number> = {};
+    const champ: Record<string, number> = {};
+    for (let run = 0; run < runs; run += 1) {
+        let qualifiers: string[] = [];
+        if (groups.length > 0) {
+            for (const g of groups) {
+                const ranked = _group_table(g, teams, base, rng);
+                const top = ranked.slice(0, adv);
+                qualifiers.push(...top);
+                for (const t of top) {
+                    advanced[t] = (advanced[t] ?? 0) + 1;
+                }
+            }
+        } else {
+            qualifiers = Object.keys(teams);
+        }
+        let winner: string | null;
+        if (qualifiers.length > 1) {
+            winner = _knockout(qualifiers, teams, base, rng);
+        } else {
+            winner = qualifiers.length > 0 ? (qualifiers[0] as string) : null;
+        }
+        if (winner !== null) {
+            champ[winner] = (champ[winner] ?? 0) + 1;
+        }
+    }
+
+    const pct = (d: Record<string, number>): Record<string, PyFloat> => {
+        // sorted(d.items(), key=lambda kv: -kv[1]) — descending by count,
+        // stable on ties (insertion order preserved).
+        const entries = Object.entries(d);
+        entries.sort((a, b) => {
+            const ka = -(a[1]);
+            const kb = -(b[1]);
+            if (ka < kb) {
+                return -1;
+            }
+            if (ka > kb) {
+                return 1;
+            }
+            return 0;
+        });
+        const out: Record<string, PyFloat> = {};
+        for (const [t, c] of entries) {
+            out[t] = new PyFloat(pyRound((100 * c) / runs, 2));
+        }
+        return out;
+    };
+
+    return {
+        runs: new PyInt(runs),
+        seed: seed === null ? null : new PyInt(seed),
+        advance_pct: pct(advanced),
+        title_pct: pct(champ),
+    };
+}
+
+// --- JSON (json.dumps(result, indent=2)) parity ----------------------------
+
+function _jsonDumps(value: unknown, indent: number): string {
+    return _escapeNonAscii(_dumpsIndent(value, indent, 0));
+}
+
+function _dumpsIndent(value: unknown, indent: number, depth: number): string {
+    const pad = ' '.repeat(indent * (depth + 1));
+    const closePad = ' '.repeat(indent * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStr(value);
+    }
+    if (value instanceof PyInt) {
+        return String(value.value);
+    }
+    if (value instanceof PyFloat) {
+        return _jsonFloat(value.value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumpsIndent(v, indent, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0) {
+        return '{}';
+    }
+    const items = keys.map((k) => `${pad}${_jsonStr(k)}: ${_dumpsIndent(obj[k], indent, depth + 1)}`);
+    return `{\n${items.join(',\n')}\n${closePad}}`;
+}
+
+/** Render a Python float — integer-valued floats keep a `.0` suffix (repr(float)). */
+function _jsonFloat(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return Number.isInteger(n) ? `${n}.0` : String(n);
+}
+
+function _jsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            default: {
+                const code = ch.codePointAt(0) ?? 0;
+                if (code < 0x20) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+            }
+        }
+    }
+    return `${out}"`;
+}
+
+/** json.dumps default ensure_ascii=True — escape any non-ASCII to \uXXXX. */
+function _escapeNonAscii(s: string): string {
+    let out = '';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) ?? 0;
+        if (code > 0x7f) {
+            if (code > 0xffff) {
+                const high = 0xd800 + ((code - 0x10000) >> 10);
+                const low = 0xdc00 + ((code - 0x10000) & 0x3ff);
+                out += `\\u${high.toString(16).padStart(4, '0')}\\u${low.toString(16).padStart(4, '0')}`;
+            } else {
+                out += `\\u${code.toString(16).padStart(4, '0')}`;
+            }
+        } else {
+            out += ch;
+        }
+    }
+    return out;
+}
+
+// --- argparse-equivalent CLI ------------------------------------------------
+
+const USAGE = 'usage: poisson_sim.py [-h] [--runs RUNS] [--seed SEED] config\n';
+
+interface Args {
+    config: string | null;
+    runs: number;
+    seed: number | null;
+}
+
+class ArgError extends Error {}
+
+function _apError(msg: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`poisson_sim.py: error: ${msg}\n`);
+    process.exitCode = 2;
+    throw new ArgError(msg);
+}
+
+/** Mirror `int(x)` parsing with argparse's invalid-value error. */
+function _parseIntArg(name: string, raw: string): number {
+    if (!/^[+-]?\d+$/u.test(raw.trim())) {
+        _apError(`argument ${name}: invalid int value: '${raw}'`);
+    }
+    return parseInt(raw, 10);
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = { config: null, runs: 20000, seed: null };
+    const positionals: string[] = [];
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i] as string;
+        const takeValue = (flag: string): string => {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                return a.slice(eq + 1);
+            }
+            i += 1;
+            if (i >= argv.length) {
+                _apError(`argument ${flag}: expected one argument`);
+            }
+            return argv[i] as string;
+        };
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(USAGE);
+            process.exitCode = 0;
+            throw new ArgError('help');
+        } else if (a === '--runs' || a.startsWith('--runs=')) {
+            args.runs = _parseIntArg('--runs', takeValue('--runs'));
+        } else if (a === '--seed' || a.startsWith('--seed=')) {
+            args.seed = _parseIntArg('--seed', takeValue('--seed'));
+        } else if (a.startsWith('-') && a !== '-') {
+            _apError(`unrecognized arguments: ${a}`);
+        } else {
+            positionals.push(a);
+        }
+    }
+    if (positionals.length > 1) {
+        _apError(`unrecognized arguments: ${positionals.slice(1).join(' ')}`);
+    }
+    if (positionals.length === 0) {
+        _apError('the following arguments are required: config');
+    }
+    args.config = positionals[0] as string;
+    return args;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgError) {
+            return process.exitCode === undefined ? 0 : (process.exitCode as number);
+        }
+        throw e;
+    }
+
+    const cfgPath = args.config as string;
+    if (!isFile(cfgPath)) {
+        process.stderr.write(`ERROR: config not found: ${cfgPath}\n`);
+        return 2;
+    }
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8')) as Config;
+    if (!('teams' in cfg) || cfg.teams === undefined) {
+        process.stderr.write("ERROR: config needs a 'teams' object.\n");
+        return 2;
+    }
+
+    const result = simulate(cfg, args.runs, args.seed);
+    process.stdout.write(`${_jsonDumps(result, 2)}\n`);
+    return 0;
+}
+
+/** Mirror Python `Path.is_file()`. */
+function isFile(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    try {
+        const rc = main();
+        if (process.exitCode === undefined) {
+            process.exitCode = rc;
+        }
+    } catch (e) {
+        if (!(e instanceof ArgError)) {
+            throw e;
+        }
+    }
+}

--- a/src/scripts/prediction-pool/pool_winsim.ts
+++ b/src/scripts/prediction-pool/pool_winsim.ts
@@ -1,0 +1,677 @@
+#!/usr/bin/env tsx
+/**
+ * Field model + P(finish 1st) simulator for prediction-pool-optimizer.
+ *
+ * TypeScript twin of `src/scripts/prediction-pool/pool_winsim.py` (ADR-094).
+ * The CLI contract is mirrored EXACTLY — the positional `config` JSON file,
+ * `--runs` / `--max-flips` / `--max-opponents` / `--top-flip` / `--seed` /
+ * `--json`, exit codes, the stdout/stderr split, and byte-identical text AND
+ * `--json` output. No behaviour changes.
+ *
+ * RNG parity: `random.Random(seed)` is reproduced bit-for-bit by `PyRandom`
+ * (MT19937) in `../_lib/py_random.js`; the only consumer is `rng.random()`
+ * (outcome sampling + field softmax-pick), consumed in the same order as the
+ * Python source.
+ *
+ * Score engine: imports `ev_table`, `grid`, `_score` from the already-ported
+ * `./score_ev.js` twin (a `.ts` MUST NOT import a `.py`; the Python source
+ * does `from score_ev import …`).
+ *
+ * Float parity: `round(x, N)` uses CPython half-to-even (pyRound from _lib);
+ * text uses Python `f"{x:.4f}"` / `f"{x:+.3f}"` / `f"{x:+.4f}"` semantics;
+ * JSON renders every Python `float` via the PyFloat marker (`my_lead`,
+ * `field_temperature`, the rule values, ev_cost, p_win figures).
+ *
+ * Original module docstring (verbatim):
+ *
+ * Honest operationalisation of the large-pool strategy note: in a big pool the
+ * target is **P(finish ahead of the whole field)**, not E(points). Maximizing EV
+ * makes your tip-set converge with everyone else's EV-max set, so you cannot open
+ * the gap you need. This script measures that — and greedily finds the few tips
+ * worth flipping off EV-max to manufacture upside.
+ *
+ * What it does:
+ *
+ *   1. Models the FIELD: each opponent commits one tip per match, drawn from a
+ *      softmax over the per-match EV table (temperature controls spread — low =
+ *      the crowd clusters tightly on EV-max, high = noisy). This is a model of
+ *      the crowd, stated as such; feed a real field distribution if you have one.
+ *   2. Pre-draws R outcome scenarios from the Poisson grids and pre-scores every
+ *      opponent once, so evaluating any of MY tip-sets is cheap.
+ *   3. Reports P(win) for the EV-max-everywhere baseline, then runs a greedy
+ *      flip search: repeatedly flip the single tip that most raises P(win),
+ *      reporting the EV cost and the P(win) gain per flip, up to --max-flips.
+ *
+ * The lesson it makes concrete: with small N the EV-max set already wins often
+ * and flips do not help (don't add variance you don't need); with large N and a
+ * deficit, a handful of calculated flips can lift P(win) materially at a small
+ * EV cost. The crossover is empirical — run it.
+ *
+ * It is an APPROXIMATION: the field is a softmax-EV model, not your real pool's
+ * tips, and the Poisson grids are only as good as the lambdas you feed (de-vigged
+ * consensus odds — see reference/odds-and-bonus.md). Outcomes and EV are exact
+ * for that model; the field shape is a prior.
+ *
+ * Input JSON:
+ * {
+ *   "rule": {"exact": 5, "diff": 3, "tendency": 2},
+ *   "participants": 120,            # field size N; opponents modelled = N-1 (capped by --max-opponents)
+ *   "my_lead": 0,                   # my current points minus the rival-to-beat's (negative = behind)
+ *   "field_temperature": 0.6,       # softmax temp for crowd spread around EV-max
+ *   "matches": [
+ *     {"match": "A", "lh": 2.0, "la": 0.7},
+ *     {"match": "B", "lh": 0.6, "la": 2.1}
+ *   ]
+ * }
+ *
+ * Usage:
+ *   python3 scripts/prediction-pool/pool_winsim.py pool.json --runs 4000 --max-flips 4 [--seed 1]
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { PyRandom } from '../_lib/py_random.js';
+import { _score, ev_table, grid, type EvRow } from './score_ev.js';
+
+/**
+ * CPython `round(value, ndigits)` — correct decimal rounding of the *exact*
+ * IEEE-754 value, half-to-even. Uses `toFixed(40)` (far beyond double
+ * precision) so a value that displays as an exact half at 17 sig digits but is
+ * truly just below/above (e.g. `31/800 = 0.03874999999999999972`) rounds the
+ * way CPython does. The value-ladder `pyRound` trusts `toPrecision(17)` and
+ * diverges on these P(win) ratios, so this twin carries its own.
+ */
+function pyRound(value: number, ndigits: number): number {
+    if (!Number.isFinite(value) || value === 0) {
+        return value;
+    }
+    const sign = value < 0 ? -1 : 1;
+    const abs = Math.abs(value);
+    const str = abs.toFixed(40);
+    const [intPart, fracRaw = ''] = str.split('.');
+    let fracPart = fracRaw;
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keepFrac = fracPart.slice(0, ndigits);
+    const decider = fracPart.slice(ndigits);
+    let scaledInt = BigInt((intPart ?? '0') + keepFrac || '0');
+    const first = decider.charAt(0);
+    const restNonZero = /[1-9]/u.test(decider.slice(1));
+    let roundUp = false;
+    if (first > '5' || (first === '5' && restNonZero)) {
+        roundUp = true;
+    } else if (first === '5' && !restNonZero) {
+        roundUp = scaledInt % 2n === 1n;
+    }
+    if (roundUp) {
+        scaledInt += 1n;
+    }
+    const factor = 10 ** ndigits;
+    return (Number(scaledInt) / factor) * sign;
+}
+
+/** Marker for a Python `float` so JSON renders integer-valued floats as `0.0`, not `0`. */
+class PyFloat {
+    constructor(readonly value: number) {}
+}
+
+/** Marker for a Python `int` so JSON renders it without a `.0` suffix. */
+class PyInt {
+    constructor(readonly value: number) {}
+}
+
+type Tip = [number, number];
+type FlatEntry = [number, Tip]; // (prob, (h, a))
+
+interface PerMatch {
+    name: string;
+    rows: EvRow[];
+    flat: FlatEntry[];
+}
+
+/** Flatten a joint grid into (prob, (h,a)) pairs for sampling. */
+function _flat_grid(g: number[][]): FlatEntry[] {
+    const flat: FlatEntry[] = [];
+    for (let h = 0; h < g.length; h += 1) {
+        const row = g[h] as number[];
+        for (let a = 0; a < row.length; a += 1) {
+            const p = row[a] as number;
+            if (p > 0) {
+                flat.push([p, [h, a]]);
+            }
+        }
+    }
+    return flat;
+}
+
+function _sample_outcome(flat: FlatEntry[], rng: PyRandom): Tip {
+    const r = rng.random();
+    let acc = 0.0;
+    for (const [p, ha] of flat) {
+        acc += p;
+        if (r <= acc) {
+            return ha;
+        }
+    }
+    return (flat[flat.length - 1] as FlatEntry)[1];
+}
+
+/** Pick a tip (h,a) from EV rows via softmax(EV / temperature). */
+function _softmax_pick(rows: EvRow[], temperature: number, rng: PyRandom): Tip {
+    if (temperature <= 0) {
+        const first = rows[0] as EvRow;
+        return [first[0], first[1]];
+    }
+    const top = rows.slice(0, 24); // the tail has negligible mass; cap for speed
+    const mx = (top[0] as EvRow)[2];
+    const weights = top.map(([, , ev]) => Math.exp((ev - mx) / temperature));
+    let tot = 0.0;
+    for (const w of weights) {
+        tot += w;
+    }
+    const r = rng.random() * tot;
+    let acc = 0.0;
+    for (let idx = 0; idx < top.length; idx += 1) {
+        const [h, a] = top[idx] as EvRow;
+        acc += weights[idx] as number;
+        if (r <= acc) {
+            return [h, a];
+        }
+    }
+    const last = top[top.length - 1] as EvRow;
+    return [last[0], last[1]];
+}
+
+interface Rule {
+    exact: number;
+    diff: number;
+    tendency: number;
+}
+
+interface MatchSpec {
+    match?: string;
+    lh: number | string;
+    la: number | string;
+}
+
+interface Config {
+    rule?: Partial<Rule>;
+    participants?: number;
+    my_lead?: number;
+    field_temperature?: number;
+    matches: MatchSpec[];
+}
+
+interface FlipRecord {
+    mi: number;
+    tip: Tip;
+    pwin: number;
+    ev_cost: number;
+    name: string;
+}
+
+interface FlipOut {
+    match: string;
+    to: string;
+    ev_cost: PyFloat;
+    p_win_after: PyFloat;
+}
+
+interface RunResult {
+    participants: PyInt;
+    opponents_modelled: PyInt;
+    runs: PyInt;
+    my_lead: PyFloat;
+    field_temperature: PyFloat;
+    rule: { exact: PyFloat; diff: PyFloat; tendency: PyFloat };
+    ev_max_set: string[];
+    p_win_ev_max: PyFloat;
+    flips: FlipOut[];
+    p_win_after_flips: PyFloat;
+}
+
+function run(
+    cfg: Config,
+    runs: number,
+    max_flips: number,
+    max_opponents: number,
+    top_flip: number,
+    seed: number,
+): RunResult {
+    const rng = new PyRandom(seed);
+    const rule = cfg.rule ?? { exact: 4, diff: 3, tendency: 2 };
+    const pe = Number(rule.exact);
+    const pd = Number(rule.diff);
+    const pt = Number(rule.tendency);
+    const n = Math.trunc(Number(cfg.participants ?? 20));
+    const my_lead = Number(cfg.my_lead ?? 0);
+    const temp = Number(cfg.field_temperature ?? 0.6);
+    const matches = cfg.matches;
+    const n_opp = Math.max(0, Math.min(n - 1, max_opponents));
+
+    // Per match: EV table + sampling grid.
+    const per: PerMatch[] = [];
+    for (const m of matches) {
+        const [rows] = ev_table(Number(m.lh), Number(m.la), pe, pd, pt, 6);
+        const g = grid(Number(m.lh), Number(m.la));
+        per.push({ name: m.match ?? '?', rows, flat: _flat_grid(g) });
+    }
+
+    // Pre-draw R outcome scenarios (one actual scoreline per match per run).
+    const scenarios: Tip[][] = [];
+    for (let i = 0; i < runs; i += 1) {
+        scenarios.push(per.map((p) => _sample_outcome(p.flat, rng)));
+    }
+
+    // Model the field: each opponent commits a fixed tip per match (softmax-EV),
+    // then score each opponent across all scenarios. Keep the per-scenario field
+    // MAX so any of my tip-sets can be evaluated against it cheaply.
+    const field_max: number[] = new Array<number>(runs).fill(-1e9);
+    for (let o = 0; o < n_opp; o += 1) {
+        const opp_tips = per.map((p) => _softmax_pick(p.rows, temp, rng));
+        for (let s_idx = 0; s_idx < scenarios.length; s_idx += 1) {
+            const sc = scenarios[s_idx] as Tip[];
+            let tot = 0.0;
+            for (let mi = 0; mi < opp_tips.length; mi += 1) {
+                const [th, ta] = opp_tips[mi] as Tip;
+                const [ah, aa] = sc[mi] as Tip;
+                tot += _score(th, ta, ah, aa, pe, pd, pt);
+            }
+            if (tot > (field_max[s_idx] as number)) {
+                field_max[s_idx] = tot;
+            }
+        }
+    }
+
+    const my_total = (tipset: Tip[], s_idx: number): number => {
+        const sc = scenarios[s_idx] as Tip[];
+        let tot = 0.0;
+        for (let mi = 0; mi < tipset.length; mi += 1) {
+            const [th, ta] = tipset[mi] as Tip;
+            const [ah, aa] = sc[mi] as Tip;
+            tot += _score(th, ta, ah, aa, pe, pd, pt);
+        }
+        return tot;
+    };
+
+    const p_win = (tipset: Tip[]): number => {
+        let wins = 0;
+        for (let s_idx = 0; s_idx < runs; s_idx += 1) {
+            if (my_total(tipset, s_idx) + my_lead > (field_max[s_idx] as number)) {
+                wins += 1;
+            }
+        }
+        return wins / runs;
+    };
+
+    // Baseline: EV-max on every match.
+    const ev_max_set: Tip[] = per.map((p) => {
+        const first = p.rows[0] as EvRow;
+        return [first[0], first[1]];
+    });
+    const base_pwin = p_win(ev_max_set);
+
+    // Greedy flips: repeatedly flip the one tip that most raises P(win),
+    // considering each match's top-`top_flip` EV candidates.
+    const current: Tip[] = ev_max_set.slice();
+    const flips: FlipRecord[] = [];
+    const used = new Set<number>();
+    for (let f = 0; f < max_flips; f += 1) {
+        let best: FlipRecord | null = null;
+        for (let mi = 0; mi < per.length; mi += 1) {
+            if (used.has(mi)) {
+                continue;
+            }
+            const p = per[mi] as PerMatch;
+            for (const [h, a, ev] of p.rows.slice(0, top_flip)) {
+                const cur = current[mi] as Tip;
+                if (h === cur[0] && a === cur[1]) {
+                    continue;
+                }
+                const trial = current.slice();
+                trial[mi] = [h, a];
+                const pw = p_win(trial);
+                const ev_cost = (p.rows[0] as EvRow)[2] - ev;
+                if (best === null || pw > best.pwin) {
+                    best = { mi, tip: [h, a], pwin: pw, ev_cost, name: p.name };
+                }
+            }
+        }
+        const threshold = flips.length > 0 ? (flips[flips.length - 1] as FlipRecord).pwin : base_pwin;
+        if (best === null || best.pwin <= threshold) {
+            break;
+        }
+        current[best.mi] = best.tip;
+        used.add(best.mi);
+        flips.push(best);
+    }
+
+    const lastPwin = flips.length > 0 ? (flips[flips.length - 1] as FlipRecord).pwin : base_pwin;
+
+    return {
+        participants: new PyInt(n),
+        opponents_modelled: new PyInt(n_opp),
+        runs: new PyInt(runs),
+        my_lead: new PyFloat(my_lead),
+        field_temperature: new PyFloat(temp),
+        rule: { exact: new PyFloat(pe), diff: new PyFloat(pd), tendency: new PyFloat(pt) },
+        ev_max_set: ev_max_set.map((tip, i) => `${(per[i] as PerMatch).name}=${tip[0]}:${tip[1]}`),
+        p_win_ev_max: new PyFloat(pyRound(base_pwin, 4)),
+        flips: flips.map((fl) => ({
+            match: fl.name,
+            to: `${fl.tip[0]}:${fl.tip[1]}`,
+            ev_cost: new PyFloat(pyRound(fl.ev_cost, 3)),
+            p_win_after: new PyFloat(pyRound(fl.pwin, 4)),
+        })),
+        p_win_after_flips: new PyFloat(pyRound(lastPwin, 4)),
+    };
+}
+
+// --- Python format helpers --------------------------------------------------
+
+/** Mirror Python `f"{x:.4f}"` — fixed 4 decimals, round-half-to-even. */
+function pyFixed(x: number, ndigits: number): string {
+    if (!Number.isFinite(x)) {
+        return String(x);
+    }
+    const neg = x < 0 || Object.is(x, -0);
+    const abs = Math.abs(x);
+    const factor = 10 ** ndigits;
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    const tol = Math.max(Math.abs(scaled), 1) * 2 ** -40;
+    let rounded: number;
+    if (Math.abs(frac - 0.5) <= tol) {
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    let intStr = String(rounded);
+    if (intStr.length <= ndigits) {
+        intStr = '0'.repeat(ndigits - intStr.length + 1) + intStr;
+    }
+    const whole = intStr.slice(0, intStr.length - ndigits);
+    const dec = intStr.slice(intStr.length - ndigits);
+    const result = ndigits > 0 ? `${whole}.${dec}` : whole;
+    return neg ? `-${result}` : result;
+}
+
+/** Mirror Python `f"{x:+.3f}"` — explicit sign, fixed decimals. */
+function pySigned(x: number, ndigits: number): string {
+    const neg = x < 0 || Object.is(x, -0);
+    const body = pyFixed(Math.abs(x), ndigits);
+    return neg ? `-${body}` : `+${body}`;
+}
+
+// --- JSON (json.dumps(res, indent=2)) parity -------------------------------
+
+function _jsonDumps(value: unknown, indent: number): string {
+    return _escapeNonAscii(_dumpsIndent(value, indent, 0));
+}
+
+function _dumpsIndent(value: unknown, indent: number, depth: number): string {
+    const pad = ' '.repeat(indent * (depth + 1));
+    const closePad = ' '.repeat(indent * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStr(value);
+    }
+    if (value instanceof PyInt) {
+        return String(value.value);
+    }
+    if (value instanceof PyFloat) {
+        return _jsonFloat(value.value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumpsIndent(v, indent, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0) {
+        return '{}';
+    }
+    const items = keys.map((k) => `${pad}${_jsonStr(k)}: ${_dumpsIndent(obj[k], indent, depth + 1)}`);
+    return `{\n${items.join(',\n')}\n${closePad}}`;
+}
+
+/** Render a Python float — integer-valued floats keep a `.0` suffix (repr(float)). */
+function _jsonFloat(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return Number.isInteger(n) ? `${n}.0` : String(n);
+}
+
+function _jsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            default: {
+                const code = ch.codePointAt(0) ?? 0;
+                if (code < 0x20) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+            }
+        }
+    }
+    return `${out}"`;
+}
+
+/** json.dumps default ensure_ascii=True — escape any non-ASCII to \uXXXX. */
+function _escapeNonAscii(s: string): string {
+    let out = '';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) ?? 0;
+        if (code > 0x7f) {
+            if (code > 0xffff) {
+                const high = 0xd800 + ((code - 0x10000) >> 10);
+                const low = 0xdc00 + ((code - 0x10000) & 0x3ff);
+                out += `\\u${high.toString(16).padStart(4, '0')}\\u${low.toString(16).padStart(4, '0')}`;
+            } else {
+                out += `\\u${code.toString(16).padStart(4, '0')}`;
+            }
+        } else {
+            out += ch;
+        }
+    }
+    return out;
+}
+
+// --- argparse-equivalent CLI ------------------------------------------------
+
+const USAGE =
+    'usage: pool_winsim.py [-h] [--runs RUNS] [--max-flips MAX_FLIPS]\n' +
+    '                      [--max-opponents MAX_OPPONENTS] [--top-flip TOP_FLIP]\n' +
+    '                      [--seed SEED] [--json]\n' +
+    '                      config\n';
+
+interface Args {
+    config: string | null;
+    runs: number;
+    max_flips: number;
+    max_opponents: number;
+    top_flip: number;
+    seed: number;
+    json: boolean;
+}
+
+class ArgError extends Error {}
+
+function _apError(msg: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`pool_winsim.py: error: ${msg}\n`);
+    process.exitCode = 2;
+    throw new ArgError(msg);
+}
+
+function _parseIntArg(name: string, raw: string): number {
+    if (!/^[+-]?\d+$/u.test(raw.trim())) {
+        _apError(`argument ${name}: invalid int value: '${raw}'`);
+    }
+    return parseInt(raw, 10);
+}
+
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        config: null,
+        runs: 4000,
+        max_flips: 4,
+        max_opponents: 300,
+        top_flip: 4,
+        seed: 1,
+        json: false,
+    };
+    const positionals: string[] = [];
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i] as string;
+        const takeValue = (flag: string): string => {
+            const eq = a.indexOf('=');
+            if (eq !== -1) {
+                return a.slice(eq + 1);
+            }
+            i += 1;
+            if (i >= argv.length) {
+                _apError(`argument ${flag}: expected one argument`);
+            }
+            return argv[i] as string;
+        };
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(USAGE);
+            process.exitCode = 0;
+            throw new ArgError('help');
+        } else if (a === '--runs' || a.startsWith('--runs=')) {
+            args.runs = _parseIntArg('--runs', takeValue('--runs'));
+        } else if (a === '--max-flips' || a.startsWith('--max-flips=')) {
+            args.max_flips = _parseIntArg('--max-flips', takeValue('--max-flips'));
+        } else if (a === '--max-opponents' || a.startsWith('--max-opponents=')) {
+            args.max_opponents = _parseIntArg('--max-opponents', takeValue('--max-opponents'));
+        } else if (a === '--top-flip' || a.startsWith('--top-flip=')) {
+            args.top_flip = _parseIntArg('--top-flip', takeValue('--top-flip'));
+        } else if (a === '--seed' || a.startsWith('--seed=')) {
+            args.seed = _parseIntArg('--seed', takeValue('--seed'));
+        } else if (a === '--json') {
+            args.json = true;
+        } else if (a.startsWith('-') && a !== '-') {
+            _apError(`unrecognized arguments: ${a}`);
+        } else {
+            positionals.push(a);
+        }
+    }
+    if (positionals.length > 1) {
+        _apError(`unrecognized arguments: ${positionals.slice(1).join(' ')}`);
+    }
+    if (positionals.length === 0) {
+        _apError('the following arguments are required: config');
+    }
+    args.config = positionals[0] as string;
+    return args;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgError) {
+            return process.exitCode === undefined ? 0 : (process.exitCode as number);
+        }
+        throw e;
+    }
+
+    const cfg = JSON.parse(fs.readFileSync(args.config as string, 'utf-8')) as Config;
+    const res = run(cfg, args.runs, args.max_flips, args.max_opponents, args.top_flip, args.seed);
+
+    if (args.json) {
+        process.stdout.write(`${_jsonDumps(res, 2)}\n`);
+        return 0;
+    }
+
+    process.stdout.write(
+        `participants ${res.participants.value} (modelled ${res.opponents_modelled.value})  ` +
+            `runs ${res.runs.value}  my_lead ${pyFloatRepr(res.my_lead.value)}  ` +
+            `field_temp ${pyFloatRepr(res.field_temperature.value)}\n`,
+    );
+    process.stdout.write(`EV-max set: ${res.ev_max_set.join(', ')}\n`);
+    process.stdout.write(`P(win) all-EV-max : ${pyFixed(res.p_win_ev_max.value, 4)}\n`);
+    if (res.flips.length === 0) {
+        process.stdout.write(
+            'greedy flips: none improved P(win) — EV-max is already best (small/easy field).\n',
+        );
+    } else {
+        process.stdout.write('suggested flips (greedy, each raises P(win) most):\n');
+        for (const f of res.flips) {
+            process.stdout.write(
+                `  flip ${f.match} -> ${f.to}  (EV cost ${pySigned(f.ev_cost.value, 3)})  ` +
+                    `P(win) ${pyFixed(f.p_win_after.value, 4)}\n`,
+            );
+        }
+        process.stdout.write(
+            `P(win) after flips: ${pyFixed(res.p_win_after_flips.value, 4)}  ` +
+                `(+${pyFixed(res.p_win_after_flips.value - res.p_win_ev_max.value, 4)})\n`,
+        );
+    }
+    return 0;
+}
+
+/** Mirror Python `str(float(x))` for the text header (my_lead / field_temp). */
+function pyFloatRepr(x: number): string {
+    if (!Number.isFinite(x)) {
+        if (Number.isNaN(x)) {
+            return 'nan';
+        }
+        return x > 0 ? 'inf' : '-inf';
+    }
+    return Number.isInteger(x) ? `${x}.0` : String(x);
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    try {
+        const rc = main();
+        if (process.exitCode === undefined) {
+            process.exitCode = rc;
+        }
+    } catch (e) {
+        if (!(e instanceof ArgError)) {
+            throw e;
+        }
+    }
+}

--- a/src/scripts/prediction-pool/score_ev.ts
+++ b/src/scripts/prediction-pool/score_ev.ts
@@ -116,7 +116,7 @@ function _sign(x: number): number {
 }
 
 /** Points a tip (th:ta) earns against an actual result (ah:aa). */
-function _score(
+export function _score(
     th: number,
     ta: number,
     ah: number,
@@ -138,7 +138,7 @@ function _score(
 }
 
 /** Joint probability of every actual scoreline up to max_goals. */
-function grid(lh: number, la: number, max_goals: number = MAX_GOALS): number[][] {
+export function grid(lh: number, la: number, max_goals: number = MAX_GOALS): number[][] {
     const ph: number[] = [];
     const pa: number[] = [];
     for (let k = 0; k <= max_goals; k += 1) {
@@ -156,10 +156,10 @@ function grid(lh: number, la: number, max_goals: number = MAX_GOALS): number[][]
     return g;
 }
 
-type EvRow = [number, number, number];
+export type EvRow = [number, number, number];
 
 /** EV (expected points) of every candidate tip up to max_tip goals/side. */
-function ev_table(
+export function ev_table(
     lh: number,
     la: number,
     pts_exact: number,

--- a/tests/scripts/_lib/py_random.test.ts
+++ b/tests/scripts/_lib/py_random.test.ts
@@ -1,0 +1,94 @@
+// Tests for src/scripts/_lib/py_random.ts (py2ts Phase 1).
+//
+// PyRandom is a bit-exact reproduction of CPython's `random.Random` (MT19937).
+// There is NO py_random.py source — the Python side is the stdlib `random`
+// module, so the oracle is real CPython spawned via `python3 -c …`. Every
+// assertion compares the TS lib against the live CPython stream for the two
+// surfaces the prediction-pool simulators consume: `random()` sequences and
+// `shuffle()`. getrandbits (the k>32 general case) is also cross-checked even
+// though the sims only ever hit k<=32 via small-list shuffles.
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { PyRandom } from '../../../src/scripts/_lib/py_random.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function py(code: string): string {
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout.trim();
+}
+
+describe.runIf(hasPython3())('PyRandom — CPython MT19937 parity', () => {
+    const seeds = [0, 1, 7, 42, 123456789, 2147483647];
+
+    it.each(seeds)('random() sequence matches CPython for seed=%s', (seed) => {
+        const oracle = py(
+            `import random,json;r=random.Random(${seed});print(json.dumps([repr(r.random()) for _ in range(20)]))`,
+        );
+        const expected = JSON.parse(oracle) as string[];
+        const r = new PyRandom(seed);
+        const got: string[] = [];
+        for (let i = 0; i < 20; i += 1) {
+            // repr(float) is the shortest round-trippable decimal; JS String()
+            // on a double produces the same shortest form for these values.
+            got.push(String(r.random()));
+        }
+        expect(got).toEqual(expected);
+    });
+
+    const shuffleCases: Array<[number, number]> = [
+        [1, 5],
+        [1, 10],
+        [1, 25],
+        [7, 10],
+        [42, 8],
+        [42, 25],
+        [99, 50],
+        [12345, 16],
+    ];
+
+    it.each(shuffleCases)('shuffle() matches CPython for seed=%s size=%s', (seed, size) => {
+        const oracle = py(
+            `import random,json;r=random.Random(${seed});l=list(range(${size}));r.shuffle(l);print(json.dumps(l))`,
+        );
+        const expected = JSON.parse(oracle) as number[];
+        const r = new PyRandom(seed);
+        const list = Array.from({ length: size }, (_, i) => i);
+        r.shuffle(list);
+        expect(list).toEqual(expected);
+    });
+
+    const bitsCases: Array<[number, number]> = [
+        [1, 8],
+        [1, 32],
+        [1, 40],
+        [1, 64],
+        [7, 53],
+        [42, 100],
+    ];
+
+    it.each(bitsCases)('getrandbits(%s bits) matches CPython for seed=%s', (seed, k) => {
+        const expected = py(`import random;r=random.Random(${seed});print(r.getrandbits(${k}))`);
+        const r = new PyRandom(seed);
+        const got = r.getrandbits(k);
+        expect(String(got)).toBe(expected);
+    });
+
+    it('large (negative-equivalent abs) seed matches CPython random()', () => {
+        const seed = 9007199254740881; // a large safe integer
+        const oracle = py(
+            `import random,json;r=random.Random(${seed});print(json.dumps([repr(r.random()) for _ in range(5)]))`,
+        );
+        const expected = JSON.parse(oracle) as string[];
+        const r = new PyRandom(seed);
+        const got = Array.from({ length: 5 }, () => String(r.random()));
+        expect(got).toEqual(expected);
+    });
+});

--- a/tests/scripts/prediction-pool_poisson_sim.test.ts
+++ b/tests/scripts/prediction-pool_poisson_sim.test.ts
@@ -1,0 +1,141 @@
+// Tests for src/scripts/prediction-pool/poisson_sim.ts (py2ts Phase 1).
+//
+// No pytest suite exists, so this is a golden-parity suite that runs python3
+// vs tsx and asserts byte-identical stdout + stderr + exit code. The sim uses
+// `random.Random(seed)`, so with a FIXED `--seed` the runs are fully
+// deterministic across runtimes (PyRandom reproduces CPython MT19937
+// bit-for-bit) — nothing needs normalisation; there are no wall-clock fields.
+//
+// The no-config argparse error wraps its usage block to the terminal width,
+// which is environment-dependent (lesson #8: argparse error PROSE is
+// Python-version / COLUMNS-dependent), so the no-args case asserts exit code 2
+// and the stable error LINE, not the full byte stream. Likewise `-h` full help
+// is COLUMNS-dependent and is not byte-asserted.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'poisson_sim.ts');
+const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'poisson_sim.py');
+const TSX_BIN =
+    process.env.TSX_BIN ??
+    path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function writeTmp(name: string, content: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'poisson-sim-'));
+    const p = path.join(d, name);
+    fs.writeFileSync(p, content);
+    tmpDirs.push(d);
+    return p;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+interface RunOut {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runPy(args: string[]): RunOut {
+    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8' });
+    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
+
+function runTs(args: string[]): RunOut {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8' });
+    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
+
+const TEAMS = JSON.stringify({
+    base_goals: 1.35,
+    teams: {
+        Germany: { att: 1.4, def: 0.7 },
+        Scotland: { att: 0.8, def: 1.2 },
+        Hungary: { att: 1.0, def: 1.0 },
+        Switzerland: { att: 1.1, def: 0.9 },
+        Spain: { att: 1.5, def: 0.75 },
+        Croatia: { att: 1.05, def: 0.95 },
+        Italy: { att: 1.2, def: 0.8 },
+        Albania: { att: 0.7, def: 1.3 },
+    },
+    groups: [
+        ['Germany', 'Scotland', 'Hungary', 'Switzerland'],
+        ['Spain', 'Croatia', 'Italy', 'Albania'],
+    ],
+    advance_per_group: 2,
+});
+
+const NO_GROUPS = JSON.stringify({
+    base_goals: 1.4,
+    teams: { A: { att: 1.2, def: 0.9 }, B: { att: 0.9, def: 1.1 }, C: { att: 1.0, def: 1.0 } },
+});
+
+describe.runIf(hasPython3())('poisson_sim — golden parity (python3 vs tsx)', () => {
+    const cases: Array<{ label: string; seed: string; runs: string; fixture: string }> = [
+        { label: 'groups runs=500 seed=0', seed: '0', runs: '500', fixture: TEAMS },
+        { label: 'groups runs=500 seed=1', seed: '1', runs: '500', fixture: TEAMS },
+        { label: 'groups runs=500 seed=7', seed: '7', runs: '500', fixture: TEAMS },
+        { label: 'groups runs=300 seed=42', seed: '42', runs: '300', fixture: TEAMS },
+        { label: 'groups runs=1000 seed=999', seed: '999', runs: '1000', fixture: TEAMS },
+        { label: 'no-groups runs=600 seed=8', seed: '8', runs: '600', fixture: NO_GROUPS },
+    ];
+
+    it.each(cases)('$label', ({ seed, runs, fixture }) => {
+        const cfg = writeTmp('config.json', fixture);
+        const args = [cfg, '--runs', runs, '--seed', seed];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('missing config file → exit 2, byte-identical', () => {
+        const args = [path.join(os.tmpdir(), 'definitely-missing-poisson.json'), '--seed', '1'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(2);
+        expect(py.status).toBe(2);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it("config without 'teams' → exit 2, byte-identical", () => {
+        const cfg = writeTmp('noteams.json', JSON.stringify({ base_goals: 1.3 }));
+        const args = [cfg, '--seed', '1'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(2);
+        expect(py.status).toBe(2);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('no args → exit 2 with the stable required-config error line', () => {
+        const py = runPy([]);
+        const ts = runTs([]);
+        expect(py.status).toBe(2);
+        expect(ts.status).toBe(2);
+        // The usage block wraps to terminal width (env-dependent); assert the
+        // stable error line both runtimes emit.
+        expect(ts.stderr).toContain('the following arguments are required: config');
+        expect(py.stderr).toContain('the following arguments are required: config');
+    });
+});

--- a/tests/scripts/prediction-pool_pool_winsim.test.ts
+++ b/tests/scripts/prediction-pool_pool_winsim.test.ts
@@ -1,0 +1,178 @@
+// Tests for src/scripts/prediction-pool/pool_winsim.ts (py2ts Phase 1).
+//
+// No pytest suite exists, so this is a golden-parity suite that runs python3
+// vs tsx and asserts byte-identical stdout + stderr + exit code across the
+// text and --json output paths. The sim uses `random.Random(seed)`, so with a
+// FIXED `--seed` the runs are fully deterministic across runtimes (PyRandom
+// reproduces CPython MT19937 bit-for-bit, and `round()` is replicated
+// half-to-even on the exact IEEE-754 value) — nothing needs normalisation;
+// there are no wall-clock fields.
+//
+// The no-config argparse error wraps to terminal width (lesson #8: argparse
+// PROSE is Python-version / COLUMNS-dependent), so the no-args case asserts
+// exit code 2 + the stable error LINE; `-h` full help is likewise not
+// byte-asserted.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'pool_winsim.ts');
+const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'pool_winsim.py');
+const TSX_BIN =
+    process.env.TSX_BIN ??
+    path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function writeTmp(name: string, content: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'pool-winsim-'));
+    const p = path.join(d, name);
+    fs.writeFileSync(p, content);
+    tmpDirs.push(d);
+    return p;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+interface RunOut {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runPy(args: string[]): RunOut {
+    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8' });
+    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
+
+function runTs(args: string[]): RunOut {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8' });
+    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
+
+const POOL = JSON.stringify({
+    rule: { exact: 5, diff: 3, tendency: 2 },
+    participants: 120,
+    my_lead: 0,
+    field_temperature: 0.6,
+    matches: [
+        { match: 'A', lh: 2.0, la: 0.7 },
+        { match: 'B', lh: 0.6, la: 2.1 },
+        { match: 'C', lh: 1.3, la: 1.3 },
+        { match: 'D', lh: 1.8, la: 1.1 },
+    ],
+});
+
+// Negative float lead + non-default temperature exercises the PyFloat
+// rendering paths (`-3.0`, `1.0`) and the signed text formatter.
+const POOL_NEG = JSON.stringify({
+    rule: { exact: 4, diff: 3, tendency: 2 },
+    participants: 50,
+    my_lead: -3,
+    field_temperature: 1.0,
+    matches: [
+        { match: 'X', lh: 1.7, la: 1.2 },
+        { match: 'Y', lh: 0.9, la: 0.9 },
+    ],
+});
+
+describe.runIf(hasPython3())('pool_winsim — golden parity (python3 vs tsx)', () => {
+    const seeds = ['1', '2', '3', '7', '42', '99', '12345'];
+
+    it.each(seeds)('text — seed=%s runs=800 max-flips=2', (seed) => {
+        const cfg = writeTmp('pool.json', POOL);
+        const args = [cfg, '--runs', '800', '--max-flips', '2', '--seed', seed];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it.each(seeds)('json — seed=%s runs=800 max-flips=2', (seed) => {
+        const cfg = writeTmp('pool.json', POOL);
+        const args = [cfg, '--runs', '800', '--max-flips', '2', '--seed', seed, '--json'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('default args (seed=1 runs=4000) json', () => {
+        const cfg = writeTmp('pool.json', POOL);
+        const args = [cfg, '--json'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('small field (max-opponents=3) text — flips often none', () => {
+        const cfg = writeTmp('pool.json', POOL);
+        const args = [cfg, '--runs', '1000', '--max-opponents', '3', '--seed', '3'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('top-flip=6 json — seed=9', () => {
+        const cfg = writeTmp('pool.json', POOL);
+        const args = [cfg, '--runs', '1500', '--top-flip', '6', '--seed', '9', '--json'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it.each([
+        ['text', false],
+        ['json', true],
+    ] as Array<[string, boolean]>)('negative float lead + temp 1.0 — %s', (_label, asJson) => {
+        const cfg = writeTmp('pool-neg.json', POOL_NEG);
+        const args = [cfg, '--runs', '1000', '--seed', '4', ...(asJson ? ['--json'] : [])];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('invalid int for --runs → exit 2, byte-identical', () => {
+        const cfg = writeTmp('pool.json', POOL);
+        const args = [cfg, '--runs', 'abc'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(2);
+        expect(py.status).toBe(2);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('no args → exit 2 with the stable required-config error line', () => {
+        const py = runPy([]);
+        const ts = runTs([]);
+        expect(py.status).toBe(2);
+        expect(ts.status).toBe(2);
+        expect(ts.stderr).toContain('the following arguments are required: config');
+        expect(py.stderr).toContain('the following arguments are required: config');
+    });
+});


### PR DESCRIPTION
Ports the prediction-pool Monte-Carlo simulators — the last RNG-dependent Phase-8 scripts. Targets `python2ts`. `.py` originals stay until the Phase 12 sweep.

## New shared lib: `_lib/py_random.ts` (the hard part)
Bit-exact CPython `random.Random` subset (MT19937): `init_by_array` int-seed splitting, `genrand_uint32`, `random()` (genrand_res53), `getrandbits` (incl. k>32), `_randbelow`, `shuffle`. **Verified against live `python3`**: `Random(1)` first-5 randoms, `Random(7).shuffle(range(10))`, `getrandbits(k=8..100)` all bit-identical. No `.py` (Python side is stdlib). Reusable for any future RNG twin.

## Twins
- `poisson_sim` — Knuth poisson + `random()` group-table tiebreak (Python `sorted`-key call order preserved) + `shuffle` knockout.
- `pool_winsim` — imports `_score`/`ev_table`/`grid` from the ported `score_ev.ts` (added 4 `export` keywords; score_ev's own tests stay green).

With a fixed `--seed`, both produce byte-identical simulation output vs python3.

## Found + fixed a rounding bug (worth a follow-up)
`value_ladder.pyRound` trusts `toPrecision(17)`: `31/800` (true IEEE-754 just *below* .5 but displays as exact .5 at 17 digits) rounds **up** wrongly vs CPython `round()`. The sim twins use a local `pyRound` (`toFixed(40)` + BigInt round-half-to-even) that matches CPython. **`value_ladder.pyRound` itself is left untouched** (minimal-safe-diff) — but it's a shared lib; **recommend a follow-up to fix it + re-verify all `pyRound` consumers** (other twins on boundary values could mis-round silently).

## Verification
`tsc` clean · phase-gate passes · 62/62 (21 py_random oracle + 21 pool_winsim + 9 poisson + 11 score_ev) · CPython cross-check bit-identical · legacy 0==0. Migration-gates 4-shard run validates on this PR's CI.