### PR TITLE
feat(py2ts): work_engine L1 — state_io + scoring + resolvers + intent + stack

### DIFF
--- a/dist/agent-src/templates/scripts/work_engine/intent/classify.ts
+++ b/dist/agent-src/templates/scripts/work_engine/intent/classify.ts
@@ -1,0 +1,425 @@
+/**
+ * Heuristic intent classifier — see `work_engine.intent` for context.
+ *
+ * TypeScript twin of `work_engine/intent/classify.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The classifier walks a small priority ladder against the lower-cased
+ * prompt + optional ticket title. First match wins; `backend-coding` is
+ * the fall-through default so every prompt always lands on a known label.
+ *
+ * Priority order (deliberately fixed):
+ *
+ * 1. **Trivial-UI** — UI signal AND a trivial-edit verb pattern (`change
+ *    color`, `make … red`, `rename label`, `fix copy`) AND no
+ *    structural verb (`add`, `build`, `create`, `introduce`).
+ * 2. **Mixed** — UI signal AND a backend signal (`endpoint`, `API`,
+ *    `migration`, `schema`, `query`, `job`, `queue`).
+ * 3. **UI-Improve** — UI signal AND an improve/redesign/refactor verb,
+ *    OR explicit "existing" surface markers.
+ * 4. **UI-Build** — UI signal AND a build/create/add verb, OR new-screen
+ *    markers (`new page`, `new screen`, `new component`).
+ * 5. **Backend-Coding** — default.
+ *
+ * The label is the dispatcher's *only* input for routing. Confidence
+ * band, `ui_intent` flag from the scorer, and AC reconstruction stay
+ * the resolution surface — the classifier does not look at them.
+ */
+import type { WorkState } from '../state.js';
+
+export const INTENT_UI_BUILD = 'ui-build';
+export const INTENT_UI_IMPROVE = 'ui-improve';
+export const INTENT_UI_TRIVIAL = 'ui-trivial';
+export const INTENT_MIXED = 'mixed';
+export const INTENT_BACKEND = 'backend-coding';
+
+/**
+ * All labels the classifier can return.
+ *
+ * Locked here so the dispatcher's mapping table and the test suite share
+ * one source of truth.
+ */
+export const KNOWN_INTENTS: ReadonlySet<string> = new Set([
+    INTENT_UI_BUILD,
+    INTENT_UI_IMPROVE,
+    INTENT_UI_TRIVIAL,
+    INTENT_MIXED,
+    INTENT_BACKEND,
+]);
+
+/**
+ * Strong UI nouns — exclusive UI meaning.
+ *
+ * Deliberately omits `table`, `list`, `input`, and `field`:
+ * `table`/`list` collide with database tables and Python/PHP lists;
+ * `input`/`field` collide with function inputs, command inputs, and
+ * JSON/DB fields. Genuine UI prompts that mean form inputs always come
+ * with a strong-UI noun nearby (`form`, `page`, `component`).
+ */
+const _UI_NOUNS: ReadonlySet<string> = new Set([
+    'ui', 'screen', 'page', 'view', 'form', 'modal', 'dialog',
+    'button', 'card', 'tile',
+    'header', 'footer', 'nav', 'navigation', 'sidebar', 'menu',
+    'dropdown', 'tab', 'panel', 'layout', 'component', 'icon',
+    'tooltip', 'toast', 'banner', 'badge', 'avatar', 'label',
+    'checkbox', 'radio', 'toggle', 'switch', 'stepper', 'wizard',
+]);
+
+const _UI_STYLE: ReadonlySet<string> = new Set([
+    'color', 'colour', 'css', 'tailwind', 'padding', 'margin',
+    'spacing', 'font', 'typography', 'responsive', 'mobile',
+    'dark mode', 'light mode', 'theme', 'shadow', 'border',
+    'rounded', 'radius',
+]);
+
+const _BACKEND_SIGNALS: ReadonlySet<string> = new Set([
+    'endpoint', 'api', 'route', 'controller', 'service',
+    'migration', 'schema', 'table', 'column', 'index', 'query',
+    'queue', 'job', 'worker', 'webhook', 'policy', 'gate',
+    'command', 'cron', 'broadcast', 'event', 'listener',
+]);
+
+const _TRIVIAL_VERBS: ReadonlySet<string> = new Set([
+    'rename', 'relabel', 'tweak', 'adjust', 'swap', 'change',
+]);
+
+const _IMPROVE_VERBS: ReadonlySet<string> = new Set([
+    'improve', 'polish', 'redesign', 'rework', 'refine',
+    'refactor', 'tighten', 'clean', 'fix', 'update', 'tune',
+]);
+
+const _BUILD_VERBS: ReadonlySet<string> = new Set([
+    'add', 'build', 'create', 'introduce', 'implement', 'ship',
+    'draft', 'scaffold', 'wire',
+]);
+
+const _NEW_SURFACE: RegExp =
+    /\b(new|fresh|blank)\s+(page|screen|view|component|form|modal|tile|dashboard)\b/;
+
+const _EXISTING_SURFACE: RegExp =
+    /\b(existing|current|the)\s+(page|screen|view|component|form|modal)\b/;
+
+const _TRIVIAL_PATTERN: RegExp =
+    /\b(make|change|update|set|swap)\b[^.]{0,40}\b(red|blue|green|yellow|black|white|primary|secondary|color|colour|copy|text|label|wording|class|prop)\b/;
+
+/**
+ * Return one of {@link KNOWN_INTENTS} for the supplied text.
+ *
+ * @param raw The user prompt or ticket body. Whitespace is normalised
+ *   internally; `""` and `null` resolve to `backend-coding`.
+ * @param title Optional ticket title. Concatenated with `raw` before
+ *   scanning so single-line ticket headlines (`"Add CSV export"`) produce
+ *   the same label whether they arrive in the body or the title slot.
+ */
+export function classify_intent(
+    raw: string,
+    opts: { title?: string | null } = {},
+): string {
+    const title = opts.title ?? null;
+    // Python: " ".join(filter(None, (title, raw))).strip().lower()
+    // filter(None, ...) drops falsy entries (None and "").
+    const parts = [title, raw].filter((p): p is string => Boolean(p));
+    const text = pyLower(pyStrip(parts.join(' ')));
+    if (!text) {
+        return INTENT_BACKEND;
+    }
+
+    const has_ui = _has_ui_signal(text);
+    const has_backend = _has_backend_signal(text);
+
+    if (has_ui && _is_trivial(text)) {
+        return INTENT_UI_TRIVIAL;
+    }
+    if (has_ui && has_backend) {
+        return INTENT_MIXED;
+    }
+    if (has_ui && _is_improve(text)) {
+        return INTENT_UI_IMPROVE;
+    }
+    if (has_ui && _is_build(text)) {
+        return INTENT_UI_BUILD;
+    }
+    if (has_ui) {
+        // UI signal but no clear verb — default to ui-improve so the
+        // full audit gate engages. ui-build would skip the existing-
+        // surface check, which is the wrong default when the prompt
+        // is ambiguous.
+        return INTENT_UI_IMPROVE;
+    }
+    return INTENT_BACKEND;
+}
+
+/**
+ * Map an intent label to a directive-set name.
+ *
+ * Centralised here so the dispatcher and the refine step share one
+ * routing table; a future intent (`infra`, `security-review`)
+ * only needs a single edit. Unknown labels raise `ValueError` —
+ * silently falling back to `backend` would mask classifier bugs.
+ */
+export function directive_set_for(intent: string): string {
+    if (!KNOWN_INTENTS.has(intent)) {
+        throw new ValueError(
+            `unknown intent ${pyStrRepr(intent)}; ` +
+                `expected one of ${pyListRepr(pySorted(KNOWN_INTENTS))}`,
+        );
+    }
+    if (intent === INTENT_UI_BUILD || intent === INTENT_UI_IMPROVE) {
+        return 'ui';
+    }
+    if (intent === INTENT_UI_TRIVIAL) {
+        return 'ui-trivial';
+    }
+    if (intent === INTENT_MIXED) {
+        return 'mixed';
+    }
+    return 'backend';
+}
+
+// --- helpers ----------------------------------------------------------
+
+function _has_ui_signal(text: string): boolean {
+    for (const w of _UI_NOUNS) {
+        if (reSearch(wordBoundary(w), text)) {
+            return true;
+        }
+    }
+    for (const s of _UI_STYLE) {
+        if (text.includes(s)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _has_backend_signal(text: string): boolean {
+    for (const w of _BACKEND_SIGNALS) {
+        if (reSearch(wordBoundary(w), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _is_trivial(text: string): boolean {
+    if (reSearch(_TRIVIAL_PATTERN, text)) {
+        return true;
+    }
+    let hasVerb = false;
+    for (const v of _TRIVIAL_VERBS) {
+        if (reSearch(wordBoundary(v), text)) {
+            hasVerb = true;
+            break;
+        }
+    }
+    return hasVerb && pySplit(text).length <= 14;
+}
+
+function _is_improve(text: string): boolean {
+    if (reSearch(_EXISTING_SURFACE, text)) {
+        return true;
+    }
+    for (const v of _IMPROVE_VERBS) {
+        if (reSearch(wordBoundary(v), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _is_build(text: string): boolean {
+    if (reSearch(_NEW_SURFACE, text)) {
+        return true;
+    }
+    for (const v of _BUILD_VERBS) {
+        if (reSearch(wordBoundary(v), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Classify `state.input` and write `intent` + `directive_set` in place.
+ *
+ * Idempotent and override-safe: if `state.intent` is already a
+ * UI-track or mixed label (`ui-build`, `ui-improve`, `ui-trivial`,
+ * `mixed`), the routing is left untouched. Only freshly-built states
+ * carrying the construction default `backend-coding` are reclassified.
+ * Loaded state files round-trip without losing a previously-recorded
+ * intent — including a manual user override in the JSON.
+ *
+ * The text fed to the classifier depends on the input envelope:
+ *
+ * - `prompt` → `state.input.data["raw"]`
+ * - `ticket` → `state.input.data["title"]` + first non-empty
+ *   acceptance criterion, falling back to `description` when AC is
+ *   missing. Title is passed separately so single-line ticket
+ *   headlines (`"Add CSV export"`) classify identically whether
+ *   they arrive in the body or the title slot.
+ * - `diff` / `file` → routed directly to `ui-improve` without
+ *   running the heuristic. Both envelopes are R3 Phase 1 inputs that
+ *   describe an existing UI surface ("improve this screen"); the
+ *   classifier's prose-oriented signals do not apply, and the audit +
+ *   design directives downstream are the right place to read the
+ *   diff/file contents.
+ */
+export function populate_routing(state: WorkState): void {
+    if (state.intent !== INTENT_BACKEND) {
+        return;
+    }
+
+    if (state.input.kind === 'diff' || state.input.kind === 'file') {
+        state.intent = INTENT_UI_IMPROVE;
+        state.directive_set = directive_set_for(INTENT_UI_IMPROVE);
+        return;
+    }
+
+    const [text, title] = _extract_text(state);
+    const intent = classify_intent(text, { title });
+    state.intent = intent;
+    state.directive_set = directive_set_for(intent);
+}
+
+function _extract_text(state: WorkState): [string, string | null] {
+    const data = state.input.data ?? {};
+    if (state.input.kind === 'prompt') {
+        // Python: str(data.get("raw") or "")
+        const raw = 'raw' in data ? data['raw'] : undefined;
+        return [pyStr(_pyTruthy(raw) ? raw : ''), null];
+    }
+    const title = 'title' in data ? data['title'] : undefined;
+    const title_str =
+        typeof title === 'string' && pyStrip(title) ? pyStr(title) : null;
+    const body_parts: string[] = [];
+    const ac = 'acceptance_criteria' in data ? data['acceptance_criteria'] : undefined;
+    if (Array.isArray(ac)) {
+        for (const item of ac) {
+            if (typeof item === 'string') {
+                body_parts.push(pyStr(item));
+            }
+        }
+    }
+    const description = 'description' in data ? data['description'] : undefined;
+    if (typeof description === 'string' && pyStrip(description)) {
+        body_parts.push(description);
+    }
+    return [body_parts.join(' '), title_str];
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/** Raised in place of Python's `ValueError` for the unknown-intent guard. */
+export class ValueError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValueError';
+        Object.setPrototypeOf(this, ValueError.prototype);
+    }
+}
+
+/**
+ * Mirror `re.escape(word)` then `re.search(rf"\b{...}\b", text)` as a boolean.
+ * The classifier's words are all `[a-z]+` ASCII, so escaping is a no-op for
+ * them; escape defensively anyway so the helper is faithful for any input.
+ * Patterns are flag-only (no `g`) — `.test` carries no `lastIndex` state.
+ */
+function wordBoundary(word: string): RegExp {
+    return new RegExp(`\\b${reEscape(word)}\\b`);
+}
+
+function reSearch(pattern: RegExp, text: string): boolean {
+    return pattern.test(text);
+}
+
+/**
+ * Mirror Python `re.escape` — escapes every character that is not an ASCII
+ * letter, digit, or underscore. CPython 3.7+ escapes only special chars, but
+ * for the ASCII-word inputs here the result is identical to the verb itself.
+ */
+function reEscape(s: string): string {
+    return s.replace(/[^A-Za-z0-9_]/g, (ch) => '\\' + ch);
+}
+
+/**
+ * Mirror Python `str.split()` (no args) — split on runs of whitespace,
+ * dropping leading/trailing empties. `trim().split(/\s+/)` matches; guard the
+ * empty string so `"".split(/\s+/)` does not yield `[""]` (Python returns []).
+ */
+function pySplit(s: string): string[] {
+    const t = s.trim();
+    if (t === '') return [];
+    return t.split(/\s+/);
+}
+
+/** Mirror Python `str.strip()` — `String.trim()` is faithful here. */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Mirror Python `str.lower()`. CPython lower-cases by full Unicode mapping;
+ * JS `toLowerCase()` follows the same Unicode default case-folding for the
+ * code points these heuristics see (the inputs are dominated by ASCII).
+ */
+function pyLower(s: string): string {
+    return s.toLowerCase();
+}
+
+/**
+ * Mirror Python `str(x)` for the values `_extract_text` coerces (str, or the
+ * `or ""` fallback which is already a string). Only string-or-empty flows here.
+ */
+function pyStr(v: unknown): string {
+    return typeof v === 'string' ? v : String(v);
+}
+
+/** Mirror Python truthiness for the `data.get("raw") or ""` short-circuit. */
+function _pyTruthy(v: unknown): v is string {
+    if (v === null || v === undefined) return false;
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'number') return v !== 0;
+    if (typeof v === 'string') return v.length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'object') return Object.keys(v).length > 0;
+    return true;
+}
+
+/**
+ * Mirror Python `repr(str)` — see the `state.py` twin's `pyStrRepr`. Used for
+ * the `{intent!r}` tail in the unknown-intent error.
+ */
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') out += '\\\\';
+        else if (ch === quote) out += '\\' + quote;
+        else if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}
+
+/** Python `repr(list_of_str)` for the `sorted(KNOWN_INTENTS)` error tail. */
+function pyListRepr(items: string[]): string {
+    return '[' + items.map((s) => pyStrRepr(s)).join(', ') + ']';
+}
+
+/**
+ * Python `sorted(set_of_str)` — code-point ascending, the default `str`
+ * ordering CPython uses.
+ */
+function pySorted(values: ReadonlySet<string>): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}

--- a/dist/agent-src/templates/scripts/work_engine/resolvers/diff.ts
+++ b/dist/agent-src/templates/scripts/work_engine/resolvers/diff.ts
@@ -1,0 +1,135 @@
+/**
+ * Diff resolver — wrap a unified-diff payload as an {@link Input} envelope.
+ *
+ * TypeScript twin of `work_engine/resolvers/diff.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The resolver is the R3 Phase 1 entry point for the "improve this screen via
+ * diff/PR" surface: a user (or `/work` adapter) hands the engine a patch text,
+ * the resolver normalises it, and the dispatcher routes it through the UI-track
+ * `ui-improve` directive set.
+ *
+ * Like `work_engine.resolvers.prompt`, this module is intentionally thin:
+ * it normalises and rejects garbage payloads, nothing more. Reconstruction of
+ * acceptance criteria + assumptions + confidence is the job of the
+ * `refine-prompt` skill (R2 Phase 3) running against the diff once the engine
+ * hits the `refine` step. Keeping the split sharp means the envelope shape
+ * stays cheap to round-trip through state and the heavy lifting stays with the
+ * agent-directive halt where it belongs.
+ *
+ * The envelope mirrors the prompt resolver's shape so a single refiner code
+ * path can read both — `{raw, reconstructed_ac, assumptions}`. The only
+ * material difference is the heuristic header check that rejects payloads
+ * that obviously are not unified-diff text.
+ */
+import { Input } from '../state.js';
+
+export const KIND = 'diff';
+/** Wire value carried in {@link Input.kind}. */
+
+const _MIN_DIFF_LEN = 1;
+/**
+ * Minimum non-whitespace character count before the heuristic runs.
+ *
+ * The resolver is not a *quality* gate; it only rejects literally empty
+ * payloads and obvious non-diffs. A semantically empty diff (e.g., headers but
+ * no hunks) is still accepted so the refiner can score its tractability and
+ * surface a `low`-band halt where appropriate.
+ */
+
+const _DIFF_MARKERS: readonly RegExp[] = [
+    /^diff --git /m,
+    /^--- /m,
+    /^\+\+\+ /m,
+    /^@@ /m,
+    /^Index: /m,
+];
+/**
+ * Heuristic markers that flag a payload as a unified or git-style diff.
+ *
+ * A payload qualifies if **any** marker matches — the resolver accepts unified
+ * diffs (`--- `/`+++ `/`@@ `), `git diff` output (`diff --git`), and
+ * the legacy `Index: ` SVN/CVS header. The match is anchored at line start so
+ * quoted snippets inside prose ("the function `--- foo` failed") do not pass
+ * the gate.
+ */
+
+/** Raised when a payload cannot be resolved into a diff envelope. */
+export class DiffResolverError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'DiffResolverError';
+        Object.setPrototypeOf(this, DiffResolverError.prototype);
+    }
+}
+
+/**
+ * Return an {@link Input} carrying the raw diff + empty refinement slots.
+ *
+ * @param raw The user-supplied diff text. Whitespace is preserved verbatim —
+ *   the refiner reads original spacing/casing when scoring goal clarity, and
+ *   a unified-diff round-trip cannot tolerate normalised whitespace.
+ * @returns Envelope of shape
+ *   `{"kind": "diff", "data": {"raw": <raw>, "reconstructed_ac": [],
+ *   "assumptions": []}}`. The two empty lists are placeholders the
+ *   `refine-prompt` skill writes into on the rebound from `refine`.
+ * @throws {@link DiffResolverError} If `raw` is not a string, contains no
+ *   non-whitespace characters, or does not match any {@link _DIFF_MARKERS}.
+ *   The marker check guards against accidentally routing free-form prose
+ *   through the diff path.
+ */
+export function build_envelope(raw: unknown): Input {
+    if (typeof raw !== 'string') {
+        throw new DiffResolverError(
+            `diff must be a string; got ${pyTypeName(raw)}`,
+        );
+    }
+    if (pyStrip(raw).length < _MIN_DIFF_LEN) {
+        throw new DiffResolverError(
+            'diff is empty or whitespace-only — nothing to resolve',
+        );
+    }
+    if (!_DIFF_MARKERS.some((marker) => reSearch(marker, raw))) {
+        throw new DiffResolverError(
+            'payload does not look like a unified diff — expected one of ' +
+                "'diff --git', '--- ', '+++ ', '@@ ', or 'Index: ' headers",
+        );
+    }
+    return new Input(KIND, {
+        raw: raw,
+        reconstructed_ac: [],
+        assumptions: [],
+    });
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * Mirror Python `re.Pattern.search` for a boolean hit. The patterns carry the
+ * `m` (MULTILINE) flag so `^` matches at every line start, identical to
+ * `re.compile(..., re.MULTILINE)`. The regexes are flag-only (no `g`), so a
+ * fresh `.test` has no `lastIndex` state to reset between calls.
+ */
+function reSearch(pattern: RegExp, text: string): boolean {
+    return pattern.test(text);
+}
+
+/**
+ * Mirror Python `str.strip()` — see `resolvers/prompt.ts` for the parity note.
+ * `String.trim()` is faithful for every realistic whitespace-only payload.
+ */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** Python `type(x).__name__` for the non-string `isinstance` guard branch. */
+function pyTypeName(v: unknown): string {
+    if (v === null) return 'NoneType';
+    if (v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}

--- a/dist/agent-src/templates/scripts/work_engine/resolvers/file.ts
+++ b/dist/agent-src/templates/scripts/work_engine/resolvers/file.ts
@@ -1,0 +1,175 @@
+/**
+ * File resolver — wrap a path reference as an {@link Input} envelope.
+ *
+ * TypeScript twin of `work_engine/resolvers/file.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The resolver is the R3 Phase 1 entry point for the "improve this existing
+ * component/page" surface: a user hands the engine a path (e.g.,
+ * `resources/views/dashboard.blade.php` or `src/components/Sidebar.tsx`),
+ * the resolver normalises it, and the dispatcher routes the envelope through
+ * the UI-track `ui-improve` directive set.
+ *
+ * Like `work_engine.resolvers.prompt` and `.diff`, this module is
+ * intentionally thin: it normalises and rejects garbage payloads, nothing
+ * more. Existence checks, mtime caching, and content reads are deferred to
+ * the `analyze` step / the audit directive — a resolver doing I/O at the
+ * command-shell boundary would couple the envelope build to filesystem state
+ * and break replay-against-state-files.
+ *
+ * The envelope mirrors the prompt and diff resolvers so a single refiner code
+ * path can read all three — `{path, reconstructed_ac, assumptions}`. The
+ * only material difference is the path-shape check that rejects values that
+ * are obviously not paths (absolute URLs, empty strings, control chars).
+ */
+import * as path from 'node:path';
+
+import { Input } from '../state.js';
+
+export const KIND = 'file';
+/** Wire value carried in {@link Input.kind}. */
+
+const _MIN_PATH_LEN = 1;
+/**
+ * Minimum non-whitespace character count for a resolvable path.
+ *
+ * A 1-char path is rare but legal (`a`); the bar exists only to reject
+ * literal empty / whitespace-only payloads which carry no signal at all.
+ */
+
+const _FORBIDDEN_PREFIXES: readonly string[] = [
+    'http://',
+    'https://',
+    'ftp://',
+    'file://',
+];
+/**
+ * Prefixes that signal the caller passed a URL, not a filesystem path.
+ *
+ * The diff resolver handles patch URLs at a future R3 layer; the file
+ * resolver only accepts on-disk references. Rejecting URLs explicitly
+ * keeps misuse loud instead of letting the audit step discover it later.
+ * The check is case-insensitive.
+ */
+
+/** Raised when a payload cannot be resolved into a file envelope. */
+export class FileResolverError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'FileResolverError';
+        Object.setPrototypeOf(this, FileResolverError.prototype);
+    }
+}
+
+/**
+ * Return an {@link Input} carrying the path + empty refinement slots.
+ *
+ * @param path_ The user-supplied path reference. The resolver normalises only
+ *   by stripping leading/trailing whitespace; case, separators, and the
+ *   relative-vs-absolute distinction are all preserved verbatim so the
+ *   downstream audit step reads exactly what the user wrote.
+ * @returns Envelope of shape
+ *   `{"kind": "file", "data": {"path": <path>, "reconstructed_ac": [],
+ *   "assumptions": []}}`. The two empty lists are placeholders the
+ *   `refine-prompt` skill writes into on the rebound from `refine`; they are
+ *   kept to preserve a single-shape envelope across all prompt-like resolvers.
+ * @throws {@link FileResolverError} If `path` is not a string, is empty /
+ *   whitespace-only, contains a NUL byte (filesystem-illegal everywhere), or
+ *   is a URL (use the diff resolver for remote-PR / patch URLs in a future R3
+ *   phase).
+ */
+export function build_envelope(path_: unknown): Input {
+    if (typeof path_ !== 'string') {
+        throw new FileResolverError(
+            `path must be a string; got ${pyTypeName(path_)}`,
+        );
+    }
+    const stripped = pyStrip(path_);
+    if (stripped.length < _MIN_PATH_LEN) {
+        throw new FileResolverError(
+            'path is empty or whitespace-only — nothing to resolve',
+        );
+    }
+    if (stripped.includes('\x00')) {
+        throw new FileResolverError(
+            'path contains a NUL byte; filesystem references must be ' +
+                'NUL-free',
+        );
+    }
+    const lowered = stripped.toLowerCase();
+    if (_FORBIDDEN_PREFIXES.some((prefix) => lowered.startsWith(prefix))) {
+        throw new FileResolverError(
+            `path looks like a URL (${pyStrRepr(pySlice(stripped, 32))}); the file resolver ` +
+                'only accepts on-disk references — use the diff resolver for ' +
+                'PR or patch URLs',
+        );
+    }
+    // Normalise separators *only* on Windows-style backslashes so
+    // `resources\\views\\foo.blade.php` round-trips as POSIX. Native
+    // POSIX paths are returned untouched so the audit step's identity
+    // comparison against directory listings stays trivial.
+    const normalised =
+        path.sep === '/' ? stripped.replace(/\\/g, '/') : stripped;
+    return new Input(KIND, {
+        path: normalised,
+        reconstructed_ac: [],
+        assumptions: [],
+    });
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * Mirror Python `str.strip()` — see `resolvers/prompt.ts` for the parity note.
+ */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Mirror Python `s[:n]` over code points. The error path renders `stripped[:32]`
+ * via `!r`; Python slices by code point, not UTF-16 unit, so use the spread
+ * iterator to slice on code-point boundaries before re-joining.
+ */
+function pySlice(s: string, n: number): string {
+    return [...s].slice(0, n).join('');
+}
+
+/**
+ * Mirror Python `repr(str)` — prefers single quotes, switches to double quotes
+ * only when the string contains a single quote but no double quote, and escapes
+ * backslash plus the active quote and the standard control characters. Matches
+ * the `state.py` twin's `pyStrRepr` so the `{...!r}` error tail is byte-equal.
+ */
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') out += '\\\\';
+        else if (ch === quote) out += '\\' + quote;
+        else if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}
+
+/** Python `type(x).__name__` for the non-string `isinstance` guard branch. */
+function pyTypeName(v: unknown): string {
+    if (v === null) return 'NoneType';
+    if (v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}

--- a/dist/agent-src/templates/scripts/work_engine/resolvers/prompt.ts
+++ b/dist/agent-src/templates/scripts/work_engine/resolvers/prompt.ts
@@ -1,0 +1,115 @@
+/**
+ * Prompt resolver — wrap a raw user prompt as an {@link Input} envelope.
+ *
+ * TypeScript twin of `work_engine/resolvers/prompt.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The resolver is intentionally minimal. It accepts a raw string, validates
+ * that it contains non-whitespace content, and returns
+ * `Input(kind="prompt", data={"raw": <text>, "reconstructed_ac": [],
+ * "assumptions": []})`. The empty AC + assumptions lists are placeholders
+ * that the `refine-prompt` skill (R2 Phase 3) fills in once the engine
+ * runs the deterministic `refine` gate against the raw text.
+ *
+ * Why split the resolver from the refiner:
+ *
+ * - The resolver runs at command boundaries (the `/work` entrypoint
+ *   builds an envelope, then hands off to `work_engine`). It must stay
+ *   side-effect-free and dependency-light so the command shell can call
+ *   it without touching the LLM-facing skill harness.
+ * - The refiner runs inside the dispatcher loop and is allowed to halt
+ *   (medium-confidence assumptions report, low-confidence one-question
+ *   block) per `docs/contracts/implement-ticket-flow.md`. That
+ *   control-flow surface does not belong in a resolver.
+ *
+ * Future R3 resolvers (`diff`, `file`) follow the same pattern: thin
+ * normalisation, no interpretation, one envelope shape per kind.
+ */
+import { Input } from '../state.js';
+
+export const KIND = 'prompt';
+/** Wire value carried in {@link Input.kind}. */
+
+const _MIN_PROMPT_LEN = 1;
+/**
+ * Minimum non-whitespace character count for a resolvable prompt.
+ *
+ * Set to 1 by design — the resolver is not a quality gate. It only
+ * rejects literally empty / whitespace-only payloads (which cannot be
+ * distinguished from missing input). Quality judgment (is the prompt
+ * clear? is it tractable?) is the `refine-prompt` skill's job, surfaced
+ * through the confidence band, not the resolver's.
+ */
+
+/** Raised when a payload cannot be resolved into a prompt envelope. */
+export class PromptResolverError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PromptResolverError';
+        Object.setPrototypeOf(this, PromptResolverError.prototype);
+    }
+}
+
+/**
+ * Return an {@link Input} carrying the raw prompt + empty refinement slots.
+ *
+ * @param raw The user-supplied prompt text. Leading/trailing whitespace is
+ *   preserved verbatim — the refiner reads the original casing and spacing
+ *   when scoring goal clarity, so collapsing whitespace here would lose
+ *   signal.
+ * @returns Envelope of shape
+ *   `{"kind": "prompt", "data": {"raw": <raw>, "reconstructed_ac": [],
+ *   "assumptions": []}}`. The two empty lists are placeholders the
+ *   `refine-prompt` skill writes into on the rebound from the `refine` step.
+ * @throws {@link PromptResolverError} If `raw` is not a string, or contains
+ *   no non-whitespace characters (the only case where the envelope would
+ *   carry no actionable signal at all).
+ */
+export function build_envelope(raw: unknown): Input {
+    if (typeof raw !== 'string') {
+        throw new PromptResolverError(
+            `prompt must be a string; got ${pyTypeName(raw)}`,
+        );
+    }
+    if (pyStrip(raw).length < _MIN_PROMPT_LEN) {
+        throw new PromptResolverError(
+            'prompt is empty or whitespace-only — nothing to resolve',
+        );
+    }
+    return new Input(KIND, {
+        raw: raw,
+        reconstructed_ac: [],
+        assumptions: [],
+    });
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * Mirror Python `str.strip()` — strips the Unicode whitespace set CPython
+ * uses (the characters for which `str.isspace()` is true). `String.trim()`
+ * strips a near-identical set; the only practical divergence for the empty-
+ * payload guard is that `trim()` does not strip a handful of exotic code
+ * points (e.g. zero-width). For a length-vs-1 gate the standard `trim` is
+ * faithful for every realistic whitespace-only prompt, and any leftover
+ * exotic char would correctly count as "non-whitespace content" under both
+ * runtimes' intent. Kept as a named helper to mark the parity point.
+ */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Python `type(x).__name__` for the values this resolver's TypeError-equivalent
+ * branch reports: the `isinstance(raw, str)` guard fires on any non-string.
+ */
+function pyTypeName(v: unknown): string {
+    if (v === null) return 'NoneType';
+    if (v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}

--- a/dist/agent-src/templates/scripts/work_engine/scoring/confidence.ts
+++ b/dist/agent-src/templates/scripts/work_engine/scoring/confidence.ts
@@ -1,0 +1,415 @@
+/**
+ * Confidence scoring for prompt-driven execution (R2 Phase 3 Step 2).
+ *
+ * TypeScript twin of `work_engine/scoring/confidence.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * The scorer judges whether a reconstructed prompt is good enough for the
+ * `work_engine` to proceed silently, halt for confirmation, or refuse to
+ * plan. It is heuristic-only — no LLM calls — so the same prompt produces
+ * the same score across replays and the freeze-guard harness can pin
+ * expectations.
+ *
+ * Rubric (each dimension 0–2, total / 10 → band):
+ *
+ * - `goal_clarity` — does the raw prompt name a single action verb +
+ *   object + observable result?
+ * - `scope_boundary` — does the prompt name a file, class, module, or
+ *   domain that bounds the change?
+ * - `ac_evidence` — did the refiner produce concrete, anchored
+ *   acceptance criteria?
+ * - `stack_data` — does the prompt imply stack / data / migration work
+ *   *and* identify the touched surface? (penalty if implied + unspecified)
+ * - `reversibility` — would a wrong reconstruction be cheaply rollback-
+ *   able?
+ *
+ * Bands (per `agents/roadmaps/archive/road-to-prompt-driven-execution.md`):
+ *
+ * - `high`   — score >= 0.8 → dispatcher proceeds silently
+ * - `medium` — 0.5 <= score < 0.8 → assumptions-report halt
+ * - `low`    — score < 0.5 → one-question halt
+ *
+ * The scorer is the single source of truth for both the rubric and the
+ * band thresholds. Documentation (SKILL.md, ADR, contexts) cite this
+ * module — they do not re-derive the values.
+ */
+
+// --- Public types ------------------------------------------------------
+
+/**
+ * Canonical dimension order. Matches the roadmap rubric and is the
+ * order `ConfidenceScore.dimensions` is rendered in by callers.
+ */
+export const DIMENSION_NAMES: readonly string[] = [
+    'goal_clarity',
+    'scope_boundary',
+    'ac_evidence',
+    'stack_data',
+    'reversibility',
+] as const;
+
+/** Per-dimension ceiling. Five dimensions × 2 = 10 = full score. */
+export const MAX_PER_DIMENSION = 2;
+
+export const BAND_HIGH_MIN = 0.8;
+export const BAND_MEDIUM_MIN = 0.5;
+/**
+ * Band thresholds. Inclusive on the lower bound, exclusive on the upper.
+ *
+ * A score of exactly 0.8 lands in `high` (per roadmap: `high >= 0.8`);
+ * exactly 0.5 lands in `medium`. Anything below 0.5 is `low`.
+ */
+
+/**
+ * Immutable result of one scoring pass.
+ *
+ * The Python source is a `@dataclass(frozen=True)`. We mirror the field set
+ * and the `field(default_factory=list)` default for `reasons` (each instance
+ * owns its own array). `Object.freeze` echoes `frozen=True` so callers cannot
+ * mutate a band after the dispatcher has routed on it.
+ */
+export class ConfidenceScore {
+    readonly band: string;
+    readonly score: number;
+    readonly dimensions: Record<string, number>;
+    readonly reasons: string[];
+    readonly ui_intent: boolean;
+
+    constructor(args: {
+        band: string;
+        score: number;
+        dimensions: Record<string, number>;
+        reasons?: string[];
+        ui_intent?: boolean;
+    }) {
+        this.band = args.band;
+        this.score = args.score;
+        this.dimensions = args.dimensions;
+        this.reasons = args.reasons ?? [];
+        this.ui_intent = args.ui_intent ?? false;
+        Object.freeze(this);
+    }
+}
+
+// --- Heuristic vocabularies -------------------------------------------
+
+const _ACTION_VERBS: ReadonlySet<string> = new Set([
+    'add', 'build', 'create', 'implement', 'introduce', 'write',
+    'fix', 'patch', 'repair', 'resolve',
+    'refactor', 'rename', 'extract', 'inline', 'split',
+    'remove', 'delete', 'drop', 'purge',
+    'update', 'upgrade', 'bump', 'migrate',
+    'optimize', 'speed', 'improve', 'tune',
+    'document', 'describe', 'explain',
+    'test', 'validate', 'verify',
+    'expose', 'publish', 'deprecate',
+    'configure', 'wire', 'connect',
+]);
+
+const _DOMAIN_NOUNS: ReadonlySet<string> = new Set([
+    'auth', 'authentication', 'authorization', 'login', 'logout', 'signup',
+    'user', 'users', 'account', 'profile',
+    'dashboard', 'search', 'checkout', 'cart', 'billing', 'payment',
+    'admin', 'settings', 'config',
+    'api', 'endpoint', 'webhook', 'queue', 'job', 'worker',
+    'frontend', 'backend', 'ui', 'view', 'page', 'form',
+    'database', 'migration', 'schema',
+    'report', 'export', 'import',
+]);
+
+const _STACK_DATA_KEYWORDS: ReadonlySet<string> = new Set([
+    'migration', 'schema', 'table', 'column', 'index',
+    'database', 'db', 'postgres', 'mysql', 'mariadb', 'sqlite',
+    'redis', 'cache', 'queue',
+    'dependency', 'package', 'library', 'framework', 'upgrade',
+    'breaking change', 'deprecate', 'api version',
+    'deploy', 'release',
+]);
+
+const _IRREVERSIBLE_KEYWORDS: ReadonlySet<string> = new Set([
+    'drop ', 'delete ', 'purge', 'wipe', 'truncate',
+    'send email', 'charge', 'refund', 'billing', 'payment', 'money',
+    'production data', 'live database', 'broadcast',
+]);
+
+const _UI_KEYWORDS: ReadonlySet<string> = new Set([
+    'redesign', 'color', 'colour', 'css', 'tailwind', 'layout',
+    'font', 'spacing', 'padding', 'margin', 'button', 'icon',
+    'responsive', 'mobile view', 'look', 'polish', 'prettier',
+    'theme', 'dark mode', 'light mode',
+]);
+
+// Python `re.compile(...)` — the four alternatives, joined verbatim. The
+// JS `RegExp` source mirrors the Python pattern character-for-character; the
+// only escaping difference is `\\` in the PHP-namespace branch, which is a
+// single backslash in the compiled pattern on both engines.
+const _FILE_PATH_RE = new RegExp(
+    '`[^`]+`' + // backtick-wrapped tokens
+        '|[\\w./-]+\\.(?:py|php|ts|tsx|js|jsx|vue|blade\\.php|sql|yml|yaml|json|md)' +
+        '|[A-Z][\\w]+(?:\\\\[A-Z][\\w]+)+' + // PHP namespaces (Foo\Bar\Baz)
+        '|[A-Z][a-zA-Z]+::[a-zA-Z]+' + // PHP static call (Foo::bar)
+        '|[a-z]+(?:[A-Z][a-z]+){2,}', // camelCase identifiers w/ >=2 humps
+);
+
+// --- Public API --------------------------------------------------------
+
+/**
+ * Score a reconstructed prompt and return the band + rubric breakdown.
+ *
+ * @param raw The original user prompt text. Pre-stripped or not; the scorer
+ *   normalises whitespace internally.
+ * @param ac Reconstructed acceptance criteria from the `refine-prompt`
+ *   skill. `null`/`undefined` is treated as an empty list (no AC produced).
+ * @param assumptions Inferred assumptions surfaced by the refiner. Currently
+ *   informational — the rubric does not penalise assumption count directly
+ *   because medium-band halts are the resolution surface.
+ */
+export function score(args: {
+    raw: string;
+    ac?: string[] | null;
+    assumptions?: string[] | null;
+}): ConfidenceScore {
+    const raw = args.raw;
+    // `(raw or "").strip()` — Python `str.strip()` removes leading/trailing
+    // whitespace per the `str.isspace` set; JS `trim()` covers the same
+    // Unicode whitespace for these inputs.
+    const text = (raw || '').trim();
+    const text_lower = text.toLowerCase();
+    const ac_list = [...(args.ac ?? [])];
+
+    const [g_val, g_reason] = _score_goal_clarity(text, text_lower);
+    const [s_val, s_reason] = _score_scope_boundary(text, text_lower);
+    const [e_val, e_reason] = _score_acceptance_evidence(ac_list);
+    const [k_val, k_reason] = _score_stack_data(text_lower);
+    const [r_val, r_reason] = _score_reversibility(text_lower);
+
+    const dimensions: Record<string, number> = {
+        goal_clarity: g_val,
+        scope_boundary: s_val,
+        ac_evidence: e_val,
+        stack_data: k_val,
+        reversibility: r_val,
+    };
+    const total = Object.values(dimensions).reduce((a, b) => a + b, 0);
+    const norm = _pyRound(total / (MAX_PER_DIMENSION * DIMENSION_NAMES.length), 4);
+    return new ConfidenceScore({
+        band: _band_from_score(norm),
+        score: norm,
+        dimensions,
+        reasons: [g_reason, s_reason, e_reason, k_reason, r_reason],
+        ui_intent: _detect_ui_intent(text_lower),
+    });
+}
+
+// --- Band mapping ------------------------------------------------------
+
+/**
+ * Map a normalised score to one of `high` / `medium` / `low`.
+ *
+ * Inclusive on the lower bound to match the roadmap contract
+ * (`high >= 0.8`); a score of exactly `0.8` lands in `high`,
+ * exactly `0.5` in `medium`, anything below `0.5` in `low`.
+ */
+function _band_from_score(score_value: number): string {
+    if (score_value >= BAND_HIGH_MIN) {
+        return 'high';
+    }
+    if (score_value >= BAND_MEDIUM_MIN) {
+        return 'medium';
+    }
+    return 'low';
+}
+
+// --- Per-dimension scorers --------------------------------------------
+
+/** Score whether the prompt names a single, observable outcome. */
+function _score_goal_clarity(text: string, text_lower: string): [number, string] {
+    if (!text) {
+        return [0, 'goal_clarity=0: empty prompt'];
+    }
+    const has_verb = [..._ACTION_VERBS].some((v) =>
+        new RegExp(`\\b${_reEscape(v)}\\w*\\b`).test(text_lower),
+    );
+    // `text.rstrip().endswith("?")`
+    const is_question = _pyRstrip(text).endsWith('?');
+    // `len(text.split())` — Python `str.split()` with no args splits on runs
+    // of whitespace and drops empty tokens.
+    const word_count = _pySplitWhitespace(text).length;
+    const conjunction_split = /\b(and then|and also|plus)\b/.test(text_lower);
+
+    if (has_verb && !is_question && 4 <= word_count && word_count <= 40 && !conjunction_split) {
+        return [2, 'goal_clarity=2: action verb + bounded length + single outcome'];
+    }
+    if (has_verb && !is_question) {
+        if (conjunction_split) {
+            return [1, 'goal_clarity=1: verb present but multiple outcomes joined'];
+        }
+        return [1, 'goal_clarity=1: verb present but length is borderline'];
+    }
+    if (is_question) {
+        return [0, 'goal_clarity=0: prompt is a question, no executable verb'];
+    }
+    return [0, 'goal_clarity=0: no recognisable action verb'];
+}
+
+/** Score whether the prompt bounds the change to a concrete surface. */
+function _score_scope_boundary(text: string, text_lower: string): [number, string] {
+    const has_path = _FILE_PATH_RE.test(text);
+    const has_domain = [..._DOMAIN_NOUNS].some((n) =>
+        new RegExp(`\\b${_reEscape(n)}\\b`).test(text_lower),
+    );
+    if (has_path) {
+        return [2, 'scope_boundary=2: explicit file/class/identifier named'];
+    }
+    if (has_domain) {
+        return [1, 'scope_boundary=1: domain noun present, no concrete path'];
+    }
+    return [0, 'scope_boundary=0: no file or domain anchor'];
+}
+
+/** Score the reconstructed AC list produced by the refiner. */
+function _score_acceptance_evidence(ac: string[]): [number, string] {
+    const n = ac.length;
+    if (n === 0) {
+        return [0, 'ac_evidence=0: no acceptance criteria reconstructed'];
+    }
+    const anchored_signals = ['should', 'must', 'given', 'when', 'then', 'expect'];
+    let anchored = 0;
+    for (const line of ac) {
+        const low = line.toLowerCase();
+        if (anchored_signals.some((s) => low.includes(s))) {
+            anchored += 1;
+        }
+    }
+    if (n >= 3 && anchored >= 2) {
+        return [2, `ac_evidence=2: ${n} criteria, ${anchored} anchored`];
+    }
+    if (n >= 1) {
+        return [1, `ac_evidence=1: ${n} criteria, ${anchored} anchored`];
+    }
+    return [0, 'ac_evidence=0: empty AC list'];
+}
+
+/** Penalise stack/data work that is implied but not bounded. */
+function _score_stack_data(text_lower: string): [number, string] {
+    const implies_stack = [..._STACK_DATA_KEYWORDS].some((k) => text_lower.includes(k));
+    if (!implies_stack) {
+        return [2, 'stack_data=2: prompt is behavioural, no stack/data signal'];
+    }
+    const has_target = /\b(table|column|index|file|migration)\s+[`"\w]/.test(text_lower);
+    if (has_target) {
+        return [2, 'stack_data=2: stack/data work named with explicit target'];
+    }
+    return [0, 'stack_data=0: stack/data work implied without target'];
+}
+
+/** Score how cheaply a wrong reconstruction could be rolled back. */
+function _score_reversibility(text_lower: string): [number, string] {
+    if ([..._IRREVERSIBLE_KEYWORDS].some((k) => text_lower.includes(k))) {
+        return [0, 'reversibility=0: irreversible keyword detected'];
+    }
+    const config_signals = ['config', 'env', 'secret', '.env', 'deploy'];
+    if (config_signals.some((s) => text_lower.includes(s))) {
+        return [1, 'reversibility=1: config/env surface, partial rollback cost'];
+    }
+    return [2, 'reversibility=2: code-only change, cheap to revert'];
+}
+
+/** Flag prompts that read as UI work for R3 routing. */
+function _detect_ui_intent(text_lower: string): boolean {
+    return [..._UI_KEYWORDS].some((k) => text_lower.includes(k));
+}
+
+// --- Python-parity primitives -----------------------------------------
+
+/** Python `re.escape` for the literal tokens in the heuristic vocabularies. */
+function _reEscape(s: string): string {
+    // Python `re.escape` escapes every non-alphanumeric, non-underscore char.
+    // The vocab tokens are ASCII letters / spaces / dots, so this matches.
+    return s.replace(/[^a-zA-Z0-9_]/g, (ch) => '\\' + ch);
+}
+
+/** Python `str.rstrip()` (no arg) — strip trailing whitespace. */
+function _pyRstrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Python `str.split()` (no arg) — split on whitespace runs, drop empties. */
+function _pySplitWhitespace(s: string): string[] {
+    const trimmed = s.trim();
+    if (trimmed === '') {
+        return [];
+    }
+    return trimmed.split(/\s+/u);
+}
+
+/**
+ * Python 3 `round(x, ndigits)` — round-half-to-even (banker's rounding) on
+ * the exact decimal expansion of the IEEE-754 double. Same algorithm as
+ * `value_ladder.ts::pyRound` / `report_renderer.ts::_pyRound`. Inlined to
+ * keep the consumer-shipped module free of cross-tree imports (ADR-094 §7).
+ */
+function _pyRound(value: number, ndigits = 0): number {
+    if (!Number.isFinite(value) || value === 0) {
+        return value;
+    }
+    const sign = value < 0 ? -1 : 1;
+    const abs = Math.abs(value);
+    const str = abs.toPrecision(17);
+    if (str.includes('e') || str.includes('E')) {
+        const factor = 10 ** ndigits;
+        return value > 0
+            ? (Math.round(abs * factor) / factor) * sign
+            : -Math.round(abs * factor) / factor;
+    }
+    let [intPart, fracPart = ''] = str.split('.');
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keep = fracPart.slice(0, ndigits);
+    const deciding = fracPart[ndigits] ?? '0';
+    const rest = fracPart.slice(ndigits + 1).replace(/0+$/, '');
+    let digits = (intPart + keep).replace(/^0+(?=\d)/, '');
+    let roundUp = false;
+    if (deciding > '5' || (deciding === '5' && rest !== '')) {
+        roundUp = true;
+    } else if (deciding === '5' && rest === '') {
+        // exact half → round to even
+        const lastKept = digits.length > 0 ? (digits[digits.length - 1] ?? '0') : '0';
+        roundUp = (lastKept.charCodeAt(0) - 48) % 2 === 1;
+    }
+    if (roundUp) {
+        digits = _incrementDecimalString(digits);
+    }
+    // Reinsert the decimal point `ndigits` places from the right.
+    let result: number;
+    if (ndigits === 0) {
+        result = Number(digits);
+    } else {
+        const padded = digits.padStart(ndigits + 1, '0');
+        const cut = padded.length - ndigits;
+        const intStr = padded.slice(0, cut) || '0';
+        const fracStr = padded.slice(cut);
+        result = Number(`${intStr}.${fracStr}`);
+    }
+    return result * sign;
+}
+
+/** Add one to a non-negative integer represented as a decimal string. */
+function _incrementDecimalString(s: string): string {
+    const chars = (s === '' ? '0' : s).split('');
+    let i = chars.length - 1;
+    while (i >= 0) {
+        const ch = chars[i] ?? '0';
+        if (ch === '9') {
+            chars[i] = '0';
+            i -= 1;
+        } else {
+            chars[i] = String.fromCharCode(ch.charCodeAt(0) + 1);
+            return chars.join('');
+        }
+    }
+    return '1' + chars.join('');
+}

--- a/dist/agent-src/templates/scripts/work_engine/scoring/decision_engine.ts
+++ b/dist/agent-src/templates/scripts/work_engine/scoring/decision_engine.ts
@@ -1,0 +1,466 @@
+/**
+ * Decision-engine gates — schema, validation, and per-phase evaluation.
+ *
+ * TypeScript twin of `work_engine/scoring/decision_engine.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * Reads the optional `decision_engine:` block from `.agent-settings.yml`.
+ * Absent block = current behaviour (observe-only, no gates fire).
+ *
+ * Schema (all keys optional; the parser rejects unknown keys hard):
+ *
+ * - `surface_traces` (bool, default `false`) — opt-in for
+ *   `DecisionTraceHook`. Predates the gates; lives here so the
+ *   `decision_engine:` block has one source-of-truth schema.
+ * - `min_confidence` (`low`/`medium`/`high`/`off`, default
+ *   `off`) — confidence-band floor; Phase=Plan refuses to advance
+ *   when the band is below.
+ * - `block_on_risk` (`low`/`medium`/`high`/`off`, default
+ *   `off`) — risk-class ceiling; Phase=Implement refuses to advance
+ *   when risk exceeds.
+ * - `require_memory_hits` (bool, default `false`) — Phase=Refine
+ *   demands `memory_hits >= 1`.
+ * - `on_block` (`stop`/`ask`/`warn`, default `stop`) —
+ *   what happens when a gate fires.
+ * - `ask_timeout_seconds` (int, default `30`) — timeout when
+ *   `on_block=ask` runs in a non-interactive context (no TTY, or
+ *   `CI=true`).
+ * - `on_block_fallback` (`stop`/`warn`, default `stop`) —
+ *   resolution after `ask_timeout` elapses.
+ *
+ * Gate-conflict resolution (first match wins, only one gate fires per
+ * phase):
+ *
+ * 1. `block_on_risk`         (highest impact)
+ * 2. `require_memory_hits`
+ * 3. `min_confidence`        (lowest impact)
+ *
+ * See `docs/contracts/decision-engine-gates.md` for the full
+ * priority matrix.
+ */
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+export const ALLOWED_KEYS: ReadonlySet<string> = new Set([
+    'surface_traces',
+    'min_confidence',
+    'block_on_risk',
+    'require_memory_hits',
+    'on_block',
+    'ask_timeout_seconds',
+    'on_block_fallback',
+]);
+
+const _LEVEL_VALUES: ReadonlySet<string> = new Set(['low', 'medium', 'high', 'off']);
+const _LEVEL_RANK: Record<string, number> = { low: 1, medium: 2, high: 3 };
+const _ON_BLOCK_VALUES: ReadonlySet<string> = new Set(['stop', 'ask', 'warn']);
+const _FALLBACK_VALUES: ReadonlySet<string> = new Set(['stop', 'warn']);
+
+/**
+ * Conflict-resolution order. Highest-impact gate first; the first
+ * firing gate emits its reason and downstream gates are skipped.
+ */
+export const GATE_PRIORITY: readonly string[] = [
+    'block_on_risk',
+    'require_memory_hits',
+    'min_confidence',
+] as const;
+
+const _PHASE_FOR_GATE: Record<string, string> = {
+    block_on_risk: 'implement',
+    require_memory_hits: 'refine',
+    min_confidence: 'plan',
+};
+
+/** Raised when the `decision_engine:` block is malformed. */
+export class DecisionEngineConfigError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, DecisionEngineConfigError.prototype);
+        this.name = 'DecisionEngineConfigError';
+    }
+}
+
+/**
+ * Resolved `decision_engine:` block. Frozen to keep gate evaluations
+ * replay-stable.
+ */
+export class DecisionEngineSettings {
+    readonly surface_traces: boolean;
+    readonly min_confidence: string;
+    readonly block_on_risk: string;
+    readonly require_memory_hits: boolean;
+    readonly on_block: string;
+    readonly ask_timeout_seconds: number;
+    readonly on_block_fallback: string;
+
+    constructor(args: {
+        surface_traces?: boolean;
+        min_confidence?: string;
+        block_on_risk?: string;
+        require_memory_hits?: boolean;
+        on_block?: string;
+        ask_timeout_seconds?: number;
+        on_block_fallback?: string;
+    } = {}) {
+        this.surface_traces = args.surface_traces ?? false;
+        this.min_confidence = args.min_confidence ?? 'off';
+        this.block_on_risk = args.block_on_risk ?? 'off';
+        this.require_memory_hits = args.require_memory_hits ?? false;
+        this.on_block = args.on_block ?? 'stop';
+        this.ask_timeout_seconds = args.ask_timeout_seconds ?? 30;
+        this.on_block_fallback = args.on_block_fallback ?? 'stop';
+        Object.freeze(this);
+    }
+
+    /** True when at least one gate is enabled. */
+    get any_gate_active(): boolean {
+        return (
+            this.min_confidence !== 'off' ||
+            this.block_on_risk !== 'off' ||
+            this.require_memory_hits
+        );
+    }
+}
+
+/**
+ * Outcome of one gate evaluation. `action` is the resolved
+ * response after applying `on_block` plus the non-TTY fallback.
+ */
+export class GateDecision {
+    readonly gate_id: string;
+    readonly phase: string;
+    readonly reason: string;
+    readonly action: string; // "stop" | "warn" | "ask" | "ask_timeout"
+
+    constructor(args: { gate_id: string; phase: string; reason: string; action: string }) {
+        this.gate_id = args.gate_id;
+        this.phase = args.phase;
+        this.reason = args.reason;
+        this.action = args.action;
+        Object.freeze(this);
+    }
+}
+
+/**
+ * Parse a `decision_engine` block into validated settings.
+ *
+ * Returns defaults when `data` is `null`/`undefined` (block absent) or an
+ * empty mapping. Raises {@link DecisionEngineConfigError} on unknown keys or
+ * invalid values.
+ */
+export function parse(data: Any): DecisionEngineSettings {
+    if (data === null || data === undefined) {
+        return new DecisionEngineSettings();
+    }
+    if (!_isPlainDict(data)) {
+        throw new DecisionEngineConfigError(
+            'decision_engine: must be a mapping, got ' + _pyTypeName(data),
+        );
+    }
+    const d = data as Record<string, unknown>;
+    const unknown: string[] = [];
+    for (const k of Object.keys(d)) {
+        if (!ALLOWED_KEYS.has(k)) {
+            unknown.push(k);
+        }
+    }
+    if (unknown.length > 0) {
+        throw new DecisionEngineConfigError(
+            'decision_engine: unknown key(s): ' +
+                _sortedStr(unknown).join(', ') +
+                '. Allowed: ' +
+                _sortedStr([...ALLOWED_KEYS]).join(', '),
+        );
+    }
+    return new DecisionEngineSettings({
+        surface_traces: _coerce_bool(_get(d, 'surface_traces', undefined), false),
+        min_confidence: _coerce_level(_get(d, 'min_confidence', 'off'), 'min_confidence'),
+        block_on_risk: _coerce_level(_get(d, 'block_on_risk', 'off'), 'block_on_risk'),
+        require_memory_hits: _coerce_bool(_get(d, 'require_memory_hits', undefined), false),
+        on_block: _coerce_choice(_get(d, 'on_block', 'stop'), 'on_block', _ON_BLOCK_VALUES),
+        ask_timeout_seconds: _coerce_int(_get(d, 'ask_timeout_seconds', 30), 'ask_timeout_seconds'),
+        on_block_fallback: _coerce_choice(
+            _get(d, 'on_block_fallback', 'stop'),
+            'on_block_fallback',
+            _FALLBACK_VALUES,
+        ),
+    });
+}
+
+function _coerce_bool(value: Any, dflt: boolean): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined) {
+        return dflt;
+    }
+    if (typeof value === 'string') {
+        const s = value.trim().toLowerCase();
+        if (s === 'true' || s === 'yes' || s === 'on' || s === '1') {
+            return true;
+        }
+        if (s === 'false' || s === 'no' || s === 'off' || s === '0') {
+            return false;
+        }
+    }
+    throw new DecisionEngineConfigError(`decision_engine.${_pyRepr(value)}: expected bool`);
+}
+
+function _coerce_level(value: Any, key: string): string {
+    if (value === null || value === undefined) {
+        return 'off';
+    }
+    // YAML 1.1 parses unquoted `off` as boolean False; accept it as the off
+    // sentinel so writers don't have to quote. Boolean True stays rejected.
+    if (typeof value === 'boolean') {
+        if (value === false) {
+            return 'off';
+        }
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: boolean True is not a valid level ` +
+                '(quote a string: low/medium/high/off)',
+        );
+    }
+    if (typeof value !== 'string') {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: expected string, got ` + _pyTypeName(value),
+        );
+    }
+    const s = value.trim().toLowerCase();
+    if (!_LEVEL_VALUES.has(s)) {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: invalid value ${_pyRepr(value)}. ` +
+                'Allowed: ' +
+                _sortedStr([..._LEVEL_VALUES]).join(', '),
+        );
+    }
+    return s;
+}
+
+function _coerce_choice(value: Any, key: string, allowed: ReadonlySet<string>): string {
+    if (typeof value !== 'string') {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: expected string, got ` + _pyTypeName(value),
+        );
+    }
+    const s = value.trim().toLowerCase();
+    if (!allowed.has(s)) {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: invalid value ${_pyRepr(value)}. ` +
+                'Allowed: ' +
+                _sortedStr([...allowed]).join(', '),
+        );
+    }
+    return s;
+}
+
+function _coerce_int(value: Any, key: string): number {
+    if (typeof value === 'boolean') {
+        throw new DecisionEngineConfigError(`decision_engine.${key}: expected int, got bool`);
+    }
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        if (value < 0) {
+            throw new DecisionEngineConfigError(`decision_engine.${key}: must be >= 0`);
+        }
+        return value;
+    }
+    throw new DecisionEngineConfigError(
+        `decision_engine.${key}: expected int, got ` + _pyTypeName(value),
+    );
+}
+
+/**
+ * Evaluate gates for `phase`. Returns the first firing gate, or `null` when
+ * no gate fires.
+ *
+ * Conflict resolution follows {@link GATE_PRIORITY} — only the first matching
+ * gate's phase is considered. Each gate maps to exactly one phase via the
+ * internal phase map.
+ */
+export function evaluate_gates(
+    settings: DecisionEngineSettings,
+    args: {
+        phase: string;
+        confidence_band: string | null;
+        risk_class: string | null;
+        memory_hits: number;
+        is_interactive?: (() => boolean) | null;
+    },
+): GateDecision | null {
+    const { phase, confidence_band, risk_class, memory_hits } = args;
+    const is_interactive = args.is_interactive ?? null;
+    if (!settings.any_gate_active) {
+        return null;
+    }
+    for (const gate_id of GATE_PRIORITY) {
+        if (_PHASE_FOR_GATE[gate_id] !== phase) {
+            continue;
+        }
+        const decision = _evaluate_single(gate_id, settings, {
+            confidence_band,
+            risk_class,
+            memory_hits,
+        });
+        if (decision !== null) {
+            const action = _resolve_action(settings, is_interactive);
+            return new GateDecision({
+                gate_id: decision.gate_id,
+                phase: decision.phase,
+                reason: decision.reason,
+                action,
+            });
+        }
+    }
+    return null;
+}
+
+function _evaluate_single(
+    gate_id: string,
+    settings: DecisionEngineSettings,
+    args: {
+        confidence_band: string | null;
+        risk_class: string | null;
+        memory_hits: number;
+    },
+): GateDecision | null {
+    const { confidence_band, risk_class, memory_hits } = args;
+    if (gate_id === 'min_confidence' && settings.min_confidence !== 'off') {
+        // min_confidence is validated to low/medium/high here, all in _LEVEL_RANK.
+        const floor = _LEVEL_RANK[settings.min_confidence] ?? 0;
+        const actual = _LEVEL_RANK[(confidence_band ?? '').toLowerCase()] ?? 0;
+        if (actual < floor) {
+            return new GateDecision({
+                gate_id,
+                phase: 'plan',
+                action: 'stop',
+                reason:
+                    `confidence_band=${_pyRepr(confidence_band)} below floor ` +
+                    `min_confidence=${_pyRepr(settings.min_confidence)}`,
+            });
+        }
+    } else if (gate_id === 'block_on_risk' && settings.block_on_risk !== 'off') {
+        // block_on_risk is validated to low/medium/high here, all in _LEVEL_RANK.
+        const ceiling = _LEVEL_RANK[settings.block_on_risk] ?? 0;
+        const actual = _LEVEL_RANK[(risk_class ?? '').toLowerCase()] ?? 0;
+        if (actual >= ceiling) {
+            return new GateDecision({
+                gate_id,
+                phase: 'implement',
+                action: 'stop',
+                reason:
+                    `risk_class=${_pyRepr(risk_class)} at/above ceiling ` +
+                    `block_on_risk=${_pyRepr(settings.block_on_risk)}`,
+            });
+        }
+    } else if (gate_id === 'require_memory_hits' && settings.require_memory_hits) {
+        if (memory_hits < 1) {
+            return new GateDecision({
+                gate_id,
+                phase: 'refine',
+                action: 'stop',
+                reason:
+                    `memory_hits=${memory_hits} but ` +
+                    'require_memory_hits=true (need >= 1)',
+            });
+        }
+    }
+    return null;
+}
+
+/**
+ * Map `on_block` to an action, applying the non-TTY fallback.
+ *
+ * Non-interactive context = either `is_interactive()` returns False, or the
+ * `CI` env var is truthy. `on_block=ask` collapses to `ask_timeout` (consumer
+ * applies `on_block_fallback`).
+ */
+function _resolve_action(
+    settings: DecisionEngineSettings,
+    is_interactive: (() => boolean) | null,
+): string {
+    if (settings.on_block === 'stop' || settings.on_block === 'warn') {
+        return settings.on_block;
+    }
+    const interactive =
+        is_interactive !== null ? is_interactive() : _default_is_interactive();
+    if (interactive) {
+        return 'ask';
+    }
+    return 'ask_timeout';
+}
+
+function _default_is_interactive(): boolean {
+    const ci = (process.env.CI ?? '').trim().toLowerCase();
+    if (ci === '1' || ci === 'true' || ci === 'yes') {
+        return false;
+    }
+    // Python: `sys.stdin.isatty() and sys.stdout.isatty()`.
+    return Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** `dict.get(key, default)` for a plain object. */
+function _get(obj: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Python `type(x).__name__` for the error-message shapes this module emits:
+ * `list`, `str`, `int`, `float`, `bool`, `dict`, `NoneType`.
+ */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/**
+ * Python `repr(x)` for the scalar shapes the error messages interpolate via
+ * `{value!r}` — strings are single-quoted, `None` → `None`, booleans →
+ * `True`/`False`, numbers as-is.
+ */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}

--- a/dist/agent-src/templates/scripts/work_engine/scoring/decision_trace.ts
+++ b/dist/agent-src/templates/scripts/work_engine/scoring/decision_trace.ts
@@ -1,0 +1,298 @@
+/**
+ * Confidence-band + risk-class heuristics for decision-trace v1.
+ *
+ * TypeScript twin of `work_engine/scoring/decision_trace.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * These heuristics back the JSON envelope emitted by
+ * `work_engine.hooks.builtin.DecisionTraceHook`. They live here
+ * (under `scoring/`) so the rules and the hook share a single source
+ * of truth, and so unit tests can exercise the heuristics without
+ * spinning up a dispatcher.
+ *
+ * Confidence-band heuristic (per
+ * `docs/contracts/decision-trace-v1.md`):
+ *
+ * - `high`   — `memory.hits >= 2` AND
+ *   `verify.first_try_passes == verify.claims` AND no ambiguity flag.
+ * - `medium` — `memory.hits >= 1` OR `verify.first_try_passes >= 1`.
+ * - `low`    — otherwise.
+ *
+ * Edge case: `verify.claims == 0` is **not** `high` by default; it
+ * folds into `medium` if at least one memory hit landed, `low`
+ * otherwise.
+ *
+ * Risk-class heuristic: maximum risk across the files the phase
+ * touched. With no file-ownership matrix wired in yet, the
+ * implementation defaults to `low` and exposes a `files` argument
+ * so a future hook can pass concrete paths. If the phase touched any
+ * files at all the heuristic returns `medium` so reviewers stay
+ * nudged toward a closer look until the matrix lands.
+ */
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+export const BAND_HIGH = 'high';
+export const BAND_MEDIUM = 'medium';
+export const BAND_LOW = 'low';
+
+export const RISK_HIGH = 'high';
+export const RISK_MEDIUM = 'medium';
+export const RISK_LOW = 'low';
+
+/** Return `high` / `medium` / `low` per the v1 heuristic. */
+export function derive_confidence_band(args: {
+    memory_hits: number;
+    verify_claims: number;
+    verify_first_try_passes: number;
+    ambiguity_flag: boolean;
+}): string {
+    const { memory_hits, verify_claims, verify_first_try_passes, ambiguity_flag } = args;
+    if (
+        memory_hits >= 2 &&
+        verify_claims > 0 &&
+        verify_first_try_passes === verify_claims &&
+        !ambiguity_flag
+    ) {
+        return BAND_HIGH;
+    }
+    if (memory_hits >= 1 || verify_first_try_passes >= 1) {
+        return BAND_MEDIUM;
+    }
+    return BAND_LOW;
+}
+
+/**
+ * Return the trace-level risk class.
+ *
+ * `changes` is the `delivery.changes` slice — a list of dicts in
+ * the canonical engine shape, or `null` for pure planning phases.
+ * Until the file-ownership matrix is wired in, "any change touched"
+ * maps to `medium`; "no change" maps to `low`. `high` is
+ * reserved for the future ownership-matrix lookup.
+ *
+ * Mirrors the Python truthiness check `if not changes:` — empty list,
+ * empty string, `0`, `null`, `undefined`, and `false` all count as falsy.
+ * Non-iterable truthy values fall through to `RISK_LOW` exactly as the
+ * Python `isinstance(changes, Iterable)` guard does.
+ */
+export function derive_risk_class(changes: Any): string {
+    if (!_pyTruthy(changes)) {
+        return RISK_LOW;
+    }
+    if (_isIterable(changes)) {
+        // `sum(1 for _ in changes)` — count the elements. Strings are
+        // iterable in Python (each char is one element); JS strings are not
+        // iterated by the `for...of` below the same way for our purposes, so
+        // mirror Python: a non-empty string counts as `count > 0`.
+        let count = 0;
+        if (typeof changes === 'string') {
+            count = _pyLen(changes);
+        } else {
+            for (const _ of changes as Iterable<unknown>) {
+                void _;
+                count += 1;
+            }
+        }
+        return count > 0 ? RISK_MEDIUM : RISK_LOW;
+    }
+    return RISK_LOW;
+}
+
+/**
+ * Reduce `state.memory` into the trace-envelope `memory` slice.
+ *
+ * The engine stores memory entries as dicts with at least an `id`
+ * or `rule_id` key plus arbitrary per-entry payload. The trace
+ * only carries ids — bodies stay behind the privacy floor.
+ */
+export function summarise_memory(
+    memory: Any,
+    args: { limit?: number } = {},
+): Record<string, Any> {
+    const limit = args.limit ?? 32;
+    if (!_pyTruthy(memory)) {
+        return { asks: 0, hits: 0, ids: [] };
+    }
+    const ids: string[] = [];
+    let asks = 0;
+    let hits = 0;
+    for (const entry of memory as Iterable<unknown>) {
+        if (!_isPlainDict(entry)) {
+            continue;
+        }
+        const e = entry as Record<string, unknown>;
+        // `int(entry.get("asks", 1) or 0) or 1` — Python: default 1 when key
+        // absent; coerce to int; `or 0` turns a falsy value into 0; outer
+        // `or 1` turns a resulting 0 into 1. Net: the increment is always >= 1.
+        asks += _pyInt(_pyOr(_get(e, 'asks', 1), 0)) || 1;
+        // `entry.get("hit", True)` — default True when absent.
+        if (_pyTruthy('hit' in e ? e['hit'] : true)) {
+            hits += 1;
+            const entry_id = _pyOr(_get(e, 'id', undefined), _get(e, 'rule_id', undefined));
+            if (_pyTruthy(entry_id) && ids.length < limit) {
+                ids.push(_pyStr(entry_id));
+            }
+        }
+    }
+    return { asks, hits, ids };
+}
+
+/**
+ * Reduce `state.verify` into the trace-envelope `verify` slice.
+ *
+ * `verify` may be `null` (no verify run yet), a dict carrying
+ * `claims` / `first_try_passes`, or a list of attempt records.
+ * Anything else collapses to zeros.
+ */
+export function summarise_verify(verify: Any): Record<string, number> {
+    if (verify === null || verify === undefined) {
+        return { claims: 0, first_try_passes: 0 };
+    }
+    if (_isPlainDict(verify)) {
+        const v = verify as Record<string, unknown>;
+        const claims = _pyInt(_pyOr(_get(v, 'claims', 0), 0));
+        const passes = _pyInt(_pyOr(_get(v, 'first_try_passes', 0), 0));
+        return { claims, first_try_passes: passes };
+    }
+    if (Array.isArray(verify)) {
+        const claims = verify.length;
+        let passes = 0;
+        for (const entry of verify) {
+            if (_isPlainDict(entry) && _pyTruthy((entry as Record<string, unknown>)['first_try_pass'])) {
+                passes += 1;
+            }
+        }
+        return { claims, first_try_passes: passes };
+    }
+    return { claims: 0, first_try_passes: 0 };
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** `dict.get(key, default)` for a plain object. */
+function _get(obj: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `a or b` — returns `a` when truthy, else `b`. */
+function _pyOr(a: unknown, b: unknown): unknown {
+    return _pyTruthy(a) ? a : b;
+}
+
+/**
+ * Python `bool(x)` truthiness: `None`/`undefined`, `False`, `0`, `0.0`,
+ * `""`, empty list/tuple/dict/set are falsy; everything else truthy.
+ */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/**
+ * Python `int(x)` for the value kinds these heuristics see — booleans
+ * (`True` → 1, `False` → 0), numbers (truncate toward zero), and numeric
+ * strings. Non-coercible values raise like CPython would; in practice the
+ * callers only pass the dict-derived scalars above.
+ */
+function _pyInt(value: unknown): number {
+    if (value === true) {
+        return 1;
+    }
+    if (value === false) {
+        return 0;
+    }
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        const n = Number(trimmed);
+        if (trimmed !== '' && Number.isFinite(n)) {
+            return Math.trunc(n);
+        }
+    }
+    throw new Error(`invalid literal for int(): ${String(value)}`);
+}
+
+/** Python `str(x)` for the scalar shapes returned by `id` / `rule_id`. */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/** Python `len(x)` for a string — code-point count, not UTF-16 unit count. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        void _;
+        n += 1;
+    }
+    return n;
+}
+
+/**
+ * Python `isinstance(x, dict)` — only a plain object (not array, not null).
+ * Mirrors the source's `isinstance(entry, dict)` guards.
+ */
+function _isPlainDict(value: unknown): boolean {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+    );
+}
+
+/**
+ * Python `isinstance(x, Iterable)` for the shapes `derive_risk_class` can
+ * see after the `if not changes:` guard: lists, strings, sets, maps, and
+ * generic iterables expose `Symbol.iterator`; plain dicts are iterable in
+ * Python (over keys) so an object also counts.
+ */
+function _isIterable(value: unknown): boolean {
+    if (value === null || value === undefined) {
+        return false;
+    }
+    if (typeof value === 'string' || Array.isArray(value)) {
+        return true;
+    }
+    if (typeof value === 'object') {
+        if (typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function') {
+            return true;
+        }
+        // Plain dict: iterable over its keys in Python.
+        return true;
+    }
+    return false;
+}

--- a/dist/agent-src/templates/scripts/work_engine/scoring/memory_visibility.ts
+++ b/dist/agent-src/templates/scripts/work_engine/scoring/memory_visibility.ts
@@ -1,0 +1,445 @@
+/**
+ * Producer-side helpers for the memory-visibility line.
+ *
+ * TypeScript twin of `work_engine/scoring/memory_visibility.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * Implements the v1 line shape from
+ * `docs/contracts/memory-visibility-v1.md`:
+ *
+ *     🧠 Memory: <hits>/<asks> · ids=[<comma-separated-ids>]
+ *     🧠 Memory: <hits>/<asks> · ids=[<...>] · affected: <keys>
+ *
+ * The optional `· affected: <keys>` trailing segment surfaces which
+ * closed-list decision-trace keys diverged because memory was
+ * consulted — see `docs/contracts/decision-trace-v1.md` "Memory
+ * consequence keys".
+ *
+ * The semantics matched to the work-engine model:
+ *
+ * - The `memory` step retrieves across the four allowed memory types
+ *   (`MEMORY_TYPES` in `directives.backend.memory`). Each type is
+ *   one `ask` from the visibility-line perspective.
+ * - `hits` counts distinct types that returned at least one entry.
+ * - `ids` is the deduped list of returned entry ids preserving the
+ *   retrieval order encoded in `state.memory`.
+ *
+ * Privacy floor: this module never emits entry bodies, summaries,
+ * `path`/`source` fields, or anything beyond `id` and `type`.
+ * The privacy regression test (`tests/contracts/test_memory_
+ * visibility_redaction.py`) keeps this guarantee enforced.
+ */
+
+import { derive_confidence_band, derive_risk_class } from './decision_trace.js';
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+export const ICON = '\u{1F9E0}'; // 🧠
+export const DEFAULT_MAX_INLINE_IDS = 5;
+export const DEFAULT_ASKED_TYPES: readonly string[] = [
+    'domain-invariants',
+    'architecture-decisions',
+    'incident-learnings',
+    'historical-patterns',
+];
+
+export const CONSEQUENCE_KEYS: readonly string[] = [
+    'confidence_band',
+    'risk_class',
+    'applied_rules',
+    'test_plan',
+] as const;
+
+/**
+ * Reduce `state.memory` into the visibility-line slice.
+ *
+ * `memory` is the list of hit dicts produced by
+ * `directives.backend.memory`. Returns `{"asks", "hits", "ids"}`
+ * with privacy-safe values only.
+ */
+export function summarise_visibility(
+    memory: Any,
+    args: { asked_types?: Iterable<string> } = {},
+): Record<string, Any> {
+    const asked = [...(args.asked_types ?? DEFAULT_ASKED_TYPES)];
+    if (!_pyTruthy(memory) || !Array.isArray(memory)) {
+        return { asks: 0, hits: 0, ids: [] };
+    }
+    const asks = asked.length;
+    const seen_types = new Set<string>();
+    const ids: string[] = [];
+    const seen_ids = new Set<string>();
+    for (const entry of memory) {
+        if (!_isPlainDict(entry)) {
+            continue;
+        }
+        const e = entry as Record<string, unknown>;
+        const type_value = e['type'];
+        if (typeof type_value === 'string') {
+            seen_types.add(type_value);
+        }
+        const entry_id = _pyOr(_get(e, 'id', undefined), _get(e, 'rule_id', undefined));
+        if (!(typeof entry_id === 'string' || _isIntLike(entry_id))) {
+            continue;
+        }
+        const sid = _pyStr(entry_id);
+        if (seen_ids.has(sid)) {
+            continue;
+        }
+        seen_ids.add(sid);
+        ids.push(sid);
+    }
+    const hits = seen_types.size > 0 ? seen_types.size : ids.length > 0 ? 1 : 0;
+    return { asks, hits, ids };
+}
+
+/**
+ * Return a comparable shape for a consequence-key value.
+ *
+ * List-shaped keys (`applied_rules`, `test_plan`) compare as
+ * sorted tuples so order is not a divergence; scalar keys
+ * (`confidence_band`, `risk_class`) compare as-is.
+ */
+function _normalise_key_value(value: Any): Any {
+    if (Array.isArray(value)) {
+        // `tuple(sorted(str(item) for item in value))`
+        return _sortedStr(value.map((item) => _pyStr(item)));
+    }
+    return value;
+}
+
+/**
+ * Return sorted keys whose values diverge between two traces.
+ *
+ * Iterates the closed `CONSEQUENCE_KEYS` list defined in
+ * `docs/contracts/decision-trace-v1.md`. A key is considered
+ * *diverged* when its normalised value differs between the two
+ * traces. Per the contract, when both sides are `None` the key
+ * is suppressed from the diff entirely.
+ */
+export function diff_consequence_keys(
+    trace_with: Record<string, Any>,
+    trace_without: Record<string, Any>,
+): string[] {
+    const affected: string[] = [];
+    for (const key of CONSEQUENCE_KEYS) {
+        const a = _get(trace_with, key, undefined);
+        const b = _get(trace_without, key, undefined);
+        if (_isNone(a) && _isNone(b)) {
+            continue;
+        }
+        if (!_pyEqual(_normalise_key_value(a), _normalise_key_value(b))) {
+            affected.push(key);
+        }
+    }
+    return _sortedStr(affected);
+}
+
+/**
+ * Compute the `affected` consequence keys for the visibility line.
+ *
+ * Returns:
+ *   - `null` when no memory was consulted (`memory_hits <= 0`)
+ *     — caller MUST omit the `· affected: …` segment.
+ *   - `[]` when memory was consulted but no closed-list key
+ *     diverged — caller MUST render `· affected: none`.
+ *   - sorted list of keys otherwise.
+ *
+ * The counterfactual trace is "what the heuristics would have
+ * emitted if `memory_hits` had been `0`". v1 covers
+ * `confidence_band` and `risk_class` via the existing scoring
+ * helpers; `applied_rules` and `test_plan` pass through
+ * unchanged because they are not yet memory-derived in the
+ * engine — the keys stay in the closed list so the diff
+ * infrastructure is in place when they wire in.
+ */
+export function compute_affected(args: {
+    memory_hits: number;
+    verify_claims?: number;
+    verify_first_try_passes?: number;
+    ambiguity_flag?: boolean;
+    changes?: Any;
+    applied_rules?: string[] | null;
+    test_plan?: string[] | null;
+}): string[] | null {
+    const memory_hits = args.memory_hits;
+    const verify_claims = args.verify_claims ?? 0;
+    const verify_first_try_passes = args.verify_first_try_passes ?? 0;
+    const ambiguity_flag = args.ambiguity_flag ?? false;
+    const changes = args.changes ?? null;
+    const applied_rules = args.applied_rules ?? null;
+    const test_plan = args.test_plan ?? null;
+
+    if (memory_hits <= 0) {
+        return null;
+    }
+    const trace_with: Record<string, Any> = {
+        confidence_band: derive_confidence_band({
+            memory_hits,
+            verify_claims,
+            verify_first_try_passes,
+            ambiguity_flag,
+        }),
+        risk_class: derive_risk_class(changes),
+        applied_rules: _pyTruthy(applied_rules) ? [...(applied_rules as string[])] : null,
+        test_plan: _pyTruthy(test_plan) ? [...(test_plan as string[])] : null,
+    };
+    const trace_without: Record<string, Any> = {
+        confidence_band: derive_confidence_band({
+            memory_hits: 0,
+            verify_claims,
+            verify_first_try_passes,
+            ambiguity_flag,
+        }),
+        risk_class: derive_risk_class(changes),
+        applied_rules: _pyTruthy(applied_rules) ? [...(applied_rules as string[])] : null,
+        test_plan: _pyTruthy(test_plan) ? [...(test_plan as string[])] : null,
+    };
+    return diff_consequence_keys(trace_with, trace_without);
+}
+
+/**
+ * Render the visibility line; return `null` when `asks == 0`.
+ *
+ * Cap inline ids at `max_inline_ids` and append `…+N` when the
+ * list is longer. Returning `null` enforces the contract clause
+ * "If `asks == 0`, the engine MUST suppress the line entirely".
+ *
+ * When `affected` is not `null`, append the
+ * `· affected: <keys>` trailing segment from
+ * `docs/contracts/memory-visibility-v1.md`: empty list renders as
+ * `affected: none` (consulted but no key diverged);
+ * non-empty list renders the comma-separated keys.
+ */
+export function format_line(
+    summary: Record<string, Any>,
+    args: { max_inline_ids?: number; affected?: string[] | null } = {},
+): string | null {
+    let max_inline_ids = args.max_inline_ids ?? DEFAULT_MAX_INLINE_IDS;
+    const affected = args.affected ?? null;
+
+    const asks = _pyInt(_pyOr(_get(summary, 'asks', 0), 0));
+    if (asks <= 0) {
+        return null;
+    }
+    const hits = _pyInt(_pyOr(_get(summary, 'hits', 0), 0));
+    const raw_ids = (_pyOr(_get(summary, 'ids', undefined), []) as unknown[]) ?? [];
+    const ids = (raw_ids as unknown[])
+        .filter((i) => typeof i === 'string' || _isIntLike(i))
+        .map((i) => _pyStr(i));
+    if (max_inline_ids < 0) {
+        max_inline_ids = 0;
+    }
+    const inline = ids.slice(0, max_inline_ids);
+    const overflow = ids.length - inline.length;
+    let rendered_ids = inline.join(', ');
+    if (overflow > 0) {
+        const suffix = rendered_ids ? ', ' : '';
+        rendered_ids = `${rendered_ids}${suffix}…+${overflow}`;
+    }
+    let line = `${ICON} Memory: ${hits}/${asks} · ids=[${rendered_ids}]`;
+    if (affected !== null) {
+        const rendered_affected = affected.length > 0 ? affected.join(',') : 'none';
+        line = `${line} · affected: ${rendered_affected}`;
+    }
+    return line;
+}
+
+/**
+ * Render the end-of-run "Memory changed decisions" report block.
+ *
+ * Per `docs/contracts/memory-visibility-v1.md`: lists
+ * `<id> → <key>` rows derived from the same diff source as the
+ * visibility line's `affected` segment. Returns `null` when
+ * no key diverged (`affected` empty / `null`) so the caller
+ * suppresses the block entirely.
+ *
+ * Attribution in v1 is aggregate: each consulted id pairs with
+ * each affected key. Per-id attribution is captured as a
+ * follow-up risk in the roadmap Risk register.
+ */
+export function format_changed_decisions_block(
+    ids: Iterable<string>,
+    affected: Iterable<string> | null | undefined,
+): string | null {
+    if (!_pyTruthy(affected)) {
+        return null;
+    }
+    const affected_list = _sortedStr([...(affected as Iterable<string>)]);
+    const id_list = [...ids].filter((i) => typeof i === 'string' || _isIntLike(i)).map((i) => _pyStr(i));
+    if (id_list.length === 0) {
+        return null;
+    }
+    const lines = ['Memory changed decisions:'];
+    for (const entry_id of id_list) {
+        for (const key of affected_list) {
+            lines.push(`- ${entry_id} → ${key}`);
+        }
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Apply the cadence + opt-out gates from the contract.
+ *
+ * `memory_cadence` is the `memory.cadence` cadence key:
+ *
+ *   - `always` (default) — emit whenever `asks >= 1`.
+ *   - `auto` — emit only when `asks >= 3` (reduces noise on
+ *     shallow-retrieval steps).
+ *   - `never` — suppress the line entirely.
+ *
+ * `visibility_off` is the legacy `memory.visibility: off` master
+ * switch and still wins over any `memory_cadence` value.
+ */
+export function should_emit(
+    summary: Record<string, Any>,
+    args: { memory_cadence?: string; visibility_off?: boolean } = {},
+): boolean {
+    const memory_cadence = args.memory_cadence ?? 'always';
+    const visibility_off = args.visibility_off ?? false;
+    if (visibility_off) {
+        return false;
+    }
+    const asks = _pyInt(_pyOr(_get(summary, 'asks', 0), 0));
+    if (asks <= 0) {
+        return false;
+    }
+    const status = (memory_cadence || 'always').trim().toLowerCase();
+    if (status === 'never') {
+        return false;
+    }
+    if (status === 'auto') {
+        return asks >= 3;
+    }
+    return true;
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** `dict.get(key, default)` for a plain object. */
+function _get(obj: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `a or b`. */
+function _pyOr(a: unknown, b: unknown): unknown {
+    return _pyTruthy(a) ? a : b;
+}
+
+/** Python `x is None`. */
+function _isNone(value: unknown): boolean {
+    return value === null || value === undefined;
+}
+
+/**
+ * Python `int` / `bool` (not `bool` masquerading) test used by the
+ * `isinstance(entry_id, (str, int))` guards. In Python `bool` is a subclass
+ * of `int`, so `True`/`False` pass; mirror that.
+ */
+function _isIntLike(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+        return true;
+    }
+    return typeof value === 'number' && Number.isInteger(value);
+}
+
+/** Python `bool(x)` truthiness. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/** Python `int(x)` for the dict-scalar / `or 0` shapes this module passes. */
+function _pyInt(value: unknown): number {
+    if (value === true) {
+        return 1;
+    }
+    if (value === false) {
+        return 0;
+    }
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        const n = Number(trimmed);
+        if (trimmed !== '' && Number.isFinite(n)) {
+            return Math.trunc(n);
+        }
+    }
+    throw new Error(`invalid literal for int(): ${String(value)}`);
+}
+
+/** Python `str(x)` for the id / list-item shapes. */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/** Python `isinstance(x, dict)` — plain object only. */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Equality matching Python `!=` for the normalised consequence-key values:
+ * scalars compare by value; lists (post-`_normalise_key_value` they are
+ * already string arrays) compare element-wise; `None` distinct from a value.
+ */
+function _pyEqual(a: unknown, b: unknown): boolean {
+    if (Array.isArray(a) && Array.isArray(b)) {
+        if (a.length !== b.length) {
+            return false;
+        }
+        for (let i = 0; i < a.length; i += 1) {
+            if (!_pyEqual(a[i], b[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return false;
+    }
+    if (_isNone(a) && _isNone(b)) {
+        return true;
+    }
+    return a === b;
+}

--- a/dist/agent-src/templates/scripts/work_engine/stack/detect.ts
+++ b/dist/agent-src/templates/scripts/work_engine/stack/detect.ts
@@ -1,0 +1,252 @@
+/**
+ * Frontend-stack detection from project manifests.
+ *
+ * TypeScript twin of `work_engine/stack/detect.py` (ADR-094 py2ts). Leaf
+ * module — stdlib only, NO intra-`work_engine` imports — so the public API
+ * names stay snake_case to mirror the Python module 1:1 (per ADR-094: Python
+ * style is part of the contract).
+ *
+ * The detector reads `composer.json` and `package.json` from a project
+ * root, applies the heuristic table below in priority order, and returns a
+ * {@link StackResult} carrying the labelled frontend plus the manifest
+ * `mtime` it was computed against. The dispatcher caches the result on
+ * `state.stack` and re-runs detection whenever the recorded `mtime`
+ * no longer matches what the filesystem reports.
+ *
+ * Heuristics (priority order — first match wins):
+ *
+ * 1. `composer.json` lists `livewire/livewire` AND `livewire/flux` →
+ *    `blade-livewire-flux`
+ * 2. `package.json` lists `react` AND any of `@radix-ui/*`,
+ *    `shadcn-ui` or has a `components.json` (the shadcn marker file)
+ *    → `react-shadcn`
+ * 3. `package.json` lists `vue` (any major) → `vue`
+ * 4. Otherwise → `plain`
+ *
+ * Detection is filesystem-cheap: at most three small JSON reads per
+ * project root. Errors (missing file, malformed JSON, missing `require`
+ * section) downgrade to `plain` rather than raising — a wrong stack
+ * label is recoverable (audit catches it, user can override), but a
+ * crash mid-dispatch is not.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * All stack labels the detector can return.
+ *
+ * Kept as a set so consumers (state schema, fixtures, tests) can
+ * validate against a single source of truth without re-deriving.
+ *
+ * Mirrors Python's `frozenset` — the membership semantics are what
+ * matter; the literal set construction order is irrelevant.
+ */
+export const KNOWN_STACKS: ReadonlySet<string> = new Set([
+    'blade-livewire-flux',
+    'react-shadcn',
+    'vue',
+    'plain',
+]);
+
+/** Fallback when no manifest signal matches. */
+export const DEFAULT_STACK = 'plain';
+
+const _SHADCN_RADIX_PREFIX = '@radix-ui/';
+const _SHADCN_PACKAGE_NAMES: ReadonlySet<string> = new Set(['shadcn-ui', 'shadcn']);
+const _FLUX_PACKAGE = 'livewire/flux';
+const _LIVEWIRE_PACKAGE = 'livewire/livewire';
+
+/**
+ * A heterogeneous JSON object, mirroring a Python `dict[str, object]`.
+ * A `null` prototype is not required — the only access is `.get(key)`-style
+ * lookup plus `isinstance(section, dict)` checks, both reproduced below.
+ */
+type Manifest = { [key: string]: unknown };
+
+/**
+ * Outcome of one detection pass.
+ *
+ * `mtime` is the latest mtime among the manifests actually consulted
+ * (`composer.json` and `package.json`), in POSIX seconds. Callers
+ * cache the result keyed on this value; a stale cache is invalidated
+ * by the next dispatch when the recorded mtime is older than what
+ * {@link latest_manifest_mtime} returns.
+ *
+ * Mirrors the Python `@dataclass(frozen=True)`: a plain immutable value
+ * carrier with `frontend` + `mtime` fields, constructed positionally /
+ * by keyword.
+ */
+export class StackResult {
+    readonly frontend: string;
+    readonly mtime: number;
+
+    constructor(args: { frontend: string; mtime: number }) {
+        this.frontend = args.frontend;
+        this.mtime = args.mtime;
+    }
+}
+
+/**
+ * Inspect `project_root` and label the frontend stack.
+ *
+ * @param project_root
+ *   Directory that should contain a `composer.json` or `package.json` at
+ *   its top level. Other layouts (monorepos, nested workspaces) call this
+ *   with the workspace root that carries the manifest you care about — the
+ *   caller picks the scope, the detector does not walk upwards.
+ * @returns
+ *   A {@link StackResult} whose `frontend` is one of {@link KNOWN_STACKS};
+ *   `mtime` is the latest manifest mtime among the files actually
+ *   consulted, or `0.0` when no manifests exist (greenfield project).
+ */
+export function detect_stack(project_root: string): StackResult {
+    const composer = _read_json(path.join(project_root, 'composer.json'));
+    const pkg = _read_json(path.join(project_root, 'package.json'));
+    const components_json = _is_file(path.join(project_root, 'components.json'));
+    const mtime = latest_manifest_mtime(project_root);
+
+    if (_is_blade_livewire_flux(composer)) {
+        return new StackResult({ frontend: 'blade-livewire-flux', mtime });
+    }
+
+    if (_is_react_shadcn(pkg, components_json)) {
+        return new StackResult({ frontend: 'react-shadcn', mtime });
+    }
+
+    if (_has_vue(pkg)) {
+        return new StackResult({ frontend: 'vue', mtime });
+    }
+
+    return new StackResult({ frontend: DEFAULT_STACK, mtime });
+}
+
+/**
+ * Return the latest mtime across the manifests we consult.
+ *
+ * Used by the dispatcher's cache check: when the persisted
+ * `state.stack.mtime` no longer matches the live value, the cached
+ * label is invalidated and detection re-runs. Returns `0.0` when no
+ * manifest is present so a fresh greenfield repo produces a stable
+ * sentinel rather than a missing-file error.
+ */
+export function latest_manifest_mtime(project_root: string): number {
+    const candidates = ['composer.json', 'package.json'];
+    const mtimes: number[] = [];
+    for (const name of candidates) {
+        const p = path.join(project_root, name);
+        if (_is_file(p)) {
+            mtimes.push(_stat_mtime(p));
+        }
+    }
+    return mtimes.length > 0 ? Math.max(...mtimes) : 0.0;
+}
+
+/**
+ * Read a JSON manifest, returning `{}` on any error.
+ *
+ * Wrong-but-recoverable beats crash-mid-dispatch. Audit and the
+ * refine step will surface the real shape of the project; the
+ * detector's job is just to pick a routing label.
+ */
+function _read_json(p: string): Manifest {
+    if (!_is_file(p)) {
+        return {};
+    }
+    let payload: unknown;
+    try {
+        payload = JSON.parse(fs.readFileSync(p, { encoding: 'utf-8' }));
+    } catch {
+        // Mirrors Python's `except (OSError, json.JSONDecodeError)`: any read
+        // or parse failure degrades to the empty manifest.
+        return {};
+    }
+    return _isDict(payload) ? payload : {};
+}
+
+/**
+ * Merge the dependency-style sections of a manifest into one map.
+ *
+ * composer.json uses `require` and `require-dev`; package.json uses
+ * `dependencies`, `devDependencies`, `peerDependencies`, and
+ * `optionalDependencies`. We only care whether a name is present
+ * anywhere — version pinning is the audit step's concern.
+ */
+function _all_dependencies(manifest: Manifest, ...keys: string[]): Manifest {
+    const merged: Manifest = {};
+    for (const key of keys) {
+        const section = manifest[key];
+        if (_isDict(section)) {
+            // `dict.update` overwrites with later keys but preserves the
+            // insertion order of first-seen keys; we only test membership,
+            // so a plain assign reproduces the relevant semantics.
+            Object.assign(merged, section);
+        }
+    }
+    return merged;
+}
+
+function _is_blade_livewire_flux(composer: Manifest): boolean {
+    const deps = _all_dependencies(composer, 'require', 'require-dev');
+    return _LIVEWIRE_PACKAGE in deps && _FLUX_PACKAGE in deps;
+}
+
+function _is_react_shadcn(pkg: Manifest, components_json: boolean): boolean {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    if (!('react' in deps)) {
+        return false;
+    }
+    const names = Object.keys(deps);
+    const has_radix = names.some((name) => name.startsWith(_SHADCN_RADIX_PREFIX));
+    const has_shadcn_pkg = names.some((name) => _SHADCN_PACKAGE_NAMES.has(name));
+    return has_radix || has_shadcn_pkg || components_json;
+}
+
+function _has_vue(pkg: Manifest): boolean {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    return 'vue' in deps;
+}
+
+// ── stdlib parity helpers ───────────────────────────────────────────────
+
+/** Python `Path.is_file()` — true only for a regular file (follows symlinks). */
+function _is_file(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Python `Path.stat().st_mtime` in POSIX seconds.
+ *
+ * Python derives `st_mtime` (a float) from the OS nanosecond timestamp.
+ * Reading `mtimeNs` (an integer, byte-identical to Python's `st_mtime_ns`)
+ * and dividing by `1e9` reproduces the same value closely. Note: the exact
+ * float byte-repr of `st_mtime` can differ between CPython and V8 for some
+ * sub-second timestamps — callers that *serialize* mtime (only
+ * `runner.to_config` does) treat it as non-deterministic and the parity
+ * tests normalize the field. The detection logic compares `mtime` only for
+ * cache-invalidation (numeric `!=`), where this precision is sufficient.
+ */
+function _stat_mtime(p: string): number {
+    const st = fs.statSync(p, { bigint: true });
+    return Number(st.mtimeNs) / 1e9;
+}
+
+/** Python `isinstance(x, dict)` — a plain (non-array, non-null) object. */
+function _isDict(v: unknown): v is Manifest {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}

--- a/dist/agent-src/templates/scripts/work_engine/stack/runner.ts
+++ b/dist/agent-src/templates/scripts/work_engine/stack/runner.ts
@@ -1,0 +1,745 @@
+/**
+ * Toolchain resolution — pick the right test/quality runner per stack.
+ *
+ * TypeScript twin of `work_engine/stack/runner.py` (ADR-094 py2ts). Leaf
+ * module — stdlib only, NO intra-`work_engine` imports — so the public API
+ * names stay snake_case to mirror the Python module 1:1 (per ADR-094: Python
+ * style is part of the contract).
+ *
+ * Sibling of {@link "./detect"} (which labels the *frontend* stack). This
+ * module answers a different question: *given a project root, which test
+ * runner and quality tools does this stack actually use, and what is the
+ * exact command to invoke them?* It is the engine behind 6.1.0 Step 6 — the
+ * toolchain resolver that lets one set of commands (`/tests execute`,
+ * `/tests create`, `/quality-fix`, `/review-changes`, `/work`) adapt to
+ * phpunit / pest / vitest / jest / playwright / pytest / go / cargo instead
+ * of exploding into per-stack command variants.
+ *
+ * Detection is filesystem-cheap and **never crashes**: a malformed manifest,
+ * a missing file, or an unknown stack degrades to a LOW-confidence empty
+ * result rather than raising — a wrong toolchain label is recoverable (the
+ * agent can ask), a crash mid-run is not. This mirrors the recoverable-error
+ * contract in {@link "./detect"}.
+ *
+ * Three opt-in flags shape the *selected* command set (the monorepo guard):
+ *
+ * - `include_e2e` — by default e2e suites (playwright / cypress) are
+ *   excluded; fast unit tests run first. Pass to add them.
+ * - `include_slow` — by default a script tagged `test:slow` /
+ *   `test:integration` is excluded. Pass to add it.
+ * - `php_only` — keep only the PHP ecosystem (the `--php` narrowing the
+ *   roadmap calls for; "only genuine PHP-space commands stay PHP-locked").
+ *
+ * The full per-stack inventory is always returned (`runners`); the
+ * `selected` tuple is what a command should actually run after applying
+ * the flags + the fast-by-default monorepo guard.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Every test-runner label the resolver can emit.
+ *
+ * Single source of truth so the state schema, fixtures, and tests validate
+ * against one set without re-deriving it. Mirrors Python's `frozenset`.
+ */
+export const KNOWN_RUNNERS: ReadonlySet<string> = new Set([
+    'pest',
+    'phpunit',
+    'vitest',
+    'jest',
+    'playwright',
+    'cypress',
+    'pytest',
+    'go-test',
+    'cargo-test',
+]);
+
+// Speed buckets. `fast` runs by default; `slow` needs `include_slow`;
+// `e2e` needs `include_e2e`. The monorepo guard reads this.
+export const SPEED_FAST = 'fast';
+export const SPEED_SLOW = 'slow';
+export const SPEED_E2E = 'e2e';
+
+// Confidence tiers — declarative, mirrors the non-interactive-contract
+// tiers (HIGH = deterministic dependency/marker; MEDIUM = heuristic;
+// LOW = nothing matched).
+export const HIGH = 'HIGH';
+export const MEDIUM = 'MEDIUM';
+export const LOW = 'LOW';
+
+const _MANIFESTS = [
+    'composer.json',
+    'package.json',
+    'pyproject.toml',
+    'go.mod',
+    'Cargo.toml',
+    'Makefile',
+    'Taskfile.yml',
+    'Taskfile.yaml',
+];
+
+/** A heterogeneous JSON object, mirroring a Python `dict[str, object]`. */
+type Manifest = { [key: string]: unknown };
+
+/** Role → wrapper-command map, mirroring Python's `dict[str, str]`. */
+type Wrappers = { [role: string]: string };
+
+/**
+ * One detected test runner for one ecosystem.
+ *
+ * `command` is the exact invocation to run the suite (a task-runner
+ * wrapper like `make test` when one exists, otherwise the direct tool).
+ * `speed` is one of {@link SPEED_FAST} / {@link SPEED_SLOW} /
+ * {@link SPEED_E2E}; the monorepo guard filters on it. `basis` names the
+ * concrete signal that matched (dependency, binary, marker file) so the
+ * routing decision is auditable, exactly like the non-interactive-contract's
+ * `basis` column.
+ *
+ * Mirrors the Python `@dataclass(frozen=True)` with positional construction
+ * and the documented field defaults.
+ */
+export class RunnerResult {
+    readonly ecosystem: string;
+    readonly runner: string;
+    readonly command: string;
+    readonly speed: string;
+    readonly confidence: string;
+    readonly basis: string;
+
+    constructor(
+        ecosystem: string,
+        runner: string,
+        command: string,
+        speed: string = SPEED_FAST,
+        confidence: string = HIGH,
+        basis = '',
+    ) {
+        this.ecosystem = ecosystem;
+        this.runner = runner;
+        this.command = command;
+        this.speed = speed;
+        this.confidence = confidence;
+        this.basis = basis;
+    }
+}
+
+/**
+ * Outcome of one toolchain-resolution pass over a project root.
+ *
+ * `runners` is the full inventory (every ecosystem detected, every speed
+ * bucket). `selected` is what a command should actually run after the flags
+ * + fast-by-default guard. `quality` is the ordered list of quality/lint
+ * commands per detected ecosystem. `confidence` is the overall tier (HIGH
+ * when ≥1 runner matched deterministically and no cross-ecosystem conflict;
+ * LOW when nothing matched). `mtime` is the latest manifest mtime, used for
+ * cache invalidation just like {@link "./detect".StackResult}.
+ */
+export class ToolchainResult {
+    readonly ecosystems: readonly string[];
+    readonly runners: readonly RunnerResult[];
+    readonly selected: readonly RunnerResult[];
+    readonly quality: readonly string[];
+    readonly confidence: string;
+    readonly mtime: number;
+
+    constructor(args: {
+        ecosystems: readonly string[];
+        runners: readonly RunnerResult[];
+        selected: readonly RunnerResult[];
+        quality: readonly string[];
+        confidence: string;
+        mtime: number;
+    }) {
+        this.ecosystems = args.ecosystems;
+        this.runners = args.runners;
+        this.selected = args.selected;
+        this.quality = args.quality;
+        this.confidence = args.confidence;
+        this.mtime = args.mtime;
+    }
+
+    /**
+     * Serialise to the auto-generated project-config shape.
+     *
+     * Written to `agents/runtime/state/toolchain.json` by
+     * {@link write_config} so the per-stack commands are captured once and
+     * re-read cheaply (keyed on `mtime`) instead of re-detected every turn.
+     */
+    to_config(): Record<string, unknown> {
+        return {
+            ecosystems: [...this.ecosystems],
+            confidence: this.confidence,
+            // `mtime` is a Python float; wrap so `write_config`'s serialiser
+            // renders an integral value as `N.0` (Python float repr).
+            mtime: pyFloat(this.mtime),
+            runners: this.runners.map((r) => ({
+                ecosystem: r.ecosystem,
+                runner: r.runner,
+                command: r.command,
+                speed: r.speed,
+                confidence: r.confidence,
+                basis: r.basis,
+            })),
+            selected: this.selected.map((r) => r.command),
+            quality: [...this.quality],
+        };
+    }
+}
+
+/**
+ * Inspect `project_root` and resolve its test/quality toolchain.
+ *
+ * @param project_root
+ *   Directory carrying the manifests (`composer.json` / `package.json` /
+ *   `pyproject.toml` / `go.mod` / `Cargo.toml`). The resolver does not walk
+ *   upwards — the caller picks the scope, matching `detect.detect_stack`.
+ * @param opts.include_slow @param opts.include_e2e
+ *   Monorepo guard. Off by default → `selected` carries only fast unit
+ *   suites. Turn on to add the slow / e2e buckets.
+ * @param opts.php_only
+ *   The `--php` narrowing — keep only the PHP ecosystem in `selected` (the
+ *   full inventory is still returned in `runners`).
+ * @returns
+ *   A {@link ToolchainResult}. Never raises. No manifest / unknown stack →
+ *   an empty result with `confidence == LOW` so the caller can fall back to
+ *   asking.
+ */
+export function resolve_toolchain(
+    project_root: string,
+    opts: { include_slow?: boolean; include_e2e?: boolean; php_only?: boolean } = {},
+): ToolchainResult {
+    const include_slow = opts.include_slow ?? false;
+    const include_e2e = opts.include_e2e ?? false;
+    const php_only = opts.php_only ?? false;
+
+    const runners: RunnerResult[] = [];
+    const quality: string[] = [];
+
+    const composer = _read_json(path.join(project_root, 'composer.json'));
+    const pkg = _read_json(path.join(project_root, 'package.json'));
+    const has_composer = _is_file(path.join(project_root, 'composer.json'));
+    const has_package = _is_file(path.join(project_root, 'package.json'));
+    const pyproject_text = _read_text(path.join(project_root, 'pyproject.toml'));
+    const has_python =
+        Boolean(pyproject_text) ||
+        _is_file(path.join(project_root, 'requirements.txt')) ||
+        _is_file(path.join(project_root, 'setup.cfg')) ||
+        _is_file(path.join(project_root, 'pytest.ini'));
+    const has_go = _is_file(path.join(project_root, 'go.mod'));
+    const has_cargo = _is_file(path.join(project_root, 'Cargo.toml'));
+
+    const wrappers = _task_runner_wrappers(project_root, pkg);
+
+    if (has_composer) {
+        runners.push(..._php_runners(project_root, composer, wrappers));
+        quality.push(..._php_quality(project_root, composer, wrappers));
+    }
+    if (has_package) {
+        runners.push(..._js_runners(pkg, wrappers));
+        quality.push(..._js_quality(pkg, wrappers));
+    }
+    if (has_python) {
+        runners.push(..._python_runners(pyproject_text));
+        quality.push(..._python_quality(pyproject_text));
+    }
+    if (has_go) {
+        runners.push(
+            new RunnerResult('go', 'go-test', 'go test ./...', SPEED_FAST, HIGH, 'go.mod present'),
+        );
+        quality.push('go vet ./...');
+    }
+    if (has_cargo) {
+        runners.push(
+            new RunnerResult('rust', 'cargo-test', 'cargo test', SPEED_FAST, HIGH, 'Cargo.toml present'),
+        );
+        quality.push('cargo clippy');
+    }
+
+    const ecosystems = _dictFromKeys(runners.map((r) => r.ecosystem));
+    const selected = _apply_guard(runners, { include_slow, include_e2e, php_only });
+    const confidence = _overall_confidence(runners);
+
+    return new ToolchainResult({
+        ecosystems,
+        runners: [...runners],
+        selected: [...selected],
+        quality: _dictFromKeys(quality),
+        confidence,
+        mtime: latest_manifest_mtime(project_root),
+    });
+}
+
+/**
+ * Persist `result` to `agents/runtime/state/toolchain.json`.
+ *
+ * The auto-generated per-stack config the roadmap calls for. Best-effort:
+ * returns the path written; never raises on a read-only or missing parent
+ * (the resolver is a routing aid, not a hard dependency).
+ */
+export function write_config(project_root: string, result: ToolchainResult): string {
+    const target = path.join(project_root, 'agents', 'runtime', 'state', 'toolchain.json');
+    try {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(
+            target,
+            jsonDumps(result.to_config(), { indent: 2, sort_keys: true }) + '\n',
+            { encoding: 'utf-8' },
+        );
+    } catch {
+        // Mirrors Python's `except OSError: pass` — best-effort write.
+    }
+    return target;
+}
+
+/**
+ * Latest mtime across every manifest the resolver consults.
+ *
+ * Cache-invalidation hook: when the persisted value no longer matches the
+ * live value the cached toolchain is stale and resolution re-runs. `0.0`
+ * when no manifest exists (greenfield) — a stable sentinel, not a
+ * missing-file error.
+ */
+export function latest_manifest_mtime(project_root: string): number {
+    const mtimes: number[] = [];
+    for (const name of _MANIFESTS) {
+        const p = path.join(project_root, name);
+        if (_is_file(p)) {
+            mtimes.push(_stat_mtime(p));
+        }
+    }
+    return mtimes.length > 0 ? Math.max(...mtimes) : 0.0;
+}
+
+// --------------------------------------------------------------------------
+// Ecosystem resolvers
+// --------------------------------------------------------------------------
+
+function _php_runners(root: string, composer: Manifest, wrappers: Wrappers): RunnerResult[] {
+    const deps = _all_dependencies(composer, 'require', 'require-dev');
+    if ('pestphp/pest' in deps || _is_file(path.join(root, 'vendor', 'bin', 'pest'))) {
+        const cmd = wrappers['php-test'] || 'vendor/bin/pest';
+        const basis =
+            'pestphp/pest' in deps
+                ? 'pestphp/pest in composer require'
+                : 'vendor/bin/pest present';
+        return [new RunnerResult('php', 'pest', cmd, SPEED_FAST, HIGH, basis)];
+    }
+    if (_is_file(path.join(root, 'artisan'))) {
+        const cmd = wrappers['php-test'] || 'php artisan test';
+        return [new RunnerResult('php', 'phpunit', cmd, SPEED_FAST, HIGH, 'artisan present (Laravel)')];
+    }
+    if ('phpunit/phpunit' in deps || _is_file(path.join(root, 'vendor', 'bin', 'phpunit'))) {
+        const cmd = wrappers['php-test'] || 'vendor/bin/phpunit';
+        return [new RunnerResult('php', 'phpunit', cmd, SPEED_FAST, HIGH, 'phpunit/phpunit detected')];
+    }
+    // composer.json with no test dependency — phpunit is the safe PHP default.
+    const cmd = wrappers['php-test'] || 'vendor/bin/phpunit';
+    return [
+        new RunnerResult(
+            'php',
+            'phpunit',
+            cmd,
+            SPEED_FAST,
+            MEDIUM,
+            'composer.json present, no explicit runner',
+        ),
+    ];
+}
+
+function _js_runners(pkg: Manifest, wrappers: Wrappers): RunnerResult[] {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    const scripts: Manifest = _isDict(pkg.scripts) ? pkg.scripts : {};
+    const pm_test = wrappers['js-test'];
+    const out: RunnerResult[] = [];
+
+    // Fast unit runner — vitest beats jest when both present (vitest is the
+    // modern default), but only one fast runner is selected.
+    if ('vitest' in deps) {
+        const cmd =
+            pm_test && _script_uses(scripts, 'test', 'vitest') ? pm_test : 'npx vitest run';
+        out.push(new RunnerResult('js', 'vitest', cmd, SPEED_FAST, HIGH, 'vitest in package deps'));
+    } else if ('jest' in deps) {
+        const cmd = pm_test && _script_uses(scripts, 'test', 'jest') ? pm_test : 'npx jest';
+        out.push(new RunnerResult('js', 'jest', cmd, SPEED_FAST, HIGH, 'jest in package deps'));
+    } else if (pm_test) {
+        out.push(
+            new RunnerResult(
+                'js',
+                'jest',
+                pm_test,
+                SPEED_FAST,
+                MEDIUM,
+                'package.json test script, runner unclear',
+            ),
+        );
+    }
+
+    // e2e runner — separate bucket, excluded unless --include-e2e.
+    if ('@playwright/test' in deps || 'playwright' in deps) {
+        const cmd = _script_command(scripts, ['test:e2e', 'e2e', 'playwright']) || 'npx playwright test';
+        out.push(
+            new RunnerResult('js', 'playwright', cmd, SPEED_E2E, HIGH, '@playwright/test in package deps'),
+        );
+    } else if ('cypress' in deps) {
+        const cmd = _script_command(scripts, ['test:e2e', 'e2e', 'cypress']) || 'npx cypress run';
+        out.push(new RunnerResult('js', 'cypress', cmd, SPEED_E2E, HIGH, 'cypress in package deps'));
+    }
+
+    // slow bucket — an explicit slow/integration script.
+    const slow_cmd = _script_command(scripts, ['test:slow', 'test:integration']);
+    if (slow_cmd) {
+        out.push(
+            new RunnerResult(
+                'js',
+                'vitest' in deps ? 'vitest' : 'jest',
+                slow_cmd,
+                SPEED_SLOW,
+                MEDIUM,
+                'test:slow/integration script',
+            ),
+        );
+    }
+    return out;
+}
+
+function _python_runners(pyproject_text: string): RunnerResult[] {
+    if (pyproject_text.includes('pytest') || pyproject_text === '') {
+        const conf = pyproject_text.includes('pytest') ? HIGH : MEDIUM;
+        const basis = pyproject_text.includes('pytest')
+            ? 'pytest in pyproject'
+            : 'python project, no explicit runner';
+        return [new RunnerResult('python', 'pytest', 'pytest', SPEED_FAST, conf, basis)];
+    }
+    return [
+        new RunnerResult('python', 'pytest', 'pytest', SPEED_FAST, MEDIUM, 'python project, no explicit runner'),
+    ];
+}
+
+function _php_quality(root: string, composer: Manifest, _wrappers: Wrappers): string[] {
+    const deps = _all_dependencies(composer, 'require', 'require-dev');
+    const out: string[] = [];
+    if ('phpstan/phpstan' in deps || _is_file(path.join(root, 'vendor', 'bin', 'phpstan'))) {
+        out.push('vendor/bin/phpstan analyse');
+    }
+    if ('laravel/pint' in deps || _is_file(path.join(root, 'vendor', 'bin', 'pint'))) {
+        out.push('vendor/bin/pint');
+    }
+    return out;
+}
+
+function _js_quality(pkg: Manifest, _wrappers: Wrappers): string[] {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    const out: string[] = [];
+    if ('typescript' in deps) {
+        out.push('npx tsc --noEmit');
+    }
+    if ('eslint' in deps) {
+        out.push('npx eslint .');
+    }
+    return out;
+}
+
+function _python_quality(pyproject_text: string): string[] {
+    const out: string[] = [];
+    if (pyproject_text.includes('ruff')) {
+        out.push('ruff check');
+    }
+    if (pyproject_text.includes('mypy')) {
+        out.push('mypy .');
+    }
+    return out;
+}
+
+// --------------------------------------------------------------------------
+// Task-runner wrappers (Makefile / Taskfile / package scripts)
+// --------------------------------------------------------------------------
+
+/**
+ * Map logical roles to a wrapper command when one exists.
+ *
+ * Wrappers win over direct tool invocation (they handle container access,
+ * env, parallelism) — the architecture rule's "Build / Task Runner
+ * Detection". Returns role → command; absent roles fall through to the
+ * direct tool.
+ */
+function _task_runner_wrappers(root: string, pkg: Manifest): Wrappers {
+    const out: Wrappers = {};
+    const makefile = _read_text(path.join(root, 'Makefile'));
+    const taskfile =
+        _read_text(path.join(root, 'Taskfile.yml')) || _read_text(path.join(root, 'Taskfile.yaml'));
+    if (makefile && _reSearch(/^test\s*:/m, makefile)) {
+        out['php-test'] = 'make test';
+    } else if (taskfile && _reSearch(/^\s*test\s*:/m, taskfile)) {
+        out['php-test'] = 'task test';
+    }
+    const scripts: Manifest = _isDict(pkg.scripts) ? pkg.scripts : {};
+    if (_isDict(scripts) && 'test' in scripts) {
+        out['js-test'] = `${_package_manager(root)} test`;
+    }
+    return out;
+}
+
+function _package_manager(root: string): string {
+    if (_is_file(path.join(root, 'pnpm-lock.yaml'))) {
+        return 'pnpm';
+    }
+    if (_is_file(path.join(root, 'yarn.lock'))) {
+        return 'yarn';
+    }
+    return 'npm';
+}
+
+// --------------------------------------------------------------------------
+// Monorepo guard + confidence
+// --------------------------------------------------------------------------
+
+function _apply_guard(
+    runners: RunnerResult[],
+    opts: { include_slow: boolean; include_e2e: boolean; php_only: boolean },
+): RunnerResult[] {
+    const out: RunnerResult[] = [];
+    for (const r of runners) {
+        if (opts.php_only && r.ecosystem !== 'php') {
+            continue;
+        }
+        if (r.speed === SPEED_E2E && !opts.include_e2e) {
+            continue;
+        }
+        if (r.speed === SPEED_SLOW && !opts.include_slow) {
+            continue;
+        }
+        out.push(r);
+    }
+    return out;
+}
+
+function _overall_confidence(runners: RunnerResult[]): string {
+    if (runners.length === 0) {
+        return LOW;
+    }
+    if (runners.some((r) => r.confidence === HIGH)) {
+        return HIGH;
+    }
+    return MEDIUM;
+}
+
+// --------------------------------------------------------------------------
+// Shared readers (mirror detect.py's recoverable-error contract)
+// --------------------------------------------------------------------------
+
+function _read_json(p: string): Manifest {
+    if (!_is_file(p)) {
+        return {};
+    }
+    let payload: unknown;
+    try {
+        payload = JSON.parse(fs.readFileSync(p, { encoding: 'utf-8' }));
+    } catch {
+        return {};
+    }
+    return _isDict(payload) ? payload : {};
+}
+
+function _read_text(p: string): string {
+    if (!_is_file(p)) {
+        return '';
+    }
+    try {
+        return fs.readFileSync(p, { encoding: 'utf-8' });
+    } catch {
+        return '';
+    }
+}
+
+function _all_dependencies(manifest: Manifest, ...keys: string[]): Manifest {
+    const merged: Manifest = {};
+    for (const key of keys) {
+        const section = manifest[key];
+        if (_isDict(section)) {
+            Object.assign(merged, section);
+        }
+    }
+    return merged;
+}
+
+function _script_uses(scripts: Manifest, name: string, tool: string): boolean {
+    const value = scripts[name];
+    return typeof value === 'string' && value.includes(tool);
+}
+
+function _script_command(scripts: Manifest, names: string[]): string {
+    for (const name of names) {
+        if (typeof scripts[name] === 'string') {
+            return `npm run ${name}`;
+        }
+    }
+    return '';
+}
+
+// --------------------------------------------------------------------------
+// stdlib parity helpers
+// --------------------------------------------------------------------------
+
+/** Python `Path.is_file()` — true only for a regular file (follows symlinks). */
+function _is_file(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Python `Path.stat().st_mtime` in POSIX seconds — see the matching note in
+ * `detect.ts`. Only `to_config` / `write_config` serialize this value, and
+ * the parity tests treat the serialized `mtime` as non-deterministic.
+ */
+function _stat_mtime(p: string): number {
+    const st = fs.statSync(p, { bigint: true });
+    return Number(st.mtimeNs) / 1e9;
+}
+
+/** Python `isinstance(x, dict)` — a plain (non-array, non-null) object. */
+function _isDict(v: unknown): v is Manifest {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Python `re.search(pattern, text)` truthiness. The patterns used here carry
+ * the multiline flag (`(?m)` in the source → `/m` here), so `^`/`$` match at
+ * line boundaries exactly like CPython's `re`.
+ */
+function _reSearch(pattern: RegExp, text: string): boolean {
+    return pattern.test(text);
+}
+
+/**
+ * Python `tuple(dict.fromkeys(seq))` — dedupe preserving first-seen insertion
+ * order. `dict.fromkeys` keeps the first occurrence's position; a JS `Set`
+ * built by iteration does the same, so `[...new Set(seq)]` is faithful.
+ */
+function _dictFromKeys(seq: string[]): string[] {
+    return [...new Set(seq)];
+}
+
+// --------------------------------------------------------------------------
+// JSON serialisation — byte-parity with `json.dumps(..., indent=2,
+// sort_keys=True)` for `write_config`.
+// --------------------------------------------------------------------------
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, sort_keys=True)` byte-for-byte.
+ *
+ * Two CPython behaviours that `JSON.stringify` does NOT reproduce on its own
+ * and are reproduced here:
+ *
+ * - `sort_keys=True` — object keys emitted in code-point ascending order.
+ *   `JSON.stringify` preserves insertion order; we pre-sort recursively.
+ * - integer-valued floats render as `N.0` (e.g. `1767222000.0`). JSON has no
+ *   float/int tag, so a JS `number` that is integral renders without `.0`.
+ *   In this module the only float is `mtime`; the parity tests normalize it
+ *   (its exact byte-repr is not reproducible across CPython/V8), but the
+ *   serialiser still applies the `N.0` rule via a tagged float wrapper so the
+ *   *shape* matches. `mtime` is the sole value passed through that wrapper.
+ *
+ * 2-space indent, `": "` key separator, `","` item separator with the
+ * indent-driven newline, `{}` / `[]` for empties, non-ASCII verbatim
+ * (`ensure_ascii` defaults to `True` in CPython, but `to_config` carries no
+ * non-ASCII, so the distinction never surfaces).
+ */
+function jsonDumps(obj: unknown, opts: { indent: number; sort_keys: boolean }): string {
+    return _encode(obj, opts, 0);
+}
+
+const _INDENT_UNIT = ' ';
+
+function _encode(value: unknown, opts: { indent: number; sort_keys: boolean }, depth: number): string {
+    if (value === null) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _encodeNumber(value, false);
+    }
+    if (value instanceof _PyFloat) {
+        return _encodeNumber(value.value, true);
+    }
+    if (typeof value === 'string') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const inner = _INDENT_UNIT.repeat(opts.indent * (depth + 1));
+        const items = value.map((v) => inner + _encode(v, opts, depth + 1));
+        const close = _INDENT_UNIT.repeat(opts.indent * depth);
+        return '[\n' + items.join(',\n') + '\n' + close + ']';
+    }
+    if (_isDict(value)) {
+        let keys = Object.keys(value);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        if (opts.sort_keys) {
+            keys = keys.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+        }
+        const inner = _INDENT_UNIT.repeat(opts.indent * (depth + 1));
+        const items = keys.map(
+            (k) => inner + JSON.stringify(k) + ': ' + _encode(value[k], opts, depth + 1),
+        );
+        const close = _INDENT_UNIT.repeat(opts.indent * depth);
+        return '{\n' + items.join(',\n') + '\n' + close + '}';
+    }
+    // Unreachable for `to_config` output; mirror `json.dumps` raising on an
+    // unserialisable type would require a TypeError — return the JS default.
+    return JSON.stringify(value);
+}
+
+/**
+ * Render a number like CPython's `float.__repr__` / `int.__repr__` inside
+ * `json.dumps`. When `isFloat` is set and the value is integral, append
+ * `.0` (Python's float repr). Non-integral floats use JS's shortest
+ * round-trip repr — which matches CPython's `repr(float)` for the values
+ * that arise here. (The `mtime` field is normalized by the parity tests, so
+ * any residual last-digit divergence on exotic sub-second timestamps is not
+ * load-bearing.)
+ */
+function _encodeNumber(n: number, isFloat: boolean): string {
+    if (isFloat && Number.isInteger(n)) {
+        return `${n}.0`;
+    }
+    return String(n);
+}
+
+/** Tag wrapper marking a JS number that must serialise with Python float repr. */
+class _PyFloat {
+    readonly value: number;
+    constructor(value: number) {
+        this.value = value;
+    }
+}
+
+/**
+ * Wrap a numeric value so {@link jsonDumps} renders it as a Python float
+ * (integer-valued → `N.0`). Exported for the parity tests / callers that
+ * round-trip a `ToolchainResult` through `to_config`.
+ */
+export function pyFloat(value: number): _PyFloat {
+    return new _PyFloat(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/state_io.ts
+++ b/dist/agent-src/templates/scripts/work_engine/state_io.ts
@@ -1,0 +1,408 @@
+/**
+ * State-file I/O helpers for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/state_io.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Holds
+ * the format-preserving load/save pair, the v0 legacy serialiser, the JSON
+ * reader, the `DeliveryState` projection helpers, and the legacy-file
+ * migration hint. Behaviour is byte-identical to the pre-split version —
+ * Goldens stay green.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { DEFAULT_STATE_FILE, LEGACY_STATE_FILE, _FMT_V0, _FMT_V1 } from './cli_args.js';
+import {
+    DeliveryState,
+    type Any as DeliveryAny,
+} from './delivery_state.js';
+import { _CLIError } from './errors.js';
+import {
+    DEFAULT_DIRECTIVE_SET,
+    DEFAULT_INTENT,
+    SCHEMA_VERSION,
+    SchemaError,
+    WorkState,
+    type Dict,
+    type JsonValue,
+    from_dict as _state_from_dict,
+    to_dict as _state_to_dict,
+} from './state.js';
+
+/**
+ * Surface a migration hint when only the pre-1.15.0 file is present.
+ *
+ * The dispatcher renamed the default state file from
+ * `.implement-ticket-state.json` to `.work-state.json` in 1.15.0
+ * (alongside the `implement_ticket → work_engine` package move).
+ * Existing checkouts that still carry the legacy file would otherwise
+ * fail with a generic "no state file" message. This helper detects
+ * the legacy file in the same directory and points the user at the
+ * one-shot migration command instead.
+ *
+ * Only fires when `state_file` has the canonical default name and
+ * sits next to a legacy file — explicit `--state-file` overrides
+ * bypass the hint so power users can carry their own naming scheme.
+ */
+export function _maybe_raise_legacy_hint(state_file: string): void {
+    // Python compares `state_file.name` (the basename) against the default's
+    // basename. The constants are plain strings (no directory part), so
+    // `path.basename(state_file)` vs the constant matches `Path.name`.
+    if (path.basename(state_file) !== path.basename(DEFAULT_STATE_FILE)) {
+        return;
+    }
+    // `state_file.with_name(LEGACY_STATE_FILE.name)` — same directory, legacy
+    // basename.
+    const legacy_candidate = path.join(path.dirname(state_file), path.basename(LEGACY_STATE_FILE));
+    if (!_isFile(legacy_candidate)) {
+        return;
+    }
+    throw new _CLIError(
+        `Found legacy state file ${legacy_candidate} but no ` +
+            `${state_file}. The default state file was renamed in 1.15.0. ` +
+            `Run \`python3 -m work_engine.migration.v0_to_v1 ` +
+            `${legacy_candidate}\` to migrate, or pass \`--state-file ` +
+            `${legacy_candidate}\` to keep using the old name. See ` +
+            'docs/MIGRATION.md.',
+    );
+}
+
+/** Load `state_file` and tag it with the wire format detected. */
+export function _load(state_file: string): [WorkState, string] {
+    const data = _read_json(state_file);
+    if (!_isPlainDict(data)) {
+        throw new _CLIError(
+            `State file ${state_file} must carry a JSON object; ` +
+                `got ${_pyTypeName(data)}.`,
+        );
+    }
+    const d = data as Record<string, JsonValue>;
+
+    // v1 declares `version`; v0 has none. Anything else is invalid.
+    if (_get(d, 'version', undefined) === SCHEMA_VERSION) {
+        try {
+            return [_state_from_dict(d as JsonValue), _FMT_V1];
+        } catch (exc) {
+            if (exc instanceof SchemaError) {
+                throw new _CLIError(`State file shape is invalid: ${exc.message}`);
+            }
+            throw exc;
+        }
+    }
+    if ('version' in d) {
+        throw new _CLIError(
+            `State file shape is invalid: unsupported version ` +
+                `${_pyRepr(_get(d, 'version', undefined))}; expected ${SCHEMA_VERSION}`,
+        );
+    }
+    if (!('ticket' in d)) {
+        throw new _CLIError(
+            "State file shape is invalid: missing 'ticket' (v0) or " +
+                "'version' (v1) — file is neither shape.",
+        );
+    }
+    try {
+        const migrated = migrate_payload(d);
+        return [_state_from_dict(migrated as JsonValue), _FMT_V0];
+    } catch (exc) {
+        if (exc instanceof SchemaError) {
+            throw new _CLIError(`State file shape is invalid: ${exc.message}`);
+        }
+        throw exc;
+    }
+}
+
+/**
+ * Project `work` into a `DeliveryState` for handler dispatch.
+ *
+ * R1 P4 S1 (Option A2): handlers continue to consume `DeliveryState`
+ * with `state.ticket`; the `WorkState` wrapper exists at the CLI
+ * boundary so the dispatcher's directive-set selection has a v1
+ * state object to read `directive_set` from. Mutable containers
+ * (`memory`, `changes`, `outcomes`, `questions`) are passed
+ * by reference — in-place mutations land on both objects without an
+ * explicit sync. Reassignments (`state.plan = …`, `state.report = …`)
+ * are mirrored back by {@link _sync_back}.
+ */
+export function _to_delivery(work: WorkState): DeliveryState {
+    return new DeliveryState({
+        ticket: work.input.data as Record<string, DeliveryAny>,
+        persona: work.persona,
+        memory: work.memory as Array<Record<string, DeliveryAny>>,
+        plan: work.plan,
+        changes: work.changes as Array<Record<string, DeliveryAny>>,
+        tests: work.tests,
+        verify: work.verify,
+        outcomes: work.outcomes,
+        questions: work.questions,
+        report: work.report,
+        ui_audit: work.ui_audit as Record<string, DeliveryAny> | null,
+        ui_design: work.ui_design as Record<string, DeliveryAny> | null,
+        ui_review: work.ui_review as Record<string, DeliveryAny> | null,
+        ui_polish: work.ui_polish as Record<string, DeliveryAny> | null,
+        contract: work.contract as Record<string, DeliveryAny> | null,
+        stitch: work.stitch as Record<string, DeliveryAny> | null,
+        stack: work.stack as Record<string, DeliveryAny> | null,
+    });
+}
+
+/**
+ * Mirror handler mutations from `delivery` back into `work`.
+ *
+ * Container fields are shared by reference (see {@link _to_delivery})
+ * so the assignment is a no-op for those — we still mirror them
+ * defensively to cover the case where a handler reassigned the
+ * attribute (`state.memory = [new_list]`) instead of mutating in
+ * place.
+ */
+export function _sync_back(work: WorkState, delivery: DeliveryState): void {
+    work.input.data = delivery.ticket as Dict;
+    work.persona = delivery.persona;
+    work.memory = delivery.memory as Dict[];
+    work.plan = delivery.plan as JsonValue;
+    work.changes = delivery.changes as Dict[];
+    work.tests = delivery.tests as JsonValue;
+    work.verify = delivery.verify as JsonValue;
+    work.outcomes = delivery.outcomes;
+    work.questions = delivery.questions;
+    work.report = delivery.report;
+    work.ui_audit = delivery.ui_audit as Dict | null;
+    work.ui_design = delivery.ui_design as Dict | null;
+    work.ui_review = delivery.ui_review as Dict | null;
+    work.ui_polish = delivery.ui_polish as Dict | null;
+    work.contract = delivery.contract as Dict | null;
+    work.stitch = delivery.stitch as Dict | null;
+    work.stack = delivery.stack as Dict | null;
+}
+
+/**
+ * Persist `work` in the wire format it was loaded with.
+ *
+ * v1 emits the canonical envelope via {@link _state_to_dict}; v0 emits the
+ * legacy flat shape that `DeliveryState.asdict` used to produce, byte-identical
+ * to the pre-Phase-4 output so the Golden Transcript replay stays green.
+ */
+export function _save(state_file: string, work: WorkState, fmt: string): void {
+    fs.mkdirSync(path.dirname(state_file), { recursive: true });
+    const payload = fmt === _FMT_V1 ? _state_to_dict(work) : _to_v0_dict(work);
+    fs.writeFileSync(
+        state_file,
+        _jsonDumps(payload) + '\n',
+        'utf-8',
+    );
+}
+
+/**
+ * Serialise `work` in the legacy v0 wire format.
+ *
+ * Field order matches `DeliveryState` declaration order so
+ * pre-Phase-4 state files round-trip byte-equal.
+ */
+export function _to_v0_dict(work: WorkState): Dict {
+    return {
+        ticket: work.input.data,
+        persona: work.persona,
+        memory: work.memory,
+        plan: work.plan,
+        changes: work.changes,
+        tests: work.tests,
+        verify: work.verify,
+        outcomes: work.outcomes,
+        questions: work.questions,
+        report: work.report,
+    };
+}
+
+export function _read_json(p: string): JsonValue {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(p, 'utf-8');
+    } catch (exc) {
+        // Python `OSError` → "Cannot read {path}: {exc}".
+        throw new _CLIError(`Cannot read ${p}: ${_osErrorText(exc, p)}`);
+    }
+    try {
+        return JSON.parse(raw) as JsonValue;
+    } catch (exc) {
+        // Python `json.JSONDecodeError` → "Invalid JSON in {path}: {exc}".
+        throw new _CLIError(`Invalid JSON in ${p}: ${(exc as Error).message}`);
+    }
+}
+
+// ── Inlined v0→v1 payload migration ──────────────────────────────────────
+//
+// The Python source imports `migrate_payload` from
+// `work_engine.migration.v0_to_v1`. A `.ts` twin may not import a `.py`
+// (ADR-094), and the full `v0_to_v1` module (with its CLI / `migrate_file`
+// surface) lands in a later phase. The `migrate_payload` slice `_load` needs
+// is reproduced here verbatim so the load path stays byte-identical; when the
+// `v0_to_v1.ts` twin lands it can re-export this or replace it 1:1.
+
+/**
+ * Return the v1 form of `payload`.
+ *
+ * A payload that already declares `version: 1` is returned unchanged
+ * (deep-copied via `JSON.parse(JSON.stringify(...))` so the caller cannot
+ * accidentally mutate the input). Anything else is treated as v0 and wrapped:
+ * `ticket` becomes `input.data`, `input.kind` is set to `"ticket"`, and the
+ * engine defaults are filled in.
+ *
+ * @throws SchemaError If the payload is not a dict, declares a higher version
+ *   than this migration knows about, or lacks a `ticket` key.
+ */
+export function migrate_payload(payload: JsonValue): Dict {
+    if (!_isPlainDict(payload)) {
+        throw new SchemaError(
+            `v0 state must be a JSON object; got ${_pyTypeName(payload)}`,
+        );
+    }
+    const p = payload as Record<string, JsonValue>;
+
+    const declared_version = _get(p, 'version', undefined);
+    if (declared_version === SCHEMA_VERSION) {
+        return JSON.parse(JSON.stringify(p)) as Dict;
+    }
+    if (declared_version !== undefined && declared_version !== null) {
+        throw new SchemaError(
+            `cannot migrate from version ${_pyRepr(declared_version)} to ` +
+                `${SCHEMA_VERSION}; this script only handles v0 (no version key)`,
+        );
+    }
+
+    if (!('ticket' in p)) {
+        throw new SchemaError(
+            "v0 state must carry a 'ticket' key; got keys: " +
+                _pyReprList(_sortedStr(Object.keys(p))),
+        );
+    }
+    const ticket = p['ticket'];
+    if (!_isPlainDict(ticket)) {
+        throw new SchemaError(
+            `v0 state.ticket must be a JSON object; got ${_pyTypeName(ticket)}`,
+        );
+    }
+
+    return {
+        version: SCHEMA_VERSION,
+        input: { kind: 'ticket', data: ticket },
+        intent: DEFAULT_INTENT,
+        directive_set: DEFAULT_DIRECTIVE_SET,
+        persona: _get(p, 'persona', 'senior-engineer') as JsonValue,
+        memory: [...((_get(p, 'memory', []) as JsonValue[]) ?? [])],
+        plan: _get(p, 'plan', null) as JsonValue,
+        changes: [...((_get(p, 'changes', []) as JsonValue[]) ?? [])],
+        tests: _get(p, 'tests', null) as JsonValue,
+        verify: _get(p, 'verify', null) as JsonValue,
+        outcomes: { ...((_get(p, 'outcomes', {}) as Dict) ?? {}) },
+        questions: [...((_get(p, 'questions', []) as JsonValue[]) ?? [])],
+        report: _get(p, 'report', '') as JsonValue,
+    };
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, ensure_ascii=False)`.
+ *
+ * For round-tripped JSON, `JSON.stringify` with a 2-space indent matches
+ * CPython byte-for-byte: 2-space indent, `": "` key separator, `{}` / `[]`
+ * for empties, non-ASCII verbatim. Same rationale as `state.ts::jsonDumps`:
+ * no float/int tag survives JSON parsing, so the CPython `N.0` divergence
+ * cannot arise here.
+ */
+function _jsonDumps(obj: Dict): string {
+    return JSON.stringify(obj, null, 2);
+}
+
+/** `dict.get(key, default)`. */
+function _get(obj: Record<string, JsonValue>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _isFile(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/** Python `type(x).__name__` for the JSON value shapes the messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/** Python `repr(x)` for the scalar shapes interpolated via `{value!r}`. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `repr(list_of_str)` — `['a', 'b']`. */
+function _pyReprList(values: string[]): string {
+    return '[' + values.map((v) => _pyRepr(v)).join(', ') + ']';
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Approximate the text of Python's `OSError` for a failed read. Python
+ * formats `errno`-based messages like "[Errno 2] No such file or directory:
+ * 'path'". Node's error `.message` is shaped differently, so this is one of
+ * the few non-byte-identical surfaces — the error *channel* (exit 2 via
+ * `_CLIError`) and the *prefix* ("Cannot read <path>: ") stay identical;
+ * only the trailing OS detail differs. Tests normalise this trailing detail.
+ */
+function _osErrorText(exc: unknown, p: string): string {
+    const e = exc as NodeJS.ErrnoException;
+    if (e && e.code === 'ENOENT') {
+        return `[Errno 2] No such file or directory: '${p}'`;
+    }
+    if (e && e.code === 'EISDIR') {
+        return `[Errno 21] Is a directory: '${p}'`;
+    }
+    if (e && e.code === 'EACCES') {
+        return `[Errno 13] Permission denied: '${p}'`;
+    }
+    return e && e.message ? e.message : String(exc);
+}

--- a/src/agent-src/templates/scripts/work_engine/intent/classify.ts
+++ b/src/agent-src/templates/scripts/work_engine/intent/classify.ts
@@ -1,0 +1,425 @@
+/**
+ * Heuristic intent classifier — see `work_engine.intent` for context.
+ *
+ * TypeScript twin of `work_engine/intent/classify.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The classifier walks a small priority ladder against the lower-cased
+ * prompt + optional ticket title. First match wins; `backend-coding` is
+ * the fall-through default so every prompt always lands on a known label.
+ *
+ * Priority order (deliberately fixed):
+ *
+ * 1. **Trivial-UI** — UI signal AND a trivial-edit verb pattern (`change
+ *    color`, `make … red`, `rename label`, `fix copy`) AND no
+ *    structural verb (`add`, `build`, `create`, `introduce`).
+ * 2. **Mixed** — UI signal AND a backend signal (`endpoint`, `API`,
+ *    `migration`, `schema`, `query`, `job`, `queue`).
+ * 3. **UI-Improve** — UI signal AND an improve/redesign/refactor verb,
+ *    OR explicit "existing" surface markers.
+ * 4. **UI-Build** — UI signal AND a build/create/add verb, OR new-screen
+ *    markers (`new page`, `new screen`, `new component`).
+ * 5. **Backend-Coding** — default.
+ *
+ * The label is the dispatcher's *only* input for routing. Confidence
+ * band, `ui_intent` flag from the scorer, and AC reconstruction stay
+ * the resolution surface — the classifier does not look at them.
+ */
+import type { WorkState } from '../state.js';
+
+export const INTENT_UI_BUILD = 'ui-build';
+export const INTENT_UI_IMPROVE = 'ui-improve';
+export const INTENT_UI_TRIVIAL = 'ui-trivial';
+export const INTENT_MIXED = 'mixed';
+export const INTENT_BACKEND = 'backend-coding';
+
+/**
+ * All labels the classifier can return.
+ *
+ * Locked here so the dispatcher's mapping table and the test suite share
+ * one source of truth.
+ */
+export const KNOWN_INTENTS: ReadonlySet<string> = new Set([
+    INTENT_UI_BUILD,
+    INTENT_UI_IMPROVE,
+    INTENT_UI_TRIVIAL,
+    INTENT_MIXED,
+    INTENT_BACKEND,
+]);
+
+/**
+ * Strong UI nouns — exclusive UI meaning.
+ *
+ * Deliberately omits `table`, `list`, `input`, and `field`:
+ * `table`/`list` collide with database tables and Python/PHP lists;
+ * `input`/`field` collide with function inputs, command inputs, and
+ * JSON/DB fields. Genuine UI prompts that mean form inputs always come
+ * with a strong-UI noun nearby (`form`, `page`, `component`).
+ */
+const _UI_NOUNS: ReadonlySet<string> = new Set([
+    'ui', 'screen', 'page', 'view', 'form', 'modal', 'dialog',
+    'button', 'card', 'tile',
+    'header', 'footer', 'nav', 'navigation', 'sidebar', 'menu',
+    'dropdown', 'tab', 'panel', 'layout', 'component', 'icon',
+    'tooltip', 'toast', 'banner', 'badge', 'avatar', 'label',
+    'checkbox', 'radio', 'toggle', 'switch', 'stepper', 'wizard',
+]);
+
+const _UI_STYLE: ReadonlySet<string> = new Set([
+    'color', 'colour', 'css', 'tailwind', 'padding', 'margin',
+    'spacing', 'font', 'typography', 'responsive', 'mobile',
+    'dark mode', 'light mode', 'theme', 'shadow', 'border',
+    'rounded', 'radius',
+]);
+
+const _BACKEND_SIGNALS: ReadonlySet<string> = new Set([
+    'endpoint', 'api', 'route', 'controller', 'service',
+    'migration', 'schema', 'table', 'column', 'index', 'query',
+    'queue', 'job', 'worker', 'webhook', 'policy', 'gate',
+    'command', 'cron', 'broadcast', 'event', 'listener',
+]);
+
+const _TRIVIAL_VERBS: ReadonlySet<string> = new Set([
+    'rename', 'relabel', 'tweak', 'adjust', 'swap', 'change',
+]);
+
+const _IMPROVE_VERBS: ReadonlySet<string> = new Set([
+    'improve', 'polish', 'redesign', 'rework', 'refine',
+    'refactor', 'tighten', 'clean', 'fix', 'update', 'tune',
+]);
+
+const _BUILD_VERBS: ReadonlySet<string> = new Set([
+    'add', 'build', 'create', 'introduce', 'implement', 'ship',
+    'draft', 'scaffold', 'wire',
+]);
+
+const _NEW_SURFACE: RegExp =
+    /\b(new|fresh|blank)\s+(page|screen|view|component|form|modal|tile|dashboard)\b/;
+
+const _EXISTING_SURFACE: RegExp =
+    /\b(existing|current|the)\s+(page|screen|view|component|form|modal)\b/;
+
+const _TRIVIAL_PATTERN: RegExp =
+    /\b(make|change|update|set|swap)\b[^.]{0,40}\b(red|blue|green|yellow|black|white|primary|secondary|color|colour|copy|text|label|wording|class|prop)\b/;
+
+/**
+ * Return one of {@link KNOWN_INTENTS} for the supplied text.
+ *
+ * @param raw The user prompt or ticket body. Whitespace is normalised
+ *   internally; `""` and `null` resolve to `backend-coding`.
+ * @param title Optional ticket title. Concatenated with `raw` before
+ *   scanning so single-line ticket headlines (`"Add CSV export"`) produce
+ *   the same label whether they arrive in the body or the title slot.
+ */
+export function classify_intent(
+    raw: string,
+    opts: { title?: string | null } = {},
+): string {
+    const title = opts.title ?? null;
+    // Python: " ".join(filter(None, (title, raw))).strip().lower()
+    // filter(None, ...) drops falsy entries (None and "").
+    const parts = [title, raw].filter((p): p is string => Boolean(p));
+    const text = pyLower(pyStrip(parts.join(' ')));
+    if (!text) {
+        return INTENT_BACKEND;
+    }
+
+    const has_ui = _has_ui_signal(text);
+    const has_backend = _has_backend_signal(text);
+
+    if (has_ui && _is_trivial(text)) {
+        return INTENT_UI_TRIVIAL;
+    }
+    if (has_ui && has_backend) {
+        return INTENT_MIXED;
+    }
+    if (has_ui && _is_improve(text)) {
+        return INTENT_UI_IMPROVE;
+    }
+    if (has_ui && _is_build(text)) {
+        return INTENT_UI_BUILD;
+    }
+    if (has_ui) {
+        // UI signal but no clear verb — default to ui-improve so the
+        // full audit gate engages. ui-build would skip the existing-
+        // surface check, which is the wrong default when the prompt
+        // is ambiguous.
+        return INTENT_UI_IMPROVE;
+    }
+    return INTENT_BACKEND;
+}
+
+/**
+ * Map an intent label to a directive-set name.
+ *
+ * Centralised here so the dispatcher and the refine step share one
+ * routing table; a future intent (`infra`, `security-review`)
+ * only needs a single edit. Unknown labels raise `ValueError` —
+ * silently falling back to `backend` would mask classifier bugs.
+ */
+export function directive_set_for(intent: string): string {
+    if (!KNOWN_INTENTS.has(intent)) {
+        throw new ValueError(
+            `unknown intent ${pyStrRepr(intent)}; ` +
+                `expected one of ${pyListRepr(pySorted(KNOWN_INTENTS))}`,
+        );
+    }
+    if (intent === INTENT_UI_BUILD || intent === INTENT_UI_IMPROVE) {
+        return 'ui';
+    }
+    if (intent === INTENT_UI_TRIVIAL) {
+        return 'ui-trivial';
+    }
+    if (intent === INTENT_MIXED) {
+        return 'mixed';
+    }
+    return 'backend';
+}
+
+// --- helpers ----------------------------------------------------------
+
+function _has_ui_signal(text: string): boolean {
+    for (const w of _UI_NOUNS) {
+        if (reSearch(wordBoundary(w), text)) {
+            return true;
+        }
+    }
+    for (const s of _UI_STYLE) {
+        if (text.includes(s)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _has_backend_signal(text: string): boolean {
+    for (const w of _BACKEND_SIGNALS) {
+        if (reSearch(wordBoundary(w), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _is_trivial(text: string): boolean {
+    if (reSearch(_TRIVIAL_PATTERN, text)) {
+        return true;
+    }
+    let hasVerb = false;
+    for (const v of _TRIVIAL_VERBS) {
+        if (reSearch(wordBoundary(v), text)) {
+            hasVerb = true;
+            break;
+        }
+    }
+    return hasVerb && pySplit(text).length <= 14;
+}
+
+function _is_improve(text: string): boolean {
+    if (reSearch(_EXISTING_SURFACE, text)) {
+        return true;
+    }
+    for (const v of _IMPROVE_VERBS) {
+        if (reSearch(wordBoundary(v), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function _is_build(text: string): boolean {
+    if (reSearch(_NEW_SURFACE, text)) {
+        return true;
+    }
+    for (const v of _BUILD_VERBS) {
+        if (reSearch(wordBoundary(v), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Classify `state.input` and write `intent` + `directive_set` in place.
+ *
+ * Idempotent and override-safe: if `state.intent` is already a
+ * UI-track or mixed label (`ui-build`, `ui-improve`, `ui-trivial`,
+ * `mixed`), the routing is left untouched. Only freshly-built states
+ * carrying the construction default `backend-coding` are reclassified.
+ * Loaded state files round-trip without losing a previously-recorded
+ * intent — including a manual user override in the JSON.
+ *
+ * The text fed to the classifier depends on the input envelope:
+ *
+ * - `prompt` → `state.input.data["raw"]`
+ * - `ticket` → `state.input.data["title"]` + first non-empty
+ *   acceptance criterion, falling back to `description` when AC is
+ *   missing. Title is passed separately so single-line ticket
+ *   headlines (`"Add CSV export"`) classify identically whether
+ *   they arrive in the body or the title slot.
+ * - `diff` / `file` → routed directly to `ui-improve` without
+ *   running the heuristic. Both envelopes are R3 Phase 1 inputs that
+ *   describe an existing UI surface ("improve this screen"); the
+ *   classifier's prose-oriented signals do not apply, and the audit +
+ *   design directives downstream are the right place to read the
+ *   diff/file contents.
+ */
+export function populate_routing(state: WorkState): void {
+    if (state.intent !== INTENT_BACKEND) {
+        return;
+    }
+
+    if (state.input.kind === 'diff' || state.input.kind === 'file') {
+        state.intent = INTENT_UI_IMPROVE;
+        state.directive_set = directive_set_for(INTENT_UI_IMPROVE);
+        return;
+    }
+
+    const [text, title] = _extract_text(state);
+    const intent = classify_intent(text, { title });
+    state.intent = intent;
+    state.directive_set = directive_set_for(intent);
+}
+
+function _extract_text(state: WorkState): [string, string | null] {
+    const data = state.input.data ?? {};
+    if (state.input.kind === 'prompt') {
+        // Python: str(data.get("raw") or "")
+        const raw = 'raw' in data ? data['raw'] : undefined;
+        return [pyStr(_pyTruthy(raw) ? raw : ''), null];
+    }
+    const title = 'title' in data ? data['title'] : undefined;
+    const title_str =
+        typeof title === 'string' && pyStrip(title) ? pyStr(title) : null;
+    const body_parts: string[] = [];
+    const ac = 'acceptance_criteria' in data ? data['acceptance_criteria'] : undefined;
+    if (Array.isArray(ac)) {
+        for (const item of ac) {
+            if (typeof item === 'string') {
+                body_parts.push(pyStr(item));
+            }
+        }
+    }
+    const description = 'description' in data ? data['description'] : undefined;
+    if (typeof description === 'string' && pyStrip(description)) {
+        body_parts.push(description);
+    }
+    return [body_parts.join(' '), title_str];
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/** Raised in place of Python's `ValueError` for the unknown-intent guard. */
+export class ValueError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ValueError';
+        Object.setPrototypeOf(this, ValueError.prototype);
+    }
+}
+
+/**
+ * Mirror `re.escape(word)` then `re.search(rf"\b{...}\b", text)` as a boolean.
+ * The classifier's words are all `[a-z]+` ASCII, so escaping is a no-op for
+ * them; escape defensively anyway so the helper is faithful for any input.
+ * Patterns are flag-only (no `g`) — `.test` carries no `lastIndex` state.
+ */
+function wordBoundary(word: string): RegExp {
+    return new RegExp(`\\b${reEscape(word)}\\b`);
+}
+
+function reSearch(pattern: RegExp, text: string): boolean {
+    return pattern.test(text);
+}
+
+/**
+ * Mirror Python `re.escape` — escapes every character that is not an ASCII
+ * letter, digit, or underscore. CPython 3.7+ escapes only special chars, but
+ * for the ASCII-word inputs here the result is identical to the verb itself.
+ */
+function reEscape(s: string): string {
+    return s.replace(/[^A-Za-z0-9_]/g, (ch) => '\\' + ch);
+}
+
+/**
+ * Mirror Python `str.split()` (no args) — split on runs of whitespace,
+ * dropping leading/trailing empties. `trim().split(/\s+/)` matches; guard the
+ * empty string so `"".split(/\s+/)` does not yield `[""]` (Python returns []).
+ */
+function pySplit(s: string): string[] {
+    const t = s.trim();
+    if (t === '') return [];
+    return t.split(/\s+/);
+}
+
+/** Mirror Python `str.strip()` — `String.trim()` is faithful here. */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Mirror Python `str.lower()`. CPython lower-cases by full Unicode mapping;
+ * JS `toLowerCase()` follows the same Unicode default case-folding for the
+ * code points these heuristics see (the inputs are dominated by ASCII).
+ */
+function pyLower(s: string): string {
+    return s.toLowerCase();
+}
+
+/**
+ * Mirror Python `str(x)` for the values `_extract_text` coerces (str, or the
+ * `or ""` fallback which is already a string). Only string-or-empty flows here.
+ */
+function pyStr(v: unknown): string {
+    return typeof v === 'string' ? v : String(v);
+}
+
+/** Mirror Python truthiness for the `data.get("raw") or ""` short-circuit. */
+function _pyTruthy(v: unknown): v is string {
+    if (v === null || v === undefined) return false;
+    if (typeof v === 'boolean') return v;
+    if (typeof v === 'number') return v !== 0;
+    if (typeof v === 'string') return v.length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'object') return Object.keys(v).length > 0;
+    return true;
+}
+
+/**
+ * Mirror Python `repr(str)` — see the `state.py` twin's `pyStrRepr`. Used for
+ * the `{intent!r}` tail in the unknown-intent error.
+ */
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') out += '\\\\';
+        else if (ch === quote) out += '\\' + quote;
+        else if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}
+
+/** Python `repr(list_of_str)` for the `sorted(KNOWN_INTENTS)` error tail. */
+function pyListRepr(items: string[]): string {
+    return '[' + items.map((s) => pyStrRepr(s)).join(', ') + ']';
+}
+
+/**
+ * Python `sorted(set_of_str)` — code-point ascending, the default `str`
+ * ordering CPython uses.
+ */
+function pySorted(values: ReadonlySet<string>): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}

--- a/src/agent-src/templates/scripts/work_engine/resolvers/diff.ts
+++ b/src/agent-src/templates/scripts/work_engine/resolvers/diff.ts
@@ -1,0 +1,135 @@
+/**
+ * Diff resolver — wrap a unified-diff payload as an {@link Input} envelope.
+ *
+ * TypeScript twin of `work_engine/resolvers/diff.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The resolver is the R3 Phase 1 entry point for the "improve this screen via
+ * diff/PR" surface: a user (or `/work` adapter) hands the engine a patch text,
+ * the resolver normalises it, and the dispatcher routes it through the UI-track
+ * `ui-improve` directive set.
+ *
+ * Like `work_engine.resolvers.prompt`, this module is intentionally thin:
+ * it normalises and rejects garbage payloads, nothing more. Reconstruction of
+ * acceptance criteria + assumptions + confidence is the job of the
+ * `refine-prompt` skill (R2 Phase 3) running against the diff once the engine
+ * hits the `refine` step. Keeping the split sharp means the envelope shape
+ * stays cheap to round-trip through state and the heavy lifting stays with the
+ * agent-directive halt where it belongs.
+ *
+ * The envelope mirrors the prompt resolver's shape so a single refiner code
+ * path can read both — `{raw, reconstructed_ac, assumptions}`. The only
+ * material difference is the heuristic header check that rejects payloads
+ * that obviously are not unified-diff text.
+ */
+import { Input } from '../state.js';
+
+export const KIND = 'diff';
+/** Wire value carried in {@link Input.kind}. */
+
+const _MIN_DIFF_LEN = 1;
+/**
+ * Minimum non-whitespace character count before the heuristic runs.
+ *
+ * The resolver is not a *quality* gate; it only rejects literally empty
+ * payloads and obvious non-diffs. A semantically empty diff (e.g., headers but
+ * no hunks) is still accepted so the refiner can score its tractability and
+ * surface a `low`-band halt where appropriate.
+ */
+
+const _DIFF_MARKERS: readonly RegExp[] = [
+    /^diff --git /m,
+    /^--- /m,
+    /^\+\+\+ /m,
+    /^@@ /m,
+    /^Index: /m,
+];
+/**
+ * Heuristic markers that flag a payload as a unified or git-style diff.
+ *
+ * A payload qualifies if **any** marker matches — the resolver accepts unified
+ * diffs (`--- `/`+++ `/`@@ `), `git diff` output (`diff --git`), and
+ * the legacy `Index: ` SVN/CVS header. The match is anchored at line start so
+ * quoted snippets inside prose ("the function `--- foo` failed") do not pass
+ * the gate.
+ */
+
+/** Raised when a payload cannot be resolved into a diff envelope. */
+export class DiffResolverError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'DiffResolverError';
+        Object.setPrototypeOf(this, DiffResolverError.prototype);
+    }
+}
+
+/**
+ * Return an {@link Input} carrying the raw diff + empty refinement slots.
+ *
+ * @param raw The user-supplied diff text. Whitespace is preserved verbatim —
+ *   the refiner reads original spacing/casing when scoring goal clarity, and
+ *   a unified-diff round-trip cannot tolerate normalised whitespace.
+ * @returns Envelope of shape
+ *   `{"kind": "diff", "data": {"raw": <raw>, "reconstructed_ac": [],
+ *   "assumptions": []}}`. The two empty lists are placeholders the
+ *   `refine-prompt` skill writes into on the rebound from `refine`.
+ * @throws {@link DiffResolverError} If `raw` is not a string, contains no
+ *   non-whitespace characters, or does not match any {@link _DIFF_MARKERS}.
+ *   The marker check guards against accidentally routing free-form prose
+ *   through the diff path.
+ */
+export function build_envelope(raw: unknown): Input {
+    if (typeof raw !== 'string') {
+        throw new DiffResolverError(
+            `diff must be a string; got ${pyTypeName(raw)}`,
+        );
+    }
+    if (pyStrip(raw).length < _MIN_DIFF_LEN) {
+        throw new DiffResolverError(
+            'diff is empty or whitespace-only — nothing to resolve',
+        );
+    }
+    if (!_DIFF_MARKERS.some((marker) => reSearch(marker, raw))) {
+        throw new DiffResolverError(
+            'payload does not look like a unified diff — expected one of ' +
+                "'diff --git', '--- ', '+++ ', '@@ ', or 'Index: ' headers",
+        );
+    }
+    return new Input(KIND, {
+        raw: raw,
+        reconstructed_ac: [],
+        assumptions: [],
+    });
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * Mirror Python `re.Pattern.search` for a boolean hit. The patterns carry the
+ * `m` (MULTILINE) flag so `^` matches at every line start, identical to
+ * `re.compile(..., re.MULTILINE)`. The regexes are flag-only (no `g`), so a
+ * fresh `.test` has no `lastIndex` state to reset between calls.
+ */
+function reSearch(pattern: RegExp, text: string): boolean {
+    return pattern.test(text);
+}
+
+/**
+ * Mirror Python `str.strip()` — see `resolvers/prompt.ts` for the parity note.
+ * `String.trim()` is faithful for every realistic whitespace-only payload.
+ */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** Python `type(x).__name__` for the non-string `isinstance` guard branch. */
+function pyTypeName(v: unknown): string {
+    if (v === null) return 'NoneType';
+    if (v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}

--- a/src/agent-src/templates/scripts/work_engine/resolvers/file.ts
+++ b/src/agent-src/templates/scripts/work_engine/resolvers/file.ts
@@ -1,0 +1,175 @@
+/**
+ * File resolver — wrap a path reference as an {@link Input} envelope.
+ *
+ * TypeScript twin of `work_engine/resolvers/file.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The resolver is the R3 Phase 1 entry point for the "improve this existing
+ * component/page" surface: a user hands the engine a path (e.g.,
+ * `resources/views/dashboard.blade.php` or `src/components/Sidebar.tsx`),
+ * the resolver normalises it, and the dispatcher routes the envelope through
+ * the UI-track `ui-improve` directive set.
+ *
+ * Like `work_engine.resolvers.prompt` and `.diff`, this module is
+ * intentionally thin: it normalises and rejects garbage payloads, nothing
+ * more. Existence checks, mtime caching, and content reads are deferred to
+ * the `analyze` step / the audit directive — a resolver doing I/O at the
+ * command-shell boundary would couple the envelope build to filesystem state
+ * and break replay-against-state-files.
+ *
+ * The envelope mirrors the prompt and diff resolvers so a single refiner code
+ * path can read all three — `{path, reconstructed_ac, assumptions}`. The
+ * only material difference is the path-shape check that rejects values that
+ * are obviously not paths (absolute URLs, empty strings, control chars).
+ */
+import * as path from 'node:path';
+
+import { Input } from '../state.js';
+
+export const KIND = 'file';
+/** Wire value carried in {@link Input.kind}. */
+
+const _MIN_PATH_LEN = 1;
+/**
+ * Minimum non-whitespace character count for a resolvable path.
+ *
+ * A 1-char path is rare but legal (`a`); the bar exists only to reject
+ * literal empty / whitespace-only payloads which carry no signal at all.
+ */
+
+const _FORBIDDEN_PREFIXES: readonly string[] = [
+    'http://',
+    'https://',
+    'ftp://',
+    'file://',
+];
+/**
+ * Prefixes that signal the caller passed a URL, not a filesystem path.
+ *
+ * The diff resolver handles patch URLs at a future R3 layer; the file
+ * resolver only accepts on-disk references. Rejecting URLs explicitly
+ * keeps misuse loud instead of letting the audit step discover it later.
+ * The check is case-insensitive.
+ */
+
+/** Raised when a payload cannot be resolved into a file envelope. */
+export class FileResolverError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'FileResolverError';
+        Object.setPrototypeOf(this, FileResolverError.prototype);
+    }
+}
+
+/**
+ * Return an {@link Input} carrying the path + empty refinement slots.
+ *
+ * @param path_ The user-supplied path reference. The resolver normalises only
+ *   by stripping leading/trailing whitespace; case, separators, and the
+ *   relative-vs-absolute distinction are all preserved verbatim so the
+ *   downstream audit step reads exactly what the user wrote.
+ * @returns Envelope of shape
+ *   `{"kind": "file", "data": {"path": <path>, "reconstructed_ac": [],
+ *   "assumptions": []}}`. The two empty lists are placeholders the
+ *   `refine-prompt` skill writes into on the rebound from `refine`; they are
+ *   kept to preserve a single-shape envelope across all prompt-like resolvers.
+ * @throws {@link FileResolverError} If `path` is not a string, is empty /
+ *   whitespace-only, contains a NUL byte (filesystem-illegal everywhere), or
+ *   is a URL (use the diff resolver for remote-PR / patch URLs in a future R3
+ *   phase).
+ */
+export function build_envelope(path_: unknown): Input {
+    if (typeof path_ !== 'string') {
+        throw new FileResolverError(
+            `path must be a string; got ${pyTypeName(path_)}`,
+        );
+    }
+    const stripped = pyStrip(path_);
+    if (stripped.length < _MIN_PATH_LEN) {
+        throw new FileResolverError(
+            'path is empty or whitespace-only — nothing to resolve',
+        );
+    }
+    if (stripped.includes('\x00')) {
+        throw new FileResolverError(
+            'path contains a NUL byte; filesystem references must be ' +
+                'NUL-free',
+        );
+    }
+    const lowered = stripped.toLowerCase();
+    if (_FORBIDDEN_PREFIXES.some((prefix) => lowered.startsWith(prefix))) {
+        throw new FileResolverError(
+            `path looks like a URL (${pyStrRepr(pySlice(stripped, 32))}); the file resolver ` +
+                'only accepts on-disk references — use the diff resolver for ' +
+                'PR or patch URLs',
+        );
+    }
+    // Normalise separators *only* on Windows-style backslashes so
+    // `resources\\views\\foo.blade.php` round-trips as POSIX. Native
+    // POSIX paths are returned untouched so the audit step's identity
+    // comparison against directory listings stays trivial.
+    const normalised =
+        path.sep === '/' ? stripped.replace(/\\/g, '/') : stripped;
+    return new Input(KIND, {
+        path: normalised,
+        reconstructed_ac: [],
+        assumptions: [],
+    });
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * Mirror Python `str.strip()` — see `resolvers/prompt.ts` for the parity note.
+ */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Mirror Python `s[:n]` over code points. The error path renders `stripped[:32]`
+ * via `!r`; Python slices by code point, not UTF-16 unit, so use the spread
+ * iterator to slice on code-point boundaries before re-joining.
+ */
+function pySlice(s: string, n: number): string {
+    return [...s].slice(0, n).join('');
+}
+
+/**
+ * Mirror Python `repr(str)` — prefers single quotes, switches to double quotes
+ * only when the string contains a single quote but no double quote, and escapes
+ * backslash plus the active quote and the standard control characters. Matches
+ * the `state.py` twin's `pyStrRepr` so the `{...!r}` error tail is byte-equal.
+ */
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') out += '\\\\';
+        else if (ch === quote) out += '\\' + quote;
+        else if (ch === '\n') out += '\\n';
+        else if (ch === '\r') out += '\\r';
+        else if (ch === '\t') out += '\\t';
+        else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}
+
+/** Python `type(x).__name__` for the non-string `isinstance` guard branch. */
+function pyTypeName(v: unknown): string {
+    if (v === null) return 'NoneType';
+    if (v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}

--- a/src/agent-src/templates/scripts/work_engine/resolvers/prompt.ts
+++ b/src/agent-src/templates/scripts/work_engine/resolvers/prompt.ts
@@ -1,0 +1,115 @@
+/**
+ * Prompt resolver — wrap a raw user prompt as an {@link Input} envelope.
+ *
+ * TypeScript twin of `work_engine/resolvers/prompt.py` (ADR-094 py2ts —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * The resolver is intentionally minimal. It accepts a raw string, validates
+ * that it contains non-whitespace content, and returns
+ * `Input(kind="prompt", data={"raw": <text>, "reconstructed_ac": [],
+ * "assumptions": []})`. The empty AC + assumptions lists are placeholders
+ * that the `refine-prompt` skill (R2 Phase 3) fills in once the engine
+ * runs the deterministic `refine` gate against the raw text.
+ *
+ * Why split the resolver from the refiner:
+ *
+ * - The resolver runs at command boundaries (the `/work` entrypoint
+ *   builds an envelope, then hands off to `work_engine`). It must stay
+ *   side-effect-free and dependency-light so the command shell can call
+ *   it without touching the LLM-facing skill harness.
+ * - The refiner runs inside the dispatcher loop and is allowed to halt
+ *   (medium-confidence assumptions report, low-confidence one-question
+ *   block) per `docs/contracts/implement-ticket-flow.md`. That
+ *   control-flow surface does not belong in a resolver.
+ *
+ * Future R3 resolvers (`diff`, `file`) follow the same pattern: thin
+ * normalisation, no interpretation, one envelope shape per kind.
+ */
+import { Input } from '../state.js';
+
+export const KIND = 'prompt';
+/** Wire value carried in {@link Input.kind}. */
+
+const _MIN_PROMPT_LEN = 1;
+/**
+ * Minimum non-whitespace character count for a resolvable prompt.
+ *
+ * Set to 1 by design — the resolver is not a quality gate. It only
+ * rejects literally empty / whitespace-only payloads (which cannot be
+ * distinguished from missing input). Quality judgment (is the prompt
+ * clear? is it tractable?) is the `refine-prompt` skill's job, surfaced
+ * through the confidence band, not the resolver's.
+ */
+
+/** Raised when a payload cannot be resolved into a prompt envelope. */
+export class PromptResolverError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PromptResolverError';
+        Object.setPrototypeOf(this, PromptResolverError.prototype);
+    }
+}
+
+/**
+ * Return an {@link Input} carrying the raw prompt + empty refinement slots.
+ *
+ * @param raw The user-supplied prompt text. Leading/trailing whitespace is
+ *   preserved verbatim — the refiner reads the original casing and spacing
+ *   when scoring goal clarity, so collapsing whitespace here would lose
+ *   signal.
+ * @returns Envelope of shape
+ *   `{"kind": "prompt", "data": {"raw": <raw>, "reconstructed_ac": [],
+ *   "assumptions": []}}`. The two empty lists are placeholders the
+ *   `refine-prompt` skill writes into on the rebound from the `refine` step.
+ * @throws {@link PromptResolverError} If `raw` is not a string, or contains
+ *   no non-whitespace characters (the only case where the envelope would
+ *   carry no actionable signal at all).
+ */
+export function build_envelope(raw: unknown): Input {
+    if (typeof raw !== 'string') {
+        throw new PromptResolverError(
+            `prompt must be a string; got ${pyTypeName(raw)}`,
+        );
+    }
+    if (pyStrip(raw).length < _MIN_PROMPT_LEN) {
+        throw new PromptResolverError(
+            'prompt is empty or whitespace-only — nothing to resolve',
+        );
+    }
+    return new Input(KIND, {
+        raw: raw,
+        reconstructed_ac: [],
+        assumptions: [],
+    });
+}
+
+// ── Python-parity helpers ───────────────────────────────────────────────
+
+/**
+ * Mirror Python `str.strip()` — strips the Unicode whitespace set CPython
+ * uses (the characters for which `str.isspace()` is true). `String.trim()`
+ * strips a near-identical set; the only practical divergence for the empty-
+ * payload guard is that `trim()` does not strip a handful of exotic code
+ * points (e.g. zero-width). For a length-vs-1 gate the standard `trim` is
+ * faithful for every realistic whitespace-only prompt, and any leftover
+ * exotic char would correctly count as "non-whitespace content" under both
+ * runtimes' intent. Kept as a named helper to mark the parity point.
+ */
+function pyStrip(s: string): string {
+    return s.trim();
+}
+
+/**
+ * Python `type(x).__name__` for the values this resolver's TypeError-equivalent
+ * branch reports: the `isinstance(raw, str)` guard fires on any non-string.
+ */
+function pyTypeName(v: unknown): string {
+    if (v === null) return 'NoneType';
+    if (v === undefined) return 'NoneType';
+    if (typeof v === 'boolean') return 'bool';
+    if (typeof v === 'string') return 'str';
+    if (typeof v === 'number') return Number.isInteger(v) ? 'int' : 'float';
+    if (Array.isArray(v)) return 'list';
+    return 'dict';
+}

--- a/src/agent-src/templates/scripts/work_engine/scoring/confidence.ts
+++ b/src/agent-src/templates/scripts/work_engine/scoring/confidence.ts
@@ -1,0 +1,415 @@
+/**
+ * Confidence scoring for prompt-driven execution (R2 Phase 3 Step 2).
+ *
+ * TypeScript twin of `work_engine/scoring/confidence.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * The scorer judges whether a reconstructed prompt is good enough for the
+ * `work_engine` to proceed silently, halt for confirmation, or refuse to
+ * plan. It is heuristic-only — no LLM calls — so the same prompt produces
+ * the same score across replays and the freeze-guard harness can pin
+ * expectations.
+ *
+ * Rubric (each dimension 0–2, total / 10 → band):
+ *
+ * - `goal_clarity` — does the raw prompt name a single action verb +
+ *   object + observable result?
+ * - `scope_boundary` — does the prompt name a file, class, module, or
+ *   domain that bounds the change?
+ * - `ac_evidence` — did the refiner produce concrete, anchored
+ *   acceptance criteria?
+ * - `stack_data` — does the prompt imply stack / data / migration work
+ *   *and* identify the touched surface? (penalty if implied + unspecified)
+ * - `reversibility` — would a wrong reconstruction be cheaply rollback-
+ *   able?
+ *
+ * Bands (per `agents/roadmaps/archive/road-to-prompt-driven-execution.md`):
+ *
+ * - `high`   — score >= 0.8 → dispatcher proceeds silently
+ * - `medium` — 0.5 <= score < 0.8 → assumptions-report halt
+ * - `low`    — score < 0.5 → one-question halt
+ *
+ * The scorer is the single source of truth for both the rubric and the
+ * band thresholds. Documentation (SKILL.md, ADR, contexts) cite this
+ * module — they do not re-derive the values.
+ */
+
+// --- Public types ------------------------------------------------------
+
+/**
+ * Canonical dimension order. Matches the roadmap rubric and is the
+ * order `ConfidenceScore.dimensions` is rendered in by callers.
+ */
+export const DIMENSION_NAMES: readonly string[] = [
+    'goal_clarity',
+    'scope_boundary',
+    'ac_evidence',
+    'stack_data',
+    'reversibility',
+] as const;
+
+/** Per-dimension ceiling. Five dimensions × 2 = 10 = full score. */
+export const MAX_PER_DIMENSION = 2;
+
+export const BAND_HIGH_MIN = 0.8;
+export const BAND_MEDIUM_MIN = 0.5;
+/**
+ * Band thresholds. Inclusive on the lower bound, exclusive on the upper.
+ *
+ * A score of exactly 0.8 lands in `high` (per roadmap: `high >= 0.8`);
+ * exactly 0.5 lands in `medium`. Anything below 0.5 is `low`.
+ */
+
+/**
+ * Immutable result of one scoring pass.
+ *
+ * The Python source is a `@dataclass(frozen=True)`. We mirror the field set
+ * and the `field(default_factory=list)` default for `reasons` (each instance
+ * owns its own array). `Object.freeze` echoes `frozen=True` so callers cannot
+ * mutate a band after the dispatcher has routed on it.
+ */
+export class ConfidenceScore {
+    readonly band: string;
+    readonly score: number;
+    readonly dimensions: Record<string, number>;
+    readonly reasons: string[];
+    readonly ui_intent: boolean;
+
+    constructor(args: {
+        band: string;
+        score: number;
+        dimensions: Record<string, number>;
+        reasons?: string[];
+        ui_intent?: boolean;
+    }) {
+        this.band = args.band;
+        this.score = args.score;
+        this.dimensions = args.dimensions;
+        this.reasons = args.reasons ?? [];
+        this.ui_intent = args.ui_intent ?? false;
+        Object.freeze(this);
+    }
+}
+
+// --- Heuristic vocabularies -------------------------------------------
+
+const _ACTION_VERBS: ReadonlySet<string> = new Set([
+    'add', 'build', 'create', 'implement', 'introduce', 'write',
+    'fix', 'patch', 'repair', 'resolve',
+    'refactor', 'rename', 'extract', 'inline', 'split',
+    'remove', 'delete', 'drop', 'purge',
+    'update', 'upgrade', 'bump', 'migrate',
+    'optimize', 'speed', 'improve', 'tune',
+    'document', 'describe', 'explain',
+    'test', 'validate', 'verify',
+    'expose', 'publish', 'deprecate',
+    'configure', 'wire', 'connect',
+]);
+
+const _DOMAIN_NOUNS: ReadonlySet<string> = new Set([
+    'auth', 'authentication', 'authorization', 'login', 'logout', 'signup',
+    'user', 'users', 'account', 'profile',
+    'dashboard', 'search', 'checkout', 'cart', 'billing', 'payment',
+    'admin', 'settings', 'config',
+    'api', 'endpoint', 'webhook', 'queue', 'job', 'worker',
+    'frontend', 'backend', 'ui', 'view', 'page', 'form',
+    'database', 'migration', 'schema',
+    'report', 'export', 'import',
+]);
+
+const _STACK_DATA_KEYWORDS: ReadonlySet<string> = new Set([
+    'migration', 'schema', 'table', 'column', 'index',
+    'database', 'db', 'postgres', 'mysql', 'mariadb', 'sqlite',
+    'redis', 'cache', 'queue',
+    'dependency', 'package', 'library', 'framework', 'upgrade',
+    'breaking change', 'deprecate', 'api version',
+    'deploy', 'release',
+]);
+
+const _IRREVERSIBLE_KEYWORDS: ReadonlySet<string> = new Set([
+    'drop ', 'delete ', 'purge', 'wipe', 'truncate',
+    'send email', 'charge', 'refund', 'billing', 'payment', 'money',
+    'production data', 'live database', 'broadcast',
+]);
+
+const _UI_KEYWORDS: ReadonlySet<string> = new Set([
+    'redesign', 'color', 'colour', 'css', 'tailwind', 'layout',
+    'font', 'spacing', 'padding', 'margin', 'button', 'icon',
+    'responsive', 'mobile view', 'look', 'polish', 'prettier',
+    'theme', 'dark mode', 'light mode',
+]);
+
+// Python `re.compile(...)` — the four alternatives, joined verbatim. The
+// JS `RegExp` source mirrors the Python pattern character-for-character; the
+// only escaping difference is `\\` in the PHP-namespace branch, which is a
+// single backslash in the compiled pattern on both engines.
+const _FILE_PATH_RE = new RegExp(
+    '`[^`]+`' + // backtick-wrapped tokens
+        '|[\\w./-]+\\.(?:py|php|ts|tsx|js|jsx|vue|blade\\.php|sql|yml|yaml|json|md)' +
+        '|[A-Z][\\w]+(?:\\\\[A-Z][\\w]+)+' + // PHP namespaces (Foo\Bar\Baz)
+        '|[A-Z][a-zA-Z]+::[a-zA-Z]+' + // PHP static call (Foo::bar)
+        '|[a-z]+(?:[A-Z][a-z]+){2,}', // camelCase identifiers w/ >=2 humps
+);
+
+// --- Public API --------------------------------------------------------
+
+/**
+ * Score a reconstructed prompt and return the band + rubric breakdown.
+ *
+ * @param raw The original user prompt text. Pre-stripped or not; the scorer
+ *   normalises whitespace internally.
+ * @param ac Reconstructed acceptance criteria from the `refine-prompt`
+ *   skill. `null`/`undefined` is treated as an empty list (no AC produced).
+ * @param assumptions Inferred assumptions surfaced by the refiner. Currently
+ *   informational — the rubric does not penalise assumption count directly
+ *   because medium-band halts are the resolution surface.
+ */
+export function score(args: {
+    raw: string;
+    ac?: string[] | null;
+    assumptions?: string[] | null;
+}): ConfidenceScore {
+    const raw = args.raw;
+    // `(raw or "").strip()` — Python `str.strip()` removes leading/trailing
+    // whitespace per the `str.isspace` set; JS `trim()` covers the same
+    // Unicode whitespace for these inputs.
+    const text = (raw || '').trim();
+    const text_lower = text.toLowerCase();
+    const ac_list = [...(args.ac ?? [])];
+
+    const [g_val, g_reason] = _score_goal_clarity(text, text_lower);
+    const [s_val, s_reason] = _score_scope_boundary(text, text_lower);
+    const [e_val, e_reason] = _score_acceptance_evidence(ac_list);
+    const [k_val, k_reason] = _score_stack_data(text_lower);
+    const [r_val, r_reason] = _score_reversibility(text_lower);
+
+    const dimensions: Record<string, number> = {
+        goal_clarity: g_val,
+        scope_boundary: s_val,
+        ac_evidence: e_val,
+        stack_data: k_val,
+        reversibility: r_val,
+    };
+    const total = Object.values(dimensions).reduce((a, b) => a + b, 0);
+    const norm = _pyRound(total / (MAX_PER_DIMENSION * DIMENSION_NAMES.length), 4);
+    return new ConfidenceScore({
+        band: _band_from_score(norm),
+        score: norm,
+        dimensions,
+        reasons: [g_reason, s_reason, e_reason, k_reason, r_reason],
+        ui_intent: _detect_ui_intent(text_lower),
+    });
+}
+
+// --- Band mapping ------------------------------------------------------
+
+/**
+ * Map a normalised score to one of `high` / `medium` / `low`.
+ *
+ * Inclusive on the lower bound to match the roadmap contract
+ * (`high >= 0.8`); a score of exactly `0.8` lands in `high`,
+ * exactly `0.5` in `medium`, anything below `0.5` in `low`.
+ */
+function _band_from_score(score_value: number): string {
+    if (score_value >= BAND_HIGH_MIN) {
+        return 'high';
+    }
+    if (score_value >= BAND_MEDIUM_MIN) {
+        return 'medium';
+    }
+    return 'low';
+}
+
+// --- Per-dimension scorers --------------------------------------------
+
+/** Score whether the prompt names a single, observable outcome. */
+function _score_goal_clarity(text: string, text_lower: string): [number, string] {
+    if (!text) {
+        return [0, 'goal_clarity=0: empty prompt'];
+    }
+    const has_verb = [..._ACTION_VERBS].some((v) =>
+        new RegExp(`\\b${_reEscape(v)}\\w*\\b`).test(text_lower),
+    );
+    // `text.rstrip().endswith("?")`
+    const is_question = _pyRstrip(text).endsWith('?');
+    // `len(text.split())` — Python `str.split()` with no args splits on runs
+    // of whitespace and drops empty tokens.
+    const word_count = _pySplitWhitespace(text).length;
+    const conjunction_split = /\b(and then|and also|plus)\b/.test(text_lower);
+
+    if (has_verb && !is_question && 4 <= word_count && word_count <= 40 && !conjunction_split) {
+        return [2, 'goal_clarity=2: action verb + bounded length + single outcome'];
+    }
+    if (has_verb && !is_question) {
+        if (conjunction_split) {
+            return [1, 'goal_clarity=1: verb present but multiple outcomes joined'];
+        }
+        return [1, 'goal_clarity=1: verb present but length is borderline'];
+    }
+    if (is_question) {
+        return [0, 'goal_clarity=0: prompt is a question, no executable verb'];
+    }
+    return [0, 'goal_clarity=0: no recognisable action verb'];
+}
+
+/** Score whether the prompt bounds the change to a concrete surface. */
+function _score_scope_boundary(text: string, text_lower: string): [number, string] {
+    const has_path = _FILE_PATH_RE.test(text);
+    const has_domain = [..._DOMAIN_NOUNS].some((n) =>
+        new RegExp(`\\b${_reEscape(n)}\\b`).test(text_lower),
+    );
+    if (has_path) {
+        return [2, 'scope_boundary=2: explicit file/class/identifier named'];
+    }
+    if (has_domain) {
+        return [1, 'scope_boundary=1: domain noun present, no concrete path'];
+    }
+    return [0, 'scope_boundary=0: no file or domain anchor'];
+}
+
+/** Score the reconstructed AC list produced by the refiner. */
+function _score_acceptance_evidence(ac: string[]): [number, string] {
+    const n = ac.length;
+    if (n === 0) {
+        return [0, 'ac_evidence=0: no acceptance criteria reconstructed'];
+    }
+    const anchored_signals = ['should', 'must', 'given', 'when', 'then', 'expect'];
+    let anchored = 0;
+    for (const line of ac) {
+        const low = line.toLowerCase();
+        if (anchored_signals.some((s) => low.includes(s))) {
+            anchored += 1;
+        }
+    }
+    if (n >= 3 && anchored >= 2) {
+        return [2, `ac_evidence=2: ${n} criteria, ${anchored} anchored`];
+    }
+    if (n >= 1) {
+        return [1, `ac_evidence=1: ${n} criteria, ${anchored} anchored`];
+    }
+    return [0, 'ac_evidence=0: empty AC list'];
+}
+
+/** Penalise stack/data work that is implied but not bounded. */
+function _score_stack_data(text_lower: string): [number, string] {
+    const implies_stack = [..._STACK_DATA_KEYWORDS].some((k) => text_lower.includes(k));
+    if (!implies_stack) {
+        return [2, 'stack_data=2: prompt is behavioural, no stack/data signal'];
+    }
+    const has_target = /\b(table|column|index|file|migration)\s+[`"\w]/.test(text_lower);
+    if (has_target) {
+        return [2, 'stack_data=2: stack/data work named with explicit target'];
+    }
+    return [0, 'stack_data=0: stack/data work implied without target'];
+}
+
+/** Score how cheaply a wrong reconstruction could be rolled back. */
+function _score_reversibility(text_lower: string): [number, string] {
+    if ([..._IRREVERSIBLE_KEYWORDS].some((k) => text_lower.includes(k))) {
+        return [0, 'reversibility=0: irreversible keyword detected'];
+    }
+    const config_signals = ['config', 'env', 'secret', '.env', 'deploy'];
+    if (config_signals.some((s) => text_lower.includes(s))) {
+        return [1, 'reversibility=1: config/env surface, partial rollback cost'];
+    }
+    return [2, 'reversibility=2: code-only change, cheap to revert'];
+}
+
+/** Flag prompts that read as UI work for R3 routing. */
+function _detect_ui_intent(text_lower: string): boolean {
+    return [..._UI_KEYWORDS].some((k) => text_lower.includes(k));
+}
+
+// --- Python-parity primitives -----------------------------------------
+
+/** Python `re.escape` for the literal tokens in the heuristic vocabularies. */
+function _reEscape(s: string): string {
+    // Python `re.escape` escapes every non-alphanumeric, non-underscore char.
+    // The vocab tokens are ASCII letters / spaces / dots, so this matches.
+    return s.replace(/[^a-zA-Z0-9_]/g, (ch) => '\\' + ch);
+}
+
+/** Python `str.rstrip()` (no arg) — strip trailing whitespace. */
+function _pyRstrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Python `str.split()` (no arg) — split on whitespace runs, drop empties. */
+function _pySplitWhitespace(s: string): string[] {
+    const trimmed = s.trim();
+    if (trimmed === '') {
+        return [];
+    }
+    return trimmed.split(/\s+/u);
+}
+
+/**
+ * Python 3 `round(x, ndigits)` — round-half-to-even (banker's rounding) on
+ * the exact decimal expansion of the IEEE-754 double. Same algorithm as
+ * `value_ladder.ts::pyRound` / `report_renderer.ts::_pyRound`. Inlined to
+ * keep the consumer-shipped module free of cross-tree imports (ADR-094 §7).
+ */
+function _pyRound(value: number, ndigits = 0): number {
+    if (!Number.isFinite(value) || value === 0) {
+        return value;
+    }
+    const sign = value < 0 ? -1 : 1;
+    const abs = Math.abs(value);
+    const str = abs.toPrecision(17);
+    if (str.includes('e') || str.includes('E')) {
+        const factor = 10 ** ndigits;
+        return value > 0
+            ? (Math.round(abs * factor) / factor) * sign
+            : -Math.round(abs * factor) / factor;
+    }
+    let [intPart, fracPart = ''] = str.split('.');
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keep = fracPart.slice(0, ndigits);
+    const deciding = fracPart[ndigits] ?? '0';
+    const rest = fracPart.slice(ndigits + 1).replace(/0+$/, '');
+    let digits = (intPart + keep).replace(/^0+(?=\d)/, '');
+    let roundUp = false;
+    if (deciding > '5' || (deciding === '5' && rest !== '')) {
+        roundUp = true;
+    } else if (deciding === '5' && rest === '') {
+        // exact half → round to even
+        const lastKept = digits.length > 0 ? (digits[digits.length - 1] ?? '0') : '0';
+        roundUp = (lastKept.charCodeAt(0) - 48) % 2 === 1;
+    }
+    if (roundUp) {
+        digits = _incrementDecimalString(digits);
+    }
+    // Reinsert the decimal point `ndigits` places from the right.
+    let result: number;
+    if (ndigits === 0) {
+        result = Number(digits);
+    } else {
+        const padded = digits.padStart(ndigits + 1, '0');
+        const cut = padded.length - ndigits;
+        const intStr = padded.slice(0, cut) || '0';
+        const fracStr = padded.slice(cut);
+        result = Number(`${intStr}.${fracStr}`);
+    }
+    return result * sign;
+}
+
+/** Add one to a non-negative integer represented as a decimal string. */
+function _incrementDecimalString(s: string): string {
+    const chars = (s === '' ? '0' : s).split('');
+    let i = chars.length - 1;
+    while (i >= 0) {
+        const ch = chars[i] ?? '0';
+        if (ch === '9') {
+            chars[i] = '0';
+            i -= 1;
+        } else {
+            chars[i] = String.fromCharCode(ch.charCodeAt(0) + 1);
+            return chars.join('');
+        }
+    }
+    return '1' + chars.join('');
+}

--- a/src/agent-src/templates/scripts/work_engine/scoring/decision_engine.ts
+++ b/src/agent-src/templates/scripts/work_engine/scoring/decision_engine.ts
@@ -1,0 +1,466 @@
+/**
+ * Decision-engine gates — schema, validation, and per-phase evaluation.
+ *
+ * TypeScript twin of `work_engine/scoring/decision_engine.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * Reads the optional `decision_engine:` block from `.agent-settings.yml`.
+ * Absent block = current behaviour (observe-only, no gates fire).
+ *
+ * Schema (all keys optional; the parser rejects unknown keys hard):
+ *
+ * - `surface_traces` (bool, default `false`) — opt-in for
+ *   `DecisionTraceHook`. Predates the gates; lives here so the
+ *   `decision_engine:` block has one source-of-truth schema.
+ * - `min_confidence` (`low`/`medium`/`high`/`off`, default
+ *   `off`) — confidence-band floor; Phase=Plan refuses to advance
+ *   when the band is below.
+ * - `block_on_risk` (`low`/`medium`/`high`/`off`, default
+ *   `off`) — risk-class ceiling; Phase=Implement refuses to advance
+ *   when risk exceeds.
+ * - `require_memory_hits` (bool, default `false`) — Phase=Refine
+ *   demands `memory_hits >= 1`.
+ * - `on_block` (`stop`/`ask`/`warn`, default `stop`) —
+ *   what happens when a gate fires.
+ * - `ask_timeout_seconds` (int, default `30`) — timeout when
+ *   `on_block=ask` runs in a non-interactive context (no TTY, or
+ *   `CI=true`).
+ * - `on_block_fallback` (`stop`/`warn`, default `stop`) —
+ *   resolution after `ask_timeout` elapses.
+ *
+ * Gate-conflict resolution (first match wins, only one gate fires per
+ * phase):
+ *
+ * 1. `block_on_risk`         (highest impact)
+ * 2. `require_memory_hits`
+ * 3. `min_confidence`        (lowest impact)
+ *
+ * See `docs/contracts/decision-engine-gates.md` for the full
+ * priority matrix.
+ */
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+export const ALLOWED_KEYS: ReadonlySet<string> = new Set([
+    'surface_traces',
+    'min_confidence',
+    'block_on_risk',
+    'require_memory_hits',
+    'on_block',
+    'ask_timeout_seconds',
+    'on_block_fallback',
+]);
+
+const _LEVEL_VALUES: ReadonlySet<string> = new Set(['low', 'medium', 'high', 'off']);
+const _LEVEL_RANK: Record<string, number> = { low: 1, medium: 2, high: 3 };
+const _ON_BLOCK_VALUES: ReadonlySet<string> = new Set(['stop', 'ask', 'warn']);
+const _FALLBACK_VALUES: ReadonlySet<string> = new Set(['stop', 'warn']);
+
+/**
+ * Conflict-resolution order. Highest-impact gate first; the first
+ * firing gate emits its reason and downstream gates are skipped.
+ */
+export const GATE_PRIORITY: readonly string[] = [
+    'block_on_risk',
+    'require_memory_hits',
+    'min_confidence',
+] as const;
+
+const _PHASE_FOR_GATE: Record<string, string> = {
+    block_on_risk: 'implement',
+    require_memory_hits: 'refine',
+    min_confidence: 'plan',
+};
+
+/** Raised when the `decision_engine:` block is malformed. */
+export class DecisionEngineConfigError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, DecisionEngineConfigError.prototype);
+        this.name = 'DecisionEngineConfigError';
+    }
+}
+
+/**
+ * Resolved `decision_engine:` block. Frozen to keep gate evaluations
+ * replay-stable.
+ */
+export class DecisionEngineSettings {
+    readonly surface_traces: boolean;
+    readonly min_confidence: string;
+    readonly block_on_risk: string;
+    readonly require_memory_hits: boolean;
+    readonly on_block: string;
+    readonly ask_timeout_seconds: number;
+    readonly on_block_fallback: string;
+
+    constructor(args: {
+        surface_traces?: boolean;
+        min_confidence?: string;
+        block_on_risk?: string;
+        require_memory_hits?: boolean;
+        on_block?: string;
+        ask_timeout_seconds?: number;
+        on_block_fallback?: string;
+    } = {}) {
+        this.surface_traces = args.surface_traces ?? false;
+        this.min_confidence = args.min_confidence ?? 'off';
+        this.block_on_risk = args.block_on_risk ?? 'off';
+        this.require_memory_hits = args.require_memory_hits ?? false;
+        this.on_block = args.on_block ?? 'stop';
+        this.ask_timeout_seconds = args.ask_timeout_seconds ?? 30;
+        this.on_block_fallback = args.on_block_fallback ?? 'stop';
+        Object.freeze(this);
+    }
+
+    /** True when at least one gate is enabled. */
+    get any_gate_active(): boolean {
+        return (
+            this.min_confidence !== 'off' ||
+            this.block_on_risk !== 'off' ||
+            this.require_memory_hits
+        );
+    }
+}
+
+/**
+ * Outcome of one gate evaluation. `action` is the resolved
+ * response after applying `on_block` plus the non-TTY fallback.
+ */
+export class GateDecision {
+    readonly gate_id: string;
+    readonly phase: string;
+    readonly reason: string;
+    readonly action: string; // "stop" | "warn" | "ask" | "ask_timeout"
+
+    constructor(args: { gate_id: string; phase: string; reason: string; action: string }) {
+        this.gate_id = args.gate_id;
+        this.phase = args.phase;
+        this.reason = args.reason;
+        this.action = args.action;
+        Object.freeze(this);
+    }
+}
+
+/**
+ * Parse a `decision_engine` block into validated settings.
+ *
+ * Returns defaults when `data` is `null`/`undefined` (block absent) or an
+ * empty mapping. Raises {@link DecisionEngineConfigError} on unknown keys or
+ * invalid values.
+ */
+export function parse(data: Any): DecisionEngineSettings {
+    if (data === null || data === undefined) {
+        return new DecisionEngineSettings();
+    }
+    if (!_isPlainDict(data)) {
+        throw new DecisionEngineConfigError(
+            'decision_engine: must be a mapping, got ' + _pyTypeName(data),
+        );
+    }
+    const d = data as Record<string, unknown>;
+    const unknown: string[] = [];
+    for (const k of Object.keys(d)) {
+        if (!ALLOWED_KEYS.has(k)) {
+            unknown.push(k);
+        }
+    }
+    if (unknown.length > 0) {
+        throw new DecisionEngineConfigError(
+            'decision_engine: unknown key(s): ' +
+                _sortedStr(unknown).join(', ') +
+                '. Allowed: ' +
+                _sortedStr([...ALLOWED_KEYS]).join(', '),
+        );
+    }
+    return new DecisionEngineSettings({
+        surface_traces: _coerce_bool(_get(d, 'surface_traces', undefined), false),
+        min_confidence: _coerce_level(_get(d, 'min_confidence', 'off'), 'min_confidence'),
+        block_on_risk: _coerce_level(_get(d, 'block_on_risk', 'off'), 'block_on_risk'),
+        require_memory_hits: _coerce_bool(_get(d, 'require_memory_hits', undefined), false),
+        on_block: _coerce_choice(_get(d, 'on_block', 'stop'), 'on_block', _ON_BLOCK_VALUES),
+        ask_timeout_seconds: _coerce_int(_get(d, 'ask_timeout_seconds', 30), 'ask_timeout_seconds'),
+        on_block_fallback: _coerce_choice(
+            _get(d, 'on_block_fallback', 'stop'),
+            'on_block_fallback',
+            _FALLBACK_VALUES,
+        ),
+    });
+}
+
+function _coerce_bool(value: Any, dflt: boolean): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined) {
+        return dflt;
+    }
+    if (typeof value === 'string') {
+        const s = value.trim().toLowerCase();
+        if (s === 'true' || s === 'yes' || s === 'on' || s === '1') {
+            return true;
+        }
+        if (s === 'false' || s === 'no' || s === 'off' || s === '0') {
+            return false;
+        }
+    }
+    throw new DecisionEngineConfigError(`decision_engine.${_pyRepr(value)}: expected bool`);
+}
+
+function _coerce_level(value: Any, key: string): string {
+    if (value === null || value === undefined) {
+        return 'off';
+    }
+    // YAML 1.1 parses unquoted `off` as boolean False; accept it as the off
+    // sentinel so writers don't have to quote. Boolean True stays rejected.
+    if (typeof value === 'boolean') {
+        if (value === false) {
+            return 'off';
+        }
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: boolean True is not a valid level ` +
+                '(quote a string: low/medium/high/off)',
+        );
+    }
+    if (typeof value !== 'string') {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: expected string, got ` + _pyTypeName(value),
+        );
+    }
+    const s = value.trim().toLowerCase();
+    if (!_LEVEL_VALUES.has(s)) {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: invalid value ${_pyRepr(value)}. ` +
+                'Allowed: ' +
+                _sortedStr([..._LEVEL_VALUES]).join(', '),
+        );
+    }
+    return s;
+}
+
+function _coerce_choice(value: Any, key: string, allowed: ReadonlySet<string>): string {
+    if (typeof value !== 'string') {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: expected string, got ` + _pyTypeName(value),
+        );
+    }
+    const s = value.trim().toLowerCase();
+    if (!allowed.has(s)) {
+        throw new DecisionEngineConfigError(
+            `decision_engine.${key}: invalid value ${_pyRepr(value)}. ` +
+                'Allowed: ' +
+                _sortedStr([...allowed]).join(', '),
+        );
+    }
+    return s;
+}
+
+function _coerce_int(value: Any, key: string): number {
+    if (typeof value === 'boolean') {
+        throw new DecisionEngineConfigError(`decision_engine.${key}: expected int, got bool`);
+    }
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        if (value < 0) {
+            throw new DecisionEngineConfigError(`decision_engine.${key}: must be >= 0`);
+        }
+        return value;
+    }
+    throw new DecisionEngineConfigError(
+        `decision_engine.${key}: expected int, got ` + _pyTypeName(value),
+    );
+}
+
+/**
+ * Evaluate gates for `phase`. Returns the first firing gate, or `null` when
+ * no gate fires.
+ *
+ * Conflict resolution follows {@link GATE_PRIORITY} — only the first matching
+ * gate's phase is considered. Each gate maps to exactly one phase via the
+ * internal phase map.
+ */
+export function evaluate_gates(
+    settings: DecisionEngineSettings,
+    args: {
+        phase: string;
+        confidence_band: string | null;
+        risk_class: string | null;
+        memory_hits: number;
+        is_interactive?: (() => boolean) | null;
+    },
+): GateDecision | null {
+    const { phase, confidence_band, risk_class, memory_hits } = args;
+    const is_interactive = args.is_interactive ?? null;
+    if (!settings.any_gate_active) {
+        return null;
+    }
+    for (const gate_id of GATE_PRIORITY) {
+        if (_PHASE_FOR_GATE[gate_id] !== phase) {
+            continue;
+        }
+        const decision = _evaluate_single(gate_id, settings, {
+            confidence_band,
+            risk_class,
+            memory_hits,
+        });
+        if (decision !== null) {
+            const action = _resolve_action(settings, is_interactive);
+            return new GateDecision({
+                gate_id: decision.gate_id,
+                phase: decision.phase,
+                reason: decision.reason,
+                action,
+            });
+        }
+    }
+    return null;
+}
+
+function _evaluate_single(
+    gate_id: string,
+    settings: DecisionEngineSettings,
+    args: {
+        confidence_band: string | null;
+        risk_class: string | null;
+        memory_hits: number;
+    },
+): GateDecision | null {
+    const { confidence_band, risk_class, memory_hits } = args;
+    if (gate_id === 'min_confidence' && settings.min_confidence !== 'off') {
+        // min_confidence is validated to low/medium/high here, all in _LEVEL_RANK.
+        const floor = _LEVEL_RANK[settings.min_confidence] ?? 0;
+        const actual = _LEVEL_RANK[(confidence_band ?? '').toLowerCase()] ?? 0;
+        if (actual < floor) {
+            return new GateDecision({
+                gate_id,
+                phase: 'plan',
+                action: 'stop',
+                reason:
+                    `confidence_band=${_pyRepr(confidence_band)} below floor ` +
+                    `min_confidence=${_pyRepr(settings.min_confidence)}`,
+            });
+        }
+    } else if (gate_id === 'block_on_risk' && settings.block_on_risk !== 'off') {
+        // block_on_risk is validated to low/medium/high here, all in _LEVEL_RANK.
+        const ceiling = _LEVEL_RANK[settings.block_on_risk] ?? 0;
+        const actual = _LEVEL_RANK[(risk_class ?? '').toLowerCase()] ?? 0;
+        if (actual >= ceiling) {
+            return new GateDecision({
+                gate_id,
+                phase: 'implement',
+                action: 'stop',
+                reason:
+                    `risk_class=${_pyRepr(risk_class)} at/above ceiling ` +
+                    `block_on_risk=${_pyRepr(settings.block_on_risk)}`,
+            });
+        }
+    } else if (gate_id === 'require_memory_hits' && settings.require_memory_hits) {
+        if (memory_hits < 1) {
+            return new GateDecision({
+                gate_id,
+                phase: 'refine',
+                action: 'stop',
+                reason:
+                    `memory_hits=${memory_hits} but ` +
+                    'require_memory_hits=true (need >= 1)',
+            });
+        }
+    }
+    return null;
+}
+
+/**
+ * Map `on_block` to an action, applying the non-TTY fallback.
+ *
+ * Non-interactive context = either `is_interactive()` returns False, or the
+ * `CI` env var is truthy. `on_block=ask` collapses to `ask_timeout` (consumer
+ * applies `on_block_fallback`).
+ */
+function _resolve_action(
+    settings: DecisionEngineSettings,
+    is_interactive: (() => boolean) | null,
+): string {
+    if (settings.on_block === 'stop' || settings.on_block === 'warn') {
+        return settings.on_block;
+    }
+    const interactive =
+        is_interactive !== null ? is_interactive() : _default_is_interactive();
+    if (interactive) {
+        return 'ask';
+    }
+    return 'ask_timeout';
+}
+
+function _default_is_interactive(): boolean {
+    const ci = (process.env.CI ?? '').trim().toLowerCase();
+    if (ci === '1' || ci === 'true' || ci === 'yes') {
+        return false;
+    }
+    // Python: `sys.stdin.isatty() and sys.stdout.isatty()`.
+    return Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** `dict.get(key, default)` for a plain object. */
+function _get(obj: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Python `type(x).__name__` for the error-message shapes this module emits:
+ * `list`, `str`, `int`, `float`, `bool`, `dict`, `NoneType`.
+ */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/**
+ * Python `repr(x)` for the scalar shapes the error messages interpolate via
+ * `{value!r}` — strings are single-quoted, `None` → `None`, booleans →
+ * `True`/`False`, numbers as-is.
+ */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}

--- a/src/agent-src/templates/scripts/work_engine/scoring/decision_trace.ts
+++ b/src/agent-src/templates/scripts/work_engine/scoring/decision_trace.ts
@@ -1,0 +1,298 @@
+/**
+ * Confidence-band + risk-class heuristics for decision-trace v1.
+ *
+ * TypeScript twin of `work_engine/scoring/decision_trace.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * These heuristics back the JSON envelope emitted by
+ * `work_engine.hooks.builtin.DecisionTraceHook`. They live here
+ * (under `scoring/`) so the rules and the hook share a single source
+ * of truth, and so unit tests can exercise the heuristics without
+ * spinning up a dispatcher.
+ *
+ * Confidence-band heuristic (per
+ * `docs/contracts/decision-trace-v1.md`):
+ *
+ * - `high`   — `memory.hits >= 2` AND
+ *   `verify.first_try_passes == verify.claims` AND no ambiguity flag.
+ * - `medium` — `memory.hits >= 1` OR `verify.first_try_passes >= 1`.
+ * - `low`    — otherwise.
+ *
+ * Edge case: `verify.claims == 0` is **not** `high` by default; it
+ * folds into `medium` if at least one memory hit landed, `low`
+ * otherwise.
+ *
+ * Risk-class heuristic: maximum risk across the files the phase
+ * touched. With no file-ownership matrix wired in yet, the
+ * implementation defaults to `low` and exposes a `files` argument
+ * so a future hook can pass concrete paths. If the phase touched any
+ * files at all the heuristic returns `medium` so reviewers stay
+ * nudged toward a closer look until the matrix lands.
+ */
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+export const BAND_HIGH = 'high';
+export const BAND_MEDIUM = 'medium';
+export const BAND_LOW = 'low';
+
+export const RISK_HIGH = 'high';
+export const RISK_MEDIUM = 'medium';
+export const RISK_LOW = 'low';
+
+/** Return `high` / `medium` / `low` per the v1 heuristic. */
+export function derive_confidence_band(args: {
+    memory_hits: number;
+    verify_claims: number;
+    verify_first_try_passes: number;
+    ambiguity_flag: boolean;
+}): string {
+    const { memory_hits, verify_claims, verify_first_try_passes, ambiguity_flag } = args;
+    if (
+        memory_hits >= 2 &&
+        verify_claims > 0 &&
+        verify_first_try_passes === verify_claims &&
+        !ambiguity_flag
+    ) {
+        return BAND_HIGH;
+    }
+    if (memory_hits >= 1 || verify_first_try_passes >= 1) {
+        return BAND_MEDIUM;
+    }
+    return BAND_LOW;
+}
+
+/**
+ * Return the trace-level risk class.
+ *
+ * `changes` is the `delivery.changes` slice — a list of dicts in
+ * the canonical engine shape, or `null` for pure planning phases.
+ * Until the file-ownership matrix is wired in, "any change touched"
+ * maps to `medium`; "no change" maps to `low`. `high` is
+ * reserved for the future ownership-matrix lookup.
+ *
+ * Mirrors the Python truthiness check `if not changes:` — empty list,
+ * empty string, `0`, `null`, `undefined`, and `false` all count as falsy.
+ * Non-iterable truthy values fall through to `RISK_LOW` exactly as the
+ * Python `isinstance(changes, Iterable)` guard does.
+ */
+export function derive_risk_class(changes: Any): string {
+    if (!_pyTruthy(changes)) {
+        return RISK_LOW;
+    }
+    if (_isIterable(changes)) {
+        // `sum(1 for _ in changes)` — count the elements. Strings are
+        // iterable in Python (each char is one element); JS strings are not
+        // iterated by the `for...of` below the same way for our purposes, so
+        // mirror Python: a non-empty string counts as `count > 0`.
+        let count = 0;
+        if (typeof changes === 'string') {
+            count = _pyLen(changes);
+        } else {
+            for (const _ of changes as Iterable<unknown>) {
+                void _;
+                count += 1;
+            }
+        }
+        return count > 0 ? RISK_MEDIUM : RISK_LOW;
+    }
+    return RISK_LOW;
+}
+
+/**
+ * Reduce `state.memory` into the trace-envelope `memory` slice.
+ *
+ * The engine stores memory entries as dicts with at least an `id`
+ * or `rule_id` key plus arbitrary per-entry payload. The trace
+ * only carries ids — bodies stay behind the privacy floor.
+ */
+export function summarise_memory(
+    memory: Any,
+    args: { limit?: number } = {},
+): Record<string, Any> {
+    const limit = args.limit ?? 32;
+    if (!_pyTruthy(memory)) {
+        return { asks: 0, hits: 0, ids: [] };
+    }
+    const ids: string[] = [];
+    let asks = 0;
+    let hits = 0;
+    for (const entry of memory as Iterable<unknown>) {
+        if (!_isPlainDict(entry)) {
+            continue;
+        }
+        const e = entry as Record<string, unknown>;
+        // `int(entry.get("asks", 1) or 0) or 1` — Python: default 1 when key
+        // absent; coerce to int; `or 0` turns a falsy value into 0; outer
+        // `or 1` turns a resulting 0 into 1. Net: the increment is always >= 1.
+        asks += _pyInt(_pyOr(_get(e, 'asks', 1), 0)) || 1;
+        // `entry.get("hit", True)` — default True when absent.
+        if (_pyTruthy('hit' in e ? e['hit'] : true)) {
+            hits += 1;
+            const entry_id = _pyOr(_get(e, 'id', undefined), _get(e, 'rule_id', undefined));
+            if (_pyTruthy(entry_id) && ids.length < limit) {
+                ids.push(_pyStr(entry_id));
+            }
+        }
+    }
+    return { asks, hits, ids };
+}
+
+/**
+ * Reduce `state.verify` into the trace-envelope `verify` slice.
+ *
+ * `verify` may be `null` (no verify run yet), a dict carrying
+ * `claims` / `first_try_passes`, or a list of attempt records.
+ * Anything else collapses to zeros.
+ */
+export function summarise_verify(verify: Any): Record<string, number> {
+    if (verify === null || verify === undefined) {
+        return { claims: 0, first_try_passes: 0 };
+    }
+    if (_isPlainDict(verify)) {
+        const v = verify as Record<string, unknown>;
+        const claims = _pyInt(_pyOr(_get(v, 'claims', 0), 0));
+        const passes = _pyInt(_pyOr(_get(v, 'first_try_passes', 0), 0));
+        return { claims, first_try_passes: passes };
+    }
+    if (Array.isArray(verify)) {
+        const claims = verify.length;
+        let passes = 0;
+        for (const entry of verify) {
+            if (_isPlainDict(entry) && _pyTruthy((entry as Record<string, unknown>)['first_try_pass'])) {
+                passes += 1;
+            }
+        }
+        return { claims, first_try_passes: passes };
+    }
+    return { claims: 0, first_try_passes: 0 };
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** `dict.get(key, default)` for a plain object. */
+function _get(obj: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `a or b` — returns `a` when truthy, else `b`. */
+function _pyOr(a: unknown, b: unknown): unknown {
+    return _pyTruthy(a) ? a : b;
+}
+
+/**
+ * Python `bool(x)` truthiness: `None`/`undefined`, `False`, `0`, `0.0`,
+ * `""`, empty list/tuple/dict/set are falsy; everything else truthy.
+ */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/**
+ * Python `int(x)` for the value kinds these heuristics see — booleans
+ * (`True` → 1, `False` → 0), numbers (truncate toward zero), and numeric
+ * strings. Non-coercible values raise like CPython would; in practice the
+ * callers only pass the dict-derived scalars above.
+ */
+function _pyInt(value: unknown): number {
+    if (value === true) {
+        return 1;
+    }
+    if (value === false) {
+        return 0;
+    }
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        const n = Number(trimmed);
+        if (trimmed !== '' && Number.isFinite(n)) {
+            return Math.trunc(n);
+        }
+    }
+    throw new Error(`invalid literal for int(): ${String(value)}`);
+}
+
+/** Python `str(x)` for the scalar shapes returned by `id` / `rule_id`. */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/** Python `len(x)` for a string — code-point count, not UTF-16 unit count. */
+function _pyLen(s: string): number {
+    let n = 0;
+    for (const _ of s) {
+        void _;
+        n += 1;
+    }
+    return n;
+}
+
+/**
+ * Python `isinstance(x, dict)` — only a plain object (not array, not null).
+ * Mirrors the source's `isinstance(entry, dict)` guards.
+ */
+function _isPlainDict(value: unknown): boolean {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+    );
+}
+
+/**
+ * Python `isinstance(x, Iterable)` for the shapes `derive_risk_class` can
+ * see after the `if not changes:` guard: lists, strings, sets, maps, and
+ * generic iterables expose `Symbol.iterator`; plain dicts are iterable in
+ * Python (over keys) so an object also counts.
+ */
+function _isIterable(value: unknown): boolean {
+    if (value === null || value === undefined) {
+        return false;
+    }
+    if (typeof value === 'string' || Array.isArray(value)) {
+        return true;
+    }
+    if (typeof value === 'object') {
+        if (typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function') {
+            return true;
+        }
+        // Plain dict: iterable over its keys in Python.
+        return true;
+    }
+    return false;
+}

--- a/src/agent-src/templates/scripts/work_engine/scoring/memory_visibility.ts
+++ b/src/agent-src/templates/scripts/work_engine/scoring/memory_visibility.ts
@@ -1,0 +1,445 @@
+/**
+ * Producer-side helpers for the memory-visibility line.
+ *
+ * TypeScript twin of `work_engine/scoring/memory_visibility.py` (ADR-094 py2ts
+ * Phase 1 — work_engine scoring subpackage). Public API names stay snake_case
+ * to mirror the Python module 1:1 (per ADR-094 — Python style is part of the
+ * contract).
+ *
+ * Implements the v1 line shape from
+ * `docs/contracts/memory-visibility-v1.md`:
+ *
+ *     🧠 Memory: <hits>/<asks> · ids=[<comma-separated-ids>]
+ *     🧠 Memory: <hits>/<asks> · ids=[<...>] · affected: <keys>
+ *
+ * The optional `· affected: <keys>` trailing segment surfaces which
+ * closed-list decision-trace keys diverged because memory was
+ * consulted — see `docs/contracts/decision-trace-v1.md` "Memory
+ * consequence keys".
+ *
+ * The semantics matched to the work-engine model:
+ *
+ * - The `memory` step retrieves across the four allowed memory types
+ *   (`MEMORY_TYPES` in `directives.backend.memory`). Each type is
+ *   one `ask` from the visibility-line perspective.
+ * - `hits` counts distinct types that returned at least one entry.
+ * - `ids` is the deduped list of returned entry ids preserving the
+ *   retrieval order encoded in `state.memory`.
+ *
+ * Privacy floor: this module never emits entry bodies, summaries,
+ * `path`/`source` fields, or anything beyond `id` and `type`.
+ * The privacy regression test (`tests/contracts/test_memory_
+ * visibility_redaction.py`) keeps this guarantee enforced.
+ */
+
+import { derive_confidence_band, derive_risk_class } from './decision_trace.js';
+
+/** Arbitrary JSON-ish value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+export const ICON = '\u{1F9E0}'; // 🧠
+export const DEFAULT_MAX_INLINE_IDS = 5;
+export const DEFAULT_ASKED_TYPES: readonly string[] = [
+    'domain-invariants',
+    'architecture-decisions',
+    'incident-learnings',
+    'historical-patterns',
+];
+
+export const CONSEQUENCE_KEYS: readonly string[] = [
+    'confidence_band',
+    'risk_class',
+    'applied_rules',
+    'test_plan',
+] as const;
+
+/**
+ * Reduce `state.memory` into the visibility-line slice.
+ *
+ * `memory` is the list of hit dicts produced by
+ * `directives.backend.memory`. Returns `{"asks", "hits", "ids"}`
+ * with privacy-safe values only.
+ */
+export function summarise_visibility(
+    memory: Any,
+    args: { asked_types?: Iterable<string> } = {},
+): Record<string, Any> {
+    const asked = [...(args.asked_types ?? DEFAULT_ASKED_TYPES)];
+    if (!_pyTruthy(memory) || !Array.isArray(memory)) {
+        return { asks: 0, hits: 0, ids: [] };
+    }
+    const asks = asked.length;
+    const seen_types = new Set<string>();
+    const ids: string[] = [];
+    const seen_ids = new Set<string>();
+    for (const entry of memory) {
+        if (!_isPlainDict(entry)) {
+            continue;
+        }
+        const e = entry as Record<string, unknown>;
+        const type_value = e['type'];
+        if (typeof type_value === 'string') {
+            seen_types.add(type_value);
+        }
+        const entry_id = _pyOr(_get(e, 'id', undefined), _get(e, 'rule_id', undefined));
+        if (!(typeof entry_id === 'string' || _isIntLike(entry_id))) {
+            continue;
+        }
+        const sid = _pyStr(entry_id);
+        if (seen_ids.has(sid)) {
+            continue;
+        }
+        seen_ids.add(sid);
+        ids.push(sid);
+    }
+    const hits = seen_types.size > 0 ? seen_types.size : ids.length > 0 ? 1 : 0;
+    return { asks, hits, ids };
+}
+
+/**
+ * Return a comparable shape for a consequence-key value.
+ *
+ * List-shaped keys (`applied_rules`, `test_plan`) compare as
+ * sorted tuples so order is not a divergence; scalar keys
+ * (`confidence_band`, `risk_class`) compare as-is.
+ */
+function _normalise_key_value(value: Any): Any {
+    if (Array.isArray(value)) {
+        // `tuple(sorted(str(item) for item in value))`
+        return _sortedStr(value.map((item) => _pyStr(item)));
+    }
+    return value;
+}
+
+/**
+ * Return sorted keys whose values diverge between two traces.
+ *
+ * Iterates the closed `CONSEQUENCE_KEYS` list defined in
+ * `docs/contracts/decision-trace-v1.md`. A key is considered
+ * *diverged* when its normalised value differs between the two
+ * traces. Per the contract, when both sides are `None` the key
+ * is suppressed from the diff entirely.
+ */
+export function diff_consequence_keys(
+    trace_with: Record<string, Any>,
+    trace_without: Record<string, Any>,
+): string[] {
+    const affected: string[] = [];
+    for (const key of CONSEQUENCE_KEYS) {
+        const a = _get(trace_with, key, undefined);
+        const b = _get(trace_without, key, undefined);
+        if (_isNone(a) && _isNone(b)) {
+            continue;
+        }
+        if (!_pyEqual(_normalise_key_value(a), _normalise_key_value(b))) {
+            affected.push(key);
+        }
+    }
+    return _sortedStr(affected);
+}
+
+/**
+ * Compute the `affected` consequence keys for the visibility line.
+ *
+ * Returns:
+ *   - `null` when no memory was consulted (`memory_hits <= 0`)
+ *     — caller MUST omit the `· affected: …` segment.
+ *   - `[]` when memory was consulted but no closed-list key
+ *     diverged — caller MUST render `· affected: none`.
+ *   - sorted list of keys otherwise.
+ *
+ * The counterfactual trace is "what the heuristics would have
+ * emitted if `memory_hits` had been `0`". v1 covers
+ * `confidence_band` and `risk_class` via the existing scoring
+ * helpers; `applied_rules` and `test_plan` pass through
+ * unchanged because they are not yet memory-derived in the
+ * engine — the keys stay in the closed list so the diff
+ * infrastructure is in place when they wire in.
+ */
+export function compute_affected(args: {
+    memory_hits: number;
+    verify_claims?: number;
+    verify_first_try_passes?: number;
+    ambiguity_flag?: boolean;
+    changes?: Any;
+    applied_rules?: string[] | null;
+    test_plan?: string[] | null;
+}): string[] | null {
+    const memory_hits = args.memory_hits;
+    const verify_claims = args.verify_claims ?? 0;
+    const verify_first_try_passes = args.verify_first_try_passes ?? 0;
+    const ambiguity_flag = args.ambiguity_flag ?? false;
+    const changes = args.changes ?? null;
+    const applied_rules = args.applied_rules ?? null;
+    const test_plan = args.test_plan ?? null;
+
+    if (memory_hits <= 0) {
+        return null;
+    }
+    const trace_with: Record<string, Any> = {
+        confidence_band: derive_confidence_band({
+            memory_hits,
+            verify_claims,
+            verify_first_try_passes,
+            ambiguity_flag,
+        }),
+        risk_class: derive_risk_class(changes),
+        applied_rules: _pyTruthy(applied_rules) ? [...(applied_rules as string[])] : null,
+        test_plan: _pyTruthy(test_plan) ? [...(test_plan as string[])] : null,
+    };
+    const trace_without: Record<string, Any> = {
+        confidence_band: derive_confidence_band({
+            memory_hits: 0,
+            verify_claims,
+            verify_first_try_passes,
+            ambiguity_flag,
+        }),
+        risk_class: derive_risk_class(changes),
+        applied_rules: _pyTruthy(applied_rules) ? [...(applied_rules as string[])] : null,
+        test_plan: _pyTruthy(test_plan) ? [...(test_plan as string[])] : null,
+    };
+    return diff_consequence_keys(trace_with, trace_without);
+}
+
+/**
+ * Render the visibility line; return `null` when `asks == 0`.
+ *
+ * Cap inline ids at `max_inline_ids` and append `…+N` when the
+ * list is longer. Returning `null` enforces the contract clause
+ * "If `asks == 0`, the engine MUST suppress the line entirely".
+ *
+ * When `affected` is not `null`, append the
+ * `· affected: <keys>` trailing segment from
+ * `docs/contracts/memory-visibility-v1.md`: empty list renders as
+ * `affected: none` (consulted but no key diverged);
+ * non-empty list renders the comma-separated keys.
+ */
+export function format_line(
+    summary: Record<string, Any>,
+    args: { max_inline_ids?: number; affected?: string[] | null } = {},
+): string | null {
+    let max_inline_ids = args.max_inline_ids ?? DEFAULT_MAX_INLINE_IDS;
+    const affected = args.affected ?? null;
+
+    const asks = _pyInt(_pyOr(_get(summary, 'asks', 0), 0));
+    if (asks <= 0) {
+        return null;
+    }
+    const hits = _pyInt(_pyOr(_get(summary, 'hits', 0), 0));
+    const raw_ids = (_pyOr(_get(summary, 'ids', undefined), []) as unknown[]) ?? [];
+    const ids = (raw_ids as unknown[])
+        .filter((i) => typeof i === 'string' || _isIntLike(i))
+        .map((i) => _pyStr(i));
+    if (max_inline_ids < 0) {
+        max_inline_ids = 0;
+    }
+    const inline = ids.slice(0, max_inline_ids);
+    const overflow = ids.length - inline.length;
+    let rendered_ids = inline.join(', ');
+    if (overflow > 0) {
+        const suffix = rendered_ids ? ', ' : '';
+        rendered_ids = `${rendered_ids}${suffix}…+${overflow}`;
+    }
+    let line = `${ICON} Memory: ${hits}/${asks} · ids=[${rendered_ids}]`;
+    if (affected !== null) {
+        const rendered_affected = affected.length > 0 ? affected.join(',') : 'none';
+        line = `${line} · affected: ${rendered_affected}`;
+    }
+    return line;
+}
+
+/**
+ * Render the end-of-run "Memory changed decisions" report block.
+ *
+ * Per `docs/contracts/memory-visibility-v1.md`: lists
+ * `<id> → <key>` rows derived from the same diff source as the
+ * visibility line's `affected` segment. Returns `null` when
+ * no key diverged (`affected` empty / `null`) so the caller
+ * suppresses the block entirely.
+ *
+ * Attribution in v1 is aggregate: each consulted id pairs with
+ * each affected key. Per-id attribution is captured as a
+ * follow-up risk in the roadmap Risk register.
+ */
+export function format_changed_decisions_block(
+    ids: Iterable<string>,
+    affected: Iterable<string> | null | undefined,
+): string | null {
+    if (!_pyTruthy(affected)) {
+        return null;
+    }
+    const affected_list = _sortedStr([...(affected as Iterable<string>)]);
+    const id_list = [...ids].filter((i) => typeof i === 'string' || _isIntLike(i)).map((i) => _pyStr(i));
+    if (id_list.length === 0) {
+        return null;
+    }
+    const lines = ['Memory changed decisions:'];
+    for (const entry_id of id_list) {
+        for (const key of affected_list) {
+            lines.push(`- ${entry_id} → ${key}`);
+        }
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Apply the cadence + opt-out gates from the contract.
+ *
+ * `memory_cadence` is the `memory.cadence` cadence key:
+ *
+ *   - `always` (default) — emit whenever `asks >= 1`.
+ *   - `auto` — emit only when `asks >= 3` (reduces noise on
+ *     shallow-retrieval steps).
+ *   - `never` — suppress the line entirely.
+ *
+ * `visibility_off` is the legacy `memory.visibility: off` master
+ * switch and still wins over any `memory_cadence` value.
+ */
+export function should_emit(
+    summary: Record<string, Any>,
+    args: { memory_cadence?: string; visibility_off?: boolean } = {},
+): boolean {
+    const memory_cadence = args.memory_cadence ?? 'always';
+    const visibility_off = args.visibility_off ?? false;
+    if (visibility_off) {
+        return false;
+    }
+    const asks = _pyInt(_pyOr(_get(summary, 'asks', 0), 0));
+    if (asks <= 0) {
+        return false;
+    }
+    const status = (memory_cadence || 'always').trim().toLowerCase();
+    if (status === 'never') {
+        return false;
+    }
+    if (status === 'auto') {
+        return asks >= 3;
+    }
+    return true;
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** `dict.get(key, default)` for a plain object. */
+function _get(obj: Record<string, unknown>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `a or b`. */
+function _pyOr(a: unknown, b: unknown): unknown {
+    return _pyTruthy(a) ? a : b;
+}
+
+/** Python `x is None`. */
+function _isNone(value: unknown): boolean {
+    return value === null || value === undefined;
+}
+
+/**
+ * Python `int` / `bool` (not `bool` masquerading) test used by the
+ * `isinstance(entry_id, (str, int))` guards. In Python `bool` is a subclass
+ * of `int`, so `True`/`False` pass; mirror that.
+ */
+function _isIntLike(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+        return true;
+    }
+    return typeof value === 'number' && Number.isInteger(value);
+}
+
+/** Python `bool(x)` truthiness. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/** Python `int(x)` for the dict-scalar / `or 0` shapes this module passes. */
+function _pyInt(value: unknown): number {
+    if (value === true) {
+        return 1;
+    }
+    if (value === false) {
+        return 0;
+    }
+    if (typeof value === 'number') {
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        const n = Number(trimmed);
+        if (trimmed !== '' && Number.isFinite(n)) {
+            return Math.trunc(n);
+        }
+    }
+    throw new Error(`invalid literal for int(): ${String(value)}`);
+}
+
+/** Python `str(x)` for the id / list-item shapes. */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+/** Python `isinstance(x, dict)` — plain object only. */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Equality matching Python `!=` for the normalised consequence-key values:
+ * scalars compare by value; lists (post-`_normalise_key_value` they are
+ * already string arrays) compare element-wise; `None` distinct from a value.
+ */
+function _pyEqual(a: unknown, b: unknown): boolean {
+    if (Array.isArray(a) && Array.isArray(b)) {
+        if (a.length !== b.length) {
+            return false;
+        }
+        for (let i = 0; i < a.length; i += 1) {
+            if (!_pyEqual(a[i], b[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return false;
+    }
+    if (_isNone(a) && _isNone(b)) {
+        return true;
+    }
+    return a === b;
+}

--- a/src/agent-src/templates/scripts/work_engine/stack/detect.ts
+++ b/src/agent-src/templates/scripts/work_engine/stack/detect.ts
@@ -1,0 +1,252 @@
+/**
+ * Frontend-stack detection from project manifests.
+ *
+ * TypeScript twin of `work_engine/stack/detect.py` (ADR-094 py2ts). Leaf
+ * module — stdlib only, NO intra-`work_engine` imports — so the public API
+ * names stay snake_case to mirror the Python module 1:1 (per ADR-094: Python
+ * style is part of the contract).
+ *
+ * The detector reads `composer.json` and `package.json` from a project
+ * root, applies the heuristic table below in priority order, and returns a
+ * {@link StackResult} carrying the labelled frontend plus the manifest
+ * `mtime` it was computed against. The dispatcher caches the result on
+ * `state.stack` and re-runs detection whenever the recorded `mtime`
+ * no longer matches what the filesystem reports.
+ *
+ * Heuristics (priority order — first match wins):
+ *
+ * 1. `composer.json` lists `livewire/livewire` AND `livewire/flux` →
+ *    `blade-livewire-flux`
+ * 2. `package.json` lists `react` AND any of `@radix-ui/*`,
+ *    `shadcn-ui` or has a `components.json` (the shadcn marker file)
+ *    → `react-shadcn`
+ * 3. `package.json` lists `vue` (any major) → `vue`
+ * 4. Otherwise → `plain`
+ *
+ * Detection is filesystem-cheap: at most three small JSON reads per
+ * project root. Errors (missing file, malformed JSON, missing `require`
+ * section) downgrade to `plain` rather than raising — a wrong stack
+ * label is recoverable (audit catches it, user can override), but a
+ * crash mid-dispatch is not.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * All stack labels the detector can return.
+ *
+ * Kept as a set so consumers (state schema, fixtures, tests) can
+ * validate against a single source of truth without re-deriving.
+ *
+ * Mirrors Python's `frozenset` — the membership semantics are what
+ * matter; the literal set construction order is irrelevant.
+ */
+export const KNOWN_STACKS: ReadonlySet<string> = new Set([
+    'blade-livewire-flux',
+    'react-shadcn',
+    'vue',
+    'plain',
+]);
+
+/** Fallback when no manifest signal matches. */
+export const DEFAULT_STACK = 'plain';
+
+const _SHADCN_RADIX_PREFIX = '@radix-ui/';
+const _SHADCN_PACKAGE_NAMES: ReadonlySet<string> = new Set(['shadcn-ui', 'shadcn']);
+const _FLUX_PACKAGE = 'livewire/flux';
+const _LIVEWIRE_PACKAGE = 'livewire/livewire';
+
+/**
+ * A heterogeneous JSON object, mirroring a Python `dict[str, object]`.
+ * A `null` prototype is not required — the only access is `.get(key)`-style
+ * lookup plus `isinstance(section, dict)` checks, both reproduced below.
+ */
+type Manifest = { [key: string]: unknown };
+
+/**
+ * Outcome of one detection pass.
+ *
+ * `mtime` is the latest mtime among the manifests actually consulted
+ * (`composer.json` and `package.json`), in POSIX seconds. Callers
+ * cache the result keyed on this value; a stale cache is invalidated
+ * by the next dispatch when the recorded mtime is older than what
+ * {@link latest_manifest_mtime} returns.
+ *
+ * Mirrors the Python `@dataclass(frozen=True)`: a plain immutable value
+ * carrier with `frontend` + `mtime` fields, constructed positionally /
+ * by keyword.
+ */
+export class StackResult {
+    readonly frontend: string;
+    readonly mtime: number;
+
+    constructor(args: { frontend: string; mtime: number }) {
+        this.frontend = args.frontend;
+        this.mtime = args.mtime;
+    }
+}
+
+/**
+ * Inspect `project_root` and label the frontend stack.
+ *
+ * @param project_root
+ *   Directory that should contain a `composer.json` or `package.json` at
+ *   its top level. Other layouts (monorepos, nested workspaces) call this
+ *   with the workspace root that carries the manifest you care about — the
+ *   caller picks the scope, the detector does not walk upwards.
+ * @returns
+ *   A {@link StackResult} whose `frontend` is one of {@link KNOWN_STACKS};
+ *   `mtime` is the latest manifest mtime among the files actually
+ *   consulted, or `0.0` when no manifests exist (greenfield project).
+ */
+export function detect_stack(project_root: string): StackResult {
+    const composer = _read_json(path.join(project_root, 'composer.json'));
+    const pkg = _read_json(path.join(project_root, 'package.json'));
+    const components_json = _is_file(path.join(project_root, 'components.json'));
+    const mtime = latest_manifest_mtime(project_root);
+
+    if (_is_blade_livewire_flux(composer)) {
+        return new StackResult({ frontend: 'blade-livewire-flux', mtime });
+    }
+
+    if (_is_react_shadcn(pkg, components_json)) {
+        return new StackResult({ frontend: 'react-shadcn', mtime });
+    }
+
+    if (_has_vue(pkg)) {
+        return new StackResult({ frontend: 'vue', mtime });
+    }
+
+    return new StackResult({ frontend: DEFAULT_STACK, mtime });
+}
+
+/**
+ * Return the latest mtime across the manifests we consult.
+ *
+ * Used by the dispatcher's cache check: when the persisted
+ * `state.stack.mtime` no longer matches the live value, the cached
+ * label is invalidated and detection re-runs. Returns `0.0` when no
+ * manifest is present so a fresh greenfield repo produces a stable
+ * sentinel rather than a missing-file error.
+ */
+export function latest_manifest_mtime(project_root: string): number {
+    const candidates = ['composer.json', 'package.json'];
+    const mtimes: number[] = [];
+    for (const name of candidates) {
+        const p = path.join(project_root, name);
+        if (_is_file(p)) {
+            mtimes.push(_stat_mtime(p));
+        }
+    }
+    return mtimes.length > 0 ? Math.max(...mtimes) : 0.0;
+}
+
+/**
+ * Read a JSON manifest, returning `{}` on any error.
+ *
+ * Wrong-but-recoverable beats crash-mid-dispatch. Audit and the
+ * refine step will surface the real shape of the project; the
+ * detector's job is just to pick a routing label.
+ */
+function _read_json(p: string): Manifest {
+    if (!_is_file(p)) {
+        return {};
+    }
+    let payload: unknown;
+    try {
+        payload = JSON.parse(fs.readFileSync(p, { encoding: 'utf-8' }));
+    } catch {
+        // Mirrors Python's `except (OSError, json.JSONDecodeError)`: any read
+        // or parse failure degrades to the empty manifest.
+        return {};
+    }
+    return _isDict(payload) ? payload : {};
+}
+
+/**
+ * Merge the dependency-style sections of a manifest into one map.
+ *
+ * composer.json uses `require` and `require-dev`; package.json uses
+ * `dependencies`, `devDependencies`, `peerDependencies`, and
+ * `optionalDependencies`. We only care whether a name is present
+ * anywhere — version pinning is the audit step's concern.
+ */
+function _all_dependencies(manifest: Manifest, ...keys: string[]): Manifest {
+    const merged: Manifest = {};
+    for (const key of keys) {
+        const section = manifest[key];
+        if (_isDict(section)) {
+            // `dict.update` overwrites with later keys but preserves the
+            // insertion order of first-seen keys; we only test membership,
+            // so a plain assign reproduces the relevant semantics.
+            Object.assign(merged, section);
+        }
+    }
+    return merged;
+}
+
+function _is_blade_livewire_flux(composer: Manifest): boolean {
+    const deps = _all_dependencies(composer, 'require', 'require-dev');
+    return _LIVEWIRE_PACKAGE in deps && _FLUX_PACKAGE in deps;
+}
+
+function _is_react_shadcn(pkg: Manifest, components_json: boolean): boolean {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    if (!('react' in deps)) {
+        return false;
+    }
+    const names = Object.keys(deps);
+    const has_radix = names.some((name) => name.startsWith(_SHADCN_RADIX_PREFIX));
+    const has_shadcn_pkg = names.some((name) => _SHADCN_PACKAGE_NAMES.has(name));
+    return has_radix || has_shadcn_pkg || components_json;
+}
+
+function _has_vue(pkg: Manifest): boolean {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    return 'vue' in deps;
+}
+
+// ── stdlib parity helpers ───────────────────────────────────────────────
+
+/** Python `Path.is_file()` — true only for a regular file (follows symlinks). */
+function _is_file(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Python `Path.stat().st_mtime` in POSIX seconds.
+ *
+ * Python derives `st_mtime` (a float) from the OS nanosecond timestamp.
+ * Reading `mtimeNs` (an integer, byte-identical to Python's `st_mtime_ns`)
+ * and dividing by `1e9` reproduces the same value closely. Note: the exact
+ * float byte-repr of `st_mtime` can differ between CPython and V8 for some
+ * sub-second timestamps — callers that *serialize* mtime (only
+ * `runner.to_config` does) treat it as non-deterministic and the parity
+ * tests normalize the field. The detection logic compares `mtime` only for
+ * cache-invalidation (numeric `!=`), where this precision is sufficient.
+ */
+function _stat_mtime(p: string): number {
+    const st = fs.statSync(p, { bigint: true });
+    return Number(st.mtimeNs) / 1e9;
+}
+
+/** Python `isinstance(x, dict)` — a plain (non-array, non-null) object. */
+function _isDict(v: unknown): v is Manifest {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}

--- a/src/agent-src/templates/scripts/work_engine/stack/runner.ts
+++ b/src/agent-src/templates/scripts/work_engine/stack/runner.ts
@@ -1,0 +1,745 @@
+/**
+ * Toolchain resolution — pick the right test/quality runner per stack.
+ *
+ * TypeScript twin of `work_engine/stack/runner.py` (ADR-094 py2ts). Leaf
+ * module — stdlib only, NO intra-`work_engine` imports — so the public API
+ * names stay snake_case to mirror the Python module 1:1 (per ADR-094: Python
+ * style is part of the contract).
+ *
+ * Sibling of {@link "./detect"} (which labels the *frontend* stack). This
+ * module answers a different question: *given a project root, which test
+ * runner and quality tools does this stack actually use, and what is the
+ * exact command to invoke them?* It is the engine behind 6.1.0 Step 6 — the
+ * toolchain resolver that lets one set of commands (`/tests execute`,
+ * `/tests create`, `/quality-fix`, `/review-changes`, `/work`) adapt to
+ * phpunit / pest / vitest / jest / playwright / pytest / go / cargo instead
+ * of exploding into per-stack command variants.
+ *
+ * Detection is filesystem-cheap and **never crashes**: a malformed manifest,
+ * a missing file, or an unknown stack degrades to a LOW-confidence empty
+ * result rather than raising — a wrong toolchain label is recoverable (the
+ * agent can ask), a crash mid-run is not. This mirrors the recoverable-error
+ * contract in {@link "./detect"}.
+ *
+ * Three opt-in flags shape the *selected* command set (the monorepo guard):
+ *
+ * - `include_e2e` — by default e2e suites (playwright / cypress) are
+ *   excluded; fast unit tests run first. Pass to add them.
+ * - `include_slow` — by default a script tagged `test:slow` /
+ *   `test:integration` is excluded. Pass to add it.
+ * - `php_only` — keep only the PHP ecosystem (the `--php` narrowing the
+ *   roadmap calls for; "only genuine PHP-space commands stay PHP-locked").
+ *
+ * The full per-stack inventory is always returned (`runners`); the
+ * `selected` tuple is what a command should actually run after applying
+ * the flags + the fast-by-default monorepo guard.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Every test-runner label the resolver can emit.
+ *
+ * Single source of truth so the state schema, fixtures, and tests validate
+ * against one set without re-deriving it. Mirrors Python's `frozenset`.
+ */
+export const KNOWN_RUNNERS: ReadonlySet<string> = new Set([
+    'pest',
+    'phpunit',
+    'vitest',
+    'jest',
+    'playwright',
+    'cypress',
+    'pytest',
+    'go-test',
+    'cargo-test',
+]);
+
+// Speed buckets. `fast` runs by default; `slow` needs `include_slow`;
+// `e2e` needs `include_e2e`. The monorepo guard reads this.
+export const SPEED_FAST = 'fast';
+export const SPEED_SLOW = 'slow';
+export const SPEED_E2E = 'e2e';
+
+// Confidence tiers — declarative, mirrors the non-interactive-contract
+// tiers (HIGH = deterministic dependency/marker; MEDIUM = heuristic;
+// LOW = nothing matched).
+export const HIGH = 'HIGH';
+export const MEDIUM = 'MEDIUM';
+export const LOW = 'LOW';
+
+const _MANIFESTS = [
+    'composer.json',
+    'package.json',
+    'pyproject.toml',
+    'go.mod',
+    'Cargo.toml',
+    'Makefile',
+    'Taskfile.yml',
+    'Taskfile.yaml',
+];
+
+/** A heterogeneous JSON object, mirroring a Python `dict[str, object]`. */
+type Manifest = { [key: string]: unknown };
+
+/** Role → wrapper-command map, mirroring Python's `dict[str, str]`. */
+type Wrappers = { [role: string]: string };
+
+/**
+ * One detected test runner for one ecosystem.
+ *
+ * `command` is the exact invocation to run the suite (a task-runner
+ * wrapper like `make test` when one exists, otherwise the direct tool).
+ * `speed` is one of {@link SPEED_FAST} / {@link SPEED_SLOW} /
+ * {@link SPEED_E2E}; the monorepo guard filters on it. `basis` names the
+ * concrete signal that matched (dependency, binary, marker file) so the
+ * routing decision is auditable, exactly like the non-interactive-contract's
+ * `basis` column.
+ *
+ * Mirrors the Python `@dataclass(frozen=True)` with positional construction
+ * and the documented field defaults.
+ */
+export class RunnerResult {
+    readonly ecosystem: string;
+    readonly runner: string;
+    readonly command: string;
+    readonly speed: string;
+    readonly confidence: string;
+    readonly basis: string;
+
+    constructor(
+        ecosystem: string,
+        runner: string,
+        command: string,
+        speed: string = SPEED_FAST,
+        confidence: string = HIGH,
+        basis = '',
+    ) {
+        this.ecosystem = ecosystem;
+        this.runner = runner;
+        this.command = command;
+        this.speed = speed;
+        this.confidence = confidence;
+        this.basis = basis;
+    }
+}
+
+/**
+ * Outcome of one toolchain-resolution pass over a project root.
+ *
+ * `runners` is the full inventory (every ecosystem detected, every speed
+ * bucket). `selected` is what a command should actually run after the flags
+ * + fast-by-default guard. `quality` is the ordered list of quality/lint
+ * commands per detected ecosystem. `confidence` is the overall tier (HIGH
+ * when ≥1 runner matched deterministically and no cross-ecosystem conflict;
+ * LOW when nothing matched). `mtime` is the latest manifest mtime, used for
+ * cache invalidation just like {@link "./detect".StackResult}.
+ */
+export class ToolchainResult {
+    readonly ecosystems: readonly string[];
+    readonly runners: readonly RunnerResult[];
+    readonly selected: readonly RunnerResult[];
+    readonly quality: readonly string[];
+    readonly confidence: string;
+    readonly mtime: number;
+
+    constructor(args: {
+        ecosystems: readonly string[];
+        runners: readonly RunnerResult[];
+        selected: readonly RunnerResult[];
+        quality: readonly string[];
+        confidence: string;
+        mtime: number;
+    }) {
+        this.ecosystems = args.ecosystems;
+        this.runners = args.runners;
+        this.selected = args.selected;
+        this.quality = args.quality;
+        this.confidence = args.confidence;
+        this.mtime = args.mtime;
+    }
+
+    /**
+     * Serialise to the auto-generated project-config shape.
+     *
+     * Written to `agents/runtime/state/toolchain.json` by
+     * {@link write_config} so the per-stack commands are captured once and
+     * re-read cheaply (keyed on `mtime`) instead of re-detected every turn.
+     */
+    to_config(): Record<string, unknown> {
+        return {
+            ecosystems: [...this.ecosystems],
+            confidence: this.confidence,
+            // `mtime` is a Python float; wrap so `write_config`'s serialiser
+            // renders an integral value as `N.0` (Python float repr).
+            mtime: pyFloat(this.mtime),
+            runners: this.runners.map((r) => ({
+                ecosystem: r.ecosystem,
+                runner: r.runner,
+                command: r.command,
+                speed: r.speed,
+                confidence: r.confidence,
+                basis: r.basis,
+            })),
+            selected: this.selected.map((r) => r.command),
+            quality: [...this.quality],
+        };
+    }
+}
+
+/**
+ * Inspect `project_root` and resolve its test/quality toolchain.
+ *
+ * @param project_root
+ *   Directory carrying the manifests (`composer.json` / `package.json` /
+ *   `pyproject.toml` / `go.mod` / `Cargo.toml`). The resolver does not walk
+ *   upwards — the caller picks the scope, matching `detect.detect_stack`.
+ * @param opts.include_slow @param opts.include_e2e
+ *   Monorepo guard. Off by default → `selected` carries only fast unit
+ *   suites. Turn on to add the slow / e2e buckets.
+ * @param opts.php_only
+ *   The `--php` narrowing — keep only the PHP ecosystem in `selected` (the
+ *   full inventory is still returned in `runners`).
+ * @returns
+ *   A {@link ToolchainResult}. Never raises. No manifest / unknown stack →
+ *   an empty result with `confidence == LOW` so the caller can fall back to
+ *   asking.
+ */
+export function resolve_toolchain(
+    project_root: string,
+    opts: { include_slow?: boolean; include_e2e?: boolean; php_only?: boolean } = {},
+): ToolchainResult {
+    const include_slow = opts.include_slow ?? false;
+    const include_e2e = opts.include_e2e ?? false;
+    const php_only = opts.php_only ?? false;
+
+    const runners: RunnerResult[] = [];
+    const quality: string[] = [];
+
+    const composer = _read_json(path.join(project_root, 'composer.json'));
+    const pkg = _read_json(path.join(project_root, 'package.json'));
+    const has_composer = _is_file(path.join(project_root, 'composer.json'));
+    const has_package = _is_file(path.join(project_root, 'package.json'));
+    const pyproject_text = _read_text(path.join(project_root, 'pyproject.toml'));
+    const has_python =
+        Boolean(pyproject_text) ||
+        _is_file(path.join(project_root, 'requirements.txt')) ||
+        _is_file(path.join(project_root, 'setup.cfg')) ||
+        _is_file(path.join(project_root, 'pytest.ini'));
+    const has_go = _is_file(path.join(project_root, 'go.mod'));
+    const has_cargo = _is_file(path.join(project_root, 'Cargo.toml'));
+
+    const wrappers = _task_runner_wrappers(project_root, pkg);
+
+    if (has_composer) {
+        runners.push(..._php_runners(project_root, composer, wrappers));
+        quality.push(..._php_quality(project_root, composer, wrappers));
+    }
+    if (has_package) {
+        runners.push(..._js_runners(pkg, wrappers));
+        quality.push(..._js_quality(pkg, wrappers));
+    }
+    if (has_python) {
+        runners.push(..._python_runners(pyproject_text));
+        quality.push(..._python_quality(pyproject_text));
+    }
+    if (has_go) {
+        runners.push(
+            new RunnerResult('go', 'go-test', 'go test ./...', SPEED_FAST, HIGH, 'go.mod present'),
+        );
+        quality.push('go vet ./...');
+    }
+    if (has_cargo) {
+        runners.push(
+            new RunnerResult('rust', 'cargo-test', 'cargo test', SPEED_FAST, HIGH, 'Cargo.toml present'),
+        );
+        quality.push('cargo clippy');
+    }
+
+    const ecosystems = _dictFromKeys(runners.map((r) => r.ecosystem));
+    const selected = _apply_guard(runners, { include_slow, include_e2e, php_only });
+    const confidence = _overall_confidence(runners);
+
+    return new ToolchainResult({
+        ecosystems,
+        runners: [...runners],
+        selected: [...selected],
+        quality: _dictFromKeys(quality),
+        confidence,
+        mtime: latest_manifest_mtime(project_root),
+    });
+}
+
+/**
+ * Persist `result` to `agents/runtime/state/toolchain.json`.
+ *
+ * The auto-generated per-stack config the roadmap calls for. Best-effort:
+ * returns the path written; never raises on a read-only or missing parent
+ * (the resolver is a routing aid, not a hard dependency).
+ */
+export function write_config(project_root: string, result: ToolchainResult): string {
+    const target = path.join(project_root, 'agents', 'runtime', 'state', 'toolchain.json');
+    try {
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(
+            target,
+            jsonDumps(result.to_config(), { indent: 2, sort_keys: true }) + '\n',
+            { encoding: 'utf-8' },
+        );
+    } catch {
+        // Mirrors Python's `except OSError: pass` — best-effort write.
+    }
+    return target;
+}
+
+/**
+ * Latest mtime across every manifest the resolver consults.
+ *
+ * Cache-invalidation hook: when the persisted value no longer matches the
+ * live value the cached toolchain is stale and resolution re-runs. `0.0`
+ * when no manifest exists (greenfield) — a stable sentinel, not a
+ * missing-file error.
+ */
+export function latest_manifest_mtime(project_root: string): number {
+    const mtimes: number[] = [];
+    for (const name of _MANIFESTS) {
+        const p = path.join(project_root, name);
+        if (_is_file(p)) {
+            mtimes.push(_stat_mtime(p));
+        }
+    }
+    return mtimes.length > 0 ? Math.max(...mtimes) : 0.0;
+}
+
+// --------------------------------------------------------------------------
+// Ecosystem resolvers
+// --------------------------------------------------------------------------
+
+function _php_runners(root: string, composer: Manifest, wrappers: Wrappers): RunnerResult[] {
+    const deps = _all_dependencies(composer, 'require', 'require-dev');
+    if ('pestphp/pest' in deps || _is_file(path.join(root, 'vendor', 'bin', 'pest'))) {
+        const cmd = wrappers['php-test'] || 'vendor/bin/pest';
+        const basis =
+            'pestphp/pest' in deps
+                ? 'pestphp/pest in composer require'
+                : 'vendor/bin/pest present';
+        return [new RunnerResult('php', 'pest', cmd, SPEED_FAST, HIGH, basis)];
+    }
+    if (_is_file(path.join(root, 'artisan'))) {
+        const cmd = wrappers['php-test'] || 'php artisan test';
+        return [new RunnerResult('php', 'phpunit', cmd, SPEED_FAST, HIGH, 'artisan present (Laravel)')];
+    }
+    if ('phpunit/phpunit' in deps || _is_file(path.join(root, 'vendor', 'bin', 'phpunit'))) {
+        const cmd = wrappers['php-test'] || 'vendor/bin/phpunit';
+        return [new RunnerResult('php', 'phpunit', cmd, SPEED_FAST, HIGH, 'phpunit/phpunit detected')];
+    }
+    // composer.json with no test dependency — phpunit is the safe PHP default.
+    const cmd = wrappers['php-test'] || 'vendor/bin/phpunit';
+    return [
+        new RunnerResult(
+            'php',
+            'phpunit',
+            cmd,
+            SPEED_FAST,
+            MEDIUM,
+            'composer.json present, no explicit runner',
+        ),
+    ];
+}
+
+function _js_runners(pkg: Manifest, wrappers: Wrappers): RunnerResult[] {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    const scripts: Manifest = _isDict(pkg.scripts) ? pkg.scripts : {};
+    const pm_test = wrappers['js-test'];
+    const out: RunnerResult[] = [];
+
+    // Fast unit runner — vitest beats jest when both present (vitest is the
+    // modern default), but only one fast runner is selected.
+    if ('vitest' in deps) {
+        const cmd =
+            pm_test && _script_uses(scripts, 'test', 'vitest') ? pm_test : 'npx vitest run';
+        out.push(new RunnerResult('js', 'vitest', cmd, SPEED_FAST, HIGH, 'vitest in package deps'));
+    } else if ('jest' in deps) {
+        const cmd = pm_test && _script_uses(scripts, 'test', 'jest') ? pm_test : 'npx jest';
+        out.push(new RunnerResult('js', 'jest', cmd, SPEED_FAST, HIGH, 'jest in package deps'));
+    } else if (pm_test) {
+        out.push(
+            new RunnerResult(
+                'js',
+                'jest',
+                pm_test,
+                SPEED_FAST,
+                MEDIUM,
+                'package.json test script, runner unclear',
+            ),
+        );
+    }
+
+    // e2e runner — separate bucket, excluded unless --include-e2e.
+    if ('@playwright/test' in deps || 'playwright' in deps) {
+        const cmd = _script_command(scripts, ['test:e2e', 'e2e', 'playwright']) || 'npx playwright test';
+        out.push(
+            new RunnerResult('js', 'playwright', cmd, SPEED_E2E, HIGH, '@playwright/test in package deps'),
+        );
+    } else if ('cypress' in deps) {
+        const cmd = _script_command(scripts, ['test:e2e', 'e2e', 'cypress']) || 'npx cypress run';
+        out.push(new RunnerResult('js', 'cypress', cmd, SPEED_E2E, HIGH, 'cypress in package deps'));
+    }
+
+    // slow bucket — an explicit slow/integration script.
+    const slow_cmd = _script_command(scripts, ['test:slow', 'test:integration']);
+    if (slow_cmd) {
+        out.push(
+            new RunnerResult(
+                'js',
+                'vitest' in deps ? 'vitest' : 'jest',
+                slow_cmd,
+                SPEED_SLOW,
+                MEDIUM,
+                'test:slow/integration script',
+            ),
+        );
+    }
+    return out;
+}
+
+function _python_runners(pyproject_text: string): RunnerResult[] {
+    if (pyproject_text.includes('pytest') || pyproject_text === '') {
+        const conf = pyproject_text.includes('pytest') ? HIGH : MEDIUM;
+        const basis = pyproject_text.includes('pytest')
+            ? 'pytest in pyproject'
+            : 'python project, no explicit runner';
+        return [new RunnerResult('python', 'pytest', 'pytest', SPEED_FAST, conf, basis)];
+    }
+    return [
+        new RunnerResult('python', 'pytest', 'pytest', SPEED_FAST, MEDIUM, 'python project, no explicit runner'),
+    ];
+}
+
+function _php_quality(root: string, composer: Manifest, _wrappers: Wrappers): string[] {
+    const deps = _all_dependencies(composer, 'require', 'require-dev');
+    const out: string[] = [];
+    if ('phpstan/phpstan' in deps || _is_file(path.join(root, 'vendor', 'bin', 'phpstan'))) {
+        out.push('vendor/bin/phpstan analyse');
+    }
+    if ('laravel/pint' in deps || _is_file(path.join(root, 'vendor', 'bin', 'pint'))) {
+        out.push('vendor/bin/pint');
+    }
+    return out;
+}
+
+function _js_quality(pkg: Manifest, _wrappers: Wrappers): string[] {
+    const deps = _all_dependencies(
+        pkg,
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+    );
+    const out: string[] = [];
+    if ('typescript' in deps) {
+        out.push('npx tsc --noEmit');
+    }
+    if ('eslint' in deps) {
+        out.push('npx eslint .');
+    }
+    return out;
+}
+
+function _python_quality(pyproject_text: string): string[] {
+    const out: string[] = [];
+    if (pyproject_text.includes('ruff')) {
+        out.push('ruff check');
+    }
+    if (pyproject_text.includes('mypy')) {
+        out.push('mypy .');
+    }
+    return out;
+}
+
+// --------------------------------------------------------------------------
+// Task-runner wrappers (Makefile / Taskfile / package scripts)
+// --------------------------------------------------------------------------
+
+/**
+ * Map logical roles to a wrapper command when one exists.
+ *
+ * Wrappers win over direct tool invocation (they handle container access,
+ * env, parallelism) — the architecture rule's "Build / Task Runner
+ * Detection". Returns role → command; absent roles fall through to the
+ * direct tool.
+ */
+function _task_runner_wrappers(root: string, pkg: Manifest): Wrappers {
+    const out: Wrappers = {};
+    const makefile = _read_text(path.join(root, 'Makefile'));
+    const taskfile =
+        _read_text(path.join(root, 'Taskfile.yml')) || _read_text(path.join(root, 'Taskfile.yaml'));
+    if (makefile && _reSearch(/^test\s*:/m, makefile)) {
+        out['php-test'] = 'make test';
+    } else if (taskfile && _reSearch(/^\s*test\s*:/m, taskfile)) {
+        out['php-test'] = 'task test';
+    }
+    const scripts: Manifest = _isDict(pkg.scripts) ? pkg.scripts : {};
+    if (_isDict(scripts) && 'test' in scripts) {
+        out['js-test'] = `${_package_manager(root)} test`;
+    }
+    return out;
+}
+
+function _package_manager(root: string): string {
+    if (_is_file(path.join(root, 'pnpm-lock.yaml'))) {
+        return 'pnpm';
+    }
+    if (_is_file(path.join(root, 'yarn.lock'))) {
+        return 'yarn';
+    }
+    return 'npm';
+}
+
+// --------------------------------------------------------------------------
+// Monorepo guard + confidence
+// --------------------------------------------------------------------------
+
+function _apply_guard(
+    runners: RunnerResult[],
+    opts: { include_slow: boolean; include_e2e: boolean; php_only: boolean },
+): RunnerResult[] {
+    const out: RunnerResult[] = [];
+    for (const r of runners) {
+        if (opts.php_only && r.ecosystem !== 'php') {
+            continue;
+        }
+        if (r.speed === SPEED_E2E && !opts.include_e2e) {
+            continue;
+        }
+        if (r.speed === SPEED_SLOW && !opts.include_slow) {
+            continue;
+        }
+        out.push(r);
+    }
+    return out;
+}
+
+function _overall_confidence(runners: RunnerResult[]): string {
+    if (runners.length === 0) {
+        return LOW;
+    }
+    if (runners.some((r) => r.confidence === HIGH)) {
+        return HIGH;
+    }
+    return MEDIUM;
+}
+
+// --------------------------------------------------------------------------
+// Shared readers (mirror detect.py's recoverable-error contract)
+// --------------------------------------------------------------------------
+
+function _read_json(p: string): Manifest {
+    if (!_is_file(p)) {
+        return {};
+    }
+    let payload: unknown;
+    try {
+        payload = JSON.parse(fs.readFileSync(p, { encoding: 'utf-8' }));
+    } catch {
+        return {};
+    }
+    return _isDict(payload) ? payload : {};
+}
+
+function _read_text(p: string): string {
+    if (!_is_file(p)) {
+        return '';
+    }
+    try {
+        return fs.readFileSync(p, { encoding: 'utf-8' });
+    } catch {
+        return '';
+    }
+}
+
+function _all_dependencies(manifest: Manifest, ...keys: string[]): Manifest {
+    const merged: Manifest = {};
+    for (const key of keys) {
+        const section = manifest[key];
+        if (_isDict(section)) {
+            Object.assign(merged, section);
+        }
+    }
+    return merged;
+}
+
+function _script_uses(scripts: Manifest, name: string, tool: string): boolean {
+    const value = scripts[name];
+    return typeof value === 'string' && value.includes(tool);
+}
+
+function _script_command(scripts: Manifest, names: string[]): string {
+    for (const name of names) {
+        if (typeof scripts[name] === 'string') {
+            return `npm run ${name}`;
+        }
+    }
+    return '';
+}
+
+// --------------------------------------------------------------------------
+// stdlib parity helpers
+// --------------------------------------------------------------------------
+
+/** Python `Path.is_file()` — true only for a regular file (follows symlinks). */
+function _is_file(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Python `Path.stat().st_mtime` in POSIX seconds — see the matching note in
+ * `detect.ts`. Only `to_config` / `write_config` serialize this value, and
+ * the parity tests treat the serialized `mtime` as non-deterministic.
+ */
+function _stat_mtime(p: string): number {
+    const st = fs.statSync(p, { bigint: true });
+    return Number(st.mtimeNs) / 1e9;
+}
+
+/** Python `isinstance(x, dict)` — a plain (non-array, non-null) object. */
+function _isDict(v: unknown): v is Manifest {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Python `re.search(pattern, text)` truthiness. The patterns used here carry
+ * the multiline flag (`(?m)` in the source → `/m` here), so `^`/`$` match at
+ * line boundaries exactly like CPython's `re`.
+ */
+function _reSearch(pattern: RegExp, text: string): boolean {
+    return pattern.test(text);
+}
+
+/**
+ * Python `tuple(dict.fromkeys(seq))` — dedupe preserving first-seen insertion
+ * order. `dict.fromkeys` keeps the first occurrence's position; a JS `Set`
+ * built by iteration does the same, so `[...new Set(seq)]` is faithful.
+ */
+function _dictFromKeys(seq: string[]): string[] {
+    return [...new Set(seq)];
+}
+
+// --------------------------------------------------------------------------
+// JSON serialisation — byte-parity with `json.dumps(..., indent=2,
+// sort_keys=True)` for `write_config`.
+// --------------------------------------------------------------------------
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, sort_keys=True)` byte-for-byte.
+ *
+ * Two CPython behaviours that `JSON.stringify` does NOT reproduce on its own
+ * and are reproduced here:
+ *
+ * - `sort_keys=True` — object keys emitted in code-point ascending order.
+ *   `JSON.stringify` preserves insertion order; we pre-sort recursively.
+ * - integer-valued floats render as `N.0` (e.g. `1767222000.0`). JSON has no
+ *   float/int tag, so a JS `number` that is integral renders without `.0`.
+ *   In this module the only float is `mtime`; the parity tests normalize it
+ *   (its exact byte-repr is not reproducible across CPython/V8), but the
+ *   serialiser still applies the `N.0` rule via a tagged float wrapper so the
+ *   *shape* matches. `mtime` is the sole value passed through that wrapper.
+ *
+ * 2-space indent, `": "` key separator, `","` item separator with the
+ * indent-driven newline, `{}` / `[]` for empties, non-ASCII verbatim
+ * (`ensure_ascii` defaults to `True` in CPython, but `to_config` carries no
+ * non-ASCII, so the distinction never surfaces).
+ */
+function jsonDumps(obj: unknown, opts: { indent: number; sort_keys: boolean }): string {
+    return _encode(obj, opts, 0);
+}
+
+const _INDENT_UNIT = ' ';
+
+function _encode(value: unknown, opts: { indent: number; sort_keys: boolean }, depth: number): string {
+    if (value === null) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _encodeNumber(value, false);
+    }
+    if (value instanceof _PyFloat) {
+        return _encodeNumber(value.value, true);
+    }
+    if (typeof value === 'string') {
+        return JSON.stringify(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const inner = _INDENT_UNIT.repeat(opts.indent * (depth + 1));
+        const items = value.map((v) => inner + _encode(v, opts, depth + 1));
+        const close = _INDENT_UNIT.repeat(opts.indent * depth);
+        return '[\n' + items.join(',\n') + '\n' + close + ']';
+    }
+    if (_isDict(value)) {
+        let keys = Object.keys(value);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        if (opts.sort_keys) {
+            keys = keys.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+        }
+        const inner = _INDENT_UNIT.repeat(opts.indent * (depth + 1));
+        const items = keys.map(
+            (k) => inner + JSON.stringify(k) + ': ' + _encode(value[k], opts, depth + 1),
+        );
+        const close = _INDENT_UNIT.repeat(opts.indent * depth);
+        return '{\n' + items.join(',\n') + '\n' + close + '}';
+    }
+    // Unreachable for `to_config` output; mirror `json.dumps` raising on an
+    // unserialisable type would require a TypeError — return the JS default.
+    return JSON.stringify(value);
+}
+
+/**
+ * Render a number like CPython's `float.__repr__` / `int.__repr__` inside
+ * `json.dumps`. When `isFloat` is set and the value is integral, append
+ * `.0` (Python's float repr). Non-integral floats use JS's shortest
+ * round-trip repr — which matches CPython's `repr(float)` for the values
+ * that arise here. (The `mtime` field is normalized by the parity tests, so
+ * any residual last-digit divergence on exotic sub-second timestamps is not
+ * load-bearing.)
+ */
+function _encodeNumber(n: number, isFloat: boolean): string {
+    if (isFloat && Number.isInteger(n)) {
+        return `${n}.0`;
+    }
+    return String(n);
+}
+
+/** Tag wrapper marking a JS number that must serialise with Python float repr. */
+class _PyFloat {
+    readonly value: number;
+    constructor(value: number) {
+        this.value = value;
+    }
+}
+
+/**
+ * Wrap a numeric value so {@link jsonDumps} renders it as a Python float
+ * (integer-valued → `N.0`). Exported for the parity tests / callers that
+ * round-trip a `ToolchainResult` through `to_config`.
+ */
+export function pyFloat(value: number): _PyFloat {
+    return new _PyFloat(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/state_io.ts
+++ b/src/agent-src/templates/scripts/work_engine/state_io.ts
@@ -1,0 +1,408 @@
+/**
+ * State-file I/O helpers for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/state_io.py` (ADR-094 py2ts Phase 1 —
+ * work_engine foundation). Public API names stay snake_case to mirror the
+ * Python module 1:1 (per ADR-094 — Python style is part of the contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Holds
+ * the format-preserving load/save pair, the v0 legacy serialiser, the JSON
+ * reader, the `DeliveryState` projection helpers, and the legacy-file
+ * migration hint. Behaviour is byte-identical to the pre-split version —
+ * Goldens stay green.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { DEFAULT_STATE_FILE, LEGACY_STATE_FILE, _FMT_V0, _FMT_V1 } from './cli_args.js';
+import {
+    DeliveryState,
+    type Any as DeliveryAny,
+} from './delivery_state.js';
+import { _CLIError } from './errors.js';
+import {
+    DEFAULT_DIRECTIVE_SET,
+    DEFAULT_INTENT,
+    SCHEMA_VERSION,
+    SchemaError,
+    WorkState,
+    type Dict,
+    type JsonValue,
+    from_dict as _state_from_dict,
+    to_dict as _state_to_dict,
+} from './state.js';
+
+/**
+ * Surface a migration hint when only the pre-1.15.0 file is present.
+ *
+ * The dispatcher renamed the default state file from
+ * `.implement-ticket-state.json` to `.work-state.json` in 1.15.0
+ * (alongside the `implement_ticket → work_engine` package move).
+ * Existing checkouts that still carry the legacy file would otherwise
+ * fail with a generic "no state file" message. This helper detects
+ * the legacy file in the same directory and points the user at the
+ * one-shot migration command instead.
+ *
+ * Only fires when `state_file` has the canonical default name and
+ * sits next to a legacy file — explicit `--state-file` overrides
+ * bypass the hint so power users can carry their own naming scheme.
+ */
+export function _maybe_raise_legacy_hint(state_file: string): void {
+    // Python compares `state_file.name` (the basename) against the default's
+    // basename. The constants are plain strings (no directory part), so
+    // `path.basename(state_file)` vs the constant matches `Path.name`.
+    if (path.basename(state_file) !== path.basename(DEFAULT_STATE_FILE)) {
+        return;
+    }
+    // `state_file.with_name(LEGACY_STATE_FILE.name)` — same directory, legacy
+    // basename.
+    const legacy_candidate = path.join(path.dirname(state_file), path.basename(LEGACY_STATE_FILE));
+    if (!_isFile(legacy_candidate)) {
+        return;
+    }
+    throw new _CLIError(
+        `Found legacy state file ${legacy_candidate} but no ` +
+            `${state_file}. The default state file was renamed in 1.15.0. ` +
+            `Run \`python3 -m work_engine.migration.v0_to_v1 ` +
+            `${legacy_candidate}\` to migrate, or pass \`--state-file ` +
+            `${legacy_candidate}\` to keep using the old name. See ` +
+            'docs/MIGRATION.md.',
+    );
+}
+
+/** Load `state_file` and tag it with the wire format detected. */
+export function _load(state_file: string): [WorkState, string] {
+    const data = _read_json(state_file);
+    if (!_isPlainDict(data)) {
+        throw new _CLIError(
+            `State file ${state_file} must carry a JSON object; ` +
+                `got ${_pyTypeName(data)}.`,
+        );
+    }
+    const d = data as Record<string, JsonValue>;
+
+    // v1 declares `version`; v0 has none. Anything else is invalid.
+    if (_get(d, 'version', undefined) === SCHEMA_VERSION) {
+        try {
+            return [_state_from_dict(d as JsonValue), _FMT_V1];
+        } catch (exc) {
+            if (exc instanceof SchemaError) {
+                throw new _CLIError(`State file shape is invalid: ${exc.message}`);
+            }
+            throw exc;
+        }
+    }
+    if ('version' in d) {
+        throw new _CLIError(
+            `State file shape is invalid: unsupported version ` +
+                `${_pyRepr(_get(d, 'version', undefined))}; expected ${SCHEMA_VERSION}`,
+        );
+    }
+    if (!('ticket' in d)) {
+        throw new _CLIError(
+            "State file shape is invalid: missing 'ticket' (v0) or " +
+                "'version' (v1) — file is neither shape.",
+        );
+    }
+    try {
+        const migrated = migrate_payload(d);
+        return [_state_from_dict(migrated as JsonValue), _FMT_V0];
+    } catch (exc) {
+        if (exc instanceof SchemaError) {
+            throw new _CLIError(`State file shape is invalid: ${exc.message}`);
+        }
+        throw exc;
+    }
+}
+
+/**
+ * Project `work` into a `DeliveryState` for handler dispatch.
+ *
+ * R1 P4 S1 (Option A2): handlers continue to consume `DeliveryState`
+ * with `state.ticket`; the `WorkState` wrapper exists at the CLI
+ * boundary so the dispatcher's directive-set selection has a v1
+ * state object to read `directive_set` from. Mutable containers
+ * (`memory`, `changes`, `outcomes`, `questions`) are passed
+ * by reference — in-place mutations land on both objects without an
+ * explicit sync. Reassignments (`state.plan = …`, `state.report = …`)
+ * are mirrored back by {@link _sync_back}.
+ */
+export function _to_delivery(work: WorkState): DeliveryState {
+    return new DeliveryState({
+        ticket: work.input.data as Record<string, DeliveryAny>,
+        persona: work.persona,
+        memory: work.memory as Array<Record<string, DeliveryAny>>,
+        plan: work.plan,
+        changes: work.changes as Array<Record<string, DeliveryAny>>,
+        tests: work.tests,
+        verify: work.verify,
+        outcomes: work.outcomes,
+        questions: work.questions,
+        report: work.report,
+        ui_audit: work.ui_audit as Record<string, DeliveryAny> | null,
+        ui_design: work.ui_design as Record<string, DeliveryAny> | null,
+        ui_review: work.ui_review as Record<string, DeliveryAny> | null,
+        ui_polish: work.ui_polish as Record<string, DeliveryAny> | null,
+        contract: work.contract as Record<string, DeliveryAny> | null,
+        stitch: work.stitch as Record<string, DeliveryAny> | null,
+        stack: work.stack as Record<string, DeliveryAny> | null,
+    });
+}
+
+/**
+ * Mirror handler mutations from `delivery` back into `work`.
+ *
+ * Container fields are shared by reference (see {@link _to_delivery})
+ * so the assignment is a no-op for those — we still mirror them
+ * defensively to cover the case where a handler reassigned the
+ * attribute (`state.memory = [new_list]`) instead of mutating in
+ * place.
+ */
+export function _sync_back(work: WorkState, delivery: DeliveryState): void {
+    work.input.data = delivery.ticket as Dict;
+    work.persona = delivery.persona;
+    work.memory = delivery.memory as Dict[];
+    work.plan = delivery.plan as JsonValue;
+    work.changes = delivery.changes as Dict[];
+    work.tests = delivery.tests as JsonValue;
+    work.verify = delivery.verify as JsonValue;
+    work.outcomes = delivery.outcomes;
+    work.questions = delivery.questions;
+    work.report = delivery.report;
+    work.ui_audit = delivery.ui_audit as Dict | null;
+    work.ui_design = delivery.ui_design as Dict | null;
+    work.ui_review = delivery.ui_review as Dict | null;
+    work.ui_polish = delivery.ui_polish as Dict | null;
+    work.contract = delivery.contract as Dict | null;
+    work.stitch = delivery.stitch as Dict | null;
+    work.stack = delivery.stack as Dict | null;
+}
+
+/**
+ * Persist `work` in the wire format it was loaded with.
+ *
+ * v1 emits the canonical envelope via {@link _state_to_dict}; v0 emits the
+ * legacy flat shape that `DeliveryState.asdict` used to produce, byte-identical
+ * to the pre-Phase-4 output so the Golden Transcript replay stays green.
+ */
+export function _save(state_file: string, work: WorkState, fmt: string): void {
+    fs.mkdirSync(path.dirname(state_file), { recursive: true });
+    const payload = fmt === _FMT_V1 ? _state_to_dict(work) : _to_v0_dict(work);
+    fs.writeFileSync(
+        state_file,
+        _jsonDumps(payload) + '\n',
+        'utf-8',
+    );
+}
+
+/**
+ * Serialise `work` in the legacy v0 wire format.
+ *
+ * Field order matches `DeliveryState` declaration order so
+ * pre-Phase-4 state files round-trip byte-equal.
+ */
+export function _to_v0_dict(work: WorkState): Dict {
+    return {
+        ticket: work.input.data,
+        persona: work.persona,
+        memory: work.memory,
+        plan: work.plan,
+        changes: work.changes,
+        tests: work.tests,
+        verify: work.verify,
+        outcomes: work.outcomes,
+        questions: work.questions,
+        report: work.report,
+    };
+}
+
+export function _read_json(p: string): JsonValue {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(p, 'utf-8');
+    } catch (exc) {
+        // Python `OSError` → "Cannot read {path}: {exc}".
+        throw new _CLIError(`Cannot read ${p}: ${_osErrorText(exc, p)}`);
+    }
+    try {
+        return JSON.parse(raw) as JsonValue;
+    } catch (exc) {
+        // Python `json.JSONDecodeError` → "Invalid JSON in {path}: {exc}".
+        throw new _CLIError(`Invalid JSON in ${p}: ${(exc as Error).message}`);
+    }
+}
+
+// ── Inlined v0→v1 payload migration ──────────────────────────────────────
+//
+// The Python source imports `migrate_payload` from
+// `work_engine.migration.v0_to_v1`. A `.ts` twin may not import a `.py`
+// (ADR-094), and the full `v0_to_v1` module (with its CLI / `migrate_file`
+// surface) lands in a later phase. The `migrate_payload` slice `_load` needs
+// is reproduced here verbatim so the load path stays byte-identical; when the
+// `v0_to_v1.ts` twin lands it can re-export this or replace it 1:1.
+
+/**
+ * Return the v1 form of `payload`.
+ *
+ * A payload that already declares `version: 1` is returned unchanged
+ * (deep-copied via `JSON.parse(JSON.stringify(...))` so the caller cannot
+ * accidentally mutate the input). Anything else is treated as v0 and wrapped:
+ * `ticket` becomes `input.data`, `input.kind` is set to `"ticket"`, and the
+ * engine defaults are filled in.
+ *
+ * @throws SchemaError If the payload is not a dict, declares a higher version
+ *   than this migration knows about, or lacks a `ticket` key.
+ */
+export function migrate_payload(payload: JsonValue): Dict {
+    if (!_isPlainDict(payload)) {
+        throw new SchemaError(
+            `v0 state must be a JSON object; got ${_pyTypeName(payload)}`,
+        );
+    }
+    const p = payload as Record<string, JsonValue>;
+
+    const declared_version = _get(p, 'version', undefined);
+    if (declared_version === SCHEMA_VERSION) {
+        return JSON.parse(JSON.stringify(p)) as Dict;
+    }
+    if (declared_version !== undefined && declared_version !== null) {
+        throw new SchemaError(
+            `cannot migrate from version ${_pyRepr(declared_version)} to ` +
+                `${SCHEMA_VERSION}; this script only handles v0 (no version key)`,
+        );
+    }
+
+    if (!('ticket' in p)) {
+        throw new SchemaError(
+            "v0 state must carry a 'ticket' key; got keys: " +
+                _pyReprList(_sortedStr(Object.keys(p))),
+        );
+    }
+    const ticket = p['ticket'];
+    if (!_isPlainDict(ticket)) {
+        throw new SchemaError(
+            `v0 state.ticket must be a JSON object; got ${_pyTypeName(ticket)}`,
+        );
+    }
+
+    return {
+        version: SCHEMA_VERSION,
+        input: { kind: 'ticket', data: ticket },
+        intent: DEFAULT_INTENT,
+        directive_set: DEFAULT_DIRECTIVE_SET,
+        persona: _get(p, 'persona', 'senior-engineer') as JsonValue,
+        memory: [...((_get(p, 'memory', []) as JsonValue[]) ?? [])],
+        plan: _get(p, 'plan', null) as JsonValue,
+        changes: [...((_get(p, 'changes', []) as JsonValue[]) ?? [])],
+        tests: _get(p, 'tests', null) as JsonValue,
+        verify: _get(p, 'verify', null) as JsonValue,
+        outcomes: { ...((_get(p, 'outcomes', {}) as Dict) ?? {}) },
+        questions: [...((_get(p, 'questions', []) as JsonValue[]) ?? [])],
+        report: _get(p, 'report', '') as JsonValue,
+    };
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, ensure_ascii=False)`.
+ *
+ * For round-tripped JSON, `JSON.stringify` with a 2-space indent matches
+ * CPython byte-for-byte: 2-space indent, `": "` key separator, `{}` / `[]`
+ * for empties, non-ASCII verbatim. Same rationale as `state.ts::jsonDumps`:
+ * no float/int tag survives JSON parsing, so the CPython `N.0` divergence
+ * cannot arise here.
+ */
+function _jsonDumps(obj: Dict): string {
+    return JSON.stringify(obj, null, 2);
+}
+
+/** `dict.get(key, default)`. */
+function _get(obj: Record<string, JsonValue>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _isFile(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+/** Python `type(x).__name__` for the JSON value shapes the messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/** Python `repr(x)` for the scalar shapes interpolated via `{value!r}`. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `repr(list_of_str)` — `['a', 'b']`. */
+function _pyReprList(values: string[]): string {
+    return '[' + values.map((v) => _pyRepr(v)).join(', ') + ']';
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/**
+ * Approximate the text of Python's `OSError` for a failed read. Python
+ * formats `errno`-based messages like "[Errno 2] No such file or directory:
+ * 'path'". Node's error `.message` is shaped differently, so this is one of
+ * the few non-byte-identical surfaces — the error *channel* (exit 2 via
+ * `_CLIError`) and the *prefix* ("Cannot read <path>: ") stay identical;
+ * only the trailing OS detail differs. Tests normalise this trailing detail.
+ */
+function _osErrorText(exc: unknown, p: string): string {
+    const e = exc as NodeJS.ErrnoException;
+    if (e && e.code === 'ENOENT') {
+        return `[Errno 2] No such file or directory: '${p}'`;
+    }
+    if (e && e.code === 'EISDIR') {
+        return `[Errno 21] Is a directory: '${p}'`;
+    }
+    if (e && e.code === 'EACCES') {
+        return `[Errno 13] Permission denied: '${p}'`;
+    }
+    return e && e.message ? e.message : String(exc);
+}

--- a/tests/scripts/work_engine/intent_classify.test.ts
+++ b/tests/scripts/work_engine/intent_classify.test.ts
@@ -1,0 +1,248 @@
+// Golden-parity rig for the py2ts work_engine `intent/classify` twin (ADR-094).
+//
+// `intent/classify.py` imports `from ..state import WorkState` only under
+// TYPE_CHECKING, so the runtime module is stdlib-only and loads cleanly with
+// the `from ..state import` lines rewritten (defensive — the TYPE_CHECKING
+// guard means no rewrite is strictly needed, but the rewrite is harmless and
+// keeps the loader uniform with the resolver rigs).
+//
+// `classify_intent` and `directive_set_for` are pure string functions — the
+// harness drives both engines from the same prompt/title and asserts identical
+// labels and identical ValueError text. `populate_routing` mutates a WorkState
+// in place; it is exercised TS-side (it needs the WorkState class) and its
+// classifier delegate is covered by the golden cases.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { Input, WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+import {
+    INTENT_BACKEND,
+    INTENT_MIXED,
+    INTENT_UI_BUILD,
+    INTENT_UI_IMPROVE,
+    INTENT_UI_TRIVIAL,
+    KNOWN_INTENTS,
+    ValueError,
+    classify_intent,
+    directive_set_for,
+    populate_routing,
+} from '../../../src/agent-src/templates/scripts/work_engine/intent/classify.js';
+
+const REPO_ROOT = path.resolve(
+    fileURLToPath(import.meta.url),
+    '..',
+    '..',
+    '..',
+    '..',
+);
+
+const WE = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+const STATE_PY = path.join(WE, 'state.py');
+const CLASSIFY_PY = path.join(WE, 'intent', 'classify.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
+        'state = importlib.util.module_from_spec(_sspec)',
+        'sys.modules["state"] = state',
+        '_sspec.loader.exec_module(state)',
+        `_src = open(${JSON.stringify(CLASSIFY_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ..state import WorkState", "from state import WorkState")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], {
+        encoding: 'utf8',
+    });
+}
+
+/** Python classify_intent(raw, title=...). args: rawJson, titleJson (or "null"). */
+function pyClassify(rawJson: string, titleJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'title = json.loads(sys.argv[2])',
+        'sys.stdout.write(mod.classify_intent(raw, title=title))',
+    ].join('\n');
+    const r = runPy(body, [rawJson, titleJson]);
+    if (r.status !== 0) throw new Error(`py classify failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function pyDirectiveSet(intentJson: string): string {
+    const body = [
+        'intent = json.loads(sys.argv[1])',
+        'sys.stdout.write(mod.directive_set_for(intent))',
+    ].join('\n');
+    const r = runPy(body, [intentJson]);
+    if (r.status !== 0) throw new Error(`py directive_set failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function pyDirectiveSetError(intentJson: string): string {
+    const body = [
+        'intent = json.loads(sys.argv[1])',
+        'try:',
+        '    mod.directive_set_for(intent)',
+        '    sys.stdout.write("__NO_ERROR__")',
+        'except ValueError as exc:',
+        '    sys.stdout.write(str(exc))',
+    ].join('\n');
+    const r = runPy(body, [intentJson]);
+    if (r.status !== 0) throw new Error(`py directive_set error-probe failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsClassify(rawJson: string, titleJson: string): string {
+    const raw = JSON.parse(rawJson) as string;
+    const title = JSON.parse(titleJson) as string | null;
+    return classify_intent(raw, { title });
+}
+
+function tsDirectiveSetError(intentJson: string): string {
+    try {
+        directive_set_for(JSON.parse(intentJson) as string);
+        return '__NO_ERROR__';
+    } catch (exc) {
+        return (exc as Error).message;
+    }
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+// [raw, title-or-null] prompt fixtures spanning every ladder rung.
+const CLASSIFY_CASES: Array<[string, string, string]> = [
+    ['empty → backend', '', 'null'],
+    ['whitespace → backend', '   \t ', 'null'],
+    ['plain backend prompt', 'add a webhook listener for the queue', 'null'],
+    ['trivial: make the button red', 'make the button red', 'null'],
+    ['trivial: rename the label (verb + short)', 'rename the sidebar label', 'null'],
+    ['trivial verb but long (>14 words) → not trivial', 'change the button color and also rework the entire dashboard layout with new cards and panels everywhere', 'null'],
+    ['mixed: form + endpoint', 'build a form that posts to a new API endpoint', 'null'],
+    ['mixed: page + migration', 'the dashboard page needs a schema migration', 'null'],
+    ['ui-improve: improve the modal', 'improve the modal spacing', 'null'],
+    ['ui-improve: existing surface marker', 'work on the existing dashboard page', 'null'],
+    ['ui-build: add a new component', 'add a new sidebar component', 'null'],
+    ['ui-build: new screen marker', 'design a new screen for onboarding', 'null'],
+    ['ui signal, no verb → ui-improve default', 'the navigation sidebar', 'null'],
+    ['ui via style word only (css)', 'tweak the css padding', 'null'],
+    ['title carries the UI signal', 'do the thing', JSON.stringify('Redesign the dashboard page')],
+    ['title + body concatenated', 'with grid layout', JSON.stringify('New tile component')],
+    ['backend word table is NOT a UI noun', 'add an index on the users table', 'null'],
+    ['style multiword dark mode', 'support dark mode on the page', 'null'],
+    ['trivial pattern across <=40 chars span', 'set the header text to primary', 'null'],
+    ['improve verb fix on a panel', 'fix the panel border', 'null'],
+];
+
+describePy('intent/classify — classify_intent label parity (python3 vs tsx)', () => {
+    for (const [label, raw, title] of CLASSIFY_CASES) {
+        it(`identical label — ${label}`, () => {
+            const py = pyClassify(JSON.stringify(raw), title);
+            const ts = tsClassify(JSON.stringify(raw), title);
+            expect(ts).toBe(py);
+        });
+    }
+});
+
+describePy('intent/classify — directive_set_for parity (python3 vs tsx)', () => {
+    for (const intent of [...KNOWN_INTENTS]) {
+        it(`identical directive set — ${intent}`, () => {
+            const py = pyDirectiveSet(JSON.stringify(intent));
+            const ts = directive_set_for(intent);
+            expect(ts).toBe(py);
+        });
+    }
+
+    const badCases = ['bogus', 'BACKEND', '', 'ui-build '];
+    for (const bad of badCases) {
+        it(`identical ValueError text — ${JSON.stringify(bad)}`, () => {
+            const py = pyDirectiveSetError(JSON.stringify(bad));
+            const ts = tsDirectiveSetError(JSON.stringify(bad));
+            expect(py).not.toBe('__NO_ERROR__');
+            expect(ts).toBe(py);
+        });
+    }
+});
+
+describe('intent/classify — TS-side unit checks (no python3 needed)', () => {
+    it('label constants', () => {
+        expect(INTENT_BACKEND).toBe('backend-coding');
+        expect(INTENT_MIXED).toBe('mixed');
+        expect([...KNOWN_INTENTS].sort()).toEqual([
+            'backend-coding',
+            'mixed',
+            'ui-build',
+            'ui-improve',
+            'ui-trivial',
+        ]);
+    });
+
+    it('directive_set_for maps every label', () => {
+        expect(directive_set_for(INTENT_UI_BUILD)).toBe('ui');
+        expect(directive_set_for(INTENT_UI_IMPROVE)).toBe('ui');
+        expect(directive_set_for(INTENT_UI_TRIVIAL)).toBe('ui-trivial');
+        expect(directive_set_for(INTENT_MIXED)).toBe('mixed');
+        expect(directive_set_for(INTENT_BACKEND)).toBe('backend');
+    });
+
+    it('directive_set_for throws ValueError on unknown', () => {
+        expect(() => directive_set_for('nope')).toThrow(ValueError);
+    });
+
+    it('populate_routing: diff/file route straight to ui-improve', () => {
+        const st = new WorkState({ input: new Input('diff', { raw: '--- a\n+++ b\n@@ -1 +1 @@\n' }) });
+        populate_routing(st);
+        expect(st.intent).toBe('ui-improve');
+        expect(st.directive_set).toBe('ui');
+    });
+
+    it('populate_routing: prompt envelope classifies from raw', () => {
+        const st = new WorkState({ input: new Input('prompt', { raw: 'make the button red' }) });
+        populate_routing(st);
+        expect(st.intent).toBe('ui-trivial');
+        expect(st.directive_set).toBe('ui-trivial');
+    });
+
+    it('populate_routing: ticket uses title + first AC', () => {
+        const st = new WorkState({
+            input: new Input('ticket', {
+                title: 'Redesign the dashboard',
+                acceptance_criteria: ['improve the layout', ''],
+            }),
+        });
+        populate_routing(st);
+        expect(st.intent).toBe('ui-improve');
+    });
+
+    it('populate_routing: idempotent / override-safe (non-backend untouched)', () => {
+        const st = new WorkState({
+            input: new Input('prompt', { raw: 'make the button red' }),
+            intent: 'mixed',
+            directive_set: 'mixed',
+        });
+        populate_routing(st);
+        expect(st.intent).toBe('mixed');
+        expect(st.directive_set).toBe('mixed');
+    });
+
+    it('populate_routing: backend default stays backend', () => {
+        const st = new WorkState({ input: new Input('prompt', { raw: 'add a queue worker' }) });
+        populate_routing(st);
+        expect(st.intent).toBe('backend-coding');
+        expect(st.directive_set).toBe('backend');
+    });
+});

--- a/tests/scripts/work_engine/resolvers_diff.test.ts
+++ b/tests/scripts/work_engine/resolvers_diff.test.ts
@@ -1,0 +1,169 @@
+// Golden-parity rig for the py2ts work_engine `resolvers/diff` twin (ADR-094).
+//
+// Loads `state.py` as module `state`, then loads `resolvers/diff.py` with its
+// `from ..state import Input` rewritten to `from state import Input`. The diff
+// resolver does no subprocess / git work — it is a pure header-heuristic check
+// on the raw payload — so the golden harness compares the built `Input`
+// envelope and the reject-path error text on both engines.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DiffResolverError,
+    KIND,
+    build_envelope,
+} from '../../../src/agent-src/templates/scripts/work_engine/resolvers/diff.js';
+
+const REPO_ROOT = path.resolve(
+    fileURLToPath(import.meta.url),
+    '..',
+    '..',
+    '..',
+    '..',
+);
+
+const WE = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+const STATE_PY = path.join(WE, 'state.py');
+const RESOLVER_PY = path.join(WE, 'resolvers', 'diff.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
+        'state = importlib.util.module_from_spec(_sspec)',
+        'sys.modules["state"] = state',
+        '_sspec.loader.exec_module(state)',
+        `_src = open(${JSON.stringify(RESOLVER_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ..state import Input", "from state import Input")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], {
+        encoding: 'utf8',
+    });
+}
+
+function pyEnvelope(rawJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'env = mod.build_envelope(raw)',
+        'sys.stdout.write(json.dumps({"kind": env.kind, "data": env.data}, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [rawJson]);
+    if (r.status !== 0) throw new Error(`py envelope failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function pyError(rawJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'try:',
+        '    mod.build_envelope(raw)',
+        '    sys.stdout.write("__NO_ERROR__")',
+        'except mod.DiffResolverError as exc:',
+        '    sys.stdout.write(type(exc).__name__ + ": " + str(exc))',
+    ].join('\n');
+    const r = runPy(body, [rawJson]);
+    if (r.status !== 0) throw new Error(`py error-probe failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsEnvelope(rawJson: string): string {
+    const env = build_envelope(JSON.parse(rawJson));
+    return JSON.stringify({ kind: env.kind, data: env.data });
+}
+
+function tsError(rawJson: string): string {
+    try {
+        build_envelope(JSON.parse(rawJson));
+        return '__NO_ERROR__';
+    } catch (exc) {
+        return `${(exc as Error).name}: ${(exc as Error).message}`;
+    }
+}
+
+const GIT_DIFF = [
+    'diff --git a/foo.ts b/foo.ts',
+    'index e69de29..4b825dc 100644',
+    '--- a/foo.ts',
+    '+++ b/foo.ts',
+    '@@ -0,0 +1 @@',
+    '+const x = 1;',
+].join('\n');
+
+const UNIFIED_DIFF = [
+    '--- old.txt',
+    '+++ new.txt',
+    '@@ -1 +1 @@',
+    '-a',
+    '+b',
+].join('\n');
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('resolvers/diff — envelope parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['git diff', JSON.stringify(GIT_DIFF)],
+        ['unified diff', JSON.stringify(UNIFIED_DIFF)],
+        ['Index: header (SVN/CVS)', JSON.stringify('Index: foo\n===\n')],
+        ['hunk-header only (semantically empty diff accepted)', JSON.stringify('@@ -1 +1 @@')],
+        ['marker not at line start is still searched line-wise', JSON.stringify('prelude\n--- a\n')],
+        ['non-ASCII in diff body verbatim', JSON.stringify('--- a\n+++ b\n@@ -1 +1 @@\n+café ☕')],
+    ];
+    for (const [label, raw] of cases) {
+        it(`Input envelope parity — ${label}`, () => {
+            // py json.dumps uses ', ' separators; tsEnvelope is compact —
+            // the envelope content is the parity surface, not the separator style.
+            expect(JSON.parse(tsEnvelope(raw))).toEqual(JSON.parse(pyEnvelope(raw)));
+        });
+    }
+});
+
+describePy('resolvers/diff — error parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['empty string', JSON.stringify('')],
+        ['whitespace-only', JSON.stringify('  \n\t ')],
+        ['prose, no diff markers', JSON.stringify('please improve the dashboard layout')],
+        ['inline marker inside prose (not at line start)', JSON.stringify('the function `--- foo` failed')],
+        ['not a string — number', JSON.stringify(7)],
+        ['not a string — null', JSON.stringify(null)],
+        ['not a string — list', JSON.stringify(['x'])],
+        ['not a string — bool', JSON.stringify(false)],
+    ];
+    for (const [label, raw] of cases) {
+        it(`identical error class + message — ${label}`, () => {
+            const py = pyError(raw);
+            const ts = tsError(raw);
+            expect(py).not.toBe('__NO_ERROR__');
+            expect(ts).toBe(py);
+        });
+    }
+});
+
+describe('resolvers/diff — TS-side unit checks (no python3 needed)', () => {
+    it('KIND constant', () => {
+        expect(KIND).toBe('diff');
+    });
+    it('accepts a git diff and builds the canonical shape', () => {
+        const env = build_envelope(GIT_DIFF);
+        expect(env.kind).toBe('diff');
+        expect(env.data).toEqual({ raw: GIT_DIFF, reconstructed_ac: [], assumptions: [] });
+    });
+    it('rejects prose with no markers', () => {
+        expect(() => build_envelope('just words here')).toThrow(DiffResolverError);
+    });
+});

--- a/tests/scripts/work_engine/resolvers_file.test.ts
+++ b/tests/scripts/work_engine/resolvers_file.test.ts
@@ -1,0 +1,166 @@
+// Golden-parity rig for the py2ts work_engine `resolvers/file` twin (ADR-094).
+//
+// Loads `state.py` as module `state`, then loads `resolvers/file.py` with its
+// `from ..state import Input` rewritten to `from state import Input`. The file
+// resolver does NO filesystem I/O (existence checks are deferred to the audit
+// step); it only strips, rejects NUL / URLs, and POSIX-normalises backslashes
+// when `os.sep == "/"`. The harness asserts envelope + error parity. The
+// backslash-normalisation branch is host-conditional on both engines (it fires
+// only on POSIX `os.sep == "/"` / `path.sep === "/"`), so the macOS / Linux CI
+// runner exercises the same branch on both sides — reason: identical host.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    FileResolverError,
+    KIND,
+    build_envelope,
+} from '../../../src/agent-src/templates/scripts/work_engine/resolvers/file.js';
+
+const REPO_ROOT = path.resolve(
+    fileURLToPath(import.meta.url),
+    '..',
+    '..',
+    '..',
+    '..',
+);
+
+const WE = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+const STATE_PY = path.join(WE, 'state.py');
+const RESOLVER_PY = path.join(WE, 'resolvers', 'file.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
+        'state = importlib.util.module_from_spec(_sspec)',
+        'sys.modules["state"] = state',
+        '_sspec.loader.exec_module(state)',
+        `_src = open(${JSON.stringify(RESOLVER_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ..state import Input", "from state import Input")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], {
+        encoding: 'utf8',
+    });
+}
+
+function pyEnvelope(rawJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'env = mod.build_envelope(raw)',
+        'sys.stdout.write(json.dumps({"kind": env.kind, "data": env.data}, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [rawJson]);
+    if (r.status !== 0) throw new Error(`py envelope failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function pyError(rawJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'try:',
+        '    mod.build_envelope(raw)',
+        '    sys.stdout.write("__NO_ERROR__")',
+        'except mod.FileResolverError as exc:',
+        '    sys.stdout.write(type(exc).__name__ + ": " + str(exc))',
+    ].join('\n');
+    const r = runPy(body, [rawJson]);
+    if (r.status !== 0) throw new Error(`py error-probe failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsEnvelope(rawJson: string): string {
+    const env = build_envelope(JSON.parse(rawJson));
+    return JSON.stringify({ kind: env.kind, data: env.data });
+}
+
+function tsError(rawJson: string): string {
+    try {
+        build_envelope(JSON.parse(rawJson));
+        return '__NO_ERROR__';
+    } catch (exc) {
+        return `${(exc as Error).name}: ${(exc as Error).message}`;
+    }
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('resolvers/file — envelope parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['posix relative path', JSON.stringify('src/components/Sidebar.tsx')],
+        ['blade path', JSON.stringify('resources/views/dashboard.blade.php')],
+        ['absolute posix path preserved', JSON.stringify('/etc/hosts')],
+        ['single char path', JSON.stringify('a')],
+        ['surrounding whitespace stripped', JSON.stringify('  src/App.tsx  ')],
+        ['windows backslashes → posix on this host', JSON.stringify('resources\\views\\foo.blade.php')],
+        ['mixed separators', JSON.stringify('src\\a/b\\c.tsx')],
+        ['non-ASCII path verbatim', JSON.stringify('src/Héllo.tsx')],
+    ];
+    for (const [label, raw] of cases) {
+        it(`Input envelope parity — ${label}`, () => {
+            // py json.dumps uses ', ' separators; tsEnvelope is compact —
+            // the envelope content is the parity surface, not the separator style.
+            expect(JSON.parse(tsEnvelope(raw))).toEqual(JSON.parse(pyEnvelope(raw)));
+        });
+    }
+});
+
+describePy('resolvers/file — error parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['empty string', JSON.stringify('')],
+        ['whitespace-only', JSON.stringify('   \t ')],
+        ['NUL byte', JSON.stringify('src/' + String.fromCharCode(0) + 'evil.tsx')],
+        ['http URL', JSON.stringify('http://example.com/patch')],
+        ['https URL', JSON.stringify('https://example.com/x')],
+        ['ftp URL', JSON.stringify('ftp://host/f')],
+        ['file URL', JSON.stringify('file:///tmp/x')],
+        ['URL case-insensitive prefix', JSON.stringify('HTTPS://Example.com/A')],
+        // The repr-of-slice tail (`{stripped[:32]!r}`) — long URL exercises the
+        // 32-codepoint truncation byte-for-byte across engines.
+        ['long https URL truncated in message', JSON.stringify('https://example.com/very/long/path/that/exceeds/thirty-two/characters')],
+        ['url-ish with non-ascii in first 32', JSON.stringify('https://exämple.com/café-page')],
+        ['not a string — number', JSON.stringify(3)],
+        ['not a string — null', JSON.stringify(null)],
+        ['not a string — list', JSON.stringify([])],
+        ['not a string — object', JSON.stringify({})],
+        ['not a string — bool', JSON.stringify(true)],
+    ];
+    for (const [label, raw] of cases) {
+        it(`identical error class + message — ${label}`, () => {
+            const py = pyError(raw);
+            const ts = tsError(raw);
+            expect(py).not.toBe('__NO_ERROR__');
+            expect(ts).toBe(py);
+        });
+    }
+});
+
+describe('resolvers/file — TS-side unit checks (no python3 needed)', () => {
+    it('KIND constant', () => {
+        expect(KIND).toBe('file');
+    });
+    it('builds the canonical envelope and posix-normalises backslashes', () => {
+        const env = build_envelope('a\\b\\c.tsx');
+        expect(env.kind).toBe('file');
+        expect(env.data).toEqual({ path: 'a/b/c.tsx', reconstructed_ac: [], assumptions: [] });
+    });
+    it('rejects URLs', () => {
+        expect(() => build_envelope('https://x.com')).toThrow(FileResolverError);
+    });
+});

--- a/tests/scripts/work_engine/resolvers_prompt.test.ts
+++ b/tests/scripts/work_engine/resolvers_prompt.test.ts
@@ -1,0 +1,165 @@
+// Golden-parity rig for the py2ts work_engine `resolvers/prompt` twin (ADR-094).
+//
+// `resolvers/prompt.py` imports `from ..state import Input`. To exercise it
+// from python3 without importing the whole `work_engine` package (whose
+// `__init__` pulls in unported siblings), we load `state.py` as the module
+// `state`, then load the resolver source with its `from ..state import Input`
+// rewritten to `from state import Input` and exec it as a standalone module.
+//
+// Each block drives `build_envelope` on BOTH engines from the same payload and
+// asserts the serialised `Input` envelope (`{kind, data}`) is byte-identical,
+// plus matching error-class name + message text on the reject paths. The TS
+// side is exercised via the same module under `node node_modules/.bin/tsx`.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    KIND,
+    PromptResolverError,
+    build_envelope,
+} from '../../../src/agent-src/templates/scripts/work_engine/resolvers/prompt.js';
+
+const REPO_ROOT = path.resolve(
+    fileURLToPath(import.meta.url),
+    '..',
+    '..',
+    '..',
+    '..',
+);
+
+const WE = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+const STATE_PY = path.join(WE, 'state.py');
+const RESOLVER_PY = path.join(WE, 'resolvers', 'prompt.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Run a python3 snippet with `state.py` loaded as module `state` and the
+ * resolver loaded as module `mod` (its `from ..state import Input` rewritten
+ * to `from state import Input`). `args` become `sys.argv[1:]`.
+ */
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
+        'state = importlib.util.module_from_spec(_sspec)',
+        'sys.modules["state"] = state',
+        '_sspec.loader.exec_module(state)',
+        `_src = open(${JSON.stringify(RESOLVER_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ..state import Input", "from state import Input")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], {
+        encoding: 'utf8',
+    });
+}
+
+/** Python: build_envelope(arg) → json.dumps({"kind","data"}) of the Input. */
+function pyEnvelope(rawJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'env = mod.build_envelope(raw)',
+        'sys.stdout.write(json.dumps({"kind": env.kind, "data": env.data}, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [rawJson]);
+    if (r.status !== 0) throw new Error(`py envelope failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+/** Python: build_envelope(arg) expecting the resolver error → "<ClassName>: <msg>". */
+function pyError(rawJson: string): string {
+    const body = [
+        'raw = json.loads(sys.argv[1])',
+        'try:',
+        '    mod.build_envelope(raw)',
+        '    sys.stdout.write("__NO_ERROR__")',
+        'except mod.PromptResolverError as exc:',
+        '    sys.stdout.write(type(exc).__name__ + ": " + str(exc))',
+    ].join('\n');
+    const r = runPy(body, [rawJson]);
+    if (r.status !== 0) throw new Error(`py error-probe failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsEnvelope(rawJson: string): string {
+    const raw = JSON.parse(rawJson);
+    const env = build_envelope(raw);
+    return JSON.stringify({ kind: env.kind, data: env.data });
+}
+
+function tsError(rawJson: string): string {
+    const raw = JSON.parse(rawJson);
+    try {
+        build_envelope(raw);
+        return '__NO_ERROR__';
+    } catch (exc) {
+        return `${(exc as Error).name}: ${(exc as Error).message}`;
+    }
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('resolvers/prompt — envelope parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['plain prompt', JSON.stringify('improve the dashboard')],
+        ['prompt with surrounding whitespace preserved', JSON.stringify('  spaced  ')],
+        ['single non-whitespace char', JSON.stringify('a')],
+        ['multiline prompt', JSON.stringify('line one\nline two\n')],
+        ['non-ASCII verbatim', JSON.stringify('café — naïve ☕')],
+        ['tabs + newlines around content', JSON.stringify('\t\nhello\n\t')],
+    ];
+    for (const [label, raw] of cases) {
+        it(`Input envelope parity — ${label}`, () => {
+            // py json.dumps uses ', ' separators; tsEnvelope is compact —
+            // the envelope content is the parity surface, not the separator style.
+            expect(JSON.parse(tsEnvelope(raw))).toEqual(JSON.parse(pyEnvelope(raw)));
+        });
+    }
+});
+
+describePy('resolvers/prompt — error parity (python3 vs tsx)', () => {
+    const cases: Array<[string, string]> = [
+        ['empty string', JSON.stringify('')],
+        ['whitespace-only', JSON.stringify('   \t\n ')],
+        ['not a string — number', JSON.stringify(5)],
+        ['not a string — null', JSON.stringify(null)],
+        ['not a string — list', JSON.stringify([1, 2])],
+        ['not a string — object', JSON.stringify({ a: 1 })],
+        ['not a string — bool', JSON.stringify(true)],
+    ];
+    for (const [label, raw] of cases) {
+        it(`identical error class + message — ${label}`, () => {
+            const py = pyError(raw);
+            const ts = tsError(raw);
+            expect(py).not.toBe('__NO_ERROR__');
+            expect(ts).toBe(py);
+        });
+    }
+});
+
+describe('resolvers/prompt — TS-side unit checks (no python3 needed)', () => {
+    it('KIND constant', () => {
+        expect(KIND).toBe('prompt');
+    });
+    it('builds the canonical envelope shape', () => {
+        const env = build_envelope('hi');
+        expect(env.kind).toBe('prompt');
+        expect(env.data).toEqual({ raw: 'hi', reconstructed_ac: [], assumptions: [] });
+    });
+    it('throws PromptResolverError on empty', () => {
+        expect(() => build_envelope('  ')).toThrow(PromptResolverError);
+    });
+});

--- a/tests/scripts/work_engine/scoring_confidence.test.ts
+++ b/tests/scripts/work_engine/scoring_confidence.test.ts
@@ -1,0 +1,189 @@
+// Golden-parity tests for work_engine/scoring/confidence.ts vs confidence.py
+// (ADR-094 py2ts Phase 1 — scoring subpackage).
+//
+// `scoring/confidence.py` has NO intra-package imports (stdlib `re` +
+// `dataclasses` only) — loaded via the direct-file importlib loader. The
+// scorer is float-heavy (normalised score = round(total/10, 4)), so the
+// parity bar is: identical band, identical score float, identical per-dimension
+// breakdown, identical reasons list, identical ui_intent — over a corpus of
+// real-shaped prompts that exercise every rubric branch. The Python side dumps
+// the dataclass via dataclasses.asdict + json; the TS side dumps the frozen
+// ConfidenceScore the same way. ASCII-only prompts keep `\b` / `\w` regex
+// semantics identical across Python (Unicode) and JS (ASCII) — a documented
+// parity boundary (ADR-094).
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    BAND_HIGH_MIN,
+    BAND_MEDIUM_MIN,
+    DIMENSION_NAMES,
+    MAX_PER_DIMENSION,
+    type ConfidenceScore,
+    score,
+} from '../../../src/agent-src/templates/scripts/work_engine/scoring/confidence.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'scoring',
+    'confidence.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** asdict-equivalent projection in Python field order. */
+function asdict(c: ConfidenceScore): Record<string, unknown> {
+    return {
+        band: c.band,
+        score: c.score,
+        dimensions: c.dimensions,
+        reasons: c.reasons,
+        ui_intent: c.ui_intent,
+    };
+}
+
+/** Python: score(raw, ac, assumptions) then dataclasses.asdict → JSON. */
+function pyScore(raw: string, ac: string[] | null, assumptions: string[] | null): unknown {
+    const loader = [
+        'import sys, json, importlib.util, dataclasses',
+        `spec = importlib.util.spec_from_file_location("conf", ${JSON.stringify(PY)})`,
+        'conf = importlib.util.module_from_spec(spec)',
+        'sys.modules["conf"] = conf',
+        'spec.loader.exec_module(conf)',
+    ].join('\n');
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'res = conf.score(raw=payload["raw"], ac=payload["ac"], assumptions=payload["assumptions"])',
+        'sys.stdout.write(json.dumps(dataclasses.asdict(res)))',
+    ].join('\n');
+    const r = spawnSync(
+        'python3',
+        ['-c', `${loader}\n${body}`, JSON.stringify({ raw, ac, assumptions })],
+        { encoding: 'utf8' },
+    );
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return JSON.parse(r.stdout);
+}
+
+describe('scoring/confidence — exported constants', () => {
+    it('thresholds + rubric shape', () => {
+        expect(BAND_HIGH_MIN).toBe(0.8);
+        expect(BAND_MEDIUM_MIN).toBe(0.5);
+        expect(MAX_PER_DIMENSION).toBe(2);
+        expect([...DIMENSION_NAMES]).toEqual([
+            'goal_clarity',
+            'scope_boundary',
+            'ac_evidence',
+            'stack_data',
+            'reversibility',
+        ]);
+    });
+});
+
+describe('scoring/confidence — score shape', () => {
+    it('empty prompt → low band (stack_data + reversibility still score 2 each)', () => {
+        const r = score({ raw: '' });
+        expect(r.band).toBe('low');
+        // goal/scope/ac are 0; an empty prompt has no stack signal (→2) and is
+        // code-only (→2), so total=4 → 0.4, matching CPython.
+        expect(r.score).toBe(0.4);
+        expect(r.dimensions.goal_clarity).toBe(0);
+        expect(r.reasons[0]).toBe('goal_clarity=0: empty prompt');
+        expect(r.ui_intent).toBe(false);
+    });
+
+    it('high-quality prompt with anchored AC → high band', () => {
+        const r = score({
+            raw: 'Add a logout button to `auth/LoginForm.tsx`',
+            ac: [
+                'should render a logout button',
+                'when clicked it must clear the session',
+                'then redirect to the login page',
+            ],
+        });
+        expect(r.band).toBe('high');
+        expect(r.score).toBeGreaterThanOrEqual(0.8);
+    });
+
+    it('ui keyword sets ui_intent', () => {
+        const r = score({ raw: 'redesign the dashboard layout with tailwind' });
+        expect(r.ui_intent).toBe(true);
+    });
+
+    it('frozen result cannot be mutated', () => {
+        const r = score({ raw: 'fix the login bug' });
+        expect(() => {
+            // @ts-expect-error — runtime frozen check
+            r.band = 'high';
+        }).toThrow();
+    });
+});
+
+// A corpus that exercises each rubric branch: verbs/no-verbs, questions,
+// conjunction splits, file paths, PHP namespaces, camelCase, domain nouns,
+// stack/data with+without target, irreversible + config + code-only.
+const PROMPTS: Array<{ raw: string; ac: string[] | null; assumptions: string[] | null }> = [
+    { raw: '', ac: null, assumptions: null },
+    { raw: 'fix the login bug in `auth/session.py`', ac: null, assumptions: null },
+    { raw: 'How does the dashboard work?', ac: null, assumptions: null },
+    { raw: 'add a button and then refactor the user model', ac: null, assumptions: null },
+    {
+        raw: 'create UserProfileCard component',
+        ac: ['should mount', 'must show the avatar', 'then load posts'],
+        assumptions: ['react'],
+    },
+    { raw: 'rename App\\Models\\User to Account', ac: [], assumptions: null },
+    { raw: 'optimize Foo::bar performance', ac: ['expect faster'], assumptions: null },
+    { raw: 'drop the users table', ac: null, assumptions: null },
+    { raw: 'add a migration for the orders column', ac: null, assumptions: null },
+    { raw: 'migrate the schema table `orders`', ac: null, assumptions: null },
+    { raw: 'update the .env config for deploy', ac: null, assumptions: null },
+    { raw: 'refactor the checkout flow', ac: ['given a cart', 'when paid'], assumptions: null },
+    {
+        raw: 'this is a very long prompt that just keeps going on and on well past the forty word boundary so that the goal clarity scorer must fall back to the borderline length branch instead of the clean two point branch because length matters here ok',
+        ac: null,
+        assumptions: null,
+    },
+    { raw: 'implement caching for the search api', ac: null, assumptions: null },
+    { raw: 'redesign the colour theme to dark mode', ac: null, assumptions: null },
+    { raw: 'charge the customer billing account', ac: null, assumptions: null },
+    { raw: 'write tests for `report.py`', ac: ['should pass', 'must cover edges'], assumptions: null },
+    { raw: 'add an endpoint', ac: null, assumptions: null },
+    { raw: 'tune the redis cache', ac: null, assumptions: null },
+    { raw: 'document the webhook handler in handler.ts', ac: ['must explain payload'], assumptions: null },
+];
+
+describe.runIf(hasPython3())('scoring/confidence — python parity', () => {
+    it.each(PROMPTS.map((p, i) => [i, p] as const))(
+        'prompt #%i scores byte-identical to CPython',
+        (_i, p) => {
+            const expected = pyScore(p.raw, p.ac, p.assumptions);
+            const got = asdict(score({ raw: p.raw, ac: p.ac, assumptions: p.assumptions }));
+            expect(got).toEqual(expected);
+        },
+    );
+
+    it('score float matches CPython for every total 0..10 (round/2-decimal parity)', () => {
+        // Build prompts that deterministically hit each total via dimension
+        // combinations is hard; instead assert the normalisation directly by
+        // re-deriving from the dimensions both engines report on the corpus.
+        for (const p of PROMPTS) {
+            const expected = pyScore(p.raw, p.ac, p.assumptions) as { score: number };
+            const got = score({ raw: p.raw, ac: p.ac, assumptions: p.assumptions });
+            // Exact float equality — round-half-even on total/10 must agree.
+            expect(got.score).toBe(expected.score);
+        }
+    });
+});

--- a/tests/scripts/work_engine/scoring_decision_engine.test.ts
+++ b/tests/scripts/work_engine/scoring_decision_engine.test.ts
@@ -1,0 +1,357 @@
+// Golden-parity tests for work_engine/scoring/decision_engine.ts vs
+// decision_engine.py (ADR-094 py2ts Phase 1 — scoring subpackage).
+//
+// `scoring/decision_engine.py` imports only stdlib (`os`, `dataclasses`,
+// `typing`) — loaded via the direct-file importlib loader. Covers: parse()
+// defaults / unknown-key rejection / per-field coercion + error text,
+// evaluate_gates() conflict-priority + per-phase routing + action resolution
+// (with an injected is_interactive so the TTY/CI path is deterministic), and
+// the gate-reason strings (which carry `repr()`-formatted values — a byte
+// surface). The `CI` env path is exercised by passing is_interactive
+// explicitly so the suite stays deterministic regardless of the runner env.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    ALLOWED_KEYS,
+    DecisionEngineConfigError,
+    DecisionEngineSettings,
+    GATE_PRIORITY,
+    GateDecision,
+    evaluate_gates,
+    parse,
+} from '../../../src/agent-src/templates/scripts/work_engine/scoring/decision_engine.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'scoring',
+    'decision_engine.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const PY_LOADER = [
+    'import sys, json, importlib.util, dataclasses',
+    `spec = importlib.util.spec_from_file_location("de", ${JSON.stringify(PY)})`,
+    'de = importlib.util.module_from_spec(spec)',
+    'sys.modules["de"] = de',
+    'spec.loader.exec_module(de)',
+].join('\n');
+
+/** Python: parse(data) → asdict, or {"error": <msg>} on DecisionEngineConfigError. */
+function pyParse(data: unknown): unknown {
+    const body = [
+        'data = json.loads(sys.argv[1])',
+        'try:',
+        '    s = de.parse(data)',
+        '    sys.stdout.write(json.dumps(dataclasses.asdict(s)))',
+        'except de.DecisionEngineConfigError as exc:',
+        '    sys.stdout.write(json.dumps({"error": str(exc)}))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', `${PY_LOADER}\n${body}`, JSON.stringify(data ?? null)], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return JSON.parse(r.stdout);
+}
+
+/** Python: evaluate_gates(parse(settings), ...) with a fixed is_interactive. */
+function pyEvaluate(
+    settings: Record<string, unknown>,
+    phase: string,
+    confidence_band: string | null,
+    risk_class: string | null,
+    memory_hits: number,
+    interactive: boolean,
+): unknown {
+    const body = [
+        'p = json.loads(sys.argv[1])',
+        's = de.parse(p["settings"])',
+        'dec = de.evaluate_gates(s, phase=p["phase"], confidence_band=p["cb"], risk_class=p["rc"], memory_hits=p["mh"], is_interactive=lambda: p["interactive"])',
+        'sys.stdout.write(json.dumps(dataclasses.asdict(dec) if dec is not None else None))',
+    ].join('\n');
+    const payload = {
+        settings,
+        phase,
+        cb: confidence_band,
+        rc: risk_class,
+        mh: memory_hits,
+        interactive,
+    };
+    const r = spawnSync('python3', ['-c', `${PY_LOADER}\n${body}`, JSON.stringify(payload)], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return JSON.parse(r.stdout);
+}
+
+function gateToDict(d: GateDecision | null): unknown {
+    if (d === null) {
+        return null;
+    }
+    return { gate_id: d.gate_id, phase: d.phase, reason: d.reason, action: d.action };
+}
+
+function settingsToDict(s: DecisionEngineSettings): Record<string, unknown> {
+    return {
+        surface_traces: s.surface_traces,
+        min_confidence: s.min_confidence,
+        block_on_risk: s.block_on_risk,
+        require_memory_hits: s.require_memory_hits,
+        on_block: s.on_block,
+        ask_timeout_seconds: s.ask_timeout_seconds,
+        on_block_fallback: s.on_block_fallback,
+    };
+}
+
+describe('scoring/decision_engine — constants', () => {
+    it('ALLOWED_KEYS + GATE_PRIORITY', () => {
+        expect([...ALLOWED_KEYS].sort()).toEqual(
+            [
+                'ask_timeout_seconds',
+                'block_on_risk',
+                'min_confidence',
+                'on_block',
+                'on_block_fallback',
+                'require_memory_hits',
+                'surface_traces',
+            ].sort(),
+        );
+        expect([...GATE_PRIORITY]).toEqual(['block_on_risk', 'require_memory_hits', 'min_confidence']);
+    });
+});
+
+describe('scoring/decision_engine — parse', () => {
+    it('null / empty → defaults, no gate active', () => {
+        const d = parse(null);
+        expect(d.min_confidence).toBe('off');
+        expect(d.any_gate_active).toBe(false);
+        expect(parse({}).any_gate_active).toBe(false);
+    });
+
+    it('unknown key → DecisionEngineConfigError with sorted names', () => {
+        expect(() => parse({ bogus: 1, zzz: 2 })).toThrow(DecisionEngineConfigError);
+        try {
+            parse({ zzz: 2, bogus: 1 });
+        } catch (e) {
+            expect((e as Error).message).toContain('unknown key(s): bogus, zzz');
+        }
+    });
+
+    it('YAML off-as-false accepted for levels; True rejected', () => {
+        expect(parse({ min_confidence: false }).min_confidence).toBe('off');
+        expect(() => parse({ min_confidence: true })).toThrow(DecisionEngineConfigError);
+    });
+
+    it('negative ask_timeout_seconds rejected', () => {
+        expect(() => parse({ ask_timeout_seconds: -1 })).toThrow(/must be >= 0/);
+    });
+
+    it('bool given to int field rejected', () => {
+        expect(() => parse({ ask_timeout_seconds: true })).toThrow(/expected int, got bool/);
+    });
+
+    it('any_gate_active true when a gate is set', () => {
+        expect(parse({ min_confidence: 'high' }).any_gate_active).toBe(true);
+        expect(parse({ require_memory_hits: true }).any_gate_active).toBe(true);
+    });
+});
+
+describe('scoring/decision_engine — evaluate_gates', () => {
+    it('no gate active → null', () => {
+        const s = parse({});
+        expect(
+            evaluate_gates(s, {
+                phase: 'plan',
+                confidence_band: 'low',
+                risk_class: 'high',
+                memory_hits: 0,
+            }),
+        ).toBeNull();
+    });
+
+    it('min_confidence floor fires on plan when band below', () => {
+        const s = parse({ min_confidence: 'high' });
+        const d = evaluate_gates(s, {
+            phase: 'plan',
+            confidence_band: 'medium',
+            risk_class: null,
+            memory_hits: 0,
+        });
+        expect(d?.gate_id).toBe('min_confidence');
+        expect(d?.phase).toBe('plan');
+        expect(d?.action).toBe('stop');
+        expect(d?.reason).toContain("confidence_band='medium' below floor");
+    });
+
+    it('block_on_risk ceiling fires on implement', () => {
+        const s = parse({ block_on_risk: 'medium' });
+        const d = evaluate_gates(s, {
+            phase: 'implement',
+            confidence_band: null,
+            risk_class: 'high',
+            memory_hits: 0,
+        });
+        expect(d?.gate_id).toBe('block_on_risk');
+        expect(d?.reason).toContain("risk_class='high' at/above ceiling");
+    });
+
+    it('require_memory_hits fires on refine when hits < 1', () => {
+        const s = parse({ require_memory_hits: true });
+        const d = evaluate_gates(s, {
+            phase: 'refine',
+            confidence_band: null,
+            risk_class: null,
+            memory_hits: 0,
+        });
+        expect(d?.gate_id).toBe('require_memory_hits');
+        expect(d?.reason).toContain('memory_hits=0 but require_memory_hits=true');
+    });
+
+    it('on_block=ask resolves via injected is_interactive', () => {
+        const s = parse({ min_confidence: 'high', on_block: 'ask' });
+        const interactive = evaluate_gates(s, {
+            phase: 'plan',
+            confidence_band: 'low',
+            risk_class: null,
+            memory_hits: 0,
+            is_interactive: () => true,
+        });
+        expect(interactive?.action).toBe('ask');
+        const headless = evaluate_gates(s, {
+            phase: 'plan',
+            confidence_band: 'low',
+            risk_class: null,
+            memory_hits: 0,
+            is_interactive: () => false,
+        });
+        expect(headless?.action).toBe('ask_timeout');
+    });
+
+    it('gate maps only to its own phase', () => {
+        const s = parse({ min_confidence: 'high' });
+        // min_confidence only fires on `plan`; on `implement` it returns null.
+        expect(
+            evaluate_gates(s, {
+                phase: 'implement',
+                confidence_band: 'low',
+                risk_class: null,
+                memory_hits: 0,
+            }),
+        ).toBeNull();
+    });
+});
+
+describe('scoring/decision_engine — class wrappers', () => {
+    it('GateDecision + DecisionEngineSettings are frozen', () => {
+        const g = new GateDecision({ gate_id: 'x', phase: 'plan', reason: 'r', action: 'stop' });
+        expect(() => {
+            // @ts-expect-error frozen
+            g.action = 'warn';
+        }).toThrow();
+        const s = new DecisionEngineSettings({ min_confidence: 'high' });
+        expect(() => {
+            // @ts-expect-error frozen
+            s.min_confidence = 'low';
+        }).toThrow();
+    });
+});
+
+const PARSE_CASES: unknown[] = [
+    null,
+    {},
+    { surface_traces: true },
+    { surface_traces: 'yes' },
+    { min_confidence: 'HIGH', block_on_risk: 'low' },
+    { min_confidence: false },
+    { min_confidence: true }, // error
+    { bogus: 1 }, // error
+    { on_block: 'warn', on_block_fallback: 'warn', ask_timeout_seconds: 5 },
+    { on_block: 'bananas' }, // error
+    { ask_timeout_seconds: -3 }, // error
+    { ask_timeout_seconds: true }, // error
+    { require_memory_hits: 'off' },
+    { min_confidence: 42 }, // error: expected string
+    'not-a-mapping', // error
+];
+
+const EVAL_CASES: Array<{
+    settings: Record<string, unknown>;
+    phase: string;
+    cb: string | null;
+    rc: string | null;
+    mh: number;
+    interactive: boolean;
+}> = [
+    { settings: {}, phase: 'plan', cb: 'low', rc: 'high', mh: 0, interactive: true },
+    { settings: { min_confidence: 'high' }, phase: 'plan', cb: 'medium', rc: null, mh: 0, interactive: true },
+    { settings: { min_confidence: 'high' }, phase: 'plan', cb: 'high', rc: null, mh: 0, interactive: true },
+    { settings: { min_confidence: 'medium' }, phase: 'plan', cb: null, rc: null, mh: 0, interactive: false },
+    { settings: { block_on_risk: 'medium' }, phase: 'implement', cb: null, rc: 'high', mh: 0, interactive: true },
+    { settings: { block_on_risk: 'high' }, phase: 'implement', cb: null, rc: 'medium', mh: 0, interactive: true },
+    { settings: { require_memory_hits: true }, phase: 'refine', cb: null, rc: null, mh: 0, interactive: true },
+    { settings: { require_memory_hits: true }, phase: 'refine', cb: null, rc: null, mh: 2, interactive: true },
+    {
+        settings: { min_confidence: 'high', on_block: 'ask' },
+        phase: 'plan',
+        cb: 'low',
+        rc: null,
+        mh: 0,
+        interactive: false,
+    },
+    {
+        settings: { min_confidence: 'high', on_block: 'warn' },
+        phase: 'plan',
+        cb: 'low',
+        rc: null,
+        mh: 0,
+        interactive: true,
+    },
+];
+
+describe.runIf(hasPython3())('scoring/decision_engine — python parity', () => {
+    it.each(PARSE_CASES.map((c, i) => [i, c] as const))(
+        'parse case #%i matches CPython (settings or error text)',
+        (_i, data) => {
+            const expected = pyParse(data) as Record<string, unknown>;
+            let got: Record<string, unknown>;
+            try {
+                got = settingsToDict(parse(data));
+            } catch (e) {
+                got = { error: (e as Error).message };
+            }
+            expect(got).toEqual(expected);
+        },
+    );
+
+    it.each(EVAL_CASES.map((c, i) => [i, c] as const))(
+        'evaluate_gates case #%i matches CPython',
+        (_i, c) => {
+            const expected = pyEvaluate(c.settings, c.phase, c.cb, c.rc, c.mh, c.interactive);
+            const got = gateToDict(
+                evaluate_gates(parse(c.settings), {
+                    phase: c.phase,
+                    confidence_band: c.cb,
+                    risk_class: c.rc,
+                    memory_hits: c.mh,
+                    is_interactive: () => c.interactive,
+                }),
+            );
+            expect(got).toEqual(expected);
+        },
+    );
+});

--- a/tests/scripts/work_engine/scoring_decision_trace.test.ts
+++ b/tests/scripts/work_engine/scoring_decision_trace.test.ts
@@ -1,0 +1,222 @@
+// Golden-parity tests for work_engine/scoring/decision_trace.ts vs
+// decision_trace.py (ADR-094 py2ts Phase 1 — scoring subpackage).
+//
+// `scoring/decision_trace.py` has NO intra-package imports — stdlib only — so
+// it loads via a direct-file importlib loader (the same pattern as
+// state.test.ts). Each block drives the heuristic on BOTH engines from the
+// same JSON fixture and asserts identical confidence bands / risk classes /
+// memory + verify summaries. Float-format parity is N/A here (these heuristics
+// emit only strings, ints, and string-id lists), but the dict-shape parity is
+// checked byte-exact via `json.dumps(..., sort_keys=False)`.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    BAND_HIGH,
+    BAND_LOW,
+    BAND_MEDIUM,
+    RISK_LOW,
+    RISK_MEDIUM,
+    derive_confidence_band,
+    derive_risk_class,
+    summarise_memory,
+    summarise_verify,
+} from '../../../src/agent-src/templates/scripts/work_engine/scoring/decision_trace.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'scoring',
+    'decision_trace.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** Run a python snippet with decision_trace.py loaded as module `dt`. */
+function runPy(body: string, args: string[] = []): string {
+    const loader = [
+        'import sys, json, importlib.util',
+        `spec = importlib.util.spec_from_file_location("dt", ${JSON.stringify(PY)})`,
+        'dt = importlib.util.module_from_spec(spec)',
+        'sys.modules["dt"] = dt',
+        'spec.loader.exec_module(dt)',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+describe('scoring/decision_trace — constants', () => {
+    it('band + risk constants match the contract', () => {
+        expect(BAND_HIGH).toBe('high');
+        expect(BAND_MEDIUM).toBe('medium');
+        expect(BAND_LOW).toBe('low');
+        expect(RISK_MEDIUM).toBe('medium');
+        expect(RISK_LOW).toBe('low');
+    });
+});
+
+describe('scoring/decision_trace — derive_confidence_band', () => {
+    const cases: Array<[number, number, number, boolean, string]> = [
+        [2, 1, 1, false, 'high'], // hits>=2, claims==passes, no ambiguity
+        [3, 4, 4, false, 'high'],
+        [2, 1, 1, true, 'medium'], // ambiguity flag drops high → medium
+        [2, 2, 1, false, 'medium'], // passes != claims → medium (hits>=1)
+        [2, 0, 0, false, 'medium'], // claims==0 not high; hits>=1 → medium
+        [1, 0, 0, false, 'medium'], // hits>=1
+        [0, 1, 1, false, 'medium'], // first_try_passes>=1
+        [0, 0, 0, false, 'low'],
+        [0, 5, 0, false, 'low'], // claims without passes, no hits → low
+    ];
+    it.each(cases)(
+        'hits=%i claims=%i passes=%i amb=%s → %s',
+        (memory_hits, verify_claims, verify_first_try_passes, ambiguity_flag, expected) => {
+            const got = derive_confidence_band({
+                memory_hits,
+                verify_claims,
+                verify_first_try_passes,
+                ambiguity_flag,
+            });
+            expect(got).toBe(expected);
+        },
+    );
+});
+
+describe('scoring/decision_trace — derive_risk_class', () => {
+    it('falsy / empty → low; non-empty list → medium', () => {
+        expect(derive_risk_class(null)).toBe(RISK_LOW);
+        expect(derive_risk_class([])).toBe(RISK_LOW);
+        expect(derive_risk_class('')).toBe(RISK_LOW);
+        expect(derive_risk_class(0)).toBe(RISK_LOW);
+        expect(derive_risk_class(false)).toBe(RISK_LOW);
+        expect(derive_risk_class([{ file: 'a.py' }])).toBe(RISK_MEDIUM);
+        expect(derive_risk_class([{ a: 1 }, { b: 2 }])).toBe(RISK_MEDIUM);
+    });
+    it('non-empty string → medium (string is iterable in Python)', () => {
+        expect(derive_risk_class('x')).toBe(RISK_MEDIUM);
+    });
+    it('non-iterable truthy (number) → low', () => {
+        expect(derive_risk_class(42)).toBe(RISK_LOW);
+    });
+});
+
+describe('scoring/decision_trace — summarise_memory', () => {
+    it('empty / falsy memory → zeros', () => {
+        expect(summarise_memory(null)).toEqual({ asks: 0, hits: 0, ids: [] });
+        expect(summarise_memory([])).toEqual({ asks: 0, hits: 0, ids: [] });
+    });
+    it('counts asks/hits and collects ids, hit defaults True', () => {
+        const memory = [
+            { id: 'a', asks: 2 },
+            { rule_id: 'b' }, // hit defaults True, asks defaults 1
+            { id: 'c', hit: false }, // not a hit
+            'not-a-dict', // skipped
+            { id: 'd', asks: 0 }, // asks=0 → `or 1` → counts 1
+        ];
+        // asks: 2 + 1 + 1 + 1(d) = 5 (only over dict entries that pass; the
+        // skipped non-dict adds nothing). hit=false entry still adds its asks.
+        const got = summarise_memory(memory);
+        // hits = a, b, d (c has hit:false → not a hit). a, b, d all carry an
+        // id/rule_id so all three land in ids, in retrieval order.
+        expect(got).toEqual({ asks: 5, hits: 3, ids: ['a', 'b', 'd'] });
+    });
+    it('respects the ids limit', () => {
+        const memory = Array.from({ length: 40 }, (_, i) => ({ id: `r${i}` }));
+        const got = summarise_memory(memory, { limit: 3 }) as { ids: string[]; hits: number };
+        expect(got.ids).toEqual(['r0', 'r1', 'r2']);
+        expect(got.hits).toBe(40);
+    });
+});
+
+describe('scoring/decision_trace — summarise_verify', () => {
+    it('null → zeros', () => {
+        expect(summarise_verify(null)).toEqual({ claims: 0, first_try_passes: 0 });
+    });
+    it('dict form', () => {
+        expect(summarise_verify({ claims: 3, first_try_passes: 2 })).toEqual({
+            claims: 3,
+            first_try_passes: 2,
+        });
+        expect(summarise_verify({})).toEqual({ claims: 0, first_try_passes: 0 });
+    });
+    it('list form counts first_try_pass', () => {
+        const verify = [{ first_try_pass: true }, { first_try_pass: false }, { x: 1 }, 'skip'];
+        expect(summarise_verify(verify)).toEqual({ claims: 4, first_try_passes: 1 });
+    });
+    it('unknown shape → zeros', () => {
+        expect(summarise_verify(42)).toEqual({ claims: 0, first_try_passes: 0 });
+        expect(summarise_verify('x')).toEqual({ claims: 0, first_try_passes: 0 });
+    });
+});
+
+describe.runIf(hasPython3())('scoring/decision_trace — python parity', () => {
+    it('derive_confidence_band matches CPython across the grid', () => {
+        const grid: Array<[number, number, number, boolean]> = [];
+        for (const h of [0, 1, 2, 3]) {
+            for (const c of [0, 1, 2]) {
+                for (const p of [0, 1, 2]) {
+                    for (const amb of [false, true]) {
+                        grid.push([h, c, p, amb]);
+                    }
+                }
+            }
+        }
+        const body = [
+            'grid = json.loads(sys.argv[1])',
+            'out = [dt.derive_confidence_band(memory_hits=h, verify_claims=c, verify_first_try_passes=p, ambiguity_flag=a) for (h,c,p,a) in grid]',
+            'sys.stdout.write(json.dumps(out))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(grid)]));
+        const got = grid.map(([h, c, p, a]) =>
+            derive_confidence_band({
+                memory_hits: h,
+                verify_claims: c,
+                verify_first_try_passes: p,
+                ambiguity_flag: a,
+            }),
+        );
+        expect(got).toEqual(expected);
+    });
+
+    it('derive_risk_class matches CPython', () => {
+        const inputs: unknown[] = [null, [], '', 0, false, [{ a: 1 }], 'x', [{ a: 1 }, { b: 2 }]];
+        const body = [
+            'inputs = json.loads(sys.argv[1])',
+            'sys.stdout.write(json.dumps([dt.derive_risk_class(x) for x in inputs]))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(inputs)]));
+        const got = inputs.map((x) => derive_risk_class(x));
+        expect(got).toEqual(expected);
+    });
+
+    it('summarise_memory + summarise_verify match CPython (dict byte-shape)', () => {
+        const memory = [
+            { id: 'a', asks: 2, type: 'domain-invariants' },
+            { rule_id: 'b' },
+            { id: 'c', hit: false },
+            { id: 'd', asks: 0 },
+        ];
+        const verify = [{ first_try_pass: true }, { first_try_pass: false }];
+        const body = [
+            'mem = json.loads(sys.argv[1]); ver = json.loads(sys.argv[2])',
+            'sm = dt.summarise_memory(mem); sv = dt.summarise_verify(ver)',
+            'sys.stdout.write(json.dumps({"memory": sm, "verify": sv}))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(memory), JSON.stringify(verify)]));
+        expect({
+            memory: summarise_memory(memory),
+            verify: summarise_verify(verify),
+        }).toEqual(expected);
+    });
+});

--- a/tests/scripts/work_engine/scoring_memory_visibility.test.ts
+++ b/tests/scripts/work_engine/scoring_memory_visibility.test.ts
@@ -1,0 +1,306 @@
+// Golden-parity tests for work_engine/scoring/memory_visibility.ts vs
+// memory_visibility.py (ADR-094 py2ts Phase 1 — scoring subpackage).
+//
+// `scoring/memory_visibility.py` carries ONE intra-package import
+// (`from .decision_trace import derive_confidence_band, derive_risk_class`).
+// The direct-file importlib loader cannot resolve a relative import on its
+// own, so the Python driver builds a synthetic package `mvpkg` whose
+// `__path__` points at the scoring dir, loads `decision_trace` as
+// `mvpkg.decision_trace`, registers it in sys.modules, then loads
+// `memory_visibility` as `mvpkg.memory_visibility` — at which point its
+// `from .decision_trace import ...` resolves against the registered submodule.
+// The TS twin imports the real `./decision_trace.js` twin, so neither side
+// touches the other language's dependency. Output strings carry the literal
+// 🧠 / · / … / → glyphs and are compared verbatim (byte surface).
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    CONSEQUENCE_KEYS,
+    DEFAULT_ASKED_TYPES,
+    DEFAULT_MAX_INLINE_IDS,
+    ICON,
+    compute_affected,
+    diff_consequence_keys,
+    format_changed_decisions_block,
+    format_line,
+    should_emit,
+    summarise_visibility,
+} from '../../../src/agent-src/templates/scripts/work_engine/scoring/memory_visibility.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCORING = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'scoring',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+// Package-aware loader: synthesise `mvpkg` with __path__ = scoring dir, load
+// decision_trace + memory_visibility as its submodules so the relative import
+// resolves.
+const PY_LOADER = [
+    'import sys, json, importlib.util, types',
+    `SCORING = ${JSON.stringify(SCORING)}`,
+    'pkg = types.ModuleType("mvpkg")',
+    'pkg.__path__ = [SCORING]',
+    'pkg.__package__ = "mvpkg"',
+    'sys.modules["mvpkg"] = pkg',
+    'def _sub(name):',
+    '    import os',
+    '    sp = importlib.util.spec_from_file_location("mvpkg." + name, os.path.join(SCORING, name + ".py"))',
+    '    m = importlib.util.module_from_spec(sp)',
+    '    sys.modules["mvpkg." + name] = m',
+    '    sp.loader.exec_module(m)',
+    '    return m',
+    '_sub("decision_trace")',
+    'mv = _sub("memory_visibility")',
+].join('\n');
+
+function runPy(body: string, args: string[] = []): string {
+    const r = spawnSync('python3', ['-c', `${PY_LOADER}\n${body}`, ...args], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+describe('scoring/memory_visibility — constants', () => {
+    it('icon + defaults + consequence keys', () => {
+        expect(ICON).toBe('\u{1F9E0}');
+        expect(DEFAULT_MAX_INLINE_IDS).toBe(5);
+        expect([...DEFAULT_ASKED_TYPES]).toEqual([
+            'domain-invariants',
+            'architecture-decisions',
+            'incident-learnings',
+            'historical-patterns',
+        ]);
+        expect([...CONSEQUENCE_KEYS]).toEqual([
+            'confidence_band',
+            'risk_class',
+            'applied_rules',
+            'test_plan',
+        ]);
+    });
+});
+
+describe('scoring/memory_visibility — summarise_visibility', () => {
+    it('empty / non-list → zeros', () => {
+        expect(summarise_visibility(null)).toEqual({ asks: 0, hits: 0, ids: [] });
+        expect(summarise_visibility({})).toEqual({ asks: 0, hits: 0, ids: [] });
+    });
+    it('counts distinct types as hits, dedupes ids in order', () => {
+        const memory = [
+            { id: 'a', type: 'domain-invariants' },
+            { id: 'a', type: 'domain-invariants' }, // dup id
+            { rule_id: 'b', type: 'incident-learnings' },
+            { id: 3, type: 'incident-learnings' }, // int id
+        ];
+        expect(summarise_visibility(memory)).toEqual({ asks: 4, hits: 2, ids: ['a', 'b', '3'] });
+    });
+    it('falls back to ids-present hit when no type field', () => {
+        const memory = [{ id: 'x' }, { id: 'y' }];
+        expect(summarise_visibility(memory)).toEqual({ asks: 4, hits: 1, ids: ['x', 'y'] });
+    });
+    it('custom asked_types changes asks count', () => {
+        expect(summarise_visibility([{ id: 'a' }], { asked_types: ['t1', 't2'] })).toEqual({
+            asks: 2,
+            hits: 1,
+            ids: ['a'],
+        });
+    });
+});
+
+describe('scoring/memory_visibility — format_line', () => {
+    it('asks==0 → null', () => {
+        expect(format_line({ asks: 0, hits: 0, ids: [] })).toBeNull();
+    });
+    it('renders icon + hits/asks + ids', () => {
+        const line = format_line({ asks: 4, hits: 2, ids: ['a', 'b'] });
+        expect(line).toBe('🧠 Memory: 2/4 · ids=[a, b]');
+    });
+    it('overflow appends …+N', () => {
+        const ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+        const line = format_line({ asks: 4, hits: 4, ids }, { max_inline_ids: 5 });
+        expect(line).toBe('🧠 Memory: 4/4 · ids=[a, b, c, d, e, …+2]');
+    });
+    it('affected segment: empty → none, non-empty → comma-joined', () => {
+        expect(format_line({ asks: 4, hits: 1, ids: ['a'] }, { affected: [] })).toBe(
+            '🧠 Memory: 1/4 · ids=[a] · affected: none',
+        );
+        expect(
+            format_line({ asks: 4, hits: 1, ids: ['a'] }, { affected: ['confidence_band', 'risk_class'] }),
+        ).toBe('🧠 Memory: 1/4 · ids=[a] · affected: confidence_band,risk_class');
+    });
+});
+
+describe('scoring/memory_visibility — diff + compute_affected', () => {
+    it('diff suppresses both-None keys; sorts result', () => {
+        const a = { confidence_band: 'high', risk_class: 'medium', applied_rules: null, test_plan: null };
+        const b = { confidence_band: 'medium', risk_class: 'medium', applied_rules: null, test_plan: null };
+        expect(diff_consequence_keys(a, b)).toEqual(['confidence_band']);
+    });
+    it('list-valued keys compare order-insensitively', () => {
+        const a = { applied_rules: ['b', 'a'] };
+        const b = { applied_rules: ['a', 'b'] };
+        expect(diff_consequence_keys(a, b)).toEqual([]);
+    });
+    it('compute_affected returns null when no memory consulted', () => {
+        expect(compute_affected({ memory_hits: 0 })).toBeNull();
+    });
+    it('compute_affected flags confidence_band divergence', () => {
+        // hits=2, claims==passes, no ambiguity → high WITH memory; without
+        // memory (hits=0) the band drops → confidence_band diverges.
+        const got = compute_affected({
+            memory_hits: 2,
+            verify_claims: 1,
+            verify_first_try_passes: 1,
+            ambiguity_flag: false,
+        });
+        expect(got).toEqual(['confidence_band']);
+    });
+    it('compute_affected returns [] when nothing diverges', () => {
+        // hits=1 vs hits=0 both yield medium/low? hits=1 → medium, hits=0 with
+        // no passes → low, so confidence_band diverges. Use a case where the
+        // band is stable: passes>=1 keeps medium at hits=1 AND hits=0.
+        const got = compute_affected({
+            memory_hits: 1,
+            verify_claims: 0,
+            verify_first_try_passes: 1,
+            ambiguity_flag: false,
+        });
+        // hits=1 → medium; hits=0, passes=1 → medium. risk same. → []
+        expect(got).toEqual([]);
+    });
+});
+
+describe('scoring/memory_visibility — format_changed_decisions_block', () => {
+    it('null when no affected', () => {
+        expect(format_changed_decisions_block(['a'], null)).toBeNull();
+        expect(format_changed_decisions_block(['a'], [])).toBeNull();
+    });
+    it('null when no ids', () => {
+        expect(format_changed_decisions_block([], ['confidence_band'])).toBeNull();
+    });
+    it('renders id × key rows with → glyph, sorted keys', () => {
+        const block = format_changed_decisions_block(['r1', 'r2'], ['risk_class', 'confidence_band']);
+        expect(block).toBe(
+            [
+                'Memory changed decisions:',
+                '- r1 → confidence_band',
+                '- r1 → risk_class',
+                '- r2 → confidence_band',
+                '- r2 → risk_class',
+            ].join('\n'),
+        );
+    });
+});
+
+describe('scoring/memory_visibility — should_emit', () => {
+    it('visibility_off wins', () => {
+        expect(should_emit({ asks: 5 }, { visibility_off: true })).toBe(false);
+    });
+    it('asks<=0 → false', () => {
+        expect(should_emit({ asks: 0 })).toBe(false);
+    });
+    it('cadence never / auto / always', () => {
+        expect(should_emit({ asks: 4 }, { memory_cadence: 'never' })).toBe(false);
+        expect(should_emit({ asks: 2 }, { memory_cadence: 'auto' })).toBe(false);
+        expect(should_emit({ asks: 3 }, { memory_cadence: 'auto' })).toBe(true);
+        expect(should_emit({ asks: 1 }, { memory_cadence: 'always' })).toBe(true);
+    });
+});
+
+describe.runIf(hasPython3())('scoring/memory_visibility — python parity', () => {
+    it('summarise_visibility matches CPython', () => {
+        const memory = [
+            { id: 'a', type: 'domain-invariants' },
+            { id: 'a', type: 'domain-invariants' },
+            { rule_id: 'b', type: 'incident-learnings' },
+            { id: 3, type: 'incident-learnings' },
+            'skip',
+        ];
+        const body = [
+            'mem = json.loads(sys.argv[1])',
+            'sys.stdout.write(json.dumps(mv.summarise_visibility(mem)))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(memory)]));
+        expect(summarise_visibility(memory)).toEqual(expected);
+    });
+
+    it('format_line matches CPython across affected variants', () => {
+        const cases = [
+            { summary: { asks: 0, hits: 0, ids: [] }, affected: null },
+            { summary: { asks: 4, hits: 2, ids: ['a', 'b'] }, affected: null },
+            { summary: { asks: 4, hits: 4, ids: ['a', 'b', 'c', 'd', 'e', 'f', 'g'] }, affected: null },
+            { summary: { asks: 4, hits: 1, ids: ['a'] }, affected: [] },
+            { summary: { asks: 4, hits: 1, ids: ['a'] }, affected: ['confidence_band', 'risk_class'] },
+        ];
+        const body = [
+            'cs = json.loads(sys.argv[1])',
+            'out = [mv.format_line(c["summary"], affected=c["affected"]) for c in cs]',
+            'sys.stdout.write(json.dumps(out))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(cases)]));
+        const got = cases.map((c) => format_line(c.summary, { affected: c.affected }));
+        expect(got).toEqual(expected);
+    });
+
+    it('compute_affected matches CPython', () => {
+        const cases = [
+            { memory_hits: 0, verify_claims: 0, verify_first_try_passes: 0, ambiguity_flag: false },
+            { memory_hits: 2, verify_claims: 1, verify_first_try_passes: 1, ambiguity_flag: false },
+            { memory_hits: 1, verify_claims: 0, verify_first_try_passes: 1, ambiguity_flag: false },
+            { memory_hits: 1, verify_claims: 0, verify_first_try_passes: 0, ambiguity_flag: false },
+        ];
+        const body = [
+            'cs = json.loads(sys.argv[1])',
+            'out = [mv.compute_affected(memory_hits=c["memory_hits"], verify_claims=c["verify_claims"], verify_first_try_passes=c["verify_first_try_passes"], ambiguity_flag=c["ambiguity_flag"]) for c in cs]',
+            'sys.stdout.write(json.dumps(out))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(cases)]));
+        const got = cases.map((c) => compute_affected(c));
+        expect(got).toEqual(expected);
+    });
+
+    it('format_changed_decisions_block matches CPython', () => {
+        const body = [
+            'out = mv.format_changed_decisions_block(["r1","r2"], ["risk_class","confidence_band"])',
+            'sys.stdout.write(json.dumps(out))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body));
+        expect(format_changed_decisions_block(['r1', 'r2'], ['risk_class', 'confidence_band'])).toBe(
+            expected,
+        );
+    });
+
+    it('should_emit matches CPython', () => {
+        const cases = [
+            { summary: { asks: 5 }, cadence: 'always', off: true },
+            { summary: { asks: 0 }, cadence: 'always', off: false },
+            { summary: { asks: 2 }, cadence: 'auto', off: false },
+            { summary: { asks: 3 }, cadence: 'auto', off: false },
+            { summary: { asks: 4 }, cadence: 'never', off: false },
+            { summary: { asks: 1 }, cadence: 'always', off: false },
+        ];
+        const body = [
+            'cs = json.loads(sys.argv[1])',
+            'out = [mv.should_emit(c["summary"], memory_cadence=c["cadence"], visibility_off=c["off"]) for c in cs]',
+            'sys.stdout.write(json.dumps(out))',
+        ].join('\n');
+        const expected = JSON.parse(runPy(body, [JSON.stringify(cases)]));
+        const got = cases.map((c) =>
+            should_emit(c.summary, { memory_cadence: c.cadence, visibility_off: c.off }),
+        );
+        expect(got).toEqual(expected);
+    });
+});

--- a/tests/scripts/work_engine/stack_detect.test.ts
+++ b/tests/scripts/work_engine/stack_detect.test.ts
@@ -1,0 +1,273 @@
+// Golden-parity rig for the py2ts work_engine `stack/detect` twin (ADR-094).
+//
+// `work_engine/stack/detect.py` is a leaf module with NO intra-`work_engine`
+// imports — stdlib only. To exercise it from python3 without importing the
+// whole `work_engine` package (whose `__init__` pulls in unported siblings),
+// we load `detect.py` via a direct-file `importlib` loader, registering the
+// module in `sys.modules` BEFORE `exec_module` so the dataclass field-type
+// resolution (under `from __future__ import annotations`) finds the module.
+// This is the same loader pattern the merged `state.test.ts` uses.
+//
+// Each block builds a fake project tree (composer.json / package.json /
+// components.json) in a tmp dir, runs `detect_stack` on BOTH engines, and
+// asserts byte-identical observable output. The serialised view is
+// `{frontend, has_mtime}` rather than the raw `mtime` float: `mtime` is the
+// filesystem `st_mtime`, whose exact float byte-repr is not reproducible
+// across CPython and V8 for sub-second timestamps (see the note in
+// `detect.ts::_stat_mtime`). We assert the deterministic detection label
+// byte-for-byte, plus the `mtime == 0.0` / `mtime > 0.0` discriminator that
+// the cache-invalidation contract actually depends on.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_STACK,
+    KNOWN_STACKS,
+    StackResult,
+    detect_stack,
+    latest_manifest_mtime,
+} from '../../../src/agent-src/templates/scripts/work_engine/stack/detect.js';
+
+// tests/scripts/work_engine/stack_detect.test.ts → four levels up is repo root.
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+
+const DETECT_PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'stack',
+    'detect.py',
+);
+
+const TSX_BIN = process.env.TSX_BIN ?? path.join('node_modules', '.bin', 'tsx');
+const DETECT_TS = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'stack',
+    'detect.ts',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Run a python3 snippet with `detect.py` loaded as the module `detect`
+ * (direct-file importlib loader; `sys.modules` registration handles the
+ * `from __future__ import annotations` dataclass type resolution). `args`
+ * become `sys.argv[1:]`.
+ */
+function runPyWithDetect(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, pathlib, importlib.util',
+        `spec = importlib.util.spec_from_file_location("detect", ${JSON.stringify(DETECT_PY)})`,
+        'detect = importlib.util.module_from_spec(spec)',
+        'sys.modules["detect"] = detect',
+        'spec.loader.exec_module(detect)',
+    ].join('\n');
+    const code = `${loader}\n${body}`;
+    return spawnSync('python3', ['-c', code, ...args], { encoding: 'utf8' });
+}
+
+/** python3: `detect_stack(root)` → `{"frontend": ..., "has_mtime": bool}`. */
+function pyDetect(root: string): string {
+    // Compact separators (`","` / `":"`) so the Python view is byte-identical
+    // to JS `JSON.stringify` — `detect` itself never serialises, so the
+    // separator choice is the harness's, not part of the twin contract.
+    const body = [
+        'root = pathlib.Path(sys.argv[1])',
+        'r = detect.detect_stack(root)',
+        'sys.stdout.write(json.dumps({"frontend": r.frontend, "has_mtime": r.mtime > 0.0}, separators=(",", ":")))',
+    ].join('\n');
+    const r = runPyWithDetect(body, [root]);
+    if (r.status !== 0) {
+        throw new Error(`python3 detect failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/**
+ * tsx: same observable view, exercised via the `.ts` module per ADR-094.
+ * Root is passed via env (`tsx -e` shifts argv indices; env is unambiguous).
+ */
+function tsDetect(root: string): string {
+    const code = [
+        `import { detect_stack } from ${JSON.stringify(DETECT_TS)};`,
+        'const root = process.env.P2T_ROOT as string;',
+        'const r = detect_stack(root);',
+        'process.stdout.write(JSON.stringify({ frontend: r.frontend, has_mtime: r.mtime > 0.0 }));',
+    ].join('\n');
+    const r = spawnSync(TSX_BIN, ['-e', code], {
+        encoding: 'utf8',
+        env: { ...process.env, P2T_ROOT: root },
+    });
+    if (r.status !== 0) {
+        throw new Error(`tsx detect failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** Assert python3 and tsx agree byte-for-byte on the observable view. */
+function expectParity(root: string): string {
+    const py = pyDetect(root);
+    const ts = tsDetect(root);
+    expect(ts).toBe(py);
+    return py;
+}
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'p2t-detect-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, body: string): void {
+    const p = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, body, 'utf8');
+}
+
+describe('stack/detect — module constants parity', () => {
+    it('DEFAULT_STACK matches the Python value', () => {
+        expect(DEFAULT_STACK).toBe('plain');
+    });
+
+    it('KNOWN_STACKS carries exactly the four Python labels', () => {
+        expect([...KNOWN_STACKS].sort()).toEqual(
+            ['blade-livewire-flux', 'plain', 'react-shadcn', 'vue'].sort(),
+        );
+    });
+
+    it('StackResult is a frozen-style value carrier', () => {
+        const r = new StackResult({ frontend: 'plain', mtime: 0.0 });
+        expect(r.frontend).toBe('plain');
+        expect(r.mtime).toBe(0.0);
+    });
+});
+
+const py3 = hasPython3();
+const golden = py3 ? describe : describe.skip;
+
+golden('stack/detect — golden parity (python3 vs tsx)', () => {
+    it('blade-livewire-flux: composer has livewire + flux', () => {
+        write('composer.json', JSON.stringify({ require: { 'livewire/livewire': '^3', 'livewire/flux': '^1' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
+    });
+
+    it('blade-livewire-flux: flux in require-dev still counts', () => {
+        write(
+            'composer.json',
+            JSON.stringify({ require: { 'livewire/livewire': '^3' }, 'require-dev': { 'livewire/flux': '^1' } }),
+        );
+        expect(expectParity(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
+    });
+
+    it('NOT blade-livewire-flux: livewire without flux falls through', () => {
+        write('composer.json', JSON.stringify({ require: { 'livewire/livewire': '^3' } }));
+        // No package.json → next branch fails too → plain.
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+    });
+
+    it('react-shadcn: react + @radix-ui/* dependency', () => {
+        write('package.json', JSON.stringify({ dependencies: { react: '^18', '@radix-ui/react-slot': '^1' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+    });
+
+    it('react-shadcn: react + shadcn-ui package', () => {
+        write('package.json', JSON.stringify({ dependencies: { react: '^18', 'shadcn-ui': '^0' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+    });
+
+    it('react-shadcn: react + components.json marker file', () => {
+        write('package.json', JSON.stringify({ dependencies: { react: '^18' } }));
+        write('components.json', '{}');
+        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+    });
+
+    it('NOT react-shadcn: components.json present but no react → plain', () => {
+        write('package.json', JSON.stringify({ dependencies: { lodash: '^4' } }));
+        write('components.json', '{}');
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+    });
+
+    it('NOT react-shadcn: react alone (no radix/shadcn/components) → plain', () => {
+        write('package.json', JSON.stringify({ dependencies: { react: '^18' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+    });
+
+    it('vue: package lists vue, no react', () => {
+        write('package.json', JSON.stringify({ dependencies: { vue: '^3' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"vue","has_mtime":true}');
+    });
+
+    it('vue via devDependencies', () => {
+        write('package.json', JSON.stringify({ devDependencies: { vue: '^2' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"vue","has_mtime":true}');
+    });
+
+    it('precedence: blade wins over react when both manifests qualify', () => {
+        write('composer.json', JSON.stringify({ require: { 'livewire/livewire': '^3', 'livewire/flux': '^1' } }));
+        write('package.json', JSON.stringify({ dependencies: { react: '^18', '@radix-ui/x': '^1' } }));
+        expect(expectParity(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
+    });
+
+    it('precedence: react-shadcn wins over vue when both react+radix and vue present', () => {
+        write(
+            'package.json',
+            JSON.stringify({ dependencies: { react: '^18', '@radix-ui/x': '^1', vue: '^3' } }),
+        );
+        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+    });
+
+    it('greenfield: no manifests → plain, mtime 0.0', () => {
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":false}');
+    });
+
+    it('malformed composer.json degrades to {} (no crash) → plain', () => {
+        write('composer.json', '{ this is not json');
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+    });
+
+    it('non-dict JSON payload (a list) degrades to {} → plain', () => {
+        write('package.json', '[1, 2, 3]');
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+    });
+
+    it('non-dict dependency section (require is a string) is ignored', () => {
+        write('composer.json', JSON.stringify({ require: 'not-a-dict' }));
+        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+    });
+
+    it('latest_manifest_mtime: only composer/package count, not components.json', () => {
+        // components.json carries no mtime weight; with only it present mtime
+        // stays 0.0. Assert on both engines.
+        write('components.json', '{}');
+        const body = [
+            'root = pathlib.Path(sys.argv[1])',
+            'sys.stdout.write(json.dumps({"zero": detect.latest_manifest_mtime(root) == 0.0}))',
+        ].join('\n');
+        const r = runPyWithDetect(body, [tmp]);
+        expect(r.status).toBe(0);
+        // Python emits spaced JSON (`": "`); compare the parsed boolean rather
+        // than byte-comparing against in-process JS `JSON.stringify` output.
+        const py = JSON.parse(r.stdout) as { zero: boolean };
+        const ts = latest_manifest_mtime(tmp) === 0.0;
+        expect(ts).toBe(py.zero);
+        expect(py.zero).toBe(true);
+    });
+});

--- a/tests/scripts/work_engine/stack_runner.test.ts
+++ b/tests/scripts/work_engine/stack_runner.test.ts
@@ -1,0 +1,459 @@
+// Golden-parity rig for the py2ts work_engine `stack/runner` twin (ADR-094).
+//
+// `work_engine/stack/runner.py` is a leaf module with NO intra-`work_engine`
+// imports — stdlib only. We load it from python3 via the same direct-file
+// `importlib` loader the merged `state.test.ts` / `stack_detect.test.ts` use,
+// registering the module in `sys.modules` BEFORE `exec_module` so dataclass
+// field-type resolution (under `from __future__ import annotations`) resolves.
+//
+// Each block builds a fake project tree (composer.json / package.json /
+// pyproject.toml / go.mod / Cargo.toml / Makefile / Taskfile.yml) in a tmp dir
+// and asserts byte-identical observable output from python3 and tsx. Two views:
+//
+//  - `resolve_toolchain` → its `to_config()` dict, serialised compactly
+//    (`separators=(",", ":")` on the Python side, `JSON.stringify` on the JS
+//    side) with the non-deterministic `mtime` float NORMALISED to the sentinel
+//    string `"<mtime>"` on BOTH engines. `mtime` is the filesystem `st_mtime`,
+//    whose exact float byte-repr is not reproducible across CPython/V8 for
+//    sub-second timestamps (see `runner.ts::_stat_mtime`); everything else in
+//    the config IS deterministic and compared byte-for-byte.
+//  - `write_config` → the on-disk file bytes (incl. `sort_keys=True` + the
+//    trailing `\n`), again with `mtime` normalised. This exercises the
+//    `json.dumps(..., indent=2, sort_keys=True)` serialiser directly.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    HIGH,
+    KNOWN_RUNNERS,
+    LOW,
+    MEDIUM,
+    RunnerResult,
+    SPEED_E2E,
+    SPEED_FAST,
+    SPEED_SLOW,
+    ToolchainResult,
+    resolve_toolchain,
+} from '../../../src/agent-src/templates/scripts/work_engine/stack/runner.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+
+const WE = ['src', 'agent-src', 'templates', 'scripts', 'work_engine', 'stack'];
+const RUNNER_PY = path.join(REPO_ROOT, ...WE, 'runner.py');
+const RUNNER_TS = path.join(REPO_ROOT, ...WE, 'runner.ts');
+const TSX_BIN = process.env.TSX_BIN ?? path.join('node_modules', '.bin', 'tsx');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+interface Flags {
+    include_slow?: boolean;
+    include_e2e?: boolean;
+    php_only?: boolean;
+}
+
+/**
+ * python3: `resolve_toolchain(root, **flags).to_config()` → compact JSON with
+ * `mtime` normalised to the sentinel so the float repr never enters the
+ * comparison. The direct-file importlib loader registers the module first.
+ */
+function pyConfig(root: string, flags: Flags): string {
+    const loader = [
+        'import sys, json, pathlib, importlib.util',
+        `spec = importlib.util.spec_from_file_location("runner", ${JSON.stringify(RUNNER_PY)})`,
+        'runner = importlib.util.module_from_spec(spec)',
+        'sys.modules["runner"] = runner',
+        'spec.loader.exec_module(runner)',
+    ].join('\n');
+    const body = [
+        'root = pathlib.Path(sys.argv[1])',
+        'flags = json.loads(sys.argv[2])',
+        'res = runner.resolve_toolchain(root, **flags)',
+        'cfg = res.to_config()',
+        'cfg["mtime"] = "<mtime>"',
+        'sys.stdout.write(json.dumps(cfg, separators=(",", ":")))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', `${loader}\n${body}`, root, JSON.stringify(flags)], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 config failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** tsx: same observable view via the `.ts` module. Root + flags passed via env. */
+function tsConfig(root: string, flags: Flags): string {
+    const code = [
+        `import { resolve_toolchain } from ${JSON.stringify(RUNNER_TS)};`,
+        'const root = process.env.P2T_ROOT as string;',
+        'const flags = JSON.parse(process.env.P2T_FLAGS as string);',
+        'const res = resolve_toolchain(root, flags);',
+        'const cfg = res.to_config() as Record<string, unknown>;',
+        'cfg.mtime = "<mtime>";',
+        'process.stdout.write(JSON.stringify(cfg));',
+    ].join('\n');
+    const r = spawnSync(TSX_BIN, ['-e', code], {
+        encoding: 'utf8',
+        env: { ...process.env, P2T_ROOT: root, P2T_FLAGS: JSON.stringify(flags) },
+    });
+    if (r.status !== 0) {
+        throw new Error(`tsx config failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** python3: `write_config` → on-disk bytes, `mtime` normalised, incl. \n. */
+function pyWriteConfig(root: string): string {
+    const loader = [
+        'import sys, json, re, pathlib, importlib.util',
+        `spec = importlib.util.spec_from_file_location("runner", ${JSON.stringify(RUNNER_PY)})`,
+        'runner = importlib.util.module_from_spec(spec)',
+        'sys.modules["runner"] = runner',
+        'spec.loader.exec_module(runner)',
+    ].join('\n');
+    const body = [
+        'root = pathlib.Path(sys.argv[1])',
+        'res = runner.resolve_toolchain(root)',
+        'target = runner.write_config(root, res)',
+        'text = pathlib.Path(target).read_text(encoding="utf-8")',
+        // Normalise the single `"mtime": <float>,` line to a sentinel.
+        'text = re.sub(r\'"mtime": [0-9.]+\', \'"mtime": "<mtime>"\', text)',
+        'sys.stdout.write(text)',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', `${loader}\n${body}`, root], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 write_config failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** tsx: `write_config` → on-disk bytes, `mtime` normalised, incl. \n. */
+function tsWriteConfig(root: string): string {
+    const code = [
+        `import { resolve_toolchain, write_config } from ${JSON.stringify(RUNNER_TS)};`,
+        'import * as fs from "node:fs";',
+        'const root = process.env.P2T_ROOT as string;',
+        'const res = resolve_toolchain(root);',
+        'const target = write_config(root, res);',
+        'let text = fs.readFileSync(target, { encoding: "utf-8" });',
+        'text = text.replace(/"mtime": [0-9.]+/, \'"mtime": "<mtime>"\');',
+        'process.stdout.write(text);',
+    ].join('\n');
+    const r = spawnSync(TSX_BIN, ['-e', code], {
+        encoding: 'utf8',
+        env: { ...process.env, P2T_ROOT: root },
+    });
+    if (r.status !== 0) {
+        throw new Error(`tsx write_config failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function expectConfigParity(root: string, flags: Flags = {}): string {
+    const py = pyConfig(root, flags);
+    const ts = tsConfig(root, flags);
+    expect(ts).toBe(py);
+    return py;
+}
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'p2t-runner-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function write(rel: string, body: string): void {
+    const p = path.join(tmp, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, body, 'utf8');
+}
+
+describe('stack/runner — module constants parity', () => {
+    it('speed + confidence constants match Python', () => {
+        expect(SPEED_FAST).toBe('fast');
+        expect(SPEED_SLOW).toBe('slow');
+        expect(SPEED_E2E).toBe('e2e');
+        expect(HIGH).toBe('HIGH');
+        expect(MEDIUM).toBe('MEDIUM');
+        expect(LOW).toBe('LOW');
+    });
+
+    it('KNOWN_RUNNERS carries exactly the nine Python labels', () => {
+        expect([...KNOWN_RUNNERS].sort()).toEqual(
+            ['pest', 'phpunit', 'vitest', 'jest', 'playwright', 'cypress', 'pytest', 'go-test', 'cargo-test'].sort(),
+        );
+    });
+
+    it('RunnerResult applies the documented defaults', () => {
+        const r = new RunnerResult('php', 'pest', 'vendor/bin/pest');
+        expect(r.speed).toBe(SPEED_FAST);
+        expect(r.confidence).toBe(HIGH);
+        expect(r.basis).toBe('');
+    });
+
+    it('ToolchainResult.to_config has the expected key shape', () => {
+        const res = new ToolchainResult({
+            ecosystems: [],
+            runners: [],
+            selected: [],
+            quality: [],
+            confidence: LOW,
+            mtime: 0.0,
+        });
+        const cfg = res.to_config();
+        expect(Object.keys(cfg).sort()).toEqual(
+            ['confidence', 'ecosystems', 'mtime', 'quality', 'runners', 'selected'].sort(),
+        );
+        expect(cfg.confidence).toBe(LOW);
+    });
+});
+
+const py3 = hasPython3();
+const golden = py3 ? describe : describe.skip;
+
+golden('stack/runner — golden parity (python3 vs tsx)', () => {
+    // ── empty / no-match ─────────────────────────────────────────────────
+    it('greenfield: no manifest → LOW confidence, empty inventory', () => {
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect(cfg.confidence).toBe('LOW');
+        expect(cfg.runners).toEqual([]);
+        expect(cfg.selected).toEqual([]);
+    });
+
+    // ── PHP branches ─────────────────────────────────────────────────────
+    it('php: pest in composer require', () => {
+        write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('pest');
+    });
+
+    it('php: vendor/bin/pest binary (no dep) wins over phpunit', () => {
+        write('composer.json', JSON.stringify({ require: {} }));
+        write('vendor/bin/pest', '#!/usr/bin/env php\n');
+        expectConfigParity(tmp);
+    });
+
+    it('php: artisan present → phpunit via php artisan test', () => {
+        write('composer.json', JSON.stringify({ require: {} }));
+        write('artisan', '#!/usr/bin/env php\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { command: string }[])[0]!.command).toBe('php artisan test');
+    });
+
+    it('php: phpunit/phpunit dependency', () => {
+        write('composer.json', JSON.stringify({ 'require-dev': { 'phpunit/phpunit': '^11' } }));
+        expectConfigParity(tmp);
+    });
+
+    it('php: composer.json with no runner → MEDIUM phpunit default', () => {
+        write('composer.json', JSON.stringify({ require: { 'monolog/monolog': '^3' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect(cfg.confidence).toBe('MEDIUM');
+        expect((cfg.runners as { confidence: string }[])[0]!.confidence).toBe('MEDIUM');
+    });
+
+    it('php quality: phpstan + pint detected', () => {
+        write(
+            'composer.json',
+            JSON.stringify({ 'require-dev': { 'phpstan/phpstan': '^1', 'laravel/pint': '^1' } }),
+        );
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect(cfg.quality).toEqual(['vendor/bin/phpstan analyse', 'vendor/bin/pint']);
+    });
+
+    it('php: Makefile test wrapper wins over the direct tool', () => {
+        write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+        write('Makefile', 'test:\n\t./vendor/bin/pest\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { command: string }[])[0]!.command).toBe('make test');
+    });
+
+    it('php: Taskfile test wrapper (no Makefile)', () => {
+        write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+        write('Taskfile.yml', "version: '3'\ntasks:\n  test:\n    cmds:\n      - vendor/bin/pest\n");
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { command: string }[])[0]!.command).toBe('task test');
+    });
+
+    // ── JS branches ──────────────────────────────────────────────────────
+    it('js: vitest beats jest when both present', () => {
+        write('package.json', JSON.stringify({ devDependencies: { vitest: '^1', jest: '^29' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('vitest');
+        expect((cfg.runners as { command: string }[])[0]!.command).toBe('npx vitest run');
+    });
+
+    it('js: vitest with a matching test script + pm wrapper', () => {
+        write(
+            'package.json',
+            JSON.stringify({ devDependencies: { vitest: '^1' }, scripts: { test: 'vitest run' } }),
+        );
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { command: string }[])[0]!.command).toBe('npm test');
+    });
+
+    it('js: jest only', () => {
+        write('package.json', JSON.stringify({ devDependencies: { jest: '^29' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('jest');
+    });
+
+    it('js: test script with unclear runner → MEDIUM jest', () => {
+        write('package.json', JSON.stringify({ scripts: { test: 'node ./run-tests.js' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { confidence: string }[])[0]!.confidence).toBe('MEDIUM');
+    });
+
+    it('js: playwright e2e excluded from selected by default', () => {
+        write(
+            'package.json',
+            JSON.stringify({ devDependencies: { vitest: '^1', '@playwright/test': '^1' } }),
+        );
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        // Inventory has both; selected (default guard) drops the e2e command.
+        expect((cfg.runners as unknown[]).length).toBe(2);
+        expect((cfg.selected as string[])).toEqual(['npx vitest run']);
+    });
+
+    it('js: --include-e2e adds playwright to selected', () => {
+        write(
+            'package.json',
+            JSON.stringify({ devDependencies: { vitest: '^1', '@playwright/test': '^1' } }),
+        );
+        const cfg = JSON.parse(expectConfigParity(tmp, { include_e2e: true })) as Record<string, unknown>;
+        expect((cfg.selected as string[]).length).toBe(2);
+    });
+
+    it('js: cypress e2e + test:e2e script command', () => {
+        write(
+            'package.json',
+            JSON.stringify({ devDependencies: { cypress: '^13' }, scripts: { 'test:e2e': 'cypress run' } }),
+        );
+        const cfg = JSON.parse(expectConfigParity(tmp, { include_e2e: true })) as Record<string, unknown>;
+        const e2e = (cfg.runners as { runner: string; command: string }[]).find((r) => r.runner === 'cypress');
+        expect(e2e?.command).toBe('npm run test:e2e');
+    });
+
+    it('js: slow bucket excluded by default, added with --include-slow', () => {
+        write(
+            'package.json',
+            JSON.stringify({ devDependencies: { vitest: '^1' }, scripts: { 'test:slow': 'vitest run slow' } }),
+        );
+        const def = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((def.selected as string[]).length).toBe(1);
+        const slow = JSON.parse(expectConfigParity(tmp, { include_slow: true })) as Record<string, unknown>;
+        expect((slow.selected as string[]).length).toBe(2);
+    });
+
+    it('js quality: typescript + eslint', () => {
+        write('package.json', JSON.stringify({ devDependencies: { typescript: '^5', eslint: '^9' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect(cfg.quality).toEqual(['npx tsc --noEmit', 'npx eslint .']);
+    });
+
+    it('js: pnpm package manager wrapper', () => {
+        write(
+            'package.json',
+            JSON.stringify({ devDependencies: { vitest: '^1' }, scripts: { test: 'vitest run' } }),
+        );
+        write('pnpm-lock.yaml', 'lockfileVersion: 9\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { command: string }[])[0]!.command).toBe('pnpm test');
+    });
+
+    // ── Python branches ──────────────────────────────────────────────────
+    it('python: pyproject mentions pytest → HIGH', () => {
+        write('pyproject.toml', '[tool.pytest.ini_options]\naddopts = "-q"\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string; confidence: string }[])[0]).toMatchObject({
+            runner: 'pytest',
+            confidence: 'HIGH',
+        });
+    });
+
+    it('python: requirements.txt only → MEDIUM pytest', () => {
+        write('requirements.txt', 'requests\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { confidence: string }[])[0]!.confidence).toBe('MEDIUM');
+    });
+
+    it('python quality: ruff + mypy from pyproject text', () => {
+        write('pyproject.toml', '[tool.ruff]\n[tool.mypy]\n[tool.pytest.ini_options]\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect(cfg.quality).toEqual(['ruff check', 'mypy .']);
+    });
+
+    // ── Go / Rust ────────────────────────────────────────────────────────
+    it('go: go.mod present', () => {
+        write('go.mod', 'module example.com/x\n\ngo 1.22\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('go-test');
+        expect(cfg.quality).toEqual(['go vet ./...']);
+    });
+
+    it('rust: Cargo.toml present', () => {
+        write('Cargo.toml', '[package]\nname = "x"\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('cargo-test');
+        expect(cfg.quality).toEqual(['cargo clippy']);
+    });
+
+    // ── Monorepo: multi-ecosystem + guards ───────────────────────────────
+    it('monorepo: php + js + python + go inventory and ecosystem order', () => {
+        write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+        write('package.json', JSON.stringify({ devDependencies: { vitest: '^1' } }));
+        write('pyproject.toml', '[tool.pytest.ini_options]\n');
+        write('go.mod', 'module x\n');
+        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        expect(cfg.ecosystems).toEqual(['php', 'js', 'python', 'go']);
+    });
+
+    it('monorepo: --php narrows selected to PHP only', () => {
+        write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+        write('package.json', JSON.stringify({ devDependencies: { vitest: '^1' } }));
+        const cfg = JSON.parse(expectConfigParity(tmp, { php_only: true })) as Record<string, unknown>;
+        // Full inventory keeps both; selected is PHP-only.
+        expect((cfg.runners as unknown[]).length).toBe(2);
+        expect((cfg.selected as string[])).toEqual(['vendor/bin/pest']);
+    });
+
+    // ── write_config byte-parity ─────────────────────────────────────────
+    it('write_config: byte-identical on-disk file (sort_keys + trailing \\n)', () => {
+        write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+        write('package.json', JSON.stringify({ devDependencies: { vitest: '^1', eslint: '^9' } }));
+        const py = pyWriteConfig(tmp);
+        // Fresh tmp for the TS write so the two don't race on the same target,
+        // but identical inputs → identical config. Re-create the same tree.
+        const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'p2t-runner-w-'));
+        try {
+            fs.writeFileSync(path.join(tmp2, 'composer.json'), JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
+            fs.writeFileSync(
+                path.join(tmp2, 'package.json'),
+                JSON.stringify({ devDependencies: { vitest: '^1', eslint: '^9' } }),
+            );
+            const ts = (function () {
+                const saved = process.env.P2T_ROOT;
+                process.env.P2T_ROOT = tmp2;
+                const out = tsWriteConfig(tmp2);
+                process.env.P2T_ROOT = saved;
+                return out;
+            })();
+            expect(ts).toBe(py);
+            // Sanity: the file ends with a newline and sorts keys.
+            expect(py.endsWith('\n')).toBe(true);
+            expect(py.indexOf('"confidence"')).toBeLessThan(py.indexOf('"ecosystems"'));
+        } finally {
+            fs.rmSync(tmp2, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/scripts/work_engine/state_io.test.ts
+++ b/tests/scripts/work_engine/state_io.test.ts
@@ -1,0 +1,357 @@
+// Golden-parity tests for work_engine/state_io.ts vs state_io.py
+// (ADR-094 py2ts Phase 1 — work_engine foundation).
+//
+// `state_io.py` is the most intra-dependent module in this batch:
+//   from . import state as _state_module
+//   from .cli_args import DEFAULT_STATE_FILE, LEGACY_STATE_FILE, _FMT_V0, _FMT_V1
+//   from .delivery_state import DeliveryState
+//   from .errors import _CLIError
+//   from .migration.v0_to_v1 import migrate_payload
+//   from .state import SchemaError, WorkState
+//
+// The direct-file importlib loader cannot resolve those relative imports on
+// its own, so the Python driver builds a synthetic `we` package whose
+// __path__ points at the work_engine dir (plus a `we.migration` subpackage),
+// preloads every sibling state_io needs into sys.modules under `we.<name>`,
+// then loads `we.state_io` — at which point its relative imports all resolve.
+// The work_engine `__init__` (which pulls unported siblings) is never
+// executed: we register the package object manually.
+//
+// The TS twin imports the real merged sibling twins (state.ts, cli_args.ts,
+// delivery_state.ts, errors.ts) and inlines the `migrate_payload` slice (the
+// full v0_to_v1.ts twin lands in a later phase) — so neither side imports the
+// other language. The parity bar is byte-identical on-disk JSON for the
+// save path (v0 and v1 round-trips) plus identical _CLIError message text on
+// every error path the contract exercises.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import { _CLIError } from '../../../src/agent-src/templates/scripts/work_engine/errors.js';
+import { WorkState, from_dict } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+import {
+    _load,
+    _save,
+    _sync_back,
+    _to_delivery,
+    _to_v0_dict,
+    migrate_payload,
+} from '../../../src/agent-src/templates/scripts/work_engine/state_io.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+// Package-aware loader: synthesise `we` + `we.migration` packages, preload
+// every sibling state_io.py imports, then load `we.state_io`.
+const PY_LOADER = [
+    'import sys, json, importlib.util, types, os',
+    `WE = ${JSON.stringify(WE)}`,
+    'we = types.ModuleType("we"); we.__path__ = [WE]; we.__package__ = "we"',
+    'sys.modules["we"] = we',
+    'mig = types.ModuleType("we.migration"); mig.__path__ = [os.path.join(WE, "migration")]; mig.__package__ = "we.migration"',
+    'sys.modules["we.migration"] = mig',
+    'def _sub(dotted, relpath):',
+    '    sp = importlib.util.spec_from_file_location("we." + dotted, os.path.join(WE, relpath))',
+    '    m = importlib.util.module_from_spec(sp)',
+    '    sys.modules["we." + dotted] = m',
+    '    sp.loader.exec_module(m)',
+    '    return m',
+    '_sub("state", "state.py")',
+    '_sub("cli_args", "cli_args.py")',
+    '_sub("delivery_state", "delivery_state.py")',
+    '_sub("errors", "errors.py")',
+    '_sub("migration.v0_to_v1", os.path.join("migration", "v0_to_v1.py"))',
+    'sio = _sub("state_io", "state_io.py")',
+].join('\n');
+
+function runPy(body: string, args: string[] = []): { stdout: string; status: number; stderr: string } {
+    const r = spawnSync('python3', ['-c', `${PY_LOADER}\n${body}`, ...args], { encoding: 'utf8' });
+    return { stdout: r.stdout, status: r.status ?? -1, stderr: r.stderr };
+}
+
+const tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'state-io-'));
+    tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (tmpDirs.length > 0) {
+        const d = tmpDirs.pop();
+        if (d && fs.existsSync(d)) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+// A representative v1 payload (canonical envelope) and a v0 payload (flat).
+const V1_PAYLOAD = {
+    version: 1,
+    input: { kind: 'ticket', data: { title: 'Fix the café login', id: 7 } },
+    intent: 'backend-coding',
+    directive_set: 'backend',
+    persona: 'qa',
+    memory: [{ id: 'r1' }],
+    plan: 'do the thing',
+    changes: [{ file: 'a.py' }],
+    tests: null,
+    verify: { claims: 2, first_try_passes: 2 },
+    outcomes: { plan: 'success' },
+    questions: [],
+    report: 'done',
+};
+
+const V0_PAYLOAD = {
+    ticket: { title: 'Legacy ticket', id: 3 },
+    persona: 'advisory',
+    memory: [],
+    plan: null,
+    changes: [],
+    tests: null,
+    verify: null,
+    outcomes: {},
+    questions: ['q1'],
+    report: '',
+};
+
+describe('state_io — migrate_payload', () => {
+    it('v1 payload returned deep-copied unchanged', () => {
+        const out = migrate_payload(V1_PAYLOAD);
+        expect(out).toEqual(V1_PAYLOAD);
+        expect(out).not.toBe(V1_PAYLOAD);
+    });
+    it('v0 payload wrapped into v1 envelope', () => {
+        const out = migrate_payload(V0_PAYLOAD) as Record<string, unknown>;
+        expect(out['version']).toBe(1);
+        expect(out['input']).toEqual({ kind: 'ticket', data: { title: 'Legacy ticket', id: 3 } });
+        expect(out['intent']).toBe('backend-coding');
+        expect(out['directive_set']).toBe('backend');
+        expect(out['persona']).toBe('advisory');
+        expect(out['questions']).toEqual(['q1']);
+    });
+    it('non-dict → SchemaError', () => {
+        expect(() => migrate_payload(42 as unknown as never)).toThrow(/v0 state must be a JSON object/);
+    });
+    it('missing ticket → SchemaError listing keys', () => {
+        expect(() => migrate_payload({ foo: 1 } as never)).toThrow(
+            /v0 state must carry a 'ticket' key; got keys: \['foo'\]/,
+        );
+    });
+    it('higher version → SchemaError', () => {
+        expect(() => migrate_payload({ version: 2 } as never)).toThrow(
+            /cannot migrate from version 2/,
+        );
+    });
+});
+
+describe('state_io — _save round-trips', () => {
+    it('v1 save is byte-identical JSON + trailing newline', () => {
+        const work = from_dict(V1_PAYLOAD);
+        const f = path.join(mkTmp(), 'sub', '.work-state.json');
+        _save(f, work, 'v1');
+        const bytes = fs.readFileSync(f, 'utf-8');
+        expect(bytes.endsWith('\n')).toBe(true);
+        // re-load round-trips
+        const [reloaded] = _load(f);
+        expect(reloaded).toBeInstanceOf(WorkState);
+    });
+
+    it('v0 save emits the legacy flat shape', () => {
+        const work = from_dict(V1_PAYLOAD);
+        const f = path.join(mkTmp(), '.work-state.json');
+        _save(f, work, 'v0');
+        const obj = JSON.parse(fs.readFileSync(f, 'utf-8'));
+        expect(Object.keys(obj)).toEqual([
+            'ticket',
+            'persona',
+            'memory',
+            'plan',
+            'changes',
+            'tests',
+            'verify',
+            'outcomes',
+            'questions',
+            'report',
+        ]);
+        expect(obj.ticket).toEqual({ title: 'Fix the café login', id: 7 });
+    });
+});
+
+describe('state_io — _to_delivery / _sync_back', () => {
+    it('projects WorkState → DeliveryState and mirrors back', () => {
+        const work = from_dict(V1_PAYLOAD);
+        const delivery = _to_delivery(work);
+        expect(delivery).toBeInstanceOf(DeliveryState);
+        expect(delivery.ticket).toEqual({ title: 'Fix the café login', id: 7 });
+        expect(delivery.persona).toBe('qa');
+        // mutate the delivery, sync back
+        delivery.report = 'updated';
+        delivery.plan = 'new plan';
+        _sync_back(work, delivery);
+        expect(work.report).toBe('updated');
+        expect(work.plan).toBe('new plan');
+        expect(work.input.data).toEqual({ title: 'Fix the café login', id: 7 });
+    });
+});
+
+describe('state_io — _load', () => {
+    it('loads v1 file and tags v1', () => {
+        const f = path.join(mkTmp(), '.work-state.json');
+        fs.writeFileSync(f, JSON.stringify(V1_PAYLOAD), 'utf-8');
+        const [work, fmt] = _load(f);
+        expect(fmt).toBe('v1');
+        expect(work.persona).toBe('qa');
+    });
+    it('loads + migrates v0 file, tags v0', () => {
+        const f = path.join(mkTmp(), '.work-state.json');
+        fs.writeFileSync(f, JSON.stringify(V0_PAYLOAD), 'utf-8');
+        const [work, fmt] = _load(f);
+        expect(fmt).toBe('v0');
+        expect(work.input.data).toEqual({ title: 'Legacy ticket', id: 3 });
+    });
+    it('non-object JSON → _CLIError', () => {
+        const f = path.join(mkTmp(), '.work-state.json');
+        fs.writeFileSync(f, '[]', 'utf-8');
+        expect(() => _load(f)).toThrow(_CLIError);
+        expect(() => _load(f)).toThrow(/must carry a JSON object; got list/);
+    });
+    it('unsupported version → _CLIError', () => {
+        const f = path.join(mkTmp(), '.work-state.json');
+        fs.writeFileSync(f, JSON.stringify({ version: 99, input: {} }), 'utf-8');
+        expect(() => _load(f)).toThrow(/unsupported version 99/);
+    });
+    it('neither shape → _CLIError', () => {
+        const f = path.join(mkTmp(), '.work-state.json');
+        fs.writeFileSync(f, JSON.stringify({ foo: 1 }), 'utf-8');
+        expect(() => _load(f)).toThrow(/missing 'ticket' \(v0\) or 'version' \(v1\)/);
+    });
+    it('invalid JSON → _CLIError', () => {
+        const f = path.join(mkTmp(), '.work-state.json');
+        fs.writeFileSync(f, '{not json', 'utf-8');
+        expect(() => _load(f)).toThrow(/Invalid JSON in/);
+    });
+});
+
+describe('state_io — _to_v0_dict', () => {
+    it('flat shape in declaration order', () => {
+        const work = from_dict(V1_PAYLOAD);
+        const v0 = _to_v0_dict(work);
+        expect(Object.keys(v0)).toEqual([
+            'ticket',
+            'persona',
+            'memory',
+            'plan',
+            'changes',
+            'tests',
+            'verify',
+            'outcomes',
+            'questions',
+            'report',
+        ]);
+    });
+});
+
+describe.runIf(hasPython3())('state_io — python parity', () => {
+    it('v1 save bytes byte-identical to CPython', () => {
+        const pyOut = path.join(mkTmp(), 'py.json');
+        const body = [
+            'import pathlib',
+            'payload = json.loads(sys.argv[1])',
+            // Build the WorkState directly via the state module, then save v1.
+            'st = sys.modules["we.state"]',
+            'work = st.from_dict(payload)',
+            'sio._save(pathlib.Path(sys.argv[2]), work, "v1")',
+            'sys.stdout.write(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))',
+        ].join('\n');
+        const r = runPy(body, [JSON.stringify(V1_PAYLOAD), pyOut]);
+        if (r.status !== 0) {
+            throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+        }
+        const tsOut = path.join(mkTmp(), 'ts.json');
+        _save(tsOut, from_dict(V1_PAYLOAD), 'v1');
+        const tsBytes = fs.readFileSync(tsOut, 'utf-8');
+        expect(tsBytes).toBe(r.stdout);
+    });
+
+    it('v0 save bytes byte-identical to CPython', () => {
+        const pyOut = path.join(mkTmp(), 'py0.json');
+        const body = [
+            'import pathlib',
+            'payload = json.loads(sys.argv[1])',
+            'st = sys.modules["we.state"]',
+            'work = st.from_dict(payload)',
+            'sio._save(pathlib.Path(sys.argv[2]), work, "v0")',
+            'sys.stdout.write(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))',
+        ].join('\n');
+        const r = runPy(body, [JSON.stringify(V1_PAYLOAD), pyOut]);
+        if (r.status !== 0) {
+            throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+        }
+        const tsOut = path.join(mkTmp(), 'ts0.json');
+        _save(tsOut, from_dict(V1_PAYLOAD), 'v0');
+        expect(fs.readFileSync(tsOut, 'utf-8')).toBe(r.stdout);
+    });
+
+    it('migrate_payload byte-shape matches CPython for a v0 payload', () => {
+        const body = [
+            'payload = json.loads(sys.argv[1])',
+            'sys.stdout.write(json.dumps(sio.migrate_payload(payload)))',
+        ].join('\n');
+        const r = runPy(body, [JSON.stringify(V0_PAYLOAD)]);
+        if (r.status !== 0) {
+            throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+        }
+        expect(migrate_payload(V0_PAYLOAD)).toEqual(JSON.parse(r.stdout));
+    });
+
+    it('_CLIError message text matches CPython on each error path', () => {
+        const cases: Array<{ name: string; content: string }> = [
+            { name: 'non-object', content: '[]' },
+            { name: 'unsupported-version', content: JSON.stringify({ version: 99, input: {} }) },
+            { name: 'neither-shape', content: JSON.stringify({ foo: 1 }) },
+            { name: 'invalid-json', content: '{not json' },
+        ];
+        for (const c of cases) {
+            const f = path.join(mkTmp(), '.work-state.json');
+            fs.writeFileSync(f, c.content, 'utf-8');
+            const body = [
+                'import pathlib',
+                'try:',
+                '    sio._load(pathlib.Path(sys.argv[1]))',
+                '    sys.stdout.write("__NO_ERROR__")',
+                'except sio._CLIError as exc:',
+                '    sys.stdout.write(str(exc))',
+            ].join('\n');
+            const r = runPy(body, [f]);
+            if (r.status !== 0) {
+                throw new Error(`python3 failed (${c.name}): ${r.stderr || r.stdout}`);
+            }
+            let tsMsg = '__NO_ERROR__';
+            try {
+                _load(f);
+            } catch (e) {
+                if (e instanceof _CLIError) {
+                    tsMsg = e.message;
+                } else {
+                    throw e;
+                }
+            }
+            // The invalid-JSON path carries the parser's own message (CPython's
+            // json vs V8's JSON differ); compare only the stable prefix there.
+            if (c.name === 'invalid-json') {
+                expect(tsMsg.startsWith(`Invalid JSON in ${f}: `)).toBe(true);
+                expect(r.stdout.startsWith(`Invalid JSON in ${f}: `)).toBe(true);
+            } else {
+                expect(tsMsg).toBe(r.stdout);
+            }
+        }
+    });
+});


### PR DESCRIPTION
## What

Phase-9 wave 2 of the Python→TypeScript migration (ADR-094): the **work_engine L1 layer** — 11 modules that depend only on the merged foundation (#534).

| Module | Twin |
|---|---|
| `state_io.py` | state JSON load/save (v0/v1) + `DeliveryState` projection |
| `scoring/decision_trace.py` | confidence-band + risk-class heuristics |
| `scoring/confidence.py` | prompt-scoring rubric |
| `scoring/decision_engine.py` | `decision_engine:` block parser + gate evaluator |
| `scoring/memory_visibility.py` | visibility-line producer |
| `resolvers/{diff,file,prompt}.py` | diff-header heuristic / path normalization / prompt envelope |
| `intent/classify.py` | intent classifier + directive-set routing |
| `stack/{detect,runner}.py` | frontend-stack detection / toolchain resolver |

## Parity

- 21 golden-parity test files; **416 work_engine tests green** (8 merged foundation + 11 new).
- Float parity via round-half-even; `mtime` non-determinism normalized with inline reason.
- ADR-051 legacy-literal counts: 0==0 across all 11 (ts==py).
- `tsc` clean; dist mirror regenerated via `condense --sync`.

## Scope

- A `.ts` never imports a `.py`. All `.py` retained — deletion is the Phase-12 sweep.
- Base: `python2ts` (never `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)