### PR TITLE
feat(py2ts): skill-bundled scripts to TS (7: corpus-grounding + tailwind/shadcn/design-tokens)

### DIFF
--- a/dist/agent-src/skills/corpus-grounding/scripts/bm25_search.ts
+++ b/dist/agent-src/skills/corpus-grounding/scripts/bm25_search.ts
@@ -1,0 +1,482 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · bm25_search — retrieval layer (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/bm25_search.py`
+ * (ADR-094 Python→TS migration). Pure-stdlib BM25 ranking over CSV corpora
+ * plus a structured pre-filter (`filters`) applied BEFORE ranking. Retrievers
+ * are selected by name (`bm25` / `structured` / `hybrid`) — never
+ * network-by-default; embeddings are intentionally absent until a measured
+ * recall failure justifies them (ADR-061 §2).
+ *
+ * Skill-shipped tool — standalone by design (no `_lib` imports), so the
+ * Python-parity primitives it needs (float math, `len()` as code-point count,
+ * `csv.DictReader` quoting, Python `re` semantics, `json.dumps` byte-parity)
+ * are inlined here. The public names below mirror the Python module 1:1
+ * (Python style is part of the contract, ADR-094).
+ *
+ * Interface-stability contract: see SKILL.md § Interface contract (v1).
+ * Breaking changes to public names below require a major bump there.
+ */
+
+import * as fs from 'node:fs';
+
+export const DEFAULT_MAX_RESULTS = 3;
+
+/**
+ * Marker for a Python `float`. CPython `json.dumps` / f-strings render an
+ * integral float (`1.0`) with its `.0`; JS numbers lose that. BM25 scores —
+ * and the structured retriever's `1.0` — are Python floats, so the `scores`
+ * array carries this marker and the serializer renders it with float
+ * semantics. Defined here (the cluster's dependency root) and re-used by
+ * `decision_engine` + `ground`.
+ */
+export class PyFloat {
+    constructor(readonly value: number) {}
+}
+
+/** Unwrap a number that may be wrapped in PyFloat. */
+export function floatVal(v: number | PyFloat): number {
+    return v instanceof PyFloat ? v.value : v;
+}
+
+/** Heterogeneous CSV row dict — string→string (csv.DictReader yields strs). */
+export type Row = Record<string, string>;
+
+/** A filter value: a single accepted value or a list of accepted values. */
+export type FilterValue = string | string[];
+export type Filters = Record<string, FilterValue>;
+
+/** search_rows return shape (interface v1). */
+export interface SearchResult {
+    count: number;
+    results: Row[];
+    scores?: PyFloat[];
+    filtered_from?: number;
+    error?: string;
+    [key: string]: unknown;
+}
+
+// ── Python-parity primitives (inlined — skill scripts ship standalone) ──────
+
+/** Python `len(str)` — number of Unicode code points, not UTF-16 units. */
+function pyLen(s: string): number {
+    let n = 0;
+    // Iterating a string yields code points (surrogate pairs counted once).
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+// ── BM25 ────────────────────────────────────────────────────────────────
+
+/** BM25 ranking (k1=1.5, b=0.75 — upstream-tuned defaults). */
+export class BM25 {
+    k1: number;
+
+    b: number;
+
+    corpus: string[][];
+
+    doc_lengths: number[];
+
+    avgdl: number;
+
+    idf: Record<string, number>;
+
+    doc_freqs: Record<string, number>;
+
+    N: number;
+
+    constructor(k1 = 1.5, b = 0.75) {
+        this.k1 = k1;
+        this.b = b;
+        this.corpus = [];
+        this.doc_lengths = [];
+        this.avgdl = 0.0;
+        this.idf = {};
+        this.doc_freqs = {};
+        this.N = 0;
+    }
+
+    /** Lowercase, strip punctuation, drop tokens shorter than 3 chars. */
+    static tokenize(text: unknown): string[] {
+        // Python: re.sub(r"[^\w\s]", " ", str(text).lower()).
+        // Python's `re` `\w` for str is Unicode (letters, digits, underscore);
+        // `\s` is Unicode whitespace. Mirror with \p{L}\p{N}_ and \s under /u.
+        const cleaned = pyStr(text).toLowerCase().replace(/[^\p{L}\p{N}_\s]/gu, ' ');
+        // Python str.split() with no arg: split on runs of whitespace, no empties.
+        return cleaned.split(/\s+/).filter((w) => w.length > 0 && pyLen(w) > 2);
+    }
+
+    fit(documents: string[]): void {
+        this.corpus = documents.map((doc) => BM25.tokenize(doc));
+        this.N = this.corpus.length;
+        if (this.N === 0) {
+            return;
+        }
+        this.doc_lengths = this.corpus.map((doc) => doc.length);
+        let total = 0;
+        for (const dl of this.doc_lengths) {
+            total += dl;
+        }
+        this.avgdl = total / this.N;
+        for (const doc of this.corpus) {
+            // Python: for word in set(doc) — dedupe per document.
+            for (const word of new Set(doc)) {
+                this.doc_freqs[word] = (this.doc_freqs[word] ?? 0) + 1;
+            }
+        }
+        for (const word of Object.keys(this.doc_freqs)) {
+            const freq = this.doc_freqs[word] as number;
+            this.idf[word] = Math.log((this.N - freq + 0.5) / (freq + 0.5) + 1);
+        }
+    }
+
+    /** Score every document; returns [index, score] sorted descending. */
+    score(query: string): [number, number][] {
+        const query_tokens = BM25.tokenize(query);
+        const scores: [number, number][] = [];
+        for (let idx = 0; idx < this.corpus.length; idx += 1) {
+            const doc = this.corpus[idx] as string[];
+            let score = 0.0;
+            const doc_len = this.doc_lengths[idx] as number;
+            const term_freqs: Record<string, number> = {};
+            for (const word of doc) {
+                term_freqs[word] = (term_freqs[word] ?? 0) + 1;
+            }
+            for (const token of query_tokens) {
+                if (token in this.idf) {
+                    const tf = term_freqs[token] ?? 0;
+                    const numerator = tf * (this.k1 + 1);
+                    const denominator = tf + this.k1 * (1 - this.b + (this.b * doc_len) / this.avgdl);
+                    score += (this.idf[token] as number) * (numerator / denominator);
+                }
+            }
+            scores.push([idx, score]);
+        }
+        // Python sorted(scores, key=lambda x: x[1], reverse=True) — stable;
+        // ties keep their original relative order. Node's Array.sort is stable;
+        // a `b - a` comparator returns 0 for ties → original order preserved,
+        // matching CPython's stable reverse sort.
+        const indexed = scores.map((pair, i) => ({ pair, i }));
+        indexed.sort((a, b) => {
+            const d = b.pair[1] - a.pair[1];
+            if (d !== 0) {
+                return d;
+            }
+            return a.i - b.i;
+        });
+        return indexed.map((x) => x.pair);
+    }
+}
+
+// ── CSV loading — mirrors Python's csv.DictReader ───────────────────────────
+
+/**
+ * Load a CSV corpus file as a list of row dicts (UTF-8).
+ *
+ * Mirrors `csv.DictReader` over the default `excel` dialect: comma delimiter,
+ * `"` quotechar, doubled-quote escaping (`""` → `"`), and field/record
+ * boundaries that respect quoting (newlines inside quotes stay in the field).
+ * The first row is the header. Extra fields beyond the header land under the
+ * `None` restkey — but the Python source never reads them, so we drop them
+ * exactly as the downstream code does (it only reads named columns).
+ */
+export function load_csv(filepath: string): Row[] {
+    const text = fs_readText(filepath);
+    const records = _parseCsv(text);
+    if (records.length === 0) {
+        return [];
+    }
+    const header = records[0] as string[];
+    const out: Row[] = [];
+    for (let r = 1; r < records.length; r += 1) {
+        const fields = records[r] as string[];
+        const row: Row = {};
+        for (let c = 0; c < header.length; c += 1) {
+            const key = header[c] as string;
+            // csv.DictReader: missing trailing fields → restval (default None,
+            // but downstream str(row.get(col, "")) coerces). Python stores None
+            // for short rows; the consumers always wrap with str(... or "").
+            // We store "" for a missing field so str() parity holds; for a
+            // present field we store the parsed value.
+            row[key] = c < fields.length ? (fields[c] as string) : '';
+        }
+        out.push(row);
+    }
+    return out;
+}
+
+/**
+ * Parse CSV text into records of fields, matching Python's csv default dialect.
+ *
+ * - Comma delimiter, `"` quote char, `""` → literal `"` inside a quoted field.
+ * - Quoted fields may contain commas and newlines.
+ * - Record terminators: `\r\n`, `\r`, or `\n` (csv universal-newline behavior).
+ * - A trailing newline does not create a trailing empty record.
+ */
+function _parseCsv(text: string): string[][] {
+    const records: string[][] = [];
+    let field = '';
+    let record: string[] = [];
+    let inQuotes = false;
+    let sawAny = false;
+    let i = 0;
+    const n = text.length;
+    const pushField = (): void => {
+        record.push(field);
+        field = '';
+    };
+    const pushRecord = (): void => {
+        records.push(record);
+        record = [];
+    };
+    while (i < n) {
+        const ch = text[i] as string;
+        if (inQuotes) {
+            if (ch === '"') {
+                if (i + 1 < n && text[i + 1] === '"') {
+                    field += '"';
+                    i += 2;
+                } else {
+                    inQuotes = false;
+                    i += 1;
+                }
+            } else {
+                field += ch;
+                i += 1;
+            }
+            continue;
+        }
+        if (ch === '"') {
+            inQuotes = true;
+            sawAny = true;
+            i += 1;
+        } else if (ch === ',') {
+            pushField();
+            sawAny = true;
+            i += 1;
+        } else if (ch === '\r' || ch === '\n') {
+            // Universal newline: \r\n counts once.
+            pushField();
+            pushRecord();
+            sawAny = false;
+            if (ch === '\r' && i + 1 < n && text[i + 1] === '\n') {
+                i += 2;
+            } else {
+                i += 1;
+            }
+        } else {
+            field += ch;
+            sawAny = true;
+            i += 1;
+        }
+    }
+    // Flush a trailing field/record only if we saw content on the last line.
+    if (sawAny || field.length > 0 || record.length > 0) {
+        pushField();
+        pushRecord();
+    }
+    return records;
+}
+
+// ── filters ───────────────────────────────────────────────────────────────
+
+/**
+ * Structured pre-filter BEFORE ranking.
+ *
+ * `filters` maps column name → required value (string, case-insensitive
+ * substring match) or list of accepted values. Unknown columns simply never
+ * match (empty result is a legitimate, visible outcome — callers surface it as
+ * an evidence gap, never silently widen).
+ */
+export function apply_filters(rows: Row[], filters: Filters | null | undefined): Row[] {
+    if (!filters || Object.keys(filters).length === 0) {
+        return rows;
+    }
+
+    const rowOk = (row: Row): boolean => {
+        for (const col of Object.keys(filters)) {
+            const want = filters[col] as FilterValue;
+            const have = pyStr(row[col] ?? '').toLowerCase();
+            if (Array.isArray(want)) {
+                // Python: any(str(w).lower() in have for w in want).
+                if (!want.some((w) => have.includes(pyStr(w).toLowerCase()))) {
+                    return false;
+                }
+            } else if (!have.includes(pyStr(want).toLowerCase())) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    return rows.filter((r) => rowOk(r));
+}
+
+// ── retrievers ──────────────────────────────────────────────────────────────
+
+type Hit = [Row, number];
+
+function _retrieve_bm25(
+    rows: Row[],
+    search_cols: string[],
+    query: string,
+    max_results: number,
+): Hit[] {
+    const documents = rows.map((row) => search_cols.map((col) => pyStr(row[col] ?? '')).join(' '));
+    const bm25 = new BM25();
+    bm25.fit(documents);
+    const ranked = bm25.score(query);
+    const out: Hit[] = [];
+    for (const [idx, score] of ranked.slice(0, max_results)) {
+        if (score > 0) {
+            out.push([rows[idx] as Row, score]);
+        }
+    }
+    return out;
+}
+
+/**
+ * Pure filter retrieval — rows already pre-filtered; rank by column order
+ * stability (score 1.0 each). Useful for exact-axis lookups.
+ */
+function _retrieve_structured(
+    rows: Row[],
+    _search_cols: string[],
+    _query: string,
+    max_results: number,
+): Hit[] {
+    return rows.slice(0, max_results).map((row) => [row, 1.0] as Hit);
+}
+
+/**
+ * Structured pre-filter is applied by the caller; hybrid = BM25 over the
+ * filtered set, falling back to stable order when the query is empty.
+ */
+function _retrieve_hybrid(
+    rows: Row[],
+    search_cols: string[],
+    query: string,
+    max_results: number,
+): Hit[] {
+    if (query.trim() === '') {
+        return _retrieve_structured(rows, search_cols, query, max_results);
+    }
+    return _retrieve_bm25(rows, search_cols, query, max_results);
+}
+
+type Retriever = (rows: Row[], search_cols: string[], query: string, max_results: number) => Hit[];
+
+/** Retriever registry — selected by name in the manifest or per call. */
+export const RETRIEVERS: Record<string, Retriever> = {
+    bm25: _retrieve_bm25,
+    structured: _retrieve_structured,
+    hybrid: _retrieve_hybrid,
+};
+
+/**
+ * Search one corpus file. Returns a dict with results + raw scores.
+ *
+ * Result shape (interface v1):
+ * `{"count": int, "results": [row-projection…], "scores": [float…],
+ *    "filtered_from": int}`
+ */
+export function search_rows(
+    filepath: string,
+    search_cols: string[],
+    output_cols: string[],
+    query: string,
+    max_results: number = DEFAULT_MAX_RESULTS,
+    filters: Filters | null = null,
+    retriever = 'bm25',
+): SearchResult {
+    if (!(retriever in RETRIEVERS)) {
+        // Python: raise ValueError(f"Unknown retriever: {retriever!r}. Available: {sorted(RETRIEVERS)}")
+        const available = Object.keys(RETRIEVERS).sort();
+        throw new ValueError(
+            `Unknown retriever: ${pyRepr(retriever)}. Available: ${pyReprList(available)}`,
+        );
+    }
+    if (!fs_exists(filepath)) {
+        return { error: `File not found: ${filepath}`, count: 0, results: [] };
+    }
+
+    let rows = load_csv(filepath);
+    const total = rows.length;
+    rows = apply_filters(rows, filters);
+
+    const hits = (RETRIEVERS[retriever] as Retriever)(rows, search_cols, query, max_results);
+    const results: Row[] = hits.map(([row]) => {
+        const projection: Row = {};
+        for (const col of output_cols) {
+            if (col in row) {
+                projection[col] = row[col] ?? '';
+            }
+        }
+        return projection;
+    });
+    return {
+        count: results.length,
+        results,
+        // Python scores are floats (BM25 math + the structured 1.0). Wrap so
+        // an integral score (e.g. 1.0) serialises with its `.0`.
+        scores: hits.map(([, score]) => new PyFloat(score)),
+        filtered_from: total,
+    };
+}
+
+// ── error parity ────────────────────────────────────────────────────────────
+
+/** Mirror of Python's ValueError, so `decision_engine` callers can map it. */
+export class ValueError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValueError';
+    }
+}
+
+// ── small Python-parity helpers reused across the cluster ───────────────────
+
+/** Python `str(x)` for the value shapes this module sees. */
+export function pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        // The Python source never passes None to pyStr without a `or ""` guard,
+        // but for safety mirror str(None) -> "None".
+        return value === null ? 'None' : 'undefined';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'True' : 'False';
+    }
+    return String(value);
+}
+
+/** Python `repr(s)` for a string — single-quoted unless it contains a `'`. */
+export function pyRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    if (hasSingle && !hasDouble) {
+        return `"${s.replace(/\\/g, '\\\\')}"`;
+    }
+    return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/** repr() of a list of strings: `['a', 'b']`. */
+export function pyReprList(items: string[]): string {
+    return `[${items.map((i) => pyRepr(i)).join(', ')}]`;
+}
+
+// ── filesystem shims (kept tiny + local so the module stays standalone) ──────
+
+function fs_readText(p: string): string {
+    return fs.readFileSync(p, 'utf-8');
+}
+
+function fs_exists(p: string): boolean {
+    return fs.existsSync(p);
+}

--- a/dist/agent-src/skills/corpus-grounding/scripts/decision_engine.ts
+++ b/dist/agent-src/skills/corpus-grounding/scripts/decision_engine.ts
@@ -1,0 +1,803 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · decision_engine — reasoning layer (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/decision_engine.py`
+ * (ADR-094 Python→TS migration). Manifest-parameterised conditional grounding
+ * (ADR-061 §3 tier 2): multi-domain search per the manifest's reasoning plan,
+ * decision-rule evaluation (JSON conditionals + an optional dynamically-loaded
+ * escape hatch where JSON caps out), best-match selection, and a
+ * grounded-output dict that ALWAYS carries a confidence score + an
+ * evidence-gap line (contract — prevents false precision / authority
+ * inflation).
+ *
+ * The Python original uses `importlib.util` to load a manifest-relative
+ * `reasoning.rules_module` Python file and call its `evaluate(...)`. The twin
+ * mirrors this with a dynamic `import()` of the manifest-relative module —
+ * resolved to a `.ts` (dev/tsx) or `.js` (compiled) twin, NEVER a `.py`. See
+ * `_load_rules_callable` for the resolution + boundary note.
+ *
+ * Pure stdlib. No network, no subprocess. Writes only under persist_grounding
+ * (opt-in). Interface contract: SKILL.md.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    DEFAULT_MAX_RESULTS,
+    floatVal,
+    load_csv,
+    PyFloat,
+    search_rows,
+    type Row,
+} from './bm25_search.js';
+import {
+    ManifestError,
+    type Manifest,
+    resolve_data_path,
+} from './schema_validator.js';
+
+// Re-export so `ground` (and external callers) can import PyFloat from here too.
+export { PyFloat } from './bm25_search.js';
+
+/** A grounded / search result dict — heterogeneous, mirrors the Python dict. */
+export type ResultDict = Record<string, unknown>;
+
+// ── Python-parity numeric helpers ───────────────────────────────────────────
+
+/**
+ * Python 3 `round(x, ndigits)` — round-half-to-even (banker's rounding) on the
+ * exact IEEE-754 value. JS `Math.round` is half-away-from-zero, so we round the
+ * 17-significant-digit decimal expansion (round-trips every double uniquely),
+ * mirroring `src/scripts/_lib/value_ladder.ts::pyRound`.
+ */
+export function pyRound(value: number, ndigits = 0): number {
+    if (!Number.isFinite(value) || value === 0) {
+        return value;
+    }
+    const sign = value < 0 ? -1 : 1;
+    const abs = Math.abs(value);
+    const str = abs.toPrecision(17);
+    if (str.includes('e') || str.includes('E')) {
+        const factor = 10 ** ndigits;
+        return value > 0
+            ? (Math.round(abs * factor) / factor) * sign
+            : -Math.round(abs * factor) / factor;
+    }
+    const dot = str.indexOf('.');
+    const intPart = dot === -1 ? str : str.slice(0, dot);
+    let fracPart = dot === -1 ? '' : str.slice(dot + 1);
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keepFrac = fracPart.slice(0, ndigits);
+    const deciderStr = fracPart.slice(ndigits);
+    const scaledIntStr = intPart + keepFrac;
+    let scaledInt = BigInt(scaledIntStr === '' ? '0' : scaledIntStr);
+    const firstDecider = deciderStr.charAt(0);
+    const restNonZero = /[1-9]/u.test(deciderStr.slice(1));
+    let roundUp = false;
+    if (firstDecider > '5' || (firstDecider === '5' && restNonZero)) {
+        roundUp = true;
+    } else if (firstDecider === '5' && !restNonZero) {
+        roundUp = scaledInt % 2n === 1n;
+    }
+    if (roundUp) {
+        scaledInt += 1n;
+    }
+    const factor = 10 ** ndigits;
+    return (Number(scaledInt) / factor) * sign;
+}
+
+/** Python `str(x)` for the value shapes this module sees. */
+function pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'True' : 'False';
+    }
+    if (value instanceof PyFloat) {
+        return _floatStr(value.value);
+    }
+    return String(value);
+}
+
+/** Python `repr()` of a string for dict-repr blobs. */
+function _strRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    let quote = "'";
+    if (hasSingle && !hasDouble) {
+        quote = '"';
+    }
+    let body = s.replace(/\\/g, '\\\\');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Python `repr()` of a value for embedding in a dict-repr blob. */
+function _valueRepr(value: unknown): string {
+    if (typeof value === 'string') {
+        return _strRepr(value);
+    }
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/**
+ * Python `str(dict)` — the repr used by `_select_best_match`'s blob match.
+ * Shape: `{'k': 'v', 'k2': 2}`. Keys are insertion-ordered (matches Python 3.7+
+ * dict ordering and JS object key order).
+ */
+function pyDictRepr(obj: ResultDict): string {
+    const parts = Object.keys(obj).map((k) => `${_strRepr(k)}: ${_valueRepr(obj[k])}`);
+    return `{${parts.join(', ')}}`;
+}
+
+/** Python float → str for f-string / repr (integral floats keep `.0`). */
+function _floatStr(n: number): string {
+    if (Number.isInteger(n)) {
+        return `${n}.0`;
+    }
+    return String(n);
+}
+
+// ── detection ────────────────────────────────────────────────────────────
+
+/** Escape a string for use as a literal inside a RegExp (Python re.escape). */
+function _reEscape(s: string): string {
+    // Python re.escape escapes all non-alphanumeric, non-underscore chars.
+    let out = '';
+    for (const ch of s) {
+        if (/[A-Za-z0-9_]/u.test(ch)) {
+            out += ch;
+        } else {
+            out += `\\${ch}`;
+        }
+    }
+    return out;
+}
+
+/** Keyword-vote routing of a query onto one of the manifest's domains. */
+export function detect_domain(manifest: Manifest, query: string): string {
+    const detect = (manifest.detect as Record<string, unknown> | null) || {};
+    const query_lower = query.toLowerCase();
+    const scores: Record<string, number> = {};
+    for (const name of Object.keys(detect)) {
+        if (name === '_stack') {
+            continue;
+        }
+        const keywords = detect[name];
+        let count = 0;
+        if (Array.isArray(keywords)) {
+            for (const kw of keywords) {
+                // Python: re.search(r"\b" + re.escape(str(kw).lower()) + r"\b", query_lower)
+                const re = new RegExp(`\\b${_reEscape(pyStr(kw).toLowerCase())}\\b`, 'u');
+                if (re.test(query_lower)) {
+                    count += 1;
+                }
+            }
+        }
+        scores[name] = count;
+    }
+    const names = Object.keys(scores);
+    if (names.length > 0) {
+        // Python: max(scores, key=lambda k: scores[k]) — first key with max value
+        // (stable; ties resolve to insertion order).
+        let best = names[0] as string;
+        for (const name of names) {
+            if ((scores[name] as number) > (scores[best] as number)) {
+                best = name;
+            }
+        }
+        if ((scores[best] as number) > 0) {
+            return best;
+        }
+    }
+    const dd = manifest.default_domain;
+    if (dd !== undefined && dd !== null && dd !== '' && dd !== false) {
+        return String(dd);
+    }
+    // next(iter(manifest["domains"])) — first domain key.
+    const domains = manifest.domains as Record<string, unknown>;
+    return Object.keys(domains)[0] as string;
+}
+
+// ── search ops ─────────────────────────────────────────────────────────────
+
+/** Search one manifest domain. Adds confidence + evidence_gap. */
+export function search_domain(
+    manifest: Manifest,
+    query: string,
+    domain: string | null = null,
+    max_results: number | null = null,
+    filters: Record<string, unknown> | null = null,
+): ResultDict {
+    let dom = domain;
+    if (dom === null) {
+        dom = detect_domain(manifest, query);
+    }
+    const domains = manifest.domains as Record<string, ResultDict>;
+    if (!(dom in domains)) {
+        return {
+            error: `Unknown domain: ${_strRepr(dom)}. Available: ${_sortedListRepr(Object.keys(domains))}`,
+            count: 0,
+            results: [],
+        };
+    }
+    const cfg = domains[dom] as ResultDict;
+    // merged_filters = dict(cfg.get("filters") or {}); if filters: merged.update(filters)
+    const merged_filters: Record<string, unknown> = { ...((cfg.filters as Record<string, unknown> | null) || {}) };
+    if (filters) {
+        for (const k of Object.keys(filters)) {
+            merged_filters[k] = filters[k];
+        }
+    }
+    const result: ResultDict = search_rows(
+        resolve_data_path(manifest, cfg.file as string),
+        cfg.search_cols as string[],
+        cfg.output_cols as string[],
+        query,
+        max_results ?? (cfg.max_results as number | undefined) ?? DEFAULT_MAX_RESULTS,
+        (Object.keys(merged_filters).length > 0 ? merged_filters : null) as never,
+        (manifest.retriever as string | undefined) ?? 'bm25',
+    ) as ResultDict;
+    result.domain = dom;
+    result.query = query;
+    result.file = cfg.file;
+    _attach_confidence(result);
+    return result;
+}
+
+/** Search one stack axis (optional manifest extension). */
+export function search_stack(
+    manifest: Manifest,
+    query: string,
+    stack: string,
+    max_results: number = DEFAULT_MAX_RESULTS,
+    filters: Record<string, unknown> | null = null,
+): ResultDict {
+    const stacks = (manifest.stacks as Record<string, string> | null) || {};
+    if (!(stack in stacks)) {
+        return {
+            error: `Unknown stack: ${_strRepr(stack)}. Available: ${_sortedListRepr(Object.keys(stacks))}`,
+            count: 0,
+            results: [],
+        };
+    }
+    const cols = manifest.stack_cols as ResultDict;
+    const result: ResultDict = search_rows(
+        resolve_data_path(manifest, stacks[stack] as string),
+        cols.search_cols as string[],
+        cols.output_cols as string[],
+        query,
+        max_results,
+        filters as never,
+        (manifest.retriever as string | undefined) ?? 'bm25',
+    ) as ResultDict;
+    result.domain = 'stack';
+    result.stack = stack;
+    result.query = query;
+    result.file = stacks[stack];
+    _attach_confidence(result);
+    return result;
+}
+
+/** Confidence from BM25 score shape; evidence gap when weak/empty. */
+function _attach_confidence(result: ResultDict): void {
+    const scores = (result.scores as (PyFloat | number)[] | null) || [];
+    const gaps: string[] = [];
+    let label: string;
+    let numeric: number;
+    if (scores.length === 0) {
+        label = 'low';
+        numeric = 0.0;
+        const dom = result.domain;
+        gaps.push(
+            `no corpus rows matched the query in domain ` +
+                `'${dom === undefined || dom === null ? '?' : String(dom)}' — answer falls back to agent priors`,
+        );
+    } else {
+        const top = floatVal(scores[0] as PyFloat | number);
+        numeric = pyRound(Math.min(1.0, top / 10.0), 3);
+        if (top >= 4.0) {
+            label = 'high';
+        } else if (top >= 1.5) {
+            label = 'medium';
+        } else {
+            label = 'low';
+            gaps.push('top BM25 score is weak — treat the match as a hint, not a verdict');
+        }
+    }
+    result.confidence = { label, score: new PyFloat(numeric) };
+    result.evidence_gap = gaps;
+}
+
+// ── rules ────────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate JSON conditional rules against the query/context.
+ *
+ * Upstream rule shape: `{"if_<condition>": "<directive>"}`. A condition matches
+ * when its underscore-separated tokens appear in the query or in a truthy
+ * context flag of the same name. Returns `{"matched": {...}, "unmatched": {...}}`
+ * — both surfaced, so the agent sees the full rule space (auditable).
+ */
+export function evaluate_rules(
+    rules: Record<string, unknown>,
+    query: string,
+    context: Record<string, unknown> | null = null,
+): ResultDict {
+    const ctx = context || {};
+    const query_lower = query.toLowerCase();
+    const matched: ResultDict = {};
+    const unmatched: ResultDict = {};
+    for (const key of Object.keys(rules || {})) {
+        const directive = rules[key];
+        const cond = key.startsWith('if_') ? key.slice(3) : key;
+        const tokens = cond.split('_').filter((t) => t.length > 0);
+        // Python: bool(context.get(cond)) or (tokens and all(t in query_lower ...))
+        const ctxHit = _bool(ctx[cond]);
+        const tokenHit = tokens.length > 0 && tokens.every((t) => query_lower.includes(t));
+        const hit = ctxHit || tokenHit;
+        (hit ? matched : unmatched)[key] = directive;
+    }
+    return { matched, unmatched };
+}
+
+/** Python bool(x) truthiness. */
+function _bool(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+/** A rules-callable: evaluate(rules, query, context) -> dict. */
+type RulesCallable = (
+    rules: Record<string, unknown>,
+    query: string,
+    context: Record<string, unknown>,
+) => ResultDict;
+
+/**
+ * Optional escape hatch: `reasoning.rules_module` beside the manifest exposing
+ * `evaluate(rules, query, context)`. The Python original loads a `.py` via
+ * `importlib`. The twin loads the corresponding module via dynamic `import()`,
+ * resolved to a `.ts`/`.js` twin — NEVER a `.py`. If the manifest names a
+ * module whose extension is `.py`, the twin remaps it to `.ts` (dev) / `.js`
+ * (compiled). A `.py`-only module with no twin is a migration boundary: the
+ * load throws ManifestError naming the missing twin (port it, or document the
+ * boundary).
+ *
+ * Runtime-safety: only a manifest-relative module inside the skill dir is
+ * loadable (same containment rule as corpus files, via resolve_data_path).
+ *
+ * NOTE: async, because dynamic import() is async. The caller (`ground`) is
+ * therefore async too.
+ */
+export async function _load_rules_callable(manifest: Manifest): Promise<RulesCallable | null> {
+    const reasoning = (manifest.reasoning as Record<string, unknown> | null) || {};
+    const rel = reasoning.rules_module as string | undefined;
+    if (!rel) {
+        return null;
+    }
+    const resolved = resolve_data_path(manifest, rel);
+    // Remap a manifest-declared .py to the ported twin; resolve a bare/.ts/.js
+    // to the on-disk twin. NEVER import a .py.
+    const candidate = _resolveTwinPath(resolved);
+    if (!fs.existsSync(candidate)) {
+        throw new ManifestError(`reasoning.rules_module not found: ${resolved}`);
+    }
+    const mod = (await import(pathToFileURL(candidate).href)) as Record<string, unknown>;
+    const fn = mod.evaluate;
+    if (typeof fn !== 'function') {
+        throw new ManifestError(`${resolved} must expose evaluate(rules, query, context)`);
+    }
+    return fn as RulesCallable;
+}
+
+/** Map a manifest-declared module path to its TS/JS twin on disk. */
+function _resolveTwinPath(resolved: string): string {
+    const ext = path.extname(resolved);
+    if (ext === '.py') {
+        const stem = resolved.slice(0, resolved.length - ext.length);
+        if (fs.existsSync(`${stem}.ts`)) {
+            return `${stem}.ts`;
+        }
+        return `${stem}.js`;
+    }
+    if (ext === '') {
+        if (fs.existsSync(`${resolved}.ts`)) {
+            return `${resolved}.ts`;
+        }
+        return `${resolved}.js`;
+    }
+    return resolved;
+}
+
+/** Exact → partial → keyword match of a category onto the rule rows. */
+function _find_reasoning_rule(rows: Row[], match_column: string, category: string): Row {
+    const category_lower = category.toLowerCase();
+    for (const rule of rows) {
+        if (pyStr(rule[match_column] ?? '').toLowerCase() === category_lower) {
+            return rule;
+        }
+    }
+    for (const rule of rows) {
+        const cat = pyStr(rule[match_column] ?? '').toLowerCase();
+        if (cat && (category_lower.includes(cat) || cat.includes(category_lower))) {
+            return rule;
+        }
+    }
+    for (const rule of rows) {
+        const cat = pyStr(rule[match_column] ?? '').toLowerCase();
+        const keywords = cat.replace(/\//g, ' ').replace(/-/g, ' ').split(/\s+/u).filter((w) => w.length > 0);
+        if (keywords.some((kw) => category_lower.includes(kw))) {
+            return rule;
+        }
+    }
+    return {};
+}
+
+/** Priority-keyword re-ranking of a domain's results (upstream port). */
+function _select_best_match(
+    results: Row[],
+    priority_keywords: string[],
+    name_col: string | null | undefined,
+): Row {
+    if (results.length === 0) {
+        return {};
+    }
+    if (priority_keywords.length === 0) {
+        return results[0] as Row;
+    }
+    if (name_col) {
+        for (const priority of priority_keywords) {
+            const p = priority.toLowerCase().trim();
+            for (const result of results) {
+                const name = pyStr(result[name_col] ?? '').toLowerCase();
+                if (p && (name.includes(p) || p.includes(name))) {
+                    return result;
+                }
+            }
+        }
+    }
+    const scored: [number, Row][] = [];
+    for (const result of results) {
+        const blob = pyDictRepr(result as ResultDict).toLowerCase();
+        let score = 0;
+        for (const kw of priority_keywords) {
+            const k = kw.toLowerCase().trim();
+            if (!k) {
+                continue;
+            }
+            if (name_col && pyStr(result[name_col] ?? '').toLowerCase().includes(k)) {
+                score += 10;
+            } else if (pyStr(result.Keywords ?? '').toLowerCase().includes(k)) {
+                score += 3;
+            } else if (blob.includes(k)) {
+                score += 1;
+            }
+        }
+        scored.push([score, result]);
+    }
+    // Python: scored.sort(key=lambda x: x[0], reverse=True) — stable.
+    const indexed = scored.map((pair, i) => ({ pair, i }));
+    indexed.sort((a, b) => {
+        const d = b.pair[0] - a.pair[0];
+        if (d !== 0) {
+            return d;
+        }
+        return a.i - b.i;
+    });
+    const sorted = indexed.map((x) => x.pair);
+    if (sorted.length > 0 && (sorted[0] as [number, Row])[0] > 0) {
+        return (sorted[0] as [number, Row])[1];
+    }
+    return results[0] as Row;
+}
+
+// ── grounding ────────────────────────────────────────────────────────────
+
+/**
+ * Conditional grounding: category → rules → planned multi-domain search.
+ *
+ * Returns the interface-v1 grounded dict (see Python docstring). Async because
+ * `_load_rules_callable` is async (dynamic import).
+ */
+export async function ground(
+    manifest: Manifest,
+    query: string,
+    context: Record<string, unknown> | null = null,
+): Promise<ResultDict> {
+    const reasoning = manifest.reasoning as Record<string, unknown> | null | undefined;
+    if (!reasoning) {
+        throw new ManifestError(
+            `manifest domain ${_valueRepr(manifest.domain)} has no reasoning block ` +
+                '(tier is lookup-only — use search instead of ground)',
+        );
+    }
+
+    const gaps: string[] = [];
+
+    // 1 — category lookup.
+    let category = (manifest.default_category as string | undefined) ?? 'General';
+    const cat_domain = reasoning.category_domain as string | undefined;
+    const cat_column = reasoning.category_column as string | undefined;
+    if (cat_domain && cat_column) {
+        const cat_result = search_domain(manifest, query, cat_domain, 1);
+        const rows = (cat_result.results as Row[] | null) || [];
+        if (rows.length > 0) {
+            const v = (rows[0] as Row)[cat_column];
+            // Python: str(rows[0].get(cat_column) or category)
+            category = v !== undefined && v !== null && v !== '' ? pyStr(v) : category;
+        } else {
+            gaps.push(
+                `category lookup in '${cat_domain}' found nothing — ` +
+                    `grounding against default category '${category}'`,
+            );
+        }
+    }
+
+    // 2 — reasoning rule for the category.
+    const rules_path = resolve_data_path(manifest, reasoning.file as string);
+    const rule_rows: Row[] = fs.existsSync(rules_path) ? load_csv(rules_path) : [];
+    const rule = _find_reasoning_rule(rule_rows, reasoning.match_column as string, category);
+    if (Object.keys(rule).length === 0) {
+        gaps.push(
+            `no reasoning rule matched category '${category}' — ` +
+                'selections below are unweighted corpus hits',
+        );
+    }
+
+    // 3 — decision rules (JSON; optional dynamically-loaded escape hatch).
+    let raw_rules: Record<string, unknown> = {};
+    const rules_column = reasoning.rules_column as string | undefined;
+    if (rules_column && _bool(rule[rules_column])) {
+        try {
+            raw_rules = JSON.parse(rule[rules_column] as string) as Record<string, unknown>;
+        } catch {
+            gaps.push(`decision rules in column '${rules_column}' are not valid JSON`);
+        }
+    }
+    const custom = await _load_rules_callable(manifest);
+    const rules_evaluation = custom
+        ? custom(raw_rules, query, context || {})
+        : evaluate_rules(raw_rules, query, context);
+
+    // 4 — priority keywords from the rule.
+    let priority: string[] = [];
+    const priority_column = reasoning.priority_column as string | undefined;
+    if (priority_column && _bool(rule[priority_column])) {
+        priority = pyStr(rule[priority_column])
+            .split('+')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+    }
+
+    // 5 — planned multi-domain search.
+    const selections: ResultDict = {};
+    const domain_confidences: number[] = [];
+    const plan = (reasoning.plan as Record<string, unknown> | null) || {};
+    const priority_domain = reasoning.priority_domain as string | undefined;
+    const name_cols = (reasoning.name_columns as Record<string, string> | null) || {};
+    for (const domain_name of Object.keys(plan)) {
+        const max_results = plan[domain_name];
+        let q = query;
+        if (domain_name === priority_domain && priority.length > 0) {
+            q = `${query} ${priority.slice(0, 2).join(' ')}`;
+        }
+        const result = search_domain(manifest, q, domain_name, _int(max_results));
+        const results = (result.results as Row[] | null) || [];
+        const best =
+            domain_name === priority_domain
+                ? _select_best_match(results, priority, name_cols[domain_name])
+                : results.length > 0
+                  ? (results[0] as Row)
+                  : {};
+        selections[domain_name] = {
+            best,
+            // Python: [r for r in results if r is not best] — identity compare.
+            alternatives: results.filter((r) => r !== best),
+            confidence: result.confidence,
+        };
+        for (const g of (result.evidence_gap as string[] | null) || []) {
+            gaps.push(g);
+        }
+        const conf = (result.confidence as ResultDict | null) || {};
+        const score = conf.score;
+        domain_confidences.push(score instanceof PyFloat ? score.value : (score as number | undefined) ?? 0.0);
+    }
+
+    // 6 — aggregate confidence (weakest link wins).
+    const numeric = domain_confidences.length > 0 ? pyRound(Math.min(...domain_confidences), 3) : 0.0;
+    const label = numeric >= 0.4 ? 'high' : numeric >= 0.15 ? 'medium' : 'low';
+
+    // rule with the rules_column dropped.
+    const ruleOut: Row = {};
+    for (const k of Object.keys(rule)) {
+        if (k !== rules_column) {
+            ruleOut[k] = rule[k] as string;
+        }
+    }
+
+    return {
+        domain: manifest.domain,
+        query,
+        category,
+        rule: ruleOut,
+        rules_evaluation,
+        selections,
+        confidence: { label, score: new PyFloat(numeric) },
+        evidence_gap:
+            gaps.length > 0 ? gaps : ['none — every planned domain returned a scored match'],
+    };
+}
+
+/** Python int(x) for a plan value (int or numeric string). */
+function _int(value: unknown): number {
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+    }
+    return Math.trunc(Number(value));
+}
+
+// ── persistence ────────────────────────────────────────────────────────────
+
+/**
+ * Opt-in (--persist): write the grounded output as a master file + optional
+ * page override (upstream MASTER.md pattern, generalized).
+ *
+ * Writes ONLY under `output_dir` (caller-chosen). Returns created paths.
+ */
+export function persist_grounding(
+    grounded: ResultDict,
+    output_dir: string,
+    project: string | null = null,
+    page: string | null = null,
+): ResultDict {
+    const project_slug = (project ?? pyStr(grounded.query ?? 'default'))
+        .toLowerCase()
+        .replace(/ /g, '-');
+    const base = path.join(output_dir, 'design-system', project_slug);
+    fs.mkdirSync(base, { recursive: true });
+    const created: string[] = [];
+
+    const master = path.join(base, 'MASTER.md');
+    fs.writeFileSync(master, _render_markdown(grounded, true), 'utf-8');
+    created.push(master);
+
+    if (page) {
+        const pages = path.join(base, 'pages');
+        fs.mkdirSync(pages, { recursive: true });
+        const page_file = path.join(pages, `${page.toLowerCase().replace(/ /g, '-')}.md`);
+        fs.writeFileSync(
+            page_file,
+            `# ${_title(page)} — page overrides\n\n` +
+                '> Rules here OVERRIDE the project MASTER.md for this page only.\n' +
+                '> Start empty; add only deviations.\n',
+            'utf-8',
+        );
+        created.push(page_file);
+    }
+    return { status: 'success', created_files: created };
+}
+
+/** Python str.title() — capitalize the first letter of each word run. */
+function _title(s: string): string {
+    return s.replace(/[A-Za-z]+/gu, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+}
+
+/** Generic markdown rendering of a grounded output (interface v1). */
+export function _render_markdown(grounded: ResultDict, master = false): string {
+    const lines: string[] = [];
+    if (master) {
+        lines.push(
+            '# Design System Master File',
+            '',
+            '> **LOGIC:** When building a specific page, first check ' +
+                '`pages/<page>.md`. If it exists, its rules **override** this ' +
+                'master file. Otherwise follow the rules below.',
+            '',
+        );
+    }
+    const conf = (grounded.confidence as ResultDict | null) || {};
+    lines.push(
+        `## Grounded recommendation: ${pyStr(grounded.query ?? '')}`,
+        '',
+        `- **Domain:** ${pyStr(grounded.domain ?? '')}`,
+        `- **Category:** ${pyStr(grounded.category ?? '')}`,
+        `- **Confidence:** ${pyStr(conf.label ?? '?')} ` + `(${_confScore(conf.score)})`,
+        '',
+    );
+    const selections = (grounded.selections as ResultDict | null) || {};
+    for (const domain of Object.keys(selections)) {
+        const sel = (selections[domain] as ResultDict | null) || {};
+        const best = (sel.best as Row | null) || {};
+        if (Object.keys(best).length === 0) {
+            continue;
+        }
+        lines.push(`### ${domain}`);
+        for (const key of Object.keys(best)) {
+            let value_str = pyStr(best[key]);
+            if (value_str.length > 300) {
+                value_str = `${value_str.slice(0, 300)}…`;
+            }
+            if (value_str) {
+                lines.push(`- **${key}:** ${value_str}`);
+            }
+        }
+        lines.push('');
+    }
+    const matched = ((grounded.rules_evaluation as ResultDict | null) || {}).matched as ResultDict | null;
+    const matchedObj = matched || {};
+    if (Object.keys(matchedObj).length > 0) {
+        lines.push('### Matched decision rules');
+        for (const key of Object.keys(matchedObj)) {
+            lines.push(`- \`${key}\` → ${pyStr(matchedObj[key])}`);
+        }
+        lines.push('');
+    }
+    lines.push('### Evidence gap');
+    for (const gap of (grounded.evidence_gap as string[] | null) || []) {
+        lines.push(`- ${gap}`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}
+
+/**
+ * Render the confidence score inside the f-string `({score})`. Python's
+ * `grounded.get('confidence', {}).get('score', 0)` defaults to int 0 (no
+ * `.0`); a present score is a float (with `.0` when integral).
+ */
+function _confScore(score: unknown): string {
+    if (score instanceof PyFloat) {
+        return _floatStr(score.value);
+    }
+    if (score === undefined || score === null) {
+        return '0';
+    }
+    return String(score);
+}
+
+/** repr of a sorted list of strings: `['a', 'b']`. */
+function _sortedListRepr(items: string[]): string {
+    const sorted = [...items].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    return `[${sorted.map((i) => _strRepr(i)).join(', ')}]`;
+}

--- a/dist/agent-src/skills/corpus-grounding/scripts/ground.ts
+++ b/dist/agent-src/skills/corpus-grounding/scripts/ground.ts
@@ -1,0 +1,541 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · ground — CLI entry point (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/ground.py`
+ * (ADR-094 Python→TS migration). Mirrors the Python CLI contract: subcommands
+ * (search / ground / validate), snake_case flags, exit codes, the
+ * stdout/stderr split, and byte-identical JSON (json.dumps indent=2,
+ * ensure_ascii=False) and markdown rendering.
+ *
+ * Usage (paths resolve as given — relative to cwd, like the Python original):
+ *
+ *   ground.ts search --manifest <manifest.json> "fintech dashboard"
+ *   ground.ts search --manifest m.json --domain color "muted palette" --json
+ *   ground.ts search --manifest m.json --filter "Severity=HIGH" "forms"
+ *   ground.ts search --manifest m.json --stack react "memo rerender"
+ *   ground.ts ground --manifest m.json "luxury e-commerce" [--persist DIR]
+ *   ground.ts validate --manifest m.json
+ *
+ * Pure stdlib · read-only except --persist · no network · no subprocess.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    PyFloat,
+    _render_markdown,
+    ground as run_ground,
+    persist_grounding,
+    type ResultDict,
+    search_domain,
+    search_stack,
+} from './decision_engine.js';
+import {
+    ManifestError,
+    load_manifest,
+    type Manifest,
+    validate_manifest,
+} from './schema_validator.js';
+
+// ── filter parsing ──────────────────────────────────────────────────────────
+
+/** Mirror _parse_filters: COLUMN=VALUE pairs → {col: value | [values]}. */
+function _parse_filters(pairs: string[]): Record<string, string | string[]> {
+    const collected: Record<string, string[]> = {};
+    for (const pair of pairs || []) {
+        if (!pair.includes('=')) {
+            // Python: raise SystemExit(f"--filter expects COLUMN=VALUE, got: {pair!r}")
+            process.stderr.write(`--filter expects COLUMN=VALUE, got: ${_repr(pair)}\n`);
+            process.exit(1);
+        }
+        const idx = pair.indexOf('=');
+        const col = pair.slice(0, idx);
+        const value = pair.slice(idx + 1);
+        if (!(col in collected)) {
+            collected[col] = [];
+        }
+        (collected[col] as string[]).push(value);
+    }
+    const out: Record<string, string | string[]> = {};
+    for (const k of Object.keys(collected)) {
+        const v = collected[k] as string[];
+        out[k] = v.length > 1 ? v : (v[0] as string);
+    }
+    return out;
+}
+
+// ── search text formatter ────────────────────────────────────────────────
+
+function _format_search(result: ResultDict): string {
+    if (_truthy(result.error)) {
+        return `Error: ${result.error as string}`;
+    }
+    const out: string[] = ['## Corpus search results'];
+    const head = `**Domain:** ${_orStr(result.stack, result.domain)} | **Query:** ${_str(result.query)}`;
+    out.push(head);
+    const conf = (result.confidence as ResultDict | null) || {};
+    out.push(
+        `**Source:** ${_str(result.file)} | **Found:** ${_str(result.count)} ` +
+            `| **Confidence:** ${_str(conf.label)} (${_confScore(conf.score)})`,
+    );
+    out.push('');
+    const results = (result.results as Record<string, unknown>[] | null) || [];
+    let i = 1;
+    for (const row of results) {
+        out.push(`### Result ${i}`);
+        for (const key of Object.keys(row)) {
+            let value_str = _str(row[key]);
+            if (value_str.length > 300) {
+                value_str = `${value_str.slice(0, 300)}…`;
+            }
+            if (value_str) {
+                out.push(`- **${key}:** ${value_str}`);
+            }
+        }
+        out.push('');
+        i += 1;
+    }
+    const gaps = (result.evidence_gap as string[] | null) || [];
+    if (gaps.length > 0) {
+        out.push('### Evidence gap');
+        for (const g of gaps) {
+            out.push(`- ${g}`);
+        }
+    }
+    return out.join('\n');
+}
+
+// ── argument parsing ─────────────────────────────────────────────────────
+
+interface Args {
+    op: 'search' | 'ground' | 'validate';
+    manifest: string;
+    json: boolean;
+    query?: string;
+    domain?: string | null;
+    stack?: string | null;
+    max_results?: number | null;
+    filter: string[];
+    retriever?: string | null;
+    hasRetriever: boolean;
+    context?: string | null;
+    persist?: string | null;
+    project_name?: string | null;
+    page?: string | null;
+}
+
+/**
+ * Minimal argparse-compatible parser for the documented surface. argparse
+ * usage/error text (exit 2) is intentionally NOT reproduced byte-for-byte
+ * (per ADR-094 test guidance — `--help` and argparse rejections are excluded
+ * from byte-parity); the success + documented-error paths are exact.
+ */
+function _parseArgs(argv: string[]): Args {
+    const op = argv[0];
+    if (op !== 'search' && op !== 'ground' && op !== 'validate') {
+        process.stderr.write(`ground: invalid operation: ${op ?? '(none)'}\n`);
+        process.exit(2);
+    }
+    const rest = argv.slice(1);
+    const args: Args = {
+        op,
+        manifest: '',
+        json: false,
+        filter: [],
+        domain: null,
+        stack: null,
+        max_results: null,
+        retriever: null,
+        hasRetriever: op === 'search',
+        context: null,
+        persist: null,
+        project_name: null,
+        page: null,
+    };
+    const positionals: string[] = [];
+    let manifestSet = false;
+    for (let i = 0; i < rest.length; i += 1) {
+        const a = rest[i] as string;
+        const eat = (): string => {
+            const v = rest[i + 1];
+            if (v === undefined) {
+                process.stderr.write(`argument ${a}: expected one argument\n`);
+                process.exit(2);
+            }
+            i += 1;
+            return v;
+        };
+        if (a === '--manifest') {
+            args.manifest = eat();
+            manifestSet = true;
+        } else if (a.startsWith('--manifest=')) {
+            args.manifest = a.slice('--manifest='.length);
+            manifestSet = true;
+        } else if (a === '--json') {
+            args.json = true;
+        } else if (a === '--domain' || a === '-d') {
+            args.domain = eat();
+        } else if (a.startsWith('--domain=')) {
+            args.domain = a.slice('--domain='.length);
+        } else if (a === '--stack' || a === '-s') {
+            args.stack = eat();
+        } else if (a.startsWith('--stack=')) {
+            args.stack = a.slice('--stack='.length);
+        } else if (a === '--max-results' || a === '-n') {
+            args.max_results = parseInt(eat(), 10);
+        } else if (a.startsWith('--max-results=')) {
+            args.max_results = parseInt(a.slice('--max-results='.length), 10);
+        } else if (a === '--filter') {
+            args.filter.push(eat());
+        } else if (a.startsWith('--filter=')) {
+            args.filter.push(a.slice('--filter='.length));
+        } else if (a === '--retriever') {
+            args.retriever = eat();
+        } else if (a.startsWith('--retriever=')) {
+            args.retriever = a.slice('--retriever='.length);
+        } else if (a === '--context') {
+            args.context = eat();
+        } else if (a.startsWith('--context=')) {
+            args.context = a.slice('--context='.length);
+        } else if (a === '--persist') {
+            args.persist = eat();
+        } else if (a.startsWith('--persist=')) {
+            args.persist = a.slice('--persist='.length);
+        } else if (a === '--project-name' || a === '-p') {
+            args.project_name = eat();
+        } else if (a.startsWith('--project-name=')) {
+            args.project_name = a.slice('--project-name='.length);
+        } else if (a === '--page') {
+            args.page = eat();
+        } else if (a.startsWith('--page=')) {
+            args.page = a.slice('--page='.length);
+        } else {
+            positionals.push(a);
+        }
+    }
+    if (!manifestSet) {
+        process.stderr.write('the following arguments are required: --manifest\n');
+        process.exit(2);
+    }
+    if (op === 'search' || op === 'ground') {
+        if (positionals.length === 0) {
+            process.stderr.write('the following arguments are required: query\n');
+            process.exit(2);
+        }
+        args.query = positionals[0] as string;
+    }
+    if ((op === 'search' || op === 'ground') && args.retriever !== null && args.retriever !== undefined) {
+        const r = args.retriever;
+        if (!['bm25', 'structured', 'hybrid'].includes(r)) {
+            process.stderr.write(
+                `argument --retriever: invalid choice: '${r}' (choose from 'bm25', 'structured', 'hybrid')\n`,
+            );
+            process.exit(2);
+        }
+    }
+    return args;
+}
+
+// ── main ────────────────────────────────────────────────────────────────
+
+export async function main(argv: string[] | null = null): Promise<number> {
+    const args = _parseArgs(argv ?? process.argv.slice(2));
+
+    try {
+        if (args.op === 'validate') {
+            const raw = JSON.parse(fs.readFileSync(args.manifest, 'utf-8')) as unknown;
+            const errors = validate_manifest(raw);
+            if (errors.length > 0) {
+                process.stdout.write('INVALID manifest:\n');
+                for (const err of errors) {
+                    process.stdout.write(`  - ${err}\n`);
+                }
+                return 1;
+            }
+            process.stdout.write('OK — manifest satisfies contract v1\n');
+            return 0;
+        }
+
+        const manifest: Manifest = load_manifest(args.manifest);
+        // Python: if args.retriever if hasattr(args, "retriever") else None.
+        // Only the search subparser defines --retriever; ground/validate don't.
+        if (args.hasRetriever && args.retriever) {
+            manifest.retriever = args.retriever;
+        }
+
+        if (args.op === 'search') {
+            let result: ResultDict;
+            if (args.stack) {
+                result = search_stack(
+                    manifest,
+                    args.query as string,
+                    args.stack,
+                    args.max_results ?? 3,
+                    _filtersOrNull(_parse_filters(args.filter)),
+                );
+            } else {
+                result = search_domain(
+                    manifest,
+                    args.query as string,
+                    args.domain ?? null,
+                    args.max_results,
+                    _filtersOrNull(_parse_filters(args.filter)),
+                );
+            }
+            process.stdout.write(
+                (args.json ? _jsonDumps(result, 2) : _format_search(result)) + '\n',
+            );
+            return _truthy(result.error) ? 1 : 0;
+        }
+
+        // ground
+        const context = args.context ? (JSON.parse(args.context) as Record<string, unknown>) : {};
+        const grounded = await run_ground(manifest, args.query as string, context);
+        if (args.persist) {
+            const info = persist_grounding(
+                grounded,
+                args.persist,
+                args.project_name ?? null,
+                args.page ?? null,
+            );
+            grounded.persisted = info;
+        }
+        if (args.json) {
+            process.stdout.write(_jsonDumps(grounded, 2) + '\n');
+        } else {
+            process.stdout.write(_render_markdown(grounded) + '\n');
+        }
+        return 0;
+    } catch (exc) {
+        // Python catches (ManifestError, json.JSONDecodeError, OSError).
+        if (_isExpected(exc)) {
+            process.stderr.write(`Error: ${_errText(exc)}\n`);
+            return 1;
+        }
+        throw exc;
+    }
+}
+
+function _isExpected(exc: unknown): boolean {
+    if (exc instanceof ManifestError) {
+        return true;
+    }
+    if (exc instanceof SyntaxError) {
+        // JSON.parse failure ≈ json.JSONDecodeError.
+        return true;
+    }
+    if (exc instanceof Error) {
+        const code = (exc as NodeJS.ErrnoException).code;
+        // OSError family — ENOENT, EISDIR, EACCES, etc.
+        if (code && /^E[A-Z]+$/u.test(code)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _errText(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+// ── value coercion helpers (Python str() / truthiness for the CLI) ──────────
+
+function _truthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+function _str(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'True' : 'False';
+    }
+    if (value instanceof PyFloat) {
+        return Number.isInteger(value.value) ? `${value.value}.0` : String(value.value);
+    }
+    return String(value);
+}
+
+/** Python f-string `{result.get('stack') or result.get('domain')}`. */
+function _orStr(a: unknown, b: unknown): string {
+    return _truthy(a) ? _str(a) : _str(b);
+}
+
+/** Render confidence score inside `(...)` — float when present (PyFloat). */
+function _confScore(score: unknown): string {
+    if (score instanceof PyFloat) {
+        return Number.isInteger(score.value) ? `${score.value}.0` : String(score.value);
+    }
+    if (score === undefined || score === null) {
+        return 'None';
+    }
+    return String(score);
+}
+
+function _filtersOrNull(
+    filters: Record<string, string | string[]>,
+): Record<string, string | string[]> | null {
+    return Object.keys(filters).length > 0 ? filters : null;
+}
+
+/** Python repr() of a string (for the --filter error). */
+function _repr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    if (hasSingle && !hasDouble) {
+        return `"${s.replace(/\\/g, '\\\\')}"`;
+    }
+    return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+// ── JSON serializer — json.dumps(indent=2, ensure_ascii=False) parity ───────
+
+function _jsonDumps(value: unknown, indent: number): string {
+    return _dumps(value, indent, 0);
+}
+
+function _dumps(value: unknown, indent: number, depth: number): string {
+    const pad = ' '.repeat(indent * (depth + 1));
+    const closePad = ' '.repeat(indent * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (value instanceof PyFloat) {
+        return _jsonFloat(value.value);
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _jsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStr(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumps(v, indent, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        const keys = Object.keys(obj);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map(
+            (k) => `${pad}${_jsonStr(k)}: ${_dumps(obj[k], indent, depth + 1)}`,
+        );
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _jsonStr(String(value));
+}
+
+function _jsonNum(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+/** Render a Python float: integer-valued floats keep the `.0` suffix. */
+function _jsonFloat(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    if (Number.isInteger(n)) {
+        return `${n}.0`;
+    }
+    return String(n);
+}
+
+/**
+ * json.dumps string escaping with ensure_ascii=False: escape only the JSON
+ * control set + quote + backslash; leave all non-ASCII raw (the `—` em-dash in
+ * the evidence-gap text re-emits verbatim).
+ */
+function _jsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) ?? 0;
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            case '\b':
+                out += '\\b';
+                break;
+            case '\f':
+                out += '\\f';
+                break;
+            default:
+                if (code < 0x20) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+        }
+    }
+    return `${out}"`;
+}
+
+const _isMain =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_isMain) {
+    main()
+        .then((code) => {
+            process.exitCode = code;
+        })
+        .catch((err: unknown) => {
+            // Unexpected error — surface like an uncaught Python traceback would
+            // (non-zero exit). Should not happen for the documented paths.
+            process.stderr.write(`${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+            process.exitCode = 1;
+        });
+}

--- a/dist/agent-src/skills/corpus-grounding/scripts/schema_validator.ts
+++ b/dist/agent-src/skills/corpus-grounding/scripts/schema_validator.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · schema_validator — manifest contract (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/schema_validator.py`
+ * (ADR-094 Python→TS migration). Validates a domain's plug-in manifest
+ * (`manifest.json`) against the schema-agnostic contract from ADR-061 §3. Each
+ * domain declares its OWN axes — the validator checks structure + provenance
+ * discipline, never a uniform schema.
+ *
+ * Pure stdlib, no network. Standalone skill script — no `_lib` imports.
+ * Interface contract: SKILL.md § Interface contract.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { pyRepr } from './bm25_search.js';
+
+export const MANIFEST_VERSION = 1;
+
+/** Output sophistication tiers (ADR-061 §3). */
+export const TIERS = ['lookup-only', 'conditional-grounding', 'constraint-emission'] as const;
+
+const _REQUIRED_TOP = ['manifest_version', 'domain', 'tier', 'domains'] as const;
+const _REQUIRED_PROVENANCE = ['owner', 'refresh_cadence', 'upstream'] as const;
+const _REQUIRED_DOMAIN_KEYS = ['file', 'search_cols', 'output_cols'] as const;
+const _REQUIRED_REASONING_KEYS = ['file', 'match_column', 'plan'] as const;
+
+/** A decoded manifest — heterogeneous JSON object. */
+export type Manifest = Record<string, unknown>;
+
+/** Raised when a manifest violates the v1 contract (Python ManifestError). */
+export class ManifestError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ManifestError';
+    }
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────────
+
+/** Python truthiness: '', 0, 0.0, [], {}, None, False are falsy. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+/** Python `isinstance(x, dict)` — a plain JSON object (not array, not null). */
+function _isDict(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `repr(x)` for the JSON value shapes a manifest carries. */
+function _repr(value: unknown): string {
+    if (typeof value === 'string') {
+        return pyRepr(value);
+    }
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'number') {
+        // Integral JSON numbers print as ints (repr(2) -> "2").
+        return String(value);
+    }
+    return String(value);
+}
+
+/** Render the TIERS tuple the way Python's f-string interpolates it. */
+function _tiersRepr(): string {
+    return `(${TIERS.map((t) => pyRepr(t)).join(', ')})`;
+}
+
+// ── manifest loading + validation ───────────────────────────────────────────
+
+/** Load + validate a manifest. Raises ManifestError on violation. */
+export function load_manifest(p: string): Manifest {
+    if (!fs.existsSync(p)) {
+        throw new ManifestError(`Manifest not found: ${p}`);
+    }
+    let data: unknown;
+    try {
+        data = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    } catch (exc) {
+        // Python: json.JSONDecodeError → ManifestError(f"... {path}: {exc}").
+        throw new ManifestError(`Manifest is not valid JSON: ${p}: ${_jsonErr(exc)}`);
+    }
+    const errors = validate_manifest(data);
+    if (errors.length > 0) {
+        throw new ManifestError(
+            `Manifest contract violations in ${p}:\n  - ${errors.join('\n  - ')}`,
+        );
+    }
+    const manifest = data as Manifest;
+    // Python: str(path.resolve().parent) — resolve() follows symlinks.
+    manifest._manifest_dir = path.dirname(pyResolve(p));
+    return manifest;
+}
+
+/** Return a list of contract violations (empty = valid). */
+export function validate_manifest(data: unknown): string[] {
+    const errors: string[] = [];
+    if (!_isDict(data)) {
+        return ['manifest must be a JSON object'];
+    }
+
+    for (const key of _REQUIRED_TOP) {
+        if (!(key in data)) {
+            errors.push(`missing required key: ${pyRepr(key)}`);
+        }
+    }
+    if (errors.length > 0) {
+        return errors;
+    }
+
+    if (data.manifest_version !== MANIFEST_VERSION) {
+        errors.push(`manifest_version ${_repr(data.manifest_version)} unsupported (engine speaks v${MANIFEST_VERSION})`);
+    }
+    if (!(TIERS as readonly string[]).includes(data.tier as string)) {
+        errors.push(`tier ${_repr(data.tier)} not in ${_tiersRepr()}`);
+    }
+
+    const domains = data.domains;
+    if (!_isDict(domains) || Object.keys(domains).length === 0) {
+        errors.push('domains must be a non-empty object');
+    } else {
+        for (const name of Object.keys(domains)) {
+            const cfg = domains[name];
+            if (!_isDict(cfg)) {
+                errors.push(`domains.${name} must be an object`);
+                continue;
+            }
+            for (const key of _REQUIRED_DOMAIN_KEYS) {
+                if (!(key in cfg)) {
+                    errors.push(`domains.${name} missing ${pyRepr(key)}`);
+                }
+            }
+            for (const key of ['search_cols', 'output_cols']) {
+                if (key in cfg && (!Array.isArray(cfg[key]) || (cfg[key] as unknown[]).length === 0)) {
+                    errors.push(`domains.${name}.${key} must be a non-empty list`);
+                }
+            }
+        }
+    }
+
+    const default_domain = data.default_domain;
+    if (_pyTruthy(default_domain) && _isDict(domains) && !(String(default_domain) in domains)) {
+        errors.push(`default_domain ${_repr(default_domain)} not in domains`);
+    }
+
+    const detect = data.detect;
+    if (detect !== undefined && detect !== null) {
+        if (!_isDict(detect)) {
+            errors.push('detect must be an object of domain → keyword list');
+        } else if (_isDict(domains)) {
+            for (const name of Object.keys(detect)) {
+                const kws = detect[name];
+                if (!(name in domains) && name !== '_stack') {
+                    errors.push(`detect.${name} references unknown domain`);
+                }
+                if (!Array.isArray(kws)) {
+                    errors.push(`detect.${name} must be a list of keywords`);
+                }
+            }
+        }
+    }
+
+    const reasoning = data.reasoning;
+    if (reasoning !== undefined && reasoning !== null) {
+        if (data.tier === 'lookup-only') {
+            errors.push('reasoning block present but tier is lookup-only');
+        }
+        if (!_isDict(reasoning)) {
+            errors.push('reasoning must be an object');
+        } else {
+            for (const key of _REQUIRED_REASONING_KEYS) {
+                if (!(key in reasoning)) {
+                    errors.push(`reasoning missing ${pyRepr(key)}`);
+                }
+            }
+            const plan = reasoning.plan;
+            if (plan !== undefined && plan !== null) {
+                if (!_isDict(plan)) {
+                    errors.push('reasoning.plan must be an object of domain → max_results');
+                } else if (_isDict(domains)) {
+                    for (const name of Object.keys(plan)) {
+                        if (!(name in domains)) {
+                            errors.push(`reasoning.plan.${name} references unknown domain`);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const stacks = data.stacks;
+    if (stacks !== undefined && stacks !== null) {
+        if (!_isDict(stacks)) {
+            errors.push('stacks must be an object of stack-id → csv path');
+        } else if (!('stack_cols' in data)) {
+            errors.push('stacks present but stack_cols missing');
+        }
+    }
+
+    // Provenance discipline (ADR-061 §6) — a corpus without an owner rots.
+    for (const key of _REQUIRED_PROVENANCE) {
+        if (!(key in data)) {
+            errors.push(`missing provenance key: ${pyRepr(key)} (ADR-061 §6)`);
+        }
+    }
+    const upstream = data.upstream;
+    if (_isDict(upstream)) {
+        for (const key of ['repo', 'sha', 'last_checked']) {
+            if (!(key in upstream)) {
+                errors.push(`upstream missing ${pyRepr(key)}`);
+            }
+        }
+    } else if (upstream !== undefined && upstream !== null) {
+        errors.push('upstream must be an object {repo, sha, last_checked}');
+    }
+
+    const retriever = data.retriever;
+    if (retriever !== undefined && retriever !== null && !['bm25', 'structured', 'hybrid'].includes(retriever as string)) {
+        errors.push(`retriever ${_repr(retriever)} unknown`);
+    }
+
+    return errors;
+}
+
+/**
+ * Resolve a corpus file path relative to the manifest's directory.
+ *
+ * Refuses absolute paths and parent-escapes — corpus files live beside their
+ * manifest by contract (runtime-safety: read-only, local).
+ */
+export function resolve_data_path(manifest: Manifest, relative: string): string {
+    // Python: rel = Path(relative); rel.is_absolute() or ".." in rel.parts.
+    if (path.isAbsolute(relative) || _pathParts(relative).includes('..')) {
+        throw new ManifestError(`corpus path must be manifest-relative: ${pyRepr(relative)}`);
+    }
+    const base = (manifest._manifest_dir as string | undefined) ?? '.';
+    const data_dir = (manifest.data_dir as string | undefined) ?? '.';
+    if (path.isAbsolute(data_dir) || _pathParts(data_dir).includes('..')) {
+        throw new ManifestError(`data_dir must be manifest-relative: ${pyRepr(data_dir)}`);
+    }
+    // Python: (base / dd / rel).resolve() — resolve() follows symlinks.
+    return pyResolve(path.join(base, data_dir, relative));
+}
+
+/** Mirror pathlib Path(p).parts for the relative-path containment check. */
+function _pathParts(p: string): string[] {
+    return p.split(/[\\/]/u).filter((seg) => seg !== '' && seg !== '.');
+}
+
+/**
+ * Mirror pathlib `Path(p).resolve()` (strict=False): make absolute, then
+ * resolve symlinks in the longest existing ancestor and append the
+ * non-existent suffix. On macOS this turns `/var/...` into `/private/var/...`,
+ * matching the Python error / file paths byte-for-byte.
+ */
+function pyResolve(p: string): string {
+    const abs = path.resolve(p);
+    let cur = abs;
+    const suffix: string[] = [];
+    for (;;) {
+        try {
+            const real = fs.realpathSync.native(cur);
+            return suffix.length > 0 ? path.join(real, ...suffix) : real;
+        } catch {
+            const parent = path.dirname(cur);
+            if (parent === cur) {
+                return abs;
+            }
+            suffix.unshift(path.basename(cur));
+            cur = parent;
+        }
+    }
+}
+
+/** Best-effort JSON parse-error text for the ManifestError message. */
+function _jsonErr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}

--- a/dist/agent-src/skills/design-tokens/scripts/tokens.ts
+++ b/dist/agent-src/skills/design-tokens/scripts/tokens.ts
@@ -1,0 +1,888 @@
+#!/usr/bin/env tsx
+/**
+ * design-tokens · tokens — DTCG token toolchain (generate / validate / embed).
+ *
+ * TypeScript twin of `src/skills/design-tokens/scripts/tokens.py` (ADR-094
+ * py2ts). The CLI contract is mirrored EXACTLY — the subcommands
+ * `generate` / `validate` / `embed`, their flags, exit codes, the
+ * stdout/stderr split, byte-identical messages, AND byte-identical generated
+ * output (the CSS / Tailwind config / embedded CSS / JSON findings are all
+ * write/print targets, so every byte — key order, quoting, whitespace,
+ * `json.dumps` separators — must match python3).
+ *
+ * No behaviour changes — latent Python quirks are replicated verbatim:
+ *   - `re.findall` group semantics (the hexColor pattern has a capture group,
+ *     so `findall` yields the group captures, not whole matches; the scanner
+ *     re-derives the whole match via `search().group(0)`).
+ *   - one finding per pattern per line (the `break` after the first hit).
+ *   - `str.strip("{}")` strips the {} *character set* off both ends.
+ *   - `Path.rglob("*")` sorted order; `.blade.php` two-suffix detection.
+ *   - `json.dumps(..., indent=2)` with the DEFAULT `ensure_ascii=True`
+ *     (non-ASCII → `\uXXXX`, astral → surrogate pairs).
+ *
+ * Pure stdlib (Node builtins only) · read-only except `generate -o` · no
+ * network · no subprocess. A `.ts` MUST NOT import a `.py`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// ── Python-shim helpers ──────────────────────────────────────────────────
+
+type Json = unknown;
+type JsonObject = Record<string, Json>;
+
+function _isPlainObject(v: unknown): v is JsonObject {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Mirror `str.strip(chars)` — strip the given char *set* off both ends. */
+function _stripChars(s: string, chars: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && chars.includes(s[start] as string)) {
+        start += 1;
+    }
+    while (end > start && chars.includes(s[end - 1] as string)) {
+        end -= 1;
+    }
+    return s.slice(start, end);
+}
+
+/** Mirror `str.strip()` over ASCII + common Unicode whitespace. */
+function _strip(s: string): string {
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/** Code-point count, mirroring Python `len(str)`. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+// ── json.dumps(..., indent=2, ensure_ascii=True) byte-parity ─────────────
+//
+// The default `ensure_ascii=True` escapes every code point >= 0x80 as a
+// `\uXXXX` sequence (astral chars become a UTF-16 surrogate pair, exactly as
+// CPython emits them). Integer-valued numbers stay integers (no `.0`) since
+// the only numbers we ever dump are violation line numbers (ints).
+
+function _pyJsonStr(s: string): string {
+    let out = '"';
+    // Iterate UTF-16 code units so astral chars emit surrogate pairs like CPython.
+    for (let i = 0; i < s.length; i += 1) {
+        const ch = s[i];
+        const code = s.charCodeAt(i);
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            case '\b':
+                out += '\\b';
+                break;
+            case '\f':
+                out += '\\f';
+                break;
+            default:
+                if (code < 0x20 || code > 0x7e) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+        }
+    }
+    return out + '"';
+}
+
+function _pyJsonNum(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+function _pyJsonScalar(value: unknown): string | null {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _pyJsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _pyJsonStr(value);
+    }
+    return null;
+}
+
+/** Mirror `json.dumps(obj, indent=2)` (ensure_ascii=True). */
+function _pyDumpsIndent2(value: unknown, depth = 0): string {
+    const scalar = _pyJsonScalar(value);
+    if (scalar !== null) {
+        return scalar;
+    }
+    const pad = ' '.repeat(2 * (depth + 1));
+    const closePad = ' '.repeat(2 * depth);
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _pyDumpsIndent2(v, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (_isPlainObject(value)) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map(
+            (k) => `${pad}${_pyJsonStr(k)}: ${_pyDumpsIndent2(value[k], depth + 1)}`,
+        );
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _pyJsonStr(String(value));
+}
+
+// --------------------------------------------------------------- generate
+
+/** Resolve `{primitive.color.blue.600}`-style references recursively. */
+export function resolveReference(value: Json, tokens: JsonObject): Json {
+    if (typeof value !== 'string' || !value.startsWith('{')) {
+        return value;
+    }
+    const stripped = _stripChars(value, '{}');
+    const pathParts = stripped.split('.');
+    let node: Json = tokens;
+    for (const key of pathParts) {
+        if (!_isPlainObject(node)) {
+            return value;
+        }
+        node = node[key] === undefined ? null : node[key];
+        if (node === null) {
+            return value;
+        }
+    }
+    if (_isPlainObject(node) && '$value' in node) {
+        return resolveReference(node['$value'], tokens);
+    }
+    return node !== null ? node : value;
+}
+
+/** Flatten a DTCG token tree into `--css-var → resolved value`. */
+export function flattenTokens(
+    obj: JsonObject,
+    tokens: JsonObject,
+    prefix: string[] | null = null,
+    result: Record<string, Json> | null = null,
+): Record<string, Json> {
+    const pfx = prefix || [];
+    const res = result !== null ? result : {};
+    for (const key of Object.keys(obj)) {
+        const value = obj[key];
+        const current = [...pfx, key];
+        if (_isPlainObject(value)) {
+            if ('$value' in value) {
+                const cssVar = '--' + current.join('-').replace(/\./g, '-');
+                res[cssVar] = resolveReference(value['$value'], tokens);
+            } else {
+                flattenTokens(value, tokens, current, res);
+            }
+        }
+    }
+    return res;
+}
+
+/** Mirror `(d.get(k) or {})` — None / missing / falsy → `{}`. */
+function _orEmpty(v: Json): JsonObject {
+    if (_isPlainObject(v)) {
+        // A non-empty dict is truthy; an empty dict ({}) is falsy in Python,
+        // but `{} or {}` is still `{}`, so returning it is correct either way.
+        return v;
+    }
+    return {};
+}
+
+export function generateCss(tokens: JsonObject): string {
+    const primitive = flattenTokens(_orEmpty(tokens['primitive']), tokens, ['primitive']);
+    const semantic = flattenTokens(_orEmpty(tokens['semantic']), tokens, []);
+    const component = flattenTokens(_orEmpty(tokens['component']), tokens, []);
+    const dark = flattenTokens(_orEmpty(_orEmpty(tokens['dark'])['semantic']), tokens, []);
+
+    const block = (entries: Record<string, Json>): string =>
+        Object.keys(entries)
+            .map((k) => `  ${k}: ${_pyValueStr(entries[k])};`)
+            .join('\n');
+
+    let css =
+        '/* Design Tokens - Auto-generated */\n' +
+        '/* Do not edit directly - modify tokens.json instead */\n\n' +
+        `/* === PRIMITIVES === */\n:root {\n${block(primitive)}\n}\n\n` +
+        `/* === SEMANTIC === */\n:root {\n${block(semantic)}\n}\n\n` +
+        `/* === COMPONENTS === */\n:root {\n${block(component)}\n}\n`;
+    if (_pyTruthy(dark)) {
+        css += `\n/* === DARK MODE === */\n.dark {\n${block(dark)}\n}\n`;
+    }
+    return css;
+}
+
+export function generateTailwind(tokens: JsonObject): string {
+    const semantic = flattenTokens(_orEmpty(tokens['semantic']), tokens, []);
+    const colors: Record<string, string> = {};
+    for (const key of Object.keys(semantic)) {
+        if (key.includes('color')) {
+            const newKey = key.replace('--color-', '').replace(/-/g, '.');
+            colors[newKey] = `var(${key})`;
+        }
+    }
+    const body = _pyDumpsIndent2(colors).replace(/"/g, "'");
+    return (
+        '// Tailwind color config - Auto-generated\n' +
+        '// Add to tailwind.config.ts theme.extend.colors\n\n' +
+        `module.exports = {\n  colors: ${body}\n};\n`
+    );
+}
+
+// --------------------------------------------------------------- validate
+
+interface Pattern {
+    regex: RegExp;
+    message: string;
+    suggestion: string;
+}
+
+// Insertion order mirrors the Python `PATTERNS` dict (hexColor → rgbColor →
+// pixelValue → remValue). Object key order is preserved in JS.
+const PATTERNS: Record<string, Pattern> = {
+    hexColor: {
+        // `#([0-9A-Fa-f]{3}){1,2}\b` — has a capture group (matters for findall).
+        regex: /#([0-9A-Fa-f]{3}){1,2}\b/,
+        message: 'Hardcoded hex color',
+        suggestion: 'Use var(--color-*) token',
+    },
+    rgbColor: {
+        regex: /rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(?:,\s*[\d.]+\s*)?\)/i,
+        message: 'Hardcoded RGB(A) color',
+        suggestion: 'Use var(--color-*) token',
+    },
+    pixelValue: {
+        regex: /:\s*(\d{2,})px/,
+        message: 'Hardcoded pixel value',
+        suggestion: 'Use var(--space-*) or var(--radius-*) token',
+    },
+    remValue: {
+        regex: /:\s*\d+\.?\d*rem/,
+        message: 'Hardcoded rem value',
+        suggestion: 'Use var(--space-*) or var(--font-size-*) token',
+    },
+};
+
+const EXTENSIONS = new Set([
+    '.css', '.scss', '.tsx', '.jsx', '.ts', '.js', '.vue',
+    '.svelte', '.html', '.blade.php',
+]);
+const SKIP_FILE_PATTERNS: RegExp[] = [
+    /\.min\.(css|js)$/,
+    /tailwind\.config/,
+    /globals\.css/,
+    /tokens\.(css|json)/,
+];
+const HEX_EXCEPTIONS = new Set(['#000', '#FFF', '#000000', '#FFFFFF']);
+const DEFAULT_IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'vendor']);
+const ALLOWED_HOST_HINTS = [
+    'fonts.googleapis.com', 'fonts.gstatic.com', 'unsplash.com', 'pexels.com',
+];
+
+interface Violation {
+    file: string;
+    line: number;
+    type: string;
+    value: string;
+    message: string;
+    suggestion: string;
+    context: string;
+    kind: string;
+}
+
+/** Recursively list files under `root`, mirroring `Path.rglob("*")` sorted. */
+function _rglobSorted(root: string): string[] {
+    const out: string[] = [];
+    const walk = (dir: string): void => {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const ent of entries) {
+            const full = path.join(dir, ent.name);
+            out.push(full);
+            if (ent.isDirectory() && !ent.isSymbolicLink()) {
+                walk(full);
+            }
+        }
+    };
+    walk(root);
+    // `sorted(root.rglob("*"))` sorts the PosixPath objects lexicographically
+    // by their string form.
+    out.sort();
+    return out;
+}
+
+function _suffix(p: string): string {
+    const name = path.basename(p);
+    const idx = name.lastIndexOf('.');
+    if (idx <= 0) {
+        return '';
+    }
+    return name.slice(idx);
+}
+
+function _iterFiles(root: string, ignore: Set<string>): string[] {
+    const files: string[] = [];
+    for (const p of _rglobSorted(root)) {
+        // `any(part in ignore for part in path.parts)` — split on the OS sep.
+        const parts = p.split(path.sep);
+        if (parts.some((part) => ignore.has(part))) {
+            continue;
+        }
+        const name = path.basename(p);
+        const suffix = name.endsWith('.blade.php') ? '.blade.php' : _suffix(p);
+        let isFile = false;
+        try {
+            isFile = fs.statSync(p).isFile();
+        } catch {
+            isFile = false;
+        }
+        if (isFile && EXTENSIONS.has(suffix)) {
+            if (SKIP_FILE_PATTERNS.some((pat) => pat.test(p))) {
+                continue;
+            }
+            files.push(p);
+        }
+    }
+    return files;
+}
+
+/**
+ * Mirror Python `regex.findall(line)` for the four patterns used here.
+ * - Patterns with NO capture group → returns each whole match.
+ * - The hexColor pattern (one capture group) → returns the GROUP capture per
+ *   match (Python `findall` semantics). The scanner re-derives the whole
+ *   match separately, so the *content* of these does not matter — only the
+ *   count (≥1 ⇒ at least one finding candidate).
+ */
+function _findall(regex: RegExp, line: string): string[] {
+    const flags = regex.flags.includes('g') ? regex.flags : regex.flags + 'g';
+    const g = new RegExp(regex.source, flags);
+    const res: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(line)) !== null) {
+        // Python findall: with one group → the group; without → whole match.
+        res.push(m.length > 1 ? (m[1] ?? '') : m[0]);
+        if (m.index === g.lastIndex) {
+            g.lastIndex += 1;
+        }
+    }
+    return res;
+}
+
+/** Mirror `regex.search(line).group(0)` — the first whole match, or null. */
+function _searchGroup0(regex: RegExp, line: string): string | null {
+    const flags = regex.flags.replace('g', '');
+    const s = new RegExp(regex.source, flags);
+    const m = s.exec(line);
+    return m ? m[0] : null;
+}
+
+export function scanFile(p: string): Violation[] {
+    const violations: Violation[] = [];
+    let text: string;
+    try {
+        text = fs.readFileSync(p, 'utf-8');
+    } catch {
+        return violations;
+    }
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+        const lineno = i + 1;
+        const line = lines[i] as string;
+        const stripped = _strip(line);
+        if (
+            stripped.startsWith('//') ||
+            stripped.startsWith('/*') ||
+            stripped.startsWith('*') ||
+            line.includes('var(--')
+        ) {
+            continue;
+        }
+        if (ALLOWED_HOST_HINTS.some((host) => line.includes(host))) {
+            continue;
+        }
+        for (const kind of Object.keys(PATTERNS)) {
+            const { regex, message, suggestion } = PATTERNS[kind] as Pattern;
+            const matches = _findall(regex, line);
+            for (const match of matches) {
+                let value: string = match;
+                if (kind === 'hexColor') {
+                    const whole = _searchGroup0(regex, line) as string;
+                    if (HEX_EXCEPTIONS.has(whole.toUpperCase())) {
+                        continue;
+                    }
+                    value = whole;
+                }
+                violations.push({
+                    file: p,
+                    line: lineno,
+                    type: kind,
+                    value,
+                    message,
+                    suggestion,
+                    context: _sliceCodePoints(stripped, 80),
+                    // Maps onto the UI directive set's finding kind so the
+                    // polish step can auto-convert against audit tokens.
+                    kind: 'token_violation',
+                });
+                break; // one finding per pattern per line is enough
+            }
+        }
+    }
+    return violations;
+}
+
+/** Mirror Python `s[:80]` over code points. */
+function _sliceCodePoints(s: string, n: number): string {
+    let out = '';
+    let count = 0;
+    for (const ch of s) {
+        if (count >= n) {
+            break;
+        }
+        out += ch;
+        count += 1;
+    }
+    return out;
+}
+
+export function formatReport(violations: Violation[]): string {
+    if (violations.length === 0) {
+        return '✅ No token violations found';
+    }
+    const out: string[] = [`⚠️  Found ${violations.length} potential token violations:`, ''];
+    const byFile = new Map<string, Violation[]>();
+    for (const v of violations) {
+        if (!byFile.has(v.file)) {
+            byFile.set(v.file, []);
+        }
+        byFile.get(v.file)!.push(v);
+    }
+    for (const [file, items] of byFile) {
+        out.push(`📁 ${file}`);
+        for (const v of items) {
+            out.push(
+                `   Line ${v.line}: ${v.message}`,
+                `   Found: ${v.value}`,
+                `   Suggestion: ${v.suggestion}`,
+                `   Context: ${v.context}`,
+                '',
+            );
+        }
+    }
+    const counts = new Map<string, number>();
+    for (const v of violations) {
+        counts.set(v.message, (counts.get(v.message) ?? 0) + 1);
+    }
+    out.push('📊 Summary:');
+    for (const [msg, n] of counts) {
+        out.push(`   ${msg}: ${n}`);
+    }
+    return out.join('\n');
+}
+
+// --------------------------------------------------------------- embed
+
+const MINIMAL_TOKEN_PREFIXES = [
+    '--primitive-spacing-', '--primitive-fontSize-', '--primitive-fontWeight-',
+    '--primitive-lineHeight-', '--primitive-radius-', '--primitive-shadow-glow-',
+    '--primitive-gradient-', '--primitive-duration-', '--color-primary',
+    '--color-secondary', '--color-accent', '--color-background',
+    '--color-surface', '--color-foreground', '--color-border',
+    '--typography-font-', '--card-',
+];
+
+/** Mirror `re.findall(pat, s)` for patterns WITHOUT a capture group. */
+function _findallNoGroup(pattern: RegExp, s: string): string[] {
+    const flags = pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g';
+    const g = new RegExp(pattern.source, flags);
+    const res: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(s)) !== null) {
+        res.push(m[0]);
+        if (m.index === g.lastIndex) {
+            g.lastIndex += 1;
+        }
+    }
+    return res;
+}
+
+/** Mirror `re.findall(r":root\s*\{([^}]+)\}", css)` — returns the group capture. */
+function _findallRootBlocks(css: string): string[] {
+    const g = /:root\s*\{([^}]+)\}/g;
+    const res: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(css)) !== null) {
+        res.push(m[1] as string);
+        if (m.index === g.lastIndex) {
+            g.lastIndex += 1;
+        }
+    }
+    return res;
+}
+
+export function extractTokens(css: string, minimal = false): string {
+    const blocks = _findallRootBlocks(css);
+    let allVars: string[] = [];
+    for (const block of blocks) {
+        allVars = allVars.concat(_findallNoGroup(/--[\w-]+:\s*[^;]+;/, block));
+    }
+    if (minimal) {
+        allVars = allVars.filter((v) => MINIMAL_TOKEN_PREFIXES.some((p) => v.includes(p)));
+    }
+    const seen: string[] = [];
+    for (const v of allVars) {
+        if (!seen.includes(v)) {
+            seen.push(v);
+        }
+    }
+    return ':root {\n  ' + seen.join('\n  ') + '\n}';
+}
+
+// --------------------------------------------------------------- shims
+
+/** Mirror Python truthiness for the values this module dumps. */
+function _pyTruthy(v: Json): boolean {
+    if (v === null || v === undefined || v === false) {
+        return false;
+    }
+    if (v === true) {
+        return true;
+    }
+    if (typeof v === 'number') {
+        return v !== 0;
+    }
+    if (typeof v === 'string') {
+        return v.length > 0;
+    }
+    if (Array.isArray(v)) {
+        return v.length > 0;
+    }
+    if (_isPlainObject(v)) {
+        return Object.keys(v).length > 0;
+    }
+    return Boolean(v);
+}
+
+/**
+ * Mirror Python f-string interpolation of a resolved token value into CSS.
+ * Resolved values are nearly always strings; non-strings fall back to
+ * Python's `str()` semantics for the scalars that can appear here.
+ */
+function _pyValueStr(v: Json): string {
+    if (typeof v === 'string') {
+        return v;
+    }
+    if (v === null || v === undefined) {
+        return 'None';
+    }
+    if (v === true) {
+        return 'True';
+    }
+    if (v === false) {
+        return 'False';
+    }
+    if (typeof v === 'number') {
+        return _pyJsonNum(v);
+    }
+    return String(v);
+}
+
+// --------------------------------------------------------------- CLI
+
+interface ArgvError extends Error {
+    code: number;
+}
+
+function _argError(msg: string): ArgvError {
+    const e = new Error(msg) as ArgvError;
+    e.code = 2;
+    return e;
+}
+
+const PROG = 'tokens';
+
+function _usageError(message: string): never {
+    // argparse prints a usage line + error to stderr and exits 2. We don't
+    // byte-compare argparse output (per the task), so emit a faithful-enough
+    // diagnostic and signal exit 2 via a thrown ArgvError the caller maps.
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw _argError(message);
+}
+
+interface GenerateArgs {
+    op: 'generate';
+    config: string;
+    output: string | null;
+    format: 'css' | 'tailwind';
+}
+interface ValidateArgs {
+    op: 'validate';
+    dir: string;
+    ignore: string[];
+    json: boolean;
+}
+interface EmbedArgs {
+    op: 'embed';
+    tokens: string;
+    minimal: boolean;
+    style: boolean;
+}
+type ParsedArgs = GenerateArgs | ValidateArgs | EmbedArgs;
+
+function _takeValue(
+    argv: string[],
+    i: number,
+    flag: string,
+): { value: string; next: number } {
+    // Support `--flag value` and `--flag=value` / short `-f value` forms.
+    const tok = argv[i] as string;
+    const eq = tok.indexOf('=');
+    if (tok.startsWith('--') && eq !== -1) {
+        return { value: tok.slice(eq + 1), next: i + 1 };
+    }
+    if (i + 1 >= argv.length) {
+        _usageError(`argument ${flag}: expected one argument`);
+    }
+    return { value: argv[i + 1] as string, next: i + 2 };
+}
+
+function _parseArgs(argv: string[]): ParsedArgs {
+    if (argv.length === 0) {
+        _usageError('the following arguments are required: op');
+    }
+    const op = argv[0] as string;
+    const rest = argv.slice(1);
+
+    if (op === 'generate') {
+        let config: string | null = null;
+        let output: string | null = null;
+        let format: 'css' | 'tailwind' = 'css';
+        let i = 0;
+        while (i < rest.length) {
+            const t = rest[i] as string;
+            const base = t.split('=')[0];
+            if (base === '--config' || base === '-c') {
+                const r = _takeValue(rest, i, '--config/-c');
+                config = r.value;
+                i = r.next;
+            } else if (base === '--output' || base === '-o') {
+                const r = _takeValue(rest, i, '--output/-o');
+                output = r.value;
+                i = r.next;
+            } else if (base === '--format' || base === '-f') {
+                const r = _takeValue(rest, i, '--format/-f');
+                if (r.value !== 'css' && r.value !== 'tailwind') {
+                    _usageError(
+                        `argument --format/-f: invalid choice: '${r.value}' (choose from 'css', 'tailwind')`,
+                    );
+                }
+                format = r.value;
+                i = r.next;
+            } else {
+                _usageError(`unrecognized arguments: ${t}`);
+            }
+        }
+        if (config === null) {
+            _usageError('the following arguments are required: --config/-c');
+        }
+        return { op: 'generate', config, output, format };
+    }
+
+    if (op === 'validate') {
+        let dir: string | null = null;
+        const ignore: string[] = [];
+        let json = false;
+        let i = 0;
+        while (i < rest.length) {
+            const t = rest[i] as string;
+            const base = t.split('=')[0];
+            if (base === '--dir' || base === '-d') {
+                const r = _takeValue(rest, i, '--dir/-d');
+                dir = r.value;
+                i = r.next;
+            } else if (base === '--ignore' || base === '-i') {
+                const r = _takeValue(rest, i, '--ignore/-i');
+                ignore.push(r.value);
+                i = r.next;
+            } else if (base === '--json') {
+                json = true;
+                i += 1;
+            } else {
+                _usageError(`unrecognized arguments: ${t}`);
+            }
+        }
+        if (dir === null) {
+            _usageError('the following arguments are required: --dir/-d');
+        }
+        return { op: 'validate', dir, ignore, json };
+    }
+
+    if (op === 'embed') {
+        let tokens: string | null = null;
+        let minimal = false;
+        let style = false;
+        let i = 0;
+        while (i < rest.length) {
+            const t = rest[i] as string;
+            const base = t.split('=')[0];
+            if (base === '--tokens' || base === '-t') {
+                const r = _takeValue(rest, i, '--tokens/-t');
+                tokens = r.value;
+                i = r.next;
+            } else if (base === '--minimal') {
+                minimal = true;
+                i += 1;
+            } else if (base === '--style') {
+                style = true;
+                i += 1;
+            } else {
+                _usageError(`unrecognized arguments: ${t}`);
+            }
+        }
+        if (tokens === null) {
+            _usageError('the following arguments are required: --tokens/-t');
+        }
+        return { op: 'embed', tokens, minimal, style };
+    }
+
+    _usageError(
+        `argument op: invalid choice: '${op}' (choose from 'generate', 'validate', 'embed')`,
+    );
+}
+
+export function main(argv: string[] | null = null): number {
+    const args = argv === null ? process.argv.slice(2) : argv;
+    let parsed: ParsedArgs;
+    try {
+        parsed = _parseArgs(args);
+    } catch (e) {
+        if (e && typeof e === 'object' && 'code' in e) {
+            return (e as ArgvError).code;
+        }
+        throw e;
+    }
+
+    if (parsed.op === 'generate') {
+        const config = parsed.config;
+        if (!_exists(config)) {
+            process.stderr.write(`Error: Config file not found: ${config}\n`);
+            return 1;
+        }
+        const tokens = JSON.parse(fs.readFileSync(config, 'utf-8')) as JsonObject;
+        const output =
+            parsed.format === 'tailwind' ? generateTailwind(tokens) : generateCss(tokens);
+        if (parsed.output) {
+            const out = parsed.output;
+            const dir = path.dirname(out);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(out, output, 'utf-8');
+            process.stdout.write(`Generated: ${out}\n`);
+        } else {
+            process.stdout.write(output + '\n');
+        }
+        return 0;
+    }
+
+    if (parsed.op === 'validate') {
+        const root = parsed.dir;
+        if (!_exists(root)) {
+            process.stderr.write(`Error: Directory not found: ${root}\n`);
+            return 1;
+        }
+        const ignore = new Set([...DEFAULT_IGNORE, ...parsed.ignore]);
+        let violations: Violation[] = [];
+        for (const file of _iterFiles(root, ignore)) {
+            violations = violations.concat(scanFile(file));
+        }
+        if (parsed.json) {
+            process.stdout.write(_pyDumpsIndent2(violations) + '\n');
+        } else {
+            process.stdout.write(formatReport(violations) + '\n');
+        }
+        return violations.length > 0 ? 1 : 0;
+    }
+
+    // embed
+    const tokensPath = parsed.tokens;
+    if (!_exists(tokensPath)) {
+        process.stderr.write(`Error: tokens css not found: ${tokensPath}\n`);
+        return 1;
+    }
+    const output = extractTokens(fs.readFileSync(tokensPath, 'utf-8'), parsed.minimal);
+    const header = '/* Design Tokens (embedded for standalone HTML) */';
+    if (parsed.style) {
+        process.stdout.write(`<style>\n${header}\n${output}\n</style>\n`);
+    } else {
+        process.stdout.write(`${header}\n${output}\n`);
+    }
+    return 0;
+}
+
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// `raise SystemExit(main())` — set process.exitCode, never call process.exit.
+const _INVOKED_DIRECTLY =
+    typeof process.argv[1] === 'string' &&
+    import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (_INVOKED_DIRECTLY) {
+    process.exitCode = main();
+}
+
+export {
+    PATTERNS,
+    EXTENSIONS,
+    SKIP_FILE_PATTERNS,
+    HEX_EXCEPTIONS,
+    DEFAULT_IGNORE,
+    ALLOWED_HOST_HINTS,
+    MINIMAL_TOKEN_PREFIXES,
+    _pyDumpsIndent2,
+    _pyLen,
+};

--- a/dist/agent-src/skills/react-shadcn-ui/scripts/shadcn_add.ts
+++ b/dist/agent-src/skills/react-shadcn-ui/scripts/shadcn_add.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env tsx
+// Modified from upstream (Apache-2.0, "claudekit" via
+// an external reference ui-styling sub-skill
+// @ b7e3af80f6e331f6fb456667b82b12cade7c9d35, last checked 2026-06-07).
+// License copy: src/skills/design-intelligence/LICENSE.apache-2.0.txt
+// (deployed: <skills-root>/design-intelligence/LICENSE.apache-2.0.txt).
+// Modifications: adopted into the agent-config skill tree; header added
+// per Apache-2.0 §4b; see design-intelligence/ATTRIBUTION.md.
+/**
+ * shadcn/ui Component Installer
+ *
+ * Add shadcn/ui components to project with automatic dependency handling.
+ * Wraps shadcn CLI for programmatic component installation.
+ *
+ * TypeScript twin of `src/skills/react-shadcn-ui/scripts/shadcn_add.py`
+ * (ADR-094). The CLI contract is mirrored EXACTLY — positional components,
+ * `--all`, `--overwrite`, `--dry-run`, `--list`, `--project-root`, exit codes
+ * (0 / 1), the stdout/stderr split, byte-identical messages, AND the exact
+ * `npx shadcn@latest …` command shape. No behaviour changes — latent Python
+ * quirks replicated.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export class ShadcnInstaller {
+    projectRoot: string;
+    dryRun: boolean;
+    componentsJson: string;
+
+    constructor(projectRoot: string | null = null, dryRun = false) {
+        this.projectRoot = projectRoot ?? process.cwd();
+        this.dryRun = dryRun;
+        this.componentsJson = path.join(this.projectRoot, 'components.json');
+    }
+
+    /** Check if shadcn is initialized — components.json exists. */
+    checkShadcnConfig(): boolean {
+        return fs.existsSync(this.componentsJson);
+    }
+
+    /** Get list of already installed components (unsorted, mirrors .py). */
+    getInstalledComponents(): string[] {
+        if (!this.checkShadcnConfig()) {
+            return [];
+        }
+        try {
+            const config = JSON.parse(fs.readFileSync(this.componentsJson, 'utf-8')) as unknown;
+            const aliasesRaw =
+                config && typeof config === 'object' && 'aliases' in config
+                    ? (config as { aliases?: unknown }).aliases
+                    : undefined;
+            const aliases =
+                aliasesRaw && typeof aliasesRaw === 'object'
+                    ? (aliasesRaw as { components?: unknown })
+                    : {};
+            const componentsAlias =
+                typeof aliases.components === 'string' ? aliases.components : 'components';
+            const componentsDir = path.join(this.projectRoot, componentsAlias.replace('@/', ''));
+            const uiDir = path.join(componentsDir, 'ui');
+
+            if (!fs.existsSync(uiDir)) {
+                return [];
+            }
+
+            return _globTsxStems(uiDir);
+        } catch {
+            // json.JSONDecodeError | KeyError | OSError → []
+            return [];
+        }
+    }
+
+    /** Add shadcn/ui components → [success, message]. */
+    addComponents(components: string[], overwrite = false): [boolean, string] {
+        if (components.length === 0) {
+            return [false, 'No components specified'];
+        }
+
+        if (!this.checkShadcnConfig()) {
+            return [false, "shadcn not initialized. Run 'npx shadcn@latest init' first"];
+        }
+
+        // Check which components already exist
+        const installed = this.getInstalledComponents();
+        const alreadyInstalled = components.filter((c) => installed.includes(c));
+
+        if (alreadyInstalled.length > 0 && !overwrite) {
+            return [
+                false,
+                `Components already installed: ${alreadyInstalled.join(', ')}. ` +
+                    'Use --overwrite to reinstall',
+            ];
+        }
+
+        // Build command
+        const cmd = ['npx', 'shadcn@latest', 'add', ...components];
+
+        if (overwrite) {
+            cmd.push('--overwrite');
+        }
+
+        if (this.dryRun) {
+            return [true, `Would run: ${cmd.join(' ')}`];
+        }
+
+        // Execute command
+        return this._runAdd(cmd, `Successfully added components: ${components.join(', ')}`);
+    }
+
+    /** Add all available shadcn/ui components → [success, message]. */
+    addAllComponents(overwrite = false): [boolean, string] {
+        if (!this.checkShadcnConfig()) {
+            return [false, "shadcn not initialized. Run 'npx shadcn@latest init' first"];
+        }
+
+        const cmd = ['npx', 'shadcn@latest', 'add', '--all'];
+
+        if (overwrite) {
+            cmd.push('--overwrite');
+        }
+
+        if (this.dryRun) {
+            return [true, `Would run: ${cmd.join(' ')}`];
+        }
+
+        return this._runAdd(cmd, 'Successfully added all components', true);
+    }
+
+    /**
+     * Mirror the subprocess.run(..., check=True) try/except for both add paths.
+     * `failAll` toggles the "Failed to add all components" vs "Failed to add
+     * components" prefix.
+     */
+    private _runAdd(cmd: string[], successBase: string, failAll = false): [boolean, string] {
+        const result = spawnSync(cmd[0] as string, cmd.slice(1), {
+            cwd: this.projectRoot,
+            encoding: 'utf-8',
+        });
+
+        // FileNotFoundError — the executable itself is missing.
+        if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [false, 'npx not found. Ensure Node.js is installed'];
+        }
+
+        const stdout = result.stdout ?? '';
+        const stderr = result.stderr ?? '';
+        const status = result.status;
+
+        if (status === 0) {
+            let successMsg = successBase;
+            if (stdout) {
+                successMsg += `\n\nOutput:\n${stdout}`;
+            }
+            return [true, successMsg];
+        }
+
+        // subprocess.CalledProcessError — e.stderr or e.stdout or str(e).
+        const detail = stderr || stdout || _calledProcessError(cmd, status, result.signal);
+        const prefix = failAll ? 'Failed to add all components' : 'Failed to add components';
+        return [false, `${prefix}: ${detail}`];
+    }
+
+    /** List installed components → [success, message]. */
+    listInstalled(): [boolean, string] {
+        if (!this.checkShadcnConfig()) {
+            return [false, 'shadcn not initialized'];
+        }
+
+        const installed = this.getInstalledComponents();
+
+        if (installed.length === 0) {
+            return [true, 'No components installed'];
+        }
+
+        const sorted = [...installed].sort(_pyStrCmp);
+        return [true, 'Installed components:\n' + sorted.map((c) => `  - ${c}`).join('\n')];
+    }
+}
+
+/** Mirror Python default str comparison (UTF-16 code-unit ordering matches for BMP). */
+function _pyStrCmp(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Mirror `[f.stem for f in ui_dir.glob("*.tsx") if f.is_file()]`. Path.glob
+ * returns only direct children whose name ends in `.tsx`; `f.stem` drops the
+ * final `.tsx` suffix; order is the directory listing (later `sorted()` in
+ * list_installed handles display order). Symlinks to files count as files.
+ */
+function _globTsxStems(uiDir: string): string[] {
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(uiDir, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    const out: string[] = [];
+    for (const e of entries) {
+        if (!e.name.endsWith('.tsx')) {
+            continue;
+        }
+        let isFile = e.isFile();
+        if (e.isSymbolicLink()) {
+            try {
+                isFile = fs.statSync(path.join(uiDir, e.name)).isFile();
+            } catch {
+                isFile = false;
+            }
+        }
+        if (isFile) {
+            out.push(e.name.slice(0, -'.tsx'.length));
+        }
+    }
+    return out;
+}
+
+/** Mirror `str(subprocess.CalledProcessError)` for the rare empty-output case. */
+function _calledProcessError(cmd: string[], status: number | null, signal: string | null): string {
+    const cmdRepr = '[' + cmd.map((c) => `'${c}'`).join(', ') + ']';
+    if (signal) {
+        return `Command ${cmdRepr} died with ${signal}.`;
+    }
+    return `Command ${cmdRepr} returned non-zero exit status ${status}.`;
+}
+
+const PROG = 'shadcn_add.py';
+
+const HELP =
+    `usage: ${PROG} [-h] [--all] [--overwrite] [--dry-run] [--list]\n` +
+    '                     [--project-root PROJECT_ROOT]\n' +
+    '                     [components ...]\n' +
+    '\n' +
+    'Add shadcn/ui components to your project\n' +
+    '\n' +
+    'positional arguments:\n' +
+    '  components            Component names to add (e.g., button, card, dialog)\n' +
+    '\n' +
+    'optional arguments:\n' +
+    '  -h, --help            show this help message and exit\n' +
+    '  --all                 Add all available components\n' +
+    '  --overwrite           Overwrite existing components\n' +
+    '  --dry-run             Show what would be done without executing\n' +
+    '  --list                List installed components\n' +
+    '  --project-root PROJECT_ROOT\n' +
+    '                        Project root directory (default: current directory)\n' +
+    '\n' +
+    'Examples:\n' +
+    '  # Add single component\n' +
+    '  python shadcn_add.py button\n' +
+    '\n' +
+    '  # Add multiple components\n' +
+    '  python shadcn_add.py button card dialog\n' +
+    '\n' +
+    '  # Add all components\n' +
+    '  python shadcn_add.py --all\n' +
+    '\n' +
+    '  # Overwrite existing components\n' +
+    '  python shadcn_add.py button --overwrite\n' +
+    '\n' +
+    '  # Dry run (show what would be done)\n' +
+    '  python shadcn_add.py button card --dry-run\n' +
+    '\n' +
+    '  # List installed components\n' +
+    '  python shadcn_add.py --list\n' +
+    '        \n';
+
+const USAGE =
+    `usage: ${PROG} [-h] [--all] [--overwrite] [--dry-run] [--list]\n` +
+    '                     [--project-root PROJECT_ROOT]\n' +
+    '                     [components ...]\n';
+
+class ArgExit extends Error {
+    constructor(public code: number) {
+        super('argexit');
+    }
+}
+
+interface Args {
+    components: string[];
+    all: boolean;
+    overwrite: boolean;
+    dry_run: boolean;
+    list: boolean;
+    project_root: string | null;
+}
+
+function argError(message: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw new ArgExit(2);
+}
+
+/** Parse argv mirroring the argparse spec (positional `components` nargs="*"). */
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        components: [],
+        all: false,
+        overwrite: false,
+        dry_run: false,
+        list: false,
+        project_root: null,
+    };
+
+    let i = 0;
+    while (i < argv.length) {
+        let a = argv[i] as string;
+        let inlineValue: string | null = null;
+        const eq = a.indexOf('=');
+        if (a.startsWith('--') && eq !== -1) {
+            inlineValue = a.slice(eq + 1);
+            a = a.slice(0, eq);
+        }
+
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(HELP);
+            throw new ArgExit(0);
+        } else if (a === '--all') {
+            args.all = true;
+        } else if (a === '--overwrite') {
+            args.overwrite = true;
+        } else if (a === '--dry-run') {
+            args.dry_run = true;
+        } else if (a === '--list') {
+            args.list = true;
+        } else if (a === '--project-root') {
+            const v = inlineValue ?? (argv[++i] as string | undefined);
+            if (v === undefined) {
+                argError('argument --project-root: expected one argument');
+            }
+            args.project_root = v;
+        } else if (a.startsWith('-') && a !== '-') {
+            argError(`unrecognized arguments: ${argv[i]}`);
+        } else {
+            args.components.push(argv[i] as string);
+        }
+        i += 1;
+    }
+    return args;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgExit) {
+            return e.code;
+        }
+        throw e;
+    }
+
+    const installer = new ShadcnInstaller(args.project_root, args.dry_run);
+
+    // Handle list command
+    if (args.list) {
+        const [success, message] = installer.listInstalled();
+        process.stdout.write(`${message}\n`);
+        return success ? 0 : 1;
+    }
+
+    // Handle add all command
+    if (args.all) {
+        const [success, message] = installer.addAllComponents(args.overwrite);
+        process.stdout.write(`${message}\n`);
+        return success ? 0 : 1;
+    }
+
+    // Handle add specific components
+    if (args.components.length === 0) {
+        process.stdout.write(HELP);
+        return 1;
+    }
+
+    const [success, message] = installer.addComponents(args.components, args.overwrite);
+
+    process.stdout.write(`${message}\n`);
+    return success ? 0 : 1;
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    process.exitCode = main();
+}

