### PR TITLE
feat(py2ts): phase 10 — ai_council layer 2 (9 twins: clients + 8 modules)

### DIFF
--- a/src/scripts/ai_council/advisors.ts
+++ b/src/scripts/ai_council/advisors.ts
@@ -1,0 +1,244 @@
+/**
+ * Thinking-style advisors — replace-mode call planning (Phase 6).
+ *
+ * TypeScript twin of `src/scripts/ai_council/advisors.py` (ADR-094 —
+ * Python→TS migration, Phase 1). When `agents/settings/.ai-council.yml`
+ * enables an advisor (e.g. `contrarian` bound to `member: anthropic`), the
+ * orchestrator REPLACES the matching plain-member call with an
+ * advisor-persona call on the same provider. Same total call count as a
+ * plain run; bounded extra cost beyond the persona-prompt token delta.
+ *
+ * This module owns:
+ *
+ * - `AdvisorPlan`  — resolved swap for a single provider (persona text,
+ *   display name, optional model override).
+ * - `plan_advisor_swap()` — walks the enabled advisors, reads their
+ *   persona files, and returns the per-provider plan map consumed by
+ *   `orchestrator.consult()` / `estimate()` and by the CLI.
+ * - `resolve_persona_text()` — reads a persona file with condensed-tree
+ *   preference and frontmatter strip.
+ *
+ * Cross-validation against the members block already ran at config load
+ * (`config._build_config`); this module trusts that contract and only
+ * enforces the **one-advisor-per-provider** rule (replace-mode invariant).
+ *
+ * Parity notes:
+ * - YAML frontmatter is parsed with `yaml` (npm) at `version: '1.1'`, the
+ *   same approach the sibling config twin uses to mirror PyYAML `safe_load`.
+ * - `str.title()` is mirrored by `_pyTitle` (uppercase first cased char
+ *   after any non-cased char; lowercase the rest).
+ * - `Path` ops use `node:path`; `Path.exists()` / `read_text()` use `fs`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+
+import { type AdvisorConfig, CouncilConfigError } from './config.js';
+
+/** Resolved advisor swap for a single provider. */
+export class AdvisorPlan {
+    readonly name: string;
+    readonly display_name: string;
+    readonly member: string;
+    readonly persona_text: string;
+    readonly model_override: string | null;
+
+    constructor(args: {
+        name: string;
+        display_name: string;
+        member: string;
+        persona_text: string;
+        model_override?: string | null;
+    }) {
+        this.name = args.name;
+        this.display_name = args.display_name;
+        this.member = args.member;
+        this.persona_text = args.persona_text;
+        this.model_override = args.model_override ?? null;
+    }
+}
+
+// Python: re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+// \A → start of string. JS has no \A; anchor with ^ + no 'm' flag means ^
+// matches only at string start. re.DOTALL → 's'.
+const _FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n/;
+
+type Dict = Record<string, unknown>;
+
+/** Return `[frontmatter_dict, body]`. Missing frontmatter → `[{}, raw]`. */
+function _split_frontmatter(raw: string): [Dict, string] {
+    const match = _FRONTMATTER_RE.exec(raw);
+    if (!match) {
+        return [{}, raw];
+    }
+    let meta: unknown;
+    try {
+        // yaml.safe_load(...) or {}  — null / empty → {}.
+        const parsed = parseYaml(match[1] as string, { version: '1.1' });
+        meta = parsed === null || parsed === undefined ? {} : parsed;
+    } catch {
+        // yaml.YAMLError → {}
+        meta = {};
+    }
+    if (!_isDict(meta)) {
+        meta = {};
+    }
+    // raw[match.end():] — slice from the end of the full match.
+    const body = raw.slice(match.index + match[0].length);
+    return [meta as Dict, body];
+}
+
+/** Prefer frontmatter `role`; fall back to titleized advisor key. */
+function _display_name_from(advisor_name: string, frontmatter: Dict): string {
+    const role = frontmatter['role'];
+    if (typeof role === 'string' && role.trim() !== '') {
+        return role.trim();
+    }
+    return _pyTitle(advisor_name.replace(/-/g, ' ').replace(/_/g, ' '));
+}
+
+/**
+ * Read a persona file, returning `[body, frontmatter]`.
+ *
+ * Condensed tree (`dist/agent-src/`) wins so production runs match the
+ * same projection the rest of the package consumes. Uncondensed tree
+ * (`.agent-src.uncondensed/`) is the fallback for in-repo development
+ * before `task sync` has projected the file.
+ */
+export function resolve_persona_text(
+    persona_path: string,
+    repo_root: string,
+): [string, Dict] {
+    const candidates = [
+        path.join(repo_root, 'dist/agent-src', persona_path),
+        path.join(repo_root, '.agent-src.uncondensed', persona_path),
+    ];
+    for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+            const raw = fs.readFileSync(candidate, 'utf-8');
+            const [meta, body] = _split_frontmatter(raw);
+            return [body.trim(), meta];
+        }
+    }
+    const searched = candidates.join('\n  - ');
+    throw new CouncilConfigError(
+        `Persona file not found for advisor (path=${_pyReprStr(persona_path)}). ` +
+            `Searched:\n  - ${searched}`,
+    );
+}
+
+/**
+ * Return `{provider_name: AdvisorPlan}` for every ENABLED advisor.
+ *
+ * Two enabled advisors targeting the same provider is a
+ * `CouncilConfigError` — replace-mode runs one advisor per provider so
+ * the call plan never doubles up by accident.
+ */
+export function plan_advisor_swap(
+    advisors: Map<string, AdvisorConfig>,
+    repo_root: string,
+): Map<string, AdvisorPlan> {
+    const plans = new Map<string, AdvisorPlan>();
+    for (const adv of advisors.values()) {
+        if (!adv.enabled) {
+            continue;
+        }
+        if (plans.has(adv.member)) {
+            const existing = (plans.get(adv.member) as AdvisorPlan).name;
+            throw new CouncilConfigError(
+                `advisors.${adv.name} and advisors.${existing} both bind ` +
+                    `member=${_pyReprStr(adv.member)}; only one advisor per provider ` +
+                    `per run (replace-mode invariant).`,
+            );
+        }
+        const [body, meta] = resolve_persona_text(adv.persona, repo_root);
+        plans.set(
+            adv.member,
+            new AdvisorPlan({
+                name: adv.name,
+                display_name: _display_name_from(adv.name, meta),
+                member: adv.member,
+                persona_text: body,
+                model_override: adv.model,
+            }),
+        );
+    }
+    return plans;
+}
+
+/** Minimal duck-typed member shape consumed by `build_persona_labels`. */
+export interface MemberLike {
+    readonly name: string;
+    readonly model: string;
+}
+
+/**
+ * Build the peer-review `source → display_name` map.
+ *
+ * `source` is the `provider:model` string the peer-review pipeline uses
+ * for anonymisation; `members` is the post-swap member list
+ * (model_override already applied), so the model field matches what the
+ * response carries.
+ */
+export function build_persona_labels(
+    plans: Map<string, AdvisorPlan>,
+    members: Iterable<MemberLike>,
+): Map<string, string> {
+    const labels = new Map<string, string>();
+    for (const m of members) {
+        const plan = plans.get(m.name);
+        if (plan === undefined) {
+            continue;
+        }
+        labels.set(`${m.name}:${m.model}`, plan.display_name);
+    }
+    return labels;
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────
+
+/** True when `v` is a plain object (Python `isinstance(meta, dict)`). */
+function _isDict(v: unknown): v is Dict {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Mirror Python `str.title()`.
+ *
+ * A character is uppercased when the previous character is not a cased
+ * letter; otherwise it is lowercased. "Cased" = a letter with case
+ * distinction (`toUpperCase() !== toLowerCase()`).
+ */
+function _pyTitle(s: string): string {
+    let out = '';
+    let prevCased = false;
+    for (const ch of s) {
+        const isCased = ch.toUpperCase() !== ch.toLowerCase();
+        if (isCased) {
+            out += prevCased ? ch.toLowerCase() : ch.toUpperCase();
+        } else {
+            out += ch;
+        }
+        prevCased = isCased;
+    }
+    return out;
+}
+
+/** Mirror Python `repr()` for a string scalar (single-quoted, escaped). */
+function _pyReprStr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = s
+        .replace(/\\/g, '\\\\')
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r')
+        .replace(/\t/g, '\\t');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    } else {
+        body = body.replace(/"/g, '\\"');
+    }
+    return `${quote}${body}${quote}`;
+}

--- a/src/scripts/ai_council/bundler.ts
+++ b/src/scripts/ai_council/bundler.ts
@@ -1,0 +1,376 @@
+/**
+ * Context bundling for council consultations.
+ *
+ * TypeScript twin of `src/scripts/ai_council/bundler.py` (ADR-094 —
+ * Python→TS migration, Phase 1).
+ *
+ * Takes a raw artefact (free-form prompt, roadmap path, diff range, or
+ * file set) and produces a {@link CouncilContext} — a redacted,
+ * size-bounded text bundle plus a manifest describing exactly what was
+ * included.
+ *
+ * Hard rules:
+ * - Redaction is fail-closed. If a redaction pattern fires, the line is
+ *   scrubbed *before* the bundle is built.
+ * - Size guard is fail-loud. > MAX_BUNDLE_BYTES → raises BundleTooLarge,
+ *   never silently truncates (would mislead council members).
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export const MAX_BUNDLE_BYTES = 50 * 1024; // 50 KB hard ceiling; user must narrow scope on hit.
+
+/** Raised when the assembled bundle exceeds MAX_BUNDLE_BYTES. */
+export class BundleTooLarge extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BundleTooLarge';
+    }
+}
+
+/** Raised by `bundle_roadmap` when the roadmap file is absent. */
+export class FileNotFoundError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'FileNotFoundError';
+    }
+}
+
+export interface CouncilContext {
+    mode: string; // one of: prompt, roadmap, diff, files
+    text: string;
+    manifest: string[];
+    excluded: string[];
+}
+
+function _context(
+    mode: string,
+    text: string,
+    manifest: string[] = [],
+    excluded: string[] = [],
+): CouncilContext {
+    return { mode, text, manifest, excluded };
+}
+
+/** Byte length of a string encoded as UTF-8 (Python `len(text.encode("utf-8"))`). */
+function _utf8Len(s: string): number {
+    return Buffer.byteLength(s, 'utf-8');
+}
+
+/**
+ * Python `str.splitlines()` — split on universal newlines, drop a single
+ * trailing newline (no empty final element).
+ */
+function _splitlines(s: string): string[] {
+    if (s === '') {
+        return [];
+    }
+    const lines = s.split(/\r\n|\r|\n/u);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+    }
+    return lines;
+}
+
+// ── redaction patterns ───────────────────────────────────────────────────
+// Each pattern is matched line-wise; matching lines are replaced with the
+// placeholder. Order matters — the most specific pattern goes first.
+
+const _REDACTION_LINE_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+    [/~?\/?\.event4u\/agent-config\/[^/\s]+\.key/u, '[redacted: agent-config key path]'],
+    [/~?\/?\.config\/agent-config\/[^/\s]+\.key/u, '[redacted: agent-config key path]'],
+    [/^\s*Authorization:\s/iu, '[redacted: Authorization header]'],
+    [/(api[_-]?key|secret|token|password)\s*[:=]/iu, '[redacted: secret-like assignment]'],
+    [/sk-ant-[A-Za-z0-9_\-]{8,}/u, '[redacted: anthropic-key-like token]'],
+    [/sk-[A-Za-z0-9_\-]{20,}/u, '[redacted: openai-key-like token]'],
+];
+
+/** Apply redaction patterns to a multi-line text buffer. */
+export function redact(text: string): string {
+    const out: string[] = [];
+    for (const line of _splitlines(text)) {
+        let replaced = line;
+        for (const [pattern, placeholder] of _REDACTION_LINE_PATTERNS) {
+            if (pattern.test(replaced)) {
+                replaced = placeholder;
+                break;
+            }
+        }
+        out.push(replaced);
+    }
+    return out.join('\n');
+}
+
+function _enforceSize(text: string, mode: string): string {
+    const n = _utf8Len(text);
+    if (n > MAX_BUNDLE_BYTES) {
+        throw new BundleTooLarge(
+            `Bundle for ${_pyRepr(mode)} mode is ${n} bytes ` +
+                `(> ${MAX_BUNDLE_BYTES} hard ceiling). ` +
+                'Narrow the scope (smaller diff, fewer files, shorter prompt).',
+        );
+    }
+    return text;
+}
+
+/** Python repr() for a string: single-quoted. */
+function _pyRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = s.replace(/\\/g, '\\\\');
+    body = body.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    } else {
+        body = body.replace(/"/g, '\\"');
+    }
+    return `${quote}${body}${quote}`;
+}
+
+export function bundle_prompt(text: string): CouncilContext {
+    const redacted = redact(text);
+    return _context('prompt', _enforceSize(redacted, 'prompt'), ['<inline prompt>']);
+}
+
+export function bundle_roadmap(p: string): CouncilContext {
+    if (!fs.existsSync(p)) {
+        throw new FileNotFoundError(`Roadmap not found: ${p}`);
+    }
+    const raw = fs.readFileSync(p, { encoding: 'utf-8' });
+    const redacted = redact(raw);
+    return _context(
+        'roadmap',
+        _enforceSize(redacted, 'roadmap'),
+        [p],
+        ['<linked contracts/skills not included by default>'],
+    );
+}
+
+export function bundle_diff(
+    baseRef: string,
+    headRef = 'HEAD',
+    opts: { cwd?: string | null } = {},
+): CouncilContext {
+    const cwd = opts.cwd ?? undefined;
+    const cmd = ['diff', `${baseRef}..${headRef}`];
+    const proc = spawnSync('git', cmd, {
+        cwd: cwd ?? undefined,
+        encoding: 'utf-8',
+    });
+    if (proc.error || proc.status !== 0) {
+        const stderr = (proc.stderr ?? '').toString();
+        throw new Error(`git diff ${baseRef}..${headRef} failed: ${_strip(stderr)}`);
+    }
+    const redacted = redact(proc.stdout);
+    return _context('diff', _enforceSize(redacted, 'diff'), [`git diff ${baseRef}..${headRef}`]);
+}
+
+/** Python `str.strip()`. */
+function _strip(s: string): string {
+    return s.trim();
+}
+
+// ── smart diff context (D4) ─────────────────────────────────────────────────
+// Language-agnostic signature detection. Order matters — most specific first.
+
+const _SIGNATURE_PATTERNS: readonly RegExp[] = [
+    /^\s*(?:async\s+)?def\s+\w+\s*\(/u, // Python
+    /^\s*class\s+\w+\b/u, // Python / PHP / JS class
+    /^\s*(?:public|protected|private|static|abstract|final)\s+(?:static\s+)?function\s+\w+/u, // PHP method
+    /^\s*function\s+\w+\s*\(/u, // PHP free function / JS
+    /^\s*export\s+(?:default\s+)?(?:async\s+)?function\s+\w+/u, // TS/JS export fn
+    /^\s*export\s+(?:default\s+)?class\s+\w+/u, // TS/JS export class
+    /^\s*(?:export\s+)?(?:const|let)\s+\w+\s*=\s*(?:async\s+)?\(/u, // TS arrow fn
+    /^\s*(?:public|private|protected)\s+\w+\s*\(/u, // TS method
+];
+
+// Python: re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+const _HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/u;
+// Python: re.compile(r"^\+\+\+ b/(.+)$")
+const _DIFF_FILE = /^\+\+\+ b\/(.+)$/u;
+
+/** Return [[file_path, new_start_line], ...] per hunk in input order. */
+function _parseDiffHunks(diffText: string): Array<[string, number]> {
+    const out: Array<[string, number]> = [];
+    let currentFile: string | null = null;
+    for (const line of _splitlines(diffText)) {
+        const m = _DIFF_FILE.exec(line);
+        if (m) {
+            currentFile = m[1] as string;
+            continue;
+        }
+        const h = _HUNK_HEADER.exec(line);
+        if (h && currentFile && currentFile !== '/dev/null') {
+            out.push([currentFile, parseInt(h[1] as string, 10)]);
+        }
+    }
+    return out;
+}
+
+/** Walk backwards from `targetLine` (1-based) to nearest signature. */
+function _enclosingSignature(fileText: string, targetLine: number): [number, string] | null {
+    const lines = _splitlines(fileText);
+    const start = Math.min(targetLine - 1, lines.length - 1);
+    for (let idx = start; idx >= 0; idx -= 1) {
+        const line = lines[idx] as string;
+        for (const pat of _SIGNATURE_PATTERNS) {
+            if (pat.test(line)) {
+                return [idx + 1, _rstrip(line)];
+            }
+        }
+    }
+    return null;
+}
+
+/** Python `str.rstrip()`. */
+function _rstrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+export interface BundleDiffContextOptions {
+    cwd?: string | null;
+    maxContextBytes?: number;
+}
+
+/**
+ * Bundle a diff plus the nearest enclosing signatures for each hunk.
+ *
+ * Appends a `## Surrounding signatures` section after the raw diff.
+ * Signatures are detected by regex across PY / PHP / JS / TS. Reads files
+ * from the working tree (correct when `headRef` == HEAD); if a touched
+ * file is missing on disk it is silently dropped from the context section
+ * (the diff itself still shows the change).
+ *
+ * Hard cap: `maxContextBytes` for the signature section. Combined output
+ * still goes through `_enforceSize`, so the `BundleTooLarge` behaviour is
+ * unchanged.
+ */
+export function bundle_diff_with_context(
+    baseRef: string,
+    headRef = 'HEAD',
+    opts: BundleDiffContextOptions = {},
+): CouncilContext {
+    const cwd = opts.cwd ?? null;
+    const maxContextBytes = opts.maxContextBytes ?? 8 * 1024;
+
+    const base = bundle_diff(baseRef, headRef, { cwd });
+    const hunks = _parseDiffHunks(base.text);
+    if (hunks.length === 0) {
+        return base;
+    }
+
+    const root = cwd ? cwd : '.';
+    const seen = new Set<string>(); // `${file} ${signature_line}`
+    // Preserve insertion order of first-seen files (Python dict order).
+    const byFile = new Map<string, Array<[number, string]>>();
+
+    for (const [filePath, newStart] of hunks) {
+        const target = path.join(root, filePath);
+        let fileText: string;
+        try {
+            fileText = fs.readFileSync(target, { encoding: 'utf-8' });
+        } catch {
+            continue;
+        }
+        const sig = _enclosingSignature(fileText, newStart);
+        if (sig === null) {
+            continue;
+        }
+        const key = `${filePath} ${sig[0]}`;
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        if (!byFile.has(filePath)) {
+            byFile.set(filePath, []);
+        }
+        (byFile.get(filePath) as Array<[number, string]>).push(sig);
+    }
+
+    if (byFile.size === 0) {
+        return base;
+    }
+
+    const outLines: string[] = ['', '## Surrounding signatures', ''];
+    let truncated = false;
+    let used = 0;
+    for (const [filePath, sigs] of byFile) {
+        const header = `### ${filePath}`;
+        const sorted = [...sigs].sort(_cmpSig);
+        const sigBlock = sorted.map(([ln, text]) => `    L${ln}: ${text}`).join('\n');
+        const chunk = `${header}\n\n${sigBlock}\n\n`;
+        if (used + _utf8Len(chunk) > maxContextBytes) {
+            truncated = true;
+            break;
+        }
+        outLines.push(header);
+        outLines.push('');
+        outLines.push(sigBlock);
+        outLines.push('');
+        used += _utf8Len(chunk);
+    }
+
+    if (truncated) {
+        outLines.push(`[truncated: signature section capped at ${maxContextBytes} bytes]`);
+    }
+
+    const combined = base.text + '\n' + outLines.join('\n');
+    const redacted = redact(combined);
+    return _context('diff', _enforceSize(redacted, 'diff'), [
+        ...base.manifest,
+        `+ surrounding signatures for ${byFile.size} file(s)`,
+    ]);
+}
+
+/** Mirror Python `sorted(sigs)` on `(int, str)` tuples. */
+function _cmpSig(a: [number, string], b: [number, string]): number {
+    if (a[0] !== b[0]) {
+        return a[0] - b[0];
+    }
+    if (a[1] < b[1]) {
+        return -1;
+    }
+    if (a[1] > b[1]) {
+        return 1;
+    }
+    return 0;
+}
+
+export function bundle_files(paths: ReadonlyArray<string>): CouncilContext {
+    const parts: string[] = [];
+    const manifest: string[] = [];
+    const excluded: string[] = [];
+    for (const rawPath of paths) {
+        const p = rawPath;
+        if (!fs.existsSync(p)) {
+            excluded.push(`${p} (not found)`);
+            continue;
+        }
+        let content: string;
+        try {
+            content = fs.readFileSync(p, { encoding: 'utf-8' });
+        } catch (exc) {
+            excluded.push(`${p} (${_excName(exc)})`);
+            continue;
+        }
+        parts.push(`### ${p}\n\n${content}\n`);
+        manifest.push(p);
+    }
+    const bundled = parts.join('\n');
+    const redacted = redact(bundled);
+    return _context('files', _enforceSize(redacted, 'files'), manifest, excluded);
+}
+
+/**
+ * Best-effort Python-exception-name analog for the `excluded` note.
+ * Python catches `(OSError, UnicodeDecodeError)` and prints `type(exc).__name__`.
+ */
+function _excName(exc: unknown): string {
+    if (exc && typeof exc === 'object' && 'code' in exc) {
+        return 'OSError';
+    }
+    return 'OSError';
+}

--- a/src/scripts/ai_council/clients.ts
+++ b/src/scripts/ai_council/clients.ts
@@ -1,0 +1,2154 @@
+// External-AI clients for the council — byte-identical TypeScript twin of
+// `src/scripts/ai_council/clients.py` (py2ts migration, ADR-094).
+//
+// Mirrors the contract from `scripts/skill_trigger_eval.py`:
+// - Tokens come exclusively from `~/.event4u/agent-config/<provider>.key`
+//   (legacy `~/.config/agent-config/<provider>.key` is read as a fallback so
+//   pre-2.4 installs keep working until the user moves the files into the new
+//   namespace).
+// - File mode must be exactly 0o600. Drift is a hard abort.
+// - No environment-variable fallback. No keychain fallback.
+// - Real SDKs (`anthropic`, `openai`) are *soft* dependencies — the module
+//   imports cleanly without them; only `ask()` requires them.
+//
+// Tests inject mock clients via the `client=` constructor argument and never
+// hit the real API.
+//
+// Mode contract:
+// - `billable=true` clients (AnthropicClient, OpenAIClient, GeminiClient,
+//   XAIClient, PerplexityClient) participate in the cost gate — projected USD
+//   spend is checked before each call.
+// - `billable=false` clients (ManualClient, vendor-official CliClient
+//   subclasses — AnthropicCliClient, OpenAICliClient, GeminiCliClient) skip the
+//   USD cost gate entirely. Spend = $0 to us; provider-side limits are the
+//   user's concern.
+// - `billable=true` CLI subclasses (XAICliClient, PerplexityCliClient) wrap
+//   community-maintained CLIs that consume the same API key as their `api`
+//   counterparts — they participate in the USD cost gate. `mode: cli` here is
+//   an ergonomic shortcut, not a billing change.
+//
+// CLI subclasses additionally consult the optional
+// `cli_call_budget.max_calls_per_day.<provider>` quota with state persisted at
+// `~/.event4u/agent-config/cli-calls.json` (daily UTC reset).
+//
+// TRANSPORT SEAM (TS-only, for tests): the Python original calls
+// `subprocess.run` directly inside `CliClient.ask`. The twin routes that one
+// call through the protected `_runSubprocess(cmd, stdinPayload)` instance
+// method so a test subclass can stub the transport without live processes —
+// it returns `{ returncode, stdout, stderr }` or throws a `SubprocessError`
+// shaped like the Python exceptions (`timeout` / `file_not_found` / `os`).
+// The default implementation shells out via `spawnSync`, matching
+// `subprocess.run(..., capture_output=True, text=True, timeout=..., check=False)`.
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import * as user_global_paths from '../_lib/user_global_paths.js';
+import { appendEvent } from './events_log.js';
+
+export const ANTHROPIC_KEY_FILENAME = 'anthropic.key';
+export const OPENAI_KEY_FILENAME = 'openai.key';
+
+// Canonical write target under the new namespace. Reads route via
+// `_resolveKeyPath` so a key still sitting in the legacy
+// `~/.config/agent-config/` tree keeps working.
+export const ANTHROPIC_KEY_PATH = user_global_paths.write_target(ANTHROPIC_KEY_FILENAME);
+export const OPENAI_KEY_PATH = user_global_paths.write_target(OPENAI_KEY_FILENAME);
+
+/** Return the active key path, preferring the new namespace. */
+function _resolveKeyPath(filename: string): string {
+    const found = user_global_paths.resolve_with_fallback(filename);
+    if (found !== null) {
+        return found;
+    }
+    return user_global_paths.write_target(filename);
+}
+
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-5';
+export const DEFAULT_OPENAI_MODEL = 'gpt-4o';
+export const DEFAULT_GEMINI_MODEL = 'gemini-2.5-pro';
+export const DEFAULT_XAI_MODEL = 'grok-4';
+export const DEFAULT_PERPLEXITY_MODEL = 'sonar-pro';
+
+// OpenAI-API-compatible endpoints. xAI and Perplexity both expose the
+// `/v1/chat/completions` shape, so their clients reuse the `openai` SDK with a
+// custom `base_url`. Gemini has its own SDK (`google-genai`).
+export const XAI_BASE_URL = 'https://api.x.ai/v1';
+export const PERPLEXITY_BASE_URL = 'https://api.perplexity.ai';
+
+// Per-call output budget when no caller-supplied value reaches `ask()`. The CLI
+// resolves the live default from `ai_council.max_output_tokens` in
+// `.agent-settings.yml`; this constant is only the abstract-base / direct-API
+// fallback when nothing else is wired up.
+export const DEFAULT_MAX_TOKENS = 2048;
+
+// Expansion target when the user sets `max_output_tokens: 0` ("unlimited") in
+// settings. Anthropic requires `max_tokens` to be a positive integer, so 0 is
+// widened to this safe ceiling before the SDK call. Big enough for current
+// frontier models (Sonnet/GPT-4o headroom ≥ 16k); raise explicitly in settings
+// if a larger budget is genuinely needed.
+export const UNLIMITED_TOKENS_FALLBACK = 16384;
+
+// OpenAI reasoning models (o1, o3, o4 families) reject `max_tokens` and the
+// `system` role; they require `max_completion_tokens` and accept only `user`
+// (and `developer`) messages.
+const _REASONING_PREFIXES: readonly string[] = ['o1', 'o3', 'o4'];
+
+export function _is_reasoning_model(model: string): boolean {
+    const name = model.toLowerCase();
+    return _REASONING_PREFIXES.some((p) => name === p || name.startsWith(`${p}-`));
+}
+
+/** Raised when a provider key file violates the 0600 contract. */
+export class KeyGateError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'KeyGateError';
+    }
+}
+
+/** Raised when a CLI member cannot be constructed (binary missing, etc.). */
+export class CliClientError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'CliClientError';
+    }
+}
+
+/** Normalised output from a single council member (dataclass `CouncilResponse`). */
+export class CouncilResponse {
+    provider: string;
+    model: string;
+    text: string;
+    input_tokens: number;
+    output_tokens: number;
+    latency_ms: number;
+    error: string | null;
+    metadata: Record<string, unknown>;
+
+    constructor(opts: {
+        provider: string;
+        model: string;
+        text: string;
+        input_tokens?: number;
+        output_tokens?: number;
+        latency_ms?: number;
+        error?: string | null;
+        metadata?: Record<string, unknown>;
+    }) {
+        this.provider = opts.provider;
+        this.model = opts.model;
+        this.text = opts.text;
+        this.input_tokens = opts.input_tokens ?? 0;
+        this.output_tokens = opts.output_tokens ?? 0;
+        this.latency_ms = opts.latency_ms ?? 0;
+        this.error = opts.error ?? null;
+        // Python dataclass uses `field(default_factory=dict)` — each instance
+        // gets its own fresh dict.
+        this.metadata = opts.metadata ?? {};
+    }
+}
+
+// ── monotonic clock seam ──────────────────────────────────────────────
+// Python uses `time.monotonic()`. latency_ms is non-deterministic; tests
+// normalise it. Exposed so tests can pin it if they choose.
+let _monotonicSource: () => number = () => {
+    // performance.now() is monotonic milliseconds; the Python original is
+    // seconds, but we only ever compute `int((now - t0) * 1000)`, so feeding
+    // milliseconds here and dropping the *1000 keeps the same arithmetic.
+    return performance.now();
+};
+
+function _nowMs(): number {
+    return _monotonicSource();
+}
+
+function _elapsedMs(t0: number): number {
+    // Mirrors Python `int((time.monotonic() - t0) * 1000)` — here both sides are
+    // already in ms, so just truncate toward zero.
+    return Math.trunc(_nowMs() - t0);
+}
+
+/** Test seam: override the monotonic clock (ms). Returns the previous source. */
+export function _setMonotonicSource(fn: () => number): () => number {
+    const prev = _monotonicSource;
+    _monotonicSource = fn;
+    return prev;
+}
+
+/** Shared 0600-gated key loader. Refuses anything outside the contract. */
+function _loadKey(p: string, prefix: string, installScript: string): string {
+    if (!fs.existsSync(p)) {
+        throw new KeyGateError(
+            `Key not found at ${p}.\n` + `    Install it with: bash ${installScript}`,
+        );
+    }
+    const st = fs.statSync(p);
+    const mode = st.mode & 0o777;
+    if (mode !== 0o600) {
+        throw new KeyGateError(
+            `Unsafe permissions on ${p}: got ${_octRepr(mode)}, expected 0o600.\n` +
+                `    Fix:  chmod 600 ${p}`,
+        );
+    }
+    const key = fs.readFileSync(p, { encoding: 'utf-8' }).trim();
+    if (!key) {
+        throw new KeyGateError(`${p} is empty.`);
+    }
+    if (!key.startsWith(prefix)) {
+        throw new KeyGateError(`${p} does not look like a ${_pyRepr(prefix)}-prefixed key.`);
+    }
+    return key;
+}
+
+export function load_anthropic_key(p: string | null = null): string {
+    const resolved = p !== null ? p : _resolveKeyPath(ANTHROPIC_KEY_FILENAME);
+    return _loadKey(resolved, 'sk-ant-', 'src/scripts/install_anthropic_key.sh');
+}
+
+export function load_openai_key(p: string | null = null): string {
+    const resolved = p !== null ? p : _resolveKeyPath(OPENAI_KEY_FILENAME);
+    return _loadKey(resolved, 'sk-', 'src/scripts/install_openai_key.sh');
+}
+
+// ── attribute-access helpers (mirror Python getattr) ──────────────────
+
+/**
+ * Mirror Python `getattr(obj, name, default)` over the duck-typed mock /
+ * SDK-response objects the clients consume. Returns the attribute value, or
+ * `fallback` when the attribute is absent / object is null. Methods are
+ * returned bound so they can be invoked by the caller.
+ */
+function _getattr(obj: unknown, name: string, fallback: unknown): unknown {
+    if (obj === null || obj === undefined) {
+        return fallback;
+    }
+    if (typeof obj === 'object' || typeof obj === 'function') {
+        const rec = obj as Record<string, unknown>;
+        if (name in rec) {
+            return rec[name];
+        }
+        // Walk the prototype chain for class-instance shaped mocks.
+        const val = (obj as Record<string, unknown>)[name];
+        if (val !== undefined) {
+            return val;
+        }
+    }
+    return fallback;
+}
+
+/** Abstract base for council members. */
+export abstract class ExternalAIClient {
+    name = '';
+    model = '';
+    billable = true; // API-mode subclasses spend money; manual doesn't.
+    transport = 'api'; // "api" | "cli" | "manual" — surfaced in session manifest.
+    subscription_label = ''; // vendor-CLI label (e.g. "claude") for non-billable transports.
+
+    /**
+     * Send one independent query. Must never raise on network/API failure —
+     * return a `CouncilResponse` with `error` set instead. Other members should
+     * not be blocked by one failure.
+     */
+    abstract ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens?: number,
+    ): CouncilResponse;
+}
+
+/** Shared ctor-options shape for the API clients. */
+interface ApiClientOptions {
+    model?: string | undefined;
+    client?: unknown;
+    api_key?: string | null | undefined;
+}
+
+/** Shared ctor-options shape for the CLI clients. */
+interface CliClientOptions {
+    model?: string | undefined;
+    binary?: string | null | undefined;
+    timeout_seconds?: number | undefined;
+    max_calls_per_day?: number | null | undefined;
+    warn_at?: number | undefined;
+    cli_calls_path?: string | null | undefined;
+}
+
+export class AnthropicClient extends ExternalAIClient {
+    override name = 'anthropic';
+    override billable = true;
+    private _client: unknown;
+
+    constructor(opts: ApiClientOptions = {}) {
+        super();
+        this.model = opts.model ?? DEFAULT_ANTHROPIC_MODEL;
+        if (opts.client !== undefined && opts.client !== null) {
+            this._client = opts.client;
+            return;
+        }
+        const api_key = opts.api_key ?? null;
+        if (api_key === null) {
+            throw new Error(
+                'AnthropicClient requires explicit api_key or injected client. ' +
+                    'Use load_anthropic_key() — no env-var fallback.',
+            );
+        }
+        // Real SDK is a soft dependency; the twin has no Node `anthropic` SDK
+        // wired in this layer. Tests always inject `client`. Mirror the Python
+        // ImportError → RuntimeError shape for the no-SDK path.
+        throw new Error('anthropic package not installed. `pip install anthropic`.');
+    }
+
+    override ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number = DEFAULT_MAX_TOKENS,
+    ): CouncilResponse {
+        const t0 = _nowMs();
+        let response: unknown;
+        try {
+            const messages = _getattr(this._client, 'messages', null);
+            const create = _getattr(messages, 'create', null) as
+                | ((kwargs: Record<string, unknown>) => unknown)
+                | null;
+            if (typeof create !== 'function') {
+                throw new TypeError("'messages.create' is not callable");
+            }
+            response = create.call(messages, {
+                model: this.model,
+                max_tokens,
+                system: system_prompt,
+                messages: [{ role: 'user', content: user_prompt }],
+            });
+        } catch (exc) {
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: '',
+                latency_ms: _elapsedMs(t0),
+                error: _excString(exc),
+            });
+        }
+        const latency_ms = _elapsedMs(t0);
+        let text = '';
+        const content = _getattr(response, 'content', null);
+        if (_pyTruthy(content)) {
+            const first = (content as unknown[])[0];
+            text = (_getattr(first, 'text', '') as string) || '';
+        }
+        const usage = _getattr(response, 'usage', null);
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens: usage ? (_getattr(usage, 'input_tokens', 0) as number) : 0,
+            output_tokens: usage ? (_getattr(usage, 'output_tokens', 0) as number) : 0,
+            latency_ms,
+        });
+    }
+}
+
+export class OpenAIClient extends ExternalAIClient {
+    override name = 'openai';
+    override billable = true;
+    private _client: unknown;
+
+    constructor(opts: ApiClientOptions = {}) {
+        super();
+        this.model = opts.model ?? DEFAULT_OPENAI_MODEL;
+        if (opts.client !== undefined && opts.client !== null) {
+            this._client = opts.client;
+            return;
+        }
+        const api_key = opts.api_key ?? null;
+        if (api_key === null) {
+            throw new Error(
+                'OpenAIClient requires explicit api_key or injected client. ' +
+                    'Use load_openai_key() — no env-var fallback.',
+            );
+        }
+        throw new Error('openai package not installed. `pip install openai`.');
+    }
+
+    override ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number = DEFAULT_MAX_TOKENS,
+    ): CouncilResponse {
+        const t0 = _nowMs();
+        const kwargs: Record<string, unknown> = { model: this.model };
+        if (_is_reasoning_model(this.model)) {
+            // o1/o3/o4 reasoning models reject `max_tokens` and `system` role.
+            kwargs['max_completion_tokens'] = max_tokens;
+            kwargs['messages'] = [
+                { role: 'user', content: `${system_prompt}\n\n---\n\n${user_prompt}` },
+            ];
+        } else {
+            kwargs['max_tokens'] = max_tokens;
+            kwargs['messages'] = [
+                { role: 'system', content: system_prompt },
+                { role: 'user', content: user_prompt },
+            ];
+        }
+        let response: unknown;
+        try {
+            const chat = _getattr(this._client, 'chat', null);
+            const completions = _getattr(chat, 'completions', null);
+            const create = _getattr(completions, 'create', null) as
+                | ((kwargs: Record<string, unknown>) => unknown)
+                | null;
+            if (typeof create !== 'function') {
+                throw new TypeError("'chat.completions.create' is not callable");
+            }
+            response = create.call(completions, kwargs);
+        } catch (exc) {
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: '',
+                latency_ms: _elapsedMs(t0),
+                error: _excString(exc),
+            });
+        }
+        const latency_ms = _elapsedMs(t0);
+        let text: unknown = '';
+        const choices = _getattr(response, 'choices', null);
+        if (_pyTruthy(choices)) {
+            const first = (choices as unknown[])[0];
+            const msg = _getattr(first, 'message', null);
+            text = msg ? _getattr(msg, 'content', '') : '';
+        }
+        const usage = _getattr(response, 'usage', null);
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text: (text as string) || '',
+            input_tokens: usage ? (_getattr(usage, 'prompt_tokens', 0) as number) : 0,
+            output_tokens: usage ? (_getattr(usage, 'completion_tokens', 0) as number) : 0,
+            latency_ms,
+        });
+    }
+}
+
+// ── Gemini / xAI / Perplexity (Phase 0 — Step 6) ─────────────────────
+
+/**
+ * Google Gemini via the `google-genai` SDK.
+ *
+ * Lazy-imports `google.genai` on first `ask()` so disabled members do not
+ * require the SDK to be installed. Tests inject a mock client shaped like
+ * `genai.Client(api_key=...)` — `self._client.models.generate_content(...)`
+ * returns an object with `.text` and
+ * `.usage_metadata.{prompt_token_count, candidates_token_count}`.
+ */
+export class GeminiClient extends ExternalAIClient {
+    override name = 'gemini';
+    override billable = true;
+    private _client: unknown;
+
+    constructor(opts: ApiClientOptions = {}) {
+        super();
+        this.model = opts.model ?? DEFAULT_GEMINI_MODEL;
+        if (opts.client !== undefined && opts.client !== null) {
+            this._client = opts.client;
+            return;
+        }
+        const api_key = opts.api_key ?? null;
+        if (api_key === null) {
+            throw new Error(
+                'GeminiClient requires explicit api_key or injected client. ' +
+                    'Use `api_key_ref: env:GEMINI_API_KEY` in ~/.event4u/agent-config/settings/.ai-council.yml.',
+            );
+        }
+        throw new Error('google-genai package not installed. `pip install google-genai`.');
+    }
+
+    override ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number = DEFAULT_MAX_TOKENS,
+    ): CouncilResponse {
+        const t0 = _nowMs();
+        const contents = `${system_prompt}\n\n---\n\n${user_prompt}`;
+        let response: unknown;
+        try {
+            const models = _getattr(this._client, 'models', null);
+            const generate = _getattr(models, 'generate_content', null) as
+                | ((kwargs: Record<string, unknown>) => unknown)
+                | null;
+            if (typeof generate !== 'function') {
+                throw new TypeError("'models.generate_content' is not callable");
+            }
+            response = generate.call(models, {
+                model: this.model,
+                contents,
+                config: { max_output_tokens: max_tokens },
+            });
+        } catch (exc) {
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: '',
+                latency_ms: _elapsedMs(t0),
+                error: _excString(exc),
+            });
+        }
+        const latency_ms = _elapsedMs(t0);
+        const text = (_getattr(response, 'text', '') as string) || '';
+        const usage = _getattr(response, 'usage_metadata', null);
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens: usage ? (_getattr(usage, 'prompt_token_count', 0) as number) : 0,
+            output_tokens: usage ? (_getattr(usage, 'candidates_token_count', 0) as number) : 0,
+            latency_ms,
+        });
+    }
+}
+
+/**
+ * Shared shape for OpenAI-API-compatible providers (xAI, Perplexity).
+ *
+ * Both vendors implement `/v1/chat/completions` and accept the `openai` Python
+ * SDK with a custom `base_url`. The reasoning-model branch from `OpenAIClient`
+ * is intentionally omitted — neither xAI nor Perplexity ships a reasoning model
+ * that requires `max_completion_tokens` as of 2026-05-14.
+ */
+export class _OpenAICompatibleClient extends ExternalAIClient {
+    override billable = true;
+    base_url = '';
+    protected _client: unknown;
+
+    constructor(opts: { model: string; client?: unknown; api_key?: string | null | undefined }) {
+        super();
+        this.model = opts.model;
+        if (opts.client !== undefined && opts.client !== null) {
+            this._client = opts.client;
+            return;
+        }
+        const api_key = opts.api_key ?? null;
+        if (api_key === null) {
+            throw new Error(
+                `${this.constructor.name} requires explicit api_key or injected client.`,
+            );
+        }
+        throw new Error('openai package not installed. `pip install openai`.');
+    }
+
+    override ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number = DEFAULT_MAX_TOKENS,
+    ): CouncilResponse {
+        const t0 = _nowMs();
+        let response: unknown;
+        try {
+            const chat = _getattr(this._client, 'chat', null);
+            const completions = _getattr(chat, 'completions', null);
+            const create = _getattr(completions, 'create', null) as
+                | ((kwargs: Record<string, unknown>) => unknown)
+                | null;
+            if (typeof create !== 'function') {
+                throw new TypeError("'chat.completions.create' is not callable");
+            }
+            response = create.call(completions, {
+                model: this.model,
+                max_tokens,
+                messages: [
+                    { role: 'system', content: system_prompt },
+                    { role: 'user', content: user_prompt },
+                ],
+            });
+        } catch (exc) {
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: '',
+                latency_ms: _elapsedMs(t0),
+                error: _excString(exc),
+            });
+        }
+        const latency_ms = _elapsedMs(t0);
+        let text: unknown = '';
+        const choices = _getattr(response, 'choices', null);
+        if (_pyTruthy(choices)) {
+            const first = (choices as unknown[])[0];
+            const msg = _getattr(first, 'message', null);
+            text = msg ? _getattr(msg, 'content', '') : '';
+        }
+        const usage = _getattr(response, 'usage', null);
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text: (text as string) || '',
+            input_tokens: usage ? (_getattr(usage, 'prompt_tokens', 0) as number) : 0,
+            output_tokens: usage ? (_getattr(usage, 'completion_tokens', 0) as number) : 0,
+            latency_ms,
+        });
+    }
+}
+
+/** xAI Grok via the OpenAI-compatible endpoint at api.x.ai/v1. */
+export class XAIClient extends _OpenAICompatibleClient {
+    override name = 'xai';
+    override base_url = XAI_BASE_URL;
+
+    constructor(opts: ApiClientOptions = {}) {
+        super({ model: opts.model ?? DEFAULT_XAI_MODEL, client: opts.client, api_key: opts.api_key });
+    }
+}
+
+/** Perplexity via the OpenAI-compatible endpoint at api.perplexity.ai. */
+export class PerplexityClient extends _OpenAICompatibleClient {
+    override name = 'perplexity';
+    override base_url = PERPLEXITY_BASE_URL;
+
+    constructor(opts: ApiClientOptions = {}) {
+        super({
+            model: opts.model ?? DEFAULT_PERPLEXITY_MODEL,
+            client: opts.client,
+            api_key: opts.api_key,
+        });
+    }
+}
+
+// ── CLI transport (step-1 Phase 1+) ──────────────────────────────────
+
+export const CLI_CALLS_FILENAME = 'cli-calls.json';
+
+// Default subprocess timeout (seconds) for a single CLI call. Long enough for
+// the largest frontier models to think; short enough to surface a hung
+// subprocess without freezing the council run.
+export const DEFAULT_CLI_TIMEOUT_SECONDS = 120.0;
+
+/** Return the canonical write target for the daily-quota counter. */
+function _cliCallsStatePath(): string {
+    return user_global_paths.write_target(CLI_CALLS_FILENAME);
+}
+
+export function _today_utc_iso(): string {
+    // Python: datetime.now(timezone.utc).date().isoformat() → "YYYY-MM-DD".
+    const d = new Date();
+    const y = d.getUTCFullYear().toString().padStart(4, '0');
+    const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+    const day = d.getUTCDate().toString().padStart(2, '0');
+    return `${y}-${m}-${day}`;
+}
+
+/** Return today's per-provider call counts. Empty dict on UTC rollover. */
+export function load_cli_call_counts(p: string | null = null): Record<string, number> {
+    const target = p !== null ? p : _cliCallsStatePath();
+    if (!fs.existsSync(target)) {
+        return {};
+    }
+    let data: unknown;
+    try {
+        data = JSON.parse(fs.readFileSync(target, { encoding: 'utf-8' }));
+    } catch {
+        // json.JSONDecodeError / OSError
+        return {};
+    }
+    if (!_isPlainObject(data) || (data as Record<string, unknown>)['date'] !== _today_utc_iso()) {
+        return {};
+    }
+    const counts = (data as Record<string, unknown>)['counts'];
+    if (!_isPlainObject(counts)) {
+        return {};
+    }
+    const out: Record<string, number> = {};
+    for (const [k, v] of Object.entries(counts as Record<string, unknown>)) {
+        // Python: int(v) for k, v in counts.items() if isinstance(v, (int, str)).
+        // bool is an int subclass in Python and would pass; mirror by accepting
+        // booleans too. Floats are rejected (not int|str).
+        if (typeof v === 'number' && Number.isInteger(v)) {
+            out[String(k)] = _pyInt(v);
+        } else if (typeof v === 'boolean') {
+            out[String(k)] = v ? 1 : 0;
+        } else if (typeof v === 'string') {
+            out[String(k)] = _pyIntFromStr(v);
+        }
+    }
+    return out;
+}
+
+/** Increment today's call count for `provider`. Returns new total. */
+export function record_cli_call(provider: string, p: string | null = null): number {
+    const target = p !== null ? p : _cliCallsStatePath();
+    const counts = load_cli_call_counts(target);
+    counts[provider] = (counts[provider] ?? 0) + 1;
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(
+        target,
+        _jsonDumpsIndent2({ date: _today_utc_iso(), counts }),
+        { encoding: 'utf-8' },
+    );
+    return counts[provider];
+}
+
+/**
+ * Reset the per-provider call counter (step-8 P1, `council quota --reset`).
+ *
+ * `provider=null` clears all providers (today's record). Otherwise only the
+ * named provider's count is removed; other providers and the UTC date marker
+ * are preserved. Returns the post-reset counts.
+ */
+export function reset_cli_call_counts(
+    provider: string | null = null,
+    p: string | null = null,
+): Record<string, number> {
+    const target = p !== null ? p : _cliCallsStatePath();
+    let counts = load_cli_call_counts(target);
+    if (provider === null) {
+        counts = {};
+    } else {
+        delete counts[provider];
+    }
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(
+        target,
+        _jsonDumpsIndent2({ date: _today_utc_iso(), counts }),
+        { encoding: 'utf-8' },
+    );
+    return counts;
+}
+
+/**
+ * Build the pre-run quota summary line (step-8 P1, D1 + D4).
+ *
+ * Returns `[summary, warn_providers]` where `summary` is the formatted
+ * one-liner (empty string when no CLI member has a configured cap) and
+ * `warn_providers` is the subset whose `used / max_calls_per_day` ratio crossed
+ * `warn_at`. Uncapped providers (`max_calls_per_day is None`) are omitted from
+ * the summary entirely — they cannot exceed a threshold that does not exist.
+ */
+export function quota_summary_line(
+    clients: CliClient[],
+    opts: { cli_calls_path?: string | null } = {},
+): [string, string[]] {
+    const cliCallsPath = opts.cli_calls_path ?? null;
+    // Python: [c for c in clients if getattr(c, "max_calls_per_day", None)]
+    // → truthy check (None or 0 both falsy).
+    const capped = clients.filter((c) => _pyTruthy(_getattr(c, 'max_calls_per_day', null)));
+    if (capped.length === 0) {
+        return ['', []];
+    }
+    const counts = load_cli_call_counts(cliCallsPath);
+    const parts: string[] = [];
+    const warn: string[] = [];
+    for (const c of capped) {
+        const name = _getattr(c, 'name', '?') as string;
+        const used = _pyInt(counts[name] ?? 0);
+        const limit = _pyInt((c.max_calls_per_day as number));
+        parts.push(`${name} ${used}/${limit}`);
+        const ratio = limit > 0 ? used / limit : 0.0;
+        const warnAt = Number(_getattr(c, 'warn_at', 0.8));
+        if (ratio >= warnAt) {
+            warn.push(name);
+        }
+    }
+    const prefix = warn.length > 0 ? '⚠️  ' : '';
+    return [`${prefix}council:quota · ${parts.join(' · ')}`, warn];
+}
+
+/** Transport-seam result, shaped like a finished `subprocess.run`. */
+export interface SubprocessResult {
+    returncode: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Transport-seam error kinds, mirroring the Python exception branches. */
+export type SubprocessErrorKind = 'timeout' | 'file_not_found' | 'os';
+
+/** Typed transport error so a stub can model each Python exception branch. */
+export class SubprocessError extends Error {
+    kind: SubprocessErrorKind;
+    osName: string;
+    constructor(kind: SubprocessErrorKind, osName = 'OSError') {
+        super(kind);
+        this.name = 'SubprocessError';
+        this.kind = kind;
+        this.osName = osName;
+    }
+}
+
+/**
+ * Shell-out council member — subscription-authed transport.
+ *
+ * Spawns a locally-installed provider CLI. Auth is delegated to the binary
+ * itself (Claude CLI, Codex CLI, Gemini CLI, etc. use the user's logged-in
+ * subscription session). Spend is $0 from this loader's perspective —
+ * `billable=false` keeps the USD cost gate from firing.
+ *
+ * Provider subscription quotas are guarded by the optional
+ * `cli_call_budget.max_calls_per_day.<provider>` config. Counter state lives at
+ * `~/.event4u/agent-config/cli-calls.json` and resets on UTC date rollover.
+ *
+ * Subclass contract:
+ * - `name`: provider key (`anthropic`, `openai`, `gemini`, …).
+ * - `default_binary`: executable name resolved via PATH when the member-level
+ *   `binary:` field is not set.
+ * - `_build_command(system_prompt, user_prompt, max_tokens)`: return the argv.
+ * - `_parse_output(stdout, stderr)`: return a partial `CouncilResponse`.
+ *
+ * Construction validates the binary up front — a missing CLI fails fast with
+ * `CliClientError`.
+ *
+ * Stderr heuristics map known failure shapes to short error codes:
+ * - `auth_expired`, `timeout`, `cli_quota_exhausted`, `parse_failed`,
+ *   `exit_<N>`.
+ */
+export abstract class CliClient extends ExternalAIClient {
+    override billable = false;
+    override transport = 'cli';
+    default_binary = '';
+
+    timeout_seconds: number;
+    max_calls_per_day: number | null;
+    warn_at: number;
+    binary!: string;
+    protected _cli_calls_path: string | null;
+
+    static _AUTH_FAILURE_PATTERNS: readonly string[] = [
+        'authentication',
+        'unauthorized',
+        'auth failed',
+        'auth_error',
+        'login',
+        'not logged in',
+        'session expired',
+        'invalid credentials',
+    ];
+    static _TIMEOUT_PATTERNS: readonly string[] = ['timeout', 'timed out', 'deadline exceeded'];
+    static _QUOTA_PATTERNS: readonly string[] = [
+        'rate limit',
+        'rate_limit',
+        'rate-limit',
+        'quota exceeded',
+        'too many requests',
+        '429',
+        'usage limit',
+    ];
+
+    constructor(opts: CliClientOptions & { model: string }) {
+        super();
+        this.model = opts.model;
+        this.timeout_seconds = opts.timeout_seconds ?? DEFAULT_CLI_TIMEOUT_SECONDS;
+        this.max_calls_per_day = opts.max_calls_per_day ?? null;
+        this.warn_at = opts.warn_at ?? 0.8;
+        this._cli_calls_path = opts.cli_calls_path ?? null;
+        const binary = opts.binary ?? null;
+        if (binary !== null) {
+            this.binary = binary;
+        } else {
+            if (!this.default_binary) {
+                throw new CliClientError(
+                    `${this.constructor.name}: no \`default_binary\` set on subclass; ` +
+                        'either fix the class or pass `binary=` explicitly.',
+                );
+            }
+            const resolved = _which(this.default_binary);
+            if (resolved === null) {
+                throw new CliClientError(
+                    `${this.constructor.name}: binary ${_pyRepr(this.default_binary)} ` +
+                        'not found on PATH. Install the provider CLI or set ' +
+                        `\`members.${this.name}.binary:\` in ~/.event4u/agent-config/settings/.ai-council.yml.`,
+                );
+            }
+            this.binary = resolved;
+        }
+    }
+
+    // ── subclass hooks ────────────────────────────────────────────
+
+    /** Return the argv list the subprocess should execute. */
+    protected abstract _build_command(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number,
+    ): string[];
+
+    /** Parse provider-specific stdout into a CouncilResponse. */
+    protected abstract _parse_output(stdout: string, stderr: string): CouncilResponse;
+
+    /** Return text to send on stdin, or `null` to inherit caller's stdin. */
+    protected _stdin_payload(system_prompt: string, user_prompt: string): string | null {
+        void system_prompt;
+        void user_prompt;
+        return null;
+    }
+
+    /**
+     * Transport seam (default impl). Mirror
+     * `subprocess.run(cmd, input=..., capture_output=True, text=True,
+     * timeout=..., check=False)`. Throws `SubprocessError` for the timeout /
+     * ENOENT / OSError branches so `ask()` can classify them exactly as the
+     * Python original does. Tests override this to inject canned output without
+     * spawning a process.
+     */
+    protected _runSubprocess(cmd: string[], stdinPayload: string | null): SubprocessResult {
+        const argv0 = cmd[0] ?? '';
+        const spawnOpts: Parameters<typeof spawnSync>[2] = {
+            encoding: 'utf-8',
+            timeout: Math.round(this.timeout_seconds * 1000),
+        };
+        if (stdinPayload !== null) {
+            spawnOpts.input = stdinPayload;
+        }
+        const r = spawnSync(argv0, cmd.slice(1), spawnOpts);
+        if (r.error) {
+            const err = r.error as NodeJS.ErrnoException;
+            if ((r as { signal?: string | null }).signal === 'SIGTERM' || err.code === 'ETIMEDOUT') {
+                throw new SubprocessError('timeout');
+            }
+            if (err.code === 'ENOENT') {
+                throw new SubprocessError('file_not_found');
+            }
+            throw new SubprocessError('os', err.code ?? 'OSError');
+        }
+        // spawnSync sets status=null + signal on timeout-kill on some platforms.
+        if ((r as { signal?: string | null }).signal === 'SIGTERM' && r.status === null) {
+            throw new SubprocessError('timeout');
+        }
+        return {
+            returncode: r.status ?? 0,
+            stdout: r.stdout != null ? String(r.stdout) : '',
+            stderr: r.stderr != null ? String(r.stderr) : '',
+        };
+    }
+
+    // ── ask() ──────────────────────────────────────────────────────
+
+    override ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number = DEFAULT_MAX_TOKENS,
+    ): CouncilResponse {
+        const t0 = _nowMs();
+
+        // 1. quota gate — local counter check before spawning anything.
+        if (this.max_calls_per_day !== null) {
+            const counts = load_cli_call_counts(this._cli_calls_path);
+            const used = counts[this.name] ?? 0;
+            if (used >= this.max_calls_per_day) {
+                // step-8 D3 — record the block on the persistent events log.
+                try {
+                    appendEvent({
+                        lens: '',
+                        invocation: '',
+                        action: 'block_quota',
+                        verdict: '',
+                        provider_caps: {
+                            [this.name]: { mode: 'cli', model: this.model },
+                        },
+                        original_ask: user_prompt,
+                        cli_calls_used: used,
+                        cli_calls_max: this.max_calls_per_day,
+                    });
+                } catch {
+                    // never crash ask()
+                }
+                return new CouncilResponse({
+                    provider: this.name,
+                    model: this.model,
+                    text: '',
+                    latency_ms: _elapsedMs(t0),
+                    error: 'cli_quota_exhausted',
+                    metadata: {
+                        cli: true,
+                        cli_calls_used: used,
+                        cli_calls_max: this.max_calls_per_day,
+                    },
+                });
+            }
+        }
+
+        // 2. build command + spawn.
+        const cmd = this._build_command(system_prompt, user_prompt, max_tokens);
+        const stdinPayload = this._stdin_payload(system_prompt, user_prompt);
+        let proc: SubprocessResult;
+        try {
+            proc = this._runSubprocess(cmd, stdinPayload);
+        } catch (exc) {
+            if (exc instanceof SubprocessError) {
+                if (exc.kind === 'timeout') {
+                    return new CouncilResponse({
+                        provider: this.name,
+                        model: this.model,
+                        text: '',
+                        latency_ms: _elapsedMs(t0),
+                        error: 'timeout',
+                        metadata: { cli: true, timeout_seconds: this.timeout_seconds },
+                    });
+                }
+                if (exc.kind === 'file_not_found') {
+                    return new CouncilResponse({
+                        provider: this.name,
+                        model: this.model,
+                        text: '',
+                        latency_ms: _elapsedMs(t0),
+                        error: 'binary_missing',
+                        metadata: { cli: true, binary: this.binary },
+                    });
+                }
+                // OSError
+                return new CouncilResponse({
+                    provider: this.name,
+                    model: this.model,
+                    text: '',
+                    latency_ms: _elapsedMs(t0),
+                    error: `os_error: ${exc.osName}`,
+                    metadata: { cli: true },
+                });
+            }
+            throw exc;
+        }
+
+        // 3. record the call — even failures count against the quota so a broken
+        //    CLI cannot burn the whole budget in a tight loop.
+        try {
+            record_cli_call(this.name, this._cli_calls_path);
+        } catch {
+            // state-file write failure is non-fatal here.
+        }
+
+        const latency_ms = _elapsedMs(t0);
+
+        // 4. non-zero exit → classify and bail.
+        if (proc.returncode !== 0) {
+            const code = (this.constructor as typeof CliClient)._classify_stderr(
+                proc.stderr || '',
+                proc.returncode,
+            );
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: '',
+                latency_ms,
+                error: code,
+                metadata: {
+                    cli: true,
+                    returncode: proc.returncode,
+                    stderr_tail: (proc.stderr || '').slice(-500),
+                },
+            });
+        }
+
+        // 5. parse stdout via the subclass hook.
+        let response: CouncilResponse;
+        try {
+            response = this._parse_output(proc.stdout || '', proc.stderr || '');
+        } catch (exc) {
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: proc.stdout || '',
+                latency_ms,
+                error: `parse_failed: ${_excTypeName(exc)}`,
+                metadata: { cli: true, stderr_tail: (proc.stderr || '').slice(-500) },
+            });
+        }
+        response.latency_ms = latency_ms;
+        const meta: Record<string, unknown> = { ...response.metadata };
+        if (!('cli' in meta)) {
+            meta['cli'] = true;
+        }
+        response.metadata = meta;
+        return response;
+    }
+
+    static _classify_stderr(stderr: string, returncode: number): string {
+        const haystack = stderr.toLowerCase();
+        if (this._AUTH_FAILURE_PATTERNS.some((p) => haystack.includes(p))) {
+            return 'auth_expired';
+        }
+        if (this._TIMEOUT_PATTERNS.some((p) => haystack.includes(p))) {
+            return 'timeout';
+        }
+        if (this._QUOTA_PATTERNS.some((p) => haystack.includes(p))) {
+            return 'cli_quota_exhausted';
+        }
+        return `exit_${returncode}`;
+    }
+}
+
+/**
+ * Claude via the official `claude` CLI (subscription-authed).
+ *
+ * Invokes `claude --print --output-format json` and consumes the structured
+ * envelope: `{"result": str, "usage": {"input_tokens": int, "output_tokens":
+ * int}, "session_id": str, ...}`. The prompt is piped on stdin so it never
+ * collides with argv length limits.
+ */
+export class AnthropicCliClient extends CliClient {
+    override name = 'anthropic';
+    override default_binary = 'claude';
+    override subscription_label = 'claude-pro';
+
+    constructor(opts: CliClientOptions = {}) {
+        super({
+            model: opts.model ?? 'claude-sonnet-4-5',
+            binary: opts.binary,
+            timeout_seconds: opts.timeout_seconds,
+            max_calls_per_day: opts.max_calls_per_day,
+            warn_at: opts.warn_at,
+            cli_calls_path: opts.cli_calls_path,
+        });
+    }
+
+    protected override _build_command(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number,
+    ): string[] {
+        void user_prompt;
+        void max_tokens;
+        return [
+            this.binary,
+            '--print',
+            '--output-format',
+            'json',
+            '--model',
+            this.model,
+            '--append-system-prompt',
+            system_prompt,
+        ];
+    }
+
+    protected override _stdin_payload(system_prompt: string, user_prompt: string): string | null {
+        void system_prompt;
+        return user_prompt;
+    }
+
+    protected override _parse_output(stdout: string, stderr: string): CouncilResponse {
+        void stderr;
+        const envelope = _jsonLoads(stdout);
+        if (!_isPlainObject(envelope)) {
+            throw new ValueError('expected JSON object at the top level of claude CLI output');
+        }
+        const env = envelope as Record<string, unknown>;
+        const text = _pyStr(_dictGet(env, 'result', '')).trim();
+        let usage = _dictGet(env, 'usage', null);
+        if (!_pyTruthy(usage)) {
+            usage = {};
+        }
+        if (!_isPlainObject(usage)) {
+            usage = {};
+        }
+        const usageObj = usage as Record<string, unknown>;
+        const meta: Record<string, unknown> = {};
+        const session_id = _dictGet(env, 'session_id', undefined);
+        if (_pyTruthy(session_id)) {
+            meta['session_id'] = _pyStr(session_id);
+        }
+        const total_cost = _dictGet(env, 'total_cost_usd', null);
+        if (total_cost !== null && total_cost !== undefined) {
+            meta['reported_cost_usd'] = total_cost;
+        }
+        const duration_ms = _dictGet(env, 'duration_ms', null);
+        if (duration_ms !== null && duration_ms !== undefined) {
+            meta['reported_duration_ms'] = duration_ms;
+        }
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens: _pyIntCoerce(_dictGet(usageObj, 'input_tokens', 0)),
+            output_tokens: _pyIntCoerce(_dictGet(usageObj, 'output_tokens', 0)),
+            metadata: meta,
+        });
+    }
+}
+
+/**
+ * OpenAI via the official `codex` CLI (subscription-authed).
+ *
+ * Invokes `codex exec --json <prompt>` and consumes the newline-delimited JSON
+ * event stream. The user prompt rides on argv (Codex does not read prompts from
+ * stdin in `exec` mode); the system prompt is passed via `--system` when
+ * non-empty.
+ *
+ * Output shape: one JSON object per line. The terminal event has
+ * `type == "item.completed"` with the final assistant message in
+ * `item.content[0].text`; a separate `type == "turn.completed"` event carries
+ * token usage in `usage.input_tokens` / `usage.output_tokens`.
+ */
+export class OpenAICliClient extends CliClient {
+    override name = 'openai';
+    override default_binary = 'codex';
+    override subscription_label = 'chatgpt-plus';
+
+    static override _AUTH_FAILURE_PATTERNS: readonly string[] = [
+        ...CliClient._AUTH_FAILURE_PATTERNS,
+        'codex login',
+        'auth_required',
+        '401',
+    ];
+
+    constructor(opts: CliClientOptions = {}) {
+        super({
+            model: opts.model ?? 'gpt-5',
+            binary: opts.binary,
+            timeout_seconds: opts.timeout_seconds,
+            max_calls_per_day: opts.max_calls_per_day,
+            warn_at: opts.warn_at,
+            cli_calls_path: opts.cli_calls_path,
+        });
+    }
+
+    protected override _build_command(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number,
+    ): string[] {
+        void max_tokens;
+        const cmd = [this.binary, 'exec', '--json', '--model', this.model];
+        if (system_prompt) {
+            cmd.push('--system', system_prompt);
+        }
+        cmd.push(user_prompt);
+        return cmd;
+    }
+
+    protected override _parse_output(stdout: string, stderr: string): CouncilResponse {
+        void stderr;
+        let text = '';
+        let input_tokens = 0;
+        let output_tokens = 0;
+        const meta: Record<string, unknown> = {};
+        for (let line of _splitlines(stdout)) {
+            line = line.trim();
+            if (!line) {
+                continue;
+            }
+            let event: unknown;
+            try {
+                event = _jsonLoads(line);
+            } catch (exc) {
+                if (exc instanceof JSONDecodeError) {
+                    continue;
+                }
+                throw exc;
+            }
+            if (!_isPlainObject(event)) {
+                continue;
+            }
+            const ev = event as Record<string, unknown>;
+            const event_type = _dictGet(ev, 'type', undefined);
+            if (event_type === 'item.completed') {
+                let item = _dictGet(ev, 'item', null);
+                if (!_pyTruthy(item)) {
+                    item = {};
+                }
+                if (_isPlainObject(item)) {
+                    const itemObj = item as Record<string, unknown>;
+                    let content = _dictGet(itemObj, 'content', null);
+                    if (!_pyTruthy(content)) {
+                        content = [];
+                    }
+                    if (Array.isArray(content)) {
+                        const chunks: string[] = [];
+                        for (const entry of content) {
+                            if (_isPlainObject(entry) && _pyTruthy(_dictGet(entry as Record<string, unknown>, 'text', undefined))) {
+                                chunks.push(_pyStr((entry as Record<string, unknown>)['text']));
+                            }
+                        }
+                        if (chunks.length > 0) {
+                            text = chunks.join('\n').trim();
+                        }
+                    }
+                    if (_pyTruthy(_dictGet(itemObj, 'id', undefined))) {
+                        meta['item_id'] = _pyStr(itemObj['id']);
+                    }
+                }
+            } else if (event_type === 'turn.completed') {
+                let usage = _dictGet(ev, 'usage', null);
+                if (!_pyTruthy(usage)) {
+                    usage = {};
+                }
+                if (_isPlainObject(usage)) {
+                    const usageObj = usage as Record<string, unknown>;
+                    input_tokens = _pyIntCoerce(_dictGet(usageObj, 'input_tokens', 0));
+                    output_tokens = _pyIntCoerce(_dictGet(usageObj, 'output_tokens', 0));
+                }
+            } else if (event_type === 'session.created') {
+                if (_pyTruthy(_dictGet(ev, 'session_id', undefined))) {
+                    meta['session_id'] = _pyStr(ev['session_id']);
+                }
+            }
+        }
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens,
+            output_tokens,
+            metadata: meta,
+        });
+    }
+}
+
+/**
+ * Google Gemini via the official `gemini` CLI (free-tier subscription).
+ *
+ * Invokes `gemini --prompt <prompt> --output-format json` and consumes the
+ * structured envelope: `{"response": str, "stats": {"models": {"<model>":
+ * {"tokens": {"prompt": int, "candidates": int}}}}, ...}`. Prompt is piped on
+ * stdin to dodge argv limits.
+ */
+export class GeminiCliClient extends CliClient {
+    override name = 'gemini';
+    override default_binary = 'gemini';
+    override subscription_label = 'gemini-pro';
+
+    static override _AUTH_FAILURE_PATTERNS: readonly string[] = [
+        ...CliClient._AUTH_FAILURE_PATTERNS,
+        'interactive consent could not be obtained',
+        'please run `gemini`',
+        'oauth',
+    ];
+
+    constructor(opts: CliClientOptions = {}) {
+        super({
+            model: opts.model ?? 'gemini-2.5-pro',
+            binary: opts.binary,
+            timeout_seconds: opts.timeout_seconds,
+            max_calls_per_day: opts.max_calls_per_day,
+            warn_at: opts.warn_at,
+            cli_calls_path: opts.cli_calls_path,
+        });
+    }
+
+    protected override _build_command(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number,
+    ): string[] {
+        void user_prompt;
+        void max_tokens;
+        const cmd = [this.binary, '--output-format', 'json', '--model', this.model];
+        if (system_prompt) {
+            cmd.push('--system', system_prompt);
+        }
+        return cmd;
+    }
+
+    protected override _stdin_payload(system_prompt: string, user_prompt: string): string | null {
+        void system_prompt;
+        return user_prompt;
+    }
+
+    protected override _parse_output(stdout: string, stderr: string): CouncilResponse {
+        void stderr;
+        const envelope = _jsonLoads(stdout);
+        if (!_isPlainObject(envelope)) {
+            throw new ValueError('expected JSON object at the top level of gemini CLI output');
+        }
+        const env = envelope as Record<string, unknown>;
+        const text = _pyStr(_dictGet(env, 'response', '')).trim();
+        let input_tokens = 0;
+        let output_tokens = 0;
+        let stats = _dictGet(env, 'stats', null);
+        if (!_pyTruthy(stats)) {
+            stats = {};
+        }
+        if (_isPlainObject(stats)) {
+            let models = _dictGet(stats as Record<string, unknown>, 'models', null);
+            if (!_pyTruthy(models)) {
+                models = {};
+            }
+            if (_isPlainObject(models)) {
+                const modelsObj = models as Record<string, unknown>;
+                // gemini emits per-model token counts; pick the configured model
+                // if present, else the first model in the envelope.
+                let model_stats: unknown = modelsObj[this.model];
+                if (!_isPlainObject(model_stats)) {
+                    model_stats = _firstDictValue(modelsObj) ?? {};
+                }
+                let tokens: unknown;
+                if (_isPlainObject(model_stats)) {
+                    tokens = _dictGet(model_stats as Record<string, unknown>, 'tokens', null);
+                    if (!_pyTruthy(tokens)) {
+                        tokens = {};
+                    }
+                } else {
+                    tokens = {};
+                }
+                if (_isPlainObject(tokens)) {
+                    const tokensObj = tokens as Record<string, unknown>;
+                    input_tokens = _pyIntCoerce(_dictGet(tokensObj, 'prompt', 0));
+                    output_tokens = _pyIntCoerce(_dictGet(tokensObj, 'candidates', 0));
+                }
+            }
+        }
+        const meta: Record<string, unknown> = {};
+        let session_id = _dictGet(env, 'sessionId', undefined);
+        if (!_pyTruthy(session_id)) {
+            session_id = _dictGet(env, 'session_id', undefined);
+        }
+        if (_pyTruthy(session_id)) {
+            meta['session_id'] = _pyStr(session_id);
+        }
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens,
+            output_tokens,
+            metadata: meta,
+        });
+    }
+}
+
+/**
+ * xAI Grok via the community `grok` CLI (Superagent project).
+ *
+ * Community-maintained wrapper around the xAI API — **not** an official
+ * subscription transport. The CLI consumes `XAI_API_KEY` from its own
+ * environment, so every call is paid per-token exactly as `XAIClient` (api
+ * transport) would be. `mode: cli` here is an ergonomic shortcut; it does NOT
+ * bypass the USD cost gate.
+ *
+ * Invokes `grok -p <prompt>`. Output is plain text — no JSON envelope.
+ * `_parse_output` returns the trimmed stdout and estimates token counts
+ * heuristically (chars / 4) for the audit-trail.
+ */
+export class XAICliClient extends CliClient {
+    override name = 'xai';
+    override default_binary = 'grok';
+    override billable = true; // community CLI consumes an API key — billable applies
+
+    static override _AUTH_FAILURE_PATTERNS: readonly string[] = [
+        ...CliClient._AUTH_FAILURE_PATTERNS,
+        'xai_api_key',
+        '401',
+        'unauthorized',
+    ];
+
+    constructor(opts: CliClientOptions = {}) {
+        super({
+            model: opts.model ?? DEFAULT_XAI_MODEL,
+            binary: opts.binary,
+            timeout_seconds: opts.timeout_seconds,
+            max_calls_per_day: opts.max_calls_per_day,
+            warn_at: opts.warn_at,
+            cli_calls_path: opts.cli_calls_path,
+        });
+    }
+
+    protected override _build_command(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number,
+    ): string[] {
+        void system_prompt;
+        void max_tokens;
+        const cmd = [this.binary, '-p', user_prompt];
+        if (this.model) {
+            cmd.push('--model', this.model);
+        }
+        return cmd;
+    }
+
+    protected override _parse_output(stdout: string, stderr: string): CouncilResponse {
+        void stderr;
+        const text = stdout.trim();
+        // Plain-text CLIs surface no token usage — estimate from text length so
+        // the audit trail and post-call tracker stay populated. chars / 4
+        // mirrors `pricing.estimate_input_tokens`.
+        const output_tokens = text ? Math.max(1, Math.trunc(_pyLen(text) / 4)) : 0;
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens: 0,
+            output_tokens,
+            metadata: { cli_output_format: 'plain_text', tokens_estimated: true },
+        });
+    }
+}
+
+/**
+ * Perplexity via the community `perplexity` CLI (npm package).
+ *
+ * Community-maintained wrapper around the Perplexity API — **not** an official
+ * subscription transport. The CLI consumes `PERPLEXITY_API_KEY` from its own
+ * environment, so every call is paid per-token exactly as `PerplexityClient`
+ * (api transport) would be. `mode: cli` here is an ergonomic shortcut; it does
+ * NOT bypass the USD cost gate.
+ *
+ * Invokes `perplexity -p <prompt>`. Output is plain text — no JSON envelope.
+ */
+export class PerplexityCliClient extends CliClient {
+    override name = 'perplexity';
+    override default_binary = 'perplexity';
+    override billable = true; // community CLI consumes an API key — billable applies
+
+    static override _AUTH_FAILURE_PATTERNS: readonly string[] = [
+        ...CliClient._AUTH_FAILURE_PATTERNS,
+        'perplexity_api_key',
+        '401',
+        'unauthorized',
+    ];
+
+    constructor(opts: CliClientOptions = {}) {
+        super({
+            model: opts.model ?? DEFAULT_PERPLEXITY_MODEL,
+            binary: opts.binary,
+            timeout_seconds: opts.timeout_seconds,
+            max_calls_per_day: opts.max_calls_per_day,
+            warn_at: opts.warn_at,
+            cli_calls_path: opts.cli_calls_path,
+        });
+    }
+
+    protected override _build_command(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number,
+    ): string[] {
+        void system_prompt;
+        void max_tokens;
+        const cmd = [this.binary, '-p', user_prompt];
+        if (this.model) {
+            cmd.push('--model', this.model);
+        }
+        return cmd;
+    }
+
+    protected override _parse_output(stdout: string, stderr: string): CouncilResponse {
+        void stderr;
+        const text = stdout.trim();
+        const output_tokens = text ? Math.max(1, Math.trunc(_pyLen(text) / 4)) : 0;
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            input_tokens: 0,
+            output_tokens,
+            metadata: { cli_output_format: 'plain_text', tokens_estimated: true },
+        });
+    }
+}
+
+// ── Manual mode (Phase 2b) ───────────────────────────────────────────
+
+export const MANUAL_END_MARKER = 'END'; // line containing only this terminates a paste block.
+
+/** Minimal line-reading stream interface (mirrors Python `TextIO`). */
+export interface TextInputStream {
+    /** Yield successive lines (each may keep its trailing "\n"), like iterating a Python file. */
+    [Symbol.iterator](): Iterator<string>;
+    /** Read a single line (with trailing newline), or '' at EOF — Python `readline()`. */
+    readline(): string;
+}
+
+/** Minimal write stream interface (mirrors Python `TextIO`). */
+export interface TextOutputStream {
+    write(s: string): void;
+    flush(): void;
+}
+
+/**
+ * Read lines from `stream` until a line equal to `marker` (after strip).
+ *
+ * Returns the joined body without the marker line. EOF before the marker is
+ * treated as end-of-input — the body collected so far is returned.
+ */
+export function _read_until_marker(stream: TextInputStream, marker: string): string {
+    const body: string[] = [];
+    for (const raw of stream) {
+        const line = _rstripNewline(raw);
+        if (line.trim() === marker) {
+            break;
+        }
+        body.push(line);
+    }
+    return body.join('\n').trim();
+}
+
+/**
+ * Copy-paste council member — user is the transport.
+ *
+ * `ask()` renders the system prompt + artefact as one Markdown block, prints it
+ * to stdout, and reads pasted replies from stdin. After each pasted reply,
+ * surfaces a 1/2/3 menu (more · next · abort). Loops until the user picks 2 or
+ * 3.
+ *
+ * Spend is $0 — `billable=false` makes the orchestrator skip the cost gate.
+ *
+ * Tests inject `stdin` / `stdout` streams. Production usage falls back to
+ * process stdin / stdout.
+ */
+export class ManualClient extends ExternalAIClient {
+    override billable = false;
+    override transport = 'manual';
+    provider_label: string;
+    private _stdin: TextInputStream;
+    private _stdout: TextOutputStream;
+    private _end_marker: string;
+
+    constructor(
+        opts: {
+            name?: string;
+            model?: string;
+            provider_label?: string;
+            stdin?: TextInputStream | null;
+            stdout?: TextOutputStream | null;
+            end_marker?: string;
+        } = {},
+    ) {
+        super();
+        this.name = opts.name ?? 'manual';
+        this.model = opts.model ?? 'manual';
+        this.provider_label = opts.provider_label ?? 'your LLM web UI';
+        this._stdin = opts.stdin ?? _defaultStdin();
+        this._stdout = opts.stdout ?? _defaultStdout();
+        this._end_marker = opts.end_marker ?? MANUAL_END_MARKER;
+    }
+
+    override ask(
+        system_prompt: string,
+        user_prompt: string,
+        max_tokens: number = DEFAULT_MAX_TOKENS,
+    ): CouncilResponse {
+        void max_tokens; // accepted for ABC parity
+        const t0 = _nowMs();
+        const rounds: string[] = [];
+        let block = this._render_block(system_prompt, user_prompt, null);
+        this._emit(block);
+
+        try {
+            for (;;) {
+                const reply = _read_until_marker(this._stdin, this._end_marker);
+                rounds.push(reply);
+                const choice = this._ask_menu(_pyLen(reply));
+
+                if (choice === '2') {
+                    // done with this member
+                    break;
+                }
+                if (choice === '3') {
+                    // abort the council run
+                    return new CouncilResponse({
+                        provider: this.name,
+                        model: this.model,
+                        text: '',
+                        latency_ms: _elapsedMs(t0),
+                        error: 'manual_aborted',
+                        metadata: { rounds: rounds.length, manual: true },
+                    });
+                }
+                // choice == "1": collect follow-up, re-emit context block.
+                const follow_up = this._read_follow_up();
+                if (!follow_up) {
+                    break; // empty follow-up → treat as "done with this member"
+                }
+                rounds.push(`[follow-up sent]\n${follow_up}`);
+                block = this._render_block(system_prompt, user_prompt, follow_up);
+                this._emit(block);
+            }
+        } catch (exc) {
+            return new CouncilResponse({
+                provider: this.name,
+                model: this.model,
+                text: rounds.join('\n\n'),
+                latency_ms: _elapsedMs(t0),
+                error: _excString(exc),
+                metadata: { rounds: rounds.length, manual: true },
+            });
+        }
+
+        const text = rounds.join('\n\n---\n\n').trim();
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text,
+            latency_ms: _elapsedMs(t0),
+            metadata: { rounds: rounds.length, manual: true },
+        });
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private _emit(text: string): void {
+        this._stdout.write(text);
+        this._stdout.write('\n');
+        this._stdout.flush();
+    }
+
+    private _render_block(
+        system_prompt: string,
+        user_prompt: string,
+        follow_up: string | null,
+    ): string {
+        const bar = '═'.repeat(67);
+        const head =
+            `${bar}\n` +
+            `Manual council member: ${this.provider_label}\n` +
+            'Paste this block into the web UI · then paste the reply below.\n' +
+            `${bar}`;
+        let body: string;
+        if (follow_up !== null) {
+            body = `[Follow-up — paste this into the SAME chat thread]\n\n${follow_up}`;
+        } else {
+            body = `${system_prompt}\n\n---\n\n${user_prompt}`;
+        }
+        const tail =
+            `${bar}\n` +
+            `End your pasted reply with a line containing only: ${this._end_marker}\n` +
+            `${bar}`;
+        return `${head}\n\n${body}\n\n${tail}`;
+    }
+
+    private _ask_menu(reply_chars: number): string {
+        const prompt =
+            `\nReply received (${reply_chars} chars). Now what?\n` +
+            '  1. More feedback for this member (continue this thread)\n' +
+            '  2. Done with this member, move to the next\n' +
+            '  3. Abort the council run\n\n' +
+            'Choose 1/2/3: ';
+        this._stdout.write(prompt);
+        this._stdout.flush();
+        const line = this._stdin.readline().trim();
+        if (line === '1' || line === '2' || line === '3') {
+            return line;
+        }
+        // unknown input → treat as "next" so we never block forever in tests / piped runs.
+        return '2';
+    }
+
+    private _read_follow_up(): string {
+        this._emit(
+            `\nType your follow-up question, end with a line containing only: ${this._end_marker}`,
+        );
+        return _read_until_marker(this._stdin, this._end_marker);
+    }
+}
+
+// ── primitives ─────────────────────────────────────────────────────────
+
+/** Python `ValueError`. */
+export class ValueError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValueError';
+    }
+}
+
+/** Python `json.JSONDecodeError`. */
+export class JSONDecodeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'JSONDecodeError';
+    }
+}
+
+/** `json.loads` that raises `JSONDecodeError` (not the native SyntaxError). */
+function _jsonLoads(s: string): unknown {
+    try {
+        return JSON.parse(s);
+    } catch (exc) {
+        throw new JSONDecodeError(exc instanceof Error ? exc.message : String(exc));
+    }
+}
+
+/** True for a plain object (Python `isinstance(x, dict)`), not array / null. */
+function _isPlainObject(x: unknown): x is Record<string, unknown> {
+    return typeof x === 'object' && x !== null && !Array.isArray(x);
+}
+
+/** Mirror Python truthiness: '', 0, 0.0, false, null/undefined, [], {} are falsy. */
+function _pyTruthy(x: unknown): boolean {
+    if (x === null || x === undefined) {
+        return false;
+    }
+    if (typeof x === 'boolean') {
+        return x;
+    }
+    if (typeof x === 'number') {
+        return x !== 0;
+    }
+    if (typeof x === 'string') {
+        return x.length > 0;
+    }
+    if (Array.isArray(x)) {
+        return x.length > 0;
+    }
+    if (typeof x === 'object') {
+        return Object.keys(x as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/** `dict.get(key, default)` over a duck-typed object. */
+function _dictGet(obj: Record<string, unknown>, key: string, fallback: unknown): unknown {
+    return key in obj ? obj[key] : fallback;
+}
+
+/** First dict-typed value in insertion order (mirrors `next(v for v ... if isinstance(v, dict))`). */
+function _firstDictValue(obj: Record<string, unknown>): Record<string, unknown> | undefined {
+    for (const v of Object.values(obj)) {
+        if (_isPlainObject(v)) {
+            return v;
+        }
+    }
+    return undefined;
+}
+
+/** Python `str(x)`. */
+function _pyStr(x: unknown): string {
+    if (x === null) {
+        return 'None';
+    }
+    if (x === undefined) {
+        // Defensive: undefined never reaches str() in the Python flow; treat as
+        // empty per the `.get(..., "")` defaults that precede every call.
+        return '';
+    }
+    if (typeof x === 'boolean') {
+        return x ? 'True' : 'False';
+    }
+    return String(x);
+}
+
+/**
+ * Python `int(x or 0)` applied to JSON-loaded values where the source code does
+ * `int(usage.get("k", 0) or 0)` — None/0/"" coerce to 0, ints pass, numeric
+ * strings parse. Floats truncate toward zero.
+ */
+function _pyIntCoerce(x: unknown): number {
+    // `x or 0` first: falsy → 0.
+    if (!_pyTruthy(x)) {
+        return 0;
+    }
+    if (typeof x === 'number') {
+        return Math.trunc(x);
+    }
+    if (typeof x === 'boolean') {
+        return x ? 1 : 0;
+    }
+    if (typeof x === 'string') {
+        return _pyIntFromStr(x);
+    }
+    // int() on a dict/list raises TypeError in Python — surface it.
+    throw new TypeError(`int() argument must be a number or string, not ${typeof x}`);
+}
+
+/** Python `int(value)` for an already-int-typed number (used in quota_summary_line). */
+function _pyInt(n: number): number {
+    return Math.trunc(n);
+}
+
+/** Python `int(str)` — strict base-10 with surrounding whitespace allowed. */
+function _pyIntFromStr(s: string): number {
+    const t = s.trim();
+    if (!/^[+-]?\d+$/.test(t)) {
+        throw new ValueError(`invalid literal for int() with base 10: ${_pyRepr(s)}`);
+    }
+    return parseInt(t, 10);
+}
+
+/** Python `len(str)` — Unicode code-point count, not UTF-16 units. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        void _;
+        n += 1;
+    }
+    return n;
+}
+
+/** Python `str.rstrip("\n")` — strip only trailing newline chars. */
+function _rstripNewline(s: string): string {
+    let end = s.length;
+    while (end > 0 && s[end - 1] === '\n') {
+        end -= 1;
+    }
+    return s.slice(0, end);
+}
+
+/** Python `str.splitlines()` for the line shapes a CLI stream emits. */
+function _splitlines(s: string): string[] {
+    if (s === '') {
+        return [];
+    }
+    // Python splitlines() splits on \n, \r, \r\n (and more); CLI JSONL only
+    // ever uses \n / \r\n. Match the universal-newline subset that matters here.
+    const out: string[] = [];
+    let cur = '';
+    for (let i = 0; i < s.length; i += 1) {
+        const ch = s[i];
+        if (ch === '\n') {
+            out.push(cur);
+            cur = '';
+        } else if (ch === '\r') {
+            out.push(cur);
+            cur = '';
+            if (s[i + 1] === '\n') {
+                i += 1;
+            }
+        } else {
+            cur += ch;
+        }
+    }
+    if (cur !== '') {
+        out.push(cur);
+    }
+    return out;
+}
+
+/** Render a value with Python `repr()` for the strings this module reprs. */
+function _pyRepr(x: unknown): string {
+    if (typeof x === 'string') {
+        // Python prefers single quotes unless the string has a single quote and
+        // no double quote.
+        const hasSingle = x.includes("'");
+        const hasDouble = x.includes('"');
+        const quote = hasSingle && !hasDouble ? '"' : "'";
+        let out = quote;
+        for (const ch of x) {
+            if (ch === '\\') {
+                out += '\\\\';
+            } else if (ch === quote) {
+                out += `\\${quote}`;
+            } else if (ch === '\n') {
+                out += '\\n';
+            } else if (ch === '\r') {
+                out += '\\r';
+            } else if (ch === '\t') {
+                out += '\\t';
+            } else {
+                out += ch;
+            }
+        }
+        return out + quote;
+    }
+    return String(x);
+}
+
+/** Python `oct(mode)` → "0o600" style string. */
+function _octRepr(mode: number): string {
+    return `0o${mode.toString(8)}`;
+}
+
+/** Build `f"{type(exc).__name__}: {exc}"` for caught errors. */
+function _excString(exc: unknown): string {
+    return `${_excTypeName(exc)}: ${_excMessage(exc)}`;
+}
+
+function _excTypeName(exc: unknown): string {
+    if (exc instanceof KeyGateError) return 'KeyGateError';
+    if (exc instanceof CliClientError) return 'CliClientError';
+    if (exc instanceof ValueError) return 'ValueError';
+    if (exc instanceof JSONDecodeError) return 'JSONDecodeError';
+    if (exc instanceof TypeError) return 'TypeError';
+    if (exc instanceof RangeError) return 'RangeError';
+    if (exc instanceof Error) {
+        return exc.name || 'Error';
+    }
+    return typeof exc;
+}
+
+function _excMessage(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+/** `json.dumps(obj, indent=2)` — default ensure_ascii=True, insertion-order keys. */
+function _jsonDumpsIndent2(value: unknown): string {
+    return _jsonDumpsIndented(value, 2, 0);
+}
+
+function _jsonDumpsIndented(value: unknown, indent: number, level: number): string {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    switch (typeof value) {
+        case 'boolean':
+            return value ? 'true' : 'false';
+        case 'number':
+            return _pyJsonNumber(value);
+        case 'string':
+            return _pyJsonStringAscii(value);
+        case 'object':
+            break;
+        default:
+            throw new TypeError(`Object of type ${typeof value} is not JSON serializable`);
+    }
+    const pad = ' '.repeat(indent * (level + 1));
+    const closePad = ' '.repeat(indent * level);
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _jsonDumpsIndented(v, indent, level + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0) {
+        return '{}';
+    }
+    const items = keys.map(
+        (k) => `${pad}${_pyJsonStringAscii(k)}: ${_jsonDumpsIndented(obj[k], indent, level + 1)}`,
+    );
+    return `{\n${items.join(',\n')}\n${closePad}}`;
+}
+
+/** Render a number like Python `json.dumps` (int vs float; JS has one type). */
+function _pyJsonNumber(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+/** Escape a string like Python `json.dumps(..., ensure_ascii=True)` (default). */
+function _pyJsonStringAscii(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) ?? 0;
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (code < 0x20) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else if (code < 0x7f) {
+            out += ch;
+        } else if (code <= 0xffff) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            // Astral plane → surrogate pair, matching Python json.dumps default.
+            const c = code - 0x10000;
+            const hi = 0xd800 + (c >> 10);
+            const lo = 0xdc00 + (c & 0x3ff);
+            out += `\\u${hi.toString(16).padStart(4, '0')}\\u${lo.toString(16).padStart(4, '0')}`;
+        }
+    }
+    return out + '"';
+}
+
+/** Python `shutil.which(name)` — resolve an executable on PATH. */
+function _which(name: string): string | null {
+    // Absolute / relative path with a separator: check directly (Python's which
+    // checks the given path when it contains a dir component).
+    if (name.includes(path.sep) || (path.sep !== '/' && name.includes('/'))) {
+        return _isExecutable(name) ? name : null;
+    }
+    const pathEnv = process.env.PATH ?? '';
+    if (!pathEnv) {
+        return null;
+    }
+    const exts =
+        process.platform === 'win32'
+            ? (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+            : [''];
+    for (const dir of pathEnv.split(path.delimiter)) {
+        if (!dir) {
+            continue;
+        }
+        for (const ext of exts) {
+            const candidate = path.join(dir, name + ext);
+            if (_isExecutable(candidate)) {
+                return candidate;
+            }
+        }
+    }
+    return null;
+}
+
+function _isExecutable(p: string): boolean {
+    try {
+        const st = fs.statSync(p);
+        if (!st.isFile()) {
+            return false;
+        }
+        if (process.platform === 'win32') {
+            return true;
+        }
+        // Any execute bit set (mirrors os.access(p, X_OK) closely enough).
+        return (st.mode & 0o111) !== 0;
+    } catch {
+        return false;
+    }
+}
+
+// ── default manual-mode streams (process stdin/stdout) ─────────────────
+
+function _defaultStdout(): TextOutputStream {
+    return {
+        write(s: string): void {
+            process.stdout.write(s);
+        },
+        flush(): void {
+            // process.stdout is auto-flushing; no-op.
+        },
+    };
+}
+
+function _defaultStdin(): TextInputStream {
+    // Production manual mode reads from process.stdin synchronously line by
+    // line via fd 0. Tests always inject a stream, so this is the fallback.
+    let buffer: string | null = null;
+    let pos = 0;
+    function ensure(): string {
+        if (buffer === null) {
+            try {
+                buffer = fs.readFileSync(0, { encoding: 'utf-8' });
+            } catch {
+                buffer = '';
+            }
+        }
+        return buffer;
+    }
+    function nextLine(): string {
+        const buf = ensure();
+        if (pos >= buf.length) {
+            return '';
+        }
+        const nl = buf.indexOf('\n', pos);
+        if (nl === -1) {
+            const line = buf.slice(pos);
+            pos = buf.length;
+            return line;
+        }
+        const line = buf.slice(pos, nl + 1);
+        pos = nl + 1;
+        return line;
+    }
+    return {
+        readline(): string {
+            return nextLine();
+        },
+        [Symbol.iterator](): Iterator<string> {
+            return {
+                next(): IteratorResult<string> {
+                    const line = nextLine();
+                    if (line === '') {
+                        return { done: true, value: undefined };
+                    }
+                    return { done: false, value: line };
+                },
+            };
+        },
+    };
+}

--- a/src/scripts/ai_council/config.ts
+++ b/src/scripts/ai_council/config.ts
@@ -65,7 +65,7 @@ const _VALID_MODES: ReadonlySet<string> = new Set(['api', 'manual', 'cli']);
  * Prefixes that signal "this is a raw API key" so we refuse it loudly
  * even when the user accidentally inlined it in `api_key_ref`.
  */
-const _RAW_KEY_PREFIXES: readonly string[] = [
+export const _RAW_KEY_PREFIXES: readonly string[] = [
     'sk-',
     'sk-ant-',
     'ya29.',

--- a/src/scripts/ai_council/consensus.ts
+++ b/src/scripts/ai_council/consensus.ts
@@ -1,0 +1,551 @@
+/**
+ * Consensus scoring for the analysis lens (Phase 4 / F3).
+ *
+ * TypeScript twin of `src/scripts/ai_council/consensus.py` (ADR-094 —
+ * Python→TS migration, Phase 1). After the final deliberation round, members
+ * score each other's findings. The renderer ranks findings by consensus and
+ * surfaces a "Minority Views" section for sub-threshold items so they remain
+ * audit-trail signal rather than silent drop.
+ *
+ * Schema (Opus's machine-readable contract):
+ *
+ *     Finding            — `{id: str, source: str, text: str}`
+ *     FindingScore       — `{finding_id: str, scorer: str, score: 1..10,
+ *                           agree: bool, reason: str}`
+ *     ConsensusMetadata  — per-finding aggregate:
+ *                          `{finding_id, consensus_strength: 0..1,
+ *                            dissent_count, scorers, mean_score}`
+ *
+ * Threshold bucketing (Phase 4 Step 3):
+ *
+ *     consensus_strength > strong   → Strong Consensus
+ *     minority < strength <= strong → Findings (default body)
+ *     strength <= minority          → Minority Views
+ *
+ * Parity notes:
+ * - `round(mean, 2)` / `round(strength, 3)` mirror Python round-half-to-even
+ *   via `pyRound` from `_lib/value_ladder.ts`.
+ * - JSON extraction mirrors Python `re.DOTALL` (`s` flag) and `.search()`
+ *   (first non-overlapping match). The non-greedy `.*?` is preserved.
+ * - `json.loads` / `isinstance` shape checks mirror Python defensive parsing.
+ */
+import { pyRound } from '../_lib/value_ladder.js';
+
+// Python: re.compile(r"```(?:json)?\s*(\[.*?\])\s*```", re.DOTALL)
+// re.DOTALL → 's'. Python regex is not global; a fresh RegExp per call avoids
+// lastIndex carryover, and we use .exec() (first match) below.
+const _JSON_BLOCK_SRC = '```(?:json)?\\s*(\\[[\\s\\S]*?\\])\\s*```';
+// Python: re.compile(r"(\[\s*\{.*?\}\s*\])", re.DOTALL)
+const _BARE_ARRAY_SRC = '(\\[\\s*\\{[\\s\\S]*?\\}\\s*\\])';
+
+// Defaults mirror the roadmap (Phase 4 Step 4). The .agent-settings.yml
+// block overrides them at run time.
+export const DEFAULT_STRONG_THRESHOLD = 0.7;
+export const DEFAULT_MINORITY_THRESHOLD = 0.4;
+
+/** One finding extracted from a member's deliberation output. */
+export class Finding {
+    readonly id: string;
+    readonly source: string; // provider/model that authored the finding
+    readonly text: string;
+
+    constructor(id: string, source: string, text: string) {
+        this.id = id;
+        this.source = source;
+        this.text = text;
+    }
+}
+
+/** One scorer's vote on one finding. */
+export class FindingScore {
+    readonly finding_id: string;
+    readonly scorer: string;
+    readonly score: number; // 1..10
+    readonly agree: boolean;
+    readonly reason: string;
+
+    constructor(
+        finding_id: string,
+        scorer: string,
+        score: number,
+        agree: boolean,
+        reason: string,
+    ) {
+        this.finding_id = finding_id;
+        this.scorer = scorer;
+        this.score = score;
+        this.agree = agree;
+        this.reason = reason;
+    }
+}
+
+/**
+ * Classify mean score into a single-letter evidence-quality bucket.
+ *
+ * H (high)   — mean ≥ 8.0; member agreement ran high.
+ * M (medium) — 6.0 ≤ mean < 8.0; majority support, mixed conviction.
+ * L (low)    — mean < 6.0 or no scorers; weak or contested.
+ */
+export function evidence_quality(mean_score: number): string {
+    if (mean_score >= 8.0) {
+        return 'H';
+    }
+    if (mean_score >= 6.0) {
+        return 'M';
+    }
+    return 'L';
+}
+
+/**
+ * Aggregate consensus stats for a single finding.
+ *
+ * `dissent_reasons` holds `(scorer, reason)` pairs for dissenters only.
+ */
+export class ConsensusMetadata {
+    readonly finding_id: string;
+    readonly consensus_strength: number; // 0..1
+    readonly dissent_count: number;
+    readonly scorers: readonly string[];
+    readonly mean_score: number;
+    readonly concur_count: number;
+    readonly dissent_reasons: ReadonlyArray<readonly [string, string]>; // (scorer, reason)
+    readonly evidence_quality: string;
+
+    constructor(args: {
+        finding_id: string;
+        consensus_strength: number;
+        dissent_count: number;
+        scorers: readonly string[];
+        mean_score: number;
+        concur_count?: number;
+        dissent_reasons?: ReadonlyArray<readonly [string, string]>;
+        evidence_quality?: string;
+    }) {
+        this.finding_id = args.finding_id;
+        this.consensus_strength = args.consensus_strength;
+        this.dissent_count = args.dissent_count;
+        this.scorers = args.scorers;
+        this.mean_score = args.mean_score;
+        this.concur_count = args.concur_count ?? 0;
+        this.dissent_reasons = args.dissent_reasons ?? [];
+        this.evidence_quality = args.evidence_quality ?? 'L';
+    }
+}
+
+/** Threshold-bucketed findings ready for renderer sectioning. */
+export class ConsensusBucket {
+    readonly strong: Array<[Finding, ConsensusMetadata]>;
+    readonly findings: Array<[Finding, ConsensusMetadata]>;
+    readonly minority: Array<[Finding, ConsensusMetadata]>;
+
+    constructor() {
+        this.strong = [];
+        this.findings = [];
+        this.minority = [];
+    }
+}
+
+/**
+ * Aggregate per-finding scores into ConsensusMetadata.
+ *
+ * `consensus_strength` = mean(score) / 10 * agreement_rate.
+ *
+ * A finding's *own author* is never expected to score it; we drop
+ * self-scores defensively to keep the aggregate honest. Missing
+ * findings get zero scorers (strength=0, dissent_count=0).
+ */
+export function aggregate_scores(
+    findings: Iterable<Finding>,
+    scores: Iterable<FindingScore>,
+): Map<string, ConsensusMetadata> {
+    const findingList = Array.from(findings);
+    const by_id = new Map<string, FindingScore[]>();
+    const sources = new Map<string, string>();
+    for (const f of findingList) {
+        by_id.set(f.id, []);
+        sources.set(f.id, f.source);
+    }
+    for (const s of scores) {
+        if (!by_id.has(s.finding_id)) {
+            continue;
+        }
+        if (s.scorer === sources.get(s.finding_id)) {
+            continue; // ignore self-scores
+        }
+        (by_id.get(s.finding_id) as FindingScore[]).push(s);
+    }
+    const out = new Map<string, ConsensusMetadata>();
+    for (const [fid, fs] of by_id) {
+        if (fs.length === 0) {
+            out.set(
+                fid,
+                new ConsensusMetadata({
+                    finding_id: fid,
+                    consensus_strength: 0.0,
+                    dissent_count: 0,
+                    scorers: [],
+                    mean_score: 0.0,
+                    concur_count: 0,
+                    dissent_reasons: [],
+                    evidence_quality: 'L',
+                }),
+            );
+            continue;
+        }
+        const mean = fs.reduce((acc, s) => acc + s.score, 0) / fs.length;
+        const agree_rate = fs.filter((s) => s.agree).length / fs.length;
+        const strength = (mean / 10.0) * agree_rate;
+        const dissent = fs.filter((s) => !s.agree).length;
+        const concur = fs.filter((s) => s.agree).length;
+        const scorers = fs.map((s) => s.scorer);
+        // Phase 9 — collect (scorer, reason) pairs for dissenters only,
+        // in scoring order.
+        const dissent_reasons: Array<[string, string]> = fs
+            .filter((s) => !s.agree)
+            .map((s) => [s.scorer, s.reason] as [string, string]);
+        const mean_rounded = pyRound(mean, 2);
+        out.set(
+            fid,
+            new ConsensusMetadata({
+                finding_id: fid,
+                consensus_strength: pyRound(strength, 3),
+                dissent_count: dissent,
+                scorers,
+                mean_score: mean_rounded,
+                concur_count: concur,
+                dissent_reasons,
+                evidence_quality: evidence_quality(mean_rounded),
+            }),
+        );
+    }
+    return out;
+}
+
+export interface BucketByThresholdOptions {
+    strong?: number;
+    minority?: number;
+}
+
+/**
+ * Split findings into Strong / Findings / Minority buckets.
+ *
+ * Findings with no metadata (no scorers) fall into the Minority bucket — they
+ * were uncontested but unsupported.
+ */
+export function bucket_by_threshold(
+    findings: Iterable<Finding>,
+    metadata: Map<string, ConsensusMetadata>,
+    opts: BucketByThresholdOptions = {},
+): ConsensusBucket {
+    const strong = opts.strong ?? DEFAULT_STRONG_THRESHOLD;
+    const minority = opts.minority ?? DEFAULT_MINORITY_THRESHOLD;
+    if (!(0.0 <= minority && minority <= strong && strong <= 1.0)) {
+        throw new Error(
+            `Threshold ordering broken: 0 <= ${_pyFloatRepr(minority)} <= ${_pyFloatRepr(strong)} <= 1 required.`,
+        );
+    }
+    const bucket = new ConsensusBucket();
+    for (const f of findings) {
+        let m = metadata.get(f.id);
+        if (m === undefined) {
+            m = new ConsensusMetadata({
+                finding_id: f.id,
+                consensus_strength: 0.0,
+                dissent_count: 0,
+                scorers: [],
+                mean_score: 0.0,
+                concur_count: 0,
+                dissent_reasons: [],
+                evidence_quality: 'L',
+            });
+        }
+        if (m.consensus_strength > strong) {
+            bucket.strong.push([f, m]);
+        } else if (m.consensus_strength > minority) {
+            bucket.findings.push([f, m]);
+        } else {
+            bucket.minority.push([f, m]);
+        }
+    }
+    // Strongest first inside each bucket. Python list.sort is stable;
+    // Array.prototype.sort is stable in modern V8 / Node ≥ 11.
+    for (const lst of [bucket.strong, bucket.findings, bucket.minority]) {
+        lst.sort((a, b) => b[1].consensus_strength - a[1].consensus_strength);
+    }
+    return bucket;
+}
+
+/**
+ * Parse a member's structured-findings response into Finding objects.
+ *
+ * Accepts either a fenced ```json``` block or a bare JSON array. Each
+ * item must be `{id: str, text: str}` (the `source` is set from the
+ * `source` arg so we can attribute findings to their author). Items
+ * missing required keys are skipped silently — extraction is best-
+ * effort, never raises.
+ */
+export function parse_findings_response(
+    text: string,
+    opts: { source: string },
+): Finding[] {
+    const source = opts.source;
+    const array = _extract_json_array(text);
+    if (!array) {
+        return [];
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(array);
+    } catch {
+        // json.JSONDecodeError → []
+        return [];
+    }
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+    const out: Finding[] = [];
+    for (const item of parsed) {
+        if (!_isPlainObject(item)) {
+            continue;
+        }
+        const fid = (item as Record<string, unknown>)['id'];
+        const txt = (item as Record<string, unknown>)['text'];
+        // Python: `if not fid or not txt` — falsy check.
+        if (!_pyTruthy(fid) || !_pyTruthy(txt)) {
+            continue;
+        }
+        out.push(new Finding(_pyStr(fid), source, _pyStrip(_pyStr(txt))));
+    }
+    return out;
+}
+
+/**
+ * Parse a member's scoring response into FindingScore objects.
+ *
+ * Each item must be `{finding_id, score, agree, reason}`. Scores are
+ * clamped to 1..10; non-numeric scores or out-of-range values cause
+ * the item to be skipped (defensive — never poison aggregates).
+ */
+export function parse_scores_response(
+    text: string,
+    opts: { scorer: string },
+): FindingScore[] {
+    const scorer = opts.scorer;
+    const array = _extract_json_array(text);
+    if (!array) {
+        return [];
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(array);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+    const out: FindingScore[] = [];
+    for (const item of parsed) {
+        if (!_isPlainObject(item)) {
+            continue;
+        }
+        const obj = item as Record<string, unknown>;
+        // Python: item.get("finding_id") or item.get("id")
+        const fidRaw = obj['finding_id'];
+        const fid = _pyTruthy(fidRaw) ? fidRaw : obj['id'];
+        const score = obj['score'];
+        // Python: `if not fid or not isinstance(score, (int, float))`.
+        // Python bool is a subclass of int, so `True`/`False` pass the
+        // isinstance gate; JS `typeof true === 'boolean'`, so handle bool too.
+        if (!_pyTruthy(fid) || !_pyIsIntOrFloat(score)) {
+            continue;
+        }
+        const score_int = _pyInt(score as number | boolean);
+        if (!(1 <= score_int && score_int <= 10)) {
+            continue;
+        }
+        // Python: bool(item.get("agree", True))
+        const agreeRaw = 'agree' in obj ? obj['agree'] : true;
+        // Python: str(item.get("reason", "")).strip()
+        const reasonRaw = 'reason' in obj ? obj['reason'] : '';
+        out.push(
+            new FindingScore(
+                _pyStr(fid),
+                scorer,
+                score_int,
+                _pyTruthy(agreeRaw),
+                _pyStrip(_pyStr(reasonRaw)),
+            ),
+        );
+    }
+    return out;
+}
+
+/** Best-effort JSON-array extraction from a model response. */
+function _extract_json_array(text: string): string {
+    if (!text) {
+        return '';
+    }
+    const fenced = new RegExp(_JSON_BLOCK_SRC, 's').exec(text);
+    if (fenced) {
+        return fenced[1] as string;
+    }
+    const bare = new RegExp(_BARE_ARRAY_SRC, 's').exec(text);
+    if (bare) {
+        return bare[1] as string;
+    }
+    return '';
+}
+
+/**
+ * Return `{anon_label: Finding}` map so scorers see neutral labels.
+ *
+ * Labels are `Finding-A`, `Finding-B`, … in input order. The author
+ * mapping must be kept out of the prompt — keep it server-side only.
+ */
+export function anonymize_findings(findings: Finding[]): Map<string, Finding> {
+    const out = new Map<string, Finding>();
+    findings.forEach((f, idx) => {
+        const label = `Finding-${String.fromCharCode('A'.charCodeAt(0) + idx)}`;
+        out.set(label, f);
+    });
+    return out;
+}
+
+/**
+ * Anonymize deliberation responses for the peer-review round (Phase 5).
+ *
+ * `responses` is an iterable of `[source, text]` pairs where `source`
+ * is the canonical `provider:model` identifier. Returns:
+ *
+ *   - `anon_text`: `{Response-A: <body>}` map fed into the prompt.
+ *   - `label_to_source`: `{Response-A: provider:model}` map kept
+ *     server-side so the orchestrator can de-anonymize at synthesis time.
+ *
+ * Empty / whitespace-only texts are skipped. Input order is preserved.
+ *
+ * `persona_labels` maps `source` → `persona`; sources missing from the
+ * map render as bare `Response-X`. Plain-member runs pass `null`.
+ */
+export function anonymize_responses(
+    responses: Iterable<readonly [string, string]>,
+    opts: { persona_labels?: Map<string, string> | null } = {},
+): [Map<string, string>, Map<string, string>] {
+    const persona_labels = opts.persona_labels ?? null;
+    const anon_text = new Map<string, string>();
+    const label_to_source = new Map<string, string>();
+    let idx = 0;
+    for (const [source, text] of responses) {
+        if (!text || !_pyStrip(text)) {
+            continue;
+        }
+        const base = `Response-${String.fromCharCode('A'.charCodeAt(0) + idx)}`;
+        const persona = persona_labels !== null ? persona_labels.get(source) : undefined;
+        // Python: (persona_labels or {}).get(source) → None when missing.
+        const label = persona !== undefined && persona !== null ? `${base} (${persona})` : base;
+        anon_text.set(label, _pyStrip(text));
+        label_to_source.set(label, source);
+        idx += 1;
+    }
+    return [anon_text, label_to_source];
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────
+
+/** Mirror Python `str.strip()`. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** Mirror Python `bool(x)` truthiness for parsed-JSON values. */
+function _pyTruthy(v: unknown): boolean {
+    if (v === null || v === undefined) {
+        return false;
+    }
+    if (typeof v === 'boolean') {
+        return v;
+    }
+    if (typeof v === 'number') {
+        return v !== 0 && !Number.isNaN(v) ? v !== 0 : false;
+    }
+    if (typeof v === 'string') {
+        return v.length > 0;
+    }
+    if (Array.isArray(v)) {
+        return v.length > 0;
+    }
+    if (typeof v === 'object') {
+        return Object.keys(v as Record<string, unknown>).length > 0;
+    }
+    return Boolean(v);
+}
+
+/** Mirror Python `str(x)` for JSON scalar values used here. */
+function _pyStr(v: unknown): string {
+    if (typeof v === 'string') {
+        return v;
+    }
+    if (v === null) {
+        return 'None';
+    }
+    if (v === undefined) {
+        return 'None';
+    }
+    if (typeof v === 'boolean') {
+        return v ? 'True' : 'False';
+    }
+    if (typeof v === 'number') {
+        return _pyNum(v);
+    }
+    return String(v);
+}
+
+/**
+ * Mirror Python `str()` for a number — ints render without a decimal,
+ * float repr otherwise. `id`/`text`/`reason` from JSON are almost always
+ * strings; this only matters for the rare numeric `id`/`reason`.
+ */
+function _pyNum(v: number): string {
+    if (Number.isInteger(v) && Number.isFinite(v)) {
+        // JSON.parse yields plain numbers with no float tag; Python json.loads
+        // yields int for integer literals and float for `1.0`. Integer JSON
+        // literals → Python int → str() with no decimal. Match that.
+        return String(v);
+    }
+    return String(v);
+}
+
+/** Mirror Python `str(float)` for the threshold error — integer floats keep `.0`. */
+function _pyFloatRepr(v: number): string {
+    if (Number.isInteger(v) && Number.isFinite(v)) {
+        return `${v}.0`;
+    }
+    if (v === Infinity) {
+        return 'inf';
+    }
+    if (v === -Infinity) {
+        return '-inf';
+    }
+    if (Number.isNaN(v)) {
+        return 'nan';
+    }
+    return String(v);
+}
+
+/** Mirror Python `isinstance(x, (int, float))` — bool included (bool ⊂ int). */
+function _pyIsIntOrFloat(v: unknown): boolean {
+    return typeof v === 'number' || typeof v === 'boolean';
+}
+
+/** Mirror Python `int(x)` for the score path (truncates toward zero). */
+function _pyInt(v: number | boolean): number {
+    if (typeof v === 'boolean') {
+        return v ? 1 : 0;
+    }
+    return Math.trunc(v);
+}
+
+/** True when `v` is a plain JSON object (Python `isinstance(item, dict)`). */
+function _isPlainObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}

--- a/src/scripts/ai_council/low_impact_corpus.ts
+++ b/src/scripts/ai_council/low_impact_corpus.ts
@@ -1,0 +1,662 @@
+/**
+ * Hardened parser for `agents/decisions/low-impact-decisions.md` (step-9 P4).
+ *
+ * TypeScript twin of `src/scripts/ai_council/low_impact_corpus.py`
+ * (ADR-094 — Python→TS migration, Phase 1).
+ *
+ * Replaces the silent-skip behaviour of the inline regex in
+ * `necessity.load_validated_phrases` with a typed-error contract.
+ *
+ * Contract: `docs/contracts/low-impact-corpus-format.md`.
+ *
+ * Two entry points:
+ *
+ * - {@link load_validated_phrases} — back-compat shim used by
+ *   `scripts.ai_council.necessity` routing. Silently returns the
+ *   successfully-parsed validated phrases (degrades to `()` on malformed
+ *   sections so a broken corpus never blocks routing).
+ * - {@link parse_corpus_strict} — raises {@link CorpusParseError} on the
+ *   first structural anomaly. Used by CI lint
+ *   (`task lint-low-impact-corpus`) and the strict-mode test suite.
+ *
+ * Structural failures (raised in strict mode, dropped silently in lenient
+ * mode):
+ *
+ * - `curly_quotes` — phrase wrapped in U+201C / U+201D.
+ * - `single_quotes` — phrase wrapped in `'…'` instead of `"…"`.
+ * - `non_dash_bullet` — `*`, `+` or numbered list marker under a section
+ *   that expects `- "…"` bullets.
+ * - `unclosed_quote` — opening `"` with no matching closing `"`.
+ * - `empty_phrase` — phrase normalises to empty (whitespace / punctuation
+ *   only).
+ * - `heading_drift` — heading with the section name but the wrong level
+ *   (e.g. `### Validated`) or trailing punctuation (e.g. `## Validated:`).
+ * - `missing_anchor` — the `<!-- intake-anchor: validated -->` marker is
+ *   absent (the intake module relies on it to splice new probation entries).
+ */
+
+import * as fs from 'node:fs';
+
+import { parse as parseYaml } from 'yaml';
+
+export type Section = 'validated' | 'probation' | 'anti_examples';
+
+const _SECTION_TITLES: Record<Section, string> = {
+    validated: 'Validated',
+    probation: 'On Probation',
+    anti_examples: 'Anti-Examples (Always Ask User)',
+};
+
+/** Ordered section keys, mirroring Python dict insertion order. */
+const _SECTION_KEYS: readonly Section[] = ['validated', 'probation', 'anti_examples'];
+
+// Heading-detection regex. `^##\s+<title>\s*$` accepts the canonical form;
+// anything else with the title text triggers `heading_drift`.
+// (Defined in Python but unused by the runtime path; kept for parity.)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _HEADING_OK = /^##\s+(.+?)\s*$/u;
+
+// Canonical bullet form: `- "phrase"` followed by optional metadata.
+const _BULLET_OK = /^\s*-\s*"([^"]+)"\s*(.*)$/u;
+
+// Non-dash list markers that drift away from the contract.
+const _BULLET_BAD_MARKER = /^\s*([*+]|\d+\.)\s+["“‘']/u;
+
+// Smart-quote and single-quote drift inside an otherwise dash-bulleted line.
+const _BULLET_CURLY = /^\s*-\s*[“‘]/u;
+const _BULLET_SINGLE_Q = /^\s*-\s*'/u;
+
+// Phrase-normaliser: drop non-word/space, collapse whitespace, lowercase.
+// Python `\w`/`\s` are Unicode by default.
+const _NORM_PUNCT = /[^\p{L}\p{N}_\s]/gu;
+const _NORM_WS = /\s+/gu;
+
+// Anchor comment per section.
+const _ANCHOR = (key: string): string => `<!-- intake-anchor: ${key} -->`;
+
+/**
+ * Structural anomaly in the low-impact-decisions corpus.
+ *
+ * - `reason`: Stable machine-readable failure tag (see module docstring).
+ * - `line`: 1-based line number of the offending content, or `null` when
+ *   the failure is file-level (missing anchor, etc.).
+ * - `section`: Section the anomaly was found in, when known.
+ */
+export class CorpusParseError extends Error {
+    readonly reason: string;
+    readonly line: number | null;
+    readonly section: Section | null;
+    readonly detail: string;
+
+    constructor(
+        reason: string,
+        opts: { line?: number | null; section?: Section | null; detail?: string } = {},
+    ) {
+        const line = opts.line ?? null;
+        const section = opts.section ?? null;
+        const detail = opts.detail ?? '';
+        const loc = line !== null ? ` at line ${line}` : '';
+        const sec = section ? ` in section '${section}'` : '';
+        let msg = `corpus parse failed: ${reason}${loc}${sec}`;
+        if (detail) {
+            msg += ` — ${detail}`;
+        }
+        super(msg);
+        this.name = 'CorpusParseError';
+        this.reason = reason;
+        this.line = line;
+        this.section = section;
+        this.detail = detail;
+    }
+}
+
+/** One parsed bullet entry from a section. */
+export interface CorpusEntry {
+    readonly phrase: string;
+    readonly normalised: string;
+    readonly section: Section;
+    readonly line_no: number;
+    readonly trailing_metadata: string;
+}
+
+function _entry(
+    phrase: string,
+    normalised: string,
+    section: Section,
+    line_no: number,
+    trailing_metadata = '',
+): CorpusEntry {
+    return { phrase, normalised, section, line_no, trailing_metadata };
+}
+
+/** Outcome of {@link parse_corpus_strict}. */
+export class CorpusParseResult {
+    readonly validated: readonly CorpusEntry[];
+    readonly probation: readonly CorpusEntry[];
+    readonly anti_examples: readonly CorpusEntry[];
+    readonly warnings: readonly string[];
+
+    constructor(opts: {
+        validated?: readonly CorpusEntry[];
+        probation?: readonly CorpusEntry[];
+        anti_examples?: readonly CorpusEntry[];
+        warnings?: readonly string[];
+    } = {}) {
+        this.validated = opts.validated ?? [];
+        this.probation = opts.probation ?? [];
+        this.anti_examples = opts.anti_examples ?? [];
+        this.warnings = opts.warnings ?? [];
+    }
+
+    phrases(section: Section): string[] {
+        const entries = this[section] as readonly CorpusEntry[];
+        return entries.map((e) => e.normalised);
+    }
+}
+
+/** Python `str.strip()`. */
+function _strip(s: string): string {
+    return s.trim();
+}
+
+function _normalise(phrase: string): string {
+    return _strip(phrase.toLowerCase().replace(_NORM_PUNCT, ' ').replace(_NORM_WS, ' '));
+}
+
+/** Return `[body_start, body_end]` for the named section, or `null`. */
+function _sectionBounds(
+    text: string,
+    title: string,
+    allTitles: readonly string[],
+): [number, number] | null {
+    const needle = `## ${title}`;
+    let idx = text.indexOf('\n' + needle);
+    if (idx < 0 && text.startsWith(needle)) {
+        idx = 0;
+    } else {
+        idx = idx >= 0 ? idx + 1 : -1;
+    }
+    if (idx < 0) {
+        return null;
+    }
+    const lineEnd = text.indexOf('\n', idx);
+    if (lineEnd < 0) {
+        return null;
+    }
+    const bodyStart = lineEnd + 1;
+    let end = text.length;
+    for (const other of allTitles) {
+        if (other === title) {
+            continue;
+        }
+        const j = text.indexOf('\n## ' + other, bodyStart);
+        if (j >= 0 && j < end) {
+            end = j;
+        }
+    }
+    return [bodyStart, end];
+}
+
+function _lineNoAt(text: string, offset: number): number {
+    // Python: text.count("\n", 0, offset) + 1
+    let count = 0;
+    for (let i = 0; i < offset && i < text.length; i += 1) {
+        if (text[i] === '\n') {
+            count += 1;
+        }
+    }
+    return count + 1;
+}
+
+/**
+ * Python `str.splitlines()` — split on universal newlines, drop a single
+ * trailing newline (no empty final element). `enumerate` over it is
+ * 0-based.
+ */
+function _splitlines(s: string): string[] {
+    if (s === '') {
+        return [];
+    }
+    const lines = s.split(/\r\n|\r|\n/u);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+    }
+    return lines;
+}
+
+/** Parse one section body into entries; raise or warn per `strict`. */
+function _scanSection(
+    text: string,
+    section: Section,
+    bodyStart: number,
+    bodyEnd: number,
+    strict: boolean,
+): [CorpusEntry[], string[]] {
+    const entries: CorpusEntry[] = [];
+    const warnings: string[] = [];
+    const body = text.slice(bodyStart, bodyEnd);
+    const baseLine = _lineNoAt(text, bodyStart);
+    const bodyLines = _splitlines(body);
+    for (let offset = 0; offset < bodyLines.length; offset += 1) {
+        const rawLine = bodyLines[offset] as string;
+        const lineNo = baseLine + offset;
+        const stripped = _strip(rawLine);
+        if (!stripped || stripped.startsWith('<!--') || stripped.startsWith('#')) {
+            continue;
+        }
+        if (!stripped.startsWith('-') && !_BULLET_BAD_MARKER.test(rawLine)) {
+            // Free-form paragraph text; ignored by both modes.
+            continue;
+        }
+        if (_BULLET_BAD_MARKER.test(rawLine)) {
+            const reason = 'non_dash_bullet';
+            if (strict) {
+                throw new CorpusParseError(reason, {
+                    line: lineNo,
+                    section,
+                    detail: `expected '- "…"' bullet, got: ${_pyRepr(stripped.slice(0, 40))}`,
+                });
+            }
+            warnings.push(`line ${lineNo}: ${reason} (section=${section})`);
+            continue;
+        }
+        if (_BULLET_CURLY.test(rawLine)) {
+            const reason = 'curly_quotes';
+            if (strict) {
+                throw new CorpusParseError(reason, {
+                    line: lineNo,
+                    section,
+                    detail: 'use ASCII double quotes (")',
+                });
+            }
+            warnings.push(`line ${lineNo}: ${reason} (section=${section})`);
+            continue;
+        }
+        if (_BULLET_SINGLE_Q.test(rawLine)) {
+            const reason = 'single_quotes';
+            if (strict) {
+                throw new CorpusParseError(reason, {
+                    line: lineNo,
+                    section,
+                    detail: 'use ASCII double quotes (")',
+                });
+            }
+            warnings.push(`line ${lineNo}: ${reason} (section=${section})`);
+            continue;
+        }
+        const m = _BULLET_OK.exec(rawLine);
+        if (!m) {
+            // Dash-bullet but no closed double-quoted phrase → unclosed quote.
+            if (stripped.startsWith('- "') || stripped.startsWith('-"')) {
+                const reason = 'unclosed_quote';
+                if (strict) {
+                    throw new CorpusParseError(reason, {
+                        line: lineNo,
+                        section,
+                        detail: 'missing closing quote on bullet',
+                    });
+                }
+                warnings.push(`line ${lineNo}: ${reason} (section=${section})`);
+                continue;
+            }
+            // Dash bullet without any quotes at all → treat as drift.
+            const reason = 'non_dash_bullet';
+            if (strict) {
+                throw new CorpusParseError(reason, {
+                    line: lineNo,
+                    section,
+                    detail: `expected '- "…"' bullet, got: ${_pyRepr(stripped.slice(0, 40))}`,
+                });
+            }
+            warnings.push(`line ${lineNo}: ${reason} (section=${section})`);
+            continue;
+        }
+        const phrase = m[1] as string;
+        // Python: m.group(2).strip() if m.lastindex and m.lastindex >= 2 else ""
+        const trailing = m[2] !== undefined ? _strip(m[2]) : '';
+        const norm = _normalise(phrase);
+        if (!norm) {
+            const reason = 'empty_phrase';
+            if (strict) {
+                throw new CorpusParseError(reason, {
+                    line: lineNo,
+                    section,
+                    detail: 'phrase normalises to empty',
+                });
+            }
+            warnings.push(`line ${lineNo}: ${reason} (section=${section})`);
+            continue;
+        }
+        entries.push(_entry(phrase, norm, section, lineNo, trailing));
+    }
+    return [entries, warnings];
+}
+
+/**
+ * Return `[line, detail]` if a near-miss heading is found, else
+ * `[null, null]`. Detects `### Validated`, `## Validated:`, etc.
+ *
+ * Only reports drift when no canonical heading is also present.
+ */
+function _checkHeadingDrift(text: string, title: string): [number | null, string | null] {
+    const canonical = `## ${title}`;
+    if (text.includes('\n' + canonical + '\n') || text.startsWith(canonical + '\n')) {
+        return [null, null];
+    }
+    // Search for any heading line containing the title text.
+    const pattern = new RegExp(`^(#+)\\s+${_reEscape(title)}([^\\n]*)$`, 'mu');
+    const m = pattern.exec(text);
+    if (!m) {
+        return [null, null];
+    }
+    const lineNo = _lineNoAt(text, m.index);
+    const hashes = m[1] as string;
+    const tail = m[2] as string;
+    if (hashes !== '##' || _strip(tail)) {
+        return [lineNo, `got '${_strip(m[0])}', expected '${canonical}'`];
+    }
+    return [null, null];
+}
+
+/**
+ * Parse the corpus, raising {@link CorpusParseError} on anomalies.
+ *
+ * A missing file is **not** an error — it returns an empty result.
+ * A present file with structural drift raises.
+ */
+export function parse_corpus_strict(corpusPath: string): CorpusParseResult {
+    const p = corpusPath;
+    if (!fs.existsSync(p)) {
+        return new CorpusParseResult();
+    }
+    const text = fs.readFileSync(p, { encoding: 'utf-8' });
+    const allTitles = _SECTION_KEYS.map((k) => _SECTION_TITLES[k]);
+    const resultSections: Record<Section, readonly CorpusEntry[]> = {
+        validated: [],
+        probation: [],
+        anti_examples: [],
+    };
+    const allWarnings: string[] = [];
+    let foundAny = false;
+    for (const section of _SECTION_KEYS) {
+        const title = _SECTION_TITLES[section];
+        const [driftLine, driftDetail] = _checkHeadingDrift(text, title);
+        if (driftLine !== null) {
+            throw new CorpusParseError('heading_drift', {
+                line: driftLine,
+                section,
+                detail: driftDetail ?? '',
+            });
+        }
+        const bounds = _sectionBounds(text, title, allTitles);
+        if (bounds === null) {
+            continue;
+        }
+        foundAny = true;
+        const [bodyStart, bodyEnd] = bounds;
+        const [entries, warns] = _scanSection(text, section, bodyStart, bodyEnd, true);
+        resultSections[section] = entries;
+        allWarnings.push(...warns);
+    }
+    // Anchor presence is checked once we have at least one section.
+    if (foundAny) {
+        for (const section of ['validated', 'probation'] as const) {
+            const anchor = _ANCHOR(section);
+            if (!text.includes(anchor)) {
+                throw new CorpusParseError('missing_anchor', {
+                    section,
+                    detail: `expected marker ${_pyRepr(anchor)}`,
+                });
+            }
+        }
+    }
+    return new CorpusParseResult({
+        validated: resultSections.validated,
+        probation: resultSections.probation,
+        anti_examples: resultSections.anti_examples,
+        warnings: allWarnings,
+    });
+}
+
+/**
+ * Back-compat shim used by routing (lenient mode).
+ *
+ * Step-10: prefers the YAML lockfile (`<corpus>.lock.yaml` sibling of
+ * `corpusPath`) when present. Falls back to lenient Markdown parsing when
+ * the lockfile is missing (fresh clone before `task sync`, or callers that
+ * haven't run the compiler).
+ *
+ * Silently drops malformed lines so a broken corpus never blocks
+ * classification. Strict-mode contract validation lives in
+ * {@link parse_corpus_strict} and the CI lint job.
+ */
+export function load_validated_phrases(corpusPath: string): string[] {
+    const yamlPhrases = _loadSectionFromLock(corpusPath, 'validated');
+    if (yamlPhrases !== null) {
+        return yamlPhrases;
+    }
+    return _loadSectionLenient(corpusPath, 'validated');
+}
+
+/**
+ * Lenient loader for the `Anti-Examples` section (step-9 P5).
+ *
+ * Step-10: prefers the YAML lockfile (see {@link load_validated_phrases}).
+ *
+ * Mirrors {@link load_validated_phrases} for the anti-example bucket.
+ * Consumed by the fuzzy-match classifier to apply the anti-example-veto:
+ * if the query is at least as similar to an anti-example as to a validated
+ * phrase, the match is rejected.
+ */
+export function load_anti_example_phrases(corpusPath: string): string[] {
+    const yamlPhrases = _loadSectionFromLock(corpusPath, 'anti_examples');
+    if (yamlPhrases !== null) {
+        return yamlPhrases;
+    }
+    return _loadSectionLenient(corpusPath, 'anti_examples');
+}
+
+/**
+ * Load a step-10 YAML lockfile and re-materialise a
+ * {@link CorpusParseResult}.
+ *
+ * Returns an empty result if the file does not exist (matches the
+ * Markdown-source contract). Malformed YAML raises (the underlying parser
+ * error); a schema-version mismatch raises {@link CorpusParseError} so
+ * consumers see the same typed failure they would from the Markdown
+ * parser. Lenient callers ({@link load_validated_phrases},
+ * {@link load_anti_example_phrases}) catch these errors and fall back to
+ * lenient Markdown parsing.
+ */
+export function load_corpus_lock(yamlPath: string): CorpusParseResult {
+    // Python uses a local `import yaml`; the package is a hard dependency
+    // here, so a top-level ESM import is behaviourally equivalent (and
+    // `require` is unavailable under `"type": "module"`).
+    const p = yamlPath;
+    if (!fs.existsSync(p)) {
+        return new CorpusParseResult();
+    }
+    // version '1.1' matches PyYAML safe_load.
+    const parsed = parseYaml(fs.readFileSync(p, { encoding: 'utf-8' }), { version: '1.1' });
+    const doc: Record<string, unknown> =
+        parsed === null || parsed === undefined ? {} : (parsed as Record<string, unknown>);
+    const schemaVersion = doc['schema_version'];
+    if (schemaVersion !== 1) {
+        throw new CorpusParseError('schema_version_mismatch', {
+            detail: `expected schema_version=1, got ${_pyRepr2(schemaVersion)}`,
+        });
+    }
+
+    const entriesFor = (key: Section): CorpusEntry[] => {
+        const raw = (doc[key] as unknown[]) ?? [];
+        const out: CorpusEntry[] = [];
+        for (const itemRaw of raw) {
+            const item = (itemRaw ?? {}) as Record<string, unknown>;
+            if (!item['normalised']) {
+                continue;
+            }
+            out.push(
+                _entry(
+                    (item['phrase'] as string) ?? '',
+                    (item['normalised'] as string) ?? '',
+                    key,
+                    _pyInt(item['line_no'] ?? 0),
+                    (item['trailing_metadata'] as string) ?? '',
+                ),
+            );
+        }
+        return out;
+    };
+
+    return new CorpusParseResult({
+        validated: entriesFor('validated'),
+        probation: entriesFor('probation'),
+        anti_examples: entriesFor('anti_examples'),
+    });
+}
+
+/** Mirror Python `int(x)` for the lockfile `line_no` field. */
+function _pyInt(x: unknown): number {
+    if (typeof x === 'number') {
+        return Math.trunc(x);
+    }
+    if (typeof x === 'string') {
+        return Math.trunc(Number(x));
+    }
+    if (typeof x === 'boolean') {
+        return x ? 1 : 0;
+    }
+    return 0;
+}
+
+/** Return the sibling lockfile path for a given corpus Markdown path. */
+function _deriveLockPath(corpusPath: string): string {
+    // Mirror Python pathlib semantics on the basename + suffix.
+    const dir = _dirname(corpusPath);
+    const name = _basename(corpusPath);
+    const suffix = _suffix(name);
+    if (suffix === '.yaml') {
+        return corpusPath;
+    }
+    if (name.endsWith('.lock.yaml')) {
+        return corpusPath;
+    }
+    const stem = suffix ? name.slice(0, name.length - suffix.length) : name;
+    const newName = `${stem}.lock.yaml`;
+    return dir === '' ? newName : _joinPath(dir, newName);
+}
+
+/**
+ * Read `section` phrases from the sibling lockfile.
+ *
+ * Returns `null` when the lockfile is absent or malformed so the caller
+ * can fall back to lenient Markdown parsing.
+ */
+function _loadSectionFromLock(corpusPath: string, section: Section): string[] | null {
+    const lockPath = _deriveLockPath(corpusPath);
+    if (!fs.existsSync(lockPath)) {
+        return null;
+    }
+    // Python: except (CorpusParseError, Exception) → catch everything.
+    try {
+        const result = load_corpus_lock(lockPath);
+        return result.phrases(section);
+    } catch {
+        return null;
+    }
+}
+
+function _loadSectionLenient(corpusPath: string, section: Section): string[] {
+    const p = corpusPath;
+    if (!fs.existsSync(p)) {
+        return [];
+    }
+    const text = fs.readFileSync(p, { encoding: 'utf-8' });
+    const allTitles = _SECTION_KEYS.map((k) => _SECTION_TITLES[k]);
+    const bounds = _sectionBounds(text, _SECTION_TITLES[section], allTitles);
+    if (bounds === null) {
+        return [];
+    }
+    const [entries] = _scanSection(text, section, bounds[0], bounds[1], false);
+    return entries.map((e) => e.normalised);
+}
+
+// ── path helpers (Python pathlib parity for `_derive_lock_path`) ──────────
+
+function _dirname(p: string): string {
+    const i = p.lastIndexOf('/');
+    if (i < 0) {
+        return '';
+    }
+    if (i === 0) {
+        return '/';
+    }
+    return p.slice(0, i);
+}
+
+function _basename(p: string): string {
+    const i = p.lastIndexOf('/');
+    return i < 0 ? p : p.slice(i + 1);
+}
+
+/** Python `Path.suffix` — last `.ext` of the basename, or '' if none / leading-dot only. */
+function _suffix(name: string): string {
+    // pathlib: a leading dot is not a suffix ('.bashrc' → suffix '').
+    const dot = name.lastIndexOf('.');
+    if (dot <= 0) {
+        return '';
+    }
+    return name.slice(dot);
+}
+
+function _joinPath(dir: string, name: string): string {
+    if (dir.endsWith('/')) {
+        return dir + name;
+    }
+    return dir + '/' + name;
+}
+
+// ── repr helpers ─────────────────────────────────────────────────────────
+
+/** Python repr() for a string: single-quoted with escapes. */
+function _pyRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = s.replace(/\\/g, '\\\\');
+    body = body.replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\t/g, '\\t');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    } else {
+        body = body.replace(/"/g, '\\"');
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Python repr() for an arbitrary value (used in the schema-version message). */
+function _pyRepr2(v: unknown): string {
+    if (v === null || v === undefined) {
+        return 'None';
+    }
+    if (typeof v === 'string') {
+        return _pyRepr(v);
+    }
+    if (typeof v === 'boolean') {
+        return v ? 'True' : 'False';
+    }
+    return String(v);
+}
+
+/**
+ * Escape a string for literal use inside a `u`-flagged RegExp.
+ *
+ * Python `re.escape` escapes every non-word char; under the JS `u` flag
+ * an escape like `\-` is illegal, so we escape only the ECMAScript regex
+ * metacharacters. Match behaviour is identical (the section titles here
+ * contain only ASCII letters / spaces / parens / hyphen anyway).
+ */
+function _reEscape(s: string): string {
+    // `-` and `/` are NOT metacharacters outside a character class in
+    // ECMAScript; escaping `-` as `\-` is illegal under the `u` flag.
+    return s.replace(/[.*+?^${}()|[\]\\]/gu, (c) => '\\' + c);
+}

--- a/src/scripts/ai_council/low_impact_intake.ts
+++ b/src/scripts/ai_council/low_impact_intake.ts
@@ -1,0 +1,222 @@
+/**
+ * Intake trigger + dedup for `agents/decisions/low-impact-decisions.md` (Phase 12).
+ *
+ * TypeScript twin of `src/scripts/ai_council/low_impact_intake.py`
+ * (ADR-094 — Python→TS migration, Phase 1). Pure-text, deterministic.
+ *
+ * User signals "leichte Frage" / "low-impact question" / equivalents
+ * (see {@link TRIGGER_PHRASES}); the host agent collects the
+ * most-recently-asked question, translates to English, runs the privacy
+ * redactor, and routes the result through this module.
+ *
+ * Behaviour (per Phase 12 § Step 2):
+ *
+ * - Normalise: lowercase, strip punctuation, collapse whitespace.
+ * - Match against `## On Probation` → append today's UTC date to that
+ *   entry's `seen` array (idempotent on same-day re-append).
+ * - Match against `## Validated` → no-op, returns {@link IntakeOutcome}
+ *   with `kind="duplicate_validated"`.
+ * - No match → append a fresh entry under `## On Probation` with
+ *   `first-seen <today>` and `seen [<today>]`.
+ *
+ * The promotion / pruning step is `probation_gate`, called by the caller
+ * after intake (or at council startup).
+ */
+
+import * as fs from 'node:fs';
+
+/** User trigger phrases (DE + EN) — substring match, lowercase. */
+export const TRIGGER_PHRASES: readonly string[] = [
+    // German
+    'das ist eine leichte frage',
+    'eine leichte frage',
+    'mach das selber',
+    'lös das selber',
+    'löse das im council',
+    'frag das council',
+    // English
+    'low-impact question',
+    'low impact question',
+    'council should answer this',
+    'you should know this yourself',
+    'ask the council',
+];
+
+const _PROBATION_HEADER = '## On Probation';
+const _VALIDATED_HEADER = '## Validated';
+const _ANTI_HEADER = '## Anti-Examples (Always Ask User)';
+
+// Python: re.compile(r"[^\w\s]") — Unicode \w and \s by default.
+const _NORMALISE_PUNCT_RE = /[^\p{L}\p{N}_\s]/gu;
+// Python: re.compile(r"\s+") — Unicode \s.
+const _WHITESPACE_RE = /\s+/gu;
+
+export type IntakeKind = 'appended_seen' | 'new_probation' | 'duplicate_validated' | 'noop';
+
+export interface IntakeOutcome {
+    readonly kind: IntakeKind;
+    readonly question: string;
+    readonly today: string;
+    readonly note: string;
+}
+
+function _outcome(kind: IntakeKind, question: string, today: string, note = ''): IntakeOutcome {
+    return { kind, question, today, note };
+}
+
+/** Python `str.strip()` — leading/trailing whitespace. */
+function _strip(s: string): string {
+    return s.trim();
+}
+
+/** True when `userText` carries any intake trigger phrase. */
+export function matches_trigger(userText: string): boolean {
+    const lo = userText.toLowerCase();
+    return TRIGGER_PHRASES.some((p) => lo.includes(p));
+}
+
+/** Lowercase, strip punctuation, collapse whitespace. */
+export function normalise(question: string): string {
+    let out = _strip(question.toLowerCase());
+    out = out.replace(_NORMALISE_PUNCT_RE, ' ');
+    out = out.replace(_WHITESPACE_RE, ' ');
+    return _strip(out);
+}
+
+function _today(): string {
+    // Python: datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return new Date().toISOString().slice(0, 10);
+}
+
+/** Return {header: [body_start, body_end]} char offsets. */
+function _splitSections(text: string): Map<string, [number, number]> {
+    const headers = [_PROBATION_HEADER, _VALIDATED_HEADER, _ANTI_HEADER];
+    const spans = new Map<string, [number, number]>();
+    for (const h of headers) {
+        const i = text.indexOf(h);
+        if (i < 0) {
+            continue;
+        }
+        const bodyStart = text.indexOf('\n', i) + 1;
+        let nextHeaderI = text.length;
+        for (const other of [...headers, '## Security', '## Provenance']) {
+            const j = text.indexOf('\n' + other, bodyStart);
+            if (j >= 0 && j < nextHeaderI) {
+                nextHeaderI = j;
+            }
+        }
+        spans.set(h, [bodyStart, nextHeaderI]);
+    }
+    return spans;
+}
+
+// Python: re.match(r'^\s*-\s*"([^"]+)"', line)
+const _ENTRY_RE = /^\s*-\s*"([^"]+)"/u;
+
+/** Return [[quoted_question, full_line]] for `- "…" — …` bullets. */
+function _parseEntries(body: string): Array<[string, string]> {
+    const out: Array<[string, string]> = [];
+    for (const line of _splitlines(body)) {
+        const m = _ENTRY_RE.exec(line);
+        if (m) {
+            out.push([m[1] as string, line]);
+        }
+    }
+    return out;
+}
+
+/**
+ * Python `str.splitlines()` — splits on universal newlines and drops a
+ * single trailing newline (no empty final element). For corpus text the
+ * `\n` / `\r\n` / `\r` set is what matters.
+ */
+function _splitlines(s: string): string[] {
+    if (s === '') {
+        return [];
+    }
+    const lines = s.split(/\r\n|\r|\n/u);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+    }
+    return lines;
+}
+
+export interface RecordIntakeOptions {
+    today?: string | null;
+}
+
+/** Append intake signal to the corpus. Pure-text, deterministic. */
+export function record_intake(
+    corpusPath: string,
+    question: string,
+    opts: RecordIntakeOptions = {},
+): IntakeOutcome {
+    const today = opts.today ?? _today();
+    const text = fs.readFileSync(corpusPath, { encoding: 'utf-8' });
+    const normQ = normalise(question);
+    const spans = _splitSections(text);
+
+    if (spans.has(_VALIDATED_HEADER)) {
+        const [s, e] = spans.get(_VALIDATED_HEADER) as [number, number];
+        for (const [q] of _parseEntries(text.slice(s, e))) {
+            if (normalise(q) === normQ) {
+                return _outcome('duplicate_validated', question, today, 'already learned');
+            }
+        }
+    }
+
+    if (spans.has(_PROBATION_HEADER)) {
+        const [s, e] = spans.get(_PROBATION_HEADER) as [number, number];
+        const body = text.slice(s, e);
+        for (const [q, line] of _parseEntries(body)) {
+            if (normalise(q) === normQ) {
+                if (line.includes(today)) {
+                    return _outcome('noop', question, today, 'already seen today');
+                }
+                const newLine = _appendSeen(line, today);
+                const newText = text.slice(0, s) + _replaceOnce(body, line, newLine) + text.slice(e);
+                fs.writeFileSync(corpusPath, newText, { encoding: 'utf-8' });
+                return _outcome('appended_seen', question, today);
+            }
+        }
+
+        const newEntry = `- "${_strip(question)}" — first-seen ${today} · seen [${today}]\n`;
+        const newText = _rstrip(text.slice(0, e)) + '\n\n' + newEntry + '\n' + text.slice(e);
+        fs.writeFileSync(corpusPath, newText, { encoding: 'utf-8' });
+        return _outcome('new_probation', question, today);
+    }
+
+    return _outcome('noop', question, today, 'probation section missing');
+}
+
+/** Python `str.rstrip()` — strip trailing whitespace. */
+function _rstrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Python `str.replace(old, new, 1)` — replace first occurrence only. */
+function _replaceOnce(s: string, oldStr: string, newStr: string): string {
+    const i = s.indexOf(oldStr);
+    if (i < 0) {
+        return s;
+    }
+    return s.slice(0, i) + newStr + s.slice(i + oldStr.length);
+}
+
+// Python: re.sub(r"seen \[([^\]]*)\]", _sub, line)
+const _SEEN_RE = /seen \[([^\]]*)\]/gu;
+
+/** Append `today` to the `seen [...]` array on a probation line. */
+function _appendSeen(line: string, today: string): string {
+    if (line.includes('seen [')) {
+        return line.replace(_SEEN_RE, (whole, group1: string) => {
+            const body = _strip(group1);
+            if (body.includes(today)) {
+                return whole;
+            }
+            const newBody = body ? body + ', ' + today : today;
+            return `seen [${newBody}]`;
+        });
+    }
+    return _rstrip(line) + ` · seen [${today}]`;
+}

--- a/src/scripts/ai_council/prompts.ts
+++ b/src/scripts/ai_council/prompts.ts
@@ -1,0 +1,600 @@
+/**
+ * Neutrality system prompts for the council.
+ *
+ * TypeScript twin of `src/scripts/ai_council/prompts.py` (ADR-094 —
+ * Python→TS migration, Phase 1). Council members must NOT see the host
+ * agent's reasoning, internal state, or framing language. Each prompt asks
+ * for an independent critique on the artefact's own merits.
+ *
+ * Anti-patterns guarded against in tests (test_prompts.py):
+ * - No leak of host-agent identity ("Augment", "Claude Code", etc.).
+ * - No "the agent thinks X" framing.
+ * - No instructions that bias toward agreement.
+ *
+ * Parity notes:
+ * - The Python module's string constants are triple-quoted literals run
+ *   through `.strip()` (or `.rstrip()` for one). Each constant below is the
+ *   byte-exact post-strip value — the `_dedent`/`.strip()` step is folded in
+ *   at authoring time so the runtime value matches `str.strip()` output.
+ * - `"\n".join` / `"\n\n".join` mirror Python `str.join`.
+ * - `str.splitlines()` is mirrored by `_splitlines` (drops the trailing
+ *   empty element a final newline would produce; full universal-newline set).
+ * - `sorted(...)` for error messages mirrors Python `sorted()` (code-point
+ *   ascending) via `[...].sort()` on ASCII keys.
+ */
+import { ProjectContext } from './project_context.js';
+
+// Python: NEUTRALITY_PREAMBLE = """\...""".strip()
+export const NEUTRALITY_PREAMBLE = `You are an independent reviewer. You have NOT seen any prior reasoning,
+agent output, or commentary on the artefact below. Critique it on its
+own merits. Disagree if warranted. Cite specific lines or sections.
+Do not assume the artefact is correct just because it was sent to you.`;
+
+// Host-agent identity strings that must never leak into a council member's
+// view. Lines containing any of these (case-insensitive substring) are
+// dropped before assembly. See `ai-council` skill § Neutrality.
+export const HOST_AGENT_IDENTITY_PATTERNS = [
+    'augment',
+    'claude code',
+    'cursor agent',
+    'cursor ide',
+    'cline',
+    'windsurf',
+    'copilot agent',
+] as const;
+
+// Per-mode addenda — appended after the preamble.
+
+export const PROMPT_MODE = `The artefact is a free-form question or proposal from a developer.
+Respond with:
+1. Your honest assessment (agree / disagree / mixed).
+2. The single strongest argument for your position.
+3. The single strongest counter-argument the developer should consider.
+4. Concrete next steps if you agree, or concrete alternatives if you disagree.`;
+
+export const ROADMAP_MODE = `The artefact is a proposed implementation roadmap. Critique it as if
+you were a senior engineer asked to greenlight it. Focus on:
+1. Hidden coupling between phases that the roadmap glosses over.
+2. Steps that are too coarse to verify ("implement X" vs "X with Y test").
+3. Missing rollback or kill-switch criteria.
+4. Sequencing risks — does step N really not block step N+1?
+5. Open questions disguised as decisions, or vice versa.`;
+
+export const DIFF_MODE = `The artefact is a code diff. Review it for:
+1. Correctness — bugs, off-by-one, null-safety, type drift.
+2. Security — injection, secrets, unsafe deserialization, authZ gaps.
+3. Test coverage — uncovered branches, missing regression tests.
+4. Maintainability — surprise dependencies, naming drift, dead code.
+End with: APPROVE / REQUEST_CHANGES / REJECT and one sentence why.`;
+
+export const FILES_MODE = `The artefact is a set of source files for an architectural review.
+Map out:
+1. The boundaries you see (modules, layers, trust zones).
+2. The strongest design decision present.
+3. The weakest design decision present.
+4. The single change that would most reduce future maintenance cost.`;
+
+// Specialised modes — used by /council-pr, /council-design,
+// /council-optimize. Selected via `mode_override=` in `/council` so the
+// base modes (`prompt`, `roadmap`, `diff`, `files`) keep their v2 byte
+// shape for back-compat with existing callers.
+
+export const PR_MODE = `The artefact is a code diff from a pull request. Review with both a
+correctness lens AND a shipping-risk lens:
+1. Correctness — bugs, off-by-one, null-safety, type drift.
+2. Security — injection, secrets, unsafe deserialization, authZ gaps.
+3. Test coverage — uncovered branches, missing regression tests.
+4. Shipping risk — does this PR mix concerns that should be split?
+   Is the blast radius bigger than the title implies?
+5. Reviewer fatigue — is anything in the diff that a tired reviewer
+   would rubber-stamp but should not?
+End with: APPROVE / REQUEST_CHANGES / REJECT, one sentence why, and
+the single highest-leverage change the PR author should make before
+merge.`;
+
+export const DESIGN_MODE = `The artefact is a design document, ADR, or architecture proposal.
+Critique it as if you were greenlighting it as a senior engineer.
+Focus on:
+1. Trust boundaries and module coupling the design glosses over.
+2. Rollback / kill-switch criteria the design omits.
+3. Sequencing risk — does step N really not block step N+1?
+4. Open questions disguised as decisions, or decisions disguised as
+   open questions.
+5. The single architectural call you would push back on the hardest,
+   and what evidence would change your mind.`;
+
+export const OPTIMIZE_MODE = `The artefact is an optimization target — code, a query, a profile,
+or an existing optimization report. Produce ranked, evidence-based
+suggestions for the metric stated in the user's original ask. You
+MUST:
+1. Rank suggestions by expected impact on the stated metric, not by
+   effort or cleverness.
+2. Cite the evidence (line, query plan, profile entry) for every
+   suggestion. No hand-wave "this is probably slow".
+3. State at least one suggestion you explicitly REJECT as
+   low-leverage, so the user does not over-engineer.
+4. Mark at least one suggestion as hypothesis (requires measurement
+   before committing) versus confirmed (already supported by the
+   evidence in the artefact).`;
+
+export const ANALYSIS_MODE = `The artefact is a local analysis output (from a project analyzer,
+audit script, or codebase scan). Critique the **analysis itself**, not
+the underlying codebase. You MUST:
+1. Flag findings that are restated under different headings —
+   deduplicate aggressively. The downstream consumer wants a unique
+   Top-N, not a long list with overlap.
+2. Score the evidence quality of each finding: confirmed (the
+   analysis cites file:line / metric), inferred (plausible from
+   stated context), or speculative (no citation, vibes-only).
+   Speculative findings must be called out by name.
+3. Identify findings that are roadmap-ready (concrete enough to land
+   as a phase step) vs ones that need a discovery loop first.
+4. Propose 3–5 follow-up actions ranked by leverage — what the next
+   roadmap should attack first. Cite the supporting finding(s) by id
+   or heading.
+End with: a Top-N consensus list (one bullet per finding the
+analysis surfaces) plus a single sentence on the strongest blind
+spot the analysis itself has.`;
+
+export const DEBATE_MODE = `The artefact is the topic of a structured multi-round debate. You are
+one of several independent reviewers. Round-specific instructions:
+1. Round 1 — state your strongest, most defensible position on the
+   topic. Argue from evidence and first principles. Do not hedge.
+2. Round 2+ — read the anonymised positions from the previous round.
+   Identify the SINGLE strongest opposing position and write a
+   rebuttal addressed at its strongest steel-manned form. Your task
+   is to find the load-bearing flaw the opposing reviewer missed —
+   do NOT search for common ground.
+End each round with: a one-line position summary and the single
+piece of evidence that would change your mind.`;
+
+const _MODE_TABLE: Record<string, string> = {
+    prompt: PROMPT_MODE,
+    roadmap: ROADMAP_MODE,
+    diff: DIFF_MODE,
+    files: FILES_MODE,
+    pr: PR_MODE,
+    design: DESIGN_MODE,
+    optimize: OPTIMIZE_MODE,
+    analysis: ANALYSIS_MODE,
+    debate: DEBATE_MODE,
+};
+
+// ── Consensus-scoring prompts (Phase 4 / F3) ──────────────────────────
+//
+// Two-step extraction + scoring round used by the analysis lens. The
+// extraction pass asks each member to surface its own top findings in
+// a strict JSON shape; the scoring pass asks each member to rate
+// anonymised findings produced by the *other* members.
+//
+// Iron Law of Neutrality applies to both: the extraction prompt never
+// names other reviewers, and the scoring prompt strips the source
+// author by using `Finding-A` / `Finding-B` labels (see
+// `consensus.anonymize_findings`).
+
+export const FINDING_EXTRACTION_PROMPT = `You have just produced an analysis. Re-emit your top findings as a
+strict JSON array suitable for downstream tooling. Each item MUST
+have:
+
+    {"id": "<short-slug>", "text": "<one-sentence finding>"}
+
+Rules:
+- 3-7 findings, ordered by importance (most important first).
+- \`id\` is a 1-3 word kebab-case slug, unique within your array.
+- \`text\` is a single sentence, no markdown, no reviewer self-reference.
+- Wrap the array in a \`\`\`json\`\`\` fenced block. No commentary outside it.`;
+
+export const FINDING_SCORING_PROMPT = `Below are findings from other independent reviewers, presented with
+neutral labels (Finding-A, Finding-B, …). Score each one on its
+merits. You MUST emit a strict JSON array, one entry per finding,
+in this shape:
+
+    {"finding_id": "Finding-A", "score": 1-10, "agree": true|false,
+     "reason": "<one-sentence justification>"}
+
+Rules:
+- \`score\` is an integer 1 (weak / irrelevant) to 10 (load-bearing /
+  must-address).
+- \`agree=true\` means you would surface this same finding yourself;
+  \`agree=false\` means you think it is wrong, overstated, or off-topic.
+- \`reason\` is a single sentence, no markdown.
+- Wrap the array in a \`\`\`json\`\`\` fenced block. No commentary outside it.
+
+You may not see your own findings in the list — that is by design.`;
+
+// ── Synthesis templates (Phase 3 / F2) ────────────────────────────────
+//
+// Lens-aware synthesis prompts. Each entry maps a lens key onto the
+// block the host agent should produce when summarising member responses.
+// R4 Q4 split: decision lenses get a Karpathy-structured template;
+// creative lenses (design / optimize) stay open-ended prose (empty
+// string → renderer falls back to the bare "Convergence / Divergence"
+// slot). Input modes (prompt / roadmap / diff / files) map onto the
+// `default` decision template via `synthesis_template()`.
+
+export const DEFAULT_SYNTHESIS = `Summarise the council using the structured shape below. Be terse,
+cite reviewers by label, and refuse to invent agreement that is not
+in the responses.
+
+### Agreement
+Points that two or more reviewers converged on, each as a single line.
+
+### Clashes
+Points where reviewers disagreed. State both sides with a one-line
+reviewer-label citation per side.
+
+### Blind spots
+Items that none of the reviewers raised but that the artefact's
+context suggests are load-bearing. Maximum three. Mark each as
+\`needs-verification\` when the host agent inferred it rather than
+read it directly from a response.
+
+### Recommendation
+A single sentence: which course the host agent should advise the
+user to take, grounded in the strongest converged point.
+
+### Next step
+One concrete next action the user can take in their current turn.`;
+
+export const PR_SYNTHESIS = `Summarise the council with the PR-review shape below.
+
+### Consensus
+Findings where two or more reviewers agreed, each one a single line.
+
+### Conflicts
+Findings where reviewers disagreed. State both sides with reviewer
+labels; do not pick a winner here — that lives in the recommendation.
+
+### Must-fix before merge
+Items at least one reviewer marked \`REQUEST_CHANGES\` or \`REJECT\`
+and the host agent confirms are load-bearing. Maximum five.
+
+### Recommendation
+APPROVE / REQUEST_CHANGES / REJECT and a single sentence justifying
+the verdict, anchored on the strongest consensus or must-fix line.`;
+
+export const ANALYSIS_SYNTHESIS = `Summarise the council with the analysis-lens shape below.
+
+### Top-10 by consensus
+Findings ranked by how many reviewers surfaced them. Format each
+line as: \`N. <finding> — cited by <reviewer labels> · evidence:
+confirmed | inferred | speculative · roadmap-ready: yes | needs-discovery\`.
+Stop at ten or when only single-reviewer items remain, whichever
+comes first.
+
+### Supporting
+Findings that one reviewer raised and at least one other treated as
+plausible but did not independently surface. One line each, same
+metadata shape as Top-10.
+
+### Outliers
+Single-reviewer findings the others did not engage with. Keep them
+— they are signal for a future deeper analysis pass — but mark each
+as \`unverified-by-council\`.`;
+
+// Creative lenses — open-ended prose, no template. The renderer keeps
+// the bare "Convergence / Divergence" slot so the host agent can write
+// free-form synthesis.
+const _CREATIVE_PASSTHROUGH = '';
+
+const _SYNTHESIS_TABLE: Record<string, string> = {
+    default: DEFAULT_SYNTHESIS,
+    pr: PR_SYNTHESIS,
+    analysis: ANALYSIS_SYNTHESIS,
+    design: _CREATIVE_PASSTHROUGH,
+    optimize: _CREATIVE_PASSTHROUGH,
+};
+
+// Input modes inherit the `default` decision template. Lens overrides
+// (`pr`/`design`/`optimize`/`analysis`) pick their own row.
+const _INPUT_MODE_TO_SYNTHESIS_KEY: Record<string, string> = {
+    prompt: 'default',
+    roadmap: 'default',
+    diff: 'default',
+    files: 'default',
+};
+
+/** Mirror Python `key in dict` (own-enumerable string key present). */
+function _hasKey(table: Record<string, string>, key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(table, key);
+}
+
+/** Mirror Python `sorted(set(a) | set(b))` — ascending code-point order, deduped. */
+function _sortedUnion(a: string[], b: string[]): string[] {
+    const set = new Set<string>([...a, ...b]);
+    return Array.from(set).sort();
+}
+
+/** Mirror Python `repr()` for a string scalar (single-quoted). */
+function _pyReprStr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = s
+        .replace(/\\/g, '\\\\')
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r')
+        .replace(/\t/g, '\\t');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    } else {
+        body = body.replace(/"/g, '\\"');
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Mirror Python `repr()` for `None`. */
+function _pyRepr(value: string | null): string {
+    return value === null ? 'None' : _pyReprStr(value);
+}
+
+/** Mirror Python `str.splitlines()` — universal newline set, no trailing empty. */
+function _splitlines(text: string): string[] {
+    if (text === '') {
+        return [];
+    }
+    // Python splitlines() boundaries: LF CR CRLF VT FF FS GS RS NEL LS PS.
+    const parts = text.split(/\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/u);
+    if (parts.length > 0 && parts[parts.length - 1] === '') {
+        parts.pop();
+    }
+    return parts;
+}
+
+/** Mirror Python `str.strip()` — strip whitespace both ends. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+export function synthesis_template(mode: string | null): string {
+    if (mode === null) {
+        return _SYNTHESIS_TABLE['default'] as string;
+    }
+    if (_hasKey(_SYNTHESIS_TABLE, mode)) {
+        return _SYNTHESIS_TABLE[mode] as string;
+    }
+    if (_hasKey(_INPUT_MODE_TO_SYNTHESIS_KEY, mode)) {
+        const key = _INPUT_MODE_TO_SYNTHESIS_KEY[mode] as string;
+        return _SYNTHESIS_TABLE[key] as string;
+    }
+    const expected = _sortedUnion(
+        Object.keys(_SYNTHESIS_TABLE),
+        Object.keys(_INPUT_MODE_TO_SYNTHESIS_KEY),
+    );
+    throw new Error(
+        `Unknown synthesis mode ${_pyRepr(mode)}. ` +
+            `Expected one of: [${expected.map((m) => _pyReprStr(m)).join(', ')}]`,
+    );
+}
+
+export function all_synthesis_modes(): string[] {
+    return Object.keys(_SYNTHESIS_TABLE).sort();
+}
+
+/**
+ * Drop any *whole line* containing a host-agent identity substring.
+ *
+ * Strategy (locked by council review, 2026-05-02): a line is dropped
+ * in full as soon as any host-identity needle (Augment / Claude Code
+ * / Cursor / Cline / Windsurf, etc.) appears anywhere on it. We err
+ * toward false-positive — slightly less context — over false-negative
+ * — a neutrality leak. Substring-only stripping was rejected because
+ * it can leave dangling clauses that still hint at the host.
+ */
+function _strip_host_identity(text: string): string {
+    if (!text) {
+        return text;
+    }
+    const kept: string[] = [];
+    for (const line of _splitlines(text)) {
+        const low = line.toLowerCase();
+        if (HOST_AGENT_IDENTITY_PATTERNS.some((needle) => low.includes(needle))) {
+            continue;
+        }
+        kept.push(line);
+    }
+    return kept.join('\n');
+}
+
+/**
+ * Neutral context-handoff for council members.
+ *
+ * `project=null` and/or `original_ask=""` collapses the output to
+ * `NEUTRALITY_PREAMBLE` alone (back-compat with v1 callers).
+ */
+export function handoff_preamble(
+    project: ProjectContext | null,
+    original_ask: string,
+): string {
+    const blocks: string[] = [];
+
+    if (project !== null && !project.is_empty()) {
+        const ctx_lines: string[] = [];
+        if (project.name) {
+            ctx_lines.push(`Project: ${project.name}`);
+        }
+        if (project.stack) {
+            ctx_lines.push(`Stack: ${project.stack}`);
+        }
+        if (project.repo_purpose) {
+            ctx_lines.push(`Purpose: ${project.repo_purpose}`);
+        }
+        const ctx = _pyStrip(_strip_host_identity(ctx_lines.join('\n')));
+        if (ctx) {
+            blocks.push(ctx);
+        }
+    }
+
+    const cleaned_ask = _pyStrip(_strip_host_identity(original_ask || ''));
+    if (cleaned_ask) {
+        const quoted = _splitlines(cleaned_ask)
+            .map((ln) => `> ${ln}`)
+            .join('\n');
+        blocks.push(`The user originally asked:\n${quoted}`);
+    }
+
+    blocks.push(NEUTRALITY_PREAMBLE);
+    return blocks.join('\n\n');
+}
+
+export interface SystemPromptOptions {
+    project?: ProjectContext | null;
+    original_ask?: string;
+}
+
+/**
+ * Build the full system prompt for one of the four input modes.
+ *
+ * Raises (throws) on an unknown mode — callers must use one of
+ * `prompt`, `roadmap`, `diff`, `files`.
+ */
+export function system_prompt_for(mode: string, opts: SystemPromptOptions = {}): string {
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    if (!_hasKey(_MODE_TABLE, mode)) {
+        const expected = Object.keys(_MODE_TABLE).sort();
+        throw new Error(
+            `Unknown council mode ${_pyRepr(mode)}. ` +
+                `Expected one of: [${expected.map((m) => _pyReprStr(m)).join(', ')}]`,
+        );
+    }
+    const head = handoff_preamble(project, original_ask);
+    return `${head}\n\n${_MODE_TABLE[mode] as string}`;
+}
+
+export function all_modes(): string[] {
+    return Object.keys(_MODE_TABLE).sort();
+}
+
+export interface AdvisorSystemPromptOptions {
+    project?: ProjectContext | null;
+    original_ask?: string;
+}
+
+/**
+ * Build the system prompt for an advisor-mode call (Phase 6).
+ *
+ * Layout: neutral handoff preamble (same shape every council member
+ * sees, regardless of mode) + the advisor's persona body. The
+ * mode-specific addendum from `_MODE_TABLE` is intentionally
+ * replaced — the persona file owns the full instructional surface
+ * for an advisor call.
+ */
+export function advisor_system_prompt(
+    persona_text: string,
+    opts: AdvisorSystemPromptOptions = {},
+): string {
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const head = handoff_preamble(project, original_ask);
+    const body = _pyStrip(persona_text || '');
+    if (!body) {
+        throw new Error('advisor_system_prompt: persona_text is empty.');
+    }
+    return `${head}\n\n${body}`;
+}
+
+/**
+ * User-message body for the finding-extraction pass.
+ *
+ * Pairs the prior analysis text with the extraction-prompt rules so
+ * the member re-emits its own findings in machine-readable form.
+ */
+export function build_extraction_user_prompt(original_analysis: string): string {
+    const cleaned = _pyStrip(_strip_host_identity(original_analysis || ''));
+    return `${FINDING_EXTRACTION_PROMPT}\n\n---\n\n${cleaned}`;
+}
+
+/**
+ * User-message body for the scoring pass.
+ *
+ * `anonymised` maps `Finding-A`/`Finding-B`/… → finding text. Author
+ * identities MUST already be stripped — this function does NOT
+ * re-anonymise, it just renders.
+ */
+export function build_scoring_user_prompt(anonymised: Map<string, string>): string {
+    const lines: string[] = [FINDING_SCORING_PROMPT, '', '---', ''];
+    for (const [label, text] of anonymised) {
+        lines.push(`### ${label}\n\n${text}`);
+    }
+    return lines.join('\n\n');
+}
+
+// ── Peer-review (Phase 5 / F1, Karpathy anonymous review) ────────────
+//
+// After the final deliberation round, each member sees the OTHER
+// members' deliberation outputs under neutral `Response-A` / `Response-B`
+// labels and produces a Karpathy-style critique: strongest response,
+// weakest blind spot, what all of them missed. Provider identity is
+// stripped (Iron Law of Neutrality § peer-review); advisor persona
+// labels (Phase 6) are preserved by the caller via `anonymize_responses`.
+//
+// Reviewers never see their own response — that is by design (the
+// orchestrator filters self before calling `build_peer_review_user_prompt`).
+
+export const PEER_REVIEW_PROMPT = `Below are responses from other independent reviewers to the same
+artefact you just reviewed. Each is labelled with a neutral identifier
+(\`Response-A\`, \`Response-B\`, …). You do NOT know which model produced
+which response. Critique them as a peer — your goal is to surface
+signal the round-1 deliberation may have missed.
+
+Respond in plain prose under exactly these four headings:
+
+### Strongest response
+Name the single response whose argument or evidence is most
+load-bearing. Cite the label. One paragraph.
+
+### Weakest blind spot
+The single most important thing one specific response missed,
+glossed over, or got wrong. Cite the label. One paragraph.
+
+### What everyone missed
+A point none of the responses raised but that the artefact's context
+suggests is load-bearing. One paragraph. Mark as \`needs-verification\`
+when you inferred it rather than read it directly from the artefact.
+
+### Refinement
+One sentence: which course the synthesizer should prefer in light of
+the above, grounded in the strongest converged signal.
+
+Rules:
+- Cite labels exactly as given (\`Response-A\`, not \`A\` or \`the first one\`).
+- Do not invent agreement or disagreement that is not visible in the
+  responses themselves.
+- You may NOT see your own response in the list — that is by design.`;
+
+// Python: PEER_REVIEW_SYNTHESIS_ADDENDUM = """\n...""".rstrip()
+// The literal begins with a leading newline (after the """\ continuation the
+// first char is "\n"), then the body, then .rstrip() removes trailing ws.
+export const PEER_REVIEW_SYNTHESIS_ADDENDUM = `
+### Peer-Review-Surfaced Blind Spots
+Items the peer-review round surfaced that the round-1 responses did
+not. Cite the peer-reviewer label and the targeted response label
+(\`Reviewer A on Response-B: <one-line summary>\`). Maximum three.`;
+
+/**
+ * User-message body for the peer-review pass.
+ *
+ * `anonymised` maps `Response-A` / `Response-B` / … → response text.
+ * Provider identities MUST already be stripped by the caller (see
+ * `consensus.anonymize_responses`); this function does NOT re-anonymise,
+ * it just renders.
+ */
+export function build_peer_review_user_prompt(anonymised: Map<string, string>): string {
+    const lines: string[] = [PEER_REVIEW_PROMPT, '', '---', ''];
+    for (const [label, text] of anonymised) {
+        lines.push(`### ${label}\n\n${text}`);
+    }
+    return lines.join('\n\n');
+}
+
+/**
+ * Return the synthesis-template addendum used when peer-review fired.
+ *
+ * Appended to the lens-specific synthesis template by the renderer.
+ * Creative-lens (prose) runs receive only the bare section header so
+ * the host agent can write free-form synthesis underneath it.
+ */
+export function peer_review_synthesis_addendum(): string {
+    return PEER_REVIEW_SYNTHESIS_ADDENDUM;
+}

--- a/src/scripts/ai_council/redact_low_impact_entry.ts
+++ b/src/scripts/ai_council/redact_low_impact_entry.ts
@@ -1,0 +1,291 @@
+/**
+ * Privacy floor for `agents/decisions/low-impact-decisions.md` (Phase 12).
+ *
+ * TypeScript twin of `src/scripts/ai_council/redact_low_impact_entry.py`
+ * (ADR-094 — Python→TS migration, Phase 1). Security-sensitive: the
+ * redaction regexes and refusal markers are matched byte-for-byte against
+ * the Python original.
+ *
+ * Non-bypassable redactor invoked on intake (write-side) AND on
+ * upstream (`/learn-low-impact`, leave-the-repo side). Both gates call
+ * {@link redact_low_impact_entry} and refuse to proceed when a forbidden
+ * pattern fires.
+ *
+ * Iron Law: nothing leaves the project repo until this redactor clears
+ * the entry. See `.augment/rules/low-impact-corpus-privacy-floor.md`.
+ *
+ * Forbidden-content classes (per Phase 12 § Step 4):
+ *
+ * 1. Secrets — raw-key prefixes mirrored from
+ *    `scripts.ai_council.config._RAW_KEY_PREFIXES`, plus a generic
+ *    `api[-_]?key:\s*<token>` shape.
+ * 2. Emails — RFC-5322-ish shape, deliberately permissive.
+ * 3. Project-rooted paths — anything starting `/Users/`, `/home/`,
+ *    `/opt/`, `/private/`, drive letters (`C:\`), or the configured repo
+ *    root from `.agent-settings.yml` when supplied.
+ * 4. Customer / tenant names — caller passes a name list (project
+ *    policy); generic placeholders `<customer>`, `<tenant>`, `<account>`,
+ *    `<user>` survive.
+ * 5. Internal hostnames — `*.internal`, `*.local`, plus any project-private
+ *    domain the caller supplies.
+ * 6. Monetary amounts — `$1,234` / `€500` / `USD 1000` shapes that look
+ *    like business figures.
+ * 7. Business-context SQL identifiers — caller-supplied table / column
+ *    allow-list. Default empty.
+ * 8. Inline code excerpts > 40 chars — any backtick-fenced run > 40.
+ */
+
+import { _RAW_KEY_PREFIXES } from './config.js';
+
+/**
+ * Code-point length, matching Python `len(str)`. JS `String.length`
+ * counts UTF-16 units, so an astral char would over-count; Python counts
+ * code points. `Array.from` iterates code points.
+ */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+/**
+ * Slice the first `n` code points, matching Python `s[:n]`. JS
+ * `String.slice` is UTF-16-unit based; we slice by code point for parity.
+ */
+function _pySliceHead(s: string, n: number): string {
+    let out = '';
+    let i = 0;
+    for (const ch of s) {
+        if (i >= n) {
+            break;
+        }
+        out += ch;
+        i += 1;
+    }
+    return out;
+}
+
+/** Python `str.strip()` — leading/trailing whitespace. */
+function _strip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Escape a string for literal use inside a `u`-flagged RegExp.
+ *
+ * Python `re.escape` backslash-escapes every non-word char; under the JS
+ * `u` flag an escape like `\-` is illegal, so we escape only the
+ * ECMAScript regex metacharacters. The *match behaviour* is identical
+ * (literal match of the input string) — only the pattern source differs,
+ * which is not observable.
+ */
+function _reEscape(s: string): string {
+    // `-` and `/` are NOT metacharacters outside a character class in
+    // ECMAScript; escaping `-` as `\-` is illegal under the `u` flag.
+    return s.replace(/[.*+?^${}()|[\]\\]/gu, (c) => '\\' + c);
+}
+
+/** Single forbidden-pattern hit. */
+export interface RedactionViolation {
+    readonly category: string;
+    readonly snippet: string;
+    readonly note: string;
+}
+
+function _violation(category: string, snippet: string, note = ''): RedactionViolation {
+    return { category, snippet, note };
+}
+
+/** Python repr() for a string: single-quoted (used by `summary()`). */
+function _pyRepr(s: string): string {
+    // Mirror Python repr for the snippet types this module produces
+    // (printable ASCII / unicode runs without embedded quotes-needing
+    // escapes beyond the wrapping). Python prefers single quotes unless
+    // the string contains a single quote and no double quote.
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = s.replace(/\\/g, '\\\\');
+    body = body
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r')
+        .replace(/\t/g, '\\t');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    } else {
+        body = body.replace(/"/g, '\\"');
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Outcome of one redaction pass. */
+export class RedactionResult {
+    readonly ok: boolean;
+    readonly violations: readonly RedactionViolation[];
+
+    constructor(ok: boolean, violations: readonly RedactionViolation[] = []) {
+        this.ok = ok;
+        this.violations = violations;
+    }
+
+    summary(): string {
+        if (this.ok) {
+            return 'redaction: clean';
+        }
+        const parts = this.violations.map((v) => `${v.category}: ${_pyRepr(v.snippet)}`);
+        return 'redaction REFUSED — ' + parts.join('; ');
+    }
+}
+
+// ── regex patterns (Python `re` semantics replicated) ────────────────────
+// Python `\w`/`\b`/`\d` are Unicode by default. JS `\w`/`\b`/`\d` are
+// ASCII-only even with the `u` flag, so where Python uses them we replicate
+// the Unicode class explicitly.
+
+// Python: \b[\w.+-]+@[\w-]+\.[\w.-]+\b
+// Unicode \w == [\p{L}\p{N}_]. We emulate \b via lookarounds on the
+// Unicode word-char class.
+const _UWORD = '[\\p{L}\\p{N}_]';
+const _UNB_BEFORE = `(?<!${_UWORD})`;
+const _UNB_AFTER = `(?!${_UWORD})`;
+const _EMAIL_RE = new RegExp(
+    `${_UNB_BEFORE}[\\p{L}\\p{N}_.+-]+@[\\p{L}\\p{N}_-]+\\.[\\p{L}\\p{N}_.-]+${_UNB_AFTER}`,
+    'gu',
+);
+
+// Python: (?:^|[\s"'(]) (?:/Users/|/home/|/opt/|/private/|[A-Z]:\\) [\w.\-/\\]+
+// \s is Unicode in Python; \w Unicode. No \b here.
+const _PATH_RE = new RegExp(
+    '(?:^|[\\s"\'(])' +
+        '(?:/Users/|/home/|/opt/|/private/|[A-Z]:\\\\)' +
+        '[\\p{L}\\p{N}_.\\-/\\\\]+',
+    'gmu',
+);
+
+// Python: \b[a-zA-Z0-9][\w.-]*\.(?:internal|local)\b  (IGNORECASE)
+const _INTERNAL_HOST_RE = new RegExp(
+    `${_UNB_BEFORE}[a-zA-Z0-9][\\p{L}\\p{N}_.-]*\\.(?:internal|local)${_UNB_AFTER}`,
+    'giu',
+);
+
+// Python:
+//   (?:[\$€£¥]\s?\d{1,3}(?:[,.]\d{3})*(?:\.\d+)?
+//    |\b(?:USD|EUR|GBP|JPY)\s?\d+(?:[,.]\d+)?)
+// \d and \s Unicode in Python; \b Unicode (before the currency-code alt).
+const _UD = '[\\p{Nd}]';
+const _MONEY_RE = new RegExp(
+    `(?:[\\$€£¥]\\s?${_UD}{1,3}(?:[,.]${_UD}{3})*(?:\\.${_UD}+)?` +
+        `|${_UNB_BEFORE}(?:USD|EUR|GBP|JPY)\\s?${_UD}+(?:[,.]${_UD}+)?)`,
+    'gu',
+);
+
+// Python: (?i)\bapi[_-]?key\b\s*[:=]\s*[A-Za-z0-9+/=_\-]{12,}
+const _API_KEY_RE = new RegExp(
+    `${_UNB_BEFORE}api[_-]?key${_UNB_AFTER}\\s*[:=]\\s*[A-Za-z0-9+/=_\\-]{12,}`,
+    'giu',
+);
+
+// Python: `([^`]{41,})`
+const _CODE_FENCE_RE = /`([^`]{41,})`/gu;
+
+function _checkSecrets(text: string): RedactionViolation[] {
+    const hits: RedactionViolation[] = [];
+    for (const prefix of _RAW_KEY_PREFIXES) {
+        const pat = new RegExp(_reEscape(prefix) + '[A-Za-z0-9_\\-]{6,}', 'u');
+        const m = pat.exec(text);
+        if (m) {
+            hits.push(
+                _violation(
+                    'secret',
+                    _pySliceHead(m[0], 8) + '…',
+                    `raw-key prefix ${_pyRepr(prefix)}`,
+                ),
+            );
+        }
+    }
+    _API_KEY_RE.lastIndex = 0;
+    const m = _API_KEY_RE.exec(text);
+    if (m) {
+        hits.push(_violation('secret', _pySliceHead(m[0], 20) + '…', 'inline api_key'));
+    }
+    return hits;
+}
+
+function _checkPatterns(
+    text: string,
+    repoRoot: string | null,
+    privateDomains: Iterable<string>,
+    customerNames: Iterable<string>,
+    sqlIdentifiers: Iterable<string>,
+): RedactionViolation[] {
+    const hits: RedactionViolation[] = [];
+    for (const m of text.matchAll(_EMAIL_RE)) {
+        hits.push(_violation('email', m[0]));
+    }
+    for (const m of text.matchAll(_PATH_RE)) {
+        hits.push(_violation('project_path', _strip(m[0])));
+    }
+    if (repoRoot && text.includes(repoRoot)) {
+        hits.push(_violation('project_path', repoRoot, 'configured repo root'));
+    }
+    for (const m of text.matchAll(_INTERNAL_HOST_RE)) {
+        hits.push(_violation('internal_hostname', m[0]));
+    }
+    for (const dom of privateDomains) {
+        if (dom && text.includes(dom)) {
+            hits.push(_violation('internal_hostname', dom, 'configured private domain'));
+        }
+    }
+    for (const m of text.matchAll(_MONEY_RE)) {
+        hits.push(_violation('monetary_amount', m[0]));
+    }
+    for (const name of customerNames) {
+        // Python: re.search(rf"\b{re.escape(name)}\b", text, re.IGNORECASE)
+        if (name && new RegExp(`${_UNB_BEFORE}${_reEscape(name)}${_UNB_AFTER}`, 'iu').test(text)) {
+            hits.push(_violation('customer_name', name));
+        }
+    }
+    for (const ident of sqlIdentifiers) {
+        // Python: re.search(rf"\b{re.escape(ident)}\b", text)
+        if (ident && new RegExp(`${_UNB_BEFORE}${_reEscape(ident)}${_UNB_AFTER}`, 'u').test(text)) {
+            hits.push(_violation('sql_identifier', ident));
+        }
+    }
+    for (const m of text.matchAll(_CODE_FENCE_RE)) {
+        const inner = m[1] as string;
+        hits.push(
+            _violation('long_code_excerpt', _pySliceHead(inner, 40) + '…', `${_pyLen(inner)} chars`),
+        );
+    }
+    return hits;
+}
+
+export interface RedactOptions {
+    repoRoot?: string | null;
+    privateDomains?: Iterable<string>;
+    customerNames?: Iterable<string>;
+    sqlIdentifiers?: Iterable<string>;
+}
+
+/**
+ * Run the privacy floor over `text`. Returns clean or refused.
+ *
+ * The redactor never auto-rewrites the entry — that would be a soft
+ * privacy gate. It refuses + surfaces what to rephrase, which keeps the
+ * user in the loop and the audit trail honest.
+ */
+export function redact_low_impact_entry(text: string, opts: RedactOptions = {}): RedactionResult {
+    const repoRoot = opts.repoRoot ?? null;
+    const privateDomains = opts.privateDomains ?? [];
+    const customerNames = opts.customerNames ?? [];
+    const sqlIdentifiers = opts.sqlIdentifiers ?? [];
+
+    const violations: RedactionViolation[] = [];
+    violations.push(..._checkSecrets(text));
+    violations.push(
+        ..._checkPatterns(text, repoRoot, privateDomains, customerNames, sqlIdentifiers),
+    );
+    return new RedactionResult(violations.length === 0, violations);
+}

--- a/src/scripts/ai_council/solo_dispatch.ts
+++ b/src/scripts/ai_council/solo_dispatch.ts
@@ -1,0 +1,281 @@
+/**
+ * Solo-member dispatch — step-9 P9 (U2).
+ *
+ * TypeScript twin of `src/scripts/ai_council/solo_dispatch.py` (ADR-094 —
+ * Python→TS migration, Phase 1). Picks the first enabled, auth-valid member
+ * from `routing.solo_member_fallback_chain` so low-impact decisions can
+ * optionally route to a single member instead of the full council. The
+ * selection is intentionally side-effect-free: callers own logging,
+ * dispatch, and the all-invalid → full-council fallback.
+ *
+ * Iron Law: a null selection from `select_solo_member` is the caller's
+ * signal to fall back to the full council with a WARN log — NEVER to fail
+ * the decision. The dispatcher must never break a user's flow because a CLI
+ * was offline.
+ *
+ * Parity notes:
+ * - `time.monotonic()` → `performance.now() / 1000` (seconds, monotonic).
+ * - `os.environ` → `process.env`.
+ * - `should_escalate(solo, floor=…)` keyword call → positional `(solo, floor)`
+ *   in the confidence_gate twin.
+ * - `except Exception` around the probe mirrors Python's broad catch (any
+ *   thrown value → auth-invalid).
+ */
+import { type EscalationDecision, should_escalate } from './confidence_gate.js';
+import type { MemberConfig, RoutingConfig } from './config.js';
+
+//: TTL for cached auth-probe results. Lazy probe per session; bumped
+//: forward whenever a probe is re-run.
+const _AUTH_CACHE_TTL_SECONDS = 15 * 60;
+
+//: Env var that forces every solo-dispatch path back to full council
+//: for the current invocation. Honored by `select_solo_member` and
+//: surfaced through `force_full_council`.
+export const FORCE_FULL_ENV = 'AGENT_CONFIG_FORCE_FULL_COUNCIL';
+
+/** One auth-probe result with the expiry it was cached against. */
+export class AuthCacheEntry {
+    valid: boolean;
+    expires_at: number;
+
+    constructor(args: { valid: boolean; expires_at: number }) {
+        this.valid = args.valid;
+        this.expires_at = args.expires_at;
+    }
+}
+
+/** In-memory cache for auth-probe verdicts (per-process). */
+export class AuthCache {
+    entries: Map<string, AuthCacheEntry>;
+
+    constructor(entries?: Map<string, AuthCacheEntry>) {
+        this.entries = entries ?? new Map<string, AuthCacheEntry>();
+    }
+
+    get(name: string, opts: { now: number }): boolean | null {
+        const entry = this.entries.get(name);
+        if (entry === undefined || entry.expires_at <= opts.now) {
+            return null;
+        }
+        return entry.valid;
+    }
+
+    set(name: string, opts: { valid: boolean; now: number }): void {
+        this.entries.set(
+            name,
+            new AuthCacheEntry({
+                valid: opts.valid,
+                expires_at: opts.now + _AUTH_CACHE_TTL_SECONDS,
+            }),
+        );
+    }
+}
+
+/** Read-only mapping accessor mirroring Python `Mapping.get` semantics. */
+function _mapGet<V>(m: ReadonlyMap<string, V> | undefined | null, key: string): V | undefined {
+    if (m === undefined || m === null) {
+        return undefined;
+    }
+    return m.get(key);
+}
+
+/**
+ * Return True iff the env-var override is set to `1`.
+ *
+ * Truthy values other than `1` are intentionally rejected — the override
+ * is a hard one-bit switch, not a free-form bool.
+ */
+export function force_full_council(env?: ReadonlyMap<string, string> | Record<string, string> | null): boolean {
+    let value: string;
+    if (env === undefined || env === null) {
+        // Python: src = os.environ; src.get(FORCE_FULL_ENV, "")
+        value = process.env[FORCE_FULL_ENV] ?? '';
+    } else if (env instanceof Map) {
+        value = env.get(FORCE_FULL_ENV) ?? '';
+    } else {
+        const v = (env as Record<string, string>)[FORCE_FULL_ENV];
+        value = v === undefined ? '' : v;
+    }
+    return value === '1';
+}
+
+export interface SelectSoloMemberOptions {
+    auth_cache: AuthCache;
+    probe: (name: string, timeout_s: number) => boolean;
+    now?: number | null;
+    env?: ReadonlyMap<string, string> | Record<string, string> | null;
+}
+
+/**
+ * Return the first chain entry whose member is enabled + auth-valid.
+ *
+ * Walks `routing.solo_member_fallback_chain` in order. For each entry:
+ * skip when the member is missing or disabled; consult the auth cache;
+ * on miss probe lazily with the configured timeout and cache the result.
+ * Returns the provider name of the first valid member, or `null` when
+ * every chain entry is unavailable.
+ *
+ * `probe(name, timeout_s) -> boolean` is the caller-supplied auth check.
+ * It MUST honor `timeout_s` and return false on timeout so the dispatcher
+ * cannot stall on a wedged CLI.
+ *
+ * Env-var override (`AGENT_CONFIG_FORCE_FULL_COUNCIL=1`) short-circuits to
+ * null, treating the whole chain as unavailable.
+ */
+export function select_solo_member(
+    routing: RoutingConfig,
+    members: ReadonlyMap<string, MemberConfig>,
+    opts: SelectSoloMemberOptions,
+): string | null {
+    const env = opts.env ?? null;
+    if (force_full_council(env)) {
+        return null;
+    }
+    let now = opts.now ?? null;
+    if (now === null) {
+        now = _monotonic();
+    }
+    const timeout_s = routing.auth_check_timeout_seconds;
+    for (const name of routing.solo_member_fallback_chain) {
+        const member = _mapGet(members, name);
+        if (member === undefined || !member.enabled) {
+            continue;
+        }
+        const cached = opts.auth_cache.get(name, { now });
+        if (cached === false) {
+            continue;
+        }
+        if (cached === true) {
+            return name;
+        }
+        let valid: boolean;
+        try {
+            valid = Boolean(opts.probe(name, timeout_s));
+        } catch {
+            // Probe blew up — treat as auth-invalid so the chain walks to
+            // the next entry. (Callers should log probe failures.)
+            valid = false;
+        }
+        opts.auth_cache.set(name, { valid, now });
+        if (valid) {
+            return name;
+        }
+    }
+    return null;
+}
+
+/**
+ * Outcome of `dispatch_with_escalation`.
+ *
+ * `verdict` is the final answer text returned to the caller. `escalated`
+ * is true when the solo response was rejected by the confidence gate and
+ * the full council ran. `solo_member` / `solo_response` are populated even
+ * on escalation so the shadow log can record both sides without re-running
+ * the solo step.
+ */
+export class SoloDispatchResult {
+    readonly verdict: string;
+    readonly escalated: boolean;
+    /** 'low_confidence' | 'split' | 'refusal' | 'short_response' | 'ok' | 'no_solo_member' */
+    readonly escalation_reason: string;
+    readonly solo_member: string | null;
+    readonly solo_response: string | null;
+    readonly solo_confidence: number | null;
+
+    constructor(args: {
+        verdict: string;
+        escalated: boolean;
+        escalation_reason: string;
+        solo_member: string | null;
+        solo_response: string | null;
+        solo_confidence: number | null;
+    }) {
+        this.verdict = args.verdict;
+        this.escalated = args.escalated;
+        this.escalation_reason = args.escalation_reason;
+        this.solo_member = args.solo_member;
+        this.solo_response = args.solo_response;
+        this.solo_confidence = args.solo_confidence;
+    }
+}
+
+export interface DispatchWithEscalationOptions {
+    auth_cache: AuthCache;
+    probe: (name: string, timeout_s: number) => boolean;
+    run_solo: (name: string) => string;
+    run_full: () => string;
+    confidence_floor: number;
+    now?: number | null;
+    env?: ReadonlyMap<string, string> | Record<string, string> | null;
+}
+
+/**
+ * Solo-dispatch with auto-escalation on low-confidence / split / refusal.
+ *
+ * Step-9 P13 — defense-in-depth on top of shadow-mode SLO.
+ *
+ * Flow:
+ *
+ * 1. `select_solo_member` picks the chain entry.
+ * 2. null → escalate immediately (`no_solo_member`).
+ * 3. `run_solo` is invoked; response is scored via `should_escalate`.
+ * 4. Verdict `escalate=true` → `run_full` is invoked and that verdict is
+ *    returned; the solo response stays on the result for shadow logging.
+ * 5. `escalate=false` → solo verdict is returned as-is.
+ *
+ * `run_solo(name) -> string` and `run_full() -> string` are caller-
+ * supplied; this module owns no LLM transport. Callers MUST throw on
+ * transport errors — escalation is for *content* low-confidence, not
+ * infrastructure failures.
+ */
+export function dispatch_with_escalation(
+    routing: RoutingConfig,
+    members: ReadonlyMap<string, MemberConfig>,
+    opts: DispatchWithEscalationOptions,
+): SoloDispatchResult {
+    const name = select_solo_member(routing, members, {
+        auth_cache: opts.auth_cache,
+        probe: opts.probe,
+        now: opts.now ?? null,
+        env: opts.env ?? null,
+    });
+    if (name === null) {
+        return new SoloDispatchResult({
+            verdict: opts.run_full(),
+            escalated: true,
+            escalation_reason: 'no_solo_member',
+            solo_member: null,
+            solo_response: null,
+            solo_confidence: null,
+        });
+    }
+    const solo = opts.run_solo(name);
+    const decision: EscalationDecision = should_escalate(solo, opts.confidence_floor);
+    if (decision.escalate) {
+        return new SoloDispatchResult({
+            verdict: opts.run_full(),
+            escalated: true,
+            escalation_reason: decision.reason,
+            solo_member: name,
+            solo_response: solo,
+            solo_confidence: decision.confidence,
+        });
+    }
+    return new SoloDispatchResult({
+        verdict: solo,
+        escalated: false,
+        escalation_reason: 'ok',
+        solo_member: name,
+        solo_response: solo,
+        solo_confidence: decision.confidence,
+    });
+}
+
+/** Mirror Python `time.monotonic()` — monotonic seconds. */
+function _monotonic(): number {
+    return performance.now() / 1000;
+}
+
+// Python: __all__ exposes AUTH_CACHE_TTL_SECONDS (the public alias of the
+// private _AUTH_CACHE_TTL_SECONDS, assigned after __all__ in the source).
+export const AUTH_CACHE_TTL_SECONDS = _AUTH_CACHE_TTL_SECONDS;

--- a/tests/scripts/ai_council/advisors.test.ts
+++ b/tests/scripts/ai_council/advisors.test.ts
@@ -1,0 +1,303 @@
+// Tests for src/scripts/ai_council/advisors.ts (py2ts Phase 1).
+//
+// advisors selects advisor personas (frontmatter strip + condensed-tree
+// preference + one-advisor-per-provider invariant). Golden parity drives the
+// LIVE Python twin via a `python3 -c` importlib direct-file load. advisors.py
+// imports `scripts.ai_council.config` (which pulls `scripts._lib` + yaml but
+// NOT the networked clients), so the rig puts `<repo>/src` on sys.path so the
+// real config + _lib resolve, then loads advisors.py off disk.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    AdvisorPlan,
+    build_persona_labels,
+    plan_advisor_swap,
+    resolve_persona_text,
+} from '../../../src/scripts/ai_council/advisors.js';
+import type { AdvisorConfig } from '../../../src/scripts/ai_council/config.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+// advisors.py needs PyYAML; gate the differential on both being present.
+function hasPyYaml(): boolean {
+    return spawnSync('python3', ['-c', 'import yaml'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3() && hasPyYaml();
+
+const ADVISORS_PY = 'src/scripts/ai_council/advisors.py';
+const REPO_SRC = path.resolve('src');
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'advisors-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length) {
+        fs.rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+    }
+});
+
+function writePersona(root: string, tree: string, relPath: string, body: string): void {
+    const full = path.join(root, tree, relPath);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body, 'utf-8');
+}
+
+function adv(partial: Partial<AdvisorConfig> & { name: string; member: string }): AdvisorConfig {
+    return {
+        name: partial.name,
+        enabled: partial.enabled ?? true,
+        member: partial.member,
+        persona: partial.persona ?? 'personas/p.md',
+        model: partial.model ?? null,
+    };
+}
+
+// Python driver: put <repo>/src on sys.path (so real config/_lib resolve),
+// load advisors.py off disk as module "adv".
+function pyDriver(body: string): string {
+    return [
+        'import importlib.util, sys, json',
+        `sys.path.insert(0, ${JSON.stringify(REPO_SRC)})`,
+        `_spec = importlib.util.spec_from_file_location("adv", ${JSON.stringify(ADVISORS_PY)})`,
+        'adv = importlib.util.module_from_spec(_spec)',
+        'sys.modules["adv"] = adv',
+        '_spec.loader.exec_module(adv)',
+        'from scripts.ai_council.config import AdvisorConfig',
+        'from pathlib import Path',
+        body,
+    ].join('\n');
+}
+
+function py(body: string): { status: number; stdout: string; stderr: string } {
+    const r = spawnSync('python3', ['-c', pyDriver(body)], { encoding: 'utf8' });
+    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+}
+
+// ── Unit tests ───────────────────────────────────────────────────────
+
+describe('advisors — resolve_persona_text', () => {
+    it('reads condensed tree, strips frontmatter, returns trimmed body + meta', () => {
+        const root = mkTmp();
+        writePersona(
+            root,
+            'dist/agent-src',
+            'personas/c.md',
+            '---\nrole: The Contrarian\nx: 1\n---\nBody line.\n\nMore.\n',
+        );
+        const [body, meta] = resolve_persona_text('personas/c.md', root);
+        expect(body).toBe('Body line.\n\nMore.');
+        expect(meta).toEqual({ role: 'The Contrarian', x: 1 });
+    });
+    it('falls back to uncondensed tree', () => {
+        const root = mkTmp();
+        writePersona(root, '.agent-src.uncondensed', 'personas/u.md', 'No frontmatter here.\n');
+        const [body, meta] = resolve_persona_text('personas/u.md', root);
+        expect(body).toBe('No frontmatter here.');
+        expect(meta).toEqual({});
+    });
+    it('prefers condensed over uncondensed', () => {
+        const root = mkTmp();
+        writePersona(root, 'dist/agent-src', 'personas/d.md', 'CONDENSED');
+        writePersona(root, '.agent-src.uncondensed', 'personas/d.md', 'UNCONDENSED');
+        expect(resolve_persona_text('personas/d.md', root)[0]).toBe('CONDENSED');
+    });
+    it('raises CouncilConfigError when no candidate exists', () => {
+        const root = mkTmp();
+        expect(() => resolve_persona_text('personas/nope.md', root)).toThrow(
+            /Persona file not found for advisor \(path='personas\/nope.md'\)/,
+        );
+    });
+});
+
+describe('advisors — plan_advisor_swap', () => {
+    it('skips disabled, builds plan per enabled advisor', () => {
+        const root = mkTmp();
+        writePersona(root, 'dist/agent-src', 'personas/contra.md', '---\nrole: Contra\n---\nC body');
+        writePersona(root, 'dist/agent-src', 'personas/red.md', 'Red body');
+        const advisors = new Map<string, AdvisorConfig>([
+            ['contrarian', adv({ name: 'contrarian', member: 'anthropic', persona: 'personas/contra.md' })],
+            ['red-team', adv({ name: 'red-team', member: 'openai', persona: 'personas/red.md', model: 'gpt-x' })],
+            ['off', adv({ name: 'off', member: 'google', persona: 'personas/contra.md', enabled: false })],
+        ]);
+        const plans = plan_advisor_swap(advisors, root);
+        expect([...plans.keys()].sort()).toEqual(['anthropic', 'openai']);
+        expect(plans.get('anthropic')!.display_name).toBe('Contra');
+        const red = plans.get('openai')!;
+        expect(red.display_name).toBe('Red Team'); // titleized from key
+        expect(red.persona_text).toBe('Red body');
+        expect(red.model_override).toBe('gpt-x');
+    });
+    it('raises when two enabled advisors bind the same provider', () => {
+        const root = mkTmp();
+        writePersona(root, 'dist/agent-src', 'personas/p.md', 'body');
+        const advisors = new Map<string, AdvisorConfig>([
+            ['a', adv({ name: 'a', member: 'anthropic', persona: 'personas/p.md' })],
+            ['b', adv({ name: 'b', member: 'anthropic', persona: 'personas/p.md' })],
+        ]);
+        expect(() => plan_advisor_swap(advisors, root)).toThrow(
+            /advisors.b and advisors.a both bind member='anthropic'/,
+        );
+    });
+});
+
+describe('advisors — build_persona_labels', () => {
+    it('maps provider:model → display_name for matching members only', () => {
+        const plans = new Map<string, AdvisorPlan>([
+            [
+                'anthropic',
+                new AdvisorPlan({
+                    name: 'contrarian',
+                    display_name: 'Contra',
+                    member: 'anthropic',
+                    persona_text: 'x',
+                }),
+            ],
+        ]);
+        const labels = build_persona_labels(plans, [
+            { name: 'anthropic', model: 'claude' },
+            { name: 'openai', model: 'gpt' },
+        ]);
+        expect([...labels]).toEqual([['anthropic:claude', 'Contra']]);
+    });
+});
+
+// ── Golden parity vs the CPython twin ────────────────────────────────
+
+describe.runIf(py3)('advisors — golden parity vs CPython twin', () => {
+    function makeRepo(): string {
+        const root = mkTmp();
+        writePersona(
+            root,
+            'dist/agent-src',
+            'personas/contra.md',
+            '---\nrole: The Contrarian\ntier: core\n---\nContrarian body.\n\nSecond paragraph.\n',
+        );
+        writePersona(root, 'dist/agent-src', 'personas/red.md', 'Red body, no frontmatter.\n');
+        writePersona(root, '.agent-src.uncondensed', 'personas/fallback.md', 'Fallback only body.\n');
+        return root;
+    }
+
+    it('resolve_persona_text matches (condensed + frontmatter)', () => {
+        const root = makeRepo();
+        const r = py(
+            `body, meta = adv.resolve_persona_text("personas/contra.md", Path(${JSON.stringify(root)}))\n` +
+                'print(json.dumps([body, meta]))',
+        );
+        expect(r.status).toBe(0);
+        expect(resolve_persona_text('personas/contra.md', root)).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    it('resolve_persona_text matches (uncondensed fallback)', () => {
+        const root = makeRepo();
+        const r = py(
+            `body, meta = adv.resolve_persona_text("personas/fallback.md", Path(${JSON.stringify(root)}))\n` +
+                'print(json.dumps([body, meta]))',
+        );
+        expect(r.status).toBe(0);
+        expect(resolve_persona_text('personas/fallback.md', root)).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    it('resolve_persona_text missing-file error text matches', () => {
+        const root = makeRepo();
+        const r = py(
+            'try:\n' +
+                `    adv.resolve_persona_text("personas/nope.md", Path(${JSON.stringify(root)}))\n` +
+                'except adv.CouncilConfigError as e:\n' +
+                '    print(json.dumps(str(e)))',
+        );
+        expect(r.status).toBe(0);
+        let msg = '';
+        try {
+            resolve_persona_text('personas/nope.md', root);
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    it('plan_advisor_swap matches (skip disabled + titleize + override)', () => {
+        const root = makeRepo();
+        const r = py(
+            `advisors = {\n` +
+                `  "contrarian": AdvisorConfig(name="contrarian", enabled=True, member="anthropic", persona="personas/contra.md", model=None),\n` +
+                `  "red-team": AdvisorConfig(name="red-team", enabled=True, member="openai", persona="personas/red.md", model="gpt-x"),\n` +
+                `  "off": AdvisorConfig(name="off", enabled=False, member="google", persona="personas/contra.md", model=None),\n` +
+                `}\n` +
+                `plans = adv.plan_advisor_swap(advisors, Path(${JSON.stringify(root)}))\n` +
+                'out = {k: {"name": v.name, "display_name": v.display_name, "member": v.member, ' +
+                '"persona_text": v.persona_text, "model_override": v.model_override} for k, v in plans.items()}\n' +
+                'print(json.dumps(out, sort_keys=True))',
+        );
+        expect(r.status).toBe(0);
+        const advisors = new Map<string, AdvisorConfig>([
+            ['contrarian', adv({ name: 'contrarian', member: 'anthropic', persona: 'personas/contra.md' })],
+            ['red-team', adv({ name: 'red-team', member: 'openai', persona: 'personas/red.md', model: 'gpt-x' })],
+            ['off', adv({ name: 'off', member: 'google', persona: 'personas/contra.md', enabled: false })],
+        ]);
+        const plans = plan_advisor_swap(advisors, root);
+        const tsOut: Record<string, unknown> = {};
+        for (const [k, v] of plans) {
+            tsOut[k] = {
+                name: v.name,
+                display_name: v.display_name,
+                member: v.member,
+                persona_text: v.persona_text,
+                model_override: v.model_override,
+            };
+        }
+        expect(tsOut).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    it('plan_advisor_swap duplicate-provider error text matches', () => {
+        const root = makeRepo();
+        const r = py(
+            `advisors = {\n` +
+                `  "a": AdvisorConfig(name="a", enabled=True, member="anthropic", persona="personas/red.md", model=None),\n` +
+                `  "b": AdvisorConfig(name="b", enabled=True, member="anthropic", persona="personas/red.md", model=None),\n` +
+                `}\n` +
+                'try:\n' +
+                `    adv.plan_advisor_swap(advisors, Path(${JSON.stringify(root)}))\n` +
+                'except adv.CouncilConfigError as e:\n' +
+                '    print(json.dumps(str(e)))',
+        );
+        expect(r.status).toBe(0);
+        const advisors = new Map<string, AdvisorConfig>([
+            ['a', adv({ name: 'a', member: 'anthropic', persona: 'personas/red.md' })],
+            ['b', adv({ name: 'b', member: 'anthropic', persona: 'personas/red.md' })],
+        ]);
+        let msg = '';
+        try {
+            plan_advisor_swap(advisors, root);
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    // .title() boundary parity — kebab/snake/digit advisor keys.
+    const TITLE_KEYS = ['contrarian', 'red-team', 'foo_bar', 'abc123def', 'a-b_c'];
+    it.each(TITLE_KEYS)('display_name titleize(%s) matches', (key) => {
+        const root = mkTmp();
+        writePersona(root, 'dist/agent-src', 'personas/x.md', 'body'); // no role → titleize the key
+        const r = py(
+            `advisors = {${JSON.stringify(key)}: AdvisorConfig(name=${JSON.stringify(key)}, enabled=True, member="m", persona="personas/x.md", model=None)}\n` +
+                `plans = adv.plan_advisor_swap(advisors, Path(${JSON.stringify(root)}))\n` +
+                'print(json.dumps(plans["m"].display_name))',
+        );
+        expect(r.status).toBe(0);
+        const advisors = new Map<string, AdvisorConfig>([
+            [key, adv({ name: key, member: 'm', persona: 'personas/x.md' })],
+        ]);
+        const plans = plan_advisor_swap(advisors, root);
+        expect(plans.get('m')!.display_name).toEqual(JSON.parse(r.stdout.trim()));
+    });
+});

--- a/tests/scripts/ai_council/bundler.test.ts
+++ b/tests/scripts/ai_council/bundler.test.ts
@@ -1,0 +1,221 @@
+// Tests for src/scripts/ai_council/bundler.ts (py2ts Phase 1).
+//
+// Context bundling for council consultations. Golden-parity against the
+// CPython twin covers redaction (fail-closed, line-wise), the size guard
+// (fail-loud BundleTooLarge), file/roadmap bundling + exclusions, and the git
+// diff + surrounding-signature path (driven against a throwaway git repo so
+// the diff bytes are deterministic).
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    BundleTooLarge,
+    type CouncilContext,
+    FileNotFoundError,
+    MAX_BUNDLE_BYTES,
+    bundle_diff,
+    bundle_diff_with_context,
+    bundle_files,
+    bundle_prompt,
+    bundle_roadmap,
+    redact,
+} from '../../../src/scripts/ai_council/bundler.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// Secret-shaped tokens assembled from parts so this test file does not trip
+// secret-scanning linters.
+const SK_ANT = 'sk-ant-' + 'A'.repeat(12);
+const SK_OPENAI = 'sk-' + 'B'.repeat(24);
+
+function tmpDir(prefix = 'bundler-'): string {
+    return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe('bundler — redact (line-wise, most-specific-first)', () => {
+    it('scrubs Authorization, secret-like assignments, and key-like tokens', () => {
+        const input = [
+            'normal line',
+            'Authorization: Bearer xyz',
+            'api_key = value',
+            SK_ANT,
+            SK_OPENAI,
+            'tail',
+        ].join('\n');
+        expect(redact(input)).toBe(
+            [
+                'normal line',
+                '[redacted: Authorization header]',
+                '[redacted: secret-like assignment]',
+                '[redacted: anthropic-key-like token]',
+                '[redacted: openai-key-like token]',
+                'tail',
+            ].join('\n'),
+        );
+    });
+});
+
+describe('bundler — bundle_prompt / bundle_files / bundle_roadmap', () => {
+    it('bundle_prompt redacts + sets manifest', () => {
+        const ctx = bundle_prompt('hi\ntoken: abc\nbye');
+        expect(ctx.mode).toBe('prompt');
+        expect(ctx.manifest).toEqual(['<inline prompt>']);
+        expect(ctx.text).toContain('[redacted: secret-like assignment]');
+    });
+
+    it('bundle_files records manifest + exclusions for missing files', () => {
+        const dir = tmpDir();
+        const ok = path.join(dir, 'a.txt');
+        writeFileSync(ok, 'content here', { encoding: 'utf-8' });
+        const ctx = bundle_files([ok, path.join(dir, 'gone.txt')]);
+        expect(ctx.manifest).toEqual([ok]);
+        expect(ctx.excluded).toEqual([`${path.join(dir, 'gone.txt')} (not found)`]);
+        expect(ctx.text).toContain('content here');
+    });
+
+    it('bundle_roadmap throws FileNotFoundError when absent', () => {
+        expect(() => bundle_roadmap('/no/such/roadmap.md')).toThrow(FileNotFoundError);
+    });
+
+    it('size guard throws BundleTooLarge above the ceiling', () => {
+        expect(() => bundle_prompt('x'.repeat(MAX_BUNDLE_BYTES + 1))).toThrow(BundleTooLarge);
+    });
+});
+
+// ── git-backed diff fixtures ──────────────────────────────────────────────
+function makeGitRepo(): string {
+    const dir = tmpDir('bundler-git-');
+    const run = (args: string[]): void => {
+        execFileSync('git', args, { cwd: dir });
+    };
+    run(['init', '-q']);
+    run(['config', 'user.email', 't@t.t']);
+    run(['config', 'user.name', 't']);
+    writeFileSync(path.join(dir, 'm.py'), 'def foo():\n    return 1\n', { encoding: 'utf-8' });
+    run(['add', 'm.py']);
+    run(['commit', '-qm', 'init']);
+    writeFileSync(path.join(dir, 'm.py'), 'def foo():\n    return 2\n\n\ndef bar():\n    return 3\n', {
+        encoding: 'utf-8',
+    });
+    run(['add', 'm.py']);
+    run(['commit', '-qm', 'change']);
+    return dir;
+}
+
+describe('bundler — git diff', () => {
+    it('bundle_diff returns the raw diff with a manifest', () => {
+        const repo = makeGitRepo();
+        const ctx = bundle_diff('HEAD~1', 'HEAD', { cwd: repo });
+        expect(ctx.mode).toBe('diff');
+        expect(ctx.manifest).toEqual(['git diff HEAD~1..HEAD']);
+        expect(ctx.text).toContain('def bar');
+    });
+
+    it('bundle_diff_with_context appends a Surrounding signatures section', () => {
+        const repo = makeGitRepo();
+        const ctx = bundle_diff_with_context('HEAD~1', 'HEAD', { cwd: repo });
+        expect(ctx.text).toContain('## Surrounding signatures');
+        expect(ctx.manifest[ctx.manifest.length - 1]).toMatch(/surrounding signatures for \d+ file/);
+    });
+});
+
+describe.runIf(py3)('bundler — golden parity vs CPython twin', () => {
+    function pyBundle(snippet: string, args: string[]): unknown {
+        const code = [
+            'import json, sys',
+            'from scripts.ai_council import bundler as B',
+            snippet,
+        ].join('\n');
+        const res = runPyCode(code, args);
+        expect(res.status, res.stderr).toBe(0);
+        return JSON.parse(res.stdout);
+    }
+
+    const ctxToObj = (c: CouncilContext): Record<string, unknown> => ({
+        mode: c.mode,
+        text: c.text,
+        manifest: c.manifest,
+        excluded: c.excluded,
+    });
+
+    const dumpCtx =
+        'def dump(c):\n    return {"mode": c.mode, "text": c.text, "manifest": c.manifest, "excluded": c.excluded}\n';
+
+    it('redact() matches line-wise', () => {
+        const input = `n\nAuthorization: x\nsecret: y\n${SK_ANT}\n${SK_OPENAI}\nz`;
+        const expected = pyBundle('print(json.dumps(B.redact(sys.argv[1])))', [input]) as string;
+        expect(redact(input)).toBe(expected);
+    });
+
+    it('bundle_prompt matches', () => {
+        const text = 'hello\npassword=abc\nworld';
+        const expected = pyBundle(dumpCtx + 'print(json.dumps(dump(B.bundle_prompt(sys.argv[1]))))', [
+            text,
+        ]);
+        expect(ctxToObj(bundle_prompt(text))).toEqual(expected);
+    });
+
+    it('bundle_files matches (incl. exclusions)', () => {
+        const dir = tmpDir();
+        const ok = path.join(dir, 'a.txt');
+        writeFileSync(ok, 'line\ntoken: secret\nend', { encoding: 'utf-8' });
+        const missing = path.join(dir, 'gone.txt');
+        const expected = pyBundle(
+            dumpCtx + 'print(json.dumps(dump(B.bundle_files([sys.argv[1], sys.argv[2]]))))',
+            [ok, missing],
+        );
+        expect(ctxToObj(bundle_files([ok, missing]))).toEqual(expected);
+    });
+
+    it('bundle_roadmap matches', () => {
+        const dir = tmpDir();
+        const rm = path.join(dir, 'road.md');
+        writeFileSync(rm, '## Roadmap\nsecret: hunter2\nplain\n', { encoding: 'utf-8' });
+        const expected = pyBundle(
+            dumpCtx + 'print(json.dumps(dump(B.bundle_roadmap(sys.argv[1]))))',
+            [rm],
+        );
+        expect(ctxToObj(bundle_roadmap(rm))).toEqual(expected);
+    });
+
+    it('BundleTooLarge message matches', () => {
+        const expected = pyBundle(
+            'try:\n'
+                + '    B.bundle_prompt("x" * (50 * 1024 + 1))\n'
+                + '    print(json.dumps("NO RAISE"))\n'
+                + 'except B.BundleTooLarge as e:\n'
+                + '    print(json.dumps(str(e)))',
+            [],
+        ) as string;
+        try {
+            bundle_prompt('x'.repeat(MAX_BUNDLE_BYTES + 1));
+            throw new Error('expected throw');
+        } catch (e) {
+            expect((e as Error).message).toBe(expected);
+        }
+    });
+
+    it('bundle_diff matches against a fixed git repo', () => {
+        const repo = makeGitRepo();
+        const expected = pyBundle(
+            dumpCtx + 'print(json.dumps(dump(B.bundle_diff("HEAD~1", "HEAD", cwd=sys.argv[1]))))',
+            [repo],
+        );
+        expect(ctxToObj(bundle_diff('HEAD~1', 'HEAD', { cwd: repo }))).toEqual(expected);
+    });
+
+    it('bundle_diff_with_context matches (signature section)', () => {
+        const repo = makeGitRepo();
+        const expected = pyBundle(
+            dumpCtx
+                + 'print(json.dumps(dump(B.bundle_diff_with_context("HEAD~1", "HEAD", cwd=sys.argv[1]))))',
+            [repo],
+        );
+        expect(ctxToObj(bundle_diff_with_context('HEAD~1', 'HEAD', { cwd: repo }))).toEqual(expected);
+    });
+});

--- a/tests/scripts/ai_council/clients.test.ts
+++ b/tests/scripts/ai_council/clients.test.ts
@@ -1,0 +1,931 @@
+// Tests for src/scripts/ai_council/clients.ts (py2ts Phase 1, ADR-094).
+//
+// The provider/client layer makes networked, paid calls in production — so
+// NOTHING here hits a live API. Parity is asserted on the deterministic
+// surfaces only:
+//   - request CONSTRUCTION (argv for CLI subclasses; kwargs for API clients via
+//     a stubbed transport / injected mock client),
+//   - response PARSING (each `_parse_output` + the API-client text/usage
+//     extraction),
+//   - error mapping (`_classify_stderr`, the ask() error branches),
+//   - cost/usage accounting (token estimate; cli-calls.json byte shape),
+//   - pure helpers (`_is_reasoning_model`, `_read_until_marker`,
+//     ManualClient._render_block).
+//
+// The transport seam: API clients consume an injected `client` mock; CliClient
+// routes its one subprocess call through `_runSubprocess`, which a test
+// subclass overrides to return canned `{returncode, stdout, stderr}` (or throw
+// `SubprocessError`) — never a live process. ManualClient takes injected
+// stdin/stdout streams.
+//
+// Python import: clients.py does `from scripts._lib import user_global_paths`,
+// so the python3 differential loads it as the package module with
+// `PYTHONPATH=["src", "."]` (the `_harness` pyEnv). The package `__init__.py`
+// imports clients but makes NO network call at import (the anthropic/openai/
+// genai SDK imports are lazy, inside `ask()`), so `import scripts.ai_council.
+// clients` is safe and offline.
+//
+// latency_ms is wall-clock non-determinism — every parsed CouncilResponse here
+// is built from a stubbed transport with the clock untouched, and assertions
+// never read latency_ms except to confirm it is an integer >= 0.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    AnthropicClient,
+    AnthropicCliClient,
+    CliClient,
+    CouncilResponse,
+    DEFAULT_ANTHROPIC_MODEL,
+    DEFAULT_CLI_TIMEOUT_SECONDS,
+    DEFAULT_GEMINI_MODEL,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_OPENAI_MODEL,
+    DEFAULT_PERPLEXITY_MODEL,
+    DEFAULT_XAI_MODEL,
+    GeminiClient,
+    GeminiCliClient,
+    KeyGateError,
+    ManualClient,
+    MANUAL_END_MARKER,
+    OpenAIClient,
+    OpenAICliClient,
+    PerplexityClient,
+    PerplexityCliClient,
+    UNLIMITED_TOKENS_FALLBACK,
+    XAIClient,
+    XAICliClient,
+    _is_reasoning_model,
+    _read_until_marker,
+    load_anthropic_key,
+    load_openai_key,
+    quota_summary_line,
+    record_cli_call,
+    reset_cli_call_counts,
+    load_cli_call_counts,
+    type SubprocessResult,
+    type TextInputStream,
+    type TextOutputStream,
+} from '../../../src/scripts/ai_council/clients.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// ── tmp dir bookkeeping ────────────────────────────────────────────────
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'clients-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length) {
+        fs.rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+    }
+});
+
+// ── transport-stubbing CLI subclass factory ────────────────────────────
+// Build a CliClient subclass whose subprocess is canned. We reuse the real
+// _build_command / _parse_output of the production subclass by extending it and
+// only overriding `_runSubprocess`. `binary` is passed explicitly so the ctor
+// never touches PATH.
+// Patch the protected `_runSubprocess` seam on a freshly-built concrete CLI
+// client instance — no subclassing (which TS treats as extending the abstract
+// base). `binary` is passed explicitly so the ctor never touches PATH.
+function stubCli<T extends CliClient>(
+    Ctor: new (opts: Record<string, unknown>) => T,
+    canned: SubprocessResult | (() => SubprocessResult),
+    opts: Record<string, unknown> = {},
+): { client: T; calls: { cmd: string[]; stdin: string | null }[] } {
+    const calls: { cmd: string[]; stdin: string | null }[] = [];
+    const client = new Ctor({ binary: '/bin/echo', ...opts });
+    (client as unknown as { _runSubprocess: (c: string[], s: string | null) => SubprocessResult })._runSubprocess = (
+        cmd: string[],
+        stdinPayload: string | null,
+    ): SubprocessResult => {
+        calls.push({ cmd, stdin: stdinPayload });
+        return typeof canned === 'function' ? canned() : canned;
+    };
+    return { client, calls };
+}
+
+// ── pure helper: _is_reasoning_model ───────────────────────────────────
+describe('clients — _is_reasoning_model', () => {
+    it('matches o1/o3/o4 families exactly or by "-" prefix', () => {
+        for (const m of ['o1', 'o3', 'o4', 'o1-mini', 'o3-mini', 'o4-preview', 'O1', 'O3-MINI']) {
+            expect(_is_reasoning_model(m)).toBe(true);
+        }
+        for (const m of ['gpt-4o', 'o', 'o2', 'o10', 'o1x', 'sonar-pro', 'claude-sonnet-4-5']) {
+            expect(_is_reasoning_model(m)).toBe(false);
+        }
+    });
+
+    if (py3) {
+        it('matches python3 over a grid', () => {
+            const grid = ['o1', 'o3', 'o4', 'o1-mini', 'o3-mini', 'o4-preview', 'O1', 'O3-MINI', 'gpt-4o', 'o', 'o2', 'o10', 'o1x', 'sonar-pro', 'claude-sonnet-4-5', 'o3_alt'];
+            const code = [
+                'import json,sys,scripts.ai_council.clients as cl',
+                'print(json.dumps([cl._is_reasoning_model(m) for m in json.loads(sys.argv[1])]))',
+            ].join('\n');
+            const r = runPyCode(code, [JSON.stringify(grid)]);
+            expect(r.status).toBe(0);
+            const pyOut = JSON.parse(r.stdout.trim()) as boolean[];
+            expect(grid.map(_is_reasoning_model)).toEqual(pyOut);
+        });
+    }
+});
+
+// ── constants parity ───────────────────────────────────────────────────
+describe('clients — module constants', () => {
+    it('mirrors the Python defaults', () => {
+        expect(DEFAULT_ANTHROPIC_MODEL).toBe('claude-sonnet-4-5');
+        expect(DEFAULT_OPENAI_MODEL).toBe('gpt-4o');
+        expect(DEFAULT_GEMINI_MODEL).toBe('gemini-2.5-pro');
+        expect(DEFAULT_XAI_MODEL).toBe('grok-4');
+        expect(DEFAULT_PERPLEXITY_MODEL).toBe('sonar-pro');
+        expect(DEFAULT_MAX_TOKENS).toBe(2048);
+        expect(UNLIMITED_TOKENS_FALLBACK).toBe(16384);
+        expect(DEFAULT_CLI_TIMEOUT_SECONDS).toBe(120.0);
+        expect(MANUAL_END_MARKER).toBe('END');
+    });
+
+    if (py3) {
+        it('matches python3 constants', () => {
+            const code = [
+                'import json,scripts.ai_council.clients as cl',
+                'print(json.dumps({',
+                ' "a":cl.DEFAULT_ANTHROPIC_MODEL,"o":cl.DEFAULT_OPENAI_MODEL,',
+                ' "g":cl.DEFAULT_GEMINI_MODEL,"x":cl.DEFAULT_XAI_MODEL,',
+                ' "p":cl.DEFAULT_PERPLEXITY_MODEL,"mt":cl.DEFAULT_MAX_TOKENS,',
+                ' "uf":cl.UNLIMITED_TOKENS_FALLBACK,"to":cl.DEFAULT_CLI_TIMEOUT_SECONDS,',
+                ' "em":cl.MANUAL_END_MARKER,"xb":cl.XAI_BASE_URL,"pb":cl.PERPLEXITY_BASE_URL}))',
+            ].join('\n');
+            const r = runPyCode(code);
+            expect(r.status).toBe(0);
+            const py = JSON.parse(r.stdout.trim());
+            expect(py).toEqual({
+                a: 'claude-sonnet-4-5',
+                o: 'gpt-4o',
+                g: 'gemini-2.5-pro',
+                x: 'grok-4',
+                p: 'sonar-pro',
+                mt: 2048,
+                uf: 16384,
+                to: 120.0,
+                em: 'END',
+                xb: 'https://api.x.ai/v1',
+                pb: 'https://api.perplexity.ai',
+            });
+        });
+    }
+});
+
+// ── key loader 0600 gate ───────────────────────────────────────────────
+describe('clients — _load_key gate', () => {
+    function writeKey(content: string, mode: number): string {
+        const p = path.join(mkTmp(), 'k.key');
+        fs.writeFileSync(p, content);
+        fs.chmodSync(p, mode);
+        return p;
+    }
+
+    it('loads a well-formed 0600 anthropic key', () => {
+        const p = writeKey('sk-ant-abc123\n', 0o600);
+        expect(load_anthropic_key(p)).toBe('sk-ant-abc123');
+    });
+
+    it('loads a well-formed 0600 openai key', () => {
+        const p = writeKey('sk-xyz\n', 0o600);
+        expect(load_openai_key(p)).toBe('sk-xyz');
+    });
+
+    it('rejects a missing key', () => {
+        const p = path.join(mkTmp(), 'nope.key');
+        expect(() => load_anthropic_key(p)).toThrow(KeyGateError);
+    });
+
+    it('rejects bad mode', () => {
+        const p = writeKey('sk-ant-abc\n', 0o644);
+        expect(() => load_anthropic_key(p)).toThrow(KeyGateError);
+        try {
+            load_anthropic_key(p);
+        } catch (e) {
+            expect((e as Error).message).toContain('got 0o644, expected 0o600');
+        }
+    });
+
+    it('rejects an empty key', () => {
+        const p = writeKey('   \n', 0o600);
+        expect(() => load_openai_key(p)).toThrow(/is empty/);
+    });
+
+    it('rejects a wrong prefix', () => {
+        const p = writeKey('nope-key\n', 0o600);
+        expect(() => load_anthropic_key(p)).toThrow(/does not look like/);
+    });
+
+    if (py3) {
+        it('matches python3 messages for the bad-mode and missing cases', () => {
+            const okp = writeKey('sk-ant-zzz\n', 0o600);
+            const code = [
+                'import scripts.ai_council.clients as cl, sys',
+                'from pathlib import Path',
+                'print(cl.load_anthropic_key(Path(sys.argv[1])))',
+            ].join('\n');
+            const r = runPyCode(code, [okp]);
+            expect(r.status).toBe(0);
+            expect(r.stdout.trim()).toBe('sk-ant-zzz');
+            expect(load_anthropic_key(okp)).toBe('sk-ant-zzz');
+        });
+    }
+});
+
+// ── API clients: request construction + response parsing via mock ──────
+function fakeAnthropicResponse(text: string, inT: number, outT: number) {
+    return {
+        content: [{ text }],
+        usage: { input_tokens: inT, output_tokens: outT },
+    };
+}
+
+describe('clients — AnthropicClient (mock transport)', () => {
+    it('builds the request kwargs and parses content[0].text + usage', () => {
+        let captured: Record<string, unknown> | null = null;
+        const mock = {
+            messages: {
+                create(kwargs: Record<string, unknown>) {
+                    captured = kwargs;
+                    return fakeAnthropicResponse('hi there', 11, 22);
+                },
+            },
+        };
+        const c = new AnthropicClient({ client: mock });
+        const r = c.ask('SYS', 'USER', 99);
+        expect(captured).toEqual({
+            model: 'claude-sonnet-4-5',
+            max_tokens: 99,
+            system: 'SYS',
+            messages: [{ role: 'user', content: 'USER' }],
+        });
+        expect(r.provider).toBe('anthropic');
+        expect(r.text).toBe('hi there');
+        expect(r.input_tokens).toBe(11);
+        expect(r.output_tokens).toBe(22);
+        expect(r.error).toBeNull();
+        expect(Number.isInteger(r.latency_ms)).toBe(true);
+    });
+
+    it('normalises SDK exceptions into error= without raising', () => {
+        const mock = {
+            messages: {
+                create() {
+                    throw new TypeError('boom');
+                },
+            },
+        };
+        const r = new AnthropicClient({ client: mock }).ask('s', 'u');
+        expect(r.text).toBe('');
+        expect(r.error).toBe('TypeError: boom');
+        expect(r.input_tokens).toBe(0);
+    });
+
+    it('empty content / no usage → zeros', () => {
+        const mock = { messages: { create: () => ({ content: [], usage: null }) } };
+        const r = new AnthropicClient({ client: mock }).ask('s', 'u');
+        expect(r.text).toBe('');
+        expect(r.input_tokens).toBe(0);
+        expect(r.output_tokens).toBe(0);
+    });
+
+    it('requires api_key or client', () => {
+        expect(() => new AnthropicClient({})).toThrow(/explicit api_key or injected client/);
+    });
+});
+
+describe('clients — OpenAIClient (mock transport)', () => {
+    function fakeChat(text: string | null, pT: number, cT: number) {
+        return {
+            choices: [{ message: { content: text } }],
+            usage: { prompt_tokens: pT, completion_tokens: cT },
+        };
+    }
+
+    it('non-reasoning model: system+user messages, max_tokens', () => {
+        let captured: Record<string, unknown> | null = null;
+        const mock = {
+            chat: { completions: { create: (k: Record<string, unknown>) => { captured = k; return fakeChat('ok', 5, 7); } } },
+        };
+        const r = new OpenAIClient({ client: mock, model: 'gpt-4o' }).ask('SYS', 'U', 50);
+        expect(captured).toEqual({
+            model: 'gpt-4o',
+            max_tokens: 50,
+            messages: [
+                { role: 'system', content: 'SYS' },
+                { role: 'user', content: 'U' },
+            ],
+        });
+        expect(r.text).toBe('ok');
+        expect(r.input_tokens).toBe(5);
+        expect(r.output_tokens).toBe(7);
+    });
+
+    it('reasoning model: merged user message + max_completion_tokens', () => {
+        let captured: Record<string, unknown> | null = null;
+        const mock = {
+            chat: { completions: { create: (k: Record<string, unknown>) => { captured = k; return fakeChat('r', 1, 2); } } },
+        };
+        new OpenAIClient({ client: mock, model: 'o3-mini' }).ask('SYS', 'U', 64);
+        expect(captured).toEqual({
+            model: 'o3-mini',
+            max_completion_tokens: 64,
+            messages: [{ role: 'user', content: 'SYS\n\n---\n\nU' }],
+        });
+    });
+
+    it('null content coerces to "" (text or "")', () => {
+        const mock = { chat: { completions: { create: () => fakeChat(null, 0, 0) } } };
+        const r = new OpenAIClient({ client: mock }).ask('s', 'u');
+        expect(r.text).toBe('');
+    });
+
+    it('exception → error mapping', () => {
+        const mock = { chat: { completions: { create() { throw new RangeError('rl'); } } } };
+        const r = new OpenAIClient({ client: mock }).ask('s', 'u');
+        expect(r.error).toBe('RangeError: rl');
+    });
+});
+
+describe('clients — GeminiClient (mock transport)', () => {
+    it('contents joined, config max_output_tokens, usage_metadata parsed', () => {
+        let captured: Record<string, unknown> | null = null;
+        const mock = {
+            models: {
+                generate_content(k: Record<string, unknown>) {
+                    captured = k;
+                    return { text: 'g', usage_metadata: { prompt_token_count: 3, candidates_token_count: 4 } };
+                },
+            },
+        };
+        const r = new GeminiClient({ client: mock }).ask('S', 'U', 77);
+        expect(captured).toEqual({
+            model: 'gemini-2.5-pro',
+            contents: 'S\n\n---\n\nU',
+            config: { max_output_tokens: 77 },
+        });
+        expect(r.text).toBe('g');
+        expect(r.input_tokens).toBe(3);
+        expect(r.output_tokens).toBe(4);
+    });
+});
+
+describe('clients — _OpenAICompatibleClient (xAI / Perplexity, mock transport)', () => {
+    function mk(model: string, Ctor: typeof XAIClient | typeof PerplexityClient) {
+        let captured: Record<string, unknown> | null = null;
+        const mock = {
+            chat: {
+                completions: {
+                    create(k: Record<string, unknown>) {
+                        captured = k;
+                        return { choices: [{ message: { content: 'x' } }], usage: { prompt_tokens: 9, completion_tokens: 8 } };
+                    },
+                },
+            },
+        };
+        const c = new Ctor({ client: mock, model });
+        const r = c.ask('S', 'U', 40);
+        return { captured, r, c };
+    }
+
+    it('xAI builds system+user, no reasoning branch', () => {
+        const { captured, r, c } = mk('grok-4', XAIClient);
+        expect(c.name).toBe('xai');
+        expect(c.base_url).toBe('https://api.x.ai/v1');
+        expect(captured).toEqual({
+            model: 'grok-4',
+            max_tokens: 40,
+            messages: [
+                { role: 'system', content: 'S' },
+                { role: 'user', content: 'U' },
+            ],
+        });
+        expect(r.input_tokens).toBe(9);
+        expect(r.output_tokens).toBe(8);
+    });
+
+    it('Perplexity wires base_url + name', () => {
+        const { c } = mk('sonar-pro', PerplexityClient);
+        expect(c.name).toBe('perplexity');
+        expect(c.base_url).toBe('https://api.perplexity.ai');
+    });
+});
+
+// ── CLI subclasses: argv construction + stdin payload ──────────────────
+describe('clients — CLI command construction', () => {
+    it('AnthropicCliClient argv + stdin payload', () => {
+        const { client, calls } = stubCli(AnthropicCliClient, {
+            returncode: 0,
+            stdout: JSON.stringify({ result: 'hi', usage: { input_tokens: 1, output_tokens: 2 } }),
+            stderr: '',
+        });
+        const r = client.ask('SYS', 'USER', 100);
+        expect(calls[0]!.cmd).toEqual([
+            '/bin/echo', '--print', '--output-format', 'json', '--model', 'claude-sonnet-4-5', '--append-system-prompt', 'SYS',
+        ]);
+        expect(calls[0]!.stdin).toBe('USER');
+        expect(r.text).toBe('hi');
+        expect(r.input_tokens).toBe(1);
+        expect(r.output_tokens).toBe(2);
+        expect(r.metadata.cli).toBe(true);
+    });
+
+    it('OpenAICliClient argv (prompt on argv, system flag, no stdin)', () => {
+        const { client, calls } = stubCli(OpenAICliClient, { returncode: 0, stdout: '', stderr: '' });
+        client.ask('SYS', 'USER', 1);
+        expect(calls[0]!.cmd).toEqual(['/bin/echo', 'exec', '--json', '--model', 'gpt-5', '--system', 'SYS', 'USER']);
+        expect(calls[0]!.stdin).toBeNull();
+    });
+
+    it('OpenAICliClient omits --system when empty', () => {
+        const { client, calls } = stubCli(OpenAICliClient, { returncode: 0, stdout: '', stderr: '' });
+        client.ask('', 'USER', 1);
+        expect(calls[0]!.cmd).toEqual(['/bin/echo', 'exec', '--json', '--model', 'gpt-5', 'USER']);
+    });
+
+    it('GeminiCliClient argv + stdin', () => {
+        const { client, calls } = stubCli(GeminiCliClient, { returncode: 0, stdout: '{}', stderr: '' });
+        client.ask('SYS', 'U', 1);
+        expect(calls[0]!.cmd).toEqual(['/bin/echo', '--output-format', 'json', '--model', 'gemini-2.5-pro', '--system', 'SYS']);
+        expect(calls[0]!.stdin).toBe('U');
+    });
+
+    it('XAICliClient / PerplexityCliClient plain argv', () => {
+        const { client: x, calls: xc } = stubCli(XAICliClient, { returncode: 0, stdout: 'grok says hi', stderr: '' });
+        x.ask('S', 'U', 1);
+        expect(xc[0]!.cmd).toEqual(['/bin/echo', '-p', 'U', '--model', 'grok-4']);
+        const { client: p, calls: pc } = stubCli(PerplexityCliClient, { returncode: 0, stdout: 'pplx', stderr: '' });
+        p.ask('S', 'U', 1);
+        expect(pc[0]!.cmd).toEqual(['/bin/echo', '-p', 'U', '--model', 'sonar-pro']);
+    });
+});
+
+// ── CLI parse_output + error mapping ───────────────────────────────────
+describe('clients — CLI response parsing', () => {
+    it('AnthropicCliClient parses metadata (session_id, cost, duration)', () => {
+        const { client } = stubCli(AnthropicCliClient, {
+            returncode: 0,
+            stdout: JSON.stringify({
+                result: '  spaced  ',
+                usage: { input_tokens: 10, output_tokens: 20 },
+                session_id: 'sess1',
+                total_cost_usd: 0.0042,
+                duration_ms: 1234,
+            }),
+            stderr: '',
+        });
+        const r = client.ask('s', 'u', 1);
+        expect(r.text).toBe('spaced');
+        expect(r.metadata).toMatchObject({
+            session_id: 'sess1',
+            reported_cost_usd: 0.0042,
+            reported_duration_ms: 1234,
+            cli: true,
+        });
+    });
+
+    it('OpenAICliClient parses NDJSON event stream (any order)', () => {
+        const lines = [
+            JSON.stringify({ type: 'session.created', session_id: 'os1' }),
+            JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 30, output_tokens: 40 } }),
+            'not json — skipped',
+            JSON.stringify({ type: 'unknown.event' }),
+            JSON.stringify({ type: 'item.completed', item: { id: 'it1', content: [{ text: 'a' }, { text: 'b' }] } }),
+        ].join('\n');
+        const { client } = stubCli(OpenAICliClient, { returncode: 0, stdout: lines, stderr: '' });
+        const r = client.ask('s', 'u', 1);
+        expect(r.text).toBe('a\nb');
+        expect(r.input_tokens).toBe(30);
+        expect(r.output_tokens).toBe(40);
+        expect(r.metadata).toMatchObject({ session_id: 'os1', item_id: 'it1', cli: true });
+    });
+
+    it('GeminiCliClient picks configured model then falls back to first', () => {
+        const { client } = stubCli(GeminiCliClient, {
+            returncode: 0,
+            stdout: JSON.stringify({
+                response: 'gem',
+                stats: { models: { 'gemini-2.5-pro': { tokens: { prompt: 5, candidates: 6 } } } },
+                sessionId: 'gs1',
+            }),
+            stderr: '',
+        });
+        const r = client.ask('s', 'u', 1);
+        expect(r.text).toBe('gem');
+        expect(r.input_tokens).toBe(5);
+        expect(r.output_tokens).toBe(6);
+        expect(r.metadata.session_id).toBe('gs1');
+
+        const { client: c2 } = stubCli(
+            GeminiCliClient,
+            { returncode: 0, stdout: JSON.stringify({ response: 'x', stats: { models: { 'other-model': { tokens: { prompt: 1, candidates: 2 } } } } }), stderr: '' },
+            { model: 'gemini-2.5-pro' },
+        );
+        const r2 = c2.ask('s', 'u', 1);
+        expect(r2.input_tokens).toBe(1);
+        expect(r2.output_tokens).toBe(2);
+    });
+
+    it('XAICliClient / PerplexityCliClient estimate output tokens chars//4', () => {
+        const { client } = stubCli(XAICliClient, { returncode: 0, stdout: '  twelve chars  ', stderr: '' });
+        const r = client.ask('s', 'u', 1);
+        expect(r.text).toBe('twelve chars'); // 12 chars
+        expect(r.output_tokens).toBe(3); // 12 // 4
+        expect(r.metadata).toMatchObject({ cli_output_format: 'plain_text', tokens_estimated: true, cli: true });
+
+        const { client: empty } = stubCli(PerplexityCliClient, { returncode: 0, stdout: '   ', stderr: '' });
+        expect(empty.ask('s', 'u', 1).output_tokens).toBe(0);
+
+        const { client: tiny } = stubCli(PerplexityCliClient, { returncode: 0, stdout: 'ab', stderr: '' });
+        expect(tiny.ask('s', 'u', 1).output_tokens).toBe(1); // max(1, 2//4=0) => 1
+    });
+
+    it('non-zero exit → classified error code + stderr_tail', () => {
+        const { client } = stubCli(AnthropicCliClient, { returncode: 2, stdout: '', stderr: 'Authentication failed: please login' });
+        const r = client.ask('s', 'u', 1);
+        expect(r.error).toBe('auth_expired');
+        expect(r.text).toBe('');
+        expect(r.metadata).toMatchObject({ returncode: 2, cli: true });
+        expect(r.metadata.stderr_tail).toBe('Authentication failed: please login');
+    });
+
+    it('parse failure → parse_failed error, stdout retained', () => {
+        const { client } = stubCli(AnthropicCliClient, { returncode: 0, stdout: 'not json at all', stderr: '' });
+        const r = client.ask('s', 'u', 1);
+        expect(r.error).toMatch(/^parse_failed: /);
+        expect(r.text).toBe('not json at all');
+    });
+
+    it('OpenAICliClient subclass stderr patterns add 401 / codex login', () => {
+        expect((OpenAICliClient as unknown as typeof CliClient)._classify_stderr('error 401 codex login required', 3)).toBe('auth_expired');
+    });
+});
+
+// ── quota gate + cli-calls.json ────────────────────────────────────────
+describe('clients — quota gate + cli-calls counter', () => {
+    it('record_cli_call writes indent=2 json and increments', () => {
+        const p = path.join(mkTmp(), 'cli-calls.json');
+        expect(record_cli_call('anthropic', p)).toBe(1);
+        expect(record_cli_call('anthropic', p)).toBe(2);
+        expect(record_cli_call('openai', p)).toBe(1);
+        const text = fs.readFileSync(p, 'utf-8');
+        const parsed = JSON.parse(text);
+        expect(parsed.counts).toEqual({ anthropic: 2, openai: 1 });
+        // indent=2 shape (two-space leading indent on nested keys).
+        expect(text).toContain('\n  "counts": {');
+        expect(text).toContain('\n    "anthropic": 2');
+        expect(text.endsWith('\n')).toBe(false); // json.dumps emits no trailing newline
+    });
+
+    it('reset clears one provider or all', () => {
+        const p = path.join(mkTmp(), 'cli-calls.json');
+        record_cli_call('a', p);
+        record_cli_call('b', p);
+        expect(reset_cli_call_counts('a', p)).toEqual({ b: 1 });
+        expect(load_cli_call_counts(p)).toEqual({ b: 1 });
+        expect(reset_cli_call_counts(null, p)).toEqual({});
+        expect(load_cli_call_counts(p)).toEqual({});
+    });
+
+    it('load returns {} on rollover (stale date)', () => {
+        const p = path.join(mkTmp(), 'cli-calls.json');
+        fs.writeFileSync(p, JSON.stringify({ date: '1999-01-01', counts: { a: 5 } }));
+        expect(load_cli_call_counts(p)).toEqual({});
+    });
+
+    it('quota gate fires when used >= max (no subprocess spawned)', () => {
+        const p = path.join(mkTmp(), 'cli-calls.json');
+        record_cli_call('anthropic', p);
+        record_cli_call('anthropic', p); // used=2
+        let spawned = false;
+        const Sub = class extends AnthropicCliClient {
+            protected override _runSubprocess(): SubprocessResult {
+                spawned = true;
+                return { returncode: 0, stdout: '{}', stderr: '' };
+            }
+        };
+        const c = new Sub({ binary: '/bin/echo', max_calls_per_day: 2, cli_calls_path: p });
+        const r = c.ask('s', 'u', 1);
+        expect(spawned).toBe(false);
+        expect(r.error).toBe('cli_quota_exhausted');
+        expect(r.metadata).toMatchObject({ cli: true, cli_calls_used: 2, cli_calls_max: 2 });
+    });
+
+    it('quota_summary_line formats capped members + warn threshold', () => {
+        const p = path.join(mkTmp(), 'cli-calls.json');
+        record_cli_call('anthropic', p);
+        record_cli_call('anthropic', p);
+        record_cli_call('anthropic', p);
+        record_cli_call('anthropic', p); // 4/5 = 0.8 → warn
+        const capped = new AnthropicCliClient({ binary: '/bin/echo', max_calls_per_day: 5, cli_calls_path: p });
+        const uncapped = new OpenAICliClient({ binary: '/bin/echo', cli_calls_path: p });
+        const [summary, warn] = quota_summary_line([capped, uncapped], { cli_calls_path: p });
+        expect(summary).toBe('⚠️  council:quota · anthropic 4/5');
+        expect(warn).toEqual(['anthropic']);
+
+        const [empty, ew] = quota_summary_line([uncapped], { cli_calls_path: p });
+        expect(empty).toBe('');
+        expect(ew).toEqual([]);
+    });
+
+    if (py3) {
+        it('record_cli_call json bytes match python3', () => {
+            const tsPath = path.join(mkTmp(), 'cli-calls.json');
+            record_cli_call('anthropic', tsPath);
+            record_cli_call('anthropic', tsPath);
+            record_cli_call('öpenai', tsPath); // non-ascii key → \u-escaped (ensure_ascii default)
+            const tsBytes = fs.readFileSync(tsPath, 'utf-8');
+
+            const pyPath = path.join(mkTmp(), 'cli-calls.json');
+            const code = [
+                'import scripts.ai_council.clients as cl, sys',
+                'from pathlib import Path',
+                'p = Path(sys.argv[1])',
+                'cl.record_cli_call("anthropic", p)',
+                'cl.record_cli_call("anthropic", p)',
+                'cl.record_cli_call("öpenai", p)',
+                'sys.stdout.write(open(p, encoding="utf-8").read())',
+            ].join('\n');
+            const r = runPyCode(code, [pyPath]);
+            expect(r.status).toBe(0);
+            // Normalise the wall-clock `date` field on BOTH sides (UTC rollover
+            // could differ across the two process spawns at a day boundary).
+            const norm = (s: string) => s.replace(/"date": "\d{4}-\d{2}-\d{2}"/, '"date": "<DATE>"');
+            expect(norm(tsBytes)).toBe(norm(r.stdout));
+        });
+    }
+});
+
+// ── CLI error-mapping parity (_classify_stderr) ────────────────────────
+describe('clients — _classify_stderr parity', () => {
+    const cases: [string, number, string][] = [
+        ['Authentication failed', 1, 'auth_expired'],
+        ['request timed out', 1, 'timeout'],
+        ['rate limit exceeded', 1, 'cli_quota_exhausted'],
+        ['HTTP 429 too many requests', 1, 'cli_quota_exhausted'],
+        ['some unknown failure', 7, 'exit_7'],
+        ['', 13, 'exit_13'],
+    ];
+
+    it('classifies the base patterns', () => {
+        for (const [stderr, rc, expected] of cases) {
+            expect((CliClient as unknown as typeof CliClient)._classify_stderr(stderr, rc)).toBe(expected);
+        }
+    });
+
+    if (py3) {
+        it('matches python3 across patterns + subclass extensions', () => {
+            const grid: [string, string, number][] = [
+                ['CliClient', 'Authentication failed', 1],
+                ['CliClient', 'deadline exceeded', 1],
+                ['CliClient', 'usage limit', 1],
+                ['CliClient', 'random', 9],
+                ['OpenAICliClient', 'error 401', 2],
+                ['OpenAICliClient', 'codex login needed', 2],
+                ['GeminiCliClient', 'oauth consent missing', 2],
+                ['XAICliClient', 'xai_api_key invalid', 2],
+                ['PerplexityCliClient', 'perplexity_api_key bad', 2],
+            ];
+            const code = [
+                'import json,sys,scripts.ai_council.clients as cl',
+                'out=[]',
+                'for cls,se,rc in json.loads(sys.argv[1]):',
+                '    out.append(getattr(cl,cls)._classify_stderr(se,rc))',
+                'print(json.dumps(out))',
+            ].join('\n');
+            const r = runPyCode(code, [JSON.stringify(grid)]);
+            expect(r.status).toBe(0);
+            const pyOut = JSON.parse(r.stdout.trim()) as string[];
+            const tsOut = grid.map(([cls, se, rc]) => {
+                const ctor: Record<string, typeof CliClient> = {
+                    CliClient: CliClient as unknown as typeof CliClient,
+                    OpenAICliClient: OpenAICliClient as unknown as typeof CliClient,
+                    GeminiCliClient: GeminiCliClient as unknown as typeof CliClient,
+                    XAICliClient: XAICliClient as unknown as typeof CliClient,
+                    PerplexityCliClient: PerplexityCliClient as unknown as typeof CliClient,
+                };
+                return ctor[cls]!._classify_stderr(se, rc);
+            });
+            expect(tsOut).toEqual(pyOut);
+        });
+    }
+});
+
+// ── CLI construction failures ──────────────────────────────────────────
+describe('clients — CliClient construction', () => {
+    it('missing binary on PATH → CliClientError', () => {
+        expect(() => new AnthropicCliClient({ binary: undefined })).toThrow(/not found on PATH|no `default_binary`/);
+        // Use a binary name that cannot exist on PATH.
+        let threw = false;
+        try {
+            new AnthropicCliClient({});
+        } catch (e) {
+            threw = e instanceof Error && /not found on PATH/.test((e as Error).message);
+        }
+        // Either claude is installed (no throw) or it threw with the PATH message.
+        expect(typeof threw).toBe('boolean');
+    });
+
+    it('explicit binary path bypasses PATH resolution', () => {
+        const c = new AnthropicCliClient({ binary: '/custom/claude' });
+        expect(c.binary).toBe('/custom/claude');
+        expect(c.billable).toBe(false);
+        expect(c.transport).toBe('cli');
+        expect(c.subscription_label).toBe('claude-pro');
+    });
+
+    it('community CLI subclasses are billable=true', () => {
+        expect(new XAICliClient({ binary: '/x' }).billable).toBe(true);
+        expect(new PerplexityCliClient({ binary: '/p' }).billable).toBe(true);
+    });
+});
+
+// ── ManualClient ───────────────────────────────────────────────────────
+function makeStdin(lines: string[]): TextInputStream {
+    // Each entry is one line WITHOUT trailing newline; we add "\n" to mirror a
+    // file iterator. Iterator and readline share one cursor.
+    const buf = lines.map((l) => `${l}\n`);
+    let i = 0;
+    return {
+        readline(): string {
+            return i < buf.length ? buf[i++] ?? '' : '';
+        },
+        [Symbol.iterator](): Iterator<string> {
+            return {
+                next(): IteratorResult<string> {
+                    if (i < buf.length) {
+                        return { done: false, value: buf[i++] ?? '' };
+                    }
+                    return { done: true, value: undefined };
+                },
+            };
+        },
+    };
+}
+function makeStdout(): TextOutputStream & { value: string } {
+    return {
+        value: '',
+        write(s: string) {
+            this.value += s;
+        },
+        flush() {
+            /* no-op */
+        },
+    };
+}
+
+describe('clients — _read_until_marker', () => {
+    it('reads until the marker line and strips', () => {
+        const s = makeStdin(['line one', 'line two', 'END', 'ignored']);
+        expect(_read_until_marker(s, 'END')).toBe('line one\nline two');
+    });
+    it('EOF before marker returns body so far', () => {
+        const s = makeStdin(['only line']);
+        expect(_read_until_marker(s, 'END')).toBe('only line');
+    });
+});
+
+describe('clients — ManualClient', () => {
+    it('single reply, "done" → joins rounds, billable=false', () => {
+        const stdin = makeStdin(['my reply here', 'END', '2']);
+        const stdout = makeStdout();
+        const c = new ManualClient({ stdin, stdout, provider_label: 'WebUI' });
+        expect(c.billable).toBe(false);
+        expect(c.transport).toBe('manual');
+        const r = c.ask('SYS', 'USER', 5);
+        expect(r.text).toBe('my reply here');
+        expect(r.error).toBeNull();
+        expect(r.metadata).toEqual({ rounds: 1, manual: true });
+        // block contains the rendered head/body/tail
+        expect(stdout.value).toContain('Manual council member: WebUI');
+        expect(stdout.value).toContain('SYS\n\n---\n\nUSER');
+        expect(stdout.value).toContain('Reply received (13 chars)');
+    });
+
+    it('abort (choice 3) → manual_aborted', () => {
+        const stdin = makeStdin(['partial', 'END', '3']);
+        const stdout = makeStdout();
+        const r = new ManualClient({ stdin, stdout }).ask('s', 'u');
+        expect(r.error).toBe('manual_aborted');
+        expect(r.text).toBe('');
+        expect(r.metadata).toEqual({ rounds: 1, manual: true });
+    });
+
+    it('follow-up (choice 1) then done', () => {
+        // reply1, END, choice=1, follow-up text, END (follow_up), reply2, END, choice=2
+        const stdin = makeStdin(['first', 'END', '1', 'more please', 'END', 'second', 'END', '2']);
+        const stdout = makeStdout();
+        const r = new ManualClient({ stdin, stdout }).ask('s', 'u');
+        // rounds: first, "[follow-up sent]\nmore please", second
+        expect(r.text).toBe('first\n\n---\n\n[follow-up sent]\nmore please\n\n---\n\nsecond');
+        expect(r.metadata).toEqual({ rounds: 3, manual: true });
+    });
+
+    it('unknown menu choice → treated as "next"', () => {
+        const stdin = makeStdin(['reply', 'END', 'garbage']);
+        const stdout = makeStdout();
+        const r = new ManualClient({ stdin, stdout }).ask('s', 'u');
+        expect(r.text).toBe('reply');
+        expect(r.metadata).toEqual({ rounds: 1, manual: true });
+    });
+
+    it('empty follow-up after choice 1 ends the member', () => {
+        const stdin = makeStdin(['first', 'END', '1', 'END']); // follow-up read hits END immediately → empty
+        const stdout = makeStdout();
+        const r = new ManualClient({ stdin, stdout }).ask('s', 'u');
+        expect(r.text).toBe('first');
+        expect(r.metadata).toEqual({ rounds: 1, manual: true });
+    });
+
+    if (py3) {
+        it('render block + transcript match python3', () => {
+            // Drive the python ManualClient with injected io.StringIO streams.
+            const code = [
+                'import io, json, sys, scripts.ai_council.clients as cl',
+                'stdin = io.StringIO("first\\nEND\\n1\\nmore please\\nEND\\nsecond\\nEND\\n2\\n")',
+                'stdout = io.StringIO()',
+                'c = cl.ManualClient(stdin=stdin, stdout=stdout, provider_label="WebUI")',
+                'r = c.ask("SYS", "USER", 5)',
+                'print(json.dumps({"text": r.text, "rounds": r.metadata["rounds"], "out": stdout.getvalue()}))',
+            ].join('\n');
+            const r = runPyCode(code);
+            expect(r.status).toBe(0);
+            const py = JSON.parse(r.stdout.trim()) as { text: string; rounds: number; out: string };
+
+            const stdin = makeStdin(['first', 'END', '1', 'more please', 'END', 'second', 'END', '2']);
+            const stdout = makeStdout();
+            const tsR = new ManualClient({ stdin, stdout, provider_label: 'WebUI' }).ask('SYS', 'USER', 5);
+            expect(tsR.text).toBe(py.text);
+            expect(tsR.metadata.rounds).toBe(py.rounds);
+            expect(stdout.value).toBe(py.out);
+        });
+    }
+});
+
+// ── full python-differential on CLI parsing (stubbed transport both sides) ──
+describe('clients — CLI parse_output byte-parity with python3', () => {
+    if (!py3) {
+        it.skip('python3 not available', () => {});
+        return;
+    }
+    // Drive both sides' _parse_output directly (pure parsing, no subprocess).
+    function pyParse(cls: string, stdout: string, model?: string): Record<string, unknown> {
+        const modelArg = model ? `, model=${JSON.stringify(model)}` : '';
+        const code = [
+            'import json, sys, scripts.ai_council.clients as cl',
+            `c = cl.${cls}(binary="/bin/echo"${modelArg})`,
+            'r = c._parse_output(sys.argv[1], "")',
+            'print(json.dumps({"text": r.text, "in": r.input_tokens, "out": r.output_tokens, "meta": r.metadata}))',
+        ].join('\n');
+        const res = runPyCode(code, [stdout]);
+        if (res.status !== 0) {
+            throw new Error(`python3 failed: ${res.stderr}`);
+        }
+        return JSON.parse(res.stdout.trim());
+    }
+
+    function tsParse<T extends CliClient>(Ctor: new (o: Record<string, unknown>) => T, stdout: string, opts: Record<string, unknown> = {}): Record<string, unknown> {
+        // _parse_output is protected; reach it via a cast on a concrete instance.
+        const c = new Ctor({ binary: '/bin/echo', ...opts }) as unknown as {
+            _parse_output(stdout: string, stderr: string): CouncilResponse;
+        };
+        const r = c._parse_output(stdout, '');
+        return { text: r.text, in: r.input_tokens, out: r.output_tokens, meta: r.metadata };
+    }
+
+    it('AnthropicCliClient envelope', () => {
+        const stdout = JSON.stringify({ result: ' hi ', usage: { input_tokens: 3, output_tokens: 5 }, session_id: 's', total_cost_usd: 0.01, duration_ms: 42 });
+        expect(tsParse(AnthropicCliClient, stdout)).toEqual(pyParse('AnthropicCliClient', stdout));
+    });
+
+    it('OpenAICliClient event stream', () => {
+        const stdout = [
+            JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 7, output_tokens: 9 } }),
+            JSON.stringify({ type: 'item.completed', item: { id: 'x', content: [{ text: 'one' }, { text: 'two' }] } }),
+            JSON.stringify({ type: 'session.created', session_id: 'sx' }),
+        ].join('\n');
+        expect(tsParse(OpenAICliClient, stdout)).toEqual(pyParse('OpenAICliClient', stdout));
+    });
+
+    it('GeminiCliClient stats', () => {
+        const stdout = JSON.stringify({ response: 'g', stats: { models: { 'gemini-2.5-pro': { tokens: { prompt: 2, candidates: 8 } } } }, sessionId: 'gx' });
+        expect(tsParse(GeminiCliClient, stdout, { model: 'gemini-2.5-pro' })).toEqual(pyParse('GeminiCliClient', stdout, 'gemini-2.5-pro'));
+    });
+
+    it('XAICliClient plain text estimate (unicode chars)', () => {
+        const stdout = '  héllo wörld 😀 chars  ';
+        expect(tsParse(XAICliClient, stdout)).toEqual(pyParse('XAICliClient', stdout));
+    });
+});

--- a/tests/scripts/ai_council/consensus.test.ts
+++ b/tests/scripts/ai_council/consensus.test.ts
@@ -1,0 +1,371 @@
+// Tests for src/scripts/ai_council/consensus.ts (py2ts Phase 1).
+//
+// consensus computes per-finding agreement/convergence (float math → format
+// parity) plus best-effort JSON extraction. Golden parity drives the LIVE
+// Python twin via a `python3 -c` importlib direct-file load (the ai_council
+// `__init__` pulls networked clients; consensus.py has no intra-package deps
+// so it loads straight off disk).
+//
+// Number divergence (ADR-094): Python `round(mean, 2)` yields a float whose
+// repr keeps `.0` (`8.0`); JS has one number type (`8`). Differential blocks
+// parse both sides as JSON so `8.0 == 8` compares equal.
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    aggregate_scores,
+    anonymize_findings,
+    anonymize_responses,
+    bucket_by_threshold,
+    DEFAULT_MINORITY_THRESHOLD,
+    DEFAULT_STRONG_THRESHOLD,
+    evidence_quality,
+    Finding,
+    FindingScore,
+    parse_findings_response,
+    parse_scores_response,
+} from '../../../src/scripts/ai_council/consensus.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+const CONSENSUS_PY = 'src/scripts/ai_council/consensus.py';
+
+function pyLoadPreamble(): string[] {
+    return [
+        'import importlib.util, sys, json',
+        `_spec = importlib.util.spec_from_file_location("cs", ${JSON.stringify(CONSENSUS_PY)})`,
+        'cs = importlib.util.module_from_spec(_spec)',
+        'sys.modules["cs"] = cs',
+        '_spec.loader.exec_module(cs)',
+    ];
+}
+
+function py(snippet: string): string {
+    const code = [...pyLoadPreamble(), snippet].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+// ── Unit tests ───────────────────────────────────────────────────────
+
+describe('consensus — evidence_quality buckets', () => {
+    it('H / M / L thresholds', () => {
+        expect(evidence_quality(8.0)).toBe('H');
+        expect(evidence_quality(9.5)).toBe('H');
+        expect(evidence_quality(7.99)).toBe('M');
+        expect(evidence_quality(6.0)).toBe('M');
+        expect(evidence_quality(5.99)).toBe('L');
+        expect(evidence_quality(0.0)).toBe('L');
+    });
+});
+
+describe('consensus — aggregate_scores', () => {
+    it('drops self-scores; empty → zero metadata', () => {
+        const findings = [new Finding('a', 'm1', 'A'), new Finding('b', 'm2', 'B')];
+        const scores = [
+            new FindingScore('a', 'm1', 10, true, 'self'), // self-score dropped
+            new FindingScore('a', 'm2', 8, true, 'good'),
+            new FindingScore('a', 'm3', 6, false, 'meh'),
+        ];
+        const meta = aggregate_scores(findings, scores);
+        const a = meta.get('a')!;
+        expect(a.scorers).toEqual(['m2', 'm3']);
+        expect(a.mean_score).toBe(7.0);
+        expect(a.dissent_count).toBe(1);
+        expect(a.concur_count).toBe(1);
+        expect(a.dissent_reasons).toEqual([['m3', 'meh']]);
+        // b has no scorers → all-zero metadata
+        const b = meta.get('b')!;
+        expect(b.consensus_strength).toBe(0.0);
+        expect(b.scorers).toEqual([]);
+        expect(b.evidence_quality).toBe('L');
+    });
+    it('consensus_strength = mean/10 * agree_rate, rounded to 3', () => {
+        const findings = [new Finding('x', 'src', 'X')];
+        const scores = [
+            new FindingScore('x', 'a', 9, true, ''),
+            new FindingScore('x', 'b', 6, false, 'no'),
+        ];
+        const m = aggregate_scores(findings, scores).get('x')!;
+        // mean=7.5, agree_rate=0.5, strength=0.375
+        expect(m.mean_score).toBe(7.5);
+        expect(m.consensus_strength).toBe(0.375);
+    });
+});
+
+describe('consensus — bucket_by_threshold', () => {
+    it('strong > strong threshold; minority gets unscored', () => {
+        const findings = [
+            new Finding('hi', 's', 'H'),
+            new Finding('mid', 's', 'M'),
+            new Finding('lo', 's', 'L'),
+            new Finding('none', 's', 'N'),
+        ];
+        const meta = new Map([
+            ['hi', aggregate_scores([findings[0]!], [new FindingScore('hi', 'a', 10, true, '')]).get('hi')!],
+            ['mid', aggregate_scores([findings[1]!], [new FindingScore('mid', 'a', 5, true, '')]).get('mid')!],
+            ['lo', aggregate_scores([findings[2]!], [new FindingScore('lo', 'a', 1, false, '')]).get('lo')!],
+        ]);
+        const b = bucket_by_threshold(findings, meta);
+        expect(b.strong.map((p) => p[0].id)).toEqual(['hi']); // 1.0 > 0.7
+        expect(b.findings.map((p) => p[0].id)).toEqual(['mid']); // 0.5 in (0.4, 0.7]
+        expect(b.minority.map((p) => p[0].id)).toEqual(['lo', 'none']); // 0.0, and unscored
+    });
+    it('raises on broken threshold ordering', () => {
+        expect(() => bucket_by_threshold([], new Map(), { strong: 0.3, minority: 0.5 })).toThrow(
+            /Threshold ordering broken/,
+        );
+    });
+    it('default thresholds are 0.7 / 0.4', () => {
+        expect(DEFAULT_STRONG_THRESHOLD).toBe(0.7);
+        expect(DEFAULT_MINORITY_THRESHOLD).toBe(0.4);
+    });
+});
+
+describe('consensus — parsing', () => {
+    it('parse_findings_response: fenced + skip bad items', () => {
+        const out = parse_findings_response(
+            '```json\n[{"id":"x","text":" hi "},{"text":"no id"},{"id":"y","text":"ok"}]\n```',
+            { source: 'src1' },
+        );
+        expect(out.map((f) => [f.id, f.source, f.text])).toEqual([
+            ['x', 'src1', 'hi'],
+            ['y', 'src1', 'ok'],
+        ]);
+    });
+    it('parse_findings_response: bare array fallback + invalid json → []', () => {
+        expect(parse_findings_response('[{"id":"z","text":"zz"}]', { source: 's' }).length).toBe(1);
+        expect(parse_findings_response('not json at all', { source: 's' })).toEqual([]);
+        expect(parse_findings_response('```json\n{bad}\n```', { source: 's' })).toEqual([]);
+    });
+    it('parse_scores_response: clamps, falls back id, defaults agree=true', () => {
+        const out = parse_scores_response(
+            '[{"finding_id":"a","score":12},{"id":"b","score":5.9,"agree":false,"reason":" r "},{"finding_id":"c","score":0}]',
+            { scorer: 'sc' },
+        );
+        // a clamped out (12>10), c clamped out (0<1); b kept (5.9 → int 5)
+        expect(out.map((s) => [s.finding_id, s.score, s.agree, s.reason])).toEqual([
+            ['b', 5, false, 'r'],
+        ]);
+    });
+    it('parse_scores_response: non-numeric score skipped', () => {
+        expect(parse_scores_response('[{"finding_id":"a","score":"hi"}]', { scorer: 'z' })).toEqual([]);
+    });
+});
+
+describe('consensus — anonymize', () => {
+    it('anonymize_findings labels A/B/C in order', () => {
+        const m = anonymize_findings([new Finding('a', 's', 'A'), new Finding('b', 's', 'B')]);
+        expect([...m.keys()]).toEqual(['Finding-A', 'Finding-B']);
+    });
+    it('anonymize_responses skips empty, applies persona, preserves order', () => {
+        const [text, src] = anonymize_responses(
+            [
+                ['p:1', ' hi '],
+                ['q:2', '   '],
+                ['r:3', 'yo'],
+            ],
+            { persona_labels: new Map([['r:3', 'Contra']]) },
+        );
+        expect([...text]).toEqual([
+            ['Response-A', 'hi'],
+            ['Response-B (Contra)', 'yo'],
+        ]);
+        expect([...src]).toEqual([
+            ['Response-A', 'p:1'],
+            ['Response-B (Contra)', 'r:3'],
+        ]);
+    });
+});
+
+// ── Golden parity vs the CPython twin ────────────────────────────────
+
+describe.runIf(py3)('consensus — golden parity vs CPython twin', () => {
+    // Drive aggregate + bucket on a fixed corpus; compare the JSON-able view.
+    const AGG_DRIVER = `
+findings = [cs.Finding(id="a", source="m1", text="A"),
+            cs.Finding(id="b", source="m2", text="B"),
+            cs.Finding(id="c", source="m3", text="C")]
+scores = [
+    cs.FindingScore(finding_id="a", scorer="m1", score=10, agree=True, reason="self"),
+    cs.FindingScore(finding_id="a", scorer="m2", score=9, agree=True, reason="strong"),
+    cs.FindingScore(finding_id="a", scorer="m3", score=7, agree=False, reason="off"),
+    cs.FindingScore(finding_id="b", scorer="m1", score=6, agree=True, reason="ok"),
+    cs.FindingScore(finding_id="b", scorer="m3", score=4, agree=False, reason="weak"),
+]
+meta = cs.aggregate_scores(findings, scores)
+def md(m):
+    return {"finding_id": m.finding_id, "consensus_strength": m.consensus_strength,
+            "dissent_count": m.dissent_count, "scorers": list(m.scorers),
+            "mean_score": m.mean_score, "concur_count": m.concur_count,
+            "dissent_reasons": [list(x) for x in m.dissent_reasons],
+            "evidence_quality": m.evidence_quality}
+print(json.dumps({k: md(v) for k, v in meta.items()}, sort_keys=True))
+bucket = cs.bucket_by_threshold(findings, meta)
+print(json.dumps({"strong": [p[0].id for p in bucket.strong],
+                  "findings": [p[0].id for p in bucket.findings],
+                  "minority": [p[0].id for p in bucket.minority]}))
+`;
+
+    it('aggregate_scores + bucket_by_threshold match', () => {
+        const out = py(AGG_DRIVER).trim().split('\n');
+        const findings = [
+            new Finding('a', 'm1', 'A'),
+            new Finding('b', 'm2', 'B'),
+            new Finding('c', 'm3', 'C'),
+        ];
+        const scores = [
+            new FindingScore('a', 'm1', 10, true, 'self'),
+            new FindingScore('a', 'm2', 9, true, 'strong'),
+            new FindingScore('a', 'm3', 7, false, 'off'),
+            new FindingScore('b', 'm1', 6, true, 'ok'),
+            new FindingScore('b', 'm3', 4, false, 'weak'),
+        ];
+        const meta = aggregate_scores(findings, scores);
+        const md = (m: ReturnType<typeof meta.get>) => ({
+            finding_id: m!.finding_id,
+            consensus_strength: m!.consensus_strength,
+            dissent_count: m!.dissent_count,
+            scorers: [...m!.scorers],
+            mean_score: m!.mean_score,
+            concur_count: m!.concur_count,
+            dissent_reasons: m!.dissent_reasons.map((x) => [...x]),
+            evidence_quality: m!.evidence_quality,
+        });
+        const tsMeta: Record<string, unknown> = {};
+        for (const [k, v] of meta) {
+            tsMeta[k] = md(v);
+        }
+        expect(tsMeta).toEqual(JSON.parse(out[0] as string));
+        const bucket = bucket_by_threshold(findings, meta);
+        expect({
+            strong: bucket.strong.map((p) => p[0].id),
+            findings: bucket.findings.map((p) => p[0].id),
+            minority: bucket.minority.map((p) => p[0].id),
+        }).toEqual(JSON.parse(out[1] as string));
+    });
+
+    // Float-format corpus: drive round(mean,2)/round(strength,3) over scores
+    // chosen to exercise half-even rounding boundaries.
+    const ROUND_CASES: Array<[number[], boolean[]]> = [
+        [[7, 8], [true, true]], // mean 7.5
+        [[1, 2, 4], [true, false, true]], // mean 2.333…
+        [[5, 6, 7], [true, true, false]], // mean 6.0, agree 0.666…
+        [[9, 9, 9], [true, true, true]], // strength 0.9
+        [[3, 3, 4, 5], [false, true, false, true]], // mean 3.75
+        [[2, 5, 5], [true, true, true]], // mean 4.0
+    ];
+
+    it.each(ROUND_CASES.map((_, i) => i))('round-parity case %i', (idx) => {
+        const [vals, agrees] = ROUND_CASES[idx]!;
+        const scores = vals.map(
+            (v, i) => new FindingScore('f', `s${i}`, v, agrees[i] as boolean, ''),
+        );
+        const m = aggregate_scores([new Finding('f', 'author', 'F')], scores).get('f')!;
+        const pyScores = vals
+            .map(
+                (v, i) =>
+                    `cs.FindingScore(finding_id="f", scorer="s${i}", score=${v}, agree=${agrees[i] ? 'True' : 'False'}, reason="")`,
+            )
+            .join(', ');
+        const expected = py(
+            `meta = cs.aggregate_scores([cs.Finding(id="f", source="author", text="F")], [${pyScores}])\n` +
+                `m = meta["f"]\n` +
+                `print(json.dumps([m.mean_score, m.consensus_strength, m.evidence_quality]))`,
+        ).trim();
+        expect([m.mean_score, m.consensus_strength, m.evidence_quality]).toEqual(JSON.parse(expected));
+    });
+
+    // JSON-extraction corpus: fenced / bare / malformed / surrounding prose.
+    const EXTRACT_CASES: Record<string, string> = {
+        fenced: '```json\n[{"id":"a","text":"alpha"}]\n```',
+        fenced_no_lang: '```\n[{"id":"b","text":"beta"}]\n```',
+        bare: 'prose before [{"id":"c","text":"gamma"}] prose after',
+        multiline: '```json\n[\n  {"id":"d","text":"delta over\\ntwo lines"}\n]\n```',
+        nested_obj: '```json\n[{"id":"e","text":"e"},{"id":"f","text":"f"}]\n```',
+        malformed: '```json\n[{"id":}]\n```',
+        none: 'no array here at all',
+        empty: '',
+    };
+
+    it.each(Object.keys(EXTRACT_CASES))('parse_findings_response(%s) matches', (key) => {
+        const text = EXTRACT_CASES[key] as string;
+        const expected = py(
+            `out = cs.parse_findings_response(${JSON.stringify(text)}, source="S")\n` +
+                `print(json.dumps([[f.id, f.source, f.text] for f in out]))`,
+        ).trim();
+        const got = parse_findings_response(text, { source: 'S' }).map((f) => [f.id, f.source, f.text]);
+        expect(got).toEqual(JSON.parse(expected));
+    });
+
+    const SCORE_CASES: Record<string, string> = {
+        ok: '[{"finding_id":"a","score":8,"agree":true,"reason":" r1 "}]',
+        clamp_high: '[{"finding_id":"a","score":11}]',
+        clamp_low: '[{"finding_id":"a","score":0}]',
+        float_score: '[{"finding_id":"a","score":7.9}]',
+        id_fallback: '[{"id":"b","score":5}]',
+        non_numeric: '[{"finding_id":"a","score":"x"}]',
+        default_agree: '[{"finding_id":"a","score":5}]',
+        bool_score: '[{"finding_id":"a","score":true}]',
+        missing_fid: '[{"score":5}]',
+    };
+
+    it.each(Object.keys(SCORE_CASES))('parse_scores_response(%s) matches', (key) => {
+        const text = SCORE_CASES[key] as string;
+        const expected = py(
+            `out = cs.parse_scores_response(${JSON.stringify(text)}, scorer="SC")\n` +
+                `print(json.dumps([[s.finding_id, s.scorer, s.score, s.agree, s.reason] for s in out]))`,
+        ).trim();
+        const got = parse_scores_response(text, { scorer: 'SC' }).map((s) => [
+            s.finding_id,
+            s.scorer,
+            s.score,
+            s.agree,
+            s.reason,
+        ]);
+        expect(got).toEqual(JSON.parse(expected));
+    });
+
+    it('threshold-ordering error text matches', () => {
+        const expected = py(
+            'import json\n' +
+                'try:\n' +
+                '    cs.bucket_by_threshold([], {}, strong=0.3, minority=0.5)\n' +
+                'except ValueError as e:\n' +
+                '    print(json.dumps(str(e)))',
+        ).trim();
+        let msg = '';
+        try {
+            bucket_by_threshold([], new Map(), { strong: 0.3, minority: 0.5 });
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toEqual(JSON.parse(expected));
+    });
+
+    it('anonymize_responses matches (persona + skip empty + order)', () => {
+        const expected = py(
+            'at, ls = cs.anonymize_responses(' +
+                '[("p:1", " hi "), ("q:2", "   "), ("r:3", "yo"), ("s:4", "z")],' +
+                ' persona_labels={"r:3": "Contra"})\n' +
+                'print(json.dumps([list(at.items()), list(ls.items())]))',
+        ).trim();
+        const [text, src] = anonymize_responses(
+            [
+                ['p:1', ' hi '],
+                ['q:2', '   '],
+                ['r:3', 'yo'],
+                ['s:4', 'z'],
+            ],
+            { persona_labels: new Map([['r:3', 'Contra']]) },
+        );
+        expect([[...text], [...src]]).toEqual(JSON.parse(expected));
+    });
+});

--- a/tests/scripts/ai_council/low_impact_corpus.test.ts
+++ b/tests/scripts/ai_council/low_impact_corpus.test.ts
@@ -1,0 +1,219 @@
+// Tests for src/scripts/ai_council/low_impact_corpus.ts (py2ts Phase 1).
+//
+// Hardened corpus parser. Golden-parity against the CPython twin covers the
+// strict-mode structural failures (heading_drift / missing_anchor / etc.), the
+// lenient loaders, and the YAML-lockfile preference path. Errors are compared
+// by reason + line + section + message string (byte-exact CorpusParseError).
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    CorpusParseError,
+    CorpusParseResult,
+    load_anti_example_phrases,
+    load_corpus_lock,
+    load_validated_phrases,
+    parse_corpus_strict,
+} from '../../../src/scripts/ai_council/low_impact_corpus.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+const GOOD = [
+    '## Validated',
+    '',
+    '<!-- intake-anchor: validated -->',
+    '',
+    '- "what port" — meta here',
+    '',
+    '## On Probation',
+    '',
+    '<!-- intake-anchor: probation -->',
+    '',
+    '- "how to test" — first-seen 2026-05-01',
+    '',
+    '## Anti-Examples (Always Ask User)',
+    '',
+    '- "delete prod?"',
+    '',
+].join('\n');
+
+function tmpFile(name: string, content: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'corpus-'));
+    const p = path.join(dir, name);
+    writeFileSync(p, content, { encoding: 'utf-8' });
+    return p;
+}
+
+describe('low_impact_corpus — parse_corpus_strict (clean)', () => {
+    it('parses entries with line numbers + trailing metadata', () => {
+        const r = parse_corpus_strict(tmpFile('c.md', GOOD));
+        expect(r.validated.map((e) => [e.phrase, e.normalised, e.line_no])).toEqual([
+            ['what port', 'what port', 5],
+        ]);
+        expect(r.probation[0]?.trailing_metadata).toBe('— first-seen 2026-05-01');
+        expect(r.anti_examples.map((e) => e.normalised)).toEqual(['delete prod']);
+        expect(r.phrases('validated')).toEqual(['what port']);
+    });
+
+    it('missing file → empty result, not an error', () => {
+        const r = parse_corpus_strict('/no/such/corpus.md');
+        expect(r).toBeInstanceOf(CorpusParseResult);
+        expect(r.validated).toEqual([]);
+    });
+});
+
+describe('low_impact_corpus — strict structural failures', () => {
+    it('heading_drift on ### Validated', () => {
+        const p = tmpFile('d.md', '### Validated\n\n- "x"\n');
+        expect(() => parse_corpus_strict(p)).toThrow(CorpusParseError);
+        try {
+            parse_corpus_strict(p);
+        } catch (e) {
+            const err = e as CorpusParseError;
+            expect(err.reason).toBe('heading_drift');
+            expect(err.line).toBe(1);
+            expect(err.section).toBe('validated');
+        }
+    });
+
+    it('missing_anchor when sections present but anchor absent', () => {
+        const p = tmpFile('n.md', '## Validated\n\n- "phrase one"\n\n## On Probation\n\n- "phrase two"\n');
+        try {
+            parse_corpus_strict(p);
+            throw new Error('expected throw');
+        } catch (e) {
+            const err = e as CorpusParseError;
+            expect(err.reason).toBe('missing_anchor');
+            expect(err.section).toBe('validated');
+            expect(err.line).toBeNull();
+        }
+    });
+});
+
+describe('low_impact_corpus — lenient loaders', () => {
+    it('load_validated_phrases / load_anti_example_phrases (markdown source)', () => {
+        const p = tmpFile('c.md', GOOD);
+        expect(load_validated_phrases(p)).toEqual(['what port']);
+        expect(load_anti_example_phrases(p)).toEqual(['delete prod']);
+    });
+
+    it('lenient on a malformed file → drops bad lines (no throw)', () => {
+        const bad = [
+            '## Validated',
+            '',
+            '<!-- intake-anchor: validated -->',
+            '',
+            '* "wrong marker"',
+            '- "good one" — x',
+            '',
+            '## On Probation',
+            '',
+            '<!-- intake-anchor: probation -->',
+            '',
+        ].join('\n');
+        expect(load_validated_phrases(tmpFile('m.md', bad))).toEqual(['good one']);
+    });
+});
+
+describe('low_impact_corpus — YAML lockfile preference', () => {
+    it('prefers the sibling lock over the markdown source', () => {
+        const dir = mkdtempSync(path.join(tmpdir(), 'corpuslk-'));
+        const md = path.join(dir, 'lid.md');
+        writeFileSync(md, GOOD, { encoding: 'utf-8' });
+        writeFileSync(
+            path.join(dir, 'lid.lock.yaml'),
+            'schema_version: 1\nvalidated:\n  - phrase: "lock phrase"\n    normalised: "lock phrase"\n    line_no: 5\n',
+            { encoding: 'utf-8' },
+        );
+        expect(load_validated_phrases(md)).toEqual(['lock phrase']);
+    });
+
+    it('schema_version mismatch raises in load_corpus_lock', () => {
+        const lk = tmpFile('x.lock.yaml', 'schema_version: 99\nvalidated: []\n');
+        expect(() => load_corpus_lock(lk)).toThrow(CorpusParseError);
+    });
+});
+
+describe.runIf(py3)('low_impact_corpus — golden parity vs CPython twin', () => {
+    /** Run a corpus call in CPython, return the parsed JSON. */
+    function pyCall(snippet: string, args: string[]): unknown {
+        const code = [
+            'import json, sys',
+            'from scripts.ai_council import low_impact_corpus as C',
+            snippet,
+        ].join('\n');
+        const res = runPyCode(code, args);
+        expect(res.status, res.stderr).toBe(0);
+        return JSON.parse(res.stdout);
+    }
+
+    const dumpEntries =
+        'def dump(es):\n'
+        + '    return [[e.phrase, e.normalised, e.section, e.line_no, e.trailing_metadata] for e in es]\n';
+
+    it('parse_corpus_strict structured output matches', () => {
+        const p = tmpFile('c.md', GOOD);
+        const expected = pyCall(
+            dumpEntries
+                + 'r = C.parse_corpus_strict(sys.argv[1])\n'
+                + 'print(json.dumps([dump(r.validated), dump(r.probation), dump(r.anti_examples)], ensure_ascii=False))',
+            [p],
+        ) as unknown[];
+        const r = parse_corpus_strict(p);
+        const map = (es: typeof r.validated): unknown[] =>
+            es.map((e) => [e.phrase, e.normalised, e.section, e.line_no, e.trailing_metadata]);
+        expect([map(r.validated), map(r.probation), map(r.anti_examples)]).toEqual(expected);
+    });
+
+    it('heading_drift error message byte-matches', () => {
+        const p = tmpFile('d.md', '### Validated\n\n- "x"\n');
+        const expected = pyCall(
+            'try:\n'
+                + '    C.parse_corpus_strict(sys.argv[1])\n'
+                + '    print(json.dumps("NO RAISE"))\n'
+                + 'except C.CorpusParseError as e:\n'
+                + '    print(json.dumps([e.reason, e.line, e.section, str(e)], ensure_ascii=False))',
+            [p],
+        ) as [string, number, string, string];
+        try {
+            parse_corpus_strict(p);
+            throw new Error('expected throw');
+        } catch (e) {
+            const err = e as CorpusParseError;
+            expect([err.reason, err.line, err.section, err.message]).toEqual(expected);
+        }
+    });
+
+    it('missing_anchor error message byte-matches', () => {
+        const p = tmpFile('n.md', '## Validated\n\n- "phrase one"\n\n## On Probation\n\n- "phrase two"\n');
+        const expected = pyCall(
+            'try:\n'
+                + '    C.parse_corpus_strict(sys.argv[1])\n'
+                + '    print(json.dumps("NO RAISE"))\n'
+                + 'except C.CorpusParseError as e:\n'
+                + '    print(json.dumps([e.reason, e.line, e.section, str(e)], ensure_ascii=False))',
+            [p],
+        ) as [string, number | null, string, string];
+        try {
+            parse_corpus_strict(p);
+            throw new Error('expected throw');
+        } catch (e) {
+            const err = e as CorpusParseError;
+            expect([err.reason, err.line, err.section, err.message]).toEqual(expected);
+        }
+    });
+
+    it('lenient load_validated / load_anti match', () => {
+        const p = tmpFile('c.md', GOOD);
+        const expected = pyCall(
+            'print(json.dumps([list(C.load_validated_phrases(sys.argv[1])), '
+                + 'list(C.load_anti_example_phrases(sys.argv[1]))], ensure_ascii=False))',
+            [p],
+        ) as [string[], string[]];
+        expect([load_validated_phrases(p), load_anti_example_phrases(p)]).toEqual(expected);
+    });
+});

--- a/tests/scripts/ai_council/low_impact_intake.test.ts
+++ b/tests/scripts/ai_council/low_impact_intake.test.ts
@@ -1,0 +1,138 @@
+// Tests for src/scripts/ai_council/low_impact_intake.ts (py2ts Phase 1).
+//
+// Pure-text, deterministic corpus mutator. Golden-parity against the CPython
+// twin: both runtimes record the SAME intake outcome AND write the SAME corpus
+// bytes (the write path is the load-bearing parity surface). `today` is passed
+// explicitly to remove the only non-deterministic input (UTC date).
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    TRIGGER_PHRASES,
+    matches_trigger,
+    normalise,
+    record_intake,
+} from '../../../src/scripts/ai_council/low_impact_intake.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+const CORPUS = [
+    '# Low-Impact Decisions',
+    '',
+    '## Validated',
+    '',
+    '<!-- intake-anchor: validated -->',
+    '',
+    '- "what port does the app use" — learned 2026-01-01',
+    '',
+    '## On Probation',
+    '',
+    '<!-- intake-anchor: probation -->',
+    '',
+    '- "how do i run tests" — first-seen 2026-05-01 · seen [2026-05-01]',
+    '',
+    '## Anti-Examples (Always Ask User)',
+    '',
+    '- "should we delete prod"',
+    '',
+].join('\n');
+
+function tmpCorpus(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'intake-'));
+    const p = path.join(dir, 'low-impact-decisions.md');
+    writeFileSync(p, CORPUS, { encoding: 'utf-8' });
+    return p;
+}
+
+describe('low_impact_intake — matches_trigger', () => {
+    it('matches DE / EN phrases case-insensitively (substring)', () => {
+        expect(matches_trigger('Das ist eine LEICHTE Frage hier')).toBe(true);
+        expect(matches_trigger('please, ask the council about this')).toBe(true);
+        expect(matches_trigger('a low impact question maybe')).toBe(true);
+    });
+    it('does not match unrelated text', () => {
+        expect(matches_trigger('deploy to production now')).toBe(false);
+    });
+    it('exports the full DE+EN phrase set', () => {
+        expect(TRIGGER_PHRASES).toContain('eine leichte frage');
+        expect(TRIGGER_PHRASES).toContain('ask the council');
+        expect(TRIGGER_PHRASES.length).toBe(11);
+    });
+});
+
+describe('low_impact_intake — normalise', () => {
+    it('lowercases, strips punctuation, collapses whitespace', () => {
+        expect(normalise('  How  do I, run TESTS?? ')).toBe('how do i run tests');
+    });
+});
+
+describe('low_impact_intake — record_intake outcomes', () => {
+    it('appends seen-date to an existing probation entry', () => {
+        const p = tmpCorpus();
+        const r = record_intake(p, 'How do I run tests?', { today: '2026-06-02' });
+        expect(r.kind).toBe('appended_seen');
+        expect(readFileSync(p, 'utf-8')).toContain('seen [2026-05-01, 2026-06-02]');
+    });
+
+    it('no-op when already seen today', () => {
+        const p = tmpCorpus();
+        const r = record_intake(p, 'how do i run tests', { today: '2026-05-01' });
+        expect(r.kind).toBe('noop');
+        expect(r.note).toBe('already seen today');
+    });
+
+    it('duplicate_validated when the question is already learned', () => {
+        const p = tmpCorpus();
+        const r = record_intake(p, 'what port does the app use', { today: '2026-06-02' });
+        expect(r.kind).toBe('duplicate_validated');
+        expect(r.note).toBe('already learned');
+    });
+
+    it('new_probation appends a fresh entry', () => {
+        const p = tmpCorpus();
+        const r = record_intake(p, 'brand new question here', { today: '2026-06-03' });
+        expect(r.kind).toBe('new_probation');
+        expect(readFileSync(p, 'utf-8')).toContain(
+            '- "brand new question here" — first-seen 2026-06-03 · seen [2026-06-03]',
+        );
+    });
+});
+
+describe.runIf(py3)('low_impact_intake — golden parity vs CPython twin', () => {
+    // Each case writes the SAME corpus to two temp files, records the same
+    // intake in CPython and TS, then asserts identical outcome + identical
+    // resulting bytes.
+    const cases: Array<{ desc: string; question: string; today: string }> = [
+        { desc: 'appended_seen', question: 'How do I run tests?', today: '2026-06-02' },
+        { desc: 'noop same-day', question: 'how do i run tests', today: '2026-05-01' },
+        { desc: 'duplicate_validated', question: 'what port does the app use', today: '2026-06-02' },
+        { desc: 'new_probation', question: 'A brand-new, punctuated question!', today: '2026-06-03' },
+    ];
+
+    it.each(cases)('$desc', ({ question, today }) => {
+        const pyPath = tmpCorpus();
+        const tsPath = tmpCorpus();
+
+        const code = [
+            'import json, sys',
+            'from scripts.ai_council.low_impact_intake import record_intake',
+            'from pathlib import Path',
+            'p, q, today = sys.argv[1], sys.argv[2], sys.argv[3]',
+            'r = record_intake(Path(p), q, today=today)',
+            'print(json.dumps([r.kind, r.question, r.today, r.note]))',
+        ].join('\n');
+        const res = runPyCode(code, [pyPath, question, today]);
+        expect(res.status, res.stderr).toBe(0);
+        const pyOutcome = JSON.parse(res.stdout) as [string, string, string, string];
+
+        const tsR = record_intake(tsPath, question, { today });
+        expect([tsR.kind, tsR.question, tsR.today, tsR.note]).toEqual(pyOutcome);
+
+        // The corpus bytes written by each runtime must be identical.
+        expect(readFileSync(tsPath, 'utf-8')).toBe(readFileSync(pyPath, 'utf-8'));
+    });
+});

--- a/tests/scripts/ai_council/prompts.test.ts
+++ b/tests/scripts/ai_council/prompts.test.ts
@@ -1,0 +1,322 @@
+// Tests for src/scripts/ai_council/prompts.ts (py2ts Phase 1).
+//
+// prompts assembles neutrality system-prompt text (pure string-building).
+// Golden parity drives the LIVE Python twin via a `python3 -c` importlib
+// direct-file load — the ai_council `__init__` pulls networked clients, so we
+// load `prompts.py` straight off disk and register it in sys.modules (the same
+// rig confidence_gate.test.ts uses). project_context is imported by prompts;
+// we register its module path too so the relative import resolves.
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { ProjectContext } from '../../../src/scripts/ai_council/project_context.js';
+import {
+    advisor_system_prompt,
+    all_modes,
+    all_synthesis_modes,
+    build_extraction_user_prompt,
+    build_peer_review_user_prompt,
+    build_scoring_user_prompt,
+    handoff_preamble,
+    HOST_AGENT_IDENTITY_PATTERNS,
+    NEUTRALITY_PREAMBLE,
+    peer_review_synthesis_addendum,
+    synthesis_template,
+    system_prompt_for,
+} from '../../../src/scripts/ai_council/prompts.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+const PROMPTS_PY = 'src/scripts/ai_council/prompts.py';
+const PCTX_PY = 'src/scripts/ai_council/project_context.py';
+
+// Register both modules off disk so prompts.py's
+// `from scripts.ai_council.project_context import ProjectContext` resolves
+// without importing the package `__init__` (networked clients).
+function pyLoadPreamble(): string[] {
+    return [
+        'import importlib.util, sys, json',
+        // project_context first — prompts imports it by package path.
+        `_pc_spec = importlib.util.spec_from_file_location("scripts.ai_council.project_context", ${JSON.stringify(PCTX_PY)})`,
+        '_pc = importlib.util.module_from_spec(_pc_spec)',
+        'sys.modules["scripts.ai_council.project_context"] = _pc',
+        '_pc_spec.loader.exec_module(_pc)',
+        `_spec = importlib.util.spec_from_file_location("pr", ${JSON.stringify(PROMPTS_PY)})`,
+        'pr = importlib.util.module_from_spec(_spec)',
+        'sys.modules["pr"] = pr',
+        '_spec.loader.exec_module(pr)',
+        'PC = _pc.ProjectContext',
+    ];
+}
+
+function py(snippet: string): string {
+    const code = [...pyLoadPreamble(), snippet].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+// ── Unit tests of the TS surface ─────────────────────────────────────
+
+describe('prompts — constants + mode tables', () => {
+    it('NEUTRALITY_PREAMBLE is stripped (no leading/trailing whitespace)', () => {
+        expect(NEUTRALITY_PREAMBLE).toBe(NEUTRALITY_PREAMBLE.trim());
+        expect(NEUTRALITY_PREAMBLE.startsWith('You are an independent reviewer')).toBe(true);
+    });
+    it('all_modes returns the 9 sorted mode keys', () => {
+        expect(all_modes()).toEqual([
+            'analysis',
+            'debate',
+            'design',
+            'diff',
+            'files',
+            'optimize',
+            'pr',
+            'prompt',
+            'roadmap',
+        ]);
+    });
+    it('all_synthesis_modes returns the 5 sorted lens keys', () => {
+        expect(all_synthesis_modes()).toEqual(['analysis', 'default', 'design', 'optimize', 'pr']);
+    });
+    it('HOST_AGENT_IDENTITY_PATTERNS covers the documented needles', () => {
+        expect(HOST_AGENT_IDENTITY_PATTERNS).toContain('augment');
+        expect(HOST_AGENT_IDENTITY_PATTERNS).toContain('claude code');
+    });
+});
+
+describe('prompts — synthesis_template', () => {
+    it('null → default decision template', () => {
+        expect(synthesis_template(null)).toBe(synthesis_template('default'));
+    });
+    it('input modes inherit default', () => {
+        for (const m of ['prompt', 'roadmap', 'diff', 'files']) {
+            expect(synthesis_template(m)).toBe(synthesis_template('default'));
+        }
+    });
+    it('creative lenses return empty string', () => {
+        expect(synthesis_template('design')).toBe('');
+        expect(synthesis_template('optimize')).toBe('');
+    });
+    it('unknown mode raises with sorted-union expected list', () => {
+        expect(() => synthesis_template('bogus')).toThrow(/Unknown synthesis mode 'bogus'/);
+        expect(() => synthesis_template('bogus')).toThrow(
+            /Expected one of: \['analysis', 'default', 'design', 'diff', 'files', 'optimize', 'pr', 'prompt', 'roadmap'\]/,
+        );
+    });
+});
+
+describe('prompts — system_prompt_for', () => {
+    it('unknown mode raises with sorted expected list', () => {
+        expect(() => system_prompt_for('bogus')).toThrow(/Unknown council mode 'bogus'/);
+    });
+    it('bare call = NEUTRALITY_PREAMBLE + addendum', () => {
+        const out = system_prompt_for('prompt');
+        expect(out.startsWith(NEUTRALITY_PREAMBLE)).toBe(true);
+    });
+    it('project + ask prepend the handoff preamble', () => {
+        const out = system_prompt_for('diff', {
+            project: new ProjectContext('Demo', 'PHP 8.3', 'A purpose.'),
+            original_ask: 'Should I ship?',
+        });
+        expect(out).toContain('Project: Demo');
+        expect(out).toContain('> Should I ship?');
+    });
+});
+
+describe('prompts — handoff_preamble neutrality', () => {
+    it('strips host-identity lines from project + ask', () => {
+        const project = new ProjectContext('Built with Augment', 'PHP', 'Uses Claude Code here.');
+        const out = handoff_preamble(project, 'Ask via Cursor IDE\nSecond line ok');
+        expect(out.toLowerCase()).not.toContain('augment');
+        expect(out.toLowerCase()).not.toContain('claude code');
+        expect(out.toLowerCase()).not.toContain('cursor ide');
+        expect(out).toContain('Second line ok');
+    });
+    it('null project + empty ask → bare preamble', () => {
+        expect(handoff_preamble(null, '')).toBe(NEUTRALITY_PREAMBLE);
+    });
+});
+
+describe('prompts — advisor + builder prompts', () => {
+    it('advisor_system_prompt appends persona body', () => {
+        const out = advisor_system_prompt('  Persona body.  ');
+        expect(out.endsWith('Persona body.')).toBe(true);
+    });
+    it('advisor_system_prompt raises on empty persona', () => {
+        expect(() => advisor_system_prompt('   ')).toThrow(/persona_text is empty/);
+    });
+    it('build_scoring_user_prompt renders labels', () => {
+        const out = build_scoring_user_prompt(
+            new Map([
+                ['Finding-A', 'first'],
+                ['Finding-B', 'second'],
+            ]),
+        );
+        expect(out).toContain('### Finding-A\n\nfirst');
+        expect(out).toContain('### Finding-B\n\nsecond');
+    });
+    it('build_peer_review_user_prompt renders labels', () => {
+        const out = build_peer_review_user_prompt(new Map([['Response-A', 'body']]));
+        expect(out).toContain('### Response-A\n\nbody');
+    });
+    it('build_extraction_user_prompt strips host identity', () => {
+        const out = build_extraction_user_prompt('line one with Windsurf\nline two');
+        expect(out.toLowerCase()).not.toContain('windsurf');
+        expect(out).toContain('line two');
+    });
+    it('peer_review_synthesis_addendum starts with a leading newline', () => {
+        expect(peer_review_synthesis_addendum().startsWith('\n### Peer-Review-Surfaced')).toBe(true);
+    });
+});
+
+// ── Golden parity vs the CPython twin ────────────────────────────────
+
+describe.runIf(py3)('prompts — golden parity vs CPython twin', () => {
+    const modes = ['prompt', 'roadmap', 'diff', 'files', 'pr', 'design', 'optimize', 'analysis', 'debate'];
+    const synthKeys = [
+        'default',
+        'pr',
+        'analysis',
+        'design',
+        'optimize',
+        'prompt',
+        'roadmap',
+        'diff',
+        'files',
+    ];
+
+    it('all_modes + all_synthesis_modes match', () => {
+        const out = py(
+            'print(json.dumps([pr.all_modes(), pr.all_synthesis_modes()]))',
+        ).trim();
+        expect([all_modes(), all_synthesis_modes()]).toEqual(JSON.parse(out));
+    });
+
+    it.each(modes)('system_prompt_for(%s) bare matches', (mode) => {
+        const out = py(
+            `print(json.dumps(pr.system_prompt_for(${JSON.stringify(mode)})))`,
+        ).trim();
+        expect(system_prompt_for(mode)).toEqual(JSON.parse(out));
+    });
+
+    it.each(modes)('system_prompt_for(%s) with project+ask matches', (mode) => {
+        const expected = py(
+            `proj = PC(name="Demo App", stack="PHP 8.3 \\u00b7 Laravel", repo_purpose="It does things. Carefully.")\n` +
+                `print(json.dumps(pr.system_prompt_for(${JSON.stringify(mode)}, project=proj, original_ask="Line A with Augment\\nLine B kept")))`,
+        ).trim();
+        const got = system_prompt_for(mode, {
+            project: new ProjectContext('Demo App', 'PHP 8.3 · Laravel', 'It does things. Carefully.'),
+            original_ask: 'Line A with Augment\nLine B kept',
+        });
+        expect(got).toEqual(JSON.parse(expected));
+    });
+
+    it.each(synthKeys)('synthesis_template(%s) matches', (key) => {
+        const expected = py(
+            `print(json.dumps(pr.synthesis_template(${JSON.stringify(key)})))`,
+        ).trim();
+        expect(synthesis_template(key)).toEqual(JSON.parse(expected));
+    });
+
+    it('synthesis_template(None) matches', () => {
+        const expected = py('print(json.dumps(pr.synthesis_template(None)))').trim();
+        expect(synthesis_template(null)).toEqual(JSON.parse(expected));
+    });
+
+    it('unknown synthesis mode error text matches', () => {
+        const expected = py(
+            'import json\n' +
+                'try:\n' +
+                '    pr.synthesis_template("bogus")\n' +
+                'except ValueError as e:\n' +
+                '    print(json.dumps(str(e)))',
+        ).trim();
+        let msg = '';
+        try {
+            synthesis_template('bogus');
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toEqual(JSON.parse(expected));
+    });
+
+    it('unknown system_prompt mode error text matches', () => {
+        const expected = py(
+            'import json\n' +
+                'try:\n' +
+                '    pr.system_prompt_for("bogus")\n' +
+                'except ValueError as e:\n' +
+                '    print(json.dumps(str(e)))',
+        ).trim();
+        let msg = '';
+        try {
+            system_prompt_for('bogus');
+        } catch (e) {
+            msg = (e as Error).message;
+        }
+        expect(msg).toEqual(JSON.parse(expected));
+    });
+
+    it('handoff_preamble neutrality strip matches', () => {
+        const ask = 'Built on Augment\nKeep this line\nAlso uses Cline here';
+        const expected = py(
+            `proj = PC(name="N with Claude Code", stack="PHP", repo_purpose="Runs on Copilot agent stack.")\n` +
+                `print(json.dumps(pr.handoff_preamble(proj, ${JSON.stringify(ask)})))`,
+        ).trim();
+        const got = handoff_preamble(
+            new ProjectContext('N with Claude Code', 'PHP', 'Runs on Copilot agent stack.'),
+            ask,
+        );
+        expect(got).toEqual(JSON.parse(expected));
+    });
+
+    it('advisor_system_prompt matches', () => {
+        const expected = py(
+            `print(json.dumps(pr.advisor_system_prompt("  My persona.\\n\\nMore.  ", original_ask="Hi")))`,
+        ).trim();
+        expect(advisor_system_prompt('  My persona.\n\nMore.  ', { original_ask: 'Hi' })).toEqual(
+            JSON.parse(expected),
+        );
+    });
+
+    it('build_extraction_user_prompt matches', () => {
+        const analysis = 'finding with Augment\nclean finding';
+        const expected = py(
+            `print(json.dumps(pr.build_extraction_user_prompt(${JSON.stringify(analysis)})))`,
+        ).trim();
+        expect(build_extraction_user_prompt(analysis)).toEqual(JSON.parse(expected));
+    });
+
+    it('build_scoring_user_prompt matches', () => {
+        const expected = py(
+            'print(json.dumps(pr.build_scoring_user_prompt({"Finding-A": "alpha", "Finding-B": "beta"})))',
+        ).trim();
+        const got = build_scoring_user_prompt(
+            new Map([
+                ['Finding-A', 'alpha'],
+                ['Finding-B', 'beta'],
+            ]),
+        );
+        expect(got).toEqual(JSON.parse(expected));
+    });
+
+    it('build_peer_review_user_prompt matches', () => {
+        const expected = py(
+            'print(json.dumps(pr.build_peer_review_user_prompt({"Response-A": "one", "Response-B (Contra)": "two"})))',
+        ).trim();
+        const got = build_peer_review_user_prompt(
+            new Map([
+                ['Response-A', 'one'],
+                ['Response-B (Contra)', 'two'],
+            ]),
+        );
+        expect(got).toEqual(JSON.parse(expected));
+    });
+});

--- a/tests/scripts/ai_council/redact_low_impact_entry.test.ts
+++ b/tests/scripts/ai_council/redact_low_impact_entry.test.ts
@@ -1,0 +1,199 @@
+// Tests for src/scripts/ai_council/redact_low_impact_entry.ts (py2ts Phase 1).
+//
+// SECURITY-SENSITIVE twin: the redaction regexes and refusal markers must
+// match the Python original byte-for-byte. Golden-parity is run against the
+// CPython twin (imported as a package member so its `from
+// scripts.ai_council.config import _RAW_KEY_PREFIXES` resolves), comparing the
+// structured result (ok / violations / summary) on fixtures that hit each of
+// the eight forbidden-content classes.
+//
+// Secret-shaped / email / path tokens are ASSEMBLED FROM ESCAPE SEQUENCES so
+// this test file does not itself trip the repo's source-confidentiality /
+// secret-scanning linters.
+import { describe, expect, it } from 'vitest';
+
+import {
+    RedactionResult,
+    redact_low_impact_entry,
+} from '../../../src/scripts/ai_council/redact_low_impact_entry.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// ── fixtures assembled from parts (never a literal secret) ────────────────
+const SK = 'sk-' + 'A'.repeat(10); // raw-key prefix class
+const SK_ANT = 'sk-ant-' + 'B'.repeat(10);
+const EMAIL = 'al' + 'ice' + '@' + 'exa' + 'mple.com';
+const UPATH = '/Users' + '/bob/proj/file.ts';
+const HOST = 'api.corp.' + 'internal';
+const MONEY = '$' + '1,234.56';
+const LONG = 'x'.repeat(45); // > 40 chars inside backticks
+const API_KEY = 'api_key' + ': ' + 'C'.repeat(14);
+
+/** Run the redactor in CPython via the package import, return the JSON dict. */
+function pyRedact(text: string, kwargs = '{}'): {
+    ok: boolean;
+    summary: string;
+    violations: Array<[string, string, string]>;
+} {
+    const code = [
+        'import json, sys',
+        'from scripts.ai_council.redact_low_impact_entry import redact_low_impact_entry',
+        'text = sys.argv[1]',
+        'kw = json.loads(sys.argv[2])',
+        'r = redact_low_impact_entry(text, **kw)',
+        'print(json.dumps({"ok": r.ok, "summary": r.summary(), '
+            + '"violations": [[v.category, v.snippet, v.note] for v in r.violations]}, ensure_ascii=False))',
+    ].join('\n');
+    const res = runPyCode(code, [text, kwargs]);
+    if (res.status !== 0) {
+        throw new Error(`python3 failed: ${res.stderr}`);
+    }
+    return JSON.parse(res.stdout);
+}
+
+function tsTuples(r: RedactionResult): Array<[string, string, string]> {
+    return r.violations.map((v) => [v.category, v.snippet, v.note]);
+}
+
+describe('redact_low_impact_entry — clean input', () => {
+    it('returns ok=true and "redaction: clean" on benign text', () => {
+        const r = redact_low_impact_entry('a generic decision about retry backoff strategy');
+        expect(r.ok).toBe(true);
+        expect(r.violations).toEqual([]);
+        expect(r.summary()).toBe('redaction: clean');
+    });
+
+    it('generic placeholders survive (<customer> etc.)', () => {
+        const r = redact_low_impact_entry('handled for <customer> and <tenant> accounts');
+        expect(r.ok).toBe(true);
+    });
+});
+
+describe('redact_low_impact_entry — eight forbidden classes', () => {
+    it('1. secret — raw-key prefix', () => {
+        const r = redact_low_impact_entry(`leaked ${SK} here`);
+        expect(r.ok).toBe(false);
+        expect(tsTuples(r)).toContainEqual(['secret', SK.slice(0, 8) + '…', "raw-key prefix 'sk-'"]);
+    });
+
+    it('1b. secret — inline api_key shape', () => {
+        const r = redact_low_impact_entry(`config ${API_KEY} value`);
+        expect(r.ok).toBe(false);
+        expect(tsTuples(r).some(([c, , n]) => c === 'secret' && n === 'inline api_key')).toBe(true);
+    });
+
+    it('2. email', () => {
+        const r = redact_low_impact_entry(`contact ${EMAIL} for details`);
+        expect(tsTuples(r)).toContainEqual(['email', EMAIL, '']);
+    });
+
+    it('3. project path', () => {
+        const r = redact_low_impact_entry(`see ${UPATH} for the change`);
+        expect(tsTuples(r)).toContainEqual(['project_path', UPATH, '']);
+    });
+
+    it('3b. configured repo root', () => {
+        const r = redact_low_impact_entry('lives under /opt/secretroot/x', { repoRoot: '/opt/secretroot' });
+        expect(tsTuples(r)).toContainEqual(['project_path', '/opt/secretroot', 'configured repo root']);
+    });
+
+    it('4. customer name (caller-supplied, case-insensitive)', () => {
+        const r = redact_low_impact_entry('the ACME deal closed', { customerNames: ['acme'] });
+        expect(tsTuples(r)).toContainEqual(['customer_name', 'acme', '']);
+    });
+
+    it('5. internal hostname', () => {
+        const r = redact_low_impact_entry(`ping ${HOST} now`);
+        expect(tsTuples(r)).toContainEqual(['internal_hostname', HOST, '']);
+    });
+
+    it('5b. configured private domain', () => {
+        const r = redact_low_impact_entry('host secret.example reached', {
+            privateDomains: ['secret.example'],
+        });
+        expect(tsTuples(r)).toContainEqual([
+            'internal_hostname',
+            'secret.example',
+            'configured private domain',
+        ]);
+    });
+
+    it('6. monetary amount', () => {
+        const r = redact_low_impact_entry(`budget ${MONEY} approved`);
+        expect(tsTuples(r)).toContainEqual(['monetary_amount', MONEY, '']);
+    });
+
+    it('7. SQL identifier (caller-supplied)', () => {
+        const r = redact_low_impact_entry('joined the orders_v2 table', {
+            sqlIdentifiers: ['orders_v2'],
+        });
+        expect(tsTuples(r)).toContainEqual(['sql_identifier', 'orders_v2', '']);
+    });
+
+    it('8. long code excerpt (> 40 chars in backticks)', () => {
+        const r = redact_low_impact_entry('snippet `' + LONG + '` end');
+        expect(tsTuples(r)).toContainEqual([
+            'long_code_excerpt',
+            LONG.slice(0, 40) + '…',
+            `${LONG.length} chars`,
+        ]);
+    });
+});
+
+describe('redact_low_impact_entry — RedactionResult.summary()', () => {
+    it('joins violations with the REFUSED marker', () => {
+        const r = redact_low_impact_entry(`${EMAIL} and ${MONEY}`);
+        expect(r.summary().startsWith('redaction REFUSED — ')).toBe(true);
+        expect(r.summary()).toContain(`email: '${EMAIL}'`);
+    });
+});
+
+describe.runIf(py3)('redact_low_impact_entry — golden parity vs CPython twin', () => {
+    const cases: Array<{ desc: string; text: string; kwargs?: string }> = [
+        { desc: 'clean', text: 'plain decision about caching' },
+        { desc: 'raw-key secret', text: `leak ${SK}` },
+        { desc: 'sk-ant secret', text: `anthropic ${SK_ANT}` },
+        { desc: 'inline api_key', text: `${API_KEY}` },
+        { desc: 'email', text: `mail ${EMAIL}` },
+        { desc: 'unix path', text: `path ${UPATH}` },
+        { desc: 'windows path', text: 'path C:\\Users\\bob\\f.txt here' },
+        { desc: 'internal host', text: `host ${HOST}` },
+        { desc: 'money usd-code', text: 'cost USD 1000 total' },
+        { desc: 'money symbol', text: `cost ${MONEY}` },
+        { desc: 'long code', text: 'code `' + LONG + '`' },
+        {
+            desc: 'all-classes combined + kwargs',
+            text: `${SK} ${EMAIL} ${UPATH} ${HOST} ${MONEY} \`${LONG}\` ${API_KEY} acme tbl`,
+            kwargs: JSON.stringify({
+                repo_root: '/Users/bob',
+                private_domains: ['priv.example'],
+                customer_names: ['acme'],
+                sql_identifiers: ['tbl'],
+            }),
+        },
+    ];
+
+    const tsKwargs = (k?: string): Parameters<typeof redact_low_impact_entry>[1] => {
+        if (!k) {
+            return {};
+        }
+        const obj = JSON.parse(k) as Record<string, unknown>;
+        return {
+            repoRoot: (obj['repo_root'] as string) ?? null,
+            privateDomains: (obj['private_domains'] as string[]) ?? [],
+            customerNames: (obj['customer_names'] as string[]) ?? [],
+            sqlIdentifiers: (obj['sql_identifiers'] as string[]) ?? [],
+        };
+    };
+
+    it.each(cases)('$desc', ({ text, kwargs }) => {
+        const expected = pyRedact(text, kwargs ?? '{}');
+        const r = redact_low_impact_entry(text, tsKwargs(kwargs));
+        // Structured parity (JSON whitespace differs between json.dumps and
+        // JSON.stringify; the content is what matters — same as modes.test.ts).
+        expect(r.ok).toBe(expected.ok);
+        expect(tsTuples(r)).toEqual(expected.violations);
+        expect(r.summary()).toBe(expected.summary);
+    });
+});

--- a/tests/scripts/ai_council/solo_dispatch.test.ts
+++ b/tests/scripts/ai_council/solo_dispatch.test.ts
@@ -1,0 +1,370 @@
+// Tests for src/scripts/ai_council/solo_dispatch.ts (py2ts Phase 1).
+//
+// solo_dispatch is the single-member path: chain-walk + lazy auth-probe cache
+// + escalation on low-confidence/split/refusal. Pure logic (no LLM transport;
+// callers inject probe / run_solo / run_full). Golden parity drives the LIVE
+// Python twin via a `python3 -c` importlib direct-file load with <repo>/src on
+// sys.path so config + confidence_gate resolve; solo_dispatch.py loads off
+// disk. `now` is injected so nothing depends on the monotonic clock.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import type { MemberConfig, RoutingConfig } from '../../../src/scripts/ai_council/config.js';
+import {
+    AUTH_CACHE_TTL_SECONDS,
+    AuthCache,
+    AuthCacheEntry,
+    dispatch_with_escalation,
+    FORCE_FULL_ENV,
+    force_full_council,
+    select_solo_member,
+    SoloDispatchResult,
+} from '../../../src/scripts/ai_council/solo_dispatch.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+const SOLO_PY = 'src/scripts/ai_council/solo_dispatch.py';
+const REPO_SRC = path.resolve('src');
+
+function member(name: string, enabled: boolean, model = 'm'): MemberConfig {
+    return {
+        name,
+        enabled,
+        model,
+        api_key_ref: null,
+        mode: null,
+        binary: null,
+        model_ladder: [],
+        participate_low_impact: true,
+    };
+}
+
+function routing(chain: string[], timeout = 3): RoutingConfig {
+    return { solo_member_fallback_chain: chain, auth_check_timeout_seconds: timeout };
+}
+
+function pyDriver(body: string): string {
+    return [
+        'import importlib.util, sys, json',
+        `sys.path.insert(0, ${JSON.stringify(REPO_SRC)})`,
+        `_spec = importlib.util.spec_from_file_location("sd", ${JSON.stringify(SOLO_PY)})`,
+        'sd = importlib.util.module_from_spec(_spec)',
+        'sys.modules["sd"] = sd',
+        '_spec.loader.exec_module(sd)',
+        'from scripts.ai_council.config import MemberConfig, RoutingConfig',
+        body,
+    ].join('\n');
+}
+
+function py(body: string): { status: number; stdout: string; stderr: string } {
+    const r = spawnSync('python3', ['-c', pyDriver(body)], { encoding: 'utf8' });
+    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+}
+
+// ── Unit tests ───────────────────────────────────────────────────────
+
+describe('solo_dispatch — constants', () => {
+    it('TTL is 15 minutes, env var name fixed', () => {
+        expect(AUTH_CACHE_TTL_SECONDS).toBe(900);
+        expect(FORCE_FULL_ENV).toBe('AGENT_CONFIG_FORCE_FULL_COUNCIL');
+    });
+});
+
+describe('solo_dispatch — force_full_council', () => {
+    it('only the literal "1" counts as force', () => {
+        expect(force_full_council(new Map())).toBe(false);
+        expect(force_full_council(new Map([[FORCE_FULL_ENV, '1']]))).toBe(true);
+        expect(force_full_council(new Map([[FORCE_FULL_ENV, '2']]))).toBe(false);
+        expect(force_full_council(new Map([[FORCE_FULL_ENV, 'true']]))).toBe(false);
+        expect(force_full_council({ [FORCE_FULL_ENV]: '1' })).toBe(true);
+    });
+});
+
+describe('solo_dispatch — AuthCache TTL', () => {
+    it('expired entry returns null; fresh returns valid', () => {
+        const c = new AuthCache();
+        c.set('x', { valid: true, now: 1000 });
+        expect(c.get('x', { now: 1000 })).toBe(true);
+        expect(c.get('x', { now: 1000 + AUTH_CACHE_TTL_SECONDS - 1 })).toBe(true);
+        // Python: entry.expires_at <= now → expired. expires_at = now+TTL.
+        expect(c.get('x', { now: 1000 + AUTH_CACHE_TTL_SECONDS })).toBeNull();
+        expect(c.get('missing', { now: 1000 })).toBeNull();
+    });
+    it('AuthCacheEntry holds valid + expiry', () => {
+        const e = new AuthCacheEntry({ valid: false, expires_at: 42 });
+        expect(e.valid).toBe(false);
+        expect(e.expires_at).toBe(42);
+    });
+});
+
+describe('solo_dispatch — select_solo_member', () => {
+    it('returns first enabled + auth-valid member', () => {
+        const c = new AuthCache();
+        const probed: string[] = [];
+        const sel = select_solo_member(routing(['x', 'y', 'z']), new Map([
+            ['x', member('x', false)],
+            ['y', member('y', true)],
+            ['z', member('z', true)],
+        ]), {
+            auth_cache: c,
+            probe: (n) => {
+                probed.push(n);
+                return n === 'y';
+            },
+            now: 1000,
+            env: new Map(),
+        });
+        expect(sel).toBe('y');
+        expect(probed).toEqual(['y']); // x skipped (disabled), y valid → stop
+    });
+    it('caches probe verdicts; cached-false skips, cached-true short-circuits', () => {
+        const c = new AuthCache();
+        const members = new Map([
+            ['x', member('x', true)],
+            ['y', member('y', true)],
+        ]);
+        let calls = 0;
+        const probe = (n: string): boolean => {
+            calls += 1;
+            return n === 'y';
+        };
+        const s1 = select_solo_member(routing(['x', 'y']), members, { auth_cache: c, probe, now: 1, env: new Map() });
+        expect(s1).toBe('y');
+        expect(calls).toBe(2); // x→false (cached), y→true (cached)
+        // second walk: x cached-false skipped without probe, y cached-true returned
+        const s2 = select_solo_member(routing(['x', 'y']), members, {
+            auth_cache: c,
+            probe: () => {
+                throw new Error('should not probe');
+            },
+            now: 1,
+            env: new Map(),
+        });
+        expect(s2).toBe('y');
+    });
+    it('probe throwing → treated as auth-invalid, walks on', () => {
+        const sel = select_solo_member(routing(['x']), new Map([['x', member('x', true)]]), {
+            auth_cache: new AuthCache(),
+            probe: () => {
+                throw new Error('boom');
+            },
+            now: 1,
+            env: new Map(),
+        });
+        expect(sel).toBeNull();
+    });
+    it('all unavailable → null', () => {
+        const sel = select_solo_member(routing(['x', 'y']), new Map([
+            ['x', member('x', false)],
+            ['y', member('y', true)],
+        ]), { auth_cache: new AuthCache(), probe: () => false, now: 1, env: new Map() });
+        expect(sel).toBeNull();
+    });
+    it('force-full env short-circuits to null', () => {
+        const sel = select_solo_member(routing(['x']), new Map([['x', member('x', true)]]), {
+            auth_cache: new AuthCache(),
+            probe: () => true,
+            now: 1,
+            env: new Map([[FORCE_FULL_ENV, '1']]),
+        });
+        expect(sel).toBeNull();
+    });
+    it('missing member name in chain is skipped', () => {
+        const sel = select_solo_member(routing(['ghost', 'y']), new Map([['y', member('y', true)]]), {
+            auth_cache: new AuthCache(),
+            probe: () => true,
+            now: 1,
+            env: new Map(),
+        });
+        expect(sel).toBe('y');
+    });
+});
+
+describe('solo_dispatch — dispatch_with_escalation', () => {
+    const members = new Map([['y', member('y', true)]]);
+    it('no solo member → run_full + no_solo_member', () => {
+        const r = dispatch_with_escalation(routing([]), new Map(), {
+            auth_cache: new AuthCache(),
+            probe: () => true,
+            run_solo: () => 'solo',
+            run_full: () => 'FULL',
+            confidence_floor: 0.5,
+            now: 1,
+            env: new Map(),
+        });
+        expect(r).toBeInstanceOf(SoloDispatchResult);
+        expect(r.verdict).toBe('FULL');
+        expect(r.escalated).toBe(true);
+        expect(r.escalation_reason).toBe('no_solo_member');
+        expect(r.solo_member).toBeNull();
+    });
+    it('refusal → escalate, keeps solo on result', () => {
+        const r = dispatch_with_escalation(routing(['y']), members, {
+            auth_cache: new AuthCache(),
+            probe: () => true,
+            run_solo: () => 'I cannot decide this one.',
+            run_full: () => 'FULL',
+            confidence_floor: 0.5,
+            now: 1,
+            env: new Map(),
+        });
+        expect(r.escalated).toBe(true);
+        expect(r.escalation_reason).toBe('refusal');
+        expect(r.solo_member).toBe('y');
+        expect(r.solo_response).toBe('I cannot decide this one.');
+        expect(r.verdict).toBe('FULL');
+    });
+    it('confident long answer → no escalation, solo verdict', () => {
+        const confident =
+            'Ship it. The migration is reversible, tests cover the critical path, and the blast radius is small.';
+        const r = dispatch_with_escalation(routing(['y']), members, {
+            auth_cache: new AuthCache(),
+            probe: () => true,
+            run_solo: () => confident,
+            run_full: () => 'FULL',
+            confidence_floor: 0.5,
+            now: 1,
+            env: new Map(),
+        });
+        expect(r.escalated).toBe(false);
+        expect(r.escalation_reason).toBe('ok');
+        expect(r.verdict).toBe(confident);
+        expect(r.solo_confidence).toBe(1.0);
+    });
+});
+
+// ── Golden parity vs the CPython twin ────────────────────────────────
+
+describe.runIf(py3)('solo_dispatch — golden parity vs CPython twin', () => {
+    // select_solo_member scenarios: each drives a Python lambda probe and
+    // compares the selected provider + the resulting cache verdict map.
+    interface SelCase {
+        chain: string[];
+        members: Array<[string, boolean]>; // [name, enabled]
+        validNames: string[]; // probe returns true for these
+        env: Record<string, string>;
+    }
+    const SEL_CASES: Record<string, SelCase> = {
+        first_valid: { chain: ['x', 'y'], members: [['x', true]], validNames: ['x'], env: {} },
+        skip_disabled: { chain: ['x', 'y'], members: [['x', false], ['y', true]], validNames: ['y'], env: {} },
+        all_invalid: { chain: ['x', 'y'], members: [['x', true], ['y', true]], validNames: [], env: {} },
+        missing_member: { chain: ['ghost', 'y'], members: [['y', true]], validNames: ['y'], env: {} },
+        force_full: { chain: ['x'], members: [['x', true]], validNames: ['x'], env: { AGENT_CONFIG_FORCE_FULL_COUNCIL: '1' } },
+        second_valid: { chain: ['x', 'y', 'z'], members: [['x', true], ['y', true], ['z', true]], validNames: ['z'], env: {} },
+    };
+
+    it.each(Object.keys(SEL_CASES))('select_solo_member(%s) matches', (key) => {
+        const cse = SEL_CASES[key]!;
+        const pyMembers = cse.members
+            .map(
+                ([n, e]) =>
+                    `${JSON.stringify(n)}: MemberConfig(name=${JSON.stringify(n)}, enabled=${e ? 'True' : 'False'}, model="m", api_key_ref=None, mode=None, binary=None, model_ladder=(), participate_low_impact=True)`,
+            )
+            .join(', ');
+        const pyValid = JSON.stringify(cse.validNames);
+        const pyEnv = JSON.stringify(cse.env);
+        const r = py(
+            `routing = RoutingConfig(solo_member_fallback_chain=${JSON.stringify(cse.chain)}, auth_check_timeout_seconds=3)\n` +
+                `members = {${pyMembers}}\n` +
+                `valid = set(${pyValid})\n` +
+                `cache = sd.AuthCache()\n` +
+                `sel = sd.select_solo_member(routing, members, auth_cache=cache, probe=lambda n, t: n in valid, now=1000.0, env=${pyEnv})\n` +
+                `entries = {k: [v.valid, v.expires_at] for k, v in cache.entries.items()}\n` +
+                `print(json.dumps([sel, entries], sort_keys=True))`,
+        );
+        expect(r.status).toBe(0);
+        const cache = new AuthCache();
+        const valid = new Set(cse.validNames);
+        const members = new Map<string, MemberConfig>(cse.members.map(([n, e]) => [n, member(n, e)]));
+        const sel = select_solo_member(
+            { solo_member_fallback_chain: cse.chain, auth_check_timeout_seconds: 3 },
+            members,
+            {
+                auth_cache: cache,
+                probe: (n) => valid.has(n),
+                now: 1000.0,
+                env: cse.env,
+            },
+        );
+        const entries: Record<string, [boolean, number]> = {};
+        for (const [k, v] of cache.entries) {
+            entries[k] = [v.valid, v.expires_at];
+        }
+        expect([sel, entries]).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    // dispatch_with_escalation: vary the solo response to hit each reason.
+    const DISPATCH_CASES: Record<string, { chain: string[]; solo: string; floor: number }> = {
+        no_solo_member: { chain: [], solo: 'unused', floor: 0.5 },
+        refusal: { chain: ['y'], solo: 'I cannot decide on this.', floor: 0.5 },
+        short_response: { chain: ['y'], solo: 'Yes do it.', floor: 0.5 },
+        split: {
+            chain: ['y'],
+            solo: 'You could either ship it or hold it — both would be defensible choices here today.',
+            floor: 0.5,
+        },
+        low_confidence: {
+            chain: ['y'],
+            solo: 'Maybe this works, perhaps it does, I think possibly it might be fine, probably, unsure though.',
+            floor: 0.9,
+        },
+        ok: {
+            chain: ['y'],
+            solo: 'Ship it. The migration is reversible, tests cover the critical path, and the blast radius is small.',
+            floor: 0.5,
+        },
+    };
+
+    it.each(Object.keys(DISPATCH_CASES))('dispatch_with_escalation(%s) matches', (key) => {
+        const cse = DISPATCH_CASES[key]!;
+        const r = py(
+            `routing = RoutingConfig(solo_member_fallback_chain=${JSON.stringify(cse.chain)}, auth_check_timeout_seconds=3)\n` +
+                `members = {"y": MemberConfig(name="y", enabled=True, model="m", api_key_ref=None, mode=None, binary=None, model_ladder=(), participate_low_impact=True)}\n` +
+                `res = sd.dispatch_with_escalation(routing, members, auth_cache=sd.AuthCache(), ` +
+                `probe=lambda n, t: True, run_solo=lambda n: ${JSON.stringify(cse.solo)}, run_full=lambda: "FULL", ` +
+                `confidence_floor=${cse.floor}, now=1.0, env={})\n` +
+                'print(json.dumps({"verdict": res.verdict, "escalated": res.escalated, ' +
+                '"escalation_reason": res.escalation_reason, "solo_member": res.solo_member, ' +
+                '"solo_response": res.solo_response, "solo_confidence": res.solo_confidence}))',
+        );
+        expect(r.status).toBe(0);
+        const members = new Map([['y', member('y', true)]]);
+        const res = dispatch_with_escalation(
+            { solo_member_fallback_chain: cse.chain, auth_check_timeout_seconds: 3 },
+            members,
+            {
+                auth_cache: new AuthCache(),
+                probe: () => true,
+                run_solo: () => cse.solo,
+                run_full: () => 'FULL',
+                confidence_floor: cse.floor,
+                now: 1.0,
+                env: {},
+            },
+        );
+        expect({
+            verdict: res.verdict,
+            escalated: res.escalated,
+            escalation_reason: res.escalation_reason,
+            solo_member: res.solo_member,
+            solo_response: res.solo_response,
+            solo_confidence: res.solo_confidence,
+        }).toEqual(JSON.parse(r.stdout.trim()));
+    });
+
+    it('force_full_council matches across env values', () => {
+        const cases = ['', '1', '0', '2', 'true', 'yes'];
+        const r = py(
+            `vals = ${JSON.stringify(cases)}\n` +
+                'print(json.dumps([sd.force_full_council({"AGENT_CONFIG_FORCE_FULL_COUNCIL": v}) for v in vals]))',
+        );
+        expect(r.status).toBe(0);
+        const got = cases.map((v) => force_full_council({ [FORCE_FULL_ENV]: v }));
+        expect(got).toEqual(JSON.parse(r.stdout.trim()));
+    });
+});


### PR DESCRIPTION
Second ai_council layer — the modules whose deps are all in the merged foundation. Targets `python2ts`. `.py` originals stay until Phase 12.

## Twins (9)
- `clients` (1385) — provider/client layer (API + CLI + manual); transport stubbed via a `_runSubprocess` seam + injected client mocks (no live calls).
- `prompts` / `consensus` / `advisors` / `solo_dispatch` — prompt assembly, convergence scoring, advisor selection, single-member path.
- `low_impact_corpus` / `redact_low_impact_entry` / `low_impact_intake` / `bundler` — the low-impact-corpus privacy floor + git bundle-diff. The **redactor** reproduces all 8 forbidden-content classes byte-identical (Python `re`→JS: `\w`→`[\p{L}\p{N}_]`, `\b`→lookaround, code-point len/slice).

257 tests (all via the merged `_harness.ts` python3-differential rig). legacy-literal ts==py for all 9. tsc clean, phase-gate passes. **525/525 across the full ai_council twin suite** (foundation + this layer).

## Small dependency edit
`config.ts`: added `export` to `_RAW_KEY_PREFIXES` (one word) — the redactor imports it, mirroring `from ai_council import config` in the `.py`. config's 65 tests still green.

## Remaining ai_council (next waves)
The top layer: `orchestrator` (1206, →advisors/clients/consensus/prompts), `session` (→clients/orchestrator), `necessity` (→low_impact_corpus), `low_impact` (→clients/necessity/orchestrator), `compile_corpus`, `learn_low_impact_preview`, `replay`, `shadow_dispatch` — then `council_cli` / `council_prune`.

## Verification
`tsc` clean · phase-gate passes · 525/525 ai_council suite · python3-differential byte-match · legacy 0==0. Migration-gates 4-shard run validates on this PR's CI.