### PR TITLE
feat(py2ts): phase 9 — work_engine foundation (8 twins: _lib + state + 5 core)

### DIFF
--- a/dist/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
+++ b/dist/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
@@ -1,0 +1,1107 @@
+/**
+ * Centralized loader for `.agent-settings.yml` with user-global fallback.
+ *
+ * TypeScript twin of `src/scripts/_lib/agent_settings.py` (ADR-094,
+ * Phase 2 / Wave 2a). Mirrors the Python module's public API exactly —
+ * same exported snake_case names, same semantics, same cascade / anchor /
+ * whitelist / merge behavior, same YAML load tolerance, same error types.
+ * Single source of truth for how scripts read agent settings.
+ *
+ * Resolution order (deepest wins; user-global is whitelist-filtered only):
+ *
+ *   N.   `~/.event4u/agent-config/agent-settings.yml` (user-global; whitelist only)
+ *   N-1. `<repo-root>/.agent-settings.yml`            (project-wide; all keys)
+ *   N-2. `<intermediate-dir>/.agent-settings.yml`     (subsystem-scoped; all keys)
+ *   1.   `<CWD>/.agent-settings.yml`                  (deepest, wins; all keys)
+ *
+ * The user-global path is resolved via the sibling `user_global_paths`
+ * twin with a read-fallback to the legacy `~/.config/agent-config/`
+ * location so pre-2.4 installs keep working during the migration.
+ *
+ * `<repo-root>` is the nearest ancestor that anchors the project
+ * (closest-leaf wins; tiebreaker `.agent-settings.yml` > `agents/` > `.git`):
+ *
+ * - `.agent-settings.yml` file,
+ * - `agents/` directory containing `roadmaps/`, `settings/.ai-council.yml`,
+ *   or `roadmaps-progress.md` (bare `agents/` does NOT anchor),
+ * - `.git` file or directory (submodule support).
+ *
+ * Set `AGENT_CONFIG_LEGACY_ANCHOR=1` to revert to the pre-Step-7
+ * `.git`-only walk for one minor-version soak. When `cwd` is `null`
+ * (default), the loader behaves identically to the pre-cascade
+ * contract: project file + user-global only, no ancestor walk.
+ *
+ * Contract — pure, read-only, tolerant:
+ *
+ * - YAML parse failure / unreadable file → defaults, logged at WARNING.
+ * - Missing files → defaults.
+ * - No file is ever created or written by this module.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import * as user_global_paths from './user_global_paths.js';
+
+/** JSON-ish value type — mirrors Python's `Any` for settings data. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SettingsValue = any;
+export type SettingsDict = Record<string, SettingsValue>;
+
+/**
+ * Module logger sink. Mirrors `logging.getLogger(__name__)` so tests can
+ * capture INFO/WARNING records the same way `caplog` does in pytest.
+ *
+ * Records are appended to `logger.records` and also emitted to the real
+ * sink (`console.info` / `console.warn`) so production behavior matches
+ * Python's logging. `name` mirrors the Python logger name used by tests.
+ */
+export interface LogRecord {
+    level: 'INFO' | 'WARNING';
+    message: string;
+}
+
+class Logger {
+    readonly name = 'scripts._lib.agent_settings';
+    readonly records: LogRecord[] = [];
+
+    info(message: string, ...args: SettingsValue[]): void {
+        this.records.push({ level: 'INFO', message: _format(message, args) });
+    }
+
+    warning(message: string, ...args: SettingsValue[]): void {
+        this.records.push({ level: 'WARNING', message: _format(message, args) });
+    }
+}
+
+/** printf-style `%s` interpolation mirroring Python's logging args. */
+function _format(template: string, args: SettingsValue[]): string {
+    let i = 0;
+    return template.replace(/%s/g, () => {
+        if (i < args.length) {
+            const value = args[i];
+            i += 1;
+            return _pystr(value);
+        }
+        return '%s';
+    });
+}
+
+/** Python-ish `str()` of a value for log messages (lists render `[...]`). */
+function _pystr(value: SettingsValue): string {
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => _pyrepr(v)).join(', ')}]`;
+    }
+    return String(value);
+}
+
+function _pyrepr(value: SettingsValue): string {
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}
+
+export const logger = new Logger();
+
+export const DEFAULT_PROJECT_FILE = '.agent-settings.yml';
+/**
+ * Per-machine override file. Gitignored. A SINGLE project-level file
+ * living under `agents/settings/` — appended as the deepest cascade
+ * layer so a developer's local values override every committed
+ * `.agent-settings.yml` without ever being committed. Missing file is
+ * harmless (read as {}).
+ */
+export const LOCAL_PROJECT_FILE = '.agent-settings.local.yml';
+/** Project-relative directory the local override lives in. */
+export const LOCAL_PROJECT_SUBDIR: readonly string[] = ['agents', 'settings'];
+
+/** Single local override: `<root>/agents/settings/.agent-settings.local.yml`. */
+function _local_settings_path(project_root: string): string {
+    return path.join(project_root, ...LOCAL_PROJECT_SUBDIR, LOCAL_PROJECT_FILE);
+}
+
+/**
+ * Canonical project settings file:
+ * `<root>/agents/settings/.agent-settings.yml`.
+ *
+ * The project settings file lives in the project's settings layer
+ * (`agents/settings/`), NOT at the repo root. The repo-root
+ * `.agent-settings.yml` is a legacy location read only as a back-compat
+ * fallback (see `project_settings_path`).
+ */
+function _canonical_settings_path(project_root: string): string {
+    return path.join(project_root, ...LOCAL_PROJECT_SUBDIR, DEFAULT_PROJECT_FILE);
+}
+
+/**
+ * Resolve the project settings file for **reading**.
+ *
+ * Returns the canonical `agents/settings/.agent-settings.yml` when it
+ * exists; otherwise the legacy repo-root `.agent-settings.yml` when that
+ * exists; otherwise the canonical path. Existence-checked, never writes.
+ */
+export function project_settings_path(project_root: string): string {
+    const canonical = _canonical_settings_path(project_root);
+    if (_exists(canonical)) {
+        return canonical;
+    }
+    const legacy = path.join(project_root, DEFAULT_PROJECT_FILE);
+    if (_exists(legacy)) {
+        return legacy;
+    }
+    return canonical;
+}
+
+/**
+ * Always the canonical **write** target:
+ * `agents/settings/.agent-settings.yml`.
+ *
+ * Writers (install, sync, migrate) target this unconditionally; the
+ * legacy root file is migrated into it, never written afresh.
+ */
+export function canonical_settings_write_path(project_root: string): string {
+    return _canonical_settings_path(project_root);
+}
+
+export const DEFAULT_TEAM_FILE = '.agent-project-settings.yml';
+export const USER_GLOBAL_FILENAME = 'agent-settings.yml';
+
+/**
+ * Canonical write target under the new `~/.event4u/agent-config/`
+ * namespace. Reads route through `_resolve_user_global_file` so pre-2.4
+ * installs are still picked up from `~/.config/agent-config/` until the
+ * migration shim copies them across.
+ *
+ * NOTE: This is a function, not a constant, because tests need it to
+ * follow `$HOME` / env overrides at call time (Python recomputes it via
+ * the loader, but exposes `DEFAULT_USER_GLOBAL_FILE` as a module
+ * attribute that the test for `defaults_resolve_when_neither_argument_given`
+ * monkeypatches). The differential pattern uses the function value;
+ * tests inject a path directly.
+ */
+export function DEFAULT_USER_GLOBAL_FILE(): string {
+    return user_global_paths.write_target(USER_GLOBAL_FILENAME);
+}
+
+/** Return the active user-global settings path with legacy fallback. */
+function _resolve_user_global_file(): string {
+    const found = user_global_paths.resolve_with_fallback(USER_GLOBAL_FILENAME);
+    if (found !== null) {
+        return found;
+    }
+    return DEFAULT_USER_GLOBAL_FILE();
+}
+
+/**
+ * Exact dotted paths allowed to cascade from user-global into the merged
+ * settings. Anything not listed here is silently ignored when present in
+ * the user-global file. Adding a key requires an ADR.
+ */
+export const MERGEABLE_KEYS: readonly string[] = [
+    'name',
+    'ide',
+    'rule_loading_tier',
+    'memory.cadence',
+    'personal.bot_icon',
+    'personal.autonomy',
+    'telegraph.speak_scope',
+];
+
+const _DEFAULTS: SettingsDict = {};
+
+/**
+ * Defaults applied by `get_modules_config` when a key is absent from both
+ * the team file and the developer cascade. Lists are returned as fresh
+ * copies — callers may mutate the result safely.
+ */
+export const MODULES_DEFAULTS: SettingsDict = {
+    enabled: false,
+    root_paths: [],
+    namespace_template: '',
+    agent_folder: 'agents',
+    skip_dirs: ['.module-template', '.example'],
+    detection_acknowledged: false,
+};
+
+/** Anchor identifier returned by `find_project_root_with_anchor`. */
+export const ANCHOR_AGENT_SETTINGS = 'agent-settings';
+export const ANCHOR_AGENTS_DIR = 'agents-dir';
+export const ANCHOR_GIT = 'git';
+
+/**
+ * Marker subpaths that qualify a bare `agents/` directory as a project
+ * anchor (D1). Any one is sufficient.
+ */
+const _AGENTS_DIR_MARKERS: readonly string[] = [
+    'roadmaps',
+    'settings/.ai-council.yml',
+    'roadmaps-progress.md',
+    '.event4u-bridge.yml',
+];
+
+/**
+ * Kill-switch (D5). When set to `"1"`, `find_project_root` /
+ * `find_project_root_with_anchor` revert to the pre-Step-7 `.git`-only
+ * walk for one minor-version soak.
+ */
+const _LEGACY_ANCHOR_ENV = 'AGENT_CONFIG_LEGACY_ANCHOR';
+
+/** `Path.exists()` — true for files, dirs, symlinks (broken or not). */
+function _exists(p: string): boolean {
+    try {
+        fs.lstatSync(p);
+        // lstat does not follow symlinks; Python's exists() does. Re-check
+        // through stat so a valid symlink target counts as existing.
+        fs.statSync(p);
+        return true;
+    } catch {
+        // lstat may succeed for a broken symlink while stat throws; Python's
+        // Path.exists() returns False for broken symlinks, matching here.
+        return false;
+    }
+}
+
+/** `Path.is_dir()`. */
+function _is_dir(p: string): boolean {
+    try {
+        return fs.statSync(p).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+/** `Path.is_file()`. */
+function _is_file(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Mirror of `Path.resolve()`: absolutize + normalize + resolve symlinks.
+ * Python's `resolve()` is `strict=False` by default — it does NOT raise
+ * on a missing path, it normalizes what it can. `fs.realpathSync` raises
+ * on a missing path, so fall back to a normalized absolute path.
+ */
+function _resolve(p: string): string {
+    const absolute = path.resolve(p);
+    try {
+        return fs.realpathSync(absolute);
+    } catch {
+        return absolute;
+    }
+}
+
+/** Ancestor chain `[start, ...parents]` mirroring `[current, *current.parents]`. */
+function _ancestor_chain(start: string): string[] {
+    const chain: string[] = [];
+    let cursor = start;
+    for (;;) {
+        chain.push(cursor);
+        const parent = path.dirname(cursor);
+        if (parent === cursor) {
+            break;
+        }
+        cursor = parent;
+    }
+    return chain;
+}
+
+/**
+ * Return the boundary-anchor name at `path` or `null`.
+ *
+ * Boundary anchors stop the walk and define the project root:
+ *
+ * - `agents/` containing a D1 marker → `"agents-dir"`
+ * - `.git` (file or directory) → `"git"`
+ *
+ * `.agent-settings.yml` is a layer marker, not a boundary anchor — it
+ * only anchors when no boundary is found in any ancestor.
+ */
+function _boundary_anchor_at(dir: string): string | null {
+    const agents_dir = path.join(dir, 'agents');
+    if (_is_dir(agents_dir)) {
+        for (const marker of _AGENTS_DIR_MARKERS) {
+            if (_exists(path.join(agents_dir, marker))) {
+                return ANCHOR_AGENTS_DIR;
+            }
+        }
+    }
+    if (_exists(path.join(dir, '.git'))) {
+        return ANCHOR_GIT;
+    }
+    return null;
+}
+
+/**
+ * Walk up from `start` and return `[root, anchor_name]` or `null`.
+ *
+ * Two-tier lookup: boundary pass (first ancestor with `.git` or an
+ * `agents/`+marker anchor, `agents/` wins ties at the same level), then a
+ * layer fallback returning the **outermost** ancestor carrying
+ * `.agent-settings.yml`. When `AGENT_CONFIG_LEGACY_ANCHOR=1`, only `.git`
+ * is considered. Pure read-only; never raises on missing paths.
+ */
+export function find_project_root_with_anchor(
+    start: string,
+): [string, string] | null {
+    const current = _exists(start) ? _resolve(start) : start;
+    const legacy = process.env[_LEGACY_ANCHOR_ENV] === '1';
+    const chain = _ancestor_chain(current);
+    if (legacy) {
+        for (const candidate of chain) {
+            if (_exists(path.join(candidate, '.git'))) {
+                return [candidate, ANCHOR_GIT];
+            }
+        }
+        return null;
+    }
+    // Boundary pass.
+    for (const candidate of chain) {
+        const anchor = _boundary_anchor_at(candidate);
+        if (anchor !== null) {
+            return [candidate, anchor];
+        }
+    }
+    // Layer fallback — outermost .agent-settings.yml wins so the cascade
+    // can layer deeper files below it.
+    let outermost: string | null = null;
+    for (const candidate of chain) {
+        if (_exists(path.join(candidate, DEFAULT_PROJECT_FILE))) {
+            outermost = candidate;
+        }
+    }
+    if (outermost !== null) {
+        return [outermost, ANCHOR_AGENT_SETTINGS];
+    }
+    return null;
+}
+
+/**
+ * Walk up from `start` and return the project root or `null`.
+ *
+ * Thin wrapper over `find_project_root_with_anchor` that drops the
+ * anchor-name component.
+ */
+export function find_project_root(start: string): string | null {
+    const result = find_project_root_with_anchor(start);
+    return result !== null ? result[0] : null;
+}
+
+/** One ancestor probe record emitted by `find_project_root_with_trace`. */
+export interface TraceRecord {
+    ancestor: string;
+    pass: 'boundary' | 'layer';
+    hit: string | null;
+    reason: string;
+}
+
+/**
+ * Walk up from `start` and return `[root, anchor, trace]`.
+ *
+ * Diagnostic variant of `find_project_root_with_anchor`. Returns the same
+ * `[root, anchor]` pair (or `[null, null]` when no anchor is found) plus
+ * an ordered list of trace records describing every ancestor probed.
+ * Pure read-only.
+ */
+export function find_project_root_with_trace(
+    start: string,
+): [string | null, string | null, TraceRecord[]] {
+    const trace: TraceRecord[] = [];
+    const current = _exists(start) ? _resolve(start) : start;
+    const legacy = process.env[_LEGACY_ANCHOR_ENV] === '1';
+    const chain = _ancestor_chain(current);
+
+    if (legacy) {
+        for (const candidate of chain) {
+            const hit = _exists(path.join(candidate, '.git'));
+            trace.push({
+                ancestor: candidate,
+                pass: 'boundary',
+                hit: hit ? ANCHOR_GIT : null,
+                reason: hit ? 'legacy: .git found' : 'legacy: no .git',
+            });
+            if (hit) {
+                return [candidate, ANCHOR_GIT, trace];
+            }
+        }
+        return [null, null, trace];
+    }
+
+    // Boundary pass — same probes as find_project_root_with_anchor.
+    for (const candidate of chain) {
+        const agents_dir = path.join(candidate, 'agents');
+        if (_is_dir(agents_dir)) {
+            for (const marker of _AGENTS_DIR_MARKERS) {
+                if (_exists(path.join(agents_dir, marker))) {
+                    trace.push({
+                        ancestor: candidate,
+                        pass: 'boundary',
+                        hit: ANCHOR_AGENTS_DIR,
+                        reason: `agents/ has ${marker}`,
+                    });
+                    return [candidate, ANCHOR_AGENTS_DIR, trace];
+                }
+            }
+        }
+        if (_exists(path.join(candidate, '.git'))) {
+            trace.push({
+                ancestor: candidate,
+                pass: 'boundary',
+                hit: ANCHOR_GIT,
+                reason: '.git present',
+            });
+            return [candidate, ANCHOR_GIT, trace];
+        }
+        trace.push({
+            ancestor: candidate,
+            pass: 'boundary',
+            hit: null,
+            reason: 'no agents/ marker, no .git',
+        });
+    }
+
+    // Layer fallback — outermost .agent-settings.yml wins.
+    let outermost: string | null = null;
+    for (const candidate of chain) {
+        const present = _exists(path.join(candidate, DEFAULT_PROJECT_FILE));
+        trace.push({
+            ancestor: candidate,
+            pass: 'layer',
+            hit: present ? ANCHOR_AGENT_SETTINGS : null,
+            reason: present
+                ? `${DEFAULT_PROJECT_FILE} present`
+                : `no ${DEFAULT_PROJECT_FILE}`,
+        });
+        if (present) {
+            outermost = candidate;
+        }
+    }
+    if (outermost !== null) {
+        return [outermost, ANCHOR_AGENT_SETTINGS, trace];
+    }
+    return [null, null, trace];
+}
+
+/**
+ * Origin tag returned by `resolve_project_root` alongside the anchor
+ * names defined above.
+ */
+export const ORIGIN_ROOT_FLAG = 'root-flag'; // --root global flag (Step 8 A3)
+export const ORIGIN_EXPLICIT = 'explicit'; // --project arg on a subcommand
+export const ORIGIN_ENV = 'env'; // AGENT_CONFIG_PROJECT_ROOT (wrapper-pinned)
+export const ORIGIN_CWD_FALLBACK = 'cwd-fallback'; // no anchor found
+
+export const PROJECT_ROOT_ENV = 'AGENT_CONFIG_PROJECT_ROOT';
+export const ROOT_OVERRIDE_ENV = 'AGENT_CONFIG_ROOT_OVERRIDE';
+
+/**
+ * Raised when an explicit project-root override points to an invalid path.
+ *
+ * `--root <path>` and `AGENT_CONFIG_PROJECT_ROOT` must fail loudly when
+ * the target does not exist or is not a directory. Callers translate this
+ * into exit code 2 (no silent CWD fallback).
+ */
+export class ProjectRootError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ProjectRootError';
+    }
+}
+
+/**
+ * Resolve `path`; throw `ProjectRootError` when invalid.
+ *
+ * `origin_label` is one of `--root`, `AGENT_CONFIG_PROJECT_ROOT`, or
+ * `--project`; surfaced verbatim in the error message.
+ */
+function _validate_root_path(p: string, origin_label: string): string {
+    const resolved = _expanduser(p);
+    if (!_exists(resolved)) {
+        throw new ProjectRootError(
+            `${origin_label} points to a path that does not exist: ${resolved}`,
+        );
+    }
+    if (!_is_dir(resolved)) {
+        throw new ProjectRootError(
+            `${origin_label} points to a non-directory: ${resolved}`,
+        );
+    }
+    return _resolve(resolved);
+}
+
+/** `Path.expanduser()` — expand a leading `~`. */
+function _expanduser(p: string): string {
+    if (p === '~') {
+        return os.homedir();
+    }
+    if (p.startsWith('~/') || (process.platform === 'win32' && p.startsWith('~\\'))) {
+        return path.join(os.homedir(), p.slice(2));
+    }
+    return p;
+}
+
+/**
+ * Return `[root, origin]` for any `cmd_*` entry point.
+ *
+ * Resolution order:
+ *
+ * 1. `AGENT_CONFIG_PROJECT_ROOT` env var with `AGENT_CONFIG_ROOT_OVERRIDE=1`
+ *    set by the master CLI's `--root` flag → `ORIGIN_ROOT_FLAG`. Fail-loud.
+ * 2. Explicit `arg` (`--project`/`--target`) → `ORIGIN_EXPLICIT`. Fail-loud.
+ * 3. `AGENT_CONFIG_PROJECT_ROOT` env (wrapper) → `ORIGIN_ENV`. Fail-loud.
+ * 4. Anchor walk from `cwd` → anchor name.
+ * 5. Fall back to `cwd` itself → `ORIGIN_CWD_FALLBACK`.
+ *
+ * Throws `ProjectRootError` when any explicit override points to a
+ * missing path or non-directory.
+ */
+export function resolve_project_root(
+    arg: string | null,
+    options: { cwd?: string | null } = {},
+): [string, string] {
+    const cwd = options.cwd ?? null;
+    if (process.env[ROOT_OVERRIDE_ENV] === '1') {
+        const env_value = process.env[PROJECT_ROOT_ENV];
+        if (env_value) {
+            return [_validate_root_path(env_value, '--root'), ORIGIN_ROOT_FLAG];
+        }
+    }
+    if (arg !== null && String(arg) !== '') {
+        return [_validate_root_path(arg, '--project'), ORIGIN_EXPLICIT];
+    }
+    const env_value = process.env[PROJECT_ROOT_ENV];
+    if (env_value) {
+        return [_validate_root_path(env_value, PROJECT_ROOT_ENV), ORIGIN_ENV];
+    }
+    const start = _resolve(cwd ?? process.cwd());
+    const walked = find_project_root_with_anchor(start);
+    if (walked !== null) {
+        return walked;
+    }
+    return [start, ORIGIN_CWD_FALLBACK];
+}
+
+/**
+ * Return the ordered cascade of in-project settings files (shallow → deep).
+ *
+ * When `cwd` is provided and `find_project_root(cwd)` succeeds, the list
+ * contains every `<dir>/.agent-settings.yml` from the repo root down to
+ * `cwd`, shallowest first, then the canonical project file under
+ * `agents/settings/`, then the per-machine local override. When `cwd` is
+ * `null` or no anchor is reached, falls back to the legacy three-path set.
+ */
+function _resolve_cascade_paths(
+    cwd: string | null,
+    project_path: string | null,
+): string[] {
+    if (cwd === null) {
+        const legacy = project_path ? project_path : DEFAULT_PROJECT_FILE;
+        const parent = path.dirname(legacy);
+        return [legacy, _canonical_settings_path(parent), _local_settings_path(parent)];
+    }
+
+    const root = find_project_root(cwd);
+    if (root === null) {
+        const legacy = project_path ? project_path : DEFAULT_PROJECT_FILE;
+        const parent = path.dirname(legacy);
+        return [legacy, _canonical_settings_path(parent), _local_settings_path(parent)];
+    }
+
+    const cwd_resolved = _resolve(cwd);
+    // Build the chain root → … → cwd (shallowest first, deepest last).
+    const chain: string[] = [];
+    let cursor = cwd_resolved;
+    for (;;) {
+        chain.push(cursor);
+        if (cursor === root) {
+            break;
+        }
+        const parent = path.dirname(cursor);
+        if (parent === cursor) {
+            break;
+        }
+        cursor = parent;
+    }
+    chain.reverse();
+    return [
+        ...chain.map((d) => path.join(d, DEFAULT_PROJECT_FILE)),
+        _canonical_settings_path(root),
+        _local_settings_path(root),
+    ];
+}
+
+/**
+ * Return the merged settings dict.
+ *
+ * `project_path` defaults to `./.agent-settings.yml` (CWD-relative).
+ * `user_global_path` defaults to the resolved user-global file. Pass
+ * `verbose=true` to log keys present in user-global that are not on the
+ * whitelist. `cwd` enables the in-project cascade. When `cwd` is `null`
+ * (default), the loader falls back to the single `project_path` behavior.
+ */
+export function load_agent_settings(
+    options: {
+        project_path?: string | null;
+        user_global_path?: string | null;
+        verbose?: boolean;
+        cwd?: string | null;
+    } = {},
+): SettingsDict {
+    const project_path = options.project_path ?? null;
+    const user_global_path = options.user_global_path ?? null;
+    const verbose = options.verbose ?? false;
+    const cwd = options.cwd ?? null;
+
+    const user_global_raw =
+        _read_yaml(user_global_path ? user_global_path : _resolve_user_global_file()) ?? {};
+
+    const [user_global_filtered, ignored] = _filter_whitelist(user_global_raw, MERGEABLE_KEYS);
+    if (verbose && ignored.length > 0) {
+        logger.info(
+            'agent_settings: ignored non-whitelisted user-global keys: %s',
+            [...ignored].sort(),
+        );
+    }
+
+    const cascade = _resolve_cascade_paths(cwd, project_path);
+
+    const merged: SettingsDict = _deep_copy_defaults(_DEFAULTS);
+    _deep_merge(merged, user_global_filtered);
+    for (const p of cascade) {
+        const layer = _read_yaml(p) ?? {};
+        if (Object.keys(layer).length > 0) {
+            _deep_merge(merged, layer);
+        }
+    }
+    return merged;
+}
+
+/**
+ * Return the merged `modules:` configuration with defaults applied.
+ *
+ * Three-tier precedence (deepest wins): `MODULES_DEFAULTS` < team file
+ * (`<project_root>/.agent-project-settings.yml`) < developer cascade
+ * (every `.agent-settings.yml`). The team layer may pin keys via a
+ * top-level `locked_keys` list of dotted paths; locked keys discard any
+ * matching developer override and emit an INFO record. Pure, read-only.
+ */
+export function get_modules_config(
+    options: {
+        project_root?: string | null;
+        team_path?: string | null;
+        project_path?: string | null;
+        cwd?: string | null;
+    } = {},
+): SettingsDict {
+    const project_root = options.project_root ?? null;
+    const team_path = options.team_path ?? null;
+    const project_path = options.project_path ?? null;
+    const cwd = options.cwd ?? null;
+
+    const cwd_resolved = cwd !== null ? cwd : process.cwd();
+
+    let team_file: string;
+    if (team_path !== null) {
+        team_file = team_path;
+    } else {
+        let root: string;
+        if (project_root !== null) {
+            root = project_root;
+        } else {
+            root = find_project_root(cwd_resolved) ?? cwd_resolved;
+        }
+        team_file = path.join(root, DEFAULT_TEAM_FILE);
+    }
+
+    const team_raw = _read_yaml(team_file) ?? {};
+    const team_modules_candidate = team_raw['modules'];
+    const team_modules: SettingsDict = _is_plain_dict(team_modules_candidate)
+        ? team_modules_candidate
+        : {};
+    const locked_keys_raw = team_raw['locked_keys'];
+    const locked_keys: string[] = Array.isArray(locked_keys_raw)
+        ? locked_keys_raw.filter((k): k is string => typeof k === 'string')
+        : [];
+
+    const dev_merged = load_agent_settings({
+        ...(project_path !== null ? { project_path } : {}),
+        ...(cwd !== null ? { cwd } : {}),
+    });
+    const dev_modules_candidate = dev_merged['modules'];
+    const dev_modules: SettingsDict = _is_plain_dict(dev_modules_candidate)
+        ? dev_modules_candidate
+        : {};
+
+    const merged: SettingsDict = _deepcopy(MODULES_DEFAULTS);
+    if (Object.keys(team_modules).length > 0) {
+        _deep_merge(merged, team_modules);
+    }
+
+    if (Object.keys(dev_modules).length > 0) {
+        for (const [key, value] of Object.entries(dev_modules)) {
+            const dotted = `modules.${key}`;
+            if (locked_keys.includes(dotted) && key in team_modules) {
+                logger.info(
+                    'agent_settings: ignoring developer override of locked key %s',
+                    dotted,
+                );
+                continue;
+            }
+            if (_is_plain_dict(value) && _is_plain_dict(merged[key])) {
+                _deep_merge(merged[key], value);
+            } else {
+                merged[key] = value;
+            }
+        }
+    }
+
+    return merged;
+}
+
+/** Discovered-module record returned by `enumerate_modules`. */
+export interface ModuleEntry {
+    name: string;
+    root_path: string;
+    module_path: string;
+    has_agent_folder: boolean;
+    agent_folder_path: string | null;
+}
+
+/**
+ * Enumerate every module under `modules.root_paths`.
+ *
+ * For each path in `modules.root_paths` (resolved relative to
+ * `project_root`), lists immediate subdirectories that survive the
+ * `modules.skip_dirs` filter and reports whether each module ships a
+ * per-module agent folder (`modules.agent_folder`, default `agents`).
+ *
+ * Returns a list sorted by `(root_path, name)`. `modules.enabled` is NOT
+ * consulted. Missing roots are skipped silently (logged at INFO). Hidden
+ * directories and `skip_dirs` entries are filtered out. Pure, read-only.
+ */
+export function enumerate_modules(
+    options: {
+        project_root?: string | null;
+        cwd?: string | null;
+        modules_config?: SettingsDict | null;
+    } = {},
+): ModuleEntry[] {
+    const project_root = options.project_root ?? null;
+    const cwd = options.cwd ?? null;
+    let modules_config = options.modules_config ?? null;
+
+    const cwd_resolved = cwd !== null ? cwd : process.cwd();
+    let root: string;
+    if (project_root !== null) {
+        root = project_root;
+    } else {
+        root = find_project_root(cwd_resolved) ?? cwd_resolved;
+    }
+    root = _resolve(root);
+
+    if (modules_config === null) {
+        modules_config = get_modules_config({ project_root: root, ...(cwd !== null ? { cwd } : {}) });
+    }
+
+    const root_paths_raw: SettingsValue[] = modules_config['root_paths'] || [];
+    const skip_dirs_raw: SettingsValue[] =
+        modules_config['skip_dirs'] || MODULES_DEFAULTS['skip_dirs'];
+    const agent_folder = String(modules_config['agent_folder'] || MODULES_DEFAULTS['agent_folder']);
+
+    const skip_dirs = new Set<string>(
+        (Array.isArray(skip_dirs_raw) ? skip_dirs_raw : [])
+            .filter((s): s is string => typeof s === 'string'),
+    );
+
+    const discovered: ModuleEntry[] = [];
+    for (const raw of Array.isArray(root_paths_raw) ? root_paths_raw : []) {
+        if (typeof raw !== 'string' || raw.trim() === '') {
+            continue;
+        }
+        const root_rel = _strip_slashes(raw.trim());
+        const root_abs = _resolve(path.join(root, root_rel));
+        try {
+            // Latent-bug candidate (replicated verbatim, see divergence
+            // notes): boundary check uses a raw string prefix match
+            // (`startswith`) rather than a path-component boundary check,
+            // so a sibling like `<root>-evil` would pass. Python does the
+            // same; flagged, not fixed.
+            if (!_is_dir(root_abs) || !root_abs.startsWith(root)) {
+                logger.info('enumerate_modules: skipping missing/out-of-tree root %s', root_rel);
+                continue;
+            }
+        } catch {
+            logger.info('enumerate_modules: unreadable root %s', root_rel);
+            continue;
+        }
+
+        let children: string[];
+        try {
+            children = fs
+                .readdirSync(root_abs)
+                .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+        } catch {
+            logger.info('enumerate_modules: cannot list %s', root_rel);
+            continue;
+        }
+
+        for (const name of children) {
+            if (name.startsWith('.') || skip_dirs.has(name)) {
+                continue;
+            }
+            const child = path.join(root_abs, name);
+            if (!_is_dir(child)) {
+                continue;
+            }
+            const agent_dir = path.join(child, agent_folder);
+            const has_agent = _is_dir(agent_dir);
+            let module_rel: string;
+            try {
+                module_rel = _relative_to(_resolve(child), root);
+            } catch {
+                continue;
+            }
+            const entry: ModuleEntry = {
+                name,
+                root_path: root_rel,
+                module_path: module_rel,
+                has_agent_folder: has_agent,
+                agent_folder_path: has_agent ? _posix_join(module_rel, agent_folder) : null,
+            };
+            discovered.push(entry);
+        }
+    }
+
+    discovered.sort((a, b) => {
+        if (a.root_path !== b.root_path) {
+            return a.root_path < b.root_path ? -1 : 1;
+        }
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+    });
+    return discovered;
+}
+
+/**
+ * Yield `[dotted_key, value, source_path]` for every leaf setting.
+ *
+ * Walks the same cascade as `load_agent_settings` and emits one tuple per
+ * leaf observed at each layer (user-global → repo-root → intermediates →
+ * CWD). Never blocks, never raises on missing files.
+ */
+export function* iter_setting_overrides(
+    options: {
+        project_path?: string | null;
+        user_global_path?: string | null;
+        cwd?: string | null;
+    } = {},
+): Generator<[string, SettingsValue, string]> {
+    const project_path = options.project_path ?? null;
+    const user_global_path = options.user_global_path ?? null;
+    const cwd = options.cwd ?? null;
+
+    const user_global_path_resolved = user_global_path
+        ? user_global_path
+        : _resolve_user_global_file();
+    const user_global_raw = _read_yaml(user_global_path_resolved) ?? {};
+    const [user_global_filtered] = _filter_whitelist(user_global_raw, MERGEABLE_KEYS);
+    if (Object.keys(user_global_filtered).length > 0) {
+        for (const key of _leaf_paths(user_global_filtered)) {
+            yield [key, _get_dotted(user_global_filtered, key), user_global_path_resolved];
+        }
+    }
+
+    for (const p of _resolve_cascade_paths(cwd, project_path)) {
+        const layer = _read_yaml(p);
+        if (!layer || Object.keys(layer).length === 0) {
+            continue;
+        }
+        for (const key of _leaf_paths(layer)) {
+            yield [key, _get_dotted(layer, key), p];
+        }
+    }
+}
+
+/** Best-effort YAML read; never raises. Returns `null` on any failure. */
+function _read_yaml(p: string): SettingsDict | null {
+    if (!_is_file(p)) {
+        return null;
+    }
+    let YAML: typeof import('yaml');
+    try {
+        // Lazy require to mirror Python's lazy `import yaml` — a missing
+        // package degrades to `null` (defaults) instead of crashing.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        YAML = require('yaml') as typeof import('yaml');
+    } catch {
+        return null;
+    }
+    let data: SettingsValue;
+    try {
+        const text = fs.readFileSync(p, 'utf-8');
+        // version '1.1' matches PyYAML's safe_load (yes/no/on/off bools,
+        // sexagesimal ints) so the differential corpus stays byte-faithful.
+        data = YAML.parse(text, { version: '1.1' });
+        if (data === null || data === undefined) {
+            data = {};
+        }
+    } catch (err) {
+        // OSError or YAML parse failure → defaults, logged at WARNING.
+        if (_is_yaml_error(err) || _is_os_error(err)) {
+            logger.warning('agent_settings: unreadable or malformed YAML at %s', p);
+            return null;
+        }
+        throw err;
+    }
+    return _is_plain_dict(data) ? data : null;
+}
+
+function _is_yaml_error(err: unknown): boolean {
+    // The `yaml` package throws YAMLParseError / YAMLWarning subclasses
+    // whose names start with "YAML"; also catch generic parse Errors.
+    if (err instanceof Error) {
+        return err.name.startsWith('YAML') || err.name === 'Error' || err.name === 'TypeError';
+    }
+    return false;
+}
+
+function _is_os_error(err: unknown): boolean {
+    return (
+        typeof err === 'object' &&
+        err !== null &&
+        'code' in err &&
+        typeof (err as { code: unknown }).code === 'string'
+    );
+}
+
+/** Return `[filtered_dict, ignored_paths]` from a user-global blob. */
+function _filter_whitelist(
+    raw: SettingsDict,
+    allowed: readonly string[],
+): [SettingsDict, string[]] {
+    const filtered: SettingsDict = {};
+    for (const dotted of allowed) {
+        const value = _get_dotted(raw, dotted);
+        if (value !== null && value !== undefined) {
+            _set_dotted(filtered, dotted, value);
+        }
+    }
+    const ignored = _leaf_paths(raw).filter((p) => !allowed.includes(p));
+    return [filtered, ignored];
+}
+
+function _get_dotted(data: SettingsDict, dotted: string): SettingsValue {
+    let cursor: SettingsValue = data;
+    for (const part of dotted.split('.')) {
+        if (!_is_plain_dict(cursor) || !(part in cursor)) {
+            return null;
+        }
+        cursor = cursor[part];
+    }
+    return cursor;
+}
+
+function _set_dotted(target: SettingsDict, dotted: string, value: SettingsValue): void {
+    const parts = dotted.split('.');
+    let cursor: SettingsDict = target;
+    for (const part of parts.slice(0, -1)) {
+        let nxt = cursor[part];
+        if (nxt === undefined) {
+            nxt = {};
+            cursor[part] = nxt;
+        }
+        if (!_is_plain_dict(nxt)) {
+            nxt = {};
+            cursor[part] = nxt;
+        }
+        cursor = nxt;
+    }
+    cursor[parts[parts.length - 1] as string] = value;
+}
+
+function _leaf_paths(data: SettingsDict, prefix = ''): string[] {
+    const paths: string[] = [];
+    for (const [key, value] of Object.entries(data)) {
+        const p = prefix ? `${prefix}.${key}` : key;
+        if (_is_plain_dict(value) && Object.keys(value).length > 0) {
+            paths.push(..._leaf_paths(value, p));
+        } else {
+            paths.push(p);
+        }
+    }
+    return paths;
+}
+
+/** Merge `src` into `dst` in-place; nested dicts merged recursively. */
+function _deep_merge(dst: SettingsDict, src: SettingsDict): void {
+    for (const [key, value] of Object.entries(src)) {
+        if (_is_plain_dict(value) && _is_plain_dict(dst[key])) {
+            _deep_merge(dst[key], value);
+        } else {
+            dst[key] = value;
+        }
+    }
+}
+
+function _deep_copy_defaults(src: SettingsDict): SettingsDict {
+    const out: SettingsDict = {};
+    _deep_merge(out, src);
+    return out;
+}
+
+/**
+ * `copy.deepcopy` for the JSON-shaped values settings hold (dicts, lists,
+ * scalars). Arrays and plain objects are cloned recursively; scalars pass
+ * through.
+ */
+function _deepcopy<T extends SettingsValue>(value: T): T {
+    if (Array.isArray(value)) {
+        return value.map((v) => _deepcopy(v)) as unknown as T;
+    }
+    if (_is_plain_dict(value)) {
+        const out: SettingsDict = {};
+        for (const [k, v] of Object.entries(value)) {
+            out[k] = _deepcopy(v);
+        }
+        return out as unknown as T;
+    }
+    return value;
+}
+
+/**
+ * `isinstance(x, dict)` — a plain object, not an array / null / class
+ * instance. Mirrors Python's `isinstance(..., dict)` for settings data,
+ * which is always built from `yaml.safe_load` (plain dicts).
+ */
+function _is_plain_dict(value: SettingsValue): value is SettingsDict {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+    );
+}
+
+/** Strip leading/trailing `/` like Python's `str.strip("/")`. */
+function _strip_slashes(s: string): string {
+    return s.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * `Path.relative_to(root)` — throws when `child` is not under `root`
+ * (mirrors Python's `ValueError`). Returns the OS-native relative path.
+ */
+function _relative_to(child: string, root: string): string {
+    const rel = path.relative(root, child);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`${child} is not in the subpath of ${root}`);
+    }
+    return rel;
+}
+
+/** Join two repo-relative path fragments with forward slashes (posix). */
+function _posix_join(a: string, b: string): string {
+    return `${a.split(path.sep).join('/')}/${b}`;
+}

--- a/dist/agent-src/templates/scripts/work_engine/_lib/user_global_paths.ts
+++ b/dist/agent-src/templates/scripts/work_engine/_lib/user_global_paths.ts
@@ -1,0 +1,329 @@
+/**
+ * Vendor-namespaced user-global path resolution.
+ *
+ * TypeScript twin of `src/scripts/_lib/user_global_paths.py` (ADR-094,
+ * Phase 2 / Wave 1 batch B). Mirrors the Python module's public API
+ * exactly — same exported snake_case names, same semantics, same
+ * path-resolution behavior. Single source of truth for "where does this
+ * package keep user-global state on disk?".
+ *
+ * Resolution order:
+ *
+ *   1. `$EVENT4U_CONFIG_HOME`  — full path override (testing + power users).
+ *   2. `~/.event4u/agent-config/`  — vendor-namespaced source-of-truth.
+ *
+ * For backward compatibility during the transition, `legacy_xdg_root()`
+ * exposes the old `~/.config/agent-config/` path so loaders can read
+ * state written by pre-2.4 installs. Writers should never target the
+ * legacy path; the auto-migration shim copies state once into the new
+ * namespace.
+ *
+ * Contract — pure, read-only, never auto-creates directories
+ * (except `migrate_legacy_namespace`, which mirrors the Python shim).
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** Environment map shape — mirrors Python's `Optional[dict]` env parameter. */
+export type EnvMap = Record<string, string | undefined>;
+
+/**
+ * Marker suffix for in-progress entry copies during migration. A copy
+ * that crashes mid-flight leaves `<name><suffix><pid>` behind so the
+ * next run can clean it up before retrying — instead of treating a
+ * partial subdir as a completed copy.
+ *
+ * Exported (despite the underscore) because the pytest suite accesses
+ * `user_global_paths._PARTIAL_SUFFIX`; the vitest port does the same.
+ */
+export const _PARTIAL_SUFFIX = '.event4u-partial-';
+
+/**
+ * Environment variable that overrides `event4u_root()` outright.
+ * Accepts a full path (`~` expanded). Primarily used by tests; power
+ * users may also point this at a custom location.
+ */
+export const EVENT4U_HOME_ENV = 'EVENT4U_CONFIG_HOME';
+
+/** Vendor-namespaced default. Relative to the user's home directory. */
+export const DEFAULT_EVENT4U_ROOT_RELATIVE = path.join('.event4u', 'agent-config');
+
+/**
+ * Legacy XDG-shaped default written by pre-2.4 installs. Read-only
+ * fallback during the transition; never the target of a write.
+ */
+export const LEGACY_XDG_ROOT_RELATIVE = path.join('.config', 'agent-config');
+
+/**
+ * Expand a leading `~` like Python's `Path.expanduser()`.
+ *
+ * Divergence candidate (flagged, not fixed): Python also expands
+ * `~user` via the pwd database; this port leaves `~user` unchanged
+ * (which is also Python's behavior when the user is unknown).
+ */
+function expanduser(p: string): string {
+    if (p === '~') {
+        return os.homedir();
+    }
+    if (p.startsWith('~/') || (process.platform === 'win32' && p.startsWith('~\\'))) {
+        return path.join(os.homedir(), p.slice(2));
+    }
+    return p;
+}
+
+/**
+ * Mirror of `pathlib.Path.is_absolute()`.
+ *
+ * On POSIX a path is absolute iff it has a root (`/...`). On Windows,
+ * pathlib requires BOTH a drive and a root (`C:\\...` or UNC) — unlike
+ * Node's `path.isAbsolute`, which accepts rootless `\\foo`. The Python
+ * semantics are replicated here.
+ */
+function is_absolute_like_python(p: string): boolean {
+    if (process.platform === 'win32') {
+        return /^[a-zA-Z]:[\\/]/.test(p) || /^([\\/]{2})[^\\/]+[\\/][^\\/]+/.test(p);
+    }
+    return p.startsWith('/');
+}
+
+/**
+ * Return the active user-global root directory.
+ *
+ * Honours `EVENT4U_CONFIG_HOME` first, falls back to
+ * `~/.event4u/agent-config/`. Never creates the directory.
+ */
+export function event4u_root(env?: EnvMap | null): string {
+    const env_map = env ?? process.env;
+    const override = env_map[EVENT4U_HOME_ENV];
+    if (override) {
+        return expanduser(override);
+    }
+    return path.join(os.homedir(), DEFAULT_EVENT4U_ROOT_RELATIVE);
+}
+
+/**
+ * Return the pre-2.4 user-global root at `~/.config/agent-config/`.
+ *
+ * Used by loaders during the transition to read settings, lockfiles,
+ * and keys written before the namespace migration ran. Writers MUST
+ * NOT target this path — only `event4u_root()` is a valid write
+ * target. Never creates the directory.
+ */
+export function legacy_xdg_root(): string {
+    return path.join(os.homedir(), LEGACY_XDG_ROOT_RELATIVE);
+}
+
+/**
+ * Resolve a named file/dir under the user-global root, with legacy fallback.
+ *
+ * Returns the new-namespace path if it exists on disk, otherwise the
+ * legacy XDG path if it exists, otherwise `null`. Callers that need
+ * the *write target* (regardless of existence) should use
+ * `path.join(event4u_root(), relative_name)` directly.
+ *
+ * `relative_name` is a forward-slash separated string (e.g.
+ * `"installed.lock"` or `"agents/global"`). It is treated as a
+ * path fragment relative to the chosen root; absolute paths are
+ * rejected with an `Error` (Python raises `ValueError`).
+ */
+export function resolve_with_fallback(
+    relative_name: string,
+    options: { env?: EnvMap | null } = {},
+): string | null {
+    if (is_absolute_like_python(relative_name)) {
+        throw new Error(
+            `resolve_with_fallback expects a relative path, got '${relative_name}'`,
+        );
+    }
+    const new_path = path.join(event4u_root(options.env ?? null), relative_name);
+    if (fs.existsSync(new_path)) {
+        return new_path;
+    }
+    const legacy_path = path.join(legacy_xdg_root(), relative_name);
+    if (fs.existsSync(legacy_path)) {
+        return legacy_path;
+    }
+    return null;
+}
+
+/**
+ * Return the canonical write target for a named user-global file/dir.
+ *
+ * Always rooted at `event4u_root()` — writers never target the
+ * legacy XDG path. Caller is responsible for `mkdir -p` on the parent
+ * before writing. Never creates the directory itself.
+ */
+export function write_target(
+    relative_name: string,
+    options: { env?: EnvMap | null } = {},
+): string {
+    if (is_absolute_like_python(relative_name)) {
+        throw new Error(`write_target expects a relative path, got '${relative_name}'`);
+    }
+    return path.join(event4u_root(options.env ?? null), relative_name);
+}
+
+/**
+ * Breadcrumb dropped into the legacy root after a successful migration.
+ * Tells the user where their state now lives and how to clean up. The
+ * legacy tree itself is never auto-deleted — only the user does that.
+ */
+export const MIGRATION_BREADCRUMB_NAME = 'MIGRATED.md';
+
+const _BREADCRUMB_TEMPLATE = `# Migrated to \`~/.event4u/agent-config/\`
+
+This directory (\`~/.config/agent-config/\`) is the **legacy** location
+for \`event4u/agent-config\` user-global state. As of v2.4 the canonical
+location is \`~/.event4u/agent-config/\`.
+
+The migration shim has already copied your settings, keys, lockfiles,
+and overrides into the new namespace. File modes (0600 on keys) were
+preserved. Loaders prefer the new path but still read from this tree
+as a fallback, so removing it is safe **once you've confirmed** the
+new location is working.
+
+## To clean up
+
+\`\`\`bash
+rm -rf ~/.config/agent-config
+\`\`\`
+
+## Why the move
+
+\`~/.config/\` is a generic XDG-shaped directory shared by many tools.
+\`~/.event4u/agent-config/\` is vendor-namespaced and avoids collisions
+with unrelated CLIs. See
+\`agents/roadmaps/road-to-event4u-namespace-and-claude-desktop.md\` for
+the full rationale.
+`;
+
+/**
+ * Copy pre-2.4 user-global state from legacy XDG root into the new namespace.
+ *
+ * Idempotent and safe to call on every install / init. Returns `true`
+ * if a copy ran during this invocation, `false` when the migration
+ * was already complete or there was nothing to migrate.
+ *
+ * Contract (mirrors the Python shim):
+ *
+ * - Never auto-deletes the legacy tree — that's the user's call (the
+ *   breadcrumb at `~/.config/agent-config/MIGRATED.md` documents it).
+ * - Preserves file modes (0600 key files stay 0600 after the copy)
+ *   and timestamps, like `shutil.copytree(..., copy_function=copy2)`.
+ * - If the new root already exists with any content, the migration
+ *   treats it as already-done and only writes the breadcrumb (if
+ *   missing) — never overwrites new-namespace state.
+ * - If the legacy root is missing or empty, the function is a no-op.
+ * - Per-entry atomic write: each entry is copied to a sibling
+ *   `<name>.event4u-partial-<pid>` and then renamed into the final
+ *   name. If a previous run crashed mid-copy, the leftover
+ *   `*.event4u-partial-*` siblings are cleaned up at the top of the
+ *   next run before retrying — a partial directory is never mistaken
+ *   for a completed copy.
+ *
+ * `legacy_root_override` is for tests; production callers omit it.
+ */
+export function migrate_legacy_namespace(
+    options: { env?: EnvMap | null; legacy_root_override?: string | null } = {},
+): boolean {
+    const legacy_root = options.legacy_root_override ?? legacy_xdg_root();
+    const new_root = event4u_root(options.env ?? null);
+
+    let legacy_stat: fs.Stats;
+    try {
+        legacy_stat = fs.statSync(legacy_root);
+    } catch {
+        return false;
+    }
+    if (!legacy_stat.isDirectory()) {
+        return false;
+    }
+
+    // Skip the migrated-breadcrumb itself when checking for content so a
+    // second invocation does not loop on its own marker.
+    const legacy_entries = fs
+        .readdirSync(legacy_root)
+        .filter((name) => name !== MIGRATION_BREADCRUMB_NAME);
+    if (legacy_entries.length === 0) {
+        return false;
+    }
+
+    // Real content check ignores partial-copy debris from a prior
+    // interrupted run; otherwise the breadcrumb would be written for
+    // a half-finished migration and retry would never run.
+    const new_has_content =
+        fs.existsSync(new_root) &&
+        fs.readdirSync(new_root).some((name) => !_is_partial_name(name));
+    if (new_has_content) {
+        _ensure_breadcrumb(legacy_root);
+        return false;
+    }
+
+    fs.mkdirSync(new_root, { recursive: true });
+    _purge_partial_entries(new_root);
+
+    for (const name of legacy_entries) {
+        const entry = path.join(legacy_root, name);
+        const target = path.join(new_root, name);
+        if (fs.existsSync(target)) {
+            continue;
+        }
+        const staging = path.join(new_root, `${name}${_PARTIAL_SUFFIX}${process.pid}`);
+        if (fs.existsSync(staging)) {
+            _remove_path(staging);
+        }
+        if (fs.statSync(entry).isDirectory()) {
+            // Mirrors shutil.copytree(copy_function=copy2): modes are
+            // preserved by the copy; timestamps via preserveTimestamps.
+            fs.cpSync(entry, staging, { recursive: true, preserveTimestamps: true });
+        } else {
+            fs.copyFileSync(entry, staging);
+            // copy2 semantics: explicitly carry over mode + timestamps.
+            const src_stat = fs.statSync(entry);
+            fs.chmodSync(staging, src_stat.mode & 0o7777);
+            fs.utimesSync(staging, src_stat.atime, src_stat.mtime);
+        }
+        fs.renameSync(staging, target);
+    }
+
+    _ensure_breadcrumb(legacy_root);
+    return true;
+}
+
+function _is_partial_name(name: string): boolean {
+    return name.includes(_PARTIAL_SUFFIX);
+}
+
+/** Remove `*.event4u-partial-*` leftovers from a previous interrupted run. */
+function _purge_partial_entries(new_root: string): void {
+    for (const name of fs.readdirSync(new_root)) {
+        if (_is_partial_name(name)) {
+            _remove_path(path.join(new_root, name));
+        }
+    }
+}
+
+function _remove_path(p: string): void {
+    let st: fs.Stats | null = null;
+    try {
+        st = fs.lstatSync(p);
+    } catch {
+        // Missing path — Python's unlink(missing_ok=True) tolerates this.
+        return;
+    }
+    if (st.isDirectory() && !st.isSymbolicLink()) {
+        fs.rmSync(p, { recursive: true });
+    } else {
+        fs.rmSync(p, { force: true });
+    }
+}
+
+/** Write the `MIGRATED.md` breadcrumb into `legacy_root` if absent. */
+function _ensure_breadcrumb(legacy_root: string): void {
+    const breadcrumb = path.join(legacy_root, MIGRATION_BREADCRUMB_NAME);
+    if (fs.existsSync(breadcrumb)) {
+        return;
+    }
+    fs.writeFileSync(breadcrumb, _BREADCRUMB_TEMPLATE, 'utf-8');
+}

--- a/dist/agent-src/templates/scripts/work_engine/cli_args.ts
+++ b/dist/agent-src/templates/scripts/work_engine/cli_args.ts
@@ -1,0 +1,249 @@
+/**
+ * Argument parser and state-file constants for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/cli_args.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`.
+ * Behaviour-preserving: the parser shape, default values, and exit-code
+ * semantics are identical to the pre-split version. The constants moved here
+ * so the parser default and the legacy-file detector both reference a single
+ * source of truth.
+ *
+ * The Python source returns an `argparse.ArgumentParser`; this twin exposes
+ * {@link parse_args} instead, mirroring argparse's runtime behaviour for the
+ * declared flags: long-option prefix abbreviation, `--flag=value` /
+ * `--flag value` forms, `store_true` flags, `-h`/`--help` exit-0, and exit-2
+ * on every error path (unknown flag, ambiguous abbreviation, missing value,
+ * explicit value on a store_true flag). `--help` prose is intentionally NOT
+ * a parity surface (ADR-094 — argparse help text is not byte-compared).
+ */
+
+// Paths are kept as plain strings here (the Python source wraps them in
+// `pathlib.Path` via `type=Path`; the consuming modules — state_io,
+// input_builders — land in a later py2ts phase and own the Path semantics).
+export const DEFAULT_STATE_FILE = '.work-state.json';
+/**
+ * State file used when `--state-file` is not passed.
+ *
+ * Renamed from `.implement-ticket-state.json` in 1.15.0 alongside the
+ * `implement_ticket → work_engine` package move. The legacy filename is
+ * still recognised on load (see {@link LEGACY_STATE_FILE} below) so that
+ * existing checkouts surface a clear migration message instead of a
+ * silent "no state file" error.
+ */
+
+export const LEGACY_STATE_FILE = '.implement-ticket-state.json';
+/**
+ * Pre-1.15.0 default state file. Detected only as a migration hint;
+ * never written to. See `docs/MIGRATION.md`.
+ */
+
+export const _FMT_V0 = 'v0';
+export const _FMT_V1 = 'v1';
+/**
+ * Wire-format markers carried alongside the loaded `WorkState`.
+ *
+ * Format-preserving roundtrip: `_load` records which shape it parsed,
+ * `_save` rewrites in that same shape. v0 in → v0 out (Goldens stay
+ * byte-equal); v1 in → v1 out (future flows produced by the migration
+ * tool or a fresh v1 init keep their envelope fields).
+ */
+
+/** Parsed namespace — mirrors the argparse `Namespace` attribute names. */
+export interface ParsedArgs {
+    state_file: string;
+    ticket_file: string | null;
+    prompt_file: string | null;
+    diff_file: string | null;
+    file_file: string | null;
+    persona: string | null;
+    no_hooks: boolean;
+    hooks_config: string | null;
+}
+
+/** Thrown internally to mirror argparse's exit-2 error path. */
+class ArgparseExit extends Error {
+    readonly code: number;
+    constructor(code: number) {
+        super(`argparse exit ${code}`);
+        Object.setPrototypeOf(this, ArgparseExit.prototype);
+        this.name = 'ArgparseExit';
+        this.code = code;
+    }
+}
+
+const PROG = 'implement-ticket';
+
+// Declared optionals, in declaration order (drives prefix-abbreviation
+// candidate ordering and the usage line, exactly as argparse builds it).
+interface OptionSpec {
+    flag: string; // canonical long option, e.g. "--state-file"
+    dest: keyof ParsedArgs; // namespace attribute
+    takesValue: boolean; // false for store_true
+}
+
+const OPTIONS: OptionSpec[] = [
+    { flag: '--state-file', dest: 'state_file', takesValue: true },
+    { flag: '--ticket-file', dest: 'ticket_file', takesValue: true },
+    { flag: '--prompt-file', dest: 'prompt_file', takesValue: true },
+    { flag: '--diff-file', dest: 'diff_file', takesValue: true },
+    { flag: '--file-file', dest: 'file_file', takesValue: true },
+    { flag: '--persona', dest: 'persona', takesValue: true },
+    { flag: '--no-hooks', dest: 'no_hooks', takesValue: false },
+    { flag: '--hooks-config', dest: 'hooks_config', takesValue: true },
+];
+
+// `-h` / `--help` is an implicit argparse optional; included as a prefix
+// abbreviation candidate so e.g. `--he` resolves to `--help`.
+const HELP_FLAGS = ['--help'];
+
+function usage(): string {
+    // Compact one-line usage marker; the exact wrapping/prose is not a parity
+    // surface (ADR-094 — argparse usage/help text is not byte-compared).
+    return `usage: ${PROG} [-h] [options]`;
+}
+
+function err(message: string): never {
+    process.stderr.write(`${usage()}\n`);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw new ArgparseExit(2);
+}
+
+/**
+ * Resolve a long option token to its canonical flag, applying argparse's
+ * unambiguous-prefix-abbreviation rule. Returns the matched spec, the
+ * sentinel `'help'`, or throws exit-2 on an ambiguous / unknown option.
+ */
+function resolveLong(name: string): OptionSpec | 'help' {
+    // Exact match first (argparse short-circuits exact hits before abbrev).
+    const exact = OPTIONS.find((o) => o.flag === name);
+    if (exact) {
+        return exact;
+    }
+    if (HELP_FLAGS.includes(name)) {
+        return 'help';
+    }
+    // Prefix abbreviation across both the declared options and --help.
+    const candidates: Array<OptionSpec | 'help'> = [];
+    for (const o of OPTIONS) {
+        if (o.flag.startsWith(name)) {
+            candidates.push(o);
+        }
+    }
+    for (const h of HELP_FLAGS) {
+        if (h.startsWith(name)) {
+            candidates.push('help');
+        }
+    }
+    if (candidates.length === 1) {
+        return candidates[0] as OptionSpec | 'help';
+    }
+    if (candidates.length === 0) {
+        // argparse reports unknown options via "unrecognized arguments".
+        err(`unrecognized arguments: ${name}`);
+    }
+    const names = candidates.map((c) => (c === 'help' ? '--help' : c.flag)).join(', ');
+    err(`ambiguous option: ${name} could match ${names}`);
+}
+
+/**
+ * Parse `argv` (the slice after the program name) into a namespace.
+ *
+ * Mirrors `argparse.ArgumentParser.parse_args`: on `-h`/`--help` it prints
+ * a help marker to stdout and exits 0; on any error it prints to stderr and
+ * exits 2 (via `process.exitCode`, never `process.exit`, per ADR-094).
+ * Returns the parsed namespace on success.
+ */
+export function parse_args(argv: string[]): ParsedArgs {
+    const ns: ParsedArgs = {
+        state_file: DEFAULT_STATE_FILE,
+        ticket_file: null,
+        prompt_file: null,
+        diff_file: null,
+        file_file: null,
+        persona: null,
+        no_hooks: false,
+        hooks_config: null,
+    };
+    const extras: string[] = [];
+
+    try {
+        let i = 0;
+        while (i < argv.length) {
+            const tok = argv[i] as string;
+            if (tok === '-h' || tok === '--help') {
+                process.stdout.write(`${usage()}\n`);
+                throw new ArgparseExit(0);
+            }
+            if (tok.startsWith('--')) {
+                let name = tok;
+                let inlineValue: string | null = null;
+                const eq = tok.indexOf('=');
+                if (eq !== -1) {
+                    name = tok.slice(0, eq);
+                    inlineValue = tok.slice(eq + 1);
+                }
+                if (name === '-h' || name === '--help') {
+                    process.stdout.write(`${usage()}\n`);
+                    throw new ArgparseExit(0);
+                }
+                const resolved = resolveLong(name);
+                if (resolved === 'help') {
+                    process.stdout.write(`${usage()}\n`);
+                    throw new ArgparseExit(0);
+                }
+                if (resolved.takesValue) {
+                    if (inlineValue !== null) {
+                        assignValue(ns, resolved, inlineValue);
+                    } else {
+                        const next = argv[i + 1];
+                        // argparse: a value beginning with `-` is still consumed
+                        // only when it does not look like a known option; the
+                        // simpler "expected one argument" path covers the
+                        // missing-trailing-value case the contract exercises.
+                        if (next === undefined) {
+                            err(`argument ${resolved.flag}: expected one argument`);
+                        }
+                        assignValue(ns, resolved, next);
+                        i += 1;
+                    }
+                } else {
+                    // store_true: an explicit `=value` is an error in argparse.
+                    if (inlineValue !== null) {
+                        err(`argument ${resolved.flag}: ignored explicit argument '${inlineValue}'`);
+                    }
+                    (ns[resolved.dest] as boolean) = true;
+                }
+            } else if (tok.startsWith('-') && tok !== '-') {
+                // Single-dash unknown short option → unrecognized.
+                extras.push(tok);
+            } else {
+                // Positional — this parser declares none, so it is an extra.
+                extras.push(tok);
+            }
+            i += 1;
+        }
+        if (extras.length > 0) {
+            err(`unrecognized arguments: ${extras.join(' ')}`);
+        }
+    } catch (e) {
+        if (e instanceof ArgparseExit) {
+            process.exitCode = e.code;
+            // Surface as a thrown sentinel so a CLI caller can stop; the test
+            // harness inspects process.exitCode (mirrors argparse SystemExit).
+            throw e;
+        }
+        throw e;
+    }
+    return ns;
+}
+
+function assignValue(ns: ParsedArgs, spec: OptionSpec, value: string): void {
+    // All value-taking flags here are string/Path; store the raw string.
+    (ns[spec.dest] as string) = value;
+}
+
+/** Re-exported sentinel so a CLI entry point can recognise the exit path. */
+export { ArgparseExit };

--- a/dist/agent-src/templates/scripts/work_engine/delivery_state.ts
+++ b/dist/agent-src/templates/scripts/work_engine/delivery_state.ts
@@ -1,0 +1,219 @@
+/**
+ * `DeliveryState` — the only object shared between orchestrator steps.
+ *
+ * TypeScript twin of `work_engine/delivery_state.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The shape mirrors `docs/contracts/implement-ticket-flow.md`. No step
+ * may invent fields not declared here; extensions require a roadmap
+ * amendment plus a flow-contract update.
+ *
+ * Steps return a `StepResult` with one of three `Outcome` values:
+ *
+ * - `SUCCESS`  — step populated its slice of `DeliveryState` and the
+ *   dispatcher continues to the next step.
+ * - `BLOCKED`  — step hit an ambiguity it cannot resolve on its own.
+ *   `questions` carries pre-formatted numbered options per the
+ *   `user-interaction` rule. The dispatcher halts.
+ * - `PARTIAL`  — step populated its slice *and* produced open
+ *   questions. The dispatcher halts with the same surface as BLOCKED;
+ *   the calling orchestrator (Phase 3) decides whether to prompt the
+ *   user to continue or stop.
+ *
+ * `DeliveryState` is a plain dataclass rather than a typed dict so
+ * step handlers can rely on attribute access, defaults, and mutation
+ * semantics without resorting to dictionary indirection.
+ */
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+/**
+ * Terminal outcome of a single step.
+ *
+ * The Python source subclasses `str` + `Enum`, so each member serialises as
+ * its string form. We mirror that with a string-valued const object: the
+ * values are exactly the strings the Python enum members carry.
+ */
+export const Outcome = {
+    SUCCESS: 'success',
+    BLOCKED: 'blocked',
+    PARTIAL: 'partial',
+} as const;
+
+export type Outcome = (typeof Outcome)[keyof typeof Outcome];
+
+/**
+ * Return value of a single `Step` invocation.
+ *
+ * `questions` is only populated for `BLOCKED` / `PARTIAL` outcomes. Each
+ * entry is a fully-formatted numbered line so the dispatcher can surface
+ * them verbatim without reformatting.
+ *
+ * Field order (outcome, questions, message) mirrors the Python dataclass so
+ * an `asdict`-style projection stays key-order identical.
+ */
+export class StepResult {
+    outcome: Outcome;
+    questions: string[];
+    message: string;
+
+    constructor(args: { outcome: Outcome; questions?: string[]; message?: string }) {
+        this.outcome = args.outcome;
+        // `field(default_factory=list)` → every instance owns its own array.
+        this.questions = args.questions ?? [];
+        this.message = args.message ?? '';
+    }
+}
+
+/**
+ * Canonical state passed between orchestrator steps.
+ *
+ * Field order matches the table in `docs/contracts/implement-ticket-flow.md`.
+ * Mutable defaults are created per-instance (the Python
+ * `field(default_factory=...)` contract) so every instance owns its own
+ * containers — a single shared array across runs would be a cross-run
+ * contamination hazard for the metrics pipeline.
+ */
+export class DeliveryState {
+    ticket: Record<string, Any>;
+    persona: string;
+    memory: Array<Record<string, Any>>;
+    plan: Any;
+    changes: Array<Record<string, Any>>;
+    tests: Any;
+    verify: Any;
+    outcomes: Record<string, string>;
+    questions: string[];
+    report: string;
+    ui_audit: Record<string, Any> | null;
+    ui_design: Record<string, Any> | null;
+    ui_review: Record<string, Any> | null;
+    ui_polish: Record<string, Any> | null;
+    contract: Record<string, Any> | null;
+    stitch: Record<string, Any> | null;
+    stack: Record<string, Any> | null;
+
+    constructor(args: {
+        ticket: Record<string, Any>;
+        persona?: string;
+        memory?: Array<Record<string, Any>>;
+        plan?: Any;
+        changes?: Array<Record<string, Any>>;
+        tests?: Any;
+        verify?: Any;
+        outcomes?: Record<string, string>;
+        questions?: string[];
+        report?: string;
+        ui_audit?: Record<string, Any> | null;
+        ui_design?: Record<string, Any> | null;
+        ui_review?: Record<string, Any> | null;
+        ui_polish?: Record<string, Any> | null;
+        contract?: Record<string, Any> | null;
+        stitch?: Record<string, Any> | null;
+        stack?: Record<string, Any> | null;
+    }) {
+        this.ticket = args.ticket;
+        this.persona = args.persona ?? 'senior-engineer';
+        this.memory = args.memory ?? [];
+        this.plan = args.plan ?? null;
+        this.changes = args.changes ?? [];
+        this.tests = args.tests ?? null;
+        this.verify = args.verify ?? null;
+        this.outcomes = args.outcomes ?? {};
+        this.questions = args.questions ?? [];
+        this.report = args.report ?? '';
+        this.ui_audit = args.ui_audit ?? null;
+        this.ui_design = args.ui_design ?? null;
+        this.ui_review = args.ui_review ?? null;
+        this.ui_polish = args.ui_polish ?? null;
+        this.contract = args.contract ?? null;
+        this.stitch = args.stitch ?? null;
+        this.stack = args.stack ?? null;
+    }
+}
+
+/**
+ * Protocol every step handler must satisfy.
+ *
+ * A step reads and writes `DeliveryState` in place; its return value
+ * carries only the terminal `Outcome` and any surfaced questions.
+ */
+export type Step = (state: DeliveryState) => StepResult;
+
+/**
+ * Marker that flags a `questions[0]` entry as agent-addressed, not
+ * user-addressed.
+ *
+ * When a step cannot run deterministically from pure Python (edits,
+ * subprocess calls, anything that needs tools the dispatcher doesn't
+ * own), it returns `BLOCKED` with this prefix as the first entry of
+ * `questions`. The orchestrator reads it and drives the matching
+ * skill; the user-facing numbered options follow on subsequent lines.
+ *
+ * The prefix is public contract: changing it breaks every agent that
+ * has learned to recognise it. See
+ * `docs/contracts/implement-ticket-flow.md#agent-directives`.
+ */
+export const AGENT_DIRECTIVE_PREFIX = '@agent-directive:';
+
+/**
+ * Python `str(value)` for the scalar value kinds an agent-directive payload
+ * carries. The Python source coerces every payload value with `str(...)`, so
+ * `True` → `"True"`, `False` → `"False"`, `None` → `"None"`; numbers and
+ * strings render as-is.
+ */
+function pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/**
+ * Format a canonical `@agent-directive:` line.
+ *
+ * `name` is the directive verb the agent dispatches on (for example
+ * `"implement-plan"` or `"run-tests"`). `payload` entries are rendered as
+ * `key=value` pairs on the same line, so the whole directive stays a single
+ * greppable string. Values are coerced with Python `str()` semantics — richer
+ * payloads belong on the `DeliveryState` itself, not in the directive line.
+ *
+ * Insertion order of `payload` keys is preserved, matching Python's `**kwargs`
+ * ordering.
+ */
+export function agent_directive(name: string, payload: Record<string, unknown> = {}): string {
+    const suffix = Object.entries(payload)
+        .map(([key, value]) => `${key}=${pyStr(value)}`)
+        .join(' ');
+    return suffix
+        ? `${AGENT_DIRECTIVE_PREFIX} ${name} ${suffix}`.trim()
+        : `${AGENT_DIRECTIVE_PREFIX} ${name}`;
+}
+
+/**
+ * True when `question` is an agent-addressed directive line.
+ *
+ * Used by the orchestrator to split `state.questions` into the
+ * agent-facing directive (at most one, always at index 0) and the
+ * user-facing numbered options (everything else).
+ */
+export function is_agent_directive(question: unknown): boolean {
+    return typeof question === 'string' && pyLstrip(question).startsWith(AGENT_DIRECTIVE_PREFIX);
+}
+
+/**
+ * Python `str.lstrip()` with no argument — strips leading whitespace as
+ * Python defines it (the `str.isspace` set). JS `String.prototype.trimStart`
+ * covers the same Unicode whitespace set for the inputs this module sees.
+ */
+function pyLstrip(s: string): string {
+    return s.trimStart();
+}

--- a/dist/agent-src/templates/scripts/work_engine/errors.ts
+++ b/dist/agent-src/templates/scripts/work_engine/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * CLI-layer error type used by the dispatcher entry point.
+ *
+ * TypeScript twin of `work_engine/errors.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Lives in its own module so the helper modules
+ * (`state_io`, `input_builders`, etc.) can raise it without depending on
+ * `cli.ts`, which would create an import cycle.
+ *
+ * Behaviour is identical to the original `cli._CLIError` it replaced
+ * in P2.3 of `road-to-post-pr29-optimize.md` — same name (private,
+ * underscore-prefixed) and same role: convert to exit code `2` at the
+ * `main()` boundary.
+ */
+
+/** Raised on configuration or I/O problems. Converted to exit code 2. */
+export class _CLIError extends Error {
+    constructor(message?: string) {
+        super(message);
+        // Restore the prototype chain so `instanceof _CLIError` works under
+        // the ES2022 target (Error subclassing caveat).
+        Object.setPrototypeOf(this, _CLIError.prototype);
+        this.name = '_CLIError';
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/orchestration.ts
+++ b/dist/agent-src/templates/scripts/work_engine/orchestration.ts
@@ -1,0 +1,366 @@
+/**
+ * State machine stub for the `/orchestrate` command.
+ *
+ * TypeScript twin of `work_engine/orchestration.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Reads a pipeline file conforming to
+ * `docs/contracts/orchestration-dsl-v1.md` and produces an ordered
+ * sequence of step descriptors the agent dispatches one at a time.
+ * The runtime itself is **not** in Python — each step is executed by the
+ * agent via skill / command / persona / subagent dispatch. This module
+ * holds the deterministic bookkeeping:
+ *
+ * - load + interpolate
+ * - step iteration with success / failure / when-guard tracking
+ * - output-map resolution at the end
+ *
+ * Design constraints (R1 carve-outs from
+ * `road-to-distribution-and-adoption.md`):
+ *
+ * - No external dependencies. YAML loading reuses the dispatcher's
+ *   loader so the runtime sees what the linter sees.
+ * - No side effects. The state machine never edits files, runs commands,
+ *   or emits hooks of its own. Audit emission is the caller's job.
+ * - Forward-ref free. `steps[].with` references can only reach
+ *   earlier steps; this is enforced both by the linter and at runtime.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Mirror of Python `re` group semantics: capture (inputs|steps), the ident,
+// and an optional `.output` suffix; `g` flag so `.sub`-style replace covers
+// every non-overlapping match like Python `re.sub`.
+const _INTERP_RE = /\$\{\{\s*(inputs|steps)\.([a-z0-9_-]+)(?:\.output)?\s*\}\}/g;
+
+/** Heterogeneous value, mirroring Python's `Any`. */
+export type Any = unknown;
+
+/** One step's record after dispatch. */
+export class StepResult {
+    step_id: string;
+    kind: string;
+    ref: string;
+    success: boolean;
+    output: string;
+    error: string | null;
+
+    constructor(
+        step_id: string,
+        kind: string,
+        ref: string,
+        success = false,
+        output = '',
+        error: string | null = null,
+    ) {
+        this.step_id = step_id;
+        this.kind = kind;
+        this.ref = ref;
+        this.success = success;
+        this.output = output;
+        this.error = error;
+    }
+}
+
+/** Bookkeeping for a single `/orchestrate` run. */
+export class PipelineState {
+    name: string;
+    inputs: Record<string, string>;
+    results: Record<string, StepResult>;
+    halted: boolean;
+    halt_reason: string | null;
+
+    constructor(args: {
+        name: string;
+        inputs: Record<string, string>;
+        results?: Record<string, StepResult>;
+        halted?: boolean;
+        halt_reason?: string | null;
+    }) {
+        this.name = args.name;
+        this.inputs = args.inputs;
+        this.results = args.results ?? {};
+        this.halted = args.halted ?? false;
+        this.halt_reason = args.halt_reason ?? null;
+    }
+}
+
+/** True when `value` is a plain object (Python `isinstance(x, dict)`). */
+function _isDict(value: unknown): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `re.Match`-style replacement function signature loader. */
+interface DispatchHookModule {
+    _load_yaml(p: string): Record<string, Any>;
+}
+
+/**
+ * Reuse the linter's loader so the runtime accepts the same shape.
+ *
+ * Walks parents to find `scripts/hooks/dispatch_hook.ts` so the loader is
+ * reachable both when this module runs from the consumer projection
+ * (`dist/agent-src/templates/scripts/work_engine/`) and from the
+ * source-of-truth tree
+ * (`packages/<pack>/.agent-src.uncondensed/templates/scripts/work_engine/`).
+ * Loaded by dynamic `import()` to avoid namespace collisions with test
+ * modules named `hooks` (the TS analogue of the Python importlib-by-path
+ * approach).
+ */
+async function _load_pipeline(p: string): Promise<Record<string, Any>> {
+    const here = fs.realpathSync(fileURLToPath(import.meta.url));
+    let candidate: string | null = null;
+    // Layout-agnostic: the dispatcher sits at `scripts/hooks/` in a consumer
+    // install + the `dist/agent-src/` projection, and at `src/scripts/hooks/`
+    // in the maintainer source tree. Probe both per parent so the loader
+    // resolves regardless of where this template runs.
+    const relCandidates = [
+        path.join('scripts', 'hooks', 'dispatch_hook.ts'),
+        path.join('src', 'scripts', 'hooks', 'dispatch_hook.ts'),
+    ];
+    let dir = path.dirname(here);
+    // Walk `here.parents` — every ancestor directory up to the filesystem root.
+    for (;;) {
+        for (const rel of relCandidates) {
+            const probe = path.join(dir, rel);
+            if (fs.existsSync(probe) && fs.statSync(probe).isFile()) {
+                candidate = probe;
+                break;
+            }
+        }
+        if (candidate !== null) {
+            break;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            break;
+        }
+        dir = parent;
+    }
+    if (candidate === null) {
+        throw new Error(
+            'could not locate scripts/hooks/dispatch_hook.ts (or ' +
+                `src/scripts/hooks/dispatch_hook.ts) from ${here}`,
+        );
+    }
+    const module = (await import(pathToFileURL(candidate).href)) as DispatchHookModule;
+    const doc = module._load_yaml(p);
+    if (!_isDict(doc)) {
+        throw new Error(`${p}: top-level must be a mapping`);
+    }
+    return doc;
+}
+
+/**
+ * Substitute `${{ inputs.X }}` / `${{ steps.Y.output }}` in a nested value.
+ * Unknown references throw — the linter should have caught them, but the
+ * runtime double-checks.
+ */
+export function _interpolate(value: Any, state: PipelineState): Any {
+    if (typeof value === 'string') {
+        return value.replace(_INTERP_RE, (_match, ns: string, ident: string) => {
+            if (ns === 'inputs') {
+                if (!(ident in state.inputs)) {
+                    // Mirror Python `KeyError(f"unknown input '{ident}'")`.
+                    throw new KeyError(`unknown input '${ident}'`);
+                }
+                return state.inputs[ident] as string;
+            }
+            if (!(ident in state.results)) {
+                throw new KeyError(`unknown step '${ident}'`);
+            }
+            return (state.results[ident] as StepResult).output;
+        });
+    }
+    if (_isDict(value)) {
+        const out: Record<string, Any> = {};
+        for (const [k, v] of Object.entries(value)) {
+            out[k] = _interpolate(v, state);
+        }
+        return out;
+    }
+    if (Array.isArray(value)) {
+        return value.map((v) => _interpolate(v, state));
+    }
+    return value;
+}
+
+/**
+ * Evaluate the limited `when` mini-language. Supports
+ * `steps.X.success` / `steps.X.failure` and equality on a single
+ * `${{ steps.X.output }}` template against a literal.
+ */
+export function _when_passes(when: string | null | undefined, state: PipelineState): boolean {
+    if (!when) {
+        return true;
+    }
+    when = when.trim();
+    const m1 = fullmatch(/steps\.([a-z0-9_-]+)\.(success|failure)/, when);
+    if (m1) {
+        const sid = m1[1] as string;
+        const kind = m1[2] as string;
+        if (!(sid in state.results)) {
+            return false;
+        }
+        const res = state.results[sid] as StepResult;
+        return kind === 'success' ? res.success : !res.success;
+    }
+    const m2 = fullmatch(/\$\{\{\s*steps\.([a-z0-9_-]+)\.output\s*\}\}\s*==\s*"([^"]*)"/, when);
+    if (m2) {
+        const sid = m2[1] as string;
+        const literal = m2[2] as string;
+        const res = state.results[sid] ?? new StepResult(sid, '', '');
+        return res.output === literal;
+    }
+    // Mirror Python `ValueError(f"unsupported when expression: {when!r}")`.
+    throw new ValueError(`unsupported when expression: ${pyRepr(when)}`);
+}
+
+/** A descriptor yielded by `iter_steps`, carrying the live state for callbacks. */
+export interface StepDescriptor {
+    id: string;
+    kind: string;
+    ref: string;
+    with: Any;
+    _state: PipelineState;
+}
+
+/**
+ * Yield interpolated step descriptors in order.
+ *
+ * Caller dispatches each descriptor via skill / command / persona /
+ * subagent and feeds the result back via {@link record_result}.
+ */
+export async function* iter_steps(
+    p: string,
+    inputs: Record<string, string>,
+): AsyncGenerator<StepDescriptor> {
+    const doc = await _load_pipeline(p);
+    const merged_inputs: Record<string, string> = {};
+    const docInputs = (doc['inputs'] as Any[] | null | undefined) || [];
+    for (const inp of docInputs) {
+        if (_isDict(inp) && typeof inp['id'] === 'string') {
+            const id = inp['id'] as string;
+            merged_inputs[id] =
+                id in inputs
+                    ? (inputs[id] as string)
+                    : (((inp['default'] as string | undefined) ?? '') as string);
+        }
+    }
+    const state = new PipelineState({
+        name: (doc['name'] as string | undefined) ?? '',
+        inputs: merged_inputs,
+    });
+    const steps = (doc['steps'] as Array<Record<string, Any>> | null | undefined) || [];
+    for (const step of steps) {
+        if (state.halted) {
+            break;
+        }
+        if (!_when_passes(step['when'] as string | null | undefined, state)) {
+            continue;
+        }
+        yield {
+            id: step['id'] as string,
+            kind: step['kind'] as string,
+            ref: step['ref'] as string,
+            with: _interpolate((step['with'] as Any) || {}, state),
+            _state: state,
+        };
+    }
+}
+
+/**
+ * Caller hands the descriptor + outcome back so subsequent steps can see
+ * `${{ steps.<id>.output }}`.
+ */
+export function record_result(
+    descriptor: StepDescriptor,
+    opts: { success: boolean; output?: string; error?: string | null },
+): void {
+    const state = descriptor._state;
+    state.results[descriptor.id] = new StepResult(
+        descriptor.id,
+        descriptor.kind,
+        descriptor.ref,
+        opts.success,
+        opts.output ?? '',
+        opts.error ?? null,
+    );
+    if (!opts.success) {
+        state.halted = true;
+        state.halt_reason = `step ${descriptor.id} failed`;
+    }
+}
+
+/**
+ * Resolve the pipeline's `outputs:` map against the captured step outputs.
+ * Returns an empty map if the pipeline declares no outputs.
+ */
+export async function resolve_outputs(
+    p: string,
+    state: PipelineState,
+): Promise<Record<string, Any>> {
+    const doc = await _load_pipeline(p);
+    const raw = (doc['outputs'] as Record<string, Any> | null | undefined) || {};
+    const out: Record<string, Any> = {};
+    for (const [k, v] of Object.entries(raw)) {
+        out[k] = _interpolate(v, state);
+    }
+    return out;
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/** Python `KeyError` — distinct class so callers can mirror the type. */
+export class KeyError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, KeyError.prototype);
+        this.name = 'KeyError';
+    }
+}
+
+/** Python `ValueError`. */
+export class ValueError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, ValueError.prototype);
+        this.name = 'ValueError';
+    }
+}
+
+/** Python `re.fullmatch(pattern, s)` — the whole string must match. */
+function fullmatch(pattern: RegExp, s: string): RegExpExecArray | null {
+    const anchored = new RegExp(`^(?:${pattern.source})$`, pattern.flags.replace('g', ''));
+    return anchored.exec(s);
+}
+
+/**
+ * Python `repr(s)` for a string — used in the `unsupported when` error.
+ * CPython prefers single quotes, switching to double only when the string
+ * contains a single quote and no double quote.
+ */
+function pyRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') {
+            body += '\\\\';
+        } else if (ch === quote) {
+            body += `\\${ch}`;
+        } else if (ch === '\n') {
+            body += '\\n';
+        } else if (ch === '\r') {
+            body += '\\r';
+        } else if (ch === '\t') {
+            body += '\\t';
+        } else {
+            body += ch;
+        }
+    }
+    return `${quote}${body}${quote}`;
+}

--- a/dist/agent-src/templates/scripts/work_engine/persona_policy.ts
+++ b/dist/agent-src/templates/scripts/work_engine/persona_policy.ts
@@ -1,0 +1,97 @@
+/**
+ * Persona policy — behavioural parameters resolved from `state.persona`.
+ *
+ * TypeScript twin of `work_engine/persona_policy.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Three personas ship today, each keyed by the string already carried
+ * on `DeliveryState.persona` (see
+ * `docs/contracts/implement-ticket-flow.md#personas`):
+ *
+ * `senior-engineer`
+ *     Default. Runs every step. No test widening.
+ * `qa`
+ *     Runs every step but widens the `test` scope to the full suite
+ *     (`scope=full` in the `run-tests` directive) so regressions
+ *     outside the changed paths are caught.
+ * `advisory`
+ *     Plan-only mode. `implement`, `test`, and `verify` short-
+ *     circuit to SUCCESS without doing work — the flow produces a
+ *     delivery report whose value is the plan itself, and next-command
+ *     suggestions are suppressed (nothing was committed).
+ *
+ * Unknown persona names fall back to `senior-engineer` rather than
+ * raising, so a mistyped value never aborts a run mid-flight. The
+ * caller is responsible for validating the string at the state-
+ * construction boundary if strict behaviour is needed.
+ */
+
+/** Name used when `state.persona` is empty or unrecognised. */
+export const DEFAULT_PERSONA = 'senior-engineer';
+
+/**
+ * Behavioural flags read by individual step handlers.
+ *
+ * The Python source is a frozen dataclass; this class mirrors its field
+ * order and default values. Instances are treated as read-only configuration
+ * (the Python `frozen=True` contract) — `_POLICIES` holds the only instances
+ * and callers never mutate them.
+ */
+export class PersonaPolicy {
+    readonly name: string;
+    readonly allows_implement: boolean;
+    readonly allows_test: boolean;
+    readonly allows_verify: boolean;
+    readonly widen_tests: boolean;
+    readonly suggests_next_commands: boolean;
+
+    constructor(args: {
+        name: string;
+        allows_implement?: boolean;
+        allows_test?: boolean;
+        allows_verify?: boolean;
+        widen_tests?: boolean;
+        suggests_next_commands?: boolean;
+    }) {
+        this.name = args.name;
+        this.allows_implement = args.allows_implement ?? true;
+        this.allows_test = args.allows_test ?? true;
+        this.allows_verify = args.allows_verify ?? true;
+        this.widen_tests = args.widen_tests ?? false;
+        this.suggests_next_commands = args.suggests_next_commands ?? true;
+        Object.freeze(this);
+    }
+}
+
+const _POLICIES: Record<string, PersonaPolicy> = {
+    'senior-engineer': new PersonaPolicy({ name: 'senior-engineer' }),
+    qa: new PersonaPolicy({ name: 'qa', widen_tests: true }),
+    advisory: new PersonaPolicy({
+        name: 'advisory',
+        allows_implement: false,
+        allows_test: false,
+        allows_verify: false,
+        suggests_next_commands: false,
+    }),
+};
+
+/**
+ * Return the policy for `persona`; fall back to the default on miss.
+ *
+ * `persona` is typed `unknown` because it originates from
+ * `DeliveryState.persona` which the Python dataclass declares as `str`
+ * but does not enforce — a caller may set it to `None`/`null` while
+ * wiring up a partial state in tests.
+ */
+export function resolve_policy(persona: unknown): PersonaPolicy {
+    if (typeof persona === 'string' && persona in _POLICIES) {
+        return _POLICIES[persona] as PersonaPolicy;
+    }
+    return _POLICIES[DEFAULT_PERSONA] as PersonaPolicy;
+}
+
+/** Return the persona names shipped today, in insertion order. */
+export function known_personas(): string[] {
+    return Object.keys(_POLICIES);
+}

--- a/dist/agent-src/templates/scripts/work_engine/state.ts
+++ b/dist/agent-src/templates/scripts/work_engine/state.ts
@@ -1,0 +1,1011 @@
+/**
+ * Schema v1 of the universal-engine work state.
+ *
+ * TypeScript twin of `work_engine/state.py` (ADR-094 py2ts). Byte-for-byte
+ * serialization parity with the Python original is the contract: field order,
+ * defaults, validation order, and error text are all part of the wire format
+ * the dispatcher and the freeze-guard replay depend on.
+ *
+ * The wire format adds five envelope fields on top of the legacy
+ * `DeliveryState` shape from `implement_ticket.delivery_state`:
+ *
+ * - `version` — integer schema version, currently `1`.
+ * - `input.kind` — typed input variant (only `"ticket"` for R1).
+ * - `input.data` — the original payload (was `state.ticket` in v0).
+ * - `intent` — coarse intent label (`"backend-coding"` for R1).
+ * - `directive_set` — name of the directive bundle the dispatcher
+ *   loads. The enum is forward-compatible: `ui`, `ui-trivial`, and
+ *   `mixed` are accepted by the schema even though only `backend`
+ *   has working directives in R1 (Phase 4 Step 4 — pre-listed to avoid
+ *   a schema bump when R3 V2 lands).
+ * - `stack` — optional `{frontend, mtime}` cache populated by
+ *   `work_engine.stack.detect` (R3 Phase 1). `null` while the
+ *   detector has not yet run; the dispatcher fills it on the first UI
+ *   dispatch and re-runs detection when `mtime` no longer matches the
+ *   filesystem (manifest edited).
+ * - `ui_audit` — optional inventory written by the
+ *   `existing-ui-audit` skill (R3 Phase 2). `null` while the audit
+ *   has not run; populated dict once the skill returns. `greenfield`
+ *   flag plus `greenfield_decision` carry the user's scaffolding
+ *   pick. The audit gate (`work_engine.directives.ui.audit`)
+ *   refuses to advance to design/apply while the slot is empty or
+ *   while `greenfield` is set without a recorded decision.
+ * - `ui_design` — optional design brief produced by
+ *   `work_engine.directives.ui.design` (R3 Phase 3 Step 1). Locks
+ *   layout / components / states / microcopy / a11y; `design_confirmed`
+ *   carries the user's sign-off.
+ * - `ui_review` — optional review-pass output written by
+ *   `work_engine.directives.ui.review` (R3 Phase 3 Step 4). Carries
+ *   the design-review findings list and a `review_clean` flag set when
+ *   no findings remain.
+ * - `ui_polish` — optional polish-pass log written by
+ *   `work_engine.directives.ui.polish` (R3 Phase 3 Step 5). Tracks
+ *   the round counter (`rounds` <= 2 ceiling) and the per-round
+ *   applied-fix list so a re-entry knows whether the loop has been
+ *   exhausted.
+ * - `contract` — optional backend-contract envelope written by
+ *   `work_engine.directives.mixed.contract` (R3 Phase 4 Step 1).
+ *   Locks `data_model` and `api_surface` before any UI work starts;
+ *   `contract_confirmed` carries the user's sign-off. The mixed UI
+ *   step refuses to advance without a confirmed contract — this is the
+ *   sentinel that prevents UI work from racing ahead of the backend.
+ * - `stitch` — optional integration-verification envelope written by
+ *   `work_engine.directives.mixed.stitch` (R3 Phase 4 Step 3).
+ *   Carries the end-to-end smoke `scenarios` list, an aggregate
+ *   `verdict` (success / blocked / partial), and the
+ *   `integration_confirmed` flag the user sets after reviewing the
+ *   integration evidence.
+ * - `halts` — append-only log of `HookHalt` events the engine
+ *   persisted into state. Populated by `emitters._emit_halt` when
+ *   it runs against an already-persisted state file (the P3 branch table
+ *   is preserved: fresh-run halts before the first `_save` still leave
+ *   no state on disk). The `explain_last` trace builder reads the
+ *   tail entry to fill the `trace.halt` slot. Each entry is
+ *   `{reason, step, surface, timestamp}`. The list defaults to empty
+ *   and is omitted from older state files via `from_dict`'s tolerant
+ *   reader — no schema-version bump.
+ *
+ * All other fields keep their v0 names so the dispatcher can read the
+ * legacy slice unchanged once Phase 3 wires the steps over.
+ *
+ * The module exposes:
+ *
+ * - `SCHEMA_VERSION` — the integer carried in `version`.
+ * - `KNOWN_INPUT_KINDS` / `KNOWN_DIRECTIVE_SETS` — the
+ *   whitelists used by validation.
+ * - `Input`, `WorkState` — typed classes.
+ * - `from_dict` / `to_dict` — JSON round-trip helpers.
+ * - `SchemaError` — raised on every validation failure.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ── JSON value model ────────────────────────────────────────────────────
+//
+// The persisted state carries arbitrary user JSON (the input payload, the
+// plan / changes / tests / verify slots). Model it as the standard JSON
+// union so the heterogeneous dict shape and any-missing-key access survive
+// without `any`.
+
+export type JsonValue =
+    | string
+    | number
+    | boolean
+    | null
+    | JsonValue[]
+    | { [key: string]: JsonValue };
+
+/** A heterogeneous JSON object, mirroring a Python `dict[str, Any]`. */
+export type Dict = { [key: string]: JsonValue };
+
+export const SCHEMA_VERSION = 1;
+/** Integer version stored under the `version` key on disk. */
+
+export const DEFAULT_INTENT = 'backend-coding';
+/** Intent applied when migrating a v0 file or building a fresh state. */
+
+export const DEFAULT_DIRECTIVE_SET = 'backend';
+/** Directive set applied when migrating a v0 file or building a fresh state. */
+
+/**
+ * Input kinds accepted by the schema.
+ *
+ * `ticket` is the R1 kind: pre-structured `{id, title, acceptance_criteria, ...}`
+ * fed by the `/implement-ticket` flow. `prompt` is the R2 kind: a free-form
+ * user prompt wrapped via `work_engine.resolvers.prompt` into
+ * `{raw, reconstructed_ac, assumptions}`; the engine refines the raw text
+ * into actionable AC + a confidence band before plan/apply/test/review run.
+ *
+ * `diff` and `file` are the R3 Phase 1 UI-improve kinds. `diff` carries a
+ * unified-diff / patch payload (`{raw, reconstructed_ac, assumptions}`) so the
+ * `directives/ui` set can take an "improve this screen" PR-style input; `file`
+ * carries a path reference to an existing component/page (`{path,
+ * reconstructed_ac, assumptions}`) for the same surface. Both default-route to
+ * `ui-improve` via `work_engine.intent.populate_routing`.
+ *
+ * Per the schema/capability split documented on
+ * `work_engine.directives.backend.SUPPORTED_KINDS`, presence here only
+ * means the *envelope* is accepted on disk — a directive set still has to
+ * list the kind in its `SUPPORTED_KINDS` tuple before the dispatcher will
+ * route it. R2 widens the envelope; R2 Phase 3 widens backend's capability
+ * tuple in lockstep with the `refine-prompt` skill landing. R3 Phase 1 widens
+ * the envelope further; `ui` capability is wired in Phase 3 of the UI track.
+ *
+ * Other kinds are rejected so unknown values surface as errors instead of
+ * silently falling through to a default branch.
+ */
+export const KNOWN_INPUT_KINDS: ReadonlySet<string> = new Set([
+    'ticket',
+    'prompt',
+    'diff',
+    'file',
+]);
+
+/**
+ * Directive sets recognised by the schema.
+ *
+ * Per the roadmap (Phase 4 Step 4), `ui`, `ui-trivial`, and `mixed`
+ * are intentionally pre-listed so a future R3 V2 release does not need a
+ * schema bump. Only `backend` has working directives in R1; the others
+ * raise `NotImplementedError` at dispatch time.
+ */
+export const KNOWN_DIRECTIVE_SETS: ReadonlySet<string> = new Set([
+    'backend',
+    'ui',
+    'ui-trivial',
+    'mixed',
+]);
+
+/** Raised when a state payload violates the v1 contract. */
+export class SchemaError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SchemaError';
+        Object.setPrototypeOf(this, SchemaError.prototype);
+    }
+}
+
+/**
+ * Typed envelope for the user-supplied work item.
+ *
+ * `kind` is one of `KNOWN_INPUT_KINDS`; `data` is the raw
+ * payload. The legacy `state.ticket` dict lands here as
+ * `Input(kind="ticket", data=<dict>)` after migration.
+ */
+export class Input {
+    kind: string;
+    data: Dict;
+
+    constructor(kind: string, data: Dict | null = null) {
+        this.kind = kind;
+        // Mirror `field(default_factory=dict)` — a fresh empty dict per instance.
+        this.data = data ?? {};
+    }
+}
+
+/**
+ * Schema v1 of the persisted work state.
+ *
+ * Field order mirrors the on-disk JSON: envelope (`version`,
+ * `input`, `intent`, `directive_set`, `stack`) first, then
+ * the legacy `DeliveryState` slice (`persona` ... `report`) so a
+ * diff between a v1 file and its v0 ancestor stays readable.
+ */
+export class WorkState {
+    input: Input;
+    intent: string;
+    directive_set: string;
+    stack: Dict | null;
+    ui_audit: Dict | null;
+    ui_design: Dict | null;
+    ui_review: Dict | null;
+    ui_polish: Dict | null;
+    contract: Dict | null;
+    stitch: Dict | null;
+    halts: Dict[];
+    version: number;
+    persona: string;
+    memory: Dict[];
+    plan: JsonValue;
+    changes: Dict[];
+    tests: JsonValue;
+    verify: JsonValue;
+    outcomes: { [key: string]: string };
+    questions: string[];
+    report: string;
+
+    constructor(opts: {
+        input: Input;
+        intent?: string;
+        directive_set?: string;
+        stack?: Dict | null;
+        ui_audit?: Dict | null;
+        ui_design?: Dict | null;
+        ui_review?: Dict | null;
+        ui_polish?: Dict | null;
+        contract?: Dict | null;
+        stitch?: Dict | null;
+        halts?: Dict[];
+        version?: number;
+        persona?: string;
+        memory?: Dict[];
+        plan?: JsonValue;
+        changes?: Dict[];
+        tests?: JsonValue;
+        verify?: JsonValue;
+        outcomes?: { [key: string]: string };
+        questions?: string[];
+        report?: string;
+    }) {
+        this.input = opts.input;
+        this.intent = opts.intent ?? DEFAULT_INTENT;
+        this.directive_set = opts.directive_set ?? DEFAULT_DIRECTIVE_SET;
+        this.stack = opts.stack ?? null;
+        this.ui_audit = opts.ui_audit ?? null;
+        this.ui_design = opts.ui_design ?? null;
+        this.ui_review = opts.ui_review ?? null;
+        this.ui_polish = opts.ui_polish ?? null;
+        this.contract = opts.contract ?? null;
+        this.stitch = opts.stitch ?? null;
+        this.halts = opts.halts ?? [];
+        this.version = opts.version ?? SCHEMA_VERSION;
+        this.persona = opts.persona ?? 'senior-engineer';
+        this.memory = opts.memory ?? [];
+        this.plan = opts.plan ?? null;
+        this.changes = opts.changes ?? [];
+        this.tests = opts.tests ?? null;
+        this.verify = opts.verify ?? null;
+        this.outcomes = opts.outcomes ?? {};
+        this.questions = opts.questions ?? [];
+        this.report = opts.report ?? '';
+    }
+}
+
+/**
+ * Serialise `state` to the canonical v1 JSON shape.
+ *
+ * Field order is fixed: `version` -> `input` -> `intent` ->
+ * `directive_set` -> legacy slice. Stable order keeps state
+ * snapshots diff-friendly across re-runs and across the freeze-guard
+ * replay. Validation runs before serialisation so an in-memory
+ * object that was mutated past the schema cannot reach disk.
+ */
+export function to_dict(state: WorkState): Dict {
+    _validate_kind(state.input.kind);
+    _validate_directive_set(state.directive_set);
+    if (state.version !== SCHEMA_VERSION) {
+        throw new SchemaError(
+            `version must be ${SCHEMA_VERSION}; got ${pyRepr(state.version)}`,
+        );
+    }
+    _validate_stack(state.stack);
+    _validate_ui_audit(state.ui_audit);
+    _validate_ui_design(state.ui_design);
+    _validate_ui_review(state.ui_review);
+    _validate_ui_polish(state.ui_polish);
+    _validate_contract(state.contract);
+    _validate_stitch(state.stitch);
+    _validate_halts(state.halts);
+    return {
+        version: state.version,
+        input: { kind: state.input.kind, data: state.input.data },
+        intent: state.intent,
+        directive_set: state.directive_set,
+        stack: state.stack,
+        ui_audit: state.ui_audit,
+        ui_design: state.ui_design,
+        ui_review: state.ui_review,
+        ui_polish: state.ui_polish,
+        contract: state.contract,
+        stitch: state.stitch,
+        halts: [...state.halts],
+        persona: state.persona,
+        memory: state.memory,
+        plan: state.plan,
+        changes: state.changes,
+        tests: state.tests,
+        verify: state.verify,
+        outcomes: state.outcomes,
+        questions: state.questions,
+        report: state.report,
+    };
+}
+
+/**
+ * Build a `WorkState` from a parsed JSON payload.
+ *
+ * Validates the envelope (`version`, `input.kind`,
+ * `directive_set`) before instantiating the class. Unknown
+ * top-level keys are tolerated and dropped — the schema is additive,
+ * not strict-rejecting, so a future field rolled out by a newer
+ * engine version does not crash an older reader.
+ */
+export function from_dict(payload: JsonValue): WorkState {
+    if (!_isDict(payload)) {
+        throw new SchemaError(
+            `state payload must be a JSON object; got ${pyTypeName(payload)}`,
+        );
+    }
+
+    const version = payload['version'];
+    if (version !== SCHEMA_VERSION) {
+        throw new SchemaError(
+            `version must be ${SCHEMA_VERSION}; got ${pyRepr(version)}. ` +
+                'Run the v0→v1 migration before loading legacy files.',
+        );
+    }
+
+    const raw_input = payload['input'];
+    if (!_isDict(raw_input)) {
+        throw new SchemaError(
+            "state.input must be a JSON object with 'kind' and 'data' keys",
+        );
+    }
+    const kind = raw_input['kind'];
+    _validate_kind(kind);
+    const data = 'data' in raw_input ? raw_input['data'] : {};
+    if (!_isDict(data)) {
+        throw new SchemaError(
+            `state.input.data must be a JSON object; got ${pyTypeName(data)}`,
+        );
+    }
+
+    const directive_set = _get(payload, 'directive_set', DEFAULT_DIRECTIVE_SET);
+    _validate_directive_set(directive_set);
+
+    const stack = payload['stack'] ?? null;
+    _validate_stack(stack);
+
+    const ui_audit = payload['ui_audit'] ?? null;
+    _validate_ui_audit(ui_audit);
+
+    const ui_design = payload['ui_design'] ?? null;
+    _validate_ui_design(ui_design);
+
+    const ui_review = payload['ui_review'] ?? null;
+    _validate_ui_review(ui_review);
+
+    const ui_polish = payload['ui_polish'] ?? null;
+    _validate_ui_polish(ui_polish);
+
+    const contract = payload['contract'] ?? null;
+    _validate_contract(contract);
+
+    const stitch = payload['stitch'] ?? null;
+    _validate_stitch(stitch);
+
+    const halts = 'halts' in payload ? payload['halts'] : [];
+    _validate_halts(halts);
+
+    return new WorkState({
+        input: new Input(kind as string, { ...(data as Dict) }),
+        intent: _get(payload, 'intent', DEFAULT_INTENT) as string,
+        directive_set: directive_set as string,
+        stack: _isDict(stack) ? { ...stack } : null,
+        ui_audit: _isDict(ui_audit) ? { ...ui_audit } : null,
+        ui_design: _isDict(ui_design) ? { ...ui_design } : null,
+        ui_review: _isDict(ui_review) ? { ...ui_review } : null,
+        ui_polish: _isDict(ui_polish) ? { ...ui_polish } : null,
+        contract: _isDict(contract) ? { ...contract } : null,
+        stitch: _isDict(stitch) ? { ...stitch } : null,
+        halts: Array.isArray(halts) ? ([...halts] as Dict[]) : [],
+        version: version as number,
+        persona: _get(payload, 'persona', 'senior-engineer') as string,
+        memory: [...(_listOrEmpty(_get(payload, 'memory', [])))] as Dict[],
+        plan: _get(payload, 'plan', null),
+        changes: [...(_listOrEmpty(_get(payload, 'changes', [])))] as Dict[],
+        tests: _get(payload, 'tests', null),
+        verify: _get(payload, 'verify', null),
+        outcomes: { ...(_dictOrEmpty(_get(payload, 'outcomes', {}))) } as {
+            [key: string]: string;
+        },
+        questions: [
+            ...(_listOrEmpty(_get(payload, 'questions', []))),
+        ] as string[],
+        report: _get(payload, 'report', '') as string,
+    });
+}
+
+/** Read a v1 state file from disk and return a `WorkState`. */
+export function load(p: string): WorkState {
+    const raw = fs.readFileSync(p, 'utf-8');
+    let payload: JsonValue;
+    try {
+        payload = JSON.parse(raw) as JsonValue;
+    } catch (exc) {
+        throw new SchemaError(`invalid JSON in ${p}: ${(exc as Error).message}`);
+    }
+    return from_dict(payload);
+}
+
+/** Write `state` to `p` as pretty JSON, terminating newline included. */
+export function dump(state: WorkState, p: string): void {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, jsonDumps(to_dict(state)) + '\n', 'utf-8');
+}
+
+function _validate_kind(kind: JsonValue | undefined): void {
+    if (typeof kind !== 'string') {
+        throw new SchemaError(
+            `state.input.kind must be a string; got ${pyTypeName(kind)}`,
+        );
+    }
+    if (!KNOWN_INPUT_KINDS.has(kind)) {
+        throw new SchemaError(
+            `unknown input.kind ${pyRepr(kind)}; ` +
+                `expected one of ${pyListRepr(pySorted(KNOWN_INPUT_KINDS))}`,
+        );
+    }
+}
+
+function _validate_directive_set(name: JsonValue): void {
+    if (typeof name !== 'string') {
+        throw new SchemaError(
+            `state.directive_set must be a string; got ${pyTypeName(name)}`,
+        );
+    }
+    if (!KNOWN_DIRECTIVE_SETS.has(name)) {
+        throw new SchemaError(
+            `unknown directive_set ${pyRepr(name)}; ` +
+                `expected one of ${pyListRepr(pySorted(KNOWN_DIRECTIVE_SETS))}`,
+        );
+    }
+}
+
+/**
+ * Reject malformed stack envelopes; tolerate `null` (not yet detected).
+ *
+ * The detector populates `state.stack` lazily — the first dispatch
+ * of a new state file may run without it set, then the dispatcher
+ * fills it in before any UI handler reads it. We only validate the
+ * shape when present so the absence-of-detection case stays a normal
+ * code path, not an error.
+ */
+function _validate_stack(stack: JsonValue): void {
+    if (stack === null) {
+        return;
+    }
+    if (!_isDict(stack)) {
+        throw new SchemaError(
+            `state.stack must be a JSON object or null; ` +
+                `got ${pyTypeName(stack)}`,
+        );
+    }
+    const frontend = stack['frontend'];
+    if (typeof frontend !== 'string' || !frontend) {
+        throw new SchemaError('state.stack.frontend must be a non-empty string');
+    }
+    const mtime = 'mtime' in stack ? stack['mtime'] : 0.0;
+    if (!_isNumber(mtime)) {
+        throw new SchemaError(
+            `state.stack.mtime must be a number; got ${pyTypeName(mtime)}`,
+        );
+    }
+}
+
+/**
+ * Reject malformed `ui_audit` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the audit has not run yet — the dispatcher's audit
+ * gate (`directives.ui.audit`) will emit the agent-directive that
+ * populates it. An empty dict is the in-progress shape after the
+ * skill returns but before findings land; the gate treats it the
+ * same as `null`. Once populated, `greenfield` (when present)
+ * must be a bool, and `greenfield_decision` (when present) must
+ * be one of the three documented choices. Other keys (`components`,
+ * `patterns`, ...) are validated by the audit handler against the
+ * skill contract — the schema only enforces shape, not content.
+ */
+function _validate_ui_audit(ui_audit: JsonValue): void {
+    if (ui_audit === null) {
+        return;
+    }
+    if (!_isDict(ui_audit)) {
+        throw new SchemaError(
+            `state.ui_audit must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_audit)}`,
+        );
+    }
+    if ('greenfield' in ui_audit && typeof ui_audit['greenfield'] !== 'boolean') {
+        throw new SchemaError(
+            'state.ui_audit.greenfield must be a boolean when present',
+        );
+    }
+    const decision = 'greenfield_decision' in ui_audit
+        ? ui_audit['greenfield_decision']
+        : null;
+    if (
+        decision !== null &&
+        decision !== 'scaffold' &&
+        decision !== 'bare' &&
+        decision !== 'external_reference'
+    ) {
+        throw new SchemaError(
+            `state.ui_audit.greenfield_decision must be one of ` +
+                `'scaffold', 'bare', 'external_reference', or null; ` +
+                `got ${pyRepr(decision)}`,
+        );
+    }
+    if (
+        'a11y_baseline' in ui_audit &&
+        !Array.isArray(ui_audit['a11y_baseline'])
+    ) {
+        throw new SchemaError(
+            'state.ui_audit.a11y_baseline must be a list when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `ui_design` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the design step has not produced a brief yet — the
+ * dispatcher's design gate (`directives.ui.design`) emits the
+ * agent-directive that populates it. An empty dict is the in-progress
+ * shape after the skill returns but before the brief lands; the gate
+ * treats it the same as `null`. Once populated, `design_confirmed`
+ * (when present) must be a bool. Other keys (`layout`, `components`,
+ * `states`, `microcopy`, `a11y`, `reused_from_audit`) are
+ * validated by the design handler against the skill contract — the
+ * schema only enforces shape, not content.
+ */
+function _validate_ui_design(ui_design: JsonValue): void {
+    if (ui_design === null) {
+        return;
+    }
+    if (!_isDict(ui_design)) {
+        throw new SchemaError(
+            `state.ui_design must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_design)}`,
+        );
+    }
+    if (
+        'design_confirmed' in ui_design &&
+        typeof ui_design['design_confirmed'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.ui_design.design_confirmed must be a boolean when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `ui_review` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the review pass has not run yet — the dispatcher's
+ * review gate (`directives.ui.review`) emits the agent-directive
+ * that populates it. An empty dict is the in-progress shape after
+ * the skill returns but before findings land. Once populated,
+ * `findings` (when present) must be a list and `review_clean`
+ * (when present) must be a bool. Field content (severity labels,
+ * fix suggestions) is validated by the review handler; the schema
+ * enforces only shape.
+ */
+function _validate_ui_review(ui_review: JsonValue): void {
+    if (ui_review === null) {
+        return;
+    }
+    if (!_isDict(ui_review)) {
+        throw new SchemaError(
+            `state.ui_review must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_review)}`,
+        );
+    }
+    if ('findings' in ui_review && !Array.isArray(ui_review['findings'])) {
+        throw new SchemaError(
+            'state.ui_review.findings must be a list when present',
+        );
+    }
+    if (
+        'review_clean' in ui_review &&
+        typeof ui_review['review_clean'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.ui_review.review_clean must be a boolean when present',
+        );
+    }
+    const a11y = 'a11y' in ui_review ? ui_review['a11y'] : null;
+    if (a11y !== null) {
+        if (!_isDict(a11y)) {
+            throw new SchemaError(
+                'state.ui_review.a11y must be a JSON object or null when present',
+            );
+        }
+        if ('violations' in a11y && !Array.isArray(a11y['violations'])) {
+            throw new SchemaError(
+                'state.ui_review.a11y.violations must be a list when present',
+            );
+        }
+        const floor = 'severity_floor' in a11y ? a11y['severity_floor'] : null;
+        if (
+            floor !== null &&
+            floor !== 'minor' &&
+            floor !== 'moderate' &&
+            floor !== 'serious' &&
+            floor !== 'critical'
+        ) {
+            throw new SchemaError(
+                `state.ui_review.a11y.severity_floor must be one of ` +
+                    `'minor', 'moderate', 'serious', 'critical', or null; ` +
+                    `got ${pyRepr(floor)}`,
+            );
+        }
+        if (
+            'accepted_violations' in a11y &&
+            !Array.isArray(a11y['accepted_violations'])
+        ) {
+            throw new SchemaError(
+                'state.ui_review.a11y.accepted_violations must be a list when present',
+            );
+        }
+    }
+    const preview = 'preview' in ui_review ? ui_review['preview'] : null;
+    if (preview !== null) {
+        if (!_isDict(preview)) {
+            throw new SchemaError(
+                'state.ui_review.preview must be a JSON object or null when present',
+            );
+        }
+        if ('render_ok' in preview && typeof preview['render_ok'] !== 'boolean') {
+            throw new SchemaError(
+                'state.ui_review.preview.render_ok must be a boolean when present',
+            );
+        }
+    }
+}
+
+/**
+ * Reject malformed `ui_polish` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the polish loop has not entered yet. Once
+ * populated, `rounds` (when present) must be an int in `[0, 2]`
+ * by default — the polish-loop ceiling defined in
+ * `agents/roadmaps/road-to-product-ui-track.md` Phase 3 Step 5.
+ * R4 Phase 2 widens the upper bound to `3` when
+ * `extension_used` is `True` (one-shot a11y extension halt).
+ * `applied` (when present) must be a list. The polish handler
+ * enforces ceiling semantics; the schema enforces only shape.
+ */
+function _validate_ui_polish(ui_polish: JsonValue): void {
+    if (ui_polish === null) {
+        return;
+    }
+    if (!_isDict(ui_polish)) {
+        throw new SchemaError(
+            `state.ui_polish must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_polish)}`,
+        );
+    }
+    if (
+        'extension_used' in ui_polish &&
+        typeof ui_polish['extension_used'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.ui_polish.extension_used must be a boolean when present',
+        );
+    }
+    const extension_used = _pyBool(
+        'extension_used' in ui_polish ? ui_polish['extension_used'] : false,
+    );
+    if ('rounds' in ui_polish) {
+        const rounds = ui_polish['rounds'];
+        if (!_isPyInt(rounds)) {
+            throw new SchemaError(
+                `state.ui_polish.rounds must be an integer; got ${pyTypeName(rounds)}`,
+            );
+        }
+        const max_rounds = extension_used ? 3 : 2;
+        if (rounds < 0 || rounds > max_rounds) {
+            throw new SchemaError(
+                `state.ui_polish.rounds must be in [0, ${max_rounds}]; ` +
+                    `got ${rounds} (extension_used=${pyBoolRepr(extension_used)})`,
+            );
+        }
+    }
+    if ('applied' in ui_polish && !Array.isArray(ui_polish['applied'])) {
+        throw new SchemaError(
+            'state.ui_polish.applied must be a list when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `contract` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the contract step has not run yet — the mixed
+ * `contract` directive (R3 Phase 4 Step 1) emits the
+ * agent-directive that populates it. Once populated,
+ * `data_model` and `api_surface` (when present) must be lists,
+ * and `contract_confirmed` (when present) must be a bool. Field
+ * content (entity names, endpoint shapes) is validated by the
+ * contract handler; the schema enforces only shape so the mixed UI
+ * step's sentinel check (`contract_confirmed is True`) stays a
+ * simple equality test.
+ */
+function _validate_contract(contract: JsonValue): void {
+    if (contract === null) {
+        return;
+    }
+    if (!_isDict(contract)) {
+        throw new SchemaError(
+            `state.contract must be a JSON object or null; ` +
+                `got ${pyTypeName(contract)}`,
+        );
+    }
+    if ('data_model' in contract && !Array.isArray(contract['data_model'])) {
+        throw new SchemaError(
+            'state.contract.data_model must be a list when present',
+        );
+    }
+    if ('api_surface' in contract && !Array.isArray(contract['api_surface'])) {
+        throw new SchemaError(
+            'state.contract.api_surface must be a list when present',
+        );
+    }
+    if (
+        'contract_confirmed' in contract &&
+        typeof contract['contract_confirmed'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.contract.contract_confirmed must be a bool when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `stitch` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the integration-verification step has not run yet
+ * — the mixed `stitch` directive (R3 Phase 4 Step 3) emits the
+ * agent-directive that populates it. Once populated, `scenarios`
+ * (when present) must be a list of integration smoke cases,
+ * `verdict` (when present) must be one of
+ * `{"success", "blocked", "partial"}`, and
+ * `integration_confirmed` (when present) must be a bool. The
+ * stitch handler enforces verdict semantics; the schema enforces
+ * only shape.
+ */
+function _validate_stitch(stitch: JsonValue): void {
+    if (stitch === null) {
+        return;
+    }
+    if (!_isDict(stitch)) {
+        throw new SchemaError(
+            `state.stitch must be a JSON object or null; ` +
+                `got ${pyTypeName(stitch)}`,
+        );
+    }
+    if ('scenarios' in stitch && !Array.isArray(stitch['scenarios'])) {
+        throw new SchemaError(
+            'state.stitch.scenarios must be a list when present',
+        );
+    }
+    if ('verdict' in stitch) {
+        const verdict = stitch['verdict'];
+        if (
+            verdict !== 'success' &&
+            verdict !== 'blocked' &&
+            verdict !== 'partial'
+        ) {
+            throw new SchemaError(
+                `state.stitch.verdict must be one of success/blocked/partial; ` +
+                    `got ${pyRepr(verdict)}`,
+            );
+        }
+    }
+    if (
+        'integration_confirmed' in stitch &&
+        typeof stitch['integration_confirmed'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.stitch.integration_confirmed must be a bool when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `halts` envelopes; tolerate `[]`.
+ *
+ * Each entry must be a dict with at minimum `reason` (str) and
+ * `surface` (list of str). `step` and `timestamp` are optional
+ * metadata appended by `emitters._emit_halt`. The schema enforces
+ * only shape — the explain renderer is responsible for fallback
+ * rendering when optional fields are absent.
+ */
+function _validate_halts(halts: JsonValue): void {
+    if (!Array.isArray(halts)) {
+        throw new SchemaError(
+            `state.halts must be a list; got ${pyTypeName(halts)}`,
+        );
+    }
+    for (let idx = 0; idx < halts.length; idx++) {
+        const entry = halts[idx];
+        if (!_isDict(entry)) {
+            throw new SchemaError(
+                `state.halts[${idx}] must be a JSON object; ` +
+                    `got ${pyTypeName(entry)}`,
+            );
+        }
+        const reason = 'reason' in entry ? entry['reason'] : undefined;
+        if (typeof reason !== 'string' || !reason) {
+            throw new SchemaError(
+                `state.halts[${idx}].reason must be a non-empty string`,
+            );
+        }
+        const surface = 'surface' in entry ? entry['surface'] : [];
+        if (!Array.isArray(surface)) {
+            throw new SchemaError(
+                `state.halts[${idx}].surface must be a list; ` +
+                    `got ${pyTypeName(surface)}`,
+            );
+        }
+        for (let j = 0; j < surface.length; j++) {
+            if (typeof surface[j] !== 'string') {
+                throw new SchemaError(
+                    `state.halts[${idx}].surface[${j}] must be a string`,
+                );
+            }
+        }
+    }
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * True when `v` is a plain JSON object (Python `dict`). Arrays and `null`
+ * are excluded, mirroring `isinstance(x, dict)`.
+ */
+function _isDict(v: JsonValue | undefined): v is Dict {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Mirror Python `isinstance(x, (int, float))` for the `mtime` check. JSON
+ * numbers (int or float) are all JS `number`; booleans are NOT numbers in
+ * Python's `(int, float)` test only because `bool` IS a subclass of `int`
+ * — but `_validate_stack` does not exclude bools, so neither do we: a JSON
+ * `true`/`false` never reaches `mtime` as a JS boolean is `typeof boolean`,
+ * not `number`. Python's `isinstance(True, (int, float))` is True; to match
+ * that edge we treat a JS boolean as a number here too.
+ */
+function _isNumber(v: JsonValue): boolean {
+    return typeof v === 'number' || typeof v === 'boolean';
+}
+
+/**
+ * Mirror Python `isinstance(x, int) and not isinstance(x, bool)` for the
+ * `rounds` check. A JSON integer parses to a JS `number` with no fractional
+ * part; a JSON float with a fractional part is rejected; a JSON bool is
+ * rejected (Python excludes bool explicitly).
+ */
+function _isPyInt(v: JsonValue | undefined): v is number {
+    return typeof v === 'number' && Number.isInteger(v);
+}
+
+/** Mirror Python `bool(x)` truthiness for the values `ui_polish` can hold. */
+function _pyBool(v: JsonValue | undefined): boolean {
+    if (v === null || v === undefined) return false;
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'number') return v !== 0;
+    if (typeof v === 'string') return v.length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    if (_isDict(v)) return Object.keys(v).length > 0;
+    return true;
+}
+
+/** Python `dict.get(key, default)` over a JSON object. */
+function _get(obj: Dict, key: string, dflt: JsonValue): JsonValue {
+    return key in obj ? (obj[key] as JsonValue) : dflt;
+}
+
+/** `list(x)` where x may be a list (copy) or anything else (Python would error,
+ * but `from_dict` only feeds it the result of `payload.get(k, [])`, so it is a
+ * list or the default `[]`). Returns the array itself for spreading. */
+function _listOrEmpty(v: JsonValue): JsonValue[] {
+    return Array.isArray(v) ? v : [];
+}
+
+/** `dict(x)` where x is the result of `payload.get(k, {})`. */
+function _dictOrEmpty(v: JsonValue): Dict {
+    return _isDict(v) ? v : {};
+}
+
+/**
+ * Python `type(x).__name__` for the JSON value classes that appear in the
+ * error messages: `dict`, `list`, `str`, `int`, `float`, `bool`, `NoneType`.
+ */
+function pyTypeName(v: JsonValue | undefined): string {
+    if (v === null || v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}
+
+/**
+ * Python `repr(x)` for the scalar values that flow into error messages
+ * (`version`, `kind`, `decision`, `floor`, `verdict`). Strings → single-quoted
+ * with Python escaping; `None` → `None`; bools → `True`/`False`; numbers as-is.
+ */
+function pyRepr(v: JsonValue | undefined): string {
+    if (v === undefined || v === null) return 'None';
+    if (typeof v === 'boolean') return v ? 'True' : 'False';
+    if (typeof v === 'number') return _pyNumRepr(v);
+    if (typeof v === 'string') return pyStrRepr(v);
+    if (Array.isArray(v)) {
+        return '[' + v.map((x) => pyRepr(x)).join(', ') + ']';
+    }
+    // dict repr is not exercised by the .py error paths; render Python-ish.
+    const items = Object.keys(v).map((k) => `${pyStrRepr(k)}: ${pyRepr(v[k])}`);
+    return '{' + items.join(', ') + '}';
+}
+
+/** Python numeric repr — integer-valued floats are never produced here because
+ * JSON-parsed numbers carry no float/int tag; an integer renders without `.0`. */
+function _pyNumRepr(n: number): string {
+    return String(n);
+}
+
+/**
+ * Python `repr(str)` — prefers single quotes, switches to double quotes only
+ * when the string contains a single quote but no double quote, and escapes
+ * backslash plus the active quote and the standard control characters.
+ */
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') out += '\\\\';
+        else if (ch === quote) out += '\\' + quote;
+        else if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}
+
+/** Python `repr(list_of_str)` for the `sorted(KNOWN_*)` error tails. */
+function pyListRepr(items: string[]): string {
+    return '[' + items.map((s) => pyStrRepr(s)).join(', ') + ']';
+}
+
+/** Python `repr(bool)` — `True` / `False`. */
+function pyBoolRepr(b: boolean): string {
+    return b ? 'True' : 'False';
+}
+
+/**
+ * Python `sorted(set_of_str)` — code-point ascending, the default `str`
+ * ordering CPython uses. `Array.prototype.sort()` with no comparator sorts
+ * by UTF-16 code unit, which matches for the BMP ASCII tokens in these sets;
+ * use an explicit code-point comparator to be faithful for any input.
+ */
+function pySorted(values: ReadonlySet<string>): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, ensure_ascii=False)`.
+ *
+ * For round-tripped JSON (the only producer of a state dict), `JSON.stringify`
+ * with a 2-space indent matches CPython byte-for-byte: 2-space indent,
+ * `": "` key separator, no trailing space after the array/object item commas,
+ * `{}` / `[]` for empties, non-ASCII left verbatim. The one structural
+ * difference CPython has — integer-valued floats rendered as `N.0` — cannot
+ * arise here: JSON has no float/int tag, so a parsed `1.0` is already the JS
+ * number `1` before it ever reaches this serialiser, exactly as a Python
+ * reader that parsed the same bytes would diverge. `to_dict` never injects a
+ * float that did not come from the parsed payload.
+ */
+function jsonDumps(obj: Dict): string {
+    return JSON.stringify(obj, null, 2);
+}

--- a/src/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
+++ b/src/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
@@ -1,0 +1,1107 @@
+/**
+ * Centralized loader for `.agent-settings.yml` with user-global fallback.
+ *
+ * TypeScript twin of `src/scripts/_lib/agent_settings.py` (ADR-094,
+ * Phase 2 / Wave 2a). Mirrors the Python module's public API exactly —
+ * same exported snake_case names, same semantics, same cascade / anchor /
+ * whitelist / merge behavior, same YAML load tolerance, same error types.
+ * Single source of truth for how scripts read agent settings.
+ *
+ * Resolution order (deepest wins; user-global is whitelist-filtered only):
+ *
+ *   N.   `~/.event4u/agent-config/agent-settings.yml` (user-global; whitelist only)
+ *   N-1. `<repo-root>/.agent-settings.yml`            (project-wide; all keys)
+ *   N-2. `<intermediate-dir>/.agent-settings.yml`     (subsystem-scoped; all keys)
+ *   1.   `<CWD>/.agent-settings.yml`                  (deepest, wins; all keys)
+ *
+ * The user-global path is resolved via the sibling `user_global_paths`
+ * twin with a read-fallback to the legacy `~/.config/agent-config/`
+ * location so pre-2.4 installs keep working during the migration.
+ *
+ * `<repo-root>` is the nearest ancestor that anchors the project
+ * (closest-leaf wins; tiebreaker `.agent-settings.yml` > `agents/` > `.git`):
+ *
+ * - `.agent-settings.yml` file,
+ * - `agents/` directory containing `roadmaps/`, `settings/.ai-council.yml`,
+ *   or `roadmaps-progress.md` (bare `agents/` does NOT anchor),
+ * - `.git` file or directory (submodule support).
+ *
+ * Set `AGENT_CONFIG_LEGACY_ANCHOR=1` to revert to the pre-Step-7
+ * `.git`-only walk for one minor-version soak. When `cwd` is `null`
+ * (default), the loader behaves identically to the pre-cascade
+ * contract: project file + user-global only, no ancestor walk.
+ *
+ * Contract — pure, read-only, tolerant:
+ *
+ * - YAML parse failure / unreadable file → defaults, logged at WARNING.
+ * - Missing files → defaults.
+ * - No file is ever created or written by this module.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import * as user_global_paths from './user_global_paths.js';
+
+/** JSON-ish value type — mirrors Python's `Any` for settings data. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SettingsValue = any;
+export type SettingsDict = Record<string, SettingsValue>;
+
+/**
+ * Module logger sink. Mirrors `logging.getLogger(__name__)` so tests can
+ * capture INFO/WARNING records the same way `caplog` does in pytest.
+ *
+ * Records are appended to `logger.records` and also emitted to the real
+ * sink (`console.info` / `console.warn`) so production behavior matches
+ * Python's logging. `name` mirrors the Python logger name used by tests.
+ */
+export interface LogRecord {
+    level: 'INFO' | 'WARNING';
+    message: string;
+}
+
+class Logger {
+    readonly name = 'scripts._lib.agent_settings';
+    readonly records: LogRecord[] = [];
+
+    info(message: string, ...args: SettingsValue[]): void {
+        this.records.push({ level: 'INFO', message: _format(message, args) });
+    }
+
+    warning(message: string, ...args: SettingsValue[]): void {
+        this.records.push({ level: 'WARNING', message: _format(message, args) });
+    }
+}
+
+/** printf-style `%s` interpolation mirroring Python's logging args. */
+function _format(template: string, args: SettingsValue[]): string {
+    let i = 0;
+    return template.replace(/%s/g, () => {
+        if (i < args.length) {
+            const value = args[i];
+            i += 1;
+            return _pystr(value);
+        }
+        return '%s';
+    });
+}
+
+/** Python-ish `str()` of a value for log messages (lists render `[...]`). */
+function _pystr(value: SettingsValue): string {
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => _pyrepr(v)).join(', ')}]`;
+    }
+    return String(value);
+}
+
+function _pyrepr(value: SettingsValue): string {
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}
+
+export const logger = new Logger();
+
+export const DEFAULT_PROJECT_FILE = '.agent-settings.yml';
+/**
+ * Per-machine override file. Gitignored. A SINGLE project-level file
+ * living under `agents/settings/` — appended as the deepest cascade
+ * layer so a developer's local values override every committed
+ * `.agent-settings.yml` without ever being committed. Missing file is
+ * harmless (read as {}).
+ */
+export const LOCAL_PROJECT_FILE = '.agent-settings.local.yml';
+/** Project-relative directory the local override lives in. */
+export const LOCAL_PROJECT_SUBDIR: readonly string[] = ['agents', 'settings'];
+
+/** Single local override: `<root>/agents/settings/.agent-settings.local.yml`. */
+function _local_settings_path(project_root: string): string {
+    return path.join(project_root, ...LOCAL_PROJECT_SUBDIR, LOCAL_PROJECT_FILE);
+}
+
+/**
+ * Canonical project settings file:
+ * `<root>/agents/settings/.agent-settings.yml`.
+ *
+ * The project settings file lives in the project's settings layer
+ * (`agents/settings/`), NOT at the repo root. The repo-root
+ * `.agent-settings.yml` is a legacy location read only as a back-compat
+ * fallback (see `project_settings_path`).
+ */
+function _canonical_settings_path(project_root: string): string {
+    return path.join(project_root, ...LOCAL_PROJECT_SUBDIR, DEFAULT_PROJECT_FILE);
+}
+
+/**
+ * Resolve the project settings file for **reading**.
+ *
+ * Returns the canonical `agents/settings/.agent-settings.yml` when it
+ * exists; otherwise the legacy repo-root `.agent-settings.yml` when that
+ * exists; otherwise the canonical path. Existence-checked, never writes.
+ */
+export function project_settings_path(project_root: string): string {
+    const canonical = _canonical_settings_path(project_root);
+    if (_exists(canonical)) {
+        return canonical;
+    }
+    const legacy = path.join(project_root, DEFAULT_PROJECT_FILE);
+    if (_exists(legacy)) {
+        return legacy;
+    }
+    return canonical;
+}
+
+/**
+ * Always the canonical **write** target:
+ * `agents/settings/.agent-settings.yml`.
+ *
+ * Writers (install, sync, migrate) target this unconditionally; the
+ * legacy root file is migrated into it, never written afresh.
+ */
+export function canonical_settings_write_path(project_root: string): string {
+    return _canonical_settings_path(project_root);
+}
+
+export const DEFAULT_TEAM_FILE = '.agent-project-settings.yml';
+export const USER_GLOBAL_FILENAME = 'agent-settings.yml';
+
+/**
+ * Canonical write target under the new `~/.event4u/agent-config/`
+ * namespace. Reads route through `_resolve_user_global_file` so pre-2.4
+ * installs are still picked up from `~/.config/agent-config/` until the
+ * migration shim copies them across.
+ *
+ * NOTE: This is a function, not a constant, because tests need it to
+ * follow `$HOME` / env overrides at call time (Python recomputes it via
+ * the loader, but exposes `DEFAULT_USER_GLOBAL_FILE` as a module
+ * attribute that the test for `defaults_resolve_when_neither_argument_given`
+ * monkeypatches). The differential pattern uses the function value;
+ * tests inject a path directly.
+ */
+export function DEFAULT_USER_GLOBAL_FILE(): string {
+    return user_global_paths.write_target(USER_GLOBAL_FILENAME);
+}
+
+/** Return the active user-global settings path with legacy fallback. */
+function _resolve_user_global_file(): string {
+    const found = user_global_paths.resolve_with_fallback(USER_GLOBAL_FILENAME);
+    if (found !== null) {
+        return found;
+    }
+    return DEFAULT_USER_GLOBAL_FILE();
+}
+
+/**
+ * Exact dotted paths allowed to cascade from user-global into the merged
+ * settings. Anything not listed here is silently ignored when present in
+ * the user-global file. Adding a key requires an ADR.
+ */
+export const MERGEABLE_KEYS: readonly string[] = [
+    'name',
+    'ide',
+    'rule_loading_tier',
+    'memory.cadence',
+    'personal.bot_icon',
+    'personal.autonomy',
+    'telegraph.speak_scope',
+];
+
+const _DEFAULTS: SettingsDict = {};
+
+/**
+ * Defaults applied by `get_modules_config` when a key is absent from both
+ * the team file and the developer cascade. Lists are returned as fresh
+ * copies — callers may mutate the result safely.
+ */
+export const MODULES_DEFAULTS: SettingsDict = {
+    enabled: false,
+    root_paths: [],
+    namespace_template: '',
+    agent_folder: 'agents',
+    skip_dirs: ['.module-template', '.example'],
+    detection_acknowledged: false,
+};
+
+/** Anchor identifier returned by `find_project_root_with_anchor`. */
+export const ANCHOR_AGENT_SETTINGS = 'agent-settings';
+export const ANCHOR_AGENTS_DIR = 'agents-dir';
+export const ANCHOR_GIT = 'git';
+
+/**
+ * Marker subpaths that qualify a bare `agents/` directory as a project
+ * anchor (D1). Any one is sufficient.
+ */
+const _AGENTS_DIR_MARKERS: readonly string[] = [
+    'roadmaps',
+    'settings/.ai-council.yml',
+    'roadmaps-progress.md',
+    '.event4u-bridge.yml',
+];
+
+/**
+ * Kill-switch (D5). When set to `"1"`, `find_project_root` /
+ * `find_project_root_with_anchor` revert to the pre-Step-7 `.git`-only
+ * walk for one minor-version soak.
+ */
+const _LEGACY_ANCHOR_ENV = 'AGENT_CONFIG_LEGACY_ANCHOR';
+
+/** `Path.exists()` — true for files, dirs, symlinks (broken or not). */
+function _exists(p: string): boolean {
+    try {
+        fs.lstatSync(p);
+        // lstat does not follow symlinks; Python's exists() does. Re-check
+        // through stat so a valid symlink target counts as existing.
+        fs.statSync(p);
+        return true;
+    } catch {
+        // lstat may succeed for a broken symlink while stat throws; Python's
+        // Path.exists() returns False for broken symlinks, matching here.
+        return false;
+    }
+}
+
+/** `Path.is_dir()`. */
+function _is_dir(p: string): boolean {
+    try {
+        return fs.statSync(p).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+/** `Path.is_file()`. */
+function _is_file(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Mirror of `Path.resolve()`: absolutize + normalize + resolve symlinks.
+ * Python's `resolve()` is `strict=False` by default — it does NOT raise
+ * on a missing path, it normalizes what it can. `fs.realpathSync` raises
+ * on a missing path, so fall back to a normalized absolute path.
+ */
+function _resolve(p: string): string {
+    const absolute = path.resolve(p);
+    try {
+        return fs.realpathSync(absolute);
+    } catch {
+        return absolute;
+    }
+}
+
+/** Ancestor chain `[start, ...parents]` mirroring `[current, *current.parents]`. */
+function _ancestor_chain(start: string): string[] {
+    const chain: string[] = [];
+    let cursor = start;
+    for (;;) {
+        chain.push(cursor);
+        const parent = path.dirname(cursor);
+        if (parent === cursor) {
+            break;
+        }
+        cursor = parent;
+    }
+    return chain;
+}
+
+/**
+ * Return the boundary-anchor name at `path` or `null`.
+ *
+ * Boundary anchors stop the walk and define the project root:
+ *
+ * - `agents/` containing a D1 marker → `"agents-dir"`
+ * - `.git` (file or directory) → `"git"`
+ *
+ * `.agent-settings.yml` is a layer marker, not a boundary anchor — it
+ * only anchors when no boundary is found in any ancestor.
+ */
+function _boundary_anchor_at(dir: string): string | null {
+    const agents_dir = path.join(dir, 'agents');
+    if (_is_dir(agents_dir)) {
+        for (const marker of _AGENTS_DIR_MARKERS) {
+            if (_exists(path.join(agents_dir, marker))) {
+                return ANCHOR_AGENTS_DIR;
+            }
+        }
+    }
+    if (_exists(path.join(dir, '.git'))) {
+        return ANCHOR_GIT;
+    }
+    return null;
+}
+
+/**
+ * Walk up from `start` and return `[root, anchor_name]` or `null`.
+ *
+ * Two-tier lookup: boundary pass (first ancestor with `.git` or an
+ * `agents/`+marker anchor, `agents/` wins ties at the same level), then a
+ * layer fallback returning the **outermost** ancestor carrying
+ * `.agent-settings.yml`. When `AGENT_CONFIG_LEGACY_ANCHOR=1`, only `.git`
+ * is considered. Pure read-only; never raises on missing paths.
+ */
+export function find_project_root_with_anchor(
+    start: string,
+): [string, string] | null {
+    const current = _exists(start) ? _resolve(start) : start;
+    const legacy = process.env[_LEGACY_ANCHOR_ENV] === '1';
+    const chain = _ancestor_chain(current);
+    if (legacy) {
+        for (const candidate of chain) {
+            if (_exists(path.join(candidate, '.git'))) {
+                return [candidate, ANCHOR_GIT];
+            }
+        }
+        return null;
+    }
+    // Boundary pass.
+    for (const candidate of chain) {
+        const anchor = _boundary_anchor_at(candidate);
+        if (anchor !== null) {
+            return [candidate, anchor];
+        }
+    }
+    // Layer fallback — outermost .agent-settings.yml wins so the cascade
+    // can layer deeper files below it.
+    let outermost: string | null = null;
+    for (const candidate of chain) {
+        if (_exists(path.join(candidate, DEFAULT_PROJECT_FILE))) {
+            outermost = candidate;
+        }
+    }
+    if (outermost !== null) {
+        return [outermost, ANCHOR_AGENT_SETTINGS];
+    }
+    return null;
+}
+
+/**
+ * Walk up from `start` and return the project root or `null`.
+ *
+ * Thin wrapper over `find_project_root_with_anchor` that drops the
+ * anchor-name component.
+ */
+export function find_project_root(start: string): string | null {
+    const result = find_project_root_with_anchor(start);
+    return result !== null ? result[0] : null;
+}
+
+/** One ancestor probe record emitted by `find_project_root_with_trace`. */
+export interface TraceRecord {
+    ancestor: string;
+    pass: 'boundary' | 'layer';
+    hit: string | null;
+    reason: string;
+}
+
+/**
+ * Walk up from `start` and return `[root, anchor, trace]`.
+ *
+ * Diagnostic variant of `find_project_root_with_anchor`. Returns the same
+ * `[root, anchor]` pair (or `[null, null]` when no anchor is found) plus
+ * an ordered list of trace records describing every ancestor probed.
+ * Pure read-only.
+ */
+export function find_project_root_with_trace(
+    start: string,
+): [string | null, string | null, TraceRecord[]] {
+    const trace: TraceRecord[] = [];
+    const current = _exists(start) ? _resolve(start) : start;
+    const legacy = process.env[_LEGACY_ANCHOR_ENV] === '1';
+    const chain = _ancestor_chain(current);
+
+    if (legacy) {
+        for (const candidate of chain) {
+            const hit = _exists(path.join(candidate, '.git'));
+            trace.push({
+                ancestor: candidate,
+                pass: 'boundary',
+                hit: hit ? ANCHOR_GIT : null,
+                reason: hit ? 'legacy: .git found' : 'legacy: no .git',
+            });
+            if (hit) {
+                return [candidate, ANCHOR_GIT, trace];
+            }
+        }
+        return [null, null, trace];
+    }
+
+    // Boundary pass — same probes as find_project_root_with_anchor.
+    for (const candidate of chain) {
+        const agents_dir = path.join(candidate, 'agents');
+        if (_is_dir(agents_dir)) {
+            for (const marker of _AGENTS_DIR_MARKERS) {
+                if (_exists(path.join(agents_dir, marker))) {
+                    trace.push({
+                        ancestor: candidate,
+                        pass: 'boundary',
+                        hit: ANCHOR_AGENTS_DIR,
+                        reason: `agents/ has ${marker}`,
+                    });
+                    return [candidate, ANCHOR_AGENTS_DIR, trace];
+                }
+            }
+        }
+        if (_exists(path.join(candidate, '.git'))) {
+            trace.push({
+                ancestor: candidate,
+                pass: 'boundary',
+                hit: ANCHOR_GIT,
+                reason: '.git present',
+            });
+            return [candidate, ANCHOR_GIT, trace];
+        }
+        trace.push({
+            ancestor: candidate,
+            pass: 'boundary',
+            hit: null,
+            reason: 'no agents/ marker, no .git',
+        });
+    }
+
+    // Layer fallback — outermost .agent-settings.yml wins.
+    let outermost: string | null = null;
+    for (const candidate of chain) {
+        const present = _exists(path.join(candidate, DEFAULT_PROJECT_FILE));
+        trace.push({
+            ancestor: candidate,
+            pass: 'layer',
+            hit: present ? ANCHOR_AGENT_SETTINGS : null,
+            reason: present
+                ? `${DEFAULT_PROJECT_FILE} present`
+                : `no ${DEFAULT_PROJECT_FILE}`,
+        });
+        if (present) {
+            outermost = candidate;
+        }
+    }
+    if (outermost !== null) {
+        return [outermost, ANCHOR_AGENT_SETTINGS, trace];
+    }
+    return [null, null, trace];
+}
+
+/**
+ * Origin tag returned by `resolve_project_root` alongside the anchor
+ * names defined above.
+ */
+export const ORIGIN_ROOT_FLAG = 'root-flag'; // --root global flag (Step 8 A3)
+export const ORIGIN_EXPLICIT = 'explicit'; // --project arg on a subcommand
+export const ORIGIN_ENV = 'env'; // AGENT_CONFIG_PROJECT_ROOT (wrapper-pinned)
+export const ORIGIN_CWD_FALLBACK = 'cwd-fallback'; // no anchor found
+
+export const PROJECT_ROOT_ENV = 'AGENT_CONFIG_PROJECT_ROOT';
+export const ROOT_OVERRIDE_ENV = 'AGENT_CONFIG_ROOT_OVERRIDE';
+
+/**
+ * Raised when an explicit project-root override points to an invalid path.
+ *
+ * `--root <path>` and `AGENT_CONFIG_PROJECT_ROOT` must fail loudly when
+ * the target does not exist or is not a directory. Callers translate this
+ * into exit code 2 (no silent CWD fallback).
+ */
+export class ProjectRootError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ProjectRootError';
+    }
+}
+
+/**
+ * Resolve `path`; throw `ProjectRootError` when invalid.
+ *
+ * `origin_label` is one of `--root`, `AGENT_CONFIG_PROJECT_ROOT`, or
+ * `--project`; surfaced verbatim in the error message.
+ */
+function _validate_root_path(p: string, origin_label: string): string {
+    const resolved = _expanduser(p);
+    if (!_exists(resolved)) {
+        throw new ProjectRootError(
+            `${origin_label} points to a path that does not exist: ${resolved}`,
+        );
+    }
+    if (!_is_dir(resolved)) {
+        throw new ProjectRootError(
+            `${origin_label} points to a non-directory: ${resolved}`,
+        );
+    }
+    return _resolve(resolved);
+}
+
+/** `Path.expanduser()` — expand a leading `~`. */
+function _expanduser(p: string): string {
+    if (p === '~') {
+        return os.homedir();
+    }
+    if (p.startsWith('~/') || (process.platform === 'win32' && p.startsWith('~\\'))) {
+        return path.join(os.homedir(), p.slice(2));
+    }
+    return p;
+}
+
+/**
+ * Return `[root, origin]` for any `cmd_*` entry point.
+ *
+ * Resolution order:
+ *
+ * 1. `AGENT_CONFIG_PROJECT_ROOT` env var with `AGENT_CONFIG_ROOT_OVERRIDE=1`
+ *    set by the master CLI's `--root` flag → `ORIGIN_ROOT_FLAG`. Fail-loud.
+ * 2. Explicit `arg` (`--project`/`--target`) → `ORIGIN_EXPLICIT`. Fail-loud.
+ * 3. `AGENT_CONFIG_PROJECT_ROOT` env (wrapper) → `ORIGIN_ENV`. Fail-loud.
+ * 4. Anchor walk from `cwd` → anchor name.
+ * 5. Fall back to `cwd` itself → `ORIGIN_CWD_FALLBACK`.
+ *
+ * Throws `ProjectRootError` when any explicit override points to a
+ * missing path or non-directory.
+ */
+export function resolve_project_root(
+    arg: string | null,
+    options: { cwd?: string | null } = {},
+): [string, string] {
+    const cwd = options.cwd ?? null;
+    if (process.env[ROOT_OVERRIDE_ENV] === '1') {
+        const env_value = process.env[PROJECT_ROOT_ENV];
+        if (env_value) {
+            return [_validate_root_path(env_value, '--root'), ORIGIN_ROOT_FLAG];
+        }
+    }
+    if (arg !== null && String(arg) !== '') {
+        return [_validate_root_path(arg, '--project'), ORIGIN_EXPLICIT];
+    }
+    const env_value = process.env[PROJECT_ROOT_ENV];
+    if (env_value) {
+        return [_validate_root_path(env_value, PROJECT_ROOT_ENV), ORIGIN_ENV];
+    }
+    const start = _resolve(cwd ?? process.cwd());
+    const walked = find_project_root_with_anchor(start);
+    if (walked !== null) {
+        return walked;
+    }
+    return [start, ORIGIN_CWD_FALLBACK];
+}
+
+/**
+ * Return the ordered cascade of in-project settings files (shallow → deep).
+ *
+ * When `cwd` is provided and `find_project_root(cwd)` succeeds, the list
+ * contains every `<dir>/.agent-settings.yml` from the repo root down to
+ * `cwd`, shallowest first, then the canonical project file under
+ * `agents/settings/`, then the per-machine local override. When `cwd` is
+ * `null` or no anchor is reached, falls back to the legacy three-path set.
+ */
+function _resolve_cascade_paths(
+    cwd: string | null,
+    project_path: string | null,
+): string[] {
+    if (cwd === null) {
+        const legacy = project_path ? project_path : DEFAULT_PROJECT_FILE;
+        const parent = path.dirname(legacy);
+        return [legacy, _canonical_settings_path(parent), _local_settings_path(parent)];
+    }
+
+    const root = find_project_root(cwd);
+    if (root === null) {
+        const legacy = project_path ? project_path : DEFAULT_PROJECT_FILE;
+        const parent = path.dirname(legacy);
+        return [legacy, _canonical_settings_path(parent), _local_settings_path(parent)];
+    }
+
+    const cwd_resolved = _resolve(cwd);
+    // Build the chain root → … → cwd (shallowest first, deepest last).
+    const chain: string[] = [];
+    let cursor = cwd_resolved;
+    for (;;) {
+        chain.push(cursor);
+        if (cursor === root) {
+            break;
+        }
+        const parent = path.dirname(cursor);
+        if (parent === cursor) {
+            break;
+        }
+        cursor = parent;
+    }
+    chain.reverse();
+    return [
+        ...chain.map((d) => path.join(d, DEFAULT_PROJECT_FILE)),
+        _canonical_settings_path(root),
+        _local_settings_path(root),
+    ];
+}
+
+/**
+ * Return the merged settings dict.
+ *
+ * `project_path` defaults to `./.agent-settings.yml` (CWD-relative).
+ * `user_global_path` defaults to the resolved user-global file. Pass
+ * `verbose=true` to log keys present in user-global that are not on the
+ * whitelist. `cwd` enables the in-project cascade. When `cwd` is `null`
+ * (default), the loader falls back to the single `project_path` behavior.
+ */
+export function load_agent_settings(
+    options: {
+        project_path?: string | null;
+        user_global_path?: string | null;
+        verbose?: boolean;
+        cwd?: string | null;
+    } = {},
+): SettingsDict {
+    const project_path = options.project_path ?? null;
+    const user_global_path = options.user_global_path ?? null;
+    const verbose = options.verbose ?? false;
+    const cwd = options.cwd ?? null;
+
+    const user_global_raw =
+        _read_yaml(user_global_path ? user_global_path : _resolve_user_global_file()) ?? {};
+
+    const [user_global_filtered, ignored] = _filter_whitelist(user_global_raw, MERGEABLE_KEYS);
+    if (verbose && ignored.length > 0) {
+        logger.info(
+            'agent_settings: ignored non-whitelisted user-global keys: %s',
+            [...ignored].sort(),
+        );
+    }
+
+    const cascade = _resolve_cascade_paths(cwd, project_path);
+
+    const merged: SettingsDict = _deep_copy_defaults(_DEFAULTS);
+    _deep_merge(merged, user_global_filtered);
+    for (const p of cascade) {
+        const layer = _read_yaml(p) ?? {};
+        if (Object.keys(layer).length > 0) {
+            _deep_merge(merged, layer);
+        }
+    }
+    return merged;
+}
+
+/**
+ * Return the merged `modules:` configuration with defaults applied.
+ *
+ * Three-tier precedence (deepest wins): `MODULES_DEFAULTS` < team file
+ * (`<project_root>/.agent-project-settings.yml`) < developer cascade
+ * (every `.agent-settings.yml`). The team layer may pin keys via a
+ * top-level `locked_keys` list of dotted paths; locked keys discard any
+ * matching developer override and emit an INFO record. Pure, read-only.
+ */
+export function get_modules_config(
+    options: {
+        project_root?: string | null;
+        team_path?: string | null;
+        project_path?: string | null;
+        cwd?: string | null;
+    } = {},
+): SettingsDict {
+    const project_root = options.project_root ?? null;
+    const team_path = options.team_path ?? null;
+    const project_path = options.project_path ?? null;
+    const cwd = options.cwd ?? null;
+
+    const cwd_resolved = cwd !== null ? cwd : process.cwd();
+
+    let team_file: string;
+    if (team_path !== null) {
+        team_file = team_path;
+    } else {
+        let root: string;
+        if (project_root !== null) {
+            root = project_root;
+        } else {
+            root = find_project_root(cwd_resolved) ?? cwd_resolved;
+        }
+        team_file = path.join(root, DEFAULT_TEAM_FILE);
+    }
+
+    const team_raw = _read_yaml(team_file) ?? {};
+    const team_modules_candidate = team_raw['modules'];
+    const team_modules: SettingsDict = _is_plain_dict(team_modules_candidate)
+        ? team_modules_candidate
+        : {};
+    const locked_keys_raw = team_raw['locked_keys'];
+    const locked_keys: string[] = Array.isArray(locked_keys_raw)
+        ? locked_keys_raw.filter((k): k is string => typeof k === 'string')
+        : [];
+
+    const dev_merged = load_agent_settings({
+        ...(project_path !== null ? { project_path } : {}),
+        ...(cwd !== null ? { cwd } : {}),
+    });
+    const dev_modules_candidate = dev_merged['modules'];
+    const dev_modules: SettingsDict = _is_plain_dict(dev_modules_candidate)
+        ? dev_modules_candidate
+        : {};
+
+    const merged: SettingsDict = _deepcopy(MODULES_DEFAULTS);
+    if (Object.keys(team_modules).length > 0) {
+        _deep_merge(merged, team_modules);
+    }
+
+    if (Object.keys(dev_modules).length > 0) {
+        for (const [key, value] of Object.entries(dev_modules)) {
+            const dotted = `modules.${key}`;
+            if (locked_keys.includes(dotted) && key in team_modules) {
+                logger.info(
+                    'agent_settings: ignoring developer override of locked key %s',
+                    dotted,
+                );
+                continue;
+            }
+            if (_is_plain_dict(value) && _is_plain_dict(merged[key])) {
+                _deep_merge(merged[key], value);
+            } else {
+                merged[key] = value;
+            }
+        }
+    }
+
+    return merged;
+}
+
+/** Discovered-module record returned by `enumerate_modules`. */
+export interface ModuleEntry {
+    name: string;
+    root_path: string;
+    module_path: string;
+    has_agent_folder: boolean;
+    agent_folder_path: string | null;
+}
+
+/**
+ * Enumerate every module under `modules.root_paths`.
+ *
+ * For each path in `modules.root_paths` (resolved relative to
+ * `project_root`), lists immediate subdirectories that survive the
+ * `modules.skip_dirs` filter and reports whether each module ships a
+ * per-module agent folder (`modules.agent_folder`, default `agents`).
+ *
+ * Returns a list sorted by `(root_path, name)`. `modules.enabled` is NOT
+ * consulted. Missing roots are skipped silently (logged at INFO). Hidden
+ * directories and `skip_dirs` entries are filtered out. Pure, read-only.
+ */
+export function enumerate_modules(
+    options: {
+        project_root?: string | null;
+        cwd?: string | null;
+        modules_config?: SettingsDict | null;
+    } = {},
+): ModuleEntry[] {
+    const project_root = options.project_root ?? null;
+    const cwd = options.cwd ?? null;
+    let modules_config = options.modules_config ?? null;
+
+    const cwd_resolved = cwd !== null ? cwd : process.cwd();
+    let root: string;
+    if (project_root !== null) {
+        root = project_root;
+    } else {
+        root = find_project_root(cwd_resolved) ?? cwd_resolved;
+    }
+    root = _resolve(root);
+
+    if (modules_config === null) {
+        modules_config = get_modules_config({ project_root: root, ...(cwd !== null ? { cwd } : {}) });
+    }
+
+    const root_paths_raw: SettingsValue[] = modules_config['root_paths'] || [];
+    const skip_dirs_raw: SettingsValue[] =
+        modules_config['skip_dirs'] || MODULES_DEFAULTS['skip_dirs'];
+    const agent_folder = String(modules_config['agent_folder'] || MODULES_DEFAULTS['agent_folder']);
+
+    const skip_dirs = new Set<string>(
+        (Array.isArray(skip_dirs_raw) ? skip_dirs_raw : [])
+            .filter((s): s is string => typeof s === 'string'),
+    );
+
+    const discovered: ModuleEntry[] = [];
+    for (const raw of Array.isArray(root_paths_raw) ? root_paths_raw : []) {
+        if (typeof raw !== 'string' || raw.trim() === '') {
+            continue;
+        }
+        const root_rel = _strip_slashes(raw.trim());
+        const root_abs = _resolve(path.join(root, root_rel));
+        try {
+            // Latent-bug candidate (replicated verbatim, see divergence
+            // notes): boundary check uses a raw string prefix match
+            // (`startswith`) rather than a path-component boundary check,
+            // so a sibling like `<root>-evil` would pass. Python does the
+            // same; flagged, not fixed.
+            if (!_is_dir(root_abs) || !root_abs.startsWith(root)) {
+                logger.info('enumerate_modules: skipping missing/out-of-tree root %s', root_rel);
+                continue;
+            }
+        } catch {
+            logger.info('enumerate_modules: unreadable root %s', root_rel);
+            continue;
+        }
+
+        let children: string[];
+        try {
+            children = fs
+                .readdirSync(root_abs)
+                .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+        } catch {
+            logger.info('enumerate_modules: cannot list %s', root_rel);
+            continue;
+        }
+
+        for (const name of children) {
+            if (name.startsWith('.') || skip_dirs.has(name)) {
+                continue;
+            }
+            const child = path.join(root_abs, name);
+            if (!_is_dir(child)) {
+                continue;
+            }
+            const agent_dir = path.join(child, agent_folder);
+            const has_agent = _is_dir(agent_dir);
+            let module_rel: string;
+            try {
+                module_rel = _relative_to(_resolve(child), root);
+            } catch {
+                continue;
+            }
+            const entry: ModuleEntry = {
+                name,
+                root_path: root_rel,
+                module_path: module_rel,
+                has_agent_folder: has_agent,
+                agent_folder_path: has_agent ? _posix_join(module_rel, agent_folder) : null,
+            };
+            discovered.push(entry);
+        }
+    }
+
+    discovered.sort((a, b) => {
+        if (a.root_path !== b.root_path) {
+            return a.root_path < b.root_path ? -1 : 1;
+        }
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+    });
+    return discovered;
+}
+
+/**
+ * Yield `[dotted_key, value, source_path]` for every leaf setting.
+ *
+ * Walks the same cascade as `load_agent_settings` and emits one tuple per
+ * leaf observed at each layer (user-global → repo-root → intermediates →
+ * CWD). Never blocks, never raises on missing files.
+ */
+export function* iter_setting_overrides(
+    options: {
+        project_path?: string | null;
+        user_global_path?: string | null;
+        cwd?: string | null;
+    } = {},
+): Generator<[string, SettingsValue, string]> {
+    const project_path = options.project_path ?? null;
+    const user_global_path = options.user_global_path ?? null;
+    const cwd = options.cwd ?? null;
+
+    const user_global_path_resolved = user_global_path
+        ? user_global_path
+        : _resolve_user_global_file();
+    const user_global_raw = _read_yaml(user_global_path_resolved) ?? {};
+    const [user_global_filtered] = _filter_whitelist(user_global_raw, MERGEABLE_KEYS);
+    if (Object.keys(user_global_filtered).length > 0) {
+        for (const key of _leaf_paths(user_global_filtered)) {
+            yield [key, _get_dotted(user_global_filtered, key), user_global_path_resolved];
+        }
+    }
+
+    for (const p of _resolve_cascade_paths(cwd, project_path)) {
+        const layer = _read_yaml(p);
+        if (!layer || Object.keys(layer).length === 0) {
+            continue;
+        }
+        for (const key of _leaf_paths(layer)) {
+            yield [key, _get_dotted(layer, key), p];
+        }
+    }
+}
+
+/** Best-effort YAML read; never raises. Returns `null` on any failure. */
+function _read_yaml(p: string): SettingsDict | null {
+    if (!_is_file(p)) {
+        return null;
+    }
+    let YAML: typeof import('yaml');
+    try {
+        // Lazy require to mirror Python's lazy `import yaml` — a missing
+        // package degrades to `null` (defaults) instead of crashing.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        YAML = require('yaml') as typeof import('yaml');
+    } catch {
+        return null;
+    }
+    let data: SettingsValue;
+    try {
+        const text = fs.readFileSync(p, 'utf-8');
+        // version '1.1' matches PyYAML's safe_load (yes/no/on/off bools,
+        // sexagesimal ints) so the differential corpus stays byte-faithful.
+        data = YAML.parse(text, { version: '1.1' });
+        if (data === null || data === undefined) {
+            data = {};
+        }
+    } catch (err) {
+        // OSError or YAML parse failure → defaults, logged at WARNING.
+        if (_is_yaml_error(err) || _is_os_error(err)) {
+            logger.warning('agent_settings: unreadable or malformed YAML at %s', p);
+            return null;
+        }
+        throw err;
+    }
+    return _is_plain_dict(data) ? data : null;
+}
+
+function _is_yaml_error(err: unknown): boolean {
+    // The `yaml` package throws YAMLParseError / YAMLWarning subclasses
+    // whose names start with "YAML"; also catch generic parse Errors.
+    if (err instanceof Error) {
+        return err.name.startsWith('YAML') || err.name === 'Error' || err.name === 'TypeError';
+    }
+    return false;
+}
+
+function _is_os_error(err: unknown): boolean {
+    return (
+        typeof err === 'object' &&
+        err !== null &&
+        'code' in err &&
+        typeof (err as { code: unknown }).code === 'string'
+    );
+}
+
+/** Return `[filtered_dict, ignored_paths]` from a user-global blob. */
+function _filter_whitelist(
+    raw: SettingsDict,
+    allowed: readonly string[],
+): [SettingsDict, string[]] {
+    const filtered: SettingsDict = {};
+    for (const dotted of allowed) {
+        const value = _get_dotted(raw, dotted);
+        if (value !== null && value !== undefined) {
+            _set_dotted(filtered, dotted, value);
+        }
+    }
+    const ignored = _leaf_paths(raw).filter((p) => !allowed.includes(p));
+    return [filtered, ignored];
+}
+
+function _get_dotted(data: SettingsDict, dotted: string): SettingsValue {
+    let cursor: SettingsValue = data;
+    for (const part of dotted.split('.')) {
+        if (!_is_plain_dict(cursor) || !(part in cursor)) {
+            return null;
+        }
+        cursor = cursor[part];
+    }
+    return cursor;
+}
+
+function _set_dotted(target: SettingsDict, dotted: string, value: SettingsValue): void {
+    const parts = dotted.split('.');
+    let cursor: SettingsDict = target;
+    for (const part of parts.slice(0, -1)) {
+        let nxt = cursor[part];
+        if (nxt === undefined) {
+            nxt = {};
+            cursor[part] = nxt;
+        }
+        if (!_is_plain_dict(nxt)) {
+            nxt = {};
+            cursor[part] = nxt;
+        }
+        cursor = nxt;
+    }
+    cursor[parts[parts.length - 1] as string] = value;
+}
+
+function _leaf_paths(data: SettingsDict, prefix = ''): string[] {
+    const paths: string[] = [];
+    for (const [key, value] of Object.entries(data)) {
+        const p = prefix ? `${prefix}.${key}` : key;
+        if (_is_plain_dict(value) && Object.keys(value).length > 0) {
+            paths.push(..._leaf_paths(value, p));
+        } else {
+            paths.push(p);
+        }
+    }
+    return paths;
+}
+
+/** Merge `src` into `dst` in-place; nested dicts merged recursively. */
+function _deep_merge(dst: SettingsDict, src: SettingsDict): void {
+    for (const [key, value] of Object.entries(src)) {
+        if (_is_plain_dict(value) && _is_plain_dict(dst[key])) {
+            _deep_merge(dst[key], value);
+        } else {
+            dst[key] = value;
+        }
+    }
+}
+
+function _deep_copy_defaults(src: SettingsDict): SettingsDict {
+    const out: SettingsDict = {};
+    _deep_merge(out, src);
+    return out;
+}
+
+/**
+ * `copy.deepcopy` for the JSON-shaped values settings hold (dicts, lists,
+ * scalars). Arrays and plain objects are cloned recursively; scalars pass
+ * through.
+ */
+function _deepcopy<T extends SettingsValue>(value: T): T {
+    if (Array.isArray(value)) {
+        return value.map((v) => _deepcopy(v)) as unknown as T;
+    }
+    if (_is_plain_dict(value)) {
+        const out: SettingsDict = {};
+        for (const [k, v] of Object.entries(value)) {
+            out[k] = _deepcopy(v);
+        }
+        return out as unknown as T;
+    }
+    return value;
+}
+
+/**
+ * `isinstance(x, dict)` — a plain object, not an array / null / class
+ * instance. Mirrors Python's `isinstance(..., dict)` for settings data,
+ * which is always built from `yaml.safe_load` (plain dicts).
+ */
+function _is_plain_dict(value: SettingsValue): value is SettingsDict {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+    );
+}
+
+/** Strip leading/trailing `/` like Python's `str.strip("/")`. */
+function _strip_slashes(s: string): string {
+    return s.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * `Path.relative_to(root)` — throws when `child` is not under `root`
+ * (mirrors Python's `ValueError`). Returns the OS-native relative path.
+ */
+function _relative_to(child: string, root: string): string {
+    const rel = path.relative(root, child);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+        throw new Error(`${child} is not in the subpath of ${root}`);
+    }
+    return rel;
+}
+
+/** Join two repo-relative path fragments with forward slashes (posix). */
+function _posix_join(a: string, b: string): string {
+    return `${a.split(path.sep).join('/')}/${b}`;
+}

--- a/src/agent-src/templates/scripts/work_engine/_lib/user_global_paths.ts
+++ b/src/agent-src/templates/scripts/work_engine/_lib/user_global_paths.ts
@@ -1,0 +1,329 @@
+/**
+ * Vendor-namespaced user-global path resolution.
+ *
+ * TypeScript twin of `src/scripts/_lib/user_global_paths.py` (ADR-094,
+ * Phase 2 / Wave 1 batch B). Mirrors the Python module's public API
+ * exactly — same exported snake_case names, same semantics, same
+ * path-resolution behavior. Single source of truth for "where does this
+ * package keep user-global state on disk?".
+ *
+ * Resolution order:
+ *
+ *   1. `$EVENT4U_CONFIG_HOME`  — full path override (testing + power users).
+ *   2. `~/.event4u/agent-config/`  — vendor-namespaced source-of-truth.
+ *
+ * For backward compatibility during the transition, `legacy_xdg_root()`
+ * exposes the old `~/.config/agent-config/` path so loaders can read
+ * state written by pre-2.4 installs. Writers should never target the
+ * legacy path; the auto-migration shim copies state once into the new
+ * namespace.
+ *
+ * Contract — pure, read-only, never auto-creates directories
+ * (except `migrate_legacy_namespace`, which mirrors the Python shim).
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/** Environment map shape — mirrors Python's `Optional[dict]` env parameter. */
+export type EnvMap = Record<string, string | undefined>;
+
+/**
+ * Marker suffix for in-progress entry copies during migration. A copy
+ * that crashes mid-flight leaves `<name><suffix><pid>` behind so the
+ * next run can clean it up before retrying — instead of treating a
+ * partial subdir as a completed copy.
+ *
+ * Exported (despite the underscore) because the pytest suite accesses
+ * `user_global_paths._PARTIAL_SUFFIX`; the vitest port does the same.
+ */
+export const _PARTIAL_SUFFIX = '.event4u-partial-';
+
+/**
+ * Environment variable that overrides `event4u_root()` outright.
+ * Accepts a full path (`~` expanded). Primarily used by tests; power
+ * users may also point this at a custom location.
+ */
+export const EVENT4U_HOME_ENV = 'EVENT4U_CONFIG_HOME';
+
+/** Vendor-namespaced default. Relative to the user's home directory. */
+export const DEFAULT_EVENT4U_ROOT_RELATIVE = path.join('.event4u', 'agent-config');
+
+/**
+ * Legacy XDG-shaped default written by pre-2.4 installs. Read-only
+ * fallback during the transition; never the target of a write.
+ */
+export const LEGACY_XDG_ROOT_RELATIVE = path.join('.config', 'agent-config');
+
+/**
+ * Expand a leading `~` like Python's `Path.expanduser()`.
+ *
+ * Divergence candidate (flagged, not fixed): Python also expands
+ * `~user` via the pwd database; this port leaves `~user` unchanged
+ * (which is also Python's behavior when the user is unknown).
+ */
+function expanduser(p: string): string {
+    if (p === '~') {
+        return os.homedir();
+    }
+    if (p.startsWith('~/') || (process.platform === 'win32' && p.startsWith('~\\'))) {
+        return path.join(os.homedir(), p.slice(2));
+    }
+    return p;
+}
+
+/**
+ * Mirror of `pathlib.Path.is_absolute()`.
+ *
+ * On POSIX a path is absolute iff it has a root (`/...`). On Windows,
+ * pathlib requires BOTH a drive and a root (`C:\\...` or UNC) — unlike
+ * Node's `path.isAbsolute`, which accepts rootless `\\foo`. The Python
+ * semantics are replicated here.
+ */
+function is_absolute_like_python(p: string): boolean {
+    if (process.platform === 'win32') {
+        return /^[a-zA-Z]:[\\/]/.test(p) || /^([\\/]{2})[^\\/]+[\\/][^\\/]+/.test(p);
+    }
+    return p.startsWith('/');
+}
+
+/**
+ * Return the active user-global root directory.
+ *
+ * Honours `EVENT4U_CONFIG_HOME` first, falls back to
+ * `~/.event4u/agent-config/`. Never creates the directory.
+ */
+export function event4u_root(env?: EnvMap | null): string {
+    const env_map = env ?? process.env;
+    const override = env_map[EVENT4U_HOME_ENV];
+    if (override) {
+        return expanduser(override);
+    }
+    return path.join(os.homedir(), DEFAULT_EVENT4U_ROOT_RELATIVE);
+}
+
+/**
+ * Return the pre-2.4 user-global root at `~/.config/agent-config/`.
+ *
+ * Used by loaders during the transition to read settings, lockfiles,
+ * and keys written before the namespace migration ran. Writers MUST
+ * NOT target this path — only `event4u_root()` is a valid write
+ * target. Never creates the directory.
+ */
+export function legacy_xdg_root(): string {
+    return path.join(os.homedir(), LEGACY_XDG_ROOT_RELATIVE);
+}
+
+/**
+ * Resolve a named file/dir under the user-global root, with legacy fallback.
+ *
+ * Returns the new-namespace path if it exists on disk, otherwise the
+ * legacy XDG path if it exists, otherwise `null`. Callers that need
+ * the *write target* (regardless of existence) should use
+ * `path.join(event4u_root(), relative_name)` directly.
+ *
+ * `relative_name` is a forward-slash separated string (e.g.
+ * `"installed.lock"` or `"agents/global"`). It is treated as a
+ * path fragment relative to the chosen root; absolute paths are
+ * rejected with an `Error` (Python raises `ValueError`).
+ */
+export function resolve_with_fallback(
+    relative_name: string,
+    options: { env?: EnvMap | null } = {},
+): string | null {
+    if (is_absolute_like_python(relative_name)) {
+        throw new Error(
+            `resolve_with_fallback expects a relative path, got '${relative_name}'`,
+        );
+    }
+    const new_path = path.join(event4u_root(options.env ?? null), relative_name);
+    if (fs.existsSync(new_path)) {
+        return new_path;
+    }
+    const legacy_path = path.join(legacy_xdg_root(), relative_name);
+    if (fs.existsSync(legacy_path)) {
+        return legacy_path;
+    }
+    return null;
+}
+
+/**
+ * Return the canonical write target for a named user-global file/dir.
+ *
+ * Always rooted at `event4u_root()` — writers never target the
+ * legacy XDG path. Caller is responsible for `mkdir -p` on the parent
+ * before writing. Never creates the directory itself.
+ */
+export function write_target(
+    relative_name: string,
+    options: { env?: EnvMap | null } = {},
+): string {
+    if (is_absolute_like_python(relative_name)) {
+        throw new Error(`write_target expects a relative path, got '${relative_name}'`);
+    }
+    return path.join(event4u_root(options.env ?? null), relative_name);
+}
+
+/**
+ * Breadcrumb dropped into the legacy root after a successful migration.
+ * Tells the user where their state now lives and how to clean up. The
+ * legacy tree itself is never auto-deleted — only the user does that.
+ */
+export const MIGRATION_BREADCRUMB_NAME = 'MIGRATED.md';
+
+const _BREADCRUMB_TEMPLATE = `# Migrated to \`~/.event4u/agent-config/\`
+
+This directory (\`~/.config/agent-config/\`) is the **legacy** location
+for \`event4u/agent-config\` user-global state. As of v2.4 the canonical
+location is \`~/.event4u/agent-config/\`.
+
+The migration shim has already copied your settings, keys, lockfiles,
+and overrides into the new namespace. File modes (0600 on keys) were
+preserved. Loaders prefer the new path but still read from this tree
+as a fallback, so removing it is safe **once you've confirmed** the
+new location is working.
+
+## To clean up
+
+\`\`\`bash
+rm -rf ~/.config/agent-config
+\`\`\`
+
+## Why the move
+
+\`~/.config/\` is a generic XDG-shaped directory shared by many tools.
+\`~/.event4u/agent-config/\` is vendor-namespaced and avoids collisions
+with unrelated CLIs. See
+\`agents/roadmaps/road-to-event4u-namespace-and-claude-desktop.md\` for
+the full rationale.
+`;
+
+/**
+ * Copy pre-2.4 user-global state from legacy XDG root into the new namespace.
+ *
+ * Idempotent and safe to call on every install / init. Returns `true`
+ * if a copy ran during this invocation, `false` when the migration
+ * was already complete or there was nothing to migrate.
+ *
+ * Contract (mirrors the Python shim):
+ *
+ * - Never auto-deletes the legacy tree — that's the user's call (the
+ *   breadcrumb at `~/.config/agent-config/MIGRATED.md` documents it).
+ * - Preserves file modes (0600 key files stay 0600 after the copy)
+ *   and timestamps, like `shutil.copytree(..., copy_function=copy2)`.
+ * - If the new root already exists with any content, the migration
+ *   treats it as already-done and only writes the breadcrumb (if
+ *   missing) — never overwrites new-namespace state.
+ * - If the legacy root is missing or empty, the function is a no-op.
+ * - Per-entry atomic write: each entry is copied to a sibling
+ *   `<name>.event4u-partial-<pid>` and then renamed into the final
+ *   name. If a previous run crashed mid-copy, the leftover
+ *   `*.event4u-partial-*` siblings are cleaned up at the top of the
+ *   next run before retrying — a partial directory is never mistaken
+ *   for a completed copy.
+ *
+ * `legacy_root_override` is for tests; production callers omit it.
+ */
+export function migrate_legacy_namespace(
+    options: { env?: EnvMap | null; legacy_root_override?: string | null } = {},
+): boolean {
+    const legacy_root = options.legacy_root_override ?? legacy_xdg_root();
+    const new_root = event4u_root(options.env ?? null);
+
+    let legacy_stat: fs.Stats;
+    try {
+        legacy_stat = fs.statSync(legacy_root);
+    } catch {
+        return false;
+    }
+    if (!legacy_stat.isDirectory()) {
+        return false;
+    }
+
+    // Skip the migrated-breadcrumb itself when checking for content so a
+    // second invocation does not loop on its own marker.
+    const legacy_entries = fs
+        .readdirSync(legacy_root)
+        .filter((name) => name !== MIGRATION_BREADCRUMB_NAME);
+    if (legacy_entries.length === 0) {
+        return false;
+    }
+
+    // Real content check ignores partial-copy debris from a prior
+    // interrupted run; otherwise the breadcrumb would be written for
+    // a half-finished migration and retry would never run.
+    const new_has_content =
+        fs.existsSync(new_root) &&
+        fs.readdirSync(new_root).some((name) => !_is_partial_name(name));
+    if (new_has_content) {
+        _ensure_breadcrumb(legacy_root);
+        return false;
+    }
+
+    fs.mkdirSync(new_root, { recursive: true });
+    _purge_partial_entries(new_root);
+
+    for (const name of legacy_entries) {
+        const entry = path.join(legacy_root, name);
+        const target = path.join(new_root, name);
+        if (fs.existsSync(target)) {
+            continue;
+        }
+        const staging = path.join(new_root, `${name}${_PARTIAL_SUFFIX}${process.pid}`);
+        if (fs.existsSync(staging)) {
+            _remove_path(staging);
+        }
+        if (fs.statSync(entry).isDirectory()) {
+            // Mirrors shutil.copytree(copy_function=copy2): modes are
+            // preserved by the copy; timestamps via preserveTimestamps.
+            fs.cpSync(entry, staging, { recursive: true, preserveTimestamps: true });
+        } else {
+            fs.copyFileSync(entry, staging);
+            // copy2 semantics: explicitly carry over mode + timestamps.
+            const src_stat = fs.statSync(entry);
+            fs.chmodSync(staging, src_stat.mode & 0o7777);
+            fs.utimesSync(staging, src_stat.atime, src_stat.mtime);
+        }
+        fs.renameSync(staging, target);
+    }
+
+    _ensure_breadcrumb(legacy_root);
+    return true;
+}
+
+function _is_partial_name(name: string): boolean {
+    return name.includes(_PARTIAL_SUFFIX);
+}
+
+/** Remove `*.event4u-partial-*` leftovers from a previous interrupted run. */
+function _purge_partial_entries(new_root: string): void {
+    for (const name of fs.readdirSync(new_root)) {
+        if (_is_partial_name(name)) {
+            _remove_path(path.join(new_root, name));
+        }
+    }
+}
+
+function _remove_path(p: string): void {
+    let st: fs.Stats | null = null;
+    try {
+        st = fs.lstatSync(p);
+    } catch {
+        // Missing path — Python's unlink(missing_ok=True) tolerates this.
+        return;
+    }
+    if (st.isDirectory() && !st.isSymbolicLink()) {
+        fs.rmSync(p, { recursive: true });
+    } else {
+        fs.rmSync(p, { force: true });
+    }
+}
+
+/** Write the `MIGRATED.md` breadcrumb into `legacy_root` if absent. */
+function _ensure_breadcrumb(legacy_root: string): void {
+    const breadcrumb = path.join(legacy_root, MIGRATION_BREADCRUMB_NAME);
+    if (fs.existsSync(breadcrumb)) {
+        return;
+    }
+    fs.writeFileSync(breadcrumb, _BREADCRUMB_TEMPLATE, 'utf-8');
+}

--- a/src/agent-src/templates/scripts/work_engine/cli_args.ts
+++ b/src/agent-src/templates/scripts/work_engine/cli_args.ts
@@ -1,0 +1,249 @@
+/**
+ * Argument parser and state-file constants for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/cli_args.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`.
+ * Behaviour-preserving: the parser shape, default values, and exit-code
+ * semantics are identical to the pre-split version. The constants moved here
+ * so the parser default and the legacy-file detector both reference a single
+ * source of truth.
+ *
+ * The Python source returns an `argparse.ArgumentParser`; this twin exposes
+ * {@link parse_args} instead, mirroring argparse's runtime behaviour for the
+ * declared flags: long-option prefix abbreviation, `--flag=value` /
+ * `--flag value` forms, `store_true` flags, `-h`/`--help` exit-0, and exit-2
+ * on every error path (unknown flag, ambiguous abbreviation, missing value,
+ * explicit value on a store_true flag). `--help` prose is intentionally NOT
+ * a parity surface (ADR-094 — argparse help text is not byte-compared).
+ */
+
+// Paths are kept as plain strings here (the Python source wraps them in
+// `pathlib.Path` via `type=Path`; the consuming modules — state_io,
+// input_builders — land in a later py2ts phase and own the Path semantics).
+export const DEFAULT_STATE_FILE = '.work-state.json';
+/**
+ * State file used when `--state-file` is not passed.
+ *
+ * Renamed from `.implement-ticket-state.json` in 1.15.0 alongside the
+ * `implement_ticket → work_engine` package move. The legacy filename is
+ * still recognised on load (see {@link LEGACY_STATE_FILE} below) so that
+ * existing checkouts surface a clear migration message instead of a
+ * silent "no state file" error.
+ */
+
+export const LEGACY_STATE_FILE = '.implement-ticket-state.json';
+/**
+ * Pre-1.15.0 default state file. Detected only as a migration hint;
+ * never written to. See `docs/MIGRATION.md`.
+ */
+
+export const _FMT_V0 = 'v0';
+export const _FMT_V1 = 'v1';
+/**
+ * Wire-format markers carried alongside the loaded `WorkState`.
+ *
+ * Format-preserving roundtrip: `_load` records which shape it parsed,
+ * `_save` rewrites in that same shape. v0 in → v0 out (Goldens stay
+ * byte-equal); v1 in → v1 out (future flows produced by the migration
+ * tool or a fresh v1 init keep their envelope fields).
+ */
+
+/** Parsed namespace — mirrors the argparse `Namespace` attribute names. */
+export interface ParsedArgs {
+    state_file: string;
+    ticket_file: string | null;
+    prompt_file: string | null;
+    diff_file: string | null;
+    file_file: string | null;
+    persona: string | null;
+    no_hooks: boolean;
+    hooks_config: string | null;
+}
+
+/** Thrown internally to mirror argparse's exit-2 error path. */
+class ArgparseExit extends Error {
+    readonly code: number;
+    constructor(code: number) {
+        super(`argparse exit ${code}`);
+        Object.setPrototypeOf(this, ArgparseExit.prototype);
+        this.name = 'ArgparseExit';
+        this.code = code;
+    }
+}
+
+const PROG = 'implement-ticket';
+
+// Declared optionals, in declaration order (drives prefix-abbreviation
+// candidate ordering and the usage line, exactly as argparse builds it).
+interface OptionSpec {
+    flag: string; // canonical long option, e.g. "--state-file"
+    dest: keyof ParsedArgs; // namespace attribute
+    takesValue: boolean; // false for store_true
+}
+
+const OPTIONS: OptionSpec[] = [
+    { flag: '--state-file', dest: 'state_file', takesValue: true },
+    { flag: '--ticket-file', dest: 'ticket_file', takesValue: true },
+    { flag: '--prompt-file', dest: 'prompt_file', takesValue: true },
+    { flag: '--diff-file', dest: 'diff_file', takesValue: true },
+    { flag: '--file-file', dest: 'file_file', takesValue: true },
+    { flag: '--persona', dest: 'persona', takesValue: true },
+    { flag: '--no-hooks', dest: 'no_hooks', takesValue: false },
+    { flag: '--hooks-config', dest: 'hooks_config', takesValue: true },
+];
+
+// `-h` / `--help` is an implicit argparse optional; included as a prefix
+// abbreviation candidate so e.g. `--he` resolves to `--help`.
+const HELP_FLAGS = ['--help'];
+
+function usage(): string {
+    // Compact one-line usage marker; the exact wrapping/prose is not a parity
+    // surface (ADR-094 — argparse usage/help text is not byte-compared).
+    return `usage: ${PROG} [-h] [options]`;
+}
+
+function err(message: string): never {
+    process.stderr.write(`${usage()}\n`);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw new ArgparseExit(2);
+}
+
+/**
+ * Resolve a long option token to its canonical flag, applying argparse's
+ * unambiguous-prefix-abbreviation rule. Returns the matched spec, the
+ * sentinel `'help'`, or throws exit-2 on an ambiguous / unknown option.
+ */
+function resolveLong(name: string): OptionSpec | 'help' {
+    // Exact match first (argparse short-circuits exact hits before abbrev).
+    const exact = OPTIONS.find((o) => o.flag === name);
+    if (exact) {
+        return exact;
+    }
+    if (HELP_FLAGS.includes(name)) {
+        return 'help';
+    }
+    // Prefix abbreviation across both the declared options and --help.
+    const candidates: Array<OptionSpec | 'help'> = [];
+    for (const o of OPTIONS) {
+        if (o.flag.startsWith(name)) {
+            candidates.push(o);
+        }
+    }
+    for (const h of HELP_FLAGS) {
+        if (h.startsWith(name)) {
+            candidates.push('help');
+        }
+    }
+    if (candidates.length === 1) {
+        return candidates[0] as OptionSpec | 'help';
+    }
+    if (candidates.length === 0) {
+        // argparse reports unknown options via "unrecognized arguments".
+        err(`unrecognized arguments: ${name}`);
+    }
+    const names = candidates.map((c) => (c === 'help' ? '--help' : c.flag)).join(', ');
+    err(`ambiguous option: ${name} could match ${names}`);
+}
+
+/**
+ * Parse `argv` (the slice after the program name) into a namespace.
+ *
+ * Mirrors `argparse.ArgumentParser.parse_args`: on `-h`/`--help` it prints
+ * a help marker to stdout and exits 0; on any error it prints to stderr and
+ * exits 2 (via `process.exitCode`, never `process.exit`, per ADR-094).
+ * Returns the parsed namespace on success.
+ */
+export function parse_args(argv: string[]): ParsedArgs {
+    const ns: ParsedArgs = {
+        state_file: DEFAULT_STATE_FILE,
+        ticket_file: null,
+        prompt_file: null,
+        diff_file: null,
+        file_file: null,
+        persona: null,
+        no_hooks: false,
+        hooks_config: null,
+    };
+    const extras: string[] = [];
+
+    try {
+        let i = 0;
+        while (i < argv.length) {
+            const tok = argv[i] as string;
+            if (tok === '-h' || tok === '--help') {
+                process.stdout.write(`${usage()}\n`);
+                throw new ArgparseExit(0);
+            }
+            if (tok.startsWith('--')) {
+                let name = tok;
+                let inlineValue: string | null = null;
+                const eq = tok.indexOf('=');
+                if (eq !== -1) {
+                    name = tok.slice(0, eq);
+                    inlineValue = tok.slice(eq + 1);
+                }
+                if (name === '-h' || name === '--help') {
+                    process.stdout.write(`${usage()}\n`);
+                    throw new ArgparseExit(0);
+                }
+                const resolved = resolveLong(name);
+                if (resolved === 'help') {
+                    process.stdout.write(`${usage()}\n`);
+                    throw new ArgparseExit(0);
+                }
+                if (resolved.takesValue) {
+                    if (inlineValue !== null) {
+                        assignValue(ns, resolved, inlineValue);
+                    } else {
+                        const next = argv[i + 1];
+                        // argparse: a value beginning with `-` is still consumed
+                        // only when it does not look like a known option; the
+                        // simpler "expected one argument" path covers the
+                        // missing-trailing-value case the contract exercises.
+                        if (next === undefined) {
+                            err(`argument ${resolved.flag}: expected one argument`);
+                        }
+                        assignValue(ns, resolved, next);
+                        i += 1;
+                    }
+                } else {
+                    // store_true: an explicit `=value` is an error in argparse.
+                    if (inlineValue !== null) {
+                        err(`argument ${resolved.flag}: ignored explicit argument '${inlineValue}'`);
+                    }
+                    (ns[resolved.dest] as boolean) = true;
+                }
+            } else if (tok.startsWith('-') && tok !== '-') {
+                // Single-dash unknown short option → unrecognized.
+                extras.push(tok);
+            } else {
+                // Positional — this parser declares none, so it is an extra.
+                extras.push(tok);
+            }
+            i += 1;
+        }
+        if (extras.length > 0) {
+            err(`unrecognized arguments: ${extras.join(' ')}`);
+        }
+    } catch (e) {
+        if (e instanceof ArgparseExit) {
+            process.exitCode = e.code;
+            // Surface as a thrown sentinel so a CLI caller can stop; the test
+            // harness inspects process.exitCode (mirrors argparse SystemExit).
+            throw e;
+        }
+        throw e;
+    }
+    return ns;
+}
+
+function assignValue(ns: ParsedArgs, spec: OptionSpec, value: string): void {
+    // All value-taking flags here are string/Path; store the raw string.
+    (ns[spec.dest] as string) = value;
+}
+
+/** Re-exported sentinel so a CLI entry point can recognise the exit path. */
+export { ArgparseExit };

--- a/src/agent-src/templates/scripts/work_engine/delivery_state.ts
+++ b/src/agent-src/templates/scripts/work_engine/delivery_state.ts
@@ -1,0 +1,219 @@
+/**
+ * `DeliveryState` — the only object shared between orchestrator steps.
+ *
+ * TypeScript twin of `work_engine/delivery_state.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The shape mirrors `docs/contracts/implement-ticket-flow.md`. No step
+ * may invent fields not declared here; extensions require a roadmap
+ * amendment plus a flow-contract update.
+ *
+ * Steps return a `StepResult` with one of three `Outcome` values:
+ *
+ * - `SUCCESS`  — step populated its slice of `DeliveryState` and the
+ *   dispatcher continues to the next step.
+ * - `BLOCKED`  — step hit an ambiguity it cannot resolve on its own.
+ *   `questions` carries pre-formatted numbered options per the
+ *   `user-interaction` rule. The dispatcher halts.
+ * - `PARTIAL`  — step populated its slice *and* produced open
+ *   questions. The dispatcher halts with the same surface as BLOCKED;
+ *   the calling orchestrator (Phase 3) decides whether to prompt the
+ *   user to continue or stop.
+ *
+ * `DeliveryState` is a plain dataclass rather than a typed dict so
+ * step handlers can rely on attribute access, defaults, and mutation
+ * semantics without resorting to dictionary indirection.
+ */
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+/**
+ * Terminal outcome of a single step.
+ *
+ * The Python source subclasses `str` + `Enum`, so each member serialises as
+ * its string form. We mirror that with a string-valued const object: the
+ * values are exactly the strings the Python enum members carry.
+ */
+export const Outcome = {
+    SUCCESS: 'success',
+    BLOCKED: 'blocked',
+    PARTIAL: 'partial',
+} as const;
+
+export type Outcome = (typeof Outcome)[keyof typeof Outcome];
+
+/**
+ * Return value of a single `Step` invocation.
+ *
+ * `questions` is only populated for `BLOCKED` / `PARTIAL` outcomes. Each
+ * entry is a fully-formatted numbered line so the dispatcher can surface
+ * them verbatim without reformatting.
+ *
+ * Field order (outcome, questions, message) mirrors the Python dataclass so
+ * an `asdict`-style projection stays key-order identical.
+ */
+export class StepResult {
+    outcome: Outcome;
+    questions: string[];
+    message: string;
+
+    constructor(args: { outcome: Outcome; questions?: string[]; message?: string }) {
+        this.outcome = args.outcome;
+        // `field(default_factory=list)` → every instance owns its own array.
+        this.questions = args.questions ?? [];
+        this.message = args.message ?? '';
+    }
+}
+
+/**
+ * Canonical state passed between orchestrator steps.
+ *
+ * Field order matches the table in `docs/contracts/implement-ticket-flow.md`.
+ * Mutable defaults are created per-instance (the Python
+ * `field(default_factory=...)` contract) so every instance owns its own
+ * containers — a single shared array across runs would be a cross-run
+ * contamination hazard for the metrics pipeline.
+ */
+export class DeliveryState {
+    ticket: Record<string, Any>;
+    persona: string;
+    memory: Array<Record<string, Any>>;
+    plan: Any;
+    changes: Array<Record<string, Any>>;
+    tests: Any;
+    verify: Any;
+    outcomes: Record<string, string>;
+    questions: string[];
+    report: string;
+    ui_audit: Record<string, Any> | null;
+    ui_design: Record<string, Any> | null;
+    ui_review: Record<string, Any> | null;
+    ui_polish: Record<string, Any> | null;
+    contract: Record<string, Any> | null;
+    stitch: Record<string, Any> | null;
+    stack: Record<string, Any> | null;
+
+    constructor(args: {
+        ticket: Record<string, Any>;
+        persona?: string;
+        memory?: Array<Record<string, Any>>;
+        plan?: Any;
+        changes?: Array<Record<string, Any>>;
+        tests?: Any;
+        verify?: Any;
+        outcomes?: Record<string, string>;
+        questions?: string[];
+        report?: string;
+        ui_audit?: Record<string, Any> | null;
+        ui_design?: Record<string, Any> | null;
+        ui_review?: Record<string, Any> | null;
+        ui_polish?: Record<string, Any> | null;
+        contract?: Record<string, Any> | null;
+        stitch?: Record<string, Any> | null;
+        stack?: Record<string, Any> | null;
+    }) {
+        this.ticket = args.ticket;
+        this.persona = args.persona ?? 'senior-engineer';
+        this.memory = args.memory ?? [];
+        this.plan = args.plan ?? null;
+        this.changes = args.changes ?? [];
+        this.tests = args.tests ?? null;
+        this.verify = args.verify ?? null;
+        this.outcomes = args.outcomes ?? {};
+        this.questions = args.questions ?? [];
+        this.report = args.report ?? '';
+        this.ui_audit = args.ui_audit ?? null;
+        this.ui_design = args.ui_design ?? null;
+        this.ui_review = args.ui_review ?? null;
+        this.ui_polish = args.ui_polish ?? null;
+        this.contract = args.contract ?? null;
+        this.stitch = args.stitch ?? null;
+        this.stack = args.stack ?? null;
+    }
+}
+
+/**
+ * Protocol every step handler must satisfy.
+ *
+ * A step reads and writes `DeliveryState` in place; its return value
+ * carries only the terminal `Outcome` and any surfaced questions.
+ */
+export type Step = (state: DeliveryState) => StepResult;
+
+/**
+ * Marker that flags a `questions[0]` entry as agent-addressed, not
+ * user-addressed.
+ *
+ * When a step cannot run deterministically from pure Python (edits,
+ * subprocess calls, anything that needs tools the dispatcher doesn't
+ * own), it returns `BLOCKED` with this prefix as the first entry of
+ * `questions`. The orchestrator reads it and drives the matching
+ * skill; the user-facing numbered options follow on subsequent lines.
+ *
+ * The prefix is public contract: changing it breaks every agent that
+ * has learned to recognise it. See
+ * `docs/contracts/implement-ticket-flow.md#agent-directives`.
+ */
+export const AGENT_DIRECTIVE_PREFIX = '@agent-directive:';
+
+/**
+ * Python `str(value)` for the scalar value kinds an agent-directive payload
+ * carries. The Python source coerces every payload value with `str(...)`, so
+ * `True` → `"True"`, `False` → `"False"`, `None` → `"None"`; numbers and
+ * strings render as-is.
+ */
+function pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/**
+ * Format a canonical `@agent-directive:` line.
+ *
+ * `name` is the directive verb the agent dispatches on (for example
+ * `"implement-plan"` or `"run-tests"`). `payload` entries are rendered as
+ * `key=value` pairs on the same line, so the whole directive stays a single
+ * greppable string. Values are coerced with Python `str()` semantics — richer
+ * payloads belong on the `DeliveryState` itself, not in the directive line.
+ *
+ * Insertion order of `payload` keys is preserved, matching Python's `**kwargs`
+ * ordering.
+ */
+export function agent_directive(name: string, payload: Record<string, unknown> = {}): string {
+    const suffix = Object.entries(payload)
+        .map(([key, value]) => `${key}=${pyStr(value)}`)
+        .join(' ');
+    return suffix
+        ? `${AGENT_DIRECTIVE_PREFIX} ${name} ${suffix}`.trim()
+        : `${AGENT_DIRECTIVE_PREFIX} ${name}`;
+}
+
+/**
+ * True when `question` is an agent-addressed directive line.
+ *
+ * Used by the orchestrator to split `state.questions` into the
+ * agent-facing directive (at most one, always at index 0) and the
+ * user-facing numbered options (everything else).
+ */
+export function is_agent_directive(question: unknown): boolean {
+    return typeof question === 'string' && pyLstrip(question).startsWith(AGENT_DIRECTIVE_PREFIX);
+}
+
+/**
+ * Python `str.lstrip()` with no argument — strips leading whitespace as
+ * Python defines it (the `str.isspace` set). JS `String.prototype.trimStart`
+ * covers the same Unicode whitespace set for the inputs this module sees.
+ */
+function pyLstrip(s: string): string {
+    return s.trimStart();
+}

--- a/src/agent-src/templates/scripts/work_engine/errors.ts
+++ b/src/agent-src/templates/scripts/work_engine/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * CLI-layer error type used by the dispatcher entry point.
+ *
+ * TypeScript twin of `work_engine/errors.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Lives in its own module so the helper modules
+ * (`state_io`, `input_builders`, etc.) can raise it without depending on
+ * `cli.ts`, which would create an import cycle.
+ *
+ * Behaviour is identical to the original `cli._CLIError` it replaced
+ * in P2.3 of `road-to-post-pr29-optimize.md` — same name (private,
+ * underscore-prefixed) and same role: convert to exit code `2` at the
+ * `main()` boundary.
+ */
+
+/** Raised on configuration or I/O problems. Converted to exit code 2. */
+export class _CLIError extends Error {
+    constructor(message?: string) {
+        super(message);
+        // Restore the prototype chain so `instanceof _CLIError` works under
+        // the ES2022 target (Error subclassing caveat).
+        Object.setPrototypeOf(this, _CLIError.prototype);
+        this.name = '_CLIError';
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/orchestration.ts
+++ b/src/agent-src/templates/scripts/work_engine/orchestration.ts
@@ -1,0 +1,366 @@
+/**
+ * State machine stub for the `/orchestrate` command.
+ *
+ * TypeScript twin of `work_engine/orchestration.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Reads a pipeline file conforming to
+ * `docs/contracts/orchestration-dsl-v1.md` and produces an ordered
+ * sequence of step descriptors the agent dispatches one at a time.
+ * The runtime itself is **not** in Python — each step is executed by the
+ * agent via skill / command / persona / subagent dispatch. This module
+ * holds the deterministic bookkeeping:
+ *
+ * - load + interpolate
+ * - step iteration with success / failure / when-guard tracking
+ * - output-map resolution at the end
+ *
+ * Design constraints (R1 carve-outs from
+ * `road-to-distribution-and-adoption.md`):
+ *
+ * - No external dependencies. YAML loading reuses the dispatcher's
+ *   loader so the runtime sees what the linter sees.
+ * - No side effects. The state machine never edits files, runs commands,
+ *   or emits hooks of its own. Audit emission is the caller's job.
+ * - Forward-ref free. `steps[].with` references can only reach
+ *   earlier steps; this is enforced both by the linter and at runtime.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Mirror of Python `re` group semantics: capture (inputs|steps), the ident,
+// and an optional `.output` suffix; `g` flag so `.sub`-style replace covers
+// every non-overlapping match like Python `re.sub`.
+const _INTERP_RE = /\$\{\{\s*(inputs|steps)\.([a-z0-9_-]+)(?:\.output)?\s*\}\}/g;
+
+/** Heterogeneous value, mirroring Python's `Any`. */
+export type Any = unknown;
+
+/** One step's record after dispatch. */
+export class StepResult {
+    step_id: string;
+    kind: string;
+    ref: string;
+    success: boolean;
+    output: string;
+    error: string | null;
+
+    constructor(
+        step_id: string,
+        kind: string,
+        ref: string,
+        success = false,
+        output = '',
+        error: string | null = null,
+    ) {
+        this.step_id = step_id;
+        this.kind = kind;
+        this.ref = ref;
+        this.success = success;
+        this.output = output;
+        this.error = error;
+    }
+}
+
+/** Bookkeeping for a single `/orchestrate` run. */
+export class PipelineState {
+    name: string;
+    inputs: Record<string, string>;
+    results: Record<string, StepResult>;
+    halted: boolean;
+    halt_reason: string | null;
+
+    constructor(args: {
+        name: string;
+        inputs: Record<string, string>;
+        results?: Record<string, StepResult>;
+        halted?: boolean;
+        halt_reason?: string | null;
+    }) {
+        this.name = args.name;
+        this.inputs = args.inputs;
+        this.results = args.results ?? {};
+        this.halted = args.halted ?? false;
+        this.halt_reason = args.halt_reason ?? null;
+    }
+}
+
+/** True when `value` is a plain object (Python `isinstance(x, dict)`). */
+function _isDict(value: unknown): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `re.Match`-style replacement function signature loader. */
+interface DispatchHookModule {
+    _load_yaml(p: string): Record<string, Any>;
+}
+
+/**
+ * Reuse the linter's loader so the runtime accepts the same shape.
+ *
+ * Walks parents to find `scripts/hooks/dispatch_hook.ts` so the loader is
+ * reachable both when this module runs from the consumer projection
+ * (`dist/agent-src/templates/scripts/work_engine/`) and from the
+ * source-of-truth tree
+ * (`packages/<pack>/.agent-src.uncondensed/templates/scripts/work_engine/`).
+ * Loaded by dynamic `import()` to avoid namespace collisions with test
+ * modules named `hooks` (the TS analogue of the Python importlib-by-path
+ * approach).
+ */
+async function _load_pipeline(p: string): Promise<Record<string, Any>> {
+    const here = fs.realpathSync(fileURLToPath(import.meta.url));
+    let candidate: string | null = null;
+    // Layout-agnostic: the dispatcher sits at `scripts/hooks/` in a consumer
+    // install + the `dist/agent-src/` projection, and at `src/scripts/hooks/`
+    // in the maintainer source tree. Probe both per parent so the loader
+    // resolves regardless of where this template runs.
+    const relCandidates = [
+        path.join('scripts', 'hooks', 'dispatch_hook.ts'),
+        path.join('src', 'scripts', 'hooks', 'dispatch_hook.ts'),
+    ];
+    let dir = path.dirname(here);
+    // Walk `here.parents` — every ancestor directory up to the filesystem root.
+    for (;;) {
+        for (const rel of relCandidates) {
+            const probe = path.join(dir, rel);
+            if (fs.existsSync(probe) && fs.statSync(probe).isFile()) {
+                candidate = probe;
+                break;
+            }
+        }
+        if (candidate !== null) {
+            break;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            break;
+        }
+        dir = parent;
+    }
+    if (candidate === null) {
+        throw new Error(
+            'could not locate scripts/hooks/dispatch_hook.ts (or ' +
+                `src/scripts/hooks/dispatch_hook.ts) from ${here}`,
+        );
+    }
+    const module = (await import(pathToFileURL(candidate).href)) as DispatchHookModule;
+    const doc = module._load_yaml(p);
+    if (!_isDict(doc)) {
+        throw new Error(`${p}: top-level must be a mapping`);
+    }
+    return doc;
+}
+
+/**
+ * Substitute `${{ inputs.X }}` / `${{ steps.Y.output }}` in a nested value.
+ * Unknown references throw — the linter should have caught them, but the
+ * runtime double-checks.
+ */
+export function _interpolate(value: Any, state: PipelineState): Any {
+    if (typeof value === 'string') {
+        return value.replace(_INTERP_RE, (_match, ns: string, ident: string) => {
+            if (ns === 'inputs') {
+                if (!(ident in state.inputs)) {
+                    // Mirror Python `KeyError(f"unknown input '{ident}'")`.
+                    throw new KeyError(`unknown input '${ident}'`);
+                }
+                return state.inputs[ident] as string;
+            }
+            if (!(ident in state.results)) {
+                throw new KeyError(`unknown step '${ident}'`);
+            }
+            return (state.results[ident] as StepResult).output;
+        });
+    }
+    if (_isDict(value)) {
+        const out: Record<string, Any> = {};
+        for (const [k, v] of Object.entries(value)) {
+            out[k] = _interpolate(v, state);
+        }
+        return out;
+    }
+    if (Array.isArray(value)) {
+        return value.map((v) => _interpolate(v, state));
+    }
+    return value;
+}
+
+/**
+ * Evaluate the limited `when` mini-language. Supports
+ * `steps.X.success` / `steps.X.failure` and equality on a single
+ * `${{ steps.X.output }}` template against a literal.
+ */
+export function _when_passes(when: string | null | undefined, state: PipelineState): boolean {
+    if (!when) {
+        return true;
+    }
+    when = when.trim();
+    const m1 = fullmatch(/steps\.([a-z0-9_-]+)\.(success|failure)/, when);
+    if (m1) {
+        const sid = m1[1] as string;
+        const kind = m1[2] as string;
+        if (!(sid in state.results)) {
+            return false;
+        }
+        const res = state.results[sid] as StepResult;
+        return kind === 'success' ? res.success : !res.success;
+    }
+    const m2 = fullmatch(/\$\{\{\s*steps\.([a-z0-9_-]+)\.output\s*\}\}\s*==\s*"([^"]*)"/, when);
+    if (m2) {
+        const sid = m2[1] as string;
+        const literal = m2[2] as string;
+        const res = state.results[sid] ?? new StepResult(sid, '', '');
+        return res.output === literal;
+    }
+    // Mirror Python `ValueError(f"unsupported when expression: {when!r}")`.
+    throw new ValueError(`unsupported when expression: ${pyRepr(when)}`);
+}
+
+/** A descriptor yielded by `iter_steps`, carrying the live state for callbacks. */
+export interface StepDescriptor {
+    id: string;
+    kind: string;
+    ref: string;
+    with: Any;
+    _state: PipelineState;
+}
+
+/**
+ * Yield interpolated step descriptors in order.
+ *
+ * Caller dispatches each descriptor via skill / command / persona /
+ * subagent and feeds the result back via {@link record_result}.
+ */
+export async function* iter_steps(
+    p: string,
+    inputs: Record<string, string>,
+): AsyncGenerator<StepDescriptor> {
+    const doc = await _load_pipeline(p);
+    const merged_inputs: Record<string, string> = {};
+    const docInputs = (doc['inputs'] as Any[] | null | undefined) || [];
+    for (const inp of docInputs) {
+        if (_isDict(inp) && typeof inp['id'] === 'string') {
+            const id = inp['id'] as string;
+            merged_inputs[id] =
+                id in inputs
+                    ? (inputs[id] as string)
+                    : (((inp['default'] as string | undefined) ?? '') as string);
+        }
+    }
+    const state = new PipelineState({
+        name: (doc['name'] as string | undefined) ?? '',
+        inputs: merged_inputs,
+    });
+    const steps = (doc['steps'] as Array<Record<string, Any>> | null | undefined) || [];
+    for (const step of steps) {
+        if (state.halted) {
+            break;
+        }
+        if (!_when_passes(step['when'] as string | null | undefined, state)) {
+            continue;
+        }
+        yield {
+            id: step['id'] as string,
+            kind: step['kind'] as string,
+            ref: step['ref'] as string,
+            with: _interpolate((step['with'] as Any) || {}, state),
+            _state: state,
+        };
+    }
+}
+
+/**
+ * Caller hands the descriptor + outcome back so subsequent steps can see
+ * `${{ steps.<id>.output }}`.
+ */
+export function record_result(
+    descriptor: StepDescriptor,
+    opts: { success: boolean; output?: string; error?: string | null },
+): void {
+    const state = descriptor._state;
+    state.results[descriptor.id] = new StepResult(
+        descriptor.id,
+        descriptor.kind,
+        descriptor.ref,
+        opts.success,
+        opts.output ?? '',
+        opts.error ?? null,
+    );
+    if (!opts.success) {
+        state.halted = true;
+        state.halt_reason = `step ${descriptor.id} failed`;
+    }
+}
+
+/**
+ * Resolve the pipeline's `outputs:` map against the captured step outputs.
+ * Returns an empty map if the pipeline declares no outputs.
+ */
+export async function resolve_outputs(
+    p: string,
+    state: PipelineState,
+): Promise<Record<string, Any>> {
+    const doc = await _load_pipeline(p);
+    const raw = (doc['outputs'] as Record<string, Any> | null | undefined) || {};
+    const out: Record<string, Any> = {};
+    for (const [k, v] of Object.entries(raw)) {
+        out[k] = _interpolate(v, state);
+    }
+    return out;
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/** Python `KeyError` — distinct class so callers can mirror the type. */
+export class KeyError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, KeyError.prototype);
+        this.name = 'KeyError';
+    }
+}
+
+/** Python `ValueError`. */
+export class ValueError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, ValueError.prototype);
+        this.name = 'ValueError';
+    }
+}
+
+/** Python `re.fullmatch(pattern, s)` — the whole string must match. */
+function fullmatch(pattern: RegExp, s: string): RegExpExecArray | null {
+    const anchored = new RegExp(`^(?:${pattern.source})$`, pattern.flags.replace('g', ''));
+    return anchored.exec(s);
+}
+
+/**
+ * Python `repr(s)` for a string — used in the `unsupported when` error.
+ * CPython prefers single quotes, switching to double only when the string
+ * contains a single quote and no double quote.
+ */
+function pyRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') {
+            body += '\\\\';
+        } else if (ch === quote) {
+            body += `\\${ch}`;
+        } else if (ch === '\n') {
+            body += '\\n';
+        } else if (ch === '\r') {
+            body += '\\r';
+        } else if (ch === '\t') {
+            body += '\\t';
+        } else {
+            body += ch;
+        }
+    }
+    return `${quote}${body}${quote}`;
+}

--- a/src/agent-src/templates/scripts/work_engine/persona_policy.ts
+++ b/src/agent-src/templates/scripts/work_engine/persona_policy.ts
@@ -1,0 +1,97 @@
+/**
+ * Persona policy — behavioural parameters resolved from `state.persona`.
+ *
+ * TypeScript twin of `work_engine/persona_policy.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Three personas ship today, each keyed by the string already carried
+ * on `DeliveryState.persona` (see
+ * `docs/contracts/implement-ticket-flow.md#personas`):
+ *
+ * `senior-engineer`
+ *     Default. Runs every step. No test widening.
+ * `qa`
+ *     Runs every step but widens the `test` scope to the full suite
+ *     (`scope=full` in the `run-tests` directive) so regressions
+ *     outside the changed paths are caught.
+ * `advisory`
+ *     Plan-only mode. `implement`, `test`, and `verify` short-
+ *     circuit to SUCCESS without doing work — the flow produces a
+ *     delivery report whose value is the plan itself, and next-command
+ *     suggestions are suppressed (nothing was committed).
+ *
+ * Unknown persona names fall back to `senior-engineer` rather than
+ * raising, so a mistyped value never aborts a run mid-flight. The
+ * caller is responsible for validating the string at the state-
+ * construction boundary if strict behaviour is needed.
+ */
+
+/** Name used when `state.persona` is empty or unrecognised. */
+export const DEFAULT_PERSONA = 'senior-engineer';
+
+/**
+ * Behavioural flags read by individual step handlers.
+ *
+ * The Python source is a frozen dataclass; this class mirrors its field
+ * order and default values. Instances are treated as read-only configuration
+ * (the Python `frozen=True` contract) — `_POLICIES` holds the only instances
+ * and callers never mutate them.
+ */
+export class PersonaPolicy {
+    readonly name: string;
+    readonly allows_implement: boolean;
+    readonly allows_test: boolean;
+    readonly allows_verify: boolean;
+    readonly widen_tests: boolean;
+    readonly suggests_next_commands: boolean;
+
+    constructor(args: {
+        name: string;
+        allows_implement?: boolean;
+        allows_test?: boolean;
+        allows_verify?: boolean;
+        widen_tests?: boolean;
+        suggests_next_commands?: boolean;
+    }) {
+        this.name = args.name;
+        this.allows_implement = args.allows_implement ?? true;
+        this.allows_test = args.allows_test ?? true;
+        this.allows_verify = args.allows_verify ?? true;
+        this.widen_tests = args.widen_tests ?? false;
+        this.suggests_next_commands = args.suggests_next_commands ?? true;
+        Object.freeze(this);
+    }
+}
+
+const _POLICIES: Record<string, PersonaPolicy> = {
+    'senior-engineer': new PersonaPolicy({ name: 'senior-engineer' }),
+    qa: new PersonaPolicy({ name: 'qa', widen_tests: true }),
+    advisory: new PersonaPolicy({
+        name: 'advisory',
+        allows_implement: false,
+        allows_test: false,
+        allows_verify: false,
+        suggests_next_commands: false,
+    }),
+};
+
+/**
+ * Return the policy for `persona`; fall back to the default on miss.
+ *
+ * `persona` is typed `unknown` because it originates from
+ * `DeliveryState.persona` which the Python dataclass declares as `str`
+ * but does not enforce — a caller may set it to `None`/`null` while
+ * wiring up a partial state in tests.
+ */
+export function resolve_policy(persona: unknown): PersonaPolicy {
+    if (typeof persona === 'string' && persona in _POLICIES) {
+        return _POLICIES[persona] as PersonaPolicy;
+    }
+    return _POLICIES[DEFAULT_PERSONA] as PersonaPolicy;
+}
+
+/** Return the persona names shipped today, in insertion order. */
+export function known_personas(): string[] {
+    return Object.keys(_POLICIES);
+}

--- a/src/agent-src/templates/scripts/work_engine/state.ts
+++ b/src/agent-src/templates/scripts/work_engine/state.ts
@@ -1,0 +1,1011 @@
+/**
+ * Schema v1 of the universal-engine work state.
+ *
+ * TypeScript twin of `work_engine/state.py` (ADR-094 py2ts). Byte-for-byte
+ * serialization parity with the Python original is the contract: field order,
+ * defaults, validation order, and error text are all part of the wire format
+ * the dispatcher and the freeze-guard replay depend on.
+ *
+ * The wire format adds five envelope fields on top of the legacy
+ * `DeliveryState` shape from `implement_ticket.delivery_state`:
+ *
+ * - `version` — integer schema version, currently `1`.
+ * - `input.kind` — typed input variant (only `"ticket"` for R1).
+ * - `input.data` — the original payload (was `state.ticket` in v0).
+ * - `intent` — coarse intent label (`"backend-coding"` for R1).
+ * - `directive_set` — name of the directive bundle the dispatcher
+ *   loads. The enum is forward-compatible: `ui`, `ui-trivial`, and
+ *   `mixed` are accepted by the schema even though only `backend`
+ *   has working directives in R1 (Phase 4 Step 4 — pre-listed to avoid
+ *   a schema bump when R3 V2 lands).
+ * - `stack` — optional `{frontend, mtime}` cache populated by
+ *   `work_engine.stack.detect` (R3 Phase 1). `null` while the
+ *   detector has not yet run; the dispatcher fills it on the first UI
+ *   dispatch and re-runs detection when `mtime` no longer matches the
+ *   filesystem (manifest edited).
+ * - `ui_audit` — optional inventory written by the
+ *   `existing-ui-audit` skill (R3 Phase 2). `null` while the audit
+ *   has not run; populated dict once the skill returns. `greenfield`
+ *   flag plus `greenfield_decision` carry the user's scaffolding
+ *   pick. The audit gate (`work_engine.directives.ui.audit`)
+ *   refuses to advance to design/apply while the slot is empty or
+ *   while `greenfield` is set without a recorded decision.
+ * - `ui_design` — optional design brief produced by
+ *   `work_engine.directives.ui.design` (R3 Phase 3 Step 1). Locks
+ *   layout / components / states / microcopy / a11y; `design_confirmed`
+ *   carries the user's sign-off.
+ * - `ui_review` — optional review-pass output written by
+ *   `work_engine.directives.ui.review` (R3 Phase 3 Step 4). Carries
+ *   the design-review findings list and a `review_clean` flag set when
+ *   no findings remain.
+ * - `ui_polish` — optional polish-pass log written by
+ *   `work_engine.directives.ui.polish` (R3 Phase 3 Step 5). Tracks
+ *   the round counter (`rounds` <= 2 ceiling) and the per-round
+ *   applied-fix list so a re-entry knows whether the loop has been
+ *   exhausted.
+ * - `contract` — optional backend-contract envelope written by
+ *   `work_engine.directives.mixed.contract` (R3 Phase 4 Step 1).
+ *   Locks `data_model` and `api_surface` before any UI work starts;
+ *   `contract_confirmed` carries the user's sign-off. The mixed UI
+ *   step refuses to advance without a confirmed contract — this is the
+ *   sentinel that prevents UI work from racing ahead of the backend.
+ * - `stitch` — optional integration-verification envelope written by
+ *   `work_engine.directives.mixed.stitch` (R3 Phase 4 Step 3).
+ *   Carries the end-to-end smoke `scenarios` list, an aggregate
+ *   `verdict` (success / blocked / partial), and the
+ *   `integration_confirmed` flag the user sets after reviewing the
+ *   integration evidence.
+ * - `halts` — append-only log of `HookHalt` events the engine
+ *   persisted into state. Populated by `emitters._emit_halt` when
+ *   it runs against an already-persisted state file (the P3 branch table
+ *   is preserved: fresh-run halts before the first `_save` still leave
+ *   no state on disk). The `explain_last` trace builder reads the
+ *   tail entry to fill the `trace.halt` slot. Each entry is
+ *   `{reason, step, surface, timestamp}`. The list defaults to empty
+ *   and is omitted from older state files via `from_dict`'s tolerant
+ *   reader — no schema-version bump.
+ *
+ * All other fields keep their v0 names so the dispatcher can read the
+ * legacy slice unchanged once Phase 3 wires the steps over.
+ *
+ * The module exposes:
+ *
+ * - `SCHEMA_VERSION` — the integer carried in `version`.
+ * - `KNOWN_INPUT_KINDS` / `KNOWN_DIRECTIVE_SETS` — the
+ *   whitelists used by validation.
+ * - `Input`, `WorkState` — typed classes.
+ * - `from_dict` / `to_dict` — JSON round-trip helpers.
+ * - `SchemaError` — raised on every validation failure.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ── JSON value model ────────────────────────────────────────────────────
+//
+// The persisted state carries arbitrary user JSON (the input payload, the
+// plan / changes / tests / verify slots). Model it as the standard JSON
+// union so the heterogeneous dict shape and any-missing-key access survive
+// without `any`.
+
+export type JsonValue =
+    | string
+    | number
+    | boolean
+    | null
+    | JsonValue[]
+    | { [key: string]: JsonValue };
+
+/** A heterogeneous JSON object, mirroring a Python `dict[str, Any]`. */
+export type Dict = { [key: string]: JsonValue };
+
+export const SCHEMA_VERSION = 1;
+/** Integer version stored under the `version` key on disk. */
+
+export const DEFAULT_INTENT = 'backend-coding';
+/** Intent applied when migrating a v0 file or building a fresh state. */
+
+export const DEFAULT_DIRECTIVE_SET = 'backend';
+/** Directive set applied when migrating a v0 file or building a fresh state. */
+
+/**
+ * Input kinds accepted by the schema.
+ *
+ * `ticket` is the R1 kind: pre-structured `{id, title, acceptance_criteria, ...}`
+ * fed by the `/implement-ticket` flow. `prompt` is the R2 kind: a free-form
+ * user prompt wrapped via `work_engine.resolvers.prompt` into
+ * `{raw, reconstructed_ac, assumptions}`; the engine refines the raw text
+ * into actionable AC + a confidence band before plan/apply/test/review run.
+ *
+ * `diff` and `file` are the R3 Phase 1 UI-improve kinds. `diff` carries a
+ * unified-diff / patch payload (`{raw, reconstructed_ac, assumptions}`) so the
+ * `directives/ui` set can take an "improve this screen" PR-style input; `file`
+ * carries a path reference to an existing component/page (`{path,
+ * reconstructed_ac, assumptions}`) for the same surface. Both default-route to
+ * `ui-improve` via `work_engine.intent.populate_routing`.
+ *
+ * Per the schema/capability split documented on
+ * `work_engine.directives.backend.SUPPORTED_KINDS`, presence here only
+ * means the *envelope* is accepted on disk — a directive set still has to
+ * list the kind in its `SUPPORTED_KINDS` tuple before the dispatcher will
+ * route it. R2 widens the envelope; R2 Phase 3 widens backend's capability
+ * tuple in lockstep with the `refine-prompt` skill landing. R3 Phase 1 widens
+ * the envelope further; `ui` capability is wired in Phase 3 of the UI track.
+ *
+ * Other kinds are rejected so unknown values surface as errors instead of
+ * silently falling through to a default branch.
+ */
+export const KNOWN_INPUT_KINDS: ReadonlySet<string> = new Set([
+    'ticket',
+    'prompt',
+    'diff',
+    'file',
+]);
+
+/**
+ * Directive sets recognised by the schema.
+ *
+ * Per the roadmap (Phase 4 Step 4), `ui`, `ui-trivial`, and `mixed`
+ * are intentionally pre-listed so a future R3 V2 release does not need a
+ * schema bump. Only `backend` has working directives in R1; the others
+ * raise `NotImplementedError` at dispatch time.
+ */
+export const KNOWN_DIRECTIVE_SETS: ReadonlySet<string> = new Set([
+    'backend',
+    'ui',
+    'ui-trivial',
+    'mixed',
+]);
+
+/** Raised when a state payload violates the v1 contract. */
+export class SchemaError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SchemaError';
+        Object.setPrototypeOf(this, SchemaError.prototype);
+    }
+}
+
+/**
+ * Typed envelope for the user-supplied work item.
+ *
+ * `kind` is one of `KNOWN_INPUT_KINDS`; `data` is the raw
+ * payload. The legacy `state.ticket` dict lands here as
+ * `Input(kind="ticket", data=<dict>)` after migration.
+ */
+export class Input {
+    kind: string;
+    data: Dict;
+
+    constructor(kind: string, data: Dict | null = null) {
+        this.kind = kind;
+        // Mirror `field(default_factory=dict)` — a fresh empty dict per instance.
+        this.data = data ?? {};
+    }
+}
+
+/**
+ * Schema v1 of the persisted work state.
+ *
+ * Field order mirrors the on-disk JSON: envelope (`version`,
+ * `input`, `intent`, `directive_set`, `stack`) first, then
+ * the legacy `DeliveryState` slice (`persona` ... `report`) so a
+ * diff between a v1 file and its v0 ancestor stays readable.
+ */
+export class WorkState {
+    input: Input;
+    intent: string;
+    directive_set: string;
+    stack: Dict | null;
+    ui_audit: Dict | null;
+    ui_design: Dict | null;
+    ui_review: Dict | null;
+    ui_polish: Dict | null;
+    contract: Dict | null;
+    stitch: Dict | null;
+    halts: Dict[];
+    version: number;
+    persona: string;
+    memory: Dict[];
+    plan: JsonValue;
+    changes: Dict[];
+    tests: JsonValue;
+    verify: JsonValue;
+    outcomes: { [key: string]: string };
+    questions: string[];
+    report: string;
+
+    constructor(opts: {
+        input: Input;
+        intent?: string;
+        directive_set?: string;
+        stack?: Dict | null;
+        ui_audit?: Dict | null;
+        ui_design?: Dict | null;
+        ui_review?: Dict | null;
+        ui_polish?: Dict | null;
+        contract?: Dict | null;
+        stitch?: Dict | null;
+        halts?: Dict[];
+        version?: number;
+        persona?: string;
+        memory?: Dict[];
+        plan?: JsonValue;
+        changes?: Dict[];
+        tests?: JsonValue;
+        verify?: JsonValue;
+        outcomes?: { [key: string]: string };
+        questions?: string[];
+        report?: string;
+    }) {
+        this.input = opts.input;
+        this.intent = opts.intent ?? DEFAULT_INTENT;
+        this.directive_set = opts.directive_set ?? DEFAULT_DIRECTIVE_SET;
+        this.stack = opts.stack ?? null;
+        this.ui_audit = opts.ui_audit ?? null;
+        this.ui_design = opts.ui_design ?? null;
+        this.ui_review = opts.ui_review ?? null;
+        this.ui_polish = opts.ui_polish ?? null;
+        this.contract = opts.contract ?? null;
+        this.stitch = opts.stitch ?? null;
+        this.halts = opts.halts ?? [];
+        this.version = opts.version ?? SCHEMA_VERSION;
+        this.persona = opts.persona ?? 'senior-engineer';
+        this.memory = opts.memory ?? [];
+        this.plan = opts.plan ?? null;
+        this.changes = opts.changes ?? [];
+        this.tests = opts.tests ?? null;
+        this.verify = opts.verify ?? null;
+        this.outcomes = opts.outcomes ?? {};
+        this.questions = opts.questions ?? [];
+        this.report = opts.report ?? '';
+    }
+}
+
+/**
+ * Serialise `state` to the canonical v1 JSON shape.
+ *
+ * Field order is fixed: `version` -> `input` -> `intent` ->
+ * `directive_set` -> legacy slice. Stable order keeps state
+ * snapshots diff-friendly across re-runs and across the freeze-guard
+ * replay. Validation runs before serialisation so an in-memory
+ * object that was mutated past the schema cannot reach disk.
+ */
+export function to_dict(state: WorkState): Dict {
+    _validate_kind(state.input.kind);
+    _validate_directive_set(state.directive_set);
+    if (state.version !== SCHEMA_VERSION) {
+        throw new SchemaError(
+            `version must be ${SCHEMA_VERSION}; got ${pyRepr(state.version)}`,
+        );
+    }
+    _validate_stack(state.stack);
+    _validate_ui_audit(state.ui_audit);
+    _validate_ui_design(state.ui_design);
+    _validate_ui_review(state.ui_review);
+    _validate_ui_polish(state.ui_polish);
+    _validate_contract(state.contract);
+    _validate_stitch(state.stitch);
+    _validate_halts(state.halts);
+    return {
+        version: state.version,
+        input: { kind: state.input.kind, data: state.input.data },
+        intent: state.intent,
+        directive_set: state.directive_set,
+        stack: state.stack,
+        ui_audit: state.ui_audit,
+        ui_design: state.ui_design,
+        ui_review: state.ui_review,
+        ui_polish: state.ui_polish,
+        contract: state.contract,
+        stitch: state.stitch,
+        halts: [...state.halts],
+        persona: state.persona,
+        memory: state.memory,
+        plan: state.plan,
+        changes: state.changes,
+        tests: state.tests,
+        verify: state.verify,
+        outcomes: state.outcomes,
+        questions: state.questions,
+        report: state.report,
+    };
+}
+
+/**
+ * Build a `WorkState` from a parsed JSON payload.
+ *
+ * Validates the envelope (`version`, `input.kind`,
+ * `directive_set`) before instantiating the class. Unknown
+ * top-level keys are tolerated and dropped — the schema is additive,
+ * not strict-rejecting, so a future field rolled out by a newer
+ * engine version does not crash an older reader.
+ */
+export function from_dict(payload: JsonValue): WorkState {
+    if (!_isDict(payload)) {
+        throw new SchemaError(
+            `state payload must be a JSON object; got ${pyTypeName(payload)}`,
+        );
+    }
+
+    const version = payload['version'];
+    if (version !== SCHEMA_VERSION) {
+        throw new SchemaError(
+            `version must be ${SCHEMA_VERSION}; got ${pyRepr(version)}. ` +
+                'Run the v0→v1 migration before loading legacy files.',
+        );
+    }
+
+    const raw_input = payload['input'];
+    if (!_isDict(raw_input)) {
+        throw new SchemaError(
+            "state.input must be a JSON object with 'kind' and 'data' keys",
+        );
+    }
+    const kind = raw_input['kind'];
+    _validate_kind(kind);
+    const data = 'data' in raw_input ? raw_input['data'] : {};
+    if (!_isDict(data)) {
+        throw new SchemaError(
+            `state.input.data must be a JSON object; got ${pyTypeName(data)}`,
+        );
+    }
+
+    const directive_set = _get(payload, 'directive_set', DEFAULT_DIRECTIVE_SET);
+    _validate_directive_set(directive_set);
+
+    const stack = payload['stack'] ?? null;
+    _validate_stack(stack);
+
+    const ui_audit = payload['ui_audit'] ?? null;
+    _validate_ui_audit(ui_audit);
+
+    const ui_design = payload['ui_design'] ?? null;
+    _validate_ui_design(ui_design);
+
+    const ui_review = payload['ui_review'] ?? null;
+    _validate_ui_review(ui_review);
+
+    const ui_polish = payload['ui_polish'] ?? null;
+    _validate_ui_polish(ui_polish);
+
+    const contract = payload['contract'] ?? null;
+    _validate_contract(contract);
+
+    const stitch = payload['stitch'] ?? null;
+    _validate_stitch(stitch);
+
+    const halts = 'halts' in payload ? payload['halts'] : [];
+    _validate_halts(halts);
+
+    return new WorkState({
+        input: new Input(kind as string, { ...(data as Dict) }),
+        intent: _get(payload, 'intent', DEFAULT_INTENT) as string,
+        directive_set: directive_set as string,
+        stack: _isDict(stack) ? { ...stack } : null,
+        ui_audit: _isDict(ui_audit) ? { ...ui_audit } : null,
+        ui_design: _isDict(ui_design) ? { ...ui_design } : null,
+        ui_review: _isDict(ui_review) ? { ...ui_review } : null,
+        ui_polish: _isDict(ui_polish) ? { ...ui_polish } : null,
+        contract: _isDict(contract) ? { ...contract } : null,
+        stitch: _isDict(stitch) ? { ...stitch } : null,
+        halts: Array.isArray(halts) ? ([...halts] as Dict[]) : [],
+        version: version as number,
+        persona: _get(payload, 'persona', 'senior-engineer') as string,
+        memory: [...(_listOrEmpty(_get(payload, 'memory', [])))] as Dict[],
+        plan: _get(payload, 'plan', null),
+        changes: [...(_listOrEmpty(_get(payload, 'changes', [])))] as Dict[],
+        tests: _get(payload, 'tests', null),
+        verify: _get(payload, 'verify', null),
+        outcomes: { ...(_dictOrEmpty(_get(payload, 'outcomes', {}))) } as {
+            [key: string]: string;
+        },
+        questions: [
+            ...(_listOrEmpty(_get(payload, 'questions', []))),
+        ] as string[],
+        report: _get(payload, 'report', '') as string,
+    });
+}
+
+/** Read a v1 state file from disk and return a `WorkState`. */
+export function load(p: string): WorkState {
+    const raw = fs.readFileSync(p, 'utf-8');
+    let payload: JsonValue;
+    try {
+        payload = JSON.parse(raw) as JsonValue;
+    } catch (exc) {
+        throw new SchemaError(`invalid JSON in ${p}: ${(exc as Error).message}`);
+    }
+    return from_dict(payload);
+}
+
+/** Write `state` to `p` as pretty JSON, terminating newline included. */
+export function dump(state: WorkState, p: string): void {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, jsonDumps(to_dict(state)) + '\n', 'utf-8');
+}
+
+function _validate_kind(kind: JsonValue | undefined): void {
+    if (typeof kind !== 'string') {
+        throw new SchemaError(
+            `state.input.kind must be a string; got ${pyTypeName(kind)}`,
+        );
+    }
+    if (!KNOWN_INPUT_KINDS.has(kind)) {
+        throw new SchemaError(
+            `unknown input.kind ${pyRepr(kind)}; ` +
+                `expected one of ${pyListRepr(pySorted(KNOWN_INPUT_KINDS))}`,
+        );
+    }
+}
+
+function _validate_directive_set(name: JsonValue): void {
+    if (typeof name !== 'string') {
+        throw new SchemaError(
+            `state.directive_set must be a string; got ${pyTypeName(name)}`,
+        );
+    }
+    if (!KNOWN_DIRECTIVE_SETS.has(name)) {
+        throw new SchemaError(
+            `unknown directive_set ${pyRepr(name)}; ` +
+                `expected one of ${pyListRepr(pySorted(KNOWN_DIRECTIVE_SETS))}`,
+        );
+    }
+}
+
+/**
+ * Reject malformed stack envelopes; tolerate `null` (not yet detected).
+ *
+ * The detector populates `state.stack` lazily — the first dispatch
+ * of a new state file may run without it set, then the dispatcher
+ * fills it in before any UI handler reads it. We only validate the
+ * shape when present so the absence-of-detection case stays a normal
+ * code path, not an error.
+ */
+function _validate_stack(stack: JsonValue): void {
+    if (stack === null) {
+        return;
+    }
+    if (!_isDict(stack)) {
+        throw new SchemaError(
+            `state.stack must be a JSON object or null; ` +
+                `got ${pyTypeName(stack)}`,
+        );
+    }
+    const frontend = stack['frontend'];
+    if (typeof frontend !== 'string' || !frontend) {
+        throw new SchemaError('state.stack.frontend must be a non-empty string');
+    }
+    const mtime = 'mtime' in stack ? stack['mtime'] : 0.0;
+    if (!_isNumber(mtime)) {
+        throw new SchemaError(
+            `state.stack.mtime must be a number; got ${pyTypeName(mtime)}`,
+        );
+    }
+}
+
+/**
+ * Reject malformed `ui_audit` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the audit has not run yet — the dispatcher's audit
+ * gate (`directives.ui.audit`) will emit the agent-directive that
+ * populates it. An empty dict is the in-progress shape after the
+ * skill returns but before findings land; the gate treats it the
+ * same as `null`. Once populated, `greenfield` (when present)
+ * must be a bool, and `greenfield_decision` (when present) must
+ * be one of the three documented choices. Other keys (`components`,
+ * `patterns`, ...) are validated by the audit handler against the
+ * skill contract — the schema only enforces shape, not content.
+ */
+function _validate_ui_audit(ui_audit: JsonValue): void {
+    if (ui_audit === null) {
+        return;
+    }
+    if (!_isDict(ui_audit)) {
+        throw new SchemaError(
+            `state.ui_audit must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_audit)}`,
+        );
+    }
+    if ('greenfield' in ui_audit && typeof ui_audit['greenfield'] !== 'boolean') {
+        throw new SchemaError(
+            'state.ui_audit.greenfield must be a boolean when present',
+        );
+    }
+    const decision = 'greenfield_decision' in ui_audit
+        ? ui_audit['greenfield_decision']
+        : null;
+    if (
+        decision !== null &&
+        decision !== 'scaffold' &&
+        decision !== 'bare' &&
+        decision !== 'external_reference'
+    ) {
+        throw new SchemaError(
+            `state.ui_audit.greenfield_decision must be one of ` +
+                `'scaffold', 'bare', 'external_reference', or null; ` +
+                `got ${pyRepr(decision)}`,
+        );
+    }
+    if (
+        'a11y_baseline' in ui_audit &&
+        !Array.isArray(ui_audit['a11y_baseline'])
+    ) {
+        throw new SchemaError(
+            'state.ui_audit.a11y_baseline must be a list when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `ui_design` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the design step has not produced a brief yet — the
+ * dispatcher's design gate (`directives.ui.design`) emits the
+ * agent-directive that populates it. An empty dict is the in-progress
+ * shape after the skill returns but before the brief lands; the gate
+ * treats it the same as `null`. Once populated, `design_confirmed`
+ * (when present) must be a bool. Other keys (`layout`, `components`,
+ * `states`, `microcopy`, `a11y`, `reused_from_audit`) are
+ * validated by the design handler against the skill contract — the
+ * schema only enforces shape, not content.
+ */
+function _validate_ui_design(ui_design: JsonValue): void {
+    if (ui_design === null) {
+        return;
+    }
+    if (!_isDict(ui_design)) {
+        throw new SchemaError(
+            `state.ui_design must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_design)}`,
+        );
+    }
+    if (
+        'design_confirmed' in ui_design &&
+        typeof ui_design['design_confirmed'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.ui_design.design_confirmed must be a boolean when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `ui_review` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the review pass has not run yet — the dispatcher's
+ * review gate (`directives.ui.review`) emits the agent-directive
+ * that populates it. An empty dict is the in-progress shape after
+ * the skill returns but before findings land. Once populated,
+ * `findings` (when present) must be a list and `review_clean`
+ * (when present) must be a bool. Field content (severity labels,
+ * fix suggestions) is validated by the review handler; the schema
+ * enforces only shape.
+ */
+function _validate_ui_review(ui_review: JsonValue): void {
+    if (ui_review === null) {
+        return;
+    }
+    if (!_isDict(ui_review)) {
+        throw new SchemaError(
+            `state.ui_review must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_review)}`,
+        );
+    }
+    if ('findings' in ui_review && !Array.isArray(ui_review['findings'])) {
+        throw new SchemaError(
+            'state.ui_review.findings must be a list when present',
+        );
+    }
+    if (
+        'review_clean' in ui_review &&
+        typeof ui_review['review_clean'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.ui_review.review_clean must be a boolean when present',
+        );
+    }
+    const a11y = 'a11y' in ui_review ? ui_review['a11y'] : null;
+    if (a11y !== null) {
+        if (!_isDict(a11y)) {
+            throw new SchemaError(
+                'state.ui_review.a11y must be a JSON object or null when present',
+            );
+        }
+        if ('violations' in a11y && !Array.isArray(a11y['violations'])) {
+            throw new SchemaError(
+                'state.ui_review.a11y.violations must be a list when present',
+            );
+        }
+        const floor = 'severity_floor' in a11y ? a11y['severity_floor'] : null;
+        if (
+            floor !== null &&
+            floor !== 'minor' &&
+            floor !== 'moderate' &&
+            floor !== 'serious' &&
+            floor !== 'critical'
+        ) {
+            throw new SchemaError(
+                `state.ui_review.a11y.severity_floor must be one of ` +
+                    `'minor', 'moderate', 'serious', 'critical', or null; ` +
+                    `got ${pyRepr(floor)}`,
+            );
+        }
+        if (
+            'accepted_violations' in a11y &&
+            !Array.isArray(a11y['accepted_violations'])
+        ) {
+            throw new SchemaError(
+                'state.ui_review.a11y.accepted_violations must be a list when present',
+            );
+        }
+    }
+    const preview = 'preview' in ui_review ? ui_review['preview'] : null;
+    if (preview !== null) {
+        if (!_isDict(preview)) {
+            throw new SchemaError(
+                'state.ui_review.preview must be a JSON object or null when present',
+            );
+        }
+        if ('render_ok' in preview && typeof preview['render_ok'] !== 'boolean') {
+            throw new SchemaError(
+                'state.ui_review.preview.render_ok must be a boolean when present',
+            );
+        }
+    }
+}
+
+/**
+ * Reject malformed `ui_polish` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the polish loop has not entered yet. Once
+ * populated, `rounds` (when present) must be an int in `[0, 2]`
+ * by default — the polish-loop ceiling defined in
+ * `agents/roadmaps/road-to-product-ui-track.md` Phase 3 Step 5.
+ * R4 Phase 2 widens the upper bound to `3` when
+ * `extension_used` is `True` (one-shot a11y extension halt).
+ * `applied` (when present) must be a list. The polish handler
+ * enforces ceiling semantics; the schema enforces only shape.
+ */
+function _validate_ui_polish(ui_polish: JsonValue): void {
+    if (ui_polish === null) {
+        return;
+    }
+    if (!_isDict(ui_polish)) {
+        throw new SchemaError(
+            `state.ui_polish must be a JSON object or null; ` +
+                `got ${pyTypeName(ui_polish)}`,
+        );
+    }
+    if (
+        'extension_used' in ui_polish &&
+        typeof ui_polish['extension_used'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.ui_polish.extension_used must be a boolean when present',
+        );
+    }
+    const extension_used = _pyBool(
+        'extension_used' in ui_polish ? ui_polish['extension_used'] : false,
+    );
+    if ('rounds' in ui_polish) {
+        const rounds = ui_polish['rounds'];
+        if (!_isPyInt(rounds)) {
+            throw new SchemaError(
+                `state.ui_polish.rounds must be an integer; got ${pyTypeName(rounds)}`,
+            );
+        }
+        const max_rounds = extension_used ? 3 : 2;
+        if (rounds < 0 || rounds > max_rounds) {
+            throw new SchemaError(
+                `state.ui_polish.rounds must be in [0, ${max_rounds}]; ` +
+                    `got ${rounds} (extension_used=${pyBoolRepr(extension_used)})`,
+            );
+        }
+    }
+    if ('applied' in ui_polish && !Array.isArray(ui_polish['applied'])) {
+        throw new SchemaError(
+            'state.ui_polish.applied must be a list when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `contract` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the contract step has not run yet — the mixed
+ * `contract` directive (R3 Phase 4 Step 1) emits the
+ * agent-directive that populates it. Once populated,
+ * `data_model` and `api_surface` (when present) must be lists,
+ * and `contract_confirmed` (when present) must be a bool. Field
+ * content (entity names, endpoint shapes) is validated by the
+ * contract handler; the schema enforces only shape so the mixed UI
+ * step's sentinel check (`contract_confirmed is True`) stays a
+ * simple equality test.
+ */
+function _validate_contract(contract: JsonValue): void {
+    if (contract === null) {
+        return;
+    }
+    if (!_isDict(contract)) {
+        throw new SchemaError(
+            `state.contract must be a JSON object or null; ` +
+                `got ${pyTypeName(contract)}`,
+        );
+    }
+    if ('data_model' in contract && !Array.isArray(contract['data_model'])) {
+        throw new SchemaError(
+            'state.contract.data_model must be a list when present',
+        );
+    }
+    if ('api_surface' in contract && !Array.isArray(contract['api_surface'])) {
+        throw new SchemaError(
+            'state.contract.api_surface must be a list when present',
+        );
+    }
+    if (
+        'contract_confirmed' in contract &&
+        typeof contract['contract_confirmed'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.contract.contract_confirmed must be a bool when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `stitch` envelopes; tolerate `null` and `{}`.
+ *
+ * `null` means the integration-verification step has not run yet
+ * — the mixed `stitch` directive (R3 Phase 4 Step 3) emits the
+ * agent-directive that populates it. Once populated, `scenarios`
+ * (when present) must be a list of integration smoke cases,
+ * `verdict` (when present) must be one of
+ * `{"success", "blocked", "partial"}`, and
+ * `integration_confirmed` (when present) must be a bool. The
+ * stitch handler enforces verdict semantics; the schema enforces
+ * only shape.
+ */
+function _validate_stitch(stitch: JsonValue): void {
+    if (stitch === null) {
+        return;
+    }
+    if (!_isDict(stitch)) {
+        throw new SchemaError(
+            `state.stitch must be a JSON object or null; ` +
+                `got ${pyTypeName(stitch)}`,
+        );
+    }
+    if ('scenarios' in stitch && !Array.isArray(stitch['scenarios'])) {
+        throw new SchemaError(
+            'state.stitch.scenarios must be a list when present',
+        );
+    }
+    if ('verdict' in stitch) {
+        const verdict = stitch['verdict'];
+        if (
+            verdict !== 'success' &&
+            verdict !== 'blocked' &&
+            verdict !== 'partial'
+        ) {
+            throw new SchemaError(
+                `state.stitch.verdict must be one of success/blocked/partial; ` +
+                    `got ${pyRepr(verdict)}`,
+            );
+        }
+    }
+    if (
+        'integration_confirmed' in stitch &&
+        typeof stitch['integration_confirmed'] !== 'boolean'
+    ) {
+        throw new SchemaError(
+            'state.stitch.integration_confirmed must be a bool when present',
+        );
+    }
+}
+
+/**
+ * Reject malformed `halts` envelopes; tolerate `[]`.
+ *
+ * Each entry must be a dict with at minimum `reason` (str) and
+ * `surface` (list of str). `step` and `timestamp` are optional
+ * metadata appended by `emitters._emit_halt`. The schema enforces
+ * only shape — the explain renderer is responsible for fallback
+ * rendering when optional fields are absent.
+ */
+function _validate_halts(halts: JsonValue): void {
+    if (!Array.isArray(halts)) {
+        throw new SchemaError(
+            `state.halts must be a list; got ${pyTypeName(halts)}`,
+        );
+    }
+    for (let idx = 0; idx < halts.length; idx++) {
+        const entry = halts[idx];
+        if (!_isDict(entry)) {
+            throw new SchemaError(
+                `state.halts[${idx}] must be a JSON object; ` +
+                    `got ${pyTypeName(entry)}`,
+            );
+        }
+        const reason = 'reason' in entry ? entry['reason'] : undefined;
+        if (typeof reason !== 'string' || !reason) {
+            throw new SchemaError(
+                `state.halts[${idx}].reason must be a non-empty string`,
+            );
+        }
+        const surface = 'surface' in entry ? entry['surface'] : [];
+        if (!Array.isArray(surface)) {
+            throw new SchemaError(
+                `state.halts[${idx}].surface must be a list; ` +
+                    `got ${pyTypeName(surface)}`,
+            );
+        }
+        for (let j = 0; j < surface.length; j++) {
+            if (typeof surface[j] !== 'string') {
+                throw new SchemaError(
+                    `state.halts[${idx}].surface[${j}] must be a string`,
+                );
+            }
+        }
+    }
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * True when `v` is a plain JSON object (Python `dict`). Arrays and `null`
+ * are excluded, mirroring `isinstance(x, dict)`.
+ */
+function _isDict(v: JsonValue | undefined): v is Dict {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Mirror Python `isinstance(x, (int, float))` for the `mtime` check. JSON
+ * numbers (int or float) are all JS `number`; booleans are NOT numbers in
+ * Python's `(int, float)` test only because `bool` IS a subclass of `int`
+ * — but `_validate_stack` does not exclude bools, so neither do we: a JSON
+ * `true`/`false` never reaches `mtime` as a JS boolean is `typeof boolean`,
+ * not `number`. Python's `isinstance(True, (int, float))` is True; to match
+ * that edge we treat a JS boolean as a number here too.
+ */
+function _isNumber(v: JsonValue): boolean {
+    return typeof v === 'number' || typeof v === 'boolean';
+}
+
+/**
+ * Mirror Python `isinstance(x, int) and not isinstance(x, bool)` for the
+ * `rounds` check. A JSON integer parses to a JS `number` with no fractional
+ * part; a JSON float with a fractional part is rejected; a JSON bool is
+ * rejected (Python excludes bool explicitly).
+ */
+function _isPyInt(v: JsonValue | undefined): v is number {
+    return typeof v === 'number' && Number.isInteger(v);
+}
+
+/** Mirror Python `bool(x)` truthiness for the values `ui_polish` can hold. */
+function _pyBool(v: JsonValue | undefined): boolean {
+    if (v === null || v === undefined) return false;
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'number') return v !== 0;
+    if (typeof v === 'string') return v.length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    if (_isDict(v)) return Object.keys(v).length > 0;
+    return true;
+}
+
+/** Python `dict.get(key, default)` over a JSON object. */
+function _get(obj: Dict, key: string, dflt: JsonValue): JsonValue {
+    return key in obj ? (obj[key] as JsonValue) : dflt;
+}
+
+/** `list(x)` where x may be a list (copy) or anything else (Python would error,
+ * but `from_dict` only feeds it the result of `payload.get(k, [])`, so it is a
+ * list or the default `[]`). Returns the array itself for spreading. */
+function _listOrEmpty(v: JsonValue): JsonValue[] {
+    return Array.isArray(v) ? v : [];
+}
+
+/** `dict(x)` where x is the result of `payload.get(k, {})`. */
+function _dictOrEmpty(v: JsonValue): Dict {
+    return _isDict(v) ? v : {};
+}
+
+/**
+ * Python `type(x).__name__` for the JSON value classes that appear in the
+ * error messages: `dict`, `list`, `str`, `int`, `float`, `bool`, `NoneType`.
+ */
+function pyTypeName(v: JsonValue | undefined): string {
+    if (v === null || v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}
+
+/**
+ * Python `repr(x)` for the scalar values that flow into error messages
+ * (`version`, `kind`, `decision`, `floor`, `verdict`). Strings → single-quoted
+ * with Python escaping; `None` → `None`; bools → `True`/`False`; numbers as-is.
+ */
+function pyRepr(v: JsonValue | undefined): string {
+    if (v === undefined || v === null) return 'None';
+    if (typeof v === 'boolean') return v ? 'True' : 'False';
+    if (typeof v === 'number') return _pyNumRepr(v);
+    if (typeof v === 'string') return pyStrRepr(v);
+    if (Array.isArray(v)) {
+        return '[' + v.map((x) => pyRepr(x)).join(', ') + ']';
+    }
+    // dict repr is not exercised by the .py error paths; render Python-ish.
+    const items = Object.keys(v).map((k) => `${pyStrRepr(k)}: ${pyRepr(v[k])}`);
+    return '{' + items.join(', ') + '}';
+}
+
+/** Python numeric repr — integer-valued floats are never produced here because
+ * JSON-parsed numbers carry no float/int tag; an integer renders without `.0`. */
+function _pyNumRepr(n: number): string {
+    return String(n);
+}
+
+/**
+ * Python `repr(str)` — prefers single quotes, switches to double quotes only
+ * when the string contains a single quote but no double quote, and escapes
+ * backslash plus the active quote and the standard control characters.
+ */
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') out += '\\\\';
+        else if (ch === quote) out += '\\' + quote;
+        else if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}
+
+/** Python `repr(list_of_str)` for the `sorted(KNOWN_*)` error tails. */
+function pyListRepr(items: string[]): string {
+    return '[' + items.map((s) => pyStrRepr(s)).join(', ') + ']';
+}
+
+/** Python `repr(bool)` — `True` / `False`. */
+function pyBoolRepr(b: boolean): string {
+    return b ? 'True' : 'False';
+}
+
+/**
+ * Python `sorted(set_of_str)` — code-point ascending, the default `str`
+ * ordering CPython uses. `Array.prototype.sort()` with no comparator sorts
+ * by UTF-16 code unit, which matches for the BMP ASCII tokens in these sets;
+ * use an explicit code-point comparator to be faithful for any input.
+ */
+function pySorted(values: ReadonlySet<string>): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, ensure_ascii=False)`.
+ *
+ * For round-tripped JSON (the only producer of a state dict), `JSON.stringify`
+ * with a 2-space indent matches CPython byte-for-byte: 2-space indent,
+ * `": "` key separator, no trailing space after the array/object item commas,
+ * `{}` / `[]` for empties, non-ASCII left verbatim. The one structural
+ * difference CPython has — integer-valued floats rendered as `N.0` — cannot
+ * arise here: JSON has no float/int tag, so a parsed `1.0` is already the JS
+ * number `1` before it ever reaches this serialiser, exactly as a Python
+ * reader that parsed the same bytes would diverge. `to_dict` never injects a
+ * float that did not come from the parsed payload.
+ */
+function jsonDumps(obj: Dict): string {
+    return JSON.stringify(obj, null, 2);
+}

--- a/tests/scripts/work_engine/_lib_agent_settings.test.ts
+++ b/tests/scripts/work_engine/_lib_agent_settings.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Golden-parity tests for the work_engine twin
+ * `src/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts`.
+ *
+ * The work_engine twin is a byte-identical copy of the dev-side twin
+ * `src/scripts/_lib/agent_settings.ts` (verified by the migration). These
+ * tests pin that behavioural parity from the work_engine path specifically:
+ *
+ *   - a unit block over the public loader / anchor surface, and
+ *   - a differential block that runs the work_engine Python module
+ *     (`work_engine/_lib/agent_settings.py`) through a `python3 -c` driver
+ *     and asserts the TS twin's merged settings / module config / anchor
+ *     resolution JSON-equal the Python reference.
+ *
+ * Adapted from the differential block of `tests/lib/agent_settings.test.ts`,
+ * repointed at the work_engine `_lib/` location. The Python import uses the
+ * package form (`sys.path = <work_engine dir>; from _lib import
+ * agent_settings`) so the relative `from . import user_global_paths` inside
+ * the module resolves against the copied sibling twin.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as ags from '../../../src/agent-src/templates/scripts/work_engine/_lib/agent_settings';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const WORK_ENGINE_DIR = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+
+const tmp_dirs: string[] = [];
+
+function make_tmp(): string {
+    // realpathSync so macOS /var → /private/var symlink resolution matches
+    // Python's tmp_path (already resolved) and the module's `_resolve`.
+    const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'we-ags-test-')));
+    tmp_dirs.push(dir);
+    return dir;
+}
+
+function write_file(p: string, body: string): string {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, body, 'utf-8');
+    return p;
+}
+
+function mkdirp(p: string): string {
+    fs.mkdirSync(p, { recursive: true });
+    return p;
+}
+
+/** A user-global path that does not exist (mirrors `tmp_path / "missing.yml"`). */
+function no_global(tmp: string): string {
+    return path.join(tmp, 'no-such-global.yml');
+}
+
+beforeEach(() => {
+    ags.logger.records.length = 0;
+});
+
+afterEach(() => {
+    while (tmp_dirs.length > 0) {
+        fs.rmSync(tmp_dirs.pop() as string, { recursive: true, force: true });
+    }
+    ags.logger.records.length = 0;
+});
+
+// --- unit surface ---------------------------------------------------------
+
+describe('work_engine agent_settings — unit surface', () => {
+    it('both files missing returns defaults ({})', () => {
+        const tmp = make_tmp();
+        const result = ags.load_agent_settings({
+            project_path: path.join(tmp, 'missing-project.yml'),
+            user_global_path: path.join(tmp, 'missing-user.yml'),
+        });
+        expect(result).toEqual({});
+    });
+
+    it('missing project yields user-global whitelisted', () => {
+        const tmp = make_tmp();
+        const user = write_file(path.join(tmp, 'user.yml'), 'name: Matze\nide: vscode\n');
+        const result = ags.load_agent_settings({
+            project_path: path.join(tmp, 'missing.yml'),
+            user_global_path: user,
+        });
+        expect(result).toEqual({ name: 'Matze', ide: 'vscode' });
+    });
+
+    it('project file overrides user-global on shared keys (deep merge)', () => {
+        const tmp = make_tmp();
+        const user = write_file(path.join(tmp, 'user.yml'), 'name: Global\nide: vscode\n');
+        const project = write_file(path.join(tmp, '.agent-settings.yml'), 'name: Project\n');
+        const result = ags.load_agent_settings({
+            project_path: project,
+            user_global_path: user,
+        });
+        expect(result.name).toBe('Project');
+        expect(result.ide).toBe('vscode');
+    });
+
+    it('find_project_root_with_anchor finds the agents/ anchor over a deep subdir', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        mkdirp(path.join(tmp, 'agents', 'roadmaps'));
+        const deep = mkdirp(path.join(tmp, 'src', 'deep'));
+        const result = ags.find_project_root_with_anchor(deep);
+        expect(result).not.toBeNull();
+        expect((result as [string, string])[0]).toBe(tmp);
+    });
+});
+
+// --- differential vs the work_engine Python reference ---------------------
+
+const PY_DRIVER = [
+    'import json, sys',
+    'from pathlib import Path',
+    'sys.path.insert(0, sys.argv[1])  # <work_engine dir> → enables `import _lib.*`',
+    'from _lib import agent_settings as ags  # noqa: E402',
+    '',
+    'mode = sys.argv[2]',
+    'arg = Path(sys.argv[3]) if len(sys.argv) > 3 else None',
+    'arg2 = Path(sys.argv[4]) if len(sys.argv) > 4 else None',
+    '',
+    'if mode == "load":',
+    '    out = ags.load_agent_settings(cwd=arg, user_global_path=arg2)',
+    'elif mode == "modules":',
+    '    out = ags.get_modules_config(project_root=arg, cwd=arg)',
+    'elif mode == "enumerate":',
+    '    out = ags.enumerate_modules(project_root=arg, cwd=arg)',
+    'elif mode == "anchor":',
+    '    res = ags.find_project_root_with_anchor(arg)',
+    '    out = [str(res[0]), res[1]] if res is not None else None',
+    'else:',
+    '    raise SystemExit(f"unknown mode {mode}")',
+    '',
+    'sys.stdout.write(json.dumps(out, sort_keys=True))',
+].join('\n');
+
+function py_driver(mode: string, ...args: string[]): unknown {
+    const proc = spawnSync('python3', ['-c', PY_DRIVER, WORK_ENGINE_DIR, mode, ...args], {
+        encoding: 'utf-8',
+    });
+    if (proc.status !== 0) {
+        throw new Error(`python driver failed (mode=${mode}): ${proc.stderr}`);
+    }
+    return JSON.parse(proc.stdout);
+}
+
+// Run only when python3 + PyYAML are available (matches the dev spike pattern).
+const PY_OK = (() => {
+    const probe = spawnSync('python3', ['-c', 'import yaml'], { encoding: 'utf-8' });
+    return probe.status === 0;
+})();
+
+describe.skipIf(!PY_OK)('work_engine agent_settings — differential vs Python', () => {
+    it('fixture A: defaults-only (bare git root, no settings)', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        const missing = no_global(tmp);
+        const ts = ags.load_agent_settings({ cwd: tmp, user_global_path: missing });
+        const py = py_driver('load', tmp, missing);
+        expect(ts).toEqual(py);
+        expect(ts).toEqual({});
+    });
+
+    it('fixture B: project-layer override (root .agent-settings.yml)', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        write_file(
+            path.join(tmp, '.agent-settings.yml'),
+            'name: Proj\nide: phpstorm\npipelines:\n  ci: true\n  retries: 3\n  channels:\n    - a\n    - b\n',
+        );
+        const missing = no_global(tmp);
+        const ts = ags.load_agent_settings({ cwd: tmp, user_global_path: missing });
+        expect(ts).toEqual(py_driver('load', tmp, missing));
+    });
+
+    it('fixture C: local-layer override (deepest wins, deep merge)', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        write_file(path.join(tmp, '.agent-settings.yml'), 'block:\n  a: 1\n  b: 2\nname: Root\n');
+        write_file(
+            path.join(tmp, 'agents', 'settings', '.agent-settings.yml'),
+            'block:\n  b: 99\nide: nvim\n',
+        );
+        write_file(
+            path.join(tmp, 'agents', 'settings', '.agent-settings.local.yml'),
+            'block:\n  c: 3\nname: LocalWins\n',
+        );
+        const missing = no_global(tmp);
+        const ts = ags.load_agent_settings({ cwd: tmp, user_global_path: missing });
+        expect(ts).toEqual(py_driver('load', tmp, missing));
+    });
+
+    it('fixture D: enumerate_modules over a module tree', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        mkdirp(path.join(tmp, 'app', 'Modules', 'Alpha', 'agents'));
+        mkdirp(path.join(tmp, 'app', 'Modules', 'Beta'));
+        mkdirp(path.join(tmp, 'app', 'Modules', '.example'));
+        mkdirp(path.join(tmp, 'packages', 'core'));
+        write_file(
+            path.join(tmp, '.agent-project-settings.yml'),
+            'modules:\n  enabled: true\n  root_paths: [app/Modules, packages]\n',
+        );
+        const ts = ags.enumerate_modules({ project_root: tmp, cwd: tmp });
+        expect(ts).toEqual(py_driver('enumerate', tmp));
+    });
+
+    it('fixture D2: get_modules_config team + dev cascade', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        write_file(
+            path.join(tmp, '.agent-project-settings.yml'),
+            'locked_keys:\n  - modules.root_paths\nmodules:\n  enabled: true\n  root_paths: [app/Modules]\n',
+        );
+        write_file(
+            path.join(tmp, '.agent-settings.yml'),
+            'modules:\n  root_paths: [src/local]\n  agent_folder: docs\n',
+        );
+        const ts = ags.get_modules_config({ project_root: tmp, cwd: tmp });
+        expect(ts).toEqual(py_driver('modules', tmp));
+    });
+
+    it('fixture E: anchor resolution (agents/ wins over .git)', () => {
+        const tmp = make_tmp();
+        mkdirp(path.join(tmp, '.git'));
+        mkdirp(path.join(tmp, 'agents', 'roadmaps'));
+        const deep = mkdirp(path.join(tmp, 'src', 'deep'));
+        const ts = ags.find_project_root_with_anchor(deep);
+        expect(ts).toEqual(py_driver('anchor', deep));
+    });
+});

--- a/tests/scripts/work_engine/_lib_user_global_paths.test.ts
+++ b/tests/scripts/work_engine/_lib_user_global_paths.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Golden-parity tests for the work_engine twin
+ * `src/agent-src/templates/scripts/work_engine/_lib/user_global_paths.ts`.
+ *
+ * The work_engine twin is a byte-identical copy of the dev-side twin
+ * `src/scripts/_lib/user_global_paths.ts` (verified by the migration). These
+ * tests pin that behavioural parity from the work_engine path specifically:
+ *
+ *   - a unit block mirroring the public surface, and
+ *   - a differential block that runs the work_engine Python module
+ *     (`work_engine/_lib/user_global_paths.py`) through a `python3 -c`
+ *     driver and asserts the TS twin's resolved paths JSON-equal the
+ *     Python reference, byte-for-byte.
+ *
+ * Adapted from `tests/lib/user_global_paths.test.ts`, repointed at the
+ * work_engine `_lib/` location. Python import uses the package form
+ * (`sys.path = <work_engine dir>; from _lib import user_global_paths`) so
+ * the relative `from .` imports inside the module resolve.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as user_global_paths from '../../../src/agent-src/templates/scripts/work_engine/_lib/user_global_paths';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const WORK_ENGINE_DIR = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+
+const tmp_dirs: string[] = [];
+const saved_env: Array<[string, string | undefined]> = [];
+
+function make_tmp(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'we-ugp-test-'));
+    tmp_dirs.push(dir);
+    return dir;
+}
+
+function patch_env(key: string, value: string | undefined): void {
+    saved_env.push([key, process.env[key]]);
+    if (value === undefined) {
+        delete process.env[key];
+    } else {
+        process.env[key] = value;
+    }
+}
+
+afterEach(() => {
+    while (saved_env.length > 0) {
+        const [key, value] = saved_env.pop() as [string, string | undefined];
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    }
+    while (tmp_dirs.length > 0) {
+        fs.rmSync(tmp_dirs.pop() as string, { recursive: true, force: true });
+    }
+});
+
+// --- unit surface ---------------------------------------------------------
+
+describe('work_engine user_global_paths — unit surface', () => {
+    it('event4u_root defaults to ~/.event4u/agent-config', () => {
+        patch_env(user_global_paths.EVENT4U_HOME_ENV, undefined);
+        patch_env('HOME', '/home/test');
+        expect(user_global_paths.event4u_root()).toBe('/home/test/.event4u/agent-config');
+    });
+
+    it('event4u_root honours the env override', () => {
+        const tmp = make_tmp();
+        const custom = path.join(tmp, 'custom-root');
+        const env = { [user_global_paths.EVENT4U_HOME_ENV]: custom };
+        expect(user_global_paths.event4u_root(env)).toBe(custom);
+    });
+
+    it('legacy_xdg_root is ~/.config/agent-config', () => {
+        patch_env('HOME', '/home/test');
+        expect(user_global_paths.legacy_xdg_root()).toBe('/home/test/.config/agent-config');
+    });
+
+    it('resolve_with_fallback prefers the new path when present', () => {
+        const tmp = make_tmp();
+        const new_root = path.join(tmp, '.event4u', 'agent-config');
+        fs.mkdirSync(new_root, { recursive: true });
+        fs.writeFileSync(path.join(new_root, 'settings.yml'), 'new=1', 'utf-8');
+        const env = { [user_global_paths.EVENT4U_HOME_ENV]: new_root };
+        expect(user_global_paths.resolve_with_fallback('settings.yml', { env })).toBe(
+            path.join(new_root, 'settings.yml'),
+        );
+    });
+
+    it('resolve_with_fallback rejects absolute paths', () => {
+        expect(() => user_global_paths.resolve_with_fallback('/etc/passwd')).toThrow(
+            /expects a relative path/,
+        );
+    });
+
+    it('write_target always lands in the new root', () => {
+        const tmp = make_tmp();
+        const custom = path.join(tmp, 'root');
+        const env = { [user_global_paths.EVENT4U_HOME_ENV]: custom };
+        expect(user_global_paths.write_target('installed.lock', { env })).toBe(
+            path.join(custom, 'installed.lock'),
+        );
+    });
+
+    it('migrate_legacy_namespace copies the legacy tree into the new root', () => {
+        const tmp = make_tmp();
+        const new_root = path.join(tmp, '.event4u', 'agent-config');
+        const env = { [user_global_paths.EVENT4U_HOME_ENV]: new_root };
+        const legacy = path.join(tmp, '.config', 'agent-config');
+        fs.mkdirSync(legacy, { recursive: true });
+        fs.writeFileSync(path.join(legacy, 'agent-settings.yml'), 'hello: world\n', 'utf-8');
+
+        const migrated = user_global_paths.migrate_legacy_namespace({
+            env,
+            legacy_root_override: legacy,
+        });
+
+        expect(migrated).toBe(true);
+        expect(fs.readFileSync(path.join(new_root, 'agent-settings.yml'), 'utf-8')).toBe(
+            'hello: world\n',
+        );
+        expect(
+            fs.existsSync(path.join(legacy, user_global_paths.MIGRATION_BREADCRUMB_NAME)),
+        ).toBe(true);
+    });
+});
+
+// --- differential vs the work_engine Python reference ---------------------
+
+const PY_DRIVER = [
+    'import json, os, sys',
+    'sys.path.insert(0, sys.argv[1])',
+    'from _lib import user_global_paths as u',
+    'out = {',
+    '    "event4u_root": str(u.event4u_root()),',
+    '    "legacy_xdg_root": str(u.legacy_xdg_root()),',
+    '    "write_target": str(u.write_target("installed.lock")),',
+    '}',
+    'r = u.resolve_with_fallback("settings.yml")',
+    'out["resolve"] = str(r) if r is not None else None',
+    'print(json.dumps(out, sort_keys=True))',
+].join('\n');
+
+interface PyPaths {
+    event4u_root: string;
+    legacy_xdg_root: string;
+    write_target: string;
+    resolve: string | null;
+}
+
+function run_py_driver(env_overrides: Record<string, string | undefined>): PyPaths {
+    const env: Record<string, string> = { PATH: process.env.PATH ?? '' };
+    for (const [key, value] of Object.entries(env_overrides)) {
+        if (value !== undefined) {
+            env[key] = value;
+        }
+    }
+    const result = spawnSync('python3', ['-c', PY_DRIVER, WORK_ENGINE_DIR], {
+        env,
+        encoding: 'utf-8',
+    });
+    expect(result.status, result.stderr).toBe(0);
+    return JSON.parse(result.stdout) as PyPaths;
+}
+
+function ts_paths(): PyPaths {
+    const resolved = user_global_paths.resolve_with_fallback('settings.yml');
+    return {
+        event4u_root: user_global_paths.event4u_root(),
+        legacy_xdg_root: user_global_paths.legacy_xdg_root(),
+        write_target: user_global_paths.write_target('installed.lock'),
+        resolve: resolved,
+    };
+}
+
+const PY_OK = spawnSync('python3', ['-c', 'import sys'], { encoding: 'utf-8' }).status === 0;
+
+describe.skipIf(!PY_OK)('work_engine user_global_paths — differential vs Python', () => {
+    it('scenario 1 — default HOME, no override', () => {
+        const home = make_tmp();
+        patch_env('HOME', home);
+        patch_env(user_global_paths.EVENT4U_HOME_ENV, undefined);
+        const py = run_py_driver({ HOME: home });
+        expect(ts_paths()).toEqual(py);
+        expect(py.resolve).toBeNull();
+    });
+
+    it('scenario 2 — EVENT4U_CONFIG_HOME override with existing file', () => {
+        const home = make_tmp();
+        const custom = path.join(make_tmp(), 'custom-root');
+        fs.mkdirSync(custom, { recursive: true });
+        fs.writeFileSync(path.join(custom, 'settings.yml'), 'x: 1\n', 'utf-8');
+        patch_env('HOME', home);
+        patch_env(user_global_paths.EVENT4U_HOME_ENV, custom);
+        const py = run_py_driver({
+            HOME: home,
+            [user_global_paths.EVENT4U_HOME_ENV]: custom,
+        });
+        expect(ts_paths()).toEqual(py);
+        expect(py.resolve).toBe(path.join(custom, 'settings.yml'));
+    });
+
+    it('scenario 3 — legacy fallback when only the XDG tree exists', () => {
+        const home = make_tmp();
+        const legacy = path.join(home, '.config', 'agent-config');
+        fs.mkdirSync(legacy, { recursive: true });
+        fs.writeFileSync(path.join(legacy, 'settings.yml'), 'legacy: 1\n', 'utf-8');
+        patch_env('HOME', home);
+        patch_env(user_global_paths.EVENT4U_HOME_ENV, undefined);
+        const py = run_py_driver({ HOME: home });
+        expect(ts_paths()).toEqual(py);
+        expect(py.resolve).toBe(path.join(legacy, 'settings.yml'));
+    });
+});

--- a/tests/scripts/work_engine/cli_args.test.ts
+++ b/tests/scripts/work_engine/cli_args.test.ts
@@ -1,0 +1,249 @@
+// Golden-parity tests for work_engine/cli_args.ts vs cli_args.py (ADR-094 py2ts
+// Phase 1). The Python source exposes `_build_parser()` returning an argparse
+// parser; the TS twin exposes `parse_args(argv)` mirroring argparse's runtime
+// behaviour for the declared flags. We compare the parsed NAMESPACE (paths as
+// strings, snake_case dests) and the EXIT CODE on every path — but NOT the
+// --help / error prose (ADR-094 explicitly excludes argparse help/usage text
+// from byte-comparison; the contract is exit-code + namespace parity).
+//
+// argparse surfaces exercised: long-option prefix abbreviation (unambiguous →
+// expand; ambiguous → exit 2; --help in the candidate set), `--flag=value` /
+// `--flag value`, store_true flags, explicit-value-on-store_true → exit 2,
+// missing value → exit 2, unknown flag → exit 2, -h/--help → exit 0.
+//
+// Python runs via a child process that catches SystemExit and prints either the
+// namespace JSON (success) or `EXIT <code>`; the work_engine module is loaded
+// with the shared direct-file importlib loader.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    ArgparseExit,
+    DEFAULT_STATE_FILE,
+    LEGACY_STATE_FILE,
+    _FMT_V0,
+    _FMT_V1,
+    parse_args,
+    type ParsedArgs,
+} from '../../../src/agent-src/templates/scripts/work_engine/cli_args.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** Run the Python parser on `argv`; return the namespace dict or the exit code. */
+function pyParse(argv: string[]): { ok: true; ns: Record<string, unknown> } | { ok: false; code: number } {
+    const code = [
+        'import importlib.util, sys, json, pathlib',
+        `WE = pathlib.Path(${JSON.stringify(WE)})`,
+        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
+        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
+        'sp = importlib.util.spec_from_file_location("we_cli_args", WE / "cli_args.py")',
+        'm = importlib.util.module_from_spec(sp); sys.modules[sp.name] = m; sp.loader.exec_module(m)',
+        'argv = json.loads(sys.argv[1])',
+        'p = m._build_parser()',
+        'import io, contextlib',
+        // Suppress argparse's --help / usage / error prose (NOT a parity
+        // surface, ADR-094) so only our OK/EXIT marker reaches the captured
+        // stdout. The marker is written to the real stdout fd after the
+        // redirect block exits.
+        'marker = None',
+        'try:',
+        '    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):',
+        '        ns = p.parse_args(argv)',
+        '    d = {k: (str(v) if isinstance(v, pathlib.Path) else v) for k, v in vars(ns).items()}',
+        '    marker = "OK\\t" + json.dumps(d)',
+        'except SystemExit as e:',
+        '    marker = "EXIT\\t" + str(int(e.code or 0))',
+        'print(marker)',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, JSON.stringify(argv)], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 crashed (status ${r.status}): ${r.stderr}`);
+    }
+    const out = r.stdout.trim();
+    if (out.startsWith('OK\t')) {
+        return { ok: true, ns: JSON.parse(out.slice(3)) as Record<string, unknown> };
+    }
+    return { ok: false, code: parseInt(out.slice(5), 10) };
+}
+
+/** Run the TS parser on `argv`; return the namespace or the exit code. */
+function tsParse(argv: string[]): { ok: true; ns: ParsedArgs } | { ok: false; code: number } {
+    const prev = process.exitCode;
+    process.exitCode = undefined;
+    try {
+        const ns = parse_args(argv);
+        return { ok: true, ns };
+    } catch (e) {
+        if (e instanceof ArgparseExit) {
+            return { ok: false, code: e.code };
+        }
+        throw e;
+    } finally {
+        process.exitCode = prev;
+    }
+}
+
+describe('work_engine/cli_args', () => {
+    afterEach(() => {
+        process.exitCode = undefined;
+    });
+
+    it('constants match the contract', () => {
+        expect(DEFAULT_STATE_FILE).toBe('.work-state.json');
+        expect(LEGACY_STATE_FILE).toBe('.implement-ticket-state.json');
+        expect(_FMT_V0).toBe('v0');
+        expect(_FMT_V1).toBe('v1');
+    });
+
+    it('no args → all defaults', () => {
+        const r = tsParse([]);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+            expect(r.ns).toEqual({
+                state_file: '.work-state.json',
+                ticket_file: null,
+                prompt_file: null,
+                diff_file: null,
+                file_file: null,
+                persona: null,
+                no_hooks: false,
+                hooks_config: null,
+            });
+        }
+    });
+
+    it('store_true flag + value flag (space form)', () => {
+        const r = tsParse(['--no-hooks', '--state-file', 'x.json']);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+            expect(r.ns.no_hooks).toBe(true);
+            expect(r.ns.state_file).toBe('x.json');
+        }
+    });
+
+    it('--flag=value form', () => {
+        const r = tsParse(['--ticket-file=t.json', '--persona=qa']);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+            expect(r.ns.ticket_file).toBe('t.json');
+            expect(r.ns.persona).toBe('qa');
+        }
+    });
+
+    it('unambiguous prefix abbreviation expands', () => {
+        const r = tsParse(['--state', 'a.json', '--no']);
+        expect(r.ok).toBe(true);
+        if (r.ok) {
+            expect(r.ns.state_file).toBe('a.json');
+            expect(r.ns.no_hooks).toBe(true);
+        }
+    });
+
+    it('ambiguous prefix → exit 2', () => {
+        // --p matches --prompt-file / --persona.
+        const r = tsParse(['--p', 'x']);
+        expect(r.ok).toBe(false);
+        if (!r.ok) {
+            expect(r.code).toBe(2);
+        }
+    });
+
+    it('unknown flag → exit 2', () => {
+        const r = tsParse(['--bogus']);
+        expect(r).toEqual({ ok: false, code: 2 });
+    });
+
+    it('missing value → exit 2', () => {
+        const r = tsParse(['--state-file']);
+        expect(r).toEqual({ ok: false, code: 2 });
+    });
+
+    it('explicit value on store_true → exit 2', () => {
+        const r = tsParse(['--no-hooks=x']);
+        expect(r).toEqual({ ok: false, code: 2 });
+    });
+
+    it('-h / --help → exit 0', () => {
+        expect(tsParse(['-h'])).toEqual({ ok: false, code: 0 });
+        expect(tsParse(['--help'])).toEqual({ ok: false, code: 0 });
+    });
+
+    describe.runIf(hasPython3())('python parity', () => {
+        // Cases that should parse cleanly. Compare the whole namespace.
+        const okCases: string[][] = [
+            [],
+            ['--no-hooks'],
+            ['--state-file', 'x.json'],
+            ['--state-file=y.json'],
+            ['--ticket-file', 't.json', '--persona', 'qa'],
+            ['--prompt-file', 'p.txt'],
+            ['--diff-file', 'd.patch'],
+            ['--file-file', 'f.txt'],
+            ['--hooks-config', '.agent-settings.yml', '--no-hooks'],
+            ['--state', 'abbrev.json'], // unambiguous prefix
+            ['--no'], // unambiguous prefix → --no-hooks
+            ['--pr', 'q.txt'], // --pr → --prompt-file (unambiguous)
+        ];
+
+        it.each(okCases.map((c) => [JSON.stringify(c), c] as [string, string[]]))(
+            'namespace parity for argv=%s',
+            (_label, argv) => {
+                const expected = pyParse(argv);
+                const got = tsParse(argv);
+                expect(expected.ok).toBe(true);
+                expect(got.ok).toBe(true);
+                if (expected.ok && got.ok) {
+                    expect(got.ns).toEqual(expected.ns);
+                }
+            },
+        );
+
+        // Cases that should exit 2. Compare the exit code only (not prose).
+        const exit2Cases: string[][] = [
+            ['--bogus'],
+            ['--state-file'], // missing value
+            ['--no-hooks=x'], // explicit value on store_true
+            ['--p', 'x'], // ambiguous abbreviation
+            ['extra-positional'],
+            ['--ticket-file'], // missing value
+            ['-x'], // unknown short
+        ];
+
+        it.each(exit2Cases.map((c) => [JSON.stringify(c), c] as [string, string[]]))(
+            'exit-2 parity for argv=%s',
+            (_label, argv) => {
+                const expected = pyParse(argv);
+                const got = tsParse(argv);
+                expect(expected.ok).toBe(false);
+                expect(got.ok).toBe(false);
+                if (!expected.ok && !got.ok) {
+                    expect(got.code).toBe(expected.code);
+                    expect(got.code).toBe(2);
+                }
+            },
+        );
+
+        const helpCases: string[][] = [['-h'], ['--help']];
+        it.each(helpCases.map((c) => [JSON.stringify(c), c] as [string, string[]]))(
+            'help exit-0 parity for argv=%s',
+            (_label, argv) => {
+                const expected = pyParse(argv);
+                const got = tsParse(argv);
+                expect(expected.ok).toBe(false);
+                expect(got.ok).toBe(false);
+                if (!expected.ok && !got.ok) {
+                    expect(got.code).toBe(expected.code);
+                    expect(got.code).toBe(0);
+                }
+            },
+        );
+    });
+});

--- a/tests/scripts/work_engine/delivery_state.test.ts
+++ b/tests/scripts/work_engine/delivery_state.test.ts
@@ -1,0 +1,224 @@
+// Golden-parity tests for work_engine/delivery_state.ts vs delivery_state.py
+// (ADR-094 py2ts Phase 1). Covers: Outcome enum string values, StepResult /
+// DeliveryState dataclass field order + defaults via asdict, per-instance
+// mutable defaults (no shared container), agent_directive formatting (incl.
+// Python str() coercion of bool/None/int payload values + kwargs order), and
+// is_agent_directive (lstrip + prefix). Python loaded via the shared direct-file
+// importlib loader (sys.modules registered before exec for the 3.9 dataclass
+// __module__ lookup; work_engine dir + repo on sys.path).
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    AGENT_DIRECTIVE_PREFIX,
+    DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+    is_agent_directive,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function pyLoaderPreamble(): string {
+    return [
+        'import importlib.util, sys, json, pathlib, dataclasses',
+        `WE = pathlib.Path(${JSON.stringify(WE)})`,
+        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
+        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
+        'def _load(name):',
+        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
+        '    m = importlib.util.module_from_spec(sp)',
+        '    sys.modules[sp.name] = m',
+        '    sp.loader.exec_module(m)',
+        '    return m',
+    ].join('\n');
+}
+
+function py(body: string): string {
+    const r = spawnSync('python3', ['-c', `${pyLoaderPreamble()}\n${body}`], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout.trim();
+}
+
+describe('work_engine/delivery_state', () => {
+    it('Outcome enum carries the string values', () => {
+        expect(Outcome.SUCCESS).toBe('success');
+        expect(Outcome.BLOCKED).toBe('blocked');
+        expect(Outcome.PARTIAL).toBe('partial');
+    });
+
+    it('AGENT_DIRECTIVE_PREFIX is the public contract literal', () => {
+        expect(AGENT_DIRECTIVE_PREFIX).toBe('@agent-directive:');
+    });
+
+    it('StepResult defaults: empty questions + message, own array per instance', () => {
+        const a = new StepResult({ outcome: Outcome.SUCCESS });
+        const b = new StepResult({ outcome: Outcome.BLOCKED });
+        expect(a.questions).toEqual([]);
+        expect(a.message).toBe('');
+        a.questions.push('x');
+        // default_factory=list → no cross-instance leakage.
+        expect(b.questions).toEqual([]);
+    });
+
+    it('DeliveryState defaults match the contract', () => {
+        const s = new DeliveryState({ ticket: { id: 'T1' } });
+        expect(s.persona).toBe('senior-engineer');
+        expect(s.memory).toEqual([]);
+        expect(s.plan).toBeNull();
+        expect(s.changes).toEqual([]);
+        expect(s.outcomes).toEqual({});
+        expect(s.questions).toEqual([]);
+        expect(s.report).toBe('');
+        expect(s.ui_audit).toBeNull();
+        expect(s.stack).toBeNull();
+    });
+
+    it('DeliveryState mutable defaults are per-instance', () => {
+        const a = new DeliveryState({ ticket: {} });
+        const b = new DeliveryState({ ticket: {} });
+        a.changes.push({ file: 'x' });
+        a.outcomes['k'] = 'v';
+        expect(b.changes).toEqual([]);
+        expect(b.outcomes).toEqual({});
+    });
+
+    it('agent_directive: name only', () => {
+        expect(agent_directive('implement-plan')).toBe('@agent-directive: implement-plan');
+    });
+
+    it('agent_directive: payload renders key=value, kwargs order preserved', () => {
+        expect(agent_directive('run-tests', { scope: 'full', n: 3 })).toBe(
+            '@agent-directive: run-tests scope=full n=3',
+        );
+    });
+
+    it('agent_directive: Python str() coercion of bool / None', () => {
+        expect(agent_directive('x', { a: true, b: false, c: null })).toBe(
+            '@agent-directive: x a=True b=False c=None',
+        );
+    });
+
+    it('is_agent_directive: lstrip then prefix match', () => {
+        expect(is_agent_directive('@agent-directive: foo')).toBe(true);
+        expect(is_agent_directive('   @agent-directive: foo')).toBe(true);
+        expect(is_agent_directive('1. user option')).toBe(false);
+        expect(is_agent_directive('')).toBe(false);
+        // non-string → false (Python isinstance guard).
+        expect(is_agent_directive(42 as unknown)).toBe(false);
+        expect(is_agent_directive(null as unknown)).toBe(false);
+    });
+
+    describe.runIf(hasPython3())('python parity', () => {
+        it('Outcome values match CPython', () => {
+            const oracle = py(
+                'm=_load("delivery_state")\n' +
+                    'print(json.dumps({k: getattr(m.Outcome, k).value for k in ' +
+                    '("SUCCESS","BLOCKED","PARTIAL")}))',
+            );
+            expect(JSON.parse(oracle)).toEqual({
+                SUCCESS: 'success',
+                BLOCKED: 'blocked',
+                PARTIAL: 'partial',
+            });
+        });
+
+        it('StepResult asdict field order matches CPython', () => {
+            const oracle = py(
+                'm=_load("delivery_state")\n' +
+                    'r=m.StepResult(outcome=m.Outcome.BLOCKED, questions=["q"], message="msg")\n' +
+                    'd=dataclasses.asdict(r)\n' +
+                    'd["outcome"]=d["outcome"].value\n' +
+                    'print(json.dumps({"keys": list(d.keys()), "val": d}))',
+            );
+            const expected = JSON.parse(oracle) as { keys: string[]; val: Record<string, unknown> };
+            const r = new StepResult({
+                outcome: Outcome.BLOCKED,
+                questions: ['q'],
+                message: 'msg',
+            });
+            expect(Object.keys(r)).toEqual(expected.keys);
+            expect({ outcome: r.outcome, questions: r.questions, message: r.message }).toEqual(
+                expected.val,
+            );
+        });
+
+        it('DeliveryState asdict field order matches CPython', () => {
+            const oracle = py(
+                'm=_load("delivery_state")\n' +
+                    's=m.DeliveryState(ticket={"id":"T1"})\n' +
+                    'print(json.dumps(list(dataclasses.asdict(s).keys())))',
+            );
+            const expected = JSON.parse(oracle) as string[];
+            const s = new DeliveryState({ ticket: { id: 'T1' } });
+            expect(Object.keys(s)).toEqual(expected);
+        });
+
+        const directiveCases: Array<[string, Record<string, unknown>]> = [
+            ['implement-plan', {}],
+            ['run-tests', { scope: 'full' }],
+            ['run-tests', { scope: 'full', n: 3 }],
+            ['x', { a: true, b: false, c: null }],
+            // NB: payload keys must not collide with the `name` positional
+            // (Python `agent_directive(name, **payload)` would TypeError on a
+            // `name=` kwarg — same constraint both sides).
+            ['x', { count: 0, label: 'a-b_c' }],
+        ];
+
+        it.each(directiveCases)('agent_directive(%j, %j) matches CPython', (name, payload) => {
+            const kwargs = Object.entries(payload)
+                .map(([k, v]) => `${k}=${pyLiteral(v)}`)
+                .join(', ');
+            const oracle = py(
+                'm=_load("delivery_state")\n' +
+                    `print(m.agent_directive(${JSON.stringify(name)}${kwargs ? ', ' + kwargs : ''}))`,
+            );
+            expect(agent_directive(name, payload)).toBe(oracle);
+        });
+
+        const directiveProbes = [
+            '@agent-directive: foo',
+            '   @agent-directive: foo',
+            '\t@agent-directive: x',
+            '1. user option',
+            '',
+            'agent-directive: no-at',
+        ];
+
+        it.each(directiveProbes)('is_agent_directive(%j) matches CPython', (q) => {
+            const oracle = py(
+                'm=_load("delivery_state")\n' +
+                    `print("true" if m.is_agent_directive(${JSON.stringify(q)}) else "false")`,
+            );
+            expect(String(is_agent_directive(q))).toBe(oracle);
+        });
+    });
+});
+
+/** Render a JS payload value as a Python literal for the `-c` oracle. */
+function pyLiteral(v: unknown): string {
+    if (v === null || v === undefined) {
+        return 'None';
+    }
+    if (v === true) {
+        return 'True';
+    }
+    if (v === false) {
+        return 'False';
+    }
+    if (typeof v === 'number') {
+        return String(v);
+    }
+    return JSON.stringify(v);
+}

--- a/tests/scripts/work_engine/errors.test.ts
+++ b/tests/scripts/work_engine/errors.test.ts
@@ -1,0 +1,92 @@
+// Golden-parity tests for work_engine/errors.ts vs errors.py (ADR-094 py2ts
+// Phase 1). errors is a leaf module: one exception class `_CLIError` whose only
+// contract is "is an Error subclass, carries its message, name is `_CLIError`".
+// The Python side is loaded via a direct-file importlib loader (the work_engine
+// dir + repo root are added to sys.path so the `from __future__ import
+// annotations` header and any sibling imports resolve). The TS side imports the
+// twin directly. No `--help` / prose surface here.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { _CLIError } from '../../../src/agent-src/templates/scripts/work_engine/errors.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+// Direct-file importlib loader: register the module in sys.modules BEFORE
+// exec_module (CPython 3.9 dataclass `__module__` lookup needs it) and add the
+// work_engine dir + repo root to sys.path so intra-package + dispatch_hook
+// imports resolve. Shared verbatim by every work_engine parity test.
+function pyLoaderPreamble(): string {
+    return [
+        'import importlib.util, sys, json, pathlib',
+        `WE = pathlib.Path(${JSON.stringify(WE)})`,
+        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
+        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
+        'def _load(name):',
+        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
+        '    m = importlib.util.module_from_spec(sp)',
+        '    sys.modules[sp.name] = m',
+        '    sp.loader.exec_module(m)',
+        '    return m',
+    ].join('\n');
+}
+
+function py(body: string): string {
+    const code = `${pyLoaderPreamble()}\n${body}`;
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout.trim();
+}
+
+describe('work_engine/errors — _CLIError', () => {
+    it('is an Error subclass carrying its message', () => {
+        const e = new _CLIError('boom');
+        expect(e).toBeInstanceOf(Error);
+        expect(e).toBeInstanceOf(_CLIError);
+        expect(e.message).toBe('boom');
+        expect(e.name).toBe('_CLIError');
+    });
+
+    it('throws and is catchable as _CLIError', () => {
+        expect(() => {
+            throw new _CLIError('cfg problem');
+        }).toThrow(_CLIError);
+    });
+
+    it('empty message round-trips', () => {
+        const e = new _CLIError();
+        expect(e.message).toBe('');
+        expect(e).toBeInstanceOf(_CLIError);
+    });
+
+    describe.runIf(hasPython3())('python parity', () => {
+        it('name + message match CPython', () => {
+            const oracle = py(
+                'm=_load("errors")\n' +
+                    'e=m._CLIError("cfg problem")\n' +
+                    'print(json.dumps({"name": type(e).__name__, "msg": str(e), ' +
+                    '"is_exc": isinstance(e, Exception)}))',
+            );
+            const expected = JSON.parse(oracle) as { name: string; msg: string; is_exc: boolean };
+            const e = new _CLIError('cfg problem');
+            expect(e.name).toBe(expected.name);
+            expect(e.message).toBe(expected.msg);
+            expect(e instanceof Error).toBe(expected.is_exc);
+        });
+
+        it('exports exactly _CLIError in __all__', () => {
+            const oracle = py('m=_load("errors")\nprint(json.dumps(m.__all__))');
+            expect(JSON.parse(oracle)).toEqual(['_CLIError']);
+        });
+    });
+});

--- a/tests/scripts/work_engine/orchestration.test.ts
+++ b/tests/scripts/work_engine/orchestration.test.ts
@@ -1,0 +1,303 @@
+// Golden-parity tests for work_engine/orchestration.ts vs orchestration.py
+// (ADR-094 py2ts Phase 1). Covers the deterministic bookkeeping surface:
+// _interpolate (scalar / nested dict / list / unknown-ref KeyError),
+// _when_passes (success/failure guards, output==literal, unsupported → ValueError),
+// iter_steps (input merge + defaults, when-skip, halt-on-failure), record_result
+// (results capture + halt), resolve_outputs. Both sides parse the SAME YAML
+// fixture: the TS twin's _load_pipeline dynamically imports the resolved
+// scripts/hooks/dispatch_hook.ts (the faithful analogue of the Python importlib
+// load of dispatch_hook.py::_load_yaml), so the loaders see the same shape.
+//
+// Python is loaded via the shared direct-file importlib loader; orchestration
+// itself dynamically importlib-loads dispatch_hook.py at runtime, so the repo
+// root must be on sys.path. Driver scripts run a full traversal and dump the
+// captured descriptors / state as JSON for byte-comparison against the TS run.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    KeyError,
+    PipelineState,
+    StepResult,
+    ValueError,
+    _interpolate,
+    _when_passes,
+    iter_steps,
+    record_result,
+    resolve_outputs,
+    type StepDescriptor,
+} from '../../../src/agent-src/templates/scripts/work_engine/orchestration.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkPipe(yaml: string): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-'));
+    tmpDirs.push(d);
+    const p = path.join(d, 'pipe.yml');
+    fs.writeFileSync(p, yaml, 'utf8');
+    return p;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+// Python driver: load orchestration via importlib, run a scripted traversal that
+// mirrors the TS driver below, and dump JSON. `mode` selects the scenario.
+function pyDrive(pipePath: string, mode: string, inputs: Record<string, string>): unknown {
+    const code = [
+        'import importlib.util, sys, json, pathlib',
+        `WE = pathlib.Path(${JSON.stringify(WE)})`,
+        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
+        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
+        'def _load(name):',
+        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
+        '    m = importlib.util.module_from_spec(sp); sys.modules[sp.name] = m; sp.loader.exec_module(m)',
+        '    return m',
+        'orch = _load("orchestration")',
+        'pipe = pathlib.Path(sys.argv[1]); mode = sys.argv[2]; inputs = json.loads(sys.argv[3])',
+        'def stable(desc):',
+        '    return {k: v for k, v in desc.items() if k != "_state"}',
+        'if mode == "all-success":',
+        '    descs = []',
+        '    it = orch.iter_steps(pipe, inputs)',
+        '    state = None',
+        '    for d in it:',
+        '        descs.append(stable(d)); state = d["_state"]',
+        '        orch.record_result(d, success=True, output=d["id"].upper()+"-OUT")',
+        '    outs = orch.resolve_outputs(pipe, state) if state is not None else {}',
+        '    print(json.dumps({"descs": descs, "outputs": outs, "halted": state.halted if state else False}))',
+        'elif mode == "fail-first":',
+        '    descs = []; it = orch.iter_steps(pipe, inputs); state = None',
+        '    for d in it:',
+        '        descs.append(stable(d)); state = d["_state"]',
+        '        orch.record_result(d, success=False, error="boom")',
+        '    print(json.dumps({"descs": descs, "halted": state.halted, "halt_reason": state.halt_reason}))',
+        'elif mode == "iter-only":',
+        '    descs = [stable(d) for d in orch.iter_steps(pipe, inputs)]',
+        '    print(json.dumps({"descs": descs}))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, pipePath, mode, JSON.stringify(inputs)], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return JSON.parse(r.stdout.trim());
+}
+
+function stable(desc: StepDescriptor): Record<string, unknown> {
+    const { _state, ...rest } = desc;
+    void _state;
+    return rest;
+}
+
+async function tsDrive(
+    pipePath: string,
+    mode: string,
+    inputs: Record<string, string>,
+): Promise<unknown> {
+    if (mode === 'all-success') {
+        const descs: Array<Record<string, unknown>> = [];
+        let state: PipelineState | null = null;
+        for await (const d of iter_steps(pipePath, inputs)) {
+            descs.push(stable(d));
+            state = d._state;
+            record_result(d, { success: true, output: `${d.id.toUpperCase()}-OUT` });
+        }
+        const outputs = state ? await resolve_outputs(pipePath, state) : {};
+        return { descs, outputs, halted: state ? state.halted : false };
+    }
+    if (mode === 'fail-first') {
+        const descs: Array<Record<string, unknown>> = [];
+        let state: PipelineState | null = null;
+        for await (const d of iter_steps(pipePath, inputs)) {
+            descs.push(stable(d));
+            state = d._state;
+            record_result(d, { success: false, error: 'boom' });
+        }
+        return {
+            descs,
+            halted: state ? state.halted : false,
+            halt_reason: state ? state.halt_reason : null,
+        };
+    }
+    // iter-only
+    const descs: Array<Record<string, unknown>> = [];
+    for await (const d of iter_steps(pipePath, inputs)) {
+        descs.push(stable(d));
+    }
+    return { descs };
+}
+
+const LINEAR_PIPE = [
+    'name: demo',
+    'inputs:',
+    '  - id: topic',
+    '    default: hello',
+    'steps:',
+    '  - id: a',
+    '    kind: skill',
+    '    ref: foo',
+    '    with:',
+    '      q: "${{ inputs.topic }}"',
+    '  - id: b',
+    '    kind: command',
+    '    ref: bar',
+    '    when: steps.a.success',
+    '    with:',
+    '      prev: "${{ steps.a.output }}"',
+    'outputs:',
+    '  result: "${{ steps.b.output }}"',
+    '',
+].join('\n');
+
+const GUARD_PIPE = [
+    'name: guarded',
+    'steps:',
+    '  - id: a',
+    '    kind: skill',
+    '    ref: foo',
+    '  - id: b',
+    '    kind: skill',
+    '    ref: bar',
+    '    when: steps.a.failure',
+    '  - id: c',
+    '    kind: skill',
+    '    ref: baz',
+    '    when: steps.a.success',
+    '',
+].join('\n');
+
+describe('work_engine/orchestration — pure helpers', () => {
+    it('_interpolate substitutes scalars, nested dicts, and lists', () => {
+        const st = new PipelineState({ name: 'x', inputs: { topic: 'world' } });
+        st.results['a'] = new StepResult('a', 'skill', 'foo', true, 'AOUT');
+        expect(_interpolate('hi ${{ inputs.topic }}', st)).toBe('hi world');
+        expect(_interpolate({ q: '${{ steps.a.output }}' }, st)).toEqual({ q: 'AOUT' });
+        expect(_interpolate(['${{ inputs.topic }}', 7], st)).toEqual(['world', 7]);
+        expect(_interpolate(42, st)).toBe(42);
+    });
+
+    it('_interpolate throws KeyError on unknown input / step', () => {
+        const st = new PipelineState({ name: 'x', inputs: {} });
+        expect(() => _interpolate('${{ inputs.missing }}', st)).toThrow(KeyError);
+        expect(() => _interpolate('${{ steps.nope.output }}', st)).toThrow(KeyError);
+    });
+
+    it('_when_passes: empty / null → true', () => {
+        const st = new PipelineState({ name: 'x', inputs: {} });
+        expect(_when_passes(null, st)).toBe(true);
+        expect(_when_passes('', st)).toBe(true);
+        expect(_when_passes(undefined, st)).toBe(true);
+    });
+
+    it('_when_passes: success / failure guards', () => {
+        const st = new PipelineState({ name: 'x', inputs: {} });
+        // unknown step → false
+        expect(_when_passes('steps.a.success', st)).toBe(false);
+        st.results['a'] = new StepResult('a', 'skill', 'foo', true, '');
+        expect(_when_passes('steps.a.success', st)).toBe(true);
+        expect(_when_passes('steps.a.failure', st)).toBe(false);
+        st.results['b'] = new StepResult('b', 'skill', 'foo', false, '');
+        expect(_when_passes('steps.b.failure', st)).toBe(true);
+    });
+
+    it('_when_passes: output == literal', () => {
+        const st = new PipelineState({ name: 'x', inputs: {} });
+        st.results['a'] = new StepResult('a', 'skill', 'foo', true, 'done');
+        expect(_when_passes('${{ steps.a.output }} == "done"', st)).toBe(true);
+        expect(_when_passes('${{ steps.a.output }} == "nope"', st)).toBe(false);
+        // missing step → default StepResult("","") output → only matches ""
+        expect(_when_passes('${{ steps.z.output }} == ""', st)).toBe(true);
+    });
+
+    it('_when_passes: unsupported expression → ValueError', () => {
+        const st = new PipelineState({ name: 'x', inputs: {} });
+        expect(() => _when_passes('garbage expr', st)).toThrow(ValueError);
+    });
+
+    it('record_result halts on failure', () => {
+        const st = new PipelineState({ name: 'x', inputs: {} });
+        const desc: StepDescriptor = { id: 'a', kind: 'skill', ref: 'foo', with: {}, _state: st };
+        record_result(desc, { success: false, error: 'oops' });
+        expect(st.halted).toBe(true);
+        expect(st.halt_reason).toBe('step a failed');
+        expect(st.results['a']?.success).toBe(false);
+    });
+
+    it('iter_steps yields interpolated descriptors in order, with-guard applied', async () => {
+        const pipe = mkPipe(LINEAR_PIPE);
+        const out = (await tsDrive(pipe, 'iter-only', {})) as {
+            descs: Array<Record<string, unknown>>;
+        };
+        // b carries `when: steps.a.success`; in iter-only mode no result is
+        // recorded for `a`, so the guard fails and b is skipped — only `a` is
+        // yielded. Identical to the CPython generator (verified in the parity
+        // suite below).
+        expect(out.descs).toEqual([
+            { id: 'a', kind: 'skill', ref: 'foo', with: { q: 'hello' } },
+        ]);
+    });
+
+    it('iter_steps merges provided inputs over defaults', async () => {
+        const pipe = mkPipe(LINEAR_PIPE);
+        const out = (await tsDrive(pipe, 'iter-only', { topic: 'world' })) as {
+            descs: Array<Record<string, unknown>>;
+        };
+        expect(out.descs[0]).toEqual({ id: 'a', kind: 'skill', ref: 'foo', with: { q: 'world' } });
+    });
+});
+
+describe.runIf(hasPython3())('work_engine/orchestration — python parity', () => {
+    it('all-success traversal matches CPython (descs + outputs)', async () => {
+        const pipe = mkPipe(LINEAR_PIPE);
+        const expected = pyDrive(pipe, 'all-success', {});
+        const got = await tsDrive(pipe, 'all-success', {});
+        expect(got).toEqual(expected);
+    });
+
+    it('all-success with provided inputs matches CPython', async () => {
+        const pipe = mkPipe(LINEAR_PIPE);
+        const expected = pyDrive(pipe, 'all-success', { topic: 'world' });
+        const got = await tsDrive(pipe, 'all-success', { topic: 'world' });
+        expect(got).toEqual(expected);
+    });
+
+    it('fail-first halts identically (no further steps yielded)', async () => {
+        const pipe = mkPipe(LINEAR_PIPE);
+        const expected = pyDrive(pipe, 'fail-first', {});
+        const got = await tsDrive(pipe, 'fail-first', {});
+        expect(got).toEqual(expected);
+    });
+
+    it('when-guard pipeline yields the same surviving steps', async () => {
+        // a succeeds → b (a.failure) skipped, c (a.success) runs.
+        const pipe = mkPipe(GUARD_PIPE);
+        const expected = pyDrive(pipe, 'all-success', {});
+        const got = await tsDrive(pipe, 'all-success', {});
+        expect(got).toEqual(expected);
+    });
+
+    it('iter-only descriptor stream matches CPython', async () => {
+        const pipe = mkPipe(LINEAR_PIPE);
+        const expected = pyDrive(pipe, 'iter-only', { topic: 'mirror' });
+        const got = await tsDrive(pipe, 'iter-only', { topic: 'mirror' });
+        expect(got).toEqual(expected);
+    });
+});

--- a/tests/scripts/work_engine/persona_policy.test.ts
+++ b/tests/scripts/work_engine/persona_policy.test.ts
@@ -1,0 +1,156 @@
+// Golden-parity tests for work_engine/persona_policy.ts vs persona_policy.py
+// (ADR-094 py2ts Phase 1). Covers: every shipped persona resolves to the right
+// policy flags, the default-on-miss fallback (None / unknown / non-string), and
+// known_personas insertion order. The Python side is loaded via a direct-file
+// importlib loader (sys.modules registered before exec so the CPython-3.9
+// dataclass `__module__` lookup succeeds; work_engine dir + repo on sys.path).
+// Policy objects are compared as asdict() dicts to assert field-name + value
+// parity in declaration order.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_PERSONA,
+    PersonaPolicy,
+    known_personas,
+    resolve_policy,
+} from '../../../src/agent-src/templates/scripts/work_engine/persona_policy.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function pyLoaderPreamble(): string {
+    return [
+        'import importlib.util, sys, json, pathlib, dataclasses',
+        `WE = pathlib.Path(${JSON.stringify(WE)})`,
+        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
+        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
+        'def _load(name):',
+        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
+        '    m = importlib.util.module_from_spec(sp)',
+        '    sys.modules[sp.name] = m',
+        '    sp.loader.exec_module(m)',
+        '    return m',
+    ].join('\n');
+}
+
+function py(body: string): string {
+    const r = spawnSync('python3', ['-c', `${pyLoaderPreamble()}\n${body}`], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr}`);
+    }
+    return r.stdout.trim();
+}
+
+/** asdict-equivalent projection of a TS PersonaPolicy, in Python field order. */
+function asdict(p: PersonaPolicy): Record<string, unknown> {
+    return {
+        name: p.name,
+        allows_implement: p.allows_implement,
+        allows_test: p.allows_test,
+        allows_verify: p.allows_verify,
+        widen_tests: p.widen_tests,
+        suggests_next_commands: p.suggests_next_commands,
+    };
+}
+
+describe('work_engine/persona_policy', () => {
+    it('DEFAULT_PERSONA is senior-engineer', () => {
+        expect(DEFAULT_PERSONA).toBe('senior-engineer');
+    });
+
+    it('senior-engineer: runs every step, no widening', () => {
+        expect(asdict(resolve_policy('senior-engineer'))).toEqual({
+            name: 'senior-engineer',
+            allows_implement: true,
+            allows_test: true,
+            allows_verify: true,
+            widen_tests: false,
+            suggests_next_commands: true,
+        });
+    });
+
+    it('qa: widens tests', () => {
+        const p = resolve_policy('qa');
+        expect(p.widen_tests).toBe(true);
+        expect(p.allows_implement).toBe(true);
+    });
+
+    it('advisory: plan-only, no next-command suggestions', () => {
+        expect(asdict(resolve_policy('advisory'))).toEqual({
+            name: 'advisory',
+            allows_implement: false,
+            allows_test: false,
+            allows_verify: false,
+            widen_tests: false,
+            suggests_next_commands: false,
+        });
+    });
+
+    it('unknown / null / non-string fall back to the default policy', () => {
+        const def = asdict(resolve_policy('senior-engineer'));
+        expect(asdict(resolve_policy('bogus'))).toEqual(def);
+        expect(asdict(resolve_policy(null))).toEqual(def);
+        expect(asdict(resolve_policy(undefined))).toEqual(def);
+        expect(asdict(resolve_policy(42))).toEqual(def);
+        expect(asdict(resolve_policy(''))).toEqual(def);
+    });
+
+    it('known_personas returns insertion order', () => {
+        expect(known_personas()).toEqual(['senior-engineer', 'qa', 'advisory']);
+    });
+
+    it('policy objects are frozen (read-only configuration)', () => {
+        const p = resolve_policy('qa');
+        expect(() => {
+            (p as unknown as { widen_tests: boolean }).widen_tests = false;
+        }).toThrow();
+    });
+
+    describe.runIf(hasPython3())('python parity', () => {
+        const personas = ['senior-engineer', 'qa', 'advisory', 'bogus', ''];
+
+        it.each(personas)('resolve_policy(%j) asdict matches CPython', (persona) => {
+            const oracle = py(
+                'm=_load("persona_policy")\n' +
+                    `print(json.dumps(dataclasses.asdict(m.resolve_policy(${JSON.stringify(persona)}))))`,
+            );
+            const expected = JSON.parse(oracle) as Record<string, unknown>;
+            expect(asdict(resolve_policy(persona))).toEqual(expected);
+        });
+
+        it('resolve_policy(None) asdict matches CPython', () => {
+            const oracle = py(
+                'm=_load("persona_policy")\n' +
+                    'print(json.dumps(dataclasses.asdict(m.resolve_policy(None))))',
+            );
+            expect(asdict(resolve_policy(null))).toEqual(JSON.parse(oracle));
+        });
+
+        it('known_personas matches CPython', () => {
+            const oracle = py(
+                'm=_load("persona_policy")\nprint(json.dumps(list(m.known_personas())))',
+            );
+            expect(known_personas()).toEqual(JSON.parse(oracle));
+        });
+
+        it('DEFAULT_PERSONA + __all__ match CPython', () => {
+            const oracle = py(
+                'm=_load("persona_policy")\n' +
+                    'print(json.dumps({"default": m.DEFAULT_PERSONA, "all": sorted(m.__all__)}))',
+            );
+            const expected = JSON.parse(oracle) as { default: string; all: string[] };
+            expect(DEFAULT_PERSONA).toBe(expected.default);
+            expect(expected.all).toEqual(
+                ['DEFAULT_PERSONA', 'PersonaPolicy', 'known_personas', 'resolve_policy'].sort(),
+            );
+        });
+    });
+});

--- a/tests/scripts/work_engine/state.test.ts
+++ b/tests/scripts/work_engine/state.test.ts
@@ -1,0 +1,464 @@
+// Golden-parity rig for the py2ts work_engine `state` twin (ADR-094).
+//
+// `work_engine/state.py` is a foundation library module with NO intra-package
+// imports — stdlib only. To exercise it from python3 without importing the
+// whole `work_engine` package (whose `__init__` pulls in unported siblings),
+// we load `state.py` via a direct-file `importlib` loader, registering the
+// module in `sys.modules` BEFORE `exec_module` so the dataclass field-type
+// resolution (under `from __future__ import annotations`) finds the module.
+//
+// Each block drives construction / serialization on BOTH engines from the
+// same JSON fixture and asserts byte-identical `json.dumps(..., indent=2,
+// ensure_ascii=False)` (the exact call `state.dump` makes) plus matching
+// validation-error text. The TS side is exercised via the same module under
+// `node node_modules/.bin/tsx` per ADR-094's runtime model.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_DIRECTIVE_SET,
+    DEFAULT_INTENT,
+    Input,
+    KNOWN_DIRECTIVE_SETS,
+    KNOWN_INPUT_KINDS,
+    SCHEMA_VERSION,
+    SchemaError,
+    dump,
+    from_dict,
+    load,
+    to_dict,
+} from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+
+// tests/scripts/work_engine/state.test.ts → four levels up is the repo root.
+const REPO_ROOT = path.resolve(
+    fileURLToPath(import.meta.url),
+    '..',
+    '..',
+    '..',
+    '..',
+);
+
+const STATE_PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'state.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Run a python3 snippet that has `state.py` loaded as the module `state`
+ * (direct-file importlib loader; `sys.modules` registration handles the
+ * `from __future__ import annotations` dataclass type resolution). `args`
+ * become `sys.argv[1:]`.
+ */
+function runPyWithState(
+    body: string,
+    args: string[] = [],
+): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `spec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
+        'state = importlib.util.module_from_spec(spec)',
+        'sys.modules["state"] = state',
+        'spec.loader.exec_module(state)',
+    ].join('\n');
+    const code = `${loader}\n${body}`;
+    return spawnSync('python3', ['-c', code, ...args], {
+        encoding: 'utf8',
+    });
+}
+
+/** Python `json.dumps(payload-built-state, indent=2, ensure_ascii=False)`. */
+function pySerialize(fixtureJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = state.from_dict(payload)',
+        'sys.stdout.write(json.dumps(state.to_dict(st), indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPyWithState(body, [fixtureJson]);
+    if (r.status !== 0) {
+        throw new Error(`python3 serialize failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** Python: from_dict then dump to a file, return the on-disk bytes (incl. \n). */
+function pyDumpFile(fixtureJson: string, outPath: string): string {
+    const body = [
+        'import pathlib',
+        'payload = json.loads(sys.argv[1])',
+        'st = state.from_dict(payload)',
+        'state.dump(st, pathlib.Path(sys.argv[2]))',
+        'sys.stdout.write(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))',
+    ].join('\n');
+    const r = runPyWithState(body, [fixtureJson, outPath]);
+    if (r.status !== 0) {
+        throw new Error(`python3 dump failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** Python: from_dict, expect SchemaError, return its message text. */
+function pyErrorMessage(fixtureJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'try:',
+        '    state.from_dict(payload)',
+        '    sys.stdout.write("__NO_ERROR__")',
+        'except state.SchemaError as exc:',
+        '    sys.stdout.write(str(exc))',
+    ].join('\n');
+    const r = runPyWithState(body, [fixtureJson]);
+    if (r.status !== 0) {
+        throw new Error(`python3 error-probe failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** TS twin: from_dict then JSON.stringify(to_dict, null, 2) — `state.dump`'s body. */
+function tsSerialize(fixtureJson: string): string {
+    const payload = JSON.parse(fixtureJson);
+    return JSON.stringify(to_dict(from_dict(payload)), null, 2);
+}
+
+/** TS twin: from_dict, capture the SchemaError message. */
+function tsErrorMessage(fixtureJson: string): string {
+    const payload = JSON.parse(fixtureJson);
+    try {
+        from_dict(payload);
+        return '__NO_ERROR__';
+    } catch (exc) {
+        return (exc as Error).message;
+    }
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+//
+// NOTE: fixtures deliberately avoid integer-valued floats (e.g. `1.0`). JSON
+// carries no float/int tag, so `1.0` collapses to the JS number `1` on parse —
+// CPython's reader keeps it a float and re-emits `1.0`. That divergence is a
+// property of the JSON-round-trip, identical for any TS reader, and the
+// Python `state.dump` path is fed JSON-parsed values too; it is not a twin
+// defect. `mtime` uses a genuine non-integer float (`2.5`) to prove real
+// floats round-trip on both sides.
+
+const FRESH_TICKET = JSON.stringify({
+    version: 1,
+    input: { kind: 'ticket', data: { id: 'T-1', title: 'Build it' } },
+});
+
+const FULL_ENVELOPE = JSON.stringify({
+    version: 1,
+    input: {
+        kind: 'prompt',
+        data: { raw: 'improve the dashboard', assumptions: ['a', 'b'] },
+    },
+    intent: 'ui-improve',
+    directive_set: 'ui',
+    stack: { frontend: 'react', mtime: 2.5 },
+    ui_audit: {
+        greenfield: true,
+        greenfield_decision: 'scaffold',
+        a11y_baseline: [{ rule: 'color-contrast' }],
+        components_found: ['Button', 'Card'],
+    },
+    ui_design: { design_confirmed: true, layout: 'grid' },
+    ui_review: {
+        findings: [{ severity: 'minor', text: 'x' }],
+        review_clean: false,
+        a11y: {
+            violations: [{ id: 'v1' }],
+            severity_floor: 'serious',
+            accepted_violations: [],
+        },
+        preview: { render_ok: true },
+    },
+    ui_polish: { rounds: 2, applied: ['fix-a'], extension_used: false },
+    contract: {
+        data_model: [{ entity: 'User' }],
+        api_surface: [{ path: '/users' }],
+        contract_confirmed: true,
+    },
+    stitch: {
+        scenarios: [{ name: 'login' }],
+        verdict: 'success',
+        integration_confirmed: true,
+    },
+    halts: [
+        { reason: 'ambiguous AC', surface: ['line 1', 'line 2'], step: 'plan' },
+    ],
+    persona: 'frontend-lead',
+    memory: [{ note: 'prior run' }],
+    plan: { steps: ['s1', 's2'] },
+    changes: [{ file: 'a.ts' }],
+    tests: { added: 3 },
+    verify: { passed: true },
+    outcomes: { plan: 'success', apply: 'partial' },
+    questions: ['Which layout?'],
+    report: 'done',
+});
+
+// Unknown top-level keys are tolerated + dropped; non-ASCII left verbatim.
+const TOLERANT_AND_UNICODE = JSON.stringify({
+    version: 1,
+    input: { kind: 'file', data: { path: 'src/Héllo.tsx' } },
+    future_field: { ignored: true },
+    report: 'café — naïve façade ☕',
+    extension_used: 'leaked-but-not-a-field',
+});
+
+// `rounds` at the extension ceiling (3) only valid when extension_used is true.
+const POLISH_EXTENSION = JSON.stringify({
+    version: 1,
+    input: { kind: 'ticket', data: {} },
+    ui_polish: { rounds: 3, extension_used: true, applied: [] },
+});
+
+const EMPTY_DICT_GATES = JSON.stringify({
+    version: 1,
+    input: { kind: 'ticket', data: {} },
+    ui_audit: {},
+    ui_design: {},
+    ui_review: {},
+    ui_polish: {},
+    contract: {},
+    stitch: {},
+});
+
+describePy('work_engine/state — golden serialization parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['fresh ticket (defaults fill in)', FRESH_TICKET],
+        ['full envelope (every slot populated)', FULL_ENVELOPE],
+        ['tolerant reader + non-ASCII round-trip', TOLERANT_AND_UNICODE],
+        ['polish at extension ceiling', POLISH_EXTENSION],
+        ['empty-dict in-progress gates', EMPTY_DICT_GATES],
+    ];
+
+    for (const [label, fixture] of cases) {
+        it(`byte-identical to_dict JSON — ${label}`, () => {
+            const py = pySerialize(fixture);
+            const ts = tsSerialize(fixture);
+            expect(ts).toBe(py);
+        });
+    }
+
+    it('dump() writes byte-identical on-disk bytes (trailing newline)', () => {
+        const tmpDir = fs_mkdtemp();
+        const pyOut = path.join(tmpDir, 'py-state.json');
+        const tsOut = path.join(tmpDir, 'ts-state.json');
+        const pyBytes = pyDumpFile(FULL_ENVELOPE, pyOut);
+        dump(from_dict(JSON.parse(FULL_ENVELOPE)), tsOut);
+        const tsBytes = fs_readFile(tsOut);
+        expect(tsBytes).toBe(pyBytes);
+        expect(tsBytes.endsWith('\n')).toBe(true);
+    });
+});
+
+describePy('work_engine/state — validation error-text parity', () => {
+    const errorCases: Array<[string, string]> = [
+        [
+            'payload not an object',
+            JSON.stringify(['not', 'a', 'dict']),
+        ],
+        [
+            'wrong version',
+            JSON.stringify({ version: 2, input: { kind: 'ticket' } }),
+        ],
+        [
+            'input not an object',
+            JSON.stringify({ version: 1, input: 'nope' }),
+        ],
+        [
+            'input.data not an object',
+            JSON.stringify({ version: 1, input: { kind: 'ticket', data: [] } }),
+        ],
+        [
+            'unknown input.kind',
+            JSON.stringify({ version: 1, input: { kind: 'bogus', data: {} } }),
+        ],
+        [
+            'unknown directive_set',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                directive_set: 'sideways',
+            }),
+        ],
+        [
+            'stack.frontend empty',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                stack: { frontend: '', mtime: 1.5 },
+            }),
+        ],
+        [
+            'stack.mtime not a number',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                stack: { frontend: 'react', mtime: 'soon' },
+            }),
+        ],
+        [
+            'ui_audit.greenfield not bool',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                ui_audit: { greenfield: 'yes' },
+            }),
+        ],
+        [
+            'ui_audit.greenfield_decision bad value',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                ui_audit: { greenfield_decision: 'rebuild' },
+            }),
+        ],
+        [
+            'ui_review.a11y.severity_floor bad value',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                ui_review: { a11y: { severity_floor: 'whatever' } },
+            }),
+        ],
+        [
+            'ui_polish.rounds out of range',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                ui_polish: { rounds: 5 },
+            }),
+        ],
+        [
+            'ui_polish.rounds not an int (float)',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                ui_polish: { rounds: 1.5 },
+            }),
+        ],
+        [
+            'stitch.verdict bad value',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                stitch: { verdict: 'maybe' },
+            }),
+        ],
+        [
+            'halts entry not an object',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                halts: ['not-a-dict'],
+            }),
+        ],
+        [
+            'halts entry missing reason',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                halts: [{ surface: [] }],
+            }),
+        ],
+        [
+            'halts surface entry not a string',
+            JSON.stringify({
+                version: 1,
+                input: { kind: 'ticket', data: {} },
+                halts: [{ reason: 'x', surface: [1] }],
+            }),
+        ],
+    ];
+
+    for (const [label, fixture] of errorCases) {
+        it(`identical SchemaError text — ${label}`, () => {
+            const py = pyErrorMessage(fixture);
+            const ts = tsErrorMessage(fixture);
+            expect(py).not.toBe('__NO_ERROR__'); // sanity: the .py really raises
+            expect(ts).toBe(py);
+        });
+    }
+});
+
+describe('work_engine/state — TS-side unit checks (no python3 needed)', () => {
+    it('module constants match the schema', () => {
+        expect(SCHEMA_VERSION).toBe(1);
+        expect(DEFAULT_INTENT).toBe('backend-coding');
+        expect(DEFAULT_DIRECTIVE_SET).toBe('backend');
+        expect([...KNOWN_INPUT_KINDS].sort()).toEqual([
+            'diff',
+            'file',
+            'prompt',
+            'ticket',
+        ]);
+        expect([...KNOWN_DIRECTIVE_SETS].sort()).toEqual([
+            'backend',
+            'mixed',
+            'ui',
+            'ui-trivial',
+        ]);
+    });
+
+    it('Input default data is a fresh empty object per instance', () => {
+        const a = new Input('ticket');
+        const b = new Input('ticket');
+        (a.data as Record<string, unknown>)['x'] = 1;
+        expect(Object.keys(b.data)).toHaveLength(0);
+    });
+
+    it('round-trip from_dict → to_dict → from_dict is stable', () => {
+        const first = to_dict(from_dict(JSON.parse(FULL_ENVELOPE)));
+        const second = to_dict(from_dict(first as never));
+        expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    });
+
+    it('to_dict validates a mutated in-memory state before serialising', () => {
+        const st = from_dict(JSON.parse(FRESH_TICKET));
+        st.directive_set = 'sideways';
+        expect(() => to_dict(st)).toThrow(SchemaError);
+    });
+
+    it('to_dict re-validates version drift', () => {
+        const st = from_dict(JSON.parse(FRESH_TICKET));
+        st.version = 99;
+        expect(() => to_dict(st)).toThrow(/version must be 1; got 99/);
+    });
+
+    it('load() round-trips a dumped file', () => {
+        const tmpDir = fs_mkdtemp();
+        const out = path.join(tmpDir, 'state.json');
+        const original = from_dict(JSON.parse(FULL_ENVELOPE));
+        dump(original, out);
+        const reread = load(out);
+        expect(JSON.stringify(to_dict(reread))).toBe(
+            JSON.stringify(to_dict(original)),
+        );
+    });
+});
+
+// ── tiny fs helpers (kept local to avoid a shared-rig dependency) ───────
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+function fs_mkdtemp(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'we-state-'));
+}
+function fs_readFile(p: string): string {
+    return fs.readFileSync(p, 'utf-8');
+}

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -9,7 +9,11 @@
     "tests/scripts/**/*.ts",
     "tests/parity/**/*.ts",
     "tests/spikes/**/*.ts",
-    "tests/lib/**/*.ts"
+    "tests/lib/**/*.ts",
+    "src/agent-src/templates/scripts/**/*.ts"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Starts the `work_engine` cluster (the consumer directive engine, ~64 files) with its **foundation layer** (no intra-work_engine deps), so the directives/hooks/resolvers/scoring subpackages + dispatcher/cli can import them next. Targets `python2ts`. `.py` originals stay until Phase 12.

## Twins (8)
- `_lib/agent_settings` + `_lib/user_global_paths` — **byte-identical** to the dev-side `src/scripts/_lib` twins → copied verbatim.
- `state` (694) — the directive-set state model (to_dict/from_dict/dump/load, phase/ui_audit gates, full SchemaError parity).
- `cli_args`, `delivery_state`, `errors`, `orchestration`, `persona_policy` — argv parsing, delivery/outcome state, exceptions, step orchestration (`iter_steps` runtime-loads `dispatch_hook.ts`, no `.py` import), persona-gate.

137 golden-parity tests (python3-differential via direct-file importlib loaders). legacy-literal ts==py for all 8. tsc clean, phase-gate passes.

## Infra
- `tsconfig.scripts.json`: include broadened to `src/agent-src/templates/scripts/**/*.ts` — covers all template + work_engine twins (the prior narrow `_lib`-only glob left the work_engine root twins **untypechecked**; fixed). Matches the include the templates-leaf PR adds, so it merges cleanly.
- `dist/agent-src/templates/scripts/work_engine/` mirror regenerated (`condense --sync`) so the consistency `sync-check` + condense zero-drift gate stay green.

## Remaining work_engine (next waves)
directives/ (22), hooks/ (16), scoring/ (4), resolvers/ (3), stack/ (2), intent/, migration/ + the upper layer (state_io, input_builders, dispatcher, emitters, cli, hook_bootstrap, __main__).

## Verification
`tsc` clean (now covering work_engine) · phase-gate passes · 137/137 · python3-differential byte-match · legacy 0==0 · condense zero-drift 94/94. Migration-gates 4-shard run validates on this PR's CI.