--- a/dist/agent-src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts
+++ b/dist/agent-src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts
@@ -1,0 +1,561 @@
+#!/usr/bin/env tsx
+// Modified from upstream (Apache-2.0, "claudekit" via
+// an external reference ui-styling sub-skill
+// @ b7e3af80f6e331f6fb456667b82b12cade7c9d35, last checked 2026-06-07).
+// License copy: src/skills/design-intelligence/LICENSE.apache-2.0.txt
+// (deployed: <skills-root>/design-intelligence/LICENSE.apache-2.0.txt).
+// Modifications: adopted into the agent-config skill tree; header added
+// per Apache-2.0 §4b; see design-intelligence/ATTRIBUTION.md.
+/**
+ * Tailwind CSS Configuration Generator
+ *
+ * Generate tailwind.config.js/ts with custom theme configuration.
+ * Supports colors, fonts, spacing, breakpoints, and plugin recommendations.
+ *
+ * TypeScript twin of `src/skills/tailwind-engineer/scripts/tailwind_config_gen.py`
+ * (ADR-094). The CLI contract is mirrored EXACTLY — snake_case-free flags
+ * (`--framework`, `--js`, `--output`, `--colors`, `--fonts`, `--spacing`,
+ * `--breakpoints`, `--plugins`, `--validate-only`), exit codes (0 / 1 / 2),
+ * the stdout/stderr split, byte-identical messages, AND byte-identical
+ * generated config text (whitespace, quoting, key order, trailing newlines).
+ * No behaviour changes — latent Python quirks replicated.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const PROG = 'tailwind_config_gen.py';
+
+// Mirror argparse's wrapped usage block (80-col default; non-tty). Used for
+// the invalid-choice / unrecognized-argument error paths.
+const USAGE =
+    `usage: ${PROG} [-h] [--framework {react,vue,svelte,nextjs}]\n` +
+    '                              [--js] [--output OUTPUT]\n' +
+    '                              [--colors [NAME:VALUE ...]]\n' +
+    '                              [--fonts [TYPE:FAMILY ...]]\n' +
+    '                              [--spacing [NAME:VALUE ...]]\n' +
+    '                              [--breakpoints [NAME:WIDTH ...]] [--plugins]\n' +
+    '                              [--validate-only]\n';
+
+type JsonVal = null | boolean | number | string | JsonVal[] | { [k: string]: JsonVal };
+type Dict = { [k: string]: JsonVal };
+
+/**
+ * json.dumps(obj, indent=2) — sort_keys False, ensure_ascii True. Mirrors the
+ * CPython encoder byte-for-byte: insertion-order keys (Map / object key
+ * order), the `: ` / `,` separators implied by `indent`, and `\uXXXX` escapes
+ * for non-ASCII. Integer floats are not produced by this generator (all values
+ * are strings / arrays / dicts), so no PyFloat branch is needed here.
+ */
+function jsonDumpsIndent2(obj: JsonVal): string {
+    const pad = '  ';
+
+    function enc(value: JsonVal, depth: number): string {
+        if (value === null) return 'null';
+        if (typeof value === 'boolean') return value ? 'true' : 'false';
+        if (typeof value === 'number') return String(value);
+        if (typeof value === 'string') return encStr(value);
+        if (Array.isArray(value)) {
+            if (value.length === 0) return '[]';
+            const inner = value.map((v) => pad.repeat(depth + 1) + enc(v, depth + 1));
+            return '[\n' + inner.join(',\n') + '\n' + pad.repeat(depth) + ']';
+        }
+        const o = value as Dict;
+        const keys = Object.keys(o);
+        if (keys.length === 0) return '{}';
+        const inner = keys.map(
+            (k) => pad.repeat(depth + 1) + encStr(k) + ': ' + enc(o[k] as JsonVal, depth + 1),
+        );
+        return '{\n' + inner.join(',\n') + '\n' + pad.repeat(depth) + '}';
+    }
+
+    function encStr(s: string): string {
+        let out = '"';
+        for (const ch of s) {
+            const cp = ch.codePointAt(0) as number;
+            if (ch === '"') out += '\\"';
+            else if (ch === '\\') out += '\\\\';
+            else if (ch === '\n') out += '\\n';
+            else if (ch === '\r') out += '\\r';
+            else if (ch === '\t') out += '\\t';
+            else if (ch === '\b') out += '\\b';
+            else if (ch === '\f') out += '\\f';
+            else if (cp < 0x20) out += '\\u' + cp.toString(16).padStart(4, '0');
+            else if (cp < 0x7f) out += ch;
+            else if (cp > 0xffff) {
+                const v = cp - 0x10000;
+                const hi = 0xd800 + (v >> 10);
+                const lo = 0xdc00 + (v & 0x3ff);
+                out += '\\u' + hi.toString(16).padStart(4, '0');
+                out += '\\u' + lo.toString(16).padStart(4, '0');
+            } else {
+                out += '\\u' + cp.toString(16).padStart(4, '0');
+            }
+        }
+        return out + '"';
+    }
+
+    return enc(obj, 0);
+}
+
+/** Mirror Python `str.strip("'\"")` — strip listed chars from both ends. */
+function _stripChars(s: string, chars: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && chars.includes(s[start] as string)) {
+        start += 1;
+    }
+    while (end > start && chars.includes(s[end - 1] as string)) {
+        end -= 1;
+    }
+    return s.slice(start, end);
+}
+
+export class TailwindConfigGenerator {
+    typescript: boolean;
+    framework: string;
+    outputPath: string;
+    config: Dict;
+
+    constructor(typescript = true, framework = 'react', outputPath: string | null = null) {
+        this.typescript = typescript;
+        this.framework = framework;
+        this.outputPath = outputPath ?? this._defaultOutputPath();
+        this.config = this._baseConfig();
+    }
+
+    /** Determine default output path — Path.cwd() / `tailwind.config.{ext}`. */
+    _defaultOutputPath(): string {
+        const ext = this.typescript ? 'ts' : 'js';
+        return path.join(process.cwd(), `tailwind.config.${ext}`);
+    }
+
+    /** Create base configuration structure. */
+    _baseConfig(): Dict {
+        return {
+            darkMode: ['class'],
+            content: this._defaultContentPaths(),
+            theme: {
+                extend: {},
+            },
+            plugins: [],
+        };
+    }
+
+    /** Get default content paths for framework. */
+    _defaultContentPaths(): string[] {
+        const paths: { [k: string]: string[] } = {
+            react: ['./src/**/*.{js,jsx,ts,tsx}', './index.html'],
+            vue: ['./src/**/*.{vue,js,ts,jsx,tsx}', './index.html'],
+            svelte: ['./src/**/*.{svelte,js,ts}', './src/app.html'],
+            nextjs: [
+                './app/**/*.{js,ts,jsx,tsx}',
+                './pages/**/*.{js,ts,jsx,tsx}',
+                './components/**/*.{js,ts,jsx,tsx}',
+            ],
+        };
+        return paths[this.framework] ?? (paths['react'] as string[]);
+    }
+
+    private _extend(): Dict {
+        return (this.config['theme'] as Dict)['extend'] as Dict;
+    }
+
+    /** Add custom colors to theme (dict.update — insertion order preserved). */
+    addColors(colors: { [k: string]: string }): void {
+        const extend = this._extend();
+        if (!('colors' in extend)) {
+            extend['colors'] = {};
+        }
+        const target = extend['colors'] as Dict;
+        for (const [k, v] of Object.entries(colors)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add full color palette (50-950 shades) for a base color. */
+    addColorPalette(name: string, _baseColor: string): void {
+        const extend = this._extend();
+        if (!('colors' in extend)) {
+            extend['colors'] = {};
+        }
+        (extend['colors'] as Dict)[name] = {
+            '50': `var(--color-${name}-50)`,
+            '100': `var(--color-${name}-100)`,
+            '200': `var(--color-${name}-200)`,
+            '300': `var(--color-${name}-300)`,
+            '400': `var(--color-${name}-400)`,
+            '500': `var(--color-${name}-500)`,
+            '600': `var(--color-${name}-600)`,
+            '700': `var(--color-${name}-700)`,
+            '800': `var(--color-${name}-800)`,
+            '900': `var(--color-${name}-900)`,
+            '950': `var(--color-${name}-950)`,
+        };
+    }
+
+    /** Add custom font families. */
+    addFonts(fonts: { [k: string]: string[] }): void {
+        const extend = this._extend();
+        if (!('fontFamily' in extend)) {
+            extend['fontFamily'] = {};
+        }
+        const target = extend['fontFamily'] as Dict;
+        for (const [k, v] of Object.entries(fonts)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add custom spacing values. */
+    addSpacing(spacing: { [k: string]: string }): void {
+        const extend = this._extend();
+        if (!('spacing' in extend)) {
+            extend['spacing'] = {};
+        }
+        const target = extend['spacing'] as Dict;
+        for (const [k, v] of Object.entries(spacing)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add custom breakpoints. */
+    addBreakpoints(breakpoints: { [k: string]: string }): void {
+        const extend = this._extend();
+        if (!('screens' in extend)) {
+            extend['screens'] = {};
+        }
+        const target = extend['screens'] as Dict;
+        for (const [k, v] of Object.entries(breakpoints)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add plugin requirements (skip duplicates, preserve order). */
+    addPlugins(plugins: string[]): void {
+        const arr = this.config['plugins'] as string[];
+        for (const plugin of plugins) {
+            if (!arr.includes(plugin)) {
+                arr.push(plugin);
+            }
+        }
+    }
+
+    /** Get plugin recommendations based on configuration. */
+    recommendPlugins(): string[] {
+        const recommendations: string[] = [];
+        recommendations.push('tailwindcss-animate');
+        if (this.framework === 'nextjs') {
+            recommendations.push('@tailwindcss/typography');
+        }
+        return recommendations;
+    }
+
+    /** Generate configuration file content. */
+    generateConfigString(): string {
+        if (this.typescript) {
+            return this._generateTypescript();
+        }
+        return this._generateJavascript();
+    }
+
+    /** Generate TypeScript configuration. */
+    _generateTypescript(): string {
+        const pluginsStr = this._formatPlugins();
+
+        // Match the .py: it builds config_json twice (the first is dead);
+        // the live one drops the plugins array, then dumps indent=2.
+        const configObj: Dict = { ...this.config };
+        delete configObj['plugins'];
+        const configJson = jsonDumpsIndent2(configObj);
+
+        return (
+            `import type { Config } from 'tailwindcss'\n` +
+            `\n` +
+            `const config: Config = {\n` +
+            `${this._indentJson(configJson, 1)}\n` +
+            `  plugins: [${pluginsStr}],\n` +
+            `}\n` +
+            `\n` +
+            `export default config\n`
+        );
+    }
+
+    /** Generate JavaScript configuration. */
+    _generateJavascript(): string {
+        const pluginsStr = this._formatPlugins();
+
+        const configObj: Dict = { ...this.config };
+        delete configObj['plugins'];
+        const configJson = jsonDumpsIndent2(configObj);
+
+        return (
+            `/** @type {import('tailwindcss').Config} */\n` +
+            `module.exports = {\n` +
+            `${this._indentJson(configJson, 1)}\n` +
+            `  plugins: [${pluginsStr}],\n` +
+            `}\n`
+        );
+    }
+
+    /** Format plugins array for config. */
+    _formatPlugins(): string {
+        const arr = this.config['plugins'] as string[];
+        if (arr.length === 0) {
+            return '';
+        }
+        const pluginRequires = arr.map((plugin) => `require('${plugin}')`);
+        return pluginRequires.join(', ');
+    }
+
+    /** Add indentation to JSON string (skip first and last brace lines). */
+    _indentJson(jsonStr: string, level: number): string {
+        const indent = '  '.repeat(level);
+        const lines = jsonStr.split('\n');
+        const indented = lines.slice(1, lines.length - 1).map((line) => indent + line);
+        return indented.join('\n');
+    }
+
+    /** Write configuration to file → [success, message]. */
+    writeConfig(): [boolean, string] {
+        try {
+            const configContent = this.generateConfigString();
+            fs.writeFileSync(this.outputPath, configContent);
+            return [true, `Configuration written to ${this.outputPath}`];
+        } catch (e) {
+            return [false, `Failed to write config: ${osErrorMessage(e)}`];
+        }
+    }
+
+    /** Validate configuration → [valid, message]. */
+    validateConfig(): [boolean, string] {
+        if ((this.config['content'] as JsonVal[]).length === 0) {
+            return [false, 'No content paths specified'];
+        }
+        if (Object.keys(this._extend()).length === 0) {
+            return [true, 'Warning: No theme extensions defined'];
+        }
+        return [true, 'Configuration valid'];
+    }
+}
+
+/** Render an OSError the way Python's `str(e)` does for write failures. */
+function osErrorMessage(e: unknown): string {
+    if (e && typeof e === 'object' && 'message' in e) {
+        return String((e as { message: unknown }).message);
+    }
+    return String(e);
+}
+
+class ArgExit extends Error {
+    constructor(public code: number) {
+        super('argexit');
+    }
+}
+
+interface Args {
+    framework: string;
+    js: boolean;
+    output: string | null;
+    colors: string[] | null;
+    fonts: string[] | null;
+    spacing: string[] | null;
+    breakpoints: string[] | null;
+    plugins: boolean;
+    validate_only: boolean;
+}
+
+/** Emit the argparse-style error (usage to stderr + error line) and exit 2. */
+function argError(message: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw new ArgExit(2);
+}
+
+const FRAMEWORK_CHOICES = ['react', 'vue', 'svelte', 'nextjs'];
+
+/** Parse argv mirroring the argparse spec (nargs="*" flags collect tokens). */
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        framework: 'react',
+        js: false,
+        output: null,
+        colors: null,
+        fonts: null,
+        spacing: null,
+        breakpoints: null,
+        plugins: false,
+        validate_only: false,
+    };
+    const starFlags = new Set(['--colors', '--fonts', '--spacing', '--breakpoints']);
+
+    let i = 0;
+    while (i < argv.length) {
+        let a = argv[i] as string;
+        let inlineValue: string | null = null;
+        const eq = a.indexOf('=');
+        if (a.startsWith('--') && eq !== -1) {
+            inlineValue = a.slice(eq + 1);
+            a = a.slice(0, eq);
+        }
+
+        if (a === '--js') {
+            args.js = true;
+        } else if (a === '--plugins') {
+            args.plugins = true;
+        } else if (a === '--validate-only') {
+            args.validate_only = true;
+        } else if (a === '--framework') {
+            const v = inlineValue ?? (argv[++i] as string | undefined);
+            if (v === undefined) {
+                argError('argument --framework: expected one argument');
+            }
+            if (!FRAMEWORK_CHOICES.includes(v)) {
+                argError(
+                    `argument --framework: invalid choice: '${v}' ` +
+                        `(choose from 'react', 'vue', 'svelte', 'nextjs')`,
+                );
+            }
+            args.framework = v;
+        } else if (a === '--output') {
+            const v = inlineValue ?? (argv[++i] as string | undefined);
+            if (v === undefined) {
+                argError('argument --output: expected one argument');
+            }
+            args.output = v;
+        } else if (starFlags.has(a)) {
+            const collected: string[] = [];
+            if (inlineValue !== null) {
+                collected.push(inlineValue);
+            } else {
+                while (i + 1 < argv.length && !(argv[i + 1] as string).startsWith('-')) {
+                    collected.push(argv[++i] as string);
+                }
+            }
+            const key = a.slice(2) as 'colors' | 'fonts' | 'spacing' | 'breakpoints';
+            args[key] = collected;
+        } else {
+            argError(`unrecognized arguments: ${a}`);
+        }
+        i += 1;
+    }
+    return args;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgExit) {
+            return e.code;
+        }
+        throw e;
+    }
+
+    const generator = new TailwindConfigGenerator(!args.js, args.framework, args.output);
+
+    // Add custom colors
+    if (args.colors) {
+        const colors: { [k: string]: string } = {};
+        for (const colorSpec of args.colors) {
+            const idx = colorSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid color spec: ${colorSpec}\n`);
+                return 1;
+            }
+            const name = colorSpec.slice(0, idx);
+            const value = colorSpec.slice(idx + 1);
+            colors[name] = value;
+        }
+        generator.addColors(colors);
+    }
+
+    // Add custom fonts
+    if (args.fonts) {
+        const fonts: { [k: string]: string[] } = {};
+        for (const fontSpec of args.fonts) {
+            const idx = fontSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid font spec: ${fontSpec}\n`);
+                return 1;
+            }
+            const fontType = fontSpec.slice(0, idx);
+            const family = fontSpec.slice(idx + 1);
+            fonts[fontType] = family.split(',').map((f) => _stripChars(f.trim(), "'\""));
+        }
+        generator.addFonts(fonts);
+    }
+
+    // Add custom spacing
+    if (args.spacing) {
+        const spacing: { [k: string]: string } = {};
+        for (const spacingSpec of args.spacing) {
+            const idx = spacingSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid spacing spec: ${spacingSpec}\n`);
+                return 1;
+            }
+            const name = spacingSpec.slice(0, idx);
+            const value = spacingSpec.slice(idx + 1);
+            spacing[name] = value;
+        }
+        generator.addSpacing(spacing);
+    }
+
+    // Add custom breakpoints
+    if (args.breakpoints) {
+        const breakpoints: { [k: string]: string } = {};
+        for (const bpSpec of args.breakpoints) {
+            const idx = bpSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid breakpoint spec: ${bpSpec}\n`);
+                return 1;
+            }
+            const name = bpSpec.slice(0, idx);
+            const width = bpSpec.slice(idx + 1);
+            breakpoints[name] = width;
+        }
+        generator.addBreakpoints(breakpoints);
+    }
+
+    // Add recommended plugins
+    if (args.plugins) {
+        const recommended = generator.recommendPlugins();
+        generator.addPlugins(recommended);
+        process.stdout.write(`Added recommended plugins: ${recommended.join(', ')}\n`);
+        process.stdout.write('\nInstall with:\n');
+        process.stdout.write(`  npm install -D ${recommended.join(' ')}\n`);
+    }
+
+    // Validate
+    const [valid, message] = generator.validateConfig();
+    if (!valid) {
+        process.stderr.write(`Validation failed: ${message}\n`);
+        return 1;
+    }
+
+    if (message.startsWith('Warning')) {
+        process.stdout.write(`${message}\n`);
+    }
+
+    // Validate only mode
+    if (args.validate_only) {
+        process.stdout.write('Configuration valid\n');
+        process.stdout.write('\nGenerated config:\n');
+        process.stdout.write(`${generator.generateConfigString()}\n`);
+        return 0;
+    }
+
+    // Write config
+    const [success, writeMsg] = generator.writeConfig();
+    process.stdout.write(`${writeMsg}\n`);
+    return success ? 0 : 1;
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    process.exitCode = main();
+}

