### PR TITLE
feat(py2ts): phase 10 — ai_council layer 3 (6 twins incl. orchestrator)

### DIFF
--- a/src/scripts/ai_council/compile_corpus.ts
+++ b/src/scripts/ai_council/compile_corpus.ts
@@ -1,0 +1,681 @@
+/**
+ * Compile the human-edited low-impact corpus Markdown to a YAML lockfile.
+ *
+ * TypeScript twin of `src/scripts/ai_council/compile_corpus.py`
+ * (ADR-094 — Python→TS migration, Phase 1).
+ *
+ * Step-10 — see `agents/roadmaps/step-10-corpus-yaml-lockfile.md`.
+ *
+ * Markdown (`agents/decisions/low-impact-decisions.md`) stays the
+ * human-authored source-of-truth for PR review. This script reads it
+ * through the hardened {@link parse_corpus_strict} parser and writes a YAML
+ * lockfile that becomes the **runtime** source-of-truth. The pattern mirrors
+ * `dist/agent-src/` vs `.agent-src.uncondensed/`: human edits Markdown,
+ * `task consistency` enforces lockfile parity via the same
+ * `git diff --quiet` gate.
+ *
+ * YAML schema (`schema_version: 1`):
+ *
+ *     schema_version: 1
+ *     provenance:
+ *       source_path: agents/decisions/low-impact-decisions.md
+ *       source_sha256: <hex>             # SHA-256 of the parsed Markdown bytes
+ *       last_upstreamed: <40-hex sha>     # mirrored from the Markdown footer
+ *     validated:
+ *       - phrase: "raw bullet text"
+ *         normalised: "raw bullet text"
+ *         line_no: 42
+ *         trailing_metadata: "validated 2025-01-15"
+ *     probation: [...]
+ *     anti_examples: [...]
+ *
+ * Determinism: sorted keys disabled (preserve schema order), entries
+ * ordered by `line_no`, single trailing newline. The YAML emitter mirrors
+ * PyYAML `safe_dump` with `allow_unicode=True` byte-for-byte so phrases with
+ * non-ASCII characters round-trip unchanged.
+ *
+ * Failure-mode contract:
+ *
+ * - Parser raises {@link CorpusParseError} -> compiler exits non-zero, does
+ *   NOT write a partial lockfile.
+ * - `--check` mode compares the freshly compiled output against the
+ *   committed lockfile and exits non-zero on drift (CI gate).
+ */
+
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    CorpusParseError,
+    type CorpusEntry,
+    type CorpusParseResult,
+    parse_corpus_strict,
+} from './low_impact_corpus.js';
+
+export const SCHEMA_VERSION = 1;
+
+// Python: re.compile(r"^last-upstreamed:\s*([0-9a-f]{40})\s*$", re.MULTILINE)
+// \s is Unicode in Python; emulate with the explicit Unicode whitespace class.
+const _SP = '[ \\t\\f\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff\\u0085]';
+const _LAST_UPSTREAMED_RE = new RegExp(
+    `^last-upstreamed:${_SP}*([0-9a-f]{40})${_SP}*$`,
+    'mu',
+);
+
+const _DEFAULT_SOURCE = 'agents/decisions/low-impact-decisions.md';
+const _DEFAULT_OUT = 'agents/decisions/low-impact-decisions.lock.yaml';
+
+/** Schema-stable mapping for one corpus entry (section dropped). */
+type EntryDict = {
+    phrase: string;
+    normalised: string;
+    line_no: number;
+    trailing_metadata: string;
+};
+
+/** The schema-v1 document shape. */
+interface LockDocument {
+    schema_version: number;
+    provenance: {
+        source_path: string;
+        source_sha256: string;
+        last_upstreamed: string;
+    };
+    validated: EntryDict[];
+    probation: EntryDict[];
+    anti_examples: EntryDict[];
+}
+
+/** Serialise a {@link CorpusEntry} to a schema-stable mapping. */
+function _entryToDict(entry: CorpusEntry): EntryDict {
+    // Python: asdict(entry); data.pop("section", None). Section is implicit by
+    // the parent key, so it is dropped to keep the YAML lean.
+    return {
+        phrase: entry.phrase,
+        normalised: entry.normalised,
+        line_no: entry.line_no,
+        trailing_metadata: entry.trailing_metadata,
+    };
+}
+
+/** Read the provenance SHA from the Markdown footer; `""` if absent. */
+function _extractLastUpstreamed(text: string): string {
+    const m = _LAST_UPSTREAMED_RE.exec(text);
+    return m ? (m[1] as string) : '';
+}
+
+/**
+ * Return `path` as a POSIX string relative to cwd when possible.
+ *
+ * Absolute paths inside the current working directory are stripped to their
+ * relative form so the committed lockfile carries
+ * `agents/decisions/low-impact-decisions.md` regardless of how the compiler
+ * was invoked (CLI default, absolute path from a test, etc.).
+ */
+function _normaliseSourcePath(p: string): string {
+    let rel: string;
+    const resolved = path.resolve(p);
+    const cwd = path.resolve(process.cwd());
+    // Python: path.resolve().relative_to(Path.cwd().resolve()) — only succeeds
+    // when resolved is inside cwd; otherwise fall back to the basename.
+    if (resolved === cwd) {
+        rel = '.';
+    } else if (resolved.startsWith(cwd + path.sep)) {
+        rel = resolved.slice(cwd.length + 1);
+    } else {
+        rel = _basename(p);
+    }
+    return rel.replace(/\\/gu, '/');
+}
+
+/** Python `Path(p).name`. */
+function _basename(p: string): string {
+    // pathlib drops trailing slashes before taking the final component.
+    let s = p;
+    while (s.length > 1 && s.endsWith('/')) {
+        s = s.slice(0, -1);
+    }
+    const i = s.lastIndexOf('/');
+    return i < 0 ? s : s.slice(i + 1);
+}
+
+/** Return the schema-v1 mapping for `parseResult`. */
+export function build_lock_document(
+    sourcePath: string,
+    parseResult: CorpusParseResult,
+    sourceText: string,
+): LockDocument {
+    const sha256 = createHash('sha256').update(Buffer.from(sourceText, 'utf-8')).digest('hex');
+    return {
+        schema_version: SCHEMA_VERSION,
+        provenance: {
+            source_path: _normaliseSourcePath(sourcePath),
+            source_sha256: sha256,
+            last_upstreamed: _extractLastUpstreamed(sourceText),
+        },
+        validated: parseResult.validated.map(_entryToDict),
+        probation: parseResult.probation.map(_entryToDict),
+        anti_examples: parseResult.anti_examples.map(_entryToDict),
+    };
+}
+
+/** Serialise `document` deterministically to YAML text (PyYAML parity). */
+export function dump_lock_yaml(document: LockDocument): string {
+    // Mirror yaml.safe_dump(sort_keys=False, allow_unicode=True,
+    // default_flow_style=False, width=10_000): block style, single trailing
+    // newline.
+    const lines: string[] = [];
+    _emitMapping(document as unknown as Record<string, unknown>, 0, lines);
+    return lines.join('\n') + '\n';
+}
+
+/** Read `source_path` Markdown, write YAML lockfile to `out_path`. */
+export function compile_corpus(sourcePath: string, outPath: string): string {
+    const sourceText = fs.existsSync(sourcePath)
+        ? fs.readFileSync(sourcePath, { encoding: 'utf-8' })
+        : '';
+    const parseResult = parse_corpus_strict(sourcePath);
+    const document = build_lock_document(sourcePath, parseResult, sourceText);
+    const yamlText = dump_lock_yaml(document);
+    fs.mkdirSync(_dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, yamlText, { encoding: 'utf-8' });
+    return yamlText;
+}
+
+/** Python `Path(p).parent` (used for mkdir of the out-file's directory). */
+function _dirname(p: string): string {
+    const i = p.lastIndexOf('/');
+    if (i < 0) {
+        return '.';
+    }
+    if (i === 0) {
+        return '/';
+    }
+    return p.slice(0, i);
+}
+
+// ── PyYAML safe_dump emitter (block style, width=10000) ──────────────────────
+// Faithful port of the subset of PyYAML's emitter that this document shape
+// exercises: a top-level mapping of scalar→{scalar|mapping|list}, lists of
+// mappings whose leaf values are str|int. width=10000 means the line-wrapping
+// branches in PyYAML's writers never fire for the short single-line content
+// here, so single-/double-quoted writers reduce to escape-then-wrap.
+
+const _BEST_INDENT = 2;
+
+function _emitMapping(map: Record<string, unknown>, indent: number, out: string[]): void {
+    const pad = ' '.repeat(indent);
+    for (const [key, value] of Object.entries(map)) {
+        const keyStr = _scalarToYaml(key, false);
+        if (_isPlainMapping(value)) {
+            const child = value as Record<string, unknown>;
+            if (Object.keys(child).length === 0) {
+                out.push(`${pad}${keyStr}: {}`);
+            } else {
+                out.push(`${pad}${keyStr}:`);
+                _emitMapping(child, indent + _BEST_INDENT, out);
+            }
+        } else if (Array.isArray(value)) {
+            if (value.length === 0) {
+                out.push(`${pad}${keyStr}: []`);
+            } else {
+                out.push(`${pad}${keyStr}:`);
+                // PyYAML block sequence under a mapping key: indentless, so the
+                // `- ` indicator sits at the parent's indent.
+                _emitSequence(value, indent, out);
+            }
+        } else {
+            out.push(`${pad}${keyStr}: ${_scalarToYaml(value, false)}`);
+        }
+    }
+}
+
+function _emitSequence(seq: unknown[], indent: number, out: string[]): void {
+    const pad = ' '.repeat(indent);
+    for (const item of seq) {
+        if (_isPlainMapping(item)) {
+            const child = item as Record<string, unknown>;
+            const lines = _emitMappingInline(child, indent + _BEST_INDENT);
+            // First key follows "- " on the same line; rest indented.
+            out.push(`${pad}- ${lines[0]}`);
+            for (let i = 1; i < lines.length; i += 1) {
+                out.push(`${pad}  ${lines[i]}`);
+            }
+        } else {
+            out.push(`${pad}- ${_scalarToYaml(item, false)}`);
+        }
+    }
+}
+
+/** Emit a mapping's `key: value` lines (no leading pad); for inline-in-list use. */
+function _emitMappingInline(map: Record<string, unknown>, _indent: number): string[] {
+    const lines: string[] = [];
+    for (const [key, value] of Object.entries(map)) {
+        const keyStr = _scalarToYaml(key, false);
+        lines.push(`${keyStr}: ${_scalarToYaml(value, false)}`);
+    }
+    return lines;
+}
+
+function _isPlainMapping(v: unknown): v is Record<string, unknown> {
+    return (
+        v !== null &&
+        typeof v === 'object' &&
+        !Array.isArray(v) &&
+        Object.getPrototypeOf(v) === Object.prototype
+    );
+}
+
+/** Render one scalar value (str | int) the way PyYAML safe_dump would. */
+function _scalarToYaml(value: unknown, simpleKeyContext: boolean): string {
+    if (typeof value === 'number') {
+        // Only ints appear in this document; render via Python int repr.
+        return String(Math.trunc(value));
+    }
+    const text = String(value);
+    const style = _chooseScalarStyle(text, simpleKeyContext);
+    if (style === '"') {
+        return _writeDoubleQuoted(text);
+    }
+    if (style === "'") {
+        return _writeSingleQuoted(text);
+    }
+    return text; // plain
+}
+
+// ── PyYAML resolver: would a plain string be implicitly re-typed? ────────────
+// Mirrors yaml.resolver.Resolver implicit resolvers for the SafeDumper.
+
+const _RESOLVER_BOOL = /^(?:yes|Yes|YES|no|No|NO|true|True|TRUE|false|False|FALSE|on|On|ON|off|Off|OFF)$/u;
+const _RESOLVER_NULL = /^(?:~|null|Null|NULL|)$/u;
+const _RESOLVER_FLOAT =
+    /^(?:[-+]?(?:[0-9][0-9_]*)\.[0-9_]*(?:[eE][-+][0-9]+)?|\.[0-9][0-9_]*(?:[eE][-+][0-9]+)?|[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+\.[0-9_]*|[-+]?\.(?:inf|Inf|INF)|\.(?:nan|NaN|NAN))$/u;
+const _RESOLVER_INT =
+    /^(?:[-+]?0b[0-1_]+|[-+]?0[0-7_]+|[-+]?(?:0|[1-9][0-9_]*)|[-+]?0x[0-9a-fA-F_]+|[-+]?[1-9][0-9_]*(?::[0-5]?[0-9])+)$/u;
+const _RESOLVER_TIMESTAMP =
+    /^(?:[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]|[0-9][0-9][0-9][0-9]-[0-9][0-9]?-[0-9][0-9]?(?:[Tt]|[ \t]+)[0-9][0-9]?:[0-9][0-9]:[0-9][0-9](?:\.[0-9]*)?(?:[ \t]*(?:Z|[-+][0-9][0-9]?(?::[0-9][0-9])?))?)$/u;
+const _RESOLVER_MERGE = /^(?:<<)$/u;
+const _RESOLVER_VALUE = /^(?:=)$/u;
+const _RESOLVER_YAML = /^(?:!|&|\*)$/u;
+
+// First-char → ordered resolver list, mirroring registration order in
+// resolver.py (bool, float, int, merge, null, timestamp, value, yaml).
+// Only the leading char gates which resolvers run; order within is the
+// registration order of add_implicit_resolver calls.
+const _RESOLVERS_BY_FIRST: Record<string, RegExp[]> = {};
+function _registerResolver(rx: RegExp, firsts: string): void {
+    for (const ch of firsts) {
+        if (!(ch in _RESOLVERS_BY_FIRST)) {
+            _RESOLVERS_BY_FIRST[ch] = [];
+        }
+        (_RESOLVERS_BY_FIRST[ch] as RegExp[]).push(rx);
+    }
+}
+// Registration order matches PyYAML Resolver.add_implicit_resolver calls.
+_registerResolver(_RESOLVER_BOOL, 'yYnNtTfFoO');
+_registerResolver(_RESOLVER_FLOAT, '-+0123456789.');
+_registerResolver(_RESOLVER_INT, '-+0123456789');
+_registerResolver(_RESOLVER_MERGE, '<');
+_registerResolver(_RESOLVER_NULL, '~nN\0'); // '' handled separately
+_registerResolver(_RESOLVER_TIMESTAMP, '0123456789');
+_registerResolver(_RESOLVER_VALUE, '=');
+_registerResolver(_RESOLVER_YAML, '!&*');
+// Empty-string resolves to null (registered under the '' key in PyYAML).
+const _RESOLVERS_EMPTY: RegExp[] = [_RESOLVER_NULL];
+
+/** True when `value`, emitted plain, would NOT resolve back to str. */
+function _wouldRetype(value: string): boolean {
+    const resolvers = value === '' ? _RESOLVERS_EMPTY : _RESOLVERS_BY_FIRST[value[0] as string] ?? [];
+    for (const rx of resolvers) {
+        if (rx.test(value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ── PyYAML analyze_scalar (block-context decision) ───────────────────────────
+
+interface ScalarAnalysis {
+    empty: boolean;
+    multiline: boolean;
+    allowBlockPlain: boolean;
+    allowSingleQuoted: boolean;
+}
+
+const _WS_SET = new Set(['\0', ' ', '\t', '\r', '\n', '\x85', '\u2028', '\u2029']);
+const _BREAK_SET = new Set(['\n', '\x85', '\u2028', '\u2029']);
+
+function _isPrintableAscii(ch: string): boolean {
+    return ch >= '\x20' && ch <= '\x7e';
+}
+
+function _isAllowedUnicode(ch: string): boolean {
+    // matches PyYAML allow_unicode branch (ch != BOM)
+    return (
+        (ch === '\x85' ||
+            (ch >= '\xa0' && ch <= '\ud7ff') ||
+            (ch >= '\ue000' && ch <= '\ufffd') ||
+            (ch >= '\u{10000}' && ch < '\u{10ffff}')) &&
+        ch !== '\ufeff'
+    );
+}
+
+function _analyzeScalar(scalar: string): ScalarAnalysis {
+    if (scalar === '') {
+        return { empty: true, multiline: false, allowBlockPlain: true, allowSingleQuoted: true };
+    }
+    const chars = Array.from(scalar); // iterate by code point, like Python str
+
+    let blockIndicators = false;
+    let lineBreaks = false;
+    let specialCharacters = false;
+
+    let leadingSpace = false;
+    let leadingBreak = false;
+    let trailingSpace = false;
+    let trailingBreak = false;
+    let breakSpace = false;
+    let spaceBreak = false;
+
+    if (scalar.startsWith('---') || scalar.startsWith('...')) {
+        blockIndicators = true;
+    }
+
+    let precededByWhitespace = true;
+    let followedByWhitespace = chars.length === 1 || _WS_SET.has(chars[1] as string);
+    let previousSpace = false;
+    let previousBreak = false;
+
+    let index = 0;
+    while (index < chars.length) {
+        const ch = chars[index] as string;
+
+        if (index === 0) {
+            if ('#,[]{}&*!|>\'"%@`'.includes(ch)) {
+                blockIndicators = true;
+            }
+            if (ch === '?' || ch === ':') {
+                if (followedByWhitespace) {
+                    blockIndicators = true;
+                }
+            }
+            if (ch === '-' && followedByWhitespace) {
+                blockIndicators = true;
+            }
+        } else {
+            if (ch === ':' && followedByWhitespace) {
+                blockIndicators = true;
+            }
+            if (ch === '#' && precededByWhitespace) {
+                blockIndicators = true;
+            }
+        }
+
+        if (_BREAK_SET.has(ch)) {
+            lineBreaks = true;
+        }
+        if (!(ch === '\n' || _isPrintableAscii(ch))) {
+            if (_isAllowedUnicode(ch)) {
+                // allow_unicode=True → not special
+            } else {
+                specialCharacters = true;
+            }
+        }
+
+        if (ch === ' ') {
+            if (index === 0) {
+                leadingSpace = true;
+            }
+            if (index === chars.length - 1) {
+                trailingSpace = true;
+            }
+            if (previousBreak) {
+                breakSpace = true;
+            }
+            previousSpace = true;
+            previousBreak = false;
+        } else if (_BREAK_SET.has(ch)) {
+            if (index === 0) {
+                leadingBreak = true;
+            }
+            if (index === chars.length - 1) {
+                trailingBreak = true;
+            }
+            if (previousSpace) {
+                spaceBreak = true;
+            }
+            previousSpace = false;
+            previousBreak = true;
+        } else {
+            previousSpace = false;
+            previousBreak = false;
+        }
+
+        index += 1;
+        precededByWhitespace = _WS_SET.has(ch);
+        followedByWhitespace =
+            index + 1 >= chars.length || _WS_SET.has(chars[index + 1] as string);
+    }
+
+    let allowBlockPlain = true;
+    let allowSingleQuoted = true;
+
+    if (leadingSpace || leadingBreak || trailingSpace || trailingBreak) {
+        allowBlockPlain = false;
+    }
+    if (breakSpace) {
+        allowBlockPlain = false;
+        allowSingleQuoted = false;
+    }
+    if (spaceBreak || specialCharacters) {
+        allowBlockPlain = false;
+        allowSingleQuoted = false;
+    }
+    if (lineBreaks) {
+        allowBlockPlain = false;
+    }
+    if (blockIndicators) {
+        allowBlockPlain = false;
+    }
+
+    return { empty: false, multiline: lineBreaks, allowBlockPlain, allowSingleQuoted };
+}
+
+/** Mirror PyYAML Emitter.choose_scalar_style for block context, default style. */
+function _chooseScalarStyle(text: string, simpleKeyContext: boolean): '' | "'" | '"' {
+    const analysis = _analyzeScalar(text);
+    // implicit[0] is true unless the plain form would re-type away from str.
+    const implicit0 = !_wouldRetype(text);
+    if (implicit0) {
+        if (
+            !(simpleKeyContext && (analysis.empty || analysis.multiline)) &&
+            !analysis.empty &&
+            analysis.allowBlockPlain
+        ) {
+            // Note: allow_block_plain already false for empty; the explicit
+            // empty guard mirrors PyYAML returning '' only when plain allowed.
+            return '';
+        }
+    }
+    if (analysis.allowSingleQuoted && !(simpleKeyContext && analysis.multiline)) {
+        return "'";
+    }
+    return '"';
+}
+
+/** PyYAML write_single_quoted with width=10000 (no wrapping). */
+function _writeSingleQuoted(text: string): string {
+    return "'" + text.replace(/'/gu, "''") + "'";
+}
+
+const _ESCAPE_REPLACEMENTS: Record<string, string> = {
+    '\x00': '0',
+    '\x07': 'a',
+    '\x08': 'b',
+    '\t': 't',
+    '\n': 'n',
+    '\x0b': 'v',
+    '\x0c': 'f',
+    '\r': 'r',
+    '\x1b': 'e',
+    '"': '"',
+    '\\': '\\',
+    '\x85': 'N',
+    '\xa0': '_',
+    '\u2028': 'L',
+    '\u2029': 'P',
+};
+
+/** PyYAML write_double_quoted with width=10000 + allow_unicode=True. */
+function _writeDoubleQuoted(text: string): string {
+    let out = '"';
+    for (const ch of text) {
+        const needsEscape =
+            ch === '"' ||
+            ch === '\\' ||
+            ch === '\x85' ||
+            ch === '\u2028' ||
+            ch === '\u2029' ||
+            ch === '\ufeff' ||
+            !(_isPrintableAscii(ch) || (ch >= '\xa0' && ch <= '\ud7ff') || (ch >= '\ue000' && ch <= '\ufffd'));
+        if (!needsEscape) {
+            out += ch;
+            continue;
+        }
+        if (ch in _ESCAPE_REPLACEMENTS) {
+            out += '\\' + _ESCAPE_REPLACEMENTS[ch];
+        } else {
+            const cp = ch.codePointAt(0) as number;
+            if (cp <= 0xff) {
+                out += '\\x' + cp.toString(16).toUpperCase().padStart(2, '0');
+            } else if (cp <= 0xffff) {
+                out += '\\u' + cp.toString(16).toUpperCase().padStart(4, '0');
+            } else {
+                out += '\\U' + cp.toString(16).toUpperCase().padStart(8, '0');
+            }
+        }
+    }
+    out += '"';
+    return out;
+}
+
+// ── CLI entry-point (argparse parity) ────────────────────────────────────────
+
+function _prog(): string {
+    return 'compile_corpus';
+}
+
+class _ExitSignal extends Error {
+    constructor(readonly code: number) {
+        super(`exit ${code}`);
+    }
+}
+
+const _USAGE = `usage: ${_prog()} [-h] [--source SOURCE] [--out OUT] [--check]`;
+
+const _HELP =
+    `${_USAGE}\n\n` +
+    'Compile low-impact-decisions.md to YAML lockfile.\n\n' +
+    'optional arguments:\n' +
+    '  -h, --help       show this help message and exit\n' +
+    '  --source SOURCE\n' +
+    '  --out OUT\n' +
+    '  --check          Exit non-zero if the lockfile is stale (CI gate).\n';
+
+function _argError(message: string): never {
+    process.stderr.write(`${_USAGE}\n`);
+    process.stderr.write(`${_prog()}: error: ${message}\n`);
+    process.exitCode = 2;
+    throw new _ExitSignal(2);
+}
+
+interface _Args {
+    source: string;
+    out: string;
+    check: boolean;
+}
+
+function _parseArgs(args: string[]): _Args {
+    let source = _DEFAULT_SOURCE;
+    let out = _DEFAULT_OUT;
+    let check = false;
+    for (let i = 0; i < args.length; i += 1) {
+        const a = args[i] as string;
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(_HELP);
+            throw new _ExitSignal(0);
+        } else if (a === '--source') {
+            const v = args[i + 1];
+            if (v === undefined) {
+                _argError('argument --source: expected one argument');
+            }
+            source = v as string;
+            i += 1;
+        } else if (a.startsWith('--source=')) {
+            source = a.slice('--source='.length);
+        } else if (a === '--out') {
+            const v = args[i + 1];
+            if (v === undefined) {
+                _argError('argument --out: expected one argument');
+            }
+            out = v as string;
+            i += 1;
+        } else if (a.startsWith('--out=')) {
+            out = a.slice('--out='.length);
+        } else if (a === '--check') {
+            check = true;
+        } else {
+            _argError(`unrecognized arguments: ${a}`);
+        }
+    }
+    return { source, out, check };
+}
+
+export function _main(argv: string[]): number {
+    let args: _Args;
+    try {
+        args = _parseArgs(argv);
+    } catch (exc) {
+        if (exc instanceof _ExitSignal) {
+            return exc.code;
+        }
+        throw exc;
+    }
+    try {
+        if (!args.check) {
+            compile_corpus(args.source, args.out);
+        } else {
+            const sourceText = fs.existsSync(args.source)
+                ? fs.readFileSync(args.source, { encoding: 'utf-8' })
+                : '';
+            const parseResult = parse_corpus_strict(args.source);
+            const document = build_lock_document(args.source, parseResult, sourceText);
+            const fresh = dump_lock_yaml(document);
+            const existing = fs.existsSync(args.out)
+                ? fs.readFileSync(args.out, { encoding: 'utf-8' })
+                : '';
+            if (fresh !== existing) {
+                process.stderr.write(
+                    `low-impact corpus lockfile is stale: ${args.out}\n` +
+                        '  run: python3 -m scripts.ai_council.compile_corpus\n',
+                );
+                return 1;
+            }
+        }
+    } catch (exc) {
+        if (exc instanceof CorpusParseError) {
+            process.stderr.write(`corpus parse failed: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+    return 0;
+}
+
+const _isMain = import.meta.url === pathToFileURL(path.resolve(process.argv[1] ?? '')).href;
+if (_isMain) {
+    process.exitCode = _main(process.argv.slice(2));
+}

--- a/src/scripts/ai_council/learn_low_impact_preview.ts
+++ b/src/scripts/ai_council/learn_low_impact_preview.ts
@@ -1,0 +1,317 @@
+/**
+ * Preview builder for `/memory learn-low-impact` (step-9 Phase 7).
+ *
+ * TypeScript twin of `src/scripts/ai_council/learn_low_impact_preview.py`
+ * (ADR-094 — Python→TS migration, Phase 1).
+ *
+ * Default invocation is `--preview`: build a structured plan describing
+ * which Validated entries would be upstreamed to the package seed without
+ * opening a PR. `--apply` (handled by the agent, not this module) is the
+ * explicit opt-in that triggers the actual upstream-contribute PR flow.
+ *
+ * The module is import-light by design — pure parsing + redaction + diff
+ * rendering. PR creation lives in the `upstream-contribute` skill;
+ * this module only hands the agent the material to surface.
+ */
+
+import * as fs from 'node:fs';
+
+import { parse_corpus_strict } from './low_impact_corpus.js';
+import {
+    type RedactionViolation,
+    redact_low_impact_entry,
+} from './redact_low_impact_entry.js';
+
+// Python: re.compile(r"^last-upstreamed:\s*([0-9a-f]{6,40}|0+)\s*$",
+//                     re.IGNORECASE | re.MULTILINE)
+// \s is Unicode in Python; emulate via the explicit Unicode whitespace class.
+const _SP = '[ \\t\\f\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff\\u0085]';
+const _PROVENANCE_RE = new RegExp(
+    `^last-upstreamed:${_SP}*([0-9a-f]{6,40}|0+)${_SP}*$`,
+    'imu',
+);
+
+/** One Validated bullet that would be upstreamed. */
+export interface PreviewEntry {
+    readonly phrase: string;
+    readonly normalised: string;
+    readonly line_no: number;
+}
+
+/** A Validated bullet the redactor refused — never upstreams. */
+export class RefusedEntry {
+    readonly phrase: string;
+    readonly line_no: number;
+    readonly violations: readonly RedactionViolation[];
+
+    constructor(phrase: string, line_no: number, violations: readonly RedactionViolation[]) {
+        this.phrase = phrase;
+        this.line_no = line_no;
+        this.violations = violations;
+    }
+
+    reason(): string {
+        // Python: "; ".join(f"{v.category}: {v.snippet}" for v in self.violations)
+        return this.violations.map((v) => `${v.category}: ${v.snippet}`).join('; ');
+    }
+}
+
+/**
+ * Structured preview for `/memory learn-low-impact --preview`.
+ *
+ * Consumed by the agent which renders the human-facing preview block,
+ * then waits for explicit `--apply` before invoking `upstream-contribute`.
+ */
+export class LearnLowImpactPreview {
+    readonly promoted: readonly PreviewEntry[];
+    readonly refused: readonly RefusedEntry[];
+    readonly already_seeded: readonly string[];
+    readonly last_upstreamed_sha: string;
+    readonly seed_path: string;
+    readonly corpus_path: string;
+    readonly repo_slug: string;
+    readonly warnings: readonly string[];
+
+    constructor(opts: {
+        promoted: readonly PreviewEntry[];
+        refused: readonly RefusedEntry[];
+        already_seeded: readonly string[];
+        last_upstreamed_sha: string;
+        seed_path: string;
+        corpus_path: string;
+        repo_slug?: string;
+        warnings?: readonly string[];
+    }) {
+        this.promoted = opts.promoted;
+        this.refused = opts.refused;
+        this.already_seeded = opts.already_seeded;
+        this.last_upstreamed_sha = opts.last_upstreamed_sha;
+        this.seed_path = opts.seed_path;
+        this.corpus_path = opts.corpus_path;
+        this.repo_slug = opts.repo_slug ?? '';
+        this.warnings = opts.warnings ?? [];
+    }
+
+    get has_work(): boolean {
+        return this.promoted.length > 0 || this.refused.length > 0;
+    }
+
+    /**
+     * True when `--apply` would actually open a PR.
+     *
+     * Iron Law: any redactor refusal blocks the PR — the author must
+     * rephrase or drop the offending entry locally and re-run.
+     */
+    get would_open_pr(): boolean {
+        return this.promoted.length > 0 && this.refused.length === 0;
+    }
+
+    /**
+     * Human-readable preview block.
+     *
+     * Mirrors the rendering convention from `/memory mine-session`:
+     * a leading title line, then bucketed entries.
+     */
+    render(): string {
+        const lines: string[] = [];
+        lines.push(
+            '## learn-low-impact preview' +
+                (this.repo_slug ? ` — repo=${this.repo_slug}` : ''),
+        );
+        lines.push(`last-upstreamed: ${this.last_upstreamed_sha}`);
+        lines.push(`seed: ${this.seed_path}`);
+        lines.push('');
+        if (this.promoted.length > 0) {
+            lines.push(`### Promoted (${this.promoted.length})`);
+            for (const e of this.promoted) {
+                lines.push(`- "${e.phrase}"  (line ${e.line_no})`);
+            }
+            lines.push('');
+        }
+        if (this.refused.length > 0) {
+            lines.push(`### Refused (${this.refused.length}) — redactor blocked`);
+            for (const r of this.refused) {
+                lines.push(`- "${r.phrase}"  (line ${r.line_no}) — ${r.reason()}`);
+            }
+            lines.push('');
+        }
+        if (this.already_seeded.length > 0) {
+            lines.push(`### Already seeded (${this.already_seeded.length})`);
+            for (const phrase of this.already_seeded) {
+                lines.push(`- "${phrase}"`);
+            }
+            lines.push('');
+        }
+        if (!this.has_work) {
+            lines.push('> No new validated entries to upstream.');
+            lines.push('');
+        }
+        if (this.refused.length > 0) {
+            lines.push(
+                '> Refusals block the PR. Rephrase the entries locally' +
+                    ' (or drop them) and re-run.',
+            );
+        } else if (this.promoted.length > 0) {
+            lines.push(
+                '> Re-run with `--apply` to open the draft PR via' +
+                    ' `upstream-contribute`.',
+            );
+        }
+        // Python: "\n".join(lines).rstrip() + "\n"
+        return _rstrip(lines.join('\n')) + '\n';
+    }
+
+    /**
+     * Source-project-stripped diff that `--apply` would propose.
+     *
+     * Emits unified-diff-style `+` lines for each promoted phrase under the
+     * seed file's `## Validated` section. The agent uses this as the
+     * `upstream-contribute` patch body.
+     */
+    render_diff(): string {
+        if (this.promoted.length === 0) {
+            return '';
+        }
+        const lines = [`--- ${this.seed_path}`, `+++ ${this.seed_path}`];
+        for (const e of this.promoted) {
+            lines.push(`+- "${e.phrase}"`);
+        }
+        return lines.join('\n') + '\n';
+    }
+
+    /** Draft PR body for the upstream contribute flow. */
+    render_pr_body(): string {
+        const n = this.promoted.length;
+        const slug = this.repo_slug || '<repo-slug>';
+        const title = `feat(low-impact-seed): add ${n} validated entries from ${slug}`;
+        const bodyLines: string[] = [
+            `# ${title}`,
+            '',
+            'Upstream from `/memory learn-low-impact --apply`.',
+            '',
+            '## Entries',
+            '',
+        ];
+        for (const e of this.promoted) {
+            bodyLines.push(`- "${e.phrase}"`);
+        }
+        bodyLines.push('');
+        bodyLines.push(`Provenance baseline: \`${this.last_upstreamed_sha}\`.`);
+        bodyLines.push('');
+        bodyLines.push(
+            'Per `low-impact-corpus-privacy-floor`, every entry above' +
+                ' cleared the redactor on intake and again at upstream.',
+        );
+        return bodyLines.join('\n') + '\n';
+    }
+}
+
+/** Python `str.rstrip()`. */
+function _rstrip(s: string): string {
+    // Python str.rstrip() strips Unicode whitespace from the end. Use the
+    // explicit Python str.isspace() set (ASCII + Unicode space separators +
+    // line/para separators + NEL); JS \s under /u is close but Python also
+    // treats a handful of separators as space.
+    const WS =
+        '\\t\\n\\v\\f\\r \\u001c\\u001d\\u001e\\u001f\\u0085\\u00a0' +
+        '\\u1680\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007' +
+        '\\u2008\\u2009\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000';
+    const re = new RegExp(`[${WS}]+$`, 'u');
+    return s.replace(re, '');
+}
+
+/**
+ * Return the set of normalised phrases already in the seed file.
+ *
+ * Missing seed file is not an error — it returns an empty set so the
+ * first-ever upstream PR can seed the whole corpus. Reuses the strict
+ * parser so the seed itself is contract-validated.
+ */
+function _readSeedPhrases(seedPath: string): Set<string> {
+    if (!fs.existsSync(seedPath)) {
+        return new Set();
+    }
+    const result = parse_corpus_strict(seedPath);
+    return new Set(result.validated.map((e) => e.normalised));
+}
+
+function _readProvenance(corpusPath: string): string {
+    if (!fs.existsSync(corpusPath)) {
+        return '0'.repeat(40);
+    }
+    const text = fs.readFileSync(corpusPath, { encoding: 'utf-8' });
+    const m = _PROVENANCE_RE.exec(text);
+    return m ? (m[1] as string).toLowerCase() : '0'.repeat(40);
+}
+
+export interface BuildPreviewOptions {
+    repoRoot?: string | null;
+    privateDomains?: Iterable<string>;
+    customerNames?: Iterable<string>;
+    sqlIdentifiers?: Iterable<string>;
+    repoSlug?: string;
+}
+
+/**
+ * Build the preview plan without performing any PR side-effects.
+ *
+ * Steps mirror the command doc:
+ *
+ * 1. Parse the local corpus (strict — drift surfaces as ParseError).
+ *    Step-10: the preview deliberately stays on the Markdown parser
+ *    (not the YAML lockfile) because it runs *before* `task sync`
+ *    rebuilds the lockfile from a user's local corpus edits.
+ * 2. Diff Validated entries against the upstream seed.
+ * 3. Run the redactor on every candidate.
+ * 4. Bucket into promoted / refused / already-seeded.
+ */
+export function build_preview(
+    corpusPath: string,
+    seedPath: string,
+    opts: BuildPreviewOptions = {},
+): LearnLowImpactPreview {
+    const repoRoot = opts.repoRoot ?? null;
+    const privateDomains = opts.privateDomains ?? [];
+    const customerNames = opts.customerNames ?? [];
+    const sqlIdentifiers = opts.sqlIdentifiers ?? [];
+    const repoSlug = opts.repoSlug ?? '';
+
+    const corpusP = String(corpusPath);
+    const seedP = String(seedPath);
+    const parsed = parse_corpus_strict(corpusP);
+    const seeded = _readSeedPhrases(seedP);
+    const promoted: PreviewEntry[] = [];
+    const refused: RefusedEntry[] = [];
+    const already: string[] = [];
+    for (const entry of parsed.validated) {
+        if (seeded.has(entry.normalised)) {
+            already.push(entry.phrase);
+            continue;
+        }
+        const result = redact_low_impact_entry(entry.phrase, {
+            repoRoot,
+            privateDomains,
+            customerNames,
+            sqlIdentifiers,
+        });
+        if (result.ok) {
+            promoted.push({
+                phrase: entry.phrase,
+                normalised: entry.normalised,
+                line_no: entry.line_no,
+            });
+        } else {
+            refused.push(new RefusedEntry(entry.phrase, entry.line_no, result.violations));
+        }
+    }
+    return new LearnLowImpactPreview({
+        promoted,
+        refused,
+        already_seeded: already,
+        last_upstreamed_sha: _readProvenance(corpusP),
+        seed_path: seedP,
+        corpus_path: corpusP,
+        repo_slug: repoSlug,
+        warnings: parsed.warnings,
+    });
+}

--- a/src/scripts/ai_council/necessity.ts
+++ b/src/scripts/ai_council/necessity.ts
@@ -1,0 +1,933 @@
+// Council-necessity classifier (Phase 6) — TypeScript twin (py2ts Phase 1).
+//
+// Heuristic pre-flight that decides whether the request actually warrants
+// a council deliberation. Three verdicts drive three exit paths in the
+// dispatcher (skip / educate / proceed). See
+// `docs/contracts/ai-council-config.md` for the trigger lists and the
+// toggle schema.
+//
+// The classifier is **shape-based**, not semantic — it scans the prompt
+// for marker words associated with each bucket. False positives are
+// preferable to false negatives on the `necessary` side (an extra council
+// run is cheaper than a missed strategic decision); the educate path
+// exists exactly to let the user override a wrong `unnecessary` verdict.
+//
+// Parity notes (ADR-094):
+// - Trigger tables are plain objects whose insertion order mirrors the
+//   Python dict literal — `_count_matches` relies on that order for
+//   tie-breaking (first-defined bucket wins).
+// - `_compile` builds `\b<escaped>\b` IGNORECASE regexes, exactly like
+//   Python `re`. The redundant whitespace branch in the Python source is
+//   preserved (both arms are identical) so the twin reads 1:1.
+// - `len(text)` → code-point count via `_pyLen` (matters for the length
+//   tier cut-offs and the truncation snippets).
+// - `:.2f` rationale formatting → `_pyFixed` (round-half-to-even), matching
+//   CPython float formatting.
+// - `re.sub` corpus normalisation mirrors `[^\w\s]` (Unicode `\w` under
+//   Python `re` defaults) and `\s+` collapsing.
+
+import { load_validated_phrases as _load } from './low_impact_corpus.js';
+
+export type NecessityVerdict = 'necessary' | 'borderline' | 'unnecessary';
+export type Invocation = 'agent' | 'user_explicit';
+
+// Length tier cut-offs in characters (stripped prompt). Tier names are
+// used in `classify_size_fit` rationales; tweak only with a parametrised
+// test update.
+const _SHORT_PROMPT_MAX = 200;
+const _MEDIUM_PROMPT_MAX = 800;
+
+// Lenses where the size classifier never suggests a downgrade. Debate is
+// structurally expensive but also depends on top-tier reasoning to produce
+// useful dissent — surfacing a downgrade prompt mid-debate degrades
+// signal-to-noise.
+const _NO_DOWNGRADE_LENSES: ReadonlySet<string> = new Set(['debate']);
+
+// Trigger words that flag a prompt as `necessary`. Each entry must be a
+// lowercase, whole-word match — surrounding word boundaries are enforced
+// by `_count_matches`. Buckets:
+//
+// - architecture: structural / boundary / cross-component decisions
+// - tradeoff: multi-stakeholder or multi-axis trade-off shape
+// - ambiguity: explicit uncertainty markers in the prompt
+// - strategic: decision verbs that move the artefact across a fork
+export const NECESSARY_TRIGGERS: Record<string, readonly string[]> = {
+    architecture: [
+        'architecture', 'architectural', 'system design', 'boundary',
+        'boundaries', 'coupling', 'decouple', 'monorepo', 'microservice',
+        'microservices', 'service boundary', 'module boundary',
+        'refactor strategy', 'migration plan', 'rewrite', 'redesign',
+    ],
+    tradeoff: [
+        'trade-off', 'tradeoff', 'trade off', 'stakeholder', 'stakeholders',
+        'competing', 'tension', 'balance', 'weigh', 'pros and cons',
+        'alternatives', 'options', 'vs', 'versus',
+    ],
+    ambiguity: [
+        'unsure', 'uncertain', 'ambiguous', 'unclear', 'not sure',
+        "don't know", 'dont know', 'open question', 'controversial',
+        'debate', 'second opinion', 'sanity check',
+    ],
+    strategic: [
+        'should we', 'shall we', 'do we', 'roadmap', 'long-term',
+        'strategic', 'strategy', 'vision', 'direction', 'decision',
+        'decide', 'choose', 'select', 'approach', 'policy',
+    ],
+};
+
+// Trigger words that flag a prompt as `unnecessary`. Same matching rules
+// as `NECESSARY_TRIGGERS`. Buckets:
+//
+// - bugfix: localised defect / error / crash hunt
+// - syntax: tooling / format / lint level
+// - single_file: implementation scoped to one file or function
+// - lookup: information retrieval, not deliberation
+export const UNNECESSARY_TRIGGERS: Record<string, readonly string[]> = {
+    bugfix: [
+        'bug', 'bugfix', 'fix bug', 'crash', 'error', 'exception',
+        'stack trace', 'traceback', 'failing test', 'fails', 'broken',
+        'regression',
+    ],
+    syntax: [
+        'syntax', 'typo', 'format', 'formatting', 'lint', 'linter',
+        'indent', 'indentation', 'rename', 'import order',
+    ],
+    single_file: [
+        'this function', 'this method', 'this file', 'one-line',
+        'one liner', 'small change', 'rename', 'extract method',
+        'extract function', 'add a getter', 'add a setter',
+    ],
+    lookup: [
+        'what is', "what's", 'what does', 'how does', 'look up',
+        'documentation', 'docs', 'example', 'snippet', 'syntax of',
+        'api of',
+    ],
+};
+
+// Lenses where the necessity bar is tighter — debate is expensive, so a
+// `borderline` verdict on the `debate` lens gets nudged toward
+// `unnecessary` when no `necessary` marker is present. `pr` lens fires on
+// diffs and stays neutral. Other lenses use the default scoring.
+const _STRICT_LENSES: ReadonlySet<string> = new Set(['debate']);
+
+/**
+ * Outcome of a necessity classification.
+ *
+ * - verdict: One of `necessary` / `borderline` / `unnecessary`.
+ * - category: Best-match trigger bucket (`architecture`, `bugfix`,
+ *   `lookup`, …) or `"unclassified"` when no marker fired.
+ * - rationale: One-line human-readable explanation suitable for inline
+ *   display in session.md or the educate path.
+ * - necessary_hits: Number of `necessary` triggers matched.
+ * - unnecessary_hits: Number of `unnecessary` triggers matched.
+ */
+export class ClassificationResult {
+    readonly verdict: NecessityVerdict;
+    readonly category: string;
+    readonly rationale: string;
+    readonly necessary_hits: number;
+    readonly unnecessary_hits: number;
+
+    constructor(args: {
+        verdict: NecessityVerdict;
+        category: string;
+        rationale: string;
+        necessary_hits: number;
+        unnecessary_hits: number;
+    }) {
+        this.verdict = args.verdict;
+        this.category = args.category;
+        this.rationale = args.rationale;
+        this.necessary_hits = args.necessary_hits;
+        this.unnecessary_hits = args.unnecessary_hits;
+    }
+}
+
+const _WORD_RE_CACHE: Map<string, RegExp> = new Map();
+
+/** Mirror Python `len(str)` — code-point count, not UTF-16 unit count. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+/** Mirror Python `str.strip()` — strips whitespace both ends. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Escape a literal for use in a RegExp body — mirrors Python `re.escape`
+ * closely enough for the alnum/punctuation trigger words used here.
+ */
+function _reEscape(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function _compile(trigger: string): RegExp {
+    const cached = _WORD_RE_CACHE.get(trigger);
+    if (cached !== undefined) {
+        return cached;
+    }
+    let pattern: string;
+    // Python builds the identical pattern on both branches; preserve the
+    // structure for a 1:1 read.
+    if ([...trigger].some((ch) => /\s/.test(ch))) {
+        pattern = '\\b' + _reEscape(trigger) + '\\b';
+    } else {
+        pattern = '\\b' + _reEscape(trigger) + '\\b';
+    }
+    const compiled = new RegExp(pattern, 'i');
+    _WORD_RE_CACHE.set(trigger, compiled);
+    return compiled;
+}
+
+/**
+ * Return `[total_hits, top_bucket_or_null]`.
+ *
+ * Top bucket = the bucket with the most matches in `text`. Ties are broken
+ * by definition order in the input object — JS objects preserve string-key
+ * insertion order, so the trigger tables above act as priority lists.
+ */
+function _count_matches(
+    text: string,
+    triggers: Record<string, readonly string[]>,
+): [number, string | null] {
+    let best_bucket: string | null = null;
+    let best_count = 0;
+    let total = 0;
+    for (const bucket of Object.keys(triggers)) {
+        const words = triggers[bucket]!;
+        let count = 0;
+        for (const w of words) {
+            if (_compile(w).test(text)) {
+                count += 1;
+            }
+        }
+        total += count;
+        if (count > best_count) {
+            best_count = count;
+            best_bucket = bucket;
+        }
+    }
+    return [total, best_bucket];
+}
+
+/**
+ * Classify a council request as necessary / borderline / unnecessary.
+ *
+ * @param prompt The raw prompt text the council would deliberate on.
+ *   Whitespace-stripped; empty input maps to `unnecessary` / `"empty"`.
+ * @param lens Active lens (`analysis`, `debate`, `pr`, …). Strict lenses
+ *   (currently `debate`) raise the bar — a borderline verdict with no
+ *   `necessary` hits flips to `unnecessary`.
+ * @param invocation Source signal — `agent` or `user_explicit`. Does not
+ *   change the verdict itself; the dispatcher routes on the pair
+ *   `(verdict, invocation)`.
+ * @returns A {@link ClassificationResult} with verdict, top-matched
+ *   category, one-line rationale, and raw hit counts (useful for tests and
+ *   session.md provenance).
+ */
+export function classify_necessity(
+    prompt: string,
+    lens = 'analysis',
+    _invocation: Invocation = 'agent',
+): ClassificationResult {
+    const text = _pyStrip(prompt || '');
+    if (!text) {
+        return new ClassificationResult({
+            verdict: 'unnecessary',
+            category: 'empty',
+            rationale: 'Empty prompt — nothing to deliberate.',
+            necessary_hits: 0,
+            unnecessary_hits: 0,
+        });
+    }
+
+    const [n_hits, n_bucket] = _count_matches(text, NECESSARY_TRIGGERS);
+    const [u_hits, u_bucket] = _count_matches(text, UNNECESSARY_TRIGGERS);
+
+    // Decision table (intentionally simple — heuristic by design):
+    //   strong necessary signal     → necessary
+    //   strong unnecessary signal   → unnecessary (unless necessary also fires)
+    //   mixed                       → borderline
+    //   no signal                   → borderline
+    let verdict: NecessityVerdict;
+    let category: string;
+    let rationale: string;
+    if (n_hits >= 2 && n_hits > u_hits) {
+        verdict = 'necessary';
+        category = n_bucket || 'unclassified';
+        rationale =
+            `Matched ${n_hits} \`necessary\` trigger(s) in bucket ` +
+            `\`${category}\`; council deliberation typically warranted.`;
+    } else if (n_hits >= 1 && u_hits === 0) {
+        verdict = n_hits >= 2 ? 'necessary' : 'borderline';
+        category = n_bucket || 'unclassified';
+        rationale =
+            `${n_hits} \`necessary\` marker(s) in \`${category}\`, no ` +
+            `\`unnecessary\` markers — leaning toward deliberation.`;
+    } else if (u_hits >= 2 && n_hits === 0) {
+        verdict = 'unnecessary';
+        category = u_bucket || 'unclassified';
+        rationale =
+            `Matched ${u_hits} \`unnecessary\` trigger(s) in bucket ` +
+            `\`${category}\`; council typically does not add value here.`;
+    } else if (u_hits >= 1 && n_hits === 0) {
+        verdict = u_hits >= 2 ? 'unnecessary' : 'borderline';
+        category = u_bucket || 'unclassified';
+        rationale =
+            `${u_hits} \`unnecessary\` marker(s) in \`${category}\`, no ` +
+            `\`necessary\` markers — leaning away from deliberation.`;
+    } else {
+        // Mixed or no markers — borderline by default.
+        verdict = 'borderline';
+        category = (n_bucket || u_bucket) || 'unclassified';
+        rationale =
+            `Mixed signals: necessary=${n_hits}, unnecessary=${u_hits}. ` +
+            `Borderline — proceed with a one-line note in session.md.`;
+    }
+
+    // Lens-strictness pass: debate-tier lenses nudge borderline →
+    // unnecessary when no `necessary` marker is present, to prevent
+    // expensive debate runs on trivial questions.
+    if (_STRICT_LENSES.has(lens) && verdict === 'borderline' && n_hits === 0) {
+        verdict = 'unnecessary';
+        rationale =
+            `Lens \`${lens}\` is strict (expensive deliberation); ` +
+            `borderline with zero \`necessary\` markers → unnecessary.`;
+    }
+
+    return new ClassificationResult({
+        verdict,
+        category,
+        rationale,
+        necessary_hits: n_hits,
+        unnecessary_hits: u_hits,
+    });
+}
+
+/**
+ * Return the user-facing educate paragraph for the dispatcher.
+ *
+ * Emitted only on the `user_explicit + unnecessary` path. The skill layer
+ * pairs this with a numbered-options prompt (1=proceed, 2=skip); the CLI
+ * surfaces it as plain text and returns a non-zero exit code unless
+ * `--proceed-anyway` is set.
+ */
+export function educate_message(result: ClassificationResult, lens: string): string {
+    return (
+        `This request looks like \`${result.category}\` ` +
+        `(${result.unnecessary_hits} matching marker(s)) on the ` +
+        `\`${lens}\` lens. Council typically adds value when the request ` +
+        `involves architectural trade-offs, multi-stakeholder ` +
+        `decisions, or strategic direction — not for localised bug ` +
+        `fixes, syntax / formatting work, or lookups.\n` +
+        `\n` +
+        `Re-run with \`--proceed-anyway\` to invoke the council anyway.`
+    );
+}
+
+// --- Phase 7: Model-size classifier + downgrade suggestion ---------------
+
+export type LengthTier = 'short' | 'medium' | 'long';
+
+/**
+ * Outcome of a model-size fit classification.
+ *
+ * - fit: `true` when `current_model` is appropriate for the prompt shape;
+ *   `false` when a cheaper / faster sibling on the same ladder would answer
+ *   as well.
+ * - suggested_model: ladder entry recommended when `fit=false`. `null`
+ *   when `fit=true` (no swap proposed).
+ * - reason: one-line human-readable rationale.
+ * - current_index: zero-based index of `current_model` in the ladder
+ *   (smallest = 0). `-1` when `current_model` is not on the ladder.
+ * - length_tier: `"short"` / `"medium"` / `"long"`.
+ * - complexity_hits: count of `necessary`-bucket markers in the prompt
+ *   (proxy for "needs big model").
+ */
+export class SizeFitVerdict {
+    readonly fit: boolean;
+    readonly suggested_model: string | null;
+    readonly reason: string;
+    readonly current_index: number;
+    readonly length_tier: LengthTier;
+    readonly complexity_hits: number;
+
+    constructor(args: {
+        fit: boolean;
+        suggested_model: string | null;
+        reason: string;
+        current_index: number;
+        length_tier: LengthTier;
+        complexity_hits: number;
+    }) {
+        this.fit = args.fit;
+        this.suggested_model = args.suggested_model;
+        this.reason = args.reason;
+        this.current_index = args.current_index;
+        this.length_tier = args.length_tier;
+        this.complexity_hits = args.complexity_hits;
+    }
+}
+
+function _length_tier(text: string): LengthTier {
+    if (_pyLen(text) < _SHORT_PROMPT_MAX) {
+        return 'short';
+    }
+    if (_pyLen(text) < _MEDIUM_PROMPT_MAX) {
+        return 'medium';
+    }
+    return 'long';
+}
+
+/**
+ * Decide whether `current_model` fits the prompt shape.
+ *
+ * Heuristic — never suggests an UP-tier swap (Phase 7 is downgrade-only).
+ * When the prompt is short AND carries no complexity markers AND the
+ * current model is above the smallest tier, suggest the next rung down.
+ * Longer prompts or multi-axis complexity keep the current model.
+ *
+ * @param prompt raw prompt text the council would deliberate on.
+ * @param current_model model id currently selected for the member.
+ * @param ladder provider's `model_ladder` ordered smallest → largest.
+ *   When `current_model` is not on the ladder, returns `fit=true` with an
+ *   explanatory reason (no downgrade suggested — caller should configure
+ *   the ladder first).
+ * @param lens active lens; `debate` lens disables downgrade suggestions to
+ *   keep dissent quality high.
+ * @returns A {@link SizeFitVerdict}.
+ */
+export function classify_size_fit(
+    prompt: string,
+    current_model: string,
+    ladder: readonly string[],
+    lens = 'analysis',
+): SizeFitVerdict {
+    const text = _pyStrip(prompt || '');
+    const tier = _length_tier(text);
+    const [n_hits] = _count_matches(text.toLowerCase(), NECESSARY_TRIGGERS);
+
+    const ladder_list = [...(ladder || [])];
+    const idx = ladder_list.indexOf(current_model);
+    if (idx === -1) {
+        return new SizeFitVerdict({
+            fit: true,
+            suggested_model: null,
+            reason:
+                `\`${current_model}\` is not on the configured ladder ` +
+                `(${ladder_list.length ? _pyListRepr(ladder_list) : 'empty'}) — no downgrade path.`,
+            current_index: -1,
+            length_tier: tier,
+            complexity_hits: n_hits,
+        });
+    }
+
+    if (idx === 0) {
+        return new SizeFitVerdict({
+            fit: true,
+            suggested_model: null,
+            reason: `\`${current_model}\` is already on the smallest tier.`,
+            current_index: idx,
+            length_tier: tier,
+            complexity_hits: n_hits,
+        });
+    }
+
+    if (_NO_DOWNGRADE_LENSES.has(lens)) {
+        return new SizeFitVerdict({
+            fit: true,
+            suggested_model: null,
+            reason:
+                `Lens \`${lens}\` keeps the top tier for dissent quality; ` +
+                `no downgrade suggested.`,
+            current_index: idx,
+            length_tier: tier,
+            complexity_hits: n_hits,
+        });
+    }
+
+    if (n_hits >= 2 || tier === 'long') {
+        return new SizeFitVerdict({
+            fit: true,
+            suggested_model: null,
+            reason:
+                `Complexity warrants the current tier ` +
+                `(length=${tier}, complexity_hits=${n_hits}).`,
+            current_index: idx,
+            length_tier: tier,
+            complexity_hits: n_hits,
+        });
+    }
+
+    if (tier === 'short' && n_hits === 0) {
+        const suggested = ladder_list[Math.max(0, idx - 1)]!;
+        return new SizeFitVerdict({
+            fit: false,
+            suggested_model: suggested,
+            reason:
+                `Short prompt (${_pyLen(text)} chars) with no complexity ` +
+                `markers — \`${suggested}\` should answer as well.`,
+            current_index: idx,
+            length_tier: tier,
+            complexity_hits: n_hits,
+        });
+    }
+
+    if (tier === 'medium' && n_hits === 0 && idx >= 1) {
+        const suggested = ladder_list[Math.max(0, idx - 1)]!;
+        return new SizeFitVerdict({
+            fit: false,
+            suggested_model: suggested,
+            reason:
+                `Medium-length prompt with no complexity markers — ` +
+                `\`${suggested}\` likely sufficient.`,
+            current_index: idx,
+            length_tier: tier,
+            complexity_hits: n_hits,
+        });
+    }
+
+    return new SizeFitVerdict({
+        fit: true,
+        suggested_model: null,
+        reason:
+            `Length / complexity balance keeps current tier ` +
+            `(length=${tier}, complexity_hits=${n_hits}).`,
+        current_index: idx,
+        length_tier: tier,
+        complexity_hits: n_hits,
+    });
+}
+
+/**
+ * Render a Python `repr(list[str])` for the not-on-ladder reason string —
+ * `['a', 'b']` style. Only reached when the ladder is non-empty.
+ */
+function _pyListRepr(items: readonly string[]): string {
+    return '[' + items.map((s) => `'${s}'`).join(', ') + ']';
+}
+
+/**
+ * User-facing downgrade-suggestion paragraph.
+ *
+ * Emitted by the dispatcher when `model_downgrade` is enabled and
+ * `classify_size_fit` returned `fit=false`. Followed by a single
+ * numbered-options prompt at the agent surface (1=use suggested / 2=keep
+ * current / 3=skip this member).
+ */
+export function downgrade_message(verdict: SizeFitVerdict, current_model: string): string {
+    return (
+        `Current model \`${current_model}\` looks oversized for this ` +
+        `request. Suggested: \`${verdict.suggested_model}\` ` +
+        `(reason: ${verdict.reason}).`
+    );
+}
+
+// --- Phase 10: Five-class impact classifier + routing --------------------
+
+export type ImpactClass =
+    | 'trivial'
+    | 'low_impact'
+    | 'medium_impact'
+    | 'high_impact'
+    | 'user_required';
+
+// Classes that are structurally LOCKED to `user` routing. The schema
+// validator in `config.py` rejects any attempt to remap these via
+// `decision_resolution.<class>.mode`. Iron Law per the roadmap: security /
+// auth / billing / tenant-boundary / migration / production-destructive
+// decisions always reach the user.
+export const LOCKED_IMPACT_CLASSES: ReadonlySet<ImpactClass> = new Set<ImpactClass>([
+    'high_impact',
+    'user_required',
+]);
+
+// User-fence markers that force `user_required` regardless of any other
+// signal. Mirrors the "fenced step" language in `scope-control`: when the
+// user has set a review gate, the agent never auto-routes the question
+// away from them.
+const _USER_FENCE_MARKERS: readonly string[] = [
+    'ask me', 'review first', 'plan only', "don't decide", 'do not decide',
+    'wait for me', "I'll decide", 'i will decide', 'let me decide',
+    'frag mich', 'warte auf mich',
+];
+
+// Trigger words per impact class. Whole-word match via `_count_matches`.
+// Ordered by structural severity — when a prompt matches multiple classes,
+// the higher-severity class wins (handled by the override precedence in
+// `classify_impact`).
+export const IMPACT_TRIGGERS: Record<ImpactClass, readonly string[]> = {
+    trivial: [
+        'naming', 'rename', 'name this', 'what should i call',
+        'whitespace', 'indent', 'indentation', 'comment style',
+        'import order', 'import ordering', 'variable case', 'snake_case',
+        'camelcase', 'typo', 'spacing',
+    ],
+    low_impact: [
+        'service vs repository', 'repository vs service', 'idiom',
+        'dto', 'dto vs array', 'value object', 'job vs sync',
+        'queue vs sync', 'test extension', 'test suffix', 'trait vs class',
+        'helper vs static', 'use composition', 'use inheritance',
+    ],
+    medium_impact: [
+        'api shape', 'endpoint shape', 'contract change', 'contract update',
+        'cross-module', 'cross module', 'module boundary', 'package boundary',
+        'interface change', 'signature change', 'breaking change',
+    ],
+    high_impact: [
+        'security', 'auth', 'authentication', 'authorization', 'permission',
+        'tenant', 'tenants', 'tenant boundary', 'migration', 'schema migration',
+        'production', 'prod database', 'destructive', 'drop table', 'truncate',
+        'delete column', 'billing', 'secret', 'secrets', 'api key',
+        'credentials', 'encryption', 'sso', 'oauth', 'iam',
+        'policy change', 'data retention', 'personal data', 'pii',
+    ],
+    user_required: [],
+};
+
+/**
+ * Outcome of an impact classification (Phase 10).
+ *
+ * - impact_class: One of {@link ImpactClass}.
+ * - confidence: 0.0–1.0 self-rated certainty in the verdict. Used by the
+ *   routing layer's `confidence_threshold` gate: high-confidence
+ *   `low_impact` skips council, low-confidence falls through to council
+ *   (Phase 11) or user.
+ * - rationale: One-line explanation suitable for inline session.md display.
+ *   Includes the matched trigger bucket when applicable.
+ * - category: Best-match trigger bucket (or `"unclassified"` when no marker
+ *   fired and the prompt defaulted to a class).
+ */
+export class ImpactVerdict {
+    readonly impact_class: ImpactClass;
+    readonly confidence: number;
+    readonly rationale: string;
+    readonly category: string;
+
+    constructor(args: {
+        impact_class: ImpactClass;
+        confidence: number;
+        rationale: string;
+        category: string;
+    }) {
+        this.impact_class = args.impact_class;
+        this.confidence = args.confidence;
+        this.rationale = args.rationale;
+        this.category = args.category;
+    }
+}
+
+/**
+ * Format `x` to `ndigits` decimals using round-half-to-even, matching
+ * CPython float formatting (`f"{x:.2f}"`).
+ */
+function _pyFixed(x: number, ndigits: number): string {
+    if (!Number.isFinite(x)) {
+        return String(x);
+    }
+    const neg = x < 0 || Object.is(x, -0);
+    const abs = Math.abs(x);
+    const factor = Math.pow(10, ndigits);
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    const tol = Math.max(Math.abs(scaled), 1) * 2 ** -40;
+    let rounded: number;
+    if (Math.abs(frac - 0.5) <= tol) {
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    let intStr = String(rounded);
+    let result: string;
+    if (ndigits === 0) {
+        result = intStr;
+    } else {
+        if (intStr.length <= ndigits) {
+            intStr = '0'.repeat(ndigits - intStr.length + 1) + intStr;
+        }
+        const whole = intStr.slice(0, intStr.length - ndigits);
+        const dec = intStr.slice(intStr.length - ndigits);
+        result = `${whole}.${dec}`;
+    }
+    return neg ? `-${result}` : result;
+}
+
+/**
+ * Classify a pending agent question by stakes / blast-radius.
+ *
+ * Heuristic, keyword-shape based — no LLM call, fully explainable.
+ * Precedence (highest wins): user-fence marker → high_impact markers →
+ * medium_impact markers → low_impact markers → trivial markers → default
+ * fallback. Confidence is rule-based and reflects how many distinct markers
+ * fired, not learned probability.
+ *
+ * @param question_text The pending question text the agent is about to
+ *   surface. Whitespace-stripped before scanning; empty input maps to
+ *   `user_required` / confidence `1.0` (no agent should silently resolve an
+ *   empty question).
+ * @returns An {@link ImpactVerdict} with class, confidence, rationale, and
+ *   matched bucket.
+ */
+export function classify_impact(question_text: string): ImpactVerdict {
+    const text = _pyStrip(question_text || '');
+    if (!text) {
+        return new ImpactVerdict({
+            impact_class: 'user_required',
+            confidence: 1.0,
+            rationale: 'Empty question — user must clarify.',
+            category: 'empty',
+        });
+    }
+
+    const lower = text.toLowerCase();
+
+    // User fence → user_required, beats every other signal. The agent
+    // never auto-routes around an explicit review gate.
+    for (const marker of _USER_FENCE_MARKERS) {
+        if (_compile(marker).test(lower)) {
+            return new ImpactVerdict({
+                impact_class: 'user_required',
+                confidence: 1.0,
+                rationale:
+                    `User-fence marker (\`${marker}\`) — explicit review ` +
+                    `gate, routes to user regardless of topic.`,
+                category: 'user_fence',
+            });
+        }
+    }
+
+    // Severity precedence: count distinct triggers per class, take the
+    // highest-severity class with at least one hit. Confidence scales with
+    // hit count for the winning class.
+    const ordered: ImpactClass[] = ['high_impact', 'medium_impact', 'low_impact', 'trivial'];
+    const hits_per_class: Map<ImpactClass, [number, string]> = new Map();
+    for (const cls of ordered) {
+        const [hits, bucket] = _count_matches(lower, { [cls]: IMPACT_TRIGGERS[cls] });
+        if (hits) {
+            hits_per_class.set(cls, [hits, bucket || cls]);
+        }
+    }
+
+    for (const cls of ordered) {
+        const entry = hits_per_class.get(cls);
+        if (entry !== undefined) {
+            const [hits, bucket] = entry;
+            let confidence = Math.min(1.0, 0.5 + 0.15 * hits);
+            // high_impact is Iron-Law: cap confidence at 1.0 with at least
+            // one explicit marker — never downgrade.
+            if (cls === 'high_impact') {
+                confidence = Math.max(confidence, 0.85);
+            }
+            const rationale =
+                `Matched ${hits} \`${cls}\` marker(s) in bucket \`${bucket}\` — ` +
+                `confidence ${_pyFixed(confidence, 2)}.`;
+            return new ImpactVerdict({
+                impact_class: cls,
+                confidence,
+                rationale,
+                category: bucket,
+            });
+        }
+    }
+
+    // No markers fired — default to medium_impact / low confidence so the
+    // routing layer falls through to council or user rather than silently
+    // letting the agent resolve.
+    return new ImpactVerdict({
+        impact_class: 'medium_impact',
+        confidence: 0.3,
+        rationale:
+            'No impact markers fired — defaulting to `medium_impact` at ' +
+            'low confidence; routing layer should escalate.',
+        category: 'unclassified',
+    });
+}
+
+/**
+ * Return normalised `## Validated` question strings from a corpus.
+ *
+ * Thin re-export of `low_impact_corpus.load_validated_phrases` — the
+ * hardened parser (step-9 P4) lives there; routing stays lenient so a
+ * broken corpus never blocks classification. Strict-mode contract
+ * validation lives in `low_impact_corpus.parse_corpus_strict`.
+ */
+export function load_validated_phrases(corpus_path: string): string[] {
+    return _load(corpus_path);
+}
+
+/**
+ * Corpus-aware variant of {@link classify_impact} (Phase 12).
+ *
+ * Loads `## Validated` phrases from every `corpus_paths` entry
+ * (project-local first, upstream seed second) and short-circuits to
+ * `low_impact` confidence `0.9` on exact-after-normalisation match.
+ * Probation / anti-example sections are excluded.
+ *
+ * The locked-class Iron Law from {@link classify_impact} still wins —
+ * user-fence markers AND `high_impact` triggers are checked BEFORE the
+ * corpus lookup, so a question with both a corpus hit and a security marker
+ * still routes to `user`.
+ */
+export function classify_impact_with_corpus(
+    question_text: string,
+    corpus_paths: readonly string[] | null = null,
+): ImpactVerdict {
+    const base = classify_impact(question_text);
+    if (LOCKED_IMPACT_CLASSES.has(base.impact_class)) {
+        return base;
+    }
+    if (!corpus_paths || corpus_paths.length === 0) {
+        return base;
+    }
+    // Python `re.sub(r"[^\w\s]", ...)` uses Unicode `\w` (`[A-Za-z0-9_]`
+    // plus all Unicode letters/digits/connector-punct) and Unicode `\s`.
+    // JS `\w` / `\s` are ASCII-only even under `/u`, so spell out the
+    // Unicode classes explicitly to keep normalisation byte-identical.
+    let norm_q = (question_text || '')
+        .toLowerCase()
+        .replace(/[^\p{L}\p{N}_\s]/gu, ' ');
+    norm_q = _pyStrip(norm_q.replace(/\s+/gu, ' '));
+    if (!norm_q) {
+        return base;
+    }
+    for (const p of corpus_paths) {
+        for (const phrase of load_validated_phrases(p)) {
+            if (norm_q === phrase) {
+                return new ImpactVerdict({
+                    impact_class: 'low_impact',
+                    confidence: 0.9,
+                    rationale:
+                        'Matched Validated corpus entry — routing as ' +
+                        '`low_impact` (Phase 12 learning loop).',
+                    category: 'corpus_validated',
+                });
+            }
+        }
+    }
+    return base;
+}
+
+export type ResolutionMode = 'agent' | 'council' | 'user';
+const _RESOLUTION_RUNGS: readonly ResolutionMode[] = ['agent', 'council', 'user'];
+
+/**
+ * Final routing decision (Phase 10).
+ *
+ * Combines {@link ImpactVerdict} with the per-class
+ * `DecisionResolutionEntry` from config to produce the mode the chokepoint
+ * should dispatch to.
+ *
+ * - verdict: Underlying impact classification.
+ * - mode: Final resolution mode after Iron-Law + confidence-gate.
+ * - upgraded: `true` when the confidence-threshold pushed the mode one rung
+ *   up (e.g. `agent` → `council`).
+ * - rationale: One-line explanation suitable for session.md.
+ */
+export class DecisionRouting {
+    readonly verdict: ImpactVerdict;
+    readonly mode: ResolutionMode;
+    readonly upgraded: boolean;
+    readonly rationale: string;
+
+    constructor(args: {
+        verdict: ImpactVerdict;
+        mode: ResolutionMode;
+        upgraded: boolean;
+        rationale: string;
+    }) {
+        this.verdict = args.verdict;
+        this.mode = args.mode;
+        this.upgraded = args.upgraded;
+        this.rationale = args.rationale;
+    }
+}
+
+/**
+ * A `DecisionResolutionEntry`-shaped object: exposes `mode` and
+ * `confidence_threshold`. Typed loosely to keep this module free of a
+ * config import cycle.
+ */
+export interface ResolutionEntryLike {
+    mode?: ResolutionMode;
+    confidence_threshold?: number;
+}
+
+/**
+ * Classify + route a pending agent question.
+ *
+ * @param question_text The text the agent was about to ask the user.
+ * @param classes Mapping `impact_class -> DecisionResolutionEntry` (typed
+ *   loosely to keep this module free of a config import cycle). Each entry
+ *   must expose `mode` and `confidence_threshold` attributes.
+ * @returns A {@link DecisionRouting} with the final mode. Iron Law:
+ *   {@link LOCKED_IMPACT_CLASSES} always returns `mode="user"` regardless of
+ *   config or confidence.
+ */
+export function route_decision(
+    question_text: string,
+    classes: Record<string, ResolutionEntryLike | undefined> | Map<string, ResolutionEntryLike>,
+): DecisionRouting {
+    const verdict = classify_impact(question_text);
+    const entry =
+        classes instanceof Map
+            ? classes.get(verdict.impact_class)
+            : classes[verdict.impact_class];
+    if (entry === undefined || entry === null) {
+        // No config — Iron-Law fallback to user.
+        return new DecisionRouting({
+            verdict,
+            mode: 'user',
+            upgraded: false,
+            rationale:
+                `No routing entry for \`${verdict.impact_class}\` — ` +
+                `defaulting to user (Iron-Law fallback).`,
+        });
+    }
+
+    const base_mode: ResolutionMode = entry.mode ?? 'user';
+    const threshold: number = entry.confidence_threshold ?? 0.6;
+
+    if (LOCKED_IMPACT_CLASSES.has(verdict.impact_class)) {
+        return new DecisionRouting({
+            verdict,
+            mode: 'user',
+            upgraded: false,
+            rationale:
+                `\`${verdict.impact_class}\` is Iron-Law locked to \`user\` ` +
+                `— bypass refused.`,
+        });
+    }
+
+    let upgraded = false;
+    let mode: ResolutionMode = base_mode;
+    if (mode !== 'user' && verdict.confidence < threshold) {
+        const idx = _RESOLUTION_RUNGS.indexOf(base_mode);
+        if (idx === -1) {
+            mode = 'user';
+            upgraded = true;
+        } else {
+            mode = _RESOLUTION_RUNGS[Math.min(idx + 1, _RESOLUTION_RUNGS.length - 1)]!;
+            upgraded = mode !== base_mode;
+        }
+    }
+
+    const rationale =
+        `Class \`${verdict.impact_class}\` (confidence ` +
+        `${_pyFixed(verdict.confidence, 2)}, threshold ${_pyFixed(threshold, 2)}) → ` +
+        `mode \`${mode}\`` +
+        (upgraded ? ` (upgraded from \`${base_mode}\`)` : '') +
+        '.';
+    return new DecisionRouting({
+        verdict,
+        mode,
+        upgraded,
+        rationale,
+    });
+}

--- a/src/scripts/ai_council/orchestrator.ts
+++ b/src/scripts/ai_council/orchestrator.ts
@@ -1,0 +1,1686 @@
+// Council orchestrator — fan out one question to multiple members.
+//
+// py2ts twin of orchestrator.py (ADR-094). Byte-for-byte parity with the
+// Python original: member dispatch order, sequential cost gating, the overrun
+// callback contract, multi-round debate / peer-review / consensus passes, and
+// the Markdown render assembly are all mirrored exactly.
+//
+// v2 contract (sequential + interactive overrun prompt):
+//
+// - Members are called **sequentially** in input order. The previous
+//   parallel ThreadPoolExecutor was traded for predictable mid-flow
+//   user prompts; with 2-3 council members the latency cost is small.
+// - `estimate(question, members, table)` returns a pre-call cost preview
+//   (input tokens + max-output ceiling + USD per member). The host
+//   agent shows this before invoking `consult()`.
+// - `consult(..., on_overrun=...)` invokes the callback BEFORE each
+//   member's actual API call when the projected total cost would push
+//   past the cost budget. The callback decides whether to proceed for
+//   this single member; the next member triggers the callback again.
+//
+// Failure normalisation (one member's exception → `error`-set
+// CouncilResponse, never raise) is unchanged.
+
+import {
+    record_spend as _record_daily_spend,
+    today_spend_usd as _today_spend_usd,
+    would_exceed as _would_exceed_daily,
+} from './budget_guard.js';
+import {
+    DEFAULT_MAX_TOKENS,
+    CouncilResponse,
+    ExternalAIClient,
+} from './clients.js';
+import {
+    ConsensusBucket,
+    ConsensusMetadata,
+    Finding,
+    FindingScore,
+    aggregate_scores,
+    anonymize_findings,
+    anonymize_responses,
+    bucket_by_threshold,
+    parse_findings_response,
+    parse_scores_response,
+} from './consensus.js';
+import {
+    CostEstimate,
+    PriceTable,
+    estimate_cost,
+    estimate_input_tokens,
+} from './pricing.js';
+import { ProjectContext } from './project_context.js';
+import { AdvisorPlan } from './advisors.js';
+import {
+    advisor_system_prompt,
+    build_extraction_user_prompt,
+    build_peer_review_user_prompt,
+    build_scoring_user_prompt,
+    peer_review_synthesis_addendum,
+    synthesis_template,
+    system_prompt_for,
+} from './prompts.js';
+
+// ── Python-format / stdlib parity helpers ────────────────────────────────
+//
+// The orchestrator formats USD / scores / strengths via Python f-string
+// specs (`:.4f`, `:.2f`, `:.1f`) which round half-to-even on the decimal
+// representation. JS `toFixed` rounds half away from zero, so the spec
+// formatting is reimplemented to stay byte-exact with the Python original.
+
+/**
+ * Format `x` to `ndigits` decimals using round-half-to-even, matching
+ * CPython's `format(x, ".<ndigits>f")`.
+ */
+function _pyFixed(x: number, ndigits: number): string {
+    if (!Number.isFinite(x)) {
+        return String(x);
+    }
+    const neg = x < 0 || Object.is(x, -0);
+    const abs = Math.abs(x);
+    const factor = Math.pow(10, ndigits);
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    const tol = Math.max(Math.abs(scaled), 1) * 2 ** -40;
+    let rounded: number;
+    if (Math.abs(frac - 0.5) <= tol) {
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    let intStr = String(rounded);
+    let result: string;
+    if (ndigits === 0) {
+        result = intStr;
+    } else {
+        if (intStr.length <= ndigits) {
+            intStr = '0'.repeat(ndigits - intStr.length + 1) + intStr;
+        }
+        const whole = intStr.slice(0, intStr.length - ndigits);
+        const dec = intStr.slice(intStr.length - ndigits);
+        result = `${whole}.${dec}`;
+    }
+    return neg ? `-${result}` : result;
+}
+
+/** Mirror Python `str.strip()` (no-arg). Sibling-twin convention uses trim(). */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Mirror Python `str.split()` (no separator) — split on runs of whitespace,
+ * dropping leading / trailing whitespace (no empty tokens).
+ */
+function _pySplitWhitespace(s: string): string[] {
+    const trimmed = s.trim();
+    if (trimmed === '') {
+        return [];
+    }
+    return trimmed.split(/\s+/);
+}
+
+/**
+ * Mirror Python `getattr(obj, name, fallback)` for the duck-typed member
+ * objects (real clients + test mocks). Returns the attribute value or the
+ * fallback when the attribute is absent / object is null.
+ */
+function _getattr(obj: unknown, name: string, fallback: unknown): unknown {
+    if (obj === null || obj === undefined) {
+        return fallback;
+    }
+    if (typeof obj === 'object' || typeof obj === 'function') {
+        const val = (obj as Record<string, unknown>)[name];
+        if (val !== undefined) {
+            return val;
+        }
+    }
+    return fallback;
+}
+
+/** Mirror Python `chr(ord("A") + idx)` — reviewer label letters. */
+function _label(idx: number): string {
+    return String.fromCharCode('A'.charCodeAt(0) + idx);
+}
+
+// ── dataclasses ───────────────────────────────────────────────────────
+
+export class CostBudget {
+    max_input_tokens: number;
+    max_output_tokens: number;
+    max_calls: number;
+    max_total_usd: number; // 0 = USD ceiling disabled (token caps still apply)
+    daily_limit_usd: number; // 0 = rolling 24h cap disabled (D3)
+
+    constructor(
+        args: {
+            max_input_tokens?: number;
+            max_output_tokens?: number;
+            max_calls?: number;
+            max_total_usd?: number;
+            daily_limit_usd?: number;
+        } = {},
+    ) {
+        this.max_input_tokens = args.max_input_tokens ?? 50_000;
+        this.max_output_tokens = args.max_output_tokens ?? 20_000;
+        this.max_calls = args.max_calls ?? 10;
+        this.max_total_usd = args.max_total_usd ?? 0.0;
+        this.daily_limit_usd = args.daily_limit_usd ?? 0.0;
+    }
+}
+
+export class CouncilQuestion {
+    mode: string; // one of: prompt, roadmap, diff, files
+    user_prompt: string; // bundled artefact text
+    max_tokens: number;
+
+    constructor(args: { mode: string; user_prompt: string; max_tokens?: number }) {
+        this.mode = args.mode;
+        this.user_prompt = args.user_prompt;
+        this.max_tokens = args.max_tokens ?? DEFAULT_MAX_TOKENS;
+    }
+}
+
+/** Passed to `on_overrun` when projected spend exceeds the budget. */
+export class OverrunEvent {
+    member_index: number;
+    member: ExternalAIClient;
+    next_estimate: CostEstimate; // this member's projected cost
+    spent_input_tokens: number; // already-billed totals BEFORE this member
+    spent_output_tokens: number;
+    spent_usd: number;
+    projected_total_usd: number; // spent_usd + next_estimate.total_usd
+    daily_spent_usd: number; // rolling 24h spend BEFORE this member (D3)
+    daily_limit_usd: number; // the configured daily cap (0 = disabled)
+    breach_kind: string; // "session" | "daily" | "tokens"
+
+    constructor(args: {
+        member_index: number;
+        member: ExternalAIClient;
+        next_estimate: CostEstimate;
+        spent_input_tokens: number;
+        spent_output_tokens: number;
+        spent_usd: number;
+        projected_total_usd: number;
+        daily_spent_usd?: number;
+        daily_limit_usd?: number;
+        breach_kind?: string;
+    }) {
+        this.member_index = args.member_index;
+        this.member = args.member;
+        this.next_estimate = args.next_estimate;
+        this.spent_input_tokens = args.spent_input_tokens;
+        this.spent_output_tokens = args.spent_output_tokens;
+        this.spent_usd = args.spent_usd;
+        this.projected_total_usd = args.projected_total_usd;
+        this.daily_spent_usd = args.daily_spent_usd ?? 0.0;
+        this.daily_limit_usd = args.daily_limit_usd ?? 0.0;
+        this.breach_kind = args.breach_kind ?? 'session';
+    }
+}
+
+// Callback signature: receive event → return True (proceed) or False (skip + tag error).
+export type OnOverrunCallback = (event: OverrunEvent) => boolean;
+
+/**
+ * Pre-flight debate cost summary (Phase 8).
+ *
+ * `low_usd` / `expected_usd` / `high_usd` are the rolled-up spend bounds
+ * across every billable member × `rounds`. The expected estimate matches
+ * the per-round `estimate()` total multiplied by rounds (worst-case
+ * `max_output_tokens`). `low_usd` discounts output to 25% of the ceiling —
+ * most members do not hit their token budget. `high_usd` adds a 20%
+ * over-run buffer per the roadmap's ±20% accuracy target.
+ *
+ * `per_member` carries one entry per billable member with the same bound
+ * triple, plus the member's transport label (api / cli / manual).
+ * `subscription_members` lists non-billable members so the disclosure
+ * block can call out the "covered by subscription" rows without summing
+ * them into USD totals.
+ */
+export class DebateCostEstimate {
+    readonly rounds: number;
+    readonly low_usd: number;
+    readonly expected_usd: number;
+    readonly high_usd: number;
+    readonly per_member: Array<Record<string, unknown>>;
+    readonly subscription_members: Array<Record<string, string>>;
+
+    constructor(args: {
+        rounds: number;
+        low_usd: number;
+        expected_usd: number;
+        high_usd: number;
+        per_member: Array<Record<string, unknown>>;
+        subscription_members: Array<Record<string, string>>;
+    }) {
+        this.rounds = args.rounds;
+        this.low_usd = args.low_usd;
+        this.expected_usd = args.expected_usd;
+        this.high_usd = args.high_usd;
+        this.per_member = args.per_member;
+        this.subscription_members = args.subscription_members;
+    }
+}
+
+export interface EstimateOptions {
+    project?: ProjectContext | null;
+    original_ask?: string;
+    advisor_plans?: Map<string, AdvisorPlan> | null;
+}
+
+export interface EstimateDebateCostOptions extends EstimateOptions {
+    rounds: number;
+}
+
+/**
+ * Project total spend for an N-round debate across all members.
+ *
+ * Mirrors `estimate()` per-member, then multiplies by `rounds` to account
+ * for the per-round preamble + critique pass. CLI / manual members
+ * (`billable=false`) are excluded from USD totals and surfaced separately
+ * in `subscription_members` so the disclosure block can label them as
+ * covered by the user's flat-rate plan.
+ */
+export function estimate_debate_cost(
+    question: CouncilQuestion,
+    members: ExternalAIClient[],
+    table: PriceTable,
+    opts: EstimateDebateCostOptions,
+): DebateCostEstimate {
+    const rounds = opts.rounds;
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const advisor_plans = opts.advisor_plans ?? null;
+    if (rounds < 1) {
+        throw new Error(`rounds must be >= 1 (got ${_pyReprInt(rounds)}).`);
+    }
+    const billable_members = members.filter(
+        (m) => _getattr(m, 'billable', true) as boolean,
+    );
+    const sub_members: Array<Record<string, string>> = members
+        .filter((m) => !(_getattr(m, 'billable', true) as boolean))
+        .map((m) => ({
+            name: m.name,
+            model: m.model,
+            transport: _getattr(m, 'transport', 'api') as string,
+            subscription_label: _getattr(m, 'subscription_label', '') as string,
+        }));
+    const per_round = estimate(question, billable_members, table, {
+        project,
+        original_ask,
+        advisor_plans,
+    });
+    const expected =
+        per_round.reduce((acc, e) => acc + _total_usd(e), 0) * rounds;
+    // Low bound: output tokens rarely reach `max_output_tokens` ceiling.
+    // Use input-only cost + 25% of the output ceiling — empirical floor
+    // from manual debate traces.
+    const low =
+        per_round.reduce((acc, e) => acc + e.input_usd + 0.25 * e.output_usd, 0) *
+        rounds;
+    // High bound: +20% over-run buffer (roadmap ±20% accuracy target).
+    const high = expected * 1.2;
+    const per_member: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < billable_members.length; i++) {
+        const member = billable_members[i] as ExternalAIClient;
+        const est = per_round[i] as CostEstimate;
+        const member_expected = _total_usd(est) * rounds;
+        per_member.push({
+            name: member.name,
+            model: member.model,
+            transport: _getattr(member, 'transport', 'api') as string,
+            low_usd: (est.input_usd + 0.25 * est.output_usd) * rounds,
+            expected_usd: member_expected,
+            high_usd: member_expected * 1.2,
+        });
+    }
+    return new DebateCostEstimate({
+        rounds,
+        low_usd: low,
+        expected_usd: expected,
+        high_usd: high,
+        per_member,
+        subscription_members: sub_members,
+    });
+}
+
+/** Mirror the Python `CostEstimate.total_usd` property. */
+function _total_usd(e: CostEstimate): number {
+    return e.input_usd + e.output_usd;
+}
+
+/**
+ * Return a pre-call cost estimate per member, in input order.
+ *
+ * `project` and `original_ask` are passed through to `system_prompt_for()`
+ * so the estimate covers the handoff preamble bytes too. Both default to
+ * v1-shape (no preamble extension).
+ *
+ * `advisor_plans` (Phase 6) — when a member's name has a plan, the estimate
+ * uses the advisor persona system prompt (typically larger than the bare
+ * mode addendum). The cost estimator must mirror `_run_round` exactly so the
+ * pre-call preview never under-states the advisor-mode bill.
+ */
+export function estimate(
+    question: CouncilQuestion,
+    members: ExternalAIClient[],
+    table: PriceTable,
+    opts: EstimateOptions = {},
+): CostEstimate[] {
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const plans = opts.advisor_plans ?? new Map<string, AdvisorPlan>();
+    const base_user_tokens = estimate_input_tokens(question.user_prompt);
+    const base_sys = system_prompt_for(question.mode, { project, original_ask });
+    const base_sys_tokens = estimate_input_tokens(base_sys);
+    const estimates: CostEstimate[] = [];
+    for (const m of members) {
+        const plan = plans.get(m.name);
+        let sys_tokens: number;
+        if (plan === undefined) {
+            sys_tokens = base_sys_tokens;
+        } else {
+            const sys_prompt = advisor_system_prompt(plan.persona_text, {
+                project,
+                original_ask,
+            });
+            sys_tokens = estimate_input_tokens(sys_prompt);
+        }
+        const input_tokens = base_user_tokens + sys_tokens;
+        estimates.push(
+            estimate_cost(m.name, m.model, input_tokens, question.max_tokens, table),
+        );
+    }
+    return estimates;
+}
+
+export interface ConsultOptions {
+    table?: PriceTable | null;
+    on_overrun?: OnOverrunCallback | null;
+    project?: ProjectContext | null;
+    original_ask?: string;
+    rounds?: number;
+    on_round_complete?:
+        | ((round_idx: number, responses: CouncilResponse[]) => void)
+        | null;
+    advisor_plans?: Map<string, AdvisorPlan> | null;
+}
+
+/**
+ * Sequentially fan out `question` to every enabled member.
+ *
+ * - If `table` is provided, USD spend is tracked against
+ *   `budget.max_total_usd` (when > 0). Without `table`, only the
+ *   token caps apply (back-compat with v1 callers).
+ * - When the projected next-member spend would breach any cap,
+ *   `on_overrun` is consulted. Returning False marks that member as
+ *   `cost_budget_exceeded`; True proceeds with the call.
+ * - Without `on_overrun`, breaching caps short-circuits remaining
+ *   members with `cost_budget_exceeded` (v1 behaviour preserved).
+ * - `project` + `original_ask` flow into `handoff_preamble()` so the
+ *   council member receives a neutral context-handoff alongside the
+ *   artefact. Both default to v1 shape (no preamble extension).
+ * - `rounds >= 2` enables multi-round debate (D1). Each subsequent
+ *   round augments the user prompt with anonymised prior-round
+ *   responses (provider/model identity stripped). Token + USD caps
+ *   accumulate across rounds. Returns the FINAL round's responses;
+ *   use `on_round_complete(round_idx, responses)` to capture
+ *   intermediate rounds.
+ * - `advisor_plans` (Phase 6) keyed by provider name swaps the
+ *   member's system prompt for the advisor persona via
+ *   `advisor_system_prompt()`. Replace-mode: no extra calls.
+ */
+export function consult(
+    members: ExternalAIClient[],
+    question: CouncilQuestion,
+    budget: CostBudget | null = null,
+    opts: ConsultOptions = {},
+): CouncilResponse[] {
+    const table = opts.table ?? null;
+    const on_overrun = opts.on_overrun ?? null;
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const rounds = opts.rounds ?? 1;
+    const on_round_complete = opts.on_round_complete ?? null;
+    const advisor_plans = opts.advisor_plans ?? null;
+
+    if (rounds < 1) {
+        throw new Error(`rounds must be >= 1 (got ${rounds})`);
+    }
+    if (members.length === 0) {
+        return [];
+    }
+    const resolvedBudget = budget ?? new CostBudget();
+    if (members.length > resolvedBudget.max_calls) {
+        throw new Error(
+            `Council has ${members.length} members but budget caps at ` +
+                `${resolvedBudget.max_calls} calls.`,
+        );
+    }
+
+    const spent: Spent = { input: 0, output: 0, usd: 0.0 };
+    let last_results: CouncilResponse[] = [];
+    let current_user_prompt = question.user_prompt;
+
+    for (let round_idx = 0; round_idx < rounds; round_idx++) {
+        const round_question =
+            round_idx === 0
+                ? question
+                : new CouncilQuestion({
+                      mode: question.mode,
+                      user_prompt: current_user_prompt,
+                      max_tokens: question.max_tokens,
+                  });
+        last_results = _run_round(members, round_question, resolvedBudget, spent, {
+            table,
+            on_overrun,
+            project,
+            original_ask,
+            advisor_plans,
+        });
+        if (on_round_complete !== null) {
+            on_round_complete(round_idx, last_results);
+        }
+        if (round_idx + 1 < rounds) {
+            current_user_prompt = _augment_for_next_round(
+                question.user_prompt,
+                last_results,
+                round_idx + 2,
+            );
+        }
+    }
+
+    return last_results;
+}
+
+interface Spent {
+    input: number;
+    output: number;
+    usd: number;
+}
+
+interface RunRoundOptions {
+    table: PriceTable | null;
+    on_overrun: OnOverrunCallback | null;
+    project: ProjectContext | null;
+    original_ask: string;
+    advisor_plans?: Map<string, AdvisorPlan> | null;
+}
+
+/** Run a single round; mutate `spent` with cumulative totals. */
+function _run_round(
+    members: ExternalAIClient[],
+    question: CouncilQuestion,
+    budget: CostBudget,
+    spent: Spent,
+    opts: RunRoundOptions,
+): CouncilResponse[] {
+    const table = opts.table;
+    const on_overrun = opts.on_overrun;
+    const project = opts.project;
+    const original_ask = opts.original_ask;
+    const plans = opts.advisor_plans ?? new Map<string, AdvisorPlan>();
+    const base_system_prompt = system_prompt_for(question.mode, {
+        project,
+        original_ask,
+    });
+
+    const _system_prompt_for_member = (m: ExternalAIClient): string => {
+        const plan = plans.get(m.name);
+        if (plan === undefined) {
+            return base_system_prompt;
+        }
+        return advisor_system_prompt(plan.persona_text, { project, original_ask });
+    };
+
+    const results: CouncilResponse[] = [];
+    const estimates: CostEstimate[] | null =
+        table !== null
+            ? estimate(question, members, table, {
+                  project,
+                  original_ask,
+                  advisor_plans: opts.advisor_plans ?? null,
+              })
+            : null;
+
+    for (let idx = 0; idx < members.length; idx++) {
+        const member = members[idx] as ExternalAIClient;
+        // ── non-billable members skip the cost gate entirely ─────────
+        // ManualClient (and future PlaywrightClient) cost us $0; their
+        // token counts are still tracked from the response below for
+        // observability, but no projection / budget breach can apply.
+        if (!(_getattr(member, 'billable', true) as boolean)) {
+            let response: CouncilResponse;
+            try {
+                response = member.ask(
+                    _system_prompt_for_member(member),
+                    question.user_prompt,
+                    question.max_tokens,
+                );
+            } catch (exc) {
+                response = new CouncilResponse({
+                    provider: member.name,
+                    model: member.model,
+                    text: '',
+                    error: _excTag(exc),
+                });
+            }
+            _stamp_transport_metadata(response, member);
+            results.push(response);
+            spent.input += response.input_tokens;
+            spent.output += response.output_tokens;
+            continue;
+        }
+
+        // ── projected spend check ────────────────────────────────────
+        const est = estimates ? (estimates[idx] as CostEstimate) : null;
+        const proj_input = spent.input + (est ? est.input_tokens : 0);
+        const proj_output = spent.output + (est ? est.output_tokens : 0);
+        const proj_usd = spent.usd + (est ? _total_usd(est) : 0.0);
+        const next_call_usd = est ? _total_usd(est) : 0.0;
+
+        const breaches_tokens =
+            proj_input > budget.max_input_tokens ||
+            proj_output > budget.max_output_tokens;
+        const breaches_usd =
+            budget.max_total_usd > 0 && proj_usd > budget.max_total_usd;
+        const breaches_daily =
+            budget.daily_limit_usd > 0 &&
+            _would_exceed_daily(budget.daily_limit_usd, next_call_usd);
+
+        if (breaches_tokens || breaches_usd || breaches_daily) {
+            const breach_kind = breaches_tokens
+                ? 'tokens'
+                : breaches_daily
+                  ? 'daily'
+                  : 'session';
+            const error_tag =
+                breach_kind === 'daily'
+                    ? 'daily_budget_exceeded'
+                    : 'cost_budget_exceeded';
+            if (on_overrun !== null && estimates !== null) {
+                const event = new OverrunEvent({
+                    member_index: idx,
+                    member,
+                    next_estimate: estimates[idx] as CostEstimate,
+                    spent_input_tokens: _pyInt(spent.input),
+                    spent_output_tokens: _pyInt(spent.output),
+                    spent_usd: spent.usd,
+                    projected_total_usd: proj_usd,
+                    daily_spent_usd:
+                        budget.daily_limit_usd > 0 ? _today_spend_usd() : 0.0,
+                    daily_limit_usd: budget.daily_limit_usd,
+                    breach_kind,
+                });
+                if (!on_overrun(event)) {
+                    results.push(_aborted(member, error_tag));
+                    continue;
+                }
+            } else {
+                // v1 behaviour: short-circuit all remaining members.
+                for (const left of members.slice(idx)) {
+                    results.push(_aborted(left, error_tag));
+                }
+                return results;
+            }
+        }
+
+        // ── actual call ──────────────────────────────────────────────
+        let response: CouncilResponse;
+        try {
+            response = member.ask(
+                _system_prompt_for_member(member),
+                question.user_prompt,
+                question.max_tokens,
+            );
+        } catch (exc) {
+            response = new CouncilResponse({
+                provider: member.name,
+                model: member.model,
+                text: '',
+                error: _excTag(exc),
+            });
+        }
+        results.push(response);
+        spent.input += response.input_tokens;
+        spent.output += response.output_tokens;
+        let actual_usd: number | null = null;
+        if (estimates !== null && table !== null) {
+            // Bill the actual output against the budget using the
+            // member's per-1M output rate. Re-use estimate_cost with
+            // the *real* token count.
+            const actual = estimate_cost(
+                member.name,
+                member.model,
+                response.input_tokens,
+                response.output_tokens,
+                table,
+            );
+            actual_usd = _total_usd(actual);
+            spent.usd += _total_usd(actual);
+            // Persist to the rolling 24h ledger when the daily cap is
+            // active. Errors are swallowed inside record_spend.
+            if (budget.daily_limit_usd > 0 && !response.error) {
+                _record_daily_spend(_total_usd(actual), member.name, member.model);
+            }
+        }
+        _stamp_transport_metadata(response, member, actual_usd);
+    }
+
+    return results;
+}
+
+function _aborted(member: ExternalAIClient, reason: string): CouncilResponse {
+    const response = new CouncilResponse({
+        provider: member.name,
+        model: member.model,
+        text: '',
+        error: reason,
+    });
+    _stamp_transport_metadata(response, member);
+    return response;
+}
+
+/**
+ * Annotate `response.metadata` with transport / billable / cost info.
+ *
+ * Phase 5 / Step 1 — the session writer and orchestrator renderer key
+ * off these fields to format the cost line as either
+ * `cost: subscription (claude-pro)` (non-billable vendor CLI) or
+ * `cost: $0.NNNN (… in / … out)` (billable api or community CLI).
+ * Stamped here (and not in each client) so the writer stays decoupled
+ * from the client class hierarchy.
+ */
+function _stamp_transport_metadata(
+    response: CouncilResponse,
+    member: ExternalAIClient,
+    cost_usd: number | null = null,
+): void {
+    const meta: Record<string, unknown> = { ...(response.metadata ?? {}) };
+    const transport = _getattr(member, 'transport', 'api') as string;
+    _setdefault(meta, 'transport', transport);
+    _setdefault(meta, 'billable', Boolean(_getattr(member, 'billable', true)));
+    const label = (_getattr(member, 'subscription_label', '') as string) || '';
+    if (label && !(_metaGet(meta, 'billable', true) as boolean)) {
+        _setdefault(meta, 'subscription_label', label);
+    }
+    if (cost_usd !== null) {
+        meta['cost_usd'] = Number(cost_usd);
+    }
+    response.metadata = meta;
+}
+
+/**
+ * Build the round-N user prompt: original artefact + anonymised prior round.
+ *
+ * Provider/model identifiers are stripped (Iron Law of Neutrality §
+ * multi-round). Reviewers are labelled "Reviewer A / B / C…" in the
+ * order they appeared. Errors are skipped — they reveal nothing
+ * useful and can leak provider error formats.
+ */
+function _augment_for_next_round(
+    original_prompt: string,
+    prior_responses: CouncilResponse[],
+    next_round_number: number,
+): string {
+    const blocks: string[] = [];
+    let label_idx = 0;
+    for (const r of prior_responses) {
+        if (r.error || !_pyStrip(r.text)) {
+            continue;
+        }
+        const label = _label(label_idx);
+        label_idx += 1;
+        blocks.push(`### Reviewer ${label}\n\n${_pyStrip(r.text)}`);
+    }
+    if (blocks.length === 0) {
+        return original_prompt;
+    }
+    const prior_block = blocks.join('\n\n');
+    return (
+        `${original_prompt}\n\n` +
+        `---\n\n` +
+        `## Prior round critiques (round ${next_round_number - 1})\n\n` +
+        `You are now in round ${next_round_number}. Below are anonymised\n` +
+        `critiques from independent reviewers in the previous round.\n` +
+        `You do NOT know which model produced which critique. Read them,\n` +
+        `then respond with:\n\n` +
+        `1. Which prior points you agree with (cite reviewer label).\n` +
+        `2. Which you disagree with and why.\n` +
+        `3. New points or refinements not raised in round 1.\n\n` +
+        `${prior_block}`
+    );
+}
+
+/**
+ * Snapshot passed to the continue-prompt callback between rounds.
+ *
+ * Phase 7 progressive-disclosure contract — the orchestrator pauses
+ * after each completed round, builds this checkpoint, and asks the
+ * caller whether to continue. Returning False stops the debate
+ * gracefully (caller receives every completed round).
+ */
+export class DebateCheckpoint {
+    completed_round: number; // 1-based index of the round just finished
+    total_planned_rounds: number;
+    cost_so_far_usd: number;
+    next_round_estimate_usd: number;
+    last_round_responses: CouncilResponse[];
+
+    constructor(args: {
+        completed_round: number;
+        total_planned_rounds: number;
+        cost_so_far_usd: number;
+        next_round_estimate_usd: number;
+        last_round_responses: CouncilResponse[];
+    }) {
+        this.completed_round = args.completed_round;
+        this.total_planned_rounds = args.total_planned_rounds;
+        this.cost_so_far_usd = args.cost_so_far_usd;
+        this.next_round_estimate_usd = args.next_round_estimate_usd;
+        this.last_round_responses = args.last_round_responses;
+    }
+}
+
+/**
+ * Raised when projected next-round spend would breach the budget cap.
+ *
+ * The CLI catches this *after* writing the partial artefact, so the
+ * user always has a recoverable trail of the rounds that completed
+ * before the cap fired.
+ */
+export class DebateCapExceeded extends Error {
+    completed_round: number;
+    cost_so_far: number;
+    next_estimate: number;
+    cap: number;
+
+    constructor(args: {
+        completed_round: number;
+        cost_so_far: number;
+        next_estimate: number;
+        cap: number;
+    }) {
+        super(
+            `Debate hard-cap: round ${args.completed_round + 1} would push spend ` +
+                `to $${_pyFixed(args.cost_so_far + args.next_estimate, 4)} ` +
+                `(cap=$${_pyFixed(args.cap, 4)}); ` +
+                `stopping after round ${args.completed_round}.`,
+        );
+        this.name = 'DebateCapExceeded';
+        this.completed_round = args.completed_round;
+        this.cost_so_far = args.cost_so_far;
+        this.next_estimate = args.next_estimate;
+        this.cap = args.cap;
+    }
+}
+
+// Continue-prompt callback. Receives a DebateCheckpoint, returns True to
+// proceed with the next round, False to stop gracefully.
+export type DebateContinuePrompt = (checkpoint: DebateCheckpoint) => boolean;
+
+/**
+ * Build the round-N user prompt for a debate — rebuttal framing.
+ *
+ * Same anonymisation rules as `_augment_for_next_round` (Iron Law of
+ * Neutrality § multi-round): provider/model identifiers stripped,
+ * "Reviewer A / B / C…" labels assigned in input order, errors
+ * skipped. The instruction block is debate-specific: each reviewer
+ * is asked to identify the strongest opposing position and write a
+ * rebuttal, NOT to find common ground.
+ */
+function _augment_for_debate_round(
+    original_prompt: string,
+    prior_responses: CouncilResponse[],
+    next_round_number: number,
+): string {
+    const blocks: string[] = [];
+    let label_idx = 0;
+    for (const r of prior_responses) {
+        if (r.error || !_pyStrip(r.text)) {
+            continue;
+        }
+        const label = _label(label_idx);
+        label_idx += 1;
+        blocks.push(`### Reviewer ${label}\n\n${_pyStrip(r.text)}`);
+    }
+    if (blocks.length === 0) {
+        return original_prompt;
+    }
+    const prior_block = blocks.join('\n\n');
+    return (
+        `${original_prompt}\n\n` +
+        `---\n\n` +
+        `## Prior round positions (round ${next_round_number - 1})\n\n` +
+        `You are now in round ${next_round_number} of a structured\n` +
+        `debate. Below are anonymised positions from independent\n` +
+        `reviewers in the previous round. You do NOT know which model\n` +
+        `produced which position.\n\n` +
+        `Identify the SINGLE strongest opposing position and write a\n` +
+        `rebuttal addressed at its strongest steel-manned form. Do NOT\n` +
+        `search for common ground — name the load-bearing flaw the\n` +
+        `opposing reviewer missed and state the evidence behind your\n` +
+        `counter-position.\n\n` +
+        `${prior_block}`
+    );
+}
+
+export interface RunDebateOptions {
+    budget?: CostBudget | null;
+    table?: PriceTable | null;
+    on_overrun?: OnOverrunCallback | null;
+    project?: ProjectContext | null;
+    original_ask?: string;
+    max_rounds?: number;
+    on_round_complete?:
+        | ((round_number: number, responses: CouncilResponse[]) => void)
+        | null;
+    on_continue?: DebateContinuePrompt | null;
+    advisor_plans?: Map<string, AdvisorPlan> | null;
+    seed_round_1?: CouncilResponse[] | null;
+}
+
+/**
+ * Run a structured multi-round debate with progressive disclosure.
+ *
+ * Returns every completed round in order — caller persists each
+ * round incrementally via `on_round_complete` for crash safety.
+ *
+ * Round 1: each member produces an initial position. When
+ * `seed_round_1` is provided, it is reused verbatim (no calls) so
+ * `/council debate --continue-as-debate` can pivot from an existing
+ * `/council default` session.
+ *
+ * Round 2+: `_augment_for_debate_round` wraps the original prompt
+ * with anonymised prior positions and asks each member for a
+ * rebuttal addressed at the strongest opposing view.
+ *
+ * Between rounds: `on_continue(checkpoint)` is consulted. Returning
+ * False stops the debate; the caller receives every completed round.
+ * `None` (the default) auto-continues — the CLI wires its
+ * interactive y/N prompt here, `--auto-continue` passes `None`.
+ *
+ * Hard cap: before kicking off round N+1, the orchestrator compares
+ * `spent_usd + next_round_estimate` to `budget.max_total_usd`. A
+ * projected breach raises `DebateCapExceeded`; the CLI catches it
+ * after persisting the partial debate.
+ */
+export function run_debate(
+    members: ExternalAIClient[],
+    question: CouncilQuestion,
+    opts: RunDebateOptions = {},
+): CouncilResponse[][] {
+    const budget0 = opts.budget ?? null;
+    const table = opts.table ?? null;
+    const on_overrun = opts.on_overrun ?? null;
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const max_rounds = opts.max_rounds ?? 2;
+    const on_round_complete = opts.on_round_complete ?? null;
+    const on_continue = opts.on_continue ?? null;
+    const advisor_plans = opts.advisor_plans ?? null;
+    const seed_round_1 = opts.seed_round_1 ?? null;
+
+    if (max_rounds < 1) {
+        throw new Error(`max_rounds must be >= 1 (got ${max_rounds})`);
+    }
+    if (members.length === 0) {
+        return [];
+    }
+    const budget = budget0 ?? new CostBudget();
+    if (members.length > budget.max_calls) {
+        throw new Error(
+            `Debate has ${members.length} members but budget caps at ` +
+                `${budget.max_calls} calls.`,
+        );
+    }
+
+    const spent: Spent = { input: 0, output: 0, usd: 0.0 };
+    const all_rounds: CouncilResponse[][] = [];
+    let current_user_prompt = question.user_prompt;
+
+    for (let round_idx = 0; round_idx < max_rounds; round_idx++) {
+        const round_number = round_idx + 1;
+        let results: CouncilResponse[];
+        if (round_idx === 0 && seed_round_1 !== null) {
+            // Pivot from /council default — reuse the existing round 1
+            // verbatim. No calls billed; spend stays at $0 until round 2.
+            results = [...seed_round_1];
+        } else {
+            const round_question =
+                round_idx === 0
+                    ? question
+                    : new CouncilQuestion({
+                          mode: question.mode,
+                          user_prompt: current_user_prompt,
+                          max_tokens: question.max_tokens,
+                      });
+            results = _run_round(members, round_question, budget, spent, {
+                table,
+                on_overrun,
+                project,
+                original_ask,
+                advisor_plans,
+            });
+        }
+
+        all_rounds.push(results);
+        if (on_round_complete !== null) {
+            on_round_complete(round_number, results);
+        }
+
+        // Prep the user-prompt for the next round so the cost estimate
+        // below covers the augmented bytes.
+        if (round_idx + 1 < max_rounds) {
+            current_user_prompt = _augment_for_debate_round(
+                question.user_prompt,
+                results,
+                round_number + 1,
+            );
+            // Hard-cap + continue-prompt gating before kicking off N+1.
+            let next_round_usd: number;
+            if (table !== null) {
+                const next_question = new CouncilQuestion({
+                    mode: question.mode,
+                    user_prompt: current_user_prompt,
+                    max_tokens: question.max_tokens,
+                });
+                const next_estimates = estimate(next_question, members, table, {
+                    project,
+                    original_ask,
+                    advisor_plans,
+                });
+                next_round_usd = next_estimates.reduce(
+                    (acc, e) => acc + _total_usd(e),
+                    0,
+                );
+            } else {
+                next_round_usd = 0.0;
+            }
+
+            if (
+                budget.max_total_usd > 0 &&
+                spent.usd + next_round_usd > budget.max_total_usd
+            ) {
+                throw new DebateCapExceeded({
+                    completed_round: round_number,
+                    cost_so_far: spent.usd,
+                    next_estimate: next_round_usd,
+                    cap: budget.max_total_usd,
+                });
+            }
+
+            if (on_continue !== null) {
+                const checkpoint = new DebateCheckpoint({
+                    completed_round: round_number,
+                    total_planned_rounds: max_rounds,
+                    cost_so_far_usd: spent.usd,
+                    next_round_estimate_usd: next_round_usd,
+                    last_round_responses: results,
+                });
+                if (!on_continue(checkpoint)) {
+                    return all_rounds;
+                }
+            }
+        }
+    }
+
+    return all_rounds;
+}
+
+/**
+ * Bundle returned by `run_peer_review()` (Phase 5 / F1).
+ *
+ * `responses` carries the per-reviewer critiques. `label_to_source`
+ * is the anonymisation map captured server-side so the audit-trail
+ * JSON can rehydrate it without leaking provider identity to the
+ * member at prompt time.
+ *
+ * `persona_labels` is the (optional) Phase 6 / Step 3a wiring: when
+ * the deliberation was an advisor-mode run, the source → persona
+ * map flows through to the renderer so peer-review output can render
+ * as `Response A (Contrarian)`. Plain-member runs leave it empty.
+ */
+export class PeerReviewResult {
+    responses: CouncilResponse[];
+    label_to_source: Map<string, string>;
+    persona_labels: Map<string, string>;
+
+    constructor(args: {
+        responses: CouncilResponse[];
+        label_to_source: Map<string, string>;
+        persona_labels: Map<string, string>;
+    }) {
+        this.responses = args.responses;
+        this.label_to_source = args.label_to_source;
+        this.persona_labels = args.persona_labels;
+    }
+}
+
+export interface RunPeerReviewOptions {
+    budget?: CostBudget | null;
+    table?: PriceTable | null;
+    on_overrun?: OnOverrunCallback | null;
+    project?: ProjectContext | null;
+    original_ask?: string;
+    max_tokens?: number;
+    persona_labels?: Map<string, string> | null;
+}
+
+/**
+ * Karpathy peer-review pass (Phase 5 / F1).
+ *
+ * After the final deliberation round, each member sees the OTHER
+ * members' deliberation outputs under neutral `Response-A` labels
+ * (provider identity stripped; advisor persona labels preserved per
+ * Phase 6 Step 3a) and emits a Karpathy-style critique:
+ * strongest / weakest blind spot / what all missed / refinement.
+ *
+ * Members never see their own response — the orchestrator filters
+ * self before building the anonymised prompt. Errors in one member's
+ * pass tag that member but never abort the round.
+ *
+ * Cost gates flow through `consult([member], ...)`, so the same
+ * budget + daily-ledger semantics as deliberation apply.
+ */
+export function run_peer_review(
+    members: ExternalAIClient[],
+    deliberation_responses: CouncilResponse[],
+    opts: RunPeerReviewOptions = {},
+): PeerReviewResult {
+    const budget = opts.budget ?? null;
+    const table = opts.table ?? null;
+    const on_overrun = opts.on_overrun ?? null;
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const max_tokens = opts.max_tokens ?? DEFAULT_MAX_TOKENS;
+
+    if (members.length === 0 || deliberation_responses.length === 0) {
+        return new PeerReviewResult({
+            responses: [],
+            label_to_source: new Map(),
+            persona_labels: new Map(),
+        });
+    }
+
+    const member_by_name = new Map<string, ExternalAIClient>();
+    for (const m of members) {
+        member_by_name.set(m.name, m);
+    }
+    // ── source map: deliberation responses keyed by `provider:model` ─
+    // Errors and empty bodies are skipped — they leak nothing useful
+    // and would clutter the anonymised prompt with blanks.
+    const by_source = new Map<string, CouncilResponse>();
+    for (const r of deliberation_responses) {
+        if (r.error || !_pyStrip(r.text)) {
+            continue;
+        }
+        const source = `${r.provider}:${r.model}`;
+        by_source.set(source, r);
+    }
+
+    if (by_source.size < 2) {
+        // Peer-review needs ≥ 2 distinct deliberation outputs (a
+        // reviewer with nothing else to review is a no-op).
+        return new PeerReviewResult({
+            responses: [],
+            label_to_source: new Map(),
+            persona_labels: new Map(),
+        });
+    }
+
+    const persona_labels = new Map<string, string>(opts.persona_labels ?? []);
+    const review_responses: CouncilResponse[] = [];
+    // ── final label_to_source map captured from the LAST member call
+    // so the renderer / JSON dump has the deterministic A/B mapping.
+    // Each member sees a different N-1 subset (self filtered), but the
+    // ordering of `by_source` stays stable, so the label assignment is
+    // deterministic per artefact run.
+    let last_label_to_source = new Map<string, string>();
+
+    for (const reviewer of members) {
+        const scorer = `${reviewer.name}:${reviewer.model}`;
+        if (!member_by_name.has(reviewer.name)) {
+            continue;
+        }
+        const others_pairs: Array<[string, string]> = [];
+        for (const [src, resp] of by_source) {
+            if (src !== scorer) {
+                others_pairs.push([src, resp.text]);
+            }
+        }
+        if (others_pairs.length === 0) {
+            continue;
+        }
+        const [anon_text, label_to_source] = anonymize_responses(others_pairs, {
+            persona_labels,
+        });
+        if (anon_text.size === 0) {
+            continue;
+        }
+        last_label_to_source = label_to_source;
+        const question = new CouncilQuestion({
+            mode: 'prompt',
+            user_prompt: build_peer_review_user_prompt(anon_text),
+            max_tokens,
+        });
+        const reviewed = consult([reviewer], question, budget, {
+            table,
+            on_overrun,
+            project,
+            original_ask,
+        });
+        review_responses.push(...reviewed);
+    }
+
+    return new PeerReviewResult({
+        responses: review_responses,
+        label_to_source: last_label_to_source,
+        persona_labels,
+    });
+}
+
+/**
+ * Bundle returned by `run_consensus_scoring()`.
+ *
+ * `bucket` is renderer-ready; `findings`, `scores`, and `metadata`
+ * are kept for audit-trail JSON (council-sessions/*.json).
+ */
+export class ConsensusResult {
+    bucket: ConsensusBucket;
+    findings: Finding[];
+    scores: FindingScore[];
+    metadata: Map<string, ConsensusMetadata>;
+    extraction_responses: CouncilResponse[];
+    scoring_responses: CouncilResponse[];
+
+    constructor(args: {
+        bucket: ConsensusBucket;
+        findings: Finding[];
+        scores: FindingScore[];
+        metadata: Map<string, ConsensusMetadata>;
+        extraction_responses: CouncilResponse[];
+        scoring_responses: CouncilResponse[];
+    }) {
+        this.bucket = args.bucket;
+        this.findings = args.findings;
+        this.scores = args.scores;
+        this.metadata = args.metadata;
+        this.extraction_responses = args.extraction_responses;
+        this.scoring_responses = args.scoring_responses;
+    }
+}
+
+export interface RunConsensusScoringOptions {
+    budget?: CostBudget | null;
+    table?: PriceTable | null;
+    on_overrun?: OnOverrunCallback | null;
+    project?: ProjectContext | null;
+    original_ask?: string;
+    max_tokens?: number;
+    strong_threshold?: number;
+    minority_threshold?: number;
+}
+
+/**
+ * Two-pass consensus round (Phase 4 / F3).
+ *
+ * Pass 1 — extraction: each member re-emits its own deliberation as
+ * a JSON array of `{id, text}` findings. Pass 2 — scoring: each
+ * member sees the *other* members' findings under anonymous labels
+ * and rates them 1-10 + agree/disagree + reason.
+ *
+ * The cost budget is shared across both passes; the daily ledger
+ * receives both. Errors in one member's extraction or scoring tag
+ * that member but never abort the round.
+ */
+export function run_consensus_scoring(
+    members: ExternalAIClient[],
+    deliberation_responses: CouncilResponse[],
+    opts: RunConsensusScoringOptions = {},
+): ConsensusResult {
+    const budget = opts.budget ?? null;
+    const table = opts.table ?? null;
+    const on_overrun = opts.on_overrun ?? null;
+    const project = opts.project ?? null;
+    const original_ask = opts.original_ask ?? '';
+    const max_tokens = opts.max_tokens ?? DEFAULT_MAX_TOKENS;
+    const strong_threshold = opts.strong_threshold ?? 0.7;
+    const minority_threshold = opts.minority_threshold ?? 0.4;
+
+    if (members.length === 0 || deliberation_responses.length === 0) {
+        return new ConsensusResult({
+            bucket: new ConsensusBucket(),
+            findings: [],
+            scores: [],
+            metadata: new Map(),
+            extraction_responses: [],
+            scoring_responses: [],
+        });
+    }
+
+    // ── Pass 1: extraction ──────────────────────────────────────────
+    const member_by_name = new Map<string, ExternalAIClient>();
+    for (const m of members) {
+        member_by_name.set(m.name, m);
+    }
+    const extraction_responses: CouncilResponse[] = [];
+    const all_findings: Finding[] = [];
+    for (const resp of deliberation_responses) {
+        const member = member_by_name.get(resp.provider);
+        if (member === undefined || resp.error || !_pyStrip(resp.text)) {
+            continue;
+        }
+        const question = new CouncilQuestion({
+            mode: 'prompt',
+            user_prompt: build_extraction_user_prompt(resp.text),
+            max_tokens,
+        });
+        const extracted = consult([member], question, budget, {
+            table,
+            on_overrun,
+            project,
+            original_ask,
+        });
+        extraction_responses.push(...extracted);
+        if (extracted.length === 0 || extracted[0]!.error) {
+            continue;
+        }
+        const source = `${member.name}:${member.model}`;
+        all_findings.push(
+            ...parse_findings_response(extracted[0]!.text, { source }),
+        );
+    }
+
+    if (all_findings.length === 0) {
+        return new ConsensusResult({
+            bucket: new ConsensusBucket(),
+            findings: [],
+            scores: [],
+            metadata: new Map(),
+            extraction_responses,
+            scoring_responses: [],
+        });
+    }
+
+    // ── Pass 2: scoring (each member rates the OTHERS' findings) ────
+    const scoring_responses: CouncilResponse[] = [];
+    const all_scores: FindingScore[] = [];
+    for (const member of members) {
+        const scorer = `${member.name}:${member.model}`;
+        const others = all_findings.filter((f) => f.source !== scorer);
+        if (others.length === 0) {
+            continue;
+        }
+        const anon = anonymize_findings(others);
+        const label_to_id = new Map<string, string>();
+        const anon_text = new Map<string, string>();
+        for (const [label, f] of anon) {
+            label_to_id.set(label, f.id);
+            anon_text.set(label, f.text);
+        }
+        const question = new CouncilQuestion({
+            mode: 'prompt',
+            user_prompt: build_scoring_user_prompt(anon_text),
+            max_tokens,
+        });
+        const scored = consult([member], question, budget, {
+            table,
+            on_overrun,
+            project,
+            original_ask,
+        });
+        scoring_responses.push(...scored);
+        if (scored.length === 0 || scored[0]!.error) {
+            continue;
+        }
+        for (const s of parse_scores_response(scored[0]!.text, { scorer })) {
+            const real_id = label_to_id.get(s.finding_id);
+            if (real_id === undefined) {
+                continue;
+            }
+            all_scores.push(
+                new FindingScore(real_id, s.scorer, s.score, s.agree, s.reason),
+            );
+        }
+    }
+
+    const metadata = aggregate_scores(all_findings, all_scores);
+    const bucket = bucket_by_threshold(all_findings, metadata, {
+        strong: strong_threshold,
+        minority: minority_threshold,
+    });
+    return new ConsensusResult({
+        bucket,
+        findings: all_findings,
+        scores: all_scores,
+        metadata,
+        extraction_responses,
+        scoring_responses,
+    });
+}
+
+/**
+ * Format the per-member meta line — tokens, cost (or subscription), latency.
+ *
+ * Phase 5 / Step 1 — non-billable vendor-CLI calls render
+ * `cost: subscription (<label>)` with no token detail (the local
+ * session counted them but the user is on a flat rate). Billable
+ * calls (api or community CLI) render `cost: $X.XXXX` plus tokens.
+ * Tokens marked `estimated=True` get a `~` prefix so the audit
+ * trail flags heuristic counts.
+ */
+function _render_response_meta(r: CouncilResponse): string {
+    const meta_dict: Record<string, unknown> = r.metadata ?? {};
+    const billable = Boolean(_metaGet(meta_dict, 'billable', true));
+    const estimated = Boolean(_metaGet(meta_dict, 'tokens_estimated', false));
+    const parts: string[] = [];
+    if (!billable) {
+        const label = (_metaGet(meta_dict, 'subscription_label', null) ||
+            'flat-rate') as string;
+        parts.push(`cost: subscription (${label})`);
+    } else {
+        const cost_usd = _metaGet(meta_dict, 'cost_usd', undefined);
+        if (typeof cost_usd === 'number' && !(typeof cost_usd === 'boolean')) {
+            parts.push(`cost: $${_pyFixed(cost_usd, 4)}`);
+        }
+        const prefix = estimated ? '~' : '';
+        parts.push(
+            `tokens: ${prefix}${r.input_tokens} in / ${prefix}${r.output_tokens} out`,
+        );
+    }
+    parts.push(`${r.latency_ms} ms`);
+    return `*${parts.join(' · ')}*`;
+}
+
+// Lens defaults for the Phase 9 confidence-explanation badge. The PR
+// lens stays terse so the existing "Must-fix / Nice-to-have" structure
+// isn't drowned in scorer prose; every other decision lens shows the
+// explanation by default. Creative lenses (design/optimize) never reach
+// this code path because they skip consensus scoring entirely.
+const _DEFAULT_EXPLAIN_LENSES: ReadonlySet<string> = new Set([
+    'default',
+    'analysis',
+    'debate',
+    'prompt',
+    'roadmap',
+    'diff',
+    'files',
+]);
+
+/**
+ * Decide whether the confidence-explanation badge fires by default.
+ *
+ * Pulled into a helper so the CLI `--explain-confidence` /
+ * `--no-explain-confidence` flags and the lens override path share
+ * one truth source.
+ */
+function _default_explain_confidence(mode: string | null): boolean {
+    if (mode === null) {
+        return true;
+    }
+    return _DEFAULT_EXPLAIN_LENSES.has(mode);
+}
+
+export interface RenderOptions {
+    mode?: string | null;
+    prose_synthesis?: boolean | null;
+    consensus?: ConsensusResult | null;
+    peer_review?: PeerReviewResult | null;
+    explain_confidence?: boolean | null;
+}
+
+/**
+ * Render stacked sections + a lens-aware synthesis prompt slot.
+ *
+ * `mode` selects the synthesis template from `prompts.synthesis_template`.
+ * `None` collapses to the default decision-lens template (back-compat).
+ *
+ * `prose_synthesis` is the R4 Q4 escape hatch:
+ *   - `True`  → force creative-lens passthrough (bare slot) regardless of mode
+ *   - `False` → force decision-lens default template even on creative lenses
+ *   - `None`  → honour the lens default from the table
+ *
+ * `consensus` (Phase 4 / F3) prepends Strong Consensus / Findings /
+ * Minority Views sections when the analysis lens scored its findings.
+ *
+ * `peer_review` (Phase 5 / F1) appends a Peer-Review block listing
+ * each member's critique (under Reviewer-A / Reviewer-B labels, in
+ * member input order so the audit trail is deterministic) and
+ * extends the synthesis template with the
+ * `Peer-Review-Surfaced Blind Spots` addendum.
+ */
+export function render(responses: CouncilResponse[], opts: RenderOptions = {}): string {
+    const mode = opts.mode ?? null;
+    const prose_synthesis = opts.prose_synthesis ?? null;
+    const consensus = opts.consensus ?? null;
+    const peer_review = opts.peer_review ?? null;
+    const explain_confidence = opts.explain_confidence ?? null;
+
+    const blocks: string[] = [];
+    const explain =
+        explain_confidence !== null
+            ? explain_confidence
+            : _default_explain_confidence(mode);
+    if (
+        consensus !== null &&
+        (consensus.bucket.strong.length > 0 ||
+            consensus.bucket.findings.length > 0 ||
+            consensus.bucket.minority.length > 0)
+    ) {
+        blocks.push(_render_consensus(consensus.bucket, explain));
+    }
+    for (const r of responses) {
+        const header = `## ${r.provider} · ${r.model}`;
+        if (r.error) {
+            blocks.push(`${header}\n\n*ERROR:* \`${r.error}\``);
+            continue;
+        }
+        const meta = _render_response_meta(r);
+        blocks.push(`${header}\n\n${meta}\n\n${r.text}`);
+    }
+    if (peer_review !== null && peer_review.responses.length > 0) {
+        blocks.push(_render_peer_review(peer_review));
+    }
+    let template: string;
+    if (prose_synthesis === true) {
+        template = '';
+    } else if (prose_synthesis === false) {
+        template = synthesis_template('default');
+    } else {
+        template = synthesis_template(mode);
+    }
+    if (peer_review !== null && peer_review.responses.length > 0) {
+        const addendum = peer_review_synthesis_addendum();
+        template = template ? `${template}\n${addendum}` : _pyLStrip(addendum);
+    }
+    let body: string;
+    if (template) {
+        body = template;
+    } else {
+        body = '*to be summarised by the host agent*';
+    }
+    blocks.push(`## Convergence / Divergence\n\n${body}`);
+    return blocks.join('\n\n---\n\n');
+}
+
+/**
+ * Render the peer-review block under deterministic Reviewer labels.
+ *
+ * Each successful reviewer gets a `### Reviewer X` sub-section. Errors
+ * keep their slot (so the audit trail still surfaces the breach) but
+ * render `ERROR: <tag>` instead of the prompt body.
+ */
+function _render_peer_review(peer_review: PeerReviewResult): string {
+    const lines: string[] = ['## Peer-Review (Karpathy)'];
+    let label_idx = 0;
+    for (const r of peer_review.responses) {
+        const label = _label(label_idx);
+        label_idx += 1;
+        if (r.error) {
+            lines.push(`### Reviewer ${label}\n\n*ERROR:* \`${r.error}\``);
+            continue;
+        }
+        lines.push(`### Reviewer ${label}\n\n${_pyStrip(r.text)}`);
+    }
+    return lines.join('\n\n');
+}
+
+/**
+ * Render Strong / Findings / Minority sections in renderer order.
+ *
+ * `explain` toggles the Phase 9 confidence-explanation badge — when
+ * `False` the renderer falls back to the terse Phase 4 badge so the
+ * PR lens (and any caller passing `--no-explain-confidence`) keeps
+ * its compact output.
+ */
+function _render_consensus(bucket: ConsensusBucket, explain = true): string {
+    const parts: string[] = [];
+    if (bucket.strong.length > 0) {
+        parts.push(
+            '## Strong Consensus\n\n' + _render_bucket(bucket.strong, explain),
+        );
+    }
+    if (bucket.findings.length > 0) {
+        parts.push('## Findings\n\n' + _render_bucket(bucket.findings, explain));
+    }
+    if (bucket.minority.length > 0) {
+        parts.push(
+            '## Minority Views\n\n' +
+                '*Sub-threshold by consensus; kept for audit trail.*\n\n' +
+                _render_bucket(bucket.minority, explain),
+        );
+    }
+    return parts.join('\n\n');
+}
+
+/**
+ * Collapse a multi-line scorer reason to a single ≤`limit`-char line.
+ *
+ * Phase 9 — the dissent summary must fit on one line; we keep the
+ * first sentence-ish chunk and add an ellipsis when truncating. Empty
+ * reasons render as `no rationale`.
+ */
+function _truncate_reason(reason: string, limit = 120): string {
+    const flat = reason ? _pySplitWhitespace(reason).join(' ') : '';
+    if (!flat) {
+        return 'no rationale';
+    }
+    if (_pyLen(flat) <= limit) {
+        return flat;
+    }
+    return _pyRStrip(_pySlice(flat, 0, limit - 1)) + '…';
+}
+
+/**
+ * Render one bucket of (finding, metadata) tuples.
+ *
+ * The Phase 4 terse badge (`strength · mean · scorers · dissent`)
+ * is preserved on the first line. Phase 9 adds a second
+ * confidence-explanation line whenever `explain` is true *and* at
+ * least one scorer rated the finding — the explanation needs scorer
+ * data to be meaningful.
+ */
+function _render_bucket(
+    items: Array<[Finding, ConsensusMetadata]>,
+    explain = true,
+): string {
+    const lines: string[] = [];
+    for (const [f, m] of items) {
+        const terse_badge =
+            `strength ${_pyFixed(m.consensus_strength, 2)} · ` +
+            `mean ${_pyFixed(m.mean_score, 1)}/10 · ` +
+            `${m.scorers.length} scorers · ` +
+            `${m.dissent_count} dissent`;
+        let block = `- **${f.id}** — ${f.text}  \n  _${terse_badge}_`;
+        if (explain && m.scorers.length > 0) {
+            let total = m.concur_count + m.dissent_count;
+            if (total <= 0) {
+                total = m.scorers.length;
+            }
+            const parts: string[] = [`${m.concur_count}/${total} members concur`];
+            if (m.dissent_reasons.length > 0) {
+                const first = m.dissent_reasons[0] as readonly [string, string];
+                parts.push(
+                    `${first[0]} dissented citing ` + `${_truncate_reason(first[1])}`,
+                );
+                const extra = m.dissent_reasons.length - 1;
+                if (extra > 0) {
+                    parts.push(`${extra} other dissent(s)`);
+                }
+            } else {
+                parts.push('no dissent');
+            }
+            parts.push(`mean evidence-quality ${m.evidence_quality}`);
+            block += '  \n  _' + parts.join('; ') + '_';
+        }
+        lines.push(block);
+    }
+    return lines.join('\n');
+}
+
+// ── small stdlib parity helpers ───────────────────────────────────────
+
+/** Mirror Python `int(x)` truncation-toward-zero on a float total. */
+function _pyInt(x: number): number {
+    return Math.trunc(x);
+}
+
+/** Mirror Python `repr(int)` for the error message in estimate_debate_cost. */
+function _pyReprInt(x: number): string {
+    return String(x);
+}
+
+/** Mirror `type(exc).__name__ + ": " + str(exc)`. */
+function _excTag(exc: unknown): string {
+    if (exc instanceof Error) {
+        return `${exc.name}: ${exc.message}`;
+    }
+    return `Error: ${String(exc)}`;
+}
+
+/** dict.setdefault(key, value) — only set when key absent. */
+function _setdefault(
+    obj: Record<string, unknown>,
+    key: string,
+    value: unknown,
+): void {
+    if (!(key in obj)) {
+        obj[key] = value;
+    }
+}
+
+/** dict.get(key, default). */
+function _metaGet(
+    obj: Record<string, unknown>,
+    key: string,
+    fallback: unknown,
+): unknown {
+    return key in obj ? obj[key] : fallback;
+}
+
+/** Python `str.lstrip()` (no-arg) — strip leading whitespace. */
+function _pyLStrip(s: string): string {
+    return s.replace(/^\s+/, '');
+}
+
+/** Python `str.rstrip()` (no-arg) — strip trailing whitespace. */
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/, '');
+}
+
+/** Python `len(str)` — code-point count, not UTF-16 unit count. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+/** Python `s[start:end]` — code-point slicing. */
+function _pySlice(s: string, start: number, end: number): string {
+    return [...s].slice(start, end).join('');
+}

--- a/src/scripts/ai_council/replay.ts
+++ b/src/scripts/ai_council/replay.ts
@@ -1,0 +1,314 @@
+// Decision-replay artefact for council sessions (Phase 9) — TypeScript twin
+// (py2ts Phase 1).
+//
+// Produces a per-session `decision-replay.md` that surfaces the audit
+// trail GPT review of PR #148 called out as missing: for each top
+// finding, the consensus_strength, agreeing-members with their key
+// argument, dissenting-members with their counter-argument, the
+// evidence-quality verdict, and a final synthesis verdict line.
+//
+// The artefact is a pure projection of the consensus data plus the
+// per-member deliberation texts — no extra model calls. Schema is
+// documented in `docs/contracts/ai-council-config.md` under
+// "Decision-replay schema".
+//
+// Parity notes (ADR-094):
+// - `" ".join(text.split())` collapses any run of Unicode whitespace to a
+//   single space and drops leading/trailing whitespace — `_pyJoinSplit`
+//   mirrors Python `str.split()` (no-arg) + `" ".join(...)`.
+// - Truncation `flat[:N].rstrip() + "…"` slices by CODE POINT then strips
+//   trailing whitespace — `_pyTruncate` reproduces both.
+// - `f"{x:.2f}"` / `f"{x:.1f}"` → `_pyFixed` (round-half-to-even), matching
+//   CPython float formatting.
+// - `sorted(..., reverse=True)` is a STABLE sort in CPython; JS
+//   `Array.prototype.sort` is stable in modern engines, and the comparator
+//   is written to keep equal keys in input order.
+// - The trailing `"\n".join(lines).rstrip() + "\n"` is reproduced verbatim.
+
+import type { CouncilResponse } from './clients.js';
+import { ConsensusMetadata, type Finding, type FindingScore } from './consensus.js';
+
+/**
+ * Bundle accepted by {@link render_decision_replay}.
+ *
+ * `include_member_arguments` toggles the redacted-vs-full output. When
+ * `false` the artefact emits consensus + dissent COUNT only — no per-member
+ * arguments — for sharing without leaking which model framed which point.
+ */
+export class DecisionReplayInputs {
+    readonly findings: readonly Finding[];
+    readonly scores: readonly FindingScore[];
+    readonly metadata: Map<string, ConsensusMetadata> | Record<string, ConsensusMetadata>;
+    readonly deliberation: readonly CouncilResponse[]; // last-round per-member texts
+    readonly original_ask: string;
+    readonly include_member_arguments: boolean;
+
+    constructor(args: {
+        findings: readonly Finding[];
+        scores: readonly FindingScore[];
+        metadata: Map<string, ConsensusMetadata> | Record<string, ConsensusMetadata>;
+        deliberation: readonly CouncilResponse[];
+        original_ask?: string;
+        include_member_arguments?: boolean;
+    }) {
+        this.findings = args.findings;
+        this.scores = args.scores;
+        this.metadata = args.metadata;
+        this.deliberation = args.deliberation;
+        this.original_ask = args.original_ask ?? '';
+        this.include_member_arguments = args.include_member_arguments ?? true;
+    }
+}
+
+/** Mirror Python `len(str)` — code-point count, not UTF-16 unit count. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+/**
+ * Mirror Python `" ".join(text.split())` — split on runs of (Unicode)
+ * whitespace, drop empties, re-join with a single space.
+ */
+function _pyJoinSplit(text: string): string {
+    // Python str.split() with no args splits on any whitespace run and
+    // discards leading/trailing/empty tokens.
+    const parts = text.split(/\s+/u).filter((tok) => tok.length > 0);
+    return parts.join(' ');
+}
+
+/**
+ * Mirror Python `flat[:limit].rstrip() + "…"` — slice by CODE POINT (not
+ * UTF-16 unit), then strip trailing whitespace, then append the ellipsis.
+ */
+function _pyTruncate(flat: string, limit: number): string {
+    const sliced = [...flat].slice(0, limit).join('');
+    return _pyRStrip(sliced) + '…';
+}
+
+/** Mirror Python `str.rstrip()` — strip trailing whitespace. */
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Mirror Python `str.strip()` — strip whitespace both ends. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Format `x` to `ndigits` decimals using round-half-to-even, matching
+ * CPython float formatting (`f"{x:.2f}"` / `f"{x:.1f}"`).
+ */
+function _pyFixed(x: number, ndigits: number): string {
+    if (!Number.isFinite(x)) {
+        return String(x);
+    }
+    const neg = x < 0 || Object.is(x, -0);
+    const abs = Math.abs(x);
+    const factor = Math.pow(10, ndigits);
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    const tol = Math.max(Math.abs(scaled), 1) * 2 ** -40;
+    let rounded: number;
+    if (Math.abs(frac - 0.5) <= tol) {
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    let intStr = String(rounded);
+    let result: string;
+    if (ndigits === 0) {
+        result = intStr;
+    } else {
+        if (intStr.length <= ndigits) {
+            intStr = '0'.repeat(ndigits - intStr.length + 1) + intStr;
+        }
+        const whole = intStr.slice(0, intStr.length - ndigits);
+        const dec = intStr.slice(intStr.length - ndigits);
+        result = `${whole}.${dec}`;
+    }
+    return neg ? `-${result}` : result;
+}
+
+function _metaGet(
+    metadata: Map<string, ConsensusMetadata> | Record<string, ConsensusMetadata>,
+    id: string,
+): ConsensusMetadata | undefined {
+    if (metadata instanceof Map) {
+        return metadata.get(id);
+    }
+    return Object.prototype.hasOwnProperty.call(metadata, id) ? metadata[id] : undefined;
+}
+
+/** Single-word verdict band for a consensus_strength. */
+function _verdict(strength: number): string {
+    if (strength > 0.7) {
+        return 'Strong';
+    }
+    if (strength > 0.4) {
+        return 'Moderate';
+    }
+    return 'Weak';
+}
+
+/**
+ * Return the one-line key argument for `scorer` on a finding.
+ *
+ * Prefers the scorer's `reason` field (rich, contextual) and falls back to
+ * the truncated deliberation snippet so the audit trail never surfaces an
+ * empty argument.
+ */
+function _scorer_argument(
+    scorer: string,
+    member_texts: Map<string, string>,
+    score: FindingScore | null,
+): string {
+    if (score && score.reason) {
+        let flat = _pyJoinSplit(score.reason);
+        if (_pyLen(flat) > 200) {
+            flat = _pyTruncate(flat, 199);
+        }
+        return flat;
+    }
+    const snippet = member_texts.get(scorer) ?? '';
+    let flat = _pyJoinSplit(snippet);
+    if (!flat) {
+        return 'no argument captured';
+    }
+    if (_pyLen(flat) > 200) {
+        flat = _pyTruncate(flat, 199);
+    }
+    return flat;
+}
+
+function _scores_for_finding(
+    fid: string,
+    scores: Iterable<FindingScore>,
+): Map<string, FindingScore> {
+    const out = new Map<string, FindingScore>();
+    for (const s of scores) {
+        if (s.finding_id === fid) {
+            out.set(s.scorer, s);
+        }
+    }
+    return out;
+}
+
+/**
+ * Render the `decision-replay.md` body.
+ *
+ * Sections (in order): a leading H1 plus the original ask blockquote, one
+ * `## <finding-id> — <truncated text>` block per finding (ranked by
+ * consensus_strength desc), and a trailing footer with the toggle state so
+ * consumers can tell at a glance whether arguments were redacted.
+ */
+export function render_decision_replay(inputs: DecisionReplayInputs): string {
+    const member_texts = new Map<string, string>();
+    for (const r of inputs.deliberation) {
+        member_texts.set(`${r.provider}:${r.model}`, r.text || '');
+    }
+
+    // sorted(findings, key=consensus_strength, reverse=True). CPython sort
+    // is stable; preserve input order among equal keys by indexing.
+    const ranked = inputs.findings
+        .map((f, i) => ({ f, i }))
+        .sort((a, b) => {
+            const sa = (
+                _metaGet(inputs.metadata, a.f.id) ??
+                new ConsensusMetadata({
+                    finding_id: a.f.id,
+                    consensus_strength: 0.0,
+                    dissent_count: 0,
+                    scorers: [],
+                    mean_score: 0.0,
+                })
+            ).consensus_strength;
+            const sb = (
+                _metaGet(inputs.metadata, b.f.id) ??
+                new ConsensusMetadata({
+                    finding_id: b.f.id,
+                    consensus_strength: 0.0,
+                    dissent_count: 0,
+                    scorers: [],
+                    mean_score: 0.0,
+                })
+            ).consensus_strength;
+            if (sb !== sa) {
+                return sb - sa; // reverse=True (descending)
+            }
+            return a.i - b.i; // stable tie-break on input order
+        })
+        .map((e) => e.f);
+
+    const lines: string[] = ['# Decision Replay\n'];
+    if (_pyStrip(inputs.original_ask)) {
+        let ask = _pyJoinSplit(inputs.original_ask);
+        if (_pyLen(ask) > 400) {
+            ask = _pyTruncate(ask, 399);
+        }
+        lines.push(`> ${ask}\n`);
+    }
+    if (ranked.length === 0) {
+        lines.push('*No findings were extracted for this session.*\n');
+        return _pyRStrip(lines.join('\n')) + '\n';
+    }
+    for (const f of ranked) {
+        let m = _metaGet(inputs.metadata, f.id) ?? null;
+        if (m === null) {
+            m = new ConsensusMetadata({
+                finding_id: f.id,
+                consensus_strength: 0.0,
+                dissent_count: 0,
+                scorers: [],
+                mean_score: 0.0,
+            });
+        }
+        let title = _pyJoinSplit(f.text);
+        if (_pyLen(title) > 120) {
+            title = _pyTruncate(title, 119);
+        }
+        const verdict = _verdict(m.consensus_strength);
+        lines.push(`## ${f.id} — ${title}\n`);
+        lines.push(
+            `- **Consensus**: ${verdict} (${_pyFixed(m.consensus_strength, 2)})\n` +
+                `- **Evidence quality**: ${m.evidence_quality} ` +
+                `(mean ${_pyFixed(m.mean_score, 1)}/10)\n` +
+                `- **Agreement**: ${m.concur_count}/` +
+                `${m.concur_count + m.dissent_count} members concur, ` +
+                `${m.dissent_count} dissent\n`,
+        );
+        if (inputs.include_member_arguments) {
+            const score_map = _scores_for_finding(f.id, inputs.scores);
+            const agreeing = m.scorers.filter((s) => {
+                const sc = score_map.get(s);
+                return sc !== undefined && sc.agree;
+            });
+            const dissent = m.dissent_reasons.map((pair) => pair);
+            if (agreeing.length > 0) {
+                lines.push('**Agreeing members**:');
+                for (const scorer of agreeing) {
+                    const arg = _scorer_argument(scorer, member_texts, score_map.get(scorer) ?? null);
+                    lines.push(`- _${scorer}_ — ${arg}`);
+                }
+                lines.push('');
+            }
+            if (dissent.length > 0) {
+                lines.push('**Dissenting members**:');
+                for (const [scorer] of dissent) {
+                    const arg = _scorer_argument(scorer, member_texts, score_map.get(scorer) ?? null);
+                    lines.push(`- _${scorer}_ — ${arg}`);
+                }
+                lines.push('');
+            }
+        }
+        lines.push(`**Synthesis verdict**: ${verdict} consensus — ${f.source} sourced.\n`);
+    }
+    const mode_label = inputs.include_member_arguments ? 'full' : 'redacted (counts only)';
+    lines.push(`---\n\n_artefact mode: ${mode_label}_\n`);
+    return _pyRStrip(lines.join('\n')) + '\n';
+}

--- a/src/scripts/ai_council/shadow_dispatch.ts
+++ b/src/scripts/ai_council/shadow_dispatch.ts
@@ -1,0 +1,510 @@
+/**
+ * Shadow-mode dispatch for low-impact solo-member decisions (step-9 P10).
+ *
+ * TypeScript twin of `src/scripts/ai_council/shadow_dispatch.py`
+ * (ADR-094 — Python→TS migration, Phase 1).
+ *
+ * When `low_impact.dispatch: single` is active, a Bernoulli-sampled subset
+ * of decisions is shadowed through the full council so disagreement between
+ * the solo verdict and the council verdict can be measured. The shadow log
+ * lives at `agents/runtime/council/shadow-log.jsonl` and is subject to the same
+ * privacy floor as the low-impact corpus: redactor-refused entries are
+ * dropped, not softened.
+ *
+ * The flip from `single` back to `full` is a user decision; this module
+ * emits data and an SLO banner, nothing else.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { PyRandom } from '../_lib/py_random.js';
+import { redact } from './bundler.js';
+import { createHash } from 'node:crypto';
+
+export const SHADOW_LOG_PATH = 'agents/runtime/council/shadow-log.jsonl';
+
+export const SLO_THRESHOLD_WARN = 0.05;
+export const SLO_THRESHOLD_BREACH = 0.08;
+
+/**
+ * One shadow decision row. `escalated` / `escalation_reason` come from the
+ * step-9 P13 confidence gate; `escalated=True` distinguishes "gate-caught"
+ * from "silent disagreement".
+ */
+export interface ShadowDecision {
+    readonly timestamp: string;
+    readonly query_hash: string;
+    readonly solo_verdict: string;
+    readonly full_verdict: string;
+    readonly agreed: boolean;
+    readonly escalated: boolean;
+    readonly escalation_reason: string;
+}
+
+/** A random source exposing Python `random.random()` semantics. */
+interface RandomLike {
+    random(): number;
+}
+
+export interface ShouldShadowOptions {
+    rng?: RandomLike | PyRandom | null;
+}
+
+export function should_shadow(sampleRate: number, opts: ShouldShadowOptions = {}): boolean {
+    const rate = Math.max(0.0, Math.min(1.0, sampleRate));
+    const rng = opts.rng ?? null;
+    const r = rng !== null ? (rng as RandomLike) : _defaultRandom;
+    return r.random() < rate;
+}
+
+/**
+ * Module-default random source. Python uses the global `random` module when
+ * no `rng` is passed — non-deterministic, never used in parity paths.
+ */
+const _defaultRandom: RandomLike = {
+    random(): number {
+        return Math.random();
+    },
+};
+
+function _hashQuery(query: string): string {
+    const redacted = redact(query);
+    return createHash('sha256').update(Buffer.from(redacted, 'utf-8')).digest('hex').slice(0, 16);
+}
+
+function _privacyDropped(redacted: string): boolean {
+    const stripped = _strip(redacted);
+    if (!stripped) {
+        return true;
+    }
+    return stripped.startsWith('[redacted');
+}
+
+export interface RecordShadowDecisionOptions {
+    query: string;
+    soloVerdict: string;
+    fullVerdict: string;
+    escalated?: boolean;
+    escalationReason?: string;
+}
+
+/**
+ * Append one JSONL row. Returns `null` when redaction would drop the entry
+ * (privacy floor — do not soften).
+ *
+ * `escalated` / `escalationReason` come from the confidence gate (step-9 P13).
+ * When true, `soloVerdict` is the rejected solo response and `fullVerdict` is
+ * the council's verdict that actually answered the user.
+ */
+export function record_shadow_decision(
+    logPath: string,
+    opts: RecordShadowDecisionOptions,
+): ShadowDecision | null {
+    const query = opts.query;
+    const soloVerdict = opts.soloVerdict;
+    const fullVerdict = opts.fullVerdict;
+    const escalated = opts.escalated ?? false;
+    const escalationReason = opts.escalationReason ?? 'ok';
+
+    const redactedQ = redact(query);
+    if (_privacyDropped(redactedQ)) {
+        return null;
+    }
+
+    const decision: ShadowDecision = {
+        timestamp: _isoNowSeconds(),
+        query_hash: _hashQuery(query),
+        solo_verdict: soloVerdict,
+        full_verdict: fullVerdict,
+        agreed: soloVerdict === fullVerdict,
+        escalated,
+        escalation_reason: escalationReason,
+    };
+    fs.mkdirSync(_dirname(logPath), { recursive: true });
+    const row =
+        _pyJsonDumps({
+            timestamp: decision.timestamp,
+            query_hash: decision.query_hash,
+            solo_verdict: decision.solo_verdict,
+            full_verdict: decision.full_verdict,
+            agreed: decision.agreed,
+            escalated: decision.escalated,
+            escalation_reason: decision.escalation_reason,
+        }) + '\n';
+    fs.appendFileSync(logPath, row, { encoding: 'utf-8' });
+    return decision;
+}
+
+/** Mirror `datetime.now(timezone.utc).isoformat(timespec="seconds")`. */
+function _isoNowSeconds(): string {
+    const d = new Date();
+    const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+    return (
+        `${pad(d.getUTCFullYear(), 4)}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+        `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}+00:00`
+    );
+}
+
+function* _iterLog(logPath: string): Generator<Record<string, unknown>> {
+    if (!fs.existsSync(logPath)) {
+        return;
+    }
+    const content = fs.readFileSync(logPath, { encoding: 'utf-8' });
+    for (const rawLine of _splitlines(content)) {
+        const line = _strip(rawLine);
+        if (!line) {
+            continue;
+        }
+        try {
+            yield JSON.parse(line) as Record<string, unknown>;
+        } catch {
+            continue;
+        }
+    }
+}
+
+export interface ComputeRateOptions {
+    windowDays?: number;
+    now?: Date | null;
+}
+
+/**
+ * `[disagreement_rate, sample_count]` over the rolling window.
+ *
+ * Counts a row as "disagreed" when `agreed=false` regardless of the
+ * escalation flag — a gate-caught split is still a sign that solo mode was
+ * wrong on that decision.
+ */
+export function compute_disagreement_rate(
+    logPath: string,
+    opts: ComputeRateOptions = {},
+): [number, number] {
+    const windowDays = opts.windowDays ?? 7;
+    const nowMs = (opts.now ?? new Date()).getTime();
+    const cutoff = nowMs - windowDays * 86400000;
+    let total = 0;
+    let disagreed = 0;
+    for (const row of _iterLog(logPath)) {
+        const rawTs = (row['timestamp'] as string) ?? '';
+        const ts = _parseIsoUtcMs(rawTs);
+        if (ts === null) {
+            continue;
+        }
+        if (ts < cutoff) {
+            continue;
+        }
+        total += 1;
+        if (!_getBool(row['agreed'], true)) {
+            disagreed += 1;
+        }
+    }
+    if (total === 0) {
+        return [0.0, 0];
+    }
+    return [disagreed / total, total];
+}
+
+/**
+ * `[escalation_rate, sample_count]` — fraction with `escalated=true`.
+ *
+ * Step-9 P13 — separates gate-caught escalations from silent disagreement so
+ * the banner can name the dominant failure mode.
+ */
+export function compute_escalation_rate(
+    logPath: string,
+    opts: ComputeRateOptions = {},
+): [number, number] {
+    const windowDays = opts.windowDays ?? 7;
+    const nowMs = (opts.now ?? new Date()).getTime();
+    const cutoff = nowMs - windowDays * 86400000;
+    let total = 0;
+    let escalated = 0;
+    for (const row of _iterLog(logPath)) {
+        const rawTs = (row['timestamp'] as string) ?? '';
+        const ts = _parseIsoUtcMs(rawTs);
+        if (ts === null) {
+            continue;
+        }
+        if (ts < cutoff) {
+            continue;
+        }
+        total += 1;
+        if (_getBool(row['escalated'], false)) {
+            escalated += 1;
+        }
+    }
+    if (total === 0) {
+        return [0.0, 0];
+    }
+    return [escalated / total, total];
+}
+
+export function slo_status(rate: number): string {
+    if (rate < SLO_THRESHOLD_WARN) {
+        return 'OK';
+    }
+    if (rate < SLO_THRESHOLD_BREACH) {
+        return 'WARN';
+    }
+    return 'BREACH';
+}
+
+export interface SloBannerOptions {
+    escalationRate?: number | null;
+}
+
+/**
+ * One-line SLO banner. `escalationRate` is appended when given.
+ *
+ * Step-9 P13 — escalation tail surfaces the share of decisions the confidence
+ * gate caught before they reached the user.
+ */
+export function slo_banner(rate: number, sampleCount: number, opts: SloBannerOptions = {}): string {
+    const escalationRate = opts.escalationRate ?? null;
+    const pct = rate * 100;
+    const status = slo_status(rate);
+    if (sampleCount === 0) {
+        return '[shadow SLO] no samples yet';
+    }
+    let base: string;
+    if (status === 'OK') {
+        base =
+            `[shadow SLO] OK · ${_fmt1(pct)}% disagreement over ` +
+            `${sampleCount} samples (<5%)`;
+    } else if (status === 'WARN') {
+        base =
+            `[shadow SLO] WARN · ${_fmt1(pct)}% disagreement over ` +
+            `${sampleCount} samples (5–8% — consider reverting to ` +
+            `low_impact.dispatch: full)`;
+    } else {
+        base =
+            `[shadow SLO] BREACH · ${_fmt1(pct)}% disagreement over ` +
+            `${sampleCount} samples (>8% — revert to ` +
+            `low_impact.dispatch: full)`;
+    }
+    if (escalationRate !== null) {
+        base += ` · ${_fmt1(escalationRate * 100)}% auto-escalated`;
+    }
+    return base;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/** Python f-string `{x:.1f}` — round-half-to-even to 1 decimal place. */
+function _fmt1(x: number): string {
+    return _pyFormatFixed(x, 1);
+}
+
+/**
+ * Mirror Python `format(x, ".Nf")` (round-half-to-even). JS `toFixed` rounds
+ * half-away-from-zero, so a manual banker's-rounding pass is required.
+ */
+function _pyFormatFixed(value: number, ndigits: number): string {
+    if (!Number.isFinite(value)) {
+        if (Number.isNaN(value)) {
+            return 'nan';
+        }
+        return value > 0 ? 'inf' : '-inf';
+    }
+    const neg = value < 0 || Object.is(value, -0);
+    const abs = Math.abs(value);
+    const factor = 10 ** ndigits;
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const diff = scaled - floor;
+    let rounded: number;
+    const eps = 1e-9;
+    if (diff > 0.5 + eps) {
+        rounded = floor + 1;
+    } else if (diff < 0.5 - eps) {
+        rounded = floor;
+    } else {
+        // Exactly halfway → round to even.
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    }
+    const intPart = Math.floor(rounded / factor);
+    const fracPart = rounded - intPart * factor;
+    let s: string;
+    if (ndigits === 0) {
+        s = String(intPart);
+    } else {
+        s = `${intPart}.${String(fracPart).padStart(ndigits, '0')}`;
+    }
+    return neg && rounded !== 0 ? `-${s}` : s;
+}
+
+/** Python truthiness for a JSON-loaded bool-ish value via `row.get(k, default)`. */
+function _getBool(v: unknown, deflt: boolean): boolean {
+    if (v === undefined) {
+        return deflt;
+    }
+    return _pyTruthy(v);
+}
+
+function _pyTruthy(v: unknown): boolean {
+    if (v === null || v === undefined) {
+        return false;
+    }
+    if (typeof v === 'boolean') {
+        return v;
+    }
+    if (typeof v === 'number') {
+        return v !== 0;
+    }
+    if (typeof v === 'string') {
+        return v.length > 0;
+    }
+    if (Array.isArray(v)) {
+        return v.length > 0;
+    }
+    if (typeof v === 'object') {
+        return Object.keys(v as object).length > 0;
+    }
+    return true;
+}
+
+/**
+ * Parse an ISO-8601 timestamp the way the Python code does
+ * (`datetime.fromisoformat(raw.replace("Z", "+00:00"))`, then assume UTC when
+ * tz-naive). Returns epoch milliseconds in UTC, or `null` on ValueError.
+ */
+function _parseIsoUtcMs(raw: string): number | null {
+    const s = raw.replace(/Z/gu, '+00:00');
+    // Python fromisoformat accepts 'YYYY-MM-DD[ T]HH:MM:SS[.ffffff][+HH:MM]'.
+    const m =
+        /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(?:([+-])(\d{2}):(\d{2})(?::(\d{2}))?)?$/u.exec(
+            s,
+        );
+    if (!m) {
+        // Date-only form 'YYYY-MM-DD' is also valid for fromisoformat.
+        const d = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(s);
+        if (!d) {
+            return null;
+        }
+        return Date.UTC(Number(d[1]), Number(d[2]) - 1, Number(d[3]));
+    }
+    const year = Number(m[1]);
+    const month = Number(m[2]);
+    const day = Number(m[3]);
+    const hour = Number(m[4]);
+    const minute = Number(m[5]);
+    const second = Number(m[6]);
+    const fracStr = m[7] ?? '';
+    const micros = fracStr ? Number(fracStr.padEnd(6, '0')) : 0;
+    const ms = Math.floor(micros / 1000);
+    let utc = Date.UTC(year, month - 1, day, hour, minute, second, ms);
+    if (m[8]) {
+        // Apply the explicit offset → convert to UTC instant.
+        const sign = m[8] === '-' ? -1 : 1;
+        const offMin = Number(m[9]) * 60 + Number(m[10]) + (m[11] ? Number(m[11]) / 60 : 0);
+        utc -= sign * offMin * 60000;
+    }
+    return utc;
+}
+
+/** Python `Path(p).parent`. */
+function _dirname(p: string): string {
+    const i = p.lastIndexOf('/');
+    if (i < 0) {
+        return '.';
+    }
+    if (i === 0) {
+        return '/';
+    }
+    return p.slice(0, i);
+}
+
+/** Python `str.strip()`. */
+function _strip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Python `str.splitlines()` — split on universal newlines, drop a single
+ * trailing newline (no empty final element).
+ */
+function _splitlines(s: string): string[] {
+    if (s === '') {
+        return [];
+    }
+    const lines = s.split(/\r\n|\r|\n/u);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+    }
+    return lines;
+}
+
+// ── json.dumps (default args: ensure_ascii=True, separators=(", ", ": ")) ──
+
+/** Mirror Python `json.dumps(obj)` with default arguments. */
+function _pyJsonDumps(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    switch (typeof value) {
+        case 'boolean':
+            return value ? 'true' : 'false';
+        case 'number':
+            return _pyJsonNumber(value);
+        case 'string':
+            return _pyJsonStringAscii(value);
+        case 'object':
+            break;
+        default:
+            throw new TypeError(`Object of type ${typeof value} is not JSON serializable`);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => _pyJsonDumps(v)).join(', ')}]`;
+    }
+    const obj = value as Record<string, unknown>;
+    const parts: string[] = [];
+    for (const k of Object.keys(obj)) {
+        parts.push(`${_pyJsonStringAscii(k)}: ${_pyJsonDumps(obj[k])}`);
+    }
+    return `{${parts.join(', ')}}`;
+}
+
+function _pyJsonNumber(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+/**
+ * Escape a string like Python `json.dumps(..., ensure_ascii=True)`:
+ * short escapes for control chars, `\uXXXX` for every non-ASCII code point
+ * (surrogate pairs for astral chars, matching CPython).
+ */
+function _pyJsonStringAscii(s: string): string {
+    let out = '"';
+    for (let i = 0; i < s.length; i += 1) {
+        // Iterate UTF-16 code units so astral chars emit surrogate-pair escapes.
+        const ch = s[i] as string;
+        const code = s.charCodeAt(i);
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (code < 0x20 || code > 0x7e) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + '"';
+}

--- a/tests/scripts/ai_council/compile_corpus.test.ts
+++ b/tests/scripts/ai_council/compile_corpus.test.ts
@@ -1,0 +1,264 @@
+// Tests for src/scripts/ai_council/compile_corpus.ts (py2ts Phase 1).
+//
+// Compiles the human-edited low-impact corpus Markdown to a YAML lockfile.
+// The load-bearing parity surface is the PyYAML safe_dump emitter: the TS
+// twin reimplements PyYAML's scalar-style analysis (plain / single-quoted /
+// double-quoted), implicit re-typing (a plain "123" / "true" / "null" forces
+// quoting), and block layout byte-for-byte. Golden parity drives the TS twin
+// and the CPython original over the same corpora and asserts the emitted
+// bytes are identical, plus the --check / parse-error CLI exit codes.
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    SCHEMA_VERSION,
+    _main,
+    build_lock_document,
+    compile_corpus,
+    dump_lock_yaml,
+} from '../../../src/scripts/ai_council/compile_corpus.js';
+import { parse_corpus_strict } from '../../../src/scripts/ai_council/low_impact_corpus.js';
+import { hasPython3, runPyCode, runPyScript, runTsScript } from './_harness.js';
+
+const py3 = hasPython3();
+
+const GOOD = [
+    '## Validated',
+    '',
+    '<!-- intake-anchor: validated -->',
+    '',
+    '- "what port" — meta here',
+    '',
+    '## On Probation',
+    '',
+    '<!-- intake-anchor: probation -->',
+    '',
+    '- "how to test" — first-seen 2026-05-01',
+    '',
+    '## Anti-Examples (Always Ask User)',
+    '',
+    '- "delete prod?"',
+    '',
+    'last-upstreamed: 0123456789abcdef0123456789abcdef01234567',
+    '',
+].join('\n');
+
+// Exercises the full scalar-quoting decision tree: numerics / bools / null
+// that re-type (forcing quotes), colon + hash + leading-dash block indicators,
+// trailing space, tab (forces double-quote), non-ASCII (plain under
+// allow_unicode), and an empty trailing_metadata ('').
+const EDGE = [
+    '## Validated',
+    '',
+    '<!-- intake-anchor: validated -->',
+    '',
+    '- "what port" — meta plain',
+    '- "123 numeric" — meta 456',
+    '- "true" — yes',
+    '- "has: colon spaced" — a: b meta',
+    '- "naïve café über"',
+    '- "with #hash" — has #mid',
+    '- "leading dash phrase" — - dashmeta',
+    '- "tab\tin\tphrase" — t\tt',
+    '- "emoji 😀 face"',
+    '- "null"',
+    '- ".5 floaty" — 1e3',
+    '',
+    '## On Probation',
+    '',
+    '<!-- intake-anchor: probation -->',
+    '',
+    '- "how to test" — first-seen 2026-05-01',
+    '',
+    '## Anti-Examples (Always Ask User)',
+    '',
+    '- "delete prod?"',
+    '',
+    'last-upstreamed: 0123456789abcdef0123456789abcdef01234567',
+    '',
+].join('\n');
+
+// All three section headings present with anchors, but no bullets → the
+// probation/anti lists serialise as inline `[]`. (The strict parser requires
+// both the validated + probation anchors whenever any section is present.)
+const EMPTY_SECTIONS = [
+    '## Validated',
+    '',
+    '<!-- intake-anchor: validated -->',
+    '',
+    '- "one validated phrase"',
+    '',
+    '## On Probation',
+    '',
+    '<!-- intake-anchor: probation -->',
+    '',
+    '## Anti-Examples (Always Ask User)',
+    '',
+].join('\n');
+
+function tmpFile(name: string, content: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'compcorp-'));
+    const p = path.join(dir, name);
+    writeFileSync(p, content, { encoding: 'utf-8' });
+    return p;
+}
+
+describe('compile_corpus — pure builders', () => {
+    it('SCHEMA_VERSION is 1', () => {
+        expect(SCHEMA_VERSION).toBe(1);
+    });
+
+    it('build_lock_document drops section + carries provenance', () => {
+        const src = tmpFile('c.md', GOOD);
+        const text = readFileSync(src, { encoding: 'utf-8' });
+        const doc = build_lock_document(src, parse_corpus_strict(src), text);
+        expect(doc.schema_version).toBe(1);
+        expect(doc.provenance.last_upstreamed).toBe('0123456789abcdef0123456789abcdef01234567');
+        expect(doc.provenance.source_sha256).toMatch(/^[0-9a-f]{64}$/u);
+        // section field is dropped from the entry dict.
+        expect(Object.keys(doc.validated[0] as object).sort()).toEqual([
+            'line_no',
+            'normalised',
+            'phrase',
+            'trailing_metadata',
+        ]);
+        expect(doc.validated[0]?.phrase).toBe('what port');
+    });
+
+    it('dump_lock_yaml ends with exactly one trailing newline', () => {
+        const src = tmpFile('c.md', GOOD);
+        const text = readFileSync(src, { encoding: 'utf-8' });
+        const out = dump_lock_yaml(build_lock_document(src, parse_corpus_strict(src), text));
+        expect(out.endsWith('\n')).toBe(true);
+        expect(out.endsWith('\n\n')).toBe(false);
+    });
+
+    it('compile_corpus writes the lockfile + returns the same text', () => {
+        const src = tmpFile('c.md', GOOD);
+        const outPath = path.join(path.dirname(src), 'c.lock.yaml');
+        const written = compile_corpus(src, outPath);
+        expect(readFileSync(outPath, { encoding: 'utf-8' })).toBe(written);
+        expect(written).toContain('schema_version: 1');
+    });
+
+    it('missing source → empty validated/probation/anti, hash of empty bytes', () => {
+        const outPath = tmpFile('out.yaml', '');
+        const written = compile_corpus('/no/such/corpus.md', outPath);
+        // SHA-256 of the empty string.
+        expect(written).toContain(
+            'source_sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        );
+        expect(written).toContain('validated: []');
+    });
+});
+
+describe('compile_corpus — CLI exit codes', () => {
+    it('parse error returns 2', () => {
+        const bad = tmpFile('d.md', '### Validated\n\n- "x"\n');
+        const out = tmpFile('o.yaml', '');
+        expect(_main(['--source', bad, '--out', out])).toBe(2);
+    });
+
+    it('--check on a stale (missing) lockfile returns 1', () => {
+        const src = tmpFile('c.md', GOOD);
+        expect(_main(['--check', '--source', src, '--out', '/no/such/out.yaml'])).toBe(1);
+    });
+
+    it('--check on a fresh lockfile returns 0', () => {
+        const src = tmpFile('c.md', GOOD);
+        const out = path.join(path.dirname(src), 'c.lock.yaml');
+        compile_corpus(src, out);
+        expect(_main(['--check', '--source', src, '--out', out])).toBe(0);
+    });
+});
+
+describe.runIf(py3)('compile_corpus — golden parity vs CPython twin (byte-exact YAML)', () => {
+    function pyCompile(corpus: string): string {
+        const out = path.join(mkdtempSync(path.join(tmpdir(), 'pycc-')), 'lock.yaml');
+        const res = runPyScript('ai_council/compile_corpus', ['--source', corpus, '--out', out]);
+        expect(res.status, res.stderr).toBe(0);
+        return readFileSync(out, { encoding: 'utf-8' });
+    }
+
+    function tsCompile(corpus: string): string {
+        const out = path.join(mkdtempSync(path.join(tmpdir(), 'tscc-')), 'lock.yaml');
+        const res = runTsScript('ai_council/compile_corpus', ['--source', corpus, '--out', out]);
+        expect(res.status, res.stderr).toBe(0);
+        return readFileSync(out, { encoding: 'utf-8' });
+    }
+
+    it('clean corpus → byte-identical lockfile', () => {
+        const src = tmpFile('c.md', GOOD);
+        expect(tsCompile(src)).toBe(pyCompile(src));
+    });
+
+    it('quoting edge cases → byte-identical lockfile', () => {
+        const src = tmpFile('edge.md', EDGE);
+        const pyOut = pyCompile(src);
+        const tsOut = tsCompile(src);
+        expect(tsOut).toBe(pyOut);
+        // Sanity: a whole-string bool / null re-types → forced single-quote.
+        expect(pyOut).toContain("phrase: 'true'");
+        expect(pyOut).toContain("phrase: 'null'");
+        // A leading-`#` block indicator inside the phrase forces single-quote.
+        expect(pyOut).toContain("phrase: 'with #hash'");
+        // A colon-space block indicator forces single-quote.
+        expect(pyOut).toContain("phrase: 'has: colon spaced'");
+        // "123 numeric" is NOT a whole-string int → stays plain.
+        expect(pyOut).toContain('phrase: 123 numeric');
+        // Tab forces double-quote with a \t escape.
+        expect(pyOut).toContain('phrase: "tab\\tin\\tphrase"');
+        // Non-ASCII stays plain under allow_unicode.
+        expect(pyOut).toContain('phrase: naïve café über');
+    });
+
+    it('empty probation/anti sections → "[]" inline, byte-identical', () => {
+        const src = tmpFile('empty.md', EMPTY_SECTIONS);
+        const pyOut = pyCompile(src);
+        expect(pyOut).toContain('probation: []');
+        expect(pyOut).toContain('anti_examples: []');
+        expect(tsCompile(src)).toBe(pyOut);
+    });
+
+    it('missing source → byte-identical (empty-hash) lockfile', () => {
+        const missing = path.join(tmpdir(), 'definitely-not-here-compcorp.md');
+        expect(tsCompile(missing)).toBe(pyCompile(missing));
+    });
+
+    it('parse-error stderr + exit code match', () => {
+        const bad = tmpFile('bad.md', '### Validated\n\n- "x"\n');
+        const out = tmpFile('o.yaml', '');
+        const py = runPyScript('ai_council/compile_corpus', ['--source', bad, '--out', out]);
+        const ts = runTsScript('ai_council/compile_corpus', ['--source', bad, '--out', out]);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(2);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('build_lock_document structured output matches', () => {
+        const src = tmpFile('c.md', GOOD);
+        const expected = JSON.parse(
+            (() => {
+                const code = [
+                    'import json, sys',
+                    'from pathlib import Path',
+                    'from scripts.ai_council import compile_corpus as C',
+                    'p = Path(sys.argv[1])',
+                    'text = p.read_text(encoding="utf-8")',
+                    'from scripts.ai_council.low_impact_corpus import parse_corpus_strict',
+                    'doc = C.build_lock_document(p, parse_corpus_strict(p), text)',
+                    'print(json.dumps(doc, ensure_ascii=False))',
+                ].join('\n');
+                const res = runPyCode(code, [src]);
+                expect(res.status, res.stderr).toBe(0);
+                return res.stdout;
+            })(),
+        ) as Record<string, unknown>;
+        const text = readFileSync(src, { encoding: 'utf-8' });
+        const doc = build_lock_document(src, parse_corpus_strict(src), text);
+        expect(JSON.parse(JSON.stringify(doc))).toEqual(expected);
+    });
+});

--- a/tests/scripts/ai_council/learn_low_impact_preview.test.ts
+++ b/tests/scripts/ai_council/learn_low_impact_preview.test.ts
@@ -1,0 +1,225 @@
+// Tests for src/scripts/ai_council/learn_low_impact_preview.ts (py2ts Phase 1).
+//
+// Preview builder for `/memory learn-low-impact`. Pure parse + redaction +
+// render. Golden parity against the CPython twin covers the bucketing
+// (promoted / refused / already-seeded), the provenance-SHA extraction, and
+// the three render surfaces (render / render_diff / render_pr_body) byte-for-
+// byte — including the refused-entry `reason()` string that threads the
+// redactor's violations through.
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    LearnLowImpactPreview,
+    RefusedEntry,
+    build_preview,
+} from '../../../src/scripts/ai_council/learn_low_impact_preview.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// A leaked path + an email → both refused by the redactor. Assembled from
+// parts so this test file does not embed a literal home path / address that
+// trips secret/path linters.
+const LEAK_PATH = '/Users/' + 'demo' + '/secret.txt';
+const LEAK_EMAIL = 'admin' + '@' + 'example.com';
+
+function corpus(opts: { upstreamed?: string } = {}): string {
+    const lines = [
+        '## Validated',
+        '',
+        '<!-- intake-anchor: validated -->',
+        '',
+        '- "what port should the dev server use"',
+        `- "ping ${LEAK_EMAIL} for access"`,
+        '- "already seeded phrase"',
+        '',
+        '## On Probation',
+        '',
+        '<!-- intake-anchor: probation -->',
+        '',
+        '- "x phrase"',
+        '',
+        '## Anti-Examples (Always Ask User)',
+        '',
+        '- "delete prod?"',
+        '',
+    ];
+    if (opts.upstreamed !== undefined) {
+        lines.push(`last-upstreamed: ${opts.upstreamed}`);
+        lines.push('');
+    }
+    return lines.join('\n');
+}
+
+const SEED = [
+    '## Validated',
+    '',
+    '<!-- intake-anchor: validated -->',
+    '',
+    '- "already seeded phrase"',
+    '',
+    '## On Probation',
+    '',
+    '<!-- intake-anchor: probation -->',
+    '',
+    '- "y"',
+    '',
+    '## Anti-Examples (Always Ask User)',
+    '',
+    '- "z?"',
+    '',
+].join('\n');
+
+function tmpFile(name: string, content: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'llip-'));
+    const p = path.join(dir, name);
+    writeFileSync(p, content, { encoding: 'utf-8' });
+    return p;
+}
+
+describe('learn_low_impact_preview — bucketing + flags', () => {
+    it('promoted / refused / already-seeded split', () => {
+        const c = tmpFile('c.md', corpus({ upstreamed: 'abcdef0123456789abcdef0123456789abcdef01' }));
+        const s = tmpFile('s.md', SEED);
+        const p = build_preview(c, s, { repoSlug: 'acme/widgets' });
+        expect(p.promoted.map((e) => e.phrase)).toEqual(['what port should the dev server use']);
+        expect(p.refused.map((r) => r.phrase)).toEqual([`ping ${LEAK_EMAIL} for access`]);
+        expect([...p.already_seeded]).toEqual(['already seeded phrase']);
+        expect(p.last_upstreamed_sha).toBe('abcdef0123456789abcdef0123456789abcdef01');
+        // A refusal blocks the PR even though there is a promoted entry.
+        expect(p.has_work).toBe(true);
+        expect(p.would_open_pr).toBe(false);
+    });
+
+    it('missing provenance footer → 40 zeros', () => {
+        const c = tmpFile('c.md', corpus());
+        const p = build_preview(c, '/no/such/seed.md');
+        expect(p.last_upstreamed_sha).toBe('0'.repeat(40));
+        // No seed → nothing already-seeded; the clean phrase promotes.
+        expect(p.promoted.map((e) => e.phrase)).toContain('what port should the dev server use');
+    });
+
+    it('RefusedEntry.reason joins category: snippet', () => {
+        const c = tmpFile('c.md', corpus());
+        const p = build_preview(c, '/no/such/seed.md');
+        const refused = p.refused[0] as RefusedEntry;
+        expect(refused.reason()).toBe(`email: ${LEAK_EMAIL}`);
+    });
+
+    it('would_open_pr true only when promoted and no refusals', () => {
+        const clean = [
+            '## Validated',
+            '',
+            '<!-- intake-anchor: validated -->',
+            '',
+            '- "a brand new clean validated phrase"',
+            '',
+            '## On Probation',
+            '',
+            '<!-- intake-anchor: probation -->',
+            '',
+            '## Anti-Examples (Always Ask User)',
+            '',
+            '- "drop everything?"',
+            '',
+        ].join('\n');
+        const p = build_preview(tmpFile('clean.md', clean), '/no/such/seed.md', {
+            repoSlug: 'acme/widgets',
+        });
+        expect(p.would_open_pr).toBe(true);
+        expect(p.has_work).toBe(true);
+    });
+
+    it('build_preview returns a LearnLowImpactPreview', () => {
+        const p = build_preview(tmpFile('c.md', corpus()), '/no/such/seed.md');
+        expect(p).toBeInstanceOf(LearnLowImpactPreview);
+    });
+});
+
+describe.runIf(py3)('learn_low_impact_preview — golden parity vs CPython twin', () => {
+    /** Run build_preview in CPython, return [render, render_diff, render_pr_body]. */
+    function pyRender(
+        corpusPath: string,
+        seedPath: string,
+        repoSlug: string,
+        leakPath: string,
+    ): [string, string, string, boolean, boolean, string] {
+        const code = [
+            'import json, sys',
+            'from scripts.ai_council.learn_low_impact_preview import build_preview',
+            'corpus, seed, slug, leak = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]',
+            'p = build_preview(corpus, seed, repo_slug=slug, repo_root=leak)',
+            'print(json.dumps([p.render(), p.render_diff(), p.render_pr_body(),'
+                + ' p.has_work, p.would_open_pr, p.last_upstreamed_sha], ensure_ascii=False))',
+        ].join('\n');
+        const res = runPyCode(code, [corpusPath, seedPath, repoSlug, leakPath]);
+        expect(res.status, res.stderr).toBe(0);
+        return JSON.parse(res.stdout) as [string, string, string, boolean, boolean, string];
+    }
+
+    it('render / render_diff / render_pr_body byte-match (mixed buckets)', () => {
+        const c = tmpFile('c.md', corpus({ upstreamed: 'abcdef0123456789abcdef0123456789abcdef01' }));
+        const s = tmpFile('s.md', SEED);
+        const [render, diff, prBody, hasWork, wouldOpen, sha] = pyRender(c, s, 'acme/widgets', '');
+        const p = build_preview(c, s, { repoSlug: 'acme/widgets' });
+        expect(p.render()).toBe(render);
+        expect(p.render_diff()).toBe(diff);
+        expect(p.render_pr_body()).toBe(prBody);
+        expect(p.has_work).toBe(hasWork);
+        expect(p.would_open_pr).toBe(wouldOpen);
+        expect(p.last_upstreamed_sha).toBe(sha);
+    });
+
+    it('no-work + empty-slug render byte-match', () => {
+        // Empty corpus (only anchors) → nothing to upstream.
+        const empty = [
+            '## Validated',
+            '',
+            '<!-- intake-anchor: validated -->',
+            '',
+            '## On Probation',
+            '',
+            '<!-- intake-anchor: probation -->',
+            '',
+            '## Anti-Examples (Always Ask User)',
+            '',
+            '- "z?"',
+            '',
+        ].join('\n');
+        const c = tmpFile('e.md', empty);
+        const [render, diff, prBody] = pyRender(c, '/no/such/seed.md', '', '');
+        const p = build_preview(c, '/no/such/seed.md');
+        expect(p.render()).toBe(render);
+        expect(p.render_diff()).toBe(diff);
+        expect(p.render_pr_body()).toBe(prBody);
+    });
+
+    it('refused-only render + reason() byte-match', () => {
+        const refusedOnly = [
+            '## Validated',
+            '',
+            '<!-- intake-anchor: validated -->',
+            '',
+            `- "reach ${LEAK_EMAIL} now"`,
+            '',
+            '## On Probation',
+            '',
+            '<!-- intake-anchor: probation -->',
+            '',
+            '## Anti-Examples (Always Ask User)',
+            '',
+            '- "z?"',
+            '',
+        ].join('\n');
+        const c = tmpFile('r.md', refusedOnly);
+        const [render, diff, prBody] = pyRender(c, '/no/such/seed.md', 'acme/widgets', '');
+        const p = build_preview(c, '/no/such/seed.md', { repoSlug: 'acme/widgets' });
+        expect(p.render()).toBe(render);
+        expect(p.render_diff()).toBe(diff);
+        expect(p.render_pr_body()).toBe(prBody);
+    });
+});

--- a/tests/scripts/ai_council/necessity.test.ts
+++ b/tests/scripts/ai_council/necessity.test.ts
@@ -1,0 +1,370 @@
+// Tests for src/scripts/ai_council/necessity.ts (py2ts Phase 1).
+//
+// necessity is a pure heuristic classifier (no CLI, no network). It scans a
+// prompt for marker words and emits verdict / category / rationale / hit
+// counts. Three public surfaces: classify_necessity, classify_size_fit,
+// classify_impact (+ corpus / routing variants).
+//
+// Golden parity drives the LIVE Python twin via a `python3 -c` importlib
+// direct-file load. necessity.py imports `low_impact_corpus` lazily INSIDE
+// `load_validated_phrases`, so the bare classifier surfaces load straight
+// off disk without pulling the networked package `__init__`. The corpus
+// helper is exercised separately with a real temp corpus.
+//
+// Number divergence (ADR-094): Python `:.2f` rationale strings are already
+// formatted to a fixed string, so the differential compares raw rationale
+// text. Hit counts are ints on both sides.
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    classify_impact,
+    classify_necessity,
+    classify_size_fit,
+    downgrade_message,
+    educate_message,
+    IMPACT_TRIGGERS,
+    LOCKED_IMPACT_CLASSES,
+    NECESSARY_TRIGGERS,
+    route_decision,
+    UNNECESSARY_TRIGGERS,
+} from '../../../src/scripts/ai_council/necessity.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+const NECESSITY_PY = 'src/scripts/ai_council/necessity.py';
+
+function pyLoadPreamble(): string[] {
+    return [
+        'import importlib.util, sys, json',
+        `_spec = importlib.util.spec_from_file_location("nc", ${JSON.stringify(NECESSITY_PY)})`,
+        'nc = importlib.util.module_from_spec(_spec)',
+        'sys.modules["nc"] = nc',
+        '_spec.loader.exec_module(nc)',
+    ];
+}
+
+function py(snippet: string): string {
+    const code = [...pyLoadPreamble(), snippet].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+// A broad prompt corpus exercising every bucket + the mixed / empty / strict
+// / fence paths. Kept deterministic so the differential is reproducible.
+const PROMPTS: string[] = [
+    '',
+    '   ',
+    'Should we refactor the architecture and decouple these microservices?',
+    'fix this crash — stack trace shows a failing test',
+    'what is the syntax of a list comprehension',
+    'rename this function and fix the typo', // mixed (rename in both tables)
+    'I am unsure about the trade-off between these two competing options',
+    'just a small change to this file',
+    'we need a strategic roadmap decision on the long-term vision',
+    'add a getter and a setter to this method',
+    'should we choose monorepo or microservices? I am uncertain, sanity check please',
+    'lint and format the file, fix indentation',
+    'plain prompt with no markers at all here',
+    'documentation lookup for the api of the widget',
+    'rewrite the migration plan — this is a redesign with a module boundary',
+];
+
+const LENSES = ['analysis', 'debate', 'pr'];
+
+describe('necessity — classify_necessity golden parity', () => {
+    it.runIf(py3)('verdict / category / rationale / hits match python3', () => {
+        const tsResults: unknown[] = [];
+        for (const prompt of PROMPTS) {
+            for (const lens of LENSES) {
+                const r = classify_necessity(prompt, lens);
+                tsResults.push({
+                    verdict: r.verdict,
+                    category: r.category,
+                    rationale: r.rationale,
+                    n: r.necessary_hits,
+                    u: r.unnecessary_hits,
+                });
+            }
+        }
+
+        const out = py(
+            `prompts = ${JSON.stringify(PROMPTS)}\n` +
+                `lenses = ${JSON.stringify(LENSES)}\n` +
+                'res = []\n' +
+                'for p in prompts:\n' +
+                '    for l in lenses:\n' +
+                '        r = nc.classify_necessity(p, l)\n' +
+                '        res.append({"verdict": r.verdict, "category": r.category,' +
+                ' "rationale": r.rationale, "n": r.necessary_hits, "u": r.unnecessary_hits})\n' +
+                'print(json.dumps(res))\n',
+        );
+        expect(tsResults).toEqual(JSON.parse(out));
+    });
+});
+
+describe('necessity — classify_size_fit golden parity', () => {
+    it.runIf(py3)('fit / suggested / reason / index / tier / hits match python3', () => {
+        const ladder = ['nano', 'mini', 'standard', 'pro'];
+        const models = ['nano', 'mini', 'pro', 'not-on-ladder'];
+        const sizePrompts = [
+            'short',
+            'rename this',
+            'should we decouple the architecture and rewrite the system design boundary',
+            'x'.repeat(250),
+            'x'.repeat(900),
+            '',
+        ];
+        const sizeLenses = ['analysis', 'debate'];
+
+        const tsResults: unknown[] = [];
+        for (const prompt of sizePrompts) {
+            for (const model of models) {
+                for (const lens of sizeLenses) {
+                    const v = classify_size_fit(prompt, model, ladder, lens);
+                    tsResults.push({
+                        fit: v.fit,
+                        suggested: v.suggested_model,
+                        reason: v.reason,
+                        idx: v.current_index,
+                        tier: v.length_tier,
+                        hits: v.complexity_hits,
+                    });
+                }
+            }
+        }
+
+        const out = py(
+            `ladder = ${JSON.stringify(ladder)}\n` +
+                `models = ${JSON.stringify(models)}\n` +
+                `prompts = ${JSON.stringify(sizePrompts)}\n` +
+                `lenses = ${JSON.stringify(sizeLenses)}\n` +
+                'res = []\n' +
+                'for p in prompts:\n' +
+                '    for m in models:\n' +
+                '        for l in lenses:\n' +
+                '            v = nc.classify_size_fit(p, m, ladder, l)\n' +
+                '            res.append({"fit": v.fit, "suggested": v.suggested_model,' +
+                ' "reason": v.reason, "idx": v.current_index, "tier": v.length_tier,' +
+                ' "hits": v.complexity_hits})\n' +
+                'print(json.dumps(res))\n',
+        );
+        expect(tsResults).toEqual(JSON.parse(out));
+    });
+});
+
+describe('necessity — classify_impact golden parity', () => {
+    it.runIf(py3)('class / confidence / rationale / category match python3', () => {
+        const impactPrompts = [
+            '',
+            'rename this variable, fix the whitespace and the typo',
+            'should we use a dto vs array here, or a value object',
+            'this is a breaking change to the api shape and module boundary',
+            'we are touching auth, tenant boundary, billing and a schema migration',
+            'plain question with no markers',
+            'plan only — ask me before deciding',
+            'add encryption and rotate the secret api key', // high_impact
+            'wait for me, I will decide on the contract change', // fence wins over medium
+        ];
+
+        const tsResults: unknown[] = impactPrompts.map((q) => {
+            const v = classify_impact(q);
+            return {
+                cls: v.impact_class,
+                conf: v.confidence,
+                rationale: v.rationale,
+                category: v.category,
+            };
+        });
+
+        const out = py(
+            `prompts = ${JSON.stringify(impactPrompts)}\n` +
+                'res = []\n' +
+                'for q in prompts:\n' +
+                '    v = nc.classify_impact(q)\n' +
+                '    res.append({"cls": v.impact_class, "conf": v.confidence,' +
+                ' "rationale": v.rationale, "category": v.category})\n' +
+                'print(json.dumps(res))\n',
+        );
+        // Confidence is a float on both sides; JSON parse makes 0.85 == 0.85.
+        expect(tsResults).toEqual(JSON.parse(out));
+    });
+});
+
+describe('necessity — route_decision golden parity', () => {
+    it.runIf(py3)('mode / upgraded / rationale match python3', () => {
+        // Python passes objects exposing .mode / .confidence_threshold; the
+        // differential builds equivalent SimpleNamespace entries.
+        const classes: Record<string, { mode: string; confidence_threshold: number }> = {
+            trivial: { mode: 'agent', confidence_threshold: 0.6 },
+            low_impact: { mode: 'agent', confidence_threshold: 0.6 },
+            medium_impact: { mode: 'council', confidence_threshold: 0.6 },
+            // high_impact / user_required intentionally omitted to also test
+            // the Iron-Law lock + the no-entry fallback.
+        };
+        const routePrompts = [
+            'rename this variable', // trivial agent
+            'plain question, no markers', // medium_impact default 0.3 < 0.6 → upgrade
+            'should we use a dto vs array', // low_impact, conf 0.65 ≥ 0.6 → agent
+            'touch auth and billing', // high_impact → user (locked)
+            'a breaking change to the api shape', // medium_impact council
+        ];
+
+        const tsResults: unknown[] = routePrompts.map((q) => {
+            const r = route_decision(q, classes as never);
+            return { mode: r.mode, upgraded: r.upgraded, rationale: r.rationale };
+        });
+
+        const out = py(
+            'from types import SimpleNamespace\n' +
+                `classes_raw = ${JSON.stringify(classes)}\n` +
+                'classes = {k: SimpleNamespace(**v) for k, v in classes_raw.items()}\n' +
+                `prompts = ${JSON.stringify(routePrompts)}\n` +
+                'res = []\n' +
+                'for q in prompts:\n' +
+                '    r = nc.route_decision(q, classes)\n' +
+                '    res.append({"mode": r.mode, "upgraded": r.upgraded, "rationale": r.rationale})\n' +
+                'print(json.dumps(res))\n',
+        );
+        expect(tsResults).toEqual(JSON.parse(out));
+    });
+});
+
+// ── Unit tests (pure logic, no python3) ──────────────────────────────────
+
+describe('necessity — classify_necessity unit', () => {
+    it('empty prompt → unnecessary / empty', () => {
+        const r = classify_necessity('   ');
+        expect(r.verdict).toBe('unnecessary');
+        expect(r.category).toBe('empty');
+        expect(r.necessary_hits).toBe(0);
+        expect(r.unnecessary_hits).toBe(0);
+    });
+    it('strong necessary signal → necessary', () => {
+        const r = classify_necessity('architecture rewrite with a migration plan');
+        expect(r.verdict).toBe('necessary');
+        expect(r.category).toBe('architecture');
+        expect(r.necessary_hits).toBeGreaterThanOrEqual(2);
+    });
+    it('strong unnecessary signal → unnecessary', () => {
+        const r = classify_necessity('fix this bug — crash with a stack trace');
+        expect(r.verdict).toBe('unnecessary');
+        expect(r.category).toBe('bugfix');
+    });
+    it('debate lens nudges borderline → unnecessary with zero necessary hits', () => {
+        const a = classify_necessity('lint the file', 'analysis');
+        const d = classify_necessity('lint the file', 'debate');
+        expect(a.verdict).toBe('borderline');
+        expect(d.verdict).toBe('unnecessary');
+    });
+});
+
+describe('necessity — classify_size_fit unit', () => {
+    const ladder = ['nano', 'mini', 'pro'];
+    it('not-on-ladder → fit, index -1', () => {
+        const v = classify_size_fit('hi', 'gpt-x', ladder);
+        expect(v.fit).toBe(true);
+        expect(v.current_index).toBe(-1);
+        expect(v.suggested_model).toBeNull();
+    });
+    it('smallest tier → fit', () => {
+        const v = classify_size_fit('hi', 'nano', ladder);
+        expect(v.fit).toBe(true);
+        expect(v.current_index).toBe(0);
+    });
+    it('debate lens never downgrades', () => {
+        const v = classify_size_fit('hi', 'pro', ladder, 'debate');
+        expect(v.fit).toBe(true);
+        expect(v.suggested_model).toBeNull();
+    });
+    it('short + no complexity → suggests next rung down', () => {
+        const v = classify_size_fit('hi', 'pro', ladder);
+        expect(v.fit).toBe(false);
+        expect(v.suggested_model).toBe('mini');
+        expect(v.length_tier).toBe('short');
+    });
+});
+
+describe('necessity — classify_impact unit', () => {
+    it('empty → user_required confidence 1.0', () => {
+        const v = classify_impact('');
+        expect(v.impact_class).toBe('user_required');
+        expect(v.confidence).toBe(1.0);
+    });
+    it('user fence beats topic', () => {
+        const v = classify_impact('plan only — change the api contract');
+        expect(v.impact_class).toBe('user_required');
+        expect(v.category).toBe('user_fence');
+    });
+    it('high_impact floors confidence at 0.85', () => {
+        const v = classify_impact('rotate the secret'); // one high marker
+        expect(v.impact_class).toBe('high_impact');
+        expect(v.confidence).toBeGreaterThanOrEqual(0.85);
+    });
+    it('no markers → medium_impact 0.3', () => {
+        const v = classify_impact('plain words here');
+        expect(v.impact_class).toBe('medium_impact');
+        expect(v.confidence).toBe(0.3);
+    });
+});
+
+describe('necessity — route_decision unit', () => {
+    it('locked class → user regardless of config', () => {
+        const r = route_decision('rotate the secret', { high_impact: { mode: 'agent' } });
+        expect(r.mode).toBe('user');
+        expect(r.upgraded).toBe(false);
+    });
+    it('no entry → user fallback', () => {
+        const r = route_decision('rename this variable', {});
+        expect(r.mode).toBe('user');
+    });
+    it('low confidence upgrades the rung', () => {
+        const r = route_decision('plain words', { medium_impact: { mode: 'agent', confidence_threshold: 0.6 } });
+        // medium_impact default confidence 0.3 < 0.6 → agent → council
+        expect(r.mode).toBe('council');
+        expect(r.upgraded).toBe(true);
+    });
+});
+
+describe('necessity — message helpers + structural parity', () => {
+    it('educate_message includes category + lens', () => {
+        const r = classify_necessity('fix this bug crash');
+        const msg = educate_message(r, 'analysis');
+        expect(msg).toContain('`bugfix`');
+        expect(msg).toContain('`analysis`');
+        expect(msg).toContain('--proceed-anyway');
+    });
+    it('downgrade_message names current + suggested', () => {
+        const v = classify_size_fit('hi', 'pro', ['nano', 'mini', 'pro']);
+        const msg = downgrade_message(v, 'pro');
+        expect(msg).toContain('`pro`');
+        expect(msg).toContain('`mini`');
+    });
+    it('LOCKED_IMPACT_CLASSES holds high_impact + user_required', () => {
+        expect(LOCKED_IMPACT_CLASSES.has('high_impact')).toBe(true);
+        expect(LOCKED_IMPACT_CLASSES.has('user_required')).toBe(true);
+        expect(LOCKED_IMPACT_CLASSES.has('trivial')).toBe(false);
+    });
+    it('trigger-table insertion order matches python (tie-break priority)', () => {
+        expect(Object.keys(NECESSARY_TRIGGERS)).toEqual([
+            'architecture',
+            'tradeoff',
+            'ambiguity',
+            'strategic',
+        ]);
+        expect(Object.keys(UNNECESSARY_TRIGGERS)).toEqual([
+            'bugfix',
+            'syntax',
+            'single_file',
+            'lookup',
+        ]);
+        expect(IMPACT_TRIGGERS.high_impact.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/scripts/ai_council/orchestrator.test.ts
+++ b/tests/scripts/ai_council/orchestrator.test.ts
@@ -1,0 +1,576 @@
+// Tests for src/scripts/ai_council/orchestrator.ts (py2ts Phase 1, ADR-094).
+//
+// orchestrator coordinates a sequential multi-member council run: member
+// dispatch, cost gating + overrun callback, multi-round debate, peer-review,
+// consensus scoring, and the Markdown render assembly. It is a pure library
+// (no __main__ / argparse / stdout) — so there is no `--help` surface to
+// byte-compare. Parity is asserted on the assembled `render()` output and the
+// orchestration control flow with STUBBED transport.
+//
+// Transport stub: tests subclass `ExternalAIClient` (TS) / build duck-typed
+// mock objects (Python) whose `ask()` returns a canned `CouncilResponse`
+// without any live network call — mirroring how clients.ts seams the
+// transport. `latency_ms` is the only non-deterministic field; the mocks pin
+// it to a fixed value so render output is byte-stable.
+//
+// Golden parity drives the LIVE Python twin via a `python3 -c` importlib
+// direct-file load. The networked ai_council `__init__` re-exports clients,
+// but loading orchestrator.py off disk only pulls the sibling submodules,
+// which lazy-import their SDKs inside `ask()` — so no network at import time.
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { CouncilResponse, ExternalAIClient } from '../../../src/scripts/ai_council/clients.js';
+import {
+    consult,
+    CostBudget,
+    CouncilQuestion,
+    DebateCapExceeded,
+    estimate,
+    estimate_debate_cost,
+    OverrunEvent,
+    render,
+    run_consensus_scoring,
+    run_debate,
+    run_peer_review,
+} from '../../../src/scripts/ai_council/orchestrator.js';
+import { load_prices } from '../../../src/scripts/ai_council/pricing.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+// ── Python driver: importlib direct-file load + a duck-typed mock client ──
+//
+// The driver defines a `Mock` member whose ask() returns a canned response so
+// no live transport runs. Each test snippet appends to this preamble and
+// prints a JSON-able view to stdout for byte comparison.
+const PY_PREAMBLE = `
+import importlib.util, sys, json
+_spec = importlib.util.spec_from_file_location("orch", "src/scripts/ai_council/orchestrator.py")
+orch = importlib.util.module_from_spec(_spec)
+sys.modules["orch"] = orch
+_spec.loader.exec_module(orch)
+from scripts.ai_council.clients import CouncilResponse
+
+class Mock:
+    def __init__(self, name, model, text="", err=None, it=10, ot=20, billable=True,
+                 transport="api", sub="", raises=False, latency=5):
+        self.name = name; self.model = model; self._t = text; self._e = err
+        self._it = it; self._ot = ot; self.billable = billable
+        self.transport = transport; self.subscription_label = sub
+        self._raises = raises; self._lat = latency
+    def ask(self, sp, up, mt):
+        if self._raises:
+            raise RuntimeError("boom")
+        return CouncilResponse(provider=self.name, model=self.model, text=self._t,
+                               error=self._e, input_tokens=self._it,
+                               output_tokens=self._ot, latency_ms=self._lat)
+`;
+
+function py(snippet: string): string {
+    const code = `${PY_PREAMBLE}\n${snippet}`;
+    const r = spawnSync('python3', ['-c', code], {
+        encoding: 'utf8',
+        env: { ...process.env, PYTHONPATH: ['src', '.'].join(':') },
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+// ── TS mock transport (mirrors the Python Mock) ──────────────────────────
+
+interface MockArgs {
+    text?: string;
+    error?: string | null;
+    it?: number;
+    ot?: number;
+    billable?: boolean;
+    transport?: string;
+    sub?: string;
+    raises?: boolean;
+    latency?: number;
+}
+
+class Mock extends ExternalAIClient {
+    private readonly _t: string;
+    private readonly _e: string | null;
+    private readonly _it: number;
+    private readonly _ot: number;
+    private readonly _raises: boolean;
+    private readonly _lat: number;
+
+    constructor(name: string, model: string, args: MockArgs = {}) {
+        super();
+        this.name = name;
+        this.model = model;
+        this._t = args.text ?? '';
+        this._e = args.error ?? null;
+        this._it = args.it ?? 10;
+        this._ot = args.ot ?? 20;
+        this.billable = args.billable ?? true;
+        this.transport = args.transport ?? 'api';
+        this.subscription_label = args.sub ?? '';
+        this._raises = args.raises ?? false;
+        this._lat = args.latency ?? 5;
+    }
+
+    override ask(): CouncilResponse {
+        if (this._raises) {
+            throw new Error('boom');
+        }
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text: this._t,
+            error: this._e,
+            input_tokens: this._it,
+            output_tokens: this._ot,
+            latency_ms: this._lat,
+        });
+    }
+}
+
+// ── Unit tests — orchestration control flow ──────────────────────────────
+
+describe('orchestrator — consult basics', () => {
+    it('empty members → []', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        expect(consult([], q)).toEqual([]);
+    });
+
+    it('dispatches members in input order, accumulates tokens', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'hello' });
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5', { text: 'A' }),
+            new Mock('openai', 'gpt-4o', { text: 'B' }),
+        ];
+        const res = consult(members, q);
+        expect(res.map((r) => [r.provider, r.model, r.text])).toEqual([
+            ['anthropic', 'claude-sonnet-4-5', 'A'],
+            ['openai', 'gpt-4o', 'B'],
+        ]);
+    });
+
+    it('member exception → error-tagged response, never raises', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        const res = consult([new Mock('anthropic', 'claude-sonnet-4-5', { raises: true })], q);
+        expect(res[0]!.error).toBe('Error: boom');
+        expect(res[0]!.text).toBe('');
+    });
+
+    it('rounds < 1 raises', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        expect(() => consult([new Mock('a', 'm')], q, null, { rounds: 0 })).toThrow(
+            /rounds must be >= 1/,
+        );
+    });
+
+    it('too many members for budget.max_calls raises', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        const members = [new Mock('a', 'm1'), new Mock('b', 'm2')];
+        const budget = new CostBudget({ max_calls: 1 });
+        expect(() => consult(members, q, budget)).toThrow(/budget caps at 1 calls/);
+    });
+
+    it('non-billable members skip cost gate but track tokens + stamp subscription', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        const m = new Mock('manual', 'human', {
+            text: 'typed',
+            billable: false,
+            transport: 'manual',
+            sub: 'flat',
+            it: 3,
+            ot: 4,
+        });
+        const res = consult([m], q);
+        expect(res[0]!.metadata['billable']).toBe(false);
+        expect(res[0]!.metadata['transport']).toBe('manual');
+        expect(res[0]!.metadata['subscription_label']).toBe('flat');
+    });
+});
+
+describe('orchestrator — cost gating', () => {
+    // Token-cap breach with no on_overrun → short-circuits remaining members.
+    it('token breach short-circuits remaining members (v1)', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x'.repeat(40) });
+        const table = load_prices();
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5'),
+            new Mock('openai', 'gpt-4o'),
+        ];
+        // Tiny input cap so member 0's projection already breaches.
+        const budget = new CostBudget({ max_input_tokens: 1, max_output_tokens: 1 });
+        const res = consult(members, q, budget, { table });
+        expect(res.map((r) => r.error)).toEqual([
+            'cost_budget_exceeded',
+            'cost_budget_exceeded',
+        ]);
+    });
+
+    it('on_overrun(false) skips the breaching member only', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x'.repeat(40) });
+        const table = load_prices();
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5', { text: 'ok', it: 1, ot: 1 }),
+            new Mock('openai', 'gpt-4o', { text: 'ok', it: 1, ot: 1 }),
+        ];
+        const seen: number[] = [];
+        const onOverrun = (e: OverrunEvent): boolean => {
+            seen.push(e.member_index);
+            return false; // skip
+        };
+        // input cap permits 1 member's projection but not two cumulatively.
+        const budget = new CostBudget({ max_input_tokens: 100000, max_output_tokens: 0 });
+        const res = consult(members, q, budget, { table, on_overrun: onOverrun });
+        expect(res.every((r) => r.error === 'cost_budget_exceeded')).toBe(true);
+        expect(seen.length).toBeGreaterThan(0);
+    });
+});
+
+describe('orchestrator — estimate', () => {
+    it('one CostEstimate per member, in order', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'hello world' });
+        const table = load_prices();
+        const members = [new Mock('anthropic', 'claude-sonnet-4-5'), new Mock('openai', 'gpt-4o')];
+        const ests = estimate(q, members, table);
+        expect(ests.map((e) => e.provider)).toEqual(['anthropic', 'openai']);
+    });
+});
+
+describe('orchestrator — estimate_debate_cost', () => {
+    it('rounds < 1 raises', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        const table = load_prices();
+        expect(() => estimate_debate_cost(q, [new Mock('a', 'm')], table, { rounds: 0 })).toThrow(
+            /rounds must be >= 1/,
+        );
+    });
+
+    it('separates billable vs subscription members; high = expected*1.2', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'hello world' });
+        const table = load_prices();
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5'),
+            new Mock('manual', 'human', { billable: false, transport: 'manual', sub: 'flat' }),
+        ];
+        const est = estimate_debate_cost(q, members, table, { rounds: 2 });
+        expect(est.subscription_members.map((s) => s['name'])).toEqual(['manual']);
+        expect(est.per_member.map((p) => p['name'])).toEqual(['anthropic']);
+        expect(est.high_usd).toBeCloseTo(est.expected_usd * 1.2, 12);
+    });
+});
+
+describe('orchestrator — run_debate', () => {
+    it('max_rounds < 1 raises', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x' });
+        expect(() => run_debate([new Mock('a', 'm')], q, { max_rounds: 0 })).toThrow(
+            /max_rounds must be >= 1/,
+        );
+    });
+
+    it('seed_round_1 reused verbatim in round 1 (no calls)', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'topic' });
+        const seed = [
+            new CouncilResponse({ provider: 'anthropic', model: 'claude-sonnet-4-5', text: 'seed A' }),
+            new CouncilResponse({ provider: 'openai', model: 'gpt-4o', text: 'seed B' }),
+        ];
+        const rounds = run_debate(
+            [new Mock('anthropic', 'claude-sonnet-4-5', { text: 'r2-A' }), new Mock('openai', 'gpt-4o', { text: 'r2-B' })],
+            q,
+            { max_rounds: 2, seed_round_1: seed },
+        );
+        expect(rounds[0]!.map((r) => r.text)).toEqual(['seed A', 'seed B']);
+        expect(rounds[1]!.map((r) => r.text)).toEqual(['r2-A', 'r2-B']);
+    });
+
+    it('DebateCapExceeded thrown when next round breaches max_total_usd', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'topic '.repeat(100) });
+        const table = load_prices();
+        const members = [new Mock('anthropic', 'claude-sonnet-4-5', { text: 'x', it: 5, ot: 5 })];
+        // Tiny USD cap → round-2 projection breaches.
+        const budget = new CostBudget({ max_total_usd: 0.0000001, max_input_tokens: 1e9, max_output_tokens: 1e9 });
+        expect(() => run_debate(members, q, { max_rounds: 2, table, budget })).toThrow(DebateCapExceeded);
+    });
+
+    it('on_continue(false) stops after the completed round', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'topic' });
+        const members = [new Mock('anthropic', 'claude-sonnet-4-5', { text: 'a' }), new Mock('openai', 'gpt-4o', { text: 'b' })];
+        const rounds = run_debate(members, q, { max_rounds: 3, on_continue: () => false });
+        expect(rounds.length).toBe(1);
+    });
+});
+
+describe('orchestrator — run_peer_review', () => {
+    it('needs >= 2 distinct deliberation outputs', () => {
+        const r = run_peer_review([new Mock('a', 'm')], [
+            new CouncilResponse({ provider: 'a', model: 'm', text: 'only one' }),
+        ]);
+        expect(r.responses).toEqual([]);
+        expect(r.label_to_source.size).toBe(0);
+    });
+
+    it('each reviewer critiques others (self filtered)', () => {
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5', { text: 'crit-A' }),
+            new Mock('openai', 'gpt-4o', { text: 'crit-B' }),
+        ];
+        const delib = [
+            new CouncilResponse({ provider: 'anthropic', model: 'claude-sonnet-4-5', text: 'pos A' }),
+            new CouncilResponse({ provider: 'openai', model: 'gpt-4o', text: 'pos B' }),
+        ];
+        const r = run_peer_review(members, delib);
+        expect(r.responses.map((x) => x.text)).toEqual(['crit-A', 'crit-B']);
+        expect(r.label_to_source.size).toBeGreaterThan(0);
+    });
+});
+
+describe('orchestrator — run_consensus_scoring', () => {
+    it('empty inputs → empty bucket', () => {
+        const r = run_consensus_scoring([], []);
+        expect(r.findings).toEqual([]);
+        expect(r.scores).toEqual([]);
+    });
+
+    it('extraction + scoring two-pass populates findings', () => {
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5', { text: '[{"id":"a","text":"finding-a"}]' }),
+            new Mock('openai', 'gpt-4o', { text: '[{"id":"b","text":"finding-b"}]' }),
+        ];
+        const delib = [
+            new CouncilResponse({ provider: 'anthropic', model: 'claude-sonnet-4-5', text: 'delib A' }),
+            new CouncilResponse({ provider: 'openai', model: 'gpt-4o', text: 'delib B' }),
+        ];
+        const r = run_consensus_scoring(members, delib);
+        expect(r.findings.map((f) => f.id).sort()).toEqual(['a', 'b']);
+    });
+});
+
+// ── Golden parity vs CPython twin ────────────────────────────────────────
+
+describe.runIf(py3)('orchestrator — golden parity vs CPython twin', () => {
+    // render() across many shapes: errors, billable api, non-billable manual,
+    // consensus, multiple modes. Mock latency pinned so output is byte-stable.
+    const RENDER_CASES: Record<string, () => { ts: string; pyMembers: string; pyArgs: string }> = {
+        plain_two: () => ({
+            ts: render(
+                consult(
+                    [
+                        new Mock('anthropic', 'claude-sonnet-4-5', { text: 'resp A', latency: 5 }),
+                        new Mock('openai', 'gpt-4o', { text: 'resp B', latency: 7 }),
+                    ],
+                    new CouncilQuestion({ mode: 'prompt', user_prompt: 'hi' }),
+                ),
+                { mode: 'prompt' },
+            ),
+            pyMembers:
+                '[Mock("anthropic","claude-sonnet-4-5",text="resp A",latency=5), ' +
+                'Mock("openai","gpt-4o",text="resp B",latency=7)]',
+            pyArgs: 'mode="prompt"',
+        }),
+        with_error: () => ({
+            ts: render(
+                consult(
+                    [
+                        new Mock('anthropic', 'claude-sonnet-4-5', { text: 'ok', latency: 5 }),
+                        new Mock('openai', 'gpt-4o', { error: 'cost_budget_exceeded', latency: 0 }),
+                    ],
+                    new CouncilQuestion({ mode: 'roadmap', user_prompt: 'plan' }),
+                ),
+                { mode: 'roadmap' },
+            ),
+            pyMembers:
+                '[Mock("anthropic","claude-sonnet-4-5",text="ok",latency=5), ' +
+                'Mock("openai","gpt-4o",err="cost_budget_exceeded",latency=0)]',
+            pyArgs: 'mode="roadmap"',
+        }),
+        non_billable: () => ({
+            ts: render(
+                consult(
+                    [
+                        new Mock('manual', 'human', {
+                            text: 'typed answer',
+                            billable: false,
+                            transport: 'manual',
+                            sub: 'claude-pro',
+                            latency: 0,
+                        }),
+                    ],
+                    new CouncilQuestion({ mode: 'prompt', user_prompt: 'q' }),
+                ),
+                { mode: 'prompt' },
+            ),
+            pyMembers:
+                '[Mock("manual","human",text="typed answer",billable=False,' +
+                'transport="manual",sub="claude-pro",latency=0)]',
+            pyArgs: 'mode="prompt"',
+        }),
+        prose_synthesis_true: () => ({
+            ts: render(
+                consult(
+                    [new Mock('anthropic', 'claude-sonnet-4-5', { text: 'creative', latency: 3 })],
+                    new CouncilQuestion({ mode: 'design', user_prompt: 'adr' }),
+                ),
+                { mode: 'design', prose_synthesis: true },
+            ),
+            pyMembers: '[Mock("anthropic","claude-sonnet-4-5",text="creative",latency=3)]',
+            pyArgs: 'mode="design", prose_synthesis=True',
+        }),
+    };
+
+    it.each(Object.keys(RENDER_CASES))('render(%s) byte-matches', (key) => {
+        const { ts, pyMembers, pyArgs } = RENDER_CASES[key]!();
+        const expected = py(
+            `q = orch.CouncilQuestion(mode=${JSON.stringify(
+                key === 'with_error' ? 'roadmap' : key === 'prose_synthesis_true' ? 'design' : 'prompt',
+            )}, user_prompt="z")\n` +
+                `members = ${pyMembers}\n` +
+                `res = orch.consult(members, q)\n` +
+                `out = orch.render(res, ${pyArgs})\n` +
+                `print(json.dumps(out))`,
+        ).trim();
+        expect(ts).toEqual(JSON.parse(expected));
+    });
+
+    // Cost-line USD formatting: drive a billable call through a real price
+    // table so cost_usd is stamped, then byte-compare the meta line.
+    it('billable cost line :.4f formatting matches', () => {
+        const table = load_prices();
+        const members = [new Mock('anthropic', 'claude-sonnet-4-5', { text: 'body', it: 1234, ot: 567, latency: 42 })];
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'x'.repeat(80) });
+        const tsOut = render(consult(members, q, new CostBudget(), { table }), { mode: 'prompt' });
+        const expected = py(
+            'import scripts.ai_council.pricing as pricing\n' +
+                'table = pricing.load_prices()\n' +
+                'q = orch.CouncilQuestion(mode="prompt", user_prompt="x"*80)\n' +
+                'members = [Mock("anthropic","claude-sonnet-4-5",text="body",it=1234,ot=567,latency=42)]\n' +
+                'res = orch.consult(members, q, table=table)\n' +
+                'print(json.dumps(orch.render(res, mode="prompt")))',
+        ).trim();
+        expect(tsOut).toEqual(JSON.parse(expected));
+    });
+
+    // _augment_for_next_round / debate prompt assembly via run_debate round 2.
+    it('multi-round debate prompt augmentation byte-matches (round 2 user prompt seen)', () => {
+        // Round 2 responses joined into one synthetic response, then rendered
+        // (matches the Python driver, which wraps the joined text the same way).
+        const round2 = run_debate(
+            [
+                new Mock('anthropic', 'claude-sonnet-4-5', { text: 'pos A', latency: 1 }),
+                new Mock('openai', 'gpt-4o', { text: 'pos B', latency: 1 }),
+            ],
+            new CouncilQuestion({ mode: 'prompt', user_prompt: 'ORIGINAL' }),
+            { max_rounds: 2 },
+        )[1]!;
+        const echoTs = render(
+            [
+                new CouncilResponse({
+                    provider: 'x',
+                    model: 'y',
+                    text: round2.map((r) => r.text).join('|'),
+                }),
+            ],
+            {},
+        );
+        const expected = py(
+            'q = orch.CouncilQuestion(mode="prompt", user_prompt="ORIGINAL")\n' +
+                'members = [Mock("anthropic","claude-sonnet-4-5",text="pos A",latency=1), ' +
+                'Mock("openai","gpt-4o",text="pos B",latency=1)]\n' +
+                'rounds = orch.run_debate(members, q, max_rounds=2)\n' +
+                'out = orch.render([CouncilResponse(provider="x",model="y",' +
+                'text="|".join(r.text for r in rounds[1]))])\n' +
+                'print(json.dumps(out))',
+        ).trim();
+        expect(echoTs).toEqual(JSON.parse(expected));
+    });
+
+    // estimate() per-member cost parity (input_usd/output_usd floats).
+    it('estimate() per-member float fields match', () => {
+        const table = load_prices();
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'estimate me '.repeat(20) });
+        const members = [new Mock('anthropic', 'claude-sonnet-4-5'), new Mock('openai', 'gpt-4o')];
+        const ts = estimate(q, members, table).map((e) => [
+            e.provider,
+            e.model,
+            e.input_tokens,
+            e.output_tokens,
+            e.input_usd,
+            e.output_usd,
+        ]);
+        const expected = py(
+            'import scripts.ai_council.pricing as pricing\n' +
+                'table = pricing.load_prices()\n' +
+                'q = orch.CouncilQuestion(mode="prompt", user_prompt="estimate me "*20)\n' +
+                'members = [Mock("anthropic","claude-sonnet-4-5"), Mock("openai","gpt-4o")]\n' +
+                'ests = orch.estimate(q, members, table)\n' +
+                'print(json.dumps([[e.provider, e.model, e.input_tokens, e.output_tokens, ' +
+                'e.input_usd, e.output_usd] for e in ests]))',
+        ).trim();
+        expect(ts).toEqual(JSON.parse(expected));
+    });
+
+    // Consensus render path: _render_bucket strength/mean :.2f / :.1f spec.
+    it('consensus render via run_consensus_scoring byte-matches', () => {
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5', {
+                text: '[{"id":"a","text":"alpha finding"}]',
+                latency: 0,
+            }),
+            new Mock('openai', 'gpt-4o', {
+                text: '[{"id":"b","text":"beta finding"}]',
+                latency: 0,
+            }),
+        ];
+        // Scoring pass: each member rates the OTHER's finding. Mock can only
+        // emit one canned text, so reuse the same members but they return the
+        // extraction text both times — scoring text is not valid JSON scores,
+        // so scores stay empty; we still exercise the extraction + render path.
+        const delib = [
+            new CouncilResponse({ provider: 'anthropic', model: 'claude-sonnet-4-5', text: 'delib A', latency_ms: 0 }),
+            new CouncilResponse({ provider: 'openai', model: 'gpt-4o', text: 'delib B', latency_ms: 0 }),
+        ];
+        const cons = run_consensus_scoring(members, delib);
+        const ts = render([], { mode: 'analysis', consensus: cons });
+        const expected = py(
+            'members = [Mock("anthropic","claude-sonnet-4-5",' +
+                'text=\'[{"id":"a","text":"alpha finding"}]\',latency=0), ' +
+                'Mock("openai","gpt-4o",text=\'[{"id":"b","text":"beta finding"}]\',latency=0)]\n' +
+                'delib = [CouncilResponse(provider="anthropic",model="claude-sonnet-4-5",text="delib A",latency_ms=0), ' +
+                'CouncilResponse(provider="openai",model="gpt-4o",text="delib B",latency_ms=0)]\n' +
+                'cons = orch.run_consensus_scoring(members, delib)\n' +
+                'print(json.dumps(orch.render([], mode="analysis", consensus=cons)))',
+        ).trim();
+        expect(ts).toEqual(JSON.parse(expected));
+    });
+
+    // Peer-review render path: deterministic Reviewer-A/B labels.
+    it('peer-review render byte-matches', () => {
+        const members = [
+            new Mock('anthropic', 'claude-sonnet-4-5', { text: 'critique from A', latency: 0 }),
+            new Mock('openai', 'gpt-4o', { text: 'critique from B', latency: 0 }),
+        ];
+        const delib = [
+            new CouncilResponse({ provider: 'anthropic', model: 'claude-sonnet-4-5', text: 'pos A', latency_ms: 0 }),
+            new CouncilResponse({ provider: 'openai', model: 'gpt-4o', text: 'pos B', latency_ms: 0 }),
+        ];
+        const pr = run_peer_review(members, delib);
+        const ts = render(
+            [new CouncilResponse({ provider: 'x', model: 'y', text: 'final', latency_ms: 0 })],
+            { mode: 'prompt', peer_review: pr },
+        );
+        const expected = py(
+            'members = [Mock("anthropic","claude-sonnet-4-5",text="critique from A",latency=0), ' +
+                'Mock("openai","gpt-4o",text="critique from B",latency=0)]\n' +
+                'delib = [CouncilResponse(provider="anthropic",model="claude-sonnet-4-5",text="pos A",latency_ms=0), ' +
+                'CouncilResponse(provider="openai",model="gpt-4o",text="pos B",latency_ms=0)]\n' +
+                'pr = orch.run_peer_review(members, delib)\n' +
+                'res = [CouncilResponse(provider="x",model="y",text="final",latency_ms=0)]\n' +
+                'print(json.dumps(orch.render(res, mode="prompt", peer_review=pr)))',
+        ).trim();
+        expect(ts).toEqual(JSON.parse(expected));
+    });
+});

