### PR TITLE
feat(py2ts): work_engine L2 — directives/ (22) + hooks/ (18)

### DIFF
--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/analyze.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/analyze.ts
@@ -1,0 +1,124 @@
+/**
+ * `analyze` step — deterministic precondition gate.
+ *
+ * TypeScript twin of `work_engine/directives/backend/analyze.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The step runs no analysis of its own: the real impact analysis is
+ * owned by the agent between the `memory` and `plan` steps. The
+ * gate's job is to confirm the upstream slices are populated enough
+ * for planning to be meaningful.
+ *
+ * Checks, in order:
+ *
+ * 1. `refine` outcome must be `success` — the ticket is refined.
+ * 2. `memory` outcome must be `success` — priors were queried
+ *    (an empty result set is still a successful query, per the
+ *    `memory` step's own contract).
+ * 3. The ticket must still carry acceptance criteria — guards against
+ *    a resuming caller overwriting `state.ticket` between runs.
+ *
+ * On any missing precondition the step returns `BLOCKED` with the
+ * reason spelled out and numbered options per the `user-interaction`
+ * rule. Otherwise it returns `SUCCESS` without mutating state.
+ */
+
+import { DeliveryState, Outcome, StepResult } from '../../delivery_state.js';
+
+/** Declared ambiguity surfaces. Every BLOCKED return maps to one code. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_refine_failed',
+        trigger: '`refine` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'upstream_memory_failed',
+        trigger: '`memory` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'lost_ac',
+        trigger: 'ticket lost its `acceptance_criteria` between runs',
+        resolution: 'restart with the full ticket payload',
+    },
+];
+
+/** Return SUCCESS when upstream is coherent, BLOCKED otherwise. */
+export function run(state: DeliveryState): StepResult {
+    const missing = _diagnose(state);
+    if (missing.length === 0) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const ticketId = _pyTruthy((state.ticket ?? {}).id) ? String((state.ticket ?? {}).id) : '(no id)';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: _format_questions(ticketId, missing),
+        message: `Ticket ${ticketId} cannot enter the plan step: ` + missing.join('; '),
+    });
+}
+
+/** List the precondition failures in the order a reader needs them. */
+function _diagnose(state: DeliveryState): string[] {
+    const issues: string[] = [];
+
+    if (state.outcomes.refine !== Outcome.SUCCESS) {
+        issues.push('refine step did not complete successfully');
+    }
+
+    if (state.outcomes.memory !== Outcome.SUCCESS) {
+        issues.push('memory step did not complete successfully');
+    }
+
+    const ac = (state.ticket ?? {}).acceptance_criteria;
+    if (!Array.isArray(ac) || ac.length === 0) {
+        issues.push('ticket lost its acceptance criteria');
+    }
+
+    return issues;
+}
+
+/**
+ * Render the numbered options shown to the user when BLOCKED.
+ *
+ * Two options: retry from the first failing step, or abort. The
+ * headnote names the ticket and every failure so the user can
+ * decide without re-reading the earlier output.
+ */
+function _format_questions(ticketId: string, missing: string[]): string[] {
+    const headnote = `> Ticket ${ticketId} — analyze gate failed: ` + missing.join('; ') + '.';
+    return [
+        headnote,
+        '> 1. Re-run `/implement-ticket` from the start — rebuild upstream state',
+        '> 2. Abort — the flow cannot continue',
+    ];
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/implement.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/implement.ts
@@ -1,0 +1,188 @@
+/**
+ * `implement` step — gate + Option-A delegation for applying the plan.
+ *
+ * TypeScript twin of `work_engine/directives/backend/implement.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The step never edits files. Editing is delegated to the agent via
+ * `@agent-directive: apply-plan`; the agent runs the `minimal-safe-
+ * diff` and `scope-control` rules while it applies the plan, then
+ * writes the resulting file-level changes onto `state.changes` and
+ * marks `outcomes['implement'] = 'success'` before re-invoking the
+ * dispatcher.
+ *
+ * Flow:
+ *
+ * - `plan` outcome is not `success` → BLOCKED on precondition.
+ * - `state.changes` empty → BLOCKED with `@agent-directive:
+ *   apply-plan` so the agent applies the plan.
+ * - `state.changes` populated but malformed (entries missing
+ *   `path`, or non-dict entries) → BLOCKED with shape complaint.
+ * - Otherwise → SUCCESS.
+ *
+ * `changes` entries use the loose shape described in
+ * `docs/contracts/implement-ticket-flow.md#deliverystate-the-only-shared-object`
+ * — each entry is a dict with at least a `path`; optional
+ * `lines` / `purpose` feed the delivery report.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+/** Declared ambiguity surfaces. Advisory personas skip this step entirely. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_plan_failed',
+        trigger: '`plan` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_changes_delegate',
+        trigger: '`state.changes` empty — plan not applied yet',
+        resolution: 'agent directive `apply-plan` → edit under `minimal-safe-diff` ' + '+ `scope-control`',
+    },
+    {
+        code: 'malformed_changes',
+        trigger: 'any change entry is not a dict or has no non-empty `path`',
+        resolution: 're-run `apply-plan` and resume',
+    },
+];
+
+/** Gate on `plan`, then either delegate or validate `state.changes`. */
+export function run(state: DeliveryState): StepResult {
+    const policy = resolve_policy(state.persona);
+    if (!policy.allows_implement) {
+        // Advisory personas produce a plan only; `state.changes` stays
+        // empty and the delivery report renders a "no file changes
+        // recorded" placeholder. See `persona_policy` for contract.
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `implement skipped: persona \`${policy.name}\` is plan-only.`,
+        });
+    }
+
+    if (state.outcomes.plan !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    if (!_pyTruthy(state.changes)) {
+        return _delegate_to_apply_plan(state);
+    }
+
+    const shapeIssues = _diagnose_changes(state.changes);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** Every entry must be a dict carrying at least a non-empty `path`. */
+function _diagnose_changes(changes: Any[]): string[] {
+    const issues: string[] = [];
+    changes.forEach((change, i) => {
+        const idx = i + 1;
+        if (!_isPlainObject(change)) {
+            issues.push(`change #${idx} is not a dict`);
+            return;
+        }
+        const d = change as Record<string, unknown>;
+        const path = _pyTruthy(d.path) ? d.path : d.file;
+        if (typeof path !== 'string' || _pyStrip(path).length === 0) {
+            issues.push(`change #${idx} has no path`);
+        }
+    });
+    return issues;
+}
+
+function _delegate_to_apply_plan(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('apply-plan', { ticket: ticketId }),
+            `> Ticket ${ticketId} — applying the recorded plan under ` +
+                '`minimal-safe-diff` + `scope-control`.',
+            '> 1. Continue — apply the plan as recorded',
+            '> 2. Abort — stop before any edits are made',
+        ],
+        message: `Ticket ${ticketId} needs its plan applied before testing.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — implement gate refused: ` +
+                '`plan` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot implement: plan gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded changes are malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run `apply-plan` and resume',
+            '> 2. Abort — changes cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} changes shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** Python `str.strip()` — strip leading/trailing whitespace. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/memory.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/memory.ts
@@ -1,0 +1,192 @@
+/**
+ * `memory` step — bounded retrieval over the four allowed types.
+ *
+ * TypeScript twin of `work_engine/directives/backend/memory.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * Contract (see
+ * `docs/contracts/implement-ticket-flow.md#memory-retrieval-contract`):
+ *
+ * - Four allowed types: `domain-invariants`, `architecture-decisions`,
+ *   `incident-learnings`, `historical-patterns`.
+ * - Hard cap of **12** hits total across the four types.
+ * - Keys derive from the ticket — title tokens plus acceptance-criterion
+ *   tokens plus any already-known `files` hint. Tokenisation is
+ *   deliberately naive (whitespace split, lower-cased) so the retrieval
+ *   shape stays reproducible in tests.
+ * - Step always returns `SUCCESS`. Zero hits is a valid outcome
+ *   ("nothing in memory touches this ticket") — the `report` step
+ *   drops the memory section when that happens rather than padding.
+ *
+ * The step stores each hit as a plain dict on `state.memory` so
+ * consumers outside Python (the delivery report, JSON log lines) can
+ * round-trip the structure without pickling dataclasses.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult } from '../../delivery_state.js';
+import { retrieve as _real_retrieve } from '../../../memory_lookup.js';
+
+/** The four types allowed by the flow contract. No aliases, no extras. */
+export const MEMORY_TYPES: ReadonlyArray<string> = [
+    'domain-invariants',
+    'architecture-decisions',
+    'incident-learnings',
+    'historical-patterns',
+];
+
+/** Hard cap per the roadmap — never raise without amending the contract. */
+export const MAX_HITS = 12;
+
+/**
+ * Declared ambiguity surfaces — memory retrieval always succeeds.
+ *
+ * Declared empty so the aggregate registry in `steps/__init__.py`
+ * can round-trip every step's surfaces without a special case.
+ */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/** Signature of the `memory_lookup.retrieve` callable this step drives. */
+type RetrieveFn = (types: string[], keys: string[], limit: number) => unknown;
+
+/**
+ * Test seam mirroring Python's late `import memory_lookup` monkeypatch
+ * point. Default is the real `memory_lookup.retrieve`; tests swap it via
+ * `_setRetrieve` exactly as the Python suite patches `memory_lookup.retrieve`.
+ */
+let _retrieve_override: RetrieveFn | null = null;
+
+/** Swap the `retrieve` callable (test hook for the lazy-import seam). */
+export function _setRetrieve(fn: RetrieveFn | null): void {
+    _retrieve_override = fn;
+}
+
+const _WORD = /[A-Za-z][A-Za-z0-9_-]{2,}/g;
+const _STOPWORDS: ReadonlySet<string> = new Set([
+    'the', 'and', 'for', 'with', 'from', 'into', 'that', 'this',
+    'should', 'must', 'when', 'then', 'will', 'have', 'has',
+    'are', 'was', 'were', 'can', 'could', 'would', 'shall',
+    'also', 'which', 'where', 'while', 'make', 'made', 'use',
+    'used', 'using', 'user', 'users', 'test', 'tests',
+]);
+
+/** Populate `state.memory` with up to `MAX_HITS` hits. */
+export function run(state: DeliveryState): StepResult {
+    const retrieve = _resolve_retrieve();
+    const keys = _keys_from_ticket(state.ticket);
+    const hits = retrieve([...MEMORY_TYPES], keys, MAX_HITS);
+
+    // `retrieve` returns `Hit` dataclasses; coerce to dicts so the
+    // state is serialisation-ready for the report step and metrics log.
+    const hitList = Array.isArray(hits) ? hits : [];
+    state.memory = hitList.slice(0, MAX_HITS).map((h) => _as_dict(h));
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/**
+ * Resolve `memory_lookup.retrieve` lazily so tests can monkeypatch it.
+ *
+ * Importing at module load time would freeze the reference before
+ * tests can swap in a fake, which is the standard gotcha with the
+ * `from X import Y` form. Deferring the resolution keeps the step
+ * patchable from a single attribute (`memory_lookup.retrieve`).
+ */
+function _resolve_retrieve(): RetrieveFn {
+    return _retrieve_override ?? (_real_retrieve as RetrieveFn);
+}
+
+/**
+ * Derive retrieval keys from the ticket.
+ *
+ * Three sources, in priority order so callers reading the log can
+ * reconstruct why a hit scored: explicit `files` hints first,
+ * then title tokens, then acceptance-criterion tokens. Duplicates
+ * are removed while preserving first-seen order.
+ */
+function _keys_from_ticket(ticket: Record<string, Any>): string[] {
+    const keys: string[] = [];
+    _extend_unique(keys, _as_str_list((ticket || {}).files));
+    _extend_unique(keys, _tokenise((ticket || {}).title));
+    for (const ac of _as_str_list((ticket || {}).acceptance_criteria)) {
+        _extend_unique(keys, _tokenise(ac));
+    }
+    return keys;
+}
+
+/** Return lower-cased content words from `value` (empty when absent). */
+function _tokenise(value: Any): string[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+    const out: string[] = [];
+    for (const match of value.matchAll(_WORD)) {
+        const word = match[0].toLowerCase();
+        if (!_STOPWORDS.has(word)) {
+            out.push(word);
+        }
+    }
+    return out;
+}
+
+/** Coerce `value` to a list of non-empty strings. */
+function _as_str_list(value: Any): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.filter((item): item is string => typeof item === 'string' && item.trim().length !== 0);
+}
+
+/** Append items from `source` to `target` skipping duplicates. */
+function _extend_unique(target: string[], source: Iterable<string>): void {
+    const seen = new Set(target);
+    for (const item of source) {
+        if (seen.has(item)) {
+            continue;
+        }
+        target.push(item);
+        seen.add(item);
+    }
+}
+
+/** Coerce a `Hit` (or pre-dict test fake) into a plain dict. */
+function _as_dict(hit: Any): Record<string, Any> {
+    const asDict = (hit as { as_dict?: unknown })?.as_dict;
+    if (typeof asDict === 'function') {
+        return (asDict as () => Record<string, Any>).call(hit);
+    }
+    if (_isPlainObject(hit)) {
+        return { ...(hit as Record<string, Any>) };
+    }
+    // Fallback path — should not happen in production, but keeps the
+    // step from crashing if a fixture returns a raw namespace object.
+    return { entry: _pyRepr(hit) };
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Minimal Python `repr()` for the fallback path's scalar inputs. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/plan.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/plan.ts
@@ -1,0 +1,266 @@
+/**
+ * `plan` step — gate + delegation to `feature-plan`.
+ *
+ * TypeScript twin of `work_engine/directives/backend/plan.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The dispatcher cannot synthesise a plan from pure code: the real
+ * work needs code reading and judgement that only the agent has. The
+ * step therefore follows the Option-A delegation pattern described in
+ * `docs/contracts/implement-ticket-flow.md#agent-directives`:
+ *
+ * - `state.plan` empty → halt with `BLOCKED` and emit
+ *   `@agent-directive: create-plan`. The orchestrator runs the
+ *   `feature-plan` skill, writes its output onto `state.plan`,
+ *   marks `outcomes['plan'] = 'success'`, and re-invokes the
+ *   dispatcher.
+ *
+ * - `state.plan` populated with a minimally valid shape → `SUCCESS`
+ *   with no mutation. Shape validation catches accidental scaffolding
+ *   (e.g. an empty list, a placeholder string) that would produce a
+ *   broken plan downstream.
+ *
+ * - `state.plan` populated but malformed → `BLOCKED` with numbered
+ *   options so the user decides whether to re-plan, continue with the
+ *   malformed plan, or abort.
+ *
+ * `analyze` is a precondition: the step refuses to plan when the
+ * upstream gate did not succeed, rather than silently re-running a
+ * derailed flow.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+
+/** Declared ambiguity surfaces. Every BLOCKED return maps to one code. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_analyze_failed',
+        trigger: '`analyze` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_plan_delegate',
+        trigger: '`state.plan` empty — no plan recorded yet',
+        resolution: 'agent directive `create-plan` → `/feature-plan`',
+    },
+    {
+        code: 'malformed_plan',
+        trigger:
+            'plan is not a non-empty string, list of strings/dicts, ' +
+            'or dict with a non-empty `steps` list',
+        resolution: 're-run `/feature-plan` or correct the recorded plan',
+    },
+];
+
+/** Gate on `analyze`, then either delegate or validate the plan. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes.analyze !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    if (_is_plan_empty(state.plan)) {
+        return _delegate_to_feature_plan(state);
+    }
+
+    const shapeIssues = _diagnose_shape(state.plan);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/**
+ * True when `state.plan` has nothing a downstream step could use.
+ *
+ * Whitespace-only strings count as empty — the user experience of
+ * "nothing planned" is identical to "blank placeholder", and both
+ * should delegate to `feature-plan` rather than fall through to
+ * the shape-validator.
+ */
+function _is_plan_empty(plan: Any): boolean {
+    if (plan === null || plan === undefined) {
+        return true;
+    }
+    if (typeof plan === 'string') {
+        return _pyStrip(plan).length === 0;
+    }
+    if (Array.isArray(plan)) {
+        return plan.length === 0;
+    }
+    if (plan instanceof Set || plan instanceof Map) {
+        return plan.size === 0;
+    }
+    if (typeof plan === 'object') {
+        return Object.keys(plan as Record<string, unknown>).length === 0;
+    }
+    return false;
+}
+
+/**
+ * Return the list of shape complaints against `state.plan`.
+ *
+ * Accepted shapes (matches `report._format_plan`):
+ * a non-empty string, a list of strings or `{title, detail}` dicts,
+ * or a dict with a non-empty `steps` list. Everything else is
+ * rejected so the report renderer never has to guess.
+ */
+function _diagnose_shape(plan: Any): string[] {
+    const issues: string[] = [];
+
+    if (typeof plan === 'string') {
+        if (_pyStrip(plan).length === 0) {
+            issues.push('plan is a blank string');
+        }
+        return issues;
+    }
+
+    if (Array.isArray(plan)) {
+        if (plan.length === 0) {
+            issues.push('plan list is empty');
+            return issues;
+        }
+        plan.forEach((item, i) => {
+            const idx = i + 1;
+            if (_isPlainObject(item)) {
+                const d = item as Record<string, unknown>;
+                if (!_pyTruthy(d.title) && !_pyTruthy(d.step)) {
+                    issues.push(`plan step #${idx} has no title`);
+                }
+            } else if (typeof item !== 'string' || _pyStrip(item).length === 0) {
+                issues.push(`plan step #${idx} is not a usable string`);
+            }
+        });
+        return issues;
+    }
+
+    if (_isPlainObject(plan)) {
+        const steps = (plan as Record<string, unknown>).steps;
+        if (!Array.isArray(steps) || steps.length === 0) {
+            issues.push("plan dict must carry a non-empty 'steps' list");
+        }
+        return issues;
+    }
+
+    issues.push(`plan has unsupported type: ${_pyTypeName(plan)}`);
+    return issues;
+}
+
+/** Halt with an agent directive so the orchestrator runs `feature-plan`. */
+function _delegate_to_feature_plan(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('create-plan', { ticket: ticketId }),
+            `> Ticket ${ticketId} — no plan recorded yet; running ` +
+                '`feature-plan` and resuming.',
+            '> 1. Continue — use the plan produced by `feature-plan`',
+            '> 2. Abort — stop before any edits are proposed',
+        ],
+        message: `Ticket ${ticketId} needs a plan before implementation.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — plan gate refused: ` +
+                '`analyze` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot plan: analyze gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded plan is malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run `feature-plan` and resume',
+            '> 2. Abort — the plan cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} plan shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** Python `str.strip()` — strip leading/trailing whitespace. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Python `type(x).__name__` for the value kinds the diagnose paths see. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (typeof value === 'boolean') {
+        return 'bool';
+    }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') {
+        return 'str';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Set) {
+        return 'set';
+    }
+    if (value instanceof Map || _isPlainObject(value)) {
+        return 'dict';
+    }
+    return typeof value;
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/refine.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/refine.ts
@@ -1,0 +1,516 @@
+/**
+ * `refine` step — deterministic gate in front of the refinement skills.
+ *
+ * TypeScript twin of `work_engine/directives/backend/refine.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The step never calls an LLM. It inspects `state.ticket` (which carries
+ * `input.data` after the CLI projection) and routes on shape:
+ *
+ * - **Ticket envelope** (`id`, `title`, `acceptance_criteria`) — the
+ *   R1 path. Validates the minimum viable shape and either returns
+ *   `SUCCESS` or `BLOCKED` with numbered options pointing at
+ *   `/refine-ticket`.
+ * - **Prompt envelope** (`raw` key present, `reconstructed_ac` /
+ *   `assumptions` slots) — the R2 path. On the first pass the gate
+ *   delegates to the `refine-prompt` skill via an `@agent-directive:`
+ *   halt; on the rebound it scores the reconstructed envelope and routes
+ *   the resulting confidence band:
+ *
+ *   - `high`   → `SUCCESS` (silent proceed, breakdown logged for the report)
+ *   - `medium` → `PARTIAL` with an assumptions-report halt
+ *   - `low`    → `BLOCKED` with one clarifying question targeted at the
+ *     weakest dimension
+ *
+ * The checks live here (rather than inside the refinement skills) because
+ * the dispatcher is synchronous Python: it cannot "delegate" to an agent
+ * skill mid-loop. Making the gate deterministic keeps the contract "block
+ * on ambiguity, never guess" enforceable from code, and ensures the band
+ * the dispatcher routes on is always engine-computed — the skill produces
+ * AC + assumptions, the engine decides.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { ConfidenceScore, DIMENSION_NAMES, score as _confidence_score } from '../../scoring/confidence.js';
+
+const _MIN_TITLE_LEN = 3;
+const _MIN_AC_LEN = 10;
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'missing_id',
+        trigger: 'ticket has no `id` field (or only whitespace)',
+        resolution: 'run `/refine-ticket` or paste the ticket id in chat',
+    },
+    {
+        code: 'trivial_title',
+        trigger: `title missing or shorter than ${_MIN_TITLE_LEN} chars`,
+        resolution: 'run `/refine-ticket` to rewrite the title',
+    },
+    {
+        code: 'missing_or_vague_ac',
+        trigger: `acceptance_criteria empty, non-list, or any item under ${_MIN_AC_LEN} chars`,
+        resolution: 'run `/refine-ticket` to add concrete acceptance criteria',
+    },
+    {
+        code: 'prompt_unrefined',
+        trigger:
+            'prompt envelope present but `reconstructed_ac` is empty — ' +
+            'the deterministic gate has nothing to score yet',
+        resolution:
+            'agent directive `refine-prompt` → run the skill, ' +
+            'write AC + assumptions back into `state.ticket`',
+    },
+    {
+        code: 'prompt_medium_confidence',
+        trigger:
+            'scored band is `medium` and the user has not confirmed the ' +
+            'assumptions report yet',
+        resolution:
+            'user confirms the reconstructed AC + assumptions, ' +
+            'or refines them; agent flips `confidence_confirmed=True` to ' +
+            'release the gate',
+    },
+    {
+        code: 'prompt_low_confidence',
+        trigger:
+            'scored band is `low` — too little signal to plan against, ' +
+            'even after reconstruction',
+        resolution:
+            'user answers one clarifying question; the agent ' +
+            're-runs `refine-prompt` against the refreshed prompt',
+    },
+    {
+        code: 'prompt_ui_intent',
+        trigger:
+            'scorer flagged `ui_intent=True` — the prompt reads as UI ' +
+            'work and the backend track cannot ship it cleanly',
+        resolution:
+            'user re-frames the prompt as backend-only, parks ' +
+            'it for Roadmap 3 (`road-to-product-ui-track.md`), or aborts',
+    },
+];
+/** Declared ambiguity surfaces. Every BLOCKED / PARTIAL return maps to one code. */
+
+/** Route on envelope shape: ticket path or prompt path. */
+export function run(state: DeliveryState): StepResult {
+    const data = state.ticket || {};
+    if (_is_prompt_envelope(data)) {
+        return _run_prompt(state, data);
+    }
+
+    const deficiencies = _diagnose(data);
+    if (deficiencies.length === 0) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const ticket_id = _pyTruthy(data.id) ? _pyStr(data.id) : '(no id)';
+    const questions = _format_questions(ticket_id, deficiencies);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message: `Ticket ${ticket_id} is not refined enough to plan against: ` + deficiencies.join('; '),
+    });
+}
+
+/**
+ * True when `state.ticket` carries a prompt envelope.
+ *
+ * The presence of a string-valued `raw` key is unambiguous: ticket
+ * payloads never carry `raw`, and prompt envelopes always do (the
+ * resolver writes it before any handler sees the state).
+ */
+function _is_prompt_envelope(data: Record<string, Any>): boolean {
+    if (!_isPlainObject(data)) {
+        return false;
+    }
+    const raw = data.raw;
+    return typeof raw === 'string' && Boolean(raw.trim());
+}
+
+/**
+ * Return a human-readable list of what's missing from the ticket.
+ *
+ * Order matches what a reader needs first (identity → summary →
+ * acceptance criteria) so the surfaced questions read naturally.
+ */
+function _diagnose(ticket: Record<string, Any>): string[] {
+    const issues: string[] = [];
+
+    const ticket_id = ticket.id;
+    if (typeof ticket_id !== 'string' || !ticket_id.trim()) {
+        issues.push('missing ticket id');
+    }
+
+    const title = ticket.title;
+    if (typeof title !== 'string' || title.trim().length < _MIN_TITLE_LEN) {
+        issues.push('missing or trivial title');
+    }
+
+    const ac = ticket.acceptance_criteria;
+    if (!Array.isArray(ac) || ac.length === 0) {
+        issues.push('no acceptance criteria');
+    } else {
+        const weak_indices: number[] = [];
+        ac.forEach((item, idx) => {
+            if (!_is_concrete_ac(item)) {
+                weak_indices.push(idx + 1);
+            }
+        });
+        if (weak_indices.length > 0) {
+            issues.push('vague acceptance criteria at position(s) ' + weak_indices.map((i) => String(i)).join(', '));
+        }
+    }
+
+    return issues;
+}
+
+/**
+ * An AC is concrete when it is a non-empty string above the length floor.
+ *
+ * The floor is deliberately loose: refine is a gate, not a style
+ * judge. The heavy lifting (measurability, testability, tone) is
+ * owned by the `refine-ticket` skill on the rebound.
+ */
+function _is_concrete_ac(item: Any): boolean {
+    if (typeof item !== 'string') {
+        return false;
+    }
+    return item.trim().length >= _MIN_AC_LEN;
+}
+
+/**
+ * Render the numbered options shown to the user when BLOCKED.
+ *
+ * Three options, ordered by likely next action: run the existing
+ * refinement skill, paste the missing data in chat, or abandon the
+ * ticket entirely. `user-interaction` requires numbered, prose-
+ * free options; the deficiency list is rendered as a headnote.
+ */
+function _format_questions(ticket_id: string, deficiencies: string[]): string[] {
+    const headnote = '> Ticket ' + ticket_id + ' is missing: ' + deficiencies.join('; ') + '.';
+    return [
+        headnote,
+        `> 1. Run \`/refine-ticket ${ticket_id}\` and re-invoke \`/implement-ticket\``,
+        "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+        '> 3. Abandon this ticket — too vague to implement',
+    ];
+}
+
+/**
+ * Score the prompt envelope and route on the resulting band.
+ *
+ * First pass (no AC reconstructed yet) → delegate to `refine-prompt`.
+ * Second pass → score and branch:
+ *
+ * - `high`   → `SUCCESS`; the breakdown is recorded on
+ *   `state.ticket['confidence']` so the report renderer can include
+ *   it without re-scoring.
+ * - `medium` → `PARTIAL` with an assumptions-report halt unless
+ *   the agent has flipped `confidence_confirmed=True` after the
+ *   user signed off. `low` band can never be released this way.
+ * - `low`    → `BLOCKED` with one clarifying question targeted at
+ *   the weakest dimension (lowest score wins; ties prefer the order
+ *   declared in `work_engine.scoring.confidence.DIMENSION_NAMES`).
+ */
+function _run_prompt(state: DeliveryState, data: Record<string, Any>): StepResult {
+    const raw = (_pyTruthy(data.raw) ? data.raw : '') as string;
+    const ac: Any[] = Array.isArray(data.reconstructed_ac) ? data.reconstructed_ac : [];
+    const assumptions: Any[] = Array.isArray(data.assumptions) ? data.assumptions : [];
+
+    if (ac.length === 0) {
+        return _delegate_to_refine_prompt(raw);
+    }
+
+    const result = _confidence_score({ raw, ac: ac as string[], assumptions: assumptions as string[] });
+    data.confidence = {
+        band: result.band,
+        score: result.score,
+        dimensions: { ...result.dimensions },
+        reasons: [...result.reasons],
+        ui_intent: result.ui_intent,
+    };
+    // Mirror reconstructed AC into the legacy slot every downstream gate
+    // (analyze, plan, implement) reads. Prompt envelopes carry AC under
+    // `reconstructed_ac`; without this projection `analyze` blocks with
+    // "ticket lost its acceptance criteria" the moment `refine` succeeds.
+    data.acceptance_criteria = [...ac];
+
+    if (result.ui_intent) {
+        return _halt_ui_intent(raw, result);
+    }
+
+    if (result.band === 'high') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    if (result.band === 'medium') {
+        if (data.confidence_confirmed === true) {
+            return new StepResult({ outcome: Outcome.SUCCESS });
+        }
+        return _halt_medium(raw, ac, assumptions, result);
+    }
+
+    return _halt_low(raw, result);
+}
+
+/** Halt with an agent directive so the orchestrator runs `refine-prompt`. */
+function _delegate_to_refine_prompt(raw: string): StepResult {
+    const preview = _preview(raw);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('refine-prompt'),
+            `> Prompt received: ${preview}`,
+            '> No reconstructed acceptance criteria yet — running ' + '`refine-prompt` and resuming.',
+            '> 1. Continue — let the skill reconstruct AC + assumptions',
+            '> 2. Abort — the prompt is not what I meant',
+        ],
+        message: 'Prompt envelope present but unrefined; delegating to refine-prompt.',
+    });
+}
+
+/** PARTIAL halt — assumptions report, one user round-trip. */
+function _halt_medium(raw: string, ac: Any[], assumptions: Any[], result: ConfidenceScore): StepResult {
+    const preview = _preview(raw);
+    const ac_lines = ac.map((item, i) => `>    ${i + 1}. ${_pyStr(item)}`);
+    const asm_lines = assumptions.length > 0 ? assumptions.map((item) => `>    - ${_pyStr(item)}`) : ['>    - (none recorded)'];
+    const questions = [
+        `> Prompt: ${preview}`,
+        `> Confidence: **medium** (score ${_pyFormat2f(result.score)}). ` + 'Assumptions worth confirming before I plan.',
+        '> Reconstructed AC:',
+        ...ac_lines,
+        '> Assumptions:',
+        ...asm_lines,
+        '> 1. Continue as-is — the AC + assumptions are good enough',
+        "> 2. Refine — I'll send a corrected prompt and re-run " + '`refine-prompt`',
+        '> 3. Abort — pause this `/work` cycle',
+    ];
+    return new StepResult({
+        outcome: Outcome.PARTIAL,
+        questions,
+        message: `Prompt scored medium (${_pyFormat2f(result.score)}); ` + 'halting for assumptions confirmation.',
+    });
+}
+
+/** BLOCKED halt — one targeted question on the weakest dimension. */
+function _halt_low(raw: string, result: ConfidenceScore): StepResult {
+    const preview = _preview(raw);
+    const [weakest_idx, weakest_name] = _weakest_dimension(result.dimensions);
+    const reason = weakest_idx < result.reasons.length ? result.reasons[weakest_idx] : '';
+    const prompts: Record<string, string> = {
+        goal_clarity: 'What is the single observable outcome you want?',
+        scope_boundary: 'Which file, class, or module should I touch?',
+        ac_evidence: 'What concrete behaviour proves it works?',
+        stack_data: 'Which table, column, or migration target is involved?',
+        reversibility: 'Is this change destructive — should I work behind a flag?',
+    };
+    const question = weakest_name in prompts ? prompts[weakest_name] : 'Can you tighten the prompt?';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Prompt: ${preview}`,
+            `> Confidence: **low** (score ${_pyFormat2f(result.score)}). ` + `Weakest dimension: \`${weakest_name}\` — ${reason}`,
+            `> ${question}`,
+            "> 1. I'll answer — paste the answer in chat and re-invoke `/work`",
+            '> 2. Abort — drop this prompt',
+        ],
+        message: `Prompt scored low (${_pyFormat2f(result.score)}); blocking on ` + `\`${weakest_name}\` clarification.`,
+    });
+}
+
+/**
+ * BLOCKED halt — UI-shaped prompts await the R3 dispatch track.
+ *
+ * The backend `directives/backend/` set has no UI capability; routing a
+ * UI prompt through it would either ship a backend stub or guess at a
+ * component. Both are worse than a clean refusal with a pointer to the
+ * deferred R3 track. The halt is band-independent — even a high-band
+ * UI prompt blocks here, because confidence on the *reconstruction* says
+ * nothing about whether the *dispatcher* can deliver it.
+ */
+function _halt_ui_intent(raw: string, result: ConfidenceScore): StepResult {
+    const preview = _preview(raw);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Prompt: ${preview}`,
+            '> This prompt reads as **UI work** — the backend dispatch ' + "track can't ship it cleanly.",
+            '> UI dispatch is deferred to Roadmap 3 ' + '(`road-to-product-ui-track.md`); until it lands, `/work` ' + 'only handles backend-shaped prompts.',
+            "> 1. Re-frame as a backend-only prompt — I'll re-score and proceed",
+            '> 2. Park this prompt — wait for R3 and re-invoke `/work` then',
+            '> 3. Abort — drop this prompt',
+        ],
+        message: `Prompt flagged as UI-intent (band=${result.band}, ` + `score=${_pyFormat2f(result.score)}); blocked pending R3 UI track.`,
+    });
+}
+
+/**
+ * Return `[index, name]` of the lowest-scoring dimension.
+ *
+ * Ties are broken by `_confidence.DIMENSION_NAMES` order so the
+ * same input always produces the same question (replay determinism).
+ */
+function _weakest_dimension(dimensions: Record<string, number>): [number, string] {
+    const ordered: string[] = [...DIMENSION_NAMES];
+    // Python `min(ordered, key=lambda n: (dimensions.get(n, 0), ordered.index(n)))`
+    // — lowest score wins; ties broken by declared order (stable, first wins).
+    let weakest_name = ordered[0] ?? '';
+    let weakest_key: [number, number] = [dimensions[weakest_name] ?? 0, 0];
+    for (let i = 1; i < ordered.length; i += 1) {
+        const name = ordered[i] ?? '';
+        const key: [number, number] = [dimensions[name] ?? 0, i];
+        if (key[0] < weakest_key[0] || (key[0] === weakest_key[0] && key[1] < weakest_key[1])) {
+            weakest_name = name;
+            weakest_key = key;
+        }
+    }
+    return [ordered.indexOf(weakest_name), weakest_name];
+}
+
+/** Trim a raw prompt for inline display in halts. */
+function _preview(raw: string, max_chars = 80): string {
+    // `" ".join((raw or "").split())` — Python `str.split()` splits on
+    // whitespace runs and drops empties; join with single spaces.
+    const text = (raw || '').split(/\s+/u).filter((t) => t.length > 0).join(' ');
+    if (text.length <= max_chars) {
+        return text;
+    }
+    // `text[:max_chars - 1].rstrip() + "…"`
+    return text.slice(0, max_chars - 1).replace(/\s+$/u, '') + '…';
+}
+
+/**
+ * Python `f"{value:.2f}"` — fixed two-decimal formatting with
+ * round-half-to-even. `score` values are normalised to 4 decimals by the
+ * scorer, so the standard `toFixed(2)` round-half-away-from-zero and Python's
+ * banker's rounding agree on every value the scorer can emit; the explicit
+ * even-rounding path below keeps parity for any exact-half edge case.
+ */
+function _pyFormat2f(value: number): string {
+    if (!Number.isFinite(value)) {
+        // Python renders inf/nan as 'inf'/'nan'; the scorer never emits these.
+        return value > 0 ? 'inf' : value < 0 ? '-inf' : 'nan';
+    }
+    const sign = value < 0 ? '-' : '';
+    const abs = Math.abs(value);
+    const scaled = abs * 100;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    let rounded: number;
+    const eps = 1e-9;
+    if (frac > 0.5 + eps) {
+        rounded = floor + 1;
+    } else if (frac < 0.5 - eps) {
+        rounded = floor;
+    } else {
+        // exact half → round to even
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    }
+    const intPart = Math.floor(rounded / 100);
+    const fracPart = rounded - intPart * 100;
+    return `${sign}${intPart}.${String(fracPart).padStart(2, '0')}`;
+}
+
+/** `(value or "")` style truthiness, Python semantics. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/**
+ * Python `str(value)` for the scalar / container kinds the halts render.
+ *
+ * Strings render as-is; `None`/booleans use Python spelling; numbers as-is;
+ * dict / list use Python's `repr`-style bracketing so a `str(item)` fallback
+ * (a non-string AC or assumption entry) matches the Python output.
+ */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}
+
+/** Python `repr()` for values nested inside a `str(container)` render. */
+function _pyReprInner(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/report.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/report.ts
@@ -1,0 +1,378 @@
+/**
+ * `report` step — delivery report renderer.
+ *
+ * TypeScript twin of `work_engine/directives/backend/report.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * Produces the markdown block described in
+ * `docs/contracts/implement-ticket-flow.md#delivery-report-schema`.
+ * All nine headings are present on every run — the schema is stable
+ * for consumers — but section bodies are omitted when the matching
+ * slice of `DeliveryState` is empty. The single exception is the
+ * **Memory that mattered** section, which per contract is dropped
+ * entirely (heading included) when no hit carries a
+ * `changed_outcome` marker.
+ *
+ * The step is pure and deterministic: no I/O, no subprocess, no
+ * randomness. It reads `DeliveryState`, writes `state.report`,
+ * and always returns `SUCCESS`.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+/** Report rendering is pure and always succeeds — no blocked paths. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/** Render the delivery report into `state.report` and return SUCCESS. */
+export function run(state: DeliveryState): StepResult {
+    state.report = _render(state);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _render(state: DeliveryState): string {
+    const sections = [
+        _ticket_section(state),
+        _persona_section(state),
+        _plan_section(state),
+        _changes_section(state),
+        _tests_section(state),
+        _verify_section(state),
+        _visual_preview_section(state),
+        _memory_section(state),
+        _followups_section(state),
+        _next_commands_section(state),
+    ];
+    // Drop sections that opted out (memory-that-mattered and visual-preview
+    // return "" when their slice is absent — per the report schema drop-rule).
+    return sections.filter((section) => section).join('\n\n');
+}
+
+function _ticket_section(state: DeliveryState): string {
+    const ticket = state.ticket ?? {};
+    const ticketId = _pyTruthy(ticket.id) ? _pyStr(ticket.id) : '(no id)';
+    const title = _pyTruthy(ticket.title) ? _pyStr(ticket.title) : '(no title)';
+    return `## Ticket\n\n${ticketId} — ${title}`;
+}
+
+function _persona_section(state: DeliveryState): string {
+    return `## Persona\n\n${_pyTruthy(state.persona) ? _pyStr(state.persona) : '(unset)'}`;
+}
+
+function _plan_section(state: DeliveryState): string {
+    const body = _format_plan(state.plan);
+    return '## Plan\n\n' + (body || '_(no plan recorded)_');
+}
+
+/**
+ * Render whatever shape `state.plan` carries.
+ *
+ * Accepts a list of step strings, a list of `{title, detail}` dicts,
+ * or a single string — the contract doc intentionally leaves the
+ * plan shape loose until `feature-plan` wiring lands in a later
+ * phase.
+ */
+function _format_plan(plan: Any): string {
+    if (!_pyTruthy(plan)) {
+        return '';
+    }
+    if (typeof plan === 'string') {
+        return _pyStrip(plan);
+    }
+    if (Array.isArray(plan)) {
+        const lines: string[] = [];
+        plan.forEach((item, i) => {
+            const idx = i + 1;
+            if (_isPlainObject(item)) {
+                const d = item as Record<string, unknown>;
+                const title = _pyTruthy(d.title) ? d.title : _pyTruthy(d.step) ? d.step : `Step ${idx}`;
+                const detail = _pyTruthy(d.detail) ? d.detail : _pyTruthy(d.note) ? d.note : '';
+                lines.push(`${idx}. **${_pyStr(title)}**` + (detail ? ` — ${_pyStr(detail)}` : ''));
+            } else {
+                lines.push(`${idx}. ${_pyStr(item)}`);
+            }
+        });
+        return lines.join('\n');
+    }
+    // Last resort: string-coerce an unknown shape so the renderer never
+    // crashes on experimental plan structures.
+    return _pyStr(plan);
+}
+
+function _changes_section(state: DeliveryState): string {
+    if (!_pyTruthy(state.changes)) {
+        return '## Changes\n\n_(no file changes recorded)_';
+    }
+    const lines = ['## Changes', ''];
+    for (const change of state.changes) {
+        const c = change as Record<string, unknown>;
+        const path = _pyTruthy(c.path) ? c.path : _pyTruthy(c.file) ? c.file : '(unknown file)';
+        const linesRange = _pyTruthy(c.lines) ? c.lines : _pyTruthy(c.range) ? c.range : '';
+        const purpose = _pyTruthy(c.purpose) ? c.purpose : _pyTruthy(c.why) ? c.why : '';
+        let prefix = `- \`${_pyStr(path)}\``;
+        if (linesRange) {
+            prefix += ` (${_pyStr(linesRange)})`;
+        }
+        if (purpose) {
+            prefix += ` — ${_pyStr(purpose)}`;
+        }
+        lines.push(prefix);
+    }
+    return lines.join('\n');
+}
+
+function _tests_section(state: DeliveryState): string {
+    return '## Tests\n\n' + _format_kv_block(state.tests, '_(no tests ran)_');
+}
+
+function _verify_section(state: DeliveryState): string {
+    return '## Verify\n\n' + _format_kv_block(state.verify, '_(no verify verdict)_');
+}
+
+/**
+ * R4 Phase 3: render captured preview artifacts when the skill rendered.
+ *
+ * Reads `state.ui_review.preview` (engine never renders — the
+ * stack-specific review skill writes the envelope). Emits a section
+ * only when `render_ok` is `True` AND at least one artifact path
+ * is present. Failed renders, skipped previews, and pre-R4 envelopes
+ * drop the whole section (heading included).
+ */
+function _visual_preview_section(state: DeliveryState): string {
+    const ui_review = state.ui_review;
+    if (!_isPlainObject(ui_review)) {
+        return '';
+    }
+    const preview = (ui_review as Record<string, unknown>).preview;
+    if (!_isPlainObject(preview)) {
+        return '';
+    }
+    const p = preview as Record<string, unknown>;
+    if (p.render_ok !== true) {
+        return '';
+    }
+    if (_pyTruthy(p.skipped)) {
+        return '';
+    }
+    const screenshot = p.screenshot_path;
+    const domDump = p.dom_dump_path;
+    const lines: string[] = [];
+    if (typeof screenshot === 'string' && screenshot) {
+        lines.push(`- Screenshot: \`${screenshot}\``);
+    }
+    if (typeof domDump === 'string' && domDump) {
+        lines.push(`- DOM dump: \`${domDump}\``);
+    }
+    if (lines.length === 0) {
+        return '';
+    }
+    return ['## Visual preview', '', ...lines].join('\n');
+}
+
+/** Render **only** hits that changed an outcome (per report schema). */
+function _memory_section(state: DeliveryState): string {
+    const influential = (state.memory || []).filter(
+        (hit) => _isPlainObject(hit) && _pyTruthy((hit as Record<string, unknown>).changed_outcome),
+    );
+    if (influential.length === 0) {
+        return ''; // drop the whole section — heading included
+    }
+    const lines = ['## Memory that mattered', ''];
+    for (const hit of influential) {
+        const h = hit as Record<string, unknown>;
+        const hitId = _pyTruthy(h.id) ? h.id : '(no id)';
+        const hitType = _pyTruthy(h.type) ? h.type : '(no type)';
+        const note = _pyTruthy(h.note) ? h.note : _pyTruthy(h.why) ? h.why : '';
+        const suffix = note ? ` — ${_pyStr(note)}` : '';
+        lines.push(`- \`${_pyStr(hitId)}\` (${_pyStr(hitType)})${suffix}`);
+    }
+    return lines.join('\n');
+}
+
+function _followups_section(state: DeliveryState): string {
+    const followups = _extract_followups(state);
+    if (followups.length === 0) {
+        return '## Follow-ups\n\n_(none)_';
+    }
+    const lines = ['## Follow-ups', ''];
+    for (const item of followups) {
+        const anchor = _pyTruthy(item.anchor) ? item.anchor : '';
+        const note = _pyTruthy(item.note) ? item.note : _pyTruthy(item.title) ? item.title : '(untitled)';
+        let prefix = `- ${_pyStr(note)}`;
+        if (anchor) {
+            prefix += ` — \`${_pyStr(anchor)}\``;
+        }
+        lines.push(prefix);
+    }
+    return lines.join('\n');
+}
+
+/** Follow-ups may live on any slice; aggregate them in reading order. */
+function _extract_followups(state: DeliveryState): Array<Record<string, Any>> {
+    const collected: Array<Record<string, Any>> = [];
+    for (const source of [state.plan, state.verify, state.tests]) {
+        if (_isPlainObject(source)) {
+            const fups = (source as Record<string, unknown>).followups;
+            for (const item of Array.isArray(fups) ? fups : []) {
+                if (_isPlainObject(item)) {
+                    collected.push(item as Record<string, Any>);
+                }
+            }
+        }
+    }
+    return collected;
+}
+
+function _next_commands_section(state: DeliveryState): string {
+    if (!resolve_policy(state.persona).suggests_next_commands) {
+        // Advisory personas produce a plan-only report; suggesting a
+        // commit or PR would mislead the reader — nothing was changed.
+        return '';
+    }
+    const commands = _suggest_commands(state);
+    const lines = ['## Suggested next commands', ''];
+    for (const cmd of commands) {
+        lines.push(`- \`${cmd}\``);
+    }
+    return lines.join('\n');
+}
+
+/** Always suggest `/commit` and `/create-pr` when verify was successful. */
+function _suggest_commands(state: DeliveryState): string[] {
+    if (state.outcomes.verify === Outcome.SUCCESS) {
+        return ['/commit', '/create-pr'];
+    }
+    return ['/commit'];
+}
+
+/** Render a dict-ish slice as a bullet list; fall back to placeholder. */
+function _format_kv_block(value: Any, empty_placeholder: string): string {
+    if (!_pyTruthy(value)) {
+        return empty_placeholder;
+    }
+    if (_isPlainObject(value)) {
+        return _render_kv_lines(Object.entries(value as Record<string, unknown>)).join('\n');
+    }
+    if (typeof value === 'string') {
+        return _pyStrip(value) || empty_placeholder;
+    }
+    return _pyStr(value);
+}
+
+/** Render `(key, value)` pairs as one Markdown bullet per pair. */
+function _render_kv_lines(pairs: Array<[string, Any]>): string[] {
+    return pairs.map(([key, value]) => `- **${key}:** ${_pyStr(value)}`);
+}
+
+/** `(value or {})` style truthiness, Python semantics. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** Python `str.strip()`. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/**
+ * Python `str(value)` for the scalar / container kinds the report renders.
+ *
+ * Strings render as-is; `None`/booleans use Python spelling; numbers as-is;
+ * dict / list use Python's `repr`-style bracketing so a `str(plan)` /
+ * `str(value)` fallback matches the Python output byte-for-byte.
+ */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return _pyNumber(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}
+
+/** Python `repr()` for values nested inside a `str(container)` render. */
+function _pyReprInner(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    if (typeof value === 'number') {
+        return _pyNumber(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}
+
+/** Python number-to-str: integer-valued floats keep no decimal in `int` path. */
+function _pyNumber(value: number): string {
+    return String(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/test.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/test.ts
@@ -1,0 +1,267 @@
+/**
+ * `test` step — gate + Option-A delegation for running the test suite.
+ *
+ * TypeScript twin of `work_engine/directives/backend/test.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The dispatcher never spawns subprocesses. Test execution is handed
+ * to the agent via `@agent-directive: run-tests scope=targeted`; the
+ * agent drives the project's test runner (pytest, Pest, phpunit, …),
+ * captures the verdict onto `state.tests`, marks
+ * `outcomes['test'] = 'success'`, and re-invokes the dispatcher.
+ *
+ * Contract for `state.tests` when populated:
+ *
+ * - Must be a dict.
+ * - Must carry a `verdict` key — one of `success`, `failed`,
+ *   or `mixed` (targeted vs full-suite split). Anything else blocks.
+ * - `failed` or `mixed` verdicts halt with the verdict as part of
+ *   the surfaced message so the user decides whether to continue or
+ *   stop. This follows the `verify-before-complete` rule: a bad test
+ *   outcome must never be silently skipped.
+ * - Optional keys (`targeted`, `full`, `duration_ms`,
+ *   `followups`) feed the delivery report.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+const _ALLOWED_VERDICTS = ['success', 'failed', 'mixed'] as const;
+
+/** Declared ambiguity surfaces. Advisory personas skip this step entirely. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_implement_failed',
+        trigger: '`implement` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_tests_delegate',
+        trigger: '`state.tests` empty — test runner not invoked yet',
+        resolution:
+            'agent directive `run-tests scope=targeted|full` → ' +
+            '`/tests-execute` (qa persona widens to full suite)',
+    },
+    {
+        code: 'malformed_tests',
+        trigger: '`state.tests` is not a dict or `verdict` is not one of ' + 'success / failed / mixed',
+        resolution: 're-run tests and record a clean verdict',
+    },
+    {
+        code: 'bad_test_verdict',
+        trigger: '`state.tests[\'verdict\']` is `failed` or `mixed`',
+        resolution: 'fix failures and re-run, or abort',
+    },
+];
+
+/** Gate on `implement`, then either delegate or validate `state.tests`. */
+export function run(state: DeliveryState): StepResult {
+    const policy = resolve_policy(state.persona);
+    if (!policy.allows_test) {
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `test skipped: persona \`${policy.name}\` is plan-only.`,
+        });
+    }
+
+    if (state.outcomes.implement !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const tests = state.tests;
+    if (!_pyTruthy(tests)) {
+        return _delegate_to_run_tests(state, policy.widen_tests);
+    }
+
+    const shapeIssues = _diagnose_tests(tests);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    // At this point `tests` is a dict with a recognised verdict.
+    const verdict = (tests as Record<string, unknown>).verdict;
+    if (verdict !== 'success') {
+        return _blocked_on_bad_verdict(state, verdict);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _diagnose_tests(tests: Any): string[] {
+    if (!_isPlainObject(tests)) {
+        return [`state.tests must be a dict, got ${_pyTypeName(tests)}`];
+    }
+    const verdict = (tests as Record<string, unknown>).verdict;
+    if (!_inAllowedVerdicts(verdict)) {
+        return [
+            `state.tests['verdict'] must be one of ` +
+                `${_ALLOWED_VERDICTS.join(', ')}; got ${_pyRepr(verdict)}`,
+        ];
+    }
+    return [];
+}
+
+/**
+ * Emit the `run-tests` directive.
+ *
+ * `widen` comes from the persona policy (`qa` widens to the full
+ * suite). The directive scope becomes the first thing an orchestrator
+ * reads, so the widened case is visible without parsing the options.
+ */
+function _delegate_to_run_tests(state: DeliveryState, widen: boolean): StepResult {
+    const ticketId = _ticketId(state);
+    const scope = widen ? 'full' : 'targeted';
+    const description = widen
+        ? 'full suite (qa persona widens to catch regressions outside ' + 'the changed paths)'
+        : 'targeted first (`--filter` on the changed paths), full ' + 'suite only if targeted passes';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('run-tests', { ticket: ticketId, scope }),
+            `> Ticket ${ticketId} — running tests: ${description}.`,
+            `> 1. Continue — run ${scope} tests now`,
+            '> 2. Abort — skip testing (NOT recommended)',
+        ],
+        message: `Ticket ${ticketId} needs its tests run before verification.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — test gate refused: ` +
+                '`implement` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot test: implement gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded test output is malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run tests and resume',
+            '> 2. Abort — test verdict cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} tests shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+function _blocked_on_bad_verdict(state: DeliveryState, verdict: Any): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — tests reported \`${String(verdict)}\`. ` +
+                'Verification cannot proceed on a non-success verdict.',
+            '> 1. Fix the failing tests and re-run `run-tests`',
+            '> 2. Continue anyway — override (NOT recommended)',
+            '> 3. Abort',
+        ],
+        message: `Ticket ${ticketId} test verdict was \`${String(verdict)}\`, not success.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+function _inAllowedVerdicts(value: unknown): boolean {
+    return (_ALLOWED_VERDICTS as ReadonlyArray<unknown>).includes(value);
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Python `type(x).__name__` for the value kinds the diagnose paths see. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (typeof value === 'boolean') {
+        return 'bool';
+    }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') {
+        return 'str';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Set) {
+        return 'set';
+    }
+    if (value instanceof Map || _isPlainObject(value)) {
+        return 'dict';
+    }
+    return typeof value;
+}
+
+/**
+ * Python `repr()` for the verdict value kinds (`{verdict!r}`).
+ *
+ * Strings render single-quoted; `None` → `None`; booleans → `True` / `False`;
+ * numbers as-is. Only the kinds an invalid `verdict` slot can carry are
+ * covered.
+ */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/verify.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/verify.ts
@@ -1,0 +1,257 @@
+/**
+ * `verify` step — gate + Option-A delegation to `review-changes`.
+ *
+ * TypeScript twin of `work_engine/directives/backend/verify.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The dispatcher does not run the review-changes judges itself; the
+ * agent invokes the composite review (bug-hunter + security +
+ * test-coverage + code-quality) and captures the consolidated
+ * verdict onto `state.verify`.
+ *
+ * `state.verify` contract when populated:
+ *
+ * - Must be a dict.
+ * - Must carry a `verdict` key — one of `success`, `blocked`,
+ *   `partial`. Matches the `Outcome` vocabulary used everywhere
+ *   else in the flow.
+ * - A `success` verdict advances the flow to `report`.
+ * - A `blocked` or `partial` verdict halts with numbered options
+ *   so the user decides whether to address the findings, override
+ *   (rarely appropriate), or abort.
+ * - Optional keys (`confidence`, `findings`, `followups`) feed
+ *   the delivery report.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+const _ALLOWED_VERDICTS = ['success', 'blocked', 'partial'] as const;
+
+/** Declared ambiguity surfaces. Advisory personas skip this step entirely. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_test_failed',
+        trigger: '`test` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_verify_delegate',
+        trigger: '`state.verify` empty — four-judge review not run yet',
+        resolution: 'agent directive `review-changes` → `/review-changes`',
+    },
+    {
+        code: 'malformed_verify',
+        trigger: '`state.verify` is not a dict or `verdict` is not one of ' + 'success / blocked / partial',
+        resolution: 're-run `/review-changes` and record a clean verdict',
+    },
+    {
+        code: 'bad_verify_verdict',
+        trigger: '`state.verify[\'verdict\']` is `blocked` or `partial`',
+        resolution:
+            'address findings and re-run `/review-changes` — never bypass ' + '(see `verify-before-complete`)',
+    },
+];
+
+/** Gate on `test`, then either delegate or validate `state.verify`. */
+export function run(state: DeliveryState): StepResult {
+    const policy = resolve_policy(state.persona);
+    if (!policy.allows_verify) {
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `verify skipped: persona \`${policy.name}\` is plan-only.`,
+        });
+    }
+
+    if (state.outcomes.test !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const verify = state.verify;
+    if (!_pyTruthy(verify)) {
+        return _delegate_to_review_changes(state);
+    }
+
+    const shapeIssues = _diagnose_verify(verify);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    const verdict = (verify as Record<string, unknown>).verdict;
+    if (verdict !== 'success') {
+        return _blocked_on_bad_verdict(state, verdict);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _diagnose_verify(verify: Any): string[] {
+    if (!_isPlainObject(verify)) {
+        return [`state.verify must be a dict, got ${_pyTypeName(verify)}`];
+    }
+    const verdict = (verify as Record<string, unknown>).verdict;
+    if (!_inAllowedVerdicts(verdict)) {
+        return [
+            `state.verify['verdict'] must be one of ` +
+                `${_ALLOWED_VERDICTS.join(', ')}; got ${_pyRepr(verdict)}`,
+        ];
+    }
+    return [];
+}
+
+function _delegate_to_review_changes(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('review-changes', { ticket: ticketId }),
+            `> Ticket ${ticketId} — running the four-judge review ` +
+                '(bugs, security, tests, code quality) before the delivery ' +
+                'report is written.',
+            '> 1. Continue — run `review-changes` now',
+            '> 2. Abort — skip review (NOT recommended)',
+        ],
+        message: `Ticket ${ticketId} needs \`review-changes\` before the report.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — verify gate refused: ` +
+                '`test` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot verify: test gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded verify output is malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run `review-changes` and resume',
+            '> 2. Abort — verify verdict cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} verify shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+function _blocked_on_bad_verdict(state: DeliveryState, verdict: Any): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — \`review-changes\` reported ` +
+                `\`${String(verdict)}\`. The delivery report cannot claim completion on a ` +
+                'non-success verdict (see `verify-before-complete`).',
+            '> 1. Address the findings and re-run `review-changes`',
+            '> 2. Continue anyway — override (NOT recommended)',
+            '> 3. Abort',
+        ],
+        message: `Ticket ${ticketId} verify verdict was \`${String(verdict)}\`, not success.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+function _inAllowedVerdicts(value: unknown): boolean {
+    return (_ALLOWED_VERDICTS as ReadonlyArray<unknown>).includes(value);
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Python `type(x).__name__` for the value kinds the diagnose paths see. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (typeof value === 'boolean') {
+        return 'bool';
+    }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') {
+        return 'str';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Set) {
+        return 'set';
+    }
+    if (value instanceof Map || _isPlainObject(value)) {
+        return 'dict';
+    }
+    return typeof value;
+}
+
+/**
+ * Python `repr()` for the verdict value kinds (`{verdict!r}`).
+ *
+ * Strings render single-quoted; `None` → `None`; booleans → `True` / `False`;
+ * numbers as-is. Only the kinds an invalid `verdict` slot can carry are
+ * covered.
+ */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/mixed/contract.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/mixed/contract.ts
@@ -1,0 +1,243 @@
+/**
+ * `contract` step — locks data_model + api_surface before any UI work.
+ *
+ * TypeScript twin of `directives/mixed/contract.py` (ADR-094 py2ts). Public
+ * API names stay snake_case to mirror the Python module 1:1.
+ *
+ * In the `mixed` directive set the `plan` slot is the contract step. It
+ * resolves the backend contract the UI will consume — entity shape, endpoint
+ * signatures, validation surface — before the UI track runs. The mixed `ui`
+ * step gates on `state.contract.contract_confirmed is True`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Top-level keys every well-formed contract must carry. */
+export const REQUIRED_CONTRACT_KEYS: ReadonlyArray<string> = ['data_model', 'api_surface'];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_analyze_failed',
+        trigger: '`analyze` outcome is not `success`',
+        resolution: 're-run the mixed flow from the start',
+    },
+    {
+        code: 'contract_missing',
+        trigger: 'state.contract is None or empty — contract has not been produced',
+        resolution:
+            'agent directive `contract-plan` → `feature-plan` skill ' +
+            'writes the contract into state.contract',
+    },
+    {
+        code: 'contract_incomplete',
+        trigger:
+            'contract is populated but missing required keys ' +
+            '(`data_model`, `api_surface`) or one of them is empty',
+        resolution:
+            'agent re-runs `feature-plan` with contract-only scope; ' +
+            'halt lists the missing slots',
+    },
+    {
+        code: 'contract_unconfirmed',
+        trigger: 'contract is well-formed but contract_confirmed is unset/False',
+        resolution:
+            'user reviews the contract summary and sets ' +
+            'state.contract.contract_confirmed = True (or asks for ' +
+            'revisions, which loops back to contract-plan)',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Python `value is None or value == [] or value == {}` — the contract step's
+ * emptiness check. NOTE: unlike `directives/ui/design`, contract does NOT treat
+ * an empty string `""` as missing; only None / empty list / empty dict count.
+ */
+function _isEmptyOrNone(value: Any): boolean {
+    if (value === null || value === undefined) return true;
+    if (Array.isArray(value)) return value.length === 0;
+    if (_isDict(value)) return Object.keys(value).length === 0;
+    return false;
+}
+
+/** Apply the contract-first lock to `state.contract`. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes['analyze'] !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const contract = state.contract;
+    if (!_is_populated(contract)) {
+        return _delegate_to_feature_plan(state);
+    }
+
+    const missing = _missing_required_keys(contract as Record<string, Any>);
+    if (missing.length > 0) {
+        return _halt_incomplete_contract(state, missing);
+    }
+
+    if ((contract as Record<string, Any>)['contract_confirmed'] === true) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_unconfirmed(state, contract as Record<string, Any>);
+}
+
+/** True when `contract` carries an actionable backend lock. */
+function _is_populated(contract: Any): boolean {
+    if (!_isDict(contract)) return false;
+    if (Object.keys(contract).length === 0) return false;
+    return REQUIRED_CONTRACT_KEYS.some((key) => key in contract);
+}
+
+/** Return required top-level keys that are missing or empty. */
+function _missing_required_keys(contract: Record<string, Any>): string[] {
+    const missing: string[] = [];
+    for (const key of REQUIRED_CONTRACT_KEYS) {
+        const value = contract[key];
+        if (_isEmptyOrNone(value)) {
+            missing.push(key);
+        }
+    }
+    return missing;
+}
+
+/** Render a one-line preview of the input being contracted. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((s) => s.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** Python `str.rstrip()` (no arg) — strip trailing whitespace. */
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Python truthiness (used for the `data.get("id") or "(no title)"` chain). */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Python `str(value)`. */
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+/** BLOCKED halt — upstream `analyze` did not succeed. */
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> `analyze` did not succeed; cannot lock the contract until ' +
+                'the upstream investigation lands.',
+            '> 1. Re-run — restart the mixed flow from the start',
+            '> 2. Abort — drop this request',
+        ],
+        message: 'contract step gated on analyze; upstream outcome is not success.',
+    });
+}
+
+/** Halt with an agent directive so the orchestrator runs `feature-plan`. */
+function _delegate_to_feature_plan(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('contract-plan'),
+            `> Input: ${preview}`,
+            '> No backend contract yet — producing one now. The contract ' +
+                'locks the data model and API surface the UI will consume; ' +
+                'the mixed `ui` step refuses to start without it.',
+            '> Scope: contract-only (no UI plan, no implementation).',
+            '> 1. Continue — produce the contract via `feature-plan`',
+            '> 2. Abort — drop this mixed request',
+        ],
+        message: 'Mixed contract missing; delegating to feature-plan (contract-only).',
+    });
+}
+
+/** BLOCKED halt — contract is missing required keys. */
+function _halt_incomplete_contract(state: DeliveryState, missing: string[]): StepResult {
+    const preview = _preview_input(state);
+    const lines: string[] = [
+        agent_directive('contract-plan'),
+        `> Input: ${preview}`,
+        '> Backend contract is incomplete. Missing required slots:',
+    ];
+    for (const p of missing) {
+        lines.push(`> - \`${p}\``);
+    }
+    lines.push(
+        '> Re-run `feature-plan` (contract-only) so every required slot ' +
+            'has a final value before the UI track starts.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: `Mixed contract incomplete; ${missing.length} required slot(s) missing.`,
+    });
+}
+
+/** BLOCKED halt — contract is well-formed; user must sign off. */
+function _halt_unconfirmed(state: DeliveryState, contract: Record<string, Any>): StepResult {
+    const preview = _preview_input(state);
+    const data_model = _pyTruthy(contract['data_model']) ? contract['data_model'] : [];
+    const api_surface = _pyTruthy(contract['api_surface']) ? contract['api_surface'] : [];
+
+    const entity_count = Array.isArray(data_model) ? data_model.length : 0;
+    const endpoint_count = Array.isArray(api_surface) ? api_surface.length : 0;
+
+    const lines: string[] = [
+        `> Input: ${preview}`,
+        '> Backend contract is ready. Summary:',
+        `> - Entities (data model): ${entity_count}`,
+        `> - Endpoints / actions (api surface): ${endpoint_count}`,
+        '> 1. Confirm — lock this contract and advance to the UI track',
+        '> 2. Revise — send feedback; loops back to `contract-plan`',
+        '> 3. Abort — drop this mixed request',
+        '',
+        '**Recommendation: 1 — Confirm** — the contract covers both ' +
+            'required slots. Caveat: flip to 2 only if an entity field or ' +
+            'endpoint signature is wrong; the UI track will treat this ' +
+            'contract as immutable input.',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: 'Mixed contract ready; halting for user confirmation before UI track.',
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/mixed/stitch.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/mixed/stitch.ts
@@ -1,0 +1,259 @@
+/**
+ * `stitch` step — integration verification across the contract / UI seam.
+ *
+ * TypeScript twin of `directives/mixed/stitch.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * In the `mixed` directive set the `test` slot is the integration boundary.
+ * The dispatcher does not run integration scenarios itself — the agent invokes
+ * the `integration-test` skill which drives end-to-end smokes and writes the
+ * verdict back to `state.stitch`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Agent directive that drives end-to-end smoke scenarios. */
+export const INTEGRATION_TEST_DIRECTIVE = 'integration-test';
+
+const _ALLOWED_VERDICTS: ReadonlyArray<string> = ['success', 'blocked', 'partial'];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_ui_failed',
+        trigger: '`implement` (mixed.ui) outcome is not `success`',
+        resolution: 're-run the mixed flow; UI track must finish before stitch',
+    },
+    {
+        code: 'empty_stitch_delegate',
+        trigger: '`state.stitch` empty — integration-test skill has not run yet',
+        resolution: 'agent directive `integration-test` → end-to-end smokes',
+    },
+    {
+        code: 'malformed_stitch',
+        trigger:
+            '`state.stitch` is not a dict or `verdict` is not one of ' +
+            'success / blocked / partial',
+        resolution: 're-run `integration-test` and record a clean verdict',
+    },
+    {
+        code: 'bad_stitch_verdict',
+        trigger:
+            "`state.stitch['verdict']` is `blocked` or `partial` " +
+            'and `integration_confirmed` is not True',
+        resolution:
+            'address findings and re-run `integration-test`, or set ' +
+            '`integration_confirmed=True` to override (rare)',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function _pyTypeName(value: Any): string {
+    if (value === null || value === undefined) return 'NoneType';
+    if (typeof value === 'boolean') return 'bool';
+    if (typeof value === 'number') return Number.isInteger(value) ? 'int' : 'float';
+    if (typeof value === 'string') return 'str';
+    if (Array.isArray(value)) return 'list';
+    return 'dict';
+}
+
+function pyRepr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    if (typeof value === 'string') return pyStrRepr(value);
+    return String(value);
+}
+
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') body += '\\\\';
+        else if (ch === quote) body += `\\${ch}`;
+        else if (ch === '\n') body += '\\n';
+        else if (ch === '\r') body += '\\r';
+        else if (ch === '\t') body += '\\t';
+        else body += ch;
+    }
+    return `${quote}${body}${quote}`;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Gate on `implement`, then validate `state.stitch`. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes['implement'] !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const stitch = state.stitch;
+    if (!_pyTruthy(stitch)) {
+        return _delegate_to_integration_test(state);
+    }
+
+    const shape_issues = _diagnose_stitch(stitch);
+    if (shape_issues.length > 0) {
+        return _blocked_on_shape(state, shape_issues);
+    }
+
+    const s = stitch as Record<string, Any>;
+    const verdict = s['verdict'];
+    if (verdict === 'success') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    if (s['integration_confirmed'] === true) {
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `stitch verdict \`${pyStr(verdict)}\` overridden by integration_confirmed=True.`,
+        });
+    }
+
+    return _blocked_on_bad_verdict(state, verdict, s);
+}
+
+/** Return shape errors; empty list when `stitch` is well-formed. */
+function _diagnose_stitch(stitch: Any): string[] {
+    if (!_isDict(stitch)) {
+        return [`state.stitch must be a dict, got ${_pyTypeName(stitch)}`];
+    }
+    const verdict = stitch['verdict'];
+    if (typeof verdict !== 'string' || !_ALLOWED_VERDICTS.includes(verdict)) {
+        return [
+            `state.stitch['verdict'] must be one of ` +
+                `${_ALLOWED_VERDICTS.join(', ')}; got ${pyRepr(verdict)}`,
+        ];
+    }
+    return [];
+}
+
+/** One-line preview of the original input for halt bodies. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** BLOCKED halt — upstream UI step did not succeed. */
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Mixed `stitch` step gated on the UI step; ' +
+                'the implement outcome is not success.',
+            '> 1. Re-run — restart the mixed flow from the start',
+            '> 2. Abort — drop this request',
+        ],
+        message: 'stitch step gated on implement; upstream UI outcome is not success.',
+    });
+}
+
+/** Halt with an agent directive so the orchestrator runs smokes. */
+function _delegate_to_integration_test(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    const contract = _isDict(state.contract) ? state.contract : {};
+    const api_surface = _pyTruthy(contract['api_surface']) ? contract['api_surface'] : [];
+    const endpoint_count = Array.isArray(api_surface) ? api_surface.length : 0;
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(INTEGRATION_TEST_DIRECTIVE),
+            `> Input: ${preview}`,
+            '> UI track finished; the contract / UI seam needs end-to-end ' +
+                'verification before the delivery report:',
+            `> - Endpoints / actions to smoke: ${endpoint_count}`,
+            '> Scenarios cover the full round-trip — fill form → ' +
+                'server validation → response → UI update. Unit-level ' +
+                'passes from the UI review do **not** substitute for this gate.',
+            '> 1. Continue — run `integration-test` now',
+            '> 2. Abort — skip integration verification (NOT recommended)',
+        ],
+        message: 'Mixed UI complete; delegating to integration-test for stitch.',
+    });
+}
+
+/** BLOCKED halt — recorded stitch verdict is malformed. */
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Recorded stitch output is malformed: ' + issues.join('; ') + '.',
+            '> 1. Re-run `integration-test` and resume',
+            '> 2. Abort — stitch verdict cannot be trusted',
+        ],
+        message: `Mixed stitch shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+/** BLOCKED halt — verdict is blocked / partial and not user-confirmed. */
+function _blocked_on_bad_verdict(
+    state: DeliveryState,
+    verdict: Any,
+    stitch: Record<string, Any>,
+): StepResult {
+    void state;
+    const scenarios = _pyTruthy(stitch['scenarios']) ? stitch['scenarios'] : [];
+    const scenario_count = Array.isArray(scenarios) ? scenarios.length : 0;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> \`integration-test\` reported \`${pyStr(verdict)}\` after running ` +
+                `${scenario_count} scenario(s). The delivery report cannot ` +
+                'claim completion on a non-success integration verdict.',
+            '> 1. Address the findings and re-run `integration-test`',
+            '> 2. Override — set `state.stitch.integration_confirmed=true` ' +
+                'and resume (rare; document why)',
+            '> 3. Abort',
+        ],
+        message:
+            `Mixed stitch verdict was \`${pyStr(verdict)}\`, not success; ` +
+            'user override required to continue.',
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/mixed/ui.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/mixed/ui.ts
@@ -1,0 +1,216 @@
+/**
+ * `ui` step — delegates to the UI track once the contract is locked.
+ *
+ * TypeScript twin of `directives/mixed/ui.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * In the `mixed` directive set the `implement` slot is the UI handoff. It
+ * gates on the upstream contract sentinel
+ * (`state.contract.contract_confirmed is True`) and then delegates the full
+ * audit → design → apply → review → polish sub-flow to the UI track via an
+ * `@agent-directive: ui-track` halt.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Agent directive that triggers the full UI sub-flow. */
+export const UI_TRACK_DIRECTIVE = 'ui-track';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_contract_failed',
+        trigger: '`plan` (contract) outcome is not `success`',
+        resolution: 're-run the mixed flow from the start',
+    },
+    {
+        code: 'contract_sentinel_missing',
+        trigger:
+            'state.contract.contract_confirmed is missing or False — ' +
+            'defense-in-depth check refuses to start the UI track',
+        resolution:
+            'loop back to the contract step; user must confirm ' +
+            'the data_model + api_surface lock before UI work begins',
+    },
+    {
+        code: 'ui_track_not_started',
+        trigger:
+            'state.ui_review is empty or missing `review_clean` — ' +
+            'the UI sub-flow has not run yet',
+        resolution:
+            'agent directive `ui-track` → orchestrator runs ' +
+            'audit → design → apply → review → polish with the contract as ' +
+            'immutable input',
+    },
+    {
+        code: 'ui_track_review_unclean',
+        trigger:
+            'UI sub-flow finished but `review_clean` is False — ' +
+            'polish ceiling reached or findings remain',
+        resolution:
+            'user picks re-run / hand off / abort; polish-ceiling ' +
+            'semantics already fired inside the UI track',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Delegate the UI sub-flow once the contract is locked. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes['plan'] !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    if (!_contract_confirmed(state)) {
+        return _blocked_on_contract_sentinel(state);
+    }
+
+    const review = _isDict(state.ui_review) ? state.ui_review : null;
+    if (review === null || !('review_clean' in review)) {
+        return _delegate_to_ui_track(state);
+    }
+
+    if (review['review_clean'] === true) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_review_unclean(state, review);
+}
+
+/** True when the contract sentinel is explicitly `True`. */
+function _contract_confirmed(state: DeliveryState): boolean {
+    const contract = state.contract;
+    if (!_isDict(contract)) return false;
+    return contract['contract_confirmed'] === true;
+}
+
+/** One-line preview of the original input for halt bodies. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** BLOCKED halt — upstream contract step did not succeed. */
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Mixed `ui` step gated on the contract step; the contract ' +
+                'outcome is not success.',
+            '> 1. Re-run — restart the mixed flow from the start',
+            '> 2. Abort — drop this request',
+        ],
+        message: 'ui step gated on plan; upstream contract outcome is not success.',
+    });
+}
+
+/** BLOCKED halt — contract sentinel missing despite plan success. */
+function _blocked_on_contract_sentinel(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Contract sentinel missing — `state.contract.contract_confirmed` ' +
+                'is not `True`. The UI track will not start until the data ' +
+                'model and API surface are locked and confirmed.',
+            '> 1. Loop back — re-enter the contract step and confirm',
+            '> 2. Abort — drop this mixed request',
+        ],
+        message:
+            'ui step refused; contract_confirmed sentinel missing despite plan success.',
+    });
+}
+
+/** Halt with an agent directive so the orchestrator runs the UI track. */
+function _delegate_to_ui_track(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    const contract = _isDict(state.contract) ? state.contract : {};
+    const data_model = _pyTruthy(contract['data_model']) ? contract['data_model'] : [];
+    const api_surface = _pyTruthy(contract['api_surface']) ? contract['api_surface'] : [];
+    const entity_count = Array.isArray(data_model) ? data_model.length : 0;
+    const endpoint_count = Array.isArray(api_surface) ? api_surface.length : 0;
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(UI_TRACK_DIRECTIVE),
+            `> Input: ${preview}`,
+            '> Contract is locked. Handing off to the UI track:',
+            `> - Entities: ${entity_count}`,
+            `> - Endpoints / actions: ${endpoint_count}`,
+            '> The UI track runs audit → design → apply → ' +
+                'review → polish with the contract as immutable input. ' +
+                'No new entities or endpoints — the contract drives the UI shape.',
+            '> 1. Continue — run the UI track',
+            '> 2. Abort — drop this mixed request',
+        ],
+        message: 'Mixed contract locked; delegating UI sub-flow to ui-track.',
+    });
+}
+
+/** BLOCKED halt — UI sub-flow finished but review is not clean. */
+function _halt_review_unclean(state: DeliveryState, review: Record<string, Any>): StepResult {
+    void state;
+    const findings = _pyTruthy(review['findings']) ? review['findings'] : [];
+    const finding_count = Array.isArray(findings) ? findings.length : 0;
+    const lines: string[] = [
+        `> UI track finished but review is not clean. Findings remaining: ${finding_count}.`,
+        '> Polish ceiling already fired inside the UI track — the ' +
+            'engine cannot resolve the remaining findings without a user ' +
+            'decision.',
+        '> 1. Re-run UI track — hand back to `ui-track` for another ' +
+            'audit → design pass (rare; usually means the contract changed)',
+        '> 2. Hand off — ship as-is and let a human resolve the ' +
+            'remaining findings outside the engine',
+        '> 3. Abort — drop this mixed request',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: `Mixed ui step halted; UI track review unclean (${finding_count} findings).`,
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/_passthrough.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/_passthrough.ts
@@ -1,0 +1,40 @@
+/**
+ * Pass-through handler for UI directive slots that have no work.
+ *
+ * TypeScript twin of `directives/ui/_passthrough.py` (ADR-094 py2ts). Public
+ * API names stay snake_case to mirror the Python module 1:1 (Python style is
+ * part of the contract). The handler is intentionally pure and
+ * side-effect-free: it neither reads nor writes `state`.
+ *
+ * Phase 6 of the UI track retired the Phase 3 deferral stub once design /
+ * apply / review / polish landed. Two slots remain semantically empty for the
+ * UI track:
+ *
+ * - `memory` — the UI track does not consult the four memory types the
+ *   backend retrieves over. UI work pivots on the audit findings in
+ *   `state.ui_audit` instead.
+ * - `plan` — `.design` produces the locked design brief that `.apply`
+ *   follows verbatim. The brief IS the plan.
+ *
+ * Both slots return `Outcome.SUCCESS` without writing to state.
+ */
+import {
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** Pass-through never blocks — empty surface, declared intent. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/**
+ * Return `SUCCESS` without mutating state.
+ *
+ * The handler neither reads nor writes `state`. The dispatcher records the
+ * step as successful in `state.outcomes` (its own bookkeeping) and advances to
+ * the next slot.
+ */
+export function run(state: DeliveryState): StepResult {
+    void state; // explicitly unused — the slot is a no-op by design
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/apply.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/apply.ts
@@ -1,0 +1,216 @@
+/**
+ * `apply` step — stack-dispatched UI implementation.
+ *
+ * TypeScript twin of `directives/ui/apply.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The apply step turns the locked design brief into actual files. Routes on
+ * `state.stack.frontend` to the appropriate implementation skill bundle, and
+ * on `state.ticket["ui_apply"]` shape: first-pass delegation, placeholder
+ * rejection, or change recording. Apply validates the output against the
+ * brief's microcopy lock so a mid-loop hallucination is caught at the boundary.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+import { PLACEHOLDER_PATTERNS } from './design.js';
+
+/** Map `state.stack.frontend` → agent-directive skill name. */
+export const STACK_DIRECTIVES: Record<string, string> = {
+    'blade-livewire-flux': 'ui-apply-blade-livewire-flux',
+    'react-shadcn': 'ui-apply-react-shadcn',
+    vue: 'ui-apply-vue',
+    plain: 'ui-apply-plain',
+};
+
+/** Fallback directive when `state.stack` is missing or malformed. */
+export const DEFAULT_DIRECTIVE = 'ui-apply-plain';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'apply_envelope_missing',
+        trigger:
+            "state.ticket['ui_apply'] unset — first pass, " +
+            'stack-specific skill has not run yet',
+        resolution:
+            'agent directive `ui-apply-<stack>` → skill ' +
+            'bundle implements the brief and writes the envelope back',
+    },
+    {
+        code: 'apply_placeholders_in_output',
+        trigger:
+            'rendered text in apply envelope contains ' +
+            'placeholder patterns (<placeholder>, Lorem, TODO:, TBD, XXX) ' +
+            '— design-brief lock failed mid-loop',
+        resolution:
+            'agent re-renders the components with the locked ' +
+            'microcopy verbatim from state.ui_design.microcopy',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Apply the stack-dispatched implementation gate. */
+export function run(state: DeliveryState): StepResult {
+    const envelope = _apply_envelope(state);
+    if (envelope === null) {
+        return _delegate_to_stack_skill(state);
+    }
+
+    const violations = _placeholder_violations_in_output(envelope);
+    if (violations.length > 0) {
+        return _halt_placeholders(state, violations);
+    }
+
+    _record_changes(state, envelope);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** Return the agent-written `ui_apply` envelope, or `null`. */
+function _apply_envelope(state: DeliveryState): Record<string, Any> | null {
+    const data = _pyTruthy(state.ticket) ? state.ticket : {};
+    const envelope = (data as Record<string, Any>)['ui_apply'];
+    if (_isDict(envelope) && _pyTruthy(envelope)) {
+        return envelope;
+    }
+    return null;
+}
+
+/** Pick the agent directive for the project's frontend stack. */
+function _resolve_directive(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend in STACK_DIRECTIVES) {
+            return STACK_DIRECTIVES[frontend] as string;
+        }
+    }
+    return DEFAULT_DIRECTIVE;
+}
+
+/** Return paths into `envelope['rendered']` whose text matches a pattern. */
+function _placeholder_violations_in_output(envelope: Record<string, Any>): string[] {
+    const rendered = envelope['rendered'];
+    if (!_isDict(rendered)) {
+        return [];
+    }
+    const violations: string[] = [];
+    _walk_rendered(rendered, '', violations);
+    return violations;
+}
+
+function _walk_rendered(node: Record<string, Any>, prefix: string, violations: string[]): void {
+    for (const key of Object.keys(node)) {
+        const value = node[key];
+        const path = prefix ? `${prefix}.${key}` : String(key);
+        if (_isDict(value)) {
+            _walk_rendered(value, path, violations);
+            continue;
+        }
+        if (typeof value !== 'string') {
+            continue;
+        }
+        const lowered = value.toLowerCase();
+        for (const pattern of PLACEHOLDER_PATTERNS) {
+            if (lowered.includes(pattern)) {
+                violations.push(path);
+                break;
+            }
+        }
+    }
+}
+
+/** First-pass halt — emit the stack-specific apply directive. */
+function _delegate_to_stack_skill(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    const stack_label = _stack_label(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            `> Stack: \`${stack_label}\`. Implementing the locked design brief.`,
+            '> Microcopy is locked — every button label, empty-state ' +
+                'message, and validation message must come verbatim from ' +
+                '`state.ui_design.microcopy`.',
+            '> 1. Continue — implement the brief and write a ' +
+                '`ui_apply` envelope back into state.ticket ' +
+                '(rendered: {path: text}, files: [...])',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: `UI apply pending; delegating to \`${directive}\` for stack \`${stack_label}\`.`,
+    });
+}
+
+/** BLOCKED halt — rendered output still carries placeholder patterns. */
+function _halt_placeholders(state: DeliveryState, violations: string[]): StepResult {
+    const directive = _resolve_directive(state);
+    const lines: string[] = [
+        agent_directive(directive),
+        '> Apply rejected: rendered output contains placeholder strings. ' +
+            'The design-brief microcopy lock failed mid-loop.',
+        '> Affected paths in `ui_apply.rendered`:',
+    ];
+    for (const p of violations) {
+        lines.push(`> - \`${p}\``);
+    }
+    lines.push(
+        '> Re-render with the locked microcopy verbatim from ' +
+            '`state.ui_design.microcopy`; apply will not write placeholder text.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message:
+            `UI apply rejected: ${violations.length} placeholder ` +
+            'violation(s) in rendered output.',
+    });
+}
+
+/** Append one `state.changes` entry per file in the apply envelope. */
+function _record_changes(state: DeliveryState, envelope: Record<string, Any>): void {
+    let files = envelope['files'];
+    if (!Array.isArray(files)) {
+        files = [];
+    }
+    const summary = _pyTruthy(envelope['summary']) ? envelope['summary'] : 'ui apply';
+    const stack_label = _stack_label(state);
+    for (const p of files as Any[]) {
+        if (typeof p !== 'string' || p === '') {
+            continue;
+        }
+        state.changes.push({
+            kind: 'ui',
+            stack: stack_label,
+            file: p,
+            summary: summary,
+        });
+    }
+}
+
+/** Return the frontend stack label, defaulting to `plain`. */
+function _stack_label(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend !== '') {
+            return frontend;
+        }
+    }
+    return 'plain';
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/audit.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/audit.ts
@@ -1,0 +1,506 @@
+/**
+ * `audit` step — mandatory pre-step for the UI directive set.
+ *
+ * TypeScript twin of `directives/ui/audit.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * Routes on `state.ui_audit` shape: first-pass delegation, greenfield decision,
+ * shadcn version mismatch, ambiguous candidate pick, or high-confidence pass.
+ * The deterministic checks live here so "no design without audit findings" is
+ * enforceable from code, not norms. Mirrors the `state.ui_audit` gate the
+ * `ui-audit-gate` rule defends.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Similarity threshold for a "strong reusable match". */
+export const STRONG_SIMILARITY = 0.7;
+
+/** Top-2 within this gap counts as ambiguous regardless of confidence. */
+export const TIE_GAP = 0.05;
+
+/** Major version the `react-shadcn-ui` skill body declares as tested against. */
+export const TESTED_AGAINST_SHADCN_MAJOR = 2;
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'audit_missing',
+        trigger: 'state.ui_audit is None or empty — skill has not run yet',
+        resolution:
+            'agent directive `existing-ui-audit` → skill writes ' +
+            'findings into state.ui_audit',
+    },
+    {
+        code: 'greenfield_undecided',
+        trigger:
+            'state.ui_audit.greenfield is True but greenfield_decision ' +
+            'is unset — user has not picked a scaffolding direction',
+        resolution:
+            'user picks scaffold / bare / external_reference; ' +
+            'agent records the choice in state.ui_audit.greenfield_decision',
+    },
+    {
+        code: 'shadcn_version_mismatch',
+        trigger:
+            'state.ui_audit.shadcn_inventory.version major differs from ' +
+            'TESTED_AGAINST_SHADCN_MAJOR — react-shadcn-ui skill was ' +
+            'tested against a different major',
+        resolution:
+            'user accepts cautious composition or aborts; ' +
+            'agent records the choice in ' +
+            'state.ui_audit.version_mismatch_decision',
+    },
+    {
+        code: 'audit_ambiguous',
+        trigger:
+            'confidence band is medium, OR inventory has multiple matches ' +
+            'with similar similarity scores, OR no match clears ' +
+            'STRONG_SIMILARITY',
+        resolution:
+            "user picks a candidate to extend (or 'build new'); " +
+            'agent records the choice in state.ui_audit.audit_path ' +
+            'and state.ui_audit.candidate_pick',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Apply the audit gate to `state.ui_audit`. */
+export function run(state: DeliveryState): StepResult {
+    const audit = state.ui_audit;
+    if (!_is_populated(audit)) {
+        return _delegate_to_audit_skill(state);
+    }
+
+    const a = audit as Record<string, Any>;
+    if (a['greenfield'] === true && !_pyTruthy(a['greenfield_decision'])) {
+        return _halt_greenfield(state, a);
+    }
+
+    // Greenfield with a recorded decision skips the candidate-pick halt and
+    // lands on SUCCESS.
+    if (a['greenfield'] === true) {
+        if (!_pyTruthy(a['audit_path'])) {
+            a['audit_path'] = 'greenfield';
+        }
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const mismatch = _detect_shadcn_version_mismatch(a);
+    if (mismatch !== null && !_pyTruthy(a['version_mismatch_decision'])) {
+        return _halt_shadcn_version_mismatch(state, mismatch);
+    }
+
+    // Idempotent re-entry: an already-decided path round-trips through SUCCESS.
+    if (a['audit_path'] === 'high_confidence' || a['audit_path'] === 'ambiguous') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const decision = _decide_path(state, a);
+    if (decision === 'high_confidence') {
+        a['audit_path'] = 'high_confidence';
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_ambiguous(state, a);
+}
+
+/** True when `audit` carries actionable findings. */
+function _is_populated(audit: Any): boolean {
+    if (!_isDict(audit)) return false;
+    if (Object.keys(audit).length === 0) return false;
+    return ['components_found', 'components', 'greenfield'].some((key) => key in audit);
+}
+
+/** Render a one-line preview of the input being audited. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** Halt with an agent directive so the orchestrator runs `existing-ui-audit`. */
+function _delegate_to_audit_skill(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('existing-ui-audit'),
+            `> Input: ${preview}`,
+            '> No UI audit findings yet — running `existing-ui-audit` ' +
+                'to inventory components, design system, tokens, and ' +
+                'candidate matches before design.',
+            '> 1. Continue — let the skill produce the audit',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: 'UI audit findings missing; delegating to existing-ui-audit skill.',
+    });
+}
+
+/** BLOCKED halt — greenfield project needs an explicit scaffolding pick. */
+function _halt_greenfield(state: DeliveryState, audit: Record<string, Any>): StepResult {
+    void audit;
+    const preview = _preview_input(state);
+    const questions: string[] = [
+        `> Input: ${preview}`,
+        '> No existing UI surface detected — this looks like greenfield.',
+        '> 1. Scaffold — minimal token set + base component primitive folder',
+        '> 2. Bare — proceed with Tailwind defaults, no scaffolding',
+        '> 3. External reference — point me at a design-system URL or file',
+        '',
+        '**Recommendation: 1 — Scaffold tokens + primitives** ' +
+            '— even one extra screen benefits from a shared base; the ' +
+            'scaffold cost is ~10 min and saves re-doing every primitive ' +
+            'on screen 2. Caveat: flip to 2 if this is a demo or ' +
+            'single-page prototype that will not grow.',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message:
+            'UI audit detected greenfield; halting for scaffolding ' +
+            'direction (scaffold / bare / external_reference).',
+    });
+}
+
+/** Return `"high_confidence"` or `"ambiguous"` for a populated audit. */
+function _decide_path(state: DeliveryState, audit: Record<string, Any>): string {
+    const band = _confidence_band(state);
+    if (band !== 'high') {
+        return 'ambiguous';
+    }
+
+    const matches = _matches(audit);
+    if (matches.length === 0) {
+        return 'ambiguous';
+    }
+
+    const scored = matches.map((m) => _similarity_of(m)).sort((x, y) => y - x);
+    const top = scored[0] as number;
+    if (top < STRONG_SIMILARITY) {
+        return 'ambiguous';
+    }
+    if (scored.length >= 2 && top - (scored[1] as number) < TIE_GAP) {
+        return 'ambiguous';
+    }
+    return 'high_confidence';
+}
+
+/** Return the scored confidence band, or `"high"` when not applicable. */
+function _confidence_band(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const confidence = data['confidence'];
+    if (_isDict(confidence)) {
+        const band = confidence['band'];
+        if (typeof band === 'string' && band !== '') {
+            return band;
+        }
+    }
+    const input_kind = data['input_kind'];
+    if (input_kind === 'diff' || input_kind === 'file') {
+        return 'high';
+    }
+    return 'medium';
+}
+
+/** Return the inventory list, preferring `components_found`. */
+function _matches(audit: Record<string, Any>): Record<string, Any>[] {
+    for (const key of ['components_found', 'components']) {
+        const value = audit[key];
+        if (Array.isArray(value) && value.length > 0) {
+            return value.filter((m): m is Record<string, Any> => _isDict(m));
+        }
+    }
+    return [];
+}
+
+/** Read a similarity score from a match entry; default to 0.0. */
+function _similarity_of(match: Record<string, Any>): number {
+    const raw = match['similarity'];
+    const f = _pyFloat(raw);
+    return f === null ? 0.0 : f;
+}
+
+/**
+ * Python `float(x)` for the JSON shapes that reach a similarity value.
+ * Returns the float, or `null` to mirror `except (TypeError, ValueError)`.
+ */
+function _pyFloat(value: Any): number | null {
+    if (typeof value === 'boolean') {
+        return value ? 1.0 : 0.0;
+    }
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const t = value.trim();
+        if (t === '') return null;
+        // Python float() accepts decimals, exponents, inf, nan; the inputs here
+        // are plain decimals — match the common numeric form.
+        if (/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(t)) {
+            return Number(t);
+        }
+        const lower = t.toLowerCase().replace(/^[+-]/, '');
+        if (lower === 'inf' || lower === 'infinity') {
+            return t.startsWith('-') ? -Infinity : Infinity;
+        }
+        if (lower === 'nan') {
+            return NaN;
+        }
+        return null;
+    }
+    return null;
+}
+
+/** Return mismatch info when the inventory diverges by a major. */
+function _detect_shadcn_version_mismatch(audit: Record<string, Any>): Record<string, Any> | null {
+    const inventory = audit['shadcn_inventory'];
+    if (!_isDict(inventory)) {
+        return null;
+    }
+    const raw_version = inventory['version'];
+    if (typeof raw_version !== 'string' || raw_version.trim() === '') {
+        return null;
+    }
+    const head = _pyRStripWs(_pyLStripChar(raw_version, 'v').split('.', 1)[0] as string);
+    const installed_major = _pyIntStrict(head);
+    if (installed_major === null) {
+        return null;
+    }
+    if (installed_major === TESTED_AGAINST_SHADCN_MAJOR) {
+        return null;
+    }
+    return {
+        installed_version: raw_version,
+        installed_major,
+        tested_major: TESTED_AGAINST_SHADCN_MAJOR,
+    };
+}
+
+/** Python `str.lstrip(ch)`. */
+function _pyLStripChar(s: string, ch: string): string {
+    let start = 0;
+    while (start < s.length && s[start] === ch) start += 1;
+    return s.slice(start);
+}
+
+/** Python `str.strip()` (no-arg) applied to the parsed head. */
+function _pyRStripWs(s: string): string {
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/**
+ * Python `str.split(sep, 1)` for a single-character separator: at most one
+ * split, returning the first segment via `[0]`.
+ */
+// (inlined via String.prototype.split(sep, limit) won't replicate Python's
+// maxsplit semantics for `[0]`; but `[0]` only needs the prefix before the
+// first separator, which `split` then index 0 yields identically.)
+
+/**
+ * Python `int(s)` on an already-trimmed integer string. Returns the int, or
+ * `null` to mirror `except ValueError`.
+ */
+function _pyIntStrict(s: string): number | null {
+    if (/^[+-]?[0-9]+$/.test(s)) {
+        return Number(s);
+    }
+    return null;
+}
+
+/** BLOCKED soft-halt — user accepts cautious composition or aborts. */
+function _halt_shadcn_version_mismatch(
+    state: DeliveryState,
+    mismatch: Record<string, Any>,
+): StepResult {
+    const preview = _preview_input(state);
+    const installed = mismatch['installed_version'];
+    const tested = mismatch['tested_major'];
+    const installed_major = mismatch['installed_major'];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Input: ${preview}`,
+            `> shadcn skill tested against v${pyStr(tested)}.x; project uses ` +
+                `\`${pyStr(installed)}\` (major v${pyStr(installed_major)}).`,
+            '> 1. Proceed with cautious composition — skill applies ' +
+                'general patterns, agent verifies primitive APIs against ' +
+                'the installed version',
+            '> 2. Abort — update the `react-shadcn-ui` skill to the ' +
+                'installed major before continuing',
+            '',
+            '**Recommendation: 1 — Proceed with caution** ' +
+                '— most shadcn primitive APIs are stable across ' +
+                "majors; the skill's structural guidance still applies. " +
+                'Caveat: flip to 2 if the design brief leans on a ' +
+                'primitive whose API changed (Form, Sheet, Dialog have ' +
+                'had breaking renames in past majors).',
+        ],
+        message:
+            `shadcn version mismatch (skill v${pyStr(tested)}.x vs project ` +
+            `${pyStr(installed)}); halting for cautious-composition decision.`,
+    });
+}
+
+/** BLOCKED halt — user picks an existing candidate or 'build new'. */
+function _halt_ambiguous(state: DeliveryState, audit: Record<string, Any>): StepResult {
+    const preview = _preview_input(state);
+    const matches = _matches(audit);
+    const scored = _stableSortByKeyDesc(matches, _similarity_of).slice(0, 3);
+
+    const lines: string[] = [
+        `> Input: ${preview}`,
+        '> Audit findings are ambiguous — pick the candidate to ' +
+            'extend, or build new:',
+    ];
+    let idx = 1;
+    for (const match of scored) {
+        const name = _pyTruthy(match['name'])
+            ? match['name']
+            : _pyTruthy(match['path'])
+              ? match['path']
+              : '(unnamed)';
+        const sim = _similarity_of(match);
+        const path = _pyTruthy(match['path']) ? match['path'] : '';
+        const suffix = path ? ` — \`${pyStr(path)}\`` : '';
+        lines.push(`> ${idx}. Extend \`${pyStr(name)}\` (similarity ${_pyFixed(sim, 2)})${suffix}`);
+        idx += 1;
+    }
+    const next_idx = scored.length + 1;
+    lines.push(`> ${next_idx}. Build new — none of the above is close enough`);
+
+    let rec: string;
+    if (scored.length > 0) {
+        const top = scored[0] as Record<string, Any>;
+        const top_name = _pyTruthy(top['name'])
+            ? top['name']
+            : _pyTruthy(top['path'])
+              ? top['path']
+              : 'candidate 1';
+        const top_sim = _similarity_of(top);
+        rec =
+            `**Recommendation: 1 — Extend \`${pyStr(top_name)}\`** — ` +
+            `similarity ${_pyFixed(top_sim, 2)} is the strongest match in the ` +
+            'inventory; reuse beats new code unless the contract ' +
+            `diverges. Caveat: flip to ${next_idx} if the existing ` +
+            'component cannot host the new behavior cleanly.';
+    } else {
+        rec =
+            `**Recommendation: ${next_idx} — Build new** — ` +
+            'no inventory match cleared the strong-similarity bar. ' +
+            'Caveat: flip to an extend option only if a near-miss ' +
+            'is a better fit than starting from scratch.';
+    }
+    lines.push('', rec);
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message:
+            'UI audit findings ambiguous; halting for candidate pick ' +
+            '(extend existing / build new).',
+    });
+}
+
+/**
+ * Python `sorted(matches, key=_similarity_of, reverse=True)` — stable sort,
+ * descending by key, ties keep original order. JS `Array.prototype.sort` is
+ * stable; for `reverse=True` Python keeps equal-key elements in original
+ * order, so a stable comparator that only compares keys (never swaps ties)
+ * reproduces it exactly.
+ */
+function _stableSortByKeyDesc(
+    items: Record<string, Any>[],
+    key: (m: Record<string, Any>) => number,
+): Record<string, Any>[] {
+    const keyed = items.map((m) => ({ m, k: key(m) }));
+    keyed.sort((a, b) => (a.k < b.k ? 1 : a.k > b.k ? -1 : 0));
+    return keyed.map((e) => e.m);
+}
+
+/**
+ * Python `format(x, '.2f')` — fixed-point, 2 decimals, round-half-to-even on
+ * the exact IEEE value. Mirrors `telemetry/report_renderer._pyFixed`.
+ */
+function _pyFixed(value: number, ndigits: number): string {
+    if (!Number.isFinite(value)) {
+        return String(value);
+    }
+    const sign = value < 0 ? '-' : '';
+    const abs = Math.abs(value);
+    const str = abs.toPrecision(17);
+    if (str.includes('e') || str.includes('E')) {
+        return sign + abs.toFixed(ndigits);
+    }
+    const dot = str.indexOf('.');
+    const intPart = dot === -1 ? str : str.slice(0, dot);
+    let fracPart = dot === -1 ? '' : str.slice(dot + 1);
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keepFrac = fracPart.slice(0, ndigits);
+    const deciderStr = fracPart.slice(ndigits);
+    let scaledInt = BigInt(intPart + keepFrac || '0');
+    const firstDecider = deciderStr.charAt(0);
+    const restNonZero = /[1-9]/u.test(deciderStr.slice(1));
+    let roundUp = false;
+    if (firstDecider > '5' || (firstDecider === '5' && restNonZero)) {
+        roundUp = true;
+    } else if (firstDecider === '5' && !restNonZero) {
+        roundUp = scaledInt % 2n === 1n;
+    }
+    if (roundUp) {
+        scaledInt += 1n;
+    }
+    let digits = scaledInt.toString();
+    while (digits.length <= ndigits) {
+        digits = `0${digits}`;
+    }
+    const outInt = ndigits === 0 ? digits : digits.slice(0, digits.length - ndigits);
+    const outFrac = ndigits === 0 ? '' : digits.slice(digits.length - ndigits);
+    const zeroValue = /^0*$/u.test(digits);
+    return `${zeroValue ? '' : sign}${outInt}${ndigits > 0 ? `.${outFrac}` : ''}`;
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/design.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/design.ts
@@ -1,0 +1,325 @@
+/**
+ * `design` step — produces the design brief that locks microcopy.
+ *
+ * TypeScript twin of `directives/ui/design.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The design step turns the audit findings into a structured design brief that
+ * `apply` consumes verbatim. The brief is the lock — apply writes the strings
+ * exactly as the brief specifies. Hallucinated microcopy at apply time is the
+ * failure mode this step exists to prevent.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Top-level keys every well-formed design brief must carry. */
+export const REQUIRED_BRIEF_KEYS: ReadonlyArray<string> = [
+    'layout',
+    'components',
+    'states',
+    'microcopy',
+    'a11y',
+];
+
+/** States the brief must cover; missing entries surface as halt items. */
+export const REQUIRED_STATE_KEYS: ReadonlyArray<string> = [
+    'empty',
+    'loading',
+    'error',
+    'success',
+    'disabled',
+];
+
+/** Lower-cased substrings that mark microcopy as unfinished. */
+export const PLACEHOLDER_PATTERNS: ReadonlyArray<string> = [
+    '<placeholder>',
+    'lorem',
+    'todo:',
+    'tbd',
+    'xxx',
+];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'design_missing',
+        trigger: 'state.ui_design is None or empty — brief has not been produced',
+        resolution:
+            'agent directive `ui-design-brief` → skill/agent ' +
+            'writes the brief into state.ui_design',
+    },
+    {
+        code: 'design_placeholders',
+        trigger:
+            'microcopy contains placeholder patterns ' +
+            '(<placeholder>, Lorem, TODO:, TBD, XXX)',
+        resolution:
+            'agent re-runs the brief with final strings; ' +
+            'halt lists the offending microcopy keys',
+    },
+    {
+        code: 'design_unconfirmed',
+        trigger: 'brief is well-formed but design_confirmed is unset/False',
+        resolution:
+            'user reviews the brief summary and sets ' +
+            'state.ui_design.design_confirmed = True (or asks for ' +
+            'revisions, which loops back to ui-design-brief)',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Python `value is None or value == "" or value == [] or value == {}`. */
+function _isEmptyOrNone(value: Any): boolean {
+    if (value === null || value === undefined) return true;
+    if (value === '') return true;
+    if (Array.isArray(value)) return value.length === 0;
+    if (_isDict(value)) return Object.keys(value).length === 0;
+    return false;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Apply the design-brief lock to `state.ui_design`. */
+export function run(state: DeliveryState): StepResult {
+    const design = state.ui_design;
+    if (!_is_populated(design)) {
+        return _delegate_to_design_skill(state);
+    }
+
+    const designDict = design as Record<string, Any>;
+    const missing = _missing_required_keys(designDict);
+    if (missing.length > 0) {
+        return _halt_incomplete_brief(state, missing);
+    }
+
+    const placeholders = _placeholder_violations(designDict);
+    if (placeholders.length > 0) {
+        return _halt_placeholders(state, placeholders);
+    }
+
+    if (designDict['design_confirmed'] === true) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_unconfirmed(state, designDict);
+}
+
+/** True when `design` carries an actionable brief. */
+function _is_populated(design: Any): boolean {
+    if (!_isDict(design)) return false;
+    if (Object.keys(design).length === 0) return false;
+    return REQUIRED_BRIEF_KEYS.some((key) => key in design);
+}
+
+/** Return required top-level keys that are missing or empty. */
+function _missing_required_keys(design: Record<string, Any>): string[] {
+    const missing: string[] = [];
+    for (const key of REQUIRED_BRIEF_KEYS) {
+        const value = design[key];
+        if (_isEmptyOrNone(value)) {
+            missing.push(key);
+            continue;
+        }
+        if (key === 'states' && _isDict(value)) {
+            for (const state_key of REQUIRED_STATE_KEYS) {
+                if (!_pyTruthy(value[state_key])) {
+                    missing.push(`states.${state_key}`);
+                }
+            }
+        }
+    }
+    return missing;
+}
+
+/** Return microcopy paths whose values match a placeholder pattern. */
+function _placeholder_violations(design: Record<string, Any>): string[] {
+    const microcopy = design['microcopy'];
+    if (!_isDict(microcopy)) return [];
+    const violations: string[] = [];
+    _walk_microcopy(microcopy, '', violations);
+    return violations;
+}
+
+function _walk_microcopy(
+    node: Record<string, Any>,
+    prefix: string,
+    violations: string[],
+): void {
+    for (const key of Object.keys(node)) {
+        const value = node[key];
+        const path = prefix ? `${prefix}.${key}` : String(key);
+        if (_isDict(value)) {
+            _walk_microcopy(value, path, violations);
+            continue;
+        }
+        if (typeof value !== 'string') {
+            continue;
+        }
+        const lowered = value.toLowerCase();
+        for (const pattern of PLACEHOLDER_PATTERNS) {
+            if (lowered.includes(pattern)) {
+                violations.push(path);
+                break;
+            }
+        }
+    }
+}
+
+/** Render a one-line preview of the input being designed. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** Halt with an agent directive so the orchestrator runs `ui-design-brief`. */
+function _delegate_to_design_skill(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('ui-design-brief'),
+            `> Input: ${preview}`,
+            '> No design brief yet — producing one now. The brief locks ' +
+                'layout, components, states, microcopy, and a11y before any ' +
+                'code is written.',
+            '> 1. Continue — produce the brief from audit findings',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: 'UI design brief missing; delegating to ui-design-brief skill.',
+    });
+}
+
+/** BLOCKED halt — brief is missing required keys. */
+function _halt_incomplete_brief(state: DeliveryState, missing: string[]): StepResult {
+    const preview = _preview_input(state);
+    const lines: string[] = [
+        agent_directive('ui-design-brief'),
+        `> Input: ${preview}`,
+        '> Design brief is incomplete. Missing required fields:',
+    ];
+    for (const p of missing) {
+        lines.push(`> - \`${p}\``);
+    }
+    lines.push(
+        '> Re-run the brief skill so every required slot has a final ' +
+            'value before apply.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: `UI design brief incomplete; ${missing.length} required field(s) missing.`,
+    });
+}
+
+/** BLOCKED halt — microcopy still carries placeholder patterns. */
+function _halt_placeholders(state: DeliveryState, violations: string[]): StepResult {
+    const preview = _preview_input(state);
+    const lines: string[] = [
+        agent_directive('ui-design-brief'),
+        `> Input: ${preview}`,
+        '> Microcopy contains placeholder patterns. Apply rejects these ' +
+            'verbatim, so they have to be replaced with final strings now:',
+    ];
+    for (const p of violations) {
+        lines.push(`> - \`microcopy.${p}\``);
+    }
+    lines.push(
+        '> Re-run the brief skill with finalised copy; the apply step ' +
+            'will write strings exactly as the brief specifies.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message:
+            `UI design brief carries ${violations.length} placeholder ` +
+            'violation(s); halting for finalised microcopy.',
+    });
+}
+
+/** BLOCKED halt — brief is well-formed; user must sign off. */
+function _halt_unconfirmed(state: DeliveryState, design: Record<string, Any>): StepResult {
+    const preview = _preview_input(state);
+    const components = _pyTruthy(design['components']) ? design['components'] : [];
+    const states = _pyTruthy(design['states']) ? design['states'] : {};
+    const microcopy = _pyTruthy(design['microcopy']) ? design['microcopy'] : {};
+
+    const component_count = Array.isArray(components) ? components.length : 0;
+    const state_count = _isDict(states) ? Object.keys(states).length : 0;
+    const microcopy_count = _isDict(microcopy) ? _count_microcopy(microcopy) : 0;
+
+    const lines: string[] = [
+        `> Input: ${preview}`,
+        '> Design brief is ready. Summary:',
+        `> - Components: ${component_count}`,
+        `> - States covered: ${state_count}`,
+        `> - Microcopy entries (locked): ${microcopy_count}`,
+        '> 1. Confirm — lock this brief and advance to apply',
+        '> 2. Revise — send feedback; loops back to ui-design-brief',
+        '> 3. Abort — drop this UI request',
+        '',
+        '**Recommendation: 1 — Confirm** — the brief covers all ' +
+            'required slots and microcopy is final. Caveat: flip to 2 only if ' +
+            'a string, state, or component is wrong; do not confirm strings ' +
+            'you have not read.',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: 'UI design brief ready; halting for user confirmation before apply.',
+    });
+}
+
+/** Count leaf string entries in `microcopy` (recursive). */
+function _count_microcopy(microcopy: Record<string, Any>): number {
+    let total = 0;
+    for (const value of Object.values(microcopy)) {
+        if (_isDict(value)) {
+            total += _count_microcopy(value);
+        } else if (typeof value === 'string') {
+            total += 1;
+        }
+    }
+    return total;
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/polish.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/polish.ts
@@ -1,0 +1,462 @@
+/**
+ * `polish` step — bounded fix loop for review findings.
+ *
+ * TypeScript twin of `directives/ui/polish.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The polish step drives the fix loop after `review` produces findings. The
+ * loop is hard-capped at two rounds (extendable by one for a11y); anything the
+ * agent cannot fix goes back to the user as a ship-as-is / abort decision.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Maximum number of polish rounds per `/work` run. */
+export const POLISH_CEILING = 2;
+
+/** Marker on a review finding that flags an a11y issue. */
+export const A11Y_VIOLATION_KIND = 'a11y_violation';
+
+/** Marker on a review finding that flags a hardcoded design value. */
+export const TOKEN_VIOLATION_KIND = 'token_violation';
+
+/** Repeat count above which an unmatched value triggers the extraction halt. */
+export const TOKEN_REPEAT_THRESHOLD = 2;
+
+/** Map `state.stack.frontend` → agent-directive skill name. */
+export const STACK_DIRECTIVES: Record<string, string> = {
+    'blade-livewire-flux': 'ui-polish-blade-livewire-flux',
+    'react-shadcn': 'ui-polish-react-shadcn',
+    vue: 'ui-polish-vue',
+    plain: 'ui-polish-plain',
+};
+
+/** Fallback directive when `state.stack` is missing or malformed. */
+export const DEFAULT_DIRECTIVE = 'ui-polish-plain';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'polish_round_pending',
+        trigger:
+            'state.ui_review.review_clean is False and ' +
+            'state.ui_polish.rounds < 2 — fixes have not yet been applied ' +
+            'for the current findings',
+        resolution:
+            'agent directive `ui-polish-<stack>` → skill ' +
+            'applies fixes, re-runs the review, increments ' +
+            'state.ui_polish.rounds',
+    },
+    {
+        code: 'polish_ceiling_reached',
+        trigger:
+            'state.ui_polish.rounds == ceiling and remaining ' +
+            'findings are non-a11y (subjective polish that did not ' +
+            'converge) — a11y blocks take precedence via ' +
+            'polish_a11y_blocking',
+        resolution:
+            'user picks: ship as-is, abort, or hand off to ' +
+            'manual fix; engine refuses to start another round',
+    },
+    {
+        code: 'polish_a11y_blocking',
+        trigger:
+            'state.ui_polish.rounds == ceiling and ' +
+            'state.ui_review.findings still contains a11y_violation ' +
+            'entries — objective gate that takes precedence over the ' +
+            'subjective polish_ceiling_reached halt',
+        resolution:
+            'user picks: extend by one round (engine sets ' +
+            'state.ui_polish.extension_used=True so the next round can ' +
+            'fire), accept-with-known-violations (engine appends the ' +
+            'leftover violations to state.ui_review.a11y.accepted_violations ' +
+            'so the review gate stops blocking on them), or abort the ' +
+            'UI request',
+    },
+    {
+        code: 'polish_token_extraction_pending',
+        trigger:
+            'state.ui_review.findings has token_violation entries ' +
+            'whose value repeats >2 times and has no match in ' +
+            'state.ui_audit.design_tokens',
+        resolution:
+            'user picks: extract as a new token (agent adds ' +
+            'it to state.ui_audit.design_tokens.<category>), inline (agent ' +
+            'drops the token_violation findings before re-entering polish), ' +
+            'or abort the UI request',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Apply the polish-loop gate. */
+export function run(state: DeliveryState): StepResult {
+    const review = _pyTruthy(state.ui_review) ? (state.ui_review as Record<string, Any>) : {};
+    let findings = 'findings' in review ? review['findings'] : [];
+    if (!Array.isArray(findings)) {
+        findings = [];
+    }
+    const review_clean = _pyTruthy(review['review_clean']);
+
+    if (review_clean || (findings as Any[]).length === 0) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const polish = _pyTruthy(state.ui_polish) ? (state.ui_polish as Record<string, Any>) : {};
+    let rounds = 'rounds' in polish ? polish['rounds'] : 0;
+    // `not isinstance(rounds, int) or isinstance(rounds, bool)` → reset to 0.
+    if (typeof rounds !== 'number' || !Number.isInteger(rounds) || typeof rounds === 'boolean') {
+        rounds = 0;
+    }
+    const extension_used = _pyTruthy(polish['extension_used']);
+    const effective_ceiling = POLISH_CEILING + (extension_used ? 1 : 0);
+
+    const findingsArr = findings as Any[];
+    if ((rounds as number) >= effective_ceiling) {
+        const a11y_findings = _a11y_findings(findingsArr);
+        if (a11y_findings.length > 0) {
+            return _halt_a11y_blocking(state, a11y_findings, rounds as number, !extension_used);
+        }
+        return _halt_ceiling(state, findingsArr.length, rounds as number, effective_ceiling);
+    }
+
+    const tokens = _design_tokens(state);
+    const [matched, unmatched_repeats] = _classify_token_violations(findingsArr, tokens);
+    if (unmatched_repeats.length > 0) {
+        return _halt_token_extraction(state, unmatched_repeats);
+    }
+
+    return _delegate_to_polish_skill(
+        state,
+        findingsArr.length,
+        matched.length,
+        rounds as number,
+        effective_ceiling,
+    );
+}
+
+/** Pick the agent directive for the project's frontend stack. */
+function _resolve_directive(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend in STACK_DIRECTIVES) {
+            return STACK_DIRECTIVES[frontend] as string;
+        }
+    }
+    return DEFAULT_DIRECTIVE;
+}
+
+/** Return the frontend stack label, defaulting to `plain`. */
+function _stack_label(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend !== '') {
+            return frontend;
+        }
+    }
+    return 'plain';
+}
+
+/** BLOCKED halt — emit the stack-specific polish directive. */
+function _delegate_to_polish_skill(
+    state: DeliveryState,
+    findings_count: number,
+    matched_token_count: number,
+    rounds: number,
+    ceiling: number,
+): StepResult {
+    const directive = _resolve_directive(state);
+    const stack_label = _stack_label(state);
+    const next_round = rounds + 1;
+    let findings_line =
+        `> ${findings_count} finding(s) from \`state.ui_review\`. ` +
+        'Apply each fix, re-run the review, and write the refreshed ' +
+        'envelope back.';
+    if (matched_token_count) {
+        findings_line =
+            `> ${findings_count} finding(s) from \`state.ui_review\` ` +
+            `(${matched_token_count} token-violation match(es) ` +
+            'auto-convert against `state.ui_audit.design_tokens`). ' +
+            'Apply each fix, re-run the review, and write the refreshed ' +
+            'envelope back.';
+    }
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            `> Stack: \`${stack_label}\`. Polish round ${next_round} of ${ceiling}.`,
+            findings_line,
+            '> Fix chart-type / contrast findings against the adopted ' +
+                "corpus rows (design-intelligence § 'Grounding the " +
+                "review/polish a11y gate'), not ad-hoc judgment.",
+            '> 1. Continue — apply fixes, re-review, and increment ' +
+                '`state.ui_polish.rounds`',
+            '> 2. Abort — drop this UI request',
+        ],
+        message:
+            `UI polish round ${next_round}/${ceiling}; delegating ` +
+            `to \`${directive}\` for stack \`${stack_label}\`.`,
+    });
+}
+
+/** BLOCKED halt — ceiling reached on subjective (non-a11y) findings. */
+function _halt_ceiling(
+    state: DeliveryState,
+    findings_count: number,
+    rounds: number,
+    ceiling: number,
+): StepResult {
+    const stack_label = _stack_label(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Stack: \`${stack_label}\`. Polish ceiling reached ` +
+                `(${rounds}/${ceiling} rounds).`,
+            `> ${findings_count} finding(s) still open in ` +
+                '`state.ui_review`. The engine refuses a third round.',
+            '> 1. Ship as-is — mark `state.ui_review.review_clean ' +
+                '= True` and continue to `report` (the open findings stay ' +
+                'in the delivery report)',
+            '> 2. Abort — drop this UI request',
+            '> 3. Hand off — a human picks up the remaining ' +
+                'findings outside the engine; re-invoke `/work` only after ' +
+                'they are resolved',
+            '',
+            '**Recommendation: 3 — Hand off** — two automated ' +
+                'rounds failed to converge. Caveat: pick 1 only when the ' +
+                'remaining findings are explicitly acceptable (low-priority ' +
+                'polish, deferred to a follow-up).',
+        ],
+        message:
+            `UI polish ceiling reached (${rounds}/${ceiling}); ` +
+            `${findings_count} finding(s) still open.`,
+    });
+}
+
+/** Return the subset of `findings` synthesised by the a11y gate. */
+function _a11y_findings(findings: Any[]): Record<string, Any>[] {
+    return findings.filter(
+        (f): f is Record<string, Any> => _isDict(f) && f['kind'] === A11Y_VIOLATION_KIND,
+    );
+}
+
+/** BLOCKED halt — ceiling reached with actionable a11y findings. */
+function _halt_a11y_blocking(
+    state: DeliveryState,
+    a11y_findings: Record<string, Any>[],
+    rounds: number,
+    extension_available: boolean,
+): StepResult {
+    const stack_label = _stack_label(state);
+    const count = a11y_findings.length;
+    const questions: string[] = [
+        `> Stack: \`${stack_label}\`. Polish ceiling reached ` +
+            `(${rounds}/${POLISH_CEILING} rounds) with ${count} a11y ` +
+            'violation(s) still open.',
+    ];
+    for (const finding of a11y_findings.slice(0, 5)) {
+        const rule = _pyTruthy(finding['rule']) ? finding['rule'] : '?';
+        const selector = _pyTruthy(finding['selector']) ? finding['selector'] : '?';
+        const severity = _pyTruthy(finding['severity']) ? finding['severity'] : '?';
+        questions.push(`> - \`${pyStr(rule)}\` on \`${pyStr(selector)}\` (severity: ${pyStr(severity)})`);
+    }
+    if (count > 5) {
+        questions.push(`> ... and ${count - 5} more`);
+    }
+    if (extension_available) {
+        questions.push(
+            '> 1. Extend — grant one extra polish round; the ' +
+                'engine sets `state.ui_polish.extension_used = True` so ' +
+                'the next delegation can fire',
+            '> 2. Accept — append the open violations to ' +
+                '`state.ui_review.a11y.accepted_violations` so the review ' +
+                'gate stops blocking on them, then continue to `report`',
+            '> 3. Abort — drop this UI request',
+            '',
+            '**Recommendation: 1 — Extend** — a11y ' +
+                'violations are objective; one more round usually closes ' +
+                'the gap. Pick 2 only when the violations are explicitly ' +
+                'out of scope for this run.',
+        );
+    } else {
+        questions.push(
+            '> 1. Accept — append the open violations to ' +
+                '`state.ui_review.a11y.accepted_violations` so the review ' +
+                'gate stops blocking on them, then continue to `report`',
+            '> 2. Abort — drop this UI request',
+            '',
+            '**Recommendation: 1 — Accept** — the one-shot ' +
+                'extension is already spent; either accept the residual ' +
+                'violations or abort.',
+        );
+    }
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message:
+            `UI polish ceiling reached (${rounds}/${POLISH_CEILING}); ` +
+            `${count} a11y violation(s) still open.`,
+    });
+}
+
+/** Return `state.ui_audit.design_tokens` as a dict, or `{}`. */
+function _design_tokens(state: DeliveryState): Record<string, Any> {
+    const audit = _pyTruthy(state.ui_audit) ? state.ui_audit : {};
+    if (!_isDict(audit)) {
+        return {};
+    }
+    const tokens = _pyTruthy(audit['design_tokens']) ? audit['design_tokens'] : {};
+    if (!_isDict(tokens)) {
+        return {};
+    }
+    return tokens;
+}
+
+/** Split `token_violation` findings into matched / unmatched-repeats. */
+function _classify_token_violations(
+    findings: Any[],
+    tokens: Record<string, Any>,
+): [Record<string, Any>[], Record<string, Any>[]] {
+    const matched: Record<string, Any>[] = [];
+    // Insertion-ordered map keyed by `${category} ${value}` to mirror the
+    // Python `dict[tuple[str, str], int]` insertion order.
+    const unmatched_counts = new Map<string, { category: string; value: string; count: number }>();
+    for (const finding of findings) {
+        if (!_isDict(finding)) {
+            continue;
+        }
+        if (finding['kind'] !== TOKEN_VIOLATION_KIND) {
+            continue;
+        }
+        const category = finding['category'];
+        const value = finding['value'];
+        if (typeof category !== 'string' || typeof value !== 'string') {
+            continue;
+        }
+        const bucket = tokens[category];
+        if (_isDict(bucket) && Object.values(bucket).includes(value)) {
+            matched.push(finding);
+            continue;
+        }
+        const key = `${category} ${value}`;
+        const existing = unmatched_counts.get(key);
+        if (existing) {
+            existing.count += 1;
+        } else {
+            unmatched_counts.set(key, { category, value, count: 1 });
+        }
+    }
+    const repeats: Record<string, Any>[] = [];
+    for (const { category, value, count } of unmatched_counts.values()) {
+        if (count > TOKEN_REPEAT_THRESHOLD) {
+            repeats.push({ category, value, count });
+        }
+    }
+    return [matched, repeats];
+}
+
+/** Build a suggested CSS-custom-property name for an extraction halt. */
+function _suggest_token_name(category: string, value: string): string {
+    let safe = '';
+    for (const c of value) {
+        safe += _isAlnum(c) ? c : '-';
+    }
+    safe = _pyStripChar(safe, '-').toLowerCase();
+    if (safe === '') {
+        safe = 'value';
+    }
+    const base = _pyRStripChar(category, 's') || category;
+    return [...`${base}-${safe}`].slice(0, 40).join('');
+}
+
+/** BLOCKED halt — repeated hardcoded value(s) without a matching token. */
+function _halt_token_extraction(
+    state: DeliveryState,
+    repeats: Record<string, Any>[],
+): StepResult {
+    const stack_label = _stack_label(state);
+    const questions: string[] = [
+        `> Stack: \`${stack_label}\`. ${repeats.length} hardcoded value(s) ` +
+            `appear >${TOKEN_REPEAT_THRESHOLD} times without a matching ` +
+            'entry in `state.ui_audit.design_tokens`.',
+    ];
+    for (const repeat of repeats) {
+        const suggested = _suggest_token_name(repeat['category'] as string, repeat['value'] as string);
+        questions.push(
+            `> - \`${pyStr(repeat['value'])}\` ` +
+                `(${pyStr(repeat['category'])}, ${pyStr(repeat['count'])}×) ` +
+                `— suggested name: \`--${suggested}\``,
+        );
+    }
+    questions.push(
+        '> 1. Extract as design token(s) — add to ' +
+            '`state.ui_audit.design_tokens.<category>` and re-enter polish; ' +
+            'matching findings auto-convert next round',
+        '> 2. Inline — keep the hardcoded value(s) for this run; ' +
+            'drop the token_violation findings from ' +
+            '`state.ui_review.findings` before re-entering polish',
+        '> 3. Abort — drop this UI request',
+        '',
+        '**Recommendation: 1 — Extract** — a value used ' +
+            `>${TOKEN_REPEAT_THRESHOLD} times is a de-facto token; ` +
+            'promoting it now keeps the design system honest. Pick 2 only ' +
+            'when the value is intentionally one-off.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message:
+            `UI polish paused; ${repeats.length} hardcoded value(s) ` +
+            'repeat without a matching design token.',
+    });
+}
+
+// ── Python string helpers ───────────────────────────────────────────────
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+/** Python `str.isalnum()` for a single code point (Unicode-aware). */
+function _isAlnum(ch: string): boolean {
+    // Python: alphanumeric = letters (incl. Unicode) or any numeric character.
+    // \p{L} (letters), \p{N} (numbers) cover str.isalnum for single chars.
+    return /[\p{L}\p{N}]/u.test(ch);
+}
+
+/** Python `str.strip(chars)` — strip the given chars from both ends. */
+function _pyStripChar(s: string, ch: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && s[start] === ch) start += 1;
+    while (end > start && s[end - 1] === ch) end -= 1;
+    return s.slice(start, end);
+}
+
+/** Python `str.rstrip(chars)` — strip the given chars from the right. */
+function _pyRStripChar(s: string, ch: string): string {
+    let end = s.length;
+    while (end > 0 && s[end - 1] === ch) end -= 1;
+    return s.slice(0, end);
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/review.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/review.ts
@@ -1,0 +1,400 @@
+/**
+ * `review` step — stack-dispatched design-review pass.
+ *
+ * TypeScript twin of `directives/ui/review.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The review step compares the rendered components from `apply` against the
+ * locked design brief and produces a structured findings list. It does not
+ * apply fixes — that is the polish step's job. Review's single output is
+ * `state.ui_review` carrying `findings` and `review_clean`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Map `state.stack.frontend` → agent-directive skill name. */
+export const STACK_DIRECTIVES: Record<string, string> = {
+    'blade-livewire-flux': 'ui-design-review-blade-livewire-flux',
+    'react-shadcn': 'ui-design-review-react-shadcn',
+    vue: 'ui-design-review-vue',
+    plain: 'ui-design-review-plain',
+};
+
+/** Fallback directive when `state.stack` is missing or malformed. */
+export const DEFAULT_DIRECTIVE = 'ui-design-review-plain';
+
+/** R4 a11y severity ranking — mirrors axe-core's impact levels. */
+export const SEVERITY_ORDER: Record<string, number> = {
+    minor: 0,
+    moderate: 1,
+    serious: 2,
+    critical: 3,
+};
+
+/** R4 a11y default severity floor. */
+export const DEFAULT_SEVERITY_FLOOR = 'moderate';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'review_envelope_missing',
+        trigger: 'state.ui_review unset / empty — review skill has not run yet',
+        resolution:
+            'agent directive `ui-design-review-<stack>` → ' +
+            'skill compares rendered components against state.ui_design ' +
+            'and writes `findings` + `review_clean` back',
+    },
+    {
+        code: 'review_findings_missing',
+        trigger: 'state.ui_review populated but `findings` key absent',
+        resolution:
+            'agent re-runs the review skill with the same ' +
+            'directive; review only succeeds once findings is a list',
+    },
+    {
+        code: 'review_clean_missing',
+        trigger:
+            'state.ui_review.findings is set but review_clean ' +
+            'is missing or not a bool — polish needs an explicit flag',
+        resolution:
+            'agent sets state.ui_review.review_clean to ' +
+            'True or False before returning the envelope; review does ' +
+            'not infer it from findings count',
+    },
+    {
+        code: 'review_a11y_pending',
+        trigger:
+            'state.ui_audit declared an `a11y_baseline` but ' +
+            'state.ui_review.a11y is missing — the review skill ran but ' +
+            'did not produce an a11y envelope',
+        resolution:
+            'agent re-runs the review skill so it captures ' +
+            'axe-core (or equivalent) findings into ' +
+            '`state.ui_review.a11y.violations`; the gate then filters ' +
+            'against the baseline and the severity floor',
+    },
+    {
+        code: 'preview_render_failed',
+        trigger:
+            'state.ui_review.preview.render_ok is False — the ' +
+            'stack-specific review skill tried to render the changed ' +
+            'components and the headless browser reported an error',
+        resolution:
+            'user picks Retry (re-run the review skill so it ' +
+            'renders again), Skip (write `state.ui_review.preview.skipped = ' +
+            'true` so the gate stops asking this run), or Abort',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Apply the design-review gate to `state.ui_review`. */
+export function run(state: DeliveryState): StepResult {
+    const review = state.ui_review;
+    if (!_is_populated(review)) {
+        return _delegate_to_review_skill(state);
+    }
+
+    const r = review as Record<string, Any>;
+    if (!('findings' in r) || !Array.isArray(r['findings'])) {
+        return _halt_findings_missing(state);
+    }
+
+    const findings = r['findings'] as Any[];
+    if (typeof r['review_clean'] !== 'boolean') {
+        return _halt_clean_missing(state, findings.length);
+    }
+
+    const a11y_halt = _apply_a11y_gate(state, r);
+    if (a11y_halt !== null) {
+        return a11y_halt;
+    }
+
+    const preview_halt = _apply_preview_gate(state, r);
+    if (preview_halt !== null) {
+        return preview_halt;
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** True when `review` is a dict with at least one own key. */
+function _is_populated(review: Any): boolean {
+    return _isDict(review) && Object.keys(review).length > 0;
+}
+
+/** Pick the agent directive for the project's frontend stack. */
+function _resolve_directive(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend in STACK_DIRECTIVES) {
+            return STACK_DIRECTIVES[frontend] as string;
+        }
+    }
+    return DEFAULT_DIRECTIVE;
+}
+
+/** Return the frontend stack label, defaulting to `plain`. */
+function _stack_label(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend !== '') {
+            return frontend;
+        }
+    }
+    return 'plain';
+}
+
+/** First-pass halt — emit the stack-specific review directive. */
+function _delegate_to_review_skill(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    const stack_label = _stack_label(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            `> Stack: \`${stack_label}\`. Reviewing rendered components ` +
+                'against the locked design brief.',
+            '> The review pass compares `state.ticket.ui_apply.rendered` ' +
+                'against `state.ui_design` (microcopy, states, a11y, layout) ' +
+                'and produces a structured `findings` list.',
+            '> Ground chart-type and contrast findings in the adopted ' +
+                "corpus (design-intelligence § 'Grounding the review/polish " +
+                "a11y gate') — cite the corpus row, don't eyeball.",
+            '> 1. Continue — run the review and write ' +
+                '`{findings: [...], review_clean: bool}` into ' +
+                '`state.ui_review`',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: `UI review pending; delegating to \`${directive}\` for stack \`${stack_label}\`.`,
+    });
+}
+
+/** BLOCKED halt — envelope present but `findings` slot is unset. */
+function _halt_findings_missing(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Review envelope is partial: `findings` list is missing.',
+            '> Re-run the review skill so `state.ui_review.findings` ' +
+                'is a list (empty when nothing is wrong).',
+        ],
+        message: 'UI review envelope incomplete; `findings` missing.',
+    });
+}
+
+/** BLOCKED halt — `review_clean` is missing or not a bool. */
+function _halt_clean_missing(state: DeliveryState, findings_count: number): StepResult {
+    const directive = _resolve_directive(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Review envelope is incomplete: `review_clean` is missing ' +
+                'or not a boolean.',
+            `> Findings count: ${findings_count}. Set ` +
+                '`state.ui_review.review_clean` to `True` (no further ' +
+                'polish needed) or `False` (polish loop should run).',
+        ],
+        message: 'UI review envelope incomplete; `review_clean` must be a bool.',
+    });
+}
+
+/** R4 Phase 1: enforce a11y gate after the basic shape gates pass. */
+function _apply_a11y_gate(state: DeliveryState, review: Record<string, Any>): StepResult | null {
+    const audit = state.ui_audit;
+    const has_baseline = _isDict(audit) && 'a11y_baseline' in audit;
+    const a11y = review['a11y'];
+
+    if (a11y === null || a11y === undefined) {
+        if (has_baseline) {
+            return _halt_a11y_pending(state);
+        }
+        return null;
+    }
+
+    const a11yDict = a11y as Record<string, Any>;
+    const violations = _pyTruthy(a11yDict['violations']) ? (a11yDict['violations'] as Any[]) : [];
+    const baseline = has_baseline ? ((audit as Record<string, Any>)['a11y_baseline'] as Any[]) : [];
+    const accepted = _pyTruthy(a11yDict['accepted_violations'])
+        ? (a11yDict['accepted_violations'] as Any[])
+        : [];
+    const floor = _pyTruthy(a11yDict['severity_floor'])
+        ? (a11yDict['severity_floor'] as string)
+        : DEFAULT_SEVERITY_FLOOR;
+
+    let new_violations = _filter_known(violations, baseline);
+    new_violations = _filter_known(new_violations, accepted);
+    const actionable = new_violations.filter((v) => _at_or_above_floor(v, floor));
+
+    if (actionable.length === 0) {
+        return null;
+    }
+
+    _synthesize_a11y_findings(review['findings'] as Any[], actionable);
+    review['review_clean'] = false;
+    return null;
+}
+
+/** Drop violations whose `(rule, selector)` matches `known`. */
+function _filter_known(violations: Any[], known: Any[]): Any[] {
+    if (!_pyTruthy(known)) {
+        return [...violations];
+    }
+    const keys = new Set<string>();
+    for (const entry of known) {
+        if (_isDict(entry)) {
+            keys.add(_keyOf(entry['rule'], entry['selector']));
+        }
+    }
+    if (keys.size === 0) {
+        return [...violations];
+    }
+    return violations.filter(
+        (v) => !(_isDict(v) && keys.has(_keyOf(v['rule'], v['selector']))),
+    );
+}
+
+/**
+ * Stable, collision-free key for a `(rule, selector)` tuple of arbitrary JSON
+ * scalars, mirroring Python tuple-equality in a JS `Set`.
+ */
+function _keyOf(rule: Any, selector: Any): string {
+    return `${_tag(rule)} ${_tag(selector)}`;
+}
+
+function _tag(v: Any): string {
+    if (v === null || v === undefined) return 'n:';
+    if (typeof v === 'boolean') return `b:${v ? '1' : '0'}`;
+    if (typeof v === 'number') return `f:${v}`;
+    if (typeof v === 'string') return `s:${v}`;
+    return `o:${JSON.stringify(v)}`;
+}
+
+/** `True` when `violation.severity` is at or above `floor`. */
+function _at_or_above_floor(violation: Any, floor: string): boolean {
+    if (!_isDict(violation)) {
+        return false;
+    }
+    const severity = violation['severity'];
+    const sevKey = typeof severity === 'string' ? severity : '';
+    const sev_rank =
+        sevKey in SEVERITY_ORDER
+            ? (SEVERITY_ORDER[sevKey] as number)
+            : (SEVERITY_ORDER[DEFAULT_SEVERITY_FLOOR] as number);
+    const floor_rank =
+        floor in SEVERITY_ORDER
+            ? (SEVERITY_ORDER[floor] as number)
+            : (SEVERITY_ORDER[DEFAULT_SEVERITY_FLOOR] as number);
+    return sev_rank >= floor_rank;
+}
+
+/** Append `a11y_violation` findings, deduped by `(rule, selector)`. */
+function _synthesize_a11y_findings(findings: Any[], actionable: Any[]): void {
+    const existing = new Set<string>();
+    for (const f of findings) {
+        if (_isDict(f) && f['kind'] === 'a11y_violation') {
+            existing.add(_keyOf(f['rule'], f['selector']));
+        }
+    }
+    for (const v of actionable) {
+        if (!_isDict(v)) {
+            continue;
+        }
+        const key = _keyOf(v['rule'], v['selector']);
+        if (existing.has(key)) {
+            continue;
+        }
+        findings.push({
+            kind: 'a11y_violation',
+            rule: v['rule'] ?? null,
+            selector: v['selector'] ?? null,
+            severity: v['severity'] ?? null,
+        });
+        existing.add(key);
+    }
+}
+
+/** BLOCKED halt — audit declared a baseline but review has no a11y. */
+function _halt_a11y_pending(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Review envelope is incomplete: the audit declared an ' +
+                '`a11y_baseline` but `state.ui_review.a11y` is missing.',
+            '> Re-run the review skill so it captures axe-core (or ' +
+                'equivalent) findings into ' +
+                '`state.ui_review.a11y.violations`. The gate filters ' +
+                'against the baseline and the severity floor ' +
+                `(default \`${DEFAULT_SEVERITY_FLOOR}\`).`,
+        ],
+        message:
+            'UI review envelope incomplete; `a11y` envelope missing ' +
+            '(audit declared a baseline).',
+    });
+}
+
+/** R4 Phase 3: validate the visual-preview envelope written by the skill. */
+function _apply_preview_gate(state: DeliveryState, review: Record<string, Any>): StepResult | null {
+    const preview = review['preview'];
+    if (!_isDict(preview)) {
+        return null;
+    }
+    if (_pyTruthy(preview['skipped'])) {
+        return null;
+    }
+    if (!('render_ok' in preview)) {
+        return null;
+    }
+    if (preview['render_ok'] === false) {
+        return _halt_preview_failed(state, preview);
+    }
+    return null;
+}
+
+/** BLOCKED halt — render reported failure; user picks the next step. */
+function _halt_preview_failed(state: DeliveryState, preview: Record<string, Any>): StepResult {
+    const directive = _resolve_directive(state);
+    const error = preview['error'];
+    const error_line =
+        typeof error === 'string' && error !== ''
+            ? `> Render error: \`${error}\`.`
+            : '> Render error: `(none reported)`.';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Visual preview failed: ' +
+                '`state.ui_review.preview.render_ok` is `False`.',
+            error_line,
+            '> 1. Retry — re-run the review skill so it renders again ' +
+                'and writes a fresh `preview` envelope',
+            '> 2. Skip — set `state.ui_review.preview.skipped = true` ' +
+                'so this run ships without a screenshot artifact',
+            '> 3. Abort — drop this UI request',
+        ],
+        message: 'UI preview render failed; awaiting user decision.',
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/_skipped.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/_skipped.ts
@@ -1,0 +1,33 @@
+/**
+ * Pass-through handler for slots the trivial path skips.
+ *
+ * TypeScript twin of `directives/ui_trivial/_skipped.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The `ui-trivial` directive set short-circuits the audit / design / review /
+ * polish loop. The dispatcher's `STEP_ORDER` is fixed (eight slots, no
+ * branching), so the trivial set fills the unused slots — `memory`,
+ * `analyze`, `plan`, `verify` — with this no-op handler. It returns `SUCCESS`
+ * without touching state, mutates nothing, and declares zero ambiguities.
+ */
+import {
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** No ambiguities — the slot is unconditionally skipped on the trivial path. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/**
+ * Return `SUCCESS` without touching `state`.
+ *
+ * Shared handler for the slots the trivial path intentionally bypasses.
+ * Keeping the slot wired (rather than raising) preserves the dispatcher's
+ * completeness-check invariant: every slot in `STEP_ORDER` has a callable
+ * handler, every directive set has a uniform shape.
+ */
+export function run(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/apply.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/apply.ts
@@ -1,0 +1,213 @@
+/**
+ * `apply` step — single-file edit path for the `ui-trivial` set.
+ *
+ * TypeScript twin of `directives/ui_trivial/apply.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The short-circuit path for micro UI edits that provably cannot warrant the
+ * full audit / design / review / polish loop. Hard preconditions enforced on
+ * every rebound: ≤ 1 file, ≤ 5 changed lines, no new component, no new state,
+ * no new dependency. Any precondition violation BLOCKS with a
+ * `reclassify-to-ui-improve` halt; the orchestrator promotes
+ * `state.directive_set` to `"ui-improve"` and re-invokes the engine.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Edit-surface ceiling — single-file edits only. */
+export const MAX_FILES = 1;
+
+/** Changed-line ceiling — anything larger is structural, not trivial. */
+export const MAX_LINES_CHANGED = 5;
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'trivial_envelope_missing',
+        trigger: "state.ticket['trivial_edit'] unset — first pass",
+        resolution:
+            'agent directive `trivial-apply` → agent performs ' +
+            'the single-file edit and writes the envelope back',
+    },
+    {
+        code: 'trivial_preconditions_violated',
+        trigger: 'edit touches >1 file, >5 lines, adds component/state/dependency',
+        resolution:
+            'agent directive `reclassify-to-ui-improve` → ' +
+            "orchestrator promotes directive_set='ui-improve' and re-runs " +
+            'through the full audit gate',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python truthiness for the values reached here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/**
+ * Python `int(x)` for the values that reach the precondition check. Mirrors
+ * CPython semantics for the shapes JSON produces:
+ *
+ * - `bool` → 0 / 1.
+ * - integer-valued / fractional `float` → truncate toward zero.
+ * - `str` → parse a base-10 integer literal (optional sign, surrounding
+ *   whitespace allowed); a non-integer string raises `ValueError`.
+ * - `None` / arrays / objects → `TypeError`.
+ *
+ * Returns the int on success, or the sentinel `null` to mirror the
+ * `except (TypeError, ValueError)` branch in the source.
+ */
+function _pyInt(value: Any): number | null {
+    if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+    }
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return null; // int(inf)/int(nan) → ValueError/OverflowError
+        }
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        // Python int() accepts an optional sign + digits + optional `_`
+        // separators between digits. The inputs here are plain integers; match
+        // the common case and reject anything else.
+        if (/^[+-]?[0-9]+$/.test(trimmed)) {
+            return Number(trimmed);
+        }
+        return null;
+    }
+    return null;
+}
+
+/** Apply the trivial-edit gate. */
+export function run(state: DeliveryState): StepResult {
+    const envelope = _trivial_envelope(state);
+    if (envelope === null) {
+        return _delegate_to_agent(state);
+    }
+
+    const violations = _check_preconditions(envelope);
+    if (violations.length > 0) {
+        return _halt_reclassify(state, violations);
+    }
+
+    _record_change(state, envelope);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** Return the agent-written `trivial_edit` envelope, or `null`. */
+function _trivial_envelope(state: DeliveryState): Record<string, Any> | null {
+    const data = _pyTruthy(state.ticket) ? state.ticket : {};
+    const envelope = (data as Record<string, Any>)['trivial_edit'];
+    if (_isDict(envelope) && _pyTruthy(envelope)) {
+        return envelope;
+    }
+    return null;
+}
+
+/** Return a list of violation codes; empty when all preconditions pass. */
+function _check_preconditions(envelope: Record<string, Any>): string[] {
+    const violations: string[] = [];
+
+    const files = envelope['files'];
+    if (!Array.isArray(files) || files.length === 0) {
+        violations.push('files_missing');
+    } else if (files.length > MAX_FILES) {
+        violations.push(`files_exceeded:${files.length}>${MAX_FILES}`);
+    }
+
+    const lines = envelope['lines_changed'];
+    const lines_int = _pyInt(lines);
+    if (lines_int === null) {
+        violations.push('lines_changed_missing');
+    } else {
+        if (lines_int > MAX_LINES_CHANGED) {
+            violations.push(`lines_exceeded:${lines_int}>${MAX_LINES_CHANGED}`);
+        }
+        if (lines_int < 0) {
+            violations.push('lines_changed_negative');
+        }
+    }
+
+    if (_pyTruthy(envelope['new_component'])) {
+        violations.push('new_component');
+    }
+    if (_pyTruthy(envelope['new_state'])) {
+        violations.push('new_state');
+    }
+    if (_pyTruthy(envelope['new_dependency'])) {
+        violations.push('new_dependency');
+    }
+
+    return violations;
+}
+
+/** First-pass halt — delegate to the agent for the single-file edit. */
+function _delegate_to_agent(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('trivial-apply'),
+            '> Trivial UI edit path — audit / design / review skipped.',
+            '> 1. Continue — perform the single-file edit, then ' +
+                'write a `trivial_edit` envelope back into state.ticket ' +
+                '(files, lines_changed, new_component, new_state, new_dependency)',
+            '> 2. Abort — drop this trivial edit',
+        ],
+        message: 'Trivial UI edit pending; delegating to agent for single-file edit.',
+    });
+}
+
+/** BLOCKED halt — orchestrator must reclassify to `ui-improve`. */
+function _halt_reclassify(state: DeliveryState, violations: string[]): StepResult {
+    state.ticket['__reclassify_to__'] = 'ui-improve';
+    delete state.ticket['trivial_edit'];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('reclassify-to-ui-improve'),
+            '> Trivial-edit preconditions violated; this work needs the ' +
+                'full audit gate.',
+            `> Violations: ${violations.join(', ')}.`,
+            '> 1. Reclassify — orchestrator sets ' +
+                '`state.directive_set = "ui-improve"` and re-runs the engine',
+            '> 2. Abort — drop this UI request',
+        ],
+        message:
+            'Trivial-edit preconditions failed ' +
+            `(${violations.join(', ')}); reclassification required.`,
+    });
+}
+
+/** Write a single `state.changes` entry summarising the trivial edit. */
+function _record_change(state: DeliveryState, envelope: Record<string, Any>): void {
+    const filesRaw = envelope['files'];
+    const files = _pyTruthy(filesRaw) ? filesRaw : [];
+    const lines = 'lines_changed' in envelope ? envelope['lines_changed'] : 0;
+    const summaryRaw = envelope['summary'];
+    const summary = _pyTruthy(summaryRaw) ? summaryRaw : 'trivial UI edit';
+    // `_record_change` only runs after preconditions pass, so `files` is a
+    // non-empty list here; mirror Python `list(files)` with a shallow copy.
+    state.changes.push({
+        kind: 'ui-trivial',
+        files: [...(files as Any[])],
+        lines_changed: lines,
+        summary: summary,
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/refine.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/refine.ts
@@ -1,0 +1,126 @@
+/**
+ * `refine` step — intent gate for the `ui-trivial` directive set.
+ *
+ * TypeScript twin of `directives/ui_trivial/refine.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * `ui-trivial` is reachable only when the intent classifier (or an explicit
+ * user override) labelled the work as `ui-trivial`. Reaching this slot through
+ * any other route is a routing error, not a user-facing ambiguity.
+ *
+ * The handler is deterministic and tiny: confirm the ticket carries the
+ * expected intent label (or accept the default when `directive_set` is already
+ * pinned), and return `SUCCESS`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** Intent label that gates entry into this directive set. */
+export const EXPECTED_INTENT = 'ui-trivial';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'wrong_intent_for_trivial',
+        trigger:
+            "state.ticket['intent'] is set and not equal to 'ui-trivial' " +
+            '— routing landed on this set by mistake',
+        resolution:
+            'abort and re-run with the correct directive_set ' +
+            "(populate_routing should select 'ui' or 'backend' instead)",
+    },
+];
+
+/**
+ * Python `repr()` for the scalar/JSON value kinds that reach the `{intent!r}`
+ * interpolation. Mirrors CPython: `None`, `True`/`False`, single-quoted
+ * strings (double-quoted only when the string contains a single quote and no
+ * double quote), numbers and everything else via `str`.
+ */
+function pyRepr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return pyStrRepr(value);
+    }
+    return String(value);
+}
+
+/** Python `str(value)` for the scalar kinds reaching the `{intent}` slot. */
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') {
+            body += '\\\\';
+        } else if (ch === quote) {
+            body += `\\${ch}`;
+        } else if (ch === '\n') {
+            body += '\\n';
+        } else if (ch === '\r') {
+            body += '\\r';
+        } else if (ch === '\t') {
+            body += '\\t';
+        } else {
+            body += ch;
+        }
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/**
+ * Confirm the ticket's intent matches the trivial path.
+ *
+ * The ticket's `intent` is optional on v0 callers; absence is treated as a
+ * silent pass since the v0 path predates intent classification. v1 callers
+ * always carry an intent — a mismatch means the dispatcher routed incorrectly
+ * and we halt loudly so the wiring bug surfaces before any edit happens.
+ */
+export function run(state: DeliveryState): StepResult {
+    const ticket = state.ticket ?? {};
+    const intent = ticket['intent'];
+    if (intent === undefined || intent === null || intent === EXPECTED_INTENT) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Routing error — the ``ui-trivial`` directive set was ' +
+                "selected but the ticket's intent is `" +
+                pyStr(intent) +
+                '`.',
+            '> 1. Reclassify — set `state.directive_set` from the ' +
+                'intent label and re-invoke the engine',
+            '> 2. Abort — drop this run',
+        ],
+        message:
+            `intent=${pyRepr(intent)} but directive_set='ui-trivial'; ` +
+            'routing must be reclassified before any edit',
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/report.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/report.ts
@@ -1,0 +1,112 @@
+/**
+ * `report` step — one-line delivery summary for the trivial path.
+ *
+ * TypeScript twin of `directives/ui_trivial/report.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The trivial summary captures what the operator needs: which file, how many
+ * lines, what the edit did, and the smoke verdict. The step is pure and
+ * deterministic: reads `DeliveryState`, writes `state.report`, always returns
+ * `SUCCESS`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** Pure render — no blocked paths. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/**
+ * Python truthiness for the values reached here: empty string / empty array /
+ * empty object / 0 / false / null / undefined are falsy.
+ */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) {
+        return false;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+/** Python `str(value)` for the `{lines}` interpolation. */
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Render the one-line trivial summary into `state.report`. */
+export function run(state: DeliveryState): StepResult {
+    state.report = _render(state);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _render(state: DeliveryState): string {
+    const change = _last_trivial_change(state);
+    if (change === null) {
+        return '_(trivial UI edit — no change recorded)_';
+    }
+
+    const filesRaw = change['files'];
+    const files = _pyTruthy(filesRaw) ? filesRaw : [];
+    const lines = 'lines_changed' in change ? change['lines_changed'] : 0;
+    const summaryRaw = change['summary'];
+    const summary = (_pyTruthy(summaryRaw) ? String(summaryRaw) : 'trivial UI edit').trim();
+    const file_str =
+        Array.isArray(files) && files.length === 1
+            ? pyStr((files as Any[])[0])
+            : `${Array.isArray(files) ? files.length : 0} files`;
+    const verdict = _smoke_verdict(state);
+    const verdict_str = verdict ? ` — smoke: **${verdict}**` : '';
+    return `**Trivial edit:** ${summary} (\`${file_str}\`, ${pyStr(lines)} lines)${verdict_str}`;
+}
+
+function _last_trivial_change(state: DeliveryState): Record<string, Any> | null {
+    const changes = _pyTruthy(state.changes) ? state.changes : [];
+    for (let i = changes.length - 1; i >= 0; i -= 1) {
+        const change = changes[i];
+        if (_isDict(change) && change['kind'] === 'ui-trivial') {
+            return change;
+        }
+    }
+    return null;
+}
+
+function _smoke_verdict(state: DeliveryState): string {
+    const tests = state.tests;
+    if (_isDict(tests)) {
+        const verdict = tests['verdict'];
+        if (typeof verdict === 'string') {
+            return verdict;
+        }
+    }
+    return '';
+}

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/test.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/test.ts
@@ -1,0 +1,164 @@
+/**
+ * `test` step — smoke-test delegate for the `ui-trivial` set.
+ *
+ * TypeScript twin of `directives/ui_trivial/test.py` (ADR-094 py2ts). Public
+ * API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The trivial path runs "apply + smoke-test only". The handler is the smaller
+ * cousin of `backend.test`: same verdict contract on `state.tests`, narrower
+ * scope on the agent directive. `failed` / `mixed` verdicts halt with the
+ * verdict echoed back; `success` flows through.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+const _ALLOWED_VERDICTS: ReadonlyArray<string> = ['success', 'failed', 'mixed'];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'empty_tests_delegate',
+        trigger: '`state.tests` empty — smoke runner not invoked yet',
+        resolution:
+            'agent directive `run-tests scope=smoke` → ' +
+            '`/tests-execute` (narrowest layer covering the touched file)',
+    },
+    {
+        code: 'malformed_tests',
+        trigger:
+            '`state.tests` is not a dict or `verdict` is not one of ' +
+            'success / failed / mixed',
+        resolution: 're-run smoke and record a clean verdict',
+    },
+    {
+        code: 'bad_test_verdict',
+        trigger: "`state.tests['verdict']` is `failed` or `mixed`",
+        resolution: 'fix the regression and re-run, or abort',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python truthiness for `if not tests`. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Python `type(x).__name__` for the dict/non-dict diagnostic. */
+function _pyTypeName(value: Any): string {
+    if (value === null || value === undefined) return 'NoneType';
+    if (typeof value === 'boolean') return 'bool';
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') return 'str';
+    if (Array.isArray(value)) return 'list';
+    return 'dict';
+}
+
+/** Python `repr()` for the verdict value (`{verdict!r}`). */
+function pyRepr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    if (typeof value === 'string') return pyStrRepr(value);
+    return String(value);
+}
+
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') body += '\\\\';
+        else if (ch === quote) body += `\\${ch}`;
+        else if (ch === '\n') body += '\\n';
+        else if (ch === '\r') body += '\\r';
+        else if (ch === '\t') body += '\\t';
+        else body += ch;
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Python `repr()` of the `_ALLOWED_VERDICTS` tuple, for `{_ALLOWED_VERDICTS}`. */
+function _allowedVerdictsRepr(): string {
+    return `(${_ALLOWED_VERDICTS.map((v) => pyStrRepr(v)).join(', ')})`;
+}
+
+/** Gate the smoke verdict; delegate when `state.tests` is empty. */
+export function run(state: DeliveryState): StepResult {
+    const tests = state.tests;
+    if (!_pyTruthy(tests)) {
+        return _delegate();
+    }
+
+    if (!_isDict(tests)) {
+        return _malformed(`state.tests is ${_pyTypeName(tests)}, expected dict`);
+    }
+
+    const verdict = tests['verdict'];
+    if (typeof verdict !== 'string' || !_ALLOWED_VERDICTS.includes(verdict)) {
+        return _malformed(
+            `state.tests['verdict']=${pyRepr(verdict)} not in ${_allowedVerdictsRepr()}`,
+        );
+    }
+
+    if (verdict === 'success') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Smoke test verdict: **${verdict}** — trivial edit may ` +
+                'have regressed the touched surface.',
+            '> 1. Investigate — read failures, fix, re-run smoke',
+            '> 2. Reclassify — promote to `ui-improve` if the regression ' +
+                'indicates the edit was less trivial than assumed',
+            '> 3. Abort — revert the edit',
+        ],
+        message: `smoke verdict=${verdict} on trivial edit`,
+    });
+}
+
+function _delegate(): StepResult {
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('run-tests', { scope: 'smoke' }),
+            '> Trivial edit applied; run the smoke test layer covering ' +
+                'the touched file.',
+            '> 1. Continue — invoke `/tests-execute` with smoke scope, ' +
+                'then write the verdict back to `state.tests`',
+            '> 2. Skip — record `state.tests = {"verdict": "success", ' +
+                '"scope": "none"}` (logged as a deferred verification)',
+            '> 3. Abort — drop this run',
+        ],
+        message: 'smoke run not yet invoked',
+    });
+}
+
+function _malformed(detail: string): StepResult {
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Malformed test envelope: ${detail}.`,
+            '> 1. Re-run smoke — produce a clean verdict',
+            '> 2. Abort — drop this run',
+        ],
+        message: detail,
+    });
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/_chat_history_base.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/_chat_history_base.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared plumbing for chat-history hooks.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/_chat_history_base.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Subprocess-driven
+ * so the work-engine package stays decoupled from `scripts/chat_history.py`'s
+ * internals. The `runner` injection point is the test seam — production passes
+ * the default runner, tests pass a fake.
+ */
+import { spawnSync } from 'node:child_process';
+import * as process from 'node:process';
+
+/**
+ * Subset of Python's `subprocess.CompletedProcess[str]` the hooks read:
+ * the return code plus the captured streams.
+ */
+export interface CompletedProcess {
+    returncode: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Callable that runs a subprocess. Production default: {@link _default_runner}. */
+export type ProcessRunner = (cmd: string[]) => CompletedProcess;
+
+export const EXIT_OK = 0;
+export const EXIT_MISSING = 10;
+export const EXIT_FOREIGN = 11;
+export const EXIT_RETURNING = 12;
+
+export function _default_runner(cmd: string[]): CompletedProcess {
+    const [program, ...args] = cmd;
+    const proc = spawnSync(program as string, args, {
+        encoding: 'utf8',
+    });
+    return {
+        // `null` status (signal/spawn failure) maps to a non-OK code.
+        returncode: proc.status === null ? -1 : proc.status,
+        stdout: proc.stdout ?? '',
+        stderr: proc.stderr ?? '',
+    };
+}
+
+/**
+ * Shared plumbing — script path and runner.
+ *
+ * Schema v4 derives session attribution from the platform `session_id`,
+ * not from a derived first-user-msg. work-engine internal hooks have no
+ * platform session in scope, so they omit `--session-id` and entries land
+ * in the `<unknown>` session bucket.
+ */
+export class _ChatHistoryHookBase {
+    readonly script_path: string;
+    private readonly _runner: ProcessRunner;
+
+    constructor(script_path: string, options: { runner?: ProcessRunner | null } = {}) {
+        this.script_path = script_path;
+        this._runner = options.runner ?? _default_runner;
+    }
+
+    protected _invoke(...args: string[]): CompletedProcess {
+        // `sys.executable` → the active interpreter; here `python3`.
+        const cmd = ['python3', this.script_path, ...args];
+        void process; // imported for parity with Python's `sys` usage.
+        return this._runner(cmd);
+    }
+}
+
+/** Python `getattr(obj, name, default)` for a duck-typed object. */
+export function _getattr(obj: unknown, name: string, dflt: unknown): unknown {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, unknown>)[name];
+    }
+    return dflt;
+}
+
+/**
+ * Python `json.dumps(obj)` with default separators (`", "`, `": "`) and
+ * `ensure_ascii=True`. Covers the simple `{"step": str}` /
+ * `{"step": str, "questions": [str, …]}` payloads the chat-history hooks
+ * build: strings, numbers, booleans, null, arrays, and plain objects in
+ * insertion order.
+ */
+export function _pyJsonDumps(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStrAscii(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => _pyJsonDumps(v)).join(', ')}]`;
+    }
+    if (typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        const items = Object.keys(obj).map((k) => `${_jsonStrAscii(k)}: ${_pyJsonDumps(obj[k])}`);
+        return `{${items.join(', ')}}`;
+    }
+    return _jsonStrAscii(String(value));
+}
+
+/** Python `json.dumps(s, ensure_ascii=True)` for a single string. */
+function _jsonStrAscii(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (code < 0x20) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else if (code < 0x7f) {
+            out += ch;
+        } else if (code <= 0xffff) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            const c = code - 0x10000;
+            const hi = 0xd800 + (c >> 10);
+            const lo = 0xdc00 + (c & 0x3ff);
+            out += `\\u${hi.toString(16).padStart(4, '0')}\\u${lo.toString(16).padStart(4, '0')}`;
+        }
+    }
+    return `${out}"`;
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_append.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_append.ts
@@ -1,0 +1,41 @@
+/**
+ * `ChatHistoryAppendHook` — phase-boundary persistence.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/chat_history_append.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on
+ * `after_step`. Appends a `--type phase` entry whenever a step closed with
+ * `Outcome.SUCCESS`. Failures bubble up as {@link HookError} so the runner
+ * converts them to warnings — append errors must not break the main flow.
+ */
+import { Outcome } from '../../delivery_state.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+import { EXIT_OK, _ChatHistoryHookBase, _getattr, _pyJsonDumps } from './_chat_history_base.js';
+
+/** Arbitrary value, mirroring the Python `Any` payload values. */
+type Any = unknown;
+
+/** Append a phase-boundary entry after every successful step. */
+export class ChatHistoryAppendHook extends _ChatHistoryHookBase {
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.AFTER_STEP, (ctx) => this._on_after_step(ctx));
+    }
+
+    private _on_after_step(ctx: HookContext): void {
+        const result = ctx.result;
+        if (
+            result === null ||
+            result === undefined ||
+            _getattr(result, 'outcome', null) !== Outcome.SUCCESS
+        ) {
+            return;
+        }
+        const payload: Record<string, Any> = { step: ctx.step_name || '<unknown>' };
+        const proc = this._invoke('append', '--type', 'phase', '--json', _pyJsonDumps(payload));
+        if (proc.returncode !== EXIT_OK) {
+            throw new HookError(`chat-history append failed (exit ${proc.returncode})`);
+        }
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_halt_append.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_halt_append.ts
@@ -1,0 +1,89 @@
+/**
+ * `ChatHistoryHaltAppendHook` — capture halt surfaces in the log.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/chat_history_halt_append.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on `on_halt`.
+ * Records a `--type decision` entry with the step name and any pending
+ * questions so a fresh chat can resume from the persisted log alone.
+ */
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+import { EXIT_OK, _ChatHistoryHookBase, _getattr, _pyJsonDumps } from './_chat_history_base.js';
+
+/** Arbitrary value, mirroring the Python `Any` payload values. */
+type Any = unknown;
+
+/** Append a decision entry whenever a step halts. */
+export class ChatHistoryHaltAppendHook extends _ChatHistoryHookBase {
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.ON_HALT, (ctx) => this._on_halt(ctx));
+    }
+
+    private _on_halt(ctx: HookContext): void {
+        let questions: string[] = [];
+        if (ctx.result !== null && ctx.result !== undefined) {
+            questions = _pyList(_pyOr(_getattr(ctx.result, 'questions', []), []));
+        }
+        if (questions.length === 0 && ctx.delivery !== null && ctx.delivery !== undefined) {
+            questions = _pyList(_pyOr(_getattr(ctx.delivery, 'questions', []), []));
+        }
+        const payload: Record<string, Any> = {
+            step: ctx.step_name || '<unknown>',
+            questions,
+        };
+        const proc = this._invoke('append', '--type', 'decision', '--json', _pyJsonDumps(payload));
+        if (proc.returncode !== EXIT_OK) {
+            throw new HookError(`chat-history halt-append failed (exit ${proc.returncode})`);
+        }
+    }
+}
+
+/** Python `a or b`. */
+function _pyOr(a: Any, b: Any): Any {
+    return _pyTruthy(a) ? a : b;
+}
+
+/** Python `list(x)` for the iterable shapes `questions` can be. */
+function _pyList(x: Any): string[] {
+    if (x === null || x === undefined) {
+        return [];
+    }
+    if (Array.isArray(x)) {
+        return [...x] as string[];
+    }
+    if (typeof x === 'string') {
+        return [...x];
+    }
+    if (typeof (x as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function') {
+        return [...(x as Iterable<string>)];
+    }
+    return [];
+}
+
+/** Python `bool(x)` truthiness for the list / falsy shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/decision_gate.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/decision_gate.ts
@@ -1,0 +1,192 @@
+/**
+ * `DecisionGateHook` — refuse to advance when an opt-in gate fires.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/decision_gate.py` (ADR-094
+ * py2ts — work_engine.hooks.builtin subpackage). Bridges
+ * `work_engine/scoring/decision_engine` into the dispatcher hook bus. Reads
+ * the gate config from {@link DecisionEngineSettings} and fires on
+ * `AFTER_STEP` only for the phase each gate owns.
+ *
+ * Three actions, mapped 1:1 from `evaluate_gates`:
+ *
+ * - `stop`        → throw {@link HookHalt} with a numbered-option surface.
+ * - `warn`        → throw {@link HookError} so the runner logs the reason.
+ * - `ask_timeout` → non-interactive context; apply `on_block_fallback` and
+ *                   re-resolve to `stop` or `warn`.
+ * - `ask`         → interactive context; collapses to `stop` with the prompt
+ *                   surface for the CLI integration.
+ *
+ * Default-off: when `settings.decision_engine` is `null` or every gate is
+ * `off` the hook short-circuits without examining state.
+ */
+import {
+    DecisionEngineSettings,
+    GateDecision,
+    evaluate_gates,
+} from '../../scoring/decision_engine.js';
+import {
+    derive_confidence_band,
+    derive_risk_class,
+    summarise_memory,
+    summarise_verify,
+} from '../../scoring/decision_trace.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError, HookHalt } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+const _BLOCK_REASON_PREFIX = 'decision_gate';
+
+/**
+ * Evaluate decision-engine gates on every `AFTER_STEP`.
+ *
+ * The hook stores `settings` as a frozen reference; tests pass a fresh
+ * instance per scenario.
+ */
+export class DecisionGateHook {
+    private readonly _settings: DecisionEngineSettings;
+
+    constructor(settings: DecisionEngineSettings) {
+        this._settings = settings;
+    }
+
+    /** Register the gate callback on `AFTER_STEP`. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.AFTER_STEP, (ctx) => this._evaluate(ctx));
+    }
+
+    // -- lifecycle callback ------------------------------------------
+
+    private _evaluate(ctx: HookContext): void {
+        if (!this._settings.any_gate_active) {
+            return;
+        }
+        const phase = ctx.step_name;
+        if (!phase) {
+            return;
+        }
+        const delivery = ctx.delivery;
+        const memory = summarise_memory(_getattr(delivery, 'memory', null));
+        const verify = summarise_verify(_getattr(delivery, 'verify', null));
+        const ambiguity = _pyTruthy(_getattr(delivery, 'questions', null));
+        const decision = evaluate_gates(this._settings, {
+            phase,
+            confidence_band: derive_confidence_band({
+                memory_hits: memory['hits'] as number,
+                verify_claims: verify['claims'] as number,
+                verify_first_try_passes: verify['first_try_passes'] as number,
+                ambiguity_flag: ambiguity,
+            }),
+            risk_class: derive_risk_class(_getattr(delivery, 'changes', null)),
+            memory_hits: memory['hits'] as number,
+        });
+        if (decision === null) {
+            return;
+        }
+        this._apply(decision);
+    }
+
+    // -- action dispatch ----------------------------------------------
+
+    private _apply(decision: GateDecision): void {
+        const action = decision.action;
+        if (action === 'warn') {
+            throw new HookError(DecisionGateHook._format_reason(decision));
+        }
+        if (action === 'ask_timeout') {
+            const fallback = this._settings.on_block_fallback;
+            if (fallback === 'warn') {
+                throw new HookError(
+                    DecisionGateHook._format_reason(decision, 'ask_timeout'),
+                );
+            }
+            throw new HookHalt(
+                `${_BLOCK_REASON_PREFIX}:${decision.gate_id}:ask_timeout`,
+                DecisionGateHook._surface(decision, 'ask_timeout'),
+            );
+        }
+        throw new HookHalt(
+            `${_BLOCK_REASON_PREFIX}:${decision.gate_id}`,
+            DecisionGateHook._surface(decision),
+        );
+    }
+
+    // -- formatting helpers -------------------------------------------
+
+    private static _format_reason(decision: GateDecision, suffix = ''): string {
+        let tag = `${_BLOCK_REASON_PREFIX}:${decision.gate_id}`;
+        if (suffix) {
+            tag = `${tag}:${suffix}`;
+        }
+        return `${tag} — ${decision.reason}`;
+    }
+
+    private static _surface(decision: GateDecision, suffix = ''): string[] {
+        let header = `Decision-engine gate fired: ${decision.gate_id} (phase=${decision.phase})`;
+        if (suffix) {
+            header = `${header} [${suffix}]`;
+        }
+        return [
+            header,
+            `Reason: ${decision.reason}`,
+            '1) Address the gate condition and resume.',
+            '2) Lower the gate in `.agent-settings.yml` ' + '(`decision_engine` block) and resume.',
+            '3) Abort the run.',
+        ];
+    }
+}
+
+/**
+ * Construct the hook from a {@link DecisionEngineSettings}-like object.
+ * Returns `null` when the config is absent or every gate is `off`; the
+ * bootstrap layer then skips registration entirely.
+ */
+export function build_decision_gate_hook(settings: Any): DecisionGateHook | null {
+    if (settings === null || settings === undefined) {
+        return null;
+    }
+    if (!(settings instanceof DecisionEngineSettings)) {
+        return null;
+    }
+    if (!settings.any_gate_active) {
+        return null;
+    }
+    return new DecisionGateHook(settings);
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the shapes `questions` can take. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/decision_trace.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/decision_trace.ts
@@ -1,0 +1,304 @@
+/**
+ * `DecisionTraceHook` — emit a decision-trace JSON per phase.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/decision_trace.py` (ADR-094
+ * py2ts — work_engine.hooks.builtin subpackage). Implements the v1 envelope
+ * from `docs/contracts/decision-trace-v1.md`. Default-off; opt-in via
+ * `.agent-settings.yml` `decision_engine.surface_traces: true`.
+ *
+ * The hook is purely observational — it never mutates `DeliveryState`, never
+ * raises terminal errors. Stream / disk failures surface as {@link HookError}
+ * (non-fatal per the three-tier contract).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+    derive_confidence_band,
+    derive_risk_class,
+    summarise_memory,
+    summarise_verify,
+} from '../../scoring/decision_trace.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+export const SCHEMA_VERSION = 1;
+const _MAX_MEMORY_IDS = 32;
+
+/**
+ * Emit one decision-trace JSON file per dispatcher step.
+ *
+ * `output_dir` is an optional override for the trace destination. When
+ * `null` the hook writes alongside the WorkState file: if the state file
+ * sits under `agents/runtime/state/work/<id>/state.json` the trace lands at
+ * `agents/runtime/state/work/<id>/decision-trace-<phase>.json`; otherwise the
+ * trace lands next to the state file as `<stem>.decision-trace-<phase>.json`.
+ */
+export class DecisionTraceHook {
+    private readonly _output_dir: string | null;
+    private _state_file: string | null = null;
+    private _step_started: Map<string, number> = new Map();
+
+    constructor(output_dir: string | null = null) {
+        this._output_dir = output_dir;
+    }
+
+    /** Register the trace callbacks on the lifecycle events used. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.BEFORE_LOAD, (ctx) => this._capture_state_file(ctx));
+        registry.register(HookEvent.AFTER_LOAD, (ctx) => this._capture_state_file(ctx));
+        registry.register(HookEvent.BEFORE_STEP, (ctx) => this._mark_step_start(ctx));
+        registry.register(HookEvent.AFTER_STEP, (ctx) => this._emit_trace(ctx));
+    }
+
+    // -- lifecycle callbacks ------------------------------------------
+
+    private _capture_state_file(ctx: HookContext): void {
+        if (ctx.state_file !== null && ctx.state_file !== undefined) {
+            this._state_file = String(ctx.state_file);
+        }
+    }
+
+    private _mark_step_start(ctx: HookContext): void {
+        if (ctx.step_name) {
+            this._step_started.set(ctx.step_name, _time());
+        }
+    }
+
+    private _emit_trace(ctx: HookContext): void {
+        if (!ctx.step_name) {
+            return;
+        }
+        let started: number;
+        if (this._step_started.has(ctx.step_name)) {
+            started = this._step_started.get(ctx.step_name) as number;
+            this._step_started.delete(ctx.step_name);
+        } else {
+            started = _time();
+        }
+        const envelope = this._build_envelope(ctx, started);
+        const target = this._target_path(ctx.step_name);
+        try {
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, _pyJsonDumpsIndent2(envelope) + '\n', { encoding: 'utf-8' });
+        } catch (exc) {
+            throw new HookError(`decision-trace write failed: ${_osErr(exc)}`);
+        }
+    }
+
+    // -- envelope construction ----------------------------------------
+
+    private _build_envelope(ctx: HookContext, started: number): Record<string, Any> {
+        const delivery = ctx.delivery;
+        const memory = summarise_memory(_getattr(delivery, 'memory', null), { limit: _MAX_MEMORY_IDS });
+        const verify = summarise_verify(_getattr(delivery, 'verify', null));
+        const ambiguity = _pyTruthy(_getattr(delivery, 'questions', null));
+        return {
+            schema_version: SCHEMA_VERSION,
+            work_id: this._work_id(),
+            phase: ctx.step_name,
+            started_at: _iso_utc(started),
+            ended_at: _iso_utc(_time()),
+            confidence_band: derive_confidence_band({
+                memory_hits: memory['hits'] as number,
+                verify_claims: verify['claims'] as number,
+                verify_first_try_passes: verify['first_try_passes'] as number,
+                ambiguity_flag: ambiguity,
+            }),
+            risk_class: derive_risk_class(_getattr(delivery, 'changes', null)),
+            rules: [],
+            memory,
+            verify,
+        };
+    }
+
+    // -- path helpers --------------------------------------------------
+
+    private _work_id(): string {
+        if (this._state_file === null) {
+            return 'unknown';
+        }
+        const parent = path.dirname(this._state_file);
+        const parentName = path.basename(parent);
+        const grandName = path.basename(path.dirname(parent));
+        if (parentName && grandName === 'work') {
+            return parentName;
+        }
+        return _stem(this._state_file);
+    }
+
+    private _target_path(phase: string): string {
+        const filename = `decision-trace-${phase}.json`;
+        if (this._output_dir !== null) {
+            return path.join(this._output_dir, filename);
+        }
+        if (this._state_file === null) {
+            return filename;
+        }
+        const parent = path.dirname(this._state_file);
+        const parentName = path.basename(parent);
+        const grandName = path.basename(path.dirname(parent));
+        if (parentName && grandName === 'work') {
+            return path.join(parent, filename);
+        }
+        return path.join(parent, `${_stem(this._state_file)}.${filename}`);
+    }
+}
+
+/** `time.time()` — epoch seconds (float). */
+function _time(): number {
+    return Date.now() / 1000;
+}
+
+/** Python `Path.stem` — filename without its final suffix. */
+function _stem(p: string): string {
+    const base = path.basename(p);
+    const dot = base.lastIndexOf('.');
+    // Python `.stem`: drop the final extension; a leading dot is not a suffix.
+    if (dot <= 0) {
+        return base;
+    }
+    return base.slice(0, dot);
+}
+
+/** `datetime.fromtimestamp(epoch, tz=utc).strftime("%Y-%m-%dT%H:%M:%SZ")`. */
+function _iso_utc(epoch: number): string {
+    const d = new Date(epoch * 1000);
+    const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+    return (
+        `${pad(d.getUTCFullYear(), 4)}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+        `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`
+    );
+}
+
+/** Render an `OSError`-like value the way `str(exc)` would for the message. */
+function _osErr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the `questions` shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/**
+ * Python `json.dumps(obj, indent=2, sort_keys=False)` (ensure_ascii=True).
+ * Insertion-ordered keys, 2-space indent, `\uXXXX`-escaped non-ASCII.
+ */
+function _pyJsonDumpsIndent2(value: Any): string {
+    return _dumpsIndent(value, 0);
+}
+
+function _dumpsIndent(value: Any, depth: number): string {
+    const pad = ' '.repeat(2 * (depth + 1));
+    const closePad = ' '.repeat(2 * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _jsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStrAscii(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumpsIndent(v, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (typeof value === 'object') {
+        const obj = value as Record<string, Any>;
+        const keys = Object.keys(obj);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map((k) => `${pad}${_jsonStrAscii(k)}: ${_dumpsIndent(obj[k], depth + 1)}`);
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _jsonStrAscii(String(value));
+}
+
+/** Python `json.dumps` number formatting (integers without `.0`). */
+function _jsonNum(n: number): string {
+    if (Number.isInteger(n)) {
+        return String(n);
+    }
+    return String(n);
+}
+
+/** Python `json.dumps(s, ensure_ascii=True)` for a single string. */
+function _jsonStrAscii(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (code < 0x20) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else if (code < 0x7f) {
+            out += ch;
+        } else if (code <= 0xffff) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            const c = code - 0x10000;
+            const hi = 0xd800 + (c >> 10);
+            const lo = 0xdc00 + (c & 0x3ff);
+            out += `\\u${hi.toString(16).padStart(4, '0')}\\u${lo.toString(16).padStart(4, '0')}`;
+        }
+    }
+    return `${out}"`;
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/directive_set_guard.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/directive_set_guard.ts
@@ -1,0 +1,110 @@
+/**
+ * `DirectiveSetGuardHook` — catch CLI / state directive-set drift.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/directive_set_guard.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on
+ * `HookEvent.BEFORE_DISPATCH`. Compares the resolved `set_name` against the
+ * `directive_set` field on the persisted `WorkState`. Mismatch →
+ * {@link HookError} (non-fatal: the runner warns), so a flow that silently
+ * re-dispatches under a different set surfaces the drift before any step runs.
+ *
+ * The guard is read-only. It does not rewrite `state.directive_set`.
+ */
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/** Asserts `set_name` matches `state.directive_set` on dispatch. */
+export class DirectiveSetGuardHook {
+    /** Register on `HookEvent.BEFORE_DISPATCH`. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.BEFORE_DISPATCH, (ctx) => this._guard(ctx));
+    }
+
+    private _guard(ctx: HookContext): void {
+        const set_name = ctx.set_name;
+        const work = ctx.work;
+        if (set_name === null || set_name === undefined || work === null || work === undefined) {
+            // `before_dispatch` always carries both refs per the context
+            // surface; missing means a hook-bug, not drift.
+            throw new HookError(
+                'directive-set guard: missing set_name or work on ' +
+                    `before_dispatch (set_name=${_pyRepr(set_name)}, work=${_pyRepr(work)})`,
+            );
+        }
+
+        const persisted = _getattr(work, 'directive_set', null);
+        if (persisted === null || persisted === undefined) {
+            // Legacy v0 envelopes have no `directive_set` field; the guard is
+            // a no-op for those — nothing to compare.
+            return;
+        }
+
+        if (persisted !== set_name) {
+            throw new HookError(
+                'directive-set drift: CLI resolved ' +
+                    `${_pyRepr(set_name)} but state carries ${_pyRepr(persisted)}`,
+            );
+        }
+    }
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/**
+ * Python `repr(x)` for the scalar shapes the guard formats. `None` →
+ * `None`; `str` → single-quoted (switching to double quotes only when the
+ * string contains a single quote but no double quote, matching CPython).
+ */
+function _pyRepr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return _reprStr(value);
+    }
+    return String(value);
+}
+
+function _reprStr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const useDouble = hasSingle && !hasDouble;
+    const quote = useDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === quote) {
+            out += `\\${quote}`;
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/halt_surface_audit.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/halt_surface_audit.ts
@@ -1,0 +1,118 @@
+/**
+ * `HaltSurfaceAuditHook` — defense-in-depth around halt surfaces.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/halt_surface_audit.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on `on_halt`
+ * and re-asserts that every halt carries a non-empty user-facing surface,
+ * mirroring the dispatcher's `_validate_step_result`.
+ *
+ * Pure observability: emits {@link HookError} (non-fatal) when the surface is
+ * empty. The runner converts it to a warning so the violation is visible.
+ */
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/** Asserts that every halt carries a non-empty user-facing surface. */
+export class HaltSurfaceAuditHook {
+    /** Register on `HookEvent.ON_HALT` only. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.ON_HALT, (ctx) => this._audit(ctx));
+    }
+
+    private _audit(ctx: HookContext): void {
+        const result = ctx.result;
+        if (result === null || result === undefined) {
+            // Hook-driven halts go through `_hook_halt_blocked` and may not
+            // carry a `StepResult` — the surface lives on `state.questions`
+            // instead. Audit that fallback too.
+            const questions = _getattr(ctx.delivery, 'questions', null);
+            if (!_pyTruthy(questions)) {
+                throw new HookError(
+                    `halt at step ${_pyRepr(ctx.step_name)} surfaced no questions ` +
+                        '(hook-driven halt with empty state.questions)',
+                );
+            }
+            return;
+        }
+
+        const questions = _getattr(result, 'questions', null);
+        if (!_pyTruthy(questions)) {
+            throw new HookError(
+                `halt at step ${_pyRepr(ctx.step_name)} surfaced no questions ` +
+                    '(StepResult.questions empty); the user has nothing to act on',
+            );
+        }
+    }
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the `questions` shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/** Python `repr(x)` for `step_name` (a string or `None`). */
+function _pyRepr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (typeof value === 'string') {
+        const hasSingle = value.includes("'");
+        const hasDouble = value.includes('"');
+        const quote = hasSingle && !hasDouble ? '"' : "'";
+        let out = quote;
+        for (const ch of value) {
+            const code = ch.codePointAt(0) as number;
+            if (ch === '\\') {
+                out += '\\\\';
+            } else if (ch === quote) {
+                out += `\\${quote}`;
+            } else if (ch === '\n') {
+                out += '\\n';
+            } else if (ch === '\r') {
+                out += '\\r';
+            } else if (ch === '\t') {
+                out += '\\t';
+            } else if (code < 0x20 || code === 0x7f) {
+                out += `\\x${code.toString(16).padStart(2, '0')}`;
+            } else {
+                out += ch;
+            }
+        }
+        return out + quote;
+    }
+    return String(value);
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Concrete observability hooks shipped with the engine.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/__init__.py` (ADR-094 py2ts —
+ * work_engine.hooks.builtin subpackage). Phase 4 hooks: low-risk, default-off,
+ * observe-only. Each hook exposes a `register(registry)` method so the
+ * registry stays the single source of truth for event → callback wiring.
+ */
+export { ChatHistoryAppendHook } from './chat_history_append.js';
+export { ChatHistoryHaltAppendHook } from './chat_history_halt_append.js';
+export { DecisionGateHook, build_decision_gate_hook } from './decision_gate.js';
+export { DecisionTraceHook } from './decision_trace.js';
+export { DirectiveSetGuardHook } from './directive_set_guard.js';
+export { HaltSurfaceAuditHook } from './halt_surface_audit.js';
+export { MemoryVisibilityHook } from './memory_visibility.js';
+export { StateShapeValidationHook } from './state_shape_validation.js';
+export { TraceHook } from './trace.js';

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/memory_visibility.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/memory_visibility.ts
@@ -1,0 +1,161 @@
+/**
+ * `MemoryVisibilityHook` — emit the visibility line on save.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/memory_visibility.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Implements the
+ * producer side of `docs/contracts/memory-visibility-v1.md`: derive
+ * `asks/hits/ids` from `state.memory` and thread the rendered line into
+ * `state.report`.
+ *
+ * Fires on `before_save`. Default-off; opt-in via `.agent-settings.yml`. The
+ * hook is purely observational: failures surface as {@link HookError}
+ * (non-fatal per the three-tier contract).
+ */
+import { summarise_memory, summarise_verify } from '../../scoring/decision_trace.js';
+import {
+    DEFAULT_ASKED_TYPES,
+    compute_affected,
+    format_changed_decisions_block,
+    format_line,
+    should_emit,
+    summarise_visibility,
+} from '../../scoring/memory_visibility.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/**
+ * Thread the `🧠 Memory: <hits>/<asks> · ids=[…]` line into the report.
+ *
+ * `memory_cadence` is the `memory.cadence` cadence key. `visibility_off`
+ * mirrors `memory.visibility: off`. `asked_types` overrides the list of
+ * memory types treated as `asks` in the visibility line.
+ */
+export class MemoryVisibilityHook {
+    private readonly _memory_cadence: string;
+    private readonly _visibility_off: boolean;
+    private readonly _asked_types: readonly string[];
+
+    constructor(
+        options: {
+            memory_cadence?: string;
+            visibility_off?: boolean;
+            asked_types?: Iterable<string> | null;
+        } = {},
+    ) {
+        this._memory_cadence = options.memory_cadence ?? 'always';
+        this._visibility_off = options.visibility_off ?? false;
+        this._asked_types =
+            options.asked_types !== undefined && options.asked_types !== null
+                ? [...options.asked_types]
+                : DEFAULT_ASKED_TYPES;
+    }
+
+    /** Register the visibility-line emitter on `before_save`. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.BEFORE_SAVE, (ctx) => this._on_before_save(ctx));
+    }
+
+    private _on_before_save(ctx: HookContext): void {
+        const work = ctx.work;
+        if (work === null || work === undefined) {
+            return;
+        }
+        const memory = _getattr(work, 'memory', null);
+        const summary = summarise_visibility(memory, { asked_types: this._asked_types });
+        if (
+            !should_emit(summary, {
+                memory_cadence: this._memory_cadence,
+                visibility_off: this._visibility_off,
+            })
+        ) {
+            return;
+        }
+        const affected = this._derive_affected(work, memory);
+        const line = format_line(summary, { affected });
+        if (!line) {
+            return;
+        }
+        const block = format_changed_decisions_block(
+            (summary['ids'] as string[]) || [],
+            affected,
+        );
+        const existing = (_getattr(work, 'report', '') as string) || '';
+        const rendered = block === null ? line : `${line}\n\n${block}`;
+        if (existing.includes(line) && (block === null || existing.includes(block))) {
+            return;
+        }
+        const sep = existing ? '\n\n' : '';
+        try {
+            (work as Record<string, Any>)['report'] = `${existing}${sep}${rendered}`;
+        } catch (exc) {
+            throw new HookError('memory-visibility: state.report not writable');
+        }
+    }
+
+    /**
+     * Compute the closed-list `affected` keys for this work step. Returns
+     * `null` when memory was not consulted (hits == 0).
+     */
+    private _derive_affected(work: Any, memory: Any): string[] | null {
+        const memory_summary = summarise_memory(memory);
+        const verify_summary = summarise_verify(_getattr(work, 'verify', null));
+        const ambiguity = _pyTruthy(_getattr(work, 'questions', null));
+        return compute_affected({
+            memory_hits: memory_summary['hits'] as number,
+            verify_claims: verify_summary['claims'] as number,
+            verify_first_try_passes: verify_summary['first_try_passes'] as number,
+            ambiguity_flag: ambiguity,
+            changes: _getattr(work, 'changes', null),
+            applied_rules: _getattr(work, 'applied_rules', null) as string[] | null,
+            test_plan: _getattr(work, 'test_plan', null) as string[] | null,
+        });
+    }
+}
+
+/**
+ * Convenience helper: render the line directly from a memory list. Used by
+ * external callers that have a `memory` list but no {@link HookContext}.
+ * Returns `null` when `asks == 0`.
+ */
+export function derive_visibility(memory: Any): string | null {
+    return format_line(summarise_visibility(memory));
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the `questions` shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/state_shape_validation.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/state_shape_validation.ts
@@ -1,0 +1,45 @@
+/**
+ * `StateShapeValidationHook` — round-trip the v1 envelope on load and save.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/state_shape_validation.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on
+ * `AFTER_LOAD` and `BEFORE_SAVE`. For each event, serialises the live
+ * `WorkState` through `state.to_dict` and re-validates via `state.from_dict`.
+ * A `SchemaError` from either side is reported as a {@link HookError} so the
+ * runner warns and continues — observability, not a gate.
+ */
+import { SchemaError, type WorkState, from_dict, to_dict } from '../../state.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Round-trips the loaded `WorkState` against the v1 schema. */
+export class StateShapeValidationHook {
+    /** Register on AFTER_LOAD and BEFORE_SAVE. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.AFTER_LOAD, (ctx) => this._validate(ctx));
+        registry.register(HookEvent.BEFORE_SAVE, (ctx) => this._validate(ctx));
+    }
+
+    private _validate(ctx: HookContext): void {
+        const work = ctx.work;
+        if (work === null || work === undefined) {
+            // Should not happen on AFTER_LOAD/BEFORE_SAVE; treat as a
+            // hook-side bug rather than swallow silently.
+            throw new HookError(
+                'state-shape validation: HookContext.work is None at ' +
+                    `event for state_file=${ctx.state_file === null ? 'None' : ctx.state_file}`,
+            );
+        }
+
+        try {
+            from_dict(to_dict(work as WorkState));
+        } catch (exc) {
+            if (exc instanceof SchemaError) {
+                throw new HookError(`state-shape validation failed: ${exc.message}`);
+            }
+            throw exc;
+        }
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/builtin/trace.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/builtin/trace.ts
@@ -1,0 +1,133 @@
+/**
+ * `TraceHook` — emit one stderr line per hook event.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/trace.py` (ADR-094 py2ts —
+ * work_engine.hooks.builtin subpackage). Registers on every `HookEvent`;
+ * output goes to a configurable stream (default `process.stderr`) so tests can
+ * capture it.
+ *
+ * Pure observability — never mutates context, never halts. A misbehaving sink
+ * raises {@link HookError}, which the runner swallows with a warning.
+ */
+import { HOOK_EVENTS, HookEvent } from '../events.js';
+import { HookContext } from '../context.js';
+import { HookError } from '../exceptions.js';
+import { HookCallback, HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/**
+ * Minimal write+flush sink, mirroring Python's `IO[str]`. `process.stderr`
+ * satisfies it; tests pass a string-collector.
+ */
+export interface TextStream {
+    write(s: string): unknown;
+    flush?(): void;
+}
+
+/** Stderr-trace hook for every lifecycle event. */
+export class TraceHook {
+    private readonly _stream: TextStream;
+    private readonly _prefix: string;
+
+    constructor(stream: TextStream | null = null, prefix = '[hook]') {
+        this._stream = stream !== null ? stream : process.stderr;
+        this._prefix = prefix;
+    }
+
+    /** Register the trace callback for every `HookEvent`. */
+    register(registry: HookRegistry): void {
+        for (const event of HOOK_EVENTS) {
+            registry.register(event, this._make_callback(event));
+        }
+    }
+
+    private _make_callback(event: HookEvent): HookCallback {
+        const _cb = (ctx: HookContext): void => {
+            try {
+                const line = this._format(event, ctx);
+                this._stream.write(line + '\n');
+                if (typeof this._stream.flush === 'function') {
+                    this._stream.flush();
+                }
+            } catch (exc) {
+                if (exc instanceof HookError) {
+                    throw exc;
+                }
+                // Mirror Python `except (OSError, ValueError)`: wrap stream
+                // failures as a non-fatal HookError; re-raise anything else.
+                throw new HookError(`trace stream unavailable: ${_errStr(exc)}`);
+            }
+        };
+        return _cb;
+    }
+
+    /**
+     * Build a one-line trace record.
+     *
+     * Format: `[hook] event=<name> step=<step> set=<set> outcome=<o>`.
+     * Missing fields are skipped so the line stays short on events that only
+     * carry a subset of the context.
+     */
+    private _format(event: HookEvent, ctx: HookContext): string {
+        const parts: string[] = [this._prefix, `event=${event}`];
+        if (ctx.step_name) {
+            parts.push(`step=${ctx.step_name}`);
+        }
+        if (ctx.set_name) {
+            parts.push(`set=${ctx.set_name}`);
+        }
+        if (ctx.result !== null && ctx.result !== undefined) {
+            const outcome = _getattr(ctx.result, 'outcome', null);
+            if (outcome !== null && outcome !== undefined) {
+                parts.push(`outcome=${_valueOf(outcome)}`);
+            }
+        }
+        if (ctx.final !== null && ctx.final !== undefined) {
+            parts.push(`final=${_valueOf(ctx.final)}`);
+        }
+        if (ctx.halting) {
+            parts.push(`halting=${ctx.halting}`);
+        }
+        if (ctx.exception !== null && ctx.exception !== undefined) {
+            parts.push(`exception=${_typeName(ctx.exception)}`);
+        }
+        return parts.join(' ');
+    }
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `getattr(x, "value", x)` — enum value if present, else the value. */
+function _valueOf(x: Any): string {
+    if (x !== null && typeof x === 'object' && 'value' in (x as object)) {
+        return String((x as Record<string, Any>)['value']);
+    }
+    return String(x);
+}
+
+/** Python `type(exc).__name__`. */
+function _typeName(exc: Any): string {
+    if (exc instanceof Error) {
+        return exc.constructor.name;
+    }
+    if (exc !== null && exc !== undefined && typeof exc === 'object') {
+        return (exc as { constructor?: { name?: string } }).constructor?.name ?? 'object';
+    }
+    return typeof exc;
+}
+
+/** `str(exc)` for the wrapped-sink-failure message. */
+function _errStr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/context.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/context.ts
@@ -1,0 +1,94 @@
+/**
+ * `HookContext` — payload carried into every hook callback.
+ *
+ * TypeScript twin of `work_engine/hooks/context.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). One class for both layers. Most fields are
+ * `null` for any given event; the per-event subset is documented below and
+ * locked by the roadmap's hook event surface table. Hooks must tolerate
+ * missing fields gracefully.
+ *
+ * Per-event subset (mirrors the roadmap):
+ *
+ * Dispatcher layer (`delivery` is set; `work` is `null`):
+ *     - `before_step`   → `step_name`, `delivery`
+ *     - `after_step`    → `step_name`, `delivery`, `result`
+ *     - `on_halt`       → `step_name`, `delivery`, `result`
+ *     - `on_error`      → `step_name`, `delivery`, `exception`
+ *
+ * CLI layer (`work` is set; `delivery` may be set after load):
+ *     - `before_load`       → `state_file`, `args`
+ *     - `after_load`        → `state_file`, `work`, `fmt`
+ *     - `before_dispatch`   → `work`, `delivery`, `set_name`
+ *     - `after_dispatch`    → `work`, `delivery`, `final`, `halting`
+ *     - `before_save`       → `work`, `delivery`, `fmt`
+ *     - `after_save`        → `work`, `state_file`, `fmt`
+ */
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+/** Per-event payload passed to every hook callback (matches the dataclass). */
+export interface HookContextInit {
+    // Dispatcher-layer refs.
+    step_name?: string | null;
+    delivery?: Any; // DeliveryState
+    result?: Any; // StepResult
+    exception?: Any; // BaseException
+
+    // CLI-layer refs.
+    work?: Any; // WorkState
+    state_file?: string | null;
+    fmt?: string | null;
+    set_name?: string | null;
+    final?: Any; // Outcome
+    halting?: string | null;
+    args?: Any; // argparse.Namespace
+
+    // Escape hatch for hook-specific state.
+    extra?: Record<string, Any>;
+}
+
+/**
+ * Per-event payload passed to every hook callback.
+ *
+ * Fields are intentionally optional — the runner does not validate which
+ * ones are populated for a given event. The contract is enforced by the
+ * call sites, not by the class.
+ *
+ * `extra` exists as an escape hatch for hook-specific state that does not
+ * warrant a dedicated field.
+ */
+export class HookContext {
+    // Dispatcher-layer refs.
+    step_name: string | null;
+    delivery: Any;
+    result: Any;
+    exception: Any;
+
+    // CLI-layer refs.
+    work: Any;
+    state_file: string | null;
+    fmt: string | null;
+    set_name: string | null;
+    final: Any;
+    halting: string | null;
+    args: Any;
+
+    // Escape hatch for hook-specific state.
+    extra: Record<string, Any>;
+
+    constructor(init: HookContextInit = {}) {
+        this.step_name = init.step_name ?? null;
+        this.delivery = init.delivery ?? null;
+        this.result = init.result ?? null;
+        this.exception = init.exception ?? null;
+        this.work = init.work ?? null;
+        this.state_file = init.state_file ?? null;
+        this.fmt = init.fmt ?? null;
+        this.set_name = init.set_name ?? null;
+        this.final = init.final ?? null;
+        this.halting = init.halting ?? null;
+        this.args = init.args ?? null;
+        this.extra = init.extra ?? {};
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/events.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/events.ts
@@ -1,0 +1,58 @@
+/**
+ * Hook event surface for `work_engine`.
+ *
+ * TypeScript twin of `work_engine/hooks/events.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Mirrors the Python `str`-Enum 1:1: each
+ * value is the event name verbatim, so round-trips stay trivial for
+ * telemetry and JSON tracing.
+ *
+ * Ten events split across two layers per
+ * `agents/roadmaps/road-to-work-engine-hooks.md` (locked).
+ *
+ * Dispatcher-layer events fire from inside `dispatcher.dispatch()` and
+ * operate on `DeliveryState` (legacy, internal). CLI-layer events fire
+ * from `cli.main()` and operate on `WorkState` (v1 envelope) plus
+ * auxiliary refs (`state_file`, `fmt`, `args`).
+ */
+
+/**
+ * Lifecycle events emitted by the work engine.
+ *
+ * Modelled as a const object + value-union so it behaves like the Python
+ * `str`-Enum: members compare equal to their string value, and the value
+ * IS the event name. `HookEvent.BEFORE_STEP === 'before_step'`.
+ */
+export const HookEvent = {
+    // Dispatcher layer (DeliveryState).
+    BEFORE_STEP: 'before_step',
+    AFTER_STEP: 'after_step',
+    ON_HALT: 'on_halt',
+    ON_ERROR: 'on_error',
+
+    // CLI layer (WorkState).
+    BEFORE_LOAD: 'before_load',
+    AFTER_LOAD: 'after_load',
+    BEFORE_DISPATCH: 'before_dispatch',
+    AFTER_DISPATCH: 'after_dispatch',
+    BEFORE_SAVE: 'before_save',
+    AFTER_SAVE: 'after_save',
+} as const;
+
+export type HookEvent = (typeof HookEvent)[keyof typeof HookEvent];
+
+/**
+ * Iteration order over every event, mirroring Python `for event in HookEvent`
+ * (declaration order). Used by {@link TraceHook} to register on all events.
+ */
+export const HOOK_EVENTS: readonly HookEvent[] = [
+    HookEvent.BEFORE_STEP,
+    HookEvent.AFTER_STEP,
+    HookEvent.ON_HALT,
+    HookEvent.ON_ERROR,
+    HookEvent.BEFORE_LOAD,
+    HookEvent.AFTER_LOAD,
+    HookEvent.BEFORE_DISPATCH,
+    HookEvent.AFTER_DISPATCH,
+    HookEvent.BEFORE_SAVE,
+    HookEvent.AFTER_SAVE,
+];

--- a/dist/agent-src/templates/scripts/work_engine/hooks/exceptions.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/exceptions.ts
@@ -1,0 +1,85 @@
+/**
+ * Hook control-flow signals.
+ *
+ * TypeScript twin of `work_engine/hooks/exceptions.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Class names stay 1:1 with the Python module.
+ *
+ * Three-tier error contract (locked by roadmap P1):
+ *
+ * - `HookError` — non-fatal. Hook implementation failed; the runner
+ *   catches it, warns, and continues with the next callback for the same
+ *   event. Work proceeds.
+ * - `HookHalt` — fatal-controlled. Hook demands a clean stop (canonical
+ *   example: chat-history `turn-check` foreign session). The runner
+ *   catches it and **returns** it to the caller, who decides how to
+ *   surface it (engine halt, CLI exit code 2 + readable surface). Not
+ *   re-raised through the dispatch loop.
+ * - any other `Error` — fatal-uncontrolled. Treated as a bug in the
+ *   hook. The runner lets it propagate verbatim; dispatch unwinds.
+ *
+ * Both signals share a private `_HookSignal` base so the runner can
+ * distinguish hook-originated control flow from genuine bugs.
+ */
+
+/**
+ * Internal marker for hook-originated control flow.
+ *
+ * Not part of the public API. The runner uses `instanceof` checks
+ * against the concrete subclasses below; the base exists only so a
+ * single `instanceof _HookSignal` would cover both signals if a future
+ * refactor needs it.
+ */
+export class _HookSignal extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, _HookSignal.prototype);
+        this.name = '_HookSignal';
+    }
+}
+
+/**
+ * Non-fatal hook failure.
+ *
+ * Raised when a hook callback fails in a way the *engine* should ignore.
+ * The runner catches it, emits a warning with the message, and moves
+ * on to the next callback registered for the event.
+ *
+ * Use this for transient or non-critical hook failures (telemetry
+ * sinks, optional reporters). Do **not** use it to signal "stop the
+ * engine" — that is what {@link HookHalt} is for.
+ */
+export class HookError extends _HookSignal {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, HookError.prototype);
+        this.name = 'HookError';
+    }
+}
+
+/**
+ * Fatal-controlled stop requested by a hook.
+ *
+ * Hooks raise this when execution must not continue. The runner catches
+ * it and returns it to the caller; the caller turns it into the
+ * appropriate halt surface (dispatcher `Outcome.BLOCKED`, CLI exit 2).
+ *
+ * `surface` is a list of pre-formatted numbered options per the
+ * `user-interaction` rule (one entry per line). Callers must not
+ * reformat — surface is rendered verbatim.
+ *
+ * `reason` is a short machine-readable code (e.g. `"foreign"`,
+ * `"missing"`, `"validation_failed"`) for logging and tests; it is not
+ * shown to the user.
+ */
+export class HookHalt extends _HookSignal {
+    readonly reason: string;
+    readonly surface: string[];
+
+    constructor(reason: string, surface: string[] | null = null) {
+        super(reason);
+        Object.setPrototypeOf(this, HookHalt.prototype);
+        this.name = 'HookHalt';
+        this.reason = reason;
+        this.surface = surface ? [...surface] : [];
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/index.ts
@@ -1,0 +1,27 @@
+/**
+ * `work_engine.hooks` — cross-cutting lifecycle hooks for the engine.
+ *
+ * TypeScript twin of `work_engine/hooks/__init__.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Public surface:
+ *
+ * - `HookEvent` — ten lifecycle events, two layers.
+ * - `HookContext` — per-event payload.
+ * - `HookError` / `HookHalt` — three-tier error contract.
+ * - `HookRegistry` — insertion-ordered event → callbacks map.
+ * - `HookRunner` — single emit point, owns the error contract.
+ */
+export {
+    ChatHistoryAppendHook,
+    ChatHistoryHaltAppendHook,
+    DecisionTraceHook,
+    DirectiveSetGuardHook,
+    HaltSurfaceAuditHook,
+    MemoryVisibilityHook,
+    StateShapeValidationHook,
+    TraceHook,
+} from './builtin/index.js';
+export { HookContext } from './context.js';
+export { HookEvent } from './events.js';
+export { HookError, HookHalt } from './exceptions.js';
+export { type HookCallback, HookRegistry } from './registry.js';
+export { HookRunner } from './runner.js';

--- a/dist/agent-src/templates/scripts/work_engine/hooks/registry.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * `HookRegistry` — insertion-ordered map from event to callbacks.
+ *
+ * TypeScript twin of `work_engine/hooks/registry.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Phase 1 ships insertion-ordered
+ * registration only.
+ *
+ * The registry is a plain container. It does not invoke callbacks, does
+ * not catch exceptions, and does not know about the error contract; that
+ * responsibility lives in {@link HookRunner}.
+ */
+import { HookContext } from './context.js';
+import { HookEvent } from './events.js';
+
+/**
+ * A hook callback. Returns `void` on success, throws `HookError` or
+ * `HookHalt` to signal control flow per `exceptions.ts`.
+ */
+export type HookCallback = (ctx: HookContext) => void;
+
+/**
+ * Insertion-ordered registry of hook callbacks per event.
+ *
+ * Single instance per CLI invocation. Built once and shared with
+ * `dispatch()` so dispatcher events and CLI events are routed through the
+ * same callback set.
+ */
+export class HookRegistry {
+    // Map preserves insertion order, mirroring Python's dict ordering.
+    private _hooks: Map<HookEvent, HookCallback[]> = new Map();
+
+    /**
+     * Register `callback` for `event`.
+     *
+     * Multiple callbacks for the same event are allowed; they fire in
+     * registration order.
+     */
+    register(event: HookEvent, callback: HookCallback): void {
+        let list = this._hooks.get(event);
+        if (list === undefined) {
+            list = [];
+            this._hooks.set(event, list);
+        }
+        list.push(callback);
+    }
+
+    /**
+     * Return callbacks registered for `event` in insertion order.
+     *
+     * Returns an empty array when no callbacks are registered — the runner
+     * uses this to short-circuit a no-op fast path.
+     */
+    for_event(event: HookEvent): HookCallback[] {
+        const list = this._hooks.get(event);
+        return list === undefined ? [] : [...list];
+    }
+
+    /**
+     * Iterate over events that have at least one callback.
+     *
+     * Diagnostics-only; not used on the hot path.
+     */
+    events(): IterableIterator<HookEvent> {
+        return this._hooks.keys();
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/runner.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/runner.ts
@@ -1,0 +1,90 @@
+/**
+ * `HookRunner` — single emit point for hook callbacks.
+ *
+ * TypeScript twin of `work_engine/hooks/runner.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Implements the three-tier error contract
+ * documented in `exceptions.ts`:
+ *
+ * - `HookError` from a callback → caught, a warning is emitted, the runner
+ *   continues with the next callback for the same event. Returns `null`
+ *   once the event is fully drained.
+ * - `HookHalt` from a callback → caught, **returned** to the caller with
+ *   no further callbacks invoked for this event. The caller decides how to
+ *   surface the halt. Never re-raised through the dispatch loop.
+ * - any other `Error` → propagates unchanged. Treated as a hook bug;
+ *   dispatch unwinds.
+ *
+ * Python parity note (intentional, documented): the original emits the
+ * non-fatal warning via `warnings.warn`, whose surface format
+ * (`<file>:<line>: UserWarning: …`) and per-location de-duplication are
+ * interpreter-internal and not portable. This twin emits the same message
+ * to `process.stderr` through the `warn` seam. The observable contract —
+ * the HookError is swallowed and dispatch continues — is preserved; the
+ * exact stderr warning text is normalised in the golden harness.
+ */
+import { HookContext } from './context.js';
+import { HookEvent } from './events.js';
+import { HookError, HookHalt } from './exceptions.js';
+import { HookRegistry } from './registry.js';
+
+/**
+ * Emit hook events through a {@link HookRegistry}.
+ *
+ * Construct once per CLI invocation, share between the CLI and the
+ * dispatcher. `emit` is the only public method on the hot path.
+ */
+export class HookRunner {
+    private _registry: HookRegistry;
+
+    constructor(registry: HookRegistry | null = null) {
+        this._registry = registry !== null ? registry : new HookRegistry();
+    }
+
+    /**
+     * Return the underlying registry.
+     *
+     * Exposed so callers can register additional hooks after construction
+     * (e.g. in tests). Not used on the hot path.
+     */
+    get registry(): HookRegistry {
+        return this._registry;
+    }
+
+    /**
+     * Fire all callbacks registered for `event`.
+     *
+     * Returns `null` when every callback completed (with or without a
+     * swallowed {@link HookError}). Returns the first {@link HookHalt}
+     * raised, after which no further callbacks are invoked for this event.
+     * Any other error propagates.
+     */
+    emit(event: HookEvent, ctx: HookContext): HookHalt | null {
+        const callbacks = this._registry.for_event(event);
+        if (callbacks.length === 0) {
+            return null;
+        }
+        for (const callback of callbacks) {
+            try {
+                callback(ctx);
+            } catch (exc) {
+                if (exc instanceof HookHalt) {
+                    return exc;
+                }
+                if (exc instanceof HookError) {
+                    this.warn(`hook ${event} raised HookError: ${exc.message}`);
+                    continue;
+                }
+                throw exc;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Emit a non-fatal hook warning. Test seam — overridable. Mirrors the
+     * role of `warnings.warn` in the Python original.
+     */
+    protected warn(message: string): void {
+        process.stderr.write(`${message}\n`);
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/hooks/settings.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hooks/settings.ts
@@ -1,0 +1,260 @@
+/**
+ * Read `hooks.*` from `.agent-settings.yml` into {@link HookSettings}.
+ *
+ * TypeScript twin of `work_engine/hooks/settings.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Mirror of the chat-history settings pattern:
+ *
+ * - The YAML read goes through `work_engine/_lib/agent_settings.load_agent_settings`,
+ *   which cascades the whitelisted DX-comfort keys from the user-global file.
+ * - Default-permissive: a missing file or missing `hooks:` block returns
+ *   {@link HookSettings} with `enabled=false` — every hook off, every golden
+ *   replay safe by construction.
+ * - Malformed YAML / unreadable file → defaults; degrade silently.
+ * - Chat-history hooks gate on **two** switches: `hooks.chat_history.enabled`
+ *   AND the global `chat_history.enabled`. Either off → no chat-history hook.
+ */
+import { load_agent_settings, type SettingsDict } from '../_lib/agent_settings.js';
+import {
+    DecisionEngineConfigError,
+    DecisionEngineSettings,
+    parse as _parse_decision_engine,
+} from '../scoring/decision_engine.js';
+
+export const DEFAULT_SETTINGS_FILE = '.agent-settings.yml';
+export const DEFAULT_CHAT_HISTORY_SCRIPT = 'scripts/chat_history.py';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/** Per-field init shape for {@link HookSettings} (mirrors the dataclass). */
+export interface HookSettingsInit {
+    enabled?: boolean;
+    trace?: boolean;
+    halt_surface_audit?: boolean;
+    state_shape_validation?: boolean;
+    directive_set_guard?: boolean;
+    decision_trace?: boolean;
+    memory_visibility?: boolean;
+    memory_visibility_off?: boolean;
+    memory_cadence?: string;
+    chat_history_enabled?: boolean;
+    chat_history_script?: string;
+    decision_engine?: DecisionEngineSettings;
+}
+
+/**
+ * Resolved view of the `hooks:` block.
+ *
+ * `enabled` is the master switch. When `false` the registry stays empty
+ * regardless of the per-hook fields; this is the default when no settings
+ * file exists or no `hooks` block is declared, and it is what keeps
+ * golden-replay tests byte-stable.
+ *
+ * `decision_engine` carries the parsed gate config so {@link DecisionGateHook}
+ * can read it without re-parsing `.agent-settings.yml`.
+ */
+export class HookSettings {
+    readonly enabled: boolean;
+    readonly trace: boolean;
+    readonly halt_surface_audit: boolean;
+    readonly state_shape_validation: boolean;
+    readonly directive_set_guard: boolean;
+    readonly decision_trace: boolean;
+    readonly memory_visibility: boolean;
+    readonly memory_visibility_off: boolean;
+    readonly memory_cadence: string;
+    readonly chat_history_enabled: boolean;
+    readonly chat_history_script: string;
+    readonly decision_engine: DecisionEngineSettings;
+
+    constructor(init: HookSettingsInit = {}) {
+        this.enabled = init.enabled ?? false;
+        this.trace = init.trace ?? false;
+        this.halt_surface_audit = init.halt_surface_audit ?? false;
+        this.state_shape_validation = init.state_shape_validation ?? false;
+        this.directive_set_guard = init.directive_set_guard ?? false;
+        this.decision_trace = init.decision_trace ?? false;
+        this.memory_visibility = init.memory_visibility ?? false;
+        this.memory_visibility_off = init.memory_visibility_off ?? false;
+        this.memory_cadence = init.memory_cadence ?? 'always';
+        this.chat_history_enabled = init.chat_history_enabled ?? false;
+        this.chat_history_script = init.chat_history_script ?? DEFAULT_CHAT_HISTORY_SCRIPT;
+        this.decision_engine = init.decision_engine ?? new DecisionEngineSettings();
+        Object.freeze(this);
+    }
+}
+
+const _DEFAULT = new HookSettings();
+
+/**
+ * Return {@link HookSettings} hydrated from `.agent-settings.yml`.
+ *
+ * `settings_path` defaults to `./.agent-settings.yml` relative to the
+ * current working directory. `user_global_path` defaults to
+ * `~/.event4u/agent-config/agent-settings.yml` and only cascades the
+ * whitelisted DX-comfort keys when the project file omits them.
+ */
+export function load_hook_settings(
+    settings_path: string | null = null,
+    user_global_path: string | null = null,
+): HookSettings {
+    const path = settings_path ? settings_path : DEFAULT_SETTINGS_FILE;
+    const raw = load_agent_settings({
+        project_path: path,
+        user_global_path,
+    });
+    if (!_pyTruthy(raw)) {
+        return _DEFAULT;
+    }
+    return _settings_from_raw(raw);
+}
+
+function _settings_from_raw(data: SettingsDict): HookSettings {
+    const hooks = data['hooks'];
+    if (!_isPlainDict(hooks)) {
+        return _DEFAULT;
+    }
+    const hooksDict = hooks as Record<string, Any>;
+    const enabled = _coerce_bool(hooksDict['enabled'], false);
+
+    const decision_engine_raw = data['decision_engine'];
+    let decision_engine_settings: DecisionEngineSettings;
+    try {
+        decision_engine_settings = _parse_decision_engine(decision_engine_raw);
+    } catch (exc) {
+        if (exc instanceof DecisionEngineConfigError) {
+            decision_engine_settings = new DecisionEngineSettings();
+        } else {
+            throw exc;
+        }
+    }
+
+    if (!enabled) {
+        return new HookSettings({
+            enabled: false,
+            decision_engine: decision_engine_settings,
+        });
+    }
+
+    const chat_section = hooksDict['chat_history'];
+    let chat_block_enabled: boolean;
+    let chat_script: string;
+    if (_isPlainDict(chat_section)) {
+        const cs = chat_section as Record<string, Any>;
+        chat_block_enabled = _coerce_bool(cs['enabled'], true);
+        chat_script = String(_pyOr(cs['script'], DEFAULT_CHAT_HISTORY_SCRIPT));
+    } else {
+        chat_block_enabled = true;
+        chat_script = DEFAULT_CHAT_HISTORY_SCRIPT;
+    }
+
+    const global_chat = data['chat_history'];
+    const global_chat_on =
+        _isPlainDict(global_chat) &&
+        _coerce_bool((global_chat as Record<string, Any>)['enabled'], false);
+
+    const decision_trace_on = decision_engine_settings.surface_traces;
+
+    const memory_section = data['memory'];
+    let visibility_off = false;
+    let memory_cadence = 'always';
+    if (_isPlainDict(memory_section)) {
+        const ms = memory_section as Record<string, Any>;
+        const rawVis = ms['visibility'];
+        if (typeof rawVis === 'string' && rawVis.trim().toLowerCase() === 'off') {
+            visibility_off = true;
+        } else if (typeof rawVis === 'boolean' && rawVis === false) {
+            visibility_off = true;
+        }
+        const cadence_raw = ms['cadence'];
+        if (cadence_raw !== null && cadence_raw !== undefined) {
+            memory_cadence = String(cadence_raw).trim().toLowerCase() || 'always';
+        }
+    }
+
+    const memory_hooks = hooksDict['memory_visibility'];
+    let memory_visibility_on: boolean;
+    if (_isPlainDict(memory_hooks)) {
+        memory_visibility_on = _coerce_bool(
+            (memory_hooks as Record<string, Any>)['enabled'],
+            true,
+        );
+    } else {
+        memory_visibility_on = true;
+    }
+
+    return new HookSettings({
+        enabled: true,
+        trace: _coerce_bool(hooksDict['trace'], false),
+        halt_surface_audit: _coerce_bool(hooksDict['halt_surface_audit'], true),
+        state_shape_validation: _coerce_bool(hooksDict['state_shape_validation'], true),
+        directive_set_guard: _coerce_bool(hooksDict['directive_set_guard'], true),
+        decision_trace: decision_trace_on,
+        memory_visibility: memory_visibility_on,
+        memory_visibility_off: visibility_off,
+        memory_cadence,
+        chat_history_enabled: chat_block_enabled && global_chat_on,
+        chat_history_script: chat_script,
+        decision_engine: decision_engine_settings,
+    });
+}
+
+function _coerce_bool(value: Any, dflt: boolean): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined) {
+        return dflt;
+    }
+    if (typeof value === 'string') {
+        const s = value.trim().toLowerCase();
+        if (s === 'true' || s === 'yes' || s === 'on' || s === '1') {
+            return true;
+        }
+        if (s === 'false' || s === 'no' || s === 'off' || s === '0') {
+            return false;
+        }
+    }
+    return dflt;
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** Python `a or b` — returns `a` when truthy, else `b`. */
+function _pyOr(a: Any, b: Any): Any {
+    return _pyTruthy(a) ? a : b;
+}
+
+/** Python `isinstance(x, dict)` — only a plain object (not array, not null). */
+function _isPlainDict(value: Any): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Python `bool(x)` truthiness: `None`/`undefined`, `False`, `0`, `""`,
+ * empty list/dict are falsy; everything else truthy.
+ */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/analyze.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/analyze.ts
@@ -1,0 +1,124 @@
+/**
+ * `analyze` step — deterministic precondition gate.
+ *
+ * TypeScript twin of `work_engine/directives/backend/analyze.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The step runs no analysis of its own: the real impact analysis is
+ * owned by the agent between the `memory` and `plan` steps. The
+ * gate's job is to confirm the upstream slices are populated enough
+ * for planning to be meaningful.
+ *
+ * Checks, in order:
+ *
+ * 1. `refine` outcome must be `success` — the ticket is refined.
+ * 2. `memory` outcome must be `success` — priors were queried
+ *    (an empty result set is still a successful query, per the
+ *    `memory` step's own contract).
+ * 3. The ticket must still carry acceptance criteria — guards against
+ *    a resuming caller overwriting `state.ticket` between runs.
+ *
+ * On any missing precondition the step returns `BLOCKED` with the
+ * reason spelled out and numbered options per the `user-interaction`
+ * rule. Otherwise it returns `SUCCESS` without mutating state.
+ */
+
+import { DeliveryState, Outcome, StepResult } from '../../delivery_state.js';
+
+/** Declared ambiguity surfaces. Every BLOCKED return maps to one code. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_refine_failed',
+        trigger: '`refine` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'upstream_memory_failed',
+        trigger: '`memory` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'lost_ac',
+        trigger: 'ticket lost its `acceptance_criteria` between runs',
+        resolution: 'restart with the full ticket payload',
+    },
+];
+
+/** Return SUCCESS when upstream is coherent, BLOCKED otherwise. */
+export function run(state: DeliveryState): StepResult {
+    const missing = _diagnose(state);
+    if (missing.length === 0) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const ticketId = _pyTruthy((state.ticket ?? {}).id) ? String((state.ticket ?? {}).id) : '(no id)';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: _format_questions(ticketId, missing),
+        message: `Ticket ${ticketId} cannot enter the plan step: ` + missing.join('; '),
+    });
+}
+
+/** List the precondition failures in the order a reader needs them. */
+function _diagnose(state: DeliveryState): string[] {
+    const issues: string[] = [];
+
+    if (state.outcomes.refine !== Outcome.SUCCESS) {
+        issues.push('refine step did not complete successfully');
+    }
+
+    if (state.outcomes.memory !== Outcome.SUCCESS) {
+        issues.push('memory step did not complete successfully');
+    }
+
+    const ac = (state.ticket ?? {}).acceptance_criteria;
+    if (!Array.isArray(ac) || ac.length === 0) {
+        issues.push('ticket lost its acceptance criteria');
+    }
+
+    return issues;
+}
+
+/**
+ * Render the numbered options shown to the user when BLOCKED.
+ *
+ * Two options: retry from the first failing step, or abort. The
+ * headnote names the ticket and every failure so the user can
+ * decide without re-reading the earlier output.
+ */
+function _format_questions(ticketId: string, missing: string[]): string[] {
+    const headnote = `> Ticket ${ticketId} — analyze gate failed: ` + missing.join('; ') + '.';
+    return [
+        headnote,
+        '> 1. Re-run `/implement-ticket` from the start — rebuild upstream state',
+        '> 2. Abort — the flow cannot continue',
+    ];
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/implement.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/implement.ts
@@ -1,0 +1,188 @@
+/**
+ * `implement` step — gate + Option-A delegation for applying the plan.
+ *
+ * TypeScript twin of `work_engine/directives/backend/implement.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The step never edits files. Editing is delegated to the agent via
+ * `@agent-directive: apply-plan`; the agent runs the `minimal-safe-
+ * diff` and `scope-control` rules while it applies the plan, then
+ * writes the resulting file-level changes onto `state.changes` and
+ * marks `outcomes['implement'] = 'success'` before re-invoking the
+ * dispatcher.
+ *
+ * Flow:
+ *
+ * - `plan` outcome is not `success` → BLOCKED on precondition.
+ * - `state.changes` empty → BLOCKED with `@agent-directive:
+ *   apply-plan` so the agent applies the plan.
+ * - `state.changes` populated but malformed (entries missing
+ *   `path`, or non-dict entries) → BLOCKED with shape complaint.
+ * - Otherwise → SUCCESS.
+ *
+ * `changes` entries use the loose shape described in
+ * `docs/contracts/implement-ticket-flow.md#deliverystate-the-only-shared-object`
+ * — each entry is a dict with at least a `path`; optional
+ * `lines` / `purpose` feed the delivery report.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+/** Declared ambiguity surfaces. Advisory personas skip this step entirely. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_plan_failed',
+        trigger: '`plan` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_changes_delegate',
+        trigger: '`state.changes` empty — plan not applied yet',
+        resolution: 'agent directive `apply-plan` → edit under `minimal-safe-diff` ' + '+ `scope-control`',
+    },
+    {
+        code: 'malformed_changes',
+        trigger: 'any change entry is not a dict or has no non-empty `path`',
+        resolution: 're-run `apply-plan` and resume',
+    },
+];
+
+/** Gate on `plan`, then either delegate or validate `state.changes`. */
+export function run(state: DeliveryState): StepResult {
+    const policy = resolve_policy(state.persona);
+    if (!policy.allows_implement) {
+        // Advisory personas produce a plan only; `state.changes` stays
+        // empty and the delivery report renders a "no file changes
+        // recorded" placeholder. See `persona_policy` for contract.
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `implement skipped: persona \`${policy.name}\` is plan-only.`,
+        });
+    }
+
+    if (state.outcomes.plan !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    if (!_pyTruthy(state.changes)) {
+        return _delegate_to_apply_plan(state);
+    }
+
+    const shapeIssues = _diagnose_changes(state.changes);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** Every entry must be a dict carrying at least a non-empty `path`. */
+function _diagnose_changes(changes: Any[]): string[] {
+    const issues: string[] = [];
+    changes.forEach((change, i) => {
+        const idx = i + 1;
+        if (!_isPlainObject(change)) {
+            issues.push(`change #${idx} is not a dict`);
+            return;
+        }
+        const d = change as Record<string, unknown>;
+        const path = _pyTruthy(d.path) ? d.path : d.file;
+        if (typeof path !== 'string' || _pyStrip(path).length === 0) {
+            issues.push(`change #${idx} has no path`);
+        }
+    });
+    return issues;
+}
+
+function _delegate_to_apply_plan(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('apply-plan', { ticket: ticketId }),
+            `> Ticket ${ticketId} — applying the recorded plan under ` +
+                '`minimal-safe-diff` + `scope-control`.',
+            '> 1. Continue — apply the plan as recorded',
+            '> 2. Abort — stop before any edits are made',
+        ],
+        message: `Ticket ${ticketId} needs its plan applied before testing.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — implement gate refused: ` +
+                '`plan` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot implement: plan gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded changes are malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run `apply-plan` and resume',
+            '> 2. Abort — changes cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} changes shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** Python `str.strip()` — strip leading/trailing whitespace. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/memory.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/memory.ts
@@ -1,0 +1,192 @@
+/**
+ * `memory` step — bounded retrieval over the four allowed types.
+ *
+ * TypeScript twin of `work_engine/directives/backend/memory.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * Contract (see
+ * `docs/contracts/implement-ticket-flow.md#memory-retrieval-contract`):
+ *
+ * - Four allowed types: `domain-invariants`, `architecture-decisions`,
+ *   `incident-learnings`, `historical-patterns`.
+ * - Hard cap of **12** hits total across the four types.
+ * - Keys derive from the ticket — title tokens plus acceptance-criterion
+ *   tokens plus any already-known `files` hint. Tokenisation is
+ *   deliberately naive (whitespace split, lower-cased) so the retrieval
+ *   shape stays reproducible in tests.
+ * - Step always returns `SUCCESS`. Zero hits is a valid outcome
+ *   ("nothing in memory touches this ticket") — the `report` step
+ *   drops the memory section when that happens rather than padding.
+ *
+ * The step stores each hit as a plain dict on `state.memory` so
+ * consumers outside Python (the delivery report, JSON log lines) can
+ * round-trip the structure without pickling dataclasses.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult } from '../../delivery_state.js';
+import { retrieve as _real_retrieve } from '../../../memory_lookup.js';
+
+/** The four types allowed by the flow contract. No aliases, no extras. */
+export const MEMORY_TYPES: ReadonlyArray<string> = [
+    'domain-invariants',
+    'architecture-decisions',
+    'incident-learnings',
+    'historical-patterns',
+];
+
+/** Hard cap per the roadmap — never raise without amending the contract. */
+export const MAX_HITS = 12;
+
+/**
+ * Declared ambiguity surfaces — memory retrieval always succeeds.
+ *
+ * Declared empty so the aggregate registry in `steps/__init__.py`
+ * can round-trip every step's surfaces without a special case.
+ */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/** Signature of the `memory_lookup.retrieve` callable this step drives. */
+type RetrieveFn = (types: string[], keys: string[], limit: number) => unknown;
+
+/**
+ * Test seam mirroring Python's late `import memory_lookup` monkeypatch
+ * point. Default is the real `memory_lookup.retrieve`; tests swap it via
+ * `_setRetrieve` exactly as the Python suite patches `memory_lookup.retrieve`.
+ */
+let _retrieve_override: RetrieveFn | null = null;
+
+/** Swap the `retrieve` callable (test hook for the lazy-import seam). */
+export function _setRetrieve(fn: RetrieveFn | null): void {
+    _retrieve_override = fn;
+}
+
+const _WORD = /[A-Za-z][A-Za-z0-9_-]{2,}/g;
+const _STOPWORDS: ReadonlySet<string> = new Set([
+    'the', 'and', 'for', 'with', 'from', 'into', 'that', 'this',
+    'should', 'must', 'when', 'then', 'will', 'have', 'has',
+    'are', 'was', 'were', 'can', 'could', 'would', 'shall',
+    'also', 'which', 'where', 'while', 'make', 'made', 'use',
+    'used', 'using', 'user', 'users', 'test', 'tests',
+]);
+
+/** Populate `state.memory` with up to `MAX_HITS` hits. */
+export function run(state: DeliveryState): StepResult {
+    const retrieve = _resolve_retrieve();
+    const keys = _keys_from_ticket(state.ticket);
+    const hits = retrieve([...MEMORY_TYPES], keys, MAX_HITS);
+
+    // `retrieve` returns `Hit` dataclasses; coerce to dicts so the
+    // state is serialisation-ready for the report step and metrics log.
+    const hitList = Array.isArray(hits) ? hits : [];
+    state.memory = hitList.slice(0, MAX_HITS).map((h) => _as_dict(h));
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/**
+ * Resolve `memory_lookup.retrieve` lazily so tests can monkeypatch it.
+ *
+ * Importing at module load time would freeze the reference before
+ * tests can swap in a fake, which is the standard gotcha with the
+ * `from X import Y` form. Deferring the resolution keeps the step
+ * patchable from a single attribute (`memory_lookup.retrieve`).
+ */
+function _resolve_retrieve(): RetrieveFn {
+    return _retrieve_override ?? (_real_retrieve as RetrieveFn);
+}
+
+/**
+ * Derive retrieval keys from the ticket.
+ *
+ * Three sources, in priority order so callers reading the log can
+ * reconstruct why a hit scored: explicit `files` hints first,
+ * then title tokens, then acceptance-criterion tokens. Duplicates
+ * are removed while preserving first-seen order.
+ */
+function _keys_from_ticket(ticket: Record<string, Any>): string[] {
+    const keys: string[] = [];
+    _extend_unique(keys, _as_str_list((ticket || {}).files));
+    _extend_unique(keys, _tokenise((ticket || {}).title));
+    for (const ac of _as_str_list((ticket || {}).acceptance_criteria)) {
+        _extend_unique(keys, _tokenise(ac));
+    }
+    return keys;
+}
+
+/** Return lower-cased content words from `value` (empty when absent). */
+function _tokenise(value: Any): string[] {
+    if (typeof value !== 'string') {
+        return [];
+    }
+    const out: string[] = [];
+    for (const match of value.matchAll(_WORD)) {
+        const word = match[0].toLowerCase();
+        if (!_STOPWORDS.has(word)) {
+            out.push(word);
+        }
+    }
+    return out;
+}
+
+/** Coerce `value` to a list of non-empty strings. */
+function _as_str_list(value: Any): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.filter((item): item is string => typeof item === 'string' && item.trim().length !== 0);
+}
+
+/** Append items from `source` to `target` skipping duplicates. */
+function _extend_unique(target: string[], source: Iterable<string>): void {
+    const seen = new Set(target);
+    for (const item of source) {
+        if (seen.has(item)) {
+            continue;
+        }
+        target.push(item);
+        seen.add(item);
+    }
+}
+
+/** Coerce a `Hit` (or pre-dict test fake) into a plain dict. */
+function _as_dict(hit: Any): Record<string, Any> {
+    const asDict = (hit as { as_dict?: unknown })?.as_dict;
+    if (typeof asDict === 'function') {
+        return (asDict as () => Record<string, Any>).call(hit);
+    }
+    if (_isPlainObject(hit)) {
+        return { ...(hit as Record<string, Any>) };
+    }
+    // Fallback path — should not happen in production, but keeps the
+    // step from crashing if a fixture returns a raw namespace object.
+    return { entry: _pyRepr(hit) };
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Minimal Python `repr()` for the fallback path's scalar inputs. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/plan.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/plan.ts
@@ -1,0 +1,266 @@
+/**
+ * `plan` step — gate + delegation to `feature-plan`.
+ *
+ * TypeScript twin of `work_engine/directives/backend/plan.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The dispatcher cannot synthesise a plan from pure code: the real
+ * work needs code reading and judgement that only the agent has. The
+ * step therefore follows the Option-A delegation pattern described in
+ * `docs/contracts/implement-ticket-flow.md#agent-directives`:
+ *
+ * - `state.plan` empty → halt with `BLOCKED` and emit
+ *   `@agent-directive: create-plan`. The orchestrator runs the
+ *   `feature-plan` skill, writes its output onto `state.plan`,
+ *   marks `outcomes['plan'] = 'success'`, and re-invokes the
+ *   dispatcher.
+ *
+ * - `state.plan` populated with a minimally valid shape → `SUCCESS`
+ *   with no mutation. Shape validation catches accidental scaffolding
+ *   (e.g. an empty list, a placeholder string) that would produce a
+ *   broken plan downstream.
+ *
+ * - `state.plan` populated but malformed → `BLOCKED` with numbered
+ *   options so the user decides whether to re-plan, continue with the
+ *   malformed plan, or abort.
+ *
+ * `analyze` is a precondition: the step refuses to plan when the
+ * upstream gate did not succeed, rather than silently re-running a
+ * derailed flow.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+
+/** Declared ambiguity surfaces. Every BLOCKED return maps to one code. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_analyze_failed',
+        trigger: '`analyze` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_plan_delegate',
+        trigger: '`state.plan` empty — no plan recorded yet',
+        resolution: 'agent directive `create-plan` → `/feature-plan`',
+    },
+    {
+        code: 'malformed_plan',
+        trigger:
+            'plan is not a non-empty string, list of strings/dicts, ' +
+            'or dict with a non-empty `steps` list',
+        resolution: 're-run `/feature-plan` or correct the recorded plan',
+    },
+];
+
+/** Gate on `analyze`, then either delegate or validate the plan. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes.analyze !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    if (_is_plan_empty(state.plan)) {
+        return _delegate_to_feature_plan(state);
+    }
+
+    const shapeIssues = _diagnose_shape(state.plan);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/**
+ * True when `state.plan` has nothing a downstream step could use.
+ *
+ * Whitespace-only strings count as empty — the user experience of
+ * "nothing planned" is identical to "blank placeholder", and both
+ * should delegate to `feature-plan` rather than fall through to
+ * the shape-validator.
+ */
+function _is_plan_empty(plan: Any): boolean {
+    if (plan === null || plan === undefined) {
+        return true;
+    }
+    if (typeof plan === 'string') {
+        return _pyStrip(plan).length === 0;
+    }
+    if (Array.isArray(plan)) {
+        return plan.length === 0;
+    }
+    if (plan instanceof Set || plan instanceof Map) {
+        return plan.size === 0;
+    }
+    if (typeof plan === 'object') {
+        return Object.keys(plan as Record<string, unknown>).length === 0;
+    }
+    return false;
+}
+
+/**
+ * Return the list of shape complaints against `state.plan`.
+ *
+ * Accepted shapes (matches `report._format_plan`):
+ * a non-empty string, a list of strings or `{title, detail}` dicts,
+ * or a dict with a non-empty `steps` list. Everything else is
+ * rejected so the report renderer never has to guess.
+ */
+function _diagnose_shape(plan: Any): string[] {
+    const issues: string[] = [];
+
+    if (typeof plan === 'string') {
+        if (_pyStrip(plan).length === 0) {
+            issues.push('plan is a blank string');
+        }
+        return issues;
+    }
+
+    if (Array.isArray(plan)) {
+        if (plan.length === 0) {
+            issues.push('plan list is empty');
+            return issues;
+        }
+        plan.forEach((item, i) => {
+            const idx = i + 1;
+            if (_isPlainObject(item)) {
+                const d = item as Record<string, unknown>;
+                if (!_pyTruthy(d.title) && !_pyTruthy(d.step)) {
+                    issues.push(`plan step #${idx} has no title`);
+                }
+            } else if (typeof item !== 'string' || _pyStrip(item).length === 0) {
+                issues.push(`plan step #${idx} is not a usable string`);
+            }
+        });
+        return issues;
+    }
+
+    if (_isPlainObject(plan)) {
+        const steps = (plan as Record<string, unknown>).steps;
+        if (!Array.isArray(steps) || steps.length === 0) {
+            issues.push("plan dict must carry a non-empty 'steps' list");
+        }
+        return issues;
+    }
+
+    issues.push(`plan has unsupported type: ${_pyTypeName(plan)}`);
+    return issues;
+}
+
+/** Halt with an agent directive so the orchestrator runs `feature-plan`. */
+function _delegate_to_feature_plan(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('create-plan', { ticket: ticketId }),
+            `> Ticket ${ticketId} — no plan recorded yet; running ` +
+                '`feature-plan` and resuming.',
+            '> 1. Continue — use the plan produced by `feature-plan`',
+            '> 2. Abort — stop before any edits are proposed',
+        ],
+        message: `Ticket ${ticketId} needs a plan before implementation.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — plan gate refused: ` +
+                '`analyze` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot plan: analyze gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded plan is malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run `feature-plan` and resume',
+            '> 2. Abort — the plan cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} plan shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** Python `str.strip()` — strip leading/trailing whitespace. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Python `type(x).__name__` for the value kinds the diagnose paths see. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (typeof value === 'boolean') {
+        return 'bool';
+    }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') {
+        return 'str';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Set) {
+        return 'set';
+    }
+    if (value instanceof Map || _isPlainObject(value)) {
+        return 'dict';
+    }
+    return typeof value;
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/refine.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/refine.ts
@@ -1,0 +1,516 @@
+/**
+ * `refine` step — deterministic gate in front of the refinement skills.
+ *
+ * TypeScript twin of `work_engine/directives/backend/refine.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The step never calls an LLM. It inspects `state.ticket` (which carries
+ * `input.data` after the CLI projection) and routes on shape:
+ *
+ * - **Ticket envelope** (`id`, `title`, `acceptance_criteria`) — the
+ *   R1 path. Validates the minimum viable shape and either returns
+ *   `SUCCESS` or `BLOCKED` with numbered options pointing at
+ *   `/refine-ticket`.
+ * - **Prompt envelope** (`raw` key present, `reconstructed_ac` /
+ *   `assumptions` slots) — the R2 path. On the first pass the gate
+ *   delegates to the `refine-prompt` skill via an `@agent-directive:`
+ *   halt; on the rebound it scores the reconstructed envelope and routes
+ *   the resulting confidence band:
+ *
+ *   - `high`   → `SUCCESS` (silent proceed, breakdown logged for the report)
+ *   - `medium` → `PARTIAL` with an assumptions-report halt
+ *   - `low`    → `BLOCKED` with one clarifying question targeted at the
+ *     weakest dimension
+ *
+ * The checks live here (rather than inside the refinement skills) because
+ * the dispatcher is synchronous Python: it cannot "delegate" to an agent
+ * skill mid-loop. Making the gate deterministic keeps the contract "block
+ * on ambiguity, never guess" enforceable from code, and ensures the band
+ * the dispatcher routes on is always engine-computed — the skill produces
+ * AC + assumptions, the engine decides.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { ConfidenceScore, DIMENSION_NAMES, score as _confidence_score } from '../../scoring/confidence.js';
+
+const _MIN_TITLE_LEN = 3;
+const _MIN_AC_LEN = 10;
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'missing_id',
+        trigger: 'ticket has no `id` field (or only whitespace)',
+        resolution: 'run `/refine-ticket` or paste the ticket id in chat',
+    },
+    {
+        code: 'trivial_title',
+        trigger: `title missing or shorter than ${_MIN_TITLE_LEN} chars`,
+        resolution: 'run `/refine-ticket` to rewrite the title',
+    },
+    {
+        code: 'missing_or_vague_ac',
+        trigger: `acceptance_criteria empty, non-list, or any item under ${_MIN_AC_LEN} chars`,
+        resolution: 'run `/refine-ticket` to add concrete acceptance criteria',
+    },
+    {
+        code: 'prompt_unrefined',
+        trigger:
+            'prompt envelope present but `reconstructed_ac` is empty — ' +
+            'the deterministic gate has nothing to score yet',
+        resolution:
+            'agent directive `refine-prompt` → run the skill, ' +
+            'write AC + assumptions back into `state.ticket`',
+    },
+    {
+        code: 'prompt_medium_confidence',
+        trigger:
+            'scored band is `medium` and the user has not confirmed the ' +
+            'assumptions report yet',
+        resolution:
+            'user confirms the reconstructed AC + assumptions, ' +
+            'or refines them; agent flips `confidence_confirmed=True` to ' +
+            'release the gate',
+    },
+    {
+        code: 'prompt_low_confidence',
+        trigger:
+            'scored band is `low` — too little signal to plan against, ' +
+            'even after reconstruction',
+        resolution:
+            'user answers one clarifying question; the agent ' +
+            're-runs `refine-prompt` against the refreshed prompt',
+    },
+    {
+        code: 'prompt_ui_intent',
+        trigger:
+            'scorer flagged `ui_intent=True` — the prompt reads as UI ' +
+            'work and the backend track cannot ship it cleanly',
+        resolution:
+            'user re-frames the prompt as backend-only, parks ' +
+            'it for Roadmap 3 (`road-to-product-ui-track.md`), or aborts',
+    },
+];
+/** Declared ambiguity surfaces. Every BLOCKED / PARTIAL return maps to one code. */
+
+/** Route on envelope shape: ticket path or prompt path. */
+export function run(state: DeliveryState): StepResult {
+    const data = state.ticket || {};
+    if (_is_prompt_envelope(data)) {
+        return _run_prompt(state, data);
+    }
+
+    const deficiencies = _diagnose(data);
+    if (deficiencies.length === 0) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const ticket_id = _pyTruthy(data.id) ? _pyStr(data.id) : '(no id)';
+    const questions = _format_questions(ticket_id, deficiencies);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message: `Ticket ${ticket_id} is not refined enough to plan against: ` + deficiencies.join('; '),
+    });
+}
+
+/**
+ * True when `state.ticket` carries a prompt envelope.
+ *
+ * The presence of a string-valued `raw` key is unambiguous: ticket
+ * payloads never carry `raw`, and prompt envelopes always do (the
+ * resolver writes it before any handler sees the state).
+ */
+function _is_prompt_envelope(data: Record<string, Any>): boolean {
+    if (!_isPlainObject(data)) {
+        return false;
+    }
+    const raw = data.raw;
+    return typeof raw === 'string' && Boolean(raw.trim());
+}
+
+/**
+ * Return a human-readable list of what's missing from the ticket.
+ *
+ * Order matches what a reader needs first (identity → summary →
+ * acceptance criteria) so the surfaced questions read naturally.
+ */
+function _diagnose(ticket: Record<string, Any>): string[] {
+    const issues: string[] = [];
+
+    const ticket_id = ticket.id;
+    if (typeof ticket_id !== 'string' || !ticket_id.trim()) {
+        issues.push('missing ticket id');
+    }
+
+    const title = ticket.title;
+    if (typeof title !== 'string' || title.trim().length < _MIN_TITLE_LEN) {
+        issues.push('missing or trivial title');
+    }
+
+    const ac = ticket.acceptance_criteria;
+    if (!Array.isArray(ac) || ac.length === 0) {
+        issues.push('no acceptance criteria');
+    } else {
+        const weak_indices: number[] = [];
+        ac.forEach((item, idx) => {
+            if (!_is_concrete_ac(item)) {
+                weak_indices.push(idx + 1);
+            }
+        });
+        if (weak_indices.length > 0) {
+            issues.push('vague acceptance criteria at position(s) ' + weak_indices.map((i) => String(i)).join(', '));
+        }
+    }
+
+    return issues;
+}
+
+/**
+ * An AC is concrete when it is a non-empty string above the length floor.
+ *
+ * The floor is deliberately loose: refine is a gate, not a style
+ * judge. The heavy lifting (measurability, testability, tone) is
+ * owned by the `refine-ticket` skill on the rebound.
+ */
+function _is_concrete_ac(item: Any): boolean {
+    if (typeof item !== 'string') {
+        return false;
+    }
+    return item.trim().length >= _MIN_AC_LEN;
+}
+
+/**
+ * Render the numbered options shown to the user when BLOCKED.
+ *
+ * Three options, ordered by likely next action: run the existing
+ * refinement skill, paste the missing data in chat, or abandon the
+ * ticket entirely. `user-interaction` requires numbered, prose-
+ * free options; the deficiency list is rendered as a headnote.
+ */
+function _format_questions(ticket_id: string, deficiencies: string[]): string[] {
+    const headnote = '> Ticket ' + ticket_id + ' is missing: ' + deficiencies.join('; ') + '.';
+    return [
+        headnote,
+        `> 1. Run \`/refine-ticket ${ticket_id}\` and re-invoke \`/implement-ticket\``,
+        "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+        '> 3. Abandon this ticket — too vague to implement',
+    ];
+}
+
+/**
+ * Score the prompt envelope and route on the resulting band.
+ *
+ * First pass (no AC reconstructed yet) → delegate to `refine-prompt`.
+ * Second pass → score and branch:
+ *
+ * - `high`   → `SUCCESS`; the breakdown is recorded on
+ *   `state.ticket['confidence']` so the report renderer can include
+ *   it without re-scoring.
+ * - `medium` → `PARTIAL` with an assumptions-report halt unless
+ *   the agent has flipped `confidence_confirmed=True` after the
+ *   user signed off. `low` band can never be released this way.
+ * - `low`    → `BLOCKED` with one clarifying question targeted at
+ *   the weakest dimension (lowest score wins; ties prefer the order
+ *   declared in `work_engine.scoring.confidence.DIMENSION_NAMES`).
+ */
+function _run_prompt(state: DeliveryState, data: Record<string, Any>): StepResult {
+    const raw = (_pyTruthy(data.raw) ? data.raw : '') as string;
+    const ac: Any[] = Array.isArray(data.reconstructed_ac) ? data.reconstructed_ac : [];
+    const assumptions: Any[] = Array.isArray(data.assumptions) ? data.assumptions : [];
+
+    if (ac.length === 0) {
+        return _delegate_to_refine_prompt(raw);
+    }
+
+    const result = _confidence_score({ raw, ac: ac as string[], assumptions: assumptions as string[] });
+    data.confidence = {
+        band: result.band,
+        score: result.score,
+        dimensions: { ...result.dimensions },
+        reasons: [...result.reasons],
+        ui_intent: result.ui_intent,
+    };
+    // Mirror reconstructed AC into the legacy slot every downstream gate
+    // (analyze, plan, implement) reads. Prompt envelopes carry AC under
+    // `reconstructed_ac`; without this projection `analyze` blocks with
+    // "ticket lost its acceptance criteria" the moment `refine` succeeds.
+    data.acceptance_criteria = [...ac];
+
+    if (result.ui_intent) {
+        return _halt_ui_intent(raw, result);
+    }
+
+    if (result.band === 'high') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    if (result.band === 'medium') {
+        if (data.confidence_confirmed === true) {
+            return new StepResult({ outcome: Outcome.SUCCESS });
+        }
+        return _halt_medium(raw, ac, assumptions, result);
+    }
+
+    return _halt_low(raw, result);
+}
+
+/** Halt with an agent directive so the orchestrator runs `refine-prompt`. */
+function _delegate_to_refine_prompt(raw: string): StepResult {
+    const preview = _preview(raw);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('refine-prompt'),
+            `> Prompt received: ${preview}`,
+            '> No reconstructed acceptance criteria yet — running ' + '`refine-prompt` and resuming.',
+            '> 1. Continue — let the skill reconstruct AC + assumptions',
+            '> 2. Abort — the prompt is not what I meant',
+        ],
+        message: 'Prompt envelope present but unrefined; delegating to refine-prompt.',
+    });
+}
+
+/** PARTIAL halt — assumptions report, one user round-trip. */
+function _halt_medium(raw: string, ac: Any[], assumptions: Any[], result: ConfidenceScore): StepResult {
+    const preview = _preview(raw);
+    const ac_lines = ac.map((item, i) => `>    ${i + 1}. ${_pyStr(item)}`);
+    const asm_lines = assumptions.length > 0 ? assumptions.map((item) => `>    - ${_pyStr(item)}`) : ['>    - (none recorded)'];
+    const questions = [
+        `> Prompt: ${preview}`,
+        `> Confidence: **medium** (score ${_pyFormat2f(result.score)}). ` + 'Assumptions worth confirming before I plan.',
+        '> Reconstructed AC:',
+        ...ac_lines,
+        '> Assumptions:',
+        ...asm_lines,
+        '> 1. Continue as-is — the AC + assumptions are good enough',
+        "> 2. Refine — I'll send a corrected prompt and re-run " + '`refine-prompt`',
+        '> 3. Abort — pause this `/work` cycle',
+    ];
+    return new StepResult({
+        outcome: Outcome.PARTIAL,
+        questions,
+        message: `Prompt scored medium (${_pyFormat2f(result.score)}); ` + 'halting for assumptions confirmation.',
+    });
+}
+
+/** BLOCKED halt — one targeted question on the weakest dimension. */
+function _halt_low(raw: string, result: ConfidenceScore): StepResult {
+    const preview = _preview(raw);
+    const [weakest_idx, weakest_name] = _weakest_dimension(result.dimensions);
+    const reason = weakest_idx < result.reasons.length ? result.reasons[weakest_idx] : '';
+    const prompts: Record<string, string> = {
+        goal_clarity: 'What is the single observable outcome you want?',
+        scope_boundary: 'Which file, class, or module should I touch?',
+        ac_evidence: 'What concrete behaviour proves it works?',
+        stack_data: 'Which table, column, or migration target is involved?',
+        reversibility: 'Is this change destructive — should I work behind a flag?',
+    };
+    const question = weakest_name in prompts ? prompts[weakest_name] : 'Can you tighten the prompt?';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Prompt: ${preview}`,
+            `> Confidence: **low** (score ${_pyFormat2f(result.score)}). ` + `Weakest dimension: \`${weakest_name}\` — ${reason}`,
+            `> ${question}`,
+            "> 1. I'll answer — paste the answer in chat and re-invoke `/work`",
+            '> 2. Abort — drop this prompt',
+        ],
+        message: `Prompt scored low (${_pyFormat2f(result.score)}); blocking on ` + `\`${weakest_name}\` clarification.`,
+    });
+}
+
+/**
+ * BLOCKED halt — UI-shaped prompts await the R3 dispatch track.
+ *
+ * The backend `directives/backend/` set has no UI capability; routing a
+ * UI prompt through it would either ship a backend stub or guess at a
+ * component. Both are worse than a clean refusal with a pointer to the
+ * deferred R3 track. The halt is band-independent — even a high-band
+ * UI prompt blocks here, because confidence on the *reconstruction* says
+ * nothing about whether the *dispatcher* can deliver it.
+ */
+function _halt_ui_intent(raw: string, result: ConfidenceScore): StepResult {
+    const preview = _preview(raw);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Prompt: ${preview}`,
+            '> This prompt reads as **UI work** — the backend dispatch ' + "track can't ship it cleanly.",
+            '> UI dispatch is deferred to Roadmap 3 ' + '(`road-to-product-ui-track.md`); until it lands, `/work` ' + 'only handles backend-shaped prompts.',
+            "> 1. Re-frame as a backend-only prompt — I'll re-score and proceed",
+            '> 2. Park this prompt — wait for R3 and re-invoke `/work` then',
+            '> 3. Abort — drop this prompt',
+        ],
+        message: `Prompt flagged as UI-intent (band=${result.band}, ` + `score=${_pyFormat2f(result.score)}); blocked pending R3 UI track.`,
+    });
+}
+
+/**
+ * Return `[index, name]` of the lowest-scoring dimension.
+ *
+ * Ties are broken by `_confidence.DIMENSION_NAMES` order so the
+ * same input always produces the same question (replay determinism).
+ */
+function _weakest_dimension(dimensions: Record<string, number>): [number, string] {
+    const ordered: string[] = [...DIMENSION_NAMES];
+    // Python `min(ordered, key=lambda n: (dimensions.get(n, 0), ordered.index(n)))`
+    // — lowest score wins; ties broken by declared order (stable, first wins).
+    let weakest_name = ordered[0] ?? '';
+    let weakest_key: [number, number] = [dimensions[weakest_name] ?? 0, 0];
+    for (let i = 1; i < ordered.length; i += 1) {
+        const name = ordered[i] ?? '';
+        const key: [number, number] = [dimensions[name] ?? 0, i];
+        if (key[0] < weakest_key[0] || (key[0] === weakest_key[0] && key[1] < weakest_key[1])) {
+            weakest_name = name;
+            weakest_key = key;
+        }
+    }
+    return [ordered.indexOf(weakest_name), weakest_name];
+}
+
+/** Trim a raw prompt for inline display in halts. */
+function _preview(raw: string, max_chars = 80): string {
+    // `" ".join((raw or "").split())` — Python `str.split()` splits on
+    // whitespace runs and drops empties; join with single spaces.
+    const text = (raw || '').split(/\s+/u).filter((t) => t.length > 0).join(' ');
+    if (text.length <= max_chars) {
+        return text;
+    }
+    // `text[:max_chars - 1].rstrip() + "…"`
+    return text.slice(0, max_chars - 1).replace(/\s+$/u, '') + '…';
+}
+
+/**
+ * Python `f"{value:.2f}"` — fixed two-decimal formatting with
+ * round-half-to-even. `score` values are normalised to 4 decimals by the
+ * scorer, so the standard `toFixed(2)` round-half-away-from-zero and Python's
+ * banker's rounding agree on every value the scorer can emit; the explicit
+ * even-rounding path below keeps parity for any exact-half edge case.
+ */
+function _pyFormat2f(value: number): string {
+    if (!Number.isFinite(value)) {
+        // Python renders inf/nan as 'inf'/'nan'; the scorer never emits these.
+        return value > 0 ? 'inf' : value < 0 ? '-inf' : 'nan';
+    }
+    const sign = value < 0 ? '-' : '';
+    const abs = Math.abs(value);
+    const scaled = abs * 100;
+    const floor = Math.floor(scaled);
+    const frac = scaled - floor;
+    let rounded: number;
+    const eps = 1e-9;
+    if (frac > 0.5 + eps) {
+        rounded = floor + 1;
+    } else if (frac < 0.5 - eps) {
+        rounded = floor;
+    } else {
+        // exact half → round to even
+        rounded = floor % 2 === 0 ? floor : floor + 1;
+    }
+    const intPart = Math.floor(rounded / 100);
+    const fracPart = rounded - intPart * 100;
+    return `${sign}${intPart}.${String(fracPart).padStart(2, '0')}`;
+}
+
+/** `(value or "")` style truthiness, Python semantics. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/**
+ * Python `str(value)` for the scalar / container kinds the halts render.
+ *
+ * Strings render as-is; `None`/booleans use Python spelling; numbers as-is;
+ * dict / list use Python's `repr`-style bracketing so a `str(item)` fallback
+ * (a non-string AC or assumption entry) matches the Python output.
+ */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}
+
+/** Python `repr()` for values nested inside a `str(container)` render. */
+function _pyReprInner(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/report.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/report.ts
@@ -1,0 +1,378 @@
+/**
+ * `report` step — delivery report renderer.
+ *
+ * TypeScript twin of `work_engine/directives/backend/report.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * Produces the markdown block described in
+ * `docs/contracts/implement-ticket-flow.md#delivery-report-schema`.
+ * All nine headings are present on every run — the schema is stable
+ * for consumers — but section bodies are omitted when the matching
+ * slice of `DeliveryState` is empty. The single exception is the
+ * **Memory that mattered** section, which per contract is dropped
+ * entirely (heading included) when no hit carries a
+ * `changed_outcome` marker.
+ *
+ * The step is pure and deterministic: no I/O, no subprocess, no
+ * randomness. It reads `DeliveryState`, writes `state.report`,
+ * and always returns `SUCCESS`.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+/** Report rendering is pure and always succeeds — no blocked paths. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/** Render the delivery report into `state.report` and return SUCCESS. */
+export function run(state: DeliveryState): StepResult {
+    state.report = _render(state);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _render(state: DeliveryState): string {
+    const sections = [
+        _ticket_section(state),
+        _persona_section(state),
+        _plan_section(state),
+        _changes_section(state),
+        _tests_section(state),
+        _verify_section(state),
+        _visual_preview_section(state),
+        _memory_section(state),
+        _followups_section(state),
+        _next_commands_section(state),
+    ];
+    // Drop sections that opted out (memory-that-mattered and visual-preview
+    // return "" when their slice is absent — per the report schema drop-rule).
+    return sections.filter((section) => section).join('\n\n');
+}
+
+function _ticket_section(state: DeliveryState): string {
+    const ticket = state.ticket ?? {};
+    const ticketId = _pyTruthy(ticket.id) ? _pyStr(ticket.id) : '(no id)';
+    const title = _pyTruthy(ticket.title) ? _pyStr(ticket.title) : '(no title)';
+    return `## Ticket\n\n${ticketId} — ${title}`;
+}
+
+function _persona_section(state: DeliveryState): string {
+    return `## Persona\n\n${_pyTruthy(state.persona) ? _pyStr(state.persona) : '(unset)'}`;
+}
+
+function _plan_section(state: DeliveryState): string {
+    const body = _format_plan(state.plan);
+    return '## Plan\n\n' + (body || '_(no plan recorded)_');
+}
+
+/**
+ * Render whatever shape `state.plan` carries.
+ *
+ * Accepts a list of step strings, a list of `{title, detail}` dicts,
+ * or a single string — the contract doc intentionally leaves the
+ * plan shape loose until `feature-plan` wiring lands in a later
+ * phase.
+ */
+function _format_plan(plan: Any): string {
+    if (!_pyTruthy(plan)) {
+        return '';
+    }
+    if (typeof plan === 'string') {
+        return _pyStrip(plan);
+    }
+    if (Array.isArray(plan)) {
+        const lines: string[] = [];
+        plan.forEach((item, i) => {
+            const idx = i + 1;
+            if (_isPlainObject(item)) {
+                const d = item as Record<string, unknown>;
+                const title = _pyTruthy(d.title) ? d.title : _pyTruthy(d.step) ? d.step : `Step ${idx}`;
+                const detail = _pyTruthy(d.detail) ? d.detail : _pyTruthy(d.note) ? d.note : '';
+                lines.push(`${idx}. **${_pyStr(title)}**` + (detail ? ` — ${_pyStr(detail)}` : ''));
+            } else {
+                lines.push(`${idx}. ${_pyStr(item)}`);
+            }
+        });
+        return lines.join('\n');
+    }
+    // Last resort: string-coerce an unknown shape so the renderer never
+    // crashes on experimental plan structures.
+    return _pyStr(plan);
+}
+
+function _changes_section(state: DeliveryState): string {
+    if (!_pyTruthy(state.changes)) {
+        return '## Changes\n\n_(no file changes recorded)_';
+    }
+    const lines = ['## Changes', ''];
+    for (const change of state.changes) {
+        const c = change as Record<string, unknown>;
+        const path = _pyTruthy(c.path) ? c.path : _pyTruthy(c.file) ? c.file : '(unknown file)';
+        const linesRange = _pyTruthy(c.lines) ? c.lines : _pyTruthy(c.range) ? c.range : '';
+        const purpose = _pyTruthy(c.purpose) ? c.purpose : _pyTruthy(c.why) ? c.why : '';
+        let prefix = `- \`${_pyStr(path)}\``;
+        if (linesRange) {
+            prefix += ` (${_pyStr(linesRange)})`;
+        }
+        if (purpose) {
+            prefix += ` — ${_pyStr(purpose)}`;
+        }
+        lines.push(prefix);
+    }
+    return lines.join('\n');
+}
+
+function _tests_section(state: DeliveryState): string {
+    return '## Tests\n\n' + _format_kv_block(state.tests, '_(no tests ran)_');
+}
+
+function _verify_section(state: DeliveryState): string {
+    return '## Verify\n\n' + _format_kv_block(state.verify, '_(no verify verdict)_');
+}
+
+/**
+ * R4 Phase 3: render captured preview artifacts when the skill rendered.
+ *
+ * Reads `state.ui_review.preview` (engine never renders — the
+ * stack-specific review skill writes the envelope). Emits a section
+ * only when `render_ok` is `True` AND at least one artifact path
+ * is present. Failed renders, skipped previews, and pre-R4 envelopes
+ * drop the whole section (heading included).
+ */
+function _visual_preview_section(state: DeliveryState): string {
+    const ui_review = state.ui_review;
+    if (!_isPlainObject(ui_review)) {
+        return '';
+    }
+    const preview = (ui_review as Record<string, unknown>).preview;
+    if (!_isPlainObject(preview)) {
+        return '';
+    }
+    const p = preview as Record<string, unknown>;
+    if (p.render_ok !== true) {
+        return '';
+    }
+    if (_pyTruthy(p.skipped)) {
+        return '';
+    }
+    const screenshot = p.screenshot_path;
+    const domDump = p.dom_dump_path;
+    const lines: string[] = [];
+    if (typeof screenshot === 'string' && screenshot) {
+        lines.push(`- Screenshot: \`${screenshot}\``);
+    }
+    if (typeof domDump === 'string' && domDump) {
+        lines.push(`- DOM dump: \`${domDump}\``);
+    }
+    if (lines.length === 0) {
+        return '';
+    }
+    return ['## Visual preview', '', ...lines].join('\n');
+}
+
+/** Render **only** hits that changed an outcome (per report schema). */
+function _memory_section(state: DeliveryState): string {
+    const influential = (state.memory || []).filter(
+        (hit) => _isPlainObject(hit) && _pyTruthy((hit as Record<string, unknown>).changed_outcome),
+    );
+    if (influential.length === 0) {
+        return ''; // drop the whole section — heading included
+    }
+    const lines = ['## Memory that mattered', ''];
+    for (const hit of influential) {
+        const h = hit as Record<string, unknown>;
+        const hitId = _pyTruthy(h.id) ? h.id : '(no id)';
+        const hitType = _pyTruthy(h.type) ? h.type : '(no type)';
+        const note = _pyTruthy(h.note) ? h.note : _pyTruthy(h.why) ? h.why : '';
+        const suffix = note ? ` — ${_pyStr(note)}` : '';
+        lines.push(`- \`${_pyStr(hitId)}\` (${_pyStr(hitType)})${suffix}`);
+    }
+    return lines.join('\n');
+}
+
+function _followups_section(state: DeliveryState): string {
+    const followups = _extract_followups(state);
+    if (followups.length === 0) {
+        return '## Follow-ups\n\n_(none)_';
+    }
+    const lines = ['## Follow-ups', ''];
+    for (const item of followups) {
+        const anchor = _pyTruthy(item.anchor) ? item.anchor : '';
+        const note = _pyTruthy(item.note) ? item.note : _pyTruthy(item.title) ? item.title : '(untitled)';
+        let prefix = `- ${_pyStr(note)}`;
+        if (anchor) {
+            prefix += ` — \`${_pyStr(anchor)}\``;
+        }
+        lines.push(prefix);
+    }
+    return lines.join('\n');
+}
+
+/** Follow-ups may live on any slice; aggregate them in reading order. */
+function _extract_followups(state: DeliveryState): Array<Record<string, Any>> {
+    const collected: Array<Record<string, Any>> = [];
+    for (const source of [state.plan, state.verify, state.tests]) {
+        if (_isPlainObject(source)) {
+            const fups = (source as Record<string, unknown>).followups;
+            for (const item of Array.isArray(fups) ? fups : []) {
+                if (_isPlainObject(item)) {
+                    collected.push(item as Record<string, Any>);
+                }
+            }
+        }
+    }
+    return collected;
+}
+
+function _next_commands_section(state: DeliveryState): string {
+    if (!resolve_policy(state.persona).suggests_next_commands) {
+        // Advisory personas produce a plan-only report; suggesting a
+        // commit or PR would mislead the reader — nothing was changed.
+        return '';
+    }
+    const commands = _suggest_commands(state);
+    const lines = ['## Suggested next commands', ''];
+    for (const cmd of commands) {
+        lines.push(`- \`${cmd}\``);
+    }
+    return lines.join('\n');
+}
+
+/** Always suggest `/commit` and `/create-pr` when verify was successful. */
+function _suggest_commands(state: DeliveryState): string[] {
+    if (state.outcomes.verify === Outcome.SUCCESS) {
+        return ['/commit', '/create-pr'];
+    }
+    return ['/commit'];
+}
+
+/** Render a dict-ish slice as a bullet list; fall back to placeholder. */
+function _format_kv_block(value: Any, empty_placeholder: string): string {
+    if (!_pyTruthy(value)) {
+        return empty_placeholder;
+    }
+    if (_isPlainObject(value)) {
+        return _render_kv_lines(Object.entries(value as Record<string, unknown>)).join('\n');
+    }
+    if (typeof value === 'string') {
+        return _pyStrip(value) || empty_placeholder;
+    }
+    return _pyStr(value);
+}
+
+/** Render `(key, value)` pairs as one Markdown bullet per pair. */
+function _render_kv_lines(pairs: Array<[string, Any]>): string[] {
+    return pairs.map(([key, value]) => `- **${key}:** ${_pyStr(value)}`);
+}
+
+/** `(value or {})` style truthiness, Python semantics. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** Python `str.strip()`. */
+function _pyStrip(s: string): string {
+    return s.trim();
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/**
+ * Python `str(value)` for the scalar / container kinds the report renders.
+ *
+ * Strings render as-is; `None`/booleans use Python spelling; numbers as-is;
+ * dict / list use Python's `repr`-style bracketing so a `str(plan)` /
+ * `str(value)` fallback matches the Python output byte-for-byte.
+ */
+function _pyStr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    if (typeof value === 'number') {
+        return _pyNumber(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}
+
+/** Python `repr()` for values nested inside a `str(container)` render. */
+function _pyReprInner(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    if (typeof value === 'number') {
+        return _pyNumber(value);
+    }
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => _pyReprInner(v)).join(', ') + ']';
+    }
+    if (_isPlainObject(value)) {
+        const parts = Object.entries(value as Record<string, unknown>).map(
+            ([k, v]) => `${_pyReprInner(k)}: ${_pyReprInner(v)}`,
+        );
+        return '{' + parts.join(', ') + '}';
+    }
+    return String(value);
+}
+
+/** Python number-to-str: integer-valued floats keep no decimal in `int` path. */
+function _pyNumber(value: number): string {
+    return String(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/test.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/test.ts
@@ -1,0 +1,267 @@
+/**
+ * `test` step — gate + Option-A delegation for running the test suite.
+ *
+ * TypeScript twin of `work_engine/directives/backend/test.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The dispatcher never spawns subprocesses. Test execution is handed
+ * to the agent via `@agent-directive: run-tests scope=targeted`; the
+ * agent drives the project's test runner (pytest, Pest, phpunit, …),
+ * captures the verdict onto `state.tests`, marks
+ * `outcomes['test'] = 'success'`, and re-invokes the dispatcher.
+ *
+ * Contract for `state.tests` when populated:
+ *
+ * - Must be a dict.
+ * - Must carry a `verdict` key — one of `success`, `failed`,
+ *   or `mixed` (targeted vs full-suite split). Anything else blocks.
+ * - `failed` or `mixed` verdicts halt with the verdict as part of
+ *   the surfaced message so the user decides whether to continue or
+ *   stop. This follows the `verify-before-complete` rule: a bad test
+ *   outcome must never be silently skipped.
+ * - Optional keys (`targeted`, `full`, `duration_ms`,
+ *   `followups`) feed the delivery report.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+const _ALLOWED_VERDICTS = ['success', 'failed', 'mixed'] as const;
+
+/** Declared ambiguity surfaces. Advisory personas skip this step entirely. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_implement_failed',
+        trigger: '`implement` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_tests_delegate',
+        trigger: '`state.tests` empty — test runner not invoked yet',
+        resolution:
+            'agent directive `run-tests scope=targeted|full` → ' +
+            '`/tests-execute` (qa persona widens to full suite)',
+    },
+    {
+        code: 'malformed_tests',
+        trigger: '`state.tests` is not a dict or `verdict` is not one of ' + 'success / failed / mixed',
+        resolution: 're-run tests and record a clean verdict',
+    },
+    {
+        code: 'bad_test_verdict',
+        trigger: '`state.tests[\'verdict\']` is `failed` or `mixed`',
+        resolution: 'fix failures and re-run, or abort',
+    },
+];
+
+/** Gate on `implement`, then either delegate or validate `state.tests`. */
+export function run(state: DeliveryState): StepResult {
+    const policy = resolve_policy(state.persona);
+    if (!policy.allows_test) {
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `test skipped: persona \`${policy.name}\` is plan-only.`,
+        });
+    }
+
+    if (state.outcomes.implement !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const tests = state.tests;
+    if (!_pyTruthy(tests)) {
+        return _delegate_to_run_tests(state, policy.widen_tests);
+    }
+
+    const shapeIssues = _diagnose_tests(tests);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    // At this point `tests` is a dict with a recognised verdict.
+    const verdict = (tests as Record<string, unknown>).verdict;
+    if (verdict !== 'success') {
+        return _blocked_on_bad_verdict(state, verdict);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _diagnose_tests(tests: Any): string[] {
+    if (!_isPlainObject(tests)) {
+        return [`state.tests must be a dict, got ${_pyTypeName(tests)}`];
+    }
+    const verdict = (tests as Record<string, unknown>).verdict;
+    if (!_inAllowedVerdicts(verdict)) {
+        return [
+            `state.tests['verdict'] must be one of ` +
+                `${_ALLOWED_VERDICTS.join(', ')}; got ${_pyRepr(verdict)}`,
+        ];
+    }
+    return [];
+}
+
+/**
+ * Emit the `run-tests` directive.
+ *
+ * `widen` comes from the persona policy (`qa` widens to the full
+ * suite). The directive scope becomes the first thing an orchestrator
+ * reads, so the widened case is visible without parsing the options.
+ */
+function _delegate_to_run_tests(state: DeliveryState, widen: boolean): StepResult {
+    const ticketId = _ticketId(state);
+    const scope = widen ? 'full' : 'targeted';
+    const description = widen
+        ? 'full suite (qa persona widens to catch regressions outside ' + 'the changed paths)'
+        : 'targeted first (`--filter` on the changed paths), full ' + 'suite only if targeted passes';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('run-tests', { ticket: ticketId, scope }),
+            `> Ticket ${ticketId} — running tests: ${description}.`,
+            `> 1. Continue — run ${scope} tests now`,
+            '> 2. Abort — skip testing (NOT recommended)',
+        ],
+        message: `Ticket ${ticketId} needs its tests run before verification.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — test gate refused: ` +
+                '`implement` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot test: implement gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded test output is malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run tests and resume',
+            '> 2. Abort — test verdict cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} tests shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+function _blocked_on_bad_verdict(state: DeliveryState, verdict: Any): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — tests reported \`${String(verdict)}\`. ` +
+                'Verification cannot proceed on a non-success verdict.',
+            '> 1. Fix the failing tests and re-run `run-tests`',
+            '> 2. Continue anyway — override (NOT recommended)',
+            '> 3. Abort',
+        ],
+        message: `Ticket ${ticketId} test verdict was \`${String(verdict)}\`, not success.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+function _inAllowedVerdicts(value: unknown): boolean {
+    return (_ALLOWED_VERDICTS as ReadonlyArray<unknown>).includes(value);
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Python `type(x).__name__` for the value kinds the diagnose paths see. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (typeof value === 'boolean') {
+        return 'bool';
+    }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') {
+        return 'str';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Set) {
+        return 'set';
+    }
+    if (value instanceof Map || _isPlainObject(value)) {
+        return 'dict';
+    }
+    return typeof value;
+}
+
+/**
+ * Python `repr()` for the verdict value kinds (`{verdict!r}`).
+ *
+ * Strings render single-quoted; `None` → `None`; booleans → `True` / `False`;
+ * numbers as-is. Only the kinds an invalid `verdict` slot can carry are
+ * covered.
+ */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/verify.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/verify.ts
@@ -1,0 +1,257 @@
+/**
+ * `verify` step — gate + Option-A delegation to `review-changes`.
+ *
+ * TypeScript twin of `work_engine/directives/backend/verify.py` (ADR-094
+ * py2ts Phase 1 — work_engine directive sets). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-094 — Python style is
+ * part of the contract).
+ *
+ * The dispatcher does not run the review-changes judges itself; the
+ * agent invokes the composite review (bug-hunter + security +
+ * test-coverage + code-quality) and captures the consolidated
+ * verdict onto `state.verify`.
+ *
+ * `state.verify` contract when populated:
+ *
+ * - Must be a dict.
+ * - Must carry a `verdict` key — one of `success`, `blocked`,
+ *   `partial`. Matches the `Outcome` vocabulary used everywhere
+ *   else in the flow.
+ * - A `success` verdict advances the flow to `report`.
+ * - A `blocked` or `partial` verdict halts with numbered options
+ *   so the user decides whether to address the findings, override
+ *   (rarely appropriate), or abort.
+ * - Optional keys (`confidence`, `findings`, `followups`) feed
+ *   the delivery report.
+ */
+
+import { type Any, DeliveryState, Outcome, StepResult, agent_directive } from '../../delivery_state.js';
+import { resolve_policy } from '../../persona_policy.js';
+
+const _ALLOWED_VERDICTS = ['success', 'blocked', 'partial'] as const;
+
+/** Declared ambiguity surfaces. Advisory personas skip this step entirely. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_test_failed',
+        trigger: '`test` outcome is not `success`',
+        resolution: 're-run `/implement-ticket` from the start',
+    },
+    {
+        code: 'empty_verify_delegate',
+        trigger: '`state.verify` empty — four-judge review not run yet',
+        resolution: 'agent directive `review-changes` → `/review-changes`',
+    },
+    {
+        code: 'malformed_verify',
+        trigger: '`state.verify` is not a dict or `verdict` is not one of ' + 'success / blocked / partial',
+        resolution: 're-run `/review-changes` and record a clean verdict',
+    },
+    {
+        code: 'bad_verify_verdict',
+        trigger: '`state.verify[\'verdict\']` is `blocked` or `partial`',
+        resolution:
+            'address findings and re-run `/review-changes` — never bypass ' + '(see `verify-before-complete`)',
+    },
+];
+
+/** Gate on `test`, then either delegate or validate `state.verify`. */
+export function run(state: DeliveryState): StepResult {
+    const policy = resolve_policy(state.persona);
+    if (!policy.allows_verify) {
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `verify skipped: persona \`${policy.name}\` is plan-only.`,
+        });
+    }
+
+    if (state.outcomes.test !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const verify = state.verify;
+    if (!_pyTruthy(verify)) {
+        return _delegate_to_review_changes(state);
+    }
+
+    const shapeIssues = _diagnose_verify(verify);
+    if (shapeIssues.length > 0) {
+        return _blocked_on_shape(state, shapeIssues);
+    }
+
+    const verdict = (verify as Record<string, unknown>).verdict;
+    if (verdict !== 'success') {
+        return _blocked_on_bad_verdict(state, verdict);
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _diagnose_verify(verify: Any): string[] {
+    if (!_isPlainObject(verify)) {
+        return [`state.verify must be a dict, got ${_pyTypeName(verify)}`];
+    }
+    const verdict = (verify as Record<string, unknown>).verdict;
+    if (!_inAllowedVerdicts(verdict)) {
+        return [
+            `state.verify['verdict'] must be one of ` +
+                `${_ALLOWED_VERDICTS.join(', ')}; got ${_pyRepr(verdict)}`,
+        ];
+    }
+    return [];
+}
+
+function _delegate_to_review_changes(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('review-changes', { ticket: ticketId }),
+            `> Ticket ${ticketId} — running the four-judge review ` +
+                '(bugs, security, tests, code quality) before the delivery ' +
+                'report is written.',
+            '> 1. Continue — run `review-changes` now',
+            '> 2. Abort — skip review (NOT recommended)',
+        ],
+        message: `Ticket ${ticketId} needs \`review-changes\` before the report.`,
+    });
+}
+
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — verify gate refused: ` +
+                '`test` step did not complete successfully.',
+            '> 1. Re-run `/implement-ticket` from the start',
+            '> 2. Abort',
+        ],
+        message: `Ticket ${ticketId} cannot verify: test gate did not pass.`,
+    });
+}
+
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — recorded verify output is malformed: ` + issues.join('; ') + '.',
+            '> 1. Re-run `review-changes` and resume',
+            '> 2. Abort — verify verdict cannot be trusted',
+        ],
+        message: `Ticket ${ticketId} verify shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+function _blocked_on_bad_verdict(state: DeliveryState, verdict: Any): StepResult {
+    const ticketId = _ticketId(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Ticket ${ticketId} — \`review-changes\` reported ` +
+                `\`${String(verdict)}\`. The delivery report cannot claim completion on a ` +
+                'non-success verdict (see `verify-before-complete`).',
+            '> 1. Address the findings and re-run `review-changes`',
+            '> 2. Continue anyway — override (NOT recommended)',
+            '> 3. Abort',
+        ],
+        message: `Ticket ${ticketId} verify verdict was \`${String(verdict)}\`, not success.`,
+    });
+}
+
+/** `(state.ticket or {}).get("id") or "(no id)"`. */
+function _ticketId(state: DeliveryState): string {
+    const id = (state.ticket ?? {}).id;
+    return _pyTruthy(id) ? String(id) : '(no id)';
+}
+
+function _inAllowedVerdicts(value: unknown): boolean {
+    return (_ALLOWED_VERDICTS as ReadonlyArray<unknown>).includes(value);
+}
+
+/** Python truthiness for the scalar/container kinds these slices carry. */
+function _pyTruthy(value: unknown): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length !== 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length !== 0;
+    }
+    if (value instanceof Set || value instanceof Map) {
+        return value.size !== 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length !== 0;
+    }
+    return true;
+}
+
+/** True for a dict-like value (mirrors Python `isinstance(x, dict)`). */
+function _isPlainObject(value: unknown): value is Record<string, unknown> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value) &&
+        !(value instanceof Set) &&
+        !(value instanceof Map)
+    );
+}
+
+/** Python `type(x).__name__` for the value kinds the diagnose paths see. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (typeof value === 'boolean') {
+        return 'bool';
+    }
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') {
+        return 'str';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Set) {
+        return 'set';
+    }
+    if (value instanceof Map || _isPlainObject(value)) {
+        return 'dict';
+    }
+    return typeof value;
+}
+
+/**
+ * Python `repr()` for the verdict value kinds (`{verdict!r}`).
+ *
+ * Strings render single-quoted; `None` → `None`; booleans → `True` / `False`;
+ * numbers as-is. Only the kinds an invalid `verdict` slot can carry are
+ * covered.
+ */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value}'`;
+    }
+    return String(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/mixed/contract.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/mixed/contract.ts
@@ -1,0 +1,243 @@
+/**
+ * `contract` step — locks data_model + api_surface before any UI work.
+ *
+ * TypeScript twin of `directives/mixed/contract.py` (ADR-094 py2ts). Public
+ * API names stay snake_case to mirror the Python module 1:1.
+ *
+ * In the `mixed` directive set the `plan` slot is the contract step. It
+ * resolves the backend contract the UI will consume — entity shape, endpoint
+ * signatures, validation surface — before the UI track runs. The mixed `ui`
+ * step gates on `state.contract.contract_confirmed is True`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Top-level keys every well-formed contract must carry. */
+export const REQUIRED_CONTRACT_KEYS: ReadonlyArray<string> = ['data_model', 'api_surface'];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_analyze_failed',
+        trigger: '`analyze` outcome is not `success`',
+        resolution: 're-run the mixed flow from the start',
+    },
+    {
+        code: 'contract_missing',
+        trigger: 'state.contract is None or empty — contract has not been produced',
+        resolution:
+            'agent directive `contract-plan` → `feature-plan` skill ' +
+            'writes the contract into state.contract',
+    },
+    {
+        code: 'contract_incomplete',
+        trigger:
+            'contract is populated but missing required keys ' +
+            '(`data_model`, `api_surface`) or one of them is empty',
+        resolution:
+            'agent re-runs `feature-plan` with contract-only scope; ' +
+            'halt lists the missing slots',
+    },
+    {
+        code: 'contract_unconfirmed',
+        trigger: 'contract is well-formed but contract_confirmed is unset/False',
+        resolution:
+            'user reviews the contract summary and sets ' +
+            'state.contract.contract_confirmed = True (or asks for ' +
+            'revisions, which loops back to contract-plan)',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Python `value is None or value == [] or value == {}` — the contract step's
+ * emptiness check. NOTE: unlike `directives/ui/design`, contract does NOT treat
+ * an empty string `""` as missing; only None / empty list / empty dict count.
+ */
+function _isEmptyOrNone(value: Any): boolean {
+    if (value === null || value === undefined) return true;
+    if (Array.isArray(value)) return value.length === 0;
+    if (_isDict(value)) return Object.keys(value).length === 0;
+    return false;
+}
+
+/** Apply the contract-first lock to `state.contract`. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes['analyze'] !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const contract = state.contract;
+    if (!_is_populated(contract)) {
+        return _delegate_to_feature_plan(state);
+    }
+
+    const missing = _missing_required_keys(contract as Record<string, Any>);
+    if (missing.length > 0) {
+        return _halt_incomplete_contract(state, missing);
+    }
+
+    if ((contract as Record<string, Any>)['contract_confirmed'] === true) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_unconfirmed(state, contract as Record<string, Any>);
+}
+
+/** True when `contract` carries an actionable backend lock. */
+function _is_populated(contract: Any): boolean {
+    if (!_isDict(contract)) return false;
+    if (Object.keys(contract).length === 0) return false;
+    return REQUIRED_CONTRACT_KEYS.some((key) => key in contract);
+}
+
+/** Return required top-level keys that are missing or empty. */
+function _missing_required_keys(contract: Record<string, Any>): string[] {
+    const missing: string[] = [];
+    for (const key of REQUIRED_CONTRACT_KEYS) {
+        const value = contract[key];
+        if (_isEmptyOrNone(value)) {
+            missing.push(key);
+        }
+    }
+    return missing;
+}
+
+/** Render a one-line preview of the input being contracted. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((s) => s.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** Python `str.rstrip()` (no arg) — strip trailing whitespace. */
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Python truthiness (used for the `data.get("id") or "(no title)"` chain). */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Python `str(value)`. */
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+/** BLOCKED halt — upstream `analyze` did not succeed. */
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> `analyze` did not succeed; cannot lock the contract until ' +
+                'the upstream investigation lands.',
+            '> 1. Re-run — restart the mixed flow from the start',
+            '> 2. Abort — drop this request',
+        ],
+        message: 'contract step gated on analyze; upstream outcome is not success.',
+    });
+}
+
+/** Halt with an agent directive so the orchestrator runs `feature-plan`. */
+function _delegate_to_feature_plan(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('contract-plan'),
+            `> Input: ${preview}`,
+            '> No backend contract yet — producing one now. The contract ' +
+                'locks the data model and API surface the UI will consume; ' +
+                'the mixed `ui` step refuses to start without it.',
+            '> Scope: contract-only (no UI plan, no implementation).',
+            '> 1. Continue — produce the contract via `feature-plan`',
+            '> 2. Abort — drop this mixed request',
+        ],
+        message: 'Mixed contract missing; delegating to feature-plan (contract-only).',
+    });
+}
+
+/** BLOCKED halt — contract is missing required keys. */
+function _halt_incomplete_contract(state: DeliveryState, missing: string[]): StepResult {
+    const preview = _preview_input(state);
+    const lines: string[] = [
+        agent_directive('contract-plan'),
+        `> Input: ${preview}`,
+        '> Backend contract is incomplete. Missing required slots:',
+    ];
+    for (const p of missing) {
+        lines.push(`> - \`${p}\``);
+    }
+    lines.push(
+        '> Re-run `feature-plan` (contract-only) so every required slot ' +
+            'has a final value before the UI track starts.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: `Mixed contract incomplete; ${missing.length} required slot(s) missing.`,
+    });
+}
+
+/** BLOCKED halt — contract is well-formed; user must sign off. */
+function _halt_unconfirmed(state: DeliveryState, contract: Record<string, Any>): StepResult {
+    const preview = _preview_input(state);
+    const data_model = _pyTruthy(contract['data_model']) ? contract['data_model'] : [];
+    const api_surface = _pyTruthy(contract['api_surface']) ? contract['api_surface'] : [];
+
+    const entity_count = Array.isArray(data_model) ? data_model.length : 0;
+    const endpoint_count = Array.isArray(api_surface) ? api_surface.length : 0;
+
+    const lines: string[] = [
+        `> Input: ${preview}`,
+        '> Backend contract is ready. Summary:',
+        `> - Entities (data model): ${entity_count}`,
+        `> - Endpoints / actions (api surface): ${endpoint_count}`,
+        '> 1. Confirm — lock this contract and advance to the UI track',
+        '> 2. Revise — send feedback; loops back to `contract-plan`',
+        '> 3. Abort — drop this mixed request',
+        '',
+        '**Recommendation: 1 — Confirm** — the contract covers both ' +
+            'required slots. Caveat: flip to 2 only if an entity field or ' +
+            'endpoint signature is wrong; the UI track will treat this ' +
+            'contract as immutable input.',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: 'Mixed contract ready; halting for user confirmation before UI track.',
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/mixed/stitch.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/mixed/stitch.ts
@@ -1,0 +1,259 @@
+/**
+ * `stitch` step — integration verification across the contract / UI seam.
+ *
+ * TypeScript twin of `directives/mixed/stitch.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * In the `mixed` directive set the `test` slot is the integration boundary.
+ * The dispatcher does not run integration scenarios itself — the agent invokes
+ * the `integration-test` skill which drives end-to-end smokes and writes the
+ * verdict back to `state.stitch`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Agent directive that drives end-to-end smoke scenarios. */
+export const INTEGRATION_TEST_DIRECTIVE = 'integration-test';
+
+const _ALLOWED_VERDICTS: ReadonlyArray<string> = ['success', 'blocked', 'partial'];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_ui_failed',
+        trigger: '`implement` (mixed.ui) outcome is not `success`',
+        resolution: 're-run the mixed flow; UI track must finish before stitch',
+    },
+    {
+        code: 'empty_stitch_delegate',
+        trigger: '`state.stitch` empty — integration-test skill has not run yet',
+        resolution: 'agent directive `integration-test` → end-to-end smokes',
+    },
+    {
+        code: 'malformed_stitch',
+        trigger:
+            '`state.stitch` is not a dict or `verdict` is not one of ' +
+            'success / blocked / partial',
+        resolution: 're-run `integration-test` and record a clean verdict',
+    },
+    {
+        code: 'bad_stitch_verdict',
+        trigger:
+            "`state.stitch['verdict']` is `blocked` or `partial` " +
+            'and `integration_confirmed` is not True',
+        resolution:
+            'address findings and re-run `integration-test`, or set ' +
+            '`integration_confirmed=True` to override (rare)',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function _pyTypeName(value: Any): string {
+    if (value === null || value === undefined) return 'NoneType';
+    if (typeof value === 'boolean') return 'bool';
+    if (typeof value === 'number') return Number.isInteger(value) ? 'int' : 'float';
+    if (typeof value === 'string') return 'str';
+    if (Array.isArray(value)) return 'list';
+    return 'dict';
+}
+
+function pyRepr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    if (typeof value === 'string') return pyStrRepr(value);
+    return String(value);
+}
+
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') body += '\\\\';
+        else if (ch === quote) body += `\\${ch}`;
+        else if (ch === '\n') body += '\\n';
+        else if (ch === '\r') body += '\\r';
+        else if (ch === '\t') body += '\\t';
+        else body += ch;
+    }
+    return `${quote}${body}${quote}`;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Gate on `implement`, then validate `state.stitch`. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes['implement'] !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    const stitch = state.stitch;
+    if (!_pyTruthy(stitch)) {
+        return _delegate_to_integration_test(state);
+    }
+
+    const shape_issues = _diagnose_stitch(stitch);
+    if (shape_issues.length > 0) {
+        return _blocked_on_shape(state, shape_issues);
+    }
+
+    const s = stitch as Record<string, Any>;
+    const verdict = s['verdict'];
+    if (verdict === 'success') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    if (s['integration_confirmed'] === true) {
+        return new StepResult({
+            outcome: Outcome.SUCCESS,
+            message: `stitch verdict \`${pyStr(verdict)}\` overridden by integration_confirmed=True.`,
+        });
+    }
+
+    return _blocked_on_bad_verdict(state, verdict, s);
+}
+
+/** Return shape errors; empty list when `stitch` is well-formed. */
+function _diagnose_stitch(stitch: Any): string[] {
+    if (!_isDict(stitch)) {
+        return [`state.stitch must be a dict, got ${_pyTypeName(stitch)}`];
+    }
+    const verdict = stitch['verdict'];
+    if (typeof verdict !== 'string' || !_ALLOWED_VERDICTS.includes(verdict)) {
+        return [
+            `state.stitch['verdict'] must be one of ` +
+                `${_ALLOWED_VERDICTS.join(', ')}; got ${pyRepr(verdict)}`,
+        ];
+    }
+    return [];
+}
+
+/** One-line preview of the original input for halt bodies. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** BLOCKED halt — upstream UI step did not succeed. */
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Mixed `stitch` step gated on the UI step; ' +
+                'the implement outcome is not success.',
+            '> 1. Re-run — restart the mixed flow from the start',
+            '> 2. Abort — drop this request',
+        ],
+        message: 'stitch step gated on implement; upstream UI outcome is not success.',
+    });
+}
+
+/** Halt with an agent directive so the orchestrator runs smokes. */
+function _delegate_to_integration_test(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    const contract = _isDict(state.contract) ? state.contract : {};
+    const api_surface = _pyTruthy(contract['api_surface']) ? contract['api_surface'] : [];
+    const endpoint_count = Array.isArray(api_surface) ? api_surface.length : 0;
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(INTEGRATION_TEST_DIRECTIVE),
+            `> Input: ${preview}`,
+            '> UI track finished; the contract / UI seam needs end-to-end ' +
+                'verification before the delivery report:',
+            `> - Endpoints / actions to smoke: ${endpoint_count}`,
+            '> Scenarios cover the full round-trip — fill form → ' +
+                'server validation → response → UI update. Unit-level ' +
+                'passes from the UI review do **not** substitute for this gate.',
+            '> 1. Continue — run `integration-test` now',
+            '> 2. Abort — skip integration verification (NOT recommended)',
+        ],
+        message: 'Mixed UI complete; delegating to integration-test for stitch.',
+    });
+}
+
+/** BLOCKED halt — recorded stitch verdict is malformed. */
+function _blocked_on_shape(state: DeliveryState, issues: string[]): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Recorded stitch output is malformed: ' + issues.join('; ') + '.',
+            '> 1. Re-run `integration-test` and resume',
+            '> 2. Abort — stitch verdict cannot be trusted',
+        ],
+        message: `Mixed stitch shape invalid: ${issues.join('; ')}.`,
+    });
+}
+
+/** BLOCKED halt — verdict is blocked / partial and not user-confirmed. */
+function _blocked_on_bad_verdict(
+    state: DeliveryState,
+    verdict: Any,
+    stitch: Record<string, Any>,
+): StepResult {
+    void state;
+    const scenarios = _pyTruthy(stitch['scenarios']) ? stitch['scenarios'] : [];
+    const scenario_count = Array.isArray(scenarios) ? scenarios.length : 0;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> \`integration-test\` reported \`${pyStr(verdict)}\` after running ` +
+                `${scenario_count} scenario(s). The delivery report cannot ` +
+                'claim completion on a non-success integration verdict.',
+            '> 1. Address the findings and re-run `integration-test`',
+            '> 2. Override — set `state.stitch.integration_confirmed=true` ' +
+                'and resume (rare; document why)',
+            '> 3. Abort',
+        ],
+        message:
+            `Mixed stitch verdict was \`${pyStr(verdict)}\`, not success; ` +
+            'user override required to continue.',
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/mixed/ui.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/mixed/ui.ts
@@ -1,0 +1,216 @@
+/**
+ * `ui` step — delegates to the UI track once the contract is locked.
+ *
+ * TypeScript twin of `directives/mixed/ui.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * In the `mixed` directive set the `implement` slot is the UI handoff. It
+ * gates on the upstream contract sentinel
+ * (`state.contract.contract_confirmed is True`) and then delegates the full
+ * audit → design → apply → review → polish sub-flow to the UI track via an
+ * `@agent-directive: ui-track` halt.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Agent directive that triggers the full UI sub-flow. */
+export const UI_TRACK_DIRECTIVE = 'ui-track';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'upstream_contract_failed',
+        trigger: '`plan` (contract) outcome is not `success`',
+        resolution: 're-run the mixed flow from the start',
+    },
+    {
+        code: 'contract_sentinel_missing',
+        trigger:
+            'state.contract.contract_confirmed is missing or False — ' +
+            'defense-in-depth check refuses to start the UI track',
+        resolution:
+            'loop back to the contract step; user must confirm ' +
+            'the data_model + api_surface lock before UI work begins',
+    },
+    {
+        code: 'ui_track_not_started',
+        trigger:
+            'state.ui_review is empty or missing `review_clean` — ' +
+            'the UI sub-flow has not run yet',
+        resolution:
+            'agent directive `ui-track` → orchestrator runs ' +
+            'audit → design → apply → review → polish with the contract as ' +
+            'immutable input',
+    },
+    {
+        code: 'ui_track_review_unclean',
+        trigger:
+            'UI sub-flow finished but `review_clean` is False — ' +
+            'polish ceiling reached or findings remain',
+        resolution:
+            'user picks re-run / hand off / abort; polish-ceiling ' +
+            'semantics already fired inside the UI track',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Delegate the UI sub-flow once the contract is locked. */
+export function run(state: DeliveryState): StepResult {
+    if (state.outcomes['plan'] !== Outcome.SUCCESS) {
+        return _blocked_on_precondition(state);
+    }
+
+    if (!_contract_confirmed(state)) {
+        return _blocked_on_contract_sentinel(state);
+    }
+
+    const review = _isDict(state.ui_review) ? state.ui_review : null;
+    if (review === null || !('review_clean' in review)) {
+        return _delegate_to_ui_track(state);
+    }
+
+    if (review['review_clean'] === true) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_review_unclean(state, review);
+}
+
+/** True when the contract sentinel is explicitly `True`. */
+function _contract_confirmed(state: DeliveryState): boolean {
+    const contract = state.contract;
+    if (!_isDict(contract)) return false;
+    return contract['contract_confirmed'] === true;
+}
+
+/** One-line preview of the original input for halt bodies. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** BLOCKED halt — upstream contract step did not succeed. */
+function _blocked_on_precondition(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Mixed `ui` step gated on the contract step; the contract ' +
+                'outcome is not success.',
+            '> 1. Re-run — restart the mixed flow from the start',
+            '> 2. Abort — drop this request',
+        ],
+        message: 'ui step gated on plan; upstream contract outcome is not success.',
+    });
+}
+
+/** BLOCKED halt — contract sentinel missing despite plan success. */
+function _blocked_on_contract_sentinel(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Contract sentinel missing — `state.contract.contract_confirmed` ' +
+                'is not `True`. The UI track will not start until the data ' +
+                'model and API surface are locked and confirmed.',
+            '> 1. Loop back — re-enter the contract step and confirm',
+            '> 2. Abort — drop this mixed request',
+        ],
+        message:
+            'ui step refused; contract_confirmed sentinel missing despite plan success.',
+    });
+}
+
+/** Halt with an agent directive so the orchestrator runs the UI track. */
+function _delegate_to_ui_track(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    const contract = _isDict(state.contract) ? state.contract : {};
+    const data_model = _pyTruthy(contract['data_model']) ? contract['data_model'] : [];
+    const api_surface = _pyTruthy(contract['api_surface']) ? contract['api_surface'] : [];
+    const entity_count = Array.isArray(data_model) ? data_model.length : 0;
+    const endpoint_count = Array.isArray(api_surface) ? api_surface.length : 0;
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(UI_TRACK_DIRECTIVE),
+            `> Input: ${preview}`,
+            '> Contract is locked. Handing off to the UI track:',
+            `> - Entities: ${entity_count}`,
+            `> - Endpoints / actions: ${endpoint_count}`,
+            '> The UI track runs audit → design → apply → ' +
+                'review → polish with the contract as immutable input. ' +
+                'No new entities or endpoints — the contract drives the UI shape.',
+            '> 1. Continue — run the UI track',
+            '> 2. Abort — drop this mixed request',
+        ],
+        message: 'Mixed contract locked; delegating UI sub-flow to ui-track.',
+    });
+}
+
+/** BLOCKED halt — UI sub-flow finished but review is not clean. */
+function _halt_review_unclean(state: DeliveryState, review: Record<string, Any>): StepResult {
+    void state;
+    const findings = _pyTruthy(review['findings']) ? review['findings'] : [];
+    const finding_count = Array.isArray(findings) ? findings.length : 0;
+    const lines: string[] = [
+        `> UI track finished but review is not clean. Findings remaining: ${finding_count}.`,
+        '> Polish ceiling already fired inside the UI track — the ' +
+            'engine cannot resolve the remaining findings without a user ' +
+            'decision.',
+        '> 1. Re-run UI track — hand back to `ui-track` for another ' +
+            'audit → design pass (rare; usually means the contract changed)',
+        '> 2. Hand off — ship as-is and let a human resolve the ' +
+            'remaining findings outside the engine',
+        '> 3. Abort — drop this mixed request',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: `Mixed ui step halted; UI track review unclean (${finding_count} findings).`,
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/_passthrough.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/_passthrough.ts
@@ -1,0 +1,40 @@
+/**
+ * Pass-through handler for UI directive slots that have no work.
+ *
+ * TypeScript twin of `directives/ui/_passthrough.py` (ADR-094 py2ts). Public
+ * API names stay snake_case to mirror the Python module 1:1 (Python style is
+ * part of the contract). The handler is intentionally pure and
+ * side-effect-free: it neither reads nor writes `state`.
+ *
+ * Phase 6 of the UI track retired the Phase 3 deferral stub once design /
+ * apply / review / polish landed. Two slots remain semantically empty for the
+ * UI track:
+ *
+ * - `memory` — the UI track does not consult the four memory types the
+ *   backend retrieves over. UI work pivots on the audit findings in
+ *   `state.ui_audit` instead.
+ * - `plan` — `.design` produces the locked design brief that `.apply`
+ *   follows verbatim. The brief IS the plan.
+ *
+ * Both slots return `Outcome.SUCCESS` without writing to state.
+ */
+import {
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** Pass-through never blocks — empty surface, declared intent. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/**
+ * Return `SUCCESS` without mutating state.
+ *
+ * The handler neither reads nor writes `state`. The dispatcher records the
+ * step as successful in `state.outcomes` (its own bookkeeping) and advances to
+ * the next slot.
+ */
+export function run(state: DeliveryState): StepResult {
+    void state; // explicitly unused — the slot is a no-op by design
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/apply.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/apply.ts
@@ -1,0 +1,216 @@
+/**
+ * `apply` step — stack-dispatched UI implementation.
+ *
+ * TypeScript twin of `directives/ui/apply.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The apply step turns the locked design brief into actual files. Routes on
+ * `state.stack.frontend` to the appropriate implementation skill bundle, and
+ * on `state.ticket["ui_apply"]` shape: first-pass delegation, placeholder
+ * rejection, or change recording. Apply validates the output against the
+ * brief's microcopy lock so a mid-loop hallucination is caught at the boundary.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+import { PLACEHOLDER_PATTERNS } from './design.js';
+
+/** Map `state.stack.frontend` → agent-directive skill name. */
+export const STACK_DIRECTIVES: Record<string, string> = {
+    'blade-livewire-flux': 'ui-apply-blade-livewire-flux',
+    'react-shadcn': 'ui-apply-react-shadcn',
+    vue: 'ui-apply-vue',
+    plain: 'ui-apply-plain',
+};
+
+/** Fallback directive when `state.stack` is missing or malformed. */
+export const DEFAULT_DIRECTIVE = 'ui-apply-plain';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'apply_envelope_missing',
+        trigger:
+            "state.ticket['ui_apply'] unset — first pass, " +
+            'stack-specific skill has not run yet',
+        resolution:
+            'agent directive `ui-apply-<stack>` → skill ' +
+            'bundle implements the brief and writes the envelope back',
+    },
+    {
+        code: 'apply_placeholders_in_output',
+        trigger:
+            'rendered text in apply envelope contains ' +
+            'placeholder patterns (<placeholder>, Lorem, TODO:, TBD, XXX) ' +
+            '— design-brief lock failed mid-loop',
+        resolution:
+            'agent re-renders the components with the locked ' +
+            'microcopy verbatim from state.ui_design.microcopy',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Apply the stack-dispatched implementation gate. */
+export function run(state: DeliveryState): StepResult {
+    const envelope = _apply_envelope(state);
+    if (envelope === null) {
+        return _delegate_to_stack_skill(state);
+    }
+
+    const violations = _placeholder_violations_in_output(envelope);
+    if (violations.length > 0) {
+        return _halt_placeholders(state, violations);
+    }
+
+    _record_changes(state, envelope);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** Return the agent-written `ui_apply` envelope, or `null`. */
+function _apply_envelope(state: DeliveryState): Record<string, Any> | null {
+    const data = _pyTruthy(state.ticket) ? state.ticket : {};
+    const envelope = (data as Record<string, Any>)['ui_apply'];
+    if (_isDict(envelope) && _pyTruthy(envelope)) {
+        return envelope;
+    }
+    return null;
+}
+
+/** Pick the agent directive for the project's frontend stack. */
+function _resolve_directive(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend in STACK_DIRECTIVES) {
+            return STACK_DIRECTIVES[frontend] as string;
+        }
+    }
+    return DEFAULT_DIRECTIVE;
+}
+
+/** Return paths into `envelope['rendered']` whose text matches a pattern. */
+function _placeholder_violations_in_output(envelope: Record<string, Any>): string[] {
+    const rendered = envelope['rendered'];
+    if (!_isDict(rendered)) {
+        return [];
+    }
+    const violations: string[] = [];
+    _walk_rendered(rendered, '', violations);
+    return violations;
+}
+
+function _walk_rendered(node: Record<string, Any>, prefix: string, violations: string[]): void {
+    for (const key of Object.keys(node)) {
+        const value = node[key];
+        const path = prefix ? `${prefix}.${key}` : String(key);
+        if (_isDict(value)) {
+            _walk_rendered(value, path, violations);
+            continue;
+        }
+        if (typeof value !== 'string') {
+            continue;
+        }
+        const lowered = value.toLowerCase();
+        for (const pattern of PLACEHOLDER_PATTERNS) {
+            if (lowered.includes(pattern)) {
+                violations.push(path);
+                break;
+            }
+        }
+    }
+}
+
+/** First-pass halt — emit the stack-specific apply directive. */
+function _delegate_to_stack_skill(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    const stack_label = _stack_label(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            `> Stack: \`${stack_label}\`. Implementing the locked design brief.`,
+            '> Microcopy is locked — every button label, empty-state ' +
+                'message, and validation message must come verbatim from ' +
+                '`state.ui_design.microcopy`.',
+            '> 1. Continue — implement the brief and write a ' +
+                '`ui_apply` envelope back into state.ticket ' +
+                '(rendered: {path: text}, files: [...])',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: `UI apply pending; delegating to \`${directive}\` for stack \`${stack_label}\`.`,
+    });
+}
+
+/** BLOCKED halt — rendered output still carries placeholder patterns. */
+function _halt_placeholders(state: DeliveryState, violations: string[]): StepResult {
+    const directive = _resolve_directive(state);
+    const lines: string[] = [
+        agent_directive(directive),
+        '> Apply rejected: rendered output contains placeholder strings. ' +
+            'The design-brief microcopy lock failed mid-loop.',
+        '> Affected paths in `ui_apply.rendered`:',
+    ];
+    for (const p of violations) {
+        lines.push(`> - \`${p}\``);
+    }
+    lines.push(
+        '> Re-render with the locked microcopy verbatim from ' +
+            '`state.ui_design.microcopy`; apply will not write placeholder text.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message:
+            `UI apply rejected: ${violations.length} placeholder ` +
+            'violation(s) in rendered output.',
+    });
+}
+
+/** Append one `state.changes` entry per file in the apply envelope. */
+function _record_changes(state: DeliveryState, envelope: Record<string, Any>): void {
+    let files = envelope['files'];
+    if (!Array.isArray(files)) {
+        files = [];
+    }
+    const summary = _pyTruthy(envelope['summary']) ? envelope['summary'] : 'ui apply';
+    const stack_label = _stack_label(state);
+    for (const p of files as Any[]) {
+        if (typeof p !== 'string' || p === '') {
+            continue;
+        }
+        state.changes.push({
+            kind: 'ui',
+            stack: stack_label,
+            file: p,
+            summary: summary,
+        });
+    }
+}
+
+/** Return the frontend stack label, defaulting to `plain`. */
+function _stack_label(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend !== '') {
+            return frontend;
+        }
+    }
+    return 'plain';
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/audit.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/audit.ts
@@ -1,0 +1,506 @@
+/**
+ * `audit` step — mandatory pre-step for the UI directive set.
+ *
+ * TypeScript twin of `directives/ui/audit.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * Routes on `state.ui_audit` shape: first-pass delegation, greenfield decision,
+ * shadcn version mismatch, ambiguous candidate pick, or high-confidence pass.
+ * The deterministic checks live here so "no design without audit findings" is
+ * enforceable from code, not norms. Mirrors the `state.ui_audit` gate the
+ * `ui-audit-gate` rule defends.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Similarity threshold for a "strong reusable match". */
+export const STRONG_SIMILARITY = 0.7;
+
+/** Top-2 within this gap counts as ambiguous regardless of confidence. */
+export const TIE_GAP = 0.05;
+
+/** Major version the `react-shadcn-ui` skill body declares as tested against. */
+export const TESTED_AGAINST_SHADCN_MAJOR = 2;
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'audit_missing',
+        trigger: 'state.ui_audit is None or empty — skill has not run yet',
+        resolution:
+            'agent directive `existing-ui-audit` → skill writes ' +
+            'findings into state.ui_audit',
+    },
+    {
+        code: 'greenfield_undecided',
+        trigger:
+            'state.ui_audit.greenfield is True but greenfield_decision ' +
+            'is unset — user has not picked a scaffolding direction',
+        resolution:
+            'user picks scaffold / bare / external_reference; ' +
+            'agent records the choice in state.ui_audit.greenfield_decision',
+    },
+    {
+        code: 'shadcn_version_mismatch',
+        trigger:
+            'state.ui_audit.shadcn_inventory.version major differs from ' +
+            'TESTED_AGAINST_SHADCN_MAJOR — react-shadcn-ui skill was ' +
+            'tested against a different major',
+        resolution:
+            'user accepts cautious composition or aborts; ' +
+            'agent records the choice in ' +
+            'state.ui_audit.version_mismatch_decision',
+    },
+    {
+        code: 'audit_ambiguous',
+        trigger:
+            'confidence band is medium, OR inventory has multiple matches ' +
+            'with similar similarity scores, OR no match clears ' +
+            'STRONG_SIMILARITY',
+        resolution:
+            "user picks a candidate to extend (or 'build new'); " +
+            'agent records the choice in state.ui_audit.audit_path ' +
+            'and state.ui_audit.candidate_pick',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Apply the audit gate to `state.ui_audit`. */
+export function run(state: DeliveryState): StepResult {
+    const audit = state.ui_audit;
+    if (!_is_populated(audit)) {
+        return _delegate_to_audit_skill(state);
+    }
+
+    const a = audit as Record<string, Any>;
+    if (a['greenfield'] === true && !_pyTruthy(a['greenfield_decision'])) {
+        return _halt_greenfield(state, a);
+    }
+
+    // Greenfield with a recorded decision skips the candidate-pick halt and
+    // lands on SUCCESS.
+    if (a['greenfield'] === true) {
+        if (!_pyTruthy(a['audit_path'])) {
+            a['audit_path'] = 'greenfield';
+        }
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const mismatch = _detect_shadcn_version_mismatch(a);
+    if (mismatch !== null && !_pyTruthy(a['version_mismatch_decision'])) {
+        return _halt_shadcn_version_mismatch(state, mismatch);
+    }
+
+    // Idempotent re-entry: an already-decided path round-trips through SUCCESS.
+    if (a['audit_path'] === 'high_confidence' || a['audit_path'] === 'ambiguous') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const decision = _decide_path(state, a);
+    if (decision === 'high_confidence') {
+        a['audit_path'] = 'high_confidence';
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_ambiguous(state, a);
+}
+
+/** True when `audit` carries actionable findings. */
+function _is_populated(audit: Any): boolean {
+    if (!_isDict(audit)) return false;
+    if (Object.keys(audit).length === 0) return false;
+    return ['components_found', 'components', 'greenfield'].some((key) => key in audit);
+}
+
+/** Render a one-line preview of the input being audited. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** Halt with an agent directive so the orchestrator runs `existing-ui-audit`. */
+function _delegate_to_audit_skill(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('existing-ui-audit'),
+            `> Input: ${preview}`,
+            '> No UI audit findings yet — running `existing-ui-audit` ' +
+                'to inventory components, design system, tokens, and ' +
+                'candidate matches before design.',
+            '> 1. Continue — let the skill produce the audit',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: 'UI audit findings missing; delegating to existing-ui-audit skill.',
+    });
+}
+
+/** BLOCKED halt — greenfield project needs an explicit scaffolding pick. */
+function _halt_greenfield(state: DeliveryState, audit: Record<string, Any>): StepResult {
+    void audit;
+    const preview = _preview_input(state);
+    const questions: string[] = [
+        `> Input: ${preview}`,
+        '> No existing UI surface detected — this looks like greenfield.',
+        '> 1. Scaffold — minimal token set + base component primitive folder',
+        '> 2. Bare — proceed with Tailwind defaults, no scaffolding',
+        '> 3. External reference — point me at a design-system URL or file',
+        '',
+        '**Recommendation: 1 — Scaffold tokens + primitives** ' +
+            '— even one extra screen benefits from a shared base; the ' +
+            'scaffold cost is ~10 min and saves re-doing every primitive ' +
+            'on screen 2. Caveat: flip to 2 if this is a demo or ' +
+            'single-page prototype that will not grow.',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message:
+            'UI audit detected greenfield; halting for scaffolding ' +
+            'direction (scaffold / bare / external_reference).',
+    });
+}
+
+/** Return `"high_confidence"` or `"ambiguous"` for a populated audit. */
+function _decide_path(state: DeliveryState, audit: Record<string, Any>): string {
+    const band = _confidence_band(state);
+    if (band !== 'high') {
+        return 'ambiguous';
+    }
+
+    const matches = _matches(audit);
+    if (matches.length === 0) {
+        return 'ambiguous';
+    }
+
+    const scored = matches.map((m) => _similarity_of(m)).sort((x, y) => y - x);
+    const top = scored[0] as number;
+    if (top < STRONG_SIMILARITY) {
+        return 'ambiguous';
+    }
+    if (scored.length >= 2 && top - (scored[1] as number) < TIE_GAP) {
+        return 'ambiguous';
+    }
+    return 'high_confidence';
+}
+
+/** Return the scored confidence band, or `"high"` when not applicable. */
+function _confidence_band(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const confidence = data['confidence'];
+    if (_isDict(confidence)) {
+        const band = confidence['band'];
+        if (typeof band === 'string' && band !== '') {
+            return band;
+        }
+    }
+    const input_kind = data['input_kind'];
+    if (input_kind === 'diff' || input_kind === 'file') {
+        return 'high';
+    }
+    return 'medium';
+}
+
+/** Return the inventory list, preferring `components_found`. */
+function _matches(audit: Record<string, Any>): Record<string, Any>[] {
+    for (const key of ['components_found', 'components']) {
+        const value = audit[key];
+        if (Array.isArray(value) && value.length > 0) {
+            return value.filter((m): m is Record<string, Any> => _isDict(m));
+        }
+    }
+    return [];
+}
+
+/** Read a similarity score from a match entry; default to 0.0. */
+function _similarity_of(match: Record<string, Any>): number {
+    const raw = match['similarity'];
+    const f = _pyFloat(raw);
+    return f === null ? 0.0 : f;
+}
+
+/**
+ * Python `float(x)` for the JSON shapes that reach a similarity value.
+ * Returns the float, or `null` to mirror `except (TypeError, ValueError)`.
+ */
+function _pyFloat(value: Any): number | null {
+    if (typeof value === 'boolean') {
+        return value ? 1.0 : 0.0;
+    }
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        const t = value.trim();
+        if (t === '') return null;
+        // Python float() accepts decimals, exponents, inf, nan; the inputs here
+        // are plain decimals — match the common numeric form.
+        if (/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(t)) {
+            return Number(t);
+        }
+        const lower = t.toLowerCase().replace(/^[+-]/, '');
+        if (lower === 'inf' || lower === 'infinity') {
+            return t.startsWith('-') ? -Infinity : Infinity;
+        }
+        if (lower === 'nan') {
+            return NaN;
+        }
+        return null;
+    }
+    return null;
+}
+
+/** Return mismatch info when the inventory diverges by a major. */
+function _detect_shadcn_version_mismatch(audit: Record<string, Any>): Record<string, Any> | null {
+    const inventory = audit['shadcn_inventory'];
+    if (!_isDict(inventory)) {
+        return null;
+    }
+    const raw_version = inventory['version'];
+    if (typeof raw_version !== 'string' || raw_version.trim() === '') {
+        return null;
+    }
+    const head = _pyRStripWs(_pyLStripChar(raw_version, 'v').split('.', 1)[0] as string);
+    const installed_major = _pyIntStrict(head);
+    if (installed_major === null) {
+        return null;
+    }
+    if (installed_major === TESTED_AGAINST_SHADCN_MAJOR) {
+        return null;
+    }
+    return {
+        installed_version: raw_version,
+        installed_major,
+        tested_major: TESTED_AGAINST_SHADCN_MAJOR,
+    };
+}
+
+/** Python `str.lstrip(ch)`. */
+function _pyLStripChar(s: string, ch: string): string {
+    let start = 0;
+    while (start < s.length && s[start] === ch) start += 1;
+    return s.slice(start);
+}
+
+/** Python `str.strip()` (no-arg) applied to the parsed head. */
+function _pyRStripWs(s: string): string {
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/**
+ * Python `str.split(sep, 1)` for a single-character separator: at most one
+ * split, returning the first segment via `[0]`.
+ */
+// (inlined via String.prototype.split(sep, limit) won't replicate Python's
+// maxsplit semantics for `[0]`; but `[0]` only needs the prefix before the
+// first separator, which `split` then index 0 yields identically.)
+
+/**
+ * Python `int(s)` on an already-trimmed integer string. Returns the int, or
+ * `null` to mirror `except ValueError`.
+ */
+function _pyIntStrict(s: string): number | null {
+    if (/^[+-]?[0-9]+$/.test(s)) {
+        return Number(s);
+    }
+    return null;
+}
+
+/** BLOCKED soft-halt — user accepts cautious composition or aborts. */
+function _halt_shadcn_version_mismatch(
+    state: DeliveryState,
+    mismatch: Record<string, Any>,
+): StepResult {
+    const preview = _preview_input(state);
+    const installed = mismatch['installed_version'];
+    const tested = mismatch['tested_major'];
+    const installed_major = mismatch['installed_major'];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Input: ${preview}`,
+            `> shadcn skill tested against v${pyStr(tested)}.x; project uses ` +
+                `\`${pyStr(installed)}\` (major v${pyStr(installed_major)}).`,
+            '> 1. Proceed with cautious composition — skill applies ' +
+                'general patterns, agent verifies primitive APIs against ' +
+                'the installed version',
+            '> 2. Abort — update the `react-shadcn-ui` skill to the ' +
+                'installed major before continuing',
+            '',
+            '**Recommendation: 1 — Proceed with caution** ' +
+                '— most shadcn primitive APIs are stable across ' +
+                "majors; the skill's structural guidance still applies. " +
+                'Caveat: flip to 2 if the design brief leans on a ' +
+                'primitive whose API changed (Form, Sheet, Dialog have ' +
+                'had breaking renames in past majors).',
+        ],
+        message:
+            `shadcn version mismatch (skill v${pyStr(tested)}.x vs project ` +
+            `${pyStr(installed)}); halting for cautious-composition decision.`,
+    });
+}
+
+/** BLOCKED halt — user picks an existing candidate or 'build new'. */
+function _halt_ambiguous(state: DeliveryState, audit: Record<string, Any>): StepResult {
+    const preview = _preview_input(state);
+    const matches = _matches(audit);
+    const scored = _stableSortByKeyDesc(matches, _similarity_of).slice(0, 3);
+
+    const lines: string[] = [
+        `> Input: ${preview}`,
+        '> Audit findings are ambiguous — pick the candidate to ' +
+            'extend, or build new:',
+    ];
+    let idx = 1;
+    for (const match of scored) {
+        const name = _pyTruthy(match['name'])
+            ? match['name']
+            : _pyTruthy(match['path'])
+              ? match['path']
+              : '(unnamed)';
+        const sim = _similarity_of(match);
+        const path = _pyTruthy(match['path']) ? match['path'] : '';
+        const suffix = path ? ` — \`${pyStr(path)}\`` : '';
+        lines.push(`> ${idx}. Extend \`${pyStr(name)}\` (similarity ${_pyFixed(sim, 2)})${suffix}`);
+        idx += 1;
+    }
+    const next_idx = scored.length + 1;
+    lines.push(`> ${next_idx}. Build new — none of the above is close enough`);
+
+    let rec: string;
+    if (scored.length > 0) {
+        const top = scored[0] as Record<string, Any>;
+        const top_name = _pyTruthy(top['name'])
+            ? top['name']
+            : _pyTruthy(top['path'])
+              ? top['path']
+              : 'candidate 1';
+        const top_sim = _similarity_of(top);
+        rec =
+            `**Recommendation: 1 — Extend \`${pyStr(top_name)}\`** — ` +
+            `similarity ${_pyFixed(top_sim, 2)} is the strongest match in the ` +
+            'inventory; reuse beats new code unless the contract ' +
+            `diverges. Caveat: flip to ${next_idx} if the existing ` +
+            'component cannot host the new behavior cleanly.';
+    } else {
+        rec =
+            `**Recommendation: ${next_idx} — Build new** — ` +
+            'no inventory match cleared the strong-similarity bar. ' +
+            'Caveat: flip to an extend option only if a near-miss ' +
+            'is a better fit than starting from scratch.';
+    }
+    lines.push('', rec);
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message:
+            'UI audit findings ambiguous; halting for candidate pick ' +
+            '(extend existing / build new).',
+    });
+}
+
+/**
+ * Python `sorted(matches, key=_similarity_of, reverse=True)` — stable sort,
+ * descending by key, ties keep original order. JS `Array.prototype.sort` is
+ * stable; for `reverse=True` Python keeps equal-key elements in original
+ * order, so a stable comparator that only compares keys (never swaps ties)
+ * reproduces it exactly.
+ */
+function _stableSortByKeyDesc(
+    items: Record<string, Any>[],
+    key: (m: Record<string, Any>) => number,
+): Record<string, Any>[] {
+    const keyed = items.map((m) => ({ m, k: key(m) }));
+    keyed.sort((a, b) => (a.k < b.k ? 1 : a.k > b.k ? -1 : 0));
+    return keyed.map((e) => e.m);
+}
+
+/**
+ * Python `format(x, '.2f')` — fixed-point, 2 decimals, round-half-to-even on
+ * the exact IEEE value. Mirrors `telemetry/report_renderer._pyFixed`.
+ */
+function _pyFixed(value: number, ndigits: number): string {
+    if (!Number.isFinite(value)) {
+        return String(value);
+    }
+    const sign = value < 0 ? '-' : '';
+    const abs = Math.abs(value);
+    const str = abs.toPrecision(17);
+    if (str.includes('e') || str.includes('E')) {
+        return sign + abs.toFixed(ndigits);
+    }
+    const dot = str.indexOf('.');
+    const intPart = dot === -1 ? str : str.slice(0, dot);
+    let fracPart = dot === -1 ? '' : str.slice(dot + 1);
+    while (fracPart.length <= ndigits) {
+        fracPart += '0';
+    }
+    const keepFrac = fracPart.slice(0, ndigits);
+    const deciderStr = fracPart.slice(ndigits);
+    let scaledInt = BigInt(intPart + keepFrac || '0');
+    const firstDecider = deciderStr.charAt(0);
+    const restNonZero = /[1-9]/u.test(deciderStr.slice(1));
+    let roundUp = false;
+    if (firstDecider > '5' || (firstDecider === '5' && restNonZero)) {
+        roundUp = true;
+    } else if (firstDecider === '5' && !restNonZero) {
+        roundUp = scaledInt % 2n === 1n;
+    }
+    if (roundUp) {
+        scaledInt += 1n;
+    }
+    let digits = scaledInt.toString();
+    while (digits.length <= ndigits) {
+        digits = `0${digits}`;
+    }
+    const outInt = ndigits === 0 ? digits : digits.slice(0, digits.length - ndigits);
+    const outFrac = ndigits === 0 ? '' : digits.slice(digits.length - ndigits);
+    const zeroValue = /^0*$/u.test(digits);
+    return `${zeroValue ? '' : sign}${outInt}${ndigits > 0 ? `.${outFrac}` : ''}`;
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/design.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/design.ts
@@ -1,0 +1,325 @@
+/**
+ * `design` step — produces the design brief that locks microcopy.
+ *
+ * TypeScript twin of `directives/ui/design.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The design step turns the audit findings into a structured design brief that
+ * `apply` consumes verbatim. The brief is the lock — apply writes the strings
+ * exactly as the brief specifies. Hallucinated microcopy at apply time is the
+ * failure mode this step exists to prevent.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Top-level keys every well-formed design brief must carry. */
+export const REQUIRED_BRIEF_KEYS: ReadonlyArray<string> = [
+    'layout',
+    'components',
+    'states',
+    'microcopy',
+    'a11y',
+];
+
+/** States the brief must cover; missing entries surface as halt items. */
+export const REQUIRED_STATE_KEYS: ReadonlyArray<string> = [
+    'empty',
+    'loading',
+    'error',
+    'success',
+    'disabled',
+];
+
+/** Lower-cased substrings that mark microcopy as unfinished. */
+export const PLACEHOLDER_PATTERNS: ReadonlyArray<string> = [
+    '<placeholder>',
+    'lorem',
+    'todo:',
+    'tbd',
+    'xxx',
+];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'design_missing',
+        trigger: 'state.ui_design is None or empty — brief has not been produced',
+        resolution:
+            'agent directive `ui-design-brief` → skill/agent ' +
+            'writes the brief into state.ui_design',
+    },
+    {
+        code: 'design_placeholders',
+        trigger:
+            'microcopy contains placeholder patterns ' +
+            '(<placeholder>, Lorem, TODO:, TBD, XXX)',
+        resolution:
+            'agent re-runs the brief with final strings; ' +
+            'halt lists the offending microcopy keys',
+    },
+    {
+        code: 'design_unconfirmed',
+        trigger: 'brief is well-formed but design_confirmed is unset/False',
+        resolution:
+            'user reviews the brief summary and sets ' +
+            'state.ui_design.design_confirmed = True (or asks for ' +
+            'revisions, which loops back to ui-design-brief)',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Python `value is None or value == "" or value == [] or value == {}`. */
+function _isEmptyOrNone(value: Any): boolean {
+    if (value === null || value === undefined) return true;
+    if (value === '') return true;
+    if (Array.isArray(value)) return value.length === 0;
+    if (_isDict(value)) return Object.keys(value).length === 0;
+    return false;
+}
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+function _pyRStrip(s: string): string {
+    return s.replace(/\s+$/u, '');
+}
+
+/** Apply the design-brief lock to `state.ui_design`. */
+export function run(state: DeliveryState): StepResult {
+    const design = state.ui_design;
+    if (!_is_populated(design)) {
+        return _delegate_to_design_skill(state);
+    }
+
+    const designDict = design as Record<string, Any>;
+    const missing = _missing_required_keys(designDict);
+    if (missing.length > 0) {
+        return _halt_incomplete_brief(state, missing);
+    }
+
+    const placeholders = _placeholder_violations(designDict);
+    if (placeholders.length > 0) {
+        return _halt_placeholders(state, placeholders);
+    }
+
+    if (designDict['design_confirmed'] === true) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return _halt_unconfirmed(state, designDict);
+}
+
+/** True when `design` carries an actionable brief. */
+function _is_populated(design: Any): boolean {
+    if (!_isDict(design)) return false;
+    if (Object.keys(design).length === 0) return false;
+    return REQUIRED_BRIEF_KEYS.some((key) => key in design);
+}
+
+/** Return required top-level keys that are missing or empty. */
+function _missing_required_keys(design: Record<string, Any>): string[] {
+    const missing: string[] = [];
+    for (const key of REQUIRED_BRIEF_KEYS) {
+        const value = design[key];
+        if (_isEmptyOrNone(value)) {
+            missing.push(key);
+            continue;
+        }
+        if (key === 'states' && _isDict(value)) {
+            for (const state_key of REQUIRED_STATE_KEYS) {
+                if (!_pyTruthy(value[state_key])) {
+                    missing.push(`states.${state_key}`);
+                }
+            }
+        }
+    }
+    return missing;
+}
+
+/** Return microcopy paths whose values match a placeholder pattern. */
+function _placeholder_violations(design: Record<string, Any>): string[] {
+    const microcopy = design['microcopy'];
+    if (!_isDict(microcopy)) return [];
+    const violations: string[] = [];
+    _walk_microcopy(microcopy, '', violations);
+    return violations;
+}
+
+function _walk_microcopy(
+    node: Record<string, Any>,
+    prefix: string,
+    violations: string[],
+): void {
+    for (const key of Object.keys(node)) {
+        const value = node[key];
+        const path = prefix ? `${prefix}.${key}` : String(key);
+        if (_isDict(value)) {
+            _walk_microcopy(value, path, violations);
+            continue;
+        }
+        if (typeof value !== 'string') {
+            continue;
+        }
+        const lowered = value.toLowerCase();
+        for (const pattern of PLACEHOLDER_PATTERNS) {
+            if (lowered.includes(pattern)) {
+                violations.push(path);
+                break;
+            }
+        }
+    }
+}
+
+/** Render a one-line preview of the input being designed. */
+function _preview_input(state: DeliveryState): string {
+    const data = (_isDict(state.ticket) ? state.ticket : {}) as Record<string, Any>;
+    const raw = data['raw'];
+    let text: string;
+    if (typeof raw === 'string' && raw.trim() !== '') {
+        text = raw.split(/\s+/u).filter((x) => x.length > 0).join(' ');
+    } else {
+        const title = data['title'];
+        if (typeof title === 'string') {
+            text = title;
+        } else {
+            const id = data['id'];
+            text = _pyTruthy(id) ? pyStr(id) : '(no title)';
+        }
+    }
+    if ([...text].length <= 80) {
+        return text;
+    }
+    return _pyRStrip([...text].slice(0, 79).join('')) + '…';
+}
+
+/** Halt with an agent directive so the orchestrator runs `ui-design-brief`. */
+function _delegate_to_design_skill(state: DeliveryState): StepResult {
+    const preview = _preview_input(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('ui-design-brief'),
+            `> Input: ${preview}`,
+            '> No design brief yet — producing one now. The brief locks ' +
+                'layout, components, states, microcopy, and a11y before any ' +
+                'code is written.',
+            '> 1. Continue — produce the brief from audit findings',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: 'UI design brief missing; delegating to ui-design-brief skill.',
+    });
+}
+
+/** BLOCKED halt — brief is missing required keys. */
+function _halt_incomplete_brief(state: DeliveryState, missing: string[]): StepResult {
+    const preview = _preview_input(state);
+    const lines: string[] = [
+        agent_directive('ui-design-brief'),
+        `> Input: ${preview}`,
+        '> Design brief is incomplete. Missing required fields:',
+    ];
+    for (const p of missing) {
+        lines.push(`> - \`${p}\``);
+    }
+    lines.push(
+        '> Re-run the brief skill so every required slot has a final ' +
+            'value before apply.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: `UI design brief incomplete; ${missing.length} required field(s) missing.`,
+    });
+}
+
+/** BLOCKED halt — microcopy still carries placeholder patterns. */
+function _halt_placeholders(state: DeliveryState, violations: string[]): StepResult {
+    const preview = _preview_input(state);
+    const lines: string[] = [
+        agent_directive('ui-design-brief'),
+        `> Input: ${preview}`,
+        '> Microcopy contains placeholder patterns. Apply rejects these ' +
+            'verbatim, so they have to be replaced with final strings now:',
+    ];
+    for (const p of violations) {
+        lines.push(`> - \`microcopy.${p}\``);
+    }
+    lines.push(
+        '> Re-run the brief skill with finalised copy; the apply step ' +
+            'will write strings exactly as the brief specifies.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message:
+            `UI design brief carries ${violations.length} placeholder ` +
+            'violation(s); halting for finalised microcopy.',
+    });
+}
+
+/** BLOCKED halt — brief is well-formed; user must sign off. */
+function _halt_unconfirmed(state: DeliveryState, design: Record<string, Any>): StepResult {
+    const preview = _preview_input(state);
+    const components = _pyTruthy(design['components']) ? design['components'] : [];
+    const states = _pyTruthy(design['states']) ? design['states'] : {};
+    const microcopy = _pyTruthy(design['microcopy']) ? design['microcopy'] : {};
+
+    const component_count = Array.isArray(components) ? components.length : 0;
+    const state_count = _isDict(states) ? Object.keys(states).length : 0;
+    const microcopy_count = _isDict(microcopy) ? _count_microcopy(microcopy) : 0;
+
+    const lines: string[] = [
+        `> Input: ${preview}`,
+        '> Design brief is ready. Summary:',
+        `> - Components: ${component_count}`,
+        `> - States covered: ${state_count}`,
+        `> - Microcopy entries (locked): ${microcopy_count}`,
+        '> 1. Confirm — lock this brief and advance to apply',
+        '> 2. Revise — send feedback; loops back to ui-design-brief',
+        '> 3. Abort — drop this UI request',
+        '',
+        '**Recommendation: 1 — Confirm** — the brief covers all ' +
+            'required slots and microcopy is final. Caveat: flip to 2 only if ' +
+            'a string, state, or component is wrong; do not confirm strings ' +
+            'you have not read.',
+    ];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: lines,
+        message: 'UI design brief ready; halting for user confirmation before apply.',
+    });
+}
+
+/** Count leaf string entries in `microcopy` (recursive). */
+function _count_microcopy(microcopy: Record<string, Any>): number {
+    let total = 0;
+    for (const value of Object.values(microcopy)) {
+        if (_isDict(value)) {
+            total += _count_microcopy(value);
+        } else if (typeof value === 'string') {
+            total += 1;
+        }
+    }
+    return total;
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/polish.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/polish.ts
@@ -1,0 +1,462 @@
+/**
+ * `polish` step — bounded fix loop for review findings.
+ *
+ * TypeScript twin of `directives/ui/polish.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The polish step drives the fix loop after `review` produces findings. The
+ * loop is hard-capped at two rounds (extendable by one for a11y); anything the
+ * agent cannot fix goes back to the user as a ship-as-is / abort decision.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Maximum number of polish rounds per `/work` run. */
+export const POLISH_CEILING = 2;
+
+/** Marker on a review finding that flags an a11y issue. */
+export const A11Y_VIOLATION_KIND = 'a11y_violation';
+
+/** Marker on a review finding that flags a hardcoded design value. */
+export const TOKEN_VIOLATION_KIND = 'token_violation';
+
+/** Repeat count above which an unmatched value triggers the extraction halt. */
+export const TOKEN_REPEAT_THRESHOLD = 2;
+
+/** Map `state.stack.frontend` → agent-directive skill name. */
+export const STACK_DIRECTIVES: Record<string, string> = {
+    'blade-livewire-flux': 'ui-polish-blade-livewire-flux',
+    'react-shadcn': 'ui-polish-react-shadcn',
+    vue: 'ui-polish-vue',
+    plain: 'ui-polish-plain',
+};
+
+/** Fallback directive when `state.stack` is missing or malformed. */
+export const DEFAULT_DIRECTIVE = 'ui-polish-plain';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'polish_round_pending',
+        trigger:
+            'state.ui_review.review_clean is False and ' +
+            'state.ui_polish.rounds < 2 — fixes have not yet been applied ' +
+            'for the current findings',
+        resolution:
+            'agent directive `ui-polish-<stack>` → skill ' +
+            'applies fixes, re-runs the review, increments ' +
+            'state.ui_polish.rounds',
+    },
+    {
+        code: 'polish_ceiling_reached',
+        trigger:
+            'state.ui_polish.rounds == ceiling and remaining ' +
+            'findings are non-a11y (subjective polish that did not ' +
+            'converge) — a11y blocks take precedence via ' +
+            'polish_a11y_blocking',
+        resolution:
+            'user picks: ship as-is, abort, or hand off to ' +
+            'manual fix; engine refuses to start another round',
+    },
+    {
+        code: 'polish_a11y_blocking',
+        trigger:
+            'state.ui_polish.rounds == ceiling and ' +
+            'state.ui_review.findings still contains a11y_violation ' +
+            'entries — objective gate that takes precedence over the ' +
+            'subjective polish_ceiling_reached halt',
+        resolution:
+            'user picks: extend by one round (engine sets ' +
+            'state.ui_polish.extension_used=True so the next round can ' +
+            'fire), accept-with-known-violations (engine appends the ' +
+            'leftover violations to state.ui_review.a11y.accepted_violations ' +
+            'so the review gate stops blocking on them), or abort the ' +
+            'UI request',
+    },
+    {
+        code: 'polish_token_extraction_pending',
+        trigger:
+            'state.ui_review.findings has token_violation entries ' +
+            'whose value repeats >2 times and has no match in ' +
+            'state.ui_audit.design_tokens',
+        resolution:
+            'user picks: extract as a new token (agent adds ' +
+            'it to state.ui_audit.design_tokens.<category>), inline (agent ' +
+            'drops the token_violation findings before re-entering polish), ' +
+            'or abort the UI request',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Apply the polish-loop gate. */
+export function run(state: DeliveryState): StepResult {
+    const review = _pyTruthy(state.ui_review) ? (state.ui_review as Record<string, Any>) : {};
+    let findings = 'findings' in review ? review['findings'] : [];
+    if (!Array.isArray(findings)) {
+        findings = [];
+    }
+    const review_clean = _pyTruthy(review['review_clean']);
+
+    if (review_clean || (findings as Any[]).length === 0) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    const polish = _pyTruthy(state.ui_polish) ? (state.ui_polish as Record<string, Any>) : {};
+    let rounds = 'rounds' in polish ? polish['rounds'] : 0;
+    // `not isinstance(rounds, int) or isinstance(rounds, bool)` → reset to 0.
+    if (typeof rounds !== 'number' || !Number.isInteger(rounds) || typeof rounds === 'boolean') {
+        rounds = 0;
+    }
+    const extension_used = _pyTruthy(polish['extension_used']);
+    const effective_ceiling = POLISH_CEILING + (extension_used ? 1 : 0);
+
+    const findingsArr = findings as Any[];
+    if ((rounds as number) >= effective_ceiling) {
+        const a11y_findings = _a11y_findings(findingsArr);
+        if (a11y_findings.length > 0) {
+            return _halt_a11y_blocking(state, a11y_findings, rounds as number, !extension_used);
+        }
+        return _halt_ceiling(state, findingsArr.length, rounds as number, effective_ceiling);
+    }
+
+    const tokens = _design_tokens(state);
+    const [matched, unmatched_repeats] = _classify_token_violations(findingsArr, tokens);
+    if (unmatched_repeats.length > 0) {
+        return _halt_token_extraction(state, unmatched_repeats);
+    }
+
+    return _delegate_to_polish_skill(
+        state,
+        findingsArr.length,
+        matched.length,
+        rounds as number,
+        effective_ceiling,
+    );
+}
+
+/** Pick the agent directive for the project's frontend stack. */
+function _resolve_directive(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend in STACK_DIRECTIVES) {
+            return STACK_DIRECTIVES[frontend] as string;
+        }
+    }
+    return DEFAULT_DIRECTIVE;
+}
+
+/** Return the frontend stack label, defaulting to `plain`. */
+function _stack_label(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend !== '') {
+            return frontend;
+        }
+    }
+    return 'plain';
+}
+
+/** BLOCKED halt — emit the stack-specific polish directive. */
+function _delegate_to_polish_skill(
+    state: DeliveryState,
+    findings_count: number,
+    matched_token_count: number,
+    rounds: number,
+    ceiling: number,
+): StepResult {
+    const directive = _resolve_directive(state);
+    const stack_label = _stack_label(state);
+    const next_round = rounds + 1;
+    let findings_line =
+        `> ${findings_count} finding(s) from \`state.ui_review\`. ` +
+        'Apply each fix, re-run the review, and write the refreshed ' +
+        'envelope back.';
+    if (matched_token_count) {
+        findings_line =
+            `> ${findings_count} finding(s) from \`state.ui_review\` ` +
+            `(${matched_token_count} token-violation match(es) ` +
+            'auto-convert against `state.ui_audit.design_tokens`). ' +
+            'Apply each fix, re-run the review, and write the refreshed ' +
+            'envelope back.';
+    }
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            `> Stack: \`${stack_label}\`. Polish round ${next_round} of ${ceiling}.`,
+            findings_line,
+            '> Fix chart-type / contrast findings against the adopted ' +
+                "corpus rows (design-intelligence § 'Grounding the " +
+                "review/polish a11y gate'), not ad-hoc judgment.",
+            '> 1. Continue — apply fixes, re-review, and increment ' +
+                '`state.ui_polish.rounds`',
+            '> 2. Abort — drop this UI request',
+        ],
+        message:
+            `UI polish round ${next_round}/${ceiling}; delegating ` +
+            `to \`${directive}\` for stack \`${stack_label}\`.`,
+    });
+}
+
+/** BLOCKED halt — ceiling reached on subjective (non-a11y) findings. */
+function _halt_ceiling(
+    state: DeliveryState,
+    findings_count: number,
+    rounds: number,
+    ceiling: number,
+): StepResult {
+    const stack_label = _stack_label(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Stack: \`${stack_label}\`. Polish ceiling reached ` +
+                `(${rounds}/${ceiling} rounds).`,
+            `> ${findings_count} finding(s) still open in ` +
+                '`state.ui_review`. The engine refuses a third round.',
+            '> 1. Ship as-is — mark `state.ui_review.review_clean ' +
+                '= True` and continue to `report` (the open findings stay ' +
+                'in the delivery report)',
+            '> 2. Abort — drop this UI request',
+            '> 3. Hand off — a human picks up the remaining ' +
+                'findings outside the engine; re-invoke `/work` only after ' +
+                'they are resolved',
+            '',
+            '**Recommendation: 3 — Hand off** — two automated ' +
+                'rounds failed to converge. Caveat: pick 1 only when the ' +
+                'remaining findings are explicitly acceptable (low-priority ' +
+                'polish, deferred to a follow-up).',
+        ],
+        message:
+            `UI polish ceiling reached (${rounds}/${ceiling}); ` +
+            `${findings_count} finding(s) still open.`,
+    });
+}
+
+/** Return the subset of `findings` synthesised by the a11y gate. */
+function _a11y_findings(findings: Any[]): Record<string, Any>[] {
+    return findings.filter(
+        (f): f is Record<string, Any> => _isDict(f) && f['kind'] === A11Y_VIOLATION_KIND,
+    );
+}
+
+/** BLOCKED halt — ceiling reached with actionable a11y findings. */
+function _halt_a11y_blocking(
+    state: DeliveryState,
+    a11y_findings: Record<string, Any>[],
+    rounds: number,
+    extension_available: boolean,
+): StepResult {
+    const stack_label = _stack_label(state);
+    const count = a11y_findings.length;
+    const questions: string[] = [
+        `> Stack: \`${stack_label}\`. Polish ceiling reached ` +
+            `(${rounds}/${POLISH_CEILING} rounds) with ${count} a11y ` +
+            'violation(s) still open.',
+    ];
+    for (const finding of a11y_findings.slice(0, 5)) {
+        const rule = _pyTruthy(finding['rule']) ? finding['rule'] : '?';
+        const selector = _pyTruthy(finding['selector']) ? finding['selector'] : '?';
+        const severity = _pyTruthy(finding['severity']) ? finding['severity'] : '?';
+        questions.push(`> - \`${pyStr(rule)}\` on \`${pyStr(selector)}\` (severity: ${pyStr(severity)})`);
+    }
+    if (count > 5) {
+        questions.push(`> ... and ${count - 5} more`);
+    }
+    if (extension_available) {
+        questions.push(
+            '> 1. Extend — grant one extra polish round; the ' +
+                'engine sets `state.ui_polish.extension_used = True` so ' +
+                'the next delegation can fire',
+            '> 2. Accept — append the open violations to ' +
+                '`state.ui_review.a11y.accepted_violations` so the review ' +
+                'gate stops blocking on them, then continue to `report`',
+            '> 3. Abort — drop this UI request',
+            '',
+            '**Recommendation: 1 — Extend** — a11y ' +
+                'violations are objective; one more round usually closes ' +
+                'the gap. Pick 2 only when the violations are explicitly ' +
+                'out of scope for this run.',
+        );
+    } else {
+        questions.push(
+            '> 1. Accept — append the open violations to ' +
+                '`state.ui_review.a11y.accepted_violations` so the review ' +
+                'gate stops blocking on them, then continue to `report`',
+            '> 2. Abort — drop this UI request',
+            '',
+            '**Recommendation: 1 — Accept** — the one-shot ' +
+                'extension is already spent; either accept the residual ' +
+                'violations or abort.',
+        );
+    }
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message:
+            `UI polish ceiling reached (${rounds}/${POLISH_CEILING}); ` +
+            `${count} a11y violation(s) still open.`,
+    });
+}
+
+/** Return `state.ui_audit.design_tokens` as a dict, or `{}`. */
+function _design_tokens(state: DeliveryState): Record<string, Any> {
+    const audit = _pyTruthy(state.ui_audit) ? state.ui_audit : {};
+    if (!_isDict(audit)) {
+        return {};
+    }
+    const tokens = _pyTruthy(audit['design_tokens']) ? audit['design_tokens'] : {};
+    if (!_isDict(tokens)) {
+        return {};
+    }
+    return tokens;
+}
+
+/** Split `token_violation` findings into matched / unmatched-repeats. */
+function _classify_token_violations(
+    findings: Any[],
+    tokens: Record<string, Any>,
+): [Record<string, Any>[], Record<string, Any>[]] {
+    const matched: Record<string, Any>[] = [];
+    // Insertion-ordered map keyed by `${category} ${value}` to mirror the
+    // Python `dict[tuple[str, str], int]` insertion order.
+    const unmatched_counts = new Map<string, { category: string; value: string; count: number }>();
+    for (const finding of findings) {
+        if (!_isDict(finding)) {
+            continue;
+        }
+        if (finding['kind'] !== TOKEN_VIOLATION_KIND) {
+            continue;
+        }
+        const category = finding['category'];
+        const value = finding['value'];
+        if (typeof category !== 'string' || typeof value !== 'string') {
+            continue;
+        }
+        const bucket = tokens[category];
+        if (_isDict(bucket) && Object.values(bucket).includes(value)) {
+            matched.push(finding);
+            continue;
+        }
+        const key = `${category} ${value}`;
+        const existing = unmatched_counts.get(key);
+        if (existing) {
+            existing.count += 1;
+        } else {
+            unmatched_counts.set(key, { category, value, count: 1 });
+        }
+    }
+    const repeats: Record<string, Any>[] = [];
+    for (const { category, value, count } of unmatched_counts.values()) {
+        if (count > TOKEN_REPEAT_THRESHOLD) {
+            repeats.push({ category, value, count });
+        }
+    }
+    return [matched, repeats];
+}
+
+/** Build a suggested CSS-custom-property name for an extraction halt. */
+function _suggest_token_name(category: string, value: string): string {
+    let safe = '';
+    for (const c of value) {
+        safe += _isAlnum(c) ? c : '-';
+    }
+    safe = _pyStripChar(safe, '-').toLowerCase();
+    if (safe === '') {
+        safe = 'value';
+    }
+    const base = _pyRStripChar(category, 's') || category;
+    return [...`${base}-${safe}`].slice(0, 40).join('');
+}
+
+/** BLOCKED halt — repeated hardcoded value(s) without a matching token. */
+function _halt_token_extraction(
+    state: DeliveryState,
+    repeats: Record<string, Any>[],
+): StepResult {
+    const stack_label = _stack_label(state);
+    const questions: string[] = [
+        `> Stack: \`${stack_label}\`. ${repeats.length} hardcoded value(s) ` +
+            `appear >${TOKEN_REPEAT_THRESHOLD} times without a matching ` +
+            'entry in `state.ui_audit.design_tokens`.',
+    ];
+    for (const repeat of repeats) {
+        const suggested = _suggest_token_name(repeat['category'] as string, repeat['value'] as string);
+        questions.push(
+            `> - \`${pyStr(repeat['value'])}\` ` +
+                `(${pyStr(repeat['category'])}, ${pyStr(repeat['count'])}×) ` +
+                `— suggested name: \`--${suggested}\``,
+        );
+    }
+    questions.push(
+        '> 1. Extract as design token(s) — add to ' +
+            '`state.ui_audit.design_tokens.<category>` and re-enter polish; ' +
+            'matching findings auto-convert next round',
+        '> 2. Inline — keep the hardcoded value(s) for this run; ' +
+            'drop the token_violation findings from ' +
+            '`state.ui_review.findings` before re-entering polish',
+        '> 3. Abort — drop this UI request',
+        '',
+        '**Recommendation: 1 — Extract** — a value used ' +
+            `>${TOKEN_REPEAT_THRESHOLD} times is a de-facto token; ` +
+            'promoting it now keeps the design system honest. Pick 2 only ' +
+            'when the value is intentionally one-off.',
+    );
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions,
+        message:
+            `UI polish paused; ${repeats.length} hardcoded value(s) ` +
+            'repeat without a matching design token.',
+    });
+}
+
+// ── Python string helpers ───────────────────────────────────────────────
+
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    return String(value);
+}
+
+/** Python `str.isalnum()` for a single code point (Unicode-aware). */
+function _isAlnum(ch: string): boolean {
+    // Python: alphanumeric = letters (incl. Unicode) or any numeric character.
+    // \p{L} (letters), \p{N} (numbers) cover str.isalnum for single chars.
+    return /[\p{L}\p{N}]/u.test(ch);
+}
+
+/** Python `str.strip(chars)` — strip the given chars from both ends. */
+function _pyStripChar(s: string, ch: string): string {
+    let start = 0;
+    let end = s.length;
+    while (start < end && s[start] === ch) start += 1;
+    while (end > start && s[end - 1] === ch) end -= 1;
+    return s.slice(start, end);
+}
+
+/** Python `str.rstrip(chars)` — strip the given chars from the right. */
+function _pyRStripChar(s: string, ch: string): string {
+    let end = s.length;
+    while (end > 0 && s[end - 1] === ch) end -= 1;
+    return s.slice(0, end);
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/review.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/review.ts
@@ -1,0 +1,400 @@
+/**
+ * `review` step — stack-dispatched design-review pass.
+ *
+ * TypeScript twin of `directives/ui/review.py` (ADR-094 py2ts). Public API
+ * names stay snake_case to mirror the Python module 1:1.
+ *
+ * The review step compares the rendered components from `apply` against the
+ * locked design brief and produces a structured findings list. It does not
+ * apply fixes — that is the polish step's job. Review's single output is
+ * `state.ui_review` carrying `findings` and `review_clean`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Map `state.stack.frontend` → agent-directive skill name. */
+export const STACK_DIRECTIVES: Record<string, string> = {
+    'blade-livewire-flux': 'ui-design-review-blade-livewire-flux',
+    'react-shadcn': 'ui-design-review-react-shadcn',
+    vue: 'ui-design-review-vue',
+    plain: 'ui-design-review-plain',
+};
+
+/** Fallback directive when `state.stack` is missing or malformed. */
+export const DEFAULT_DIRECTIVE = 'ui-design-review-plain';
+
+/** R4 a11y severity ranking — mirrors axe-core's impact levels. */
+export const SEVERITY_ORDER: Record<string, number> = {
+    minor: 0,
+    moderate: 1,
+    serious: 2,
+    critical: 3,
+};
+
+/** R4 a11y default severity floor. */
+export const DEFAULT_SEVERITY_FLOOR = 'moderate';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'review_envelope_missing',
+        trigger: 'state.ui_review unset / empty — review skill has not run yet',
+        resolution:
+            'agent directive `ui-design-review-<stack>` → ' +
+            'skill compares rendered components against state.ui_design ' +
+            'and writes `findings` + `review_clean` back',
+    },
+    {
+        code: 'review_findings_missing',
+        trigger: 'state.ui_review populated but `findings` key absent',
+        resolution:
+            'agent re-runs the review skill with the same ' +
+            'directive; review only succeeds once findings is a list',
+    },
+    {
+        code: 'review_clean_missing',
+        trigger:
+            'state.ui_review.findings is set but review_clean ' +
+            'is missing or not a bool — polish needs an explicit flag',
+        resolution:
+            'agent sets state.ui_review.review_clean to ' +
+            'True or False before returning the envelope; review does ' +
+            'not infer it from findings count',
+    },
+    {
+        code: 'review_a11y_pending',
+        trigger:
+            'state.ui_audit declared an `a11y_baseline` but ' +
+            'state.ui_review.a11y is missing — the review skill ran but ' +
+            'did not produce an a11y envelope',
+        resolution:
+            'agent re-runs the review skill so it captures ' +
+            'axe-core (or equivalent) findings into ' +
+            '`state.ui_review.a11y.violations`; the gate then filters ' +
+            'against the baseline and the severity floor',
+    },
+    {
+        code: 'preview_render_failed',
+        trigger:
+            'state.ui_review.preview.render_ok is False — the ' +
+            'stack-specific review skill tried to render the changed ' +
+            'components and the headless browser reported an error',
+        resolution:
+            'user picks Retry (re-run the review skill so it ' +
+            'renders again), Skip (write `state.ui_review.preview.skipped = ' +
+            'true` so the gate stops asking this run), or Abort',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Apply the design-review gate to `state.ui_review`. */
+export function run(state: DeliveryState): StepResult {
+    const review = state.ui_review;
+    if (!_is_populated(review)) {
+        return _delegate_to_review_skill(state);
+    }
+
+    const r = review as Record<string, Any>;
+    if (!('findings' in r) || !Array.isArray(r['findings'])) {
+        return _halt_findings_missing(state);
+    }
+
+    const findings = r['findings'] as Any[];
+    if (typeof r['review_clean'] !== 'boolean') {
+        return _halt_clean_missing(state, findings.length);
+    }
+
+    const a11y_halt = _apply_a11y_gate(state, r);
+    if (a11y_halt !== null) {
+        return a11y_halt;
+    }
+
+    const preview_halt = _apply_preview_gate(state, r);
+    if (preview_halt !== null) {
+        return preview_halt;
+    }
+
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** True when `review` is a dict with at least one own key. */
+function _is_populated(review: Any): boolean {
+    return _isDict(review) && Object.keys(review).length > 0;
+}
+
+/** Pick the agent directive for the project's frontend stack. */
+function _resolve_directive(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend in STACK_DIRECTIVES) {
+            return STACK_DIRECTIVES[frontend] as string;
+        }
+    }
+    return DEFAULT_DIRECTIVE;
+}
+
+/** Return the frontend stack label, defaulting to `plain`. */
+function _stack_label(state: DeliveryState): string {
+    const stack = _pyTruthy(state.stack) ? state.stack : {};
+    if (_isDict(stack)) {
+        const frontend = stack['frontend'];
+        if (typeof frontend === 'string' && frontend !== '') {
+            return frontend;
+        }
+    }
+    return 'plain';
+}
+
+/** First-pass halt — emit the stack-specific review directive. */
+function _delegate_to_review_skill(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    const stack_label = _stack_label(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            `> Stack: \`${stack_label}\`. Reviewing rendered components ` +
+                'against the locked design brief.',
+            '> The review pass compares `state.ticket.ui_apply.rendered` ' +
+                'against `state.ui_design` (microcopy, states, a11y, layout) ' +
+                'and produces a structured `findings` list.',
+            '> Ground chart-type and contrast findings in the adopted ' +
+                "corpus (design-intelligence § 'Grounding the review/polish " +
+                "a11y gate') — cite the corpus row, don't eyeball.",
+            '> 1. Continue — run the review and write ' +
+                '`{findings: [...], review_clean: bool}` into ' +
+                '`state.ui_review`',
+            '> 2. Abort — drop this UI request',
+        ],
+        message: `UI review pending; delegating to \`${directive}\` for stack \`${stack_label}\`.`,
+    });
+}
+
+/** BLOCKED halt — envelope present but `findings` slot is unset. */
+function _halt_findings_missing(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Review envelope is partial: `findings` list is missing.',
+            '> Re-run the review skill so `state.ui_review.findings` ' +
+                'is a list (empty when nothing is wrong).',
+        ],
+        message: 'UI review envelope incomplete; `findings` missing.',
+    });
+}
+
+/** BLOCKED halt — `review_clean` is missing or not a bool. */
+function _halt_clean_missing(state: DeliveryState, findings_count: number): StepResult {
+    const directive = _resolve_directive(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Review envelope is incomplete: `review_clean` is missing ' +
+                'or not a boolean.',
+            `> Findings count: ${findings_count}. Set ` +
+                '`state.ui_review.review_clean` to `True` (no further ' +
+                'polish needed) or `False` (polish loop should run).',
+        ],
+        message: 'UI review envelope incomplete; `review_clean` must be a bool.',
+    });
+}
+
+/** R4 Phase 1: enforce a11y gate after the basic shape gates pass. */
+function _apply_a11y_gate(state: DeliveryState, review: Record<string, Any>): StepResult | null {
+    const audit = state.ui_audit;
+    const has_baseline = _isDict(audit) && 'a11y_baseline' in audit;
+    const a11y = review['a11y'];
+
+    if (a11y === null || a11y === undefined) {
+        if (has_baseline) {
+            return _halt_a11y_pending(state);
+        }
+        return null;
+    }
+
+    const a11yDict = a11y as Record<string, Any>;
+    const violations = _pyTruthy(a11yDict['violations']) ? (a11yDict['violations'] as Any[]) : [];
+    const baseline = has_baseline ? ((audit as Record<string, Any>)['a11y_baseline'] as Any[]) : [];
+    const accepted = _pyTruthy(a11yDict['accepted_violations'])
+        ? (a11yDict['accepted_violations'] as Any[])
+        : [];
+    const floor = _pyTruthy(a11yDict['severity_floor'])
+        ? (a11yDict['severity_floor'] as string)
+        : DEFAULT_SEVERITY_FLOOR;
+
+    let new_violations = _filter_known(violations, baseline);
+    new_violations = _filter_known(new_violations, accepted);
+    const actionable = new_violations.filter((v) => _at_or_above_floor(v, floor));
+
+    if (actionable.length === 0) {
+        return null;
+    }
+
+    _synthesize_a11y_findings(review['findings'] as Any[], actionable);
+    review['review_clean'] = false;
+    return null;
+}
+
+/** Drop violations whose `(rule, selector)` matches `known`. */
+function _filter_known(violations: Any[], known: Any[]): Any[] {
+    if (!_pyTruthy(known)) {
+        return [...violations];
+    }
+    const keys = new Set<string>();
+    for (const entry of known) {
+        if (_isDict(entry)) {
+            keys.add(_keyOf(entry['rule'], entry['selector']));
+        }
+    }
+    if (keys.size === 0) {
+        return [...violations];
+    }
+    return violations.filter(
+        (v) => !(_isDict(v) && keys.has(_keyOf(v['rule'], v['selector']))),
+    );
+}
+
+/**
+ * Stable, collision-free key for a `(rule, selector)` tuple of arbitrary JSON
+ * scalars, mirroring Python tuple-equality in a JS `Set`.
+ */
+function _keyOf(rule: Any, selector: Any): string {
+    return `${_tag(rule)} ${_tag(selector)}`;
+}
+
+function _tag(v: Any): string {
+    if (v === null || v === undefined) return 'n:';
+    if (typeof v === 'boolean') return `b:${v ? '1' : '0'}`;
+    if (typeof v === 'number') return `f:${v}`;
+    if (typeof v === 'string') return `s:${v}`;
+    return `o:${JSON.stringify(v)}`;
+}
+
+/** `True` when `violation.severity` is at or above `floor`. */
+function _at_or_above_floor(violation: Any, floor: string): boolean {
+    if (!_isDict(violation)) {
+        return false;
+    }
+    const severity = violation['severity'];
+    const sevKey = typeof severity === 'string' ? severity : '';
+    const sev_rank =
+        sevKey in SEVERITY_ORDER
+            ? (SEVERITY_ORDER[sevKey] as number)
+            : (SEVERITY_ORDER[DEFAULT_SEVERITY_FLOOR] as number);
+    const floor_rank =
+        floor in SEVERITY_ORDER
+            ? (SEVERITY_ORDER[floor] as number)
+            : (SEVERITY_ORDER[DEFAULT_SEVERITY_FLOOR] as number);
+    return sev_rank >= floor_rank;
+}
+
+/** Append `a11y_violation` findings, deduped by `(rule, selector)`. */
+function _synthesize_a11y_findings(findings: Any[], actionable: Any[]): void {
+    const existing = new Set<string>();
+    for (const f of findings) {
+        if (_isDict(f) && f['kind'] === 'a11y_violation') {
+            existing.add(_keyOf(f['rule'], f['selector']));
+        }
+    }
+    for (const v of actionable) {
+        if (!_isDict(v)) {
+            continue;
+        }
+        const key = _keyOf(v['rule'], v['selector']);
+        if (existing.has(key)) {
+            continue;
+        }
+        findings.push({
+            kind: 'a11y_violation',
+            rule: v['rule'] ?? null,
+            selector: v['selector'] ?? null,
+            severity: v['severity'] ?? null,
+        });
+        existing.add(key);
+    }
+}
+
+/** BLOCKED halt — audit declared a baseline but review has no a11y. */
+function _halt_a11y_pending(state: DeliveryState): StepResult {
+    const directive = _resolve_directive(state);
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Review envelope is incomplete: the audit declared an ' +
+                '`a11y_baseline` but `state.ui_review.a11y` is missing.',
+            '> Re-run the review skill so it captures axe-core (or ' +
+                'equivalent) findings into ' +
+                '`state.ui_review.a11y.violations`. The gate filters ' +
+                'against the baseline and the severity floor ' +
+                `(default \`${DEFAULT_SEVERITY_FLOOR}\`).`,
+        ],
+        message:
+            'UI review envelope incomplete; `a11y` envelope missing ' +
+            '(audit declared a baseline).',
+    });
+}
+
+/** R4 Phase 3: validate the visual-preview envelope written by the skill. */
+function _apply_preview_gate(state: DeliveryState, review: Record<string, Any>): StepResult | null {
+    const preview = review['preview'];
+    if (!_isDict(preview)) {
+        return null;
+    }
+    if (_pyTruthy(preview['skipped'])) {
+        return null;
+    }
+    if (!('render_ok' in preview)) {
+        return null;
+    }
+    if (preview['render_ok'] === false) {
+        return _halt_preview_failed(state, preview);
+    }
+    return null;
+}
+
+/** BLOCKED halt — render reported failure; user picks the next step. */
+function _halt_preview_failed(state: DeliveryState, preview: Record<string, Any>): StepResult {
+    const directive = _resolve_directive(state);
+    const error = preview['error'];
+    const error_line =
+        typeof error === 'string' && error !== ''
+            ? `> Render error: \`${error}\`.`
+            : '> Render error: `(none reported)`.';
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive(directive),
+            '> Visual preview failed: ' +
+                '`state.ui_review.preview.render_ok` is `False`.',
+            error_line,
+            '> 1. Retry — re-run the review skill so it renders again ' +
+                'and writes a fresh `preview` envelope',
+            '> 2. Skip — set `state.ui_review.preview.skipped = true` ' +
+                'so this run ships without a screenshot artifact',
+            '> 3. Abort — drop this UI request',
+        ],
+        message: 'UI preview render failed; awaiting user decision.',
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/_skipped.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/_skipped.ts
@@ -1,0 +1,33 @@
+/**
+ * Pass-through handler for slots the trivial path skips.
+ *
+ * TypeScript twin of `directives/ui_trivial/_skipped.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The `ui-trivial` directive set short-circuits the audit / design / review /
+ * polish loop. The dispatcher's `STEP_ORDER` is fixed (eight slots, no
+ * branching), so the trivial set fills the unused slots — `memory`,
+ * `analyze`, `plan`, `verify` — with this no-op handler. It returns `SUCCESS`
+ * without touching state, mutates nothing, and declares zero ambiguities.
+ */
+import {
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** No ambiguities — the slot is unconditionally skipped on the trivial path. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/**
+ * Return `SUCCESS` without touching `state`.
+ *
+ * Shared handler for the slots the trivial path intentionally bypasses.
+ * Keeping the slot wired (rather than raising) preserves the dispatcher's
+ * completeness-check invariant: every slot in `STEP_ORDER` has a callable
+ * handler, every directive set has a uniform shape.
+ */
+export function run(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/apply.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/apply.ts
@@ -1,0 +1,213 @@
+/**
+ * `apply` step — single-file edit path for the `ui-trivial` set.
+ *
+ * TypeScript twin of `directives/ui_trivial/apply.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The short-circuit path for micro UI edits that provably cannot warrant the
+ * full audit / design / review / polish loop. Hard preconditions enforced on
+ * every rebound: ≤ 1 file, ≤ 5 changed lines, no new component, no new state,
+ * no new dependency. Any precondition violation BLOCKS with a
+ * `reclassify-to-ui-improve` halt; the orchestrator promotes
+ * `state.directive_set` to `"ui-improve"` and re-invokes the engine.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+/** Edit-surface ceiling — single-file edits only. */
+export const MAX_FILES = 1;
+
+/** Changed-line ceiling — anything larger is structural, not trivial. */
+export const MAX_LINES_CHANGED = 5;
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'trivial_envelope_missing',
+        trigger: "state.ticket['trivial_edit'] unset — first pass",
+        resolution:
+            'agent directive `trivial-apply` → agent performs ' +
+            'the single-file edit and writes the envelope back',
+    },
+    {
+        code: 'trivial_preconditions_violated',
+        trigger: 'edit touches >1 file, >5 lines, adds component/state/dependency',
+        resolution:
+            'agent directive `reclassify-to-ui-improve` → ' +
+            "orchestrator promotes directive_set='ui-improve' and re-runs " +
+            'through the full audit gate',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python truthiness for the values reached here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/**
+ * Python `int(x)` for the values that reach the precondition check. Mirrors
+ * CPython semantics for the shapes JSON produces:
+ *
+ * - `bool` → 0 / 1.
+ * - integer-valued / fractional `float` → truncate toward zero.
+ * - `str` → parse a base-10 integer literal (optional sign, surrounding
+ *   whitespace allowed); a non-integer string raises `ValueError`.
+ * - `None` / arrays / objects → `TypeError`.
+ *
+ * Returns the int on success, or the sentinel `null` to mirror the
+ * `except (TypeError, ValueError)` branch in the source.
+ */
+function _pyInt(value: Any): number | null {
+    if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+    }
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            return null; // int(inf)/int(nan) → ValueError/OverflowError
+        }
+        return Math.trunc(value);
+    }
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        // Python int() accepts an optional sign + digits + optional `_`
+        // separators between digits. The inputs here are plain integers; match
+        // the common case and reject anything else.
+        if (/^[+-]?[0-9]+$/.test(trimmed)) {
+            return Number(trimmed);
+        }
+        return null;
+    }
+    return null;
+}
+
+/** Apply the trivial-edit gate. */
+export function run(state: DeliveryState): StepResult {
+    const envelope = _trivial_envelope(state);
+    if (envelope === null) {
+        return _delegate_to_agent(state);
+    }
+
+    const violations = _check_preconditions(envelope);
+    if (violations.length > 0) {
+        return _halt_reclassify(state, violations);
+    }
+
+    _record_change(state, envelope);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+/** Return the agent-written `trivial_edit` envelope, or `null`. */
+function _trivial_envelope(state: DeliveryState): Record<string, Any> | null {
+    const data = _pyTruthy(state.ticket) ? state.ticket : {};
+    const envelope = (data as Record<string, Any>)['trivial_edit'];
+    if (_isDict(envelope) && _pyTruthy(envelope)) {
+        return envelope;
+    }
+    return null;
+}
+
+/** Return a list of violation codes; empty when all preconditions pass. */
+function _check_preconditions(envelope: Record<string, Any>): string[] {
+    const violations: string[] = [];
+
+    const files = envelope['files'];
+    if (!Array.isArray(files) || files.length === 0) {
+        violations.push('files_missing');
+    } else if (files.length > MAX_FILES) {
+        violations.push(`files_exceeded:${files.length}>${MAX_FILES}`);
+    }
+
+    const lines = envelope['lines_changed'];
+    const lines_int = _pyInt(lines);
+    if (lines_int === null) {
+        violations.push('lines_changed_missing');
+    } else {
+        if (lines_int > MAX_LINES_CHANGED) {
+            violations.push(`lines_exceeded:${lines_int}>${MAX_LINES_CHANGED}`);
+        }
+        if (lines_int < 0) {
+            violations.push('lines_changed_negative');
+        }
+    }
+
+    if (_pyTruthy(envelope['new_component'])) {
+        violations.push('new_component');
+    }
+    if (_pyTruthy(envelope['new_state'])) {
+        violations.push('new_state');
+    }
+    if (_pyTruthy(envelope['new_dependency'])) {
+        violations.push('new_dependency');
+    }
+
+    return violations;
+}
+
+/** First-pass halt — delegate to the agent for the single-file edit. */
+function _delegate_to_agent(state: DeliveryState): StepResult {
+    void state;
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('trivial-apply'),
+            '> Trivial UI edit path — audit / design / review skipped.',
+            '> 1. Continue — perform the single-file edit, then ' +
+                'write a `trivial_edit` envelope back into state.ticket ' +
+                '(files, lines_changed, new_component, new_state, new_dependency)',
+            '> 2. Abort — drop this trivial edit',
+        ],
+        message: 'Trivial UI edit pending; delegating to agent for single-file edit.',
+    });
+}
+
+/** BLOCKED halt — orchestrator must reclassify to `ui-improve`. */
+function _halt_reclassify(state: DeliveryState, violations: string[]): StepResult {
+    state.ticket['__reclassify_to__'] = 'ui-improve';
+    delete state.ticket['trivial_edit'];
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('reclassify-to-ui-improve'),
+            '> Trivial-edit preconditions violated; this work needs the ' +
+                'full audit gate.',
+            `> Violations: ${violations.join(', ')}.`,
+            '> 1. Reclassify — orchestrator sets ' +
+                '`state.directive_set = "ui-improve"` and re-runs the engine',
+            '> 2. Abort — drop this UI request',
+        ],
+        message:
+            'Trivial-edit preconditions failed ' +
+            `(${violations.join(', ')}); reclassification required.`,
+    });
+}
+
+/** Write a single `state.changes` entry summarising the trivial edit. */
+function _record_change(state: DeliveryState, envelope: Record<string, Any>): void {
+    const filesRaw = envelope['files'];
+    const files = _pyTruthy(filesRaw) ? filesRaw : [];
+    const lines = 'lines_changed' in envelope ? envelope['lines_changed'] : 0;
+    const summaryRaw = envelope['summary'];
+    const summary = _pyTruthy(summaryRaw) ? summaryRaw : 'trivial UI edit';
+    // `_record_change` only runs after preconditions pass, so `files` is a
+    // non-empty list here; mirror Python `list(files)` with a shallow copy.
+    state.changes.push({
+        kind: 'ui-trivial',
+        files: [...(files as Any[])],
+        lines_changed: lines,
+        summary: summary,
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/refine.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/refine.ts
@@ -1,0 +1,126 @@
+/**
+ * `refine` step — intent gate for the `ui-trivial` directive set.
+ *
+ * TypeScript twin of `directives/ui_trivial/refine.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * `ui-trivial` is reachable only when the intent classifier (or an explicit
+ * user override) labelled the work as `ui-trivial`. Reaching this slot through
+ * any other route is a routing error, not a user-facing ambiguity.
+ *
+ * The handler is deterministic and tiny: confirm the ticket carries the
+ * expected intent label (or accept the default when `directive_set` is already
+ * pinned), and return `SUCCESS`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** Intent label that gates entry into this directive set. */
+export const EXPECTED_INTENT = 'ui-trivial';
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'wrong_intent_for_trivial',
+        trigger:
+            "state.ticket['intent'] is set and not equal to 'ui-trivial' " +
+            '— routing landed on this set by mistake',
+        resolution:
+            'abort and re-run with the correct directive_set ' +
+            "(populate_routing should select 'ui' or 'backend' instead)",
+    },
+];
+
+/**
+ * Python `repr()` for the scalar/JSON value kinds that reach the `{intent!r}`
+ * interpolation. Mirrors CPython: `None`, `True`/`False`, single-quoted
+ * strings (double-quoted only when the string contains a single quote and no
+ * double quote), numbers and everything else via `str`.
+ */
+function pyRepr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return pyStrRepr(value);
+    }
+    return String(value);
+}
+
+/** Python `str(value)` for the scalar kinds reaching the `{intent}` slot. */
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') {
+            body += '\\\\';
+        } else if (ch === quote) {
+            body += `\\${ch}`;
+        } else if (ch === '\n') {
+            body += '\\n';
+        } else if (ch === '\r') {
+            body += '\\r';
+        } else if (ch === '\t') {
+            body += '\\t';
+        } else {
+            body += ch;
+        }
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/**
+ * Confirm the ticket's intent matches the trivial path.
+ *
+ * The ticket's `intent` is optional on v0 callers; absence is treated as a
+ * silent pass since the v0 path predates intent classification. v1 callers
+ * always carry an intent — a mismatch means the dispatcher routed incorrectly
+ * and we halt loudly so the wiring bug surfaces before any edit happens.
+ */
+export function run(state: DeliveryState): StepResult {
+    const ticket = state.ticket ?? {};
+    const intent = ticket['intent'];
+    if (intent === undefined || intent === null || intent === EXPECTED_INTENT) {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            '> Routing error — the ``ui-trivial`` directive set was ' +
+                "selected but the ticket's intent is `" +
+                pyStr(intent) +
+                '`.',
+            '> 1. Reclassify — set `state.directive_set` from the ' +
+                'intent label and re-invoke the engine',
+            '> 2. Abort — drop this run',
+        ],
+        message:
+            `intent=${pyRepr(intent)} but directive_set='ui-trivial'; ` +
+            'routing must be reclassified before any edit',
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/report.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/report.ts
@@ -1,0 +1,112 @@
+/**
+ * `report` step — one-line delivery summary for the trivial path.
+ *
+ * TypeScript twin of `directives/ui_trivial/report.py` (ADR-094 py2ts).
+ * Public API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The trivial summary captures what the operator needs: which file, how many
+ * lines, what the edit did, and the smoke verdict. The step is pure and
+ * deterministic: reads `DeliveryState`, writes `state.report`, always returns
+ * `SUCCESS`.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+} from '../../delivery_state.js';
+
+/** Pure render — no blocked paths. */
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [];
+
+/**
+ * Python truthiness for the values reached here: empty string / empty array /
+ * empty object / 0 / false / null / undefined are falsy.
+ */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) {
+        return false;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value).length > 0;
+    }
+    return true;
+}
+
+/** Python `str(value)` for the `{lines}` interpolation. */
+function pyStr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    return String(value);
+}
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Render the one-line trivial summary into `state.report`. */
+export function run(state: DeliveryState): StepResult {
+    state.report = _render(state);
+    return new StepResult({ outcome: Outcome.SUCCESS });
+}
+
+function _render(state: DeliveryState): string {
+    const change = _last_trivial_change(state);
+    if (change === null) {
+        return '_(trivial UI edit — no change recorded)_';
+    }
+
+    const filesRaw = change['files'];
+    const files = _pyTruthy(filesRaw) ? filesRaw : [];
+    const lines = 'lines_changed' in change ? change['lines_changed'] : 0;
+    const summaryRaw = change['summary'];
+    const summary = (_pyTruthy(summaryRaw) ? String(summaryRaw) : 'trivial UI edit').trim();
+    const file_str =
+        Array.isArray(files) && files.length === 1
+            ? pyStr((files as Any[])[0])
+            : `${Array.isArray(files) ? files.length : 0} files`;
+    const verdict = _smoke_verdict(state);
+    const verdict_str = verdict ? ` — smoke: **${verdict}**` : '';
+    return `**Trivial edit:** ${summary} (\`${file_str}\`, ${pyStr(lines)} lines)${verdict_str}`;
+}
+
+function _last_trivial_change(state: DeliveryState): Record<string, Any> | null {
+    const changes = _pyTruthy(state.changes) ? state.changes : [];
+    for (let i = changes.length - 1; i >= 0; i -= 1) {
+        const change = changes[i];
+        if (_isDict(change) && change['kind'] === 'ui-trivial') {
+            return change;
+        }
+    }
+    return null;
+}
+
+function _smoke_verdict(state: DeliveryState): string {
+    const tests = state.tests;
+    if (_isDict(tests)) {
+        const verdict = tests['verdict'];
+        if (typeof verdict === 'string') {
+            return verdict;
+        }
+    }
+    return '';
+}

--- a/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/test.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/test.ts
@@ -1,0 +1,164 @@
+/**
+ * `test` step — smoke-test delegate for the `ui-trivial` set.
+ *
+ * TypeScript twin of `directives/ui_trivial/test.py` (ADR-094 py2ts). Public
+ * API names stay snake_case to mirror the Python module 1:1.
+ *
+ * The trivial path runs "apply + smoke-test only". The handler is the smaller
+ * cousin of `backend.test`: same verdict contract on `state.tests`, narrower
+ * scope on the agent directive. `failed` / `mixed` verdicts halt with the
+ * verdict echoed back; `success` flows through.
+ */
+import {
+    type Any,
+    type DeliveryState,
+    Outcome,
+    StepResult,
+    agent_directive,
+} from '../../delivery_state.js';
+
+const _ALLOWED_VERDICTS: ReadonlyArray<string> = ['success', 'failed', 'mixed'];
+
+export const AMBIGUITIES: ReadonlyArray<Record<string, string>> = [
+    {
+        code: 'empty_tests_delegate',
+        trigger: '`state.tests` empty — smoke runner not invoked yet',
+        resolution:
+            'agent directive `run-tests scope=smoke` → ' +
+            '`/tests-execute` (narrowest layer covering the touched file)',
+    },
+    {
+        code: 'malformed_tests',
+        trigger:
+            '`state.tests` is not a dict or `verdict` is not one of ' +
+            'success / failed / mixed',
+        resolution: 're-run smoke and record a clean verdict',
+    },
+    {
+        code: 'bad_test_verdict',
+        trigger: "`state.tests['verdict']` is `failed` or `mixed`",
+        resolution: 'fix the regression and re-run, or abort',
+    },
+];
+
+function _isDict(value: Any): value is Record<string, Any> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python truthiness for `if not tests`. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined) return false;
+    if (typeof value === 'string') return value.length > 0;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    return true;
+}
+
+/** Python `type(x).__name__` for the dict/non-dict diagnostic. */
+function _pyTypeName(value: Any): string {
+    if (value === null || value === undefined) return 'NoneType';
+    if (typeof value === 'boolean') return 'bool';
+    if (typeof value === 'number') {
+        return Number.isInteger(value) ? 'int' : 'float';
+    }
+    if (typeof value === 'string') return 'str';
+    if (Array.isArray(value)) return 'list';
+    return 'dict';
+}
+
+/** Python `repr()` for the verdict value (`{verdict!r}`). */
+function pyRepr(value: Any): string {
+    if (value === null || value === undefined) return 'None';
+    if (value === true) return 'True';
+    if (value === false) return 'False';
+    if (typeof value === 'string') return pyStrRepr(value);
+    return String(value);
+}
+
+function pyStrRepr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const quote = hasSingle && !hasDouble ? '"' : "'";
+    let body = '';
+    for (const ch of s) {
+        if (ch === '\\') body += '\\\\';
+        else if (ch === quote) body += `\\${ch}`;
+        else if (ch === '\n') body += '\\n';
+        else if (ch === '\r') body += '\\r';
+        else if (ch === '\t') body += '\\t';
+        else body += ch;
+    }
+    return `${quote}${body}${quote}`;
+}
+
+/** Python `repr()` of the `_ALLOWED_VERDICTS` tuple, for `{_ALLOWED_VERDICTS}`. */
+function _allowedVerdictsRepr(): string {
+    return `(${_ALLOWED_VERDICTS.map((v) => pyStrRepr(v)).join(', ')})`;
+}
+
+/** Gate the smoke verdict; delegate when `state.tests` is empty. */
+export function run(state: DeliveryState): StepResult {
+    const tests = state.tests;
+    if (!_pyTruthy(tests)) {
+        return _delegate();
+    }
+
+    if (!_isDict(tests)) {
+        return _malformed(`state.tests is ${_pyTypeName(tests)}, expected dict`);
+    }
+
+    const verdict = tests['verdict'];
+    if (typeof verdict !== 'string' || !_ALLOWED_VERDICTS.includes(verdict)) {
+        return _malformed(
+            `state.tests['verdict']=${pyRepr(verdict)} not in ${_allowedVerdictsRepr()}`,
+        );
+    }
+
+    if (verdict === 'success') {
+        return new StepResult({ outcome: Outcome.SUCCESS });
+    }
+
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Smoke test verdict: **${verdict}** — trivial edit may ` +
+                'have regressed the touched surface.',
+            '> 1. Investigate — read failures, fix, re-run smoke',
+            '> 2. Reclassify — promote to `ui-improve` if the regression ' +
+                'indicates the edit was less trivial than assumed',
+            '> 3. Abort — revert the edit',
+        ],
+        message: `smoke verdict=${verdict} on trivial edit`,
+    });
+}
+
+function _delegate(): StepResult {
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            agent_directive('run-tests', { scope: 'smoke' }),
+            '> Trivial edit applied; run the smoke test layer covering ' +
+                'the touched file.',
+            '> 1. Continue — invoke `/tests-execute` with smoke scope, ' +
+                'then write the verdict back to `state.tests`',
+            '> 2. Skip — record `state.tests = {"verdict": "success", ' +
+                '"scope": "none"}` (logged as a deferred verification)',
+            '> 3. Abort — drop this run',
+        ],
+        message: 'smoke run not yet invoked',
+    });
+}
+
+function _malformed(detail: string): StepResult {
+    return new StepResult({
+        outcome: Outcome.BLOCKED,
+        questions: [
+            `> Malformed test envelope: ${detail}.`,
+            '> 1. Re-run smoke — produce a clean verdict',
+            '> 2. Abort — drop this run',
+        ],
+        message: detail,
+    });
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/_chat_history_base.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/_chat_history_base.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared plumbing for chat-history hooks.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/_chat_history_base.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Subprocess-driven
+ * so the work-engine package stays decoupled from `scripts/chat_history.py`'s
+ * internals. The `runner` injection point is the test seam — production passes
+ * the default runner, tests pass a fake.
+ */
+import { spawnSync } from 'node:child_process';
+import * as process from 'node:process';
+
+/**
+ * Subset of Python's `subprocess.CompletedProcess[str]` the hooks read:
+ * the return code plus the captured streams.
+ */
+export interface CompletedProcess {
+    returncode: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Callable that runs a subprocess. Production default: {@link _default_runner}. */
+export type ProcessRunner = (cmd: string[]) => CompletedProcess;
+
+export const EXIT_OK = 0;
+export const EXIT_MISSING = 10;
+export const EXIT_FOREIGN = 11;
+export const EXIT_RETURNING = 12;
+
+export function _default_runner(cmd: string[]): CompletedProcess {
+    const [program, ...args] = cmd;
+    const proc = spawnSync(program as string, args, {
+        encoding: 'utf8',
+    });
+    return {
+        // `null` status (signal/spawn failure) maps to a non-OK code.
+        returncode: proc.status === null ? -1 : proc.status,
+        stdout: proc.stdout ?? '',
+        stderr: proc.stderr ?? '',
+    };
+}
+
+/**
+ * Shared plumbing — script path and runner.
+ *
+ * Schema v4 derives session attribution from the platform `session_id`,
+ * not from a derived first-user-msg. work-engine internal hooks have no
+ * platform session in scope, so they omit `--session-id` and entries land
+ * in the `<unknown>` session bucket.
+ */
+export class _ChatHistoryHookBase {
+    readonly script_path: string;
+    private readonly _runner: ProcessRunner;
+
+    constructor(script_path: string, options: { runner?: ProcessRunner | null } = {}) {
+        this.script_path = script_path;
+        this._runner = options.runner ?? _default_runner;
+    }
+
+    protected _invoke(...args: string[]): CompletedProcess {
+        // `sys.executable` → the active interpreter; here `python3`.
+        const cmd = ['python3', this.script_path, ...args];
+        void process; // imported for parity with Python's `sys` usage.
+        return this._runner(cmd);
+    }
+}
+
+/** Python `getattr(obj, name, default)` for a duck-typed object. */
+export function _getattr(obj: unknown, name: string, dflt: unknown): unknown {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, unknown>)[name];
+    }
+    return dflt;
+}
+
+/**
+ * Python `json.dumps(obj)` with default separators (`", "`, `": "`) and
+ * `ensure_ascii=True`. Covers the simple `{"step": str}` /
+ * `{"step": str, "questions": [str, …]}` payloads the chat-history hooks
+ * build: strings, numbers, booleans, null, arrays, and plain objects in
+ * insertion order.
+ */
+export function _pyJsonDumps(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return String(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStrAscii(value);
+    }
+    if (Array.isArray(value)) {
+        return `[${value.map((v) => _pyJsonDumps(v)).join(', ')}]`;
+    }
+    if (typeof value === 'object') {
+        const obj = value as Record<string, unknown>;
+        const items = Object.keys(obj).map((k) => `${_jsonStrAscii(k)}: ${_pyJsonDumps(obj[k])}`);
+        return `{${items.join(', ')}}`;
+    }
+    return _jsonStrAscii(String(value));
+}
+
+/** Python `json.dumps(s, ensure_ascii=True)` for a single string. */
+function _jsonStrAscii(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (code < 0x20) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else if (code < 0x7f) {
+            out += ch;
+        } else if (code <= 0xffff) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            const c = code - 0x10000;
+            const hi = 0xd800 + (c >> 10);
+            const lo = 0xdc00 + (c & 0x3ff);
+            out += `\\u${hi.toString(16).padStart(4, '0')}\\u${lo.toString(16).padStart(4, '0')}`;
+        }
+    }
+    return `${out}"`;
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_append.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_append.ts
@@ -1,0 +1,41 @@
+/**
+ * `ChatHistoryAppendHook` — phase-boundary persistence.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/chat_history_append.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on
+ * `after_step`. Appends a `--type phase` entry whenever a step closed with
+ * `Outcome.SUCCESS`. Failures bubble up as {@link HookError} so the runner
+ * converts them to warnings — append errors must not break the main flow.
+ */
+import { Outcome } from '../../delivery_state.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+import { EXIT_OK, _ChatHistoryHookBase, _getattr, _pyJsonDumps } from './_chat_history_base.js';
+
+/** Arbitrary value, mirroring the Python `Any` payload values. */
+type Any = unknown;
+
+/** Append a phase-boundary entry after every successful step. */
+export class ChatHistoryAppendHook extends _ChatHistoryHookBase {
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.AFTER_STEP, (ctx) => this._on_after_step(ctx));
+    }
+
+    private _on_after_step(ctx: HookContext): void {
+        const result = ctx.result;
+        if (
+            result === null ||
+            result === undefined ||
+            _getattr(result, 'outcome', null) !== Outcome.SUCCESS
+        ) {
+            return;
+        }
+        const payload: Record<string, Any> = { step: ctx.step_name || '<unknown>' };
+        const proc = this._invoke('append', '--type', 'phase', '--json', _pyJsonDumps(payload));
+        if (proc.returncode !== EXIT_OK) {
+            throw new HookError(`chat-history append failed (exit ${proc.returncode})`);
+        }
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_halt_append.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_halt_append.ts
@@ -1,0 +1,89 @@
+/**
+ * `ChatHistoryHaltAppendHook` — capture halt surfaces in the log.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/chat_history_halt_append.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on `on_halt`.
+ * Records a `--type decision` entry with the step name and any pending
+ * questions so a fresh chat can resume from the persisted log alone.
+ */
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+import { EXIT_OK, _ChatHistoryHookBase, _getattr, _pyJsonDumps } from './_chat_history_base.js';
+
+/** Arbitrary value, mirroring the Python `Any` payload values. */
+type Any = unknown;
+
+/** Append a decision entry whenever a step halts. */
+export class ChatHistoryHaltAppendHook extends _ChatHistoryHookBase {
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.ON_HALT, (ctx) => this._on_halt(ctx));
+    }
+
+    private _on_halt(ctx: HookContext): void {
+        let questions: string[] = [];
+        if (ctx.result !== null && ctx.result !== undefined) {
+            questions = _pyList(_pyOr(_getattr(ctx.result, 'questions', []), []));
+        }
+        if (questions.length === 0 && ctx.delivery !== null && ctx.delivery !== undefined) {
+            questions = _pyList(_pyOr(_getattr(ctx.delivery, 'questions', []), []));
+        }
+        const payload: Record<string, Any> = {
+            step: ctx.step_name || '<unknown>',
+            questions,
+        };
+        const proc = this._invoke('append', '--type', 'decision', '--json', _pyJsonDumps(payload));
+        if (proc.returncode !== EXIT_OK) {
+            throw new HookError(`chat-history halt-append failed (exit ${proc.returncode})`);
+        }
+    }
+}
+
+/** Python `a or b`. */
+function _pyOr(a: Any, b: Any): Any {
+    return _pyTruthy(a) ? a : b;
+}
+
+/** Python `list(x)` for the iterable shapes `questions` can be. */
+function _pyList(x: Any): string[] {
+    if (x === null || x === undefined) {
+        return [];
+    }
+    if (Array.isArray(x)) {
+        return [...x] as string[];
+    }
+    if (typeof x === 'string') {
+        return [...x];
+    }
+    if (typeof (x as { [Symbol.iterator]?: unknown })[Symbol.iterator] === 'function') {
+        return [...(x as Iterable<string>)];
+    }
+    return [];
+}
+
+/** Python `bool(x)` truthiness for the list / falsy shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_gate.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_gate.ts
@@ -1,0 +1,192 @@
+/**
+ * `DecisionGateHook` — refuse to advance when an opt-in gate fires.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/decision_gate.py` (ADR-094
+ * py2ts — work_engine.hooks.builtin subpackage). Bridges
+ * `work_engine/scoring/decision_engine` into the dispatcher hook bus. Reads
+ * the gate config from {@link DecisionEngineSettings} and fires on
+ * `AFTER_STEP` only for the phase each gate owns.
+ *
+ * Three actions, mapped 1:1 from `evaluate_gates`:
+ *
+ * - `stop`        → throw {@link HookHalt} with a numbered-option surface.
+ * - `warn`        → throw {@link HookError} so the runner logs the reason.
+ * - `ask_timeout` → non-interactive context; apply `on_block_fallback` and
+ *                   re-resolve to `stop` or `warn`.
+ * - `ask`         → interactive context; collapses to `stop` with the prompt
+ *                   surface for the CLI integration.
+ *
+ * Default-off: when `settings.decision_engine` is `null` or every gate is
+ * `off` the hook short-circuits without examining state.
+ */
+import {
+    DecisionEngineSettings,
+    GateDecision,
+    evaluate_gates,
+} from '../../scoring/decision_engine.js';
+import {
+    derive_confidence_band,
+    derive_risk_class,
+    summarise_memory,
+    summarise_verify,
+} from '../../scoring/decision_trace.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError, HookHalt } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+const _BLOCK_REASON_PREFIX = 'decision_gate';
+
+/**
+ * Evaluate decision-engine gates on every `AFTER_STEP`.
+ *
+ * The hook stores `settings` as a frozen reference; tests pass a fresh
+ * instance per scenario.
+ */
+export class DecisionGateHook {
+    private readonly _settings: DecisionEngineSettings;
+
+    constructor(settings: DecisionEngineSettings) {
+        this._settings = settings;
+    }
+
+    /** Register the gate callback on `AFTER_STEP`. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.AFTER_STEP, (ctx) => this._evaluate(ctx));
+    }
+
+    // -- lifecycle callback ------------------------------------------
+
+    private _evaluate(ctx: HookContext): void {
+        if (!this._settings.any_gate_active) {
+            return;
+        }
+        const phase = ctx.step_name;
+        if (!phase) {
+            return;
+        }
+        const delivery = ctx.delivery;
+        const memory = summarise_memory(_getattr(delivery, 'memory', null));
+        const verify = summarise_verify(_getattr(delivery, 'verify', null));
+        const ambiguity = _pyTruthy(_getattr(delivery, 'questions', null));
+        const decision = evaluate_gates(this._settings, {
+            phase,
+            confidence_band: derive_confidence_band({
+                memory_hits: memory['hits'] as number,
+                verify_claims: verify['claims'] as number,
+                verify_first_try_passes: verify['first_try_passes'] as number,
+                ambiguity_flag: ambiguity,
+            }),
+            risk_class: derive_risk_class(_getattr(delivery, 'changes', null)),
+            memory_hits: memory['hits'] as number,
+        });
+        if (decision === null) {
+            return;
+        }
+        this._apply(decision);
+    }
+
+    // -- action dispatch ----------------------------------------------
+
+    private _apply(decision: GateDecision): void {
+        const action = decision.action;
+        if (action === 'warn') {
+            throw new HookError(DecisionGateHook._format_reason(decision));
+        }
+        if (action === 'ask_timeout') {
+            const fallback = this._settings.on_block_fallback;
+            if (fallback === 'warn') {
+                throw new HookError(
+                    DecisionGateHook._format_reason(decision, 'ask_timeout'),
+                );
+            }
+            throw new HookHalt(
+                `${_BLOCK_REASON_PREFIX}:${decision.gate_id}:ask_timeout`,
+                DecisionGateHook._surface(decision, 'ask_timeout'),
+            );
+        }
+        throw new HookHalt(
+            `${_BLOCK_REASON_PREFIX}:${decision.gate_id}`,
+            DecisionGateHook._surface(decision),
+        );
+    }
+
+    // -- formatting helpers -------------------------------------------
+
+    private static _format_reason(decision: GateDecision, suffix = ''): string {
+        let tag = `${_BLOCK_REASON_PREFIX}:${decision.gate_id}`;
+        if (suffix) {
+            tag = `${tag}:${suffix}`;
+        }
+        return `${tag} — ${decision.reason}`;
+    }
+
+    private static _surface(decision: GateDecision, suffix = ''): string[] {
+        let header = `Decision-engine gate fired: ${decision.gate_id} (phase=${decision.phase})`;
+        if (suffix) {
+            header = `${header} [${suffix}]`;
+        }
+        return [
+            header,
+            `Reason: ${decision.reason}`,
+            '1) Address the gate condition and resume.',
+            '2) Lower the gate in `.agent-settings.yml` ' + '(`decision_engine` block) and resume.',
+            '3) Abort the run.',
+        ];
+    }
+}
+
+/**
+ * Construct the hook from a {@link DecisionEngineSettings}-like object.
+ * Returns `null` when the config is absent or every gate is `off`; the
+ * bootstrap layer then skips registration entirely.
+ */
+export function build_decision_gate_hook(settings: Any): DecisionGateHook | null {
+    if (settings === null || settings === undefined) {
+        return null;
+    }
+    if (!(settings instanceof DecisionEngineSettings)) {
+        return null;
+    }
+    if (!settings.any_gate_active) {
+        return null;
+    }
+    return new DecisionGateHook(settings);
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the shapes `questions` can take. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_trace.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_trace.ts
@@ -1,0 +1,304 @@
+/**
+ * `DecisionTraceHook` — emit a decision-trace JSON per phase.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/decision_trace.py` (ADR-094
+ * py2ts — work_engine.hooks.builtin subpackage). Implements the v1 envelope
+ * from `docs/contracts/decision-trace-v1.md`. Default-off; opt-in via
+ * `.agent-settings.yml` `decision_engine.surface_traces: true`.
+ *
+ * The hook is purely observational — it never mutates `DeliveryState`, never
+ * raises terminal errors. Stream / disk failures surface as {@link HookError}
+ * (non-fatal per the three-tier contract).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+    derive_confidence_band,
+    derive_risk_class,
+    summarise_memory,
+    summarise_verify,
+} from '../../scoring/decision_trace.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+export const SCHEMA_VERSION = 1;
+const _MAX_MEMORY_IDS = 32;
+
+/**
+ * Emit one decision-trace JSON file per dispatcher step.
+ *
+ * `output_dir` is an optional override for the trace destination. When
+ * `null` the hook writes alongside the WorkState file: if the state file
+ * sits under `agents/runtime/state/work/<id>/state.json` the trace lands at
+ * `agents/runtime/state/work/<id>/decision-trace-<phase>.json`; otherwise the
+ * trace lands next to the state file as `<stem>.decision-trace-<phase>.json`.
+ */
+export class DecisionTraceHook {
+    private readonly _output_dir: string | null;
+    private _state_file: string | null = null;
+    private _step_started: Map<string, number> = new Map();
+
+    constructor(output_dir: string | null = null) {
+        this._output_dir = output_dir;
+    }
+
+    /** Register the trace callbacks on the lifecycle events used. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.BEFORE_LOAD, (ctx) => this._capture_state_file(ctx));
+        registry.register(HookEvent.AFTER_LOAD, (ctx) => this._capture_state_file(ctx));
+        registry.register(HookEvent.BEFORE_STEP, (ctx) => this._mark_step_start(ctx));
+        registry.register(HookEvent.AFTER_STEP, (ctx) => this._emit_trace(ctx));
+    }
+
+    // -- lifecycle callbacks ------------------------------------------
+
+    private _capture_state_file(ctx: HookContext): void {
+        if (ctx.state_file !== null && ctx.state_file !== undefined) {
+            this._state_file = String(ctx.state_file);
+        }
+    }
+
+    private _mark_step_start(ctx: HookContext): void {
+        if (ctx.step_name) {
+            this._step_started.set(ctx.step_name, _time());
+        }
+    }
+
+    private _emit_trace(ctx: HookContext): void {
+        if (!ctx.step_name) {
+            return;
+        }
+        let started: number;
+        if (this._step_started.has(ctx.step_name)) {
+            started = this._step_started.get(ctx.step_name) as number;
+            this._step_started.delete(ctx.step_name);
+        } else {
+            started = _time();
+        }
+        const envelope = this._build_envelope(ctx, started);
+        const target = this._target_path(ctx.step_name);
+        try {
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, _pyJsonDumpsIndent2(envelope) + '\n', { encoding: 'utf-8' });
+        } catch (exc) {
+            throw new HookError(`decision-trace write failed: ${_osErr(exc)}`);
+        }
+    }
+
+    // -- envelope construction ----------------------------------------
+
+    private _build_envelope(ctx: HookContext, started: number): Record<string, Any> {
+        const delivery = ctx.delivery;
+        const memory = summarise_memory(_getattr(delivery, 'memory', null), { limit: _MAX_MEMORY_IDS });
+        const verify = summarise_verify(_getattr(delivery, 'verify', null));
+        const ambiguity = _pyTruthy(_getattr(delivery, 'questions', null));
+        return {
+            schema_version: SCHEMA_VERSION,
+            work_id: this._work_id(),
+            phase: ctx.step_name,
+            started_at: _iso_utc(started),
+            ended_at: _iso_utc(_time()),
+            confidence_band: derive_confidence_band({
+                memory_hits: memory['hits'] as number,
+                verify_claims: verify['claims'] as number,
+                verify_first_try_passes: verify['first_try_passes'] as number,
+                ambiguity_flag: ambiguity,
+            }),
+            risk_class: derive_risk_class(_getattr(delivery, 'changes', null)),
+            rules: [],
+            memory,
+            verify,
+        };
+    }
+
+    // -- path helpers --------------------------------------------------
+
+    private _work_id(): string {
+        if (this._state_file === null) {
+            return 'unknown';
+        }
+        const parent = path.dirname(this._state_file);
+        const parentName = path.basename(parent);
+        const grandName = path.basename(path.dirname(parent));
+        if (parentName && grandName === 'work') {
+            return parentName;
+        }
+        return _stem(this._state_file);
+    }
+
+    private _target_path(phase: string): string {
+        const filename = `decision-trace-${phase}.json`;
+        if (this._output_dir !== null) {
+            return path.join(this._output_dir, filename);
+        }
+        if (this._state_file === null) {
+            return filename;
+        }
+        const parent = path.dirname(this._state_file);
+        const parentName = path.basename(parent);
+        const grandName = path.basename(path.dirname(parent));
+        if (parentName && grandName === 'work') {
+            return path.join(parent, filename);
+        }
+        return path.join(parent, `${_stem(this._state_file)}.${filename}`);
+    }
+}
+
+/** `time.time()` — epoch seconds (float). */
+function _time(): number {
+    return Date.now() / 1000;
+}
+
+/** Python `Path.stem` — filename without its final suffix. */
+function _stem(p: string): string {
+    const base = path.basename(p);
+    const dot = base.lastIndexOf('.');
+    // Python `.stem`: drop the final extension; a leading dot is not a suffix.
+    if (dot <= 0) {
+        return base;
+    }
+    return base.slice(0, dot);
+}
+
+/** `datetime.fromtimestamp(epoch, tz=utc).strftime("%Y-%m-%dT%H:%M:%SZ")`. */
+function _iso_utc(epoch: number): string {
+    const d = new Date(epoch * 1000);
+    const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+    return (
+        `${pad(d.getUTCFullYear(), 4)}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
+        `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`
+    );
+}
+
+/** Render an `OSError`-like value the way `str(exc)` would for the message. */
+function _osErr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the `questions` shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/**
+ * Python `json.dumps(obj, indent=2, sort_keys=False)` (ensure_ascii=True).
+ * Insertion-ordered keys, 2-space indent, `\uXXXX`-escaped non-ASCII.
+ */
+function _pyJsonDumpsIndent2(value: Any): string {
+    return _dumpsIndent(value, 0);
+}
+
+function _dumpsIndent(value: Any, depth: number): string {
+    const pad = ' '.repeat(2 * (depth + 1));
+    const closePad = ' '.repeat(2 * depth);
+    if (value === null || value === undefined) {
+        return 'null';
+    }
+    if (typeof value === 'boolean') {
+        return value ? 'true' : 'false';
+    }
+    if (typeof value === 'number') {
+        return _jsonNum(value);
+    }
+    if (typeof value === 'string') {
+        return _jsonStrAscii(value);
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+        const items = value.map((v) => pad + _dumpsIndent(v, depth + 1));
+        return `[\n${items.join(',\n')}\n${closePad}]`;
+    }
+    if (typeof value === 'object') {
+        const obj = value as Record<string, Any>;
+        const keys = Object.keys(obj);
+        if (keys.length === 0) {
+            return '{}';
+        }
+        const items = keys.map((k) => `${pad}${_jsonStrAscii(k)}: ${_dumpsIndent(obj[k], depth + 1)}`);
+        return `{\n${items.join(',\n')}\n${closePad}}`;
+    }
+    return _jsonStrAscii(String(value));
+}
+
+/** Python `json.dumps` number formatting (integers without `.0`). */
+function _jsonNum(n: number): string {
+    if (Number.isInteger(n)) {
+        return String(n);
+    }
+    return String(n);
+}
+
+/** Python `json.dumps(s, ensure_ascii=True)` for a single string. */
+function _jsonStrAscii(s: string): string {
+    let out = '"';
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '"') {
+            out += '\\"';
+        } else if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (ch === '\b') {
+            out += '\\b';
+        } else if (ch === '\f') {
+            out += '\\f';
+        } else if (code < 0x20) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else if (code < 0x7f) {
+            out += ch;
+        } else if (code <= 0xffff) {
+            out += `\\u${code.toString(16).padStart(4, '0')}`;
+        } else {
+            const c = code - 0x10000;
+            const hi = 0xd800 + (c >> 10);
+            const lo = 0xdc00 + (c & 0x3ff);
+            out += `\\u${hi.toString(16).padStart(4, '0')}\\u${lo.toString(16).padStart(4, '0')}`;
+        }
+    }
+    return `${out}"`;
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/directive_set_guard.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/directive_set_guard.ts
@@ -1,0 +1,110 @@
+/**
+ * `DirectiveSetGuardHook` — catch CLI / state directive-set drift.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/directive_set_guard.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on
+ * `HookEvent.BEFORE_DISPATCH`. Compares the resolved `set_name` against the
+ * `directive_set` field on the persisted `WorkState`. Mismatch →
+ * {@link HookError} (non-fatal: the runner warns), so a flow that silently
+ * re-dispatches under a different set surfaces the drift before any step runs.
+ *
+ * The guard is read-only. It does not rewrite `state.directive_set`.
+ */
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/** Asserts `set_name` matches `state.directive_set` on dispatch. */
+export class DirectiveSetGuardHook {
+    /** Register on `HookEvent.BEFORE_DISPATCH`. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.BEFORE_DISPATCH, (ctx) => this._guard(ctx));
+    }
+
+    private _guard(ctx: HookContext): void {
+        const set_name = ctx.set_name;
+        const work = ctx.work;
+        if (set_name === null || set_name === undefined || work === null || work === undefined) {
+            // `before_dispatch` always carries both refs per the context
+            // surface; missing means a hook-bug, not drift.
+            throw new HookError(
+                'directive-set guard: missing set_name or work on ' +
+                    `before_dispatch (set_name=${_pyRepr(set_name)}, work=${_pyRepr(work)})`,
+            );
+        }
+
+        const persisted = _getattr(work, 'directive_set', null);
+        if (persisted === null || persisted === undefined) {
+            // Legacy v0 envelopes have no `directive_set` field; the guard is
+            // a no-op for those — nothing to compare.
+            return;
+        }
+
+        if (persisted !== set_name) {
+            throw new HookError(
+                'directive-set drift: CLI resolved ' +
+                    `${_pyRepr(set_name)} but state carries ${_pyRepr(persisted)}`,
+            );
+        }
+    }
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/**
+ * Python `repr(x)` for the scalar shapes the guard formats. `None` →
+ * `None`; `str` → single-quoted (switching to double quotes only when the
+ * string contains a single quote but no double quote, matching CPython).
+ */
+function _pyRepr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return _reprStr(value);
+    }
+    return String(value);
+}
+
+function _reprStr(s: string): string {
+    const hasSingle = s.includes("'");
+    const hasDouble = s.includes('"');
+    const useDouble = hasSingle && !hasDouble;
+    const quote = useDouble ? '"' : "'";
+    let out = quote;
+    for (const ch of s) {
+        const code = ch.codePointAt(0) as number;
+        if (ch === '\\') {
+            out += '\\\\';
+        } else if (ch === quote) {
+            out += `\\${quote}`;
+        } else if (ch === '\n') {
+            out += '\\n';
+        } else if (ch === '\r') {
+            out += '\\r';
+        } else if (ch === '\t') {
+            out += '\\t';
+        } else if (code < 0x20 || code === 0x7f) {
+            out += `\\x${code.toString(16).padStart(2, '0')}`;
+        } else {
+            out += ch;
+        }
+    }
+    return out + quote;
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/halt_surface_audit.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/halt_surface_audit.ts
@@ -1,0 +1,118 @@
+/**
+ * `HaltSurfaceAuditHook` — defense-in-depth around halt surfaces.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/halt_surface_audit.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on `on_halt`
+ * and re-asserts that every halt carries a non-empty user-facing surface,
+ * mirroring the dispatcher's `_validate_step_result`.
+ *
+ * Pure observability: emits {@link HookError} (non-fatal) when the surface is
+ * empty. The runner converts it to a warning so the violation is visible.
+ */
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/** Asserts that every halt carries a non-empty user-facing surface. */
+export class HaltSurfaceAuditHook {
+    /** Register on `HookEvent.ON_HALT` only. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.ON_HALT, (ctx) => this._audit(ctx));
+    }
+
+    private _audit(ctx: HookContext): void {
+        const result = ctx.result;
+        if (result === null || result === undefined) {
+            // Hook-driven halts go through `_hook_halt_blocked` and may not
+            // carry a `StepResult` — the surface lives on `state.questions`
+            // instead. Audit that fallback too.
+            const questions = _getattr(ctx.delivery, 'questions', null);
+            if (!_pyTruthy(questions)) {
+                throw new HookError(
+                    `halt at step ${_pyRepr(ctx.step_name)} surfaced no questions ` +
+                        '(hook-driven halt with empty state.questions)',
+                );
+            }
+            return;
+        }
+
+        const questions = _getattr(result, 'questions', null);
+        if (!_pyTruthy(questions)) {
+            throw new HookError(
+                `halt at step ${_pyRepr(ctx.step_name)} surfaced no questions ` +
+                    '(StepResult.questions empty); the user has nothing to act on',
+            );
+        }
+    }
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the `questions` shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}
+
+/** Python `repr(x)` for `step_name` (a string or `None`). */
+function _pyRepr(value: Any): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (typeof value === 'string') {
+        const hasSingle = value.includes("'");
+        const hasDouble = value.includes('"');
+        const quote = hasSingle && !hasDouble ? '"' : "'";
+        let out = quote;
+        for (const ch of value) {
+            const code = ch.codePointAt(0) as number;
+            if (ch === '\\') {
+                out += '\\\\';
+            } else if (ch === quote) {
+                out += `\\${quote}`;
+            } else if (ch === '\n') {
+                out += '\\n';
+            } else if (ch === '\r') {
+                out += '\\r';
+            } else if (ch === '\t') {
+                out += '\\t';
+            } else if (code < 0x20 || code === 0x7f) {
+                out += `\\x${code.toString(16).padStart(2, '0')}`;
+            } else {
+                out += ch;
+            }
+        }
+        return out + quote;
+    }
+    return String(value);
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Concrete observability hooks shipped with the engine.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/__init__.py` (ADR-094 py2ts —
+ * work_engine.hooks.builtin subpackage). Phase 4 hooks: low-risk, default-off,
+ * observe-only. Each hook exposes a `register(registry)` method so the
+ * registry stays the single source of truth for event → callback wiring.
+ */
+export { ChatHistoryAppendHook } from './chat_history_append.js';
+export { ChatHistoryHaltAppendHook } from './chat_history_halt_append.js';
+export { DecisionGateHook, build_decision_gate_hook } from './decision_gate.js';
+export { DecisionTraceHook } from './decision_trace.js';
+export { DirectiveSetGuardHook } from './directive_set_guard.js';
+export { HaltSurfaceAuditHook } from './halt_surface_audit.js';
+export { MemoryVisibilityHook } from './memory_visibility.js';
+export { StateShapeValidationHook } from './state_shape_validation.js';
+export { TraceHook } from './trace.js';

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/memory_visibility.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/memory_visibility.ts
@@ -1,0 +1,161 @@
+/**
+ * `MemoryVisibilityHook` — emit the visibility line on save.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/memory_visibility.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Implements the
+ * producer side of `docs/contracts/memory-visibility-v1.md`: derive
+ * `asks/hits/ids` from `state.memory` and thread the rendered line into
+ * `state.report`.
+ *
+ * Fires on `before_save`. Default-off; opt-in via `.agent-settings.yml`. The
+ * hook is purely observational: failures surface as {@link HookError}
+ * (non-fatal per the three-tier contract).
+ */
+import { summarise_memory, summarise_verify } from '../../scoring/decision_trace.js';
+import {
+    DEFAULT_ASKED_TYPES,
+    compute_affected,
+    format_changed_decisions_block,
+    format_line,
+    should_emit,
+    summarise_visibility,
+} from '../../scoring/memory_visibility.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/**
+ * Thread the `🧠 Memory: <hits>/<asks> · ids=[…]` line into the report.
+ *
+ * `memory_cadence` is the `memory.cadence` cadence key. `visibility_off`
+ * mirrors `memory.visibility: off`. `asked_types` overrides the list of
+ * memory types treated as `asks` in the visibility line.
+ */
+export class MemoryVisibilityHook {
+    private readonly _memory_cadence: string;
+    private readonly _visibility_off: boolean;
+    private readonly _asked_types: readonly string[];
+
+    constructor(
+        options: {
+            memory_cadence?: string;
+            visibility_off?: boolean;
+            asked_types?: Iterable<string> | null;
+        } = {},
+    ) {
+        this._memory_cadence = options.memory_cadence ?? 'always';
+        this._visibility_off = options.visibility_off ?? false;
+        this._asked_types =
+            options.asked_types !== undefined && options.asked_types !== null
+                ? [...options.asked_types]
+                : DEFAULT_ASKED_TYPES;
+    }
+
+    /** Register the visibility-line emitter on `before_save`. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.BEFORE_SAVE, (ctx) => this._on_before_save(ctx));
+    }
+
+    private _on_before_save(ctx: HookContext): void {
+        const work = ctx.work;
+        if (work === null || work === undefined) {
+            return;
+        }
+        const memory = _getattr(work, 'memory', null);
+        const summary = summarise_visibility(memory, { asked_types: this._asked_types });
+        if (
+            !should_emit(summary, {
+                memory_cadence: this._memory_cadence,
+                visibility_off: this._visibility_off,
+            })
+        ) {
+            return;
+        }
+        const affected = this._derive_affected(work, memory);
+        const line = format_line(summary, { affected });
+        if (!line) {
+            return;
+        }
+        const block = format_changed_decisions_block(
+            (summary['ids'] as string[]) || [],
+            affected,
+        );
+        const existing = (_getattr(work, 'report', '') as string) || '';
+        const rendered = block === null ? line : `${line}\n\n${block}`;
+        if (existing.includes(line) && (block === null || existing.includes(block))) {
+            return;
+        }
+        const sep = existing ? '\n\n' : '';
+        try {
+            (work as Record<string, Any>)['report'] = `${existing}${sep}${rendered}`;
+        } catch (exc) {
+            throw new HookError('memory-visibility: state.report not writable');
+        }
+    }
+
+    /**
+     * Compute the closed-list `affected` keys for this work step. Returns
+     * `null` when memory was not consulted (hits == 0).
+     */
+    private _derive_affected(work: Any, memory: Any): string[] | null {
+        const memory_summary = summarise_memory(memory);
+        const verify_summary = summarise_verify(_getattr(work, 'verify', null));
+        const ambiguity = _pyTruthy(_getattr(work, 'questions', null));
+        return compute_affected({
+            memory_hits: memory_summary['hits'] as number,
+            verify_claims: verify_summary['claims'] as number,
+            verify_first_try_passes: verify_summary['first_try_passes'] as number,
+            ambiguity_flag: ambiguity,
+            changes: _getattr(work, 'changes', null),
+            applied_rules: _getattr(work, 'applied_rules', null) as string[] | null,
+            test_plan: _getattr(work, 'test_plan', null) as string[] | null,
+        });
+    }
+}
+
+/**
+ * Convenience helper: render the line directly from a memory list. Used by
+ * external callers that have a `memory` list but no {@link HookContext}.
+ * Returns `null` when `asks == 0`.
+ */
+export function derive_visibility(memory: Any): string | null {
+    return format_line(summarise_visibility(memory));
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `bool(x)` truthiness for the `questions` shapes seen here. */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/state_shape_validation.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/state_shape_validation.ts
@@ -1,0 +1,45 @@
+/**
+ * `StateShapeValidationHook` — round-trip the v1 envelope on load and save.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/state_shape_validation.py`
+ * (ADR-094 py2ts — work_engine.hooks.builtin subpackage). Fires on
+ * `AFTER_LOAD` and `BEFORE_SAVE`. For each event, serialises the live
+ * `WorkState` through `state.to_dict` and re-validates via `state.from_dict`.
+ * A `SchemaError` from either side is reported as a {@link HookError} so the
+ * runner warns and continues — observability, not a gate.
+ */
+import { SchemaError, type WorkState, from_dict, to_dict } from '../../state.js';
+import { HookContext } from '../context.js';
+import { HookEvent } from '../events.js';
+import { HookError } from '../exceptions.js';
+import { HookRegistry } from '../registry.js';
+
+/** Round-trips the loaded `WorkState` against the v1 schema. */
+export class StateShapeValidationHook {
+    /** Register on AFTER_LOAD and BEFORE_SAVE. */
+    register(registry: HookRegistry): void {
+        registry.register(HookEvent.AFTER_LOAD, (ctx) => this._validate(ctx));
+        registry.register(HookEvent.BEFORE_SAVE, (ctx) => this._validate(ctx));
+    }
+
+    private _validate(ctx: HookContext): void {
+        const work = ctx.work;
+        if (work === null || work === undefined) {
+            // Should not happen on AFTER_LOAD/BEFORE_SAVE; treat as a
+            // hook-side bug rather than swallow silently.
+            throw new HookError(
+                'state-shape validation: HookContext.work is None at ' +
+                    `event for state_file=${ctx.state_file === null ? 'None' : ctx.state_file}`,
+            );
+        }
+
+        try {
+            from_dict(to_dict(work as WorkState));
+        } catch (exc) {
+            if (exc instanceof SchemaError) {
+                throw new HookError(`state-shape validation failed: ${exc.message}`);
+            }
+            throw exc;
+        }
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/builtin/trace.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/builtin/trace.ts
@@ -1,0 +1,133 @@
+/**
+ * `TraceHook` — emit one stderr line per hook event.
+ *
+ * TypeScript twin of `work_engine/hooks/builtin/trace.py` (ADR-094 py2ts —
+ * work_engine.hooks.builtin subpackage). Registers on every `HookEvent`;
+ * output goes to a configurable stream (default `process.stderr`) so tests can
+ * capture it.
+ *
+ * Pure observability — never mutates context, never halts. A misbehaving sink
+ * raises {@link HookError}, which the runner swallows with a warning.
+ */
+import { HOOK_EVENTS, HookEvent } from '../events.js';
+import { HookContext } from '../context.js';
+import { HookError } from '../exceptions.js';
+import { HookCallback, HookRegistry } from '../registry.js';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/**
+ * Minimal write+flush sink, mirroring Python's `IO[str]`. `process.stderr`
+ * satisfies it; tests pass a string-collector.
+ */
+export interface TextStream {
+    write(s: string): unknown;
+    flush?(): void;
+}
+
+/** Stderr-trace hook for every lifecycle event. */
+export class TraceHook {
+    private readonly _stream: TextStream;
+    private readonly _prefix: string;
+
+    constructor(stream: TextStream | null = null, prefix = '[hook]') {
+        this._stream = stream !== null ? stream : process.stderr;
+        this._prefix = prefix;
+    }
+
+    /** Register the trace callback for every `HookEvent`. */
+    register(registry: HookRegistry): void {
+        for (const event of HOOK_EVENTS) {
+            registry.register(event, this._make_callback(event));
+        }
+    }
+
+    private _make_callback(event: HookEvent): HookCallback {
+        const _cb = (ctx: HookContext): void => {
+            try {
+                const line = this._format(event, ctx);
+                this._stream.write(line + '\n');
+                if (typeof this._stream.flush === 'function') {
+                    this._stream.flush();
+                }
+            } catch (exc) {
+                if (exc instanceof HookError) {
+                    throw exc;
+                }
+                // Mirror Python `except (OSError, ValueError)`: wrap stream
+                // failures as a non-fatal HookError; re-raise anything else.
+                throw new HookError(`trace stream unavailable: ${_errStr(exc)}`);
+            }
+        };
+        return _cb;
+    }
+
+    /**
+     * Build a one-line trace record.
+     *
+     * Format: `[hook] event=<name> step=<step> set=<set> outcome=<o>`.
+     * Missing fields are skipped so the line stays short on events that only
+     * carry a subset of the context.
+     */
+    private _format(event: HookEvent, ctx: HookContext): string {
+        const parts: string[] = [this._prefix, `event=${event}`];
+        if (ctx.step_name) {
+            parts.push(`step=${ctx.step_name}`);
+        }
+        if (ctx.set_name) {
+            parts.push(`set=${ctx.set_name}`);
+        }
+        if (ctx.result !== null && ctx.result !== undefined) {
+            const outcome = _getattr(ctx.result, 'outcome', null);
+            if (outcome !== null && outcome !== undefined) {
+                parts.push(`outcome=${_valueOf(outcome)}`);
+            }
+        }
+        if (ctx.final !== null && ctx.final !== undefined) {
+            parts.push(`final=${_valueOf(ctx.final)}`);
+        }
+        if (ctx.halting) {
+            parts.push(`halting=${ctx.halting}`);
+        }
+        if (ctx.exception !== null && ctx.exception !== undefined) {
+            parts.push(`exception=${_typeName(ctx.exception)}`);
+        }
+        return parts.join(' ');
+    }
+}
+
+/** Python `getattr(obj, name, default)`. */
+function _getattr(obj: Any, name: string, dflt: Any): Any {
+    if (obj !== null && typeof obj === 'object' && name in (obj as object)) {
+        return (obj as Record<string, Any>)[name];
+    }
+    return dflt;
+}
+
+/** Python `getattr(x, "value", x)` — enum value if present, else the value. */
+function _valueOf(x: Any): string {
+    if (x !== null && typeof x === 'object' && 'value' in (x as object)) {
+        return String((x as Record<string, Any>)['value']);
+    }
+    return String(x);
+}
+
+/** Python `type(exc).__name__`. */
+function _typeName(exc: Any): string {
+    if (exc instanceof Error) {
+        return exc.constructor.name;
+    }
+    if (exc !== null && exc !== undefined && typeof exc === 'object') {
+        return (exc as { constructor?: { name?: string } }).constructor?.name ?? 'object';
+    }
+    return typeof exc;
+}
+
+/** `str(exc)` for the wrapped-sink-failure message. */
+function _errStr(exc: unknown): string {
+    if (exc instanceof Error) {
+        return exc.message;
+    }
+    return String(exc);
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/context.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/context.ts
@@ -1,0 +1,94 @@
+/**
+ * `HookContext` — payload carried into every hook callback.
+ *
+ * TypeScript twin of `work_engine/hooks/context.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). One class for both layers. Most fields are
+ * `null` for any given event; the per-event subset is documented below and
+ * locked by the roadmap's hook event surface table. Hooks must tolerate
+ * missing fields gracefully.
+ *
+ * Per-event subset (mirrors the roadmap):
+ *
+ * Dispatcher layer (`delivery` is set; `work` is `null`):
+ *     - `before_step`   → `step_name`, `delivery`
+ *     - `after_step`    → `step_name`, `delivery`, `result`
+ *     - `on_halt`       → `step_name`, `delivery`, `result`
+ *     - `on_error`      → `step_name`, `delivery`, `exception`
+ *
+ * CLI layer (`work` is set; `delivery` may be set after load):
+ *     - `before_load`       → `state_file`, `args`
+ *     - `after_load`        → `state_file`, `work`, `fmt`
+ *     - `before_dispatch`   → `work`, `delivery`, `set_name`
+ *     - `after_dispatch`    → `work`, `delivery`, `final`, `halting`
+ *     - `before_save`       → `work`, `delivery`, `fmt`
+ *     - `after_save`        → `work`, `state_file`, `fmt`
+ */
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+export type Any = unknown;
+
+/** Per-event payload passed to every hook callback (matches the dataclass). */
+export interface HookContextInit {
+    // Dispatcher-layer refs.
+    step_name?: string | null;
+    delivery?: Any; // DeliveryState
+    result?: Any; // StepResult
+    exception?: Any; // BaseException
+
+    // CLI-layer refs.
+    work?: Any; // WorkState
+    state_file?: string | null;
+    fmt?: string | null;
+    set_name?: string | null;
+    final?: Any; // Outcome
+    halting?: string | null;
+    args?: Any; // argparse.Namespace
+
+    // Escape hatch for hook-specific state.
+    extra?: Record<string, Any>;
+}
+
+/**
+ * Per-event payload passed to every hook callback.
+ *
+ * Fields are intentionally optional — the runner does not validate which
+ * ones are populated for a given event. The contract is enforced by the
+ * call sites, not by the class.
+ *
+ * `extra` exists as an escape hatch for hook-specific state that does not
+ * warrant a dedicated field.
+ */
+export class HookContext {
+    // Dispatcher-layer refs.
+    step_name: string | null;
+    delivery: Any;
+    result: Any;
+    exception: Any;
+
+    // CLI-layer refs.
+    work: Any;
+    state_file: string | null;
+    fmt: string | null;
+    set_name: string | null;
+    final: Any;
+    halting: string | null;
+    args: Any;
+
+    // Escape hatch for hook-specific state.
+    extra: Record<string, Any>;
+
+    constructor(init: HookContextInit = {}) {
+        this.step_name = init.step_name ?? null;
+        this.delivery = init.delivery ?? null;
+        this.result = init.result ?? null;
+        this.exception = init.exception ?? null;
+        this.work = init.work ?? null;
+        this.state_file = init.state_file ?? null;
+        this.fmt = init.fmt ?? null;
+        this.set_name = init.set_name ?? null;
+        this.final = init.final ?? null;
+        this.halting = init.halting ?? null;
+        this.args = init.args ?? null;
+        this.extra = init.extra ?? {};
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/events.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/events.ts
@@ -1,0 +1,58 @@
+/**
+ * Hook event surface for `work_engine`.
+ *
+ * TypeScript twin of `work_engine/hooks/events.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Mirrors the Python `str`-Enum 1:1: each
+ * value is the event name verbatim, so round-trips stay trivial for
+ * telemetry and JSON tracing.
+ *
+ * Ten events split across two layers per
+ * `agents/roadmaps/road-to-work-engine-hooks.md` (locked).
+ *
+ * Dispatcher-layer events fire from inside `dispatcher.dispatch()` and
+ * operate on `DeliveryState` (legacy, internal). CLI-layer events fire
+ * from `cli.main()` and operate on `WorkState` (v1 envelope) plus
+ * auxiliary refs (`state_file`, `fmt`, `args`).
+ */
+
+/**
+ * Lifecycle events emitted by the work engine.
+ *
+ * Modelled as a const object + value-union so it behaves like the Python
+ * `str`-Enum: members compare equal to their string value, and the value
+ * IS the event name. `HookEvent.BEFORE_STEP === 'before_step'`.
+ */
+export const HookEvent = {
+    // Dispatcher layer (DeliveryState).
+    BEFORE_STEP: 'before_step',
+    AFTER_STEP: 'after_step',
+    ON_HALT: 'on_halt',
+    ON_ERROR: 'on_error',
+
+    // CLI layer (WorkState).
+    BEFORE_LOAD: 'before_load',
+    AFTER_LOAD: 'after_load',
+    BEFORE_DISPATCH: 'before_dispatch',
+    AFTER_DISPATCH: 'after_dispatch',
+    BEFORE_SAVE: 'before_save',
+    AFTER_SAVE: 'after_save',
+} as const;
+
+export type HookEvent = (typeof HookEvent)[keyof typeof HookEvent];
+
+/**
+ * Iteration order over every event, mirroring Python `for event in HookEvent`
+ * (declaration order). Used by {@link TraceHook} to register on all events.
+ */
+export const HOOK_EVENTS: readonly HookEvent[] = [
+    HookEvent.BEFORE_STEP,
+    HookEvent.AFTER_STEP,
+    HookEvent.ON_HALT,
+    HookEvent.ON_ERROR,
+    HookEvent.BEFORE_LOAD,
+    HookEvent.AFTER_LOAD,
+    HookEvent.BEFORE_DISPATCH,
+    HookEvent.AFTER_DISPATCH,
+    HookEvent.BEFORE_SAVE,
+    HookEvent.AFTER_SAVE,
+];

--- a/src/agent-src/templates/scripts/work_engine/hooks/exceptions.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/exceptions.ts
@@ -1,0 +1,85 @@
+/**
+ * Hook control-flow signals.
+ *
+ * TypeScript twin of `work_engine/hooks/exceptions.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Class names stay 1:1 with the Python module.
+ *
+ * Three-tier error contract (locked by roadmap P1):
+ *
+ * - `HookError` — non-fatal. Hook implementation failed; the runner
+ *   catches it, warns, and continues with the next callback for the same
+ *   event. Work proceeds.
+ * - `HookHalt` — fatal-controlled. Hook demands a clean stop (canonical
+ *   example: chat-history `turn-check` foreign session). The runner
+ *   catches it and **returns** it to the caller, who decides how to
+ *   surface it (engine halt, CLI exit code 2 + readable surface). Not
+ *   re-raised through the dispatch loop.
+ * - any other `Error` — fatal-uncontrolled. Treated as a bug in the
+ *   hook. The runner lets it propagate verbatim; dispatch unwinds.
+ *
+ * Both signals share a private `_HookSignal` base so the runner can
+ * distinguish hook-originated control flow from genuine bugs.
+ */
+
+/**
+ * Internal marker for hook-originated control flow.
+ *
+ * Not part of the public API. The runner uses `instanceof` checks
+ * against the concrete subclasses below; the base exists only so a
+ * single `instanceof _HookSignal` would cover both signals if a future
+ * refactor needs it.
+ */
+export class _HookSignal extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, _HookSignal.prototype);
+        this.name = '_HookSignal';
+    }
+}
+
+/**
+ * Non-fatal hook failure.
+ *
+ * Raised when a hook callback fails in a way the *engine* should ignore.
+ * The runner catches it, emits a warning with the message, and moves
+ * on to the next callback registered for the event.
+ *
+ * Use this for transient or non-critical hook failures (telemetry
+ * sinks, optional reporters). Do **not** use it to signal "stop the
+ * engine" — that is what {@link HookHalt} is for.
+ */
+export class HookError extends _HookSignal {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, HookError.prototype);
+        this.name = 'HookError';
+    }
+}
+
+/**
+ * Fatal-controlled stop requested by a hook.
+ *
+ * Hooks raise this when execution must not continue. The runner catches
+ * it and returns it to the caller; the caller turns it into the
+ * appropriate halt surface (dispatcher `Outcome.BLOCKED`, CLI exit 2).
+ *
+ * `surface` is a list of pre-formatted numbered options per the
+ * `user-interaction` rule (one entry per line). Callers must not
+ * reformat — surface is rendered verbatim.
+ *
+ * `reason` is a short machine-readable code (e.g. `"foreign"`,
+ * `"missing"`, `"validation_failed"`) for logging and tests; it is not
+ * shown to the user.
+ */
+export class HookHalt extends _HookSignal {
+    readonly reason: string;
+    readonly surface: string[];
+
+    constructor(reason: string, surface: string[] | null = null) {
+        super(reason);
+        Object.setPrototypeOf(this, HookHalt.prototype);
+        this.name = 'HookHalt';
+        this.reason = reason;
+        this.surface = surface ? [...surface] : [];
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/index.ts
@@ -1,0 +1,27 @@
+/**
+ * `work_engine.hooks` — cross-cutting lifecycle hooks for the engine.
+ *
+ * TypeScript twin of `work_engine/hooks/__init__.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Public surface:
+ *
+ * - `HookEvent` — ten lifecycle events, two layers.
+ * - `HookContext` — per-event payload.
+ * - `HookError` / `HookHalt` — three-tier error contract.
+ * - `HookRegistry` — insertion-ordered event → callbacks map.
+ * - `HookRunner` — single emit point, owns the error contract.
+ */
+export {
+    ChatHistoryAppendHook,
+    ChatHistoryHaltAppendHook,
+    DecisionTraceHook,
+    DirectiveSetGuardHook,
+    HaltSurfaceAuditHook,
+    MemoryVisibilityHook,
+    StateShapeValidationHook,
+    TraceHook,
+} from './builtin/index.js';
+export { HookContext } from './context.js';
+export { HookEvent } from './events.js';
+export { HookError, HookHalt } from './exceptions.js';
+export { type HookCallback, HookRegistry } from './registry.js';
+export { HookRunner } from './runner.js';

--- a/src/agent-src/templates/scripts/work_engine/hooks/registry.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/registry.ts
@@ -1,0 +1,66 @@
+/**
+ * `HookRegistry` — insertion-ordered map from event to callbacks.
+ *
+ * TypeScript twin of `work_engine/hooks/registry.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Phase 1 ships insertion-ordered
+ * registration only.
+ *
+ * The registry is a plain container. It does not invoke callbacks, does
+ * not catch exceptions, and does not know about the error contract; that
+ * responsibility lives in {@link HookRunner}.
+ */
+import { HookContext } from './context.js';
+import { HookEvent } from './events.js';
+
+/**
+ * A hook callback. Returns `void` on success, throws `HookError` or
+ * `HookHalt` to signal control flow per `exceptions.ts`.
+ */
+export type HookCallback = (ctx: HookContext) => void;
+
+/**
+ * Insertion-ordered registry of hook callbacks per event.
+ *
+ * Single instance per CLI invocation. Built once and shared with
+ * `dispatch()` so dispatcher events and CLI events are routed through the
+ * same callback set.
+ */
+export class HookRegistry {
+    // Map preserves insertion order, mirroring Python's dict ordering.
+    private _hooks: Map<HookEvent, HookCallback[]> = new Map();
+
+    /**
+     * Register `callback` for `event`.
+     *
+     * Multiple callbacks for the same event are allowed; they fire in
+     * registration order.
+     */
+    register(event: HookEvent, callback: HookCallback): void {
+        let list = this._hooks.get(event);
+        if (list === undefined) {
+            list = [];
+            this._hooks.set(event, list);
+        }
+        list.push(callback);
+    }
+
+    /**
+     * Return callbacks registered for `event` in insertion order.
+     *
+     * Returns an empty array when no callbacks are registered — the runner
+     * uses this to short-circuit a no-op fast path.
+     */
+    for_event(event: HookEvent): HookCallback[] {
+        const list = this._hooks.get(event);
+        return list === undefined ? [] : [...list];
+    }
+
+    /**
+     * Iterate over events that have at least one callback.
+     *
+     * Diagnostics-only; not used on the hot path.
+     */
+    events(): IterableIterator<HookEvent> {
+        return this._hooks.keys();
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/runner.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/runner.ts
@@ -1,0 +1,90 @@
+/**
+ * `HookRunner` — single emit point for hook callbacks.
+ *
+ * TypeScript twin of `work_engine/hooks/runner.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Implements the three-tier error contract
+ * documented in `exceptions.ts`:
+ *
+ * - `HookError` from a callback → caught, a warning is emitted, the runner
+ *   continues with the next callback for the same event. Returns `null`
+ *   once the event is fully drained.
+ * - `HookHalt` from a callback → caught, **returned** to the caller with
+ *   no further callbacks invoked for this event. The caller decides how to
+ *   surface the halt. Never re-raised through the dispatch loop.
+ * - any other `Error` → propagates unchanged. Treated as a hook bug;
+ *   dispatch unwinds.
+ *
+ * Python parity note (intentional, documented): the original emits the
+ * non-fatal warning via `warnings.warn`, whose surface format
+ * (`<file>:<line>: UserWarning: …`) and per-location de-duplication are
+ * interpreter-internal and not portable. This twin emits the same message
+ * to `process.stderr` through the `warn` seam. The observable contract —
+ * the HookError is swallowed and dispatch continues — is preserved; the
+ * exact stderr warning text is normalised in the golden harness.
+ */
+import { HookContext } from './context.js';
+import { HookEvent } from './events.js';
+import { HookError, HookHalt } from './exceptions.js';
+import { HookRegistry } from './registry.js';
+
+/**
+ * Emit hook events through a {@link HookRegistry}.
+ *
+ * Construct once per CLI invocation, share between the CLI and the
+ * dispatcher. `emit` is the only public method on the hot path.
+ */
+export class HookRunner {
+    private _registry: HookRegistry;
+
+    constructor(registry: HookRegistry | null = null) {
+        this._registry = registry !== null ? registry : new HookRegistry();
+    }
+
+    /**
+     * Return the underlying registry.
+     *
+     * Exposed so callers can register additional hooks after construction
+     * (e.g. in tests). Not used on the hot path.
+     */
+    get registry(): HookRegistry {
+        return this._registry;
+    }
+
+    /**
+     * Fire all callbacks registered for `event`.
+     *
+     * Returns `null` when every callback completed (with or without a
+     * swallowed {@link HookError}). Returns the first {@link HookHalt}
+     * raised, after which no further callbacks are invoked for this event.
+     * Any other error propagates.
+     */
+    emit(event: HookEvent, ctx: HookContext): HookHalt | null {
+        const callbacks = this._registry.for_event(event);
+        if (callbacks.length === 0) {
+            return null;
+        }
+        for (const callback of callbacks) {
+            try {
+                callback(ctx);
+            } catch (exc) {
+                if (exc instanceof HookHalt) {
+                    return exc;
+                }
+                if (exc instanceof HookError) {
+                    this.warn(`hook ${event} raised HookError: ${exc.message}`);
+                    continue;
+                }
+                throw exc;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Emit a non-fatal hook warning. Test seam — overridable. Mirrors the
+     * role of `warnings.warn` in the Python original.
+     */
+    protected warn(message: string): void {
+        process.stderr.write(`${message}\n`);
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/hooks/settings.ts
+++ b/src/agent-src/templates/scripts/work_engine/hooks/settings.ts
@@ -1,0 +1,260 @@
+/**
+ * Read `hooks.*` from `.agent-settings.yml` into {@link HookSettings}.
+ *
+ * TypeScript twin of `work_engine/hooks/settings.py` (ADR-094 py2ts —
+ * work_engine.hooks subpackage). Mirror of the chat-history settings pattern:
+ *
+ * - The YAML read goes through `work_engine/_lib/agent_settings.load_agent_settings`,
+ *   which cascades the whitelisted DX-comfort keys from the user-global file.
+ * - Default-permissive: a missing file or missing `hooks:` block returns
+ *   {@link HookSettings} with `enabled=false` — every hook off, every golden
+ *   replay safe by construction.
+ * - Malformed YAML / unreadable file → defaults; degrade silently.
+ * - Chat-history hooks gate on **two** switches: `hooks.chat_history.enabled`
+ *   AND the global `chat_history.enabled`. Either off → no chat-history hook.
+ */
+import { load_agent_settings, type SettingsDict } from '../_lib/agent_settings.js';
+import {
+    DecisionEngineConfigError,
+    DecisionEngineSettings,
+    parse as _parse_decision_engine,
+} from '../scoring/decision_engine.js';
+
+export const DEFAULT_SETTINGS_FILE = '.agent-settings.yml';
+export const DEFAULT_CHAT_HISTORY_SCRIPT = 'scripts/chat_history.py';
+
+/** Arbitrary value, mirroring the Python `Any` fields. */
+type Any = unknown;
+
+/** Per-field init shape for {@link HookSettings} (mirrors the dataclass). */
+export interface HookSettingsInit {
+    enabled?: boolean;
+    trace?: boolean;
+    halt_surface_audit?: boolean;
+    state_shape_validation?: boolean;
+    directive_set_guard?: boolean;
+    decision_trace?: boolean;
+    memory_visibility?: boolean;
+    memory_visibility_off?: boolean;
+    memory_cadence?: string;
+    chat_history_enabled?: boolean;
+    chat_history_script?: string;
+    decision_engine?: DecisionEngineSettings;
+}
+
+/**
+ * Resolved view of the `hooks:` block.
+ *
+ * `enabled` is the master switch. When `false` the registry stays empty
+ * regardless of the per-hook fields; this is the default when no settings
+ * file exists or no `hooks` block is declared, and it is what keeps
+ * golden-replay tests byte-stable.
+ *
+ * `decision_engine` carries the parsed gate config so {@link DecisionGateHook}
+ * can read it without re-parsing `.agent-settings.yml`.
+ */
+export class HookSettings {
+    readonly enabled: boolean;
+    readonly trace: boolean;
+    readonly halt_surface_audit: boolean;
+    readonly state_shape_validation: boolean;
+    readonly directive_set_guard: boolean;
+    readonly decision_trace: boolean;
+    readonly memory_visibility: boolean;
+    readonly memory_visibility_off: boolean;
+    readonly memory_cadence: string;
+    readonly chat_history_enabled: boolean;
+    readonly chat_history_script: string;
+    readonly decision_engine: DecisionEngineSettings;
+
+    constructor(init: HookSettingsInit = {}) {
+        this.enabled = init.enabled ?? false;
+        this.trace = init.trace ?? false;
+        this.halt_surface_audit = init.halt_surface_audit ?? false;
+        this.state_shape_validation = init.state_shape_validation ?? false;
+        this.directive_set_guard = init.directive_set_guard ?? false;
+        this.decision_trace = init.decision_trace ?? false;
+        this.memory_visibility = init.memory_visibility ?? false;
+        this.memory_visibility_off = init.memory_visibility_off ?? false;
+        this.memory_cadence = init.memory_cadence ?? 'always';
+        this.chat_history_enabled = init.chat_history_enabled ?? false;
+        this.chat_history_script = init.chat_history_script ?? DEFAULT_CHAT_HISTORY_SCRIPT;
+        this.decision_engine = init.decision_engine ?? new DecisionEngineSettings();
+        Object.freeze(this);
+    }
+}
+
+const _DEFAULT = new HookSettings();
+
+/**
+ * Return {@link HookSettings} hydrated from `.agent-settings.yml`.
+ *
+ * `settings_path` defaults to `./.agent-settings.yml` relative to the
+ * current working directory. `user_global_path` defaults to
+ * `~/.event4u/agent-config/agent-settings.yml` and only cascades the
+ * whitelisted DX-comfort keys when the project file omits them.
+ */
+export function load_hook_settings(
+    settings_path: string | null = null,
+    user_global_path: string | null = null,
+): HookSettings {
+    const path = settings_path ? settings_path : DEFAULT_SETTINGS_FILE;
+    const raw = load_agent_settings({
+        project_path: path,
+        user_global_path,
+    });
+    if (!_pyTruthy(raw)) {
+        return _DEFAULT;
+    }
+    return _settings_from_raw(raw);
+}
+
+function _settings_from_raw(data: SettingsDict): HookSettings {
+    const hooks = data['hooks'];
+    if (!_isPlainDict(hooks)) {
+        return _DEFAULT;
+    }
+    const hooksDict = hooks as Record<string, Any>;
+    const enabled = _coerce_bool(hooksDict['enabled'], false);
+
+    const decision_engine_raw = data['decision_engine'];
+    let decision_engine_settings: DecisionEngineSettings;
+    try {
+        decision_engine_settings = _parse_decision_engine(decision_engine_raw);
+    } catch (exc) {
+        if (exc instanceof DecisionEngineConfigError) {
+            decision_engine_settings = new DecisionEngineSettings();
+        } else {
+            throw exc;
+        }
+    }
+
+    if (!enabled) {
+        return new HookSettings({
+            enabled: false,
+            decision_engine: decision_engine_settings,
+        });
+    }
+
+    const chat_section = hooksDict['chat_history'];
+    let chat_block_enabled: boolean;
+    let chat_script: string;
+    if (_isPlainDict(chat_section)) {
+        const cs = chat_section as Record<string, Any>;
+        chat_block_enabled = _coerce_bool(cs['enabled'], true);
+        chat_script = String(_pyOr(cs['script'], DEFAULT_CHAT_HISTORY_SCRIPT));
+    } else {
+        chat_block_enabled = true;
+        chat_script = DEFAULT_CHAT_HISTORY_SCRIPT;
+    }
+
+    const global_chat = data['chat_history'];
+    const global_chat_on =
+        _isPlainDict(global_chat) &&
+        _coerce_bool((global_chat as Record<string, Any>)['enabled'], false);
+
+    const decision_trace_on = decision_engine_settings.surface_traces;
+
+    const memory_section = data['memory'];
+    let visibility_off = false;
+    let memory_cadence = 'always';
+    if (_isPlainDict(memory_section)) {
+        const ms = memory_section as Record<string, Any>;
+        const rawVis = ms['visibility'];
+        if (typeof rawVis === 'string' && rawVis.trim().toLowerCase() === 'off') {
+            visibility_off = true;
+        } else if (typeof rawVis === 'boolean' && rawVis === false) {
+            visibility_off = true;
+        }
+        const cadence_raw = ms['cadence'];
+        if (cadence_raw !== null && cadence_raw !== undefined) {
+            memory_cadence = String(cadence_raw).trim().toLowerCase() || 'always';
+        }
+    }
+
+    const memory_hooks = hooksDict['memory_visibility'];
+    let memory_visibility_on: boolean;
+    if (_isPlainDict(memory_hooks)) {
+        memory_visibility_on = _coerce_bool(
+            (memory_hooks as Record<string, Any>)['enabled'],
+            true,
+        );
+    } else {
+        memory_visibility_on = true;
+    }
+
+    return new HookSettings({
+        enabled: true,
+        trace: _coerce_bool(hooksDict['trace'], false),
+        halt_surface_audit: _coerce_bool(hooksDict['halt_surface_audit'], true),
+        state_shape_validation: _coerce_bool(hooksDict['state_shape_validation'], true),
+        directive_set_guard: _coerce_bool(hooksDict['directive_set_guard'], true),
+        decision_trace: decision_trace_on,
+        memory_visibility: memory_visibility_on,
+        memory_visibility_off: visibility_off,
+        memory_cadence,
+        chat_history_enabled: chat_block_enabled && global_chat_on,
+        chat_history_script: chat_script,
+        decision_engine: decision_engine_settings,
+    });
+}
+
+function _coerce_bool(value: Any, dflt: boolean): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (value === null || value === undefined) {
+        return dflt;
+    }
+    if (typeof value === 'string') {
+        const s = value.trim().toLowerCase();
+        if (s === 'true' || s === 'yes' || s === 'on' || s === '1') {
+            return true;
+        }
+        if (s === 'false' || s === 'no' || s === 'off' || s === '0') {
+            return false;
+        }
+    }
+    return dflt;
+}
+
+// ── Python-parity primitives ────────────────────────────────────────────
+
+/** Python `a or b` — returns `a` when truthy, else `b`. */
+function _pyOr(a: Any, b: Any): Any {
+    return _pyTruthy(a) ? a : b;
+}
+
+/** Python `isinstance(x, dict)` — only a plain object (not array, not null). */
+function _isPlainDict(value: Any): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Python `bool(x)` truthiness: `None`/`undefined`, `False`, `0`, `""`,
+ * empty list/dict are falsy; everything else truthy.
+ */
+function _pyTruthy(value: Any): boolean {
+    if (value === null || value === undefined || value === false) {
+        return false;
+    }
+    if (value === true) {
+        return true;
+    }
+    if (typeof value === 'number') {
+        return value !== 0;
+    }
+    if (typeof value === 'string') {
+        return value.length > 0;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (value instanceof Map || value instanceof Set) {
+        return value.size > 0;
+    }
+    if (typeof value === 'object') {
+        return Object.keys(value as Record<string, unknown>).length > 0;
+    }
+    return true;
+}

--- a/tests/scripts/work_engine/_hooks_pyloader.ts
+++ b/tests/scripts/work_engine/_hooks_pyloader.ts
@@ -1,0 +1,102 @@
+// Shared python3 importlib loader for the work_engine.hooks subpackage
+// (ADR-094 py2ts parity harness). NOT a test file — the vitest include glob is
+// `*.test.{ts,tsx}`, so this `_`-prefixed helper is never collected.
+//
+// The hooks `.py` modules use relative imports (`from ..registry import …`,
+// `from ...delivery_state import …`). To exec a single hook module in python3
+// without importing the whole `work_engine` package (whose `__init__` pulls in
+// unported siblings), we synthesise namespace-package stubs for
+// `work_engine`, `work_engine.hooks`, and `work_engine.hooks.builtin`, then
+// load each requested submodule under its fully-qualified name BEFORE the
+// importer runs — exactly the "register deps in sys.modules before exec_module"
+// pattern the merged hook tests use.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+export const WE_DIR = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+);
+export const HOOKS_DIR = path.join(WE_DIR, 'hooks');
+export const BUILTIN_DIR = path.join(HOOKS_DIR, 'builtin');
+
+export function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Build a python3 prelude that registers namespace stubs and loads the named
+ * foundation submodules. After the prelude, each loaded module is bound to a
+ * short local name (the submodule's leaf, e.g. `registry`, `runner`).
+ *
+ * `foundation` — leaf names under `work_engine.hooks` to load (order matters:
+ * dependencies first). `builtin` — leaf names under
+ * `work_engine.hooks.builtin`. `we` — leaf names under `work_engine` itself
+ * (e.g. `delivery_state`, `state`, `scoring.decision_engine`).
+ */
+export function pyHooksLoader(opts: {
+    we?: string[];
+    foundation?: string[];
+    builtin?: string[];
+}): string {
+    const we = opts.we ?? [];
+    const foundation = opts.foundation ?? [];
+    const builtin = opts.builtin ?? [];
+    const lines: string[] = [
+        'import sys, json, types, importlib.util, os',
+        `WE_DIR = ${JSON.stringify(WE_DIR)}`,
+        `HOOKS_DIR = ${JSON.stringify(HOOKS_DIR)}`,
+        `BUILTIN_DIR = ${JSON.stringify(BUILTIN_DIR)}`,
+        'def _mkpkg(name, p):',
+        '    pkg = types.ModuleType(name)',
+        '    pkg.__path__ = [p]',
+        '    pkg.__package__ = name',
+        '    sys.modules[name] = pkg',
+        '    return pkg',
+        'def _load(modname, filepath):',
+        '    spec = importlib.util.spec_from_file_location(modname, filepath)',
+        '    mod = importlib.util.module_from_spec(spec)',
+        '    sys.modules[modname] = mod',
+        '    spec.loader.exec_module(mod)',
+        '    return mod',
+        '_mkpkg("work_engine", WE_DIR)',
+        '_mkpkg("work_engine.scoring", os.path.join(WE_DIR, "scoring"))',
+        '_mkpkg("work_engine._lib", os.path.join(WE_DIR, "_lib"))',
+        '_mkpkg("work_engine.hooks", HOOKS_DIR)',
+        '_mkpkg("work_engine.hooks.builtin", BUILTIN_DIR)',
+    ];
+    for (const leaf of we) {
+        const sub = leaf.split('.').join('/');
+        lines.push(
+            `_load("work_engine.${leaf}", os.path.join(WE_DIR, ${JSON.stringify(`${sub}.py`)}))`,
+        );
+    }
+    for (const leaf of foundation) {
+        lines.push(
+            `${leaf} = _load("work_engine.hooks.${leaf}", os.path.join(HOOKS_DIR, ${JSON.stringify(`${leaf}.py`)}))`,
+        );
+    }
+    for (const leaf of builtin) {
+        // Bind under the exact leaf name (Python allows leading-underscore
+        // local names, e.g. `_chat_history_base`).
+        lines.push(
+            `${leaf} = _load("work_engine.hooks.builtin.${leaf}", os.path.join(BUILTIN_DIR, ${JSON.stringify(`${leaf}.py`)}))`,
+        );
+    }
+    return lines.join('\n');
+}
+
+/** Run a python3 snippet with the hooks namespace pre-loaded. */
+export function runPyHooks(
+    opts: { we?: string[]; foundation?: string[]; builtin?: string[] },
+    body: string,
+): SpawnSyncReturns<string> {
+    const code = `${pyHooksLoader(opts)}\n${body}`;
+    return spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+}

--- a/tests/scripts/work_engine/directives_backend_analyze.test.ts
+++ b/tests/scripts/work_engine/directives_backend_analyze.test.ts
@@ -1,0 +1,141 @@
+// Golden-parity tests for work_engine/directives/backend/analyze.ts vs
+// analyze.py (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `analyze.py` has intra-package imports (`from ...delivery_state import …`),
+// so the direct-file importlib loader used by state.test.ts does NOT work here.
+// Instead we add `src/agent-src/templates/scripts` to `sys.path` and
+// `import work_engine.directives.backend.analyze` as a real package member —
+// the package `__init__` imports its (still-Python) siblings, which all exist
+// in source until the Phase-12 sweep. The TS twin is exercised in-process; the
+// Python original via a python3 subprocess. Both build a `DeliveryState` from
+// the same JSON fixture and emit `{outcome, questions, message}` as
+// `json.dumps(..., indent=2, ensure_ascii=False)` for a byte-exact compare.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/analyze.js';
+import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Drive `work_engine.directives.backend.<MODULE>.run` on python3 from a JSON
+ * state fixture; emit `{outcome, questions, message}` as canonical JSON.
+ */
+function runPy(moduleName: string, stateJson: string): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        `import importlib`,
+        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** TS twin: build DeliveryState from the fixture, run, emit canonical JSON. */
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const r: StepResult = run(new DeliveryState(state));
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
+}
+
+/** Build the matching python fixture JSON from the same constructor args. */
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/backend/analyze — AMBIGUITIES', () => {
+    it('declares the three precondition surfaces in order', () => {
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual([
+            'upstream_refine_failed',
+            'upstream_memory_failed',
+            'lost_ac',
+        ]);
+    });
+});
+
+describeParity('directives/backend/analyze — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        [
+            'all preconditions met → SUCCESS',
+            {
+                ticket: { id: 'T-1', acceptance_criteria: ['must do X'] },
+                outcomes: { refine: 'success', memory: 'success' },
+            },
+        ],
+        [
+            'refine not success → BLOCKED (single reason)',
+            {
+                ticket: { id: 'T-2', acceptance_criteria: ['a'] },
+                outcomes: { memory: 'success' },
+            },
+        ],
+        [
+            'memory not success → BLOCKED',
+            {
+                ticket: { id: 'T-3', acceptance_criteria: ['a'] },
+                outcomes: { refine: 'success' },
+            },
+        ],
+        [
+            'lost acceptance criteria (empty list) → BLOCKED',
+            {
+                ticket: { id: 'T-4', acceptance_criteria: [] },
+                outcomes: { refine: 'success', memory: 'success' },
+            },
+        ],
+        [
+            'acceptance_criteria not a list → BLOCKED',
+            {
+                ticket: { id: 'T-5', acceptance_criteria: 'a string not a list' },
+                outcomes: { refine: 'success', memory: 'success' },
+            },
+        ],
+        [
+            'all three missing → BLOCKED (three reasons joined)',
+            {
+                ticket: { id: 'T-6' },
+                outcomes: {},
+            },
+        ],
+        [
+            'no ticket id → "(no id)" in headnote',
+            {
+                ticket: {},
+                outcomes: {},
+            },
+        ],
+        [
+            'empty-string ticket id falls back to "(no id)"',
+            {
+                ticket: { id: '' },
+                outcomes: { refine: 'success', memory: 'success' },
+            },
+        ],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        const tsOut = runTs(state);
+        const pyOut = runPy('analyze', pyFixture(state));
+        expect(tsOut).toBe(pyOut);
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_implement.test.ts
+++ b/tests/scripts/work_engine/directives_backend_implement.test.ts
@@ -1,0 +1,109 @@
+// Golden-parity tests for work_engine/directives/backend/implement.ts vs
+// implement.py (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `implement.py` imports `...delivery_state` and `...persona_policy`, so it
+// loads as a real package member via `sys.path` + import. Persona gating
+// (advisory short-circuits to SUCCESS) is covered alongside the plan-gate and
+// changes-shape paths. TS twin in-process; Python via python3 subprocess;
+// byte-exact `{outcome, questions, message}` compare. No non-determinism.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/implement.js';
+import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(moduleName: string, stateJson: string): string {
+    const code = [
+        'import sys, json, importlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const r: StepResult = run(new DeliveryState(state));
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
+}
+
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+const ok = { plan: 'success' };
+
+describe('directives/backend/implement — AMBIGUITIES', () => {
+    it('declares the three surfaces in order', () => {
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual([
+            'upstream_plan_failed',
+            'empty_changes_delegate',
+            'malformed_changes',
+        ]);
+    });
+});
+
+describeParity('directives/backend/implement — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        [
+            'advisory persona → SUCCESS short-circuit (skip)',
+            { ticket: { id: 'I-1' }, persona: 'advisory', outcomes: ok },
+        ],
+        ['plan not success → BLOCKED precondition', { ticket: { id: 'I-2' }, outcomes: {} }],
+        ['empty changes → delegate apply-plan', { ticket: { id: 'I-3' }, outcomes: ok }],
+        [
+            'valid changes → SUCCESS',
+            { ticket: { id: 'I-4' }, changes: [{ path: 'a.ts' }, { file: 'b.ts' }], outcomes: ok },
+        ],
+        [
+            'malformed change (no path/file) → BLOCKED shape',
+            { ticket: { id: 'I-5' }, changes: [{ purpose: 'x' }], outcomes: ok },
+        ],
+        [
+            'malformed change (non-dict entry) → BLOCKED shape',
+            { ticket: { id: 'I-6' }, changes: ['not a dict'] as unknown as Array<Record<string, unknown>>, outcomes: ok },
+        ],
+        [
+            'malformed change (blank path) → BLOCKED shape',
+            { ticket: { id: 'I-7' }, changes: [{ path: '   ' }], outcomes: ok },
+        ],
+        [
+            'multiple malformed changes → BLOCKED shape (joined)',
+            { ticket: { id: 'I-8' }, changes: ['x', { why: 'y' }] as unknown as Array<Record<string, unknown>>, outcomes: ok },
+        ],
+        [
+            'qa persona behaves like senior (no skip) → delegate',
+            { ticket: { id: 'I-9' }, persona: 'qa', outcomes: ok },
+        ],
+        [
+            'path falsy falls back to file key → SUCCESS',
+            { ticket: { id: 'I-10' }, changes: [{ path: '', file: 'real.ts' }], outcomes: ok },
+        ],
+        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        expect(runTs(state)).toBe(runPy('implement', pyFixture(state)));
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_memory.test.ts
+++ b/tests/scripts/work_engine/directives_backend_memory.test.ts
@@ -1,0 +1,137 @@
+// Golden-parity tests for work_engine/directives/backend/memory.ts vs
+// memory.py (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `memory.py` imports `...delivery_state` and lazily imports `memory_lookup`
+// (so tests can monkeypatch `memory_lookup.retrieve`). The TS twin mirrors the
+// lazy seam with `_setRetrieve`. To make retrieval deterministic and to assert
+// the key-derivation contract (files → title tokens → AC tokens, stopword-
+// filtered, deduped, lower-cased), the fake `retrieve` echoes the exact keys it
+// receives back as a single hit. Both engines then expose `state.memory` as
+// canonical JSON for a byte-exact compare; the echoed keys prove the tokeniser
+// matched (Python `re` vs JS regex). The MAX_HITS cap is exercised with a fake
+// returning >12 hits. No real filesystem access → fully deterministic.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    AMBIGUITIES,
+    MAX_HITS,
+    MEMORY_TYPES,
+    _setRetrieve,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js';
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Python driver: monkeypatch `memory_lookup.retrieve` with a fake whose
+ * behaviour is selected by `mode`, run `memory.run`, emit `state.memory` JSON.
+ *
+ * - `echo` : returns a single dict hit carrying the received `types`/`keys`.
+ * - `cap`  : returns 20 dict hits so the MAX_HITS truncation is observable.
+ */
+function runPy(stateJson: string, mode: string): string {
+    const code = [
+        'import sys, json, importlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'import memory_lookup',
+        'mode = sys.argv[2]',
+        'def fake(types, keys, limit):',
+        '    if mode == "cap":',
+        '        return [{"id": "h%d" % i, "type": "historical-patterns", "n": i} for i in range(20)]',
+        '    return [{"types": list(types), "keys": list(keys), "limit": limit}]',
+        'memory_lookup.retrieve = fake',
+        'mod = importlib.import_module("work_engine.directives.backend.memory")',
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "memory": st.memory}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson, mode], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+type Mode = 'echo' | 'cap';
+
+function tsFake(mode: Mode) {
+    return (types: string[], keys: string[], limit: number): unknown => {
+        if (mode === 'cap') {
+            return Array.from({ length: 20 }, (_v, i) => ({ id: `h${i}`, type: 'historical-patterns', n: i }));
+        }
+        return [{ types: [...types], keys: [...keys], limit }];
+    };
+}
+
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0], mode: Mode): string {
+    _setRetrieve(tsFake(mode));
+    const st = new DeliveryState(state);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, memory: st.memory }, null, 2);
+}
+
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+afterEach(() => {
+    _setRetrieve(null);
+});
+
+describe('directives/backend/memory — constants', () => {
+    it('exposes the four memory types and the 12-hit cap', () => {
+        expect([...MEMORY_TYPES]).toEqual([
+            'domain-invariants',
+            'architecture-decisions',
+            'incident-learnings',
+            'historical-patterns',
+        ]);
+        expect(MAX_HITS).toBe(12);
+        expect(AMBIGUITIES).toEqual([]);
+    });
+});
+
+describeParity('directives/backend/memory — golden parity (ts == py)', () => {
+    const echoCases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        [
+            'files + title + AC keys derived, deduped, stopword-filtered',
+            {
+                ticket: {
+                    id: 'M-1',
+                    files: ['app/Service.ts', 'app/Service.ts'],
+                    title: 'Add OAuth2 login-flow to the v2 API',
+                    acceptance_criteria: ['The user must be able to log in', 'Token refresh works'],
+                },
+            },
+        ],
+        ['empty ticket → no keys', { ticket: {} }],
+        ['title only, short words (<3 chars) dropped', { ticket: { id: 'M-2', title: 'a be the API v2' } }],
+        ['non-string title ignored', { ticket: { id: 'M-3', title: 12345 } }],
+        ['files non-list ignored, AC drives keys', { ticket: { id: 'M-4', files: 'not-a-list', acceptance_criteria: ['Refactor the parser module'] } }],
+        ['hyphen + underscore words kept whole', { ticket: { id: 'M-5', title: 'rename build_step and login-flow' } }],
+    ];
+
+    it.each(echoCases)('echo: %s', (_label, state) => {
+        expect(runTs(state, 'echo')).toBe(runPy(pyFixture(state), 'echo'));
+    });
+
+    it('cap: >12 hits truncated to MAX_HITS', () => {
+        const state = { ticket: { id: 'M-CAP', title: 'cap test' } };
+        expect(runTs(state, 'cap')).toBe(runPy(pyFixture(state), 'cap'));
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_plan.test.ts
+++ b/tests/scripts/work_engine/directives_backend_plan.test.ts
@@ -1,0 +1,106 @@
+// Golden-parity tests for work_engine/directives/backend/plan.ts vs plan.py
+// (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `plan.py` has intra-package imports, so it loads as a real package member
+// via `sys.path` + `import work_engine.directives.backend.plan` (the package
+// __init__ pulls still-Python siblings, all present until Phase 12). The TS
+// twin runs in-process; the Python original via python3 subprocess. Both build
+// a `DeliveryState` from the same JSON fixture and emit
+// `{outcome, questions, message}` for a byte-exact compare.
+//
+// Non-determinism: none. Note a deliberate parity carve-out — the
+// "unsupported plan type" branch is exercised with a string/list/dict-of-
+// non-steps, never a JSON float, because JSON `5.0` decodes to a JS integer
+// (`int` typename) but a Python `float` (`float` typename); that single
+// `type().__name__` divergence is a JSON-round-trip artifact, not a logic gap.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/plan.js';
+import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(moduleName: string, stateJson: string): string {
+    const code = [
+        'import sys, json, importlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const r: StepResult = run(new DeliveryState(state));
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
+}
+
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+const ok = { analyze: 'success' };
+
+describe('directives/backend/plan — AMBIGUITIES', () => {
+    it('declares the three surfaces in order', () => {
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual(['upstream_analyze_failed', 'empty_plan_delegate', 'malformed_plan']);
+    });
+});
+
+describeParity('directives/backend/plan — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        ['analyze not success → BLOCKED precondition', { ticket: { id: 'P-1' }, outcomes: {} }],
+        ['empty plan (null) → delegate create-plan', { ticket: { id: 'P-2' }, outcomes: ok }],
+        ['blank-string plan → delegate (whitespace == empty)', { ticket: { id: 'P-3' }, plan: '   ', outcomes: ok }],
+        ['empty list plan → delegate', { ticket: { id: 'P-4' }, plan: [], outcomes: ok }],
+        ['empty dict plan → delegate', { ticket: { id: 'P-5' }, plan: {}, outcomes: ok }],
+        ['valid string plan → SUCCESS', { ticket: { id: 'P-6' }, plan: 'do the thing', outcomes: ok }],
+        ['valid list-of-strings plan → SUCCESS', { ticket: { id: 'P-7' }, plan: ['step one', 'step two'], outcomes: ok }],
+        [
+            'valid list-of-dicts plan → SUCCESS',
+            { ticket: { id: 'P-8' }, plan: [{ title: 'A' }, { step: 'B' }], outcomes: ok },
+        ],
+        ['valid dict-with-steps → SUCCESS', { ticket: { id: 'P-9' }, plan: { steps: ['x', 'y'] }, outcomes: ok }],
+        [
+            'malformed list (dict without title) → BLOCKED shape',
+            { ticket: { id: 'P-10' }, plan: [{ note: 'no title here' }], outcomes: ok },
+        ],
+        [
+            'malformed list (blank string entry) → BLOCKED shape',
+            { ticket: { id: 'P-11' }, plan: ['   '], outcomes: ok },
+        ],
+        [
+            'malformed list (multiple complaints) → BLOCKED shape',
+            { ticket: { id: 'P-12' }, plan: [{ note: 'x' }, '   '], outcomes: ok },
+        ],
+        [
+            'dict without steps list → BLOCKED shape',
+            { ticket: { id: 'P-13' }, plan: { name: 'no steps' }, outcomes: ok },
+        ],
+        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        expect(runTs(state)).toBe(runPy('plan', pyFixture(state)));
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_refine.test.ts
+++ b/tests/scripts/work_engine/directives_backend_refine.test.ts
@@ -1,0 +1,252 @@
+// Golden-parity tests for work_engine/directives/backend/refine.ts vs
+// refine.py (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `refine.py` imports `...delivery_state` + `...scoring.confidence`, so the
+// direct-file importlib loader used by state.test.ts does NOT work here.
+// Instead we add `src/agent-src/templates/scripts` to `sys.path` and
+// `import work_engine.directives.backend.refine` as a real package member —
+// the package `__init__` imports its (still-Python) siblings, which all exist
+// in source until the Phase-12 sweep. The TS twin is exercised in-process; the
+// Python original via a python3 subprocess.
+//
+// The gate routes on envelope shape (ticket path vs prompt path) and mutates
+// `state.ticket` on the prompt path (`confidence`, `acceptance_criteria`). Both
+// engines build a `DeliveryState` from the same JSON fixture, run, and emit
+// `{outcome, questions, message, ticket}` as
+// `json.dumps(..., indent=2, ensure_ascii=False)` for a byte-exact compare.
+// Coverage: ticket-path SUCCESS + every deficiency permutation, the headnote
+// id fallback, the prompt-path delegate (no AC) directive, and the high /
+// medium / medium-confirmed / low / ui-intent confidence bands incl. the
+// confidence projection. No non-determinism.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/refine.js';
+import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/**
+ * Drive `work_engine.directives.backend.refine.run` on python3 from a JSON
+ * state fixture; emit `{outcome, questions, message, ticket}` as canonical
+ * JSON. `ticket` is included because the prompt path mutates it in place
+ * (confidence breakdown + acceptance_criteria projection).
+ */
+function runPy(stateJson: string): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'import importlib',
+        'mod = importlib.import_module("work_engine.directives.backend.refine")',
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "ticket": st.ticket}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** TS twin: build DeliveryState from the fixture, run, emit canonical JSON. */
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const st = new DeliveryState(state);
+    const r: StepResult = run(st);
+    return JSON.stringify(
+        { outcome: r.outcome, questions: r.questions, message: r.message, ticket: st.ticket },
+        null,
+        2,
+    );
+}
+
+/** Build the matching python fixture JSON from the same constructor args. */
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/backend/refine — AMBIGUITIES', () => {
+    it('declares the seven surfaces in order', () => {
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual([
+            'missing_id',
+            'trivial_title',
+            'missing_or_vague_ac',
+            'prompt_unrefined',
+            'prompt_medium_confidence',
+            'prompt_low_confidence',
+            'prompt_ui_intent',
+        ]);
+    });
+
+    it('renders the configurable length floors into trigger text', () => {
+        const trivialTitle = AMBIGUITIES.find((a) => a.code === 'trivial_title');
+        const vagueAc = AMBIGUITIES.find((a) => a.code === 'missing_or_vague_ac');
+        expect(trivialTitle?.trigger).toContain('3 chars');
+        expect(vagueAc?.trigger).toContain('10 chars');
+    });
+});
+
+describeParity('directives/backend/refine — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        // --- ticket path ---------------------------------------------------
+        [
+            'well-formed ticket → SUCCESS',
+            {
+                ticket: {
+                    id: 'T-1',
+                    title: 'Build the widget',
+                    acceptance_criteria: ['the user must see the widget on load'],
+                },
+            },
+        ],
+        [
+            'empty ticket → all three deficiencies, "(no id)" headnote',
+            { ticket: {} },
+        ],
+        [
+            'missing id only → single deficiency',
+            { ticket: { title: 'A solid title', acceptance_criteria: ['the user must see the widget on load'] } },
+        ],
+        [
+            'trivial title (under floor) → BLOCKED',
+            { ticket: { id: 'T-2', title: 'ab', acceptance_criteria: ['the user must see the widget on load'] } },
+        ],
+        [
+            'whitespace-only id falls back to "(no id)" in headnote',
+            { ticket: { id: '   ', title: 'A solid title', acceptance_criteria: ['the user must see the widget'] } },
+        ],
+        [
+            'acceptance_criteria not a list → "no acceptance criteria"',
+            { ticket: { id: 'T-3', title: 'A solid title', acceptance_criteria: 'a string' } },
+        ],
+        [
+            'empty acceptance_criteria list → "no acceptance criteria"',
+            { ticket: { id: 'T-4', title: 'A solid title', acceptance_criteria: [] } },
+        ],
+        [
+            'vague AC items (under floor + non-string) → position list',
+            {
+                ticket: {
+                    id: 'T-5',
+                    title: 'A solid title',
+                    acceptance_criteria: ['short', 'the user must see the widget on load', 42],
+                },
+            },
+        ],
+        [
+            'all three deficiencies with a real id',
+            { ticket: { id: 'T-6', title: 'x', acceptance_criteria: [] } },
+        ],
+        // --- prompt path: delegate (no reconstructed AC) -------------------
+        [
+            'prompt envelope, no AC → delegate directive',
+            { ticket: { raw: 'add a rate limiter to the login endpoint behind a config flag' } },
+        ],
+        [
+            'prompt envelope, AC not a list → delegate directive',
+            { ticket: { raw: 'add a rate limiter', reconstructed_ac: 'not a list' } },
+        ],
+        [
+            'prompt envelope, long raw → preview is truncated with ellipsis',
+            {
+                ticket: {
+                    raw:
+                        'add a comprehensive distributed rate limiter to the authentication login endpoint ' +
+                        'with redis backing and per-tenant buckets and graceful degradation behaviour',
+                },
+            },
+        ],
+        // --- prompt path: high band → SUCCESS + confidence projection ------
+        [
+            // Score lands at 0.9 (reversibility=1 via the "config flag" surface),
+            // not an integer-valued 1.0, so the projected `score` float renders
+            // byte-identically through both engines' json.dumps.
+            'prompt high band → SUCCESS, confidence + AC projected onto ticket',
+            {
+                ticket: {
+                    raw: 'add a rate limiter to the login endpoint in `auth/limiter.py` behind a config flag',
+                    reconstructed_ac: [
+                        'given a burst of requests, the endpoint must reject over the cap',
+                        'when under the cap, requests should pass through unchanged',
+                        'then the limiter must expose a per-tenant counter',
+                    ],
+                    assumptions: ['default cap is 100 req/min'],
+                },
+            },
+        ],
+        // --- prompt path: medium band → PARTIAL halt ----------------------
+        [
+            'prompt medium band → PARTIAL assumptions halt',
+            {
+                ticket: {
+                    raw: 'improve the checkout flow',
+                    reconstructed_ac: ['the user should reach payment faster'],
+                    assumptions: ['fewer steps is the goal', 'no new payment provider'],
+                },
+            },
+        ],
+        [
+            'prompt medium band, confidence_confirmed → SUCCESS',
+            {
+                ticket: {
+                    raw: 'improve the checkout flow',
+                    reconstructed_ac: ['the user should reach payment faster'],
+                    assumptions: ['fewer steps is the goal'],
+                    confidence_confirmed: true,
+                },
+            },
+        ],
+        [
+            'prompt medium band, no assumptions → "(none recorded)" line',
+            {
+                ticket: {
+                    raw: 'improve the checkout flow',
+                    reconstructed_ac: ['the user should reach payment faster'],
+                },
+            },
+        ],
+        // --- prompt path: low band → BLOCKED single targeted question -----
+        [
+            'prompt low band → BLOCKED, weakest-dimension question',
+            {
+                ticket: {
+                    raw: 'do the thing?',
+                    reconstructed_ac: ['x'],
+                },
+            },
+        ],
+        // --- prompt path: ui-intent → BLOCKED regardless of band ----------
+        [
+            'prompt ui-intent → BLOCKED pending R3 (even with strong AC)',
+            {
+                ticket: {
+                    raw: 'redesign the dashboard layout with new tailwind colors and spacing',
+                    reconstructed_ac: [
+                        'given the dashboard, the new theme must apply on load',
+                        'when toggled, dark mode should persist across reloads',
+                        'then the spacing must match the design tokens',
+                    ],
+                },
+            },
+        ],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        const tsOut = runTs(state);
+        const pyOut = runPy(pyFixture(state));
+        expect(tsOut).toBe(pyOut);
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_report.test.ts
+++ b/tests/scripts/work_engine/directives_backend_report.test.ts
@@ -1,0 +1,139 @@
+// Golden-parity tests for work_engine/directives/backend/report.ts vs
+// report.py (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `report.py` imports `...delivery_state` + `...persona_policy`, so it loads as
+// a real package member via `sys.path` + import. The renderer is pure — it
+// reads DeliveryState and writes `state.report`. Both engines build the same
+// DeliveryState fixture, run, and emit the rendered `state.report` string
+// (raw, not JSON-wrapped) for a byte-exact compare. Coverage: every section's
+// populated + empty body, the memory-that-mattered drop rule, the visual-
+// preview gating, follow-up aggregation order, kv-block rendering, and the
+// advisory persona's suppressed next-commands section. No non-determinism.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/report.js';
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** Python driver: run report.run, emit the raw rendered `state.report`. */
+function runPy(stateJson: string): string {
+    const code = [
+        'import sys, json, importlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'mod = importlib.import_module("work_engine.directives.backend.report")',
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'mod.run(st)',
+        'sys.stdout.write(st.report)',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const st = new DeliveryState(state);
+    run(st);
+    return st.report;
+}
+
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/backend/report — AMBIGUITIES', () => {
+    it('declares no surfaces (pure renderer)', () => {
+        expect(AMBIGUITIES).toEqual([]);
+    });
+});
+
+describeParity('directives/backend/report — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        ['minimal state (all empties / placeholders)', { ticket: {} }],
+        [
+            'fully populated, verify success → both next-commands',
+            {
+                ticket: { id: 'R-1', title: 'Build the thing' },
+                persona: 'senior-engineer',
+                plan: [{ title: 'Step A', detail: 'do A' }, 'plain step'],
+                changes: [{ path: 'a.ts', lines: 'L1-L9', purpose: 'add' }, { file: 'b.ts' }],
+                tests: { verdict: 'success', targeted: 12 },
+                verify: { verdict: 'success', confidence: 'high' },
+                outcomes: { verify: 'success' },
+            },
+        ],
+        [
+            'string plan body',
+            { ticket: { id: 'R-2', title: 'T' }, plan: '  do this thing  ' },
+        ],
+        [
+            'memory that mattered drops non-influential hits',
+            {
+                ticket: { id: 'R-3' },
+                memory: [
+                    { id: 'm1', type: 'domain-invariants', changed_outcome: true, note: 'mattered' },
+                    { id: 'm2', type: 'historical-patterns' },
+                ],
+            },
+        ],
+        [
+            'memory all non-influential → section dropped',
+            { ticket: { id: 'R-4' }, memory: [{ id: 'm1', type: 'x' }] },
+        ],
+        [
+            'visual preview rendered (render_ok + paths)',
+            {
+                ticket: { id: 'R-5' },
+                ui_review: { preview: { render_ok: true, screenshot_path: 'shot.png', dom_dump_path: 'dom.html' } },
+            },
+        ],
+        [
+            'visual preview skipped (render_ok false) → dropped',
+            { ticket: { id: 'R-6' }, ui_review: { preview: { render_ok: false, screenshot_path: 'x.png' } } },
+        ],
+        [
+            'visual preview render_ok but no paths → dropped',
+            { ticket: { id: 'R-7' }, ui_review: { preview: { render_ok: true } } },
+        ],
+        [
+            'follow-ups aggregated from plan/verify/tests in order',
+            {
+                ticket: { id: 'R-8' },
+                plan: { steps: ['x'], followups: [{ note: 'plan fup', anchor: 'P#1' }] },
+                verify: { verdict: 'success', followups: [{ title: 'verify fup' }] },
+                tests: { verdict: 'success', followups: [{ note: 'test fup' }] },
+            },
+        ],
+        [
+            'advisory persona suppresses next-commands',
+            { ticket: { id: 'R-9' }, persona: 'advisory', outcomes: { verify: 'success' } },
+        ],
+        [
+            'verify not success → only /commit suggested',
+            { ticket: { id: 'R-10' }, outcomes: {} },
+        ],
+        [
+            'tests as a plain string (kv-block string branch)',
+            { ticket: { id: 'R-11' }, tests: '  all good  ' },
+        ],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        expect(runTs(state)).toBe(runPy(pyFixture(state)));
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_test.test.ts
+++ b/tests/scripts/work_engine/directives_backend_test.test.ts
@@ -1,0 +1,103 @@
+// Golden-parity tests for work_engine/directives/backend/test.ts vs test.py
+// (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `test.py` imports `...delivery_state` + `...persona_policy`, so it loads as a
+// real package member via `sys.path` + import. Covers persona gating (advisory
+// skip, qa widen=full), verdict validation (`{verdict!r}` repr in the malformed
+// message), and the bad-verdict halt. TS twin in-process; Python via python3
+// subprocess; byte-exact `{outcome, questions, message}` compare. Malformed-
+// verdict fixtures use only None / plain strings so the `repr()` rendering
+// (`'x'`, `None`) is unambiguous across engines. No non-determinism.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/test.js';
+import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(moduleName: string, stateJson: string): string {
+    const code = [
+        'import sys, json, importlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const r: StepResult = run(new DeliveryState(state));
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
+}
+
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+const ok = { implement: 'success' };
+
+describe('directives/backend/test — AMBIGUITIES', () => {
+    it('declares the four surfaces in order', () => {
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual([
+            'upstream_implement_failed',
+            'empty_tests_delegate',
+            'malformed_tests',
+            'bad_test_verdict',
+        ]);
+    });
+});
+
+describeParity('directives/backend/test — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        ['advisory persona → SUCCESS short-circuit', { ticket: { id: 'T-1' }, persona: 'advisory', outcomes: ok }],
+        ['implement not success → BLOCKED precondition', { ticket: { id: 'T-2' }, outcomes: {} }],
+        ['empty tests, senior → delegate targeted', { ticket: { id: 'T-3' }, outcomes: ok }],
+        ['empty tests, qa → delegate full (widen)', { ticket: { id: 'T-4' }, persona: 'qa', outcomes: ok }],
+        ['success verdict → SUCCESS', { ticket: { id: 'T-5' }, tests: { verdict: 'success' }, outcomes: ok }],
+        [
+            'failed verdict → BLOCKED bad verdict',
+            { ticket: { id: 'T-6' }, tests: { verdict: 'failed' }, outcomes: ok },
+        ],
+        [
+            'mixed verdict → BLOCKED bad verdict',
+            { ticket: { id: 'T-7' }, tests: { verdict: 'mixed' }, outcomes: ok },
+        ],
+        [
+            'tests not a dict → BLOCKED malformed (typename)',
+            { ticket: { id: 'T-8' }, tests: ['list not dict'], outcomes: ok },
+        ],
+        [
+            'unknown verdict string → BLOCKED malformed (repr)',
+            { ticket: { id: 'T-9' }, tests: { verdict: 'weird' }, outcomes: ok },
+        ],
+        [
+            'missing verdict key (None) → BLOCKED malformed (repr None)',
+            { ticket: { id: 'T-10' }, tests: { duration_ms: 5 }, outcomes: ok },
+        ],
+        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        expect(runTs(state)).toBe(runPy('test', pyFixture(state)));
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_verify.test.ts
+++ b/tests/scripts/work_engine/directives_backend_verify.test.ts
@@ -1,0 +1,96 @@
+// Golden-parity tests for work_engine/directives/backend/verify.ts vs
+// verify.py (ADR-094 py2ts Phase 1 — backend directive set).
+//
+// `verify.py` imports `...delivery_state` + `...persona_policy`, so it loads as
+// a real package member via `sys.path` + import. Covers persona gating
+// (advisory skip), verdict validation (`{verdict!r}` repr in the malformed
+// message), and the bad-verdict halt (`blocked` / `partial`). TS twin
+// in-process; Python via python3 subprocess; byte-exact compare. Malformed-
+// verdict fixtures use only None / plain strings for unambiguous repr. No
+// non-determinism.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/verify.js';
+import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(moduleName: string, stateJson: string): string {
+    const code = [
+        'import sys, json, importlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
+        'from work_engine.delivery_state import DeliveryState',
+        'payload = json.loads(sys.argv[1])',
+        'st = DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    const r: StepResult = run(new DeliveryState(state));
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
+}
+
+function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+    return JSON.stringify(state);
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+const ok = { test: 'success' };
+
+describe('directives/backend/verify — AMBIGUITIES', () => {
+    it('declares the four surfaces in order', () => {
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual([
+            'upstream_test_failed',
+            'empty_verify_delegate',
+            'malformed_verify',
+            'bad_verify_verdict',
+        ]);
+    });
+});
+
+describeParity('directives/backend/verify — golden parity (ts == py)', () => {
+    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
+        ['advisory persona → SUCCESS short-circuit', { ticket: { id: 'V-1' }, persona: 'advisory', outcomes: ok }],
+        ['test not success → BLOCKED precondition', { ticket: { id: 'V-2' }, outcomes: {} }],
+        ['empty verify → delegate review-changes', { ticket: { id: 'V-3' }, outcomes: ok }],
+        ['success verdict → SUCCESS', { ticket: { id: 'V-4' }, verify: { verdict: 'success' }, outcomes: ok }],
+        ['blocked verdict → BLOCKED bad verdict', { ticket: { id: 'V-5' }, verify: { verdict: 'blocked' }, outcomes: ok }],
+        ['partial verdict → BLOCKED bad verdict', { ticket: { id: 'V-6' }, verify: { verdict: 'partial' }, outcomes: ok }],
+        [
+            'verify not a dict → BLOCKED malformed (typename)',
+            { ticket: { id: 'V-7' }, verify: 'a string', outcomes: ok },
+        ],
+        [
+            'unknown verdict string → BLOCKED malformed (repr)',
+            { ticket: { id: 'V-8' }, verify: { verdict: 'failed' }, outcomes: ok },
+        ],
+        [
+            'missing verdict key (None) → BLOCKED malformed (repr None)',
+            { ticket: { id: 'V-9' }, verify: { confidence: 'high' }, outcomes: ok },
+        ],
+        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
+    ];
+
+    it.each(cases)('%s', (_label, state) => {
+        expect(runTs(state)).toBe(runPy('verify', pyFixture(state)));
+    });
+});

--- a/tests/scripts/work_engine/directives_mixed_contract.test.ts
+++ b/tests/scripts/work_engine/directives_mixed_contract.test.ts
@@ -1,0 +1,139 @@
+// Golden-parity rig for the py2ts `directives/mixed/contract` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). Drives `run` on
+// both engines from the same payload and asserts the `{outcome, questions,
+// message}` projection — covering the analyze-precondition gate, the
+// first-pass delegate, the incomplete-contract listing (`==[]`/`=={}`/`""`
+// empty checks), the unconfirmed-summary halt with counts, and the confirmed
+// success. The `_preview_input` truncation / whitespace-collapse is exercised
+// via the `raw` / `title` / `id` fallbacks.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    REQUIRED_CONTRACT_KEYS,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/mixed/contract.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'mixed', 'contract.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+const longTitle = 'A'.repeat(120);
+
+describePy('directives/mixed/contract — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['analyze not success → blocked', { ticket: { id: 'T' }, outcomes: {} }],
+        ['analyze success, no contract → delegate (title preview)', {
+            ticket: { title: 'Build dashboard' },
+            outcomes: { analyze: 'success' },
+        }],
+        ['delegate with raw whitespace-collapse preview', {
+            ticket: { raw: '  improve   the\n dashboard  ' },
+            outcomes: { analyze: 'success' },
+        }],
+        ['delegate with id fallback', {
+            ticket: { id: 'TASK-42' },
+            outcomes: { analyze: 'success' },
+        }],
+        ['delegate no-title fallback', {
+            ticket: {},
+            outcomes: { analyze: 'success' },
+        }],
+        ['delegate long-title truncation (… ellipsis)', {
+            ticket: { title: longTitle },
+            outcomes: { analyze: 'success' },
+        }],
+        ['incomplete: data_model empty list', {
+            ticket: { id: 'T' },
+            outcomes: { analyze: 'success' },
+            contract: { data_model: [], api_surface: [{ path: '/x' }] },
+        }],
+        ['incomplete: api_surface missing', {
+            ticket: { id: 'T' },
+            outcomes: { analyze: 'success' },
+            contract: { data_model: [{ entity: 'User' }] },
+        }],
+        ['incomplete: both empty (empty dict + empty string)', {
+            ticket: { id: 'T' },
+            outcomes: { analyze: 'success' },
+            contract: { data_model: {}, api_surface: '' },
+        }],
+        ['well-formed, unconfirmed → summary halt', {
+            ticket: { id: 'T' },
+            outcomes: { analyze: 'success' },
+            contract: { data_model: [{ entity: 'User' }, { entity: 'Org' }], api_surface: [{ path: '/u' }] },
+        }],
+        ['well-formed, confirmed → success', {
+            ticket: { id: 'T' },
+            outcomes: { analyze: 'success' },
+            contract: { data_model: [{ entity: 'User' }], api_surface: [{ path: '/u' }], contract_confirmed: true },
+        }],
+        ['confirmed flag falsy (not strictly true) → halt', {
+            ticket: { id: 'T' },
+            outcomes: { analyze: 'success' },
+            contract: { data_model: [{ entity: 'User' }], api_surface: [{ path: '/u' }], contract_confirmed: 'yes' },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/mixed/contract — TS-side unit checks', () => {
+    it('required keys + ambiguities', () => {
+        expect([...REQUIRED_CONTRACT_KEYS]).toEqual(['data_model', 'api_surface']);
+        expect(AMBIGUITIES).toHaveLength(4);
+    });
+});

--- a/tests/scripts/work_engine/directives_mixed_stitch.test.ts
+++ b/tests/scripts/work_engine/directives_mixed_stitch.test.ts
@@ -1,0 +1,130 @@
+// Golden-parity rig for the py2ts `directives/mixed/stitch` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). Asserts the
+// `{outcome, questions, message}` projection across the implement-precondition
+// gate, the empty-stitch delegate (with endpoint count from the contract), the
+// malformed-shape diagnostics (`type(x).__name__`, `{verdict!r}`), the
+// blocked/partial halt with scenario count, and the integration_confirmed
+// override success.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    INTEGRATION_TEST_DIRECTIVE,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/mixed/stitch.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'mixed', 'stitch.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/mixed/stitch — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['implement not success → blocked', { ticket: {}, outcomes: {} }],
+        ['empty stitch → delegate (endpoint count)', {
+            ticket: { raw: 'wire it up' },
+            outcomes: { implement: 'success' },
+            contract: { api_surface: [{ path: '/a' }, { path: '/b' }] },
+        }],
+        ['empty stitch, no contract → delegate (0 endpoints)', {
+            ticket: { id: 'T' },
+            outcomes: { implement: 'success' },
+        }],
+        ['stitch not a dict → blocked shape (type name)', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: ['nope'],
+        }],
+        ['bad verdict (repr) → blocked shape', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: { verdict: 'maybe' },
+        }],
+        ['verdict missing → blocked shape (None repr)', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: { scenarios: [] },
+        }],
+        ['success verdict → success', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: { verdict: 'success' },
+        }],
+        ['blocked verdict, not confirmed → halt (scenario count)', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: { verdict: 'blocked', scenarios: [{ n: 1 }, { n: 2 }] },
+        }],
+        ['partial verdict, confirmed → override success', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: { verdict: 'partial', integration_confirmed: true },
+        }],
+        ['partial verdict, confirmed falsy → halt', {
+            ticket: {},
+            outcomes: { implement: 'success' },
+            stitch: { verdict: 'partial', integration_confirmed: 'sure' },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/mixed/stitch — TS-side unit checks', () => {
+    it('directive name + ambiguities', () => {
+        expect(INTEGRATION_TEST_DIRECTIVE).toBe('integration-test');
+        expect(AMBIGUITIES).toHaveLength(4);
+    });
+});

--- a/tests/scripts/work_engine/directives_mixed_ui.test.ts
+++ b/tests/scripts/work_engine/directives_mixed_ui.test.ts
@@ -1,0 +1,125 @@
+// Golden-parity rig for the py2ts `directives/mixed/ui` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). Asserts the
+// `{outcome, questions, message}` projection across the plan-precondition gate,
+// the contract-sentinel defense-in-depth halt, the ui-track delegation (with
+// entity / endpoint counts), the review-clean success, and the
+// review-unclean escalation halt (with finding count).
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    UI_TRACK_DIRECTIVE,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/mixed/ui.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'mixed', 'ui.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+const confirmed = { data_model: [{ entity: 'User' }], api_surface: [{ path: '/u' }], contract_confirmed: true };
+
+describePy('directives/mixed/ui — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['plan not success → blocked', { ticket: {}, outcomes: {} }],
+        ['plan success, contract not confirmed → sentinel halt', {
+            ticket: {},
+            outcomes: { plan: 'success' },
+            contract: { data_model: [{ entity: 'User' }], api_surface: [{ path: '/u' }] },
+        }],
+        ['plan success, no contract dict → sentinel halt', {
+            ticket: {},
+            outcomes: { plan: 'success' },
+        }],
+        ['confirmed, ui_review missing → delegate ui-track', {
+            ticket: { raw: 'build the screen' },
+            outcomes: { plan: 'success' },
+            contract: confirmed,
+        }],
+        ['confirmed, ui_review without review_clean → delegate', {
+            ticket: {},
+            outcomes: { plan: 'success' },
+            contract: confirmed,
+            ui_review: { findings: [] },
+        }],
+        ['confirmed, review_clean true → success', {
+            ticket: {},
+            outcomes: { plan: 'success' },
+            contract: confirmed,
+            ui_review: { review_clean: true, findings: [] },
+        }],
+        ['confirmed, review_clean false → unclean halt (finding count)', {
+            ticket: {},
+            outcomes: { plan: 'success' },
+            contract: confirmed,
+            ui_review: { review_clean: false, findings: [{ a: 1 }, { b: 2 }, { c: 3 }] },
+        }],
+        ['confirmed, review_clean truthy-not-true → unclean halt', {
+            ticket: {},
+            outcomes: { plan: 'success' },
+            contract: confirmed,
+            ui_review: { review_clean: 'yes', findings: [] },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/mixed/ui — TS-side unit checks', () => {
+    it('directive name + ambiguities', () => {
+        expect(UI_TRACK_DIRECTIVE).toBe('ui-track');
+        expect(AMBIGUITIES).toHaveLength(4);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui__passthrough.test.ts
+++ b/tests/scripts/work_engine/directives_ui__passthrough.test.ts
@@ -1,0 +1,88 @@
+// Golden-parity rig for the py2ts `directives/ui/_passthrough` twin (ADR-094).
+//
+// Loader pattern: `delivery_state.py` registered as the module
+// `delivery_state` before exec (so the `from __future__ import annotations`
+// dataclass type resolution finds it), then the handler source loaded with its
+// `from ...delivery_state import` rewritten to `from delivery_state import`.
+// Each block drives `run(state)` on both engines from the same payload and
+// asserts the `{outcome, questions, message}` projection is identical.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/_passthrough.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui', '_passthrough.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui/_passthrough — golden parity (python3 vs tsx)', () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+        ['empty ticket', { ticket: {} }],
+        ['populated state', { ticket: { id: 'T-1' }, memory: [{ note: 'x' }], plan: { a: 1 } }],
+    ];
+    for (const [label, payload] of cases) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            expect(JSON.parse(tsRun(payload))).toEqual(JSON.parse(pyRun(JSON.stringify(payload))));
+        });
+    }
+});
+
+describe('directives/ui/_passthrough — TS-side unit checks', () => {
+    it('AMBIGUITIES is empty', () => {
+        expect(AMBIGUITIES).toHaveLength(0);
+    });
+    it('run never mutates state', () => {
+        const st = new DeliveryState({ ticket: { id: 'X' }, memory: [{ a: 1 }] });
+        const before = JSON.stringify(st);
+        run(st);
+        expect(JSON.stringify(st)).toBe(before);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_apply.test.ts
+++ b/tests/scripts/work_engine/directives_ui_apply.test.ts
@@ -1,0 +1,151 @@
+// Golden-parity rig for the py2ts `directives/ui/apply` twin (ADR-094).
+//
+// `apply.py` imports `from ...delivery_state import ...` AND
+// `from .design import PLACEHOLDER_PATTERNS` (a sibling owned by this same
+// migration batch). The python loader therefore registers `delivery_state`,
+// loads `design.py` (with its own relative import rewritten) as the module
+// `design`, then loads `apply.py` with BOTH relative imports rewritten to flat
+// `from delivery_state import` / `from design import`. The `.ts` twin imports
+// `PLACEHOLDER_PATTERNS` from its own `./design.js` — a `.ts` never imports a
+// `.py`.
+//
+// `apply.run` mutates `state.changes` on success, so the projection includes
+// the StepResult AND `state.changes`. Covers: first-pass stack-dispatched
+// delegate (every stack + unknown→plain fallback), the placeholder rejection
+// (recursive `rendered` walk, dotted paths), and the change recording.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    DEFAULT_DIRECTIVE,
+    STACK_DIRECTIVES,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/apply.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const DESIGN_PY = path.join(WE, 'directives', 'ui', 'design.py');
+const MOD_PY = path.join(WE, 'directives', 'ui', 'apply.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        // Load the sibling `design` module (its own relative import rewritten),
+        // register it so `apply`'s `from design import PLACEHOLDER_PATTERNS`
+        // resolves.
+        `_design_src = open(${JSON.stringify(DESIGN_PY)}, encoding="utf-8").read()`,
+        '_design_src = _design_src.replace("from ...delivery_state import", "from delivery_state import")',
+        'design = type(sys)("design")',
+        'sys.modules["design"] = design',
+        'exec(compile(_design_src, "design", "exec"), design.__dict__)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        '_src = _src.replace("from .design import", "from design import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "changes": st.changes}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({
+        outcome: r.outcome,
+        questions: r.questions,
+        message: r.message,
+        changes: st.changes,
+    });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui/apply — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['first pass, no stack → delegate ui-apply-plain', { ticket: {} }],
+        ['first pass, blade stack → delegate matching directive', {
+            ticket: {},
+            stack: { frontend: 'blade-livewire-flux' },
+        }],
+        ['first pass, react-shadcn stack', { ticket: {}, stack: { frontend: 'react-shadcn' } }],
+        ['first pass, unknown stack → plain fallback (label kept)', {
+            ticket: {},
+            stack: { frontend: 'svelte' },
+        }],
+        ['empty ui_apply dict → delegate', { ticket: { ui_apply: {} } }],
+        ['placeholder in rendered output → reject (dotted path)', {
+            ticket: {
+                ui_apply: {
+                    rendered: { 'Button.tsx': 'click', 'Card.tsx': 'TODO: copy' },
+                    files: ['Button.tsx'],
+                },
+            },
+            stack: { frontend: 'react-shadcn' },
+        }],
+        ['nested rendered placeholder', {
+            ticket: { ui_apply: { rendered: { group: { a: 'Lorem ipsum' } }, files: ['a.tsx'] } },
+        }],
+        ['valid apply → record one change per file', {
+            ticket: { ui_apply: { rendered: { 'A.tsx': 'Save' }, files: ['A.tsx', 'B.tsx'], summary: 'render cards' } },
+            stack: { frontend: 'vue' },
+        }],
+        ['valid apply, files with a non-string entry → skipped', {
+            ticket: { ui_apply: { rendered: { 'A.tsx': 'ok' }, files: ['A.tsx', 42, '', 'B.tsx'] } },
+        }],
+        ['valid apply, no files → no changes recorded', {
+            ticket: { ui_apply: { rendered: { 'A.tsx': 'ok' } } },
+        }],
+        ['rendered not a dict → no violations, records', {
+            ticket: { ui_apply: { rendered: 'just a string', files: ['A.tsx'] } },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult + changes — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui/apply — TS-side unit checks', () => {
+    it('directives map + fallback + ambiguities', () => {
+        expect(DEFAULT_DIRECTIVE).toBe('ui-apply-plain');
+        expect(STACK_DIRECTIVES['react-shadcn']).toBe('ui-apply-react-shadcn');
+        expect(AMBIGUITIES).toHaveLength(2);
+    });
+    it('imports PLACEHOLDER_PATTERNS from the design twin (not the .py)', () => {
+        const st = new DeliveryState({
+            ticket: { ui_apply: { rendered: { x: 'xxx' }, files: ['x.tsx'] } },
+        } as never);
+        expect(run(st).outcome).toBe('blocked');
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_audit.test.ts
+++ b/tests/scripts/work_engine/directives_ui_audit.test.ts
@@ -1,0 +1,153 @@
+// Golden-parity rig for the py2ts `directives/ui/audit` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). `audit.run`
+// mutates `state.ui_audit` (writes `audit_path`), so the projection includes
+// the StepResult AND the mutated `state.ui_audit`. Covers: first-pass delegate,
+// greenfield-undecided halt, greenfield-decided success (records
+// `audit_path = "greenfield"`), shadcn version-mismatch soft halt (`int()` of
+// the parsed major), idempotent re-entry on a recorded path, high-confidence
+// success (`STRONG_SIMILARITY` + `TIE_GAP` + `float()` coercion), and the
+// ambiguous candidate-pick halt with the `.2f` similarity rendering
+// (round-half-to-even, e.g. 0.125 → 0.12).
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    STRONG_SIMILARITY,
+    TESTED_AGAINST_SHADCN_MAJOR,
+    TIE_GAP,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/audit.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui', 'audit.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "ui_audit": st.ui_audit}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({
+        outcome: r.outcome,
+        questions: r.questions,
+        message: r.message,
+        ui_audit: st.ui_audit,
+    });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui/audit — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['no audit → delegate', { ticket: { title: 'New screen' } }],
+        ['empty dict audit → delegate', { ticket: {}, ui_audit: {} }],
+        ['greenfield, no decision → halt', { ticket: {}, ui_audit: { greenfield: true } }],
+        ['greenfield, decided → success records audit_path', {
+            ticket: {},
+            ui_audit: { greenfield: true, greenfield_decision: 'scaffold' },
+        }],
+        ['greenfield, decided, audit_path already set → unchanged success', {
+            ticket: {},
+            ui_audit: { greenfield: true, greenfield_decision: 'bare', audit_path: 'greenfield' },
+        }],
+        ['shadcn major mismatch → soft halt', {
+            ticket: {},
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.9 }], shadcn_inventory: { version: 'v3.1.0' } },
+            // confidence medium by default → would be ambiguous, but mismatch halts first
+        }],
+        ['shadcn major matches → no halt (then ambiguous path)', {
+            ticket: { confidence: { band: 'medium' } },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.9 }], shadcn_inventory: { version: '2.4.0' } },
+        }],
+        ['shadcn version unparseable → skipped', {
+            ticket: { confidence: { band: 'high' } },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.95 }], shadcn_inventory: { version: 'latest' } },
+        }],
+        ['idempotent: audit_path high_confidence → success', {
+            ticket: {},
+            ui_audit: { components_found: [{ name: 'A' }], audit_path: 'high_confidence' },
+        }],
+        ['high confidence (band high, strong, no tie) → success', {
+            ticket: { confidence: { band: 'high' } },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.9 }, { name: 'B', similarity: 0.4 }] },
+        }],
+        ['high band but tie within TIE_GAP → ambiguous', {
+            ticket: { confidence: { band: 'high' } },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.9 }, { name: 'B', similarity: 0.88 }] },
+        }],
+        ['high band but below STRONG_SIMILARITY → ambiguous', {
+            ticket: { confidence: { band: 'high' } },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.5 }] },
+        }],
+        ['medium band → ambiguous (.2f banker rounding 0.125→0.12)', {
+            ticket: { confidence: { band: 'medium' } },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.125 }, { name: 'B', similarity: 0.7449 }] },
+        }],
+        ['ambiguous with path fallback + similarity as string', {
+            ticket: { confidence: { band: 'medium' } },
+            ui_audit: { components_found: [{ path: 'src/X.tsx', similarity: '0.62' }, { name: 'Y' }] },
+        }],
+        ['diff input_kind → high band default', {
+            ticket: { input_kind: 'diff' },
+            ui_audit: { components_found: [{ name: 'A', similarity: 0.85 }] },
+        }],
+        ['ambiguous, no matches at all → build-new recommendation', {
+            ticket: { confidence: { band: 'medium' } },
+            ui_audit: { components_found: [], greenfield: false },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult + ui_audit — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui/audit — TS-side unit checks', () => {
+    it('constants + ambiguities', () => {
+        expect(STRONG_SIMILARITY).toBe(0.7);
+        expect(TIE_GAP).toBe(0.05);
+        expect(TESTED_AGAINST_SHADCN_MAJOR).toBe(2);
+        expect(AMBIGUITIES).toHaveLength(4);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_design.test.ts
+++ b/tests/scripts/work_engine/directives_ui_design.test.ts
@@ -1,0 +1,133 @@
+// Golden-parity rig for the py2ts `directives/ui/design` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). Asserts the
+// `{outcome, questions, message}` projection across the first-pass delegate,
+// the incomplete-brief listing (required keys + per-state sub-keys), the
+// placeholder-microcopy rejection (recursive walk, dotted paths), the
+// unconfirmed-summary halt (component / state / recursive microcopy counts),
+// and the confirmed success.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    PLACEHOLDER_PATTERNS,
+    REQUIRED_BRIEF_KEYS,
+    REQUIRED_STATE_KEYS,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/design.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui', 'design.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+const fullStates = { empty: 'No items', loading: 'Loading…', error: 'Failed', success: 'Done', disabled: 'Off' };
+const fullBrief = {
+    layout: 'grid',
+    components: [{ name: 'Card' }],
+    states: fullStates,
+    microcopy: { buttons: { submit: 'Save', cancel: 'Cancel' }, empty: 'Nothing here' },
+    a11y: { contrast: 'AA' },
+};
+
+describePy('directives/ui/design — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['no design → delegate', { ticket: { title: 'Make a form' } }],
+        ['empty dict design → delegate', { ticket: {}, ui_design: {} }],
+        ['missing layout + components → incomplete', {
+            ticket: {},
+            ui_design: { states: fullStates, microcopy: { ok: 'Yes' }, a11y: { x: 1 } },
+        }],
+        ['states present but missing sub-keys → incomplete list', {
+            ticket: {},
+            ui_design: {
+                layout: 'grid',
+                components: [{ name: 'C' }],
+                states: { empty: 'x', loading: 'y' },
+                microcopy: { ok: 'Yes' },
+                a11y: { x: 1 },
+            },
+        }],
+        ['placeholder microcopy (recursive, dotted path)', {
+            ticket: {},
+            ui_design: {
+                ...fullBrief,
+                microcopy: { buttons: { submit: 'TODO: finalize' }, empty: 'Lorem ipsum' },
+            },
+        }],
+        ['well-formed, unconfirmed → summary halt', {
+            ticket: { raw: 'design the card' },
+            ui_design: fullBrief,
+        }],
+        ['confirmed → success', {
+            ticket: {},
+            ui_design: { ...fullBrief, design_confirmed: true },
+        }],
+        ['empty-string layout treated as missing', {
+            ticket: {},
+            ui_design: { ...fullBrief, layout: '' },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui/design — TS-side unit checks', () => {
+    it('constants + ambiguities', () => {
+        expect([...REQUIRED_BRIEF_KEYS]).toEqual(['layout', 'components', 'states', 'microcopy', 'a11y']);
+        expect([...REQUIRED_STATE_KEYS]).toEqual(['empty', 'loading', 'error', 'success', 'disabled']);
+        expect([...PLACEHOLDER_PATTERNS]).toEqual(['<placeholder>', 'lorem', 'todo:', 'tbd', 'xxx']);
+        expect(AMBIGUITIES).toHaveLength(3);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_polish.test.ts
+++ b/tests/scripts/work_engine/directives_ui_polish.test.ts
@@ -1,0 +1,169 @@
+// Golden-parity rig for the py2ts `directives/ui/polish` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). Asserts the
+// `{outcome, questions, message}` projection across: review-clean / no-findings
+// success, the delegate-with-round-count path (incl. matched-token auto-convert
+// line), the token-extraction halt (insertion-ordered repeats, `isalnum`-based
+// suggested-name slug, `×` count), the subjective ceiling halt, the a11y
+// ceiling halt (extension-available vs spent, truncated to 5 + "... and N
+// more"), and the extension-aware effective ceiling.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    A11Y_VIOLATION_KIND,
+    AMBIGUITIES,
+    POLISH_CEILING,
+    TOKEN_REPEAT_THRESHOLD,
+    TOKEN_VIOLATION_KIND,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/polish.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui', 'polish.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+const tokenFinding = (value: string) => ({ kind: 'token_violation', category: 'colors', value });
+const a11yFinding = (rule: string) => ({ kind: 'a11y_violation', rule, selector: `.${rule}`, severity: 'serious' });
+
+describePy('directives/ui/polish — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['review_clean true → success', { ticket: {}, ui_review: { review_clean: true, findings: [{ x: 1 }] } }],
+        ['no findings → success', { ticket: {}, ui_review: { review_clean: false, findings: [] } }],
+        ['unclean, round 0 → delegate (round 1 of 2)', {
+            ticket: {},
+            ui_review: { review_clean: false, findings: [{ a: 1 }, { b: 2 }] },
+        }],
+        ['delegate with matched-token auto-convert line', {
+            ticket: {},
+            ui_review: { review_clean: false, findings: [tokenFinding('#fff')] },
+            ui_audit: { design_tokens: { colors: { white: '#fff' } } },
+            ui_polish: { rounds: 0 },
+        }],
+        ['token extraction halt (unmatched repeats >2, slug + ×)', {
+            ticket: {},
+            ui_review: {
+                review_clean: false,
+                findings: [tokenFinding('#abc123'), tokenFinding('#abc123'), tokenFinding('#abc123')],
+            },
+            ui_audit: { design_tokens: {} },
+            ui_polish: { rounds: 0 },
+        }],
+        ['token repeats exactly threshold (2) → no extraction, delegate', {
+            ticket: {},
+            ui_review: {
+                review_clean: false,
+                findings: [tokenFinding('#abc123'), tokenFinding('#abc123')],
+            },
+            ui_audit: { design_tokens: {} },
+            ui_polish: { rounds: 0 },
+        }],
+        ['subjective ceiling reached (rounds 2) → ceiling halt', {
+            ticket: {},
+            ui_review: { review_clean: false, findings: [{ note: 'spacing off' }] },
+            ui_polish: { rounds: 2 },
+        }],
+        ['a11y ceiling, extension available → a11y halt with extend option', {
+            ticket: {},
+            ui_review: { review_clean: false, findings: [a11yFinding('color-contrast'), a11yFinding('label')] },
+            ui_polish: { rounds: 2 },
+        }],
+        ['a11y ceiling, extension spent → accept/abort only', {
+            ticket: {},
+            ui_review: { review_clean: false, findings: [a11yFinding('color-contrast')] },
+            ui_polish: { rounds: 3, extension_used: true },
+        }],
+        ['a11y ceiling, >5 findings → truncation "... and N more"', {
+            ticket: {},
+            ui_review: {
+                review_clean: false,
+                findings: [
+                    a11yFinding('r1'), a11yFinding('r2'), a11yFinding('r3'),
+                    a11yFinding('r4'), a11yFinding('r5'), a11yFinding('r6'), a11yFinding('r7'),
+                ],
+            },
+            ui_polish: { rounds: 2 },
+        }],
+        ['extension lifts ceiling to 3 → still delegates at round 2', {
+            ticket: {},
+            ui_review: { review_clean: false, findings: [{ note: 'x' }] },
+            ui_polish: { rounds: 2, extension_used: true },
+        }],
+        ['suggested-name slug from non-alnum value', {
+            ticket: {},
+            ui_review: {
+                review_clean: false,
+                findings: [
+                    { kind: 'token_violation', category: 'spacing', value: '12px !important' },
+                    { kind: 'token_violation', category: 'spacing', value: '12px !important' },
+                    { kind: 'token_violation', category: 'spacing', value: '12px !important' },
+                ],
+            },
+            ui_audit: { design_tokens: {} },
+            ui_polish: { rounds: 0 },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui/polish — TS-side unit checks', () => {
+    it('constants + ambiguities', () => {
+        expect(POLISH_CEILING).toBe(2);
+        expect(TOKEN_REPEAT_THRESHOLD).toBe(2);
+        expect(A11Y_VIOLATION_KIND).toBe('a11y_violation');
+        expect(TOKEN_VIOLATION_KIND).toBe('token_violation');
+        expect(AMBIGUITIES).toHaveLength(4);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_review.test.ts
+++ b/tests/scripts/work_engine/directives_ui_review.test.ts
@@ -1,0 +1,190 @@
+// Golden-parity rig for the py2ts `directives/ui/review` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). `review.run` can
+// mutate `state.ui_review` (synthesises a11y findings, forces
+// `review_clean = False`), so the projection includes the StepResult AND the
+// mutated `state.ui_review`. Covers: first-pass delegate, findings-missing /
+// review_clean-missing shape halts, the a11y gate (baseline / accepted /
+// severity-floor filtering, dedup, synthesis + review_clean flip), the
+// a11y-pending halt, and the preview-render gate (skip / failed / ok).
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    DEFAULT_SEVERITY_FLOOR,
+    SEVERITY_ORDER,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/review.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui', 'review.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "ui_review": st.ui_review}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({
+        outcome: r.outcome,
+        questions: r.questions,
+        message: r.message,
+        ui_review: st.ui_review,
+    });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui/review — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['no review → delegate', { ticket: {} }],
+        ['empty dict review → delegate', { ticket: {}, ui_review: {} }],
+        ['findings missing → shape halt', { ticket: {}, ui_review: { review_clean: true } }],
+        ['findings not a list → shape halt', { ticket: {}, ui_review: { findings: 'nope', review_clean: true } }],
+        ['review_clean missing → shape halt (findings count)', {
+            ticket: {},
+            ui_review: { findings: [{ a: 1 }, { b: 2 }] },
+        }],
+        ['review_clean not a bool → shape halt', {
+            ticket: {},
+            ui_review: { findings: [], review_clean: 'yes' },
+        }],
+        ['well-formed, no a11y / no preview → success', {
+            ticket: {},
+            ui_review: { findings: [], review_clean: true },
+        }],
+        ['audit baseline declared but review.a11y missing → pending halt', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [] },
+            ui_review: { findings: [], review_clean: true },
+        }],
+        ['a11y violations above floor → synthesise + flip review_clean', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: { violations: [{ rule: 'color-contrast', selector: '.btn', severity: 'serious' }] },
+            },
+        }],
+        ['a11y violation below floor → no actionable, success', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: { violations: [{ rule: 'minor-thing', selector: '.x', severity: 'minor' }] },
+            },
+        }],
+        ['a11y violation in baseline → filtered out, success', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [{ rule: 'color-contrast', selector: '.btn' }] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: { violations: [{ rule: 'color-contrast', selector: '.btn', severity: 'critical' }] },
+            },
+        }],
+        ['a11y violation in accepted → filtered out, success', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [{ rule: 'r', selector: '.s', severity: 'serious' }],
+                    accepted_violations: [{ rule: 'r', selector: '.s' }],
+                },
+            },
+        }],
+        ['a11y synthesis dedup (existing finding) → no duplicate', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [{ kind: 'a11y_violation', rule: 'r', selector: '.s', severity: 'serious' }],
+                review_clean: false,
+                a11y: { violations: [{ rule: 'r', selector: '.s', severity: 'serious' }] },
+            },
+        }],
+        ['custom severity_floor critical → serious filtered out', {
+            ticket: {},
+            ui_audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [{ rule: 'r', selector: '.s', severity: 'serious' }],
+                    severity_floor: 'critical',
+                },
+            },
+        }],
+        ['preview render_ok false → preview-failed halt (error line)', {
+            ticket: {},
+            ui_review: { findings: [], review_clean: true, preview: { render_ok: false, error: 'timeout' } },
+        }],
+        ['preview render_ok false, no error → "(none reported)"', {
+            ticket: {},
+            ui_review: { findings: [], review_clean: true, preview: { render_ok: false } },
+        }],
+        ['preview skipped → success', {
+            ticket: {},
+            ui_review: { findings: [], review_clean: true, preview: { skipped: true, render_ok: false } },
+        }],
+        ['preview render_ok true → success', {
+            ticket: {},
+            ui_review: { findings: [], review_clean: true, preview: { render_ok: true, screenshot_path: 'x.png' } },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult + ui_review — ${label}`, () => {
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui/review — TS-side unit checks', () => {
+    it('constants + ambiguities', () => {
+        expect(DEFAULT_SEVERITY_FLOOR).toBe('moderate');
+        expect(SEVERITY_ORDER).toEqual({ minor: 0, moderate: 1, serious: 2, critical: 3 });
+        expect(AMBIGUITIES).toHaveLength(5);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_trivial__skipped.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial__skipped.test.ts
@@ -1,0 +1,102 @@
+// Golden-parity rig for the py2ts `directives/ui_trivial/_skipped` twin (ADR-094).
+//
+// `_skipped.py` imports `from ...delivery_state import DeliveryState, Outcome,
+// StepResult`. To exercise it from python3 without importing the whole
+// `work_engine` package (whose `__init__` pulls in unported siblings), we load
+// `delivery_state.py` as the module `delivery_state` (registered in
+// `sys.modules` BEFORE exec so the `from __future__ import annotations`
+// dataclass field-type resolution finds it), then load the handler source with
+// its `from ...delivery_state import` rewritten to `from delivery_state import`
+// and exec it as a standalone module.
+//
+// Each block drives `run(state)` on BOTH engines from the same payload and
+// asserts the StepResult projection (`{outcome, questions, message}`) is
+// byte-identical. The TS side runs under `node node_modules/.bin/tsx`.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/_skipped.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui_trivial', '_skipped.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+/** Python: build a DeliveryState from the payload, run, project the result. */
+function pyRun(ticketJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [ticketJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui_trivial/_skipped — golden parity (python3 vs tsx)', () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+        ['empty ticket', { ticket: {} }],
+        ['populated ticket ignored', { ticket: { id: 'T-1', intent: 'whatever' } }],
+        ['fully populated state', {
+            ticket: { id: 'T-9' },
+            changes: [{ kind: 'ui' }],
+            tests: { verdict: 'failed' },
+        }],
+    ];
+    for (const [label, payload] of cases) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            const py = pyRun(JSON.stringify(payload));
+            const ts = tsRun(payload);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui_trivial/_skipped — TS-side unit checks', () => {
+    it('AMBIGUITIES is empty (no blocked paths)', () => {
+        expect(AMBIGUITIES).toHaveLength(0);
+    });
+    it('run never mutates state', () => {
+        const st = new DeliveryState({ ticket: { id: 'X' } });
+        const before = JSON.stringify(st);
+        run(st);
+        expect(JSON.stringify(st)).toBe(before);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_trivial_apply.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial_apply.test.ts
@@ -1,0 +1,131 @@
+// Golden-parity rig for the py2ts `directives/ui_trivial/apply` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). `apply.run`
+// mutates state (records a change on success; sets `__reclassify_to__` and
+// drops `trivial_edit` on the reclassify halt), so the projection includes the
+// StepResult AND the mutated `state.ticket` + `state.changes`. Covers the
+// first-pass delegate, every precondition violation (`int()` coercion of
+// `lines_changed`, file count, component/state/dependency flags), and the
+// success record.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    MAX_FILES,
+    MAX_LINES_CHANGED,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/apply.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui_trivial', 'apply.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "ticket": st.ticket, "changes": st.changes}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({
+        outcome: r.outcome,
+        questions: r.questions,
+        message: r.message,
+        ticket: st.ticket,
+        changes: st.changes,
+    });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui_trivial/apply — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['first pass (no envelope) → delegate', { ticket: {} }],
+        ['empty envelope dict → delegate', { ticket: { trivial_edit: {} } }],
+        ['valid trivial edit → success + record', {
+            ticket: { trivial_edit: { files: ['src/a.tsx'], lines_changed: 3, summary: 'tweak' } },
+        }],
+        ['valid, lines as string "5" (int coercion)', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: '5' } },
+        }],
+        ['too many files → reclassify', {
+            ticket: { trivial_edit: { files: ['a.tsx', 'b.tsx'], lines_changed: 2 } },
+        }],
+        ['too many lines → reclassify', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: 9 } },
+        }],
+        ['lines missing → reclassify (lines_changed_missing)', {
+            ticket: { trivial_edit: { files: ['a.tsx'] } },
+        }],
+        ['lines is null → reclassify', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: null } },
+        }],
+        ['negative lines → reclassify', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: -1 } },
+        }],
+        ['new component → reclassify', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: 1, new_component: true } },
+        }],
+        ['new state + new dependency → reclassify (both codes)', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: 1, new_state: true, new_dependency: true } },
+        }],
+        ['files missing → reclassify (files_missing)', {
+            ticket: { trivial_edit: { lines_changed: 1 } },
+        }],
+        ['lines as float 2.9 (truncates to 2) → success', {
+            ticket: { trivial_edit: { files: ['a.tsx'], lines_changed: 2.9 } },
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult + state — ${label}`, () => {
+            // `run` mutates state; snapshot the payload JSON before tsRun so the
+            // python side receives the un-mutated input.
+            const json = JSON.stringify(payload);
+            const py = pyRun(json);
+            const ts = tsRun(JSON.parse(json) as Record<string, unknown>);
+            expect(JSON.parse(ts)).toEqual(JSON.parse(py));
+        });
+    }
+});
+
+describe('directives/ui_trivial/apply — TS-side unit checks', () => {
+    it('ceilings + ambiguities', () => {
+        expect(MAX_FILES).toBe(1);
+        expect(MAX_LINES_CHANGED).toBe(5);
+        expect(AMBIGUITIES).toHaveLength(2);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_trivial_refine.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial_refine.test.ts
@@ -1,0 +1,91 @@
+// Golden-parity rig for the py2ts `directives/ui_trivial/refine` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts): `delivery_state`
+// registered before exec, handler `from ...delivery_state import` rewritten to
+// `from delivery_state import`. Drives `run(state)` on both engines and asserts
+// the `{outcome, questions, message}` projection is byte-identical, covering the
+// silent-pass, matching-intent, and wrong-intent (BLOCKED) paths plus the
+// `{intent!r}` repr in the message.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    EXPECTED_INTENT,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/refine.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui_trivial', 'refine.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui_trivial/refine — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['no intent → silent pass', { ticket: { id: 'T-1' } }],
+        ['matching intent → success', { ticket: { intent: 'ui-trivial' } }],
+        ['null intent → silent pass', { ticket: { intent: null } }],
+        ['wrong intent (string) → blocked', { ticket: { intent: 'backend-coding' } }],
+        ['wrong intent with single quote → blocked', { ticket: { intent: "it's-weird" } }],
+        ['wrong intent (number) → blocked', { ticket: { intent: 42 } }],
+        ['wrong intent (bool true) → blocked', { ticket: { intent: true } }],
+        ['empty ticket → silent pass', { ticket: {} }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            expect(JSON.parse(tsRun(payload))).toEqual(JSON.parse(pyRun(JSON.stringify(payload))));
+        });
+    }
+});
+
+describe('directives/ui_trivial/refine — TS-side unit checks', () => {
+    it('EXPECTED_INTENT + one declared ambiguity', () => {
+        expect(EXPECTED_INTENT).toBe('ui-trivial');
+        expect(AMBIGUITIES).toHaveLength(1);
+        expect(AMBIGUITIES[0]?.code).toBe('wrong_intent_for_trivial');
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_trivial_report.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial_report.test.ts
@@ -1,0 +1,111 @@
+// Golden-parity rig for the py2ts `directives/ui_trivial/report` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). `report.run`
+// writes `state.report`, so the projection includes both the StepResult and
+// the rendered `state.report` string — covering the no-change placeholder, the
+// single-file vs multi-file rendering, the smoke-verdict suffix, and the
+// `lines_changed` default.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/report.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui_trivial', 'report.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "report": st.report}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({
+        outcome: r.outcome,
+        questions: r.questions,
+        message: r.message,
+        report: st.report,
+    });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui_trivial/report — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['no trivial change → placeholder', { ticket: {}, changes: [] }],
+        ['non-trivial changes only → placeholder', { ticket: {}, changes: [{ kind: 'ui' }] }],
+        ['single file + lines + summary', {
+            ticket: {},
+            changes: [{ kind: 'ui-trivial', files: ['src/a.tsx'], lines_changed: 3, summary: 'tweak label' }],
+            tests: { verdict: 'success' },
+        }],
+        ['multi file (count rendering)', {
+            ticket: {},
+            changes: [{ kind: 'ui-trivial', files: ['a.tsx', 'b.tsx'], lines_changed: 4 }],
+        }],
+        ['missing lines_changed default 0, no summary, no smoke', {
+            ticket: {},
+            changes: [{ kind: 'ui-trivial', files: ['only.tsx'] }],
+        }],
+        ['picks the LAST trivial change', {
+            ticket: {},
+            changes: [
+                { kind: 'ui-trivial', files: ['old.tsx'], lines_changed: 1, summary: 'old' },
+                { kind: 'ui-trivial', files: ['new.tsx'], lines_changed: 2, summary: 'new' },
+            ],
+            tests: { verdict: 'mixed' },
+        }],
+        ['empty files list → 0 files', {
+            ticket: {},
+            changes: [{ kind: 'ui-trivial', files: [], lines_changed: 0 }],
+        }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult + report — ${label}`, () => {
+            expect(JSON.parse(tsRun(payload))).toEqual(JSON.parse(pyRun(JSON.stringify(payload))));
+        });
+    }
+});
+
+describe('directives/ui_trivial/report — TS-side unit checks', () => {
+    it('AMBIGUITIES is empty (pure render)', () => {
+        expect(AMBIGUITIES).toHaveLength(0);
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_trivial_test.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial_test.test.ts
@@ -1,0 +1,94 @@
+// Golden-parity rig for the py2ts `directives/ui_trivial/test` twin (ADR-094).
+//
+// Loader pattern (see directives_ui_trivial__skipped.test.ts). Drives `run` on
+// both engines and asserts the `{outcome, questions, message}` projection,
+// covering the empty-delegate path (with the `run-tests scope=smoke`
+// agent-directive), the malformed-dict / bad-verdict diagnostics (including the
+// `type(x).__name__`, `{verdict!r}` repr, and the `_ALLOWED_VERDICTS` tuple
+// repr), and the failed / mixed verdict halts.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/test.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
+const DS_PY = path.join(WE, 'delivery_state.py');
+const MOD_PY = path.join(WE, 'directives', 'ui_trivial', 'test.py');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, json, importlib.util',
+        `_dspec = importlib.util.spec_from_file_location("delivery_state", ${JSON.stringify(DS_PY)})`,
+        'delivery_state = importlib.util.module_from_spec(_dspec)',
+        'sys.modules["delivery_state"] = delivery_state',
+        '_dspec.loader.exec_module(delivery_state)',
+        `_src = open(${JSON.stringify(MOD_PY)}, encoding="utf-8").read()`,
+        '_src = _src.replace("from ...delivery_state import", "from delivery_state import")',
+        'mod = type(sys)("mod")',
+        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], { encoding: 'utf8' });
+}
+
+function pyRun(payloadJson: string): string {
+    const body = [
+        'payload = json.loads(sys.argv[1])',
+        'st = delivery_state.DeliveryState(**payload)',
+        'r = mod.run(st)',
+        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
+        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
+    ].join('\n');
+    const r = runPy(body, [payloadJson]);
+    if (r.status !== 0) throw new Error(`py run failed: ${r.stderr || r.stdout}`);
+    return r.stdout;
+}
+
+function tsRun(payload: Record<string, unknown>): string {
+    const st = new DeliveryState(payload as never);
+    const r = run(st);
+    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message });
+}
+
+const PY = hasPython3();
+const describePy = PY ? describe : describe.skip;
+
+describePy('directives/ui_trivial/test — golden parity (python3 vs tsx)', () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+        ['empty tests → delegate', { ticket: {}, tests: null }],
+        ['empty dict tests → delegate (falsy)', { ticket: {}, tests: {} }],
+        ['tests is a list → malformed (type name)', { ticket: {}, tests: ['x'] }],
+        ['unknown verdict (string) → malformed', { ticket: {}, tests: { verdict: 'weird' } }],
+        ['verdict missing → malformed (None repr)', { ticket: {}, tests: { scope: 'smoke' } }],
+        ['verdict is a number → malformed (repr)', { ticket: {}, tests: { verdict: 7 } }],
+        ['success → flows through', { ticket: {}, tests: { verdict: 'success' } }],
+        ['failed → blocked halt', { ticket: {}, tests: { verdict: 'failed' } }],
+        ['mixed → blocked halt', { ticket: {}, tests: { verdict: 'mixed' } }],
+    ];
+    for (const [label, payload] of fixtures) {
+        it(`byte-identical StepResult — ${label}`, () => {
+            expect(JSON.parse(tsRun(payload))).toEqual(JSON.parse(pyRun(JSON.stringify(payload))));
+        });
+    }
+});
+
+describe('directives/ui_trivial/test — TS-side unit checks', () => {
+    it('three declared ambiguities', () => {
+        expect(AMBIGUITIES).toHaveLength(3);
+        expect(AMBIGUITIES.map((a) => a.code)).toEqual([
+            'empty_tests_delegate',
+            'malformed_tests',
+            'bad_test_verdict',
+        ]);
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_chat_history.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_chat_history.test.ts
@@ -1,0 +1,249 @@
+// Golden-parity + unit tests for the py2ts chat-history hooks twins (ADR-094):
+// _chat_history_base, chat_history_append, chat_history_halt_append.
+//
+// The hooks shell out to scripts/chat_history.py via an injectable runner. We
+// inject a fake runner on both engines that captures the argv (especially the
+// `--json` payload, which must be byte-identical to Python's json.dumps) and
+// returns a controllable exit code. No real subprocess is spawned.
+import { describe, expect, it } from 'vitest';
+
+import { Outcome, StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import { ChatHistoryAppendHook } from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_append.js';
+import { ChatHistoryHaltAppendHook } from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/chat_history_halt_append.js';
+import {
+    EXIT_FOREIGN,
+    EXIT_MISSING,
+    EXIT_OK,
+    EXIT_RETURNING,
+    type CompletedProcess,
+    type ProcessRunner,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/_chat_history_base.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookError } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+function fakeRunner(rc: number): { runner: ProcessRunner; calls: string[][] } {
+    const calls: string[][] = [];
+    const runner: ProcessRunner = (cmd) => {
+        calls.push([...cmd]);
+        return { returncode: rc, stdout: '', stderr: '' } as CompletedProcess;
+    };
+    return { runner, calls };
+}
+
+/** Run a callback registered on `event` by invoking the hook's registration. */
+function fireAppend(ctx: HookContext, rc: number): { calls: string[][]; error: HookError | null } {
+    const { runner, calls } = fakeRunner(rc);
+    const hook = new ChatHistoryAppendHook('scripts/chat_history.py', { runner });
+    const reg = new HookRegistry();
+    hook.register(reg);
+    let error: HookError | null = null;
+    try {
+        for (const cb of reg.for_event(HookEvent.AFTER_STEP)) cb(ctx);
+    } catch (e) {
+        if (e instanceof HookError) error = e;
+        else throw e;
+    }
+    return { calls, error };
+}
+
+function fireHalt(ctx: HookContext, rc: number): { calls: string[][]; error: HookError | null } {
+    const { runner, calls } = fakeRunner(rc);
+    const hook = new ChatHistoryHaltAppendHook('scripts/chat_history.py', { runner });
+    const reg = new HookRegistry();
+    hook.register(reg);
+    let error: HookError | null = null;
+    try {
+        for (const cb of reg.for_event(HookEvent.ON_HALT)) cb(ctx);
+    } catch (e) {
+        if (e instanceof HookError) error = e;
+        else throw e;
+    }
+    return { calls, error };
+}
+
+describe('chat_history base — exit constants', () => {
+    it('match the Python module', () => {
+        expect([EXIT_OK, EXIT_MISSING, EXIT_FOREIGN, EXIT_RETURNING]).toEqual([0, 10, 11, 12]);
+    });
+});
+
+describe('ChatHistoryAppendHook — TS unit checks', () => {
+    it('no result → no subprocess', () => {
+        const { calls } = fireAppend(new HookContext(), EXIT_OK);
+        expect(calls).toEqual([]);
+    });
+
+    it('non-success outcome → no subprocess', () => {
+        const ctx = new HookContext({
+            step_name: 'memory',
+            result: new StepResult({ outcome: Outcome.BLOCKED }),
+        });
+        expect(fireAppend(ctx, EXIT_OK).calls).toEqual([]);
+    });
+
+    it('SUCCESS → invokes append with the phase payload', () => {
+        const ctx = new HookContext({
+            step_name: 'memory',
+            result: new StepResult({ outcome: Outcome.SUCCESS }),
+        });
+        const { calls, error } = fireAppend(ctx, EXIT_OK);
+        expect(error).toBeNull();
+        expect(calls.length).toBe(1);
+        expect(calls[0]).toEqual([
+            'python3',
+            'scripts/chat_history.py',
+            'append',
+            '--type',
+            'phase',
+            '--json',
+            '{"step": "memory"}',
+        ]);
+    });
+
+    it('missing step_name → "<unknown>" in payload', () => {
+        const ctx = new HookContext({ result: new StepResult({ outcome: Outcome.SUCCESS }) });
+        const { calls } = fireAppend(ctx, EXIT_OK);
+        expect(calls[0]?.[6]).toBe('{"step": "<unknown>"}');
+    });
+
+    it('non-zero exit → HookError', () => {
+        const ctx = new HookContext({
+            step_name: 'verify',
+            result: new StepResult({ outcome: Outcome.SUCCESS }),
+        });
+        const { error } = fireAppend(ctx, 3);
+        expect(error).toBeInstanceOf(HookError);
+        expect(error?.message).toBe('chat-history append failed (exit 3)');
+    });
+});
+
+describe('ChatHistoryHaltAppendHook — TS unit checks', () => {
+    it('questions from result win over delivery', () => {
+        const ctx = new HookContext({
+            step_name: 'refine',
+            result: new StepResult({ outcome: Outcome.BLOCKED, questions: ['1) a', '2) b'] }),
+            delivery: { questions: ['ignored'] },
+        });
+        const { calls } = fireHalt(ctx, EXIT_OK);
+        expect(calls[0]?.[6]).toBe('{"step": "refine", "questions": ["1) a", "2) b"]}');
+    });
+
+    it('falls back to delivery.questions when result has none', () => {
+        const ctx = new HookContext({
+            step_name: 'refine',
+            delivery: { questions: ['1) x'] },
+        });
+        const { calls } = fireHalt(ctx, EXIT_OK);
+        expect(calls[0]?.[6]).toBe('{"step": "refine", "questions": ["1) x"]}');
+    });
+
+    it('empty questions → empty list payload', () => {
+        const ctx = new HookContext({ step_name: 'plan' });
+        const { calls } = fireHalt(ctx, EXIT_OK);
+        expect(calls[0]?.[6]).toBe('{"step": "plan", "questions": []}');
+    });
+
+    it('non-zero exit → HookError', () => {
+        const ctx = new HookContext({ step_name: 'plan' });
+        const { error } = fireHalt(ctx, EXIT_FOREIGN);
+        expect(error?.message).toBe('chat-history halt-append failed (exit 11)');
+    });
+});
+
+describePy('chat-history hooks — payload parity (python3 vs TS)', () => {
+    function pyAppendPayload(stepName: string | null): string {
+        const stepArg = stepName === null ? 'None' : JSON.stringify(stepName);
+        const r = runPyHooks(
+            {
+                we: ['delivery_state'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['_chat_history_base', 'chat_history_append'],
+            },
+            [
+                'captured = {}',
+                'def fake(cmd):',
+                '    captured["cmd"] = list(cmd)',
+                '    import types',
+                '    return types.SimpleNamespace(returncode=0, stdout="", stderr="")',
+                'hook = chat_history_append.ChatHistoryAppendHook("scripts/chat_history.py", runner=fake)',
+                'Outcome = sys.modules["work_engine.delivery_state"].Outcome',
+                'StepResult = sys.modules["work_engine.delivery_state"].StepResult',
+                `ctx = context.HookContext(step_name=${stepArg}, result=StepResult(outcome=Outcome.SUCCESS))`,
+                'hook._on_after_step(ctx)',
+                'print(captured["cmd"][6])',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py append failed: ${r.stderr || r.stdout}`);
+        return r.stdout.replace(/\n$/, '');
+    }
+
+    function pyHaltPayload(stepName: string, questions: string[]): string {
+        const r = runPyHooks(
+            {
+                we: ['delivery_state'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['_chat_history_base', 'chat_history_halt_append'],
+            },
+            [
+                'captured = {}',
+                'def fake(cmd):',
+                '    captured["cmd"] = list(cmd)',
+                '    import types',
+                '    return types.SimpleNamespace(returncode=0, stdout="", stderr="")',
+                'hook = chat_history_halt_append.ChatHistoryHaltAppendHook("scripts/chat_history.py", runner=fake)',
+                'StepResult = sys.modules["work_engine.delivery_state"].StepResult',
+                'Outcome = sys.modules["work_engine.delivery_state"].Outcome',
+                `ctx = context.HookContext(step_name=${JSON.stringify(stepName)}, result=StepResult(outcome=Outcome.BLOCKED, questions=${JSON.stringify(questions)}))`,
+                'hook._on_halt(ctx)',
+                'print(captured["cmd"][6])',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py halt failed: ${r.stderr || r.stdout}`);
+        return r.stdout.replace(/\n$/, '');
+    }
+
+    it('append --json payload is byte-identical', () => {
+        for (const step of ['memory', 'a "quoted" step', 'üñ', null] as Array<string | null>) {
+            const ctx = new HookContext({
+                step_name: step,
+                result: new StepResult({ outcome: Outcome.SUCCESS }),
+            });
+            const tsPayload = fireAppend(ctx, EXIT_OK).calls[0]?.[6];
+            expect(tsPayload).toBe(pyAppendPayload(step));
+        }
+    });
+
+    it('halt --json payload is byte-identical', () => {
+        const cases: Array<[string, string[]]> = [
+            ['refine', ['1) a', '2) b']],
+            ['plan', []],
+            ['x', ['ünïcode 🧠', 'tab\there']],
+        ];
+        for (const [step, qs] of cases) {
+            const ctx = new HookContext({
+                step_name: step,
+                result: new StepResult({ outcome: Outcome.BLOCKED, questions: qs }),
+            });
+            const tsPayload = fireHalt(ctx, EXIT_OK).calls[0]?.[6];
+            expect(tsPayload).toBe(pyHaltPayload(step, qs));
+        }
+    });
+
+    it('exit constants match Python', () => {
+        const r = runPyHooks(
+            {
+                we: ['delivery_state'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['_chat_history_base'],
+            },
+            'print(json.dumps([_chat_history_base.EXIT_OK, _chat_history_base.EXIT_MISSING, _chat_history_base.EXIT_FOREIGN, _chat_history_base.EXIT_RETURNING]))',
+        );
+        expect(r.status).toBe(0);
+        expect(JSON.parse(r.stdout.trim())).toEqual([EXIT_OK, EXIT_MISSING, EXIT_FOREIGN, EXIT_RETURNING]);
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_decision_gate.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_decision_gate.test.ts
@@ -1,0 +1,208 @@
+// Golden-parity + unit tests for the py2ts decision_gate hook twin (ADR-094).
+// Bridges scoring.decision_engine into the AFTER_STEP hook bus. The HookHalt
+// surface (numbered options) and HookError reason text must be byte-identical.
+import { describe, expect, it } from 'vitest';
+
+import {
+    DecisionGateHook,
+    build_decision_gate_hook,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_gate.js';
+import { DecisionEngineSettings } from '../../../src/agent-src/templates/scripts/work_engine/scoring/decision_engine.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookError, HookHalt } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+interface Fired {
+    halt: HookHalt | null;
+    error: HookError | null;
+}
+
+function fire(settings: DecisionEngineSettings, ctx: HookContext): Fired {
+    const hook = new DecisionGateHook(settings);
+    const reg = new HookRegistry();
+    hook.register(reg);
+    const out: Fired = { halt: null, error: null };
+    try {
+        for (const cb of reg.for_event(HookEvent.AFTER_STEP)) cb(ctx);
+    } catch (e) {
+        if (e instanceof HookHalt) out.halt = e;
+        else if (e instanceof HookError) out.error = e;
+        else throw e;
+    }
+    return out;
+}
+
+// require_memory_hits gate owns the `refine` phase; empty memory triggers it.
+const refineCtx = new HookContext({ step_name: 'refine', delivery: { memory: [] } });
+
+describe('DecisionGateHook — TS unit checks', () => {
+    it('no active gate → short-circuit, nothing thrown', () => {
+        const out = fire(new DecisionEngineSettings(), refineCtx);
+        expect(out.halt).toBeNull();
+        expect(out.error).toBeNull();
+    });
+
+    it('no step_name → no-op', () => {
+        const out = fire(
+            new DecisionEngineSettings({ require_memory_hits: true }),
+            new HookContext({ delivery: { memory: [] } }),
+        );
+        expect(out.halt).toBeNull();
+        expect(out.error).toBeNull();
+    });
+
+    it('on_block=stop → HookHalt with numbered-option surface', () => {
+        const out = fire(
+            new DecisionEngineSettings({ require_memory_hits: true, on_block: 'stop' }),
+            refineCtx,
+        );
+        expect(out.halt).toBeInstanceOf(HookHalt);
+        expect(out.halt?.reason).toBe('decision_gate:require_memory_hits');
+        expect(out.halt?.surface).toEqual([
+            'Decision-engine gate fired: require_memory_hits (phase=refine)',
+            'Reason: memory_hits=0 but require_memory_hits=true (need >= 1)',
+            '1) Address the gate condition and resume.',
+            '2) Lower the gate in `.agent-settings.yml` (`decision_engine` block) and resume.',
+            '3) Abort the run.',
+        ]);
+    });
+
+    it('on_block=warn → HookError with the reason tag', () => {
+        const out = fire(
+            new DecisionEngineSettings({ require_memory_hits: true, on_block: 'warn' }),
+            refineCtx,
+        );
+        expect(out.error).toBeInstanceOf(HookError);
+        expect(out.error?.message).toBe(
+            'decision_gate:require_memory_hits — memory_hits=0 but require_memory_hits=true (need >= 1)',
+        );
+    });
+
+    it('gate satisfied (memory present) → no halt', () => {
+        const out = fire(
+            new DecisionEngineSettings({ require_memory_hits: true, on_block: 'stop' }),
+            new HookContext({ step_name: 'refine', delivery: { memory: [{ id: 'r1', hit: true }] } }),
+        );
+        expect(out.halt).toBeNull();
+        expect(out.error).toBeNull();
+    });
+
+    it('build_decision_gate_hook returns null on inactive / non-settings input', () => {
+        expect(build_decision_gate_hook(null)).toBeNull();
+        expect(build_decision_gate_hook(new DecisionEngineSettings())).toBeNull();
+        expect(build_decision_gate_hook({} as unknown)).toBeNull();
+        expect(
+            build_decision_gate_hook(new DecisionEngineSettings({ require_memory_hits: true })),
+        ).toBeInstanceOf(DecisionGateHook);
+    });
+});
+
+describePy('DecisionGateHook — surface/reason parity (python3 vs TS)', () => {
+    function pyFire(deKwargs: string, ctxExpr: string): { kind: string; reason: string; surface: string[] | null } {
+        const r = runPyHooks(
+            {
+                we: ['scoring.decision_engine', 'scoring.decision_trace'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['decision_gate'],
+            },
+            [
+                'de = sys.modules["work_engine.scoring.decision_engine"]',
+                `settings = de.DecisionEngineSettings(${deKwargs})`,
+                'hook = decision_gate.DecisionGateHook(settings)',
+                `ctx = ${ctxExpr}`,
+                'kind, reason, surface = "none", "", None',
+                'try:',
+                '    hook._evaluate(ctx)',
+                'except exceptions.HookHalt as h:',
+                '    kind, reason, surface = "halt", h.reason, list(h.surface)',
+                'except exceptions.HookError as e:',
+                '    kind, reason = "error", str(e)',
+                'print(json.dumps({"kind": kind, "reason": reason, "surface": surface}))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py gate failed: ${r.stderr || r.stdout}`);
+        return JSON.parse(r.stdout.trim());
+    }
+
+    const ctxExpr = "context.HookContext(step_name='refine', delivery=type('D',(),{'memory':[]})())";
+
+    it('on_block=stop surface matches byte-for-byte', () => {
+        const py = pyFire('require_memory_hits=True, on_block="stop"', ctxExpr);
+        const ts = fire(
+            new DecisionEngineSettings({ require_memory_hits: true, on_block: 'stop' }),
+            refineCtx,
+        );
+        expect(py.kind).toBe('halt');
+        expect(ts.halt?.reason).toBe(py.reason);
+        expect(ts.halt?.surface).toEqual(py.surface);
+    });
+
+    it('on_block=warn reason matches', () => {
+        const py = pyFire('require_memory_hits=True, on_block="warn"', ctxExpr);
+        const ts = fire(
+            new DecisionEngineSettings({ require_memory_hits: true, on_block: 'warn' }),
+            refineCtx,
+        );
+        expect(py.kind).toBe('error');
+        expect(ts.error?.message).toBe(py.reason);
+    });
+
+    it('ask_timeout (CI) → halt with [ask_timeout] suffix, surface matches', () => {
+        // Force non-interactive: on_block=ask + CI env → ask_timeout; fallback
+        // stop → HookHalt with the ask_timeout suffix.
+        const prevCI = process.env.CI;
+        process.env.CI = '1';
+        try {
+            const py = pyFireWithCI('require_memory_hits=True, on_block="ask", on_block_fallback="stop"', ctxExpr);
+            const ts = fire(
+                new DecisionEngineSettings({
+                    require_memory_hits: true,
+                    on_block: 'ask',
+                    on_block_fallback: 'stop',
+                }),
+                refineCtx,
+            );
+            expect(py.kind).toBe('halt');
+            expect(ts.halt?.reason).toBe('decision_gate:require_memory_hits:ask_timeout');
+            expect(ts.halt?.reason).toBe(py.reason);
+            expect(ts.halt?.surface).toEqual(py.surface);
+        } finally {
+            if (prevCI === undefined) delete process.env.CI;
+            else process.env.CI = prevCI;
+        }
+    });
+
+    function pyFireWithCI(
+        deKwargs: string,
+        ctxExpr2: string,
+    ): { kind: string; reason: string; surface: string[] | null } {
+        const r = runPyHooks(
+            {
+                we: ['scoring.decision_engine', 'scoring.decision_trace'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['decision_gate'],
+            },
+            [
+                'os.environ["CI"] = "1"',
+                'de = sys.modules["work_engine.scoring.decision_engine"]',
+                `settings = de.DecisionEngineSettings(${deKwargs})`,
+                'hook = decision_gate.DecisionGateHook(settings)',
+                `ctx = ${ctxExpr2}`,
+                'kind, reason, surface = "none", "", None',
+                'try:',
+                '    hook._evaluate(ctx)',
+                'except exceptions.HookHalt as h:',
+                '    kind, reason, surface = "halt", h.reason, list(h.surface)',
+                'except exceptions.HookError as e:',
+                '    kind, reason = "error", str(e)',
+                'print(json.dumps({"kind": kind, "reason": reason, "surface": surface}))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py gate(CI) failed: ${r.stderr || r.stdout}`);
+        return JSON.parse(r.stdout.trim());
+    }
+});

--- a/tests/scripts/work_engine/hooks_builtin_decision_trace.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_decision_trace.test.ts
@@ -1,0 +1,174 @@
+// Golden-parity + unit tests for the py2ts decision_trace hook twin (ADR-094).
+// The hook writes a decision-trace JSON file per phase. The envelope must be
+// byte-identical (json.dumps(indent=2, sort_keys=False) + "\n") on both
+// engines; the two timestamp fields are non-deterministic so they are
+// normalised to a fixed token before the byte comparison (documented in-line).
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    DecisionTraceHook,
+    SCHEMA_VERSION,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_trace.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-dtrace-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// Normalise the two ISO-8601 timestamp fields so the byte comparison is over
+// the deterministic envelope shape, not the wall clock.
+function normaliseTrace(text: string): string {
+    return text
+        .replace(/"started_at": "[^"]*"/, '"started_at": "<TS>"')
+        .replace(/"ended_at": "[^"]*"/, '"ended_at": "<TS>"');
+}
+
+/** Drive the TS hook through BEFORE_LOAD → BEFORE_STEP → AFTER_STEP. */
+function runTsTrace(stateFile: string, phase: string, delivery: Record<string, unknown>): string {
+    const hook = new DecisionTraceHook();
+    const reg = new HookRegistry();
+    hook.register(reg);
+    const ctxLoad = new HookContext({ state_file: stateFile });
+    for (const cb of reg.for_event(HookEvent.BEFORE_LOAD)) cb(ctxLoad);
+    const ctxStep = new HookContext({ step_name: phase, delivery });
+    for (const cb of reg.for_event(HookEvent.BEFORE_STEP)) cb(ctxStep);
+    for (const cb of reg.for_event(HookEvent.AFTER_STEP)) cb(ctxStep);
+    // The hook computes the target relative to the state file; resolve it.
+    const target = resolveTarget(stateFile, phase);
+    return fs.readFileSync(target, 'utf-8');
+}
+
+function resolveTarget(stateFile: string, phase: string): string {
+    const filename = `decision-trace-${phase}.json`;
+    const parent = path.dirname(stateFile);
+    const grand = path.basename(path.dirname(parent));
+    if (path.basename(parent) && grand === 'work') {
+        return path.join(parent, filename);
+    }
+    const stem = path.basename(stateFile).replace(/\.[^.]+$/, '');
+    return path.join(parent, `${stem}.${filename}`);
+}
+
+describe('DecisionTraceHook — TS unit checks', () => {
+    it('SCHEMA_VERSION is 1', () => {
+        expect(SCHEMA_VERSION).toBe(1);
+    });
+
+    it('writes an envelope with the v1 shape under a work/<id>/ path', () => {
+        const dir = path.join(tmp, 'work', 'abc123');
+        fs.mkdirSync(dir, { recursive: true });
+        const stateFile = path.join(dir, 'state.json');
+        const text = runTsTrace(stateFile, 'memory', {
+            memory: [{ id: 'r1', hit: true }],
+            verify: { claims: 2, first_try_passes: 2 },
+            changes: [{ file: 'a.ts' }],
+        });
+        const env = JSON.parse(text) as Record<string, unknown>;
+        expect(env['schema_version']).toBe(1);
+        expect(env['work_id']).toBe('abc123');
+        expect(env['phase']).toBe('memory');
+        expect(env['rules']).toEqual([]);
+        // summarise_memory: each entry adds asks (default 1) → 1 entry = asks 1.
+        expect(env['memory']).toEqual({ asks: 1, hits: 1, ids: ['r1'] });
+        expect(text.endsWith('}\n')).toBe(true); // trailing newline
+    });
+
+    it('work_id falls back to the file stem outside a work/ tree', () => {
+        const stateFile = path.join(tmp, 'mystate.json');
+        runTsTrace(stateFile, 'plan', {});
+        expect(fs.existsSync(path.join(tmp, 'mystate.decision-trace-plan.json'))).toBe(true);
+        const env = JSON.parse(
+            fs.readFileSync(path.join(tmp, 'mystate.decision-trace-plan.json'), 'utf-8'),
+        ) as Record<string, unknown>;
+        expect(env['work_id']).toBe('mystate');
+    });
+
+    it('no step_name on AFTER_STEP → no file written', () => {
+        const hook = new DecisionTraceHook();
+        const reg = new HookRegistry();
+        hook.register(reg);
+        for (const cb of reg.for_event(HookEvent.AFTER_STEP)) cb(new HookContext());
+        expect(fs.readdirSync(tmp)).toEqual([]);
+    });
+});
+
+describePy('DecisionTraceHook — envelope parity (python3 vs TS)', () => {
+    function pyTrace(stateFile: string, phase: string, deliveryExpr: string): string {
+        const r = runPyHooks(
+            {
+                we: ['scoring.decision_trace'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['decision_trace'],
+            },
+            [
+                'import pathlib',
+                'hook = decision_trace.DecisionTraceHook()',
+                `sf = pathlib.Path(${JSON.stringify(stateFile)})`,
+                'hook.register(registry.HookRegistry()) if False else None',
+                'hook._capture_state_file(context.HookContext(state_file=sf))',
+                `delivery = ${deliveryExpr}`,
+                `hook._mark_step_start(context.HookContext(step_name=${JSON.stringify(phase)}, delivery=delivery))`,
+                `hook._emit_trace(context.HookContext(step_name=${JSON.stringify(phase)}, delivery=delivery))`,
+                `target = hook._target_path(${JSON.stringify(phase)})`,
+                'print(target.read_text(encoding="utf-8"), end="")',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py trace failed: ${r.stderr || r.stdout}`);
+        return r.stdout;
+    }
+
+    it('envelope is byte-identical under work/<id>/ (timestamps normalised)', () => {
+        // Two separate temp dirs so each engine writes its own copy.
+        const tsDir = path.join(tmp, 'ts', 'work', 'id99');
+        const pyDir = path.join(tmp, 'py', 'work', 'id99');
+        fs.mkdirSync(tsDir, { recursive: true });
+        fs.mkdirSync(pyDir, { recursive: true });
+
+        const tsText = runTsTrace(path.join(tsDir, 'state.json'), 'memory', {
+            memory: [
+                { id: 'r1', hit: true },
+                { id: 'r2', hit: true, asks: 2 },
+            ],
+            verify: { claims: 2, first_try_passes: 2 },
+            changes: [{ file: 'a.ts' }],
+            questions: [],
+        });
+        const pyText = pyTrace(
+            path.join(pyDir, 'state.json'),
+            'memory',
+            "type('D',(),{'memory':[{'id':'r1','hit':True},{'id':'r2','hit':True,'asks':2}],'verify':{'claims':2,'first_try_passes':2},'changes':[{'file':'a.ts'}],'questions':[]})()",
+        );
+        expect(normaliseTrace(tsText)).toBe(normaliseTrace(pyText));
+    });
+
+    it('empty-delivery envelope matches (low band, low risk, empty memory)', () => {
+        const tsDir = path.join(tmp, 'ts2');
+        const pyDir = path.join(tmp, 'py2');
+        fs.mkdirSync(tsDir, { recursive: true });
+        fs.mkdirSync(pyDir, { recursive: true });
+
+        const tsText = runTsTrace(path.join(tsDir, 's.json'), 'refine', {});
+        const pyText = pyTrace(path.join(pyDir, 's.json'), 'refine', "type('D',(),{})()");
+        expect(normaliseTrace(tsText)).toBe(normaliseTrace(pyText));
+    });
+
+    it('timestamp format is the contract ISO-8601 UTC second-precision form', () => {
+        const tsDir = path.join(tmp, 'ts3');
+        fs.mkdirSync(tsDir, { recursive: true });
+        const text = runTsTrace(path.join(tsDir, 's.json'), 'plan', {});
+        expect(text).toMatch(/"started_at": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"/);
+        expect(text).toMatch(/"ended_at": "\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"/);
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_directive_set_guard.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_directive_set_guard.test.ts
@@ -1,0 +1,105 @@
+// Golden-parity + unit tests for the py2ts directive_set_guard hook twin
+// (ADR-094). The hook raises HookError on drift; the message uses Python
+// `!r` repr formatting, so the parity layer checks the exact message text.
+import { describe, expect, it } from 'vitest';
+
+import { DirectiveSetGuardHook } from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/directive_set_guard.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookError } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+function fire(ctx: HookContext): HookError | null {
+    const hook = new DirectiveSetGuardHook();
+    const reg = new HookRegistry();
+    hook.register(reg);
+    try {
+        for (const cb of reg.for_event(HookEvent.BEFORE_DISPATCH)) cb(ctx);
+    } catch (e) {
+        if (e instanceof HookError) return e;
+        throw e;
+    }
+    return null;
+}
+
+describe('DirectiveSetGuardHook — TS unit checks', () => {
+    it('registers only on BEFORE_DISPATCH', () => {
+        const hook = new DirectiveSetGuardHook();
+        const reg = new HookRegistry();
+        hook.register(reg);
+        expect([...reg.events()]).toEqual([HookEvent.BEFORE_DISPATCH]);
+    });
+
+    it('missing work → HookError (both refs repr as None when absent)', () => {
+        const err = fire(new HookContext({}));
+        expect(err?.message).toBe(
+            'directive-set guard: missing set_name or work on before_dispatch (set_name=None, work=None)',
+        );
+    });
+
+    it('set_name present but work missing → HookError naming the set_name repr', () => {
+        const err = fire(new HookContext({ set_name: 'backend' }));
+        expect(err?.message).toBe(
+            "directive-set guard: missing set_name or work on before_dispatch (set_name='backend', work=None)",
+        );
+    });
+
+    it('matching set_name → no error', () => {
+        const err = fire(new HookContext({ set_name: 'backend', work: { directive_set: 'backend' } }));
+        expect(err).toBeNull();
+    });
+
+    it('legacy v0 (no directive_set) → no-op', () => {
+        const err = fire(new HookContext({ set_name: 'backend', work: {} }));
+        expect(err).toBeNull();
+    });
+
+    it('drift → HookError with repr-quoted names', () => {
+        const err = fire(new HookContext({ set_name: 'frontend', work: { directive_set: 'backend' } }));
+        expect(err?.message).toBe("directive-set drift: CLI resolved 'frontend' but state carries 'backend'");
+    });
+});
+
+describePy('DirectiveSetGuardHook — message parity (python3 vs TS)', () => {
+    function pyGuard(setName: string | null, work: string): string {
+        const setArg = setName === null ? 'None' : JSON.stringify(setName);
+        const r = runPyHooks(
+            {
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['directive_set_guard'],
+            },
+            [
+                'hook = directive_set_guard.DirectiveSetGuardHook()',
+                `work = ${work}`,
+                `ctx = context.HookContext(set_name=${setArg}, work=work)`,
+                'msg = None',
+                'try:',
+                '    hook._guard(ctx)',
+                'except exceptions.HookError as e:',
+                '    msg = str(e)',
+                'print(json.dumps({"msg": msg}))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py guard failed: ${r.stderr || r.stdout}`);
+        return (JSON.parse(r.stdout.trim()) as { msg: string | null }).msg ?? '<none>';
+    }
+
+    it('drift message matches', () => {
+        const ts = fire(new HookContext({ set_name: 'frontend', work: { directive_set: 'backend' } }))?.message;
+        expect(ts).toBe(pyGuard('frontend', "type('W', (), {'directive_set': 'backend'})()"));
+    });
+
+    it('drift with a single-quote in the value → repr switches to double quotes', () => {
+        const ts = fire(new HookContext({ set_name: "it's", work: { directive_set: 'backend' } }))?.message;
+        expect(ts).toBe(pyGuard("it's", "type('W', (), {'directive_set': 'backend'})()"));
+    });
+
+    it('matching set → no error on both', () => {
+        const ts = fire(new HookContext({ set_name: 'backend', work: { directive_set: 'backend' } }));
+        expect(ts).toBeNull();
+        expect(pyGuard('backend', "type('W', (), {'directive_set': 'backend'})()")).toBe('<none>');
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_halt_surface_audit.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_halt_surface_audit.test.ts
@@ -1,0 +1,110 @@
+// Golden-parity + unit tests for the py2ts halt_surface_audit hook twin
+// (ADR-094). Fires on ON_HALT, raises HookError (non-fatal) when the halt
+// surface is empty. Messages use `!r` repr on step_name.
+import { describe, expect, it } from 'vitest';
+
+import { HaltSurfaceAuditHook } from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/halt_surface_audit.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookError } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+function fire(ctx: HookContext): HookError | null {
+    const hook = new HaltSurfaceAuditHook();
+    const reg = new HookRegistry();
+    hook.register(reg);
+    try {
+        for (const cb of reg.for_event(HookEvent.ON_HALT)) cb(ctx);
+    } catch (e) {
+        if (e instanceof HookError) return e;
+        throw e;
+    }
+    return null;
+}
+
+describe('HaltSurfaceAuditHook — TS unit checks', () => {
+    it('registers only on ON_HALT', () => {
+        const hook = new HaltSurfaceAuditHook();
+        const reg = new HookRegistry();
+        hook.register(reg);
+        expect([...reg.events()]).toEqual([HookEvent.ON_HALT]);
+    });
+
+    it('StepResult with questions → no error', () => {
+        const err = fire(new HookContext({ step_name: 'refine', result: { questions: ['1) a'] } }));
+        expect(err).toBeNull();
+    });
+
+    it('StepResult with empty questions → HookError', () => {
+        const err = fire(new HookContext({ step_name: 'refine', result: { questions: [] } }));
+        expect(err?.message).toBe(
+            "halt at step 'refine' surfaced no questions (StepResult.questions empty); the user has nothing to act on",
+        );
+    });
+
+    it('no result, delivery has questions → no error', () => {
+        const err = fire(new HookContext({ step_name: 'plan', delivery: { questions: ['1) x'] } }));
+        expect(err).toBeNull();
+    });
+
+    it('no result, empty delivery.questions → HookError (hook-driven halt)', () => {
+        const err = fire(new HookContext({ step_name: 'plan', delivery: { questions: [] } }));
+        expect(err?.message).toBe(
+            "halt at step 'plan' surfaced no questions (hook-driven halt with empty state.questions)",
+        );
+    });
+
+    it('null step_name reprs as None', () => {
+        const err = fire(new HookContext({ result: { questions: [] } }));
+        expect(err?.message).toBe(
+            'halt at step None surfaced no questions (StepResult.questions empty); the user has nothing to act on',
+        );
+    });
+});
+
+describePy('HaltSurfaceAuditHook — message parity (python3 vs TS)', () => {
+    function pyAudit(snippet: string): string {
+        const r = runPyHooks(
+            {
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['halt_surface_audit'],
+            },
+            [
+                'hook = halt_surface_audit.HaltSurfaceAuditHook()',
+                snippet,
+                'msg = None',
+                'try:',
+                '    hook._audit(ctx)',
+                'except exceptions.HookError as e:',
+                '    msg = str(e)',
+                'print(json.dumps({"msg": msg}))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py audit failed: ${r.stderr || r.stdout}`);
+        return (JSON.parse(r.stdout.trim()) as { msg: string | null }).msg ?? '<none>';
+    }
+
+    it('StepResult empty-questions message matches', () => {
+        const ts = fire(new HookContext({ step_name: 'refine', result: { questions: [] } }))?.message;
+        expect(ts).toBe(
+            pyAudit("ctx = context.HookContext(step_name='refine', result=type('R',(),{'questions':[]})())"),
+        );
+    });
+
+    it('hook-driven empty-delivery message matches', () => {
+        const ts = fire(new HookContext({ step_name: 'plan', delivery: { questions: [] } }))?.message;
+        expect(ts).toBe(
+            pyAudit("ctx = context.HookContext(step_name='plan', delivery=type('D',(),{'questions':[]})())"),
+        );
+    });
+
+    it('step_name with apostrophe → repr switches quotes, matches', () => {
+        const ts = fire(new HookContext({ step_name: "it's", result: { questions: [] } }))?.message;
+        expect(ts).toBe(
+            pyAudit("ctx = context.HookContext(step_name=\"it's\", result=type('R',(),{'questions':[]})())"),
+        );
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_memory_visibility.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_memory_visibility.test.ts
@@ -1,0 +1,175 @@
+// Golden-parity + unit tests for the py2ts memory_visibility hook twin
+// (ADR-094). The hook threads the `🧠 Memory: …` line into work.report on
+// BEFORE_SAVE; the resulting report text must be byte-identical.
+import { describe, expect, it } from 'vitest';
+
+import {
+    MemoryVisibilityHook,
+    derive_visibility,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/memory_visibility.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+interface FakeWork {
+    memory: unknown;
+    verify?: unknown;
+    questions?: unknown;
+    changes?: unknown;
+    applied_rules?: unknown;
+    test_plan?: unknown;
+    report: string;
+}
+
+function fireSave(
+    work: FakeWork,
+    opts: { memory_cadence?: string; visibility_off?: boolean } = {},
+): string {
+    const hook = new MemoryVisibilityHook(opts);
+    const reg = new HookRegistry();
+    hook.register(reg);
+    const ctx = new HookContext({ work });
+    for (const cb of reg.for_event(HookEvent.BEFORE_SAVE)) cb(ctx);
+    return work.report;
+}
+
+describe('MemoryVisibilityHook — TS unit checks', () => {
+    it('null work → no-op', () => {
+        const hook = new MemoryVisibilityHook();
+        const reg = new HookRegistry();
+        hook.register(reg);
+        // Should not throw.
+        for (const cb of reg.for_event(HookEvent.BEFORE_SAVE)) cb(new HookContext());
+        expect(true).toBe(true);
+    });
+
+    it('visibility_off → report untouched', () => {
+        const work: FakeWork = { memory: [{ id: 'r1', type: 'rule', hit: true }], report: 'orig' };
+        expect(fireSave(work, { visibility_off: true })).toBe('orig');
+    });
+
+    it('cadence never → report untouched', () => {
+        const work: FakeWork = { memory: [{ id: 'r1', type: 'rule' }], report: '' };
+        expect(fireSave(work, { memory_cadence: 'never' })).toBe('');
+    });
+
+    it('emits the visibility line into an empty report', () => {
+        const work: FakeWork = { memory: [{ id: 'r1', type: 'rule', hit: true }], report: '' };
+        const out = fireSave(work);
+        expect(out).toContain('🧠 Memory:');
+        expect(out).toContain('ids=[r1]');
+    });
+
+    it('appends after existing report with a blank-line separator', () => {
+        const work: FakeWork = { memory: [{ id: 'r1', type: 'rule' }], report: 'Existing.' };
+        const out = fireSave(work);
+        expect(out.startsWith('Existing.\n\n🧠 Memory:')).toBe(true);
+    });
+
+    it('idempotent — re-firing does not double-append the same line', () => {
+        const work: FakeWork = { memory: [{ id: 'r1', type: 'rule' }], report: '' };
+        const first = fireSave(work);
+        const second = fireSave(work);
+        expect(second).toBe(first);
+    });
+
+    it('derive_visibility renders directly from a memory list', () => {
+        expect(derive_visibility([])).toBeNull();
+        const line = derive_visibility([{ id: 'x', type: 'rule' }]);
+        expect(line).toContain('🧠 Memory:');
+    });
+});
+
+describePy('MemoryVisibilityHook — report parity (python3 vs TS)', () => {
+    function pyReport(
+        workExpr: string,
+        cadence: string,
+        visibilityOff: boolean,
+    ): string {
+        const r = runPyHooks(
+            {
+                we: ['scoring.decision_trace', 'scoring.memory_visibility'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['memory_visibility'],
+            },
+            [
+                `hook = memory_visibility.MemoryVisibilityHook(memory_cadence=${JSON.stringify(cadence)}, visibility_off=${visibilityOff ? 'True' : 'False'})`,
+                `work = ${workExpr}`,
+                'hook._on_before_save(context.HookContext(work=work))',
+                'print(json.dumps(work.report))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py mvis failed: ${r.stderr || r.stdout}`);
+        return JSON.parse(r.stdout.trim()) as string;
+    }
+
+    // A mutable Python work object with settable .report.
+    function pyWork(fields: string): string {
+        return `type('W',(),{${fields}})()`;
+    }
+
+    it('rich memory + verify → report line byte-identical', () => {
+        const memory = [
+            { id: 'r1', type: 'rule', hit: true },
+            { id: 'r2', type: 'incident', hit: true },
+        ];
+        const tsWork: FakeWork = {
+            memory,
+            verify: { claims: 2, first_try_passes: 2 },
+            questions: [],
+            changes: [{ file: 'a.ts' }],
+            report: '',
+        };
+        const tsOut = fireSave(tsWork);
+        const pyOut = pyReport(
+            pyWork(
+                "'memory':[{'id':'r1','type':'rule','hit':True},{'id':'r2','type':'incident','hit':True}],'verify':{'claims':2,'first_try_passes':2},'questions':[],'changes':[{'file':'a.ts'}],'report':''",
+            ),
+            'always',
+            false,
+        );
+        expect(tsOut).toBe(pyOut);
+    });
+
+    it('existing report → separator + line byte-identical', () => {
+        const tsWork: FakeWork = {
+            memory: [{ id: 'r1', type: 'rule', hit: true }],
+            verify: null,
+            report: 'Prior body.',
+        };
+        const tsOut = fireSave(tsWork);
+        const pyOut = pyReport(
+            pyWork("'memory':[{'id':'r1','type':'rule','hit':True}],'verify':None,'report':'Prior body.'"),
+            'always',
+            false,
+        );
+        expect(tsOut).toBe(pyOut);
+    });
+
+    it('cadence auto with few asks → both suppress', () => {
+        // asks = len(asked_types) = 4 ≥ 3, so auto DOES emit — assert parity.
+        const tsWork: FakeWork = { memory: [{ id: 'r1', type: 'rule', hit: true }], report: '' };
+        const tsOut = fireSave(tsWork, { memory_cadence: 'auto' });
+        const pyOut = pyReport(
+            pyWork("'memory':[{'id':'r1','type':'rule','hit':True}],'report':''"),
+            'auto',
+            false,
+        );
+        expect(tsOut).toBe(pyOut);
+    });
+
+    it('visibility_off → both leave report untouched', () => {
+        const tsWork: FakeWork = { memory: [{ id: 'r1', type: 'rule' }], report: 'keep' };
+        const tsOut = fireSave(tsWork, { visibility_off: true });
+        const pyOut = pyReport(
+            pyWork("'memory':[{'id':'r1','type':'rule'}],'report':'keep'"),
+            'always',
+            true,
+        );
+        expect(tsOut).toBe('keep');
+        expect(tsOut).toBe(pyOut);
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_state_shape_validation.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_state_shape_validation.test.ts
@@ -1,0 +1,132 @@
+// Golden-parity + unit tests for the py2ts state_shape_validation hook twin
+// (ADR-094). Round-trips the live WorkState through state.to_dict/from_dict on
+// AFTER_LOAD + BEFORE_SAVE; a SchemaError becomes a non-fatal HookError.
+import { describe, expect, it } from 'vitest';
+
+import { StateShapeValidationHook } from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/state_shape_validation.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookError } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { Input, WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+function fire(event: HookEvent, ctx: HookContext): HookError | null {
+    const hook = new StateShapeValidationHook();
+    const reg = new HookRegistry();
+    hook.register(reg);
+    try {
+        for (const cb of reg.for_event(event)) cb(ctx);
+    } catch (e) {
+        if (e instanceof HookError) return e;
+        throw e;
+    }
+    return null;
+}
+
+describe('StateShapeValidationHook — TS unit checks', () => {
+    it('registers on AFTER_LOAD and BEFORE_SAVE', () => {
+        const hook = new StateShapeValidationHook();
+        const reg = new HookRegistry();
+        hook.register(reg);
+        expect([...reg.events()].sort()).toEqual([HookEvent.AFTER_LOAD, HookEvent.BEFORE_SAVE].sort());
+    });
+
+    it('valid WorkState round-trips with no error', () => {
+        const work = new WorkState({ input: new Input('ticket', { id: 'T-1' }) });
+        expect(fire(HookEvent.AFTER_LOAD, new HookContext({ work }))).toBeNull();
+        expect(fire(HookEvent.BEFORE_SAVE, new HookContext({ work }))).toBeNull();
+    });
+
+    it('null work → HookError naming the state_file', () => {
+        const err = fire(HookEvent.AFTER_LOAD, new HookContext({ state_file: '/tmp/s.json' }));
+        expect(err?.message).toBe(
+            'state-shape validation: HookContext.work is None at event for state_file=/tmp/s.json',
+        );
+    });
+
+    it('null work + null state_file → message says None', () => {
+        const err = fire(HookEvent.BEFORE_SAVE, new HookContext());
+        expect(err?.message).toBe(
+            'state-shape validation: HookContext.work is None at event for state_file=None',
+        );
+    });
+
+    it('invalid directive_set → SchemaError surfaced as HookError', () => {
+        const work = new WorkState({ input: new Input('ticket'), directive_set: 'not-a-real-set' });
+        const err = fire(HookEvent.BEFORE_SAVE, new HookContext({ work }));
+        expect(err).toBeInstanceOf(HookError);
+        expect(err?.message.startsWith('state-shape validation failed:')).toBe(true);
+    });
+});
+
+describePy('StateShapeValidationHook — parity (python3 vs TS)', () => {
+    // state.py is the same foundation twin; load it under work_engine.state so
+    // the hook's `from ...state import …` resolves.
+    function pyValidate(stateBuilder: string, stateFile: string | null): { msg: string | null } {
+        const sfArg = stateFile === null ? 'None' : JSON.stringify(stateFile);
+        const r = runPyHooks(
+            {
+                we: ['state'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['state_shape_validation'],
+            },
+            [
+                'st = sys.modules["work_engine.state"]',
+                `work = ${stateBuilder}`,
+                'hook = state_shape_validation.StateShapeValidationHook()',
+                `ctx = context.HookContext(work=work, state_file=${sfArg})`,
+                'msg = None',
+                'try:',
+                '    hook._validate(ctx)',
+                'except exceptions.HookError as e:',
+                '    msg = str(e)',
+                'print(json.dumps({"msg": msg}))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py state-shape failed: ${r.stderr || r.stdout}`);
+        return JSON.parse(r.stdout.trim());
+    }
+
+    it('valid WorkState → no error on both', () => {
+        const work = new WorkState({ input: new Input('ticket', { id: 'T-1' }) });
+        expect(fire(HookEvent.BEFORE_SAVE, new HookContext({ work }))).toBeNull();
+        expect(pyValidate('st.WorkState(input=st.Input(kind="ticket", data={"id": "T-1"}))', null).msg).toBeNull();
+    });
+
+    it('invalid directive_set → identical HookError message', () => {
+        const work = new WorkState({ input: new Input('ticket'), directive_set: 'not-a-real-set' });
+        const tsMsg = fire(HookEvent.BEFORE_SAVE, new HookContext({ work }))?.message;
+        const pyMsg = pyValidate(
+            'st.WorkState(input=st.Input(kind="ticket"), directive_set="not-a-real-set")',
+            null,
+        ).msg;
+        expect(tsMsg).toBe(pyMsg);
+    });
+
+    it('null work message matches (with + without state_file)', () => {
+        const r1 = runPyHooks(
+            {
+                we: ['state'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['state_shape_validation'],
+            },
+            [
+                'import pathlib',
+                'hook = state_shape_validation.StateShapeValidationHook()',
+                'msg = None',
+                'try:',
+                '    hook._validate(context.HookContext(work=None, state_file=pathlib.Path("/tmp/s.json")))',
+                'except exceptions.HookError as e:',
+                '    msg = str(e)',
+                'print(json.dumps({"msg": msg}))',
+            ].join('\n'),
+        );
+        expect(r1.status).toBe(0);
+        const pyMsg = (JSON.parse(r1.stdout.trim()) as { msg: string }).msg;
+        const tsMsg = fire(HookEvent.AFTER_LOAD, new HookContext({ state_file: '/tmp/s.json' }))?.message;
+        expect(tsMsg).toBe(pyMsg);
+    });
+});

--- a/tests/scripts/work_engine/hooks_builtin_trace.test.ts
+++ b/tests/scripts/work_engine/hooks_builtin_trace.test.ts
@@ -1,0 +1,162 @@
+// Golden-parity + unit tests for the py2ts trace hook twin (ADR-094). Emits
+// one line per event to a configurable stream; the line format must match.
+import { describe, expect, it } from 'vitest';
+
+import { Outcome, StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import { TraceHook, type TextStream } from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/trace.js';
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookError } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookEvent, HOOK_EVENTS } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+function collector(): { stream: TextStream; lines: string[] } {
+    const lines: string[] = [];
+    const stream: TextStream = {
+        write(s: string) {
+            lines.push(s);
+            return true;
+        },
+        flush() {},
+    };
+    return { stream, lines };
+}
+
+function traceLine(event: HookEvent, ctx: HookContext, prefix = '[hook]'): string {
+    const { stream, lines } = collector();
+    const hook = new TraceHook(stream, prefix);
+    const reg = new HookRegistry();
+    hook.register(reg);
+    for (const cb of reg.for_event(event)) cb(ctx);
+    return lines.join('').replace(/\n$/, '');
+}
+
+describe('TraceHook — TS unit checks', () => {
+    it('registers on every event', () => {
+        const hook = new TraceHook(collector().stream);
+        const reg = new HookRegistry();
+        hook.register(reg);
+        expect([...reg.events()]).toEqual([...HOOK_EVENTS]);
+    });
+
+    it('minimal line: just prefix + event', () => {
+        expect(traceLine(HookEvent.BEFORE_LOAD, new HookContext())).toBe('[hook] event=before_load');
+    });
+
+    it('includes step/set when present', () => {
+        const ctx = new HookContext({ step_name: 'memory', set_name: 'backend' });
+        expect(traceLine(HookEvent.BEFORE_DISPATCH, ctx)).toBe(
+            '[hook] event=before_dispatch step=memory set=backend',
+        );
+    });
+
+    it('includes outcome value from result', () => {
+        const ctx = new HookContext({
+            step_name: 'verify',
+            result: new StepResult({ outcome: Outcome.SUCCESS }),
+        });
+        expect(traceLine(HookEvent.AFTER_STEP, ctx)).toBe(
+            '[hook] event=after_step step=verify outcome=success',
+        );
+    });
+
+    it('includes final, halting, exception type', () => {
+        const ctx = new HookContext({
+            final: Outcome.BLOCKED,
+            halting: 'phase',
+            exception: new TypeError('x'),
+        });
+        expect(traceLine(HookEvent.AFTER_DISPATCH, ctx)).toBe(
+            '[hook] event=after_dispatch final=blocked halting=phase exception=TypeError',
+        );
+    });
+
+    it('custom prefix is honoured', () => {
+        expect(traceLine(HookEvent.ON_ERROR, new HookContext(), '>>')).toBe('>> event=on_error');
+    });
+
+    it('a failing sink surfaces a HookError', () => {
+        const badStream: TextStream = {
+            write() {
+                throw new Error('closed');
+            },
+        };
+        const hook = new TraceHook(badStream);
+        const reg = new HookRegistry();
+        hook.register(reg);
+        let err: unknown = null;
+        try {
+            for (const cb of reg.for_event(HookEvent.BEFORE_STEP)) cb(new HookContext());
+        } catch (e) {
+            err = e;
+        }
+        expect(err).toBeInstanceOf(HookError);
+        expect((err as HookError).message).toBe('trace stream unavailable: closed');
+    });
+});
+
+describePy('TraceHook — line-format parity (python3 vs TS)', () => {
+    function pyLine(event: string, ctxExpr: string): string {
+        const r = runPyHooks(
+            {
+                we: ['delivery_state'],
+                foundation: ['exceptions', 'context', 'events', 'registry'],
+                builtin: ['trace'],
+            },
+            [
+                'import io',
+                'buf = io.StringIO()',
+                'hook = trace.TraceHook(stream=buf)',
+                'ds = sys.modules["work_engine.delivery_state"]',
+                `ctx = ${ctxExpr}`,
+                `cb = hook._make_callback(events.HookEvent.${event})`,
+                'cb(ctx)',
+                'print(json.dumps(buf.getvalue()))',
+            ].join('\n'),
+        );
+        if (r.status !== 0) throw new Error(`py trace failed: ${r.stderr || r.stdout}`);
+        return (JSON.parse(r.stdout.trim()) as string).replace(/\n$/, '');
+    }
+
+    it('event-only line matches', () => {
+        expect(traceLine(HookEvent.BEFORE_LOAD, new HookContext())).toBe(
+            pyLine('BEFORE_LOAD', 'context.HookContext()'),
+        );
+    });
+
+    it('step+set line matches', () => {
+        const ts = traceLine(
+            HookEvent.BEFORE_DISPATCH,
+            new HookContext({ step_name: 'memory', set_name: 'backend' }),
+        );
+        expect(ts).toBe(pyLine('BEFORE_DISPATCH', "context.HookContext(step_name='memory', set_name='backend')"));
+    });
+
+    it('outcome line matches (enum .value resolved)', () => {
+        const ts = traceLine(
+            HookEvent.AFTER_STEP,
+            new HookContext({ step_name: 'verify', result: new StepResult({ outcome: Outcome.SUCCESS }) }),
+        );
+        expect(ts).toBe(
+            pyLine(
+                'AFTER_STEP',
+                "context.HookContext(step_name='verify', result=ds.StepResult(outcome=ds.Outcome.SUCCESS))",
+            ),
+        );
+    });
+
+    it('final+halting+exception line matches', () => {
+        const ts = traceLine(
+            HookEvent.AFTER_DISPATCH,
+            new HookContext({ final: Outcome.BLOCKED, halting: 'phase', exception: new TypeError('x') }),
+        );
+        expect(ts).toBe(
+            pyLine(
+                'AFTER_DISPATCH',
+                "context.HookContext(final=ds.Outcome.BLOCKED, halting='phase', exception=TypeError('x'))",
+            ),
+        );
+    });
+});

--- a/tests/scripts/work_engine/hooks_context.test.ts
+++ b/tests/scripts/work_engine/hooks_context.test.ts
@@ -1,0 +1,107 @@
+// Golden-parity + unit tests for the py2ts work_engine.hooks `context` twin
+// (ADR-094). `context.py` is a dataclass with stdlib-only imports.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const CONTEXT_PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'hooks',
+    'context.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, importlib.util',
+        `spec = importlib.util.spec_from_file_location("context", ${JSON.stringify(CONTEXT_PY)})`,
+        'context = importlib.util.module_from_spec(spec)',
+        'sys.modules["context"] = context',
+        'spec.loader.exec_module(context)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`], { encoding: 'utf8' });
+}
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+describe('work_engine.hooks.context — TS unit checks', () => {
+    it('all fields default to null / empty extra', () => {
+        const c = new HookContext();
+        expect(c.step_name).toBeNull();
+        expect(c.delivery).toBeNull();
+        expect(c.result).toBeNull();
+        expect(c.exception).toBeNull();
+        expect(c.work).toBeNull();
+        expect(c.state_file).toBeNull();
+        expect(c.fmt).toBeNull();
+        expect(c.set_name).toBeNull();
+        expect(c.final).toBeNull();
+        expect(c.halting).toBeNull();
+        expect(c.args).toBeNull();
+        expect(c.extra).toEqual({});
+    });
+
+    it('extra is per-instance (no shared default mapping)', () => {
+        const a = new HookContext();
+        const b = new HookContext();
+        a.extra['k'] = 1;
+        expect(b.extra).toEqual({});
+    });
+
+    it('keyword construction populates the requested fields', () => {
+        const c = new HookContext({ step_name: 'memory', set_name: 'backend', halting: 'phase' });
+        expect(c.step_name).toBe('memory');
+        expect(c.set_name).toBe('backend');
+        expect(c.halting).toBe('phase');
+        expect(c.work).toBeNull();
+    });
+});
+
+describePy('work_engine.hooks.context — parity (python3 vs TS)', () => {
+    it('default field set + None-defaults match the dataclass', () => {
+        const r = runPy(
+            [
+                'import dataclasses, json',
+                'c = context.HookContext()',
+                'd = dataclasses.asdict(c)',
+                'print(json.dumps(d, default=str))',
+            ].join('\n'),
+        );
+        expect(r.status).toBe(0);
+        const py = JSON.parse(r.stdout) as Record<string, unknown>;
+        const c = new HookContext();
+        // Same field names, all None/empty.
+        expect(Object.keys(py).sort()).toEqual(
+            [
+                'args',
+                'delivery',
+                'exception',
+                'extra',
+                'final',
+                'fmt',
+                'halting',
+                'result',
+                'set_name',
+                'state_file',
+                'step_name',
+                'work',
+            ].sort(),
+        );
+        expect(py['step_name']).toBeNull();
+        expect(py['extra']).toEqual({});
+        expect(c.step_name).toBeNull();
+        expect(c.extra).toEqual({});
+    });
+});

--- a/tests/scripts/work_engine/hooks_events.test.ts
+++ b/tests/scripts/work_engine/hooks_events.test.ts
@@ -1,0 +1,89 @@
+// Golden-parity + unit tests for the py2ts work_engine.hooks `events` twin
+// (ADR-094). `events.py` is a str-Enum with no intra-package imports.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    HOOK_EVENTS,
+    HookEvent,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const EVENTS_PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'hooks',
+    'events.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, importlib.util',
+        `spec = importlib.util.spec_from_file_location("events", ${JSON.stringify(EVENTS_PY)})`,
+        'events = importlib.util.module_from_spec(spec)',
+        'sys.modules["events"] = events',
+        'spec.loader.exec_module(events)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`], { encoding: 'utf8' });
+}
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+describe('work_engine.hooks.events — TS unit checks', () => {
+    it('every member value equals its event name', () => {
+        expect(HookEvent.BEFORE_STEP).toBe('before_step');
+        expect(HookEvent.AFTER_STEP).toBe('after_step');
+        expect(HookEvent.ON_HALT).toBe('on_halt');
+        expect(HookEvent.ON_ERROR).toBe('on_error');
+        expect(HookEvent.BEFORE_LOAD).toBe('before_load');
+        expect(HookEvent.AFTER_LOAD).toBe('after_load');
+        expect(HookEvent.BEFORE_DISPATCH).toBe('before_dispatch');
+        expect(HookEvent.AFTER_DISPATCH).toBe('after_dispatch');
+        expect(HookEvent.BEFORE_SAVE).toBe('before_save');
+        expect(HookEvent.AFTER_SAVE).toBe('after_save');
+    });
+
+    it('HOOK_EVENTS preserves Python declaration order', () => {
+        expect([...HOOK_EVENTS]).toEqual([
+            'before_step',
+            'after_step',
+            'on_halt',
+            'on_error',
+            'before_load',
+            'after_load',
+            'before_dispatch',
+            'after_dispatch',
+            'before_save',
+            'after_save',
+        ]);
+    });
+});
+
+describePy('work_engine.hooks.events — parity (python3 vs TS)', () => {
+    it('member values + iteration order match Python', () => {
+        const r = runPy('import json; print(json.dumps([e.value for e in events.HookEvent]))');
+        expect(r.status).toBe(0);
+        const pyOrder = JSON.parse(r.stdout) as string[];
+        expect(pyOrder).toEqual([...HOOK_EVENTS]);
+    });
+
+    it('str-Enum: member == its string value', () => {
+        const r = runPy(
+            'print(events.HookEvent.BEFORE_STEP == "before_step", events.HookEvent.AFTER_SAVE == "after_save")',
+        );
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe('True True\n');
+        expect(HookEvent.BEFORE_STEP === 'before_step').toBe(true);
+        expect(HookEvent.AFTER_SAVE === 'after_save').toBe(true);
+    });
+});

--- a/tests/scripts/work_engine/hooks_exceptions.test.ts
+++ b/tests/scripts/work_engine/hooks_exceptions.test.ts
@@ -1,0 +1,124 @@
+// Golden-parity + unit tests for the py2ts work_engine.hooks `exceptions` twin
+// (ADR-094). `exceptions.py` has no intra-package imports — it is loaded via a
+// direct-file importlib loader. The TS twin is exercised directly.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    HookError,
+    HookHalt,
+    _HookSignal,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const EXC_PY = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'scripts',
+    'work_engine',
+    'hooks',
+    'exceptions.py',
+);
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function runPy(body: string): SpawnSyncReturns<string> {
+    const loader = [
+        'import sys, importlib.util',
+        `spec = importlib.util.spec_from_file_location("exceptions", ${JSON.stringify(EXC_PY)})`,
+        'exceptions = importlib.util.module_from_spec(spec)',
+        'sys.modules["exceptions"] = exceptions',
+        'spec.loader.exec_module(exceptions)',
+    ].join('\n');
+    return spawnSync('python3', ['-c', `${loader}\n${body}`], { encoding: 'utf8' });
+}
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+describe('work_engine.hooks.exceptions — TS unit checks', () => {
+    it('HookError and HookHalt extend _HookSignal and Error', () => {
+        const e = new HookError('boom');
+        expect(e instanceof _HookSignal).toBe(true);
+        expect(e instanceof Error).toBe(true);
+        expect(e.name).toBe('HookError');
+        expect(e.message).toBe('boom');
+
+        const h = new HookHalt('foreign');
+        expect(h instanceof _HookSignal).toBe(true);
+        expect(h instanceof Error).toBe(true);
+        expect(h.name).toBe('HookHalt');
+    });
+
+    it('HookError is NOT a HookHalt and vice versa', () => {
+        expect(new HookError('x') instanceof HookHalt).toBe(false);
+        expect(new HookHalt('x') instanceof HookError).toBe(false);
+    });
+
+    it('HookHalt stores reason; default surface is an empty list', () => {
+        const h = new HookHalt('missing');
+        expect(h.reason).toBe('missing');
+        expect(h.surface).toEqual([]);
+        expect(h.message).toBe('missing'); // super(reason)
+    });
+
+    it('HookHalt copies the surface list (no shared reference)', () => {
+        const src = ['1) a', '2) b'];
+        const h = new HookHalt('validation_failed', src);
+        expect(h.surface).toEqual(['1) a', '2) b']);
+        src.push('3) c');
+        expect(h.surface).toEqual(['1) a', '2) b']); // not aliased
+    });
+
+    it('null surface yields an empty list', () => {
+        expect(new HookHalt('r', null).surface).toEqual([]);
+    });
+});
+
+describePy('work_engine.hooks.exceptions — parity (python3 vs TS)', () => {
+    it('Python hierarchy matches: HookError/HookHalt subclass _HookSignal', () => {
+        const r = runPy(
+            [
+                'print(issubclass(exceptions.HookError, exceptions._HookSignal))',
+                'print(issubclass(exceptions.HookHalt, exceptions._HookSignal))',
+                'print(issubclass(exceptions.HookError, exceptions.HookHalt))',
+            ].join('\n'),
+        );
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe('True\nTrue\nFalse\n');
+        // TS analog:
+        expect(new HookError('x') instanceof _HookSignal).toBe(true);
+        expect(new HookHalt('x') instanceof _HookSignal).toBe(true);
+        expect(new HookError('x') instanceof HookHalt).toBe(false);
+    });
+
+    it('HookHalt(reason, surface) — reason + surface match across engines', () => {
+        const r = runPy(
+            [
+                'h = exceptions.HookHalt("foreign", ["1) a", "2) b"])',
+                'print(h.reason)',
+                'import json; print(json.dumps(h.surface))',
+                'h2 = exceptions.HookHalt("missing")',
+                'print(json.dumps(h2.surface))',
+            ].join('\n'),
+        );
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe('foreign\n["1) a", "2) b"]\n[]\n');
+
+        const h = new HookHalt('foreign', ['1) a', '2) b']);
+        expect(h.reason).toBe('foreign');
+        expect(h.surface).toEqual(['1) a', '2) b']);
+        expect(new HookHalt('missing').surface).toEqual([]);
+    });
+
+    it('__all__ exports the two public signals', () => {
+        const r = runPy('import json; print(json.dumps(sorted(exceptions.__all__)))');
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe('["HookError", "HookHalt"]\n');
+    });
+});

--- a/tests/scripts/work_engine/hooks_index.test.ts
+++ b/tests/scripts/work_engine/hooks_index.test.ts
@@ -1,0 +1,68 @@
+// Parity test for the py2ts hooks barrel twins (ADR-094):
+// hooks/index.ts (== hooks/__init__.py) and hooks/builtin/index.ts
+// (== hooks/builtin/__init__.py). Asserts the public export set matches the
+// Python `__all__`, and that each export is a usable value.
+import { describe, expect, it } from 'vitest';
+
+import * as builtinIndex from '../../../src/agent-src/templates/scripts/work_engine/hooks/builtin/index.js';
+import * as hooksIndex from '../../../src/agent-src/templates/scripts/work_engine/hooks/index.js';
+
+// Expected runtime exports (types are erased; `HookCallback` is type-only).
+const HOOKS_VALUE_EXPORTS = [
+    'ChatHistoryAppendHook',
+    'ChatHistoryHaltAppendHook',
+    'DecisionTraceHook',
+    'DirectiveSetGuardHook',
+    'HaltSurfaceAuditHook',
+    'HookContext',
+    'HookError',
+    'HookEvent',
+    'HookHalt',
+    'HookRegistry',
+    'HookRunner',
+    'MemoryVisibilityHook',
+    'StateShapeValidationHook',
+    'TraceHook',
+].sort();
+
+const BUILTIN_VALUE_EXPORTS = [
+    'ChatHistoryAppendHook',
+    'ChatHistoryHaltAppendHook',
+    'DecisionGateHook',
+    'DecisionTraceHook',
+    'DirectiveSetGuardHook',
+    'HaltSurfaceAuditHook',
+    'MemoryVisibilityHook',
+    'StateShapeValidationHook',
+    'TraceHook',
+    'build_decision_gate_hook',
+].sort();
+
+describe('work_engine.hooks barrel — index.ts', () => {
+    it('re-exports the public surface (minus the type-only HookCallback)', () => {
+        const got = Object.keys(hooksIndex).sort();
+        expect(got).toEqual(HOOKS_VALUE_EXPORTS);
+    });
+
+    it('HookEvent is the const event object', () => {
+        expect(hooksIndex.HookEvent.BEFORE_STEP).toBe('before_step');
+    });
+
+    it('exported hook classes are constructable', () => {
+        expect(new hooksIndex.HookRegistry()).toBeInstanceOf(hooksIndex.HookRegistry);
+        expect(new hooksIndex.HookContext()).toBeInstanceOf(hooksIndex.HookContext);
+        expect(new hooksIndex.HookHalt('r').reason).toBe('r');
+    });
+});
+
+describe('work_engine.hooks.builtin barrel — builtin/index.ts', () => {
+    it('re-exports every concrete hook + build_decision_gate_hook', () => {
+        const got = Object.keys(builtinIndex).sort();
+        expect(got).toEqual(BUILTIN_VALUE_EXPORTS);
+    });
+
+    it('build_decision_gate_hook is a function returning null on inactive config', () => {
+        expect(typeof builtinIndex.build_decision_gate_hook).toBe('function');
+        expect(builtinIndex.build_decision_gate_hook(null)).toBeNull();
+    });
+});

--- a/tests/scripts/work_engine/hooks_registry.test.ts
+++ b/tests/scripts/work_engine/hooks_registry.test.ts
@@ -1,0 +1,84 @@
+// Golden-parity + unit tests for the py2ts work_engine.hooks `registry` twin
+// (ADR-094). `registry.py` imports `.context` + `.events`; loaded via the
+// shared package-stub importlib loader.
+import { describe, expect, it } from 'vitest';
+
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+describe('work_engine.hooks.registry — TS unit checks', () => {
+    it('for_event returns [] when nothing registered', () => {
+        const r = new HookRegistry();
+        expect(r.for_event(HookEvent.AFTER_STEP)).toEqual([]);
+    });
+
+    it('callbacks fire in registration order', () => {
+        const r = new HookRegistry();
+        const seen: number[] = [];
+        r.register(HookEvent.AFTER_STEP, () => seen.push(1));
+        r.register(HookEvent.AFTER_STEP, () => seen.push(2));
+        r.register(HookEvent.AFTER_STEP, () => seen.push(3));
+        const ctx = new HookContext();
+        for (const cb of r.for_event(HookEvent.AFTER_STEP)) {
+            cb(ctx);
+        }
+        expect(seen).toEqual([1, 2, 3]);
+    });
+
+    it('events() only yields events with at least one callback', () => {
+        const r = new HookRegistry();
+        r.register(HookEvent.ON_HALT, () => {});
+        r.register(HookEvent.BEFORE_STEP, () => {});
+        expect([...r.events()]).toEqual(['on_halt', 'before_step']);
+    });
+
+    it('for_event returns a copy (mutating it does not affect the registry)', () => {
+        const r = new HookRegistry();
+        r.register(HookEvent.AFTER_STEP, () => {});
+        const list = r.for_event(HookEvent.AFTER_STEP);
+        list.push(() => {});
+        expect(r.for_event(HookEvent.AFTER_STEP).length).toBe(1);
+    });
+});
+
+describePy('work_engine.hooks.registry — parity (python3 vs TS)', () => {
+    it('insertion order + events() ordering match Python', () => {
+        const r = runPyHooks(
+            { foundation: ['exceptions', 'context', 'events', 'registry'] },
+            [
+                'reg = registry.HookRegistry()',
+                'order = []',
+                'reg.register(events.HookEvent.AFTER_STEP, lambda c: order.append(1))',
+                'reg.register(events.HookEvent.AFTER_STEP, lambda c: order.append(2))',
+                'reg.register(events.HookEvent.ON_HALT, lambda c: order.append(9))',
+                'cbs = reg.for_event(events.HookEvent.AFTER_STEP)',
+                'ctx = context.HookContext()',
+                '[cb(ctx) for cb in cbs]',
+                'print(json.dumps(order))',
+                'print(json.dumps([e.value for e in reg.events()]))',
+                'print(json.dumps([cb is not None for cb in reg.for_event(events.HookEvent.BEFORE_STEP)]))',
+            ].join('\n'),
+        );
+        expect(r.status).toBe(0);
+        const [pyOrder, pyEvents, pyEmpty] = r.stdout.trim().split('\n').map((l) => JSON.parse(l));
+        expect(pyOrder).toEqual([1, 2]);
+        expect(pyEvents).toEqual(['after_step', 'on_halt']);
+        expect(pyEmpty).toEqual([]);
+
+        // TS analog.
+        const reg = new HookRegistry();
+        const order: number[] = [];
+        reg.register(HookEvent.AFTER_STEP, () => order.push(1));
+        reg.register(HookEvent.AFTER_STEP, () => order.push(2));
+        reg.register(HookEvent.ON_HALT, () => order.push(9));
+        const ctx = new HookContext();
+        for (const cb of reg.for_event(HookEvent.AFTER_STEP)) cb(ctx);
+        expect(order).toEqual([1, 2]);
+        expect([...reg.events()]).toEqual(['after_step', 'on_halt']);
+        expect(reg.for_event(HookEvent.BEFORE_STEP)).toEqual([]);
+    });
+});

--- a/tests/scripts/work_engine/hooks_runner.test.ts
+++ b/tests/scripts/work_engine/hooks_runner.test.ts
@@ -1,0 +1,194 @@
+// Golden-parity + unit tests for the py2ts work_engine.hooks `runner` twin
+// (ADR-094). Exercises the three-tier error contract:
+//   HookError  → swallowed (warned), dispatch continues, emit returns null.
+//   HookHalt   → returned immediately, remaining callbacks skipped.
+//   other Err  → propagates unchanged.
+//
+// The runner emits its non-fatal warning via `warnings.warn` (Python) /
+// `process.stderr` (TS). That surface format is interpreter-internal and not
+// portable, so the parity layer asserts the *behavioural* contract (swallow +
+// continue + return value) and that *a* warning was emitted — it does not
+// byte-compare the warning text. Documented divergence per ADR-094 §6.
+import { describe, expect, it } from 'vitest';
+
+import { HookContext } from '../../../src/agent-src/templates/scripts/work_engine/hooks/context.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/events.js';
+import { HookError, HookHalt } from '../../../src/agent-src/templates/scripts/work_engine/hooks/exceptions.js';
+import { HookRegistry } from '../../../src/agent-src/templates/scripts/work_engine/hooks/registry.js';
+import { HookRunner } from '../../../src/agent-src/templates/scripts/work_engine/hooks/runner.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+function quietRunner(registry: HookRegistry): { runner: HookRunner; warnings: string[] } {
+    const warnings: string[] = [];
+    class QuietRunner extends HookRunner {
+        protected override warn(message: string): void {
+            warnings.push(message);
+        }
+    }
+    return { runner: new QuietRunner(registry), warnings };
+}
+
+describe('work_engine.hooks.runner — TS unit checks', () => {
+    it('no callbacks → emit returns null (fast path)', () => {
+        const { runner } = quietRunner(new HookRegistry());
+        expect(runner.emit(HookEvent.AFTER_STEP, new HookContext())).toBeNull();
+    });
+
+    it('all callbacks succeed → returns null, all fire', () => {
+        const reg = new HookRegistry();
+        const seen: number[] = [];
+        reg.register(HookEvent.AFTER_STEP, () => seen.push(1));
+        reg.register(HookEvent.AFTER_STEP, () => seen.push(2));
+        const { runner } = quietRunner(reg);
+        expect(runner.emit(HookEvent.AFTER_STEP, new HookContext())).toBeNull();
+        expect(seen).toEqual([1, 2]);
+    });
+
+    it('HookError is swallowed + warned; dispatch continues', () => {
+        const reg = new HookRegistry();
+        const seen: number[] = [];
+        reg.register(HookEvent.AFTER_STEP, () => {
+            throw new HookError('boom');
+        });
+        reg.register(HookEvent.AFTER_STEP, () => seen.push(2));
+        const { runner, warnings } = quietRunner(reg);
+        expect(runner.emit(HookEvent.AFTER_STEP, new HookContext())).toBeNull();
+        expect(seen).toEqual([2]); // continued past the failing callback
+        expect(warnings).toEqual(['hook after_step raised HookError: boom']);
+    });
+
+    it('HookHalt is returned; remaining callbacks skipped', () => {
+        const reg = new HookRegistry();
+        const seen: number[] = [];
+        const halt = new HookHalt('foreign', ['1) a']);
+        reg.register(HookEvent.ON_HALT, () => {
+            throw halt;
+        });
+        reg.register(HookEvent.ON_HALT, () => seen.push(2));
+        const { runner } = quietRunner(reg);
+        const ret = runner.emit(HookEvent.ON_HALT, new HookContext());
+        expect(ret).toBe(halt);
+        expect(ret?.reason).toBe('foreign');
+        expect(ret?.surface).toEqual(['1) a']);
+        expect(seen).toEqual([]); // skipped
+    });
+
+    it('non-signal error propagates unchanged', () => {
+        const reg = new HookRegistry();
+        reg.register(HookEvent.AFTER_STEP, () => {
+            throw new TypeError('bug');
+        });
+        const { runner } = quietRunner(reg);
+        expect(() => runner.emit(HookEvent.AFTER_STEP, new HookContext())).toThrow(TypeError);
+    });
+
+    it('registry getter exposes the underlying registry for late registration', () => {
+        const reg = new HookRegistry();
+        const runner = new HookRunner(reg);
+        expect(runner.registry).toBe(reg);
+        const seen: number[] = [];
+        runner.registry.register(HookEvent.BEFORE_STEP, () => seen.push(1));
+        runner.emit(HookEvent.BEFORE_STEP, new HookContext());
+        expect(seen).toEqual([1]);
+    });
+
+    it('default constructor builds its own empty registry', () => {
+        const runner = new HookRunner();
+        expect(runner.emit(HookEvent.AFTER_STEP, new HookContext())).toBeNull();
+    });
+
+    it('default warn emits the message line to stderr (write seam)', () => {
+        // Drive the real `warn` seam through a HookRunner whose stderr write is
+        // redirected to a collector, proving the default path emits the exact
+        // message line `hook <event> raised HookError: <msg>\n`.
+        const reg = new HookRegistry();
+        reg.register(HookEvent.AFTER_STEP, () => {
+            throw new HookError('xyz');
+        });
+        const collected: string[] = [];
+        const orig = process.stderr.write.bind(process.stderr);
+        (process.stderr as unknown as { write: (s: string) => boolean }).write = (s: string) => {
+            collected.push(s);
+            return true;
+        };
+        try {
+            new HookRunner(reg).emit(HookEvent.AFTER_STEP, new HookContext());
+        } finally {
+            (process.stderr as unknown as { write: typeof orig }).write = orig;
+        }
+        expect(collected).toContain('hook after_step raised HookError: xyz\n');
+    });
+});
+
+describePy('work_engine.hooks.runner — behavioural parity (python3 vs TS)', () => {
+    it('HookError swallowed → continue + return None + warn emitted', () => {
+        const r = runPyHooks(
+            { foundation: ['exceptions', 'context', 'events', 'registry', 'runner'] },
+            [
+                'import warnings',
+                'reg = registry.HookRegistry()',
+                'seen = []',
+                'def bad(c): raise exceptions.HookError("boom")',
+                'reg.register(events.HookEvent.AFTER_STEP, bad)',
+                'reg.register(events.HookEvent.AFTER_STEP, lambda c: seen.append(2))',
+                'run = runner.HookRunner(reg)',
+                'with warnings.catch_warnings(record=True) as w:',
+                '    warnings.simplefilter("always")',
+                '    ret = run.emit(events.HookEvent.AFTER_STEP, context.HookContext())',
+                'print(json.dumps({"ret_is_none": ret is None, "seen": seen, "nwarn": len(w), "msg": str(w[0].message) if w else None}))',
+            ].join('\n'),
+        );
+        expect(r.status).toBe(0);
+        const py = JSON.parse(r.stdout.trim()) as Record<string, unknown>;
+        expect(py['ret_is_none']).toBe(true);
+        expect(py['seen']).toEqual([2]);
+        expect(py['nwarn']).toBe(1);
+        expect(py['msg']).toBe('hook after_step raised HookError: boom');
+
+        // TS analog (same observable behaviour + same warning message text).
+        const reg = new HookRegistry();
+        const seen: number[] = [];
+        reg.register(HookEvent.AFTER_STEP, () => {
+            throw new HookError('boom');
+        });
+        reg.register(HookEvent.AFTER_STEP, () => seen.push(2));
+        const { runner, warnings } = quietRunner(reg);
+        const ret = runner.emit(HookEvent.AFTER_STEP, new HookContext());
+        expect(ret).toBeNull();
+        expect(seen).toEqual([2]);
+        expect(warnings).toEqual(['hook after_step raised HookError: boom']);
+    });
+
+    it('HookHalt returned + skips rest; non-signal error propagates', () => {
+        const r = runPyHooks(
+            { foundation: ['exceptions', 'context', 'events', 'registry', 'runner'] },
+            [
+                'reg = registry.HookRegistry()',
+                'seen = []',
+                'def halt(c): raise exceptions.HookHalt("foreign", ["1) a"])',
+                'reg.register(events.HookEvent.ON_HALT, halt)',
+                'reg.register(events.HookEvent.ON_HALT, lambda c: seen.append(2))',
+                'run = runner.HookRunner(reg)',
+                'ret = run.emit(events.HookEvent.ON_HALT, context.HookContext())',
+                'reg2 = registry.HookRegistry()',
+                'def bug(c): raise TypeError("bug")',
+                'reg2.register(events.HookEvent.AFTER_STEP, bug)',
+                'run2 = runner.HookRunner(reg2)',
+                'propagated = False',
+                'try:',
+                '    run2.emit(events.HookEvent.AFTER_STEP, context.HookContext())',
+                'except TypeError:',
+                '    propagated = True',
+                'print(json.dumps({"reason": ret.reason, "surface": ret.surface, "seen": seen, "propagated": propagated}))',
+            ].join('\n'),
+        );
+        expect(r.status).toBe(0);
+        const py = JSON.parse(r.stdout.trim()) as Record<string, unknown>;
+        expect(py['reason']).toBe('foreign');
+        expect(py['surface']).toEqual(['1) a']);
+        expect(py['seen']).toEqual([]);
+        expect(py['propagated']).toBe(true);
+    });
+});

--- a/tests/scripts/work_engine/hooks_settings.test.ts
+++ b/tests/scripts/work_engine/hooks_settings.test.ts
@@ -1,0 +1,176 @@
+// Golden-parity tests for the py2ts work_engine.hooks `settings` twin
+// (ADR-094). `settings.py` reads `.agent-settings.yml` via
+// work_engine._lib.agent_settings and parses the decision_engine block; the
+// TS twin mirrors the resolution exactly. Each scenario resolves the same
+// fixture on both engines and compares the full resolved HookSettings view.
+//
+// A non-existent `user_global_path` is passed on both sides so the host's
+// real user-global config never leaks into the comparison.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { load_hook_settings } from '../../../src/agent-src/templates/scripts/work_engine/hooks/settings.js';
+import { hasPython3, runPyHooks } from './_hooks_pyloader.js';
+
+const describePy = hasPython3() ? describe : describe.skip;
+
+let tmp: string;
+let NO_GLOBAL: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-settings-'));
+    NO_GLOBAL = path.join(tmp, 'does-not-exist-user-global.yml');
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Snapshot a HookSettings into a plain comparable object. */
+function snapshotTs(settings_path: string): Record<string, unknown> {
+    const s = load_hook_settings(settings_path, NO_GLOBAL);
+    return {
+        enabled: s.enabled,
+        trace: s.trace,
+        halt_surface_audit: s.halt_surface_audit,
+        state_shape_validation: s.state_shape_validation,
+        directive_set_guard: s.directive_set_guard,
+        decision_trace: s.decision_trace,
+        memory_visibility: s.memory_visibility,
+        memory_visibility_off: s.memory_visibility_off,
+        memory_cadence: s.memory_cadence,
+        chat_history_enabled: s.chat_history_enabled,
+        chat_history_script: s.chat_history_script,
+        de_surface_traces: s.decision_engine.surface_traces,
+        de_min_confidence: s.decision_engine.min_confidence,
+        de_block_on_risk: s.decision_engine.block_on_risk,
+        de_require_memory_hits: s.decision_engine.require_memory_hits,
+        de_on_block: s.decision_engine.on_block,
+        de_on_block_fallback: s.decision_engine.on_block_fallback,
+    };
+}
+
+/** Resolve the same fixture in python3 and snapshot the dataclass fields. */
+function snapshotPy(settings_path: string): Record<string, unknown> {
+    const r = runPyHooks(
+        {
+            we: ['_lib.user_global_paths', '_lib.agent_settings', 'scoring.decision_engine'],
+            foundation: ['settings'],
+        },
+        [
+            `s = settings.load_hook_settings(${JSON.stringify(settings_path)}, ${JSON.stringify(NO_GLOBAL)})`,
+            'out = {',
+            '  "enabled": s.enabled,',
+            '  "trace": s.trace,',
+            '  "halt_surface_audit": s.halt_surface_audit,',
+            '  "state_shape_validation": s.state_shape_validation,',
+            '  "directive_set_guard": s.directive_set_guard,',
+            '  "decision_trace": s.decision_trace,',
+            '  "memory_visibility": s.memory_visibility,',
+            '  "memory_visibility_off": s.memory_visibility_off,',
+            '  "memory_cadence": s.memory_cadence,',
+            '  "chat_history_enabled": s.chat_history_enabled,',
+            '  "chat_history_script": s.chat_history_script,',
+            '  "de_surface_traces": s.decision_engine.surface_traces,',
+            '  "de_min_confidence": s.decision_engine.min_confidence,',
+            '  "de_block_on_risk": s.decision_engine.block_on_risk,',
+            '  "de_require_memory_hits": s.decision_engine.require_memory_hits,',
+            '  "de_on_block": s.decision_engine.on_block,',
+            '  "de_on_block_fallback": s.decision_engine.on_block_fallback,',
+            '}',
+            'print(json.dumps(out, sort_keys=True))',
+        ].join('\n'),
+    );
+    if (r.status !== 0) {
+        throw new Error(`python3 settings probe failed: ${r.stderr || r.stdout}`);
+    }
+    return JSON.parse(r.stdout.trim()) as Record<string, unknown>;
+}
+
+function writeYaml(body: string): string {
+    const p = path.join(tmp, `${Math.random().toString(36).slice(2)}.agent-settings.yml`);
+    fs.writeFileSync(p, body, 'utf-8');
+    return p;
+}
+
+describe('work_engine.hooks.settings — TS unit checks', () => {
+    it('missing file → default-permissive (everything off)', () => {
+        const snap = snapshotTs(path.join(tmp, 'nope.yml'));
+        expect(snap['enabled']).toBe(false);
+        expect(snap['halt_surface_audit']).toBe(false);
+        expect(snap['chat_history_enabled']).toBe(false);
+        expect(snap['memory_cadence']).toBe('always');
+        expect(snap['chat_history_script']).toBe('scripts/chat_history.py');
+    });
+
+    it('hooks block absent → defaults', () => {
+        const p = writeYaml('foo: bar\n');
+        const snap = snapshotTs(p);
+        expect(snap['enabled']).toBe(false);
+    });
+
+    it('master switch on → per-hook defaults apply', () => {
+        const p = writeYaml('hooks:\n  enabled: true\n');
+        const snap = snapshotTs(p);
+        expect(snap['enabled']).toBe(true);
+        expect(snap['halt_surface_audit']).toBe(true);
+        expect(snap['state_shape_validation']).toBe(true);
+        expect(snap['directive_set_guard']).toBe(true);
+        expect(snap['trace']).toBe(false);
+        expect(snap['memory_visibility']).toBe(true);
+    });
+
+    it('chat-history gates on both switches', () => {
+        const both = writeYaml('hooks:\n  enabled: true\n  chat_history:\n    enabled: true\nchat_history:\n  enabled: true\n');
+        expect(snapshotTs(both)['chat_history_enabled']).toBe(true);
+        const onlyHook = writeYaml('hooks:\n  enabled: true\n  chat_history:\n    enabled: true\n');
+        expect(snapshotTs(onlyHook)['chat_history_enabled']).toBe(false);
+    });
+
+    it('memory.visibility: off flips memory_visibility_off', () => {
+        const p = writeYaml('hooks:\n  enabled: true\nmemory:\n  visibility: off\n  cadence: AUTO\n');
+        const snap = snapshotTs(p);
+        expect(snap['memory_visibility_off']).toBe(true);
+        expect(snap['memory_cadence']).toBe('auto');
+    });
+
+    it('decision_engine.surface_traces mirrors into decision_trace', () => {
+        const p = writeYaml('hooks:\n  enabled: true\ndecision_engine:\n  surface_traces: true\n');
+        const snap = snapshotTs(p);
+        expect(snap['de_surface_traces']).toBe(true);
+        expect(snap['decision_trace']).toBe(true);
+    });
+});
+
+describePy('work_engine.hooks.settings — parity (python3 vs TS)', () => {
+    const cases: Array<[string, string]> = [
+        ['default (master off)', 'hooks:\n  enabled: false\n'],
+        ['master on + defaults', 'hooks:\n  enabled: true\n'],
+        [
+            'chat-history both on',
+            'hooks:\n  enabled: true\n  chat_history:\n    enabled: true\n    script: scripts/custom_ch.py\nchat_history:\n  enabled: true\n',
+        ],
+        ['memory off + cadence', 'hooks:\n  enabled: true\nmemory:\n  visibility: off\n  cadence: auto\n'],
+        [
+            'decision_engine gates',
+            'hooks:\n  enabled: true\ndecision_engine:\n  surface_traces: true\n  min_confidence: medium\n  block_on_risk: high\n  on_block: ask\n  on_block_fallback: warn\n',
+        ],
+        [
+            'per-hook overrides false',
+            'hooks:\n  enabled: true\n  trace: true\n  halt_surface_audit: false\n  state_shape_validation: false\n  directive_set_guard: false\n  memory_visibility:\n    enabled: false\n',
+        ],
+        ['malformed decision_engine → defaults', 'hooks:\n  enabled: true\ndecision_engine:\n  bogus_key: 1\n'],
+    ];
+
+    for (const [name, yaml] of cases) {
+        it(`resolves identically: ${name}`, () => {
+            const p = writeYaml(yaml);
+            expect(snapshotTs(p)).toEqual(snapshotPy(p));
+        });
+    }
+
+    it('missing file resolves identically (both default-permissive)', () => {
+        const p = path.join(tmp, 'absent.yml');
+        expect(snapshotTs(p)).toEqual(snapshotPy(p));
+    });
+});


### PR DESCRIPTION
## What

Phase-9 wave 3 of the Python→TypeScript migration (ADR-094): the **work_engine L2 layer** — directive-implementation scripts + the hooks subpackage. 40 twins, depending only on the already-merged foundation + L1.

| Group | Twins |
|---|---|
| `directives/backend/` | analyze, plan, implement, test, verify, refine, report, memory (8) |
| `directives/ui/` | _passthrough, apply, audit, design, polish, review (6) |
| `directives/ui_trivial/` | _skipped, apply, refine, report, test (5) |
| `directives/mixed/` | contract, stitch, ui (3) |
| `hooks/` core | exceptions, context, events, registry, runner, settings + package index (7) |
| `hooks/builtin/` | _chat_history_base, chat_history_append, chat_history_halt_append, decision_gate, decision_trace, directive_set_guard, halt_surface_audit, memory_visibility, state_shape_validation, trace + index (11) |

## Parity

- 37 golden-parity test files; **401 work_engine L2 tests green** (directives 234, hooks 127, refine 20 + structure).
- Python-faithful primitives: round-half-even `.2f`, `_pyTruthy`, `!r` repr (incl. single→double quote switch), `type().__name__`, code-point slicing, dict insertion order, ISO-8601 UTC timestamps.
- Integer-valued-float JSON edge cases (`1.0`→`1` in JS) avoided in fixtures with inline reasons; one contract-vs-design empty-string divergence caught by the harness and fixed.
- ADR-051 legacy-literal counts ts==py across all 40; `tsc` clean; dist mirror regenerated.

## Scope

- A `.ts` never imports a `.py`. `hooks/` is self-contained (internal registry/events/context/exceptions). All `.py` retained — Phase-12 sweep.
- The directive-set `__init__.py` (dispatcher wiring) + the top-level dispatcher/emitters/input_builders are a later wave.
- Base: `python2ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)