--- a/src/skills/corpus-grounding/scripts/bm25_search.ts
+++ b/src/skills/corpus-grounding/scripts/bm25_search.ts
@@ -1,0 +1,482 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · bm25_search — retrieval layer (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/bm25_search.py`
+ * (ADR-094 Python→TS migration). Pure-stdlib BM25 ranking over CSV corpora
+ * plus a structured pre-filter (`filters`) applied BEFORE ranking. Retrievers
+ * are selected by name (`bm25` / `structured` / `hybrid`) — never
+ * network-by-default; embeddings are intentionally absent until a measured
+ * recall failure justifies them (ADR-061 §2).
+ *
+ * Skill-shipped tool — standalone by design (no `_lib` imports), so the
+ * Python-parity primitives it needs (float math, `len()` as code-point count,
+ * `csv.DictReader` quoting, Python `re` semantics, `json.dumps` byte-parity)
+ * are inlined here. The public names below mirror the Python module 1:1
+ * (Python style is part of the contract, ADR-094).
+ *
+ * Interface-stability contract: see SKILL.md § Interface contract (v1).
+ * Breaking changes to public names below require a major bump there.
+ */
+
+import * as fs from 'node:fs';
+
+export const DEFAULT_MAX_RESULTS = 3;
+
+/**
+ * Marker for a Python `float`. CPython `json.dumps` / f-strings render an
+ * integral float (`1.0`) with its `.0`; JS numbers lose that. BM25 scores —
+ * and the structured retriever's `1.0` — are Python floats, so the `scores`
+ * array carries this marker and the serializer renders it with float
+ * semantics. Defined here (the cluster's dependency root) and re-used by
+ * `decision_engine` + `ground`.
+ */
+export class PyFloat {
+    constructor(readonly value: number) {}
+}
+
+/** Unwrap a number that may be wrapped in PyFloat. */
+export function floatVal(v: number | PyFloat): number {
+    return v instanceof PyFloat ? v.value : v;
+}
+
+/** Heterogeneous CSV row dict — string→string (csv.DictReader yields strs). */
+export type Row = Record<string, string>;
+
+/** A filter value: a single accepted value or a list of accepted values. */
+export type FilterValue = string | string[];
+export type Filters = Record<string, FilterValue>;
+
+/** search_rows return shape (interface v1). */
+export interface SearchResult {
+    count: number;
+    results: Row[];
+    scores?: PyFloat[];
+    filtered_from?: number;
+    error?: string;
+    [key: string]: unknown;
+}
+
+// ── Python-parity primitives (inlined — skill scripts ship standalone) ──────
+
+/** Python `len(str)` — number of Unicode code points, not UTF-16 units. */
+function pyLen(s: string): number {
+    let n = 0;
+    // Iterating a string yields code points (surrogate pairs counted once).
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+// ── BM25 ────────────────────────────────────────────────────────────────
+
+/** BM25 ranking (k1=1.5, b=0.75 — upstream-tuned defaults). */
+export class BM25 {
+    k1: number;
+
+    b: number;
+
+    corpus: string[][];
+
+    doc_lengths: number[];
+
+    avgdl: number;
+
+    idf: Record<string, number>;
+
+    doc_freqs: Record<string, number>;
+
+    N: number;
+
+    constructor(k1 = 1.5, b = 0.75) {
+        this.k1 = k1;
+        this.b = b;
+        this.corpus = [];
+        this.doc_lengths = [];
+        this.avgdl = 0.0;
+        this.idf = {};
+        this.doc_freqs = {};
+        this.N = 0;
+    }
+
+    /** Lowercase, strip punctuation, drop tokens shorter than 3 chars. */
+    static tokenize(text: unknown): string[] {
+        // Python: re.sub(r"[^\w\s]", " ", str(text).lower()).
+        // Python's `re` `\w` for str is Unicode (letters, digits, underscore);
+        // `\s` is Unicode whitespace. Mirror with \p{L}\p{N}_ and \s under /u.
+        const cleaned = pyStr(text).toLowerCase().replace(/[^\p{L}\p{N}_\s]/gu, ' ');
+        // Python str.split() with no arg: split on runs of whitespace, no empties.
+        return cleaned.split(/\s+/).filter((w) => w.length > 0 && pyLen(w) > 2);
+    }
+
+    fit(documents: string[]): void {
+        this.corpus = documents.map((doc) => BM25.tokenize(doc));
+        this.N = this.corpus.length;
+        if (this.N === 0) {
+            return;
+        }
+        this.doc_lengths = this.corpus.map((doc) => doc.length);
+        let total = 0;
+        for (const dl of this.doc_lengths) {
+            total += dl;
+        }
+        this.avgdl = total / this.N;
+        for (const doc of this.corpus) {
+            // Python: for word in set(doc) — dedupe per document.
+            for (const word of new Set(doc)) {
+                this.doc_freqs[word] = (this.doc_freqs[word] ?? 0) + 1;
+            }
+        }
+        for (const word of Object.keys(this.doc_freqs)) {
+            const freq = this.doc_freqs[word] as number;
+            this.idf[word] = Math.log((this.N - freq + 0.5) / (freq + 0.5) + 1);
+        }
+    }
+
+    /** Score every document; returns [index, score] sorted descending. */
+    score(query: string): [number, number][] {
+        const query_tokens = BM25.tokenize(query);
+        const scores: [number, number][] = [];
+        for (let idx = 0; idx < this.corpus.length; idx += 1) {
+            const doc = this.corpus[idx] as string[];
+            let score = 0.0;
+            const doc_len = this.doc_lengths[idx] as number;
+            const term_freqs: Record<string, number> = {};
+            for (const word of doc) {
+                term_freqs[word] = (term_freqs[word] ?? 0) + 1;
+            }
+            for (const token of query_tokens) {
+                if (token in this.idf) {
+                    const tf = term_freqs[token] ?? 0;
+                    const numerator = tf * (this.k1 + 1);
+                    const denominator = tf + this.k1 * (1 - this.b + (this.b * doc_len) / this.avgdl);
+                    score += (this.idf[token] as number) * (numerator / denominator);
+                }
+            }
+            scores.push([idx, score]);
+        }
+        // Python sorted(scores, key=lambda x: x[1], reverse=True) — stable;
+        // ties keep their original relative order. Node's Array.sort is stable;
+        // a `b - a` comparator returns 0 for ties → original order preserved,
+        // matching CPython's stable reverse sort.
+        const indexed = scores.map((pair, i) => ({ pair, i }));
+        indexed.sort((a, b) => {
+            const d = b.pair[1] - a.pair[1];
+            if (d !== 0) {
+                return d;
+            }
+            return a.i - b.i;
+        });
+        return indexed.map((x) => x.pair);
+    }
+}
+
+// ── CSV loading — mirrors Python's csv.DictReader ───────────────────────────
+
+/**
+ * Load a CSV corpus file as a list of row dicts (UTF-8).
+ *
+ * Mirrors `csv.DictReader` over the default `excel` dialect: comma delimiter,
+ * `"` quotechar, doubled-quote escaping (`""` → `"`), and field/record
+ * boundaries that respect quoting (newlines inside quotes stay in the field).
+ * The first row is the header. Extra fields beyond the header land under the
+ * `None` restkey — but the Python source never reads them, so we drop them
+ * exactly as the downstream code does (it only reads named columns).
+ */
+export function load_csv(filepath: string): Row[] {
+    const text = fs_readText(filepath);
+    const records = _parseCsv(text);
+    if (records.length === 0) {
+        return [];
+    }
+    const header = records[0] as string[];
+    const out: Row[] = [];
+    for (let r = 1; r < records.length; r += 1) {
+        const fields = records[r] as string[];
+        const row: Row = {};
+        for (let c = 0; c < header.length; c += 1) {
+            const key = header[c] as string;
+            // csv.DictReader: missing trailing fields → restval (default None,
+            // but downstream str(row.get(col, "")) coerces). Python stores None
+            // for short rows; the consumers always wrap with str(... or "").
+            // We store "" for a missing field so str() parity holds; for a
+            // present field we store the parsed value.
+            row[key] = c < fields.length ? (fields[c] as string) : '';
+        }
+        out.push(row);
+    }
+    return out;
+}
+
+/**
+ * Parse CSV text into records of fields, matching Python's csv default dialect.
+ *
+ * - Comma delimiter, `"` quote char, `""` → literal `"` inside a quoted field.
+ * - Quoted fields may contain commas and newlines.
+ * - Record terminators: `\r\n`, `\r`, or `\n` (csv universal-newline behavior).
+ * - A trailing newline does not create a trailing empty record.
+ */
+function _parseCsv(text: string): string[][] {
+    const records: string[][] = [];
+    let field = '';
+    let record: string[] = [];
+    let inQuotes = false;
+    let sawAny = false;
+    let i = 0;
+    const n = text.length;
+    const pushField = (): void => {
+        record.push(field);
+        field = '';
+    };
+    const pushRecord = (): void => {
+        records.push(record);
+        record = [];
+    };
+    while (i < n) {
+        const ch = text[i] as string;
+        if (inQuotes) {
+            if (ch === '"') {
+                if (i + 1 < n && text[i + 1] === '"') {
+                    field += '"';
+                    i += 2;
+                } else {
+                    inQuotes = false;
+                    i += 1;
+                }
+            } else {
+                field += ch;
+                i += 1;
+            }
+            continue;
+        }
+        if (ch === '"') {
+            inQuotes = true;
+            sawAny = true;
+            i += 1;
+        } else if (ch === ',') {
+            pushField();
+            sawAny = true;
+            i += 1;
+        } else if (ch === '\r' || ch === '\n') {
+            // Universal newline: \r\n counts once.
+            pushField();
+            pushRecord();
+            sawAny = false;
+            if (ch === '\r' && i + 1 < n && text[i + 1] === '\n') {
+                i += 2;
+            } else {
+                i += 1;
+            }
+        } else {
+            field += ch;
+            sawAny = true;
+            i += 1;
+        }
+    }
+    // Flush a trailing field/record only if we saw content on the last line.
+    if (sawAny || field.length > 0 || record.length > 0) {
+        pushField();
+        pushRecord();
+    }
+    return records;
+}
+
+// ── filters ───────────────────────────────────────────────────────────────
+
+/**
+ * Structured pre-filter BEFORE ranking.
+ *
+ * `filters` maps column name → required value (string, case-insensitive
+ * substring match) or list of accepted values. Unknown columns simply never
+ * match (empty result is a legitimate, visible outcome — callers surface it as
+ * an evidence gap, never silently widen).
+ */
+export function apply_filters(rows: Row[], filters: Filters | null | undefined): Row[] {
+    if (!filters || Object.keys(filters).length === 0) {
+        return rows;
+    }
+
+    const rowOk = (row: Row): boolean => {
+        for (const col of Object.keys(filters)) {
+            const want = filters[col] as FilterValue;
+            const have = pyStr(row[col] ?? '').toLowerCase();
+            if (Array.isArray(want)) {
+                // Python: any(str(w).lower() in have for w in want).
+                if (!want.some((w) => have.includes(pyStr(w).toLowerCase()))) {
+                    return false;
+                }
+            } else if (!have.includes(pyStr(want).toLowerCase())) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    return rows.filter((r) => rowOk(r));
+}
+
+// ── retrievers ──────────────────────────────────────────────────────────────
+
+type Hit = [Row, number];
+
+function _retrieve_bm25(
+    rows: Row[],
+    search_cols: string[],
+    query: string,
+    max_results: number,
+): Hit[] {
+    const documents = rows.map((row) => search_cols.map((col) => pyStr(row[col] ?? '')).join(' '));
+    const bm25 = new BM25();
+    bm25.fit(documents);
+    const ranked = bm25.score(query);
+    const out: Hit[] = [];
+    for (const [idx, score] of ranked.slice(0, max_results)) {
+        if (score > 0) {
+            out.push([rows[idx] as Row, score]);
+        }
+    }
+    return out;
+}
+
+/**
+ * Pure filter retrieval — rows already pre-filtered; rank by column order
+ * stability (score 1.0 each). Useful for exact-axis lookups.
+ */
+function _retrieve_structured(
+    rows: Row[],
+    _search_cols: string[],
+    _query: string,
+    max_results: number,
+): Hit[] {
+    return rows.slice(0, max_results).map((row) => [row, 1.0] as Hit);
+}
+
+/**
+ * Structured pre-filter is applied by the caller; hybrid = BM25 over the
+ * filtered set, falling back to stable order when the query is empty.
+ */
+function _retrieve_hybrid(
+    rows: Row[],
+    search_cols: string[],
+    query: string,
+    max_results: number,
+): Hit[] {
+    if (query.trim() === '') {
+        return _retrieve_structured(rows, search_cols, query, max_results);
+    }
+    return _retrieve_bm25(rows, search_cols, query, max_results);
+}
+
+type Retriever = (rows: Row[], search_cols: string[], query: string, max_results: number) => Hit[];
+
+/** Retriever registry — selected by name in the manifest or per call. */
+export const RETRIEVERS: Record<string, Retriever> = {
+    bm25: _retrieve_bm25,
+    structured: _retrieve_structured,
+    hybrid: _retrieve_hybrid,
+};
+
+/**
+ * Search one corpus file. Returns a dict with results + raw scores.
+ *
+ * Result shape (interface v1):
+ * `{"count": int, "results": [row-projection…], "scores": [float…],
+ *    "filtered_from": int}`
+ */
+export function search_rows(
+    filepath: string,
+    search_cols: string[],
+    output_cols: string[],
+    query: string,
+    max_results: number = DEFAULT_MAX_RESULTS,
+    filters: Filters | null = null,
+    retriever = 'bm25',
+): SearchResult {
+    if (!(retriever in RETRIEVERS)) {
+        // Python: raise ValueError(f"Unknown retriever: {retriever!r}. Available: {sorted(RETRIEVERS)}")
+        const available = Object.keys(RETRIEVERS).sort();
+        throw new ValueError(
+            `Unknown retriever: ${pyRepr(retriever)}. Available: ${pyReprList(available)}`,
+        );
+    }
+    if (!fs_exists(filepath)) {
+        return { error: `File not found: ${filepath}`, count: 0, results: [] };
+    }
+
+    let rows = load_csv(filepath);
+    const total = rows.length;
+    rows = apply_filters(rows, filters);
+
+    const hits = (RETRIEVERS[retriever] as Retriever)(rows, search_cols, query, max_results);
+    const results: Row[] = hits.map(([row]) => {
+        const projection: Row = {};
+        for (const col of output_cols) {
+            if (col in row) {
+                projection[col] = row[col] ?? '';
+            }
+        }
+        return projection;
+    });
+    return {
+        count: results.length,
+        results,
+        // Python scores are floats (BM25 math + the structured 1.0). Wrap so
+        // an integral score (e.g. 1.0) serialises with its `.0`.
+        scores: hits.map(([, score]) => new PyFloat(score)),
+        filtered_from: total,
+    };
+}
+
+// ── error parity ────────────────────────────────────────────────────────────
+
+/** Mirror of Python's ValueError, so `decision_engine` callers can map it. */
+export class ValueError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValueError';
+    }
+}
+
+// ── small Python-parity helpers reused across the cluster ───────────────────
+
+/** Python `str(x)` for the value shapes this module sees. */
+export function pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        // The Python source never passes None to pyStr without a `or ""` guard,
+        // but for safety mirror str(None) -> "None".
+        return value === null ? 'None' : 'undefined';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'True' : 'False';
+    }
+    return String(value);
+}
+
+/** Python `repr(s)` for a string — single-quoted unless it contains a `'`. */
+export function pyRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    if (hasSingle && !hasDouble) {
+        return `"${s.replace(/\\/g, '\\\\')}"`;
+    }
+    return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+/** repr() of a list of strings: `['a', 'b']`. */
+export function pyReprList(items: string[]): string {
+    return `[${items.map((i) => pyRepr(i)).join(', ')}]`;
+}
+
+// ── filesystem shims (kept tiny + local so the module stays standalone) ──────
+
+function fs_readText(p: string): string {
+    return fs.readFileSync(p, 'utf-8');
+}
+
+function fs_exists(p: string): boolean {
+    return fs.existsSync(p);
+}

--- a/src/skills/corpus-grounding/scripts/decision_engine.ts
+++ b/src/skills/corpus-grounding/scripts/decision_engine.ts
@@ -1,0 +1,803 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · decision_engine — reasoning layer (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/decision_engine.py`
+ * (ADR-094 Python→TS migration). Manifest-parameterised conditional grounding
+ * (ADR-061 §3 tier 2): multi-domain search per the manifest's reasoning plan,
+ * decision-rule evaluation (JSON conditionals + an optional dynamically-loaded
+ * escape hatch where JSON caps out), best-match selection, and a
+ * grounded-output dict that ALWAYS carries a confidence score + an
+ * evidence-gap line (contract — prevents false precision / authority
+ * inflation).
+ *
+ * The Python original uses `importlib.util` to load a manifest-relative
+ * `reasoning.rules_module` Python file and call its `evaluate(...)`. The twin
+ * mirrors this with a dynamic `import()` of the manifest-relative module —
+ * resolved to a `.ts` (dev/tsx) or `.js` (compiled) twin, NEVER a `.py`. See
+ * `_load_rules_callable` for the resolution + boundary note.
+ *
+ * Pure stdlib. No network, no subprocess. Writes only under persist_grounding
+ * (opt-in). Interface contract: SKILL.md.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    DEFAULT_MAX_RESULTS,
+    floatVal,
+    load_csv,
+    PyFloat,
+    search_rows,
+    type Row,
+} from './bm25_search.js';
+import {
+    ManifestError,
+    type Manifest,
+    resolve_data_path,
+} from './schema_validator.js';
+
+// Re-export so `ground` (and external callers) can import PyFloat from here too.
+export { PyFloat } from './bm25_search.js';
+
+/** A grounded / search result dict — heterogeneous, mirrors the Python dict. */
+export type ResultDict = Record<string, unknown>;
+
+// ── Python-parity numeric helpers ───────────────────────────────────────────
+
+/**
+ * Python 3 `round(x, ndigits)` — round-half-to-even (banker's rounding) on the
+ * exact IEEE-754 value. JS `Math.round` is half-away-from-zero, so we round the
+ * 17-significant-digit decimal expansion (round-trips every double uniquely),
+ * mirroring `src/scripts/_lib/value_ladder.ts::pyRound`.
+ */
+export function pyRound(value: number, ndigits = 0): number {
+    if (!Number.isFinite(value) || value === 0) {
+        return value;
+    }
+    const sign = value < 0 ? -1 : 1;
+    const abs = Math.abs(value);
+    const str = abs.toPrecision(17);
+    if (str.includes('e') || str.includes('E')) {
+        const factor = 10 ** ndigits;
+        return value > 0
+            ? (Math.round(abs * factor) / factor) * sign
+            : -Math.round(abs * factor) / factor;
+    }
+    const dot = str.indexOf('.');
+    const intPart = dot === -1 ? str : str.slice(0, dot);
+    let fracPart = dot === -1 ? '' : str.slice(dot + 1);
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keepFrac = fracPart.slice(0, ndigits);
+    const deciderStr = fracPart.slice(ndigits);
+    const scaledIntStr = intPart + keepFrac;
+    let scaledInt = BigInt(scaledIntStr === '' ? '0' : scaledIntStr);
+    const firstDecider = deciderStr.charAt(0);
+    const restNonZero = /[1-9]/u.test(deciderStr.slice(1));
+    let roundUp = false;
+    if (firstDecider > '5' || (firstDecider === '5' && restNonZero)) {
+        roundUp = true;
+    } else if (firstDecider === '5' && !restNonZero) {
+        roundUp = scaledInt % 2n === 1n;
+    }
+    if (roundUp) {
+        scaledInt += 1n;
+    }
+    const factor = 10 ** ndigits;
+    return (Number(scaledInt) / factor) * sign;
+}
+
+/** Python `str(x)` for the value shapes this module sees. */
+function pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'True' : 'False';
+    }
+    if (value instanceof PyFloat) {
+        return _floatStr(value.value);
+    }
+    return String(value);
+}
+
+/** Python `repr()` of a string for dict-repr blobs. */
+function _strRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    let quote = "'";
+    if (hasSingle && !hasDouble) {
+        quote = '"';
+    }
+    let body = s.replace(/\\/g, '\\\\');
+    if (quote === "'") {
+        body = body.replace(/'/g, "\\'");
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Python `repr()` of a value for embedding in a dict-repr blob. */
+function _valueRepr(value: unknown): string {
+    if (typeof value === 'string') {
+        return _strRepr(value);
+    }
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/**
+ * Python `str(dict)` — the repr used by `_select_best_match`'s blob match.
+ * Shape: `{'k': 'v', 'k2': 2}`. Keys are insertion-ordered (matches Python 3.7+
+ * dict ordering and JS object key order).
+ */
+function pyDictRepr(obj: ResultDict): string {
+    const parts = Object.keys(obj).map((k) => `${_strRepr(k)}: ${_valueRepr(obj[k])}`);
+    return `{${parts.join(', ')}}`;
+}
+
+/** Python float → str for f-string / repr (integral floats keep `.0`). */
+function _floatStr(n: number): string {
+    if (Number.isInteger(n)) {
+        return `${n}.0`;
+    }
+    return String(n);
+}
+
+// ── detection ────────────────────────────────────────────────────────────
+
+/** Escape a string for use as a literal inside a RegExp (Python re.escape). */
+function _reEscape(s: string): string {
+    // Python re.escape escapes all non-alphanumeric, non-underscore chars.
+    let out = '';
+    for (const ch of s) {
+        if (/[A-Za-z0-9_]/u.test(ch)) {
+            out += ch;
+        } else {
+            out += `\\${ch}`;
+        }
+    }
+    return out;
+}
+
+/** Keyword-vote routing of a query onto one of the manifest's domains. */
+export function detect_domain(manifest: Manifest, query: string): string {
+    const detect = (manifest.detect as Record<string, unknown> | null) || {};
+    const query_lower = query.toLowerCase();
+    const scores: Record<string, number> = {};
+    for (const name of Object.keys(detect)) {
+        if (name === '_stack') {
+            continue;
+        }
+        const keywords = detect[name];
+        let count = 0;
+        if (Array.isArray(keywords)) {
+            for (const kw of keywords) {
+                // Python: re.search(r"\b" + re.escape(str(kw).lower()) + r"\b", query_lower)
+                const re = new RegExp(`\\b${_reEscape(pyStr(kw).toLowerCase())}\\b`, 'u');
+                if (re.test(query_lower)) {
+                    count += 1;
+                }
+            }
+        }
+        scores[name] = count;
+    }
+    const names = Object.keys(scores);
+    if (names.length > 0) {
+        // Python: max(scores, key=lambda k: scores[k]) — first key with max value
+        // (stable; ties resolve to insertion order).
+        let best = names[0] as string;
+        for (const name of names) {
+            if ((scores[name] as number) > (scores[best] as number)) {
+                best = name;
+            }
+        }
+        if ((scores[best] as number) > 0) {
+            return best;
+        }
+    }
+    const dd = manifest.default_domain;
+    if (dd !== undefined && dd !== null && dd !== '' && dd !== false) {
+        return String(dd);
+    }
+    // next(iter(manifest["domains"])) — first domain key.
+    const domains = manifest.domains as Record<string, unknown>;
+    return Object.keys(domains)[0] as string;
+}
+
+// ── search ops ─────────────────────────────────────────────────────────────
+
+/** Search one manifest domain. Adds confidence + evidence_gap. */
+export function search_domain(
+    manifest: Manifest,
+    query: string,
+    domain: string | null = null,
+    max_results: number | null = null,
+    filters: Record<string, unknown> | null = null,
+): ResultDict {
+    let dom = domain;
+    if (dom === null) {
+        dom = detect_domain(manifest, query);
+    }
+    const domains = manifest.domains as Record<string, ResultDict>;
+    if (!(dom in domains)) {
+        return {
+            error: `Unknown domain: ${_strRepr(dom)}. Available: ${_sortedListRepr(Object.keys(domains))}`,
+            count: 0,
+            results: [],
+        };
+    }
+    const cfg = domains[dom] as ResultDict;
+    // merged_filters = dict(cfg.get("filters") or {}); if filters: merged.update(filters)
+    const merged_filters: Record<string, unknown> = { ...((cfg.filters as Record<string, unknown> | null) || {}) };
+    if (filters) {
+        for (const k of Object.keys(filters)) {
+            merged_filters[k] = filters[k];
+        }
+    }
+    const result: ResultDict = search_rows(
+        resolve_data_path(manifest, cfg.file as string),
+        cfg.search_cols as string[],
+        cfg.output_cols as string[],
+        query,
+        max_results ?? (cfg.max_results as number | undefined) ?? DEFAULT_MAX_RESULTS,
+        (Object.keys(merged_filters).length > 0 ? merged_filters : null) as never,
+        (manifest.retriever as string | undefined) ?? 'bm25',
+    ) as ResultDict;
+    result.domain = dom;
+    result.query = query;
+    result.file = cfg.file;
+    _attach_confidence(result);
+    return result;
+}
+
+/** Search one stack axis (optional manifest extension). */
+export function search_stack(
+    manifest: Manifest,
+    query: string,
+    stack: string,
+    max_results: number = DEFAULT_MAX_RESULTS,
+    filters: Record<string, unknown> | null = null,
+): ResultDict {
+    const stacks = (manifest.stacks as Record<string, string> | null) || {};
+    if (!(stack in stacks)) {
+        return {
+            error: `Unknown stack: ${_strRepr(stack)}. Available: ${_sortedListRepr(Object.keys(stacks))}`,
+            count: 0,
+            results: [],
+        };
+    }
+    const cols = manifest.stack_cols as ResultDict;
+    const result: ResultDict = search_rows(
+        resolve_data_path(manifest, stacks[stack] as string),
+        cols.search_cols as string[],
+        cols.output_cols as string[],
+        query,
+        max_results,
+        filters as never,
+        (manifest.retriever as string | undefined) ?? 'bm25',
+    ) as ResultDict;
+    result.domain = 'stack';
+    result.stack = stack;
+    result.query = query;
+    result.file = stacks[stack];
+    _attach_confidence(result);
+    return result;
+}
+
+/** Confidence from BM25 score shape; evidence gap when weak/empty. */
+function _attach_confidence(result: ResultDict): void {
+    const scores = (result.scores as (PyFloat | number)[] | null) || [];
+    const gaps: string[] = [];
+    let label: string;
+    let numeric: number;
+    if (scores.length === 0) {
+        label = 'low';
+        numeric = 0.0;
+        const dom = result.domain;
+        gaps.push(
+            `no corpus rows matched the query in domain ` +
+                `'${dom === undefined || dom === null ? '?' : String(dom)}' — answer falls back to agent priors`,
+        );
+    } else {
+        const top = floatVal(scores[0] as PyFloat | number);
+        numeric = pyRound(Math.min(1.0, top / 10.0), 3);
+        if (top >= 4.0) {
+            label = 'high';
+        } else if (top >= 1.5) {
+            label = 'medium';
+        } else {
+            label = 'low';
+            gaps.push('top BM25 score is weak — treat the match as a hint, not a verdict');
+        }
+    }
+    result.confidence = { label, score: new PyFloat(numeric) };
+    result.evidence_gap = gaps;
+}
+
+// ── rules ────────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate JSON conditional rules against the query/context.
+ *
+ * Upstream rule shape: `{"if_<condition>": "<directive>"}`. A condition matches
+ * when its underscore-separated tokens appear in the query or in a truthy
+ * context flag of the same name. Returns `{"matched": {...}, "unmatched": {...}}`
+ * — both surfaced, so the agent sees the full rule space (auditable).
+ */
+export function evaluate_rules(
+    rules: Record<string, unknown>,
+    query: string,
+    context: Record<string, unknown> | null = null,
+): ResultDict {
+    const ctx = context || {};
+    const query_lower = query.toLowerCase();
+    const matched: ResultDict = {};
+    const unmatched: ResultDict = {};
+    for (const key of Object.keys(rules || {})) {
+        const directive = rules[key];
+        const cond = key.startsWith('if_') ? key.slice(3) : key;
+        const tokens = cond.split('_').filter((t) => t.length > 0);
+        // Python: bool(context.get(cond)) or (tokens and all(t in query_lower ...))
+        const ctxHit = _bool(ctx[cond]);
+        const tokenHit = tokens.length > 0 && tokens.every((t) => query_lower.includes(t));
+        const hit = ctxHit || tokenHit;
+        (hit ? matched : unmatched)[key] = directive;
+    }
+    return { matched, unmatched };
+}
+
+/** Python bool(x) truthiness. */
+function _bool(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+/** A rules-callable: evaluate(rules, query, context) -> dict. */
+type RulesCallable = (
+    rules: Record<string, unknown>,
+    query: string,
+    context: Record<string, unknown>,
+) => ResultDict;
+
+/**
+ * Optional escape hatch: `reasoning.rules_module` beside the manifest exposing
+ * `evaluate(rules, query, context)`. The Python original loads a `.py` via
+ * `importlib`. The twin loads the corresponding module via dynamic `import()`,
+ * resolved to a `.ts`/`.js` twin — NEVER a `.py`. If the manifest names a
+ * module whose extension is `.py`, the twin remaps it to `.ts` (dev) / `.js`
+ * (compiled). A `.py`-only module with no twin is a migration boundary: the
+ * load throws ManifestError naming the missing twin (port it, or document the
+ * boundary).
+ *
+ * Runtime-safety: only a manifest-relative module inside the skill dir is
+ * loadable (same containment rule as corpus files, via resolve_data_path).
+ *
+ * NOTE: async, because dynamic import() is async. The caller (`ground`) is
+ * therefore async too.
+ */
+export async function _load_rules_callable(manifest: Manifest): Promise<RulesCallable | null> {
+    const reasoning = (manifest.reasoning as Record<string, unknown> | null) || {};
+    const rel = reasoning.rules_module as string | undefined;
+    if (!rel) {
+        return null;
+    }
+    const resolved = resolve_data_path(manifest, rel);
+    // Remap a manifest-declared .py to the ported twin; resolve a bare/.ts/.js
+    // to the on-disk twin. NEVER import a .py.
+    const candidate = _resolveTwinPath(resolved);
+    if (!fs.existsSync(candidate)) {
+        throw new ManifestError(`reasoning.rules_module not found: ${resolved}`);
+    }
+    const mod = (await import(pathToFileURL(candidate).href)) as Record<string, unknown>;
+    const fn = mod.evaluate;
+    if (typeof fn !== 'function') {
+        throw new ManifestError(`${resolved} must expose evaluate(rules, query, context)`);
+    }
+    return fn as RulesCallable;
+}
+
+/** Map a manifest-declared module path to its TS/JS twin on disk. */
+function _resolveTwinPath(resolved: string): string {
+    const ext = path.extname(resolved);
+    if (ext === '.py') {
+        const stem = resolved.slice(0, resolved.length - ext.length);
+        if (fs.existsSync(`${stem}.ts`)) {
+            return `${stem}.ts`;
+        }
+        return `${stem}.js`;
+    }
+    if (ext === '') {
+        if (fs.existsSync(`${resolved}.ts`)) {
+            return `${resolved}.ts`;
+        }
+        return `${resolved}.js`;
+    }
+    return resolved;
+}
+
+/** Exact → partial → keyword match of a category onto the rule rows. */
+function _find_reasoning_rule(rows: Row[], match_column: string, category: string): Row {
+    const category_lower = category.toLowerCase();
+    for (const rule of rows) {
+        if (pyStr(rule[match_column] ?? '').toLowerCase() === category_lower) {
+            return rule;
+        }
+    }
+    for (const rule of rows) {
+        const cat = pyStr(rule[match_column] ?? '').toLowerCase();
+        if (cat && (category_lower.includes(cat) || cat.includes(category_lower))) {
+            return rule;
+        }
+    }
+    for (const rule of rows) {
+        const cat = pyStr(rule[match_column] ?? '').toLowerCase();
+        const keywords = cat.replace(/\//g, ' ').replace(/-/g, ' ').split(/\s+/u).filter((w) => w.length > 0);
+        if (keywords.some((kw) => category_lower.includes(kw))) {
+            return rule;
+        }
+    }
+    return {};
+}
+
+/** Priority-keyword re-ranking of a domain's results (upstream port). */
+function _select_best_match(
+    results: Row[],
+    priority_keywords: string[],
+    name_col: string | null | undefined,
+): Row {
+    if (results.length === 0) {
+        return {};
+    }
+    if (priority_keywords.length === 0) {
+        return results[0] as Row;
+    }
+    if (name_col) {
+        for (const priority of priority_keywords) {
+            const p = priority.toLowerCase().trim();
+            for (const result of results) {
+                const name = pyStr(result[name_col] ?? '').toLowerCase();
+                if (p && (name.includes(p) || p.includes(name))) {
+                    return result;
+                }
+            }
+        }
+    }
+    const scored: [number, Row][] = [];
+    for (const result of results) {
+        const blob = pyDictRepr(result as ResultDict).toLowerCase();
+        let score = 0;
+        for (const kw of priority_keywords) {
+            const k = kw.toLowerCase().trim();
+            if (!k) {
+                continue;
+            }
+            if (name_col && pyStr(result[name_col] ?? '').toLowerCase().includes(k)) {
+                score += 10;
+            } else if (pyStr(result.Keywords ?? '').toLowerCase().includes(k)) {
+                score += 3;
+            } else if (blob.includes(k)) {
+                score += 1;
+            }
+        }
+        scored.push([score, result]);
+    }
+    // Python: scored.sort(key=lambda x: x[0], reverse=True) — stable.
+    const indexed = scored.map((pair, i) => ({ pair, i }));
+    indexed.sort((a, b) => {
+        const d = b.pair[0] - a.pair[0];
+        if (d !== 0) {
+            return d;
+        }
+        return a.i - b.i;
+    });
+    const sorted = indexed.map((x) => x.pair);
+    if (sorted.length > 0 && (sorted[0] as [number, Row])[0] > 0) {
+        return (sorted[0] as [number, Row])[1];
+    }
+    return results[0] as Row;
+}
+
+// ── grounding ────────────────────────────────────────────────────────────
+
+/**
+ * Conditional grounding: category → rules → planned multi-domain search.
+ *
+ * Returns the interface-v1 grounded dict (see Python docstring). Async because
+ * `_load_rules_callable` is async (dynamic import).
+ */
+export async function ground(
+    manifest: Manifest,
+    query: string,
+    context: Record<string, unknown> | null = null,
+): Promise<ResultDict> {
+    const reasoning = manifest.reasoning as Record<string, unknown> | null | undefined;
+    if (!reasoning) {
+        throw new ManifestError(
+            `manifest domain ${_valueRepr(manifest.domain)} has no reasoning block ` +
+                '(tier is lookup-only — use search instead of ground)',
+        );
+    }
+
+    const gaps: string[] = [];
+
+    // 1 — category lookup.
+    let category = (manifest.default_category as string | undefined) ?? 'General';
+    const cat_domain = reasoning.category_domain as string | undefined;
+    const cat_column = reasoning.category_column as string | undefined;
+    if (cat_domain && cat_column) {
+        const cat_result = search_domain(manifest, query, cat_domain, 1);
+        const rows = (cat_result.results as Row[] | null) || [];
+        if (rows.length > 0) {
+            const v = (rows[0] as Row)[cat_column];
+            // Python: str(rows[0].get(cat_column) or category)
+            category = v !== undefined && v !== null && v !== '' ? pyStr(v) : category;
+        } else {
+            gaps.push(
+                `category lookup in '${cat_domain}' found nothing — ` +
+                    `grounding against default category '${category}'`,
+            );
+        }
+    }
+
+    // 2 — reasoning rule for the category.
+    const rules_path = resolve_data_path(manifest, reasoning.file as string);
+    const rule_rows: Row[] = fs.existsSync(rules_path) ? load_csv(rules_path) : [];
+    const rule = _find_reasoning_rule(rule_rows, reasoning.match_column as string, category);
+    if (Object.keys(rule).length === 0) {
+        gaps.push(
+            `no reasoning rule matched category '${category}' — ` +
+                'selections below are unweighted corpus hits',
+        );
+    }
+
+    // 3 — decision rules (JSON; optional dynamically-loaded escape hatch).
+    let raw_rules: Record<string, unknown> = {};
+    const rules_column = reasoning.rules_column as string | undefined;
+    if (rules_column && _bool(rule[rules_column])) {
+        try {
+            raw_rules = JSON.parse(rule[rules_column] as string) as Record<string, unknown>;
+        } catch {
+            gaps.push(`decision rules in column '${rules_column}' are not valid JSON`);
+        }
+    }
+    const custom = await _load_rules_callable(manifest);
+    const rules_evaluation = custom
+        ? custom(raw_rules, query, context || {})
+        : evaluate_rules(raw_rules, query, context);
+
+    // 4 — priority keywords from the rule.
+    let priority: string[] = [];
+    const priority_column = reasoning.priority_column as string | undefined;
+    if (priority_column && _bool(rule[priority_column])) {
+        priority = pyStr(rule[priority_column])
+            .split('+')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+    }
+
+    // 5 — planned multi-domain search.
+    const selections: ResultDict = {};
+    const domain_confidences: number[] = [];
+    const plan = (reasoning.plan as Record<string, unknown> | null) || {};
+    const priority_domain = reasoning.priority_domain as string | undefined;
+    const name_cols = (reasoning.name_columns as Record<string, string> | null) || {};
+    for (const domain_name of Object.keys(plan)) {
+        const max_results = plan[domain_name];
+        let q = query;
+        if (domain_name === priority_domain && priority.length > 0) {
+            q = `${query} ${priority.slice(0, 2).join(' ')}`;
+        }
+        const result = search_domain(manifest, q, domain_name, _int(max_results));
+        const results = (result.results as Row[] | null) || [];
+        const best =
+            domain_name === priority_domain
+                ? _select_best_match(results, priority, name_cols[domain_name])
+                : results.length > 0
+                  ? (results[0] as Row)
+                  : {};
+        selections[domain_name] = {
+            best,
+            // Python: [r for r in results if r is not best] — identity compare.
+            alternatives: results.filter((r) => r !== best),
+            confidence: result.confidence,
+        };
+        for (const g of (result.evidence_gap as string[] | null) || []) {
+            gaps.push(g);
+        }
+        const conf = (result.confidence as ResultDict | null) || {};
+        const score = conf.score;
+        domain_confidences.push(score instanceof PyFloat ? score.value : (score as number | undefined) ?? 0.0);
+    }
+
+    // 6 — aggregate confidence (weakest link wins).
+    const numeric = domain_confidences.length > 0 ? pyRound(Math.min(...domain_confidences), 3) : 0.0;
+    const label = numeric >= 0.4 ? 'high' : numeric >= 0.15 ? 'medium' : 'low';
+
+    // rule with the rules_column dropped.
+    const ruleOut: Row = {};
+    for (const k of Object.keys(rule)) {
+        if (k !== rules_column) {
+            ruleOut[k] = rule[k] as string;
+        }
+    }
+
+    return {
+        domain: manifest.domain,
+        query,
+        category,
+        rule: ruleOut,
+        rules_evaluation,
+        selections,
+        confidence: { label, score: new PyFloat(numeric) },
+        evidence_gap:
+            gaps.length > 0 ? gaps : ['none — every planned domain returned a scored match'],
+    };
+}
+
+/** Python int(x) for a plan value (int or numeric string). */
+function _int(value: unknown): number {
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+    }
+    return Math.trunc(Number(value));
+}
+
+// ── persistence ────────────────────────────────────────────────────────────
+
+/**
+ * Opt-in (--persist): write the grounded output as a master file + optional
+ * page override (upstream MASTER.md pattern, generalized).
+ *
+ * Writes ONLY under `output_dir` (caller-chosen). Returns created paths.
+ */
+export function persist_grounding(
+    grounded: ResultDict,
+    output_dir: string,
+    project: string | null = null,
+    page: string | null = null,
+): ResultDict {
+    const project_slug = (project ?? pyStr(grounded.query ?? 'default'))
+        .toLowerCase()
+        .replace(/ /g, '-');
+    const base = path.join(output_dir, 'design-system', project_slug);
+    fs.mkdirSync(base, { recursive: true });
+    const created: string[] = [];
+
+    const master = path.join(base, 'MASTER.md');
+    fs.writeFileSync(master, _render_markdown(grounded, true), 'utf-8');
+    created.push(master);
+
+    if (page) {
+        const pages = path.join(base, 'pages');
+        fs.mkdirSync(pages, { recursive: true });
+        const page_file = path.join(pages, `${page.toLowerCase().replace(/ /g, '-')}.md`);
+        fs.writeFileSync(
+            page_file,
+            `# ${_title(page)} — page overrides\n\n` +
+                '> Rules here OVERRIDE the project MASTER.md for this page only.\n' +
+                '> Start empty; add only deviations.\n',
+            'utf-8',
+        );
+        created.push(page_file);
+    }
+    return { status: 'success', created_files: created };
+}
+
+/** Python str.title() — capitalize the first letter of each word run. */
+function _title(s: string): string {
+    return s.replace(/[A-Za-z]+/gu, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase());
+}
+
+/** Generic markdown rendering of a grounded output (interface v1). */
+export function _render_markdown(grounded: ResultDict, master = false): string {
+    const lines: string[] = [];
+    if (master) {
+        lines.push(
+            '# Design System Master File',
+            '',
+            '> **LOGIC:** When building a specific page, first check ' +
+                '`pages/<page>.md`. If it exists, its rules **override** this ' +
+                'master file. Otherwise follow the rules below.',
+            '',
+        );
+    }
+    const conf = (grounded.confidence as ResultDict | null) || {};
+    lines.push(
+        `## Grounded recommendation: ${pyStr(grounded.query ?? '')}`,
+        '',
+        `- **Domain:** ${pyStr(grounded.domain ?? '')}`,
+        `- **Category:** ${pyStr(grounded.category ?? '')}`,
+        `- **Confidence:** ${pyStr(conf.label ?? '?')} ` + `(${_confScore(conf.score)})`,
+        '',
+    );
+    const selections = (grounded.selections as ResultDict | null) || {};
+    for (const domain of Object.keys(selections)) {
+        const sel = (selections[domain] as ResultDict | null) || {};
+        const best = (sel.best as Row | null) || {};
+        if (Object.keys(best).length === 0) {
+            continue;
+        }
+        lines.push(`### ${domain}`);
+        for (const key of Object.keys(best)) {
+            let value_str = pyStr(best[key]);
+            if (value_str.length > 300) {
+                value_str = `${value_str.slice(0, 300)}…`;
+            }
+            if (value_str) {
+                lines.push(`- **${key}:** ${value_str}`);
+            }
+        }
+        lines.push('');
+    }
+    const matched = ((grounded.rules_evaluation as ResultDict | null) || {}).matched as ResultDict | null;
+    const matchedObj = matched || {};
+    if (Object.keys(matchedObj).length > 0) {
+        lines.push('### Matched decision rules');
+        for (const key of Object.keys(matchedObj)) {
+            lines.push(`- \`${key}\` → ${pyStr(matchedObj[key])}`);
+        }
+        lines.push('');
+    }
+    lines.push('### Evidence gap');
+    for (const gap of (grounded.evidence_gap as string[] | null) || []) {
+        lines.push(`- ${gap}`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}
+
+/**
+ * Render the confidence score inside the f-string `({score})`. Python's
+ * `grounded.get('confidence', {}).get('score', 0)` defaults to int 0 (no
+ * `.0`); a present score is a float (with `.0` when integral).
+ */
+function _confScore(score: unknown): string {
+    if (score instanceof PyFloat) {
+        return _floatStr(score.value);
+    }
+    if (score === undefined || score === null) {
+        return '0';
+    }
+    return String(score);
+}
+
+/** repr of a sorted list of strings: `['a', 'b']`. */
+function _sortedListRepr(items: string[]): string {
+    const sorted = [...items].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    return `[${sorted.map((i) => _strRepr(i)).join(', ')}]`;
+}

--- a/src/skills/corpus-grounding/scripts/ground.ts
+++ b/src/skills/corpus-grounding/scripts/ground.ts
@@ -1,0 +1,541 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · ground — CLI entry point (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/ground.py`
+ * (ADR-094 Python→TS migration). Mirrors the Python CLI contract: subcommands
+ * (search / ground / validate), snake_case flags, exit codes, the
+ * stdout/stderr split, and byte-identical JSON (json.dumps indent=2,
+ * ensure_ascii=False) and markdown rendering.
+ *
+ * Usage (paths resolve as given — relative to cwd, like the Python original):
+ *
+ *   ground.ts search --manifest <manifest.json> "fintech dashboard"
+ *   ground.ts search --manifest m.json --domain color "muted palette" --json
+ *   ground.ts search --manifest m.json --filter "Severity=HIGH" "forms"
+ *   ground.ts search --manifest m.json --stack react "memo rerender"
+ *   ground.ts ground --manifest m.json "luxury e-commerce" [--persist DIR]
+ *   ground.ts validate --manifest m.json
+ *
+ * Pure stdlib · read-only except --persist · no network · no subprocess.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+    PyFloat,
+    _render_markdown,
+    ground as run_ground,
+    persist_grounding,
+    type ResultDict,
+    search_domain,
+    search_stack,
+} from './decision_engine.js';
+import {
+    ManifestError,
+    load_manifest,
+    type Manifest,
+    validate_manifest,
+} from './schema_validator.js';
+
+// ── filter parsing ──────────────────────────────────────────────────────────
+
+/** Mirror _parse_filters: COLUMN=VALUE pairs → {col: value | [values]}. */
+function _parse_filters(pairs: string[]): Record<string, string | string[]> {
+    const collected: Record<string, string[]> = {};
+    for (const pair of pairs || []) {
+        if (!pair.includes('=')) {
+            // Python: raise SystemExit(f"--filter expects COLUMN=VALUE, got: {pair!r}")
+            process.stderr.write(`--filter expects COLUMN=VALUE, got: ${_repr(pair)}\n`);
+            process.exit(1);
+        }
+        const idx = pair.indexOf('=');
+        const col = pair.slice(0, idx);
+        const value = pair.slice(idx + 1);
+        if (!(col in collected)) {
+            collected[col] = [];
+        }
+        (collected[col] as string[]).push(value);
+    }
+    const out: Record<string, string | string[]> = {};
+    for (const k of Object.keys(collected)) {
+        const v = collected[k] as string[];
+        out[k] = v.length > 1 ? v : (v[0] as string);
+    }
+    return out;
+}
+
+// ── search text formatter ────────────────────────────────────────────────
+
+function _format_search(result: ResultDict): string {
+    if (_truthy(result.error)) {
+        return `Error: ${result.error as string}`;
+    }
+    const out: string[] = ['## Corpus search results'];
+    const head = `**Domain:** ${_orStr(result.stack, result.domain)} | **Query:** ${_str(result.query)}`;
+    out.push(head);
+    const conf = (result.confidence as ResultDict | null) || {};
+    out.push(
+        `**Source:** ${_str(result.file)} | **Found:** ${_str(result.count)} ` +
+            `| **Confidence:** ${_str(conf.label)} (${_confScore(conf.score)})`,
+    );
+    out.push('');
+    const results = (result.results as Record<string, unknown>[] | null) || [];
+    let i = 1;
+    for (const row of results) {
+        out.push(`### Result ${i}`);
+        for (const key of Object.keys(row)) {
+            let value_str = _str(row[key]);
+            if (value_str.length > 300) {
+                value_str = `${value_str.slice(0, 300)}…`;
+            }
+            if (value_str) {
+                out.push(`- **${key}:** ${value_str}`);
+            }
+        }
+        out.push('');
+        i += 1;
+    }
+    const gaps = (result.evidence_gap as string[] | null) || [];
+    if (gaps.length > 0) {
+        out.push('### Evidence gap');
+        for (const g of gaps) {
+            out.push(`- ${g}`);
+        }
+    }
+    return out.join('\n');
+}
+
+// ── argument parsing ─────────────────────────────────────────────────────
+
+interface Args {
+    op: 'search' | 'ground' | 'validate';
+    manifest: string;
+    json: boolean;
+    query?: string;
+    domain?: string | null;
+    stack?: string | null;
+    max_results?: number | null;
+    filter: string[];
+    retriever?: string | null;
+    hasRetriever: boolean;
+    context?: string | null;
+    persist?: string | null;
+    project_name?: string | null;
+    page?: string | null;
+}
+
+/**
+ * Minimal argparse-compatible parser for the documented surface. argparse
+ * usage/error text (exit 2) is intentionally NOT reproduced byte-for-byte
+ * (per ADR-094 test guidance — `--help` and argparse rejections are excluded
+ * from byte-parity); the success + documented-error paths are exact.
+ */
+function _parseArgs(argv: string[]): Args {
+    const op = argv[0];
+    if (op !== 'search' && op !== 'ground' && op !== 'validate') {
+        process.stderr.write(`ground: invalid operation: ${op ?? '(none)'}\n`);
+        process.exit(2);
+    }
+    const rest = argv.slice(1);
+    const args: Args = {
+        op,
+        manifest: '',
+        json: false,
+        filter: [],
+        domain: null,
+        stack: null,
+        max_results: null,
+        retriever: null,
+        hasRetriever: op === 'search',
+        context: null,
+        persist: null,
+        project_name: null,
+        page: null,
+    };
+    const positionals: string[] = [];
+    let manifestSet = false;
+    for (let i = 0; i < rest.length; i += 1) {
+        const a = rest[i] as string;
+        const eat = (): string => {
+            const v = rest[i + 1];
+            if (v === undefined) {
+                process.stderr.write(`argument ${a}: expected one argument\n`);
+                process.exit(2);
+            }
+            i += 1;
+            return v;
+        };
+        if (a === '--manifest') {
+            args.manifest = eat();
+            manifestSet = true;
+        } else if (a.startsWith('--manifest=')) {
+            args.manifest = a.slice('--manifest='.length);
+            manifestSet = true;
+        } else if (a === '--json') {
+            args.json = true;
+        } else if (a === '--domain' || a === '-d') {
+            args.domain = eat();
+        } else if (a.startsWith('--domain=')) {
+            args.domain = a.slice('--domain='.length);
+        } else if (a === '--stack' || a === '-s') {
+            args.stack = eat();
+        } else if (a.startsWith('--stack=')) {
+            args.stack = a.slice('--stack='.length);
+        } else if (a === '--max-results' || a === '-n') {
+            args.max_results = parseInt(eat(), 10);
+        } else if (a.startsWith('--max-results=')) {
+            args.max_results = parseInt(a.slice('--max-results='.length), 10);
+        } else if (a === '--filter') {
+            args.filter.push(eat());
+        } else if (a.startsWith('--filter=')) {
+            args.filter.push(a.slice('--filter='.length));
+        } else if (a === '--retriever') {
+            args.retriever = eat();
+        } else if (a.startsWith('--retriever=')) {
+            args.retriever = a.slice('--retriever='.length);
+        } else if (a === '--context') {
+            args.context = eat();
+        } else if (a.startsWith('--context=')) {
+            args.context = a.slice('--context='.length);
+        } else if (a === '--persist') {
+            args.persist = eat();
+        } else if (a.startsWith('--persist=')) {
+            args.persist = a.slice('--persist='.length);
+        } else if (a === '--project-name' || a === '-p') {
+            args.project_name = eat();
+        } else if (a.startsWith('--project-name=')) {
+            args.project_name = a.slice('--project-name='.length);
+        } else if (a === '--page') {
+            args.page = eat();
+        } else if (a.startsWith('--page=')) {
+            args.page = a.slice('--page='.length);
+        } else {
+            positionals.push(a);
+        }
+    }
+    if (!manifestSet) {
+        process.stderr.write('the following arguments are required: --manifest\n');
+        process.exit(2);
+    }
+    if (op === 'search' || op === 'ground') {
+        if (positionals.length === 0) {
+            process.stderr.write('the following arguments are required: query\n');
+            process.exit(2);
+        }
+        args.query = positionals[0] as string;
+    }
+    if ((op === 'search' || op === 'ground') && args.retriever !== null && args.retriever !== undefined) {
+        const r = args.retriever;
+        if (!['bm25', 'structured', 'hybrid'].includes(r)) {
+            process.stderr.write(
+                `argument --retriever: invalid choice: '${r}' (choose from 'bm25', 'structured', 'hybrid')\n`,
+            );
+            process.exit(2);
+        }
+    }
+    return args;
+}
+
+// ── main ────────────────────────────────────────────────────────────────
+
+export async function main(argv: string[] | null = null): Promise<number> {
+    const args = _parseArgs(argv ?? process.argv.slice(2));
+
+    try {
+        if (args.op === 'validate') {
+            const raw = JSON.parse(fs.readFileSync(args.manifest, 'utf-8')) as unknown;
+            const errors = validate_manifest(raw);
+            if (errors.length > 0) {
+                process.stdout.write('INVALID manifest:\n');
+                for (const err of errors) {
+                    process.stdout.write(`  - ${err}\n`);
+                }
+                return 1;
+            }
+            process.stdout.write('OK — manifest satisfies contract v1\n');
+            return 0;
+        }
+
+        const manifest: Manifest = load_manifest(args.manifest);
+        // Python: if args.retriever if hasattr(args, "retriever") else None.
+        // Only the search subparser defines --retriever; ground/validate don't.
+        if (args.hasRetriever && args.retriever) {
+            manifest.retriever = args.retriever;
+        }
+
+        if (args.op === 'search') {
+            let result: ResultDict;
+            if (args.stack) {
+                result = search_stack(
+                    manifest,
+                    args.query as string,
+                    args.stack,
+                    args.max_results ?? 3,
+                    _filtersOrNull(_parse_filters(args.filter)),
+                );
+            } else {
+                result = search_domain(
+                    manifest,
+                    args.query as string,
+                    args.domain ?? null,
+                    args.max_results,
+                    _filtersOrNull(_parse_filters(args.filter)),
+                );
+            }
+            process.stdout.write(
+                (args.json ? _jsonDumps(result, 2) : _format_search(result)) + '\n',
+            );
+            return _truthy(result.error) ? 1 : 0;
+        }
+
+        // ground
+        const context = args.context ? (JSON.parse(args.context) as Record<string, unknown>) : {};
+        const grounded = await run_ground(manifest, args.query as string, context);
+        if (args.persist) {
+            const info = persist_grounding(
+                grounded,
+                args.persist,
+                args.project_name ?? null,
+                args.page ?? null,
+            );
+            grounded.persisted = info;
+        }
+        if (args.json) {
+            process.stdout.write(_jsonDumps(grounded, 2) + '\n');
+        } else {
+            process.stdout.write(_render_markdown(grounded) + '\n');
+        }
+        return 0;
+    } catch (exc) {
+        // Python catches (ManifestError, json.JSONDecodeError, OSError).
+        if (_isExpected(exc)) {
+            process.stderr.write(`Error: ${_errText(exc)}\n`);
+            return 1;
+        }
+        throw exc;
+    }
+}
+
+function _isExpected(exc: unknown): boolean {
+    if (exc instanceof ManifestError) {
+        return true;
+    }
+    if (exc instanceof SyntaxError) {
+        // JSON.parse failure ≈ json.JSONDecodeError.
+        return true;
+    }
+    if (exc instanceof Error) {
+        const code = (exc as NodeJS.ErrnoException).code;
+        // OSError family — ENOENT, EISDIR, EACCES, etc.
+        if (code && /^E[A-Z]+$/u.test(code)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _errText(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+// ── value coercion helpers (Python str() / truthiness for the CLI) ──────────
+
+function _truthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+function _str(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'True' : 'False';
+    }
+    if (value instanceof PyFloat) {
+        return Number.isInteger(value.value) ? `${value.value}.0` : String(value.value);
+    }
+    return String(value);
+}
+
+/** Python f-string `{result.get('stack') or result.get('domain')}`. */
+function _orStr(a: unknown, b: unknown): string {
+    return _truthy(a) ? _str(a) : _str(b);
+}
+
+/** Render confidence score inside `(...)` — float when present (PyFloat). */
+function _confScore(score: unknown): string {
+    if (score instanceof PyFloat) {
+        return Number.isInteger(score.value) ? `${score.value}.0` : String(score.value);
+    }
+    if (score === undefined || score === null) {
+        return 'None';
+    }
+    return String(score);
+}
+
+function _filtersOrNull(
+    filters: Record<string, string | string[]>,
+): Record<string, string | string[]> | null {
+    return Object.keys(filters).length > 0 ? filters : null;
+}
+
+/** Python repr() of a string (for the --filter error). */
+function _repr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    if (hasSingle && !hasDouble) {
+        return `"${s.replace(/\\/g, '\\\\')}"`;
+    }
+    return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+// ── JSON serializer — json.dumps(indent=2, ensure_ascii=False) parity ───────
+
+function _jsonDumps(value: unknown, indent: number): string {
+    return _dumps(value, indent, 0);
+}
+
+function _dumps(value: unknown, indent: number, depth: number): string {
+    const pad = ' '.repeat(indent * (depth + 1));
+    const closePad = ' '.repeat(indent * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (value instanceof PyFloat) {
+        return _jsonFloat(value.value);
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _jsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStr(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumps(v, indent, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        const keys = Object.keys(obj);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map(
+            (k) => `${pad}${_jsonStr(k)}: ${_dumps(obj[k], indent, depth + 1)}`,
+        );
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _jsonStr(String(value));
+}
+
+function _jsonNum(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+/** Render a Python float: integer-valued floats keep the `.0` suffix. */
+function _jsonFloat(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    if (Number.isInteger(n)) {
+        return `${n}.0`;
+    }
+    return String(n);
+}
+
+/**
+ * json.dumps string escaping with ensure_ascii=False: escape only the JSON
+ * control set + quote + backslash; leave all non-ASCII raw (the `—` em-dash in
+ * the evidence-gap text re-emits verbatim).
+ */
+function _jsonStr(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) ?? 0;
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            case '\b':
+                out += '\\b';
+                break;
+            case '\f':
+                out += '\\f';
+                break;
+            default:
+                if (code < 0x20) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+        }
+    }
+    return `${out}"`;
+}
+
+const _isMain =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_isMain) {
+    main()
+        .then((code) => {
+            process.exitCode = code;
+        })
+        .catch((err: unknown) => {
+            // Unexpected error — surface like an uncaught Python traceback would
+            // (non-zero exit). Should not happen for the documented paths.
+            process.stderr.write(`${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+            process.exitCode = 1;
+        });
+}

--- a/src/skills/corpus-grounding/scripts/schema_validator.ts
+++ b/src/skills/corpus-grounding/scripts/schema_validator.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * corpus-grounding · schema_validator — manifest contract (interface v1).
+ *
+ * TypeScript twin of `src/skills/corpus-grounding/scripts/schema_validator.py`
+ * (ADR-094 Python→TS migration). Validates a domain's plug-in manifest
+ * (`manifest.json`) against the schema-agnostic contract from ADR-061 §3. Each
+ * domain declares its OWN axes — the validator checks structure + provenance
+ * discipline, never a uniform schema.
+ *
+ * Pure stdlib, no network. Standalone skill script — no `_lib` imports.
+ * Interface contract: SKILL.md § Interface contract.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { pyRepr } from './bm25_search.js';
+
+export const MANIFEST_VERSION = 1;
+
+/** Output sophistication tiers (ADR-061 §3). */
+export const TIERS = ['lookup-only', 'conditional-grounding', 'constraint-emission'] as const;
+
+const _REQUIRED_TOP = ['manifest_version', 'domain', 'tier', 'domains'] as const;
+const _REQUIRED_PROVENANCE = ['owner', 'refresh_cadence', 'upstream'] as const;
+const _REQUIRED_DOMAIN_KEYS = ['file', 'search_cols', 'output_cols'] as const;
+const _REQUIRED_REASONING_KEYS = ['file', 'match_column', 'plan'] as const;
+
+/** A decoded manifest — heterogeneous JSON object. */
+export type Manifest = Record<string, unknown>;
+
+/** Raised when a manifest violates the v1 contract (Python ManifestError). */
+export class ManifestError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ManifestError';
+    }
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────────
+
+/** Python truthiness: '', 0, 0.0, [], {}, None, False are falsy. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+/** Python `isinstance(x, dict)` — a plain JSON object (not array, not null). */
+function _isDict(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `repr(x)` for the JSON value shapes a manifest carries. */
+function _repr(value: unknown): string {
+    if (typeof value === 'string') {
+        return pyRepr(value);
+    }
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'number') {
+        // Integral JSON numbers print as ints (repr(2) -> "2").
+        return String(value);
+    }
+    return String(value);
+}
+
+/** Render the TIERS tuple the way Python's f-string interpolates it. */
+function _tiersRepr(): string {
+    return `(${TIERS.map((t) => pyRepr(t)).join(', ')})`;
+}
+
+// ── manifest loading + validation ───────────────────────────────────────────
+
+/** Load + validate a manifest. Raises ManifestError on violation. */
+export function load_manifest(p: string): Manifest {
+    if (!fs.existsSync(p)) {
+        throw new ManifestError(`Manifest not found: ${p}`);
+    }
+    let data: unknown;
+    try {
+        data = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    } catch (exc) {
+        // Python: json.JSONDecodeError → ManifestError(f"... {path}: {exc}").
+        throw new ManifestError(`Manifest is not valid JSON: ${p}: ${_jsonErr(exc)}`);
+    }
+    const errors = validate_manifest(data);
+    if (errors.length > 0) {
+        throw new ManifestError(
+            `Manifest contract violations in ${p}:\n  - ${errors.join('\n  - ')}`,
+        );
+    }
+    const manifest = data as Manifest;
+    // Python: str(path.resolve().parent) — resolve() follows symlinks.
+    manifest._manifest_dir = path.dirname(pyResolve(p));
+    return manifest;
+}
+
+/** Return a list of contract violations (empty = valid). */
+export function validate_manifest(data: unknown): string[] {
+    const errors: string[] = [];
+    if (!_isDict(data)) {
+        return ['manifest must be a JSON object'];
+    }
+
+    for (const key of _REQUIRED_TOP) {
+        if (!(key in data)) {
+            errors.push(`missing required key: ${pyRepr(key)}`);
+        }
+    }
+    if (errors.length > 0) {
+        return errors;
+    }
+
+    if (data.manifest_version !== MANIFEST_VERSION) {
+        errors.push(`manifest_version ${_repr(data.manifest_version)} unsupported (engine speaks v${MANIFEST_VERSION})`);
+    }
+    if (!(TIERS as readonly string[]).includes(data.tier as string)) {
+        errors.push(`tier ${_repr(data.tier)} not in ${_tiersRepr()}`);
+    }
+
+    const domains = data.domains;
+    if (!_isDict(domains) || Object.keys(domains).length === 0) {
+        errors.push('domains must be a non-empty object');
+    } else {
+        for (const name of Object.keys(domains)) {
+            const cfg = domains[name];
+            if (!_isDict(cfg)) {
+                errors.push(`domains.${name} must be an object`);
+                continue;
+            }
+            for (const key of _REQUIRED_DOMAIN_KEYS) {
+                if (!(key in cfg)) {
+                    errors.push(`domains.${name} missing ${pyRepr(key)}`);
+                }
+            }
+            for (const key of ['search_cols', 'output_cols']) {
+                if (key in cfg && (!Array.isArray(cfg[key]) || (cfg[key] as unknown[]).length === 0)) {
+                    errors.push(`domains.${name}.${key} must be a non-empty list`);
+                }
+            }
+        }
+    }
+
+    const default_domain = data.default_domain;
+    if (_pyTruthy(default_domain) && _isDict(domains) && !(String(default_domain) in domains)) {
+        errors.push(`default_domain ${_repr(default_domain)} not in domains`);
+    }
+
+    const detect = data.detect;
+    if (detect !== undefined && detect !== null) {
+        if (!_isDict(detect)) {
+            errors.push('detect must be an object of domain → keyword list');
+        } else if (_isDict(domains)) {
+            for (const name of Object.keys(detect)) {
+                const kws = detect[name];
+                if (!(name in domains) && name !== '_stack') {
+                    errors.push(`detect.${name} references unknown domain`);
+                }
+                if (!Array.isArray(kws)) {
+                    errors.push(`detect.${name} must be a list of keywords`);
+                }
+            }
+        }
+    }
+
+    const reasoning = data.reasoning;
+    if (reasoning !== undefined && reasoning !== null) {
+        if (data.tier === 'lookup-only') {
+            errors.push('reasoning block present but tier is lookup-only');
+        }
+        if (!_isDict(reasoning)) {
+            errors.push('reasoning must be an object');
+        } else {
+            for (const key of _REQUIRED_REASONING_KEYS) {
+                if (!(key in reasoning)) {
+                    errors.push(`reasoning missing ${pyRepr(key)}`);
+                }
+            }
+            const plan = reasoning.plan;
+            if (plan !== undefined && plan !== null) {
+                if (!_isDict(plan)) {
+                    errors.push('reasoning.plan must be an object of domain → max_results');
+                } else if (_isDict(domains)) {
+                    for (const name of Object.keys(plan)) {
+                        if (!(name in domains)) {
+                            errors.push(`reasoning.plan.${name} references unknown domain`);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const stacks = data.stacks;
+    if (stacks !== undefined && stacks !== null) {
+        if (!_isDict(stacks)) {
+            errors.push('stacks must be an object of stack-id → csv path');
+        } else if (!('stack_cols' in data)) {
+            errors.push('stacks present but stack_cols missing');
+        }
+    }
+
+    // Provenance discipline (ADR-061 §6) — a corpus without an owner rots.
+    for (const key of _REQUIRED_PROVENANCE) {
+        if (!(key in data)) {
+            errors.push(`missing provenance key: ${pyRepr(key)} (ADR-061 §6)`);
+        }
+    }
+    const upstream = data.upstream;
+    if (_isDict(upstream)) {
+        for (const key of ['repo', 'sha', 'last_checked']) {
+            if (!(key in upstream)) {
+                errors.push(`upstream missing ${pyRepr(key)}`);
+            }
+        }
+    } else if (upstream !== undefined && upstream !== null) {
+        errors.push('upstream must be an object {repo, sha, last_checked}');
+    }
+
+    const retriever = data.retriever;
+    if (retriever !== undefined && retriever !== null && !['bm25', 'structured', 'hybrid'].includes(retriever as string)) {
+        errors.push(`retriever ${_repr(retriever)} unknown`);
+    }
+
+    return errors;
+}
+
+/**
+ * Resolve a corpus file path relative to the manifest's directory.
+ *
+ * Refuses absolute paths and parent-escapes — corpus files live beside their
+ * manifest by contract (runtime-safety: read-only, local).
+ */
+export function resolve_data_path(manifest: Manifest, relative: string): string {
+    // Python: rel = Path(relative); rel.is_absolute() or ".." in rel.parts.
+    if (path.isAbsolute(relative) || _pathParts(relative).includes('..')) {
+        throw new ManifestError(`corpus path must be manifest-relative: ${pyRepr(relative)}`);
+    }
+    const base = (manifest._manifest_dir as string | undefined) ?? '.';
+    const data_dir = (manifest.data_dir as string | undefined) ?? '.';
+    if (path.isAbsolute(data_dir) || _pathParts(data_dir).includes('..')) {
+        throw new ManifestError(`data_dir must be manifest-relative: ${pyRepr(data_dir)}`);
+    }
+    // Python: (base / dd / rel).resolve() — resolve() follows symlinks.
+    return pyResolve(path.join(base, data_dir, relative));
+}
+
+/** Mirror pathlib Path(p).parts for the relative-path containment check. */
+function _pathParts(p: string): string[] {
+    return p.split(/[\\/]/u).filter((seg) => seg !== '' && seg !== '.');
+}
+
+/**
+ * Mirror pathlib `Path(p).resolve()` (strict=False): make absolute, then
+ * resolve symlinks in the longest existing ancestor and append the
+ * non-existent suffix. On macOS this turns `/var/...` into `/private/var/...`,
+ * matching the Python error / file paths byte-for-byte.
+ */
+function pyResolve(p: string): string {
+    const abs = path.resolve(p);
+    let cur = abs;
+    const suffix: string[] = [];
+    for (;;) {
+        try {
+            const real = fs.realpathSync.native(cur);
+            return suffix.length > 0 ? path.join(real, ...suffix) : real;
+        } catch {
+            const parent = path.dirname(cur);
+            if (parent === cur) {
+                return abs;
+            }
+            suffix.unshift(path.basename(cur));
+            cur = parent;
+        }
+    }
+}
+
+/** Best-effort JSON parse-error text for the ManifestError message. */
+function _jsonErr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}

--- a/src/skills/design-tokens/scripts/tokens.ts
+++ b/src/skills/design-tokens/scripts/tokens.ts
@@ -1,0 +1,888 @@
+#!/usr/bin/env tsx
+/**
+ * design-tokens · tokens — DTCG token toolchain (generate / validate / embed).
+ *
+ * TypeScript twin of `src/skills/design-tokens/scripts/tokens.py` (ADR-094
+ * py2ts). The CLI contract is mirrored EXACTLY — the subcommands
+ * `generate` / `validate` / `embed`, their flags, exit codes, the
+ * stdout/stderr split, byte-identical messages, AND byte-identical generated
+ * output (the CSS / Tailwind config / embedded CSS / JSON findings are all
+ * write/print targets, so every byte — key order, quoting, whitespace,
+ * `json.dumps` separators — must match python3).
+ *
+ * No behaviour changes — latent Python quirks are replicated verbatim:
+ *   - `re.findall` group semantics (the hexColor pattern has a capture group,
+ *     so `findall` yields the group captures, not whole matches; the scanner
+ *     re-derives the whole match via `search().group(0)`).
+ *   - one finding per pattern per line (the `break` after the first hit).
+ *   - `str.strip("{}")` strips the {} *character set* off both ends.
+ *   - `Path.rglob("*")` sorted order; `.blade.php` two-suffix detection.
+ *   - `json.dumps(..., indent=2)` with the DEFAULT `ensure_ascii=True`
+ *     (non-ASCII → `\uXXXX`, astral → surrogate pairs).
+ *
+ * Pure stdlib (Node builtins only) · read-only except `generate -o` · no
+ * network · no subprocess. A `.ts` MUST NOT import a `.py`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// ── Python-shim helpers ──────────────────────────────────────────────────
+
+type Json = unknown;
+type JsonObject = Record<string, Json>;
+
+function _isPlainObject(v: unknown): v is JsonObject {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** Mirror `str.strip(chars)` — strip the given char *set* off both ends. */
+function _stripChars(s: string, chars: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && chars.includes(s[start] as string)) {
+        start += 1;
+    }
+    while (end > start && chars.includes(s[end - 1] as string)) {
+        end -= 1;
+    }
+    return s.slice(start, end);
+}
+
+/** Mirror `str.strip()` over ASCII + common Unicode whitespace. */
+function _strip(s: string): string {
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/** Code-point count, mirroring Python `len(str)`. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        n += 1;
+    }
+    return n;
+}
+
+// ── json.dumps(..., indent=2, ensure_ascii=True) byte-parity ─────────────
+//
+// The default `ensure_ascii=True` escapes every code point >= 0x80 as a
+// `\uXXXX` sequence (astral chars become a UTF-16 surrogate pair, exactly as
+// CPython emits them). Integer-valued numbers stay integers (no `.0`) since
+// the only numbers we ever dump are violation line numbers (ints).
+
+function _pyJsonStr(s: string): string {
+    let out = '"';
+    // Iterate UTF-16 code units so astral chars emit surrogate pairs like CPython.
+    for (let i = 0; i < s.length; i += 1) {
+        const ch = s[i];
+        const code = s.charCodeAt(i);
+        switch (ch) {
+            case '"':
+                out += '\\"';
+                break;
+            case '\\':
+                out += '\\\\';
+                break;
+            case '\n':
+                out += '\\n';
+                break;
+            case '\r':
+                out += '\\r';
+                break;
+            case '\t':
+                out += '\\t';
+                break;
+            case '\b':
+                out += '\\b';
+                break;
+            case '\f':
+                out += '\\f';
+                break;
+            default:
+                if (code < 0x20 || code > 0x7e) {
+                    out += `\\u${code.toString(16).padStart(4, '0')}`;
+                } else {
+                    out += ch;
+                }
+        }
+    }
+    return out + '"';
+}
+
+function _pyJsonNum(n: number): string {
+    if (!Number.isFinite(n)) {
+        if (Number.isNaN(n)) {
+            return 'NaN';
+        }
+        return n > 0 ? 'Infinity' : '-Infinity';
+    }
+    return String(n);
+}
+
+function _pyJsonScalar(value: unknown): string | null {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _pyJsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _pyJsonStr(value);
+    }
+    return null;
+}
+
+/** Mirror `json.dumps(obj, indent=2)` (ensure_ascii=True). */
+function _pyDumpsIndent2(value: unknown, depth = 0): string {
+    const scalar = _pyJsonScalar(value);
+    if (scalar !== null) {
+        return scalar;
+    }
+    const pad = ' '.repeat(2 * (depth + 1));
+    const closePad = ' '.repeat(2 * depth);
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _pyDumpsIndent2(v, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (_isPlainObject(value)) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map(
+            (k) => `${pad}${_pyJsonStr(k)}: ${_pyDumpsIndent2(value[k], depth + 1)}`,
+        );
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _pyJsonStr(String(value));
+}
+
+// --------------------------------------------------------------- generate
+
+/** Resolve `{primitive.color.blue.600}`-style references recursively. */
+export function resolveReference(value: Json, tokens: JsonObject): Json {
+    if (typeof value !== 'string' || !value.startsWith('{')) {
+        return value;
+    }
+    const stripped = _stripChars(value, '{}');
+    const pathParts = stripped.split('.');
+    let node: Json = tokens;
+    for (const key of pathParts) {
+        if (!_isPlainObject(node)) {
+            return value;
+        }
+        node = node[key] === undefined ? null : node[key];
+        if (node === null) {
+            return value;
+        }
+    }
+    if (_isPlainObject(node) && '$value' in node) {
+        return resolveReference(node['$value'], tokens);
+    }
+    return node !== null ? node : value;
+}
+
+/** Flatten a DTCG token tree into `--css-var → resolved value`. */
+export function flattenTokens(
+    obj: JsonObject,
+    tokens: JsonObject,
+    prefix: string[] | null = null,
+    result: Record<string, Json> | null = null,
+): Record<string, Json> {
+    const pfx = prefix || [];
+    const res = result !== null ? result : {};
+    for (const key of Object.keys(obj)) {
+        const value = obj[key];
+        const current = [...pfx, key];
+        if (_isPlainObject(value)) {
+            if ('$value' in value) {
+                const cssVar = '--' + current.join('-').replace(/\./g, '-');
+                res[cssVar] = resolveReference(value['$value'], tokens);
+            } else {
+                flattenTokens(value, tokens, current, res);
+            }
+        }
+    }
+    return res;
+}
+
+/** Mirror `(d.get(k) or {})` — None / missing / falsy → `{}`. */
+function _orEmpty(v: Json): JsonObject {
+    if (_isPlainObject(v)) {
+        // A non-empty dict is truthy; an empty dict ({}) is falsy in Python,
+        // but `{} or {}` is still `{}`, so returning it is correct either way.
+        return v;
+    }
+    return {};
+}
+
+export function generateCss(tokens: JsonObject): string {
+    const primitive = flattenTokens(_orEmpty(tokens['primitive']), tokens, ['primitive']);
+    const semantic = flattenTokens(_orEmpty(tokens['semantic']), tokens, []);
+    const component = flattenTokens(_orEmpty(tokens['component']), tokens, []);
+    const dark = flattenTokens(_orEmpty(_orEmpty(tokens['dark'])['semantic']), tokens, []);
+
+    const block = (entries: Record<string, Json>): string =>
+        Object.keys(entries)
+            .map((k) => `  ${k}: ${_pyValueStr(entries[k])};`)
+            .join('\n');
+
+    let css =
+        '/* Design Tokens - Auto-generated */\n' +
+        '/* Do not edit directly - modify tokens.json instead */\n\n' +
+        `/* === PRIMITIVES === */\n:root {\n${block(primitive)}\n}\n\n` +
+        `/* === SEMANTIC === */\n:root {\n${block(semantic)}\n}\n\n` +
+        `/* === COMPONENTS === */\n:root {\n${block(component)}\n}\n`;
+    if (_pyTruthy(dark)) {
+        css += `\n/* === DARK MODE === */\n.dark {\n${block(dark)}\n}\n`;
+    }
+    return css;
+}
+
+export function generateTailwind(tokens: JsonObject): string {
+    const semantic = flattenTokens(_orEmpty(tokens['semantic']), tokens, []);
+    const colors: Record<string, string> = {};
+    for (const key of Object.keys(semantic)) {
+        if (key.includes('color')) {
+            const newKey = key.replace('--color-', '').replace(/-/g, '.');
+            colors[newKey] = `var(${key})`;
+        }
+    }
+    const body = _pyDumpsIndent2(colors).replace(/"/g, "'");
+    return (
+        '// Tailwind color config - Auto-generated\n' +
+        '// Add to tailwind.config.ts theme.extend.colors\n\n' +
+        `module.exports = {\n  colors: ${body}\n};\n`
+    );
+}
+
+// --------------------------------------------------------------- validate
+
+interface Pattern {
+    regex: RegExp;
+    message: string;
+    suggestion: string;
+}
+
+// Insertion order mirrors the Python `PATTERNS` dict (hexColor → rgbColor →
+// pixelValue → remValue). Object key order is preserved in JS.
+const PATTERNS: Record<string, Pattern> = {
+    hexColor: {
+        // `#([0-9A-Fa-f]{3}){1,2}\b` — has a capture group (matters for findall).
+        regex: /#([0-9A-Fa-f]{3}){1,2}\b/,
+        message: 'Hardcoded hex color',
+        suggestion: 'Use var(--color-*) token',
+    },
+    rgbColor: {
+        regex: /rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(?:,\s*[\d.]+\s*)?\)/i,
+        message: 'Hardcoded RGB(A) color',
+        suggestion: 'Use var(--color-*) token',
+    },
+    pixelValue: {
+        regex: /:\s*(\d{2,})px/,
+        message: 'Hardcoded pixel value',
+        suggestion: 'Use var(--space-*) or var(--radius-*) token',
+    },
+    remValue: {
+        regex: /:\s*\d+\.?\d*rem/,
+        message: 'Hardcoded rem value',
+        suggestion: 'Use var(--space-*) or var(--font-size-*) token',
+    },
+};
+
+const EXTENSIONS = new Set([
+    '.css', '.scss', '.tsx', '.jsx', '.ts', '.js', '.vue',
+    '.svelte', '.html', '.blade.php',
+]);
+const SKIP_FILE_PATTERNS: RegExp[] = [
+    /\.min\.(css|js)$/,
+    /tailwind\.config/,
+    /globals\.css/,
+    /tokens\.(css|json)/,
+];
+const HEX_EXCEPTIONS = new Set(['#000', '#FFF', '#000000', '#FFFFFF']);
+const DEFAULT_IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'vendor']);
+const ALLOWED_HOST_HINTS = [
+    'fonts.googleapis.com', 'fonts.gstatic.com', 'unsplash.com', 'pexels.com',
+];
+
+interface Violation {
+    file: string;
+    line: number;
+    type: string;
+    value: string;
+    message: string;
+    suggestion: string;
+    context: string;
+    kind: string;
+}
+
+/** Recursively list files under `root`, mirroring `Path.rglob("*")` sorted. */
+function _rglobSorted(root: string): string[] {
+    const out: string[] = [];
+    const walk = (dir: string): void => {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const ent of entries) {
+            const full = path.join(dir, ent.name);
+            out.push(full);
+            if (ent.isDirectory() && !ent.isSymbolicLink()) {
+                walk(full);
+            }
+        }
+    };
+    walk(root);
+    // `sorted(root.rglob("*"))` sorts the PosixPath objects lexicographically
+    // by their string form.
+    out.sort();
+    return out;
+}
+
+function _suffix(p: string): string {
+    const name = path.basename(p);
+    const idx = name.lastIndexOf('.');
+    if (idx <= 0) {
+        return '';
+    }
+    return name.slice(idx);
+}
+
+function _iterFiles(root: string, ignore: Set<string>): string[] {
+    const files: string[] = [];
+    for (const p of _rglobSorted(root)) {
+        // `any(part in ignore for part in path.parts)` — split on the OS sep.
+        const parts = p.split(path.sep);
+        if (parts.some((part) => ignore.has(part))) {
+            continue;
+        }
+        const name = path.basename(p);
+        const suffix = name.endsWith('.blade.php') ? '.blade.php' : _suffix(p);
+        let isFile = false;
+        try {
+            isFile = fs.statSync(p).isFile();
+        } catch {
+            isFile = false;
+        }
+        if (isFile && EXTENSIONS.has(suffix)) {
+            if (SKIP_FILE_PATTERNS.some((pat) => pat.test(p))) {
+                continue;
+            }
+            files.push(p);
+        }
+    }
+    return files;
+}
+
+/**
+ * Mirror Python `regex.findall(line)` for the four patterns used here.
+ * - Patterns with NO capture group → returns each whole match.
+ * - The hexColor pattern (one capture group) → returns the GROUP capture per
+ *   match (Python `findall` semantics). The scanner re-derives the whole
+ *   match separately, so the *content* of these does not matter — only the
+ *   count (≥1 ⇒ at least one finding candidate).
+ */
+function _findall(regex: RegExp, line: string): string[] {
+    const flags = regex.flags.includes('g') ? regex.flags : regex.flags + 'g';
+    const g = new RegExp(regex.source, flags);
+    const res: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(line)) !== null) {
+        // Python findall: with one group → the group; without → whole match.
+        res.push(m.length > 1 ? (m[1] ?? '') : m[0]);
+        if (m.index === g.lastIndex) {
+            g.lastIndex += 1;
+        }
+    }
+    return res;
+}
+
+/** Mirror `regex.search(line).group(0)` — the first whole match, or null. */
+function _searchGroup0(regex: RegExp, line: string): string | null {
+    const flags = regex.flags.replace('g', '');
+    const s = new RegExp(regex.source, flags);
+    const m = s.exec(line);
+    return m ? m[0] : null;
+}
+
+export function scanFile(p: string): Violation[] {
+    const violations: Violation[] = [];
+    let text: string;
+    try {
+        text = fs.readFileSync(p, 'utf-8');
+    } catch {
+        return violations;
+    }
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+        const lineno = i + 1;
+        const line = lines[i] as string;
+        const stripped = _strip(line);
+        if (
+            stripped.startsWith('//') ||
+            stripped.startsWith('/*') ||
+            stripped.startsWith('*') ||
+            line.includes('var(--')
+        ) {
+            continue;
+        }
+        if (ALLOWED_HOST_HINTS.some((host) => line.includes(host))) {
+            continue;
+        }
+        for (const kind of Object.keys(PATTERNS)) {
+            const { regex, message, suggestion } = PATTERNS[kind] as Pattern;
+            const matches = _findall(regex, line);
+            for (const match of matches) {
+                let value: string = match;
+                if (kind === 'hexColor') {
+                    const whole = _searchGroup0(regex, line) as string;
+                    if (HEX_EXCEPTIONS.has(whole.toUpperCase())) {
+                        continue;
+                    }
+                    value = whole;
+                }
+                violations.push({
+                    file: p,
+                    line: lineno,
+                    type: kind,
+                    value,
+                    message,
+                    suggestion,
+                    context: _sliceCodePoints(stripped, 80),
+                    // Maps onto the UI directive set's finding kind so the
+                    // polish step can auto-convert against audit tokens.
+                    kind: 'token_violation',
+                });
+                break; // one finding per pattern per line is enough
+            }
+        }
+    }
+    return violations;
+}
+
+/** Mirror Python `s[:80]` over code points. */
+function _sliceCodePoints(s: string, n: number): string {
+    let out = '';
+    let count = 0;
+    for (const ch of s) {
+        if (count >= n) {
+            break;
+        }
+        out += ch;
+        count += 1;
+    }
+    return out;
+}
+
+export function formatReport(violations: Violation[]): string {
+    if (violations.length === 0) {
+        return '✅ No token violations found';
+    }
+    const out: string[] = [`⚠️  Found ${violations.length} potential token violations:`, ''];
+    const byFile = new Map<string, Violation[]>();
+    for (const v of violations) {
+        if (!byFile.has(v.file)) {
+            byFile.set(v.file, []);
+        }
+        byFile.get(v.file)!.push(v);
+    }
+    for (const [file, items] of byFile) {
+        out.push(`📁 ${file}`);
+        for (const v of items) {
+            out.push(
+                `   Line ${v.line}: ${v.message}`,
+                `   Found: ${v.value}`,
+                `   Suggestion: ${v.suggestion}`,
+                `   Context: ${v.context}`,
+                '',
+            );
+        }
+    }
+    const counts = new Map<string, number>();
+    for (const v of violations) {
+        counts.set(v.message, (counts.get(v.message) ?? 0) + 1);
+    }
+    out.push('📊 Summary:');
+    for (const [msg, n] of counts) {
+        out.push(`   ${msg}: ${n}`);
+    }
+    return out.join('\n');
+}
+
+// --------------------------------------------------------------- embed
+
+const MINIMAL_TOKEN_PREFIXES = [
+    '--primitive-spacing-', '--primitive-fontSize-', '--primitive-fontWeight-',
+    '--primitive-lineHeight-', '--primitive-radius-', '--primitive-shadow-glow-',
+    '--primitive-gradient-', '--primitive-duration-', '--color-primary',
+    '--color-secondary', '--color-accent', '--color-background',
+    '--color-surface', '--color-foreground', '--color-border',
+    '--typography-font-', '--card-',
+];
+
+/** Mirror `re.findall(pat, s)` for patterns WITHOUT a capture group. */
+function _findallNoGroup(pattern: RegExp, s: string): string[] {
+    const flags = pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g';
+    const g = new RegExp(pattern.source, flags);
+    const res: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(s)) !== null) {
+        res.push(m[0]);
+        if (m.index === g.lastIndex) {
+            g.lastIndex += 1;
+        }
+    }
+    return res;
+}
+
+/** Mirror `re.findall(r":root\s*\{([^}]+)\}", css)` — returns the group capture. */
+function _findallRootBlocks(css: string): string[] {
+    const g = /:root\s*\{([^}]+)\}/g;
+    const res: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = g.exec(css)) !== null) {
+        res.push(m[1] as string);
+        if (m.index === g.lastIndex) {
+            g.lastIndex += 1;
+        }
+    }
+    return res;
+}
+
+export function extractTokens(css: string, minimal = false): string {
+    const blocks = _findallRootBlocks(css);
+    let allVars: string[] = [];
+    for (const block of blocks) {
+        allVars = allVars.concat(_findallNoGroup(/--[\w-]+:\s*[^;]+;/, block));
+    }
+    if (minimal) {
+        allVars = allVars.filter((v) => MINIMAL_TOKEN_PREFIXES.some((p) => v.includes(p)));
+    }
+    const seen: string[] = [];
+    for (const v of allVars) {
+        if (!seen.includes(v)) {
+            seen.push(v);
+        }
+    }
+    return ':root {\n  ' + seen.join('\n  ') + '\n}';
+}
+
+// --------------------------------------------------------------- shims
+
+/** Mirror Python truthiness for the values this module dumps. */
+function _pyTruthy(v: Json): boolean {
+    if (v === null || v === undefined || v === false) {
+        return false;
+    }
+    if (v === true) {
+        return true;
+    }
+    if (typeof v === 'number') {
+        return v !== 0;
+    }
+    if (typeof v === 'string') {
+        return v.length > 0;
+    }
+    if (Array.isArray(v)) {
+        return v.length > 0;
+    }
+    if (_isPlainObject(v)) {
+        return Object.keys(v).length > 0;
+    }
+    return Boolean(v);
+}
+
+/**
+ * Mirror Python f-string interpolation of a resolved token value into CSS.
+ * Resolved values are nearly always strings; non-strings fall back to
+ * Python's `str()` semantics for the scalars that can appear here.
+ */
+function _pyValueStr(v: Json): string {
+    if (typeof v === 'string') {
+        return v;
+    }
+    if (v === null || v === undefined) {
+        return 'None';
+    }
+    if (v === true) {
+        return 'True';
+    }
+    if (v === false) {
+        return 'False';
+    }
+    if (typeof v === 'number') {
+        return _pyJsonNum(v);
+    }
+    return String(v);
+}
+
+// --------------------------------------------------------------- CLI
+
+interface ArgvError extends Error {
+    code: number;
+}
+
+function _argError(msg: string): ArgvError {
+    const e = new Error(msg) as ArgvError;
+    e.code = 2;
+    return e;
+}
+
+const PROG = 'tokens';
+
+function _usageError(message: string): never {
+    // argparse prints a usage line + error to stderr and exits 2. We don't
+    // byte-compare argparse output (per the task), so emit a faithful-enough
+    // diagnostic and signal exit 2 via a thrown ArgvError the caller maps.
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw _argError(message);
+}
+
+interface GenerateArgs {
+    op: 'generate';
+    config: string;
+    output: string | null;
+    format: 'css' | 'tailwind';
+}
+interface ValidateArgs {
+    op: 'validate';
+    dir: string;
+    ignore: string[];
+    json: boolean;
+}
+interface EmbedArgs {
+    op: 'embed';
+    tokens: string;
+    minimal: boolean;
+    style: boolean;
+}
+type ParsedArgs = GenerateArgs | ValidateArgs | EmbedArgs;
+
+function _takeValue(
+    argv: string[],
+    i: number,
+    flag: string,
+): { value: string; next: number } {
+    // Support `--flag value` and `--flag=value` / short `-f value` forms.
+    const tok = argv[i] as string;
+    const eq = tok.indexOf('=');
+    if (tok.startsWith('--') && eq !== -1) {
+        return { value: tok.slice(eq + 1), next: i + 1 };
+    }
+    if (i + 1 >= argv.length) {
+        _usageError(`argument ${flag}: expected one argument`);
+    }
+    return { value: argv[i + 1] as string, next: i + 2 };
+}
+
+function _parseArgs(argv: string[]): ParsedArgs {
+    if (argv.length === 0) {
+        _usageError('the following arguments are required: op');
+    }
+    const op = argv[0] as string;
+    const rest = argv.slice(1);
+
+    if (op === 'generate') {
+        let config: string | null = null;
+        let output: string | null = null;
+        let format: 'css' | 'tailwind' = 'css';
+        let i = 0;
+        while (i < rest.length) {
+            const t = rest[i] as string;
+            const base = t.split('=')[0];
+            if (base === '--config' || base === '-c') {
+                const r = _takeValue(rest, i, '--config/-c');
+                config = r.value;
+                i = r.next;
+            } else if (base === '--output' || base === '-o') {
+                const r = _takeValue(rest, i, '--output/-o');
+                output = r.value;
+                i = r.next;
+            } else if (base === '--format' || base === '-f') {
+                const r = _takeValue(rest, i, '--format/-f');
+                if (r.value !== 'css' && r.value !== 'tailwind') {
+                    _usageError(
+                        `argument --format/-f: invalid choice: '${r.value}' (choose from 'css', 'tailwind')`,
+                    );
+                }
+                format = r.value;
+                i = r.next;
+            } else {
+                _usageError(`unrecognized arguments: ${t}`);
+            }
+        }
+        if (config === null) {
+            _usageError('the following arguments are required: --config/-c');
+        }
+        return { op: 'generate', config, output, format };
+    }
+
+    if (op === 'validate') {
+        let dir: string | null = null;
+        const ignore: string[] = [];
+        let json = false;
+        let i = 0;
+        while (i < rest.length) {
+            const t = rest[i] as string;
+            const base = t.split('=')[0];
+            if (base === '--dir' || base === '-d') {
+                const r = _takeValue(rest, i, '--dir/-d');
+                dir = r.value;
+                i = r.next;
+            } else if (base === '--ignore' || base === '-i') {
+                const r = _takeValue(rest, i, '--ignore/-i');
+                ignore.push(r.value);
+                i = r.next;
+            } else if (base === '--json') {
+                json = true;
+                i += 1;
+            } else {
+                _usageError(`unrecognized arguments: ${t}`);
+            }
+        }
+        if (dir === null) {
+            _usageError('the following arguments are required: --dir/-d');
+        }
+        return { op: 'validate', dir, ignore, json };
+    }
+
+    if (op === 'embed') {
+        let tokens: string | null = null;
+        let minimal = false;
+        let style = false;
+        let i = 0;
+        while (i < rest.length) {
+            const t = rest[i] as string;
+            const base = t.split('=')[0];
+            if (base === '--tokens' || base === '-t') {
+                const r = _takeValue(rest, i, '--tokens/-t');
+                tokens = r.value;
+                i = r.next;
+            } else if (base === '--minimal') {
+                minimal = true;
+                i += 1;
+            } else if (base === '--style') {
+                style = true;
+                i += 1;
+            } else {
+                _usageError(`unrecognized arguments: ${t}`);
+            }
+        }
+        if (tokens === null) {
+            _usageError('the following arguments are required: --tokens/-t');
+        }
+        return { op: 'embed', tokens, minimal, style };
+    }
+
+    _usageError(
+        `argument op: invalid choice: '${op}' (choose from 'generate', 'validate', 'embed')`,
+    );
+}
+
+export function main(argv: string[] | null = null): number {
+    const args = argv === null ? process.argv.slice(2) : argv;
+    let parsed: ParsedArgs;
+    try {
+        parsed = _parseArgs(args);
+    } catch (e) {
+        if (e && typeof e === 'object' && 'code' in e) {
+            return (e as ArgvError).code;
+        }
+        throw e;
+    }
+
+    if (parsed.op === 'generate') {
+        const config = parsed.config;
+        if (!_exists(config)) {
+            process.stderr.write(`Error: Config file not found: ${config}\n`);
+            return 1;
+        }
+        const tokens = JSON.parse(fs.readFileSync(config, 'utf-8')) as JsonObject;
+        const output =
+            parsed.format === 'tailwind' ? generateTailwind(tokens) : generateCss(tokens);
+        if (parsed.output) {
+            const out = parsed.output;
+            const dir = path.dirname(out);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(out, output, 'utf-8');
+            process.stdout.write(`Generated: ${out}\n`);
+        } else {
+            process.stdout.write(output + '\n');
+        }
+        return 0;
+    }
+
+    if (parsed.op === 'validate') {
+        const root = parsed.dir;
+        if (!_exists(root)) {
+            process.stderr.write(`Error: Directory not found: ${root}\n`);
+            return 1;
+        }
+        const ignore = new Set([...DEFAULT_IGNORE, ...parsed.ignore]);
+        let violations: Violation[] = [];
+        for (const file of _iterFiles(root, ignore)) {
+            violations = violations.concat(scanFile(file));
+        }
+        if (parsed.json) {
+            process.stdout.write(_pyDumpsIndent2(violations) + '\n');
+        } else {
+            process.stdout.write(formatReport(violations) + '\n');
+        }
+        return violations.length > 0 ? 1 : 0;
+    }
+
+    // embed
+    const tokensPath = parsed.tokens;
+    if (!_exists(tokensPath)) {
+        process.stderr.write(`Error: tokens css not found: ${tokensPath}\n`);
+        return 1;
+    }
+    const output = extractTokens(fs.readFileSync(tokensPath, 'utf-8'), parsed.minimal);
+    const header = '/* Design Tokens (embedded for standalone HTML) */';
+    if (parsed.style) {
+        process.stdout.write(`<style>\n${header}\n${output}\n</style>\n`);
+    } else {
+        process.stdout.write(`${header}\n${output}\n`);
+    }
+    return 0;
+}
+
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// `raise SystemExit(main())` — set process.exitCode, never call process.exit.
+const _INVOKED_DIRECTLY =
+    typeof process.argv[1] === 'string' &&
+    import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (_INVOKED_DIRECTLY) {
+    process.exitCode = main();
+}
+
+export {
+    PATTERNS,
+    EXTENSIONS,
+    SKIP_FILE_PATTERNS,
+    HEX_EXCEPTIONS,
+    DEFAULT_IGNORE,
+    ALLOWED_HOST_HINTS,
+    MINIMAL_TOKEN_PREFIXES,
+    _pyDumpsIndent2,
+    _pyLen,
+};