--- a/tests/scripts/ai_council/replay.test.ts
+++ b/tests/scripts/ai_council/replay.test.ts
@@ -1,0 +1,313 @@
+// Tests for src/scripts/ai_council/replay.ts (py2ts Phase 1).
+//
+// replay is a pure projection: it renders a `decision-replay.md` body from
+// consensus findings / scores / metadata + per-member deliberation texts.
+// No CLI, no network.
+//
+// Golden parity: a single JSON fixture describes the findings, scores,
+// metadata, and deliberation. Both runtimes reconstruct the dataclasses
+// from that fixture and render the body; the test asserts the rendered
+// strings are BYTE-IDENTICAL. replay.py imports its consensus / clients
+// siblings, so the Python side runs through the real package path (the
+// `_harness` PYTHONPATH wires `src` + repo root, matching pyproject).
+import { describe, expect, it } from 'vitest';
+
+import { CouncilResponse } from '../../../src/scripts/ai_council/clients.js';
+import {
+    ConsensusMetadata,
+    Finding,
+    FindingScore,
+} from '../../../src/scripts/ai_council/consensus.js';
+import {
+    DecisionReplayInputs,
+    render_decision_replay,
+} from '../../../src/scripts/ai_council/replay.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// ── Shared fixture ───────────────────────────────────────────────────────
+// A single declarative spec consumed identically by both runtimes.
+
+interface Spec {
+    findings: Array<{ id: string; source: string; text: string }>;
+    scores: Array<{
+        finding_id: string;
+        scorer: string;
+        score: number;
+        agree: boolean;
+        reason: string;
+    }>;
+    metadata: Array<{
+        finding_id: string;
+        consensus_strength: number;
+        dissent_count: number;
+        scorers: string[];
+        mean_score: number;
+        concur_count: number;
+        dissent_reasons: Array<[string, string]>;
+        evidence_quality: string;
+    }>;
+    deliberation: Array<{ provider: string; model: string; text: string }>;
+    original_ask: string;
+    include_member_arguments: boolean;
+}
+
+function buildTsInputs(spec: Spec): DecisionReplayInputs {
+    const findings = spec.findings.map((f) => new Finding(f.id, f.source, f.text));
+    const scores = spec.scores.map(
+        (s) => new FindingScore(s.finding_id, s.scorer, s.score, s.agree, s.reason),
+    );
+    const metadata = new Map<string, ConsensusMetadata>();
+    for (const m of spec.metadata) {
+        metadata.set(
+            m.finding_id,
+            new ConsensusMetadata({
+                finding_id: m.finding_id,
+                consensus_strength: m.consensus_strength,
+                dissent_count: m.dissent_count,
+                scorers: m.scorers,
+                mean_score: m.mean_score,
+                concur_count: m.concur_count,
+                dissent_reasons: m.dissent_reasons,
+                evidence_quality: m.evidence_quality,
+            }),
+        );
+    }
+    const deliberation = spec.deliberation.map(
+        (d) => new CouncilResponse({ provider: d.provider, model: d.model, text: d.text }),
+    );
+    return new DecisionReplayInputs({
+        findings,
+        scores,
+        metadata,
+        deliberation,
+        original_ask: spec.original_ask,
+        include_member_arguments: spec.include_member_arguments,
+    });
+}
+
+/** Render the Python twin's body for `spec` via the real package path. */
+function pyRender(spec: Spec): string {
+    const code = [
+        'import sys, json',
+        'from scripts.ai_council.replay import DecisionReplayInputs, render_decision_replay',
+        'from scripts.ai_council.consensus import Finding, FindingScore, ConsensusMetadata',
+        'from scripts.ai_council.clients import CouncilResponse',
+        'spec = json.loads(sys.stdin.read())',
+        'findings = [Finding(f["id"], f["source"], f["text"]) for f in spec["findings"]]',
+        'scores = [FindingScore(s["finding_id"], s["scorer"], s["score"], s["agree"], s["reason"]) for s in spec["scores"]]',
+        'metadata = {m["finding_id"]: ConsensusMetadata(' +
+            'finding_id=m["finding_id"], consensus_strength=m["consensus_strength"],' +
+            ' dissent_count=m["dissent_count"], scorers=tuple(m["scorers"]),' +
+            ' mean_score=m["mean_score"], concur_count=m["concur_count"],' +
+            ' dissent_reasons=tuple((a, b) for a, b in m["dissent_reasons"]),' +
+            ' evidence_quality=m["evidence_quality"]) for m in spec["metadata"]}',
+        'deliberation = [CouncilResponse(provider=d["provider"], model=d["model"], text=d["text"]) for d in spec["deliberation"]]',
+        'inputs = DecisionReplayInputs(findings=findings, scores=scores, metadata=metadata,' +
+            ' deliberation=deliberation, original_ask=spec["original_ask"],' +
+            ' include_member_arguments=spec["include_member_arguments"])',
+        'sys.stdout.write(render_decision_replay(inputs))',
+    ].join('\n');
+    const r = runPyCode(code, [], { input: JSON.stringify(spec) });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+// Three findings with distinct consensus strengths (test the rank order),
+// dissent reasons, a long-text title (truncation), whitespace collapsing,
+// and a member whose argument falls back to the deliberation snippet.
+const FULL_SPEC: Spec = {
+    findings: [
+        { id: 'F2', source: 'openai/gpt-4o', text: '  weak    finding   with\n\nmessy   whitespace  ' },
+        { id: 'F1', source: 'anthropic/claude', text: 'x'.repeat(140) }, // > 120 → truncated
+        { id: 'F3', source: 'openai/gpt-4o', text: 'moderate finding' },
+        { id: 'F4', source: 'anthropic/claude', text: 'unscored finding (no metadata entry)' },
+    ],
+    scores: [
+        { finding_id: 'F1', scorer: 'm2', score: 9, agree: true, reason: 'strong agree reason' },
+        { finding_id: 'F1', scorer: 'm3', score: 4, agree: false, reason: 'dissent reason here' },
+        { finding_id: 'F3', scorer: 'm2', score: 7, agree: true, reason: '' }, // empty reason → snippet fallback
+        { finding_id: 'F2', scorer: 'm3', score: 3, agree: false, reason: 'weak dissent' },
+    ],
+    metadata: [
+        {
+            finding_id: 'F1',
+            consensus_strength: 0.85,
+            dissent_count: 1,
+            scorers: ['m2', 'm3'],
+            mean_score: 6.5,
+            concur_count: 1,
+            dissent_reasons: [['m3', 'dissent reason here']],
+            evidence_quality: 'M',
+        },
+        {
+            finding_id: 'F2',
+            consensus_strength: 0.2,
+            dissent_count: 1,
+            scorers: ['m3'],
+            mean_score: 3.0,
+            concur_count: 0,
+            dissent_reasons: [['m3', 'weak dissent']],
+            evidence_quality: 'L',
+        },
+        {
+            finding_id: 'F3',
+            consensus_strength: 0.55,
+            dissent_count: 0,
+            scorers: ['m2'],
+            mean_score: 7.0,
+            concur_count: 1,
+            dissent_reasons: [],
+            evidence_quality: 'M',
+        },
+    ],
+    deliberation: [
+        { provider: 'm2', model: '', text: 'm2 deliberation snippet that is the fallback argument' },
+        { provider: 'm3', model: '', text: 'm3 deliberation text' },
+    ],
+    original_ask: '   Should we adopt   the new\n\narchitecture?   ',
+    include_member_arguments: true,
+};
+
+const REDACTED_SPEC: Spec = {
+    ...FULL_SPEC,
+    include_member_arguments: false,
+};
+
+const EMPTY_SPEC: Spec = {
+    findings: [],
+    scores: [],
+    metadata: [],
+    deliberation: [],
+    original_ask: '',
+    include_member_arguments: true,
+};
+
+const LONG_ASK_SPEC: Spec = {
+    findings: [{ id: 'F1', source: 's', text: 'a finding' }],
+    scores: [],
+    metadata: [
+        {
+            finding_id: 'F1',
+            consensus_strength: 0.9,
+            dissent_count: 0,
+            scorers: [],
+            mean_score: 8.0,
+            concur_count: 1,
+            dissent_reasons: [],
+            evidence_quality: 'H',
+        },
+    ],
+    deliberation: [],
+    original_ask: ('word '.repeat(120)).trim(), // > 400 chars → truncated
+    include_member_arguments: true,
+};
+
+describe('replay — render byte-parity with python3', () => {
+    it.runIf(py3)('full artefact (arguments included)', () => {
+        const ts = render_decision_replay(buildTsInputs(FULL_SPEC));
+        expect(ts).toBe(pyRender(FULL_SPEC));
+    });
+    it.runIf(py3)('redacted artefact (counts only)', () => {
+        const ts = render_decision_replay(buildTsInputs(REDACTED_SPEC));
+        expect(ts).toBe(pyRender(REDACTED_SPEC));
+    });
+    it.runIf(py3)('empty findings → placeholder line', () => {
+        const ts = render_decision_replay(buildTsInputs(EMPTY_SPEC));
+        expect(ts).toBe(pyRender(EMPTY_SPEC));
+    });
+    it.runIf(py3)('long original ask → truncated', () => {
+        const ts = render_decision_replay(buildTsInputs(LONG_ASK_SPEC));
+        expect(ts).toBe(pyRender(LONG_ASK_SPEC));
+    });
+});
+
+// ── Unit tests (pure logic, no python3) ──────────────────────────────────
+
+describe('replay — render structural unit', () => {
+    it('empty findings renders the placeholder + trailing newline', () => {
+        const out = render_decision_replay(buildTsInputs(EMPTY_SPEC));
+        expect(out).toBe(
+            '# Decision Replay\n\n*No findings were extracted for this session.*\n',
+        );
+    });
+
+    it('ranks findings by consensus_strength descending', () => {
+        const out = render_decision_replay(buildTsInputs(FULL_SPEC));
+        const idxF1 = out.indexOf('## F1 —');
+        const idxF3 = out.indexOf('## F3 —');
+        const idxF2 = out.indexOf('## F2 —');
+        const idxF4 = out.indexOf('## F4 —'); // no metadata → strength 0.0, last
+        expect(idxF1).toBeGreaterThanOrEqual(0);
+        expect(idxF1).toBeLessThan(idxF3);
+        expect(idxF3).toBeLessThan(idxF2);
+        expect(idxF2).toBeLessThan(idxF4);
+    });
+
+    it('collapses whitespace in the original ask blockquote', () => {
+        const out = render_decision_replay(buildTsInputs(FULL_SPEC));
+        expect(out).toContain('> Should we adopt the new architecture?\n');
+    });
+
+    it('truncates a >120-char finding title with an ellipsis', () => {
+        const out = render_decision_replay(buildTsInputs(FULL_SPEC));
+        expect(out).toContain('## F1 — ' + 'x'.repeat(119) + '…');
+    });
+
+    it('redacted mode omits member arguments + sets footer label', () => {
+        const out = render_decision_replay(buildTsInputs(REDACTED_SPEC));
+        expect(out).not.toContain('**Agreeing members**');
+        expect(out).not.toContain('**Dissenting members**');
+        expect(out).toContain('_artefact mode: redacted (counts only)_');
+    });
+
+    it('full mode includes the footer label + synthesis verdict', () => {
+        const out = render_decision_replay(buildTsInputs(FULL_SPEC));
+        expect(out).toContain('_artefact mode: full_');
+        expect(out).toContain('**Synthesis verdict**: Strong consensus — anthropic/claude sourced.');
+    });
+
+    it('empty-reason scorer with no matching deliberation key → "no argument captured"', () => {
+        const out = render_decision_replay(buildTsInputs(FULL_SPEC));
+        // F3 / m2 has an empty reason. member_texts is keyed by
+        // `provider:model` ("m2:"), so the bare scorer name "m2" misses the
+        // lookup → empty snippet → the captured-fallback sentinel (matches
+        // the Python twin exactly).
+        expect(out).toContain('_m2_ — no argument captured');
+    });
+
+    it('consensus float formatting uses :.2f / :.1f', () => {
+        const out = render_decision_replay(buildTsInputs(FULL_SPEC));
+        expect(out).toContain('**Consensus**: Strong (0.85)');
+        expect(out).toContain('(mean 6.5/10)');
+    });
+
+    it('empty-reason scorer DOES fall back to snippet when keyed provider:model', () => {
+        // Scorer id matches the deliberation key (`provider:model`), so the
+        // snippet lookup hits and the collapsed text is used as the argument.
+        const spec: Spec = {
+            findings: [{ id: 'F1', source: 's/m', text: 'a finding' }],
+            scores: [{ finding_id: 'F1', scorer: 'prov:model-1', score: 8, agree: true, reason: '' }],
+            metadata: [
+                {
+                    finding_id: 'F1',
+                    consensus_strength: 0.9,
+                    dissent_count: 0,
+                    scorers: ['prov:model-1'],
+                    mean_score: 8.0,
+                    concur_count: 1,
+                    dissent_reasons: [],
+                    evidence_quality: 'H',
+                },
+            ],
+            deliberation: [{ provider: 'prov', model: 'model-1', text: '  some   raw   snippet  ' }],
+            original_ask: '',
+            include_member_arguments: true,
+        };
+        const out = render_decision_replay(buildTsInputs(spec));
+        expect(out).toContain('_prov:model-1_ — some raw snippet');
+    });
+});

--- a/tests/scripts/ai_council/shadow_dispatch.test.ts
+++ b/tests/scripts/ai_council/shadow_dispatch.test.ts
@@ -1,0 +1,238 @@
+// Tests for src/scripts/ai_council/shadow_dispatch.ts (py2ts Phase 1).
+//
+// Shadow-mode dispatch for low-impact solo decisions. Golden parity against
+// the CPython twin covers: the seeded-rng Bernoulli sampler (PyRandom mirrors
+// CPython's Mersenne-Twister `random()`), the JSONL row format (default
+// json.dumps separators + ensure_ascii=True), the privacy-floor drop, the
+// rolling-window disagreement / escalation rates over a fixed log, the SLO
+// status thresholds, and the banner string (·, en-dash, em-dash literals +
+// the `{:.1f}` banker's-rounding format).
+import { mkdtempSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { PyRandom } from '../../../src/scripts/_lib/py_random.js';
+import {
+    SLO_THRESHOLD_BREACH,
+    SLO_THRESHOLD_WARN,
+    compute_disagreement_rate,
+    compute_escalation_rate,
+    record_shadow_decision,
+    should_shadow,
+    slo_banner,
+    slo_status,
+} from '../../../src/scripts/ai_council/shadow_dispatch.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// A fixed log with three in-window rows (2/3 disagree, 1/3 escalated), one
+// out-of-window row, one garbage line, and one unparsable-timestamp row.
+const LOG_ROWS = [
+    '{"timestamp": "2026-06-10T00:00:00+00:00", "query_hash": "aa", "solo_verdict": "x", "full_verdict": "x", "agreed": true, "escalated": false, "escalation_reason": "ok"}',
+    '{"timestamp": "2026-06-10T00:00:00+00:00", "query_hash": "bb", "solo_verdict": "x", "full_verdict": "y", "agreed": false, "escalated": true, "escalation_reason": "low-conf"}',
+    '{"timestamp": "2026-06-10T00:00:00+00:00", "query_hash": "cc", "solo_verdict": "x", "full_verdict": "z", "agreed": false, "escalated": false, "escalation_reason": "ok"}',
+    '{"timestamp": "2026-01-01T00:00:00Z", "query_hash": "old", "agreed": false, "escalated": true}',
+    'garbage line not json',
+    '{"timestamp": "not-a-date", "agreed": false}',
+    '',
+].join('\n');
+
+const NOW_MS = Date.UTC(2026, 5, 14, 0, 0, 0); // 2026-06-14T00:00:00Z
+
+function tmpFile(name: string, content: string): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'shadow-'));
+    const p = path.join(dir, name);
+    writeFileSync(p, content, { encoding: 'utf-8' });
+    return p;
+}
+
+describe('shadow_dispatch — pure functions', () => {
+    it('should_shadow with a seeded rng is deterministic', () => {
+        const r = new PyRandom(42);
+        const out: boolean[] = [];
+        for (let i = 0; i < 8; i += 1) {
+            out.push(should_shadow(0.3, { rng: r }));
+        }
+        expect(out).toEqual([false, true, true, true, false, false, false, true]);
+    });
+
+    it('should_shadow clamps the rate to [0, 1]', () => {
+        // rate <= 0 → never (random() is always >= 0); rate >= 1 → always.
+        expect(should_shadow(-5, { rng: new PyRandom(1) })).toBe(false);
+        expect(should_shadow(5, { rng: new PyRandom(1) })).toBe(true);
+    });
+
+    it('slo_status thresholds', () => {
+        expect(slo_status(0.0)).toBe('OK');
+        expect(slo_status(SLO_THRESHOLD_WARN - 0.001)).toBe('OK');
+        expect(slo_status(SLO_THRESHOLD_WARN)).toBe('WARN');
+        expect(slo_status(SLO_THRESHOLD_BREACH - 0.001)).toBe('WARN');
+        expect(slo_status(SLO_THRESHOLD_BREACH)).toBe('BREACH');
+        expect(slo_status(0.5)).toBe('BREACH');
+    });
+
+    it('slo_banner no-samples short-circuit', () => {
+        expect(slo_banner(0.0, 0)).toBe('[shadow SLO] no samples yet');
+    });
+
+    it('compute_* over the fixed window', () => {
+        const log = tmpFile('s.jsonl', LOG_ROWS);
+        expect(compute_disagreement_rate(log, { windowDays: 7, now: new Date(NOW_MS) })).toEqual([
+            2 / 3,
+            3,
+        ]);
+        expect(compute_escalation_rate(log, { windowDays: 7, now: new Date(NOW_MS) })).toEqual([
+            1 / 3,
+            3,
+        ]);
+    });
+
+    it('compute_* on a missing log → [0, 0]', () => {
+        expect(compute_disagreement_rate('/no/such/log.jsonl')).toEqual([0.0, 0]);
+        expect(compute_escalation_rate('/no/such/log.jsonl')).toEqual([0.0, 0]);
+    });
+
+    it('record_shadow_decision drops a privacy-violating query', () => {
+        const log = tmpFile('rec.jsonl', '');
+        unlinkSync(log);
+        const dropped = record_shadow_decision(log, {
+            query: 'Authorization: Bearer something',
+            soloVerdict: 'a',
+            fullVerdict: 'a',
+        });
+        expect(dropped).toBeNull();
+    });
+
+    it('record_shadow_decision appends a JSONL row + sets agreed', () => {
+        const log = tmpFile('rec.jsonl', '');
+        unlinkSync(log);
+        const d = record_shadow_decision(log, {
+            query: 'plain query about ports',
+            soloVerdict: 'yes',
+            fullVerdict: 'no',
+            escalated: true,
+            escalationReason: 'low-conf',
+        });
+        expect(d).not.toBeNull();
+        expect(d?.agreed).toBe(false);
+        const row = JSON.parse(readFileSync(log, { encoding: 'utf-8' }).trim());
+        expect(row.solo_verdict).toBe('yes');
+        expect(row.escalated).toBe(true);
+        expect(row.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/u);
+    });
+});
+
+describe.runIf(py3)('shadow_dispatch — golden parity vs CPython twin', () => {
+    it('should_shadow seeded-rng sequence matches CPython', () => {
+        const code = [
+            'import json, random, sys',
+            'from scripts.ai_council.shadow_dispatch import should_shadow',
+            'r = random.Random(int(sys.argv[1]))',
+            'print(json.dumps([should_shadow(0.3, rng=r) for _ in range(8)]))',
+        ].join('\n');
+        const res = runPyCode(code, ['42']);
+        expect(res.status, res.stderr).toBe(0);
+        const expected = JSON.parse(res.stdout) as boolean[];
+        const r = new PyRandom(42);
+        const out: boolean[] = [];
+        for (let i = 0; i < 8; i += 1) {
+            out.push(should_shadow(0.3, { rng: r }));
+        }
+        expect(out).toEqual(expected);
+    });
+
+    it('compute_* + slo_banner match over the fixed log', () => {
+        const log = tmpFile('s.jsonl', LOG_ROWS);
+        const code = [
+            'import json, sys',
+            'from datetime import datetime, timezone',
+            'from pathlib import Path',
+            'from scripts.ai_council import shadow_dispatch as S',
+            'now = datetime(2026, 6, 14, 0, 0, 0, tzinfo=timezone.utc)',
+            'lp = Path(sys.argv[1])',
+            'dr, dn = S.compute_disagreement_rate(lp, window_days=7, now=now)',
+            'er, en = S.compute_escalation_rate(lp, window_days=7, now=now)',
+            'print(json.dumps({',
+            '  "dr": dr, "dn": dn, "er": er, "en": en,',
+            '  "ok": S.slo_banner(0.0333, 30),',
+            '  "warn": S.slo_banner(0.06, 50, escalation_rate=0.025),',
+            '  "breach": S.slo_banner(0.095, 100),',
+            '  "round_half_even": [S.slo_banner(0.025, 40), S.slo_banner(0.035, 40)],',
+            '}, ensure_ascii=False))',
+        ].join('\n');
+        const res = runPyCode(code, [log]);
+        expect(res.status, res.stderr).toBe(0);
+        const exp = JSON.parse(res.stdout) as Record<string, unknown>;
+
+        const [dr, dn] = compute_disagreement_rate(log, { windowDays: 7, now: new Date(NOW_MS) });
+        const [er, en] = compute_escalation_rate(log, { windowDays: 7, now: new Date(NOW_MS) });
+        expect(dr).toBe(exp['dr']);
+        expect(dn).toBe(exp['dn']);
+        expect(er).toBe(exp['er']);
+        expect(en).toBe(exp['en']);
+        expect(slo_banner(0.0333, 30)).toBe(exp['ok']);
+        expect(slo_banner(0.06, 50, { escalationRate: 0.025 })).toBe(exp['warn']);
+        expect(slo_banner(0.095, 100)).toBe(exp['breach']);
+        expect([slo_banner(0.025, 40), slo_banner(0.035, 40)]).toEqual(exp['round_half_even']);
+    });
+
+    it('record_shadow_decision JSONL row matches (timestamp normalised)', () => {
+        const tsLog = tmpFile('ts.jsonl', '');
+        unlinkSync(tsLog);
+        record_shadow_decision(tsLog, {
+            query: 'café query with emoji 😀 and ports',
+            soloVerdict: 'yes',
+            fullVerdict: 'no',
+            escalated: true,
+            escalationReason: 'low-conf',
+        });
+        const tsRow = readFileSync(tsLog, { encoding: 'utf-8' }).replace(
+            /"timestamp": "[^"]+"/u,
+            '"timestamp": "<TS>"',
+        );
+
+        const code = [
+            'import re, sys',
+            'from pathlib import Path',
+            'from scripts.ai_council.shadow_dispatch import record_shadow_decision',
+            'lp = Path(sys.argv[1])',
+            'record_shadow_decision(lp, query="café query with emoji 😀 and ports",'
+                + ' solo_verdict="yes", full_verdict="no", escalated=True,'
+                + ' escalation_reason="low-conf")',
+            'row = lp.read_text(encoding="utf-8")',
+            'sys.stdout.write(re.sub(r\'"timestamp": "[^"]+"\', \'"timestamp": "<TS>"\', row))',
+        ].join('\n');
+        const pyLog = tmpFile('py.jsonl', '');
+        const res = runPyCode(code, [pyLog]);
+        expect(res.status, res.stderr).toBe(0);
+        expect(tsRow).toBe(res.stdout);
+    });
+
+    it('privacy-drop returns None on both sides', () => {
+        const code = [
+            'import json, sys',
+            'from pathlib import Path',
+            'from scripts.ai_council.shadow_dispatch import record_shadow_decision',
+            'lp = Path(sys.argv[1])',
+            'r = record_shadow_decision(lp, query="Authorization: Bearer zzz",'
+                + ' solo_verdict="a", full_verdict="a")',
+            'print(json.dumps(r is None))',
+        ].join('\n');
+        const pyLog = tmpFile('p.jsonl', '');
+        const res = runPyCode(code, [pyLog]);
+        expect(res.status, res.stderr).toBe(0);
+        expect(JSON.parse(res.stdout)).toBe(true);
+
+        const tsLog = tmpFile('t.jsonl', '');
+        unlinkSync(tsLog);
+        const dropped = record_shadow_decision(tsLog, {
+            query: 'Authorization: Bearer zzz',
+            soloVerdict: 'a',
+            fullVerdict: 'a',
+        });
+        expect(dropped).toBeNull();
+    });
+});


