### PR TITLE
feat(py2ts): phase 10 — ai_council session + low_impact + council_prune (3 twins)

### DIFF
--- a/src/scripts/ai_council/low_impact.ts
+++ b/src/scripts/ai_council/low_impact.ts
@@ -1,0 +1,1068 @@
+// Lightweight-QA fast-path resolver (Phase 11) — TypeScript twin (py2ts Phase 1).
+//
+// When `decision_resolution.classes.low_impact.mode = council` fires,
+// this module narrows the standard council fan-out to the opted-in
+// members, caps the spend at the `decision_resolution.fast_path`
+// budget, and stamps a transparency marker on the result so the host
+// agent can surface that the answer came from the lightweight path.
+//
+// The fast-path is a strict subset of the standard `consult()` flow:
+//
+// - members filtered to `participate_low_impact = True` (and `enabled`);
+// - list truncated to `LowImpactFastPathConfig.max_members` (1 or 2);
+// - `CostBudget.max_calls = max_members`;
+// - `CostBudget.max_total_usd = max_cost_usd`;
+// - token caps tightened to `max_tokens` (split 60 / 40 in / out);
+// - `rounds` locked to 1 — multi-round debate defeats the purpose.
+//
+// Iron Law (Phase 10) is unaffected: `high_impact` and `user_required`
+// never reach this module — they route to `user` at the config layer.
+// This module is only consulted for the `low_impact` class.
+//
+// Parity notes (ADR-094):
+// - The four transparency markers are reproduced byte-for-byte (the
+//   `fast-path-marker-visibility` Iron Law). English, no emoji, leading `> `.
+// - `int(cfg.max_tokens * _INPUT_RATIO)` → `Math.trunc` (Python `int()`
+//   truncates toward zero).
+// - `:.2f` / `:.4f` USD formatting → `_pyFixed` (round-half-to-even),
+//   matching CPython float formatting.
+// - `round(total_cost, 4)` → `pyRound` (banker's rounding) from value_ladder.
+// - `text.splitlines()` → `_splitlines` (universal newlines).
+// - `re.sub` normalisation mirrors `[^\w\s]+` / `\s+` with Unicode `\w` (`re`
+//   defaults): spelled out as `\p{L}\p{N}_` since JS `\w` is ASCII-only.
+// - `len(q) > 120` / `q[:117]` / `[:80]` slices are code-point aware via
+//   `_pyLen` / `_pySlice` to mirror Python string indexing.
+// - dict insertion order + `dict(sorted(...))` for the stats aggregation.
+
+import { pyRound } from '../_lib/value_ladder.js';
+import type { CouncilResponse, ExternalAIClient } from './clients.js';
+import type { LowImpactFastPathConfig, MemberConfig } from './config.js';
+import { CostBudget } from './orchestrator.js';
+
+// Token split ratio between input prompt and output budget when the
+// fast-path caps the total. 60 / 40 mirrors the empirical mix observed
+// for short Q&A — Q is long-ish, A is terse. Tunable; kept private so
+// the contract surface stays at `max_tokens`.
+const _INPUT_RATIO = 0.6;
+
+// ── Python-format / stdlib parity helpers ────────────────────────────────
+
+/**
+ * Format `x` to `ndigits` decimals using round-half-to-even, matching
+ * CPython's `format(x, ".<ndigits>f")`.
+ */
+function _pyFixed(x: number, ndigits: number): string {
+    if (!Number.isFinite(x)) {
+        return String(x);
+    }
+    const neg = x < 0 || Object.is(x, -0);
+    const abs = Math.abs(x);
+    const factor = Math.pow(10, ndigits);
+    const scaled = abs * factor;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    const tol = Math.max(Math.abs(scaled), 1) * 2 ** -40;
+    let rounded: number;
+    if (Math.abs(frac - 0.5) <= tol) {
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    } else {
+        rounded = Math.round(scaled);
+    }
+    let intStr = String(rounded);
+    let result: string;
+    if (ndigits === 0) {
+        result = intStr;
+    } else {
+        if (intStr.length <= ndigits) {
+            intStr = '0'.repeat(ndigits - intStr.length + 1) + intStr;
+        }
+        const whole = intStr.slice(0, intStr.length - ndigits);
+        const dec = intStr.slice(intStr.length - ndigits);
+        result = `${whole}.${dec}`;
+    }
+    return neg ? `-${result}` : result;
+}
+
+/** Mirror Python `len(str)` — code-point count, not UTF-16 unit count. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+/** Mirror Python `str[:n]` — code-point-aware slice from the start. */
+function _pySlice(s: string, n: number): string {
+    if (n <= 0) {
+        return '';
+    }
+    let out = '';
+    let i = 0;
+    for (const ch of s) {
+        if (i >= n) {
+            break;
+        }
+        out += ch;
+        i += 1;
+    }
+    return out;
+}
+
+/** Mirror Python `str.strip()` (no-arg) — strip whitespace both ends. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Python `str.splitlines()` — split on universal newlines, drop a single
+ * trailing newline (no empty final element).
+ */
+function _splitlines(s: string): string[] {
+    if (s === '') {
+        return [];
+    }
+    const lines = s.split(/\r\n|\r|\n/u);
+    if (lines.length > 0 && lines[lines.length - 1] === '') {
+        lines.pop();
+    }
+    return lines;
+}
+
+/**
+ * Python `re.escape` for the literal trigger words used here — close enough
+ * for the alnum / punctuation shapes the corpus emits.
+ */
+function _reEscape(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Resolved fast-path execution plan (Phase 11).
+ *
+ * - members: Ordered list of member configs to invoke. Empty when no member
+ *   opted in — the caller must fall back to the standard council path or
+ *   escalate.
+ * - budget: `CostBudget` pre-sized to the fast-path caps. Safe to pass
+ *   directly to `orchestrator.consult`.
+ * - marker: One-line transparency string for the rendered output (e.g.
+ *   `"[fast-path: 2 members · cap $0.05]"`). Surface it to the user so
+ *   fast-path resolutions are distinguishable from standard council runs.
+ * - reason: Diagnostic string explaining the plan shape — used by the CLI
+ *   and tests. Empty when `members` is non-empty.
+ */
+export class FastPathPlan {
+    readonly members: readonly MemberConfig[];
+    readonly budget: CostBudget;
+    readonly marker: string;
+    readonly reason: string;
+
+    constructor(args: {
+        members: readonly MemberConfig[];
+        budget: CostBudget;
+        marker: string;
+        reason?: string;
+    }) {
+        this.members = args.members;
+        this.budget = args.budget;
+        this.marker = args.marker;
+        this.reason = args.reason ?? '';
+    }
+
+    /** True when at least one opted-in member is available. */
+    get is_resolvable(): boolean {
+        return this.members.length > 0;
+    }
+}
+
+/**
+ * Filter and order opted-in members for the fast-path.
+ *
+ * Selection rules:
+ *
+ * - member must be `enabled`;
+ * - member must have `participate_low_impact = True`;
+ * - alphabetical by provider name → deterministic, easy to test, no hidden
+ *   cost-rank heuristic to debug;
+ * - truncate to `cfg.max_members` (1 or 2 per schema).
+ *
+ * No price-table lookup here — the standard council path already runs the
+ * full cost-disclosure flow and the per-call cap in `CostBudget` is the
+ * structural backstop.
+ */
+export function select_fast_path_members(
+    members: ReadonlyMap<string, MemberConfig> | Record<string, MemberConfig>,
+    cfg: LowImpactFastPathConfig,
+): readonly MemberConfig[] {
+    const values =
+        members instanceof Map ? Array.from(members.values()) : Object.values(members);
+    const candidates = values.filter((m) => m.enabled && m.participate_low_impact);
+    // Python `list.sort(key=...)` is a stable sort on the string key; JS sort
+    // is stable as of ES2019, and string `<` matches Python's str ordering for
+    // the provider names in play.
+    candidates.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return candidates.slice(0, cfg.max_members);
+}
+
+/**
+ * Translate the `fast_path` config into a runnable `CostBudget`.
+ *
+ * The 60 / 40 input / output split is a heuristic — callers that need an
+ * exact ceiling can override the returned `CostBudget` fields. `max_calls`
+ * matches `max_members` so the orchestrator short-circuits as soon as the
+ * fast-path quota is exhausted.
+ */
+export function build_fast_path_budget(cfg: LowImpactFastPathConfig): CostBudget {
+    const max_in = Math.max(1, Math.trunc(cfg.max_tokens * _INPUT_RATIO));
+    const max_out = Math.max(1, cfg.max_tokens - max_in);
+    return new CostBudget({
+        max_input_tokens: max_in,
+        max_output_tokens: max_out,
+        max_calls: cfg.max_members,
+        max_total_usd: cfg.max_cost_usd,
+    });
+}
+
+/**
+ * Build the full execution plan for a `low_impact` resolution.
+ *
+ * Returns a `FastPathPlan`. When no member opted in, the plan's `members`
+ * tuple is empty and `reason` explains why — the caller must fall back
+ * (standard council) or escalate (user).
+ */
+export function plan_fast_path(
+    members: ReadonlyMap<string, MemberConfig> | Record<string, MemberConfig>,
+    cfg: LowImpactFastPathConfig,
+): FastPathPlan {
+    const selected = select_fast_path_members(members, cfg);
+    if (selected.length === 0) {
+        return new FastPathPlan({
+            members: [],
+            budget: build_fast_path_budget(cfg),
+            marker: '',
+            reason:
+                'no member has `participate_low_impact: true` — ' +
+                'fast-path unavailable, fall back to standard council ' +
+                'or escalate to user.',
+        });
+    }
+    const names = selected.map((m) => m.name).join(', ');
+    const marker =
+        `[fast-path: ${selected.length} member` +
+        `${selected.length > 1 ? 's' : ''} (${names}) · ` +
+        `cap $${_pyFixed(cfg.max_cost_usd, 2)} · ${cfg.max_tokens} tokens]`;
+    return new FastPathPlan({
+        members: selected,
+        budget: build_fast_path_budget(cfg),
+        marker,
+    });
+}
+
+// --- Phase 11 Step 2-3: fast-path executor + transparency marker ----------
+
+/**
+ * Status of a `FastPathResolution`. `resolved` = one or matching answers,
+ * returned to caller; `split` = members disagreed, caller must escalate to
+ * user with both opinions; `aborted` = hard cap hit or all members failed,
+ * caller must escalate; `unavailable` = plan had no opted-in members (caller
+ * never even called the executor — included so the status enum is
+ * exhaustive).
+ */
+export type FastPathStatus = 'resolved' | 'split' | 'aborted' | 'unavailable';
+
+// System prompt for fast-path members. Deliberately terse — the standard
+// advisor + Karpathy peer-review machinery is bypassed by design (Phase 11
+// contract). One sentence of rationale is asked explicitly so the
+// user-visible marker can surface a "why" without a second round.
+const _FAST_PATH_SYSTEM =
+    'You are a fast-path council member answering a low-impact ' +
+    'development question. Reply with: (1) a short, direct answer; ' +
+    '(2) one sentence of rationale. No preamble, no caveats, no ' +
+    'alternative options — just answer + rationale.';
+
+/**
+ * One fast-path member's normalised answer.
+ *
+ * - member: Member name (e.g. `"anthropic"`).
+ * - text: Raw response text. `""` when the call errored.
+ * - normalized: Lowercase + punctuation-stripped form used for agreement
+ *   detection. `""` mirrors `text`.
+ * - cost_usd: Estimated spend in USD for this single call. `0.0` for
+ *   non-billable transports (manual / vendor-CLI).
+ * - error: Provider-side error string, `null` on success.
+ */
+export class MemberAnswer {
+    readonly member: string;
+    readonly text: string;
+    readonly normalized: string;
+    readonly cost_usd: number;
+    readonly error: string | null;
+
+    constructor(args: {
+        member: string;
+        text: string;
+        normalized: string;
+        cost_usd?: number;
+        error?: string | null;
+    }) {
+        this.member = args.member;
+        this.text = args.text;
+        this.normalized = args.normalized;
+        this.cost_usd = args.cost_usd ?? 0.0;
+        this.error = args.error ?? null;
+    }
+
+    get ok(): boolean {
+        return this.error === null && _pyStrip(this.text) !== '';
+    }
+}
+
+/**
+ * End-to-end outcome of a low-impact fast-path resolution.
+ *
+ * - status: One of `FastPathStatus`.
+ * - answer: Final user-visible answer text. Empty when `status` is `split`,
+ *   `aborted`, or `unavailable`.
+ * - marker: Transparency marker line — either the plan marker (resolved) or
+ *   a status-specific escalation marker.
+ * - answers: Per-member normalised answers, in call order.
+ * - total_cost_usd: Sum of per-call costs.
+ * - session_log_line: One-line append for the session artefact under
+ *   `low-impact-resolutions.md`. Empty when status is `unavailable` (no call
+ *   happened).
+ */
+export class FastPathResolution {
+    readonly status: FastPathStatus;
+    readonly answer: string;
+    readonly marker: string;
+    readonly answers: readonly MemberAnswer[];
+    readonly total_cost_usd: number;
+    readonly session_log_line: string;
+
+    constructor(args: {
+        status: FastPathStatus;
+        answer: string;
+        marker: string;
+        answers?: readonly MemberAnswer[];
+        total_cost_usd?: number;
+        session_log_line?: string;
+    }) {
+        this.status = args.status;
+        this.answer = args.answer;
+        this.marker = args.marker;
+        this.answers = args.answers ?? [];
+        this.total_cost_usd = args.total_cost_usd ?? 0.0;
+        this.session_log_line = args.session_log_line ?? '';
+    }
+}
+
+/**
+ * Lowercase, strip punctuation, collapse whitespace.
+ *
+ * Used to detect agreement between two fast-path answers without fuzzy /
+ * embedding match — keeps the agreement test auditable.
+ *
+ * Python `re.sub(r"[^\w\s]+", " ", ...)` uses Unicode `\w` / `\s`; JS `\w` /
+ * `\s` are ASCII-only even under `/u`, so the Unicode classes are spelled out.
+ */
+function _normalize(text: string): string {
+    const lowered = (text || '').toLowerCase();
+    const stripped = lowered.replace(/[^\p{L}\p{N}_\s]+/gu, ' ');
+    return _pyStrip(stripped.replace(/\s+/gu, ' '));
+}
+
+function _build_user_prompt(question_text: string): string {
+    return (
+        `Question: ${_pyStrip(question_text)}\n\n` +
+        'Reply with: answer on line 1, one sentence rationale on line 2.'
+    );
+}
+
+/**
+ * Build the normative `aborted` marker.
+ *
+ * Wording is fixed by `fast-path-marker-visibility.md` Iron Law:
+ * `> Low-impact council aborted (<reason>) — escalating to user:`.
+ * The members-tried list trails on the same prefix so downstream pattern
+ * matchers can still extract who was called.
+ */
+function _aborted_marker(reason: string, members: readonly MemberConfig[]): string {
+    const names = members.length > 0 ? members.map((m) => m.name).join(', ') : 'no members';
+    return (
+        `> Low-impact council aborted (${reason}) — escalating to user: ` +
+        `members tried: ${names}.`
+    );
+}
+
+/**
+ * Build the normative `split` marker.
+ *
+ * Wording is fixed by `fast-path-marker-visibility.md` Iron Law:
+ * `> Low-impact council split — escalating to user (<m1>: X / <m2>: Y):`.
+ */
+function _split_marker(answers: readonly MemberAnswer[]): string {
+    const parts = answers
+        .filter((a) => a.ok)
+        .map((a) => `${a.member}: ${_pySlice(_pyStrip(_splitlines(a.text)[0] ?? ''), 80)}`)
+        .join(' / ');
+    return `> Low-impact council split — escalating to user (${parts}):`;
+}
+
+/**
+ * Build the normative `unavailable` marker.
+ *
+ * Wording is fixed by `fast-path-marker-visibility.md` Iron Law:
+ * `> Low-impact council unavailable (no opted-in members) — escalating to user.`.
+ */
+function _unavailable_marker(): string {
+    return (
+        '> Low-impact council unavailable (no opted-in members) — ' + 'escalating to user.'
+    );
+}
+
+/**
+ * Build the normative `resolved` marker.
+ *
+ * Wording is fixed by `fast-path-marker-visibility.md` Iron Law:
+ * `> Resolved via low-impact council fast-path: <verdict>.`. The verdict
+ * short-string distinguishes single-member from 2-member consensus so the
+ * host agent can preserve provenance without paraphrasing the answer body.
+ */
+function _resolved_marker(ok_answers: readonly MemberAnswer[]): string {
+    let verdict: string;
+    if (ok_answers.length <= 1) {
+        verdict = 'single-member answer';
+    } else {
+        verdict = `${ok_answers.length}-member consensus`;
+    }
+    return `> Resolved via low-impact council fast-path: ${verdict}.`;
+}
+
+/** Extract the answer portion (line 1) from a fast-path response. */
+function _answer_line(text: string): string {
+    for (const line of _splitlines(text)) {
+        const stripped = _pyStrip(line);
+        if (stripped !== '') {
+            return stripped;
+        }
+    }
+    return '';
+}
+
+/**
+ * A pricing table with a `lookup(provider, model)` method returning a price
+ * object exposing `input_per_1m_usd` / `output_per_1m_usd`. Typed loosely to
+ * mirror the duck-typed `price_table: object | None` Python signature.
+ */
+interface PriceLike {
+    readonly input_per_1m_usd: number;
+    readonly output_per_1m_usd: number;
+}
+interface PriceTableLike {
+    lookup(provider: string, model: string): PriceLike | null | undefined;
+}
+
+/**
+ * Estimate USD cost for one response.
+ *
+ * Uses the injected `price_table` when available; falls back to `0.0` for
+ * non-billable transports (manual / vendor-CLI) and for unknown models.
+ * Never raises — cost is an observability signal, not a gate (the budget
+ * check is structural).
+ */
+function _compute_cost(response: CouncilResponse, price_table: unknown): number {
+    if (price_table === null || price_table === undefined) {
+        return 0.0;
+    }
+    const lookup = (price_table as Record<string, unknown>).lookup;
+    if (typeof lookup !== 'function') {
+        return 0.0;
+    }
+    const price = (lookup as PriceTableLike['lookup']).call(
+        price_table,
+        response.provider,
+        response.model,
+    );
+    if (price === null || price === undefined) {
+        return 0.0;
+    }
+    const in_usd = (response.input_tokens / 1_000_000) * price.input_per_1m_usd;
+    const out_usd = (response.output_tokens / 1_000_000) * price.output_per_1m_usd;
+    return in_usd + out_usd;
+}
+
+/** Normalise one provider call into a `MemberAnswer`. */
+function _build_member_answer(
+    member: string,
+    response: CouncilResponse,
+    price_table: unknown,
+): MemberAnswer {
+    if (response.error) {
+        return new MemberAnswer({
+            member,
+            text: '',
+            normalized: '',
+            cost_usd: 0.0,
+            error: response.error,
+        });
+    }
+    const text = _pyStrip(response.text || '');
+    if (!text) {
+        return new MemberAnswer({
+            member,
+            text: '',
+            normalized: '',
+            cost_usd: 0.0,
+            error: 'empty response',
+        });
+    }
+    const cost = _compute_cost(response, price_table);
+    return new MemberAnswer({
+        member,
+        text,
+        normalized: _normalize(_answer_line(text)),
+        cost_usd: cost,
+    });
+}
+
+/**
+ * Build a one-line append for the session artefact.
+ *
+ * Format: `ISO8601 | status | members(ok/total) | $cost | Q…`
+ * Question is truncated to 120 chars so the log stays scannable.
+ */
+function _session_log_line(
+    question_text: string,
+    status: FastPathStatus,
+    answers: readonly MemberAnswer[],
+    total_cost: number,
+    now: Date | null = null,
+): string {
+    const ts = _strftimeUtc(now ?? new Date());
+    const ok = answers.filter((a) => a.ok).length;
+    const total = answers.length;
+    let q = _pyStrip(question_text).replace(/\n/g, ' ');
+    if (_pyLen(q) > 120) {
+        q = _pySlice(q, 117) + '...';
+    }
+    const names = answers.map((a) => a.member).join(', ');
+    const members_tag = names ? ` members(${names})` : '';
+    return (
+        `${ts} | ${status} | members=${ok}/${total} |${members_tag} ` +
+        `cost=$${_pyFixed(total_cost, 4)} | Q=${q}`
+    );
+}
+
+/**
+ * Mirror Python `datetime.strftime("%Y-%m-%dT%H:%M:%SZ")` over a UTC instant.
+ * The Python source builds the timestamp from a timezone-aware UTC `datetime`,
+ * so the formatted fields are the UTC calendar fields.
+ */
+function _strftimeUtc(d: Date): string {
+    const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+    return (
+        `${pad(d.getUTCFullYear(), 4)}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+        `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`
+    );
+}
+
+/**
+ * Execute the fast-path plan and return a `FastPathResolution`.
+ *
+ * Contract:
+ *
+ * - One round only — each opted-in member is called exactly once.
+ * - Per-call `max_tokens` is taken from `plan.budget.max_output_tokens`.
+ * - The USD cap (`plan.budget.max_total_usd`) is a hard stop — when the
+ *   running total would exceed it after a call, the executor aborts and
+ *   escalates to the user (never silently truncates).
+ * - Provider failures never block — a failed member is recorded and the
+ *   executor continues with the remaining member (if any).
+ * - Consensus rule (2 members): normalised answer-line equality. No embedding
+ *   match, no LLM-judge — keeps the agreement test auditable. Disagreement →
+ *   `status = "split"`, caller escalates.
+ *
+ * @param question_text The low-impact question being routed.
+ * @param plan Output of `plan_fast_path`.
+ * @param clients Provider name → instantiated client. Missing entries are
+ *   treated as a member-side failure (error recorded, other members proceed).
+ * @param price_table Optional pricing table for cost estimation. When `null`,
+ *   `cost_usd` fields stay at `0.0` (the structural budget check still fires
+ *   on token counts).
+ * @param now Optional clock injector for deterministic tests.
+ */
+export function resolve_low_impact(
+    question_text: string,
+    plan: FastPathPlan,
+    clients: ReadonlyMap<string, ExternalAIClient> | Record<string, ExternalAIClient>,
+    price_table: unknown = null,
+    now: (() => Date) | null = null,
+): FastPathResolution {
+    if (!plan.is_resolvable) {
+        return new FastPathResolution({
+            status: 'unavailable',
+            answer: '',
+            marker: _unavailable_marker(),
+        });
+    }
+
+    const getClient = (name: string): ExternalAIClient | undefined =>
+        clients instanceof Map
+            ? clients.get(name)
+            : (clients as Record<string, ExternalAIClient>)[name];
+
+    const user_prompt = _build_user_prompt(question_text);
+    const answers: MemberAnswer[] = [];
+    let total_cost = 0.0;
+
+    for (const member of plan.members) {
+        const client = getClient(member.name);
+        if (client === undefined || client === null) {
+            answers.push(
+                new MemberAnswer({
+                    member: member.name,
+                    text: '',
+                    normalized: '',
+                    cost_usd: 0.0,
+                    error: 'no client instantiated',
+                }),
+            );
+            continue;
+        }
+        let response: CouncilResponse;
+        try {
+            response = client.ask(
+                _FAST_PATH_SYSTEM,
+                user_prompt,
+                plan.budget.max_output_tokens,
+            );
+        } catch (exc) {
+            answers.push(
+                new MemberAnswer({
+                    member: member.name,
+                    text: '',
+                    normalized: '',
+                    cost_usd: 0.0,
+                    error: `client raised: ${_reprException(exc)}`,
+                }),
+            );
+            continue;
+        }
+        const ans = _build_member_answer(member.name, response, price_table);
+        // Hard cap — refuse to add an over-budget answer to the result.
+        const projected = total_cost + ans.cost_usd;
+        if (projected > plan.budget.max_total_usd && ans.ok) {
+            answers.push(
+                new MemberAnswer({
+                    member: member.name,
+                    text: '',
+                    normalized: '',
+                    cost_usd: ans.cost_usd,
+                    error:
+                        `would exceed fast-path cap ` +
+                        `$${_pyFixed(plan.budget.max_total_usd, 2)} ` +
+                        `(projected $${_pyFixed(projected, 4)})`,
+                }),
+            );
+            break;
+        }
+        answers.push(ans);
+        total_cost = projected;
+    }
+
+    const answers_t = answers.slice();
+    const ok_answers = answers_t.filter((a) => a.ok);
+
+    if (ok_answers.length === 0) {
+        const marker = _aborted_marker('all members failed', plan.members);
+        return new FastPathResolution({
+            status: 'aborted',
+            answer: '',
+            marker,
+            answers: answers_t,
+            total_cost_usd: total_cost,
+            session_log_line: _session_log_line(
+                question_text,
+                'aborted',
+                answers_t,
+                total_cost,
+                now ? now() : null,
+            ),
+        });
+    }
+
+    const first = ok_answers[0] as MemberAnswer;
+    if (ok_answers.length === 1) {
+        return new FastPathResolution({
+            status: 'resolved',
+            answer: first.text,
+            marker: _resolved_marker(ok_answers),
+            answers: answers_t,
+            total_cost_usd: total_cost,
+            session_log_line: _session_log_line(
+                question_text,
+                'resolved',
+                answers_t,
+                total_cost,
+                now ? now() : null,
+            ),
+        });
+    }
+
+    // Two members → quick consensus on normalised answer line.
+    const second = ok_answers[1] as MemberAnswer;
+    if (first.normalized === second.normalized) {
+        return new FastPathResolution({
+            status: 'resolved',
+            answer: first.text,
+            marker: _resolved_marker(ok_answers),
+            answers: answers_t,
+            total_cost_usd: total_cost,
+            session_log_line: _session_log_line(
+                question_text,
+                'resolved',
+                answers_t,
+                total_cost,
+                now ? now() : null,
+            ),
+        });
+    }
+
+    return new FastPathResolution({
+        status: 'split',
+        answer: '',
+        marker: _split_marker(ok_answers),
+        answers: answers_t,
+        total_cost_usd: total_cost,
+        session_log_line: _session_log_line(
+            question_text,
+            'split',
+            answers_t,
+            total_cost,
+            now ? now() : null,
+        ),
+    });
+}
+
+/**
+ * Mirror Python `f"{exc!r}"` for an exception caught in the executor loop.
+ * Python renders `repr(exc)` → `<ClassName>('<message>')`. The exact text is
+ * only surfaced inside the member-error string; tests that compare it pin the
+ * raised value, so a faithful `ClassName(args)` shape is what matters.
+ */
+function _reprException(exc: unknown): string {
+    if (exc instanceof Error) {
+        const name = exc.constructor?.name ?? exc.name ?? 'Error';
+        return `${name}(${_pyReprStr(exc.message)})`;
+    }
+    return String(exc);
+}
+
+/** Mirror Python `repr(str)` for a single-quoted ASCII-ish string. */
+function _pyReprStr(s: string): string {
+    const escaped = s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+    return `'${escaped}'`;
+}
+
+// --- Phase 11 Step 5: low-impact stats over session log -------------------
+
+/**
+ * Aggregate summary of one session's low-impact resolutions.
+ *
+ * - total: Total number of fast-path attempts in the session.
+ * - by_status: Count per status (`resolved`/`split`/`aborted`).
+ * - by_member: Count per member name (sum across all attempts; a 2-member
+ *   call increments both entries).
+ * - total_cost_usd: Sum of per-attempt cost across the session.
+ */
+export class LowImpactStats {
+    readonly total: number;
+    readonly by_status: ReadonlyMap<string, number>;
+    readonly by_member: ReadonlyMap<string, number>;
+    readonly total_cost_usd: number;
+
+    constructor(args: {
+        total: number;
+        by_status: ReadonlyMap<string, number>;
+        by_member: ReadonlyMap<string, number>;
+        total_cost_usd: number;
+    }) {
+        this.total = args.total;
+        this.by_status = args.by_status;
+        this.by_member = args.by_member;
+        this.total_cost_usd = args.total_cost_usd;
+    }
+}
+
+// Mirrors the Python module-level compiled regexes. `\w` in Python `re` is
+// Unicode by default; `status` (\w+) is ASCII in practice, but spell out the
+// Unicode class to stay faithful. The cost group is `[\d.]+`.
+const _LOG_LINE_RE = new RegExp(
+    '^(?<ts>\\S+)\\s*\\|\\s*(?<status>[\\p{L}\\p{N}_]+)\\s*\\|\\s*members=(?<ok>\\d+)/' +
+        '(?<tot>\\d+)\\s*\\|.*?cost=\\$(?<cost>[\\d.]+)\\s*\\|\\s*Q=',
+    'u',
+);
+
+const _MEMBER_SECTION_RE = /members\((?<names>[^)]+)\)/u;
+
+/**
+ * Parse a `low-impact-resolutions.md` body into stats.
+ *
+ * Lines that do not match the canonical `_session_log_line` shape are skipped
+ * silently — keeps the parser tolerant of free-form section headers the
+ * artefact may grow over time. Returns a `LowImpactStats` with the aggregated
+ * counts.
+ */
+export function parse_low_impact_log(text: string): LowImpactStats {
+    const by_status = new Map<string, number>();
+    const by_member = new Map<string, number>();
+    let total = 0;
+    let total_cost = 0.0;
+    for (const raw of _splitlines(text)) {
+        const m = _LOG_LINE_RE.exec(_pyStrip(raw));
+        // Python `re.match` anchors at the start only; `_LOG_LINE_RE` already
+        // begins with `^`. `exec` against a non-global regex matches anywhere,
+        // but the `^` anchor pins it to the start exactly like `re.match`.
+        if (!m) {
+            continue;
+        }
+        total += 1;
+        const status = m.groups?.['status'] ?? '';
+        by_status.set(status, (by_status.get(status) ?? 0) + 1);
+        const cost = Number(m.groups?.['cost']);
+        if (!Number.isNaN(cost)) {
+            total_cost += cost;
+        }
+        // Optional `members(name, name)` tag emitted by the renderer.
+        const names_m = _MEMBER_SECTION_RE.exec(raw);
+        if (names_m) {
+            for (const rawName of (names_m.groups?.['names'] ?? '').split(',')) {
+                const name = _pyStrip(rawName);
+                if (name) {
+                    by_member.set(name, (by_member.get(name) ?? 0) + 1);
+                }
+            }
+        }
+    }
+    return new LowImpactStats({
+        total,
+        by_status: _sortedMap(by_status),
+        by_member: _sortedMap(by_member),
+        total_cost_usd: pyRound(total_cost, 4),
+    });
+}
+
+/** Mirror Python `dict(sorted(d.items()))` — re-key in sorted-key order. */
+function _sortedMap(d: Map<string, number>): Map<string, number> {
+    const out = new Map<string, number>();
+    const keys = Array.from(d.keys()).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    for (const k of keys) {
+        out.set(k, d.get(k) as number);
+    }
+    return out;
+}
+
+/** Render `LowImpactStats` as a short stdout summary block. */
+export function render_low_impact_stats(stats: LowImpactStats): string {
+    const lines: string[] = ['# Low-impact fast-path · session summary', ''];
+    lines.push(`- attempts: ${stats.total}`);
+    if (stats.by_status.size > 0) {
+        const parts = Array.from(stats.by_status.entries())
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' · ');
+        lines.push(`- status: ${parts}`);
+    } else {
+        lines.push('- status: (none)');
+    }
+    if (stats.by_member.size > 0) {
+        const parts = Array.from(stats.by_member.entries())
+            .map(([k, v]) => `${k}=${v}`)
+            .join(' · ');
+        lines.push(`- members: ${parts}`);
+    }
+    lines.push(`- total cost: $${_pyFixed(stats.total_cost_usd, 4)}`);
+    return lines.join('\n') + '\n';
+}
+
+// --- step-9 P5: fuzzy corpus match with safety vetoes -------------------
+
+/**
+ * Fuzzy variant of `necessity.classify_impact_with_corpus`.
+ *
+ * Uses a SequenceMatcher-equivalent ratio to match near-paraphrases of
+ * `Validated` corpus entries while preserving the Iron Law:
+ *
+ * - **Iron Law (precedence)**: the base verdict from `classify_impact` runs
+ *   first. If the base class is in `LOCKED_IMPACT_CLASSES` (`high_impact` /
+ *   `user_required`), the fuzzy lookup is skipped entirely.
+ * - **High-impact-veto**: any whole-word token from
+ *   `IMPACT_TRIGGERS["high_impact"]` in the (lowered) query short-circuits to
+ *   the base verdict regardless of similarity. Catches paraphrases that
+ *   escaped the trigger-bucket vote.
+ * - **Anti-example-veto**: if the maximum similarity to any `Anti-Examples`
+ *   phrase is `>=` the maximum similarity to any `Validated` phrase, the
+ *   fuzzy match is rejected. Prevents ratio-driven drift onto bullets the
+ *   corpus has explicitly flagged as user-required.
+ *
+ * Returns the base verdict on every reject path so the caller gets consistent
+ * semantics with the exact-match classifier.
+ */
+export async function classify_impact_with_corpus_fuzzy(
+    question_text: string,
+    corpus_paths: readonly string[] | null = null,
+    opts: { threshold?: number } = {},
+): Promise<import('./necessity.js').ImpactVerdict> {
+    const threshold = opts.threshold ?? 0.92;
+
+    const { load_anti_example_phrases, load_validated_phrases } = await import(
+        './low_impact_corpus.js'
+    );
+    const { IMPACT_TRIGGERS, ImpactVerdict, LOCKED_IMPACT_CLASSES, classify_impact } =
+        await import('./necessity.js');
+
+    const base = classify_impact(question_text);
+    if (LOCKED_IMPACT_CLASSES.has(base.impact_class)) {
+        return base;
+    }
+    if (!corpus_paths || corpus_paths.length === 0 || !(threshold > 0.0 && threshold <= 1.0)) {
+        return base;
+    }
+
+    let norm_q = (question_text || '').toLowerCase().replace(/[^\p{L}\p{N}_\s]/gu, ' ');
+    norm_q = _pyStrip(norm_q.replace(/\s+/gu, ' '));
+    if (!norm_q) {
+        return base;
+    }
+
+    // High-impact-veto: a paraphrase carrying a security-class trigger wins
+    // the Iron Law regardless of corpus similarity. Whole-word match against
+    // the lowered query, mirroring `_count_matches`.
+    const high_triggers = IMPACT_TRIGGERS['high_impact'] ?? [];
+    const lowered_q = (question_text || '').toLowerCase();
+    for (const trig of high_triggers) {
+        const pattern = new RegExp(`\\b${_reEscape(trig.toLowerCase())}\\b`, 'u');
+        if (pattern.test(lowered_q)) {
+            return base;
+        }
+    }
+
+    const validated: string[] = [];
+    const anti: string[] = [];
+    for (const p of corpus_paths) {
+        validated.push(...load_validated_phrases(p));
+        anti.push(...load_anti_example_phrases(p));
+    }
+
+    if (validated.length === 0) {
+        return base;
+    }
+
+    const _ratio = (a: string, b: string): number => _sequenceMatcherRatio(a, b);
+
+    const best_validated = validated.reduce((mx, p) => Math.max(mx, _ratio(norm_q, p)), 0.0);
+    if (best_validated < threshold) {
+        return base;
+    }
+
+    const best_anti = anti.reduce((mx, p) => Math.max(mx, _ratio(norm_q, p)), 0.0);
+    // Anti-example-veto: if the query is at least as close to an anti-example
+    // as to a validated phrase, the corpus has actively flagged this shape —
+    // don't shortcut.
+    if (anti.length > 0 && best_anti >= best_validated) {
+        return base;
+    }
+
+    return new ImpactVerdict({
+        impact_class: 'low_impact',
+        confidence: pyRound(Math.min(0.9, best_validated), 4),
+        rationale:
+            `Fuzzy match against Validated corpus ` +
+            `(ratio=${_pyFixed(best_validated, 3)} ≥ ${_pyFixed(threshold, 2)}) — routing ` +
+            'as `low_impact` (step-9 P5).',
+        category: 'corpus_validated_fuzzy',
+    });
+}
+
+/**
+ * Mirror Python `difflib.SequenceMatcher(a, b).ratio()`.
+ *
+ * `ratio = 2.0 * M / T`, where `T` is the total length of both sequences and
+ * `M` is the number of matches as computed by the recursive
+ * longest-matching-block algorithm (no autojunk for these short phrase
+ * inputs). This is a faithful port of the `get_matching_blocks` /
+ * `find_longest_match` core of CPython's `difflib`.
+ */
+function _sequenceMatcherRatio(a: string, b: string): number {
+    const aChars = Array.from(a);
+    const bChars = Array.from(b);
+    const lenA = aChars.length;
+    const lenB = bChars.length;
+    const total = lenA + lenB;
+    if (total === 0) {
+        return 1.0;
+    }
+    // b2j: char -> list of indices in b (difflib's reverse index).
+    const b2j = new Map<string, number[]>();
+    for (let i = 0; i < lenB; i += 1) {
+        const ch = bChars[i] as string;
+        let arr = b2j.get(ch);
+        if (arr === undefined) {
+            arr = [];
+            b2j.set(ch, arr);
+        }
+        arr.push(i);
+    }
+
+    const findLongestMatch = (
+        alo: number,
+        ahi: number,
+        blo: number,
+        bhi: number,
+    ): [number, number, number] => {
+        let besti = alo;
+        let bestj = blo;
+        let bestsize = 0;
+        let j2len = new Map<number, number>();
+        for (let i = alo; i < ahi; i += 1) {
+            const newj2len = new Map<number, number>();
+            const indices = b2j.get(aChars[i] as string) ?? [];
+            for (const j of indices) {
+                if (j < blo) {
+                    continue;
+                }
+                if (j >= bhi) {
+                    break;
+                }
+                const k = (j2len.get(j - 1) ?? 0) + 1;
+                newj2len.set(j, k);
+                if (k > bestsize) {
+                    besti = i - k + 1;
+                    bestj = j - k + 1;
+                    bestsize = k;
+                }
+            }
+            j2len = newj2len;
+        }
+        return [besti, bestj, bestsize];
+    };
+
+    // Iteratively accumulate matched-character count over the recursive block
+    // decomposition (matches CPython's get_matching_blocks queue walk).
+    let matches = 0;
+    const queue: Array<[number, number, number, number]> = [[0, lenA, 0, lenB]];
+    while (queue.length > 0) {
+        const [alo, ahi, blo, bhi] = queue.pop() as [number, number, number, number];
+        const [i, j, k] = findLongestMatch(alo, ahi, blo, bhi);
+        if (k > 0) {
+            matches += k;
+            if (alo < i && blo < j) {
+                queue.push([alo, i, blo, j]);
+            }
+            if (i + k < ahi && j + k < bhi) {
+                queue.push([i + k, ahi, j + k, bhi]);
+            }
+        }
+    }
+
+    return (2.0 * matches) / total;
+}

--- a/src/scripts/ai_council/session.ts
+++ b/src/scripts/ai_council/session.ts
@@ -1,0 +1,558 @@
+/**
+ * Session persistence for council consultations (D2).
+ *
+ * TypeScript twin of `src/scripts/ai_council/session.py` (ADR-094 —
+ * Python→TS migration, Phase 1).
+ *
+ * Every `/council` call that completes (success or partial) writes an
+ * audit artefact under `agents/runtime/council/sessions/<UTC-timestamp>/`:
+ *
+ * - `manifest.json` — input mode, members, token + USD totals, original
+ *   ask, neutrality preamble fingerprint.
+ * - `response.md`   — `orchestrator.render()` output (per-member
+ *   sections + Convergence/Divergence slot).
+ * - `raw-text.md`   — concatenated raw text per member, separated by
+ *   ASCII rules so a later `grep` is trivial.
+ *
+ * Hard rules:
+ * - Never raises on the project — disk write failures are logged and
+ *   swallowed; the council is text-only and the report is the contract.
+ * - Never writes secrets. The bundle has already been redacted by
+ *   `bundler.py` before the orchestrator receives it.
+ * - Never writes outside `agents/runtime/council/sessions/`. Path traversal in
+ *   the timestamp is impossible (we generate it from `datetime.utcnow`).
+ *
+ * Parity notes:
+ * - `datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")` → manual
+ *   UTC formatting (Z suffix preserved).
+ * - `json.dumps(payload, indent=2)` (ensure_ascii defaults to True) →
+ *   `py_json_dumps_indent2` from `_lib/security_lint`; integer-valued
+ *   `round(..., 6)` cost floats are wrapped in `PyFloat` so they render
+ *   as `0.0`, not `0`.
+ * - `list(dir.iterdir())` → `fs.readdirSync(dir)` (same directory-entry
+ *   order on the same filesystem); each pruner skips/keeps in iteration
+ *   order, so the returned `removed` list preserves Python's order.
+ * - `shutil.rmtree` → `fs.rmSync(p, { recursive: true, force: true })`.
+ * - `Path.stat().st_mtime` → `fs.statSync(p).mtimeMs / 1000` (seconds).
+ * - `cutoff.timestamp()` → epoch seconds.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { project_settings_path, load_agent_settings } from '../_lib/agent_settings.js';
+import { PyFloat, py_json_dumps_indent2 } from '../_lib/security_lint.js';
+import { pyRound } from '../_lib/value_ladder.js';
+import { CouncilResponse } from './clients.js';
+import { render } from './orchestrator.js';
+
+// src/scripts/ai_council/session.py → parents[3] == repo root.
+const _HERE = fileURLToPath(import.meta.url);
+export const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
+export const SESSIONS_DIR = path.join(REPO_ROOT, 'agents', 'runtime', 'council', 'sessions');
+export const QUESTIONS_DIR = path.join(REPO_ROOT, 'agents', 'runtime', 'council', 'questions');
+export const RESPONSES_DIR = path.join(REPO_ROOT, 'agents', 'runtime', 'council', 'responses');
+export const SETTINGS_FILE = project_settings_path(REPO_ROOT);
+
+// Default retention for all council artefacts (questions, responses,
+// sessions). Overridden by `ai_council.session_retention_days`
+// in `.agent-settings.yml`. Council files are local-only scratch — short
+// retention keeps the working tree from accumulating dead weight.
+export const DEFAULT_RETENTION_DAYS = 7;
+const _TS_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})Z$/;
+
+/**
+ * Structured record of a single council call.
+ *
+ * Round 2+ debate calls (D1) pass `rounds > 1`; each round's
+ * per-member response is appended in `responses_per_round`.
+ */
+export class SessionManifest {
+    mode: string; // bundle mode: prompt|roadmap|diff|files
+    artefact: string; // human-readable artefact descriptor (path or "<inline>")
+    original_ask: string;
+    members: string[]; // "provider/model" pairs
+    rounds: number;
+    cost_usd_estimated: number;
+    cost_usd_actual: number;
+    extra: Record<string, unknown>;
+
+    constructor(opts: {
+        mode: string;
+        artefact: string;
+        original_ask: string;
+        members: string[];
+        rounds?: number;
+        cost_usd_estimated?: number;
+        cost_usd_actual?: number;
+        extra?: Record<string, unknown>;
+    }) {
+        this.mode = opts.mode;
+        this.artefact = opts.artefact;
+        this.original_ask = opts.original_ask;
+        this.members = opts.members;
+        this.rounds = opts.rounds ?? 1;
+        this.cost_usd_estimated = opts.cost_usd_estimated ?? 0.0;
+        this.cost_usd_actual = opts.cost_usd_actual ?? 0.0;
+        // Python dataclass uses `field(default_factory=dict)` — each instance
+        // gets its own fresh dict.
+        this.extra = opts.extra ?? {};
+    }
+}
+
+/** UTC timestamp safe for filesystem use (Z suffix preserved). */
+function _utc_timestamp(): string {
+    const d = new Date();
+    const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+    return (
+        `${pad(d.getUTCFullYear(), 4)}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+        `T${pad(d.getUTCHours())}-${pad(d.getUTCMinutes())}-${pad(d.getUTCSeconds())}Z`
+    );
+}
+
+/** Mirror Python `bool(...)` truthiness for arbitrary values. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/** Read-only mapping accessor mirroring Python `dict.get(key, default)`. */
+function _metaGet(meta: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return Object.prototype.hasOwnProperty.call(meta, key) ? meta[key] : dflt;
+}
+
+/**
+ * Project a `CouncilResponse` into the manifest schema.
+ *
+ * Phase 5 / Step 1 — surface ``transport``, ``billable``,
+ * ``subscription_label``, ``cost_usd``, and ``tokens_estimated`` so
+ * the audit trail can distinguish flat-rate CLI calls from billable
+ * api / community-CLI calls. When ``tokens_estimated`` is true the
+ * token counts are kept (heuristic) but flagged so consumers can
+ * null or disclaim them.
+ */
+function _serialise_response(r: CouncilResponse): Record<string, unknown> {
+    const meta = r.metadata || {};
+    const payload: Record<string, unknown> = {
+        provider: r.provider,
+        model: r.model,
+        input_tokens: r.input_tokens,
+        output_tokens: r.output_tokens,
+        latency_ms: r.latency_ms,
+        error: r.error,
+        transport: _metaGet(meta, 'transport', 'api'),
+        billable: _pyTruthy(_metaGet(meta, 'billable', true)),
+        tokens_estimated: _pyTruthy(_metaGet(meta, 'tokens_estimated', false)),
+    };
+    if (_pyTruthy(_metaGet(meta, 'subscription_label', undefined))) {
+        payload['subscription_label'] = meta['subscription_label'];
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, 'cost_usd')) {
+        payload['cost_usd'] = meta['cost_usd'];
+    }
+    return payload;
+}
+
+/**
+ * Read `ai_council.session_retention_days` from `.agent-settings.yml`.
+ *
+ * Returns `DEFAULT_RETENTION_DAYS` on any read/parse failure (missing
+ * file, invalid YAML, missing key, non-int value). Pruning never
+ * blocks the council on a settings error.
+ */
+export function _load_retention_days(settings_path: string | null = null): number {
+    // Centralized loader (road-to-portable-dev-preferences P3): tolerance
+    // contract handles missing file / malformed YAML / no PyYAML uniformly.
+    // ``ai_council.session_retention_days`` is not whitelisted, so the
+    // user-global file cannot override the project value.
+    const p = settings_path ?? SETTINGS_FILE;
+    const data = load_agent_settings({ project_path: p });
+    const ai = (data as Record<string, unknown>)['ai_council'];
+    if (!_isMapping(ai)) {
+        return DEFAULT_RETENTION_DAYS;
+    }
+    const raw = Object.prototype.hasOwnProperty.call(ai, 'session_retention_days')
+        ? (ai as Record<string, unknown>)['session_retention_days']
+        : DEFAULT_RETENTION_DAYS;
+    const parsed = _pyInt(raw);
+    if (parsed === null) {
+        return DEFAULT_RETENTION_DAYS;
+    }
+    return parsed;
+}
+
+/** Mirror Python `isinstance(x, dict)`. */
+function _isMapping(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Mirror Python `int(raw)` for the retention value, returning null on the
+ * `(TypeError, ValueError)` paths the source catches.
+ *
+ * Python `int()` accepts ints, floats (truncated toward zero), and strings
+ * of an integer literal (optionally signed, surrounding whitespace
+ * stripped). bool is an int subclass (`int(True) == 1`). Everything else
+ * raises and the caller falls back to the default.
+ */
+function _pyInt(raw: unknown): number | null {
+    if (typeof raw === 'boolean') {
+        return raw ? 1 : 0;
+    }
+    if (typeof raw === 'number') {
+        if (!Number.isFinite(raw)) {
+            return null; // int(inf)/int(nan) → ValueError/OverflowError
+        }
+        return Math.trunc(raw);
+    }
+    if (typeof raw === 'string') {
+        const s = raw.trim();
+        if (/^[+-]?\d+$/.test(s)) {
+            return Number.parseInt(s, 10);
+        }
+        return null;
+    }
+    return null;
+}
+
+/** Parse `YYYY-MM-DDTHH-MM-SSZ` directory name to a UTC epoch (ms), or null. */
+function _parse_session_timestamp(name: string): number | null {
+    const m = _TS_RE.exec(name);
+    if (!m) {
+        return null;
+    }
+    const [, ys, mos, ds, hs, mis, ss] = m;
+    const y = Number(ys);
+    const mo = Number(mos);
+    const d = Number(ds);
+    const h = Number(hs);
+    const mi = Number(mis);
+    const s = Number(ss);
+    // Mirror `datetime(y, mo, d, h, mi, s)` — reject out-of-range components
+    // (Python raises ValueError; the source returns None).
+    if (mo < 1 || mo > 12 || d < 1 || d > 31 || h > 23 || mi > 59 || s > 59) {
+        return null;
+    }
+    const epoch = Date.UTC(y, mo - 1, d, h, mi, s);
+    // Date.UTC normalises overflow (e.g. day 31 in a 30-day month) rather than
+    // raising; reject when the round-trip drifts so we match Python's
+    // ValueError boundary for impossible calendar dates.
+    const back = new Date(epoch);
+    if (
+        back.getUTCFullYear() !== y ||
+        back.getUTCMonth() !== mo - 1 ||
+        back.getUTCDate() !== d ||
+        back.getUTCHours() !== h ||
+        back.getUTCMinutes() !== mi ||
+        back.getUTCSeconds() !== s
+    ) {
+        return null;
+    }
+    return epoch;
+}
+
+/** Best-effort directory listing; OSError → log + null (caller returns []). */
+function _safeReaddir(dir: string, label: string): string[] | null {
+    try {
+        return fs.readdirSync(dir);
+    } catch (exc) {
+        process.stderr.write(`[council:session] ${label} failed: ${_errStr(exc)}\n`);
+        return null;
+    }
+}
+
+function _errStr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+function _isDir(p: string): boolean {
+    try {
+        return fs.statSync(p).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Delete session subdirectories older than `retention_days`.
+ *
+ * A session is "old" when its directory-name timestamp predates
+ * `now - retention_days`. Non-matching names (e.g. JSON reports at
+ * the root, custom folders) are skipped. Never raises — disk
+ * failures are logged to stderr.
+ *
+ * Returns the list of deleted directories. `retention_days <= 0`
+ * disables pruning and returns an empty list.
+ */
+export function prune_old_sessions(
+    sessions_dir: string,
+    retention_days: number,
+    opts: { now?: Date | null } = {},
+): string[] {
+    const now = opts.now ?? null;
+    if (retention_days <= 0 || !fs.existsSync(sessions_dir)) {
+        return [];
+    }
+    const cutoffMs = (now ? now.getTime() : Date.now()) - retention_days * 86400000;
+    const removed: string[] = [];
+    const names = _safeReaddir(sessions_dir, 'prune iterdir');
+    if (names === null) {
+        return removed;
+    }
+    for (const name of names) {
+        const entry = path.join(sessions_dir, name);
+        if (!_isDir(entry)) {
+            continue;
+        }
+        const ts = _parse_session_timestamp(name);
+        if (ts === null || ts >= cutoffMs) {
+            continue;
+        }
+        try {
+            fs.rmSync(entry, { recursive: true, force: true });
+            removed.push(entry);
+        } catch (exc) {
+            process.stderr.write(
+                `[council:session] prune rmtree failed for ${entry}: ${_errStr(exc)}\n`,
+            );
+        }
+    }
+    return removed;
+}
+
+/**
+ * Delete files and timestamp-less directories older than `retention_days`.
+ *
+ * mtime-based — used for `agents/runtime/council/questions/`,
+ * `agents/runtime/council/responses/`, and root-level files in
+ * `agents/runtime/council/sessions/` that don't match the
+ * timestamp-subdir convention handled by `prune_old_sessions`.
+ *
+ * Walks the directory non-recursively. For files: deletes when
+ * mtime predates the cutoff. For sub-directories without a
+ * timestamp name: deletes recursively when mtime predates the
+ * cutoff. Never raises — disk failures log to stderr.
+ *
+ * Returns the list of deleted paths. `retention_days <= 0`
+ * disables pruning and returns an empty list.
+ */
+export function prune_old_artifacts(
+    artifact_dir: string,
+    retention_days: number,
+    opts: { now?: Date | null } = {},
+): string[] {
+    const now = opts.now ?? null;
+    if (retention_days <= 0 || !fs.existsSync(artifact_dir)) {
+        return [];
+    }
+    const cutoffMs = (now ? now.getTime() : Date.now()) - retention_days * 86400000;
+    const cutoffTs = cutoffMs / 1000;
+    const removed: string[] = [];
+    const names = _safeReaddir(artifact_dir, 'artifact iterdir');
+    if (names === null) {
+        return removed;
+    }
+    for (const name of names) {
+        const entry = path.join(artifact_dir, name);
+        const isDir = _isDir(entry);
+        // Timestamp subdirs are owned by prune_old_sessions; skip them
+        // so the two pruners don't race.
+        if (isDir && _parse_session_timestamp(name) !== null) {
+            continue;
+        }
+        let mtime: number;
+        try {
+            mtime = fs.statSync(entry).mtimeMs / 1000;
+        } catch (exc) {
+            process.stderr.write(
+                `[council:session] artifact stat failed for ${entry}: ${_errStr(exc)}\n`,
+            );
+            continue;
+        }
+        if (mtime >= cutoffTs) {
+            continue;
+        }
+        try {
+            if (isDir) {
+                fs.rmSync(entry, { recursive: true, force: true });
+            } else {
+                fs.rmSync(entry);
+            }
+            removed.push(entry);
+        } catch (exc) {
+            process.stderr.write(
+                `[council:session] artifact remove failed for ${entry}: ${_errStr(exc)}\n`,
+            );
+        }
+    }
+    return removed;
+}
+
+/**
+ * Prune every council artefact dir under `repo_root` in one pass.
+ *
+ * Reads `retention_days` from settings if not supplied. Used by the
+ * `task council-prune` target and by `save()`. Never raises.
+ *
+ * Returns a dict keyed by directory label — `sessions`,
+ * `questions`, `responses` — each mapped to the list of
+ * paths actually removed.
+ */
+export function prune_all_council_artifacts(
+    retention_days: number | null = null,
+    opts: { repo_root?: string | null; now?: Date | null } = {},
+): Record<string, string[]> {
+    const root = opts.repo_root ?? REPO_ROOT;
+    const now = opts.now ?? null;
+    const days = retention_days === null ? _load_retention_days() : retention_days;
+    const sessions = path.join(root, 'agents', 'runtime', 'council', 'sessions');
+    const questions = path.join(root, 'agents', 'runtime', 'council', 'questions');
+    const responses = path.join(root, 'agents', 'runtime', 'council', 'responses');
+    return {
+        sessions: [
+            ...prune_old_sessions(sessions, days, { now }),
+            ...prune_old_artifacts(sessions, days, { now }),
+        ],
+        questions: prune_old_artifacts(questions, days, { now }),
+        responses: prune_old_artifacts(responses, days, { now }),
+    };
+}
+
+/**
+ * Persist a council call. Returns the session directory.
+ *
+ * `responses` accepts either:
+ * - `CouncilResponse[]` — single round (round 1 only).
+ * - `CouncilResponse[][]` — multi-round, one list per round in execution
+ *   order.
+ *
+ * `retention_days` controls auto-pruning of older council artefacts
+ * after the new one is written — sibling sessions plus, when
+ * `sessions_dir` is not overridden, files in `runtime/council/questions/`
+ * and `runtime/council/responses/`. `null` reads the value
+ * from `.agent-settings.yml` (`ai_council.session_retention_days`,
+ * default `7`); `0` disables pruning.
+ *
+ * Disk-write failures are surfaced via a stderr line but do not
+ * raise; the caller's text report is the source of truth.
+ */
+export function save(opts: {
+    manifest: SessionManifest;
+    responses: CouncilResponse[] | CouncilResponse[][];
+    sessions_dir?: string | null;
+    timestamp?: string | null;
+    retention_days?: number | null;
+}): string {
+    const manifest = opts.manifest;
+    const responses = opts.responses;
+    const sessions_dir = opts.sessions_dir ?? null;
+    const timestamp = opts.timestamp ?? null;
+    const retention_days = opts.retention_days ?? null;
+
+    let rounds_data: CouncilResponse[][];
+    if (
+        responses.length > 0 &&
+        Array.isArray(responses) &&
+        responses[0] instanceof CouncilResponse
+    ) {
+        rounds_data = [responses as CouncilResponse[]];
+    } else {
+        rounds_data = responses as CouncilResponse[][];
+    }
+
+    const base = sessions_dir ?? SESSIONS_DIR;
+    const ts = timestamp ?? _utc_timestamp();
+    const session_dir = path.join(base, ts);
+
+    try {
+        fs.mkdirSync(session_dir, { recursive: true });
+    } catch (exc) {
+        process.stderr.write(`[council:session] mkdir failed: ${_errStr(exc)}\n`);
+        return session_dir;
+    }
+
+    const manifest_payload: Record<string, unknown> = {
+        timestamp_utc: ts,
+        mode: manifest.mode,
+        artefact: manifest.artefact,
+        original_ask: manifest.original_ask,
+        members: manifest.members,
+        rounds: manifest.rounds,
+        cost_usd_estimated: new PyFloat(_pyRound6(manifest.cost_usd_estimated)),
+        cost_usd_actual: new PyFloat(_pyRound6(manifest.cost_usd_actual)),
+        responses_per_round: rounds_data.map((round_responses) =>
+            round_responses.map((r) => _serialise_response(r)),
+        ),
+        ...manifest.extra,
+    };
+
+    try {
+        fs.writeFileSync(
+            path.join(session_dir, 'manifest.json'),
+            py_json_dumps_indent2(manifest_payload) + '\n',
+            { encoding: 'utf-8' },
+        );
+        // Render uses the LAST round (the moderator-facing summary).
+        const last_round: CouncilResponse[] =
+            rounds_data.length > 0 ? (rounds_data[rounds_data.length - 1] as CouncilResponse[]) : [];
+        fs.writeFileSync(path.join(session_dir, 'response.md'), render(last_round) + '\n', {
+            encoding: 'utf-8',
+        });
+        const raw_blocks: string[] = [];
+        rounds_data.forEach((round_responses, idx) => {
+            const round_idx = idx + 1;
+            for (const r of round_responses) {
+                raw_blocks.push(
+                    `=== round ${round_idx} · ${r.provider}/${r.model} ===\n\n` + `${r.text}\n`,
+                );
+            }
+        });
+        fs.writeFileSync(
+            path.join(session_dir, 'raw-text.md'),
+            raw_blocks.join('\n') + (raw_blocks.length > 0 ? '\n' : ''),
+            { encoding: 'utf-8' },
+        );
+    } catch (exc) {
+        process.stderr.write(`[council:session] write failed: ${_errStr(exc)}\n`);
+    }
+
+    const days = retention_days === null ? _load_retention_days() : retention_days;
+    prune_old_sessions(base, days);
+    prune_old_artifacts(base, days);
+    // In production (no sessions_dir override), also prune the sibling
+    // council artefact dirs so questions/responses aren't left as dead
+    // weight. Tests that pass an explicit sessions_dir stay isolated
+    // from the wider tree.
+    if (sessions_dir === null) {
+        prune_old_artifacts(QUESTIONS_DIR, days);
+        prune_old_artifacts(RESPONSES_DIR, days);
+    }
+
+    return session_dir;
+}
+
+/** Mirror Python `round(value, 6)` via the canonical `value_ladder` primitive. */
+function _pyRound6(value: number): number {
+    return pyRound(value, 6);
+}

--- a/src/scripts/council_prune.ts
+++ b/src/scripts/council_prune.ts
@@ -1,0 +1,153 @@
+/**
+ * Manual pruner for council artefacts.
+ *
+ * TypeScript twin of `src/scripts/council_prune.py` (ADR-094 — Python→TS
+ * migration, Phase 1).
+ *
+ * Deletes council files older than `ai_council.session_retention_days`
+ * (default 7) across all four artefact directories:
+ *
+ *   - agents/runtime/council/sessions/   (timestamp subdirs + root files)
+ *   - agents/runtime/council/questions/  (mtime-based)
+ *   - agents/runtime/council/responses/  (mtime-based)
+ *
+ * Same logic as the auto-prune that runs on every `council save()`,
+ * exposed as a Task target so the user can sweep on demand.
+ *
+ * Invocation (from project root):
+ *   ./scripts-run src/scripts/council_prune [--days N] [--dry-run]
+ *
+ * Exit code 0 always — pruning is a hygiene operation, never a build
+ * gate. Disk failures are logged to stderr by the underlying pruner.
+ *
+ * Parity notes:
+ * - `argparse` → hand-rolled parser matching the two options (`--days`,
+ *   `--dry-run`); arg errors exit 2 with the argparse-shaped usage line.
+ * - `_load_retention_days` / `prune_all_council_artifacts` import the
+ *   `./ai_council/session` twin (a `.ts` MUST NOT import a `.py`).
+ * - `raise SystemExit(main())` → `process.exitCode = main()` (never
+ *   `process.exit`).
+ */
+
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { _load_retention_days, prune_all_council_artifacts } from './ai_council/session.js';
+
+function _prog(): string {
+    return 'council_prune.py';
+}
+
+class _ExitSignal extends Error {
+    constructor(readonly code: number) {
+        super(`exit ${code}`);
+    }
+}
+
+const _USAGE = `usage: ${_prog()} [-h] [--days DAYS] [--dry-run]`;
+
+const _HELP =
+    `${_USAGE}\n\n` +
+    'Manual pruner for council artefacts.\n\n' +
+    'optional arguments:\n' +
+    '  -h, --help   show this help message and exit\n' +
+    '  --days DAYS  Override retention_days (default: from .agent-settings.yml)\n' +
+    '  --dry-run    List what would be deleted without removing anything.\n';
+
+function _argError(message: string): never {
+    process.stderr.write(`${_USAGE}\n`);
+    process.stderr.write(`${_prog()}: error: ${message}\n`);
+    process.exitCode = 2;
+    throw new _ExitSignal(2);
+}
+
+interface _Args {
+    days: number | null;
+    dry_run: boolean;
+}
+
+/** Mirror argparse `type=int` for `--days` — int literal or error exit 2. */
+function _parseDays(raw: string): number {
+    const s = raw.trim();
+    if (/^[+-]?\d+$/.test(s)) {
+        return Number.parseInt(s, 10);
+    }
+    _argError(`argument --days: invalid int value: '${raw}'`);
+}
+
+function _parseArgs(args: string[]): _Args {
+    let days: number | null = null;
+    let dry_run = false;
+    for (let i = 0; i < args.length; i += 1) {
+        const a = args[i] as string;
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(_HELP);
+            throw new _ExitSignal(0);
+        } else if (a === '--days') {
+            const v = args[i + 1];
+            if (v === undefined) {
+                _argError('argument --days: expected one argument');
+            }
+            days = _parseDays(v as string);
+            i += 1;
+        } else if (a.startsWith('--days=')) {
+            days = _parseDays(a.slice('--days='.length));
+        } else if (a === '--dry-run') {
+            dry_run = true;
+        } else {
+            _argError(`unrecognized arguments: ${a}`);
+        }
+    }
+    return { days, dry_run };
+}
+
+export function main(argv: string[]): number {
+    let args: _Args;
+    try {
+        args = _parseArgs(argv);
+    } catch (exc) {
+        if (exc instanceof _ExitSignal) {
+            return exc.code;
+        }
+        throw exc;
+    }
+
+    const days = args.days !== null ? args.days : _load_retention_days();
+    if (days <= 0) {
+        process.stdout.write(`council-prune: retention_days=${days} → pruning disabled.\n`);
+        return 0;
+    }
+
+    if (args.dry_run) {
+        // The pruner doesn't have a true dry-run mode; we approximate
+        // by reporting current contents and the cutoff.
+        process.stdout.write(`council-prune: dry-run, cutoff = retention_days=${days}\n`);
+        process.stdout.write('council-prune: actual deletion requires omitting --dry-run\n');
+        return 0;
+    }
+
+    process.stdout.write(`council-prune: retention_days=${days}\n`);
+    const result = prune_all_council_artifacts(days);
+    let total = 0;
+    for (const label of Object.keys(result)) {
+        const removed = result[label] as string[];
+        if (removed.length > 0) {
+            process.stdout.write(`  ${label}: ${removed.length} pruned\n`);
+            for (const p of removed) {
+                process.stdout.write(`    - ${p}\n`);
+            }
+            total += removed.length;
+        }
+    }
+    if (total === 0) {
+        process.stdout.write('council-prune: nothing to prune.\n');
+    } else {
+        process.stdout.write(`council-prune: pruned ${total} entries total.\n`);
+    }
+    return 0;
+}
+
+const _isMain = import.meta.url === pathToFileURL(path.resolve(process.argv[1] ?? '')).href;
+if (_isMain) {
+    process.exitCode = main(process.argv.slice(2));
+}

--- a/tests/scripts/ai_council/low_impact.test.ts
+++ b/tests/scripts/ai_council/low_impact.test.ts
@@ -1,0 +1,633 @@
+// Tests for src/scripts/ai_council/low_impact.ts (py2ts Phase 1, ADR-094).
+//
+// low_impact is the lightweight-QA fast-path resolver: it narrows the council
+// fan-out to opted-in members, caps spend, runs one round, and stamps a
+// transparency marker. It is a pure library (no __main__ / argparse / stdout)
+// — so there is no `--help` surface to byte-compare. Parity is asserted on the
+// public surfaces with STUBBED transport.
+//
+// The load-bearing contract is the `fast-path-marker-visibility` Iron Law: the
+// four markers (resolved / unavailable / split / aborted) are reproduced
+// BYTE-FOR-BYTE. Each is asserted exactly against the live Python twin.
+//
+// Transport stub: tests subclass `ExternalAIClient` (TS) / build duck-typed
+// mock objects (Python) whose `ask()` returns a canned `CouncilResponse`
+// without any live network call — mirroring how clients.ts seams the
+// transport. Members are duck-typed `MemberConfig`-shaped objects; the config
+// is a duck-typed `LowImpactFastPathConfig`-shaped object (only max_members /
+// max_tokens / max_cost_usd are read by the planner).
+//
+// Golden parity drives the LIVE Python twin via a `python3 -c` importlib
+// direct-file load. low_impact.py imports its siblings at module top
+// (`from scripts.ai_council...`), so the loader runs with PYTHONPATH=src:.
+// (mirroring pyproject `pythonpath = ["src", "."]`); the siblings lazy-import
+// their SDKs inside `ask()`, so no network at import time.
+//
+// Normalisation (ADR-094):
+// - The clock is injected (`now=...`) on both sides → the ISO8601 timestamp in
+//   the session-log line is deterministic; no timestamp normalisation needed.
+// - `latency_ms` never reaches a compared surface (markers + log line don't
+//   carry it).
+// - One intentional divergence (cited at its assertion): the `client raised:
+//   <repr>` member-error string differs between Python `RuntimeError('boom')`
+//   and JS `Error('boom')`. It is NOT a marker surface — the aborted marker
+//   carries only `members tried: <names>`, so every compared marker stays
+//   byte-identical. The error-string field itself is asserted structurally
+//   (prefix + member), not byte-compared, for that one path.
+import { spawnSync } from 'node:child_process';
+
+import { describe, expect, it } from 'vitest';
+
+import { CouncilResponse, ExternalAIClient } from '../../../src/scripts/ai_council/clients.js';
+import type { LowImpactFastPathConfig, MemberConfig } from '../../../src/scripts/ai_council/config.js';
+import {
+    build_fast_path_budget,
+    classify_impact_with_corpus_fuzzy,
+    FastPathPlan,
+    LowImpactStats,
+    parse_low_impact_log,
+    plan_fast_path,
+    render_low_impact_stats,
+    resolve_low_impact,
+    select_fast_path_members,
+} from '../../../src/scripts/ai_council/low_impact.js';
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const py3 = hasPython3();
+
+// ── Python driver: importlib direct-file load + duck-typed mock member ────
+//
+// `Mem` is a MemberConfig-shaped duck; `Cfg` a LowImpactFastPathConfig-shaped
+// duck; `Mock` an ExternalAIClient-shaped duck whose ask() returns a canned
+// response. A fixed clock is passed so the session-log timestamp is stable.
+const PY_PREAMBLE = `
+import importlib.util, sys, json
+from datetime import datetime, timezone
+_spec = importlib.util.spec_from_file_location("li", "src/scripts/ai_council/low_impact.py")
+li = importlib.util.module_from_spec(_spec)
+sys.modules["li"] = li
+_spec.loader.exec_module(li)
+from scripts.ai_council.clients import CouncilResponse
+
+class Mem:
+    def __init__(self, name, enabled=True, pli=True):
+        self.name = name; self.enabled = enabled; self.participate_low_impact = pli
+        self.model = "m"; self.api_key_ref = None
+
+class Cfg:
+    def __init__(self, max_members=2, max_tokens=400, max_cost_usd=0.05):
+        self.max_members = max_members; self.max_tokens = max_tokens
+        self.max_cost_usd = max_cost_usd
+
+class Mock:
+    def __init__(self, name, model="m", text="", err=None, it=10, ot=20, raises=False):
+        self.name = name; self.model = model; self._t = text; self._e = err
+        self._it = it; self._ot = ot; self._raises = raises
+        self.billable = True; self.transport = "api"; self.subscription_label = ""
+    def ask(self, sp, up, max_tokens=None):
+        if self._raises:
+            raise RuntimeError("boom")
+        return CouncilResponse(provider=self.name, model=self.model, text=self._t,
+                               error=self._e, input_tokens=self._it, output_tokens=self._ot)
+
+FIXED = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+CLOCK = lambda: FIXED
+`;
+
+function py(snippet: string): string {
+    const code = `${PY_PREAMBLE}\n${snippet}`;
+    const r = spawnSync('python3', ['-c', code], {
+        encoding: 'utf8',
+        env: { ...process.env, PYTHONPATH: ['src', '.'].join(':') },
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+// ── TS stubs (mirror the Python ducks) ───────────────────────────────────
+
+function mem(name: string, enabled = true, pli = true): MemberConfig {
+    return {
+        name,
+        enabled,
+        participate_low_impact: pli,
+        model: 'm',
+        api_key_ref: null,
+        mode: null,
+        binary: null,
+        model_ladder: [],
+    };
+}
+
+function cfg(max_members = 2, max_tokens = 400, max_cost_usd = 0.05): LowImpactFastPathConfig {
+    return {
+        max_members,
+        max_rounds: 1,
+        max_tokens,
+        max_cost_usd,
+        // `build_fast_path_budget` never reads fuzzy_match; cast to keep the
+        // duck minimal (mirrors the Python `Cfg` which omits it too).
+    } as unknown as LowImpactFastPathConfig;
+}
+
+interface MockArgs {
+    model?: string;
+    text?: string;
+    error?: string | null;
+    it?: number;
+    ot?: number;
+    raises?: boolean;
+}
+
+class Mock extends ExternalAIClient {
+    private readonly _t: string;
+    private readonly _e: string | null;
+    private readonly _it: number;
+    private readonly _ot: number;
+    private readonly _raises: boolean;
+
+    constructor(name: string, args: MockArgs = {}) {
+        super();
+        this.name = name;
+        this.model = args.model ?? 'm';
+        this._t = args.text ?? '';
+        this._e = args.error ?? null;
+        this._it = args.it ?? 10;
+        this._ot = args.ot ?? 20;
+        this._raises = args.raises ?? false;
+    }
+
+    override ask(): CouncilResponse {
+        if (this._raises) {
+            throw new Error('boom');
+        }
+        return new CouncilResponse({
+            provider: this.name,
+            model: this.model,
+            text: this._t,
+            error: this._e,
+            input_tokens: this._it,
+            output_tokens: this._ot,
+        });
+    }
+}
+
+// Fixed UTC clock matching the Python `FIXED` instant 2026-01-02T03:04:05Z.
+const CLOCK = (): Date => new Date(Date.UTC(2026, 0, 2, 3, 4, 5));
+
+// ───────────────────────────────────────────────────────────────────────
+// The four markers — byte-for-byte parity (the Iron-Law surface).
+// ───────────────────────────────────────────────────────────────────────
+
+describe('low_impact — fast-path markers (byte-for-byte)', () => {
+    it('UNAVAILABLE marker — no opted-in members', () => {
+        const plan = plan_fast_path({}, cfg());
+        const res = resolve_low_impact('q', plan, {});
+        expect(res.status).toBe('unavailable');
+        expect(res.marker).toBe(
+            '> Low-impact council unavailable (no opted-in members) — escalating to user.',
+        );
+        expect(res.session_log_line).toBe('');
+    });
+
+    it.runIf(py3)('UNAVAILABLE marker matches python3', () => {
+        const plan = plan_fast_path({}, cfg());
+        const res = resolve_low_impact('q', plan, {});
+        const out = py(
+            'plan = li.plan_fast_path({}, Cfg())\n' +
+                'r = li.resolve_low_impact("q", plan, {})\n' +
+                'print(json.dumps({"status": r.status, "marker": r.marker, "log": r.session_log_line}))\n',
+        );
+        expect({ status: res.status, marker: res.marker, log: res.session_log_line }).toEqual(
+            JSON.parse(out),
+        );
+    });
+
+    it('RESOLVED marker — single member', () => {
+        const plan = plan_fast_path({ anthropic: mem('anthropic') }, cfg(1));
+        const clients = { anthropic: new Mock('anthropic', { text: 'use a DTO\nclearer contract' }) };
+        const res = resolve_low_impact('dto or array?', plan, clients, null, CLOCK);
+        expect(res.status).toBe('resolved');
+        expect(res.marker).toBe(
+            '> Resolved via low-impact council fast-path: single-member answer.',
+        );
+        expect(res.answer).toBe('use a DTO\nclearer contract');
+    });
+
+    it('RESOLVED marker — 2-member consensus', () => {
+        const plan = plan_fast_path({ anthropic: mem('anthropic'), openai: mem('openai') }, cfg(2));
+        const clients = {
+            anthropic: new Mock('anthropic', { text: 'Use a DTO.\nClearer.' }),
+            openai: new Mock('openai', { text: 'use a dto\ndifferent rationale' }),
+        };
+        const res = resolve_low_impact('dto?', plan, clients, null, CLOCK);
+        expect(res.status).toBe('resolved');
+        expect(res.marker).toBe(
+            '> Resolved via low-impact council fast-path: 2-member consensus.',
+        );
+    });
+
+    it('SPLIT marker — 2 members disagree', () => {
+        const plan = plan_fast_path({ anthropic: mem('anthropic'), openai: mem('openai') }, cfg(2));
+        const clients = {
+            anthropic: new Mock('anthropic', { text: 'use a DTO' }),
+            openai: new Mock('openai', { text: 'use an array' }),
+        };
+        const res = resolve_low_impact('dto?', plan, clients, null, CLOCK);
+        expect(res.status).toBe('split');
+        expect(res.marker).toBe(
+            '> Low-impact council split — escalating to user (anthropic: use a DTO / openai: use an array):',
+        );
+    });
+
+    it('ABORTED marker — all members failed', () => {
+        const plan = plan_fast_path({ anthropic: mem('anthropic'), openai: mem('openai') }, cfg(2));
+        const clients = {
+            anthropic: new Mock('anthropic', { error: 'rate limited' }),
+            openai: new Mock('openai', { text: '' }), // empty → error "empty response"
+        };
+        const res = resolve_low_impact('dto?', plan, clients, null, CLOCK);
+        expect(res.status).toBe('aborted');
+        expect(res.marker).toBe(
+            '> Low-impact council aborted (all members failed) — escalating to user: members tried: anthropic, openai.',
+        );
+    });
+
+    it.runIf(py3)('all four markers + answer + log match python3', () => {
+        // Drive resolved(single), resolved(consensus), split, aborted on both
+        // sides with the SAME stubbed transport + fixed clock.
+        const tsCases: unknown[] = [];
+
+        // resolved single
+        {
+            const plan = plan_fast_path({ a: mem('a') }, cfg(1));
+            const r = resolve_low_impact('q', plan, { a: new Mock('a', { text: 'ans\nwhy' }) }, null, CLOCK);
+            tsCases.push({ status: r.status, marker: r.marker, answer: r.answer, log: r.session_log_line });
+        }
+        // resolved consensus
+        {
+            const plan = plan_fast_path({ a: mem('a'), b: mem('b') }, cfg(2));
+            const r = resolve_low_impact(
+                'q',
+                plan,
+                { a: new Mock('a', { text: 'Yes.\nx' }), b: new Mock('b', { text: 'yes\ny' }) },
+                null,
+                CLOCK,
+            );
+            tsCases.push({ status: r.status, marker: r.marker, answer: r.answer, log: r.session_log_line });
+        }
+        // split
+        {
+            const plan = plan_fast_path({ a: mem('a'), b: mem('b') }, cfg(2));
+            const r = resolve_low_impact(
+                'q',
+                plan,
+                { a: new Mock('a', { text: 'yes' }), b: new Mock('b', { text: 'no' }) },
+                null,
+                CLOCK,
+            );
+            tsCases.push({ status: r.status, marker: r.marker, answer: r.answer, log: r.session_log_line });
+        }
+        // aborted
+        {
+            const plan = plan_fast_path({ a: mem('a'), b: mem('b') }, cfg(2));
+            const r = resolve_low_impact(
+                'q',
+                plan,
+                { a: new Mock('a', { error: 'rate limited' }), b: new Mock('b', { text: '' }) },
+                null,
+                CLOCK,
+            );
+            tsCases.push({ status: r.status, marker: r.marker, answer: r.answer, log: r.session_log_line });
+        }
+
+        const out = py(
+            'cases = []\n' +
+                'plan = li.plan_fast_path({"a": Mem("a")}, Cfg(max_members=1))\n' +
+                'r = li.resolve_low_impact("q", plan, {"a": Mock("a", text="ans\\nwhy")}, now=CLOCK)\n' +
+                'cases.append({"status": r.status, "marker": r.marker, "answer": r.answer, "log": r.session_log_line})\n' +
+                'plan = li.plan_fast_path({"a": Mem("a"), "b": Mem("b")}, Cfg(max_members=2))\n' +
+                'r = li.resolve_low_impact("q", plan, {"a": Mock("a", text="Yes.\\nx"), "b": Mock("b", text="yes\\ny")}, now=CLOCK)\n' +
+                'cases.append({"status": r.status, "marker": r.marker, "answer": r.answer, "log": r.session_log_line})\n' +
+                'plan = li.plan_fast_path({"a": Mem("a"), "b": Mem("b")}, Cfg(max_members=2))\n' +
+                'r = li.resolve_low_impact("q", plan, {"a": Mock("a", text="yes"), "b": Mock("b", text="no")}, now=CLOCK)\n' +
+                'cases.append({"status": r.status, "marker": r.marker, "answer": r.answer, "log": r.session_log_line})\n' +
+                'plan = li.plan_fast_path({"a": Mem("a"), "b": Mem("b")}, Cfg(max_members=2))\n' +
+                'r = li.resolve_low_impact("q", plan, {"a": Mock("a", err="rate limited"), "b": Mock("b", text="")}, now=CLOCK)\n' +
+                'cases.append({"status": r.status, "marker": r.marker, "answer": r.answer, "log": r.session_log_line})\n' +
+                'print(json.dumps(cases))\n',
+        );
+        expect(tsCases).toEqual(JSON.parse(out));
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Planner surfaces — plan marker, budget, member selection.
+// ───────────────────────────────────────────────────────────────────────
+
+describe('low_impact — plan_fast_path / select / budget', () => {
+    it('selects enabled+opted-in, alphabetical, truncated to max_members', () => {
+        const members = {
+            zeta: mem('zeta'),
+            alpha: mem('alpha'),
+            beta_off: mem('beta', false, true),
+            gamma_noopt: mem('gamma', true, false),
+        };
+        const picked = select_fast_path_members(members, cfg(2)).map((m) => m.name);
+        expect(picked).toEqual(['alpha', 'zeta']);
+    });
+
+    it('budget — 60/40 split, max_calls=max_members', () => {
+        const b = build_fast_path_budget(cfg(2, 400, 0.05));
+        expect(b.max_input_tokens).toBe(240); // int(400*0.6)
+        expect(b.max_output_tokens).toBe(160);
+        expect(b.max_calls).toBe(2);
+        expect(b.max_total_usd).toBeCloseTo(0.05, 12);
+    });
+
+    it('plan marker (resolvable) + reason (unavailable)', () => {
+        const plan = plan_fast_path({ openai: mem('openai'), anthropic: mem('anthropic') }, cfg(2, 400, 0.05));
+        expect(plan.is_resolvable).toBe(true);
+        expect(plan.marker).toBe('[fast-path: 2 members (anthropic, openai) · cap $0.05 · 400 tokens]');
+
+        const none = plan_fast_path({ a: mem('a', true, false) }, cfg());
+        expect(none.is_resolvable).toBe(false);
+        expect(none.marker).toBe('');
+        expect(none.reason).toContain('participate_low_impact: true');
+    });
+
+    it.runIf(py3)('plan marker + budget fields match python3', () => {
+        const plan = plan_fast_path({ openai: mem('openai'), anthropic: mem('anthropic') }, cfg(1, 250, 0.123));
+        const tsView = {
+            marker: plan.marker,
+            members: plan.members.map((m) => m.name),
+            in: plan.budget.max_input_tokens,
+            out: plan.budget.max_output_tokens,
+            calls: plan.budget.max_calls,
+            usd: plan.budget.max_total_usd,
+        };
+        const out = py(
+            'plan = li.plan_fast_path({"openai": Mem("openai"), "anthropic": Mem("anthropic")}, Cfg(max_members=1, max_tokens=250, max_cost_usd=0.123))\n' +
+                'print(json.dumps({"marker": plan.marker, "members": [m.name for m in plan.members],' +
+                ' "in": plan.budget.max_input_tokens, "out": plan.budget.max_output_tokens,' +
+                ' "calls": plan.budget.max_calls, "usd": plan.budget.max_total_usd}))\n',
+        );
+        expect(tsView).toEqual(JSON.parse(out));
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Cost-cap abort — over-budget answer is refused.
+// ───────────────────────────────────────────────────────────────────────
+
+describe('low_impact — cost cap', () => {
+    // A duck-typed price table: charges $1/1M tokens both ways.
+    const priceTable = {
+        lookup() {
+            return { input_per_1m_usd: 1_000_000, output_per_1m_usd: 1_000_000 };
+        },
+    };
+
+    it('over-budget member → aborted (no ok answer survives)', () => {
+        const plan = plan_fast_path({ a: mem('a') }, cfg(1, 400, 0.01));
+        // it=10, ot=20 → cost = 30 USD ≫ cap 0.01 → refused, no ok answer.
+        const res = resolve_low_impact('q', plan, { a: new Mock('a', { text: 'x' }) }, priceTable, CLOCK);
+        expect(res.status).toBe('aborted');
+        expect(res.marker).toBe(
+            '> Low-impact council aborted (all members failed) — escalating to user: members tried: a.',
+        );
+    });
+
+    it.runIf(py3)('cost-cap abort matches python3', () => {
+        const plan = plan_fast_path({ a: mem('a') }, cfg(1, 400, 0.01));
+        const res = resolve_low_impact('q', plan, { a: new Mock('a', { text: 'x' }) }, priceTable, CLOCK);
+        const out = py(
+            'class PT:\n' +
+                '    def lookup(self, p, m):\n' +
+                '        class P: input_per_1m_usd = 1000000; output_per_1m_usd = 1000000\n' +
+                '        return P()\n' +
+                'plan = li.plan_fast_path({"a": Mem("a")}, Cfg(max_members=1, max_tokens=400, max_cost_usd=0.01))\n' +
+                'r = li.resolve_low_impact("q", plan, {"a": Mock("a", text="x")}, price_table=PT(), now=CLOCK)\n' +
+                'print(json.dumps({"status": r.status, "marker": r.marker}))\n',
+        );
+        expect({ status: res.status, marker: res.marker }).toEqual(JSON.parse(out));
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Missing-client + raising-client (the one cited divergence).
+// ───────────────────────────────────────────────────────────────────────
+
+describe('low_impact — member failure paths', () => {
+    it('missing client → recorded as failure, aborted marker stays byte-stable', () => {
+        const plan = plan_fast_path({ a: mem('a') }, cfg(1));
+        const res = resolve_low_impact('q', plan, {}, null, CLOCK); // no client for "a"
+        expect(res.status).toBe('aborted');
+        expect(res.answers[0]!.error).toBe('no client instantiated');
+        expect(res.marker).toBe(
+            '> Low-impact council aborted (all members failed) — escalating to user: members tried: a.',
+        );
+    });
+
+    it('raising client → error recorded (repr divergence is non-marker)', () => {
+        const plan = plan_fast_path({ a: mem('a') }, cfg(1));
+        const res = resolve_low_impact('q', plan, { a: new Mock('a', { raises: true }) }, null, CLOCK);
+        expect(res.status).toBe('aborted');
+        // INTENTIONAL DIVERGENCE (ADR-094): the `client raised: <repr>` string
+        // differs (Python `RuntimeError('boom')` vs JS `Error('boom')`). It is
+        // NOT a marker surface, so the aborted marker stays byte-identical —
+        // assert the error structurally, the marker byte-for-byte.
+        expect(res.answers[0]!.error).toMatch(/^client raised: /);
+        expect(res.marker).toBe(
+            '> Low-impact council aborted (all members failed) — escalating to user: members tried: a.',
+        );
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Stats parse / render over the session-log shape.
+// ───────────────────────────────────────────────────────────────────────
+
+describe('low_impact — parse_low_impact_log / render_low_impact_stats', () => {
+    const LOG = [
+        '# header that should be skipped',
+        '2026-01-02T03:04:05Z | resolved | members=1/1 | members(anthropic) cost=$0.0010 | Q=dto?',
+        '2026-01-02T03:04:06Z | split | members=2/2 | members(anthropic, openai) cost=$0.0500 | Q=array?',
+        'not a log line at all',
+        '2026-01-02T03:04:07Z | resolved | members=2/2 | members(openai, anthropic) cost=$0.0000 | Q=trait?',
+    ].join('\n');
+
+    it('parses counts + sorted maps + rounded cost', () => {
+        const stats = parse_low_impact_log(LOG);
+        expect(stats.total).toBe(3);
+        expect(Object.fromEntries(stats.by_status)).toEqual({ resolved: 2, split: 1 });
+        expect(Object.fromEntries(stats.by_member)).toEqual({ anthropic: 3, openai: 2 });
+        expect(stats.total_cost_usd).toBeCloseTo(0.051, 12);
+        // insertion order = sorted-key order
+        expect([...stats.by_status.keys()]).toEqual(['resolved', 'split']);
+        expect([...stats.by_member.keys()]).toEqual(['anthropic', 'openai']);
+    });
+
+    it('renders the summary block', () => {
+        const stats = parse_low_impact_log(LOG);
+        const rendered = render_low_impact_stats(stats);
+        expect(rendered).toBe(
+            '# Low-impact fast-path · session summary\n' +
+                '\n' +
+                '- attempts: 3\n' +
+                '- status: resolved=2 · split=1\n' +
+                '- members: anthropic=3 · openai=2\n' +
+                '- total cost: $0.0510\n',
+        );
+    });
+
+    it('empty body → zeroed stats + (none) status', () => {
+        const stats = parse_low_impact_log('');
+        expect(stats.total).toBe(0);
+        const rendered = render_low_impact_stats(stats);
+        expect(rendered).toBe(
+            '# Low-impact fast-path · session summary\n\n- attempts: 0\n- status: (none)\n- total cost: $0.0000\n',
+        );
+    });
+
+    it.runIf(py3)('parse + render match python3', () => {
+        const stats = parse_low_impact_log(LOG);
+        const tsView = {
+            total: stats.total,
+            by_status: Object.fromEntries(stats.by_status),
+            by_member: Object.fromEntries(stats.by_member),
+            cost: stats.total_cost_usd,
+            rendered: render_low_impact_stats(stats),
+        };
+        const out = py(
+            `log = ${JSON.stringify(LOG)}\n` +
+                's = li.parse_low_impact_log(log)\n' +
+                'print(json.dumps({"total": s.total, "by_status": s.by_status,' +
+                ' "by_member": s.by_member, "cost": s.total_cost_usd,' +
+                ' "rendered": li.render_low_impact_stats(s)}))\n',
+        );
+        expect(tsView).toEqual(JSON.parse(out));
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Stats class — direct construction (insertion-order semantics).
+// ───────────────────────────────────────────────────────────────────────
+
+describe('low_impact — LowImpactStats render', () => {
+    it('no members → members line omitted', () => {
+        const stats = new LowImpactStats({
+            total: 1,
+            by_status: new Map([['aborted', 1]]),
+            by_member: new Map(),
+            total_cost_usd: 0,
+        });
+        expect(render_low_impact_stats(stats)).toBe(
+            '# Low-impact fast-path · session summary\n\n- attempts: 1\n- status: aborted=1\n- total cost: $0.0000\n',
+        );
+    });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// Fuzzy corpus classifier — Iron-Law precedence + vetoes.
+// ───────────────────────────────────────────────────────────────────────
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+describe('low_impact — classify_impact_with_corpus_fuzzy', () => {
+    function writeCorpus(validated: string[], anti: string[]): { dir: string; file: string } {
+        const dir = mkdtempSync(path.join(tmpdir(), 'li-corpus-'));
+        const file = path.join(dir, 'low-impact-decisions.md');
+        const body = [
+            '## Validated',
+            '',
+            ...validated.map((v) => `- "${v}"`),
+            '',
+            '## Anti-Examples (Always Ask User)',
+            '',
+            ...anti.map((a) => `- "${a}"`),
+            '',
+        ].join('\n');
+        writeFileSync(file, body, 'utf8');
+        return { dir, file };
+    }
+
+    it('no corpus → base verdict', async () => {
+        const v = await classify_impact_with_corpus_fuzzy('use a dto vs array', null);
+        // "dto" is a low_impact trigger → base is already low_impact.
+        expect(v.impact_class).toBe('low_impact');
+        expect(v.category).not.toBe('corpus_validated_fuzzy');
+    });
+
+    it('locked class (high_impact) skips fuzzy entirely', async () => {
+        const { dir, file } = writeCorpus(['rotate the secret api key'], []);
+        try {
+            const v = await classify_impact_with_corpus_fuzzy('rotate the secret api key', [file]);
+            expect(v.impact_class).toBe('high_impact'); // veto never reached; base locked
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('near-paraphrase of a Validated phrase → corpus_validated_fuzzy', async () => {
+        const { dir, file } = writeCorpus(['use composition over inheritance here'], []);
+        try {
+            const v = await classify_impact_with_corpus_fuzzy(
+                'use composition over inheritance here.',
+                [file],
+                { threshold: 0.9 },
+            );
+            expect(v.impact_class).toBe('low_impact');
+            expect(v.category).toBe('corpus_validated_fuzzy');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it.runIf(py3)('fuzzy classifier matches python3 across cases', async () => {
+        const { dir, file } = writeCorpus(
+            ['use composition over inheritance here', 'prefer a value object for money'],
+            ['drop the production database now'],
+        );
+        try {
+            const cases: Array<{ q: string; th: number }> = [
+                { q: 'use composition over inheritance here.', th: 0.9 },
+                { q: 'totally unrelated sentence about widgets', th: 0.9 },
+                { q: 'prefer a value object for money', th: 0.92 },
+                { q: '', th: 0.9 },
+            ];
+            const tsView = [];
+            for (const c of cases) {
+                const v = await classify_impact_with_corpus_fuzzy(c.q, [file], { threshold: c.th });
+                tsView.push({
+                    cls: v.impact_class,
+                    conf: v.confidence,
+                    rationale: v.rationale,
+                    category: v.category,
+                });
+            }
+            const out = py(
+                `casesj = ${JSON.stringify(cases)}\n` +
+                    `corpus = ${JSON.stringify(file)}\n` +
+                    'res = []\n' +
+                    'for c in casesj:\n' +
+                    '    v = li.classify_impact_with_corpus_fuzzy(c["q"], (corpus,), threshold=c["th"])\n' +
+                    '    res.append({"cls": v.impact_class, "conf": v.confidence,' +
+                    ' "rationale": v.rationale, "category": v.category})\n' +
+                    'print(json.dumps(res))\n',
+            );
+            expect(tsView).toEqual(JSON.parse(out));
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+// A no-op reference so `FastPathPlan` import is exercised by the type system.
+void FastPathPlan;

--- a/tests/scripts/ai_council/session.test.ts
+++ b/tests/scripts/ai_council/session.test.ts
@@ -1,0 +1,480 @@
+// Tests for src/scripts/ai_council/session.ts (py2ts Phase 1, ADR-094).
+//
+// session persists a council call to a sessions dir: manifest.json (JSON),
+// response.md (orchestrator.render output), raw-text.md (concatenated raw
+// member text). It also prunes old session subdirs (timestamp-named) and old
+// root files / non-timestamp dirs (mtime-based).
+//
+// Golden parity: every write/list/prune case runs the REAL python3 package
+// path (`_harness` PYTHONPATH wires `src` + repo root, matching pyproject) and
+// the tsx twin on identical tmp fixtures with a pinned timestamp + pinned
+// `now`, then asserts BYTE-IDENTICAL written/pruned artefacts and the same
+// `removed` ordering. session imports clients + orchestrator siblings, so the
+// Python side exercises the real merged twins.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CouncilResponse } from '../../../src/scripts/ai_council/clients.js';
+import {
+    SessionManifest,
+    prune_all_council_artifacts,
+    prune_old_artifacts,
+    prune_old_sessions,
+    save,
+} from '../../../src/scripts/ai_council/session.js';
+import { hasPython3, runPyCode } from './_harness.js';
+
+const py3 = hasPython3();
+
+// ── tmp-dir bookkeeping ────────────────────────────────────────────────────
+const _tmpDirs: string[] = [];
+
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'session-ts-'));
+    _tmpDirs.push(d);
+    return d;
+}
+
+afterEach(() => {
+    for (const d of _tmpDirs.splice(0)) {
+        fs.rmSync(d, { recursive: true, force: true });
+    }
+});
+
+// ── Shared fixtures ────────────────────────────────────────────────────────
+// A declarative spec consumed identically by both runtimes for the save() case.
+
+interface RespSpec {
+    provider: string;
+    model: string;
+    text: string;
+    input_tokens?: number;
+    output_tokens?: number;
+    latency_ms?: number;
+    error?: string | null;
+    metadata?: Record<string, unknown>;
+}
+
+interface SaveSpec {
+    manifest: {
+        mode: string;
+        artefact: string;
+        original_ask: string;
+        members: string[];
+        rounds: number;
+        cost_usd_estimated: number;
+        cost_usd_actual: number;
+        extra: Record<string, unknown>;
+    };
+    rounds: RespSpec[][];
+    timestamp: string;
+}
+
+const SAVE_SPEC: SaveSpec = {
+    manifest: {
+        mode: 'prompt',
+        artefact: '<inline>',
+        // Non-ASCII (é, ü) exercises ensure_ascii=True \uXXXX escaping.
+        original_ask: 'Should we adopt the new café architecture? — über',
+        members: ['anthropic/claude-sonnet-4-5', 'openai/gpt-4o'],
+        rounds: 2,
+        // Integer-valued float must render 0.0 (PyFloat), non-integer keeps digits.
+        cost_usd_estimated: 0.5,
+        cost_usd_actual: 0.0,
+        extra: { preamble_fingerprint: 'abc123', nested: { k: 1, list: [1, 2, 3] } },
+    },
+    rounds: [
+        [
+            {
+                provider: 'anthropic',
+                model: 'claude-sonnet-4-5',
+                text: 'Round-1 anthropic text with é and a newline\nsecond line',
+                input_tokens: 1200,
+                output_tokens: 340,
+                latency_ms: 4521,
+                error: null,
+                metadata: {
+                    transport: 'cli',
+                    billable: false,
+                    tokens_estimated: true,
+                    subscription_label: 'claude-pro',
+                    cost_usd: 0.0,
+                },
+            },
+            {
+                provider: 'openai',
+                model: 'gpt-4o',
+                text: 'Round-1 openai text',
+                input_tokens: 900,
+                output_tokens: 210,
+                latency_ms: 3300,
+                error: null,
+                metadata: { transport: 'api', cost_usd: 0.004215 },
+            },
+        ],
+        [
+            {
+                provider: 'anthropic',
+                model: 'claude-sonnet-4-5',
+                text: 'Round-2 synthesis line',
+                input_tokens: 400,
+                output_tokens: 120,
+                latency_ms: 2100,
+                error: null,
+            },
+            {
+                provider: 'openai',
+                model: 'gpt-4o',
+                text: 'Round-2 openai with an error',
+                input_tokens: 0,
+                output_tokens: 0,
+                latency_ms: 50,
+                error: 'rate_limited',
+                metadata: { transport: 'api' },
+            },
+        ],
+    ],
+    timestamp: '2026-06-14T12-00-00Z',
+};
+
+// Single-round (flat list) spec — exercises the `list[CouncilResponse]` branch.
+const SINGLE_ROUND_SPEC: SaveSpec = {
+    manifest: {
+        mode: 'diff',
+        artefact: 'agents/roadmaps/road-to-x.md',
+        original_ask: '',
+        members: ['openai/gpt-4o'],
+        rounds: 1,
+        cost_usd_estimated: 0.0,
+        cost_usd_actual: 0.123456,
+        extra: {},
+    },
+    rounds: [
+        [
+            {
+                provider: 'openai',
+                model: 'gpt-4o',
+                text: 'solo verdict',
+            },
+        ],
+    ],
+    timestamp: '2026-01-02T03-04-05Z',
+};
+
+// Empty responses — render([]) + empty raw-text.md.
+const EMPTY_SPEC: SaveSpec = {
+    manifest: {
+        mode: 'files',
+        artefact: '<inline>',
+        original_ask: 'nothing',
+        members: [],
+        rounds: 1,
+        cost_usd_estimated: 0.0,
+        cost_usd_actual: 0.0,
+        extra: {},
+    },
+    rounds: [[]],
+    timestamp: '2025-12-31T23-59-59Z',
+};
+
+function buildTsResponses(rounds: RespSpec[][]): CouncilResponse[][] {
+    return rounds.map((round) =>
+        round.map((r) => {
+            // Build opts with only the present optional fields so
+            // exactOptionalPropertyTypes is satisfied (mirrors the Python
+            // `.get(k, default)` defaults handled inside CouncilResponse).
+            const opts: ConstructorParameters<typeof CouncilResponse>[0] = {
+                provider: r.provider,
+                model: r.model,
+                text: r.text,
+                error: r.error ?? null,
+            };
+            if (r.input_tokens !== undefined) opts.input_tokens = r.input_tokens;
+            if (r.output_tokens !== undefined) opts.output_tokens = r.output_tokens;
+            if (r.latency_ms !== undefined) opts.latency_ms = r.latency_ms;
+            if (r.metadata !== undefined) opts.metadata = r.metadata;
+            return new CouncilResponse(opts);
+        }),
+    );
+}
+
+/** Run the TS twin's save() into `base` for `spec`. */
+function tsSave(spec: SaveSpec, base: string): string {
+    const manifest = new SessionManifest({
+        mode: spec.manifest.mode,
+        artefact: spec.manifest.artefact,
+        original_ask: spec.manifest.original_ask,
+        members: spec.manifest.members,
+        rounds: spec.manifest.rounds,
+        cost_usd_estimated: spec.manifest.cost_usd_estimated,
+        cost_usd_actual: spec.manifest.cost_usd_actual,
+        extra: spec.manifest.extra,
+    });
+    return save({
+        manifest,
+        responses: buildTsResponses(spec.rounds),
+        sessions_dir: base,
+        timestamp: spec.timestamp,
+        retention_days: 0, // disable pruning so save() is write-only here
+    });
+}
+
+/** Run the python3 twin's save() into `base` for `spec` (real package path). */
+function pySave(spec: SaveSpec, base: string): void {
+    const code = [
+        'import sys, json',
+        'from pathlib import Path',
+        'from scripts.ai_council import session as S',
+        'from scripts.ai_council.clients import CouncilResponse',
+        'spec = json.loads(sys.stdin.read())',
+        'base = Path(sys.argv[1])',
+        'def mk(r):',
+        '    return CouncilResponse(provider=r["provider"], model=r["model"], text=r["text"],',
+        '        input_tokens=r.get("input_tokens", 0), output_tokens=r.get("output_tokens", 0),',
+        '        latency_ms=r.get("latency_ms", 0), error=r.get("error"),',
+        '        metadata=r.get("metadata") or {})',
+        'rounds = [[mk(r) for r in rnd] for rnd in spec["rounds"]]',
+        'm = spec["manifest"]',
+        // JSON has no int/float distinction, so a `0.0` fixture value arrives
+        // as a Python int after json.loads — coerce the cost fields to float
+        // to mirror session.py's float contract (the round(...) call would
+        // otherwise emit `0` not `0.0`).
+        'man = S.SessionManifest(mode=m["mode"], artefact=m["artefact"],',
+        '    original_ask=m["original_ask"], members=m["members"], rounds=m["rounds"],',
+        '    cost_usd_estimated=float(m["cost_usd_estimated"]),',
+        '    cost_usd_actual=float(m["cost_usd_actual"]),',
+        '    extra=m["extra"])',
+        'S.save(manifest=man, responses=rounds, sessions_dir=base,',
+        '    timestamp=spec["timestamp"], retention_days=0)',
+    ].join('\n');
+    const r = runPyCode(code, [base], { input: JSON.stringify(spec) });
+    if (r.status !== 0) {
+        throw new Error(`python3 save failed: ${r.stderr}`);
+    }
+}
+
+function readArtefact(base: string, ts: string, name: string): string {
+    return fs.readFileSync(path.join(base, ts, name), { encoding: 'utf-8' });
+}
+
+describe.runIf(py3)('session.save — byte-parity with python3', () => {
+    for (const [label, spec] of [
+        ['multi-round', SAVE_SPEC],
+        ['single-round flat list', SINGLE_ROUND_SPEC],
+        ['empty responses', EMPTY_SPEC],
+    ] as const) {
+        it(`writes identical manifest/response/raw-text — ${label}`, () => {
+            const tsBase = mkTmp();
+            const pyBase = mkTmp();
+            const tsDir = tsSave(spec, tsBase);
+            pySave(spec, pyBase);
+
+            expect(path.basename(tsDir)).toBe(spec.timestamp);
+            for (const f of ['manifest.json', 'response.md', 'raw-text.md']) {
+                const tsContent = readArtefact(tsBase, spec.timestamp, f);
+                const pyContent = readArtefact(pyBase, spec.timestamp, f);
+                expect(tsContent, `${f} byte-parity`).toBe(pyContent);
+            }
+        });
+    }
+});
+
+// ── Prune parity ────────────────────────────────────────────────────────────
+// Seed an identical fixture tree in two tmp roots, prune both at a pinned
+// `now`, and assert the same `removed` ordering AND the same survivors.
+
+interface PruneSpec {
+    // timestamp-named session subdirs (each gets a manifest.json child)
+    sessionDirs: string[];
+    // root-level files in sessions/ with an mtime epoch (seconds)
+    sessionRootFiles: Array<{ name: string; mtime: number }>;
+    questionFiles: Array<{ name: string; mtime: number }>;
+    responseFiles: Array<{ name: string; mtime: number }>;
+    retentionDays: number;
+    nowEpochMs: number;
+}
+
+const OLD_MTIME = Date.UTC(2020, 0, 1, 0, 0, 0) / 1000; // far in the past
+const NEW_MTIME = Date.UTC(2099, 0, 1, 0, 0, 0) / 1000; // far in the future
+const NOW_MS = Date.UTC(2026, 5, 14, 12, 0, 0);
+
+const PRUNE_SPEC: PruneSpec = {
+    sessionDirs: [
+        '2020-01-01T00-00-00Z', // old → pruned
+        '2099-01-01T00-00-00Z', // new → kept
+        '2026-06-10T00-00-00Z', // within 7-day window of now → kept
+        'not-a-timestamp', // non-matching dir name → skipped by prune_old_sessions, mtime by artifacts
+    ],
+    sessionRootFiles: [
+        { name: 'report-old.json', mtime: OLD_MTIME },
+        { name: 'report-new.json', mtime: NEW_MTIME },
+    ],
+    questionFiles: [
+        { name: 'q-old.md', mtime: OLD_MTIME },
+        { name: 'q-new.md', mtime: NEW_MTIME },
+    ],
+    responseFiles: [
+        { name: 'r-old.json', mtime: OLD_MTIME },
+        { name: 'r-new.json', mtime: NEW_MTIME },
+    ],
+    retentionDays: 7,
+    nowEpochMs: NOW_MS,
+};
+
+function seedPruneFixture(root: string, spec: PruneSpec): void {
+    const sessions = path.join(root, 'agents', 'runtime', 'council', 'sessions');
+    const questions = path.join(root, 'agents', 'runtime', 'council', 'questions');
+    const responses = path.join(root, 'agents', 'runtime', 'council', 'responses');
+    fs.mkdirSync(sessions, { recursive: true });
+    fs.mkdirSync(questions, { recursive: true });
+    fs.mkdirSync(responses, { recursive: true });
+    for (const name of spec.sessionDirs) {
+        const d = path.join(sessions, name);
+        fs.mkdirSync(d, { recursive: true });
+        fs.writeFileSync(path.join(d, 'manifest.json'), '{}\n');
+        if (name === 'not-a-timestamp') {
+            // mtime-based: make it old so prune_old_artifacts removes it.
+            fs.utimesSync(d, OLD_MTIME, OLD_MTIME);
+        }
+    }
+    const writeWithMtime = (dir: string, f: { name: string; mtime: number }): void => {
+        const p = path.join(dir, f.name);
+        fs.writeFileSync(p, `${f.name}\n`);
+        fs.utimesSync(p, f.mtime, f.mtime);
+    };
+    for (const f of spec.sessionRootFiles) writeWithMtime(sessions, f);
+    for (const f of spec.questionFiles) writeWithMtime(questions, f);
+    for (const f of spec.responseFiles) writeWithMtime(responses, f);
+}
+
+/** Run TS prune_all_council_artifacts; return removed-by-label + survivors. */
+function tsPrune(root: string, spec: PruneSpec): { removed: string[]; survivors: string[] } {
+    const res = prune_all_council_artifacts(spec.retentionDays, {
+        repo_root: root,
+        now: new Date(spec.nowEpochMs),
+    });
+    const removed: string[] = [];
+    for (const label of Object.keys(res)) {
+        for (const p of res[label] as string[]) {
+            removed.push(`${label}: ${path.basename(p)}`);
+        }
+    }
+    return { removed, survivors: survivorList(root) };
+}
+
+/** Run python3 prune_all_council_artifacts; return removed-by-label + survivors. */
+function pyPrune(root: string, spec: PruneSpec): { removed: string[]; survivors: string[] } {
+    const code = [
+        'import sys, json, datetime as dt',
+        'from pathlib import Path',
+        'from scripts.ai_council import session as S',
+        'root = Path(sys.argv[1])',
+        'spec = json.loads(sys.stdin.read())',
+        'now = dt.datetime.fromtimestamp(spec["nowEpochMs"] / 1000, tz=dt.timezone.utc)',
+        'res = S.prune_all_council_artifacts(retention_days=spec["retentionDays"],',
+        '    repo_root=root, now=now)',
+        'out = []',
+        'for label in res:',
+        '    for p in res[label]:',
+        '        out.append(f"{label}: {Path(p).name}")',
+        'sys.stdout.write("\\n".join(out))',
+    ].join('\n');
+    const r = runPyCode(code, [root], { input: JSON.stringify(spec) });
+    if (r.status !== 0) {
+        throw new Error(`python3 prune failed: ${r.stderr}`);
+    }
+    const removed = r.stdout.length > 0 ? r.stdout.split('\n') : [];
+    return { removed, survivors: survivorList(root) };
+}
+
+function survivorList(root: string): string[] {
+    const dir = path.join(root, 'agents');
+    const out: string[] = [];
+    const walk = (p: string): void => {
+        for (const name of fs.readdirSync(p).sort()) {
+            const child = path.join(p, name);
+            const rel = path.relative(root, child);
+            if (fs.statSync(child).isDirectory()) {
+                walk(child);
+            } else {
+                out.push(rel);
+            }
+        }
+    };
+    walk(dir);
+    return out.sort();
+}
+
+describe.runIf(py3)('session.prune_all_council_artifacts — parity with python3', () => {
+    it('removes the same paths in the same order and leaves the same survivors', () => {
+        const tsRoot = mkTmp();
+        const pyRoot = mkTmp();
+        seedPruneFixture(tsRoot, PRUNE_SPEC);
+        seedPruneFixture(pyRoot, PRUNE_SPEC);
+
+        const tsRes = tsPrune(tsRoot, PRUNE_SPEC);
+        const pyRes = pyPrune(pyRoot, PRUNE_SPEC);
+
+        // The set of removed paths must match. NOTE: session.py iterates each
+        // dir via `Path.iterdir()`, whose order is OS-/filesystem-dependent
+        // and therefore not a Python guarantee (macOS APFS readdir order ≠
+        // CPython scandir order). The faithful invariant is the same *set* of
+        // removals + identical survivors, not a specific intra-dir order, so we
+        // compare sorted (the per-dir removal order is genuinely
+        // non-deterministic in the original too).
+        expect([...tsRes.removed].sort()).toEqual([...pyRes.removed].sort());
+        // Whatever survived must be identical sets.
+        expect(tsRes.survivors).toEqual(pyRes.survivors);
+        // Sanity: the old artefacts are gone, the new ones remain.
+        expect(tsRes.removed).toContain('sessions: 2020-01-01T00-00-00Z');
+        expect(tsRes.removed).toContain('sessions: report-old.json');
+        expect(tsRes.removed).toContain('sessions: not-a-timestamp');
+        expect(tsRes.removed).toContain('questions: q-old.md');
+        expect(tsRes.removed).toContain('responses: r-old.json');
+    });
+
+    it('retention_days <= 0 disables pruning (no removals)', () => {
+        const tsRoot = mkTmp();
+        const pyRoot = mkTmp();
+        const disabled: PruneSpec = { ...PRUNE_SPEC, retentionDays: 0 };
+        seedPruneFixture(tsRoot, disabled);
+        seedPruneFixture(pyRoot, disabled);
+        const tsRes = tsPrune(tsRoot, disabled);
+        const pyRes = pyPrune(pyRoot, disabled);
+        expect(tsRes.removed).toEqual([]);
+        expect(pyRes.removed).toEqual([]);
+        expect(tsRes.survivors).toEqual(pyRes.survivors);
+    });
+});
+
+// ── Unit-level behaviour (no python3 needed) ────────────────────────────────
+
+describe('session.prune_old_sessions — unit', () => {
+    it('returns [] for a missing sessions dir', () => {
+        expect(prune_old_sessions(path.join(mkTmp(), 'nope'), 7)).toEqual([]);
+    });
+
+    it('skips non-timestamp directory names', () => {
+        const base = mkTmp();
+        fs.mkdirSync(path.join(base, 'custom-folder'));
+        fs.mkdirSync(path.join(base, '2020-01-01T00-00-00Z'));
+        const removed = prune_old_sessions(base, 7, { now: new Date(NOW_MS) });
+        expect(removed.map((p) => path.basename(p))).toEqual(['2020-01-01T00-00-00Z']);
+        expect(fs.existsSync(path.join(base, 'custom-folder'))).toBe(true);
+    });
+});
+
+describe('session.prune_old_artifacts — unit', () => {
+    it('skips timestamp subdirs (owned by prune_old_sessions)', () => {
+        const base = mkTmp();
+        const tsDir = path.join(base, '2020-01-01T00-00-00Z');
+        fs.mkdirSync(tsDir);
+        fs.utimesSync(tsDir, OLD_MTIME, OLD_MTIME);
+        const removed = prune_old_artifacts(base, 7, { now: new Date(NOW_MS) });
+        expect(removed).toEqual([]);
+        expect(fs.existsSync(tsDir)).toBe(true);
+    });
+});

--- a/tests/scripts/council_prune.test.ts
+++ b/tests/scripts/council_prune.test.ts
@@ -1,0 +1,80 @@
+// Tests for src/scripts/council_prune.ts (py2ts Phase 1, ADR-094).
+//
+// council_prune is the manual CLI wrapper around session.prune_all_council_
+// artifacts. Exit code is always 0 for the operational paths; arg errors exit
+// 2 with the argparse-shaped usage + error lines.
+//
+// Golden parity: run the REAL python3 script and the tsx twin with identical
+// argv and assert byte-identical stdout/stderr + exit code for the
+// side-effect-free paths (--days 0 → disabled, --dry-run, bad args). Per the
+// migration convention we do NOT byte-compare the full --help prose — only the
+// exit code and the usage line. The default (no --days) path is intentionally
+// not exercised here because it prunes the real working tree; the prune logic
+// itself is covered by session.test.ts against tmp fixtures.
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { hasPython3, runPyScript, runTsScript } from './ai_council/_harness.js';
+
+const py3 = hasPython3();
+
+// tests/scripts/council_prune.test.ts → two levels up is the repo root.
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+
+function runPy(args: string[]): { status: number; stdout: string; stderr: string } {
+    const r = runPyScript('council_prune', args, { cwd: REPO_ROOT });
+    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+}
+
+function runTs(args: string[]): { status: number; stdout: string; stderr: string } {
+    const r = runTsScript('council_prune', args, { cwd: REPO_ROOT });
+    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+}
+
+const USAGE = 'usage: council_prune.py [-h] [--days DAYS] [--dry-run]';
+
+describe.runIf(py3)('council_prune CLI — byte-parity with python3', () => {
+    for (const [label, args] of [
+        ['--days 0 (pruning disabled)', ['--days', '0']],
+        ['--days -1 (pruning disabled)', ['--days', '-1']],
+        ['--days 7 --dry-run', ['--days', '7', '--dry-run']],
+        ['--days=7 --dry-run (=-form)', ['--days=7', '--dry-run']],
+    ] as const) {
+        it(`exit + stdout + stderr identical — ${label}`, () => {
+            const py = runPy([...args]);
+            const ts = runTs([...args]);
+            expect(ts.status, 'exit code').toBe(py.status);
+            expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
+            expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+            // Operational paths always exit 0.
+            expect(ts.status).toBe(0);
+        });
+    }
+
+    it('--help: exit 0 + usage line (prose not byte-compared per convention)', () => {
+        const py = runPy(['--help']);
+        const ts = runTs(['--help']);
+        expect(ts.status).toBe(0);
+        expect(py.status).toBe(0);
+        expect(ts.stdout.split('\n')[0]).toBe(USAGE);
+        expect(py.stdout.split('\n')[0]).toBe(USAGE);
+    });
+
+    for (const [label, args] of [
+        ['unrecognized arg', ['--bogus']],
+        ['bad --days int value', ['--days', 'abc']],
+        ['--days missing value', ['--days']],
+    ] as const) {
+        it(`arg error: exit 2 + identical usage/error lines — ${label}`, () => {
+            const py = runPy([...args]);
+            const ts = runTs([...args]);
+            expect(ts.status, 'exit code').toBe(2);
+            expect(py.status, 'exit code').toBe(2);
+            // argparse writes usage + a `prog: error: …` line to stderr.
+            expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+            expect(ts.stderr.split('\n')[0]).toBe(USAGE);
+        });
+    }
+});


### PR DESCRIPTION
Penultimate ai_council wave. Targets `python2ts`. `.py` originals stay until Phase 12.

## Twins (3)
- `ai_council/session` (366) — session lifecycle + retention pruning (→clients/orchestrator).
- `council_prune` (81) — the CLI session pruner (→the new session.ts).
- `ai_council/low_impact` (714) — the low-impact council fast-path (→clients/config/low_impact_corpus/necessity/orchestrator). All four `fast-path-marker-visibility` Iron-Law markers reproduced **byte-for-byte**; `difflib.SequenceMatcher.ratio` ported faithfully.

40 tests (python3-differential; markers byte-identical). legacy-literal ts==py for all 3. tsc clean, phase-gate passes. **663/663 across the full ai_council + council_prune twin suite.**

## Remaining ai_council — the final piece
Only `council_cli` (2571 LOC — the council entrypoint; imports `low_impact` + the whole cluster, all now merged) remains. It gets its own dedicated wave; after it lands, ai_council is fully twinned (the `_one_off_*` scripts are Phase-12 deletion candidates, not ports).

## Verification
`tsc` clean · phase-gate passes · 663/663 · python3-differential byte-match (incl. all 4 fast-path markers) · legacy 0==0. Migration-gates 4-shard run validates on this PR's CI.