--- a/src/skills/react-shadcn-ui/scripts/shadcn_add.ts
+++ b/src/skills/react-shadcn-ui/scripts/shadcn_add.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env tsx
+// Modified from upstream (Apache-2.0, "claudekit" via
+// an external reference ui-styling sub-skill
+// @ b7e3af80f6e331f6fb456667b82b12cade7c9d35, last checked 2026-06-07).
+// License copy: src/skills/design-intelligence/LICENSE.apache-2.0.txt
+// (deployed: <skills-root>/design-intelligence/LICENSE.apache-2.0.txt).
+// Modifications: adopted into the agent-config skill tree; header added
+// per Apache-2.0 §4b; see design-intelligence/ATTRIBUTION.md.
+/**
+ * shadcn/ui Component Installer
+ *
+ * Add shadcn/ui components to project with automatic dependency handling.
+ * Wraps shadcn CLI for programmatic component installation.
+ *
+ * TypeScript twin of `src/skills/react-shadcn-ui/scripts/shadcn_add.py`
+ * (ADR-094). The CLI contract is mirrored EXACTLY — positional components,
+ * `--all`, `--overwrite`, `--dry-run`, `--list`, `--project-root`, exit codes
+ * (0 / 1), the stdout/stderr split, byte-identical messages, AND the exact
+ * `npx shadcn@latest …` command shape. No behaviour changes — latent Python
+ * quirks replicated.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export class ShadcnInstaller {
+    projectRoot: string;
+    dryRun: boolean;
+    componentsJson: string;
+
+    constructor(projectRoot: string | null = null, dryRun = false) {
+        this.projectRoot = projectRoot ?? process.cwd();
+        this.dryRun = dryRun;
+        this.componentsJson = path.join(this.projectRoot, 'components.json');
+    }
+
+    /** Check if shadcn is initialized — components.json exists. */
+    checkShadcnConfig(): boolean {
+        return fs.existsSync(this.componentsJson);
+    }
+
+    /** Get list of already installed components (unsorted, mirrors .py). */
+    getInstalledComponents(): string[] {
+        if (!this.checkShadcnConfig()) {
+            return [];
+        }
+        try {
+            const config = JSON.parse(fs.readFileSync(this.componentsJson, 'utf-8')) as unknown;
+            const aliasesRaw =
+                config && typeof config === 'object' && 'aliases' in config
+                    ? (config as { aliases?: unknown }).aliases
+                    : undefined;
+            const aliases =
+                aliasesRaw && typeof aliasesRaw === 'object'
+                    ? (aliasesRaw as { components?: unknown })
+                    : {};
+            const componentsAlias =
+                typeof aliases.components === 'string' ? aliases.components : 'components';
+            const componentsDir = path.join(this.projectRoot, componentsAlias.replace('@/', ''));
+            const uiDir = path.join(componentsDir, 'ui');
+
+            if (!fs.existsSync(uiDir)) {
+                return [];
+            }
+
+            return _globTsxStems(uiDir);
+        } catch {
+            // json.JSONDecodeError | KeyError | OSError → []
+            return [];
+        }
+    }
+
+    /** Add shadcn/ui components → [success, message]. */
+    addComponents(components: string[], overwrite = false): [boolean, string] {
+        if (components.length === 0) {
+            return [false, 'No components specified'];
+        }
+
+        if (!this.checkShadcnConfig()) {
+            return [false, "shadcn not initialized. Run 'npx shadcn@latest init' first"];
+        }
+
+        // Check which components already exist
+        const installed = this.getInstalledComponents();
+        const alreadyInstalled = components.filter((c) => installed.includes(c));
+
+        if (alreadyInstalled.length > 0 && !overwrite) {
+            return [
+                false,
+                `Components already installed: ${alreadyInstalled.join(', ')}. ` +
+                    'Use --overwrite to reinstall',
+            ];
+        }
+
+        // Build command
+        const cmd = ['npx', 'shadcn@latest', 'add', ...components];
+
+        if (overwrite) {
+            cmd.push('--overwrite');
+        }
+
+        if (this.dryRun) {
+            return [true, `Would run: ${cmd.join(' ')}`];
+        }
+
+        // Execute command
+        return this._runAdd(cmd, `Successfully added components: ${components.join(', ')}`);
+    }
+
+    /** Add all available shadcn/ui components → [success, message]. */
+    addAllComponents(overwrite = false): [boolean, string] {
+        if (!this.checkShadcnConfig()) {
+            return [false, "shadcn not initialized. Run 'npx shadcn@latest init' first"];
+        }
+
+        const cmd = ['npx', 'shadcn@latest', 'add', '--all'];
+
+        if (overwrite) {
+            cmd.push('--overwrite');
+        }
+
+        if (this.dryRun) {
+            return [true, `Would run: ${cmd.join(' ')}`];
+        }
+
+        return this._runAdd(cmd, 'Successfully added all components', true);
+    }
+
+    /**
+     * Mirror the subprocess.run(..., check=True) try/except for both add paths.
+     * `failAll` toggles the "Failed to add all components" vs "Failed to add
+     * components" prefix.
+     */
+    private _runAdd(cmd: string[], successBase: string, failAll = false): [boolean, string] {
+        const result = spawnSync(cmd[0] as string, cmd.slice(1), {
+            cwd: this.projectRoot,
+            encoding: 'utf-8',
+        });
+
+        // FileNotFoundError — the executable itself is missing.
+        if (result.error && (result.error as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [false, 'npx not found. Ensure Node.js is installed'];
+        }
+
+        const stdout = result.stdout ?? '';
+        const stderr = result.stderr ?? '';
+        const status = result.status;
+
+        if (status === 0) {
+            let successMsg = successBase;
+            if (stdout) {
+                successMsg += `\n\nOutput:\n${stdout}`;
+            }
+            return [true, successMsg];
+        }
+
+        // subprocess.CalledProcessError — e.stderr or e.stdout or str(e).
+        const detail = stderr || stdout || _calledProcessError(cmd, status, result.signal);
+        const prefix = failAll ? 'Failed to add all components' : 'Failed to add components';
+        return [false, `${prefix}: ${detail}`];
+    }
+
+    /** List installed components → [success, message]. */
+    listInstalled(): [boolean, string] {
+        if (!this.checkShadcnConfig()) {
+            return [false, 'shadcn not initialized'];
+        }
+
+        const installed = this.getInstalledComponents();
+
+        if (installed.length === 0) {
+            return [true, 'No components installed'];
+        }
+
+        const sorted = [...installed].sort(_pyStrCmp);
+        return [true, 'Installed components:\n' + sorted.map((c) => `  - ${c}`).join('\n')];
+    }
+}
+
+/** Mirror Python default str comparison (UTF-16 code-unit ordering matches for BMP). */
+function _pyStrCmp(a: string, b: string): number {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Mirror `[f.stem for f in ui_dir.glob("*.tsx") if f.is_file()]`. Path.glob
+ * returns only direct children whose name ends in `.tsx`; `f.stem` drops the
+ * final `.tsx` suffix; order is the directory listing (later `sorted()` in
+ * list_installed handles display order). Symlinks to files count as files.
+ */
+function _globTsxStems(uiDir: string): string[] {
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(uiDir, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    const out: string[] = [];
+    for (const e of entries) {
+        if (!e.name.endsWith('.tsx')) {
+            continue;
+        }
+        let isFile = e.isFile();
+        if (e.isSymbolicLink()) {
+            try {
+                isFile = fs.statSync(path.join(uiDir, e.name)).isFile();
+            } catch {
+                isFile = false;
+            }
+        }
+        if (isFile) {
+            out.push(e.name.slice(0, -'.tsx'.length));
+        }
+    }
+    return out;
+}
+
+/** Mirror `str(subprocess.CalledProcessError)` for the rare empty-output case. */
+function _calledProcessError(cmd: string[], status: number | null, signal: string | null): string {
+    const cmdRepr = '[' + cmd.map((c) => `'${c}'`).join(', ') + ']';
+    if (signal) {
+        return `Command ${cmdRepr} died with ${signal}.`;
+    }
+    return `Command ${cmdRepr} returned non-zero exit status ${status}.`;
+}
+
+const PROG = 'shadcn_add.py';
+
+const HELP =
+    `usage: ${PROG} [-h] [--all] [--overwrite] [--dry-run] [--list]\n` +
+    '                     [--project-root PROJECT_ROOT]\n' +
+    '                     [components ...]\n' +
+    '\n' +
+    'Add shadcn/ui components to your project\n' +
+    '\n' +
+    'positional arguments:\n' +
+    '  components            Component names to add (e.g., button, card, dialog)\n' +
+    '\n' +
+    'optional arguments:\n' +
+    '  -h, --help            show this help message and exit\n' +
+    '  --all                 Add all available components\n' +
+    '  --overwrite           Overwrite existing components\n' +
+    '  --dry-run             Show what would be done without executing\n' +
+    '  --list                List installed components\n' +
+    '  --project-root PROJECT_ROOT\n' +
+    '                        Project root directory (default: current directory)\n' +
+    '\n' +
+    'Examples:\n' +
+    '  # Add single component\n' +
+    '  python shadcn_add.py button\n' +
+    '\n' +
+    '  # Add multiple components\n' +
+    '  python shadcn_add.py button card dialog\n' +
+    '\n' +
+    '  # Add all components\n' +
+    '  python shadcn_add.py --all\n' +
+    '\n' +
+    '  # Overwrite existing components\n' +
+    '  python shadcn_add.py button --overwrite\n' +
+    '\n' +
+    '  # Dry run (show what would be done)\n' +
+    '  python shadcn_add.py button card --dry-run\n' +
+    '\n' +
+    '  # List installed components\n' +
+    '  python shadcn_add.py --list\n' +
+    '        \n';
+
+const USAGE =
+    `usage: ${PROG} [-h] [--all] [--overwrite] [--dry-run] [--list]\n` +
+    '                     [--project-root PROJECT_ROOT]\n' +
+    '                     [components ...]\n';
+
+class ArgExit extends Error {
+    constructor(public code: number) {
+        super('argexit');
+    }
+}
+
+interface Args {
+    components: string[];
+    all: boolean;
+    overwrite: boolean;
+    dry_run: boolean;
+    list: boolean;
+    project_root: string | null;
+}
+
+function argError(message: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw new ArgExit(2);
+}
+
+/** Parse argv mirroring the argparse spec (positional `components` nargs="*"). */
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        components: [],
+        all: false,
+        overwrite: false,
+        dry_run: false,
+        list: false,
+        project_root: null,
+    };
+
+    let i = 0;
+    while (i < argv.length) {
+        let a = argv[i] as string;
+        let inlineValue: string | null = null;
+        const eq = a.indexOf('=');
+        if (a.startsWith('--') && eq !== -1) {
+            inlineValue = a.slice(eq + 1);
+            a = a.slice(0, eq);
+        }
+
+        if (a === '-h' || a === '--help') {
+            process.stdout.write(HELP);
+            throw new ArgExit(0);
+        } else if (a === '--all') {
+            args.all = true;
+        } else if (a === '--overwrite') {
+            args.overwrite = true;
+        } else if (a === '--dry-run') {
+            args.dry_run = true;
+        } else if (a === '--list') {
+            args.list = true;
+        } else if (a === '--project-root') {
+            const v = inlineValue ?? (argv[++i] as string | undefined);
+            if (v === undefined) {
+                argError('argument --project-root: expected one argument');
+            }
+            args.project_root = v;
+        } else if (a.startsWith('-') && a !== '-') {
+            argError(`unrecognized arguments: ${argv[i]}`);
+        } else {
+            args.components.push(argv[i] as string);
+        }
+        i += 1;
+    }
+    return args;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgExit) {
+            return e.code;
+        }
+        throw e;
+    }
+
+    const installer = new ShadcnInstaller(args.project_root, args.dry_run);
+
+    // Handle list command
+    if (args.list) {
+        const [success, message] = installer.listInstalled();
+        process.stdout.write(`${message}\n`);
+        return success ? 0 : 1;
+    }
+
+    // Handle add all command
+    if (args.all) {
+        const [success, message] = installer.addAllComponents(args.overwrite);
+        process.stdout.write(`${message}\n`);
+        return success ? 0 : 1;
+    }
+
+    // Handle add specific components
+    if (args.components.length === 0) {
+        process.stdout.write(HELP);
+        return 1;
+    }
+
+    const [success, message] = installer.addComponents(args.components, args.overwrite);
+
+    process.stdout.write(`${message}\n`);
+    return success ? 0 : 1;
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    process.exitCode = main();
+}