### PR DESCRIPTION
Third ai_council layer — the modules unblocked by layer 2. Targets `python2ts`. `.py` originals stay until Phase 12.

## Twins (6)
- `orchestrator` (1206) — the council core (multi-member dispatch, consensus, budget, debate, render/estimate); imports the merged advisors/clients/consensus/prompts/budget_guard/pricing/project_context twins; transport stubbed (no live calls).
- `necessity` (782) — call-necessity classifier (→low_impact_corpus).
- `replay` (155) — decision-replay renderer (→clients/consensus).
- `compile_corpus` (179) — hand-ported PyYAML `safe_dump` emitter for byte-exact YAML (→low_impact_corpus).
- `learn_low_impact_preview` (252) — preview/diff/PR-body render (→low_impact_corpus/redact).
- `shadow_dispatch` (235) — seeded-RNG shadow sampling + SLO banner (→bundler + `_lib/py_random`).

98 tests (all python3-differential). legacy-literal ts==py for all 6. tsc clean, phase-gate passes. **623/623 across the full ai_council twin suite.**

## Remaining ai_council (next + final wave)
`session` (→clients/orchestrator — now unblocked), `low_impact` (→clients/necessity/orchestrator — now unblocked), then the entrypoints `council_cli` / `council_prune`. After that ai_council is fully twinned.

## Verification
`tsc` clean · phase-gate passes · 623/623 ai_council suite · python3-differential byte-match · legacy match. Migration-gates 4-shard run validates on this PR's CI.