--- a/src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts
+++ b/src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts
@@ -1,0 +1,561 @@
+#!/usr/bin/env tsx
+// Modified from upstream (Apache-2.0, "claudekit" via
+// an external reference ui-styling sub-skill
+// @ b7e3af80f6e331f6fb456667b82b12cade7c9d35, last checked 2026-06-07).
+// License copy: src/skills/design-intelligence/LICENSE.apache-2.0.txt
+// (deployed: <skills-root>/design-intelligence/LICENSE.apache-2.0.txt).
+// Modifications: adopted into the agent-config skill tree; header added
+// per Apache-2.0 §4b; see design-intelligence/ATTRIBUTION.md.
+/**
+ * Tailwind CSS Configuration Generator
+ *
+ * Generate tailwind.config.js/ts with custom theme configuration.
+ * Supports colors, fonts, spacing, breakpoints, and plugin recommendations.
+ *
+ * TypeScript twin of `src/skills/tailwind-engineer/scripts/tailwind_config_gen.py`
+ * (ADR-094). The CLI contract is mirrored EXACTLY — snake_case-free flags
+ * (`--framework`, `--js`, `--output`, `--colors`, `--fonts`, `--spacing`,
+ * `--breakpoints`, `--plugins`, `--validate-only`), exit codes (0 / 1 / 2),
+ * the stdout/stderr split, byte-identical messages, AND byte-identical
+ * generated config text (whitespace, quoting, key order, trailing newlines).
+ * No behaviour changes — latent Python quirks replicated.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const PROG = 'tailwind_config_gen.py';
+
+// Mirror argparse's wrapped usage block (80-col default; non-tty). Used for
+// the invalid-choice / unrecognized-argument error paths.
+const USAGE =
+    `usage: ${PROG} [-h] [--framework {react,vue,svelte,nextjs}]\n` +
+    '                              [--js] [--output OUTPUT]\n' +
+    '                              [--colors [NAME:VALUE ...]]\n' +
+    '                              [--fonts [TYPE:FAMILY ...]]\n' +
+    '                              [--spacing [NAME:VALUE ...]]\n' +
+    '                              [--breakpoints [NAME:WIDTH ...]] [--plugins]\n' +
+    '                              [--validate-only]\n';
+
+type JsonVal = null | boolean | number | string | JsonVal[] | { [k: string]: JsonVal };
+type Dict = { [k: string]: JsonVal };
+
+/**
+ * json.dumps(obj, indent=2) — sort_keys False, ensure_ascii True. Mirrors the
+ * CPython encoder byte-for-byte: insertion-order keys (Map / object key
+ * order), the `: ` / `,` separators implied by `indent`, and `\uXXXX` escapes
+ * for non-ASCII. Integer floats are not produced by this generator (all values
+ * are strings / arrays / dicts), so no PyFloat branch is needed here.
+ */
+function jsonDumpsIndent2(obj: JsonVal): string {
+    const pad = '  ';
+
+    function enc(value: JsonVal, depth: number): string {
+        if (value === null) return 'null';
+        if (typeof value === 'boolean') return value ? 'true' : 'false';
+        if (typeof value === 'number') return String(value);
+        if (typeof value === 'string') return encStr(value);
+        if (Array.isArray(value)) {
+            if (value.length === 0) return '[]';
+            const inner = value.map((v) => pad.repeat(depth + 1) + enc(v, depth + 1));
+            return '[\n' + inner.join(',\n') + '\n' + pad.repeat(depth) + ']';
+        }
+        const o = value as Dict;
+        const keys = Object.keys(o);
+        if (keys.length === 0) return '{}';
+        const inner = keys.map(
+            (k) => pad.repeat(depth + 1) + encStr(k) + ': ' + enc(o[k] as JsonVal, depth + 1),
+        );
+        return '{\n' + inner.join(',\n') + '\n' + pad.repeat(depth) + '}';
+    }
+
+    function encStr(s: string): string {
+        let out = '"';
+        for (const ch of s) {
+            const cp = ch.codePointAt(0) as number;
+            if (ch === '"') out += '\\"';
+            else if (ch === '\\') out += '\\\\';
+            else if (ch === '\n') out += '\\n';
+            else if (ch === '\r') out += '\\r';
+            else if (ch === '\t') out += '\\t';
+            else if (ch === '\b') out += '\\b';
+            else if (ch === '\f') out += '\\f';
+            else if (cp < 0x20) out += '\\u' + cp.toString(16).padStart(4, '0');
+            else if (cp < 0x7f) out += ch;
+            else if (cp > 0xffff) {
+                const v = cp - 0x10000;
+                const hi = 0xd800 + (v >> 10);
+                const lo = 0xdc00 + (v & 0x3ff);
+                out += '\\u' + hi.toString(16).padStart(4, '0');
+                out += '\\u' + lo.toString(16).padStart(4, '0');
+            } else {
+                out += '\\u' + cp.toString(16).padStart(4, '0');
+            }
+        }
+        return out + '"';
+    }
+
+    return enc(obj, 0);
+}
+
+/** Mirror Python `str.strip("'\"")` — strip listed chars from both ends. */
+function _stripChars(s: string, chars: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && chars.includes(s[start] as string)) {
+        start += 1;
+    }
+    while (end > start && chars.includes(s[end - 1] as string)) {
+        end -= 1;
+    }
+    return s.slice(start, end);
+}
+
+export class TailwindConfigGenerator {
+    typescript: boolean;
+    framework: string;
+    outputPath: string;
+    config: Dict;
+
+    constructor(typescript = true, framework = 'react', outputPath: string | null = null) {
+        this.typescript = typescript;
+        this.framework = framework;
+        this.outputPath = outputPath ?? this._defaultOutputPath();
+        this.config = this._baseConfig();
+    }
+
+    /** Determine default output path — Path.cwd() / `tailwind.config.{ext}`. */
+    _defaultOutputPath(): string {
+        const ext = this.typescript ? 'ts' : 'js';
+        return path.join(process.cwd(), `tailwind.config.${ext}`);
+    }
+
+    /** Create base configuration structure. */
+    _baseConfig(): Dict {
+        return {
+            darkMode: ['class'],
+            content: this._defaultContentPaths(),
+            theme: {
+                extend: {},
+            },
+            plugins: [],
+        };
+    }
+
+    /** Get default content paths for framework. */
+    _defaultContentPaths(): string[] {
+        const paths: { [k: string]: string[] } = {
+            react: ['./src/**/*.{js,jsx,ts,tsx}', './index.html'],
+            vue: ['./src/**/*.{vue,js,ts,jsx,tsx}', './index.html'],
+            svelte: ['./src/**/*.{svelte,js,ts}', './src/app.html'],
+            nextjs: [
+                './app/**/*.{js,ts,jsx,tsx}',
+                './pages/**/*.{js,ts,jsx,tsx}',
+                './components/**/*.{js,ts,jsx,tsx}',
+            ],
+        };
+        return paths[this.framework] ?? (paths['react'] as string[]);
+    }
+
+    private _extend(): Dict {
+        return (this.config['theme'] as Dict)['extend'] as Dict;
+    }
+
+    /** Add custom colors to theme (dict.update — insertion order preserved). */
+    addColors(colors: { [k: string]: string }): void {
+        const extend = this._extend();
+        if (!('colors' in extend)) {
+            extend['colors'] = {};
+        }
+        const target = extend['colors'] as Dict;
+        for (const [k, v] of Object.entries(colors)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add full color palette (50-950 shades) for a base color. */
+    addColorPalette(name: string, _baseColor: string): void {
+        const extend = this._extend();
+        if (!('colors' in extend)) {
+            extend['colors'] = {};
+        }
+        (extend['colors'] as Dict)[name] = {
+            '50': `var(--color-${name}-50)`,
+            '100': `var(--color-${name}-100)`,
+            '200': `var(--color-${name}-200)`,
+            '300': `var(--color-${name}-300)`,
+            '400': `var(--color-${name}-400)`,
+            '500': `var(--color-${name}-500)`,
+            '600': `var(--color-${name}-600)`,
+            '700': `var(--color-${name}-700)`,
+            '800': `var(--color-${name}-800)`,
+            '900': `var(--color-${name}-900)`,
+            '950': `var(--color-${name}-950)`,
+        };
+    }
+
+    /** Add custom font families. */
+    addFonts(fonts: { [k: string]: string[] }): void {
+        const extend = this._extend();
+        if (!('fontFamily' in extend)) {
+            extend['fontFamily'] = {};
+        }
+        const target = extend['fontFamily'] as Dict;
+        for (const [k, v] of Object.entries(fonts)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add custom spacing values. */
+    addSpacing(spacing: { [k: string]: string }): void {
+        const extend = this._extend();
+        if (!('spacing' in extend)) {
+            extend['spacing'] = {};
+        }
+        const target = extend['spacing'] as Dict;
+        for (const [k, v] of Object.entries(spacing)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add custom breakpoints. */
+    addBreakpoints(breakpoints: { [k: string]: string }): void {
+        const extend = this._extend();
+        if (!('screens' in extend)) {
+            extend['screens'] = {};
+        }
+        const target = extend['screens'] as Dict;
+        for (const [k, v] of Object.entries(breakpoints)) {
+            target[k] = v;
+        }
+    }
+
+    /** Add plugin requirements (skip duplicates, preserve order). */
+    addPlugins(plugins: string[]): void {
+        const arr = this.config['plugins'] as string[];
+        for (const plugin of plugins) {
+            if (!arr.includes(plugin)) {
+                arr.push(plugin);
+            }
+        }
+    }
+
+    /** Get plugin recommendations based on configuration. */
+    recommendPlugins(): string[] {
+        const recommendations: string[] = [];
+        recommendations.push('tailwindcss-animate');
+        if (this.framework === 'nextjs') {
+            recommendations.push('@tailwindcss/typography');
+        }
+        return recommendations;
+    }
+
+    /** Generate configuration file content. */
+    generateConfigString(): string {
+        if (this.typescript) {
+            return this._generateTypescript();
+        }
+        return this._generateJavascript();
+    }
+
+    /** Generate TypeScript configuration. */
+    _generateTypescript(): string {
+        const pluginsStr = this._formatPlugins();
+
+        // Match the .py: it builds config_json twice (the first is dead);
+        // the live one drops the plugins array, then dumps indent=2.
+        const configObj: Dict = { ...this.config };
+        delete configObj['plugins'];
+        const configJson = jsonDumpsIndent2(configObj);
+
+        return (
+            `import type { Config } from 'tailwindcss'\n` +
+            `\n` +
+            `const config: Config = {\n` +
+            `${this._indentJson(configJson, 1)}\n` +
+            `  plugins: [${pluginsStr}],\n` +
+            `}\n` +
+            `\n` +
+            `export default config\n`
+        );
+    }
+
+    /** Generate JavaScript configuration. */
+    _generateJavascript(): string {
+        const pluginsStr = this._formatPlugins();
+
+        const configObj: Dict = { ...this.config };
+        delete configObj['plugins'];
+        const configJson = jsonDumpsIndent2(configObj);
+
+        return (
+            `/** @type {import('tailwindcss').Config} */\n` +
+            `module.exports = {\n` +
+            `${this._indentJson(configJson, 1)}\n` +
+            `  plugins: [${pluginsStr}],\n` +
+            `}\n`
+        );
+    }
+
+    /** Format plugins array for config. */
+    _formatPlugins(): string {
+        const arr = this.config['plugins'] as string[];
+        if (arr.length === 0) {
+            return '';
+        }
+        const pluginRequires = arr.map((plugin) => `require('${plugin}')`);
+        return pluginRequires.join(', ');
+    }
+
+    /** Add indentation to JSON string (skip first and last brace lines). */
+    _indentJson(jsonStr: string, level: number): string {
+        const indent = '  '.repeat(level);
+        const lines = jsonStr.split('\n');
+        const indented = lines.slice(1, lines.length - 1).map((line) => indent + line);
+        return indented.join('\n');
+    }
+
+    /** Write configuration to file → [success, message]. */
+    writeConfig(): [boolean, string] {
+        try {
+            const configContent = this.generateConfigString();
+            fs.writeFileSync(this.outputPath, configContent);
+            return [true, `Configuration written to ${this.outputPath}`];
+        } catch (e) {
+            return [false, `Failed to write config: ${osErrorMessage(e)}`];
+        }
+    }
+
+    /** Validate configuration → [valid, message]. */
+    validateConfig(): [boolean, string] {
+        if ((this.config['content'] as JsonVal[]).length === 0) {
+            return [false, 'No content paths specified'];
+        }
+        if (Object.keys(this._extend()).length === 0) {
+            return [true, 'Warning: No theme extensions defined'];
+        }
+        return [true, 'Configuration valid'];
+    }
+}
+
+/** Render an OSError the way Python's `str(e)` does for write failures. */
+function osErrorMessage(e: unknown): string {
+    if (e && typeof e === 'object' && 'message' in e) {
+        return String((e as { message: unknown }).message);
+    }
+    return String(e);
+}
+
+class ArgExit extends Error {
+    constructor(public code: number) {
+        super('argexit');
+    }
+}
+
+interface Args {
+    framework: string;
+    js: boolean;
+    output: string | null;
+    colors: string[] | null;
+    fonts: string[] | null;
+    spacing: string[] | null;
+    breakpoints: string[] | null;
+    plugins: boolean;
+    validate_only: boolean;
+}
+
+/** Emit the argparse-style error (usage to stderr + error line) and exit 2. */
+function argError(message: string): never {
+    process.stderr.write(USAGE);
+    process.stderr.write(`${PROG}: error: ${message}\n`);
+    throw new ArgExit(2);
+}
+
+const FRAMEWORK_CHOICES = ['react', 'vue', 'svelte', 'nextjs'];
+
+/** Parse argv mirroring the argparse spec (nargs="*" flags collect tokens). */
+function parseArgs(argv: string[]): Args {
+    const args: Args = {
+        framework: 'react',
+        js: false,
+        output: null,
+        colors: null,
+        fonts: null,
+        spacing: null,
+        breakpoints: null,
+        plugins: false,
+        validate_only: false,
+    };
+    const starFlags = new Set(['--colors', '--fonts', '--spacing', '--breakpoints']);
+
+    let i = 0;
+    while (i < argv.length) {
+        let a = argv[i] as string;
+        let inlineValue: string | null = null;
+        const eq = a.indexOf('=');
+        if (a.startsWith('--') && eq !== -1) {
+            inlineValue = a.slice(eq + 1);
+            a = a.slice(0, eq);
+        }
+
+        if (a === '--js') {
+            args.js = true;
+        } else if (a === '--plugins') {
+            args.plugins = true;
+        } else if (a === '--validate-only') {
+            args.validate_only = true;
+        } else if (a === '--framework') {
+            const v = inlineValue ?? (argv[++i] as string | undefined);
+            if (v === undefined) {
+                argError('argument --framework: expected one argument');
+            }
+            if (!FRAMEWORK_CHOICES.includes(v)) {
+                argError(
+                    `argument --framework: invalid choice: '${v}' ` +
+                        `(choose from 'react', 'vue', 'svelte', 'nextjs')`,
+                );
+            }
+            args.framework = v;
+        } else if (a === '--output') {
+            const v = inlineValue ?? (argv[++i] as string | undefined);
+            if (v === undefined) {
+                argError('argument --output: expected one argument');
+            }
+            args.output = v;
+        } else if (starFlags.has(a)) {
+            const collected: string[] = [];
+            if (inlineValue !== null) {
+                collected.push(inlineValue);
+            } else {
+                while (i + 1 < argv.length && !(argv[i + 1] as string).startsWith('-')) {
+                    collected.push(argv[++i] as string);
+                }
+            }
+            const key = a.slice(2) as 'colors' | 'fonts' | 'spacing' | 'breakpoints';
+            args[key] = collected;
+        } else {
+            argError(`unrecognized arguments: ${a}`);
+        }
+        i += 1;
+    }
+    return args;
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    let args: Args;
+    try {
+        args = parseArgs(argv);
+    } catch (e) {
+        if (e instanceof ArgExit) {
+            return e.code;
+        }
+        throw e;
+    }
+
+    const generator = new TailwindConfigGenerator(!args.js, args.framework, args.output);
+
+    // Add custom colors
+    if (args.colors) {
+        const colors: { [k: string]: string } = {};
+        for (const colorSpec of args.colors) {
+            const idx = colorSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid color spec: ${colorSpec}\n`);
+                return 1;
+            }
+            const name = colorSpec.slice(0, idx);
+            const value = colorSpec.slice(idx + 1);
+            colors[name] = value;
+        }
+        generator.addColors(colors);
+    }
+
+    // Add custom fonts
+    if (args.fonts) {
+        const fonts: { [k: string]: string[] } = {};
+        for (const fontSpec of args.fonts) {
+            const idx = fontSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid font spec: ${fontSpec}\n`);
+                return 1;
+            }
+            const fontType = fontSpec.slice(0, idx);
+            const family = fontSpec.slice(idx + 1);
+            fonts[fontType] = family.split(',').map((f) => _stripChars(f.trim(), "'\""));
+        }
+        generator.addFonts(fonts);
+    }
+
+    // Add custom spacing
+    if (args.spacing) {
+        const spacing: { [k: string]: string } = {};
+        for (const spacingSpec of args.spacing) {
+            const idx = spacingSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid spacing spec: ${spacingSpec}\n`);
+                return 1;
+            }
+            const name = spacingSpec.slice(0, idx);
+            const value = spacingSpec.slice(idx + 1);
+            spacing[name] = value;
+        }
+        generator.addSpacing(spacing);
+    }
+
+    // Add custom breakpoints
+    if (args.breakpoints) {
+        const breakpoints: { [k: string]: string } = {};
+        for (const bpSpec of args.breakpoints) {
+            const idx = bpSpec.indexOf(':');
+            if (idx === -1) {
+                process.stderr.write(`Invalid breakpoint spec: ${bpSpec}\n`);
+                return 1;
+            }
+            const name = bpSpec.slice(0, idx);
+            const width = bpSpec.slice(idx + 1);
+            breakpoints[name] = width;
+        }
+        generator.addBreakpoints(breakpoints);
+    }
+
+    // Add recommended plugins
+    if (args.plugins) {
+        const recommended = generator.recommendPlugins();
+        generator.addPlugins(recommended);
+        process.stdout.write(`Added recommended plugins: ${recommended.join(', ')}\n`);
+        process.stdout.write('\nInstall with:\n');
+        process.stdout.write(`  npm install -D ${recommended.join(' ')}\n`);
+    }
+
+    // Validate
+    const [valid, message] = generator.validateConfig();
+    if (!valid) {
+        process.stderr.write(`Validation failed: ${message}\n`);
+        return 1;
+    }
+
+    if (message.startsWith('Warning')) {
+        process.stdout.write(`${message}\n`);
+    }
+
+    // Validate only mode
+    if (args.validate_only) {
+        process.stdout.write('Configuration valid\n');
+        process.stdout.write('\nGenerated config:\n');
+        process.stdout.write(`${generator.generateConfigString()}\n`);
+        return 0;
+    }
+
+    // Write config
+    const [success, writeMsg] = generator.writeConfig();
+    process.stdout.write(`${writeMsg}\n`);
+    return success ? 0 : 1;
+}
+
+const _invokedDirectly =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_invokedDirectly) {
+    process.exitCode = main();
+}

--- a/tests/scripts/skills_corpus_grounding_bm25_search.test.ts
+++ b/tests/scripts/skills_corpus_grounding_bm25_search.test.ts
@@ -1,0 +1,160 @@
+// Tests for src/skills/corpus-grounding/scripts/bm25_search.ts (ADR-094 py2ts).
+//
+// No pytest suite exists for the skill scripts, so this is a differential
+// suite: TS unit tests over the BM25 math / CSV parsing / filters, PLUS a
+// golden-parity layer that runs the Python module's functions (via a direct
+// importlib loader, since the skill scripts are not an importable package)
+// and the TS twin on identical inputs and asserts byte-identical JSON. The
+// CLI-level end-to-end parity (which exercises search_rows through ground.py)
+// lives in skills_corpus_grounding_ground.test.ts.
+//
+// Float parity is the load-bearing concern here: BM25 produces tf-idf floats
+// whose exact bit pattern (and the descending-with-stable-ties sort) must
+// match CPython. Determinism: pure functions over inline fixtures, no clock,
+// no network, no git drift.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import * as bm from '../../src/skills/corpus-grounding/scripts/bm25_search.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const SCRIPTS = path.join(REPO_ROOT, 'src', 'skills', 'corpus-grounding', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** Run a python snippet that imports the .py module by file path (importlib). */
+function py(modAttr: string, snippet: string): string {
+    const loader = `
+import importlib.util, json, sys
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, ${JSON.stringify(SCRIPTS)} + "/" + name + ".py")
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+${modAttr}
+${snippet}
+`;
+    const r = spawnSync('python3', ['-c', loader], { encoding: 'utf8', cwd: REPO_ROOT });
+    if (r.status !== 0) {
+        throw new Error(`python failed: ${r.stderr}`);
+    }
+    return r.stdout;
+}
+
+describe('bm25_search — tokenize parity', () => {
+    it('lowercases, strips punctuation, drops <3-char tokens (code-point length)', () => {
+        expect(bm.BM25.tokenize('Über-Café 123 a_b naïve €5 你好世界 ab abc')).toEqual([
+            'über',
+            'café',
+            '123',
+            'a_b',
+            'naïve',
+            '你好世界',
+            'abc',
+        ]);
+    });
+
+    it('coerces non-string input via str() before tokenizing', () => {
+        expect(bm.BM25.tokenize(12345)).toEqual(['12345']);
+    });
+});
+
+describe('bm25_search — BM25 scoring math', () => {
+    const docs = [
+        'Muted Palette muted calm soft A restrained low-saturation palette',
+        'Vibrant Palette vibrant bold bright High-saturation energetic colors',
+        'Fintech Blue fintech trust blue Conservative blue trust palette',
+    ];
+
+    it('produces the canonical tf-idf scores, sorted descending with stable ties', () => {
+        const b = new bm.BM25();
+        b.fit(docs);
+        const scored = b.score('muted calm palette');
+        expect(scored.map(([, s]) => s)).toEqual([
+            2.572773032492082, 0.13353139262452257, 0.13353139262452257,
+        ]);
+        // Stable tie: indices 1 and 2 keep original order.
+        expect(scored.map(([i]) => i)).toEqual([0, 1, 2]);
+    });
+
+    it('empty corpus → no scores', () => {
+        const b = new bm.BM25();
+        b.fit([]);
+        expect(b.N).toBe(0);
+        expect(b.score('anything')).toEqual([]);
+    });
+});
+
+describe('bm25_search — filters', () => {
+    const rows: bm.Row[] = [
+        { Name: 'A', Severity: 'HIGH' },
+        { Name: 'B', Severity: 'low' },
+        { Name: 'C', Severity: 'High and dry' },
+    ];
+    it('no filters → all rows', () => {
+        expect(bm.apply_filters(rows, null)).toEqual(rows);
+        expect(bm.apply_filters(rows, {})).toEqual(rows);
+    });
+    it('single value is a case-insensitive substring match', () => {
+        expect(bm.apply_filters(rows, { Severity: 'high' }).map((r) => r.Name)).toEqual(['A', 'C']);
+    });
+    it('list value matches when ANY accepted value is a substring', () => {
+        expect(bm.apply_filters(rows, { Severity: ['low', 'dry'] }).map((r) => r.Name)).toEqual([
+            'B',
+            'C',
+        ]);
+    });
+    it('unknown column never matches → empty', () => {
+        expect(bm.apply_filters(rows, { Nope: 'x' })).toEqual([]);
+    });
+});
+
+describe('bm25_search — search_rows', () => {
+    it('unknown retriever raises ValueError with the Python message', () => {
+        expect(() => bm.search_rows('whatever.csv', [], [], 'q', 3, null, 'bogus')).toThrow(
+            "Unknown retriever: 'bogus'. Available: ['bm25', 'hybrid', 'structured']",
+        );
+    });
+    it('missing file → error dict, no scores key', () => {
+        const r = bm.search_rows('/nonexistent/path/x.csv', ['Name'], ['Name'], 'q');
+        expect(r.error).toBe('File not found: /nonexistent/path/x.csv');
+        expect(r.count).toBe(0);
+        expect(r.results).toEqual([]);
+        expect('scores' in r).toBe(false);
+    });
+});
+
+describe.runIf(hasPython3())('bm25_search — golden parity (python3 importlib)', () => {
+    it('BM25.score floats match CPython bit-for-bit', () => {
+        const docs = [
+            'Muted Palette muted calm soft A restrained low-saturation palette',
+            'Vibrant Palette vibrant bold bright High-saturation energetic colors',
+            'Fintech Blue fintech trust blue Conservative blue trust palette',
+        ];
+        const out = py(
+            'bm = _load("bm25_search")',
+            `b = bm.BM25(); b.fit(${JSON.stringify(docs)})
+print(json.dumps([repr(s) for _, s in b.score("muted calm palette")]))`,
+        );
+        const pyScores = JSON.parse(out.trim()) as string[];
+        const tsB = new bm.BM25();
+        tsB.fit(docs);
+        const tsScores = tsB.score('muted calm palette').map(([, s]) => String(s));
+        expect(tsScores).toEqual(pyScores);
+    });
+
+    it('tokenize parity on a tricky unicode string', () => {
+        const sample = 'Über-Café 123 a_b naïve €5 你好世界 ab abc';
+        const out = py(
+            'bm = _load("bm25_search")',
+            `print(json.dumps(bm.BM25.tokenize(${JSON.stringify(sample)})))`,
+        );
+        expect(bm.BM25.tokenize(sample)).toEqual(JSON.parse(out.trim()));
+    });
+});

--- a/tests/scripts/skills_corpus_grounding_ground.test.ts
+++ b/tests/scripts/skills_corpus_grounding_ground.test.ts
@@ -1,0 +1,333 @@
+// Tests for src/skills/corpus-grounding/scripts/ground.ts + decision_engine.ts
+// (ADR-094 py2ts). End-to-end golden-parity: build a small corpus + manifest,
+// then run ground.py and ground.ts on every documented subcommand/flag and
+// assert byte-identical stdout + stderr + exit code. This exercises the whole
+// cluster — bm25_search (ranking + filters), schema_validator (validate +
+// load + resolve), decision_engine (search_domain/stack, evaluate_rules,
+// best-match, ground aggregate, persist, render), and the ground CLI surface
+// (JSON ensure_ascii=False, markdown render, error paths).
+//
+// The dynamic-import escape hatch (reasoning.rules_module) is covered with a
+// matched .py (importlib) + .ts (dynamic import()) pair. --persist writes are
+// compared in throwaway tmp dirs and asserted byte-identical, never touching
+// the live tree. Float parity (BM25 tf-idf → confidence scores, the .0 on
+// integral floats) is the load-bearing concern and is checked by the JSON
+// byte-comparison.
+//
+// argparse usage/--help text (exit-2 rejections) is intentionally NOT
+// byte-compared per ADR-094 test guidance; the documented success + error
+// paths are exact. Determinism: inline fixtures in tmp dirs, no clock, no
+// network, no git drift.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as de from '../../src/skills/corpus-grounding/scripts/decision_engine.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const SCRIPTS = path.join(REPO_ROOT, 'src', 'skills', 'corpus-grounding', 'scripts');
+const PY = path.join(SCRIPTS, 'ground.py');
+const TS = path.join(SCRIPTS, 'ground.ts');
+const TSX = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+const TSX_BIN = process.env.TSX_BIN ? path.resolve(REPO_ROOT, process.env.TSX_BIN) : TSX;
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-ground-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+/** Build a complete corpus + manifest fixture; return the manifest path. */
+function buildFixture(): { dir: string; manifest: string; lookupOnly: string } {
+    const dir = mkTmp();
+    fs.writeFileSync(
+        path.join(dir, 'color.csv'),
+        'Name,Keywords,Description,Severity\n' +
+            'Muted Palette,muted calm soft,A restrained low-saturation palette,LOW\n' +
+            'Vibrant Palette,vibrant bold bright,High-saturation energetic colors,HIGH\n' +
+            'Fintech Blue,fintech trust blue,Conservative blue trust palette,MEDIUM\n',
+    );
+    fs.writeFileSync(
+        path.join(dir, 'layout.csv'),
+        'Name,Keywords,Description\n' +
+            'Dashboard Grid,dashboard grid cards,A card grid layout for dashboards\n' +
+            'Hero Layout,hero landing,A hero landing layout\n',
+    );
+    fs.writeFileSync(
+        path.join(dir, 'rules.csv'),
+        'Category,Rules,Priority\n' +
+            'Dashboard,"{""if_dark_mode"": ""use elevated surfaces"", ""if_data_heavy"": ""prefer tables""}",muted+fintech\n' +
+            'General,"{""if_mobile"": ""stack vertically""}",vibrant\n',
+    );
+    const manifest = {
+        manifest_version: 1,
+        domain: 'design',
+        tier: 'conditional-grounding',
+        default_domain: 'color',
+        owner: 'test',
+        refresh_cadence: 'quarterly',
+        upstream: { repo: 'x', sha: 'y', last_checked: '2026-01-01' },
+        retriever: 'bm25',
+        domains: {
+            color: {
+                file: 'color.csv',
+                search_cols: ['Name', 'Keywords', 'Description'],
+                output_cols: ['Name', 'Description'],
+                max_results: 3,
+            },
+            layout: {
+                file: 'layout.csv',
+                search_cols: ['Name', 'Keywords', 'Description'],
+                output_cols: ['Name', 'Description'],
+            },
+        },
+        detect: { color: ['palette', 'color', 'muted'], layout: ['dashboard', 'grid', 'layout'] },
+        reasoning: {
+            file: 'rules.csv',
+            match_column: 'Category',
+            rules_column: 'Rules',
+            priority_column: 'Priority',
+            category_domain: 'layout',
+            category_column: 'Name',
+            priority_domain: 'color',
+            name_columns: { color: 'Name' },
+            plan: { color: 2, layout: 1 },
+        },
+    };
+    const manifestPath = path.join(dir, 'manifest.json');
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    // A lookup-only manifest whose domain file is missing (file-not-found path).
+    const lookup = {
+        manifest_version: 1,
+        domain: 'd',
+        tier: 'lookup-only',
+        owner: 'o',
+        refresh_cadence: 'q',
+        upstream: { repo: 'r', sha: 's', last_checked: 'l' },
+        domains: { color: { file: 'missing.csv', search_cols: ['Name'], output_cols: ['Name'] } },
+    };
+    const lookupPath = path.join(dir, 'lookup.json');
+    fs.writeFileSync(lookupPath, JSON.stringify(lookup));
+    return { dir, manifest: manifestPath, lookupOnly: lookupPath };
+}
+
+function run(bin: string, args: string[]): SpawnSyncReturns<string> {
+    return spawnSync(bin, args, { encoding: 'utf8', cwd: REPO_ROOT });
+}
+
+function assertParity(args: string[], normalize?: (s: string) => string): void {
+    const py = run('python3', [PY, ...args]);
+    const ts = run(TSX_BIN, [TS, ...args]);
+    const norm = normalize ?? ((s: string): string => s);
+    expect(ts.status).toBe(py.status);
+    expect(norm(ts.stdout)).toBe(norm(py.stdout));
+    expect(norm(ts.stderr)).toBe(norm(py.stderr));
+}
+
+// ── TS unit tests (pure helpers / async ground) ─────────────────────────────
+
+describe('decision_engine — detect_domain', () => {
+    const manifest = {
+        detect: { color: ['palette', 'muted'], layout: ['dashboard', 'grid'] },
+        default_domain: 'color',
+        domains: { color: {}, layout: {} },
+    };
+    it('routes by keyword vote (word-boundary)', () => {
+        expect(de.detect_domain(manifest, 'a muted palette please')).toBe('color');
+        expect(de.detect_domain(manifest, 'dashboard grid view')).toBe('layout');
+    });
+    it('falls back to default_domain when no keyword hits', () => {
+        expect(de.detect_domain(manifest, 'nothing relevant')).toBe('color');
+    });
+    it('falls back to the first domain when no default + no hit', () => {
+        const m = { detect: {}, domains: { layout: {}, color: {} } };
+        expect(de.detect_domain(m, 'x')).toBe('layout');
+    });
+});
+
+describe('decision_engine — evaluate_rules', () => {
+    it('matches on query tokens and truthy context flags; surfaces both sets', () => {
+        const out = de.evaluate_rules(
+            { if_dark_mode: 'A', if_data_heavy: 'B', if_mobile: 'C' },
+            'a data heavy view',
+            { dark_mode: true },
+        );
+        expect(out).toEqual({
+            matched: { if_dark_mode: 'A', if_data_heavy: 'B' },
+            unmatched: { if_mobile: 'C' },
+        });
+    });
+});
+
+describe('decision_engine — ground (async) on a real fixture', () => {
+    it('returns a grounded dict with a weakest-link aggregate confidence', async () => {
+        const { manifest } = buildFixture();
+        const m = (await import('../../src/skills/corpus-grounding/scripts/schema_validator.js')).load_manifest(manifest);
+        const grounded = await de.ground(m, 'dashboard with muted palette');
+        expect(grounded.domain).toBe('design');
+        expect(grounded.category).toBe('Dashboard Grid');
+        expect((grounded.confidence as Record<string, unknown>).label).toBeDefined();
+        expect(Array.isArray(grounded.evidence_gap)).toBe(true);
+    });
+});
+
+// ── Golden parity (python3 vs tsx) ──────────────────────────────────────────
+
+describe.runIf(hasPython3())('ground — golden parity (python3 vs tsx)', () => {
+    it('validate (valid) — OK + exit 0', () => {
+        const { manifest } = buildFixture();
+        assertParity(['validate', '--manifest', manifest]);
+    });
+
+    it('validate (invalid) — INVALID list + exit 1', () => {
+        const dir = mkTmp();
+        const bad = path.join(dir, 'bad.json');
+        fs.writeFileSync(bad, '{"manifest_version": 2}');
+        assertParity(['validate', '--manifest', bad]);
+    });
+
+    it('search auto-detect domain (--json)', () => {
+        const { manifest } = buildFixture();
+        assertParity(['search', '--manifest', manifest, 'muted calm palette', '--json']);
+    });
+
+    it('search explicit domain (text render)', () => {
+        const { manifest } = buildFixture();
+        assertParity(['search', '--manifest', manifest, '--domain', 'color', 'vibrant bold']);
+    });
+
+    it('search structured retriever + filter (--json)', () => {
+        const { manifest } = buildFixture();
+        assertParity([
+            'search', '--manifest', manifest, '--domain', 'color',
+            '--filter', 'Severity=HIGH', '--retriever', 'structured', 'x', '--json',
+        ]);
+    });
+
+    it('search hybrid retriever + empty query falls back to stable order', () => {
+        const { manifest } = buildFixture();
+        assertParity(['search', '--manifest', manifest, '--domain', 'color', '--retriever', 'hybrid', '', '--json']);
+    });
+
+    it('search repeated --filter (list value)', () => {
+        const { manifest } = buildFixture();
+        assertParity([
+            'search', '--manifest', manifest, '--domain', 'color',
+            '--filter', 'Severity=HIGH', '--filter', 'Severity=LOW', 'palette', '--json',
+        ]);
+    });
+
+    it('search no match → confidence 0.0 + evidence gap', () => {
+        const { manifest } = buildFixture();
+        assertParity(['search', '--manifest', manifest, '--domain', 'color', 'zzz nonexistent qqq', '--json']);
+    });
+
+    it('search file-not-found → error dict + exit 1 (path normalised)', () => {
+        const { dir, lookupOnly } = buildFixture();
+        const norm = (s: string): string => s.split(dir).join('DIR').split(fs.realpathSync.native(dir)).join('DIR');
+        assertParity(['search', '--manifest', lookupOnly, '--domain', 'color', 'x', '--json'], norm);
+    });
+
+    it('search unknown domain → error dict + exit 1', () => {
+        const { manifest } = buildFixture();
+        assertParity(['search', '--manifest', manifest, '--domain', 'bogus', 'x', '--json']);
+    });
+
+    it('search unknown stack → error dict + exit 1', () => {
+        const { manifest } = buildFixture();
+        assertParity(['search', '--manifest', manifest, '--stack', 'react', 'x', '--json']);
+    });
+
+    it('ground (--json) — full reasoning plan + aggregate confidence', () => {
+        const { manifest } = buildFixture();
+        assertParity(['ground', '--manifest', manifest, 'dashboard with muted palette', '--json']);
+    });
+
+    it('ground (markdown render)', () => {
+        const { manifest } = buildFixture();
+        assertParity(['ground', '--manifest', manifest, 'dashboard with muted palette']);
+    });
+
+    it('ground with --context flags', () => {
+        const { manifest } = buildFixture();
+        assertParity([
+            'ground', '--manifest', manifest, 'dashboard data heavy',
+            '--context', '{"dark_mode": true}', '--json',
+        ]);
+    });
+
+    it('ground manifest-not-found → Error on stderr + exit 1', () => {
+        const dir = mkTmp();
+        const missing = path.join(dir, 'nope.json');
+        const norm = (s: string): string => s.split(dir).join('DIR').split(fs.realpathSync.native(dir)).join('DIR');
+        assertParity(['ground', '--manifest', missing, 'x'], norm);
+    });
+
+    it('ground on a lookup-only manifest → ManifestError on stderr + exit 1', () => {
+        const { lookupOnly } = buildFixture();
+        assertParity(['ground', '--manifest', lookupOnly, 'x']);
+    });
+
+    it('ground --persist writes a byte-identical MASTER.md + page override', () => {
+        const { manifest } = buildFixture();
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        const py = run('python3', [PY, 'ground', '--manifest', manifest, 'Lux Store', '--persist', pyDir, '--page', 'Home', '--json']);
+        const ts = run(TSX_BIN, [TS, 'ground', '--manifest', manifest, 'Lux Store', '--persist', tsDir, '--page', 'Home', '--json']);
+        expect(ts.status).toBe(py.status);
+        // stdout embeds the persist dir path; normalise it.
+        expect(ts.stdout.split(tsDir).join('DIR')).toBe(py.stdout.split(pyDir).join('DIR'));
+        expect(ts.stderr).toBe(py.stderr);
+        const rel = path.join('design-system', 'lux-store');
+        expect(fs.readFileSync(path.join(tsDir, rel, 'MASTER.md'), 'utf8')).toBe(
+            fs.readFileSync(path.join(pyDir, rel, 'MASTER.md'), 'utf8'),
+        );
+        expect(fs.readFileSync(path.join(tsDir, rel, 'pages', 'home.md'), 'utf8')).toBe(
+            fs.readFileSync(path.join(pyDir, rel, 'pages', 'home.md'), 'utf8'),
+        );
+    });
+
+    it('reasoning.rules_module escape hatch — importlib (.py) vs dynamic import (.ts)', () => {
+        const { dir, manifest } = buildFixture();
+        // Matched module pair beside the manifest: .py for python, .ts for the twin.
+        fs.writeFileSync(
+            path.join(dir, 'custom_rules.py'),
+            'def evaluate(rules, query, context):\n' +
+                '    return {"matched": {"CUSTOM": "fired:" + query}, "unmatched": dict(rules)}\n',
+        );
+        fs.writeFileSync(
+            path.join(dir, 'custom_rules.ts'),
+            'export function evaluate(rules: Record<string, unknown>, query: string, _context: Record<string, unknown>) {\n' +
+                '    return { matched: { CUSTOM: "fired:" + query }, unmatched: { ...rules } };\n' +
+                '}\n',
+        );
+        const m = JSON.parse(fs.readFileSync(manifest, 'utf8')) as Record<string, unknown>;
+        (m.reasoning as Record<string, unknown>).rules_module = 'custom_rules.py';
+        const custom = path.join(dir, 'm_custom.json');
+        fs.writeFileSync(custom, JSON.stringify(m));
+        assertParity(['ground', '--manifest', custom, 'dashboard with muted palette', '--json']);
+    });
+});

--- a/tests/scripts/skills_corpus_grounding_schema_validator.test.ts
+++ b/tests/scripts/skills_corpus_grounding_schema_validator.test.ts
@@ -1,0 +1,183 @@
+// Tests for src/skills/corpus-grounding/scripts/schema_validator.ts (ADR-094).
+//
+// TS unit tests over validate_manifest / load_manifest / resolve_data_path,
+// PLUS a golden-parity layer that runs the Python module's validate_manifest
+// (via a direct importlib loader) on the same manifests and asserts the
+// violation-list is byte-identical (the messages embed Python repr() of keys
+// and the TIERS tuple, so this catches any repr drift).
+//
+// Determinism: pure functions over inline fixtures + tmp files cleaned in
+// afterEach; no clock, no network, no git drift.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as sv from '../../src/skills/corpus-grounding/scripts/schema_validator.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const SCRIPTS = path.join(REPO_ROOT, 'src', 'skills', 'corpus-grounding', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cg-sv-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+/** Run python validate_manifest on a JSON-encoded manifest, return the list. */
+function pyValidate(manifest: unknown): string[] {
+    const code = `
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("schema_validator", ${JSON.stringify(SCRIPTS)} + "/schema_validator.py")
+m = importlib.util.module_from_spec(spec); sys.modules["schema_validator"] = m
+spec.loader.exec_module(m)
+data = json.loads(${JSON.stringify(JSON.stringify(manifest))})
+print(json.dumps(m.validate_manifest(data)))
+`;
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8', cwd: REPO_ROOT });
+    if (r.status !== 0) {
+        throw new Error(`python failed: ${r.stderr}`);
+    }
+    return JSON.parse(r.stdout.trim()) as string[];
+}
+
+const VALID: Record<string, unknown> = {
+    manifest_version: 1,
+    domain: 'design',
+    tier: 'lookup-only',
+    owner: 'o',
+    refresh_cadence: 'q',
+    upstream: { repo: 'r', sha: 's', last_checked: 'l' },
+    domains: { color: { file: 'c.csv', search_cols: ['Name'], output_cols: ['Name'] } },
+};
+
+describe('schema_validator — validate_manifest', () => {
+    it('accepts a minimal valid manifest', () => {
+        expect(sv.validate_manifest(VALID)).toEqual([]);
+    });
+
+    it('non-object input is rejected', () => {
+        expect(sv.validate_manifest(42)).toEqual(['manifest must be a JSON object']);
+        expect(sv.validate_manifest([1, 2])).toEqual(['manifest must be a JSON object']);
+    });
+
+    it('missing top-level keys short-circuit (no further checks)', () => {
+        expect(sv.validate_manifest({ manifest_version: 2 })).toEqual([
+            "missing required key: 'domain'",
+            "missing required key: 'tier'",
+            "missing required key: 'domains'",
+        ]);
+    });
+
+    it('reports version / tier / provenance violations with Python repr()', () => {
+        expect(sv.validate_manifest({ manifest_version: 2, domain: 'd', tier: 'x', domains: {} })).toEqual([
+            'manifest_version 2 unsupported (engine speaks v1)',
+            "tier 'x' not in ('lookup-only', 'conditional-grounding', 'constraint-emission')",
+            'domains must be a non-empty object',
+            "missing provenance key: 'owner' (ADR-061 §6)",
+            "missing provenance key: 'refresh_cadence' (ADR-061 §6)",
+            "missing provenance key: 'upstream' (ADR-061 §6)",
+        ]);
+    });
+
+    it('reasoning-present-on-lookup-only + non-empty-list + bad upstream', () => {
+        expect(
+            sv.validate_manifest({
+                manifest_version: 1,
+                domain: 'd',
+                tier: 'lookup-only',
+                domains: { a: { file: 'f', search_cols: [], output_cols: ['x'] } },
+                owner: 'o',
+                refresh_cadence: 'c',
+                upstream: 'bad',
+                reasoning: {},
+            }),
+        ).toEqual([
+            'domains.a.search_cols must be a non-empty list',
+            'reasoning block present but tier is lookup-only',
+            "reasoning missing 'file'",
+            "reasoning missing 'match_column'",
+            "reasoning missing 'plan'",
+            'upstream must be an object {repo, sha, last_checked}',
+        ]);
+    });
+});
+
+describe('schema_validator — load_manifest + resolve_data_path', () => {
+    it('load_manifest throws ManifestError on a missing file', () => {
+        expect(() => sv.load_manifest('/nope/missing.json')).toThrow(sv.ManifestError);
+        expect(() => sv.load_manifest('/nope/missing.json')).toThrow('Manifest not found: /nope/missing.json');
+    });
+
+    it('load_manifest attaches _manifest_dir (symlink-resolved)', () => {
+        const d = mkTmp();
+        const p = path.join(d, 'manifest.json');
+        fs.writeFileSync(p, JSON.stringify(VALID));
+        const m = sv.load_manifest(p);
+        // Python str(path.resolve().parent) — equals the realpath of the dir.
+        expect(m._manifest_dir).toBe(fs.realpathSync.native(d));
+    });
+
+    it('resolve_data_path refuses absolute + parent-escape paths', () => {
+        const m = { _manifest_dir: '/base' };
+        expect(() => sv.resolve_data_path(m, '/etc/passwd')).toThrow(
+            "corpus path must be manifest-relative: '/etc/passwd'",
+        );
+        expect(() => sv.resolve_data_path(m, '../escape.csv')).toThrow(
+            "corpus path must be manifest-relative: '../escape.csv'",
+        );
+    });
+
+    it('resolve_data_path joins base + data_dir + relative', () => {
+        const d = mkTmp();
+        const m = { _manifest_dir: d };
+        expect(sv.resolve_data_path(m, 'corpus.csv')).toBe(path.join(fs.realpathSync.native(d), 'corpus.csv'));
+    });
+});
+
+describe.runIf(hasPython3())('schema_validator — golden parity (python3 importlib)', () => {
+    const cases: [string, unknown][] = [
+        ['valid', VALID],
+        ['non-object', 42],
+        ['missing-top', { manifest_version: 2 }],
+        ['version/tier/provenance', { manifest_version: 2, domain: 'd', tier: 'x', domains: {} }],
+        [
+            'big-mixed',
+            {
+                manifest_version: 1,
+                domain: 'd',
+                tier: 'conditional-grounding',
+                domains: { a: {} },
+                owner: 'o',
+                refresh_cadence: 'c',
+                upstream: { repo: 'r' },
+                default_domain: 'zzz',
+                detect: { q: [1], a: 'nope' },
+                reasoning: { plan: { nope: 1 } },
+                stacks: { s: 'p' },
+                retriever: 'weird',
+            },
+        ],
+    ];
+    for (const [name, manifest] of cases) {
+        it(`validate_manifest matches python for: ${name}`, () => {
+            expect(sv.validate_manifest(manifest)).toEqual(pyValidate(manifest));
+        });
+    }
+});

--- a/tests/scripts/skills_design_tokens_tokens.test.ts
+++ b/tests/scripts/skills_design_tokens_tokens.test.ts
@@ -1,0 +1,308 @@
+// Golden-parity tests for src/skills/design-tokens/scripts/tokens.ts
+// (py2ts migration, ADR-094).
+//
+// `tokens` is a DTCG token toolchain with three subcommands —
+// `generate` (tokens.json → CSS vars / Tailwind colors), `validate`
+// (scan a tree for hardcoded values that should be tokens), and `embed`
+// (extract inline CSS from a generated tokens.css). All four output
+// surfaces are byte targets: the generated CSS / Tailwind config / embedded
+// CSS / JSON findings, plus the stdout/stderr split and exit code.
+//
+// The contract here is python3 vs tsx byte-identical: for every fixture and
+// every subcommand, `python3 tokens.py …` and `tsx tokens.ts …` must produce
+// identical stdout, identical stderr, identical exit code, and (for
+// `generate -o`) an identical written file. The shipped starter token JSON
+// is the primary fixture; synthetic CSS / code trees cover the validate
+// scanner's edge cases (hex exceptions, RGB(A), px/rem, skip patterns,
+// ignore dirs, allowed-host hints, comment lines, non-ASCII paths,
+// `.blade.php` two-suffix detection). Skipped when python3 is absent.
+//
+// argparse `--help` is intentionally NOT byte-compared (per the migration
+// task) — the TS arg parser emits faithful-enough diagnostics, not an
+// argparse clone.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const SKILL_DIR = path.join(REPO_ROOT, 'src', 'skills', 'design-tokens');
+const TS_SCRIPT = path.join(SKILL_DIR, 'scripts', 'tokens.ts');
+const PY_SCRIPT = path.join(SKILL_DIR, 'scripts', 'tokens.py');
+const STARTER = path.join(SKILL_DIR, 'templates', 'design-tokens-starter.json');
+const TSX_BIN =
+    process.env.TSX_BIN ??
+    path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+const runnable = hasPython3() && fs.existsSync(PY_SCRIPT) && fs.existsSync(STARTER);
+
+interface Run {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+}
+function runPy(args: string[]): Run {
+    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+function runTs(args: string[]): Run {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+}
+
+/** Assert python3 and tsx agree on stdout, stderr, and exit code byte-for-byte. */
+function expectParity(args: string[]): { py: Run; ts: Run } {
+    const py = runPy(args);
+    const ts = runTs(args);
+    expect(ts.status).toBe(py.status);
+    expect(ts.stdout).toBe(py.stdout);
+    expect(ts.stderr).toBe(py.stderr);
+    return { py, ts };
+}
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tokens-gp-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe.skipIf(!runnable)('tokens — generate (python3 vs tsx)', () => {
+    it('CSS from the shipped starter token JSON is byte-identical', () => {
+        expectParity(['generate', '--config', STARTER]);
+    });
+
+    it('Tailwind config from the shipped starter is byte-identical (json.dumps quoting)', () => {
+        expectParity(['generate', '--config', STARTER, '--format', 'tailwind']);
+    });
+
+    it('short flags (-c / -f) match', () => {
+        expectParity(['generate', '-c', STARTER, '-f', 'css']);
+        expectParity(['generate', '-c', STARTER, '-f', 'tailwind']);
+    });
+
+    it('dark-mode block emits only when tokens.dark.semantic is present', () => {
+        const cfg = path.join(tmp, 'dark.json');
+        fs.writeFileSync(
+            cfg,
+            JSON.stringify({
+                semantic: {
+                    color: { primary: { $value: '#111', $type: 'color' } },
+                },
+                dark: {
+                    semantic: {
+                        color: { primary: { $value: '#eee', $type: 'color' } },
+                    },
+                },
+            }),
+            'utf-8',
+        );
+        expectParity(['generate', '--config', cfg]);
+    });
+
+    it('reference resolution ({primitive.color.x}) resolves identically', () => {
+        const cfg = path.join(tmp, 'ref.json');
+        fs.writeFileSync(
+            cfg,
+            JSON.stringify({
+                primitive: {
+                    color: { blue: { '600': { $value: '#2563EB', $type: 'color' } } },
+                },
+                semantic: {
+                    color: { accent: { $value: '{primitive.color.blue.600}', $type: 'color' } },
+                },
+            }),
+            'utf-8',
+        );
+        expectParity(['generate', '--config', cfg]);
+        expectParity(['generate', '--config', cfg, '--format', 'tailwind']);
+    });
+
+    it('unresolvable / dangling reference falls back to the literal identically', () => {
+        const cfg = path.join(tmp, 'dangling.json');
+        fs.writeFileSync(
+            cfg,
+            JSON.stringify({
+                semantic: {
+                    color: { x: { $value: '{primitive.color.nope.999}', $type: 'color' } },
+                },
+            }),
+            'utf-8',
+        );
+        expectParity(['generate', '--config', cfg]);
+    });
+
+    it('empty / missing top-level sections produce identical empty :root blocks', () => {
+        const cfg = path.join(tmp, 'empty.json');
+        fs.writeFileSync(cfg, JSON.stringify({}), 'utf-8');
+        expectParity(['generate', '--config', cfg]);
+    });
+
+    it('-o writes a byte-identical CSS file and prints the same Generated: line', () => {
+        const pyOut = path.join(tmp, 'py', 'nested', 'out.css');
+        const tsOut = path.join(tmp, 'ts', 'nested', 'out.css');
+        const py = runPy(['generate', '--config', STARTER, '-o', pyOut]);
+        const ts = runTs(['generate', '--config', STARTER, '-o', tsOut]);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stderr).toBe(py.stderr);
+        // stdout differs only by the (different) output path token.
+        expect(ts.stdout.replace(tsOut, 'OUT')).toBe(py.stdout.replace(pyOut, 'OUT'));
+        expect(fs.readFileSync(tsOut, 'utf-8')).toBe(fs.readFileSync(pyOut, 'utf-8'));
+    });
+
+    it('missing config file → same error + exit 1', () => {
+        const { py } = expectParity(['generate', '--config', path.join(tmp, 'nope.json')]);
+        expect(py.status).toBe(1);
+    });
+});
+
+describe.skipIf(!runnable)('tokens — validate (python3 vs tsx)', () => {
+    // A tree exercising every scanner branch: hex (+ exception), RGB(A),
+    // px (2+ digits only), rem, comment lines, var(--) skip, allowed-host
+    // skip, ignored dir, skip-file pattern (.min.css), nested dir ordering.
+    function buildTree(root: string): void {
+        fs.mkdirSync(path.join(root, 'src', 'components'), { recursive: true });
+        fs.mkdirSync(path.join(root, 'node_modules', 'pkg'), { recursive: true });
+        fs.writeFileSync(
+            path.join(root, 'src', 'a.css'),
+            [
+                '.box { color: #ff0000; padding: 16px; margin: 2rem; }',
+                '.ok { color: var(--color-primary); }',
+                '/* comment #abcdef stays ignored */',
+                '// line comment #123456',
+                '* { color: #000000; }', // hex exception → no finding
+                '.exc { color: #FFF; }', // hex exception
+                '.rgb { background: rgba(1, 2, 3, 0.5); }',
+                '.rgb2 { background: rgb(10,20,30); }',
+                '.host { color: #abcdef; background: url(fonts.googleapis.com/x); }', // allowed-host skip
+                '.px1 { width: 5px; }', // single digit → no pixel finding
+                '.px2 { width: 100px; }',
+                '.rem { font-size: 1.5rem; }',
+                '.multi { color: #aaa; border-color: #bbb; }', // two hex, one finding
+            ].join('\n'),
+            'utf-8',
+        );
+        fs.writeFileSync(
+            path.join(root, 'src', 'components', 'b.tsx'),
+            'const s = { color: "#00FF00", width: "120px" };\n',
+            'utf-8',
+        );
+        fs.writeFileSync(
+            path.join(root, 'node_modules', 'pkg', 'c.css'),
+            '.ignored { color: #abcdef; }\n',
+            'utf-8',
+        );
+        fs.writeFileSync(path.join(root, 'src', 'x.min.css'), '.skip { color: #111111; }\n', 'utf-8');
+        fs.writeFileSync(path.join(root, 'src', 'tokens.css'), '.skip { color: #222222; }\n', 'utf-8');
+        fs.writeFileSync(path.join(root, 'src', 'notscanned.txt'), 'color: #999999;\n', 'utf-8');
+    }
+
+    it('text report (file grouping + summary) is byte-identical, exit 1 on findings', () => {
+        const root = path.join(tmp, 'tree');
+        buildTree(root);
+        const { py } = expectParity(['validate', '--dir', root]);
+        expect(py.status).toBe(1);
+    });
+
+    it('--json findings array is byte-identical (json.dumps indent=2)', () => {
+        const root = path.join(tmp, 'tree');
+        buildTree(root);
+        expectParity(['validate', '--dir', root, '--json']);
+    });
+
+    it('--ignore (repeatable) prunes the same subtrees', () => {
+        const root = path.join(tmp, 'tree');
+        buildTree(root);
+        expectParity(['validate', '--dir', root, '-i', 'components']);
+        expectParity(['validate', '--dir', root, '-i', 'components', '-i', 'src']);
+    });
+
+    it('clean tree → "No token violations" + exit 0', () => {
+        const root = path.join(tmp, 'clean');
+        fs.mkdirSync(root, { recursive: true });
+        fs.writeFileSync(path.join(root, 'a.css'), '.ok { color: var(--color-x); }\n', 'utf-8');
+        const { py } = expectParity(['validate', '--dir', root]);
+        expect(py.status).toBe(0);
+    });
+
+    it('.blade.php two-suffix detection + non-ASCII path JSON escaping match', () => {
+        const root = path.join(tmp, 'blade');
+        fs.mkdirSync(path.join(root, 'views'), { recursive: true });
+        // Non-ASCII filename → exercises ensure_ascii=True \uXXXX escaping in JSON.
+        fs.writeFileSync(
+            path.join(root, 'views', 'café.blade.php'),
+            'class="p" style="color: #abcdef"\n',
+            'utf-8',
+        );
+        expectParity(['validate', '--dir', root, '--json']);
+        expectParity(['validate', '--dir', root]);
+    });
+
+    it('missing directory → same error + exit 1', () => {
+        const { py } = expectParity(['validate', '--dir', path.join(tmp, 'nope')]);
+        expect(py.status).toBe(1);
+    });
+});
+
+describe.skipIf(!runnable)('tokens — embed (python3 vs tsx)', () => {
+    function buildCss(): string {
+        const out = path.join(tmp, 'tokens.css');
+        const r = runPy(['generate', '--config', STARTER, '-o', out]);
+        expect(r.status).toBe(0);
+        return out;
+    }
+
+    it('default embed (dedup + :root wrap) is byte-identical', () => {
+        expectParity(['embed', '--tokens', buildCss()]);
+    });
+
+    it('--minimal (prefix filter) is byte-identical', () => {
+        expectParity(['embed', '--tokens', buildCss(), '--minimal']);
+    });
+
+    it('--style wraps in <style> tags identically', () => {
+        expectParity(['embed', '--tokens', buildCss(), '--style']);
+        expectParity(['embed', '--tokens', buildCss(), '--minimal', '--style']);
+    });
+
+    it('duplicate :root vars are de-duplicated identically (insertion order kept)', () => {
+        const css = path.join(tmp, 'dup.css');
+        fs.writeFileSync(
+            css,
+            ':root {\n  --a: 1;\n  --b: 2;\n}\n:root {\n  --a: 1;\n  --c: 3;\n}\n',
+            'utf-8',
+        );
+        expectParity(['embed', '--tokens', css]);
+    });
+
+    it('missing tokens css → same error + exit 1', () => {
+        const { py } = expectParity(['embed', '--tokens', path.join(tmp, 'nope.css')]);
+        expect(py.status).toBe(1);
+    });
+});
+
+describe.skipIf(!runnable)('tokens — CLI errors (python3 vs tsx, exit code only)', () => {
+    // argparse usage text is NOT byte-compared (per the migration task) — only
+    // the exit code (2) is contractual for arg-parse errors.
+    it('unknown subcommand exits non-zero in both', () => {
+        const py = runPy(['frobnicate']);
+        const ts = runTs(['frobnicate']);
+        expect(py.status).not.toBe(0);
+        expect(ts.status).not.toBe(0);
+        expect(ts.status).toBe(py.status);
+    });
+
+    it('missing required --config exits non-zero in both', () => {
+        const py = runPy(['generate']);
+        const ts = runTs(['generate']);
+        expect(py.status).not.toBe(0);
+        expect(ts.status).not.toBe(0);
+        expect(ts.status).toBe(py.status);
+    });
+});

--- a/tests/scripts/skills_react_shadcn_ui_shadcn_add.test.ts
+++ b/tests/scripts/skills_react_shadcn_ui_shadcn_add.test.ts
@@ -1,0 +1,166 @@
+// Tests for src/skills/react-shadcn-ui/scripts/shadcn_add.ts (py2ts, ADR-094).
+//
+// No pytest suite exists, so this is a golden-parity suite that runs python3
+// vs tsx on synthetic fixtures and compares stdout + stderr + exit code
+// byte-for-byte. It covers the main paths (no-init guard, dry-run command
+// shape for add / add-all / overwrite, --list empty + sorted listing,
+// already-installed guard, the components.json alias-default fallback) and
+// the error paths (no components → print_help + exit 1, unrecognized flag →
+// exit 2).
+//
+// No real `npx` is ever spawned: every "would run" path uses --dry-run, and
+// the not-initialized / already-installed paths short-circuit before exec, so
+// the suite is deterministic and side-effect-free (throwaway tmp dirs only).
+// The argparse --help text is NOT byte-compared as a contract, but the
+// no-components path runs print_help → stdout and we assert exit-code parity.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(
+    REPO_ROOT,
+    'src',
+    'skills',
+    'react-shadcn-ui',
+    'scripts',
+    'shadcn_add.ts',
+);
+const PY_SCRIPT = path.join(
+    REPO_ROOT,
+    'src',
+    'skills',
+    'react-shadcn-ui',
+    'scripts',
+    'shadcn_add.py',
+);
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'shadcn-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+function runPy(args: string[], cwd: string) {
+    return spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
+}
+function runTs(args: string[], cwd: string) {
+    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
+}
+function assertParity(args: string[], cwd: string, expectedStatus?: number) {
+    const py = runPy(args, cwd);
+    const ts = runTs(args, cwd);
+    expect(ts.status).toBe(py.status);
+    if (expectedStatus !== undefined) {
+        expect(ts.status).toBe(expectedStatus);
+    }
+    expect(ts.stdout).toBe(py.stdout);
+    expect(ts.stderr).toBe(py.stderr);
+    return ts;
+}
+
+/** Seed a project dir with a components.json + optional installed *.tsx set. */
+function seed(installed: string[] | null, componentsJson = '{"aliases":{"components":"@/components"}}'): string {
+    const d = mkTmp();
+    if (componentsJson !== '') {
+        fs.writeFileSync(path.join(d, 'components.json'), componentsJson);
+    }
+    if (installed) {
+        const uiDir = path.join(d, 'components', 'ui');
+        fs.mkdirSync(uiDir, { recursive: true });
+        for (const c of installed) {
+            fs.writeFileSync(path.join(uiDir, `${c}.tsx`), '');
+        }
+    }
+    return d;
+}
+
+describe.runIf(hasPython3())('shadcn_add — golden parity (python3 vs tsx)', () => {
+    it('--list with no components.json → "shadcn not initialized" + exit 1', () => {
+        const d = mkTmp();
+        assertParity(['--list'], d, 1);
+    });
+
+    it('add a component with no components.json → init-required + exit 1', () => {
+        const d = mkTmp();
+        const ts = assertParity(['button'], d, 1);
+        expect(ts.stdout).toContain("shadcn not initialized. Run 'npx shadcn@latest init' first");
+    });
+
+    it('dry-run add (initialized) → "Would run: npx shadcn@latest add …" + exit 0', () => {
+        const d = seed(null);
+        const ts = assertParity(['button', 'card', '--dry-run'], d, 0);
+        expect(ts.stdout).toBe('Would run: npx shadcn@latest add button card\n');
+    });
+
+    it('dry-run --all (initialized) → add --all command shape + exit 0', () => {
+        const d = seed(null);
+        const ts = assertParity(['--all', '--dry-run'], d, 0);
+        expect(ts.stdout).toBe('Would run: npx shadcn@latest add --all\n');
+    });
+
+    it('dry-run --overwrite appends the --overwrite flag', () => {
+        const d = seed(['button']);
+        const ts = assertParity(['button', '--overwrite', '--dry-run'], d, 0);
+        expect(ts.stdout).toBe('Would run: npx shadcn@latest add button --overwrite\n');
+    });
+
+    it('--list (initialized, empty ui dir) → "No components installed" + exit 0', () => {
+        const d = seed(null);
+        assertParity(['--list'], d, 0);
+    });
+
+    it('--list emits a sorted "- name" listing of installed *.tsx stems', () => {
+        const d = seed(['button', 'card', 'alert-dialog']);
+        const ts = assertParity(['--list'], d, 0);
+        expect(ts.stdout).toBe('Installed components:\n  - alert-dialog\n  - button\n  - card\n');
+    });
+
+    it('already-installed component without --overwrite → guard message + exit 1', () => {
+        const d = seed(['button']);
+        const ts = assertParity(['button', 'dialog'], d, 1);
+        expect(ts.stdout).toContain('Components already installed: button. Use --overwrite to reinstall');
+    });
+
+    it('components.json without an aliases key falls back to the default "components" dir', () => {
+        const d = seed(['button', 'card', 'alert-dialog'], '{}');
+        const ts = assertParity(['--list'], d, 0);
+        expect(ts.stdout).toBe('Installed components:\n  - alert-dialog\n  - button\n  - card\n');
+    });
+
+    it('no components (and no --all/--list) → print_help to stdout + exit 1', () => {
+        const d = seed(null);
+        // --help text is not part of the byte contract, but exit-code + the
+        // stdout/stderr split must match (print_help → stdout, then exit 1).
+        assertParity([], d, 1);
+    });
+
+    it('unrecognized flag → byte-identical usage + error + exit 2', () => {
+        const d = mkTmp();
+        const ts = assertParity(['--bogus'], d, 2);
+        expect(ts.stderr).toContain('unrecognized arguments: --bogus');
+    });
+});

--- a/tests/scripts/skills_react_shadcn_ui_shadcn_add.test.ts
+++ b/tests/scripts/skills_react_shadcn_ui_shadcn_add.test.ts
@@ -153,9 +153,19 @@ describe.runIf(hasPython3())('shadcn_add — golden parity (python3 vs tsx)', ()
 
     it('no components (and no --all/--list) → print_help to stdout + exit 1', () => {
         const d = seed(null);
-        // --help text is not part of the byte contract, but exit-code + the
-        // stdout/stderr split must match (print_help → stdout, then exit 1).
-        assertParity([], d, 1);
+        // print_help emits argparse usage prose, which is COLUMNS- and
+        // Python-version-dependent (width wrapping) — NOT a byte contract
+        // (passed on local python3, diverged on the CI runner's). Assert the
+        // exit code + the stdout/stderr split (help → stdout, empty stderr) +
+        // a stable usage-line token, not byte-identical prose. Convention:
+        // run_skill_evals / score_ev / airgap twins.
+        const ts = runTs([], d);
+        const py = runPy([], d);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(1);
+        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stdout).toMatch(/usage:\s+shadcn_add/u);
+        expect(py.stdout).toMatch(/usage:\s+shadcn_add/u);
     });
 
     it('unrecognized flag → byte-identical usage + error + exit 2', () => {

--- a/tests/scripts/skills_tailwind_engineer_tailwind_config_gen.test.ts
+++ b/tests/scripts/skills_tailwind_engineer_tailwind_config_gen.test.ts
@@ -1,0 +1,176 @@
+// Tests for src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts (py2ts, ADR-094).
+//
+// No pytest suite exists, so this is a golden-parity suite that runs python3
+// vs tsx on fixtures and compares stdout + stderr + exit code byte-for-byte,
+// plus a byte-identical check on the WRITTEN config file (.ts and .js). It
+// covers the main generation paths (validate-only default react, full
+// option matrix with --js/--colors/--fonts/--spacing/--breakpoints/--plugins
+// on nextjs, the file-write path) and the error paths (bad color/font/spacing/
+// breakpoint spec → exit 1, argparse invalid framework choice → exit 2).
+//
+// The argparse --help text is intentionally NOT byte-compared (an argparse
+// internal detail); the invalid-choice usage block IS compared because the
+// twin pins it as a fixed-width-80 constant. Everything is deterministic —
+// the write path uses throwaway tmp dirs, so there is zero git drift.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(
+    REPO_ROOT,
+    'src',
+    'skills',
+    'tailwind-engineer',
+    'scripts',
+    'tailwind_config_gen.ts',
+);
+const PY_SCRIPT = path.join(
+    REPO_ROOT,
+    'src',
+    'skills',
+    'tailwind-engineer',
+    'scripts',
+    'tailwind_config_gen.py',
+);
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'tw-cfg-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+function runPy(args: string[], cwd: string = REPO_ROOT) {
+    return spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
+}
+function runTs(args: string[], cwd: string = REPO_ROOT) {
+    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
+}
+
+describe.runIf(hasPython3())('tailwind_config_gen — golden parity (python3 vs tsx)', () => {
+    it('--validate-only default (react) prints a byte-identical config + exit 0', () => {
+        const args = ['--validate-only'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('full option matrix (--js nextjs + colors/fonts/spacing/breakpoints/plugins) matches', () => {
+        const args = [
+            '--validate-only',
+            '--js',
+            '--framework',
+            'nextjs',
+            '--colors',
+            'brand:#3b82f6',
+            'accent:#8b5cf6',
+            '--fonts',
+            'sans:Inter,system-ui,sans-serif',
+            "display:'Playfair Display',serif",
+            '--spacing',
+            'navbar:4rem',
+            '--breakpoints',
+            '3xl:1920px',
+            '--plugins',
+        ];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it.each([
+        ['vue'],
+        ['svelte'],
+    ])('--validate-only --framework %s matches', (fw) => {
+        const args = ['--validate-only', '--framework', fw];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+    });
+
+    it('writes a byte-identical tailwind.config.ts (the file-write path)', () => {
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        const pyOut = path.join(pyDir, 'tailwind.config.ts');
+        const tsOut = path.join(tsDir, 'tailwind.config.ts');
+        const py = runPy(['--colors', 'brand:#3b82f6', '--output', pyOut]);
+        const ts = runTs(['--colors', 'brand:#3b82f6', '--output', tsOut]);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(0);
+        // stdout embeds the absolute output path; normalise that one token.
+        expect(ts.stdout.replace(tsOut, 'OUT')).toBe(py.stdout.replace(pyOut, 'OUT'));
+        expect(ts.stderr).toBe(py.stderr);
+        expect(fs.readFileSync(tsOut, 'utf8')).toBe(fs.readFileSync(pyOut, 'utf8'));
+    });
+
+    it('writes a byte-identical tailwind.config.js (--js write path)', () => {
+        const pyDir = mkTmp();
+        const tsDir = mkTmp();
+        const pyOut = path.join(pyDir, 'tailwind.config.js');
+        const tsOut = path.join(tsDir, 'tailwind.config.js');
+        const py = runPy(['--js', '--plugins', '--framework', 'nextjs', '--output', pyOut]);
+        const ts = runTs(['--js', '--plugins', '--framework', 'nextjs', '--output', tsOut]);
+        expect(ts.status).toBe(py.status);
+        expect(ts.stdout.replace(tsOut, 'OUT')).toBe(py.stdout.replace(pyOut, 'OUT'));
+        expect(ts.stderr).toBe(py.stderr);
+        expect(fs.readFileSync(tsOut, 'utf8')).toBe(fs.readFileSync(pyOut, 'utf8'));
+    });
+
+    it.each([
+        ['--colors', 'Invalid color spec: nocolon'],
+        ['--fonts', 'Invalid font spec: nocolon'],
+        ['--spacing', 'Invalid spacing spec: nocolon'],
+        ['--breakpoints', 'Invalid breakpoint spec: nocolon'],
+    ])('bad %s spec → byte-identical error + exit 1', (flag, marker) => {
+        const args = [flag, 'nocolon'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(1);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toContain(marker);
+    });
+
+    it('invalid --framework choice → byte-identical usage + error + exit 2', () => {
+        const args = ['--framework', 'angular'];
+        const py = runPy(args);
+        const ts = runTs(args);
+        expect(ts.status).toBe(py.status);
+        expect(ts.status).toBe(2);
+        expect(ts.stdout).toBe(py.stdout);
+        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toContain("invalid choice: 'angular'");
+    });
+});

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "src/scripts/**/*.ts",
+    "src/skills/**/scripts/**/*.ts",
     "src/agent-src/templates/scripts/**/*.ts",
     "tests/scripts/**/*.ts",
     "tests/parity/**/*.ts",


### PR DESCRIPTION
Ports the 7 skill-bundled Python scripts (independent of work_engine / ai_council). Targets `python2ts`. `.py` originals stay until Phase 12.

## Twins (7)
- **corpus-grounding (4):** `bm25_search`, `schema_validator`, `decision_engine`, `ground` (ADR-061). `decision_engine`'s `importlib` dynamic rules-module load → dynamic `import()` of the `.ts`/`.js` twin (never `.py`; `ground`/`main` became async). BM25 tf-idf scores bit-identical.
- **design generators (3):** `tailwind-engineer/tailwind_config_gen`, `react-shadcn-ui/shadcn_add`, `design-tokens/tokens` — generated config/component/token output byte-identical.

93 golden-parity tests. legacy-literal ts==py==0 for all 7. tsc clean, phase-gate passes, condense zero-drift 94/94.

## Infra
- `tsconfig.scripts.json`: +include `src/skills/**/scripts/**/*.ts` (skill twins weren't covered). Separate array entry from the `templates/scripts/**` include — merges cleanly with the work_engine PR.
- `dist/agent-src/skills/**/scripts/` mirror regenerated (`condense --sync`).
- The `.ts` headers anonymize the upstream source per `source-confidentiality` (the grandfathered `.py` headers named it).

## Note (pre-existing, non-gating)
`check_no_external_sources` flags two pre-existing `agents/roadmap-assets/road-to-image-brand-typography*` files (external tokens, main content) — NOT these twins, and it is not a `python2ts`-PR gate (recent PRs are green).

## Verification
`tsc` clean · phase-gate passes · 93/93 · condense zero-drift 94/94 · python3-differential byte-match · legacy 0==0. Migration-gates 4-shard run validates on this PR's CI.