### PR TITLE
feat(py2ts): work_engine TOP layer — dispatcher/emitters/input_builders/cli + wiring

### DIFF
--- a/dist/agent-src/templates/scripts/work_engine/__main__.ts
+++ b/dist/agent-src/templates/scripts/work_engine/__main__.ts
@@ -1,0 +1,14 @@
+/**
+ * Module entry point — lets the work engine run as a script.
+ *
+ * TypeScript twin of `work_engine/__main__.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). The Python source is the
+ * `python3 -m work_engine` shim (`from .cli import main; sys.exit(main())`).
+ * The twin mirrors it: import `main`, run it, and set `process.exitCode` to the
+ * returned code — never `process.exit`, per ADR-096 (so flushing + cleanup run
+ * exactly as Node's natural shutdown does).
+ */
+
+import { main } from './cli.js';
+
+process.exitCode = main();

--- a/dist/agent-src/templates/scripts/work_engine/cli.ts
+++ b/dist/agent-src/templates/scripts/work_engine/cli.ts
@@ -1,0 +1,206 @@
+/**
+ * Command-line entry point for `/implement-ticket`.
+ *
+ * TypeScript twin of `work_engine/cli.py` (ADR-096 py2ts Phase 1 — work_engine
+ * TOP/integration layer). Public API names stay snake_case to mirror the Python
+ * module 1:1 (per ADR-096 — Python style is part of the contract).
+ *
+ * Minimal Option-A transport: the script loads a persisted state file, runs the
+ * dispatcher once, writes the updated state back, and prints either the delivery
+ * report (on SUCCESS) or the halt surface — directive plus numbered questions —
+ * on BLOCKED/PARTIAL.
+ *
+ * The script never edits code, runs tests, or opens pull requests. All of that
+ * is delegated to the agent via `@agent-directive:` markers.
+ *
+ * Layout (post P2.3 of `road-to-post-pr29-optimize.md`): this file is a thin
+ * orchestrator. The argument parser, state I/O, file-input builders, hook
+ * bootstrap, and stdout/stderr emitters live in their own leaf modules under
+ * `work_engine` — see `cli_args`, `state_io`, `input_builders`, `hook_bootstrap`,
+ * `emitters`, `errors`. Public names (`main`, `DEFAULT_STATE_FILE`) and the
+ * private surface (`_build_hook_registry`, `_CLIError`, `_load_or_build`, …) are
+ * re-exported here so existing imports continue to resolve.
+ *
+ * Exit codes:
+ *
+ * - `0` — flow reached SUCCESS; `state.report` printed.
+ * - `1` — flow halted BLOCKED; halt surface printed on stdout, the state file
+ *   carries the updated `outcomes` and `questions` so the agent can resume.
+ * - `2` — argument or I/O error. The state file is *not* written in this case.
+ */
+
+import {
+    ArgparseExit,
+    DEFAULT_STATE_FILE,
+    LEGACY_STATE_FILE,
+    _FMT_V0,
+    _FMT_V1,
+    parse_args,
+} from './cli_args.js';
+import { Outcome } from './delivery_state.js';
+import {
+    NotImplementedError,
+    ValueError,
+    assert_kind_supported,
+    dispatch,
+    load_directive_set,
+    select_directive_set,
+} from './dispatcher.js';
+import { _emit, _emit_halt } from './emitters.js';
+import { _CLIError } from './errors.js';
+import { _build_hook_registry, _register_chat_history_hooks } from './hook_bootstrap.js';
+import { HookContext, HookEvent, HookRunner } from './hooks/index.js';
+import {
+    _build_from_diff_file,
+    _build_from_file_file,
+    _build_from_prompt_file,
+    _load_or_build,
+} from './input_builders.js';
+import {
+    _load,
+    _maybe_raise_legacy_hint,
+    _read_json,
+    _save,
+    _sync_back,
+    _to_delivery,
+    _to_v0_dict,
+} from './state_io.js';
+import type { WorkState } from './state.js';
+
+/**
+ * Run one dispatch cycle against the persisted state.
+ *
+ * `argv` is taken as-is; pass `null` to fall back to `process.argv.slice(2)`
+ * (the usual entry-point contract).
+ */
+export function main(argv: string[] | null = null): number {
+    // The Python source does `_build_parser().parse_args(argv)`. The cli_args
+    // twin folds the parser into `parse_args`, which on `-h`/`--help` or any
+    // arg error sets `process.exitCode` and throws the `ArgparseExit` sentinel
+    // (mirroring argparse's `SystemExit`). main() converts that to its return
+    // code so the entry point and the test harness agree on the exit.
+    let args;
+    try {
+        args = parse_args(argv ?? process.argv.slice(2));
+    } catch (exc) {
+        if (exc instanceof ArgparseExit) {
+            return exc.code;
+        }
+        throw exc;
+    }
+    const state_file: string = args.state_file;
+
+    const runner = new HookRunner(_build_hook_registry(args));
+
+    let halt = runner.emit(
+        HookEvent.BEFORE_LOAD,
+        new HookContext({ state_file, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { state_file, event: 'BEFORE_LOAD' });
+    }
+
+    let work: WorkState;
+    let fmt: string;
+    try {
+        [work, fmt] = _load_or_build(state_file, args);
+    } catch (exc) {
+        if (exc instanceof _CLIError) {
+            process.stderr.write(`error: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+
+    halt = runner.emit(
+        HookEvent.AFTER_LOAD,
+        new HookContext({ state_file, work, fmt, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'AFTER_LOAD' });
+    }
+
+    let set_name: string;
+    let steps;
+    try {
+        set_name = select_directive_set(work);
+        assert_kind_supported(work.input.kind, set_name);
+        steps = load_directive_set(set_name);
+    } catch (exc) {
+        if (exc instanceof ValueError || exc instanceof NotImplementedError) {
+            process.stderr.write(`error: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+
+    const delivery = _to_delivery(work);
+
+    halt = runner.emit(
+        HookEvent.BEFORE_DISPATCH,
+        new HookContext({ work, delivery, set_name, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'BEFORE_DISPATCH' });
+    }
+
+    const [final, halting] = dispatch(delivery, steps, runner);
+
+    halt = runner.emit(
+        HookEvent.AFTER_DISPATCH,
+        new HookContext({ work, delivery, final, halting, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'AFTER_DISPATCH' });
+    }
+
+    _sync_back(work, delivery);
+
+    halt = runner.emit(
+        HookEvent.BEFORE_SAVE,
+        new HookContext({ work, delivery, fmt, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'BEFORE_SAVE' });
+    }
+
+    _save(state_file, work, fmt);
+
+    halt = runner.emit(
+        HookEvent.AFTER_SAVE,
+        new HookContext({ work, state_file, fmt, args }),
+    );
+    if (halt !== null) {
+        // State is already on disk; exit 2 still per the P3 branch table.
+        return _emit_halt(halt, { work, state_file, event: 'AFTER_SAVE' });
+    }
+
+    _emit(work, final, halting);
+    return final === Outcome.SUCCESS ? 0 : 1;
+}
+
+// Re-export the leaf-module surface so existing imports / patch targets that
+// reached for `work_engine.cli.<name>` continue to resolve (mirrors the Python
+// `__all__`).
+export {
+    DEFAULT_STATE_FILE,
+    LEGACY_STATE_FILE,
+    _CLIError,
+    _FMT_V0,
+    _FMT_V1,
+    _build_from_diff_file,
+    _build_from_file_file,
+    _build_from_prompt_file,
+    _build_hook_registry,
+    _emit,
+    _emit_halt,
+    _load,
+    _load_or_build,
+    _maybe_raise_legacy_hint,
+    _read_json,
+    _register_chat_history_hooks,
+    _save,
+    _sync_back,
+    _to_delivery,
+    _to_v0_dict,
+};

--- a/dist/agent-src/templates/scripts/work_engine/directives/backend/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/backend/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Backend directive set — step handlers for the backend-coding flow.
+ *
+ * TypeScript twin of `work_engine/directives/backend/__init__.py` (ADR-096
+ * py2ts Phase 1 — work_engine TOP/integration layer). The `__init__.py` →
+ * `index.ts` mapping mirrors the hooks subpackage convention. Public API
+ * names stay snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * Each module exposes a single `run` callable that matches the `Step`
+ * protocol defined in `../../delivery_state`. The dispatcher wires them into
+ * the `STEP_ORDER` mapping at call time.
+ *
+ * The deterministic gates (`refine`, `memory`, `analyze`) validate upstream
+ * state; the delegation gates (`plan`, `implement`, `test`, `verify`) halt
+ * with `@agent-directive:` markers so the orchestrator can invoke the matching
+ * skill and resume. `report` renders the delivery Markdown once everything
+ * else has succeeded.
+ */
+
+import type { Step } from '../../delivery_state.js';
+
+import * as analyze from './analyze.js';
+import * as implement from './implement.js';
+import * as memory from './memory.js';
+import * as plan from './plan.js';
+import * as refine from './refine.js';
+import * as report from './report.js';
+import * as test from './test.js';
+import * as verify from './verify.js';
+
+/** External name carried in `state.directive_set` for this set. */
+export const DIRECTIVE_SET_NAME = 'backend';
+
+/**
+ * Input kinds this directive set knows how to handle.
+ *
+ * Read by `work_engine.dispatcher.assert_kind_supported` before the loop
+ * starts. The schema's `work_engine.state.KNOWN_INPUT_KINDS` is the *envelope*
+ * whitelist (what is accepted on disk); `SUPPORTED_KINDS` is the *capability*
+ * whitelist (what this set can actually drive end to end).
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt'];
+
+// Mirror the Python `_STEPS` tuple: (refine, memory, analyze, plan, implement,
+// test, verify, report). The leaf name is the dispatcher slot key; in Python
+// it is derived via `step.__name__.rsplit(".", 1)[-1]` — hardcoded here since
+// the modules are imported statically.
+const _STEPS: ReadonlyArray<[string, { run: Step; AMBIGUITIES: ReadonlyArray<Record<string, string>> }]> = [
+    ['refine', refine],
+    ['memory', memory],
+    ['analyze', analyze],
+    ['plan', plan],
+    ['implement', implement],
+    ['test', test],
+    ['verify', verify],
+    ['report', report],
+];
+
+/**
+ * Return `{step_name: AMBIGUITIES}` for every step in flow order.
+ *
+ * Used by documentation generators and the `test_ambiguity_coverage` suite to
+ * prove every step explicitly declares what can surface a `BLOCKED` outcome.
+ * Steps that always succeed (`memory`, `report`) return an empty tuple —
+ * declared intent, not an omission.
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    const out: Record<string, ReadonlyArray<Record<string, string>>> = {};
+    for (const [name, step] of _STEPS) {
+        out[name] = step.AMBIGUITIES;
+    }
+    return out;
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Each value is the module-level `run` callable matching the
+ * `work_engine.delivery_state.Step` protocol — exactly what
+ * `work_engine.dispatcher.dispatch` calls. Order of insertion matches the
+ * canonical backend flow (refine → memory → analyze → plan → implement →
+ * test → verify → report).
+ */
+export function get_steps(): Map<string, Step> {
+    const out = new Map<string, Step>();
+    for (const [name, step] of _STEPS) {
+        out.set(name, step.run);
+    }
+    return out;
+}
+
+// Re-export the step modules as namespaces (Python `__all__` lists them as
+// importable members of the package).
+export { analyze, implement, memory, plan, refine, report, test, verify };

--- a/dist/agent-src/templates/scripts/work_engine/directives/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Directive-set bundles consumed by the dispatcher.
+ *
+ * TypeScript twin of `work_engine/directives/__init__.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). The `__init__.py` → `index.ts`
+ * mapping mirrors the hooks subpackage convention.
+ *
+ * A *directive set* is a coherent group of step handlers (refine,
+ * memory, analyze, plan, implement, test, verify, report) tuned for a
+ * particular kind of work — backend coding, UI work, mixed front+back
+ * work, and so on. The dispatcher selects exactly one set per cycle
+ * (see `dispatcher.select_directive_set`) and walks its eight steps
+ * in the canonical order.
+ *
+ * Each set is a sub-package exposing a single function:
+ *
+ *     function get_steps(): Mapping<string, Step>
+ *
+ * The mapping must cover every entry in `dispatcher.STEP_ORDER`;
+ * incomplete bundles raise at dispatch time.
+ *
+ * The schema (`state.KNOWN_DIRECTIVE_SETS`) carries the *external*
+ * names `ui`, `ui-trivial`, `mixed`; the directory layout uses
+ * underscores (`ui_trivial`) because Python packages cannot contain
+ * hyphens. The dispatcher's loader is the single place that translates
+ * between the two.
+ */
+
+// The Python `__init__` declares `__all__: list[str] = []` — no re-exports.
+// This twin is the package marker module; consumers import the per-set
+// `index.ts` directly (e.g. `./backend/index.js`).
+export {};

--- a/dist/agent-src/templates/scripts/work_engine/directives/mixed/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/mixed/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Mixed (backend + UI) directive set.
+ *
+ * TypeScript twin of `work_engine/directives/mixed/__init__.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). The `__init__.py` → `index.ts`
+ * mapping mirrors the hooks subpackage convention. Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * `mixed` is the directive set for tickets that touch both layers. Its plan
+ * slot locks the backend contract (data shape + API surface) before any UI
+ * work begins; its implement slot delegates the full UI sub-flow once the
+ * contract is confirmed; its test slot stitches the seam with end-to-end smoke
+ * scenarios.
+ *
+ * Slot mapping (mirrors `work_engine.directives.backend.get_steps`):
+ *
+ * - `refine`    → backend.refine  — intent classification + ticket / prompt gate.
+ * - `memory`    → backend.memory  — engineering-memory pull.
+ * - `analyze`   → backend.analyze — backend analysis precondition.
+ * - `plan`      → `contract`      — backend contract lock.
+ * - `implement` → `ui`            — delegate to UI sub-flow.
+ * - `test`      → `stitch`        — integration verification.
+ * - `verify`    → backend.verify  — four-judge review on the merged diff.
+ * - `report`    → backend.report  — delivery markdown.
+ *
+ * The shared steps are reused by reference, not by duplication.
+ */
+
+import type { Step } from '../../delivery_state.js';
+import {
+    analyze as backend_analyze,
+    memory as backend_memory,
+    refine as backend_refine,
+    report as backend_report,
+    verify as backend_verify,
+} from '../backend/index.js';
+
+import * as contract from './contract.js';
+import * as stitch from './stitch.js';
+import * as ui from './ui.js';
+
+/** External name carried in `state.directive_set` for this set. */
+export const DIRECTIVE_SET_NAME = 'mixed';
+
+/** Roadmap that promotes the Phase 4 stub to working handlers. */
+export const ROADMAP = 'agents/roadmaps/road-to-product-ui-track.md';
+
+/**
+ * Input kinds this directive set accepts.
+ *
+ * `mixed` accepts the same envelope shapes as `backend`: ticket payloads
+ * (refined by the ticket flow) and free-form prompts (refined by
+ * `refine-prompt`). The `diff` / `file` envelopes stay UI-only since they
+ * describe an existing screen, not a backend contract surface.
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt'];
+
+/**
+ * Wire the eight-step dispatcher slots for the mixed set.
+ *
+ * `refine` / `memory` / `analyze` / `verify` / `report` reuse the backend
+ * handlers verbatim; `plan` / `implement` / `test` are the mixed-specific
+ * contract → ui → stitch chain.
+ */
+function _build_step_map(): Map<string, Step> {
+    return new Map<string, Step>([
+        ['refine', backend_refine.run],
+        ['memory', backend_memory.run],
+        ['analyze', backend_analyze.run],
+        ['plan', contract.run],
+        ['implement', ui.run],
+        ['test', stitch.run],
+        ['verify', backend_verify.run],
+        ['report', backend_report.run],
+    ]);
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Mirrors `work_engine.directives.backend.get_steps` and
+ * `work_engine.directives.ui.get_steps`.
+ */
+export function get_steps(): Map<string, Step> {
+    return _build_step_map();
+}
+
+/**
+ * Per-step ambiguity declarations.
+ *
+ * Each handler re-exports its own `AMBIGUITIES`. The mapping is rebuilt per
+ * call (cheap; documentation generators and the `test_ambiguity_coverage`
+ * suite invoke this once per run).
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    return {
+        refine: backend_refine.AMBIGUITIES,
+        memory: backend_memory.AMBIGUITIES,
+        analyze: backend_analyze.AMBIGUITIES,
+        plan: contract.AMBIGUITIES,
+        implement: ui.AMBIGUITIES,
+        test: stitch.AMBIGUITIES,
+        verify: backend_verify.AMBIGUITIES,
+        report: backend_report.AMBIGUITIES,
+    };
+}
+
+export { contract, stitch, ui };

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui/index.ts
@@ -1,0 +1,98 @@
+/**
+ * UI directive set — every slot wired to a working handler.
+ *
+ * TypeScript twin of `work_engine/directives/ui/__init__.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). The `__init__.py` → `index.ts`
+ * mapping mirrors the hooks subpackage convention. Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * The eight-step shape mirrors `work_engine.directives.backend`:
+ *
+ * - `refine`    → `audit`        — existing-UI inventory gate.
+ * - `memory`    → `_passthrough` — UI track does not consult memory.
+ * - `analyze`   → `design`       — produces the locked design brief.
+ * - `plan`      → `_passthrough` — design brief is the plan.
+ * - `implement` → `apply`        — stack-dispatched render of the brief.
+ * - `test`      → `review`       — design-review pass produces findings.
+ * - `verify`    → `polish`       — bounded fix loop (≤ 2 rounds).
+ * - `report`    → backend.report — shared delivery-Markdown renderer.
+ */
+
+import type { Step } from '../../delivery_state.js';
+import { report } from '../backend/index.js';
+
+import * as _passthrough from './_passthrough.js';
+import * as apply from './apply.js';
+import * as audit from './audit.js';
+import * as design from './design.js';
+import * as polish from './polish.js';
+import * as review from './review.js';
+
+/** External name carried in `state.directive_set` for this set. */
+export const DIRECTIVE_SET_NAME = 'ui';
+
+/** Roadmap that promoted the deferral stub to fully wired handlers. */
+export const ROADMAP = 'agents/roadmaps/road-to-product-ui-track.md';
+
+/**
+ * Input kinds this directive set knows how to handle.
+ *
+ * Wires every UI-classifiable input shape (ticket prose, free-form prompt,
+ * `diff` / `file` improve-this-screen envelopes) through to this set.
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt', 'diff', 'file'];
+
+/**
+ * Wire the eight-step dispatcher slots for the UI set.
+ *
+ * `refine` runs audit; `memory` and `plan` are pass-through no-ops; `analyze`
+ * runs design; `implement` runs apply; `test` runs review; `verify` runs
+ * polish; `report` re-uses the shared backend renderer. The mapping is rebuilt
+ * per call (cheap; the dispatcher invokes `get_steps` once per run).
+ */
+function _build_step_map(): Map<string, Step> {
+    const passthrough = _passthrough.run;
+    return new Map<string, Step>([
+        ['refine', audit.run],
+        ['memory', passthrough],
+        ['analyze', design.run],
+        ['plan', passthrough],
+        ['implement', apply.run],
+        ['test', review.run],
+        ['verify', polish.run],
+        ['report', report.run],
+    ]);
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Mirrors `work_engine.directives.backend.get_steps`.
+ */
+export function get_steps(): Map<string, Step> {
+    return _build_step_map();
+}
+
+/**
+ * Per-step ambiguity declarations.
+ *
+ * Mirrors `work_engine.directives.backend.all_ambiguities`. Each working
+ * handler re-exports its own `AMBIGUITIES`; the pass-through slots re-export
+ * `_passthrough.AMBIGUITIES` (empty) so doc generators see a uniform shape
+ * across all eight steps. `report` borrows the backend renderer's surface.
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    const passthrough = _passthrough.AMBIGUITIES;
+    return {
+        refine: audit.AMBIGUITIES,
+        memory: passthrough,
+        analyze: design.AMBIGUITIES,
+        plan: passthrough,
+        implement: apply.AMBIGUITIES,
+        test: review.AMBIGUITIES,
+        verify: polish.AMBIGUITIES,
+        report: report.AMBIGUITIES,
+    };
+}
+
+export { apply, audit, design, polish, report, review };

--- a/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/index.ts
+++ b/dist/agent-src/templates/scripts/work_engine/directives/ui_trivial/index.ts
@@ -1,0 +1,111 @@
+/**
+ * UI-trivial directive set — single-file ≤5-line micro-edit path.
+ *
+ * TypeScript twin of `work_engine/directives/ui_trivial/__init__.py` (ADR-096
+ * py2ts Phase 1 — work_engine TOP/integration layer). The `__init__.py` →
+ * `index.ts` mapping mirrors the hooks subpackage convention. Public API names
+ * stay snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * The eight-step shape mirrors `work_engine.directives.backend` /
+ * `work_engine.directives.ui` — eight slots, fixed order, no branching:
+ *
+ * - `refine`    → `refine`   — confirm intent gate.
+ * - `memory`    → `_skipped` — bypassed.
+ * - `analyze`   → `_skipped` — bypassed.
+ * - `plan`      → `_skipped` — bypassed.
+ * - `implement` → `apply`    — hard preconditions; reclassify to `ui-improve`
+ *   (full audit gate) when violated.
+ * - `test`      → `test`     — smoke-test delegate.
+ * - `verify`    → `_skipped` — bypassed.
+ * - `report`    → `report`   — one-line delivery summary.
+ *
+ * The directory uses an underscore (`ui_trivial`) because Python packages
+ * cannot contain hyphens. The schema carries the external hyphenated name
+ * `"ui-trivial"`; the dispatcher's loader is the single place that translates
+ * between them.
+ */
+
+import type { Step } from '../../delivery_state.js';
+
+import * as _skipped from './_skipped.js';
+import * as apply from './apply.js';
+import * as refine from './refine.js';
+import * as report from './report.js';
+import * as test from './test.js';
+
+/**
+ * External name carried in `state.directive_set` for this set.
+ *
+ * Note the hyphen — this is the schema/wire form, not the module name. The
+ * module name (`ui_trivial`) is an implementation detail of the loader.
+ */
+export const DIRECTIVE_SET_NAME = 'ui-trivial';
+
+/** Roadmap that defines this directive bundle (Phase 2 Step 6). */
+export const ROADMAP = 'agents/roadmaps/road-to-product-ui-track.md';
+
+/**
+ * Input kinds this directive set knows how to handle.
+ *
+ * The intent classifier reaches `ui-trivial` from any of the four input
+ * kinds; the trivial set keeps the same tuple so input routing stays
+ * unchanged once the intent label has landed.
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt', 'diff', 'file'];
+
+/**
+ * Wire the eight-step dispatcher slots for the trivial set.
+ *
+ * `refine` validates the intent gate; `implement`, `test`, and `report` carry
+ * the trivial-path behavior; the four bypassed slots share `_skipped` so the
+ * dispatcher's completeness check is satisfied without inventing per-slot
+ * stubs. The mapping is rebuilt per call (cheap; the dispatcher invokes
+ * `get_steps` once per run).
+ */
+function _build_step_map(): Map<string, Step> {
+    const skipped = _skipped.run;
+    return new Map<string, Step>([
+        ['refine', refine.run],
+        ['memory', skipped],
+        ['analyze', skipped],
+        ['plan', skipped],
+        ['implement', apply.run],
+        ['test', test.run],
+        ['verify', skipped],
+        ['report', report.run],
+    ]);
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Mirrors `work_engine.directives.backend.get_steps`. `refine`, `implement`,
+ * `test`, and `report` carry trivial-path behavior; the four bypassed slots
+ * delegate to `_skipped`.
+ */
+export function get_steps(): Map<string, Step> {
+    return _build_step_map();
+}
+
+/**
+ * Per-step ambiguity declarations.
+ *
+ * Mirrors `work_engine.directives.backend.all_ambiguities`. The four bypassed
+ * slots re-export `_skipped.AMBIGUITIES` (empty) so doc generators see a
+ * uniform shape across all eight steps.
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    const skipped = _skipped.AMBIGUITIES;
+    return {
+        refine: refine.AMBIGUITIES,
+        memory: skipped,
+        analyze: skipped,
+        plan: skipped,
+        implement: apply.AMBIGUITIES,
+        test: test.AMBIGUITIES,
+        verify: skipped,
+        report: report.AMBIGUITIES,
+    };
+}
+
+export { apply, refine, report, test };

--- a/dist/agent-src/templates/scripts/work_engine/dispatcher.ts
+++ b/dist/agent-src/templates/scripts/work_engine/dispatcher.ts
@@ -1,0 +1,513 @@
+/**
+ * Linear step dispatcher for `/implement-ticket`.
+ *
+ * TypeScript twin of `work_engine/dispatcher.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * The dispatcher holds no business logic. It walks the fixed eight-step order
+ * declared in `docs/contracts/implement-ticket-flow.md`, hands each step a live
+ * `DeliveryState`, and honours the three terminal outcomes:
+ *
+ * - `SUCCESS` — record and advance.
+ * - `BLOCKED` — record, copy questions onto the state, halt.
+ * - `PARTIAL` — record, copy questions onto the state, halt.
+ *
+ * Resumption semantics (Option A, flow contract §agent-directives): steps whose
+ * name is already marked `success` in `state.outcomes` are **skipped**. This
+ * lets a caller re-invoke the dispatcher after executing an agent-directive,
+ * update the relevant slice of `DeliveryState`, record `success` on the resumed
+ * step, and continue without replaying earlier work.
+ *
+ * Step handlers are injected by the caller rather than discovered at import
+ * time, so the dispatcher is trivially testable and never depends on handler
+ * import order.
+ */
+
+import {
+    DeliveryState,
+    Outcome,
+    type Step,
+    StepResult,
+} from './delivery_state.js';
+import { HookContext, HookEvent, HookHalt, HookRunner } from './hooks/index.js';
+import { KNOWN_DIRECTIVE_SETS } from './state.js';
+
+// Static directive-set registry. The Python source uses `import_module` to load
+// `work_engine.directives.<pkg>` dynamically; a `.ts` twin may not import a
+// `.py` and resolves statically instead (ADR-096). The map is keyed by the
+// *wire* name (the `_PACKAGE_NAME_OVERRIDES` translation is folded into the
+// keys here, e.g. `ui-trivial` → the `ui_trivial` module).
+import * as _backend from './directives/backend/index.js';
+import * as _mixed from './directives/mixed/index.js';
+import * as _ui from './directives/ui/index.js';
+import * as _ui_trivial from './directives/ui_trivial/index.js';
+
+/** Shape every directive-set index module exposes. */
+interface DirectiveSetModule {
+    get_steps?: () => Map<string, Step>;
+    SUPPORTED_KINDS?: ReadonlyArray<string>;
+}
+
+/**
+ * Shared empty-registry runner reused when `dispatch` is called without an
+ * explicit `hooks` argument. `HookRunner.emit` short-circuits when no callbacks
+ * are registered, so the hot path stays branch-light while the call sites stay
+ * uniform.
+ */
+const _NOOP_RUNNER: HookRunner = new HookRunner();
+
+/**
+ * Canonical execution order. Eight steps, fixed, no branching.
+ *
+ * Changing this order is a roadmap-level decision — not a PR rider — per the
+ * surface-growth guardrails in `agents/roadmaps/road-to-implement-ticket.md`.
+ */
+export const STEP_ORDER: ReadonlyArray<string> = [
+    'refine',
+    'memory',
+    'analyze',
+    'plan',
+    'implement',
+    'test',
+    'verify',
+    'report',
+];
+
+/**
+ * Directive set chosen when `state` does not carry one explicitly.
+ *
+ * Backwards compatibility for v0 `DeliveryState` callers: the legacy shape has
+ * no `directive_set` field, so `select_directive_set` falls back to `"backend"`
+ * and the engine behaves exactly as it did before R1 Phase 4.
+ */
+export const DEFAULT_DIRECTIVE_SET = 'backend';
+
+// Schema enum names use hyphens (`ui-trivial`) but Python packages cannot. The
+// loader is the single place that bridges between the two forms; everywhere
+// else uses the wire form. (Folded into `_DIRECTIVE_SET_MODULES` keys here.)
+const _PACKAGE_NAME_OVERRIDES: Record<string, string> = { 'ui-trivial': 'ui_trivial' };
+
+/** Wire-name → static directive-set module. */
+const _DIRECTIVE_SET_MODULES: Record<string, DirectiveSetModule> = {
+    backend: _backend,
+    ui: _ui,
+    'ui-trivial': _ui_trivial,
+    mixed: _mixed,
+};
+
+/**
+ * Run the eight steps linearly against `state`.
+ *
+ * Returns a `[final_outcome, halting_step]` tuple. `halting_step` is `null`
+ * when every step succeeded; otherwise it carries the name of the step whose
+ * result halted the flow.
+ *
+ * `state` is mutated in place: each step's outcome is recorded in
+ * `state.outcomes` under the step name, and any surfaced questions land on
+ * `state.questions`.
+ *
+ * `steps` maps step name to handler. Every entry in {@link STEP_ORDER} must be
+ * present; missing entries throw (mirroring Python `KeyError`) at dispatch time
+ * rather than silently skipping, so incomplete wiring surfaces as a hard
+ * failure.
+ *
+ * `hooks` is an optional {@link HookRunner}. `null` preserves every existing
+ * call site verbatim — internally `dispatch` falls back to a shared
+ * empty-registry runner so hook bookkeeping stays uniform without a per-emit
+ * `if hooks is null` branch.
+ *
+ * @throws KeyError-equivalent If `steps` does not cover every entry in
+ *   {@link STEP_ORDER}.
+ */
+export function dispatch(
+    state: DeliveryState,
+    steps: Map<string, Step>,
+    hooks: HookRunner | null = null,
+): [Outcome, string | null] {
+    _assert_all_steps_present(steps);
+
+    // Clear stale questions from a previous halt before we resume so the caller
+    // never mistakes old options for fresh ones.
+    state.questions = [];
+
+    const runner = hooks !== null ? hooks : _NOOP_RUNNER;
+
+    for (const name of STEP_ORDER) {
+        if (_get(state.outcomes, name) === Outcome.SUCCESS) {
+            // Already completed on an earlier invocation — skip per the resume
+            // contract. The caller is responsible for keeping `state.outcomes`
+            // and the matching slice in sync.
+            continue;
+        }
+
+        const before_halt = runner.emit(
+            HookEvent.BEFORE_STEP,
+            new HookContext({ step_name: name, delivery: state }),
+        );
+        if (before_halt !== null) {
+            return _hook_halt_blocked(state, runner, name, before_halt, null);
+        }
+
+        const handler = _stepLookup(steps, name);
+        let result: StepResult;
+        try {
+            result = handler(state);
+        } catch (exc) {
+            // Let dispatcher-layer observers see the failure before the
+            // exception unwinds the engine. `on_error` is observe-only; the
+            // original exception is always re-raised.
+            runner.emit(
+                HookEvent.ON_ERROR,
+                new HookContext({ step_name: name, delivery: state, exception: exc }),
+            );
+            throw exc;
+        }
+        _validate_step_result(name, result);
+
+        state.outcomes[name] = result.outcome;
+
+        const after_halt = runner.emit(
+            HookEvent.AFTER_STEP,
+            new HookContext({ step_name: name, delivery: state, result }),
+        );
+        if (after_halt !== null) {
+            return _hook_halt_blocked(state, runner, name, after_halt, result);
+        }
+
+        if (result.outcome === Outcome.BLOCKED) {
+            state.questions = [...result.questions];
+            _emit_on_halt(runner, name, state, result);
+            return [Outcome.BLOCKED, name];
+        }
+
+        if (result.outcome === Outcome.PARTIAL) {
+            state.questions = [...result.questions];
+            _emit_on_halt(runner, name, state, result);
+            return [Outcome.PARTIAL, name];
+        }
+    }
+
+    return [Outcome.SUCCESS, null];
+}
+
+/**
+ * Translate a hook-driven {@link HookHalt} into a clean engine halt.
+ *
+ * Hook-driven halts are treated as first-class engine halts per the P2
+ * contract: the dispatcher returns `[BLOCKED, step_name]` with `state.questions`
+ * rendered verbatim from the halt's `surface`. The step's outcome marker is set
+ * to `"blocked"` only when the halt fires before the handler ran (so resume
+ * re-enters the gate); when it fires after the handler, the marker the handler
+ * produced is preserved so resume reflects what actually happened.
+ */
+function _hook_halt_blocked(
+    state: DeliveryState,
+    runner: HookRunner,
+    name: string,
+    halt: HookHalt,
+    result: StepResult | null,
+): [Outcome, string | null] {
+    if (result === null) {
+        state.outcomes[name] = Outcome.BLOCKED;
+    }
+    state.questions = [...halt.surface];
+    _emit_on_halt(runner, name, state, result);
+    return [Outcome.BLOCKED, name];
+}
+
+/**
+ * Fire `on_halt` as an observe-only event.
+ *
+ * A {@link HookHalt} raised from inside `on_halt` would create a halt-of-a-halt
+ * loop; the runner returns it but the dispatcher deliberately ignores it — the
+ * halt surface is already populated.
+ */
+function _emit_on_halt(
+    runner: HookRunner,
+    name: string,
+    state: DeliveryState,
+    result: StepResult | null,
+): void {
+    runner.emit(
+        HookEvent.ON_HALT,
+        new HookContext({ step_name: name, delivery: state, result }),
+    );
+}
+
+/**
+ * Reject an incomplete step mapping up front.
+ *
+ * We deliberately fail loudly here: a missing step would otherwise raise deep
+ * inside the dispatch loop after partial state mutation, which makes debugging
+ * the wiring harder than it needs to be.
+ */
+function _assert_all_steps_present(steps: Map<string, Step>): void {
+    const missing = STEP_ORDER.filter((name) => !steps.has(name));
+    if (missing.length > 0) {
+        throw new KeyError('Step mapping is missing handlers for: ' + missing.join(', '));
+    }
+}
+
+/**
+ * Enforce the blocked/partial invariant: questions must be set.
+ *
+ * A step that blocks without surfacing a question is a bug — there is nothing
+ * for the user to answer. We throw `ValueError` instead of silently recording
+ * the outcome so the defect is visible at the earliest possible point.
+ */
+function _validate_step_result(name: string, result: StepResult): void {
+    if (
+        (result.outcome === Outcome.BLOCKED || result.outcome === Outcome.PARTIAL) &&
+        result.questions.length === 0
+    ) {
+        throw new ValueError(
+            `Step ${_pyRepr(name)} returned ${result.outcome} with no questions; ` +
+                'blocked and partial outcomes must surface at least one numbered option.',
+        );
+    }
+}
+
+/**
+ * Return the directive set name to dispatch `state` against.
+ *
+ * Looks for `state.directive_set` (the v1 `work_engine.state.WorkState` field)
+ * and falls back to {@link DEFAULT_DIRECTIVE_SET} when the attribute is missing
+ * — the legacy v0 `DeliveryState` has no such field.
+ *
+ * The returned name is validated against {@link KNOWN_DIRECTIVE_SETS}; an
+ * unknown value throws `ValueError` rather than silently falling back, so a typo
+ * in a hand-written state file fails loudly.
+ */
+export function select_directive_set(state: unknown): string {
+    const name = _getattr(state, 'directive_set', DEFAULT_DIRECTIVE_SET);
+    if (typeof name !== 'string' || name.length === 0) {
+        throw new ValueError(
+            `directive_set must be a non-empty string; got ${_pyRepr(name)}`,
+        );
+    }
+    if (!KNOWN_DIRECTIVE_SETS.has(name)) {
+        throw new ValueError(
+            `unknown directive_set ${_pyRepr(name)}; ` +
+                `known sets: ${_pyReprList(_sortedStr([...KNOWN_DIRECTIVE_SETS]))}`,
+        );
+    }
+    return name;
+}
+
+/**
+ * Resolve the `directives.<name>` package and return its step mapping.
+ *
+ * The selected set's index module exposes a `get_steps()` factory that returns
+ * the `{step_name: handler}` mapping the dispatcher walks. The schema enum
+ * carries hyphenated wire names (`ui-trivial`) but Python packages must use
+ * underscores; {@link _PACKAGE_NAME_OVERRIDES} is the single translation point
+ * (folded into the static module registry here).
+ */
+export function load_directive_set(name: string): Map<string, Step> {
+    const moduleEntry = _import_directive_set(name);
+    const get_steps = moduleEntry.module.get_steps;
+    if (typeof get_steps !== 'function') {
+        throw new AttributeError(
+            `work_engine.directives.${moduleEntry.leaf} ` +
+                'does not expose a callable get_steps()',
+        );
+    }
+    const steps = get_steps();
+    if (!(steps instanceof Map)) {
+        throw new TypeError_(
+            `work_engine.directives.${moduleEntry.leaf}` +
+                `.get_steps() must return a Mapping; ` +
+                `got ${_pyTypeName(steps)}`,
+        );
+    }
+    return steps;
+}
+
+/**
+ * Throw `NotImplementedError` if `set_name` cannot handle `kind`.
+ *
+ * Reads the per-set `SUPPORTED_KINDS` tuple and checks membership. Distinct from
+ * {@link select_directive_set}, which only validates the directive-set *name*:
+ * this gate validates the name/kind *pair*.
+ *
+ * Sets that have no `SUPPORTED_KINDS` attribute are treated as "supports
+ * nothing".
+ */
+export function assert_kind_supported(kind: string, set_name: string): void {
+    const moduleEntry = _import_directive_set(set_name);
+    const supported = moduleEntry.module.SUPPORTED_KINDS ?? [];
+    if (!supported.includes(kind)) {
+        throw new NotImplementedError(
+            `directive_set ${_pyRepr(set_name)} does not handle ` +
+                `input.kind=${_pyRepr(kind)}; supported kinds: ` +
+                `${_pyReprList(_sortedStr(_dedup([...supported])))}`,
+        );
+    }
+}
+
+/** Validate `name` and resolve the matching static package module. */
+function _import_directive_set(name: string): { module: DirectiveSetModule; leaf: string } {
+    if (!KNOWN_DIRECTIVE_SETS.has(name)) {
+        throw new ValueError(
+            `unknown directive_set ${_pyRepr(name)}; ` +
+                `known sets: ${_pyReprList(_sortedStr([...KNOWN_DIRECTIVE_SETS]))}`,
+        );
+    }
+    const leaf = _PACKAGE_NAME_OVERRIDES[name] ?? name;
+    const module = _DIRECTIVE_SET_MODULES[name];
+    if (module === undefined) {
+        // A name in KNOWN_DIRECTIVE_SETS with no registered module would mean
+        // the static registry drifted from the schema enum — surface it loudly,
+        // mirroring Python's ImportError from a missing package.
+        throw new ModuleNotFoundError(
+            `No module named 'work_engine.directives.${leaf}'`,
+        );
+    }
+    return { module, leaf };
+}
+
+// ── Python-parity helpers ────────────────────────────────────────────────
+
+/** `Map.get` with a key-membership guard mirroring `dict.get`. */
+function _get(obj: Record<string, string>, key: string): string | undefined {
+    return key in obj ? obj[key] : undefined;
+}
+
+/** Look up a step handler, throwing the KeyError shape on a miss. */
+function _stepLookup(steps: Map<string, Step>, name: string): Step {
+    const handler = steps.get(name);
+    if (handler === undefined) {
+        throw new KeyError(_pyRepr(name));
+    }
+    return handler;
+}
+
+/** Python `getattr(obj, attr, default)` for plain object attribute access. */
+function _getattr(obj: unknown, attr: string, dflt: unknown): unknown {
+    if (obj !== null && typeof obj === 'object' && attr in (obj as Record<string, unknown>)) {
+        const v = (obj as Record<string, unknown>)[attr];
+        return v === undefined ? dflt : v;
+    }
+    return dflt;
+}
+
+/** Python `repr(x)` for the scalar shapes interpolated via `{value!r}`. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `repr(list_of_str)` — `['a', 'b']`. */
+function _pyReprList(values: string[]): string {
+    return '[' + values.map((v) => _pyRepr(v)).join(', ') + ']';
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Python `set(...)` dedup (insertion order does not matter; sorted after). */
+function _dedup(values: string[]): string[] {
+    return [...new Set(values)];
+}
+
+/** Python `type(x).__name__` for the shapes the error messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Map) {
+        // A Map is the TS stand-in for the Python `dict` get_steps returns; the
+        // only non-Map path here is the guard, so report `dict`.
+        return 'dict';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+// ── Python-exception name parity ─────────────────────────────────────────
+// The dispatcher raises KeyError / ValueError / TypeError / AttributeError /
+// NotImplementedError / ImportError-family. JS only has a handful of builtins,
+// so these named subclasses carry the Python exception *name* for callers that
+// branch on it (cli.ts catches ValueError + NotImplementedError equivalents).
+
+/** Python `KeyError`. */
+export class KeyError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, KeyError.prototype);
+        this.name = 'KeyError';
+    }
+}
+
+/** Python `ValueError`. */
+export class ValueError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, ValueError.prototype);
+        this.name = 'ValueError';
+    }
+}
+
+/** Python `TypeError` (named `TypeError_` to avoid the JS builtin clash). */
+export class TypeError_ extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, TypeError_.prototype);
+        this.name = 'TypeError';
+    }
+}
+
+/** Python `AttributeError`. */
+export class AttributeError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, AttributeError.prototype);
+        this.name = 'AttributeError';
+    }
+}
+
+/** Python `NotImplementedError`. */
+export class NotImplementedError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, NotImplementedError.prototype);
+        this.name = 'NotImplementedError';
+    }
+}
+
+/** Python `ModuleNotFoundError` (subclass of ImportError). */
+export class ModuleNotFoundError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, ModuleNotFoundError.prototype);
+        this.name = 'ModuleNotFoundError';
+    }
+}

--- a/dist/agent-src/templates/scripts/work_engine/emitters.ts
+++ b/dist/agent-src/templates/scripts/work_engine/emitters.ts
@@ -1,0 +1,118 @@
+/**
+ * Stdout / stderr emitters for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/emitters.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Holds
+ * the two output helpers that shape the wire surface of `main()`: the
+ * SUCCESS/halt branch printed on stdout, and the lifecycle-hook halt surface
+ * printed on stderr.
+ */
+
+import * as fs from 'node:fs';
+
+import { Outcome } from './delivery_state.js';
+import { HookHalt } from './hooks/index.js';
+import { WorkState, dump } from './state.js';
+
+/**
+ * Print the terminal surface for `final` to stdout.
+ *
+ * On SUCCESS, the delivery report. Otherwise a `[halt]` status line plus the
+ * surfaced questions verbatim.
+ */
+export function _emit(work: WorkState, final: Outcome, halting: string | null): void {
+    if (final === Outcome.SUCCESS) {
+        process.stdout.write(work.report + '\n');
+        return;
+    }
+    process.stdout.write(`[halt] outcome=${final} step=${halting || '(none)'}\n`);
+    for (const line of work.questions) {
+        process.stdout.write(line + '\n');
+    }
+}
+
+/**
+ * Render a {@link HookHalt} surface to stderr and return exit 2.
+ *
+ * Per the P3 halt branch table, every CLI-layer halt yields exit code `2`
+ * regardless of which event fired it. State persistence is governed by *where*
+ * in `main` the halt is detected: the call site decides whether `_save`
+ * already ran.
+ *
+ * When `work` + `state_file` are provided AND the state file already exists on
+ * disk, the halt is appended to `work.halts[]` and the state is re-saved. This
+ * lets `agent-config explain last` surface the halt reason later. Fresh-run
+ * halts before the first `_save` (state file absent) still leave no state on
+ * disk — the pre-explain-v2 contract is preserved.
+ */
+export function _emit_halt(
+    halt: HookHalt,
+    opts: {
+        work?: WorkState | null;
+        state_file?: string | null;
+        event?: string | null;
+    } = {},
+): number {
+    const work = opts.work ?? null;
+    const state_file = opts.state_file ?? null;
+    const event = opts.event ?? null;
+
+    if (halt.surface.length > 0) {
+        for (const line of halt.surface) {
+            process.stderr.write(line + '\n');
+        }
+    } else {
+        process.stderr.write(`halt: ${halt.reason}\n`);
+    }
+    if (work !== null && state_file !== null && _exists(state_file)) {
+        work.halts.push({
+            reason: halt.reason,
+            step: event || '',
+            surface: [...halt.surface],
+            timestamp: _utcNowIso(),
+        });
+        try {
+            dump(work, state_file);
+        } catch {
+            // never let halt persistence mask the halt
+        }
+    }
+    return 2;
+}
+
+/** Python `Path.exists()`. */
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Mirror Python `datetime.now(tz=timezone.utc).isoformat()`.
+ *
+ * CPython renders an aware UTC datetime as `YYYY-MM-DDTHH:MM:SS.ffffff+00:00`
+ * (microsecond precision, explicit `+00:00` offset). `Date.toISOString()`
+ * yields `YYYY-MM-DDTHH:MM:SS.sssZ` (millisecond precision, `Z` suffix), so
+ * this rebuilds the CPython shape: pad milliseconds to microseconds and
+ * replace the `Z` with `+00:00`. This timestamp is wall-clock and therefore
+ * non-deterministic — tests normalise it.
+ */
+function _utcNowIso(): string {
+    const iso = new Date().toISOString(); // e.g. 2026-06-15T03:11:58.123Z
+    // Strip the trailing 'Z', expand .sss → .ssssss (µs), append +00:00.
+    const body = iso.slice(0, -1); // drop 'Z'
+    const dot = body.lastIndexOf('.');
+    if (dot === -1) {
+        return body + '.000000+00:00';
+    }
+    const frac = body.slice(dot + 1); // milliseconds, 3 digits
+    const micros = (frac + '000000').slice(0, 6);
+    return body.slice(0, dot + 1) + micros + '+00:00';
+}

--- a/dist/agent-src/templates/scripts/work_engine/hook_bootstrap.ts
+++ b/dist/agent-src/templates/scripts/work_engine/hook_bootstrap.ts
@@ -1,0 +1,103 @@
+/**
+ * Lifecycle-hook registry assembly for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/hook_bootstrap.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Owns
+ * nothing but `_build_hook_registry` and its chat-history helper.
+ */
+
+import type { ParsedArgs } from './cli_args.js';
+import { HookRegistry } from './hooks/index.js';
+import {
+    ChatHistoryAppendHook,
+    ChatHistoryHaltAppendHook,
+    DecisionTraceHook,
+    DirectiveSetGuardHook,
+    HaltSurfaceAuditHook,
+    MemoryVisibilityHook,
+    StateShapeValidationHook,
+    TraceHook,
+    build_decision_gate_hook,
+} from './hooks/builtin/index.js';
+import { HookSettings, load_hook_settings } from './hooks/settings.js';
+
+/**
+ * Build the CLI-side {@link HookRegistry} for one `main()` run.
+ *
+ * Reads `hooks.*` from `.agent-settings.yml` and registers the enabled hooks.
+ * The master switch `hooks.enabled` defaults to `false` when the block (or the
+ * file) is missing — the registry stays empty and golden replay flows are
+ * byte-stable.
+ *
+ * `--no-hooks` on the CLI forces an empty registry regardless of settings,
+ * which is the explicit escape hatch golden-replay test harnesses can use.
+ */
+export function _build_hook_registry(args: ParsedArgs): HookRegistry {
+    const registry = new HookRegistry();
+    if (_getattr(args, 'no_hooks', false)) {
+        return registry;
+    }
+
+    const settings_path = _getattr(args, 'hooks_config', null) as string | null;
+    const settings = load_hook_settings(settings_path);
+    if (!settings.enabled) {
+        return registry;
+    }
+
+    if (settings.trace) {
+        new TraceHook().register(registry);
+    }
+    if (settings.halt_surface_audit) {
+        new HaltSurfaceAuditHook().register(registry);
+    }
+    if (settings.state_shape_validation) {
+        new StateShapeValidationHook().register(registry);
+    }
+    if (settings.directive_set_guard) {
+        new DirectiveSetGuardHook().register(registry);
+    }
+    if (settings.decision_trace) {
+        new DecisionTraceHook().register(registry);
+    }
+    const gate_hook = build_decision_gate_hook(settings.decision_engine);
+    if (gate_hook !== null) {
+        gate_hook.register(registry);
+    }
+    if (settings.memory_visibility) {
+        new MemoryVisibilityHook({
+            memory_cadence: settings.memory_cadence,
+            visibility_off: settings.memory_visibility_off,
+        }).register(registry);
+    }
+    if (settings.chat_history_enabled) {
+        _register_chat_history_hooks(registry, settings);
+    }
+
+    return registry;
+}
+
+/**
+ * Register the structural chat-history hooks bound to the configured script.
+ *
+ * Hook-only contract (post road-to-chat-history-hook-only): only the append +
+ * halt-append hooks remain; cooperative `turn-check` / `heartbeat` hooks were
+ * removed when the cooperative always-rules were retired.
+ */
+export function _register_chat_history_hooks(registry: HookRegistry, settings: HookSettings): void {
+    const script = settings.chat_history_script;
+    new ChatHistoryAppendHook(script).register(registry);
+    new ChatHistoryHaltAppendHook(script).register(registry);
+}
+
+/** Python `getattr(obj, attr, default)` for plain object attribute access. */
+function _getattr(obj: unknown, attr: string, dflt: unknown): unknown {
+    if (obj !== null && typeof obj === 'object' && attr in (obj as Record<string, unknown>)) {
+        const v = (obj as Record<string, unknown>)[attr];
+        return v === undefined ? dflt : v;
+    }
+    return dflt;
+}

--- a/dist/agent-src/templates/scripts/work_engine/input_builders.ts
+++ b/dist/agent-src/templates/scripts/work_engine/input_builders.ts
@@ -1,0 +1,260 @@
+/**
+ * File-based input builders and the load-or-build dispatch helper.
+ *
+ * TypeScript twin of `work_engine/input_builders.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Owns the
+ * CLI's "first run" path: when no state file exists, build a fresh `WorkState`
+ * from `--ticket-file`, `--prompt-file`, `--diff-file` or `--file-file`. Every
+ * builder is byte-identical in behaviour to the pre-split version.
+ */
+
+import * as fs from 'node:fs';
+
+import { _FMT_V0, _FMT_V1, type ParsedArgs } from './cli_args.js';
+import { _CLIError } from './errors.js';
+import { populate_routing } from './intent/classify.js';
+import { DiffResolverError, build_envelope as _build_diff_envelope } from './resolvers/diff.js';
+import { FileResolverError, build_envelope as _build_file_envelope } from './resolvers/file.js';
+import { PromptResolverError, build_envelope as _build_prompt_envelope } from './resolvers/prompt.js';
+import { Input, WorkState, type Dict } from './state.js';
+import { _load, _maybe_raise_legacy_hint, _read_json } from './state_io.js';
+
+/**
+ * Return the WorkState to dispatch against plus its wire format.
+ *
+ * Either loaded from `state_file` (format-preserving) or freshly built from
+ * `--ticket-file` (R1), `--prompt-file` (R2), `--diff-file` (R3) or
+ * `--file-file` (R3). Fresh ticket files default to v0 wire format so newly
+ * captured Goldens stay byte-equal with the pre-Phase-4 baseline; the prompt /
+ * diff / file paths emit v1 directly (v0 has no envelope concept for these
+ * kinds). v1 round-trips for state files already on disk in v1 shape.
+ */
+export function _load_or_build(state_file: string, args: ParsedArgs): [WorkState, string] {
+    if (_exists(state_file)) {
+        return _load(state_file);
+    }
+    _maybe_raise_legacy_hint(state_file);
+    const inputs: Array<[string, string | null]> = [
+        ['--ticket-file', args.ticket_file],
+        ['--prompt-file', args.prompt_file],
+        ['--diff-file', args.diff_file],
+        ['--file-file', args.file_file],
+    ];
+    const supplied = inputs.filter(([, value]) => value !== null).map(([name]) => name);
+    if (supplied.length > 1) {
+        throw new _CLIError(
+            `${supplied.join(', ')} are mutually exclusive; pass exactly ` +
+                'one when building an initial state.',
+        );
+    }
+    if (supplied.length === 0) {
+        throw new _CLIError(
+            `No state file at ${state_file} and no --ticket-file, ` +
+                '--prompt-file, --diff-file, or --file-file given; cannot ' +
+                'build an initial state.',
+        );
+    }
+    if (args.prompt_file !== null) {
+        return [_build_from_prompt_file(args), _FMT_V1];
+    }
+    if (args.diff_file !== null) {
+        return [_build_from_diff_file(args), _FMT_V1];
+    }
+    if (args.file_file !== null) {
+        return [_build_from_file_file(args), _FMT_V1];
+    }
+    const ticket = _read_json(args.ticket_file as string);
+    if (!_isPlainDict(ticket)) {
+        throw new _CLIError(
+            `--ticket-file must carry a JSON object; got ${_pyTypeName(ticket)}.`,
+        );
+    }
+    const work = new WorkState({ input: new Input('ticket', ticket as Dict) });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return [work, _FMT_V0];
+}
+
+/**
+ * Read `--prompt-file` as raw text and wrap it in a prompt envelope.
+ *
+ * The file is read verbatim (UTF-8) and handed to the prompt resolver, which
+ * validates non-emptiness and returns the canonical
+ * `Input(kind="prompt", data={raw, reconstructed_ac, assumptions})` envelope.
+ * Persona is honoured the same way as the ticket path.
+ */
+export function _build_from_prompt_file(args: ParsedArgs): WorkState {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(args.prompt_file as string, 'utf-8');
+    } catch (exc) {
+        throw new _CLIError(`Cannot read ${args.prompt_file}: ${_osErrorText(exc, args.prompt_file as string)}`);
+    }
+    let envelope: Input;
+    try {
+        envelope = _build_prompt_envelope(raw);
+    } catch (exc) {
+        if (exc instanceof PromptResolverError) {
+            throw new _CLIError(`--prompt-file is not a valid prompt: ${exc.message}`);
+        }
+        throw exc;
+    }
+    const work = new WorkState({ input: envelope });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return work;
+}
+
+/**
+ * Read `--diff-file` as raw text and wrap it in a diff envelope.
+ *
+ * The file is read verbatim (UTF-8) and handed to the diff resolver, which
+ * validates the unified-diff header heuristic and returns the canonical
+ * `Input(kind="diff", data={raw, reconstructed_ac, assumptions})` envelope.
+ * `populate_routing` then routes the envelope to the UI-improve directive set
+ * without running the prose classifier.
+ */
+export function _build_from_diff_file(args: ParsedArgs): WorkState {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(args.diff_file as string, 'utf-8');
+    } catch (exc) {
+        throw new _CLIError(`Cannot read ${args.diff_file}: ${_osErrorText(exc, args.diff_file as string)}`);
+    }
+    let envelope: Input;
+    try {
+        envelope = _build_diff_envelope(raw);
+    } catch (exc) {
+        if (exc instanceof DiffResolverError) {
+            throw new _CLIError(`--diff-file is not a valid diff: ${exc.message}`);
+        }
+        throw exc;
+    }
+    const work = new WorkState({ input: envelope });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return work;
+}
+
+/**
+ * Read `--file-file` as a single-line path and wrap it in a file envelope.
+ *
+ * The file is read verbatim (UTF-8); the first non-empty line is taken as the
+ * path reference and handed to the file resolver, which validates path shape
+ * (non-empty, NUL-free, not a URL) and returns the canonical
+ * `Input(kind="file", data={path, reconstructed_ac, assumptions})` envelope.
+ * Trailing whitespace and additional lines are ignored.
+ */
+export function _build_from_file_file(args: ParsedArgs): WorkState {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(args.file_file as string, 'utf-8');
+    } catch (exc) {
+        throw new _CLIError(`Cannot read ${args.file_file}: ${_osErrorText(exc, args.file_file as string)}`);
+    }
+    // Python: `raw.strip().splitlines()[0] if raw.strip() else ""`.
+    const stripped = _pyStrip(raw);
+    const path_ = stripped ? _firstLine(stripped) : '';
+    let envelope: Input;
+    try {
+        envelope = _build_file_envelope(path_);
+    } catch (exc) {
+        if (exc instanceof FileResolverError) {
+            throw new _CLIError(`--file-file does not carry a valid path: ${exc.message}`);
+        }
+        throw exc;
+    }
+    const work = new WorkState({ input: envelope });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return work;
+}
+
+// ── Python-parity helpers ────────────────────────────────────────────────
+
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `type(x).__name__` for the JSON value shapes the messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value as number) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/** Python `str.strip()` — strip leading/trailing whitespace. */
+function _pyStrip(s: string): string {
+    // Python str.strip() with no arg removes ASCII + Unicode whitespace; JS \s
+    // covers the common set adequately for the single-line-path contract.
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/**
+ * Python `str.splitlines()[0]` on an already-`strip()`ped string.
+ *
+ * The caller consumes only the first line; the stripped input has no leading
+ * boundary, so splitting on the universal-newline set and returning element 0
+ * is byte-equivalent to `splitlines()[0]` for the single-line-path contract.
+ */
+function _firstLine(s: string): string {
+    const m = s.split(/\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/u);
+    return m[0] ?? '';
+}
+
+/**
+ * Approximate the text of Python's `OSError` for a failed read (mirrors
+ * `state_io.ts::_osErrorText`). The error *channel* (exit 2 via `_CLIError`)
+ * and the *prefix* ("Cannot read <path>: ") stay identical; only the trailing
+ * OS detail differs — tests normalise it.
+ */
+function _osErrorText(exc: unknown, p: string): string {
+    const e = exc as NodeJS.ErrnoException;
+    if (e && e.code === 'ENOENT') {
+        return `[Errno 2] No such file or directory: '${p}'`;
+    }
+    if (e && e.code === 'EISDIR') {
+        return `[Errno 21] Is a directory: '${p}'`;
+    }
+    if (e && e.code === 'EACCES') {
+        return `[Errno 13] Permission denied: '${p}'`;
+    }
+    return e && e.message ? e.message : String(exc);
+}

--- a/dist/agent-src/templates/scripts/work_engine/migration/v0_to_v1.ts
+++ b/dist/agent-src/templates/scripts/work_engine/migration/v0_to_v1.ts
@@ -1,0 +1,531 @@
+/**
+ * Migrate a v0 `DeliveryState` JSON file to the v1 schema.
+ *
+ * TypeScript twin of `work_engine/migration/v0_to_v1.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-096 — Python style is
+ * part of the contract).
+ *
+ * The v0 era used `.implement-ticket-state.json` and stored the ticket
+ * under a flat `ticket` key. v1 wraps the payload under `input.kind`
+ * / `input.data` and adds `intent`, `directive_set`, and
+ * `version`. The default destination is `.work-state.json` next to
+ * the v0 file; the v0 file is renamed to `.implement-ticket-state.json.bak`
+ * to preserve the rollback surface.
+ *
+ * The module is both importable and runnable:
+ *
+ *     node node_modules/.bin/tsx work_engine/migration/v0_to_v1.ts .implement-ticket-state.json
+ *
+ * Idempotency: `migrate_payload` accepts a payload that already looks
+ * like v1 and returns it unchanged. `migrate_file` refuses to migrate
+ * twice — if the destination already exists it raises rather than
+ * silently overwriting work.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+    DEFAULT_DIRECTIVE_SET,
+    DEFAULT_INTENT,
+    SCHEMA_VERSION,
+    SchemaError,
+    type Dict,
+    type JsonValue,
+} from '../state.js';
+
+export const DEFAULT_V0_FILENAME = '.implement-ticket-state.json';
+/**
+ * Path the dispatcher used while the engine still lived under
+ * `implement_ticket`. The migration looks here when no source path is
+ * passed on the CLI.
+ */
+
+export const DEFAULT_V1_FILENAME = '.work-state.json';
+/** Canonical filename for the v1 wire format. */
+
+export const BACKUP_SUFFIX = '.bak';
+/**
+ * Appended to the v0 source path when the migration archives it.
+ *
+ * If the `.bak` slot is already taken (re-running the migration after
+ * an aborted run, manual rollback, etc.) the rotator falls back to
+ * `.bak.1`, `.bak.2`, ... — see {@link _rotate_backup_path}. The
+ * migration never silently overwrites an existing backup.
+ */
+
+const _MAX_BACKUP_ROTATIONS = 999;
+/**
+ * Hard ceiling on rotated backup filenames; surfaces an explicit
+ * {@link SchemaError} instead of looping forever if a checkout has
+ * hundreds of stale backups.
+ */
+
+/**
+ * Return the next free `.bak` slot for `source`.
+ *
+ * Tries `source.bak` first, then `source.bak.1`,
+ * `source.bak.2`, ... up to {@link _MAX_BACKUP_ROTATIONS}. The
+ * rotator only inspects existence — collision-safe by construction —
+ * and never deletes or overwrites prior backups.
+ */
+export function _rotate_backup_path(source: string): string {
+    // Python `source.with_suffix(source.suffix + BACKUP_SUFFIX)`: append the
+    // backup suffix to the existing suffix. `Path.with_suffix` replaces the
+    // final extension, so `.json` → `.json.bak` is exactly `source + ".bak"`
+    // here because BACKUP_SUFFIX leads with a dot and there is no embedded
+    // dot to collide with. Mirror `_with_suffix` semantics for parity.
+    const primary = _with_suffix(source, _suffix(source) + BACKUP_SUFFIX);
+    if (!_exists(primary)) {
+        return primary;
+    }
+    for (let index = 1; index <= _MAX_BACKUP_ROTATIONS; index++) {
+        const candidate = _with_suffix(primary, _suffix(primary) + `.${index}`);
+        if (!_exists(candidate)) {
+            return candidate;
+        }
+    }
+    throw new SchemaError(
+        `refusing to rotate backup for ${source}: more than ` +
+            `${_MAX_BACKUP_ROTATIONS} stale .bak files already exist; ` +
+            'clean them up before re-running the migration',
+    );
+}
+
+/**
+ * Return the v1 form of `payload`.
+ *
+ * A payload that already declares `version: 1` is returned
+ * unchanged (deep-copied via `JSON.parse(JSON.stringify(...))` so the
+ * caller cannot accidentally mutate the input). Anything else is
+ * treated as v0 and wrapped: `ticket` becomes `input.data`,
+ * `input.kind` is set to `"ticket"`, and the engine defaults are
+ * filled in.
+ *
+ * @throws SchemaError If the payload is not a dict, declares a higher version
+ *   than this migration knows about, or lacks a `ticket` key.
+ */
+export function migrate_payload(payload: JsonValue): Dict {
+    if (!_isPlainDict(payload)) {
+        throw new SchemaError(
+            `v0 state must be a JSON object; got ${_pyTypeName(payload)}`,
+        );
+    }
+    const p = payload as Record<string, JsonValue>;
+
+    const declared_version = _get(p, 'version', undefined);
+    if (declared_version === SCHEMA_VERSION) {
+        return JSON.parse(JSON.stringify(p)) as Dict;
+    }
+    if (declared_version !== undefined && declared_version !== null) {
+        throw new SchemaError(
+            `cannot migrate from version ${_pyRepr(declared_version)} to ` +
+                `${SCHEMA_VERSION}; this script only handles v0 (no version key)`,
+        );
+    }
+
+    if (!('ticket' in p)) {
+        throw new SchemaError(
+            "v0 state must carry a 'ticket' key; got keys: " +
+                _pyReprList(_sortedStr(Object.keys(p))),
+        );
+    }
+    const ticket = p['ticket'];
+    if (!_isPlainDict(ticket)) {
+        throw new SchemaError(
+            `v0 state.ticket must be a JSON object; got ${_pyTypeName(ticket)}`,
+        );
+    }
+
+    return {
+        version: SCHEMA_VERSION,
+        input: { kind: 'ticket', data: ticket },
+        intent: DEFAULT_INTENT,
+        directive_set: DEFAULT_DIRECTIVE_SET,
+        persona: _get(p, 'persona', 'senior-engineer') as JsonValue,
+        memory: [...((_get(p, 'memory', []) as JsonValue[]) ?? [])],
+        plan: _get(p, 'plan', null) as JsonValue,
+        changes: [...((_get(p, 'changes', []) as JsonValue[]) ?? [])],
+        tests: _get(p, 'tests', null) as JsonValue,
+        verify: _get(p, 'verify', null) as JsonValue,
+        outcomes: { ...((_get(p, 'outcomes', {}) as Dict) ?? {}) },
+        questions: [...((_get(p, 'questions', []) as JsonValue[]) ?? [])],
+        report: _get(p, 'report', '') as JsonValue,
+    };
+}
+
+/**
+ * Migrate the v0 state file at `source` and write the v1 result.
+ *
+ * `destination` defaults to {@link DEFAULT_V1_FILENAME} next to
+ * `source`. When `backup` is true (the default) the original
+ * file is renamed with {@link BACKUP_SUFFIX} appended; when false,
+ * the original is left untouched. The destination must not exist —
+ * refusing to overwrite is the safety net against accidental
+ * double-migration on CI.
+ *
+ * Returns the destination path on success.
+ */
+export function migrate_file(
+    source: string,
+    opts: { destination?: string | null; backup?: boolean } = {},
+): string {
+    const destination = opts.destination ?? null;
+    const backup = opts.backup ?? true;
+
+    if (!_isFile(source)) {
+        throw new SchemaError(`v0 state file not found: ${source}`);
+    }
+
+    const raw = fs.readFileSync(source, 'utf-8');
+    let payload: JsonValue;
+    try {
+        payload = JSON.parse(raw) as JsonValue;
+    } catch (exc) {
+        // Python `json.JSONDecodeError` → "invalid JSON in {source}: {exc}".
+        throw new SchemaError(`invalid JSON in ${source}: ${(exc as Error).message}`);
+    }
+
+    const target = destination ?? _with_name(source, DEFAULT_V1_FILENAME);
+    if (_exists(target)) {
+        throw new SchemaError(
+            `refusing to overwrite existing destination ${target}; ` +
+                'delete or rename it first',
+        );
+    }
+
+    const migrated = migrate_payload(payload);
+    fs.mkdirSync(_parent(target), { recursive: true });
+    fs.writeFileSync(
+        target,
+        _jsonDumps(migrated) + '\n',
+        'utf-8',
+    );
+
+    if (backup) {
+        const backup_path = _rotate_backup_path(source);
+        // Python `shutil.move(str(source), str(backup_path))` — rename within
+        // the same directory; `fs.renameSync` matches that fast path.
+        fs.renameSync(source, backup_path);
+    }
+
+    return target;
+}
+
+/**
+ * CLI entry point — `node node_modules/.bin/tsx work_engine/migration/v0_to_v1.ts`.
+ *
+ * Exits `0` on success, `2` on any {@link SchemaError} so the
+ * invoking shell can branch on the failure category. Returns the exit
+ * code (the caller sets `process.exitCode`, never `process.exit`, per
+ * ADR-096).
+ */
+export function main(argv: string[] | null = null): number {
+    const args = _parse_args(argv ?? process.argv.slice(2));
+    if (args === null) {
+        // `-h` / `--help` already printed usage and signalled exit 0.
+        return 0;
+    }
+
+    let target: string;
+    try {
+        target = migrate_file(args.source, {
+            destination: args.destination,
+            backup: !args.no_backup,
+        });
+    } catch (exc) {
+        if (exc instanceof SchemaError) {
+            process.stderr.write(`error: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+
+    process.stdout.write(`migrated ${args.source} → ${target}\n`);
+    return 0;
+}
+
+// ── Argument parsing ─────────────────────────────────────────────────────
+//
+// The Python source uses `argparse` with a single optional positional
+// (`source`, default `.implement-ticket-state.json`) plus `--destination`
+// and `--no-backup`. argparse `--help`/error prose is not a parity surface
+// (ADR-096); the parser mirrors argparse's runtime behaviour: long-option
+// prefix abbreviation, `--flag=value` / `--flag value` forms, the store_true
+// `--no-backup`, `-h`/`--help` exit-0, exit-2 on every error path.
+
+interface MigrationArgs {
+    source: string;
+    destination: string | null;
+    no_backup: boolean;
+}
+
+const _PROG = 'work_engine.migration.v0_to_v1';
+
+interface _OptionSpec {
+    flag: string;
+    dest: 'destination' | 'no_backup';
+    takesValue: boolean;
+}
+
+const _OPTIONS: _OptionSpec[] = [
+    { flag: '--destination', dest: 'destination', takesValue: true },
+    { flag: '--no-backup', dest: 'no_backup', takesValue: false },
+];
+
+const _HELP_FLAGS = ['--help'];
+
+function _usage(): string {
+    // Compact one-line usage marker; the exact wrapping/prose is not a parity
+    // surface (ADR-096 — argparse usage/help text is not byte-compared).
+    return `usage: ${_PROG} [-h] [--destination DESTINATION] [--no-backup] [source]`;
+}
+
+function _argErr(message: string): never {
+    process.stderr.write(`${_usage()}\n`);
+    process.stderr.write(`${_PROG}: error: ${message}\n`);
+    process.exitCode = 2;
+    throw new _ArgparseExit(2);
+}
+
+function _resolveLong(name: string): _OptionSpec | 'help' {
+    const exact = _OPTIONS.find((o) => o.flag === name);
+    if (exact) {
+        return exact;
+    }
+    if (_HELP_FLAGS.includes(name)) {
+        return 'help';
+    }
+    const candidates: Array<_OptionSpec | 'help'> = [];
+    for (const o of _OPTIONS) {
+        if (o.flag.startsWith(name)) {
+            candidates.push(o);
+        }
+    }
+    for (const h of _HELP_FLAGS) {
+        if (h.startsWith(name)) {
+            candidates.push('help');
+        }
+    }
+    if (candidates.length === 1) {
+        return candidates[0] as _OptionSpec | 'help';
+    }
+    if (candidates.length === 0) {
+        _argErr(`unrecognized arguments: ${name}`);
+    }
+    const names = candidates.map((c) => (c === 'help' ? '--help' : c.flag)).join(', ');
+    _argErr(`ambiguous option: ${name} could match ${names}`);
+}
+
+/** Thrown internally to mirror argparse's exit path (sentinel). */
+class _ArgparseExit extends Error {
+    readonly code: number;
+    constructor(code: number) {
+        super(`argparse exit ${code}`);
+        Object.setPrototypeOf(this, _ArgparseExit.prototype);
+        this.name = 'ArgparseExit';
+        this.code = code;
+    }
+}
+
+/**
+ * Parse `argv` (the slice after the program name). Returns `null` on
+ * `-h`/`--help` (usage printed, exit 0 signalled); throws {@link _ArgparseExit}
+ * (with `process.exitCode` set to 2) on any error path. Mirrors the argparse
+ * positional default of `.implement-ticket-state.json`.
+ */
+function _parse_args(argv: string[]): MigrationArgs | null {
+    const args: MigrationArgs = {
+        source: DEFAULT_V0_FILENAME,
+        destination: null,
+        no_backup: false,
+    };
+    const positionals: string[] = [];
+    const extras: string[] = [];
+    let sawSource = false;
+
+    let i = 0;
+    while (i < argv.length) {
+        const tok = argv[i] as string;
+        if (tok === '-h' || tok === '--help') {
+            process.stdout.write(`${_usage()}\n`);
+            return null;
+        }
+        if (tok.startsWith('--')) {
+            let name = tok;
+            let inlineValue: string | null = null;
+            const eq = tok.indexOf('=');
+            if (eq !== -1) {
+                name = tok.slice(0, eq);
+                inlineValue = tok.slice(eq + 1);
+            }
+            const resolved = _resolveLong(name);
+            if (resolved === 'help') {
+                process.stdout.write(`${_usage()}\n`);
+                return null;
+            }
+            if (resolved.takesValue) {
+                if (inlineValue !== null) {
+                    args.destination = inlineValue;
+                } else {
+                    const next = argv[i + 1];
+                    if (next === undefined) {
+                        _argErr(`argument ${resolved.flag}: expected one argument`);
+                    }
+                    args.destination = next as string;
+                    i += 1;
+                }
+            } else {
+                if (inlineValue !== null) {
+                    _argErr(`argument ${resolved.flag}: ignored explicit argument '${inlineValue}'`);
+                }
+                args.no_backup = true;
+            }
+        } else if (tok.startsWith('-') && tok !== '-') {
+            extras.push(tok);
+        } else if (!sawSource) {
+            args.source = tok;
+            sawSource = true;
+            positionals.push(tok);
+        } else {
+            extras.push(tok);
+        }
+        i += 1;
+    }
+    if (extras.length > 0) {
+        _argErr(`unrecognized arguments: ${extras.join(' ')}`);
+    }
+    return args;
+}
+
+// ── Path / filesystem parity helpers ─────────────────────────────────────
+
+/** Python `Path.suffix` — the final dotted extension (incl. the dot), or "". */
+function _suffix(p: string): string {
+    const base = path.basename(p);
+    const dot = base.lastIndexOf('.');
+    // Python: a leading dot (dotfile, no other dot) has no suffix.
+    if (dot <= 0) {
+        return '';
+    }
+    return base.slice(dot);
+}
+
+/** Python `Path.with_suffix(newSuffix)` — replace the final extension. */
+function _with_suffix(p: string, newSuffix: string): string {
+    const dir = path.dirname(p);
+    const base = path.basename(p);
+    const cur = _suffix(p);
+    const stem = cur ? base.slice(0, base.length - cur.length) : base;
+    const joined = stem + newSuffix;
+    return dir === '.' && !p.includes('/') && !p.includes(path.sep) ? joined : path.join(dir, joined);
+}
+
+/** Python `Path.with_name(name)` — same directory, replaced basename. */
+function _with_name(p: string, name: string): string {
+    const dir = path.dirname(p);
+    return dir === '.' && !p.includes('/') && !p.includes(path.sep) ? name : path.join(dir, name);
+}
+
+/** Python `Path.parent` — the containing directory. */
+function _parent(p: string): string {
+    return path.dirname(p);
+}
+
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function _isFile(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+// ── Python-parity primitives (mirrors state_io.ts) ───────────────────────
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, ensure_ascii=False)`.
+ *
+ * For round-tripped JSON, `JSON.stringify` with a 2-space indent matches
+ * CPython byte-for-byte: 2-space indent, `": "` key separator, `{}` / `[]`
+ * for empties, non-ASCII verbatim. Same rationale as `state_io.ts::_jsonDumps`:
+ * no float/int tag survives JSON parsing, so the CPython `N.0` divergence
+ * cannot arise here.
+ */
+function _jsonDumps(obj: Dict): string {
+    return JSON.stringify(obj, null, 2);
+}
+
+/** `dict.get(key, default)`. */
+function _get(obj: Record<string, JsonValue>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `type(x).__name__` for the JSON value shapes the messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/** Python `repr(x)` for the scalar shapes interpolated via `{value!r}`. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `repr(list_of_str)` — `['a', 'b']`. */
+function _pyReprList(values: string[]): string {
+    return '[' + values.map((v) => _pyRepr(v)).join(', ') + ']';
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+// `python3 -m work_engine.migration.v0_to_v1` parity: run main() when invoked
+// directly. tsx sets `import.meta.url` to the entry file URL.
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main();
+}

--- a/src/agent-src/templates/scripts/work_engine/__main__.ts
+++ b/src/agent-src/templates/scripts/work_engine/__main__.ts
@@ -1,0 +1,14 @@
+/**
+ * Module entry point — lets the work engine run as a script.
+ *
+ * TypeScript twin of `work_engine/__main__.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). The Python source is the
+ * `python3 -m work_engine` shim (`from .cli import main; sys.exit(main())`).
+ * The twin mirrors it: import `main`, run it, and set `process.exitCode` to the
+ * returned code — never `process.exit`, per ADR-096 (so flushing + cleanup run
+ * exactly as Node's natural shutdown does).
+ */
+
+import { main } from './cli.js';
+
+process.exitCode = main();

--- a/src/agent-src/templates/scripts/work_engine/cli.ts
+++ b/src/agent-src/templates/scripts/work_engine/cli.ts
@@ -1,0 +1,206 @@
+/**
+ * Command-line entry point for `/implement-ticket`.
+ *
+ * TypeScript twin of `work_engine/cli.py` (ADR-096 py2ts Phase 1 — work_engine
+ * TOP/integration layer). Public API names stay snake_case to mirror the Python
+ * module 1:1 (per ADR-096 — Python style is part of the contract).
+ *
+ * Minimal Option-A transport: the script loads a persisted state file, runs the
+ * dispatcher once, writes the updated state back, and prints either the delivery
+ * report (on SUCCESS) or the halt surface — directive plus numbered questions —
+ * on BLOCKED/PARTIAL.
+ *
+ * The script never edits code, runs tests, or opens pull requests. All of that
+ * is delegated to the agent via `@agent-directive:` markers.
+ *
+ * Layout (post P2.3 of `road-to-post-pr29-optimize.md`): this file is a thin
+ * orchestrator. The argument parser, state I/O, file-input builders, hook
+ * bootstrap, and stdout/stderr emitters live in their own leaf modules under
+ * `work_engine` — see `cli_args`, `state_io`, `input_builders`, `hook_bootstrap`,
+ * `emitters`, `errors`. Public names (`main`, `DEFAULT_STATE_FILE`) and the
+ * private surface (`_build_hook_registry`, `_CLIError`, `_load_or_build`, …) are
+ * re-exported here so existing imports continue to resolve.
+ *
+ * Exit codes:
+ *
+ * - `0` — flow reached SUCCESS; `state.report` printed.
+ * - `1` — flow halted BLOCKED; halt surface printed on stdout, the state file
+ *   carries the updated `outcomes` and `questions` so the agent can resume.
+ * - `2` — argument or I/O error. The state file is *not* written in this case.
+ */
+
+import {
+    ArgparseExit,
+    DEFAULT_STATE_FILE,
+    LEGACY_STATE_FILE,
+    _FMT_V0,
+    _FMT_V1,
+    parse_args,
+} from './cli_args.js';
+import { Outcome } from './delivery_state.js';
+import {
+    NotImplementedError,
+    ValueError,
+    assert_kind_supported,
+    dispatch,
+    load_directive_set,
+    select_directive_set,
+} from './dispatcher.js';
+import { _emit, _emit_halt } from './emitters.js';
+import { _CLIError } from './errors.js';
+import { _build_hook_registry, _register_chat_history_hooks } from './hook_bootstrap.js';
+import { HookContext, HookEvent, HookRunner } from './hooks/index.js';
+import {
+    _build_from_diff_file,
+    _build_from_file_file,
+    _build_from_prompt_file,
+    _load_or_build,
+} from './input_builders.js';
+import {
+    _load,
+    _maybe_raise_legacy_hint,
+    _read_json,
+    _save,
+    _sync_back,
+    _to_delivery,
+    _to_v0_dict,
+} from './state_io.js';
+import type { WorkState } from './state.js';
+
+/**
+ * Run one dispatch cycle against the persisted state.
+ *
+ * `argv` is taken as-is; pass `null` to fall back to `process.argv.slice(2)`
+ * (the usual entry-point contract).
+ */
+export function main(argv: string[] | null = null): number {
+    // The Python source does `_build_parser().parse_args(argv)`. The cli_args
+    // twin folds the parser into `parse_args`, which on `-h`/`--help` or any
+    // arg error sets `process.exitCode` and throws the `ArgparseExit` sentinel
+    // (mirroring argparse's `SystemExit`). main() converts that to its return
+    // code so the entry point and the test harness agree on the exit.
+    let args;
+    try {
+        args = parse_args(argv ?? process.argv.slice(2));
+    } catch (exc) {
+        if (exc instanceof ArgparseExit) {
+            return exc.code;
+        }
+        throw exc;
+    }
+    const state_file: string = args.state_file;
+
+    const runner = new HookRunner(_build_hook_registry(args));
+
+    let halt = runner.emit(
+        HookEvent.BEFORE_LOAD,
+        new HookContext({ state_file, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { state_file, event: 'BEFORE_LOAD' });
+    }
+
+    let work: WorkState;
+    let fmt: string;
+    try {
+        [work, fmt] = _load_or_build(state_file, args);
+    } catch (exc) {
+        if (exc instanceof _CLIError) {
+            process.stderr.write(`error: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+
+    halt = runner.emit(
+        HookEvent.AFTER_LOAD,
+        new HookContext({ state_file, work, fmt, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'AFTER_LOAD' });
+    }
+
+    let set_name: string;
+    let steps;
+    try {
+        set_name = select_directive_set(work);
+        assert_kind_supported(work.input.kind, set_name);
+        steps = load_directive_set(set_name);
+    } catch (exc) {
+        if (exc instanceof ValueError || exc instanceof NotImplementedError) {
+            process.stderr.write(`error: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+
+    const delivery = _to_delivery(work);
+
+    halt = runner.emit(
+        HookEvent.BEFORE_DISPATCH,
+        new HookContext({ work, delivery, set_name, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'BEFORE_DISPATCH' });
+    }
+
+    const [final, halting] = dispatch(delivery, steps, runner);
+
+    halt = runner.emit(
+        HookEvent.AFTER_DISPATCH,
+        new HookContext({ work, delivery, final, halting, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'AFTER_DISPATCH' });
+    }
+
+    _sync_back(work, delivery);
+
+    halt = runner.emit(
+        HookEvent.BEFORE_SAVE,
+        new HookContext({ work, delivery, fmt, args }),
+    );
+    if (halt !== null) {
+        return _emit_halt(halt, { work, state_file, event: 'BEFORE_SAVE' });
+    }
+
+    _save(state_file, work, fmt);
+
+    halt = runner.emit(
+        HookEvent.AFTER_SAVE,
+        new HookContext({ work, state_file, fmt, args }),
+    );
+    if (halt !== null) {
+        // State is already on disk; exit 2 still per the P3 branch table.
+        return _emit_halt(halt, { work, state_file, event: 'AFTER_SAVE' });
+    }
+
+    _emit(work, final, halting);
+    return final === Outcome.SUCCESS ? 0 : 1;
+}
+
+// Re-export the leaf-module surface so existing imports / patch targets that
+// reached for `work_engine.cli.<name>` continue to resolve (mirrors the Python
+// `__all__`).
+export {
+    DEFAULT_STATE_FILE,
+    LEGACY_STATE_FILE,
+    _CLIError,
+    _FMT_V0,
+    _FMT_V1,
+    _build_from_diff_file,
+    _build_from_file_file,
+    _build_from_prompt_file,
+    _build_hook_registry,
+    _emit,
+    _emit_halt,
+    _load,
+    _load_or_build,
+    _maybe_raise_legacy_hint,
+    _read_json,
+    _register_chat_history_hooks,
+    _save,
+    _sync_back,
+    _to_delivery,
+    _to_v0_dict,
+};

--- a/src/agent-src/templates/scripts/work_engine/directives/backend/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/backend/index.ts
@@ -1,0 +1,94 @@
+/**
+ * Backend directive set — step handlers for the backend-coding flow.
+ *
+ * TypeScript twin of `work_engine/directives/backend/__init__.py` (ADR-096
+ * py2ts Phase 1 — work_engine TOP/integration layer). The `__init__.py` →
+ * `index.ts` mapping mirrors the hooks subpackage convention. Public API
+ * names stay snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * Each module exposes a single `run` callable that matches the `Step`
+ * protocol defined in `../../delivery_state`. The dispatcher wires them into
+ * the `STEP_ORDER` mapping at call time.
+ *
+ * The deterministic gates (`refine`, `memory`, `analyze`) validate upstream
+ * state; the delegation gates (`plan`, `implement`, `test`, `verify`) halt
+ * with `@agent-directive:` markers so the orchestrator can invoke the matching
+ * skill and resume. `report` renders the delivery Markdown once everything
+ * else has succeeded.
+ */
+
+import type { Step } from '../../delivery_state.js';
+
+import * as analyze from './analyze.js';
+import * as implement from './implement.js';
+import * as memory from './memory.js';
+import * as plan from './plan.js';
+import * as refine from './refine.js';
+import * as report from './report.js';
+import * as test from './test.js';
+import * as verify from './verify.js';
+
+/** External name carried in `state.directive_set` for this set. */
+export const DIRECTIVE_SET_NAME = 'backend';
+
+/**
+ * Input kinds this directive set knows how to handle.
+ *
+ * Read by `work_engine.dispatcher.assert_kind_supported` before the loop
+ * starts. The schema's `work_engine.state.KNOWN_INPUT_KINDS` is the *envelope*
+ * whitelist (what is accepted on disk); `SUPPORTED_KINDS` is the *capability*
+ * whitelist (what this set can actually drive end to end).
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt'];
+
+// Mirror the Python `_STEPS` tuple: (refine, memory, analyze, plan, implement,
+// test, verify, report). The leaf name is the dispatcher slot key; in Python
+// it is derived via `step.__name__.rsplit(".", 1)[-1]` — hardcoded here since
+// the modules are imported statically.
+const _STEPS: ReadonlyArray<[string, { run: Step; AMBIGUITIES: ReadonlyArray<Record<string, string>> }]> = [
+    ['refine', refine],
+    ['memory', memory],
+    ['analyze', analyze],
+    ['plan', plan],
+    ['implement', implement],
+    ['test', test],
+    ['verify', verify],
+    ['report', report],
+];
+
+/**
+ * Return `{step_name: AMBIGUITIES}` for every step in flow order.
+ *
+ * Used by documentation generators and the `test_ambiguity_coverage` suite to
+ * prove every step explicitly declares what can surface a `BLOCKED` outcome.
+ * Steps that always succeed (`memory`, `report`) return an empty tuple —
+ * declared intent, not an omission.
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    const out: Record<string, ReadonlyArray<Record<string, string>>> = {};
+    for (const [name, step] of _STEPS) {
+        out[name] = step.AMBIGUITIES;
+    }
+    return out;
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Each value is the module-level `run` callable matching the
+ * `work_engine.delivery_state.Step` protocol — exactly what
+ * `work_engine.dispatcher.dispatch` calls. Order of insertion matches the
+ * canonical backend flow (refine → memory → analyze → plan → implement →
+ * test → verify → report).
+ */
+export function get_steps(): Map<string, Step> {
+    const out = new Map<string, Step>();
+    for (const [name, step] of _STEPS) {
+        out.set(name, step.run);
+    }
+    return out;
+}
+
+// Re-export the step modules as namespaces (Python `__all__` lists them as
+// importable members of the package).
+export { analyze, implement, memory, plan, refine, report, test, verify };

--- a/src/agent-src/templates/scripts/work_engine/directives/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Directive-set bundles consumed by the dispatcher.
+ *
+ * TypeScript twin of `work_engine/directives/__init__.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). The `__init__.py` → `index.ts`
+ * mapping mirrors the hooks subpackage convention.
+ *
+ * A *directive set* is a coherent group of step handlers (refine,
+ * memory, analyze, plan, implement, test, verify, report) tuned for a
+ * particular kind of work — backend coding, UI work, mixed front+back
+ * work, and so on. The dispatcher selects exactly one set per cycle
+ * (see `dispatcher.select_directive_set`) and walks its eight steps
+ * in the canonical order.
+ *
+ * Each set is a sub-package exposing a single function:
+ *
+ *     function get_steps(): Mapping<string, Step>
+ *
+ * The mapping must cover every entry in `dispatcher.STEP_ORDER`;
+ * incomplete bundles raise at dispatch time.
+ *
+ * The schema (`state.KNOWN_DIRECTIVE_SETS`) carries the *external*
+ * names `ui`, `ui-trivial`, `mixed`; the directory layout uses
+ * underscores (`ui_trivial`) because Python packages cannot contain
+ * hyphens. The dispatcher's loader is the single place that translates
+ * between the two.
+ */
+
+// The Python `__init__` declares `__all__: list[str] = []` — no re-exports.
+// This twin is the package marker module; consumers import the per-set
+// `index.ts` directly (e.g. `./backend/index.js`).
+export {};

--- a/src/agent-src/templates/scripts/work_engine/directives/mixed/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/mixed/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Mixed (backend + UI) directive set.
+ *
+ * TypeScript twin of `work_engine/directives/mixed/__init__.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). The `__init__.py` → `index.ts`
+ * mapping mirrors the hooks subpackage convention. Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * `mixed` is the directive set for tickets that touch both layers. Its plan
+ * slot locks the backend contract (data shape + API surface) before any UI
+ * work begins; its implement slot delegates the full UI sub-flow once the
+ * contract is confirmed; its test slot stitches the seam with end-to-end smoke
+ * scenarios.
+ *
+ * Slot mapping (mirrors `work_engine.directives.backend.get_steps`):
+ *
+ * - `refine`    → backend.refine  — intent classification + ticket / prompt gate.
+ * - `memory`    → backend.memory  — engineering-memory pull.
+ * - `analyze`   → backend.analyze — backend analysis precondition.
+ * - `plan`      → `contract`      — backend contract lock.
+ * - `implement` → `ui`            — delegate to UI sub-flow.
+ * - `test`      → `stitch`        — integration verification.
+ * - `verify`    → backend.verify  — four-judge review on the merged diff.
+ * - `report`    → backend.report  — delivery markdown.
+ *
+ * The shared steps are reused by reference, not by duplication.
+ */
+
+import type { Step } from '../../delivery_state.js';
+import {
+    analyze as backend_analyze,
+    memory as backend_memory,
+    refine as backend_refine,
+    report as backend_report,
+    verify as backend_verify,
+} from '../backend/index.js';
+
+import * as contract from './contract.js';
+import * as stitch from './stitch.js';
+import * as ui from './ui.js';
+
+/** External name carried in `state.directive_set` for this set. */
+export const DIRECTIVE_SET_NAME = 'mixed';
+
+/** Roadmap that promotes the Phase 4 stub to working handlers. */
+export const ROADMAP = 'agents/roadmaps/road-to-product-ui-track.md';
+
+/**
+ * Input kinds this directive set accepts.
+ *
+ * `mixed` accepts the same envelope shapes as `backend`: ticket payloads
+ * (refined by the ticket flow) and free-form prompts (refined by
+ * `refine-prompt`). The `diff` / `file` envelopes stay UI-only since they
+ * describe an existing screen, not a backend contract surface.
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt'];
+
+/**
+ * Wire the eight-step dispatcher slots for the mixed set.
+ *
+ * `refine` / `memory` / `analyze` / `verify` / `report` reuse the backend
+ * handlers verbatim; `plan` / `implement` / `test` are the mixed-specific
+ * contract → ui → stitch chain.
+ */
+function _build_step_map(): Map<string, Step> {
+    return new Map<string, Step>([
+        ['refine', backend_refine.run],
+        ['memory', backend_memory.run],
+        ['analyze', backend_analyze.run],
+        ['plan', contract.run],
+        ['implement', ui.run],
+        ['test', stitch.run],
+        ['verify', backend_verify.run],
+        ['report', backend_report.run],
+    ]);
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Mirrors `work_engine.directives.backend.get_steps` and
+ * `work_engine.directives.ui.get_steps`.
+ */
+export function get_steps(): Map<string, Step> {
+    return _build_step_map();
+}
+
+/**
+ * Per-step ambiguity declarations.
+ *
+ * Each handler re-exports its own `AMBIGUITIES`. The mapping is rebuilt per
+ * call (cheap; documentation generators and the `test_ambiguity_coverage`
+ * suite invoke this once per run).
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    return {
+        refine: backend_refine.AMBIGUITIES,
+        memory: backend_memory.AMBIGUITIES,
+        analyze: backend_analyze.AMBIGUITIES,
+        plan: contract.AMBIGUITIES,
+        implement: ui.AMBIGUITIES,
+        test: stitch.AMBIGUITIES,
+        verify: backend_verify.AMBIGUITIES,
+        report: backend_report.AMBIGUITIES,
+    };
+}
+
+export { contract, stitch, ui };

--- a/src/agent-src/templates/scripts/work_engine/directives/ui/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui/index.ts
@@ -1,0 +1,98 @@
+/**
+ * UI directive set — every slot wired to a working handler.
+ *
+ * TypeScript twin of `work_engine/directives/ui/__init__.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). The `__init__.py` → `index.ts`
+ * mapping mirrors the hooks subpackage convention. Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * The eight-step shape mirrors `work_engine.directives.backend`:
+ *
+ * - `refine`    → `audit`        — existing-UI inventory gate.
+ * - `memory`    → `_passthrough` — UI track does not consult memory.
+ * - `analyze`   → `design`       — produces the locked design brief.
+ * - `plan`      → `_passthrough` — design brief is the plan.
+ * - `implement` → `apply`        — stack-dispatched render of the brief.
+ * - `test`      → `review`       — design-review pass produces findings.
+ * - `verify`    → `polish`       — bounded fix loop (≤ 2 rounds).
+ * - `report`    → backend.report — shared delivery-Markdown renderer.
+ */
+
+import type { Step } from '../../delivery_state.js';
+import { report } from '../backend/index.js';
+
+import * as _passthrough from './_passthrough.js';
+import * as apply from './apply.js';
+import * as audit from './audit.js';
+import * as design from './design.js';
+import * as polish from './polish.js';
+import * as review from './review.js';
+
+/** External name carried in `state.directive_set` for this set. */
+export const DIRECTIVE_SET_NAME = 'ui';
+
+/** Roadmap that promoted the deferral stub to fully wired handlers. */
+export const ROADMAP = 'agents/roadmaps/road-to-product-ui-track.md';
+
+/**
+ * Input kinds this directive set knows how to handle.
+ *
+ * Wires every UI-classifiable input shape (ticket prose, free-form prompt,
+ * `diff` / `file` improve-this-screen envelopes) through to this set.
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt', 'diff', 'file'];
+
+/**
+ * Wire the eight-step dispatcher slots for the UI set.
+ *
+ * `refine` runs audit; `memory` and `plan` are pass-through no-ops; `analyze`
+ * runs design; `implement` runs apply; `test` runs review; `verify` runs
+ * polish; `report` re-uses the shared backend renderer. The mapping is rebuilt
+ * per call (cheap; the dispatcher invokes `get_steps` once per run).
+ */
+function _build_step_map(): Map<string, Step> {
+    const passthrough = _passthrough.run;
+    return new Map<string, Step>([
+        ['refine', audit.run],
+        ['memory', passthrough],
+        ['analyze', design.run],
+        ['plan', passthrough],
+        ['implement', apply.run],
+        ['test', review.run],
+        ['verify', polish.run],
+        ['report', report.run],
+    ]);
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Mirrors `work_engine.directives.backend.get_steps`.
+ */
+export function get_steps(): Map<string, Step> {
+    return _build_step_map();
+}
+
+/**
+ * Per-step ambiguity declarations.
+ *
+ * Mirrors `work_engine.directives.backend.all_ambiguities`. Each working
+ * handler re-exports its own `AMBIGUITIES`; the pass-through slots re-export
+ * `_passthrough.AMBIGUITIES` (empty) so doc generators see a uniform shape
+ * across all eight steps. `report` borrows the backend renderer's surface.
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    const passthrough = _passthrough.AMBIGUITIES;
+    return {
+        refine: audit.AMBIGUITIES,
+        memory: passthrough,
+        analyze: design.AMBIGUITIES,
+        plan: passthrough,
+        implement: apply.AMBIGUITIES,
+        test: review.AMBIGUITIES,
+        verify: polish.AMBIGUITIES,
+        report: report.AMBIGUITIES,
+    };
+}
+
+export { apply, audit, design, polish, report, review };

--- a/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/index.ts
+++ b/src/agent-src/templates/scripts/work_engine/directives/ui_trivial/index.ts
@@ -1,0 +1,111 @@
+/**
+ * UI-trivial directive set — single-file ≤5-line micro-edit path.
+ *
+ * TypeScript twin of `work_engine/directives/ui_trivial/__init__.py` (ADR-096
+ * py2ts Phase 1 — work_engine TOP/integration layer). The `__init__.py` →
+ * `index.ts` mapping mirrors the hooks subpackage convention. Public API names
+ * stay snake_case to mirror the Python module 1:1 (per ADR-096).
+ *
+ * The eight-step shape mirrors `work_engine.directives.backend` /
+ * `work_engine.directives.ui` — eight slots, fixed order, no branching:
+ *
+ * - `refine`    → `refine`   — confirm intent gate.
+ * - `memory`    → `_skipped` — bypassed.
+ * - `analyze`   → `_skipped` — bypassed.
+ * - `plan`      → `_skipped` — bypassed.
+ * - `implement` → `apply`    — hard preconditions; reclassify to `ui-improve`
+ *   (full audit gate) when violated.
+ * - `test`      → `test`     — smoke-test delegate.
+ * - `verify`    → `_skipped` — bypassed.
+ * - `report`    → `report`   — one-line delivery summary.
+ *
+ * The directory uses an underscore (`ui_trivial`) because Python packages
+ * cannot contain hyphens. The schema carries the external hyphenated name
+ * `"ui-trivial"`; the dispatcher's loader is the single place that translates
+ * between them.
+ */
+
+import type { Step } from '../../delivery_state.js';
+
+import * as _skipped from './_skipped.js';
+import * as apply from './apply.js';
+import * as refine from './refine.js';
+import * as report from './report.js';
+import * as test from './test.js';
+
+/**
+ * External name carried in `state.directive_set` for this set.
+ *
+ * Note the hyphen — this is the schema/wire form, not the module name. The
+ * module name (`ui_trivial`) is an implementation detail of the loader.
+ */
+export const DIRECTIVE_SET_NAME = 'ui-trivial';
+
+/** Roadmap that defines this directive bundle (Phase 2 Step 6). */
+export const ROADMAP = 'agents/roadmaps/road-to-product-ui-track.md';
+
+/**
+ * Input kinds this directive set knows how to handle.
+ *
+ * The intent classifier reaches `ui-trivial` from any of the four input
+ * kinds; the trivial set keeps the same tuple so input routing stays
+ * unchanged once the intent label has landed.
+ */
+export const SUPPORTED_KINDS: ReadonlyArray<string> = ['ticket', 'prompt', 'diff', 'file'];
+
+/**
+ * Wire the eight-step dispatcher slots for the trivial set.
+ *
+ * `refine` validates the intent gate; `implement`, `test`, and `report` carry
+ * the trivial-path behavior; the four bypassed slots share `_skipped` so the
+ * dispatcher's completeness check is satisfied without inventing per-slot
+ * stubs. The mapping is rebuilt per call (cheap; the dispatcher invokes
+ * `get_steps` once per run).
+ */
+function _build_step_map(): Map<string, Step> {
+    const skipped = _skipped.run;
+    return new Map<string, Step>([
+        ['refine', refine.run],
+        ['memory', skipped],
+        ['analyze', skipped],
+        ['plan', skipped],
+        ['implement', apply.run],
+        ['test', test.run],
+        ['verify', skipped],
+        ['report', report.run],
+    ]);
+}
+
+/**
+ * Return the `{step_name: handler}` mapping the dispatcher walks.
+ *
+ * Mirrors `work_engine.directives.backend.get_steps`. `refine`, `implement`,
+ * `test`, and `report` carry trivial-path behavior; the four bypassed slots
+ * delegate to `_skipped`.
+ */
+export function get_steps(): Map<string, Step> {
+    return _build_step_map();
+}
+
+/**
+ * Per-step ambiguity declarations.
+ *
+ * Mirrors `work_engine.directives.backend.all_ambiguities`. The four bypassed
+ * slots re-export `_skipped.AMBIGUITIES` (empty) so doc generators see a
+ * uniform shape across all eight steps.
+ */
+export function all_ambiguities(): Record<string, ReadonlyArray<Record<string, string>>> {
+    const skipped = _skipped.AMBIGUITIES;
+    return {
+        refine: refine.AMBIGUITIES,
+        memory: skipped,
+        analyze: skipped,
+        plan: skipped,
+        implement: apply.AMBIGUITIES,
+        test: test.AMBIGUITIES,
+        verify: skipped,
+        report: report.AMBIGUITIES,
+    };
+}
+
+export { apply, refine, report, test };

--- a/src/agent-src/templates/scripts/work_engine/dispatcher.ts
+++ b/src/agent-src/templates/scripts/work_engine/dispatcher.ts
@@ -1,0 +1,513 @@
+/**
+ * Linear step dispatcher for `/implement-ticket`.
+ *
+ * TypeScript twin of `work_engine/dispatcher.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * The dispatcher holds no business logic. It walks the fixed eight-step order
+ * declared in `docs/contracts/implement-ticket-flow.md`, hands each step a live
+ * `DeliveryState`, and honours the three terminal outcomes:
+ *
+ * - `SUCCESS` — record and advance.
+ * - `BLOCKED` — record, copy questions onto the state, halt.
+ * - `PARTIAL` — record, copy questions onto the state, halt.
+ *
+ * Resumption semantics (Option A, flow contract §agent-directives): steps whose
+ * name is already marked `success` in `state.outcomes` are **skipped**. This
+ * lets a caller re-invoke the dispatcher after executing an agent-directive,
+ * update the relevant slice of `DeliveryState`, record `success` on the resumed
+ * step, and continue without replaying earlier work.
+ *
+ * Step handlers are injected by the caller rather than discovered at import
+ * time, so the dispatcher is trivially testable and never depends on handler
+ * import order.
+ */
+
+import {
+    DeliveryState,
+    Outcome,
+    type Step,
+    StepResult,
+} from './delivery_state.js';
+import { HookContext, HookEvent, HookHalt, HookRunner } from './hooks/index.js';
+import { KNOWN_DIRECTIVE_SETS } from './state.js';
+
+// Static directive-set registry. The Python source uses `import_module` to load
+// `work_engine.directives.<pkg>` dynamically; a `.ts` twin may not import a
+// `.py` and resolves statically instead (ADR-096). The map is keyed by the
+// *wire* name (the `_PACKAGE_NAME_OVERRIDES` translation is folded into the
+// keys here, e.g. `ui-trivial` → the `ui_trivial` module).
+import * as _backend from './directives/backend/index.js';
+import * as _mixed from './directives/mixed/index.js';
+import * as _ui from './directives/ui/index.js';
+import * as _ui_trivial from './directives/ui_trivial/index.js';
+
+/** Shape every directive-set index module exposes. */
+interface DirectiveSetModule {
+    get_steps?: () => Map<string, Step>;
+    SUPPORTED_KINDS?: ReadonlyArray<string>;
+}
+
+/**
+ * Shared empty-registry runner reused when `dispatch` is called without an
+ * explicit `hooks` argument. `HookRunner.emit` short-circuits when no callbacks
+ * are registered, so the hot path stays branch-light while the call sites stay
+ * uniform.
+ */
+const _NOOP_RUNNER: HookRunner = new HookRunner();
+
+/**
+ * Canonical execution order. Eight steps, fixed, no branching.
+ *
+ * Changing this order is a roadmap-level decision — not a PR rider — per the
+ * surface-growth guardrails in `agents/roadmaps/road-to-implement-ticket.md`.
+ */
+export const STEP_ORDER: ReadonlyArray<string> = [
+    'refine',
+    'memory',
+    'analyze',
+    'plan',
+    'implement',
+    'test',
+    'verify',
+    'report',
+];
+
+/**
+ * Directive set chosen when `state` does not carry one explicitly.
+ *
+ * Backwards compatibility for v0 `DeliveryState` callers: the legacy shape has
+ * no `directive_set` field, so `select_directive_set` falls back to `"backend"`
+ * and the engine behaves exactly as it did before R1 Phase 4.
+ */
+export const DEFAULT_DIRECTIVE_SET = 'backend';
+
+// Schema enum names use hyphens (`ui-trivial`) but Python packages cannot. The
+// loader is the single place that bridges between the two forms; everywhere
+// else uses the wire form. (Folded into `_DIRECTIVE_SET_MODULES` keys here.)
+const _PACKAGE_NAME_OVERRIDES: Record<string, string> = { 'ui-trivial': 'ui_trivial' };
+
+/** Wire-name → static directive-set module. */
+const _DIRECTIVE_SET_MODULES: Record<string, DirectiveSetModule> = {
+    backend: _backend,
+    ui: _ui,
+    'ui-trivial': _ui_trivial,
+    mixed: _mixed,
+};
+
+/**
+ * Run the eight steps linearly against `state`.
+ *
+ * Returns a `[final_outcome, halting_step]` tuple. `halting_step` is `null`
+ * when every step succeeded; otherwise it carries the name of the step whose
+ * result halted the flow.
+ *
+ * `state` is mutated in place: each step's outcome is recorded in
+ * `state.outcomes` under the step name, and any surfaced questions land on
+ * `state.questions`.
+ *
+ * `steps` maps step name to handler. Every entry in {@link STEP_ORDER} must be
+ * present; missing entries throw (mirroring Python `KeyError`) at dispatch time
+ * rather than silently skipping, so incomplete wiring surfaces as a hard
+ * failure.
+ *
+ * `hooks` is an optional {@link HookRunner}. `null` preserves every existing
+ * call site verbatim — internally `dispatch` falls back to a shared
+ * empty-registry runner so hook bookkeeping stays uniform without a per-emit
+ * `if hooks is null` branch.
+ *
+ * @throws KeyError-equivalent If `steps` does not cover every entry in
+ *   {@link STEP_ORDER}.
+ */
+export function dispatch(
+    state: DeliveryState,
+    steps: Map<string, Step>,
+    hooks: HookRunner | null = null,
+): [Outcome, string | null] {
+    _assert_all_steps_present(steps);
+
+    // Clear stale questions from a previous halt before we resume so the caller
+    // never mistakes old options for fresh ones.
+    state.questions = [];
+
+    const runner = hooks !== null ? hooks : _NOOP_RUNNER;
+
+    for (const name of STEP_ORDER) {
+        if (_get(state.outcomes, name) === Outcome.SUCCESS) {
+            // Already completed on an earlier invocation — skip per the resume
+            // contract. The caller is responsible for keeping `state.outcomes`
+            // and the matching slice in sync.
+            continue;
+        }
+
+        const before_halt = runner.emit(
+            HookEvent.BEFORE_STEP,
+            new HookContext({ step_name: name, delivery: state }),
+        );
+        if (before_halt !== null) {
+            return _hook_halt_blocked(state, runner, name, before_halt, null);
+        }
+
+        const handler = _stepLookup(steps, name);
+        let result: StepResult;
+        try {
+            result = handler(state);
+        } catch (exc) {
+            // Let dispatcher-layer observers see the failure before the
+            // exception unwinds the engine. `on_error` is observe-only; the
+            // original exception is always re-raised.
+            runner.emit(
+                HookEvent.ON_ERROR,
+                new HookContext({ step_name: name, delivery: state, exception: exc }),
+            );
+            throw exc;
+        }
+        _validate_step_result(name, result);
+
+        state.outcomes[name] = result.outcome;
+
+        const after_halt = runner.emit(
+            HookEvent.AFTER_STEP,
+            new HookContext({ step_name: name, delivery: state, result }),
+        );
+        if (after_halt !== null) {
+            return _hook_halt_blocked(state, runner, name, after_halt, result);
+        }
+
+        if (result.outcome === Outcome.BLOCKED) {
+            state.questions = [...result.questions];
+            _emit_on_halt(runner, name, state, result);
+            return [Outcome.BLOCKED, name];
+        }
+
+        if (result.outcome === Outcome.PARTIAL) {
+            state.questions = [...result.questions];
+            _emit_on_halt(runner, name, state, result);
+            return [Outcome.PARTIAL, name];
+        }
+    }
+
+    return [Outcome.SUCCESS, null];
+}
+
+/**
+ * Translate a hook-driven {@link HookHalt} into a clean engine halt.
+ *
+ * Hook-driven halts are treated as first-class engine halts per the P2
+ * contract: the dispatcher returns `[BLOCKED, step_name]` with `state.questions`
+ * rendered verbatim from the halt's `surface`. The step's outcome marker is set
+ * to `"blocked"` only when the halt fires before the handler ran (so resume
+ * re-enters the gate); when it fires after the handler, the marker the handler
+ * produced is preserved so resume reflects what actually happened.
+ */
+function _hook_halt_blocked(
+    state: DeliveryState,
+    runner: HookRunner,
+    name: string,
+    halt: HookHalt,
+    result: StepResult | null,
+): [Outcome, string | null] {
+    if (result === null) {
+        state.outcomes[name] = Outcome.BLOCKED;
+    }
+    state.questions = [...halt.surface];
+    _emit_on_halt(runner, name, state, result);
+    return [Outcome.BLOCKED, name];
+}
+
+/**
+ * Fire `on_halt` as an observe-only event.
+ *
+ * A {@link HookHalt} raised from inside `on_halt` would create a halt-of-a-halt
+ * loop; the runner returns it but the dispatcher deliberately ignores it — the
+ * halt surface is already populated.
+ */
+function _emit_on_halt(
+    runner: HookRunner,
+    name: string,
+    state: DeliveryState,
+    result: StepResult | null,
+): void {
+    runner.emit(
+        HookEvent.ON_HALT,
+        new HookContext({ step_name: name, delivery: state, result }),
+    );
+}
+
+/**
+ * Reject an incomplete step mapping up front.
+ *
+ * We deliberately fail loudly here: a missing step would otherwise raise deep
+ * inside the dispatch loop after partial state mutation, which makes debugging
+ * the wiring harder than it needs to be.
+ */
+function _assert_all_steps_present(steps: Map<string, Step>): void {
+    const missing = STEP_ORDER.filter((name) => !steps.has(name));
+    if (missing.length > 0) {
+        throw new KeyError('Step mapping is missing handlers for: ' + missing.join(', '));
+    }
+}
+
+/**
+ * Enforce the blocked/partial invariant: questions must be set.
+ *
+ * A step that blocks without surfacing a question is a bug — there is nothing
+ * for the user to answer. We throw `ValueError` instead of silently recording
+ * the outcome so the defect is visible at the earliest possible point.
+ */
+function _validate_step_result(name: string, result: StepResult): void {
+    if (
+        (result.outcome === Outcome.BLOCKED || result.outcome === Outcome.PARTIAL) &&
+        result.questions.length === 0
+    ) {
+        throw new ValueError(
+            `Step ${_pyRepr(name)} returned ${result.outcome} with no questions; ` +
+                'blocked and partial outcomes must surface at least one numbered option.',
+        );
+    }
+}
+
+/**
+ * Return the directive set name to dispatch `state` against.
+ *
+ * Looks for `state.directive_set` (the v1 `work_engine.state.WorkState` field)
+ * and falls back to {@link DEFAULT_DIRECTIVE_SET} when the attribute is missing
+ * — the legacy v0 `DeliveryState` has no such field.
+ *
+ * The returned name is validated against {@link KNOWN_DIRECTIVE_SETS}; an
+ * unknown value throws `ValueError` rather than silently falling back, so a typo
+ * in a hand-written state file fails loudly.
+ */
+export function select_directive_set(state: unknown): string {
+    const name = _getattr(state, 'directive_set', DEFAULT_DIRECTIVE_SET);
+    if (typeof name !== 'string' || name.length === 0) {
+        throw new ValueError(
+            `directive_set must be a non-empty string; got ${_pyRepr(name)}`,
+        );
+    }
+    if (!KNOWN_DIRECTIVE_SETS.has(name)) {
+        throw new ValueError(
+            `unknown directive_set ${_pyRepr(name)}; ` +
+                `known sets: ${_pyReprList(_sortedStr([...KNOWN_DIRECTIVE_SETS]))}`,
+        );
+    }
+    return name;
+}
+
+/**
+ * Resolve the `directives.<name>` package and return its step mapping.
+ *
+ * The selected set's index module exposes a `get_steps()` factory that returns
+ * the `{step_name: handler}` mapping the dispatcher walks. The schema enum
+ * carries hyphenated wire names (`ui-trivial`) but Python packages must use
+ * underscores; {@link _PACKAGE_NAME_OVERRIDES} is the single translation point
+ * (folded into the static module registry here).
+ */
+export function load_directive_set(name: string): Map<string, Step> {
+    const moduleEntry = _import_directive_set(name);
+    const get_steps = moduleEntry.module.get_steps;
+    if (typeof get_steps !== 'function') {
+        throw new AttributeError(
+            `work_engine.directives.${moduleEntry.leaf} ` +
+                'does not expose a callable get_steps()',
+        );
+    }
+    const steps = get_steps();
+    if (!(steps instanceof Map)) {
+        throw new TypeError_(
+            `work_engine.directives.${moduleEntry.leaf}` +
+                `.get_steps() must return a Mapping; ` +
+                `got ${_pyTypeName(steps)}`,
+        );
+    }
+    return steps;
+}
+
+/**
+ * Throw `NotImplementedError` if `set_name` cannot handle `kind`.
+ *
+ * Reads the per-set `SUPPORTED_KINDS` tuple and checks membership. Distinct from
+ * {@link select_directive_set}, which only validates the directive-set *name*:
+ * this gate validates the name/kind *pair*.
+ *
+ * Sets that have no `SUPPORTED_KINDS` attribute are treated as "supports
+ * nothing".
+ */
+export function assert_kind_supported(kind: string, set_name: string): void {
+    const moduleEntry = _import_directive_set(set_name);
+    const supported = moduleEntry.module.SUPPORTED_KINDS ?? [];
+    if (!supported.includes(kind)) {
+        throw new NotImplementedError(
+            `directive_set ${_pyRepr(set_name)} does not handle ` +
+                `input.kind=${_pyRepr(kind)}; supported kinds: ` +
+                `${_pyReprList(_sortedStr(_dedup([...supported])))}`,
+        );
+    }
+}
+
+/** Validate `name` and resolve the matching static package module. */
+function _import_directive_set(name: string): { module: DirectiveSetModule; leaf: string } {
+    if (!KNOWN_DIRECTIVE_SETS.has(name)) {
+        throw new ValueError(
+            `unknown directive_set ${_pyRepr(name)}; ` +
+                `known sets: ${_pyReprList(_sortedStr([...KNOWN_DIRECTIVE_SETS]))}`,
+        );
+    }
+    const leaf = _PACKAGE_NAME_OVERRIDES[name] ?? name;
+    const module = _DIRECTIVE_SET_MODULES[name];
+    if (module === undefined) {
+        // A name in KNOWN_DIRECTIVE_SETS with no registered module would mean
+        // the static registry drifted from the schema enum — surface it loudly,
+        // mirroring Python's ImportError from a missing package.
+        throw new ModuleNotFoundError(
+            `No module named 'work_engine.directives.${leaf}'`,
+        );
+    }
+    return { module, leaf };
+}
+
+// ── Python-parity helpers ────────────────────────────────────────────────
+
+/** `Map.get` with a key-membership guard mirroring `dict.get`. */
+function _get(obj: Record<string, string>, key: string): string | undefined {
+    return key in obj ? obj[key] : undefined;
+}
+
+/** Look up a step handler, throwing the KeyError shape on a miss. */
+function _stepLookup(steps: Map<string, Step>, name: string): Step {
+    const handler = steps.get(name);
+    if (handler === undefined) {
+        throw new KeyError(_pyRepr(name));
+    }
+    return handler;
+}
+
+/** Python `getattr(obj, attr, default)` for plain object attribute access. */
+function _getattr(obj: unknown, attr: string, dflt: unknown): unknown {
+    if (obj !== null && typeof obj === 'object' && attr in (obj as Record<string, unknown>)) {
+        const v = (obj as Record<string, unknown>)[attr];
+        return v === undefined ? dflt : v;
+    }
+    return dflt;
+}
+
+/** Python `repr(x)` for the scalar shapes interpolated via `{value!r}`. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `repr(list_of_str)` — `['a', 'b']`. */
+function _pyReprList(values: string[]): string {
+    return '[' + values.map((v) => _pyRepr(v)).join(', ') + ']';
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Python `set(...)` dedup (insertion order does not matter; sorted after). */
+function _dedup(values: string[]): string[] {
+    return [...new Set(values)];
+}
+
+/** Python `type(x).__name__` for the shapes the error messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    if (value instanceof Map) {
+        // A Map is the TS stand-in for the Python `dict` get_steps returns; the
+        // only non-Map path here is the guard, so report `dict`.
+        return 'dict';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+// ── Python-exception name parity ─────────────────────────────────────────
+// The dispatcher raises KeyError / ValueError / TypeError / AttributeError /
+// NotImplementedError / ImportError-family. JS only has a handful of builtins,
+// so these named subclasses carry the Python exception *name* for callers that
+// branch on it (cli.ts catches ValueError + NotImplementedError equivalents).
+
+/** Python `KeyError`. */
+export class KeyError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, KeyError.prototype);
+        this.name = 'KeyError';
+    }
+}
+
+/** Python `ValueError`. */
+export class ValueError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, ValueError.prototype);
+        this.name = 'ValueError';
+    }
+}
+
+/** Python `TypeError` (named `TypeError_` to avoid the JS builtin clash). */
+export class TypeError_ extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, TypeError_.prototype);
+        this.name = 'TypeError';
+    }
+}
+
+/** Python `AttributeError`. */
+export class AttributeError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, AttributeError.prototype);
+        this.name = 'AttributeError';
+    }
+}
+
+/** Python `NotImplementedError`. */
+export class NotImplementedError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, NotImplementedError.prototype);
+        this.name = 'NotImplementedError';
+    }
+}
+
+/** Python `ModuleNotFoundError` (subclass of ImportError). */
+export class ModuleNotFoundError extends Error {
+    constructor(message?: string) {
+        super(message);
+        Object.setPrototypeOf(this, ModuleNotFoundError.prototype);
+        this.name = 'ModuleNotFoundError';
+    }
+}

--- a/src/agent-src/templates/scripts/work_engine/emitters.ts
+++ b/src/agent-src/templates/scripts/work_engine/emitters.ts
@@ -1,0 +1,118 @@
+/**
+ * Stdout / stderr emitters for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/emitters.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Holds
+ * the two output helpers that shape the wire surface of `main()`: the
+ * SUCCESS/halt branch printed on stdout, and the lifecycle-hook halt surface
+ * printed on stderr.
+ */
+
+import * as fs from 'node:fs';
+
+import { Outcome } from './delivery_state.js';
+import { HookHalt } from './hooks/index.js';
+import { WorkState, dump } from './state.js';
+
+/**
+ * Print the terminal surface for `final` to stdout.
+ *
+ * On SUCCESS, the delivery report. Otherwise a `[halt]` status line plus the
+ * surfaced questions verbatim.
+ */
+export function _emit(work: WorkState, final: Outcome, halting: string | null): void {
+    if (final === Outcome.SUCCESS) {
+        process.stdout.write(work.report + '\n');
+        return;
+    }
+    process.stdout.write(`[halt] outcome=${final} step=${halting || '(none)'}\n`);
+    for (const line of work.questions) {
+        process.stdout.write(line + '\n');
+    }
+}
+
+/**
+ * Render a {@link HookHalt} surface to stderr and return exit 2.
+ *
+ * Per the P3 halt branch table, every CLI-layer halt yields exit code `2`
+ * regardless of which event fired it. State persistence is governed by *where*
+ * in `main` the halt is detected: the call site decides whether `_save`
+ * already ran.
+ *
+ * When `work` + `state_file` are provided AND the state file already exists on
+ * disk, the halt is appended to `work.halts[]` and the state is re-saved. This
+ * lets `agent-config explain last` surface the halt reason later. Fresh-run
+ * halts before the first `_save` (state file absent) still leave no state on
+ * disk — the pre-explain-v2 contract is preserved.
+ */
+export function _emit_halt(
+    halt: HookHalt,
+    opts: {
+        work?: WorkState | null;
+        state_file?: string | null;
+        event?: string | null;
+    } = {},
+): number {
+    const work = opts.work ?? null;
+    const state_file = opts.state_file ?? null;
+    const event = opts.event ?? null;
+
+    if (halt.surface.length > 0) {
+        for (const line of halt.surface) {
+            process.stderr.write(line + '\n');
+        }
+    } else {
+        process.stderr.write(`halt: ${halt.reason}\n`);
+    }
+    if (work !== null && state_file !== null && _exists(state_file)) {
+        work.halts.push({
+            reason: halt.reason,
+            step: event || '',
+            surface: [...halt.surface],
+            timestamp: _utcNowIso(),
+        });
+        try {
+            dump(work, state_file);
+        } catch {
+            // never let halt persistence mask the halt
+        }
+    }
+    return 2;
+}
+
+/** Python `Path.exists()`. */
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Mirror Python `datetime.now(tz=timezone.utc).isoformat()`.
+ *
+ * CPython renders an aware UTC datetime as `YYYY-MM-DDTHH:MM:SS.ffffff+00:00`
+ * (microsecond precision, explicit `+00:00` offset). `Date.toISOString()`
+ * yields `YYYY-MM-DDTHH:MM:SS.sssZ` (millisecond precision, `Z` suffix), so
+ * this rebuilds the CPython shape: pad milliseconds to microseconds and
+ * replace the `Z` with `+00:00`. This timestamp is wall-clock and therefore
+ * non-deterministic — tests normalise it.
+ */
+function _utcNowIso(): string {
+    const iso = new Date().toISOString(); // e.g. 2026-06-15T03:11:58.123Z
+    // Strip the trailing 'Z', expand .sss → .ssssss (µs), append +00:00.
+    const body = iso.slice(0, -1); // drop 'Z'
+    const dot = body.lastIndexOf('.');
+    if (dot === -1) {
+        return body + '.000000+00:00';
+    }
+    const frac = body.slice(dot + 1); // milliseconds, 3 digits
+    const micros = (frac + '000000').slice(0, 6);
+    return body.slice(0, dot + 1) + micros + '+00:00';
+}

--- a/src/agent-src/templates/scripts/work_engine/hook_bootstrap.ts
+++ b/src/agent-src/templates/scripts/work_engine/hook_bootstrap.ts
@@ -1,0 +1,103 @@
+/**
+ * Lifecycle-hook registry assembly for the CLI entry point.
+ *
+ * TypeScript twin of `work_engine/hook_bootstrap.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Owns
+ * nothing but `_build_hook_registry` and its chat-history helper.
+ */
+
+import type { ParsedArgs } from './cli_args.js';
+import { HookRegistry } from './hooks/index.js';
+import {
+    ChatHistoryAppendHook,
+    ChatHistoryHaltAppendHook,
+    DecisionTraceHook,
+    DirectiveSetGuardHook,
+    HaltSurfaceAuditHook,
+    MemoryVisibilityHook,
+    StateShapeValidationHook,
+    TraceHook,
+    build_decision_gate_hook,
+} from './hooks/builtin/index.js';
+import { HookSettings, load_hook_settings } from './hooks/settings.js';
+
+/**
+ * Build the CLI-side {@link HookRegistry} for one `main()` run.
+ *
+ * Reads `hooks.*` from `.agent-settings.yml` and registers the enabled hooks.
+ * The master switch `hooks.enabled` defaults to `false` when the block (or the
+ * file) is missing — the registry stays empty and golden replay flows are
+ * byte-stable.
+ *
+ * `--no-hooks` on the CLI forces an empty registry regardless of settings,
+ * which is the explicit escape hatch golden-replay test harnesses can use.
+ */
+export function _build_hook_registry(args: ParsedArgs): HookRegistry {
+    const registry = new HookRegistry();
+    if (_getattr(args, 'no_hooks', false)) {
+        return registry;
+    }
+
+    const settings_path = _getattr(args, 'hooks_config', null) as string | null;
+    const settings = load_hook_settings(settings_path);
+    if (!settings.enabled) {
+        return registry;
+    }
+
+    if (settings.trace) {
+        new TraceHook().register(registry);
+    }
+    if (settings.halt_surface_audit) {
+        new HaltSurfaceAuditHook().register(registry);
+    }
+    if (settings.state_shape_validation) {
+        new StateShapeValidationHook().register(registry);
+    }
+    if (settings.directive_set_guard) {
+        new DirectiveSetGuardHook().register(registry);
+    }
+    if (settings.decision_trace) {
+        new DecisionTraceHook().register(registry);
+    }
+    const gate_hook = build_decision_gate_hook(settings.decision_engine);
+    if (gate_hook !== null) {
+        gate_hook.register(registry);
+    }
+    if (settings.memory_visibility) {
+        new MemoryVisibilityHook({
+            memory_cadence: settings.memory_cadence,
+            visibility_off: settings.memory_visibility_off,
+        }).register(registry);
+    }
+    if (settings.chat_history_enabled) {
+        _register_chat_history_hooks(registry, settings);
+    }
+
+    return registry;
+}
+
+/**
+ * Register the structural chat-history hooks bound to the configured script.
+ *
+ * Hook-only contract (post road-to-chat-history-hook-only): only the append +
+ * halt-append hooks remain; cooperative `turn-check` / `heartbeat` hooks were
+ * removed when the cooperative always-rules were retired.
+ */
+export function _register_chat_history_hooks(registry: HookRegistry, settings: HookSettings): void {
+    const script = settings.chat_history_script;
+    new ChatHistoryAppendHook(script).register(registry);
+    new ChatHistoryHaltAppendHook(script).register(registry);
+}
+
+/** Python `getattr(obj, attr, default)` for plain object attribute access. */
+function _getattr(obj: unknown, attr: string, dflt: unknown): unknown {
+    if (obj !== null && typeof obj === 'object' && attr in (obj as Record<string, unknown>)) {
+        const v = (obj as Record<string, unknown>)[attr];
+        return v === undefined ? dflt : v;
+    }
+    return dflt;
+}

--- a/src/agent-src/templates/scripts/work_engine/input_builders.ts
+++ b/src/agent-src/templates/scripts/work_engine/input_builders.ts
@@ -1,0 +1,260 @@
+/**
+ * File-based input builders and the load-or-build dispatch helper.
+ *
+ * TypeScript twin of `work_engine/input_builders.py` (ADR-096 py2ts Phase 1 —
+ * work_engine TOP/integration layer). Public API names stay snake_case to
+ * mirror the Python module 1:1 (per ADR-096 — Python style is part of the
+ * contract).
+ *
+ * Extracted from `cli.py` in P2.3 of `road-to-post-pr29-optimize.md`. Owns the
+ * CLI's "first run" path: when no state file exists, build a fresh `WorkState`
+ * from `--ticket-file`, `--prompt-file`, `--diff-file` or `--file-file`. Every
+ * builder is byte-identical in behaviour to the pre-split version.
+ */
+
+import * as fs from 'node:fs';
+
+import { _FMT_V0, _FMT_V1, type ParsedArgs } from './cli_args.js';
+import { _CLIError } from './errors.js';
+import { populate_routing } from './intent/classify.js';
+import { DiffResolverError, build_envelope as _build_diff_envelope } from './resolvers/diff.js';
+import { FileResolverError, build_envelope as _build_file_envelope } from './resolvers/file.js';
+import { PromptResolverError, build_envelope as _build_prompt_envelope } from './resolvers/prompt.js';
+import { Input, WorkState, type Dict } from './state.js';
+import { _load, _maybe_raise_legacy_hint, _read_json } from './state_io.js';
+
+/**
+ * Return the WorkState to dispatch against plus its wire format.
+ *
+ * Either loaded from `state_file` (format-preserving) or freshly built from
+ * `--ticket-file` (R1), `--prompt-file` (R2), `--diff-file` (R3) or
+ * `--file-file` (R3). Fresh ticket files default to v0 wire format so newly
+ * captured Goldens stay byte-equal with the pre-Phase-4 baseline; the prompt /
+ * diff / file paths emit v1 directly (v0 has no envelope concept for these
+ * kinds). v1 round-trips for state files already on disk in v1 shape.
+ */
+export function _load_or_build(state_file: string, args: ParsedArgs): [WorkState, string] {
+    if (_exists(state_file)) {
+        return _load(state_file);
+    }
+    _maybe_raise_legacy_hint(state_file);
+    const inputs: Array<[string, string | null]> = [
+        ['--ticket-file', args.ticket_file],
+        ['--prompt-file', args.prompt_file],
+        ['--diff-file', args.diff_file],
+        ['--file-file', args.file_file],
+    ];
+    const supplied = inputs.filter(([, value]) => value !== null).map(([name]) => name);
+    if (supplied.length > 1) {
+        throw new _CLIError(
+            `${supplied.join(', ')} are mutually exclusive; pass exactly ` +
+                'one when building an initial state.',
+        );
+    }
+    if (supplied.length === 0) {
+        throw new _CLIError(
+            `No state file at ${state_file} and no --ticket-file, ` +
+                '--prompt-file, --diff-file, or --file-file given; cannot ' +
+                'build an initial state.',
+        );
+    }
+    if (args.prompt_file !== null) {
+        return [_build_from_prompt_file(args), _FMT_V1];
+    }
+    if (args.diff_file !== null) {
+        return [_build_from_diff_file(args), _FMT_V1];
+    }
+    if (args.file_file !== null) {
+        return [_build_from_file_file(args), _FMT_V1];
+    }
+    const ticket = _read_json(args.ticket_file as string);
+    if (!_isPlainDict(ticket)) {
+        throw new _CLIError(
+            `--ticket-file must carry a JSON object; got ${_pyTypeName(ticket)}.`,
+        );
+    }
+    const work = new WorkState({ input: new Input('ticket', ticket as Dict) });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return [work, _FMT_V0];
+}
+
+/**
+ * Read `--prompt-file` as raw text and wrap it in a prompt envelope.
+ *
+ * The file is read verbatim (UTF-8) and handed to the prompt resolver, which
+ * validates non-emptiness and returns the canonical
+ * `Input(kind="prompt", data={raw, reconstructed_ac, assumptions})` envelope.
+ * Persona is honoured the same way as the ticket path.
+ */
+export function _build_from_prompt_file(args: ParsedArgs): WorkState {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(args.prompt_file as string, 'utf-8');
+    } catch (exc) {
+        throw new _CLIError(`Cannot read ${args.prompt_file}: ${_osErrorText(exc, args.prompt_file as string)}`);
+    }
+    let envelope: Input;
+    try {
+        envelope = _build_prompt_envelope(raw);
+    } catch (exc) {
+        if (exc instanceof PromptResolverError) {
+            throw new _CLIError(`--prompt-file is not a valid prompt: ${exc.message}`);
+        }
+        throw exc;
+    }
+    const work = new WorkState({ input: envelope });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return work;
+}
+
+/**
+ * Read `--diff-file` as raw text and wrap it in a diff envelope.
+ *
+ * The file is read verbatim (UTF-8) and handed to the diff resolver, which
+ * validates the unified-diff header heuristic and returns the canonical
+ * `Input(kind="diff", data={raw, reconstructed_ac, assumptions})` envelope.
+ * `populate_routing` then routes the envelope to the UI-improve directive set
+ * without running the prose classifier.
+ */
+export function _build_from_diff_file(args: ParsedArgs): WorkState {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(args.diff_file as string, 'utf-8');
+    } catch (exc) {
+        throw new _CLIError(`Cannot read ${args.diff_file}: ${_osErrorText(exc, args.diff_file as string)}`);
+    }
+    let envelope: Input;
+    try {
+        envelope = _build_diff_envelope(raw);
+    } catch (exc) {
+        if (exc instanceof DiffResolverError) {
+            throw new _CLIError(`--diff-file is not a valid diff: ${exc.message}`);
+        }
+        throw exc;
+    }
+    const work = new WorkState({ input: envelope });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return work;
+}
+
+/**
+ * Read `--file-file` as a single-line path and wrap it in a file envelope.
+ *
+ * The file is read verbatim (UTF-8); the first non-empty line is taken as the
+ * path reference and handed to the file resolver, which validates path shape
+ * (non-empty, NUL-free, not a URL) and returns the canonical
+ * `Input(kind="file", data={path, reconstructed_ac, assumptions})` envelope.
+ * Trailing whitespace and additional lines are ignored.
+ */
+export function _build_from_file_file(args: ParsedArgs): WorkState {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(args.file_file as string, 'utf-8');
+    } catch (exc) {
+        throw new _CLIError(`Cannot read ${args.file_file}: ${_osErrorText(exc, args.file_file as string)}`);
+    }
+    // Python: `raw.strip().splitlines()[0] if raw.strip() else ""`.
+    const stripped = _pyStrip(raw);
+    const path_ = stripped ? _firstLine(stripped) : '';
+    let envelope: Input;
+    try {
+        envelope = _build_file_envelope(path_);
+    } catch (exc) {
+        if (exc instanceof FileResolverError) {
+            throw new _CLIError(`--file-file does not carry a valid path: ${exc.message}`);
+        }
+        throw exc;
+    }
+    const work = new WorkState({ input: envelope });
+    if (args.persona) {
+        work.persona = args.persona;
+    }
+    populate_routing(work);
+    return work;
+}
+
+// ── Python-parity helpers ────────────────────────────────────────────────
+
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `type(x).__name__` for the JSON value shapes the messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value as number) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/** Python `str.strip()` — strip leading/trailing whitespace. */
+function _pyStrip(s: string): string {
+    // Python str.strip() with no arg removes ASCII + Unicode whitespace; JS \s
+    // covers the common set adequately for the single-line-path contract.
+    return s.replace(/^\s+/u, '').replace(/\s+$/u, '');
+}
+
+/**
+ * Python `str.splitlines()[0]` on an already-`strip()`ped string.
+ *
+ * The caller consumes only the first line; the stripped input has no leading
+ * boundary, so splitting on the universal-newline set and returning element 0
+ * is byte-equivalent to `splitlines()[0]` for the single-line-path contract.
+ */
+function _firstLine(s: string): string {
+    const m = s.split(/\r\n|[\n\r\v\f\x1c\x1d\x1e\x85\u2028\u2029]/u);
+    return m[0] ?? '';
+}
+
+/**
+ * Approximate the text of Python's `OSError` for a failed read (mirrors
+ * `state_io.ts::_osErrorText`). The error *channel* (exit 2 via `_CLIError`)
+ * and the *prefix* ("Cannot read <path>: ") stay identical; only the trailing
+ * OS detail differs — tests normalise it.
+ */
+function _osErrorText(exc: unknown, p: string): string {
+    const e = exc as NodeJS.ErrnoException;
+    if (e && e.code === 'ENOENT') {
+        return `[Errno 2] No such file or directory: '${p}'`;
+    }
+    if (e && e.code === 'EISDIR') {
+        return `[Errno 21] Is a directory: '${p}'`;
+    }
+    if (e && e.code === 'EACCES') {
+        return `[Errno 13] Permission denied: '${p}'`;
+    }
+    return e && e.message ? e.message : String(exc);
+}

--- a/src/agent-src/templates/scripts/work_engine/migration/v0_to_v1.ts
+++ b/src/agent-src/templates/scripts/work_engine/migration/v0_to_v1.ts
@@ -1,0 +1,531 @@
+/**
+ * Migrate a v0 `DeliveryState` JSON file to the v1 schema.
+ *
+ * TypeScript twin of `work_engine/migration/v0_to_v1.py` (ADR-096 py2ts
+ * Phase 1 — work_engine TOP/integration layer). Public API names stay
+ * snake_case to mirror the Python module 1:1 (per ADR-096 — Python style is
+ * part of the contract).
+ *
+ * The v0 era used `.implement-ticket-state.json` and stored the ticket
+ * under a flat `ticket` key. v1 wraps the payload under `input.kind`
+ * / `input.data` and adds `intent`, `directive_set`, and
+ * `version`. The default destination is `.work-state.json` next to
+ * the v0 file; the v0 file is renamed to `.implement-ticket-state.json.bak`
+ * to preserve the rollback surface.
+ *
+ * The module is both importable and runnable:
+ *
+ *     node node_modules/.bin/tsx work_engine/migration/v0_to_v1.ts .implement-ticket-state.json
+ *
+ * Idempotency: `migrate_payload` accepts a payload that already looks
+ * like v1 and returns it unchanged. `migrate_file` refuses to migrate
+ * twice — if the destination already exists it raises rather than
+ * silently overwriting work.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+    DEFAULT_DIRECTIVE_SET,
+    DEFAULT_INTENT,
+    SCHEMA_VERSION,
+    SchemaError,
+    type Dict,
+    type JsonValue,
+} from '../state.js';
+
+export const DEFAULT_V0_FILENAME = '.implement-ticket-state.json';
+/**
+ * Path the dispatcher used while the engine still lived under
+ * `implement_ticket`. The migration looks here when no source path is
+ * passed on the CLI.
+ */
+
+export const DEFAULT_V1_FILENAME = '.work-state.json';
+/** Canonical filename for the v1 wire format. */
+
+export const BACKUP_SUFFIX = '.bak';
+/**
+ * Appended to the v0 source path when the migration archives it.
+ *
+ * If the `.bak` slot is already taken (re-running the migration after
+ * an aborted run, manual rollback, etc.) the rotator falls back to
+ * `.bak.1`, `.bak.2`, ... — see {@link _rotate_backup_path}. The
+ * migration never silently overwrites an existing backup.
+ */
+
+const _MAX_BACKUP_ROTATIONS = 999;
+/**
+ * Hard ceiling on rotated backup filenames; surfaces an explicit
+ * {@link SchemaError} instead of looping forever if a checkout has
+ * hundreds of stale backups.
+ */
+
+/**
+ * Return the next free `.bak` slot for `source`.
+ *
+ * Tries `source.bak` first, then `source.bak.1`,
+ * `source.bak.2`, ... up to {@link _MAX_BACKUP_ROTATIONS}. The
+ * rotator only inspects existence — collision-safe by construction —
+ * and never deletes or overwrites prior backups.
+ */
+export function _rotate_backup_path(source: string): string {
+    // Python `source.with_suffix(source.suffix + BACKUP_SUFFIX)`: append the
+    // backup suffix to the existing suffix. `Path.with_suffix` replaces the
+    // final extension, so `.json` → `.json.bak` is exactly `source + ".bak"`
+    // here because BACKUP_SUFFIX leads with a dot and there is no embedded
+    // dot to collide with. Mirror `_with_suffix` semantics for parity.
+    const primary = _with_suffix(source, _suffix(source) + BACKUP_SUFFIX);
+    if (!_exists(primary)) {
+        return primary;
+    }
+    for (let index = 1; index <= _MAX_BACKUP_ROTATIONS; index++) {
+        const candidate = _with_suffix(primary, _suffix(primary) + `.${index}`);
+        if (!_exists(candidate)) {
+            return candidate;
+        }
+    }
+    throw new SchemaError(
+        `refusing to rotate backup for ${source}: more than ` +
+            `${_MAX_BACKUP_ROTATIONS} stale .bak files already exist; ` +
+            'clean them up before re-running the migration',
+    );
+}
+
+/**
+ * Return the v1 form of `payload`.
+ *
+ * A payload that already declares `version: 1` is returned
+ * unchanged (deep-copied via `JSON.parse(JSON.stringify(...))` so the
+ * caller cannot accidentally mutate the input). Anything else is
+ * treated as v0 and wrapped: `ticket` becomes `input.data`,
+ * `input.kind` is set to `"ticket"`, and the engine defaults are
+ * filled in.
+ *
+ * @throws SchemaError If the payload is not a dict, declares a higher version
+ *   than this migration knows about, or lacks a `ticket` key.
+ */
+export function migrate_payload(payload: JsonValue): Dict {
+    if (!_isPlainDict(payload)) {
+        throw new SchemaError(
+            `v0 state must be a JSON object; got ${_pyTypeName(payload)}`,
+        );
+    }
+    const p = payload as Record<string, JsonValue>;
+
+    const declared_version = _get(p, 'version', undefined);
+    if (declared_version === SCHEMA_VERSION) {
+        return JSON.parse(JSON.stringify(p)) as Dict;
+    }
+    if (declared_version !== undefined && declared_version !== null) {
+        throw new SchemaError(
+            `cannot migrate from version ${_pyRepr(declared_version)} to ` +
+                `${SCHEMA_VERSION}; this script only handles v0 (no version key)`,
+        );
+    }
+
+    if (!('ticket' in p)) {
+        throw new SchemaError(
+            "v0 state must carry a 'ticket' key; got keys: " +
+                _pyReprList(_sortedStr(Object.keys(p))),
+        );
+    }
+    const ticket = p['ticket'];
+    if (!_isPlainDict(ticket)) {
+        throw new SchemaError(
+            `v0 state.ticket must be a JSON object; got ${_pyTypeName(ticket)}`,
+        );
+    }
+
+    return {
+        version: SCHEMA_VERSION,
+        input: { kind: 'ticket', data: ticket },
+        intent: DEFAULT_INTENT,
+        directive_set: DEFAULT_DIRECTIVE_SET,
+        persona: _get(p, 'persona', 'senior-engineer') as JsonValue,
+        memory: [...((_get(p, 'memory', []) as JsonValue[]) ?? [])],
+        plan: _get(p, 'plan', null) as JsonValue,
+        changes: [...((_get(p, 'changes', []) as JsonValue[]) ?? [])],
+        tests: _get(p, 'tests', null) as JsonValue,
+        verify: _get(p, 'verify', null) as JsonValue,
+        outcomes: { ...((_get(p, 'outcomes', {}) as Dict) ?? {}) },
+        questions: [...((_get(p, 'questions', []) as JsonValue[]) ?? [])],
+        report: _get(p, 'report', '') as JsonValue,
+    };
+}
+
+/**
+ * Migrate the v0 state file at `source` and write the v1 result.
+ *
+ * `destination` defaults to {@link DEFAULT_V1_FILENAME} next to
+ * `source`. When `backup` is true (the default) the original
+ * file is renamed with {@link BACKUP_SUFFIX} appended; when false,
+ * the original is left untouched. The destination must not exist —
+ * refusing to overwrite is the safety net against accidental
+ * double-migration on CI.
+ *
+ * Returns the destination path on success.
+ */
+export function migrate_file(
+    source: string,
+    opts: { destination?: string | null; backup?: boolean } = {},
+): string {
+    const destination = opts.destination ?? null;
+    const backup = opts.backup ?? true;
+
+    if (!_isFile(source)) {
+        throw new SchemaError(`v0 state file not found: ${source}`);
+    }
+
+    const raw = fs.readFileSync(source, 'utf-8');
+    let payload: JsonValue;
+    try {
+        payload = JSON.parse(raw) as JsonValue;
+    } catch (exc) {
+        // Python `json.JSONDecodeError` → "invalid JSON in {source}: {exc}".
+        throw new SchemaError(`invalid JSON in ${source}: ${(exc as Error).message}`);
+    }
+
+    const target = destination ?? _with_name(source, DEFAULT_V1_FILENAME);
+    if (_exists(target)) {
+        throw new SchemaError(
+            `refusing to overwrite existing destination ${target}; ` +
+                'delete or rename it first',
+        );
+    }
+
+    const migrated = migrate_payload(payload);
+    fs.mkdirSync(_parent(target), { recursive: true });
+    fs.writeFileSync(
+        target,
+        _jsonDumps(migrated) + '\n',
+        'utf-8',
+    );
+
+    if (backup) {
+        const backup_path = _rotate_backup_path(source);
+        // Python `shutil.move(str(source), str(backup_path))` — rename within
+        // the same directory; `fs.renameSync` matches that fast path.
+        fs.renameSync(source, backup_path);
+    }
+
+    return target;
+}
+
+/**
+ * CLI entry point — `node node_modules/.bin/tsx work_engine/migration/v0_to_v1.ts`.
+ *
+ * Exits `0` on success, `2` on any {@link SchemaError} so the
+ * invoking shell can branch on the failure category. Returns the exit
+ * code (the caller sets `process.exitCode`, never `process.exit`, per
+ * ADR-096).
+ */
+export function main(argv: string[] | null = null): number {
+    const args = _parse_args(argv ?? process.argv.slice(2));
+    if (args === null) {
+        // `-h` / `--help` already printed usage and signalled exit 0.
+        return 0;
+    }
+
+    let target: string;
+    try {
+        target = migrate_file(args.source, {
+            destination: args.destination,
+            backup: !args.no_backup,
+        });
+    } catch (exc) {
+        if (exc instanceof SchemaError) {
+            process.stderr.write(`error: ${exc.message}\n`);
+            return 2;
+        }
+        throw exc;
+    }
+
+    process.stdout.write(`migrated ${args.source} → ${target}\n`);
+    return 0;
+}
+
+// ── Argument parsing ─────────────────────────────────────────────────────
+//
+// The Python source uses `argparse` with a single optional positional
+// (`source`, default `.implement-ticket-state.json`) plus `--destination`
+// and `--no-backup`. argparse `--help`/error prose is not a parity surface
+// (ADR-096); the parser mirrors argparse's runtime behaviour: long-option
+// prefix abbreviation, `--flag=value` / `--flag value` forms, the store_true
+// `--no-backup`, `-h`/`--help` exit-0, exit-2 on every error path.
+
+interface MigrationArgs {
+    source: string;
+    destination: string | null;
+    no_backup: boolean;
+}
+
+const _PROG = 'work_engine.migration.v0_to_v1';
+
+interface _OptionSpec {
+    flag: string;
+    dest: 'destination' | 'no_backup';
+    takesValue: boolean;
+}
+
+const _OPTIONS: _OptionSpec[] = [
+    { flag: '--destination', dest: 'destination', takesValue: true },
+    { flag: '--no-backup', dest: 'no_backup', takesValue: false },
+];
+
+const _HELP_FLAGS = ['--help'];
+
+function _usage(): string {
+    // Compact one-line usage marker; the exact wrapping/prose is not a parity
+    // surface (ADR-096 — argparse usage/help text is not byte-compared).
+    return `usage: ${_PROG} [-h] [--destination DESTINATION] [--no-backup] [source]`;
+}
+
+function _argErr(message: string): never {
+    process.stderr.write(`${_usage()}\n`);
+    process.stderr.write(`${_PROG}: error: ${message}\n`);
+    process.exitCode = 2;
+    throw new _ArgparseExit(2);
+}
+
+function _resolveLong(name: string): _OptionSpec | 'help' {
+    const exact = _OPTIONS.find((o) => o.flag === name);
+    if (exact) {
+        return exact;
+    }
+    if (_HELP_FLAGS.includes(name)) {
+        return 'help';
+    }
+    const candidates: Array<_OptionSpec | 'help'> = [];
+    for (const o of _OPTIONS) {
+        if (o.flag.startsWith(name)) {
+            candidates.push(o);
+        }
+    }
+    for (const h of _HELP_FLAGS) {
+        if (h.startsWith(name)) {
+            candidates.push('help');
+        }
+    }
+    if (candidates.length === 1) {
+        return candidates[0] as _OptionSpec | 'help';
+    }
+    if (candidates.length === 0) {
+        _argErr(`unrecognized arguments: ${name}`);
+    }
+    const names = candidates.map((c) => (c === 'help' ? '--help' : c.flag)).join(', ');
+    _argErr(`ambiguous option: ${name} could match ${names}`);
+}
+
+/** Thrown internally to mirror argparse's exit path (sentinel). */
+class _ArgparseExit extends Error {
+    readonly code: number;
+    constructor(code: number) {
+        super(`argparse exit ${code}`);
+        Object.setPrototypeOf(this, _ArgparseExit.prototype);
+        this.name = 'ArgparseExit';
+        this.code = code;
+    }
+}
+
+/**
+ * Parse `argv` (the slice after the program name). Returns `null` on
+ * `-h`/`--help` (usage printed, exit 0 signalled); throws {@link _ArgparseExit}
+ * (with `process.exitCode` set to 2) on any error path. Mirrors the argparse
+ * positional default of `.implement-ticket-state.json`.
+ */
+function _parse_args(argv: string[]): MigrationArgs | null {
+    const args: MigrationArgs = {
+        source: DEFAULT_V0_FILENAME,
+        destination: null,
+        no_backup: false,
+    };
+    const positionals: string[] = [];
+    const extras: string[] = [];
+    let sawSource = false;
+
+    let i = 0;
+    while (i < argv.length) {
+        const tok = argv[i] as string;
+        if (tok === '-h' || tok === '--help') {
+            process.stdout.write(`${_usage()}\n`);
+            return null;
+        }
+        if (tok.startsWith('--')) {
+            let name = tok;
+            let inlineValue: string | null = null;
+            const eq = tok.indexOf('=');
+            if (eq !== -1) {
+                name = tok.slice(0, eq);
+                inlineValue = tok.slice(eq + 1);
+            }
+            const resolved = _resolveLong(name);
+            if (resolved === 'help') {
+                process.stdout.write(`${_usage()}\n`);
+                return null;
+            }
+            if (resolved.takesValue) {
+                if (inlineValue !== null) {
+                    args.destination = inlineValue;
+                } else {
+                    const next = argv[i + 1];
+                    if (next === undefined) {
+                        _argErr(`argument ${resolved.flag}: expected one argument`);
+                    }
+                    args.destination = next as string;
+                    i += 1;
+                }
+            } else {
+                if (inlineValue !== null) {
+                    _argErr(`argument ${resolved.flag}: ignored explicit argument '${inlineValue}'`);
+                }
+                args.no_backup = true;
+            }
+        } else if (tok.startsWith('-') && tok !== '-') {
+            extras.push(tok);
+        } else if (!sawSource) {
+            args.source = tok;
+            sawSource = true;
+            positionals.push(tok);
+        } else {
+            extras.push(tok);
+        }
+        i += 1;
+    }
+    if (extras.length > 0) {
+        _argErr(`unrecognized arguments: ${extras.join(' ')}`);
+    }
+    return args;
+}
+
+// ── Path / filesystem parity helpers ─────────────────────────────────────
+
+/** Python `Path.suffix` — the final dotted extension (incl. the dot), or "". */
+function _suffix(p: string): string {
+    const base = path.basename(p);
+    const dot = base.lastIndexOf('.');
+    // Python: a leading dot (dotfile, no other dot) has no suffix.
+    if (dot <= 0) {
+        return '';
+    }
+    return base.slice(dot);
+}
+
+/** Python `Path.with_suffix(newSuffix)` — replace the final extension. */
+function _with_suffix(p: string, newSuffix: string): string {
+    const dir = path.dirname(p);
+    const base = path.basename(p);
+    const cur = _suffix(p);
+    const stem = cur ? base.slice(0, base.length - cur.length) : base;
+    const joined = stem + newSuffix;
+    return dir === '.' && !p.includes('/') && !p.includes(path.sep) ? joined : path.join(dir, joined);
+}
+
+/** Python `Path.with_name(name)` — same directory, replaced basename. */
+function _with_name(p: string, name: string): string {
+    const dir = path.dirname(p);
+    return dir === '.' && !p.includes('/') && !p.includes(path.sep) ? name : path.join(dir, name);
+}
+
+/** Python `Path.parent` — the containing directory. */
+function _parent(p: string): string {
+    return path.dirname(p);
+}
+
+function _exists(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function _isFile(p: string): boolean {
+    try {
+        return fs.statSync(p).isFile();
+    } catch {
+        return false;
+    }
+}
+
+// ── Python-parity primitives (mirrors state_io.ts) ───────────────────────
+
+/**
+ * Mirror Python `json.dumps(obj, indent=2, ensure_ascii=False)`.
+ *
+ * For round-tripped JSON, `JSON.stringify` with a 2-space indent matches
+ * CPython byte-for-byte: 2-space indent, `": "` key separator, `{}` / `[]`
+ * for empties, non-ASCII verbatim. Same rationale as `state_io.ts::_jsonDumps`:
+ * no float/int tag survives JSON parsing, so the CPython `N.0` divergence
+ * cannot arise here.
+ */
+function _jsonDumps(obj: Dict): string {
+    return JSON.stringify(obj, null, 2);
+}
+
+/** `dict.get(key, default)`. */
+function _get(obj: Record<string, JsonValue>, key: string, dflt: unknown): unknown {
+    return key in obj ? obj[key] : dflt;
+}
+
+/** Python `isinstance(x, dict)` — plain object only (not array, not null). */
+function _isPlainDict(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Python `type(x).__name__` for the JSON value shapes the messages emit. */
+function _pyTypeName(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'NoneType';
+    }
+    if (Array.isArray(value)) {
+        return 'list';
+    }
+    switch (typeof value) {
+        case 'string':
+            return 'str';
+        case 'boolean':
+            return 'bool';
+        case 'number':
+            return Number.isInteger(value) ? 'int' : 'float';
+        case 'object':
+            return 'dict';
+        default:
+            return typeof value;
+    }
+}
+
+/** Python `repr(x)` for the scalar shapes interpolated via `{value!r}`. */
+function _pyRepr(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'None';
+    }
+    if (value === true) {
+        return 'True';
+    }
+    if (value === false) {
+        return 'False';
+    }
+    if (typeof value === 'string') {
+        return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    }
+    return String(value);
+}
+
+/** Python `repr(list_of_str)` — `['a', 'b']`. */
+function _pyReprList(values: string[]): string {
+    return '[' + values.map((v) => _pyRepr(v)).join(', ') + ']';
+}
+
+/** Python `sorted(list_of_str)` — code-point ascending. */
+function _sortedStr(values: string[]): string[] {
+    return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+// `python3 -m work_engine.migration.v0_to_v1` parity: run main() when invoked
+// directly. tsx sets `import.meta.url` to the entry file URL.
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main();
+}

--- a/tests/scripts/work_engine/__main__.test.ts
+++ b/tests/scripts/work_engine/__main__.test.ts
@@ -1,0 +1,97 @@
+// Golden-parity tests for work_engine/__main__.ts vs __main__.py (ADR-096 py2ts
+// Phase 1 — work_engine TOP/integration layer).
+//
+// `__main__.py` is the thin `python3 -m work_engine` entry shim: it imports
+// `cli.main`, runs it, and exits with its return code. The twin sets
+// `process.exitCode = main()`. Both are run as subprocesses in identical temp
+// CWDs; the exit code + stdout + stderr are compared. The argv-passing path
+// mirrors the cli test (a runner file forwards argv into the module).
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+const MAIN_TS = path.join(SCRIPTS_ROOT, 'work_engine', '__main__.ts');
+const TSX_BIN = process.env['TSX_BIN'] ?? path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+interface Run {
+    status: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Run `python3 -m work_engine` semantics in `cwd` with `argv`. */
+function runPy(cwd: string, argv: string[]): Run {
+    // `python3 -m work_engine` runs the package's __main__ with sys.argv set.
+    const r = spawnSync('python3', ['-m', 'work_engine', ...argv], {
+        encoding: 'utf8',
+        cwd,
+        env: { ...process.env, PYTHONPATH: SCRIPTS_ROOT },
+    });
+    return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
+}
+
+/**
+ * Run the TS `__main__` entry. `__main__.ts` calls `main()` with no argv (it
+ * reads `process.argv.slice(2)` inside `main`), so a runner file imports it
+ * after the real argv is in place — the import side-effect runs the entry.
+ */
+function runTs(cwd: string, argv: string[]): Run {
+    const runner = path.join(cwd, '_main_runner.ts');
+    fs.writeFileSync(runner, `import ${JSON.stringify(MAIN_TS)};\n`, 'utf-8');
+    try {
+        const r = spawnSync('node', [TSX_BIN, runner, ...argv], { encoding: 'utf8', cwd });
+        return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
+    } finally {
+        fs.rmSync(runner, { force: true });
+    }
+}
+
+let tmpPy: string;
+let tmpTs: string;
+beforeEach(() => {
+    tmpPy = fs.mkdtempSync(path.join(os.tmpdir(), 'main-py-'));
+    tmpTs = fs.mkdtempSync(path.join(os.tmpdir(), 'main-ts-'));
+});
+afterEach(() => {
+    fs.rmSync(tmpPy, { recursive: true, force: true });
+    fs.rmSync(tmpTs, { recursive: true, force: true });
+});
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describeParity('__main__ — entry-point parity', () => {
+    it('no input → exit 2 + identical stderr', () => {
+        const pyR = runPy(tmpPy, ['--no-hooks']);
+        const tsR = runTs(tmpTs, ['--no-hooks']);
+        expect(tsR.status).toBe(2);
+        expect(pyR.status).toBe(2);
+        expect(tsR.stderr).toBe(pyR.stderr);
+    });
+
+    it('fresh ticket → BLOCKED exit 1 + identical stdout', () => {
+        const fixture = JSON.stringify({ id: 'T-1', title: 'x' });
+        fs.writeFileSync(path.join(tmpPy, 'ticket.json'), fixture, 'utf-8');
+        fs.writeFileSync(path.join(tmpTs, 'ticket.json'), fixture, 'utf-8');
+        const pyR = runPy(tmpPy, ['--no-hooks', '--ticket-file', 'ticket.json']);
+        const tsR = runTs(tmpTs, ['--no-hooks', '--ticket-file', 'ticket.json']);
+        expect(tsR.status).toBe(pyR.status);
+        expect(tsR.stdout).toBe(pyR.stdout);
+    });
+});
+
+describe('__main__ — runs the entry without throwing', () => {
+    it('TS entry executes and yields a numeric exit code', () => {
+        const tsR = runTs(tmpTs, ['--no-hooks']);
+        expect(typeof tsR.status).toBe('number');
+    });
+});

--- a/tests/scripts/work_engine/cli.test.ts
+++ b/tests/scripts/work_engine/cli.test.ts
@@ -1,0 +1,195 @@
+// Golden-parity tests for work_engine/cli.ts vs cli.py (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer).
+//
+// `cli.py` is the work-engine CLI entry point (argparse). Both engines are
+// driven as subprocesses on identical fixtures in identical temp CWDs, and the
+// (exit code, stdout, stderr, persisted-state-file bytes) are compared
+// byte-for-byte. The argparse `--help` prose is NOT a parity surface (ADR-096);
+// only the exit code + the `usage:` token are asserted there.
+//
+// Python runs through the real `work_engine` package on sys.path; TS runs via
+// `tsx -e` importing `cli.ts::main`. Hooks are disabled (`--no-hooks`) so the
+// transport surface stays byte-stable independent of any settings file.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+const CLI_TS = path.join(SCRIPTS_ROOT, 'work_engine', 'cli.ts');
+const TSX_BIN = process.env['TSX_BIN'] ?? path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+interface Run {
+    status: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Run the Python CLI in `cwd` with `argv`. */
+function runPy(cwd: string, argv: string[]): Run {
+    const code = [
+        'import sys',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine.cli import main',
+        'sys.exit(main(sys.argv[1:]))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, ...argv], { encoding: 'utf8', cwd });
+    return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
+}
+
+/**
+ * Run the TS CLI (via tsx) in `cwd` with `argv`.
+ *
+ * `tsx -e <code> -- <args>` does not forward the trailing args into
+ * `process.argv` (they are consumed by the `--` separator), so instead a tiny
+ * runner `.ts` file is written into `cwd` and invoked with the argv directly —
+ * which forwards `--help` and friends verbatim. The runner is `_`-prefixed and
+ * lives only inside the per-test temp dir, so it never pollutes the state-file
+ * comparison.
+ */
+function runTs(cwd: string, argv: string[]): Run {
+    const runner = path.join(cwd, '_cli_runner.ts');
+    const code = [
+        `import { main } from ${JSON.stringify(CLI_TS)};`,
+        'const rc = main(process.argv.slice(2));',
+        'process.exitCode = rc;',
+        '',
+    ].join('\n');
+    fs.writeFileSync(runner, code, 'utf-8');
+    try {
+        const r = spawnSync('node', [TSX_BIN, runner, ...argv], { encoding: 'utf8', cwd });
+        return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
+    } finally {
+        fs.rmSync(runner, { force: true });
+    }
+}
+
+let tmpPy: string;
+let tmpTs: string;
+beforeEach(() => {
+    tmpPy = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-py-'));
+    tmpTs = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-ts-'));
+});
+afterEach(() => {
+    fs.rmSync(tmpPy, { recursive: true, force: true });
+    fs.rmSync(tmpTs, { recursive: true, force: true });
+});
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+/** Write the same ticket fixture into both CWDs. */
+function seedTicket(filename: string, payload: unknown): void {
+    fs.writeFileSync(path.join(tmpPy, filename), JSON.stringify(payload), 'utf-8');
+    fs.writeFileSync(path.join(tmpTs, filename), JSON.stringify(payload), 'utf-8');
+}
+
+function readStateMaybe(dir: string, name = '.work-state.json'): string | null {
+    const p = path.join(dir, name);
+    return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null;
+}
+
+describeParity('cli main — full transport parity', () => {
+    it('fresh ticket run halts BLOCKED at refine (exit 1) — same stdout + state', () => {
+        // A ticket with a trivial title trips the refine deficiency gate →
+        // BLOCKED at the first step. Deterministic, no agent directive needed.
+        seedTicket('ticket.json', { id: 'T-1', title: 'x' });
+        const pyR = runPy(tmpPy, ['--no-hooks', '--ticket-file', 'ticket.json']);
+        const tsR = runTs(tmpTs, ['--no-hooks', '--ticket-file', 'ticket.json']);
+
+        expect(tsR.status).toBe(pyR.status);
+        expect(tsR.stdout).toBe(pyR.stdout);
+        // The persisted state file must be byte-identical (v0 wire format).
+        expect(readStateMaybe(tmpTs)).toBe(readStateMaybe(tmpPy));
+    });
+
+    it('missing input (no state file, no flags) → exit 2 + error on stderr', () => {
+        const pyR = runPy(tmpPy, ['--no-hooks']);
+        const tsR = runTs(tmpTs, ['--no-hooks']);
+        expect(tsR.status).toBe(2);
+        expect(pyR.status).toBe(2);
+        expect(tsR.stderr).toBe(pyR.stderr);
+        // No state file written on the error path.
+        expect(readStateMaybe(tmpTs)).toBeNull();
+        expect(readStateMaybe(tmpPy)).toBeNull();
+    });
+
+    it('non-object ticket file → exit 2 + identical error text', () => {
+        seedTicket('bad.json', [1, 2, 3]);
+        const pyR = runPy(tmpPy, ['--no-hooks', '--ticket-file', 'bad.json']);
+        const tsR = runTs(tmpTs, ['--no-hooks', '--ticket-file', 'bad.json']);
+        expect(tsR.status).toBe(2);
+        expect(pyR.status).toBe(2);
+        expect(tsR.stderr).toBe(pyR.stderr);
+    });
+
+    it('resumes a v1 state file to SUCCESS (exit 0) — same report + state', () => {
+        // Pre-seed a v1 state file with every step already marked success so the
+        // dispatcher walks straight to SUCCESS and prints the stored report.
+        const v1 = {
+            version: 1,
+            input: { kind: 'ticket', data: { id: 'T-9', title: 'Resume me' } },
+            intent: 'backend-coding',
+            directive_set: 'backend',
+            stack: null,
+            ui_audit: null,
+            ui_design: null,
+            ui_review: null,
+            ui_polish: null,
+            contract: null,
+            stitch: null,
+            halts: [],
+            persona: 'senior-engineer',
+            memory: [],
+            plan: null,
+            changes: [],
+            tests: null,
+            verify: null,
+            outcomes: {
+                refine: 'success',
+                memory: 'success',
+                analyze: 'success',
+                plan: 'success',
+                implement: 'success',
+                test: 'success',
+                verify: 'success',
+                report: 'success',
+            },
+            questions: [],
+            report: 'DELIVERY REPORT BODY',
+        };
+        fs.writeFileSync(path.join(tmpPy, '.work-state.json'), JSON.stringify(v1, null, 2) + '\n', 'utf-8');
+        fs.writeFileSync(path.join(tmpTs, '.work-state.json'), JSON.stringify(v1, null, 2) + '\n', 'utf-8');
+
+        const pyR = runPy(tmpPy, ['--no-hooks']);
+        const tsR = runTs(tmpTs, ['--no-hooks']);
+        expect(tsR.status).toBe(pyR.status);
+        expect(tsR.stdout).toBe(pyR.stdout);
+        expect(readStateMaybe(tmpTs)).toBe(readStateMaybe(tmpPy));
+    });
+});
+
+describeParity('cli main — argparse exit codes', () => {
+    it('--help exits 0 (prose not byte-compared; usage token only)', () => {
+        const pyR = runPy(tmpPy, ['--help']);
+        const tsR = runTs(tmpTs, ['--help']);
+        expect(tsR.status).toBe(0);
+        expect(pyR.status).toBe(0);
+        expect(tsR.stdout.startsWith('usage:')).toBe(true);
+        expect(pyR.stdout.startsWith('usage:')).toBe(true);
+    });
+
+    it('unrecognized flag exits 2', () => {
+        const pyR = runPy(tmpPy, ['--no-such-flag']);
+        const tsR = runTs(tmpTs, ['--no-such-flag']);
+        expect(tsR.status).toBe(2);
+        expect(pyR.status).toBe(2);
+    });
+});

--- a/tests/scripts/work_engine/directives_backend_init.test.ts
+++ b/tests/scripts/work_engine/directives_backend_init.test.ts
@@ -1,0 +1,106 @@
+// Golden-parity tests for work_engine/directives/backend/index.ts vs
+// directives/backend/__init__.py (ADR-096 py2ts Phase 1 — work_engine
+// TOP/integration layer).
+//
+// The wiring module exposes DIRECTIVE_SET_NAME, SUPPORTED_KINDS, get_steps(),
+// and all_ambiguities(). get_steps() returns callables (not JSON-comparable),
+// so parity is on the *step-name order* and the all_ambiguities() structure
+// (per-step ambiguity code lists). The Python package is imported via
+// sys.path + import_module (siblings exist as .py until the Phase-12 sweep).
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DIRECTIVE_SET_NAME,
+    SUPPORTED_KINDS,
+    all_ambiguities,
+    get_steps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** Emit `{name, kinds, step_order, ambiguities}` for the backend set on py3. */
+function pySummary(): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'm = __import__("work_engine.directives.backend", fromlist=["x"])',
+        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
+        'out = {',
+        '  "name": m.DIRECTIVE_SET_NAME,',
+        '  "kinds": list(m.SUPPORTED_KINDS),',
+        '  "step_order": list(m.get_steps().keys()),',
+        '  "ambiguities": amb,',
+        '}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function tsSummary(): string {
+    const amb: Record<string, Array<string | undefined>> = {};
+    for (const [k, v] of Object.entries(all_ambiguities())) {
+        amb[k] = v.map((a) => a['code']);
+    }
+    const out = {
+        name: DIRECTIVE_SET_NAME,
+        kinds: [...SUPPORTED_KINDS],
+        step_order: [...get_steps().keys()],
+        ambiguities: amb,
+    };
+    // sort_keys parity: re-serialise with sorted keys.
+    return JSON.stringify(_sortKeys(out), null, 2);
+}
+
+function _sortKeys(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(_sortKeys);
+    }
+    if (value && typeof value === 'object') {
+        const sorted: Record<string, unknown> = {};
+        for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[k] = _sortKeys((value as Record<string, unknown>)[k]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/backend index — shape', () => {
+    it('DIRECTIVE_SET_NAME + SUPPORTED_KINDS', () => {
+        expect(DIRECTIVE_SET_NAME).toBe('backend');
+        expect([...SUPPORTED_KINDS]).toEqual(['ticket', 'prompt']);
+    });
+
+    it('get_steps walks the canonical eight-step order', () => {
+        expect([...get_steps().keys()]).toEqual([
+            'refine', 'memory', 'analyze', 'plan', 'implement', 'test', 'verify', 'report',
+        ]);
+    });
+
+    it('every step maps to a callable', () => {
+        for (const handler of get_steps().values()) {
+            expect(typeof handler).toBe('function');
+        }
+    });
+});
+
+describeParity('directives/backend index — golden parity', () => {
+    it('matches python3 (name + kinds + order + ambiguity codes)', () => {
+        expect(tsSummary()).toBe(pySummary());
+    });
+});

--- a/tests/scripts/work_engine/directives_init.test.ts
+++ b/tests/scripts/work_engine/directives_init.test.ts
@@ -1,0 +1,41 @@
+// Parity test for work_engine/directives/index.ts vs directives/__init__.py
+// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer). The Python
+// `__init__` declares `__all__ = []` (no re-exports); the TS twin is the empty
+// package-marker module. Parity is the empty public surface.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import * as directives from '../../../src/agent-src/templates/scripts/work_engine/directives/index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/index — empty package marker', () => {
+    it('exposes no runtime members (mirrors __all__ = [])', () => {
+        // `export {}` yields a module object with no own enumerable members.
+        expect(Object.keys(directives)).toEqual([]);
+    });
+});
+
+describeParity('directives/__init__ — __all__ parity', () => {
+    it('python __all__ is empty', () => {
+        const code = [
+            'import sys, json',
+            `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+            'm = __import__("work_engine.directives", fromlist=["x"])',
+            'sys.stdout.write(json.dumps(getattr(m, "__all__", None)))',
+        ].join('\n');
+        const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe('[]');
+    });
+});

--- a/tests/scripts/work_engine/directives_mixed_init.test.ts
+++ b/tests/scripts/work_engine/directives_mixed_init.test.ts
@@ -1,0 +1,87 @@
+// Golden-parity tests for work_engine/directives/mixed/index.ts vs
+// directives/mixed/__init__.py (ADR-096 py2ts Phase 1 — work_engine
+// TOP/integration layer). The mixed set reuses five backend handlers by
+// reference; parity is on name / roadmap / kinds / step-order / ambiguity-code
+// structure.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DIRECTIVE_SET_NAME,
+    ROADMAP,
+    SUPPORTED_KINDS,
+    all_ambiguities,
+    get_steps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/mixed/index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function pySummary(): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'm = __import__("work_engine.directives.mixed", fromlist=["x"])',
+        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
+        'out = {"name": m.DIRECTIVE_SET_NAME, "roadmap": m.ROADMAP, "kinds": list(m.SUPPORTED_KINDS), "step_order": list(m.get_steps().keys()), "ambiguities": amb}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function _sortKeys(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(_sortKeys);
+    if (value && typeof value === 'object') {
+        const sorted: Record<string, unknown> = {};
+        for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[k] = _sortKeys((value as Record<string, unknown>)[k]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+function tsSummary(): string {
+    const amb: Record<string, Array<string | undefined>> = {};
+    for (const [k, v] of Object.entries(all_ambiguities())) amb[k] = v.map((a) => a['code']);
+    return JSON.stringify(
+        _sortKeys({ name: DIRECTIVE_SET_NAME, roadmap: ROADMAP, kinds: [...SUPPORTED_KINDS], step_order: [...get_steps().keys()], ambiguities: amb }),
+        null,
+        2,
+    );
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/mixed index — shape', () => {
+    it('name / roadmap / kinds', () => {
+        expect(DIRECTIVE_SET_NAME).toBe('mixed');
+        expect(ROADMAP).toBe('agents/roadmaps/road-to-product-ui-track.md');
+        expect([...SUPPORTED_KINDS]).toEqual(['ticket', 'prompt']);
+    });
+    it('get_steps order', () => {
+        expect([...get_steps().keys()]).toEqual([
+            'refine', 'memory', 'analyze', 'plan', 'implement', 'test', 'verify', 'report',
+        ]);
+    });
+    it('all callables', () => {
+        for (const h of get_steps().values()) expect(typeof h).toBe('function');
+    });
+});
+
+describeParity('directives/mixed index — golden parity', () => {
+    it('matches python3', () => {
+        expect(tsSummary()).toBe(pySummary());
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_init.test.ts
+++ b/tests/scripts/work_engine/directives_ui_init.test.ts
@@ -1,0 +1,86 @@
+// Golden-parity tests for work_engine/directives/ui/index.ts vs
+// directives/ui/__init__.py (ADR-096 py2ts Phase 1 — work_engine
+// TOP/integration layer). Parity on name / roadmap / kinds / step-order /
+// ambiguity-code structure (get_steps() returns callables — not comparable).
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DIRECTIVE_SET_NAME,
+    ROADMAP,
+    SUPPORTED_KINDS,
+    all_ambiguities,
+    get_steps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function pySummary(): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'm = __import__("work_engine.directives.ui", fromlist=["x"])',
+        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
+        'out = {"name": m.DIRECTIVE_SET_NAME, "roadmap": m.ROADMAP, "kinds": list(m.SUPPORTED_KINDS), "step_order": list(m.get_steps().keys()), "ambiguities": amb}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function _sortKeys(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(_sortKeys);
+    if (value && typeof value === 'object') {
+        const sorted: Record<string, unknown> = {};
+        for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[k] = _sortKeys((value as Record<string, unknown>)[k]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+function tsSummary(): string {
+    const amb: Record<string, Array<string | undefined>> = {};
+    for (const [k, v] of Object.entries(all_ambiguities())) amb[k] = v.map((a) => a['code']);
+    return JSON.stringify(
+        _sortKeys({ name: DIRECTIVE_SET_NAME, roadmap: ROADMAP, kinds: [...SUPPORTED_KINDS], step_order: [...get_steps().keys()], ambiguities: amb }),
+        null,
+        2,
+    );
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/ui index — shape', () => {
+    it('name / roadmap / kinds', () => {
+        expect(DIRECTIVE_SET_NAME).toBe('ui');
+        expect(ROADMAP).toBe('agents/roadmaps/road-to-product-ui-track.md');
+        expect([...SUPPORTED_KINDS]).toEqual(['ticket', 'prompt', 'diff', 'file']);
+    });
+    it('get_steps order', () => {
+        expect([...get_steps().keys()]).toEqual([
+            'refine', 'memory', 'analyze', 'plan', 'implement', 'test', 'verify', 'report',
+        ]);
+    });
+    it('all callables', () => {
+        for (const h of get_steps().values()) expect(typeof h).toBe('function');
+    });
+});
+
+describeParity('directives/ui index — golden parity', () => {
+    it('matches python3', () => {
+        expect(tsSummary()).toBe(pySummary());
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_trivial_init.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial_init.test.ts
@@ -1,0 +1,86 @@
+// Golden-parity tests for work_engine/directives/ui_trivial/index.ts vs
+// directives/ui_trivial/__init__.py (ADR-096 py2ts Phase 1 — work_engine
+// TOP/integration layer). Note: DIRECTIVE_SET_NAME is the hyphenated wire form
+// `ui-trivial` while the package dir is underscore `ui_trivial`.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DIRECTIVE_SET_NAME,
+    ROADMAP,
+    SUPPORTED_KINDS,
+    all_ambiguities,
+    get_steps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function pySummary(): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'm = __import__("work_engine.directives.ui_trivial", fromlist=["x"])',
+        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
+        'out = {"name": m.DIRECTIVE_SET_NAME, "roadmap": m.ROADMAP, "kinds": list(m.SUPPORTED_KINDS), "step_order": list(m.get_steps().keys()), "ambiguities": amb}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function _sortKeys(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(_sortKeys);
+    if (value && typeof value === 'object') {
+        const sorted: Record<string, unknown> = {};
+        for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+            sorted[k] = _sortKeys((value as Record<string, unknown>)[k]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+function tsSummary(): string {
+    const amb: Record<string, Array<string | undefined>> = {};
+    for (const [k, v] of Object.entries(all_ambiguities())) amb[k] = v.map((a) => a['code']);
+    return JSON.stringify(
+        _sortKeys({ name: DIRECTIVE_SET_NAME, roadmap: ROADMAP, kinds: [...SUPPORTED_KINDS], step_order: [...get_steps().keys()], ambiguities: amb }),
+        null,
+        2,
+    );
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('directives/ui_trivial index — shape', () => {
+    it('hyphenated wire name + roadmap + kinds', () => {
+        expect(DIRECTIVE_SET_NAME).toBe('ui-trivial');
+        expect(ROADMAP).toBe('agents/roadmaps/road-to-product-ui-track.md');
+        expect([...SUPPORTED_KINDS]).toEqual(['ticket', 'prompt', 'diff', 'file']);
+    });
+    it('get_steps order', () => {
+        expect([...get_steps().keys()]).toEqual([
+            'refine', 'memory', 'analyze', 'plan', 'implement', 'test', 'verify', 'report',
+        ]);
+    });
+    it('all callables', () => {
+        for (const h of get_steps().values()) expect(typeof h).toBe('function');
+    });
+});
+
+describeParity('directives/ui_trivial index — golden parity', () => {
+    it('matches python3', () => {
+        expect(tsSummary()).toBe(pySummary());
+    });
+});

--- a/tests/scripts/work_engine/dispatcher.test.ts
+++ b/tests/scripts/work_engine/dispatcher.test.ts
@@ -1,0 +1,246 @@
+// Golden-parity tests for work_engine/dispatcher.ts vs dispatcher.py (ADR-096
+// py2ts Phase 1 — work_engine TOP/integration layer).
+//
+// `dispatcher.py` imports `.delivery_state`, `.hooks`, `.state` and (via
+// `load_directive_set`) the real `directives.<set>` packages. The parity rig
+// runs it through the real `work_engine` package on sys.path. The dispatch loop
+// itself (`dispatch`) is driven with synthetic step maps so the success /
+// blocked / partial / resume-skip / missing-step / no-questions invariants are
+// exercised deterministically on both engines, comparing the resulting
+// `(outcome, halting, state.outcomes, state.questions)` byte-for-byte.
+//
+// The directive-set resolution surface (select_directive_set / load /
+// assert_kind_supported) is exercised against the real four sets — TS resolves
+// them statically, Python via import_module; both produce the canonical
+// eight-step order and the same error text for the typo / unsupported-kind
+// paths.
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_DIRECTIVE_SET,
+    STEP_ORDER,
+    ValueError,
+    assert_kind_supported,
+    dispatch,
+    load_directive_set,
+    select_directive_set,
+} from '../../../src/agent-src/templates/scripts/work_engine/dispatcher.js';
+import {
+    DeliveryState,
+    Outcome,
+    type Step,
+    StepResult,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import { Input, WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+// ── dispatch() — synthetic step maps, both engines ────────────────────────
+
+// A "step plan" is a JSON-serialisable map of {stepName: {outcome, questions}}.
+// Both engines build a step map from it where each handler returns the declared
+// StepResult; a missing entry means a step that always SUCCEEDS.
+type StepPlan = Record<string, { outcome: string; questions?: string[] }>;
+
+function tsStepMap(plan: StepPlan): Map<string, Step> {
+    const m = new Map<string, Step>();
+    for (const name of STEP_ORDER) {
+        const spec = plan[name];
+        m.set(name, () =>
+            new StepResult({
+                outcome: (spec ? spec.outcome : Outcome.SUCCESS) as Outcome,
+                questions: spec?.questions ?? [],
+            }),
+        );
+    }
+    return m;
+}
+
+function tsDispatch(plan: StepPlan, preOutcomes: Record<string, string> = {}): string {
+    const st = new DeliveryState({ ticket: { id: 'T' }, outcomes: { ...preOutcomes } });
+    const [final, halting] = dispatch(st, tsStepMap(plan));
+    return JSON.stringify(
+        { final, halting, outcomes: st.outcomes, questions: st.questions },
+        null,
+        2,
+    );
+}
+
+function pyDispatch(plan: StepPlan, preOutcomes: Record<string, string> = {}): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine.dispatcher import dispatch, STEP_ORDER',
+        'from work_engine.delivery_state import DeliveryState, Outcome, StepResult',
+        'plan = json.loads(sys.argv[1])',
+        'pre = json.loads(sys.argv[2])',
+        'def make(name):',
+        '    spec = plan.get(name)',
+        '    outcome = Outcome(spec["outcome"]) if spec else Outcome.SUCCESS',
+        '    questions = spec.get("questions", []) if spec else []',
+        '    def handler(state):',
+        '        return StepResult(outcome=outcome, questions=list(questions))',
+        '    return handler',
+        'steps = {name: make(name) for name in STEP_ORDER}',
+        'st = DeliveryState(ticket={"id": "T"}, outcomes=dict(pre))',
+        'final, halting = dispatch(st, steps)',
+        'out = {"final": final.value, "halting": halting, "outcomes": st.outcomes, "questions": st.questions}',
+        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, JSON.stringify(plan), JSON.stringify(preOutcomes)], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+describe('dispatch — local invariants', () => {
+    it('all-success walks the full order', () => {
+        const st = new DeliveryState({ ticket: {} });
+        const [final, halting] = dispatch(st, tsStepMap({}));
+        expect(final).toBe(Outcome.SUCCESS);
+        expect(halting).toBeNull();
+        expect(Object.keys(st.outcomes)).toEqual([...STEP_ORDER]);
+    });
+
+    it('missing step throws (KeyError-equivalent)', () => {
+        const partial = new Map<string, Step>();
+        partial.set('refine', () => new StepResult({ outcome: Outcome.SUCCESS }));
+        expect(() => dispatch(new DeliveryState({ ticket: {} }), partial)).toThrow();
+    });
+
+    it('blocked with no questions throws (ValueError-equivalent)', () => {
+        const m = tsStepMap({ plan: { outcome: Outcome.BLOCKED, questions: [] } });
+        expect(() => dispatch(new DeliveryState({ ticket: {} }), m)).toThrow();
+    });
+});
+
+describeParity('dispatch — golden parity', () => {
+    const PLANS: Array<[string, StepPlan, Record<string, string>]> = [
+        ['all success', {}, {}],
+        ['blocked at plan', { plan: { outcome: 'blocked', questions: ['1. a', '2. b'] } }, {}],
+        ['partial at verify', { verify: { outcome: 'partial', questions: ['1. retry'] } }, {}],
+        ['blocked at refine (first step)', { refine: { outcome: 'blocked', questions: ['q'] } }, {}],
+        ['resume skips already-success steps', { test: { outcome: 'blocked', questions: ['q'] } }, { refine: 'success', memory: 'success', analyze: 'success', plan: 'success', implement: 'success' }],
+        ['resume: all already success', {}, { refine: 'success', memory: 'success', analyze: 'success', plan: 'success', implement: 'success', test: 'success', verify: 'success', report: 'success' }],
+    ];
+    for (const [name, plan, pre] of PLANS) {
+        it(name, () => {
+            expect(tsDispatch(plan, pre)).toBe(pyDispatch(plan, pre));
+        });
+    }
+});
+
+// ── select_directive_set / load / assert_kind_supported ───────────────────
+
+function pyResolve(body: string): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine import dispatcher as d',
+        'from work_engine.state import Input, WorkState',
+        body,
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+describe('select_directive_set — local', () => {
+    it('reads WorkState.directive_set', () => {
+        const w = new WorkState({ input: new Input('ticket', {}), directive_set: 'ui' });
+        expect(select_directive_set(w)).toBe('ui');
+    });
+    it('falls back to backend on a fieldless object', () => {
+        expect(select_directive_set(new DeliveryState({ ticket: {} }))).toBe(DEFAULT_DIRECTIVE_SET);
+    });
+    it('throws ValueError on an unknown set', () => {
+        const w = new WorkState({ input: new Input('ticket', {}), directive_set: 'nope' });
+        expect(() => select_directive_set(w)).toThrow(ValueError);
+    });
+});
+
+describeParity('select_directive_set — error-text parity', () => {
+    it('unknown-set message matches python3', () => {
+        const tsMsg = (() => {
+            try {
+                const w = new WorkState({ input: new Input('ticket', {}), directive_set: 'nope' });
+                select_directive_set(w);
+                return '__NO_ERROR__';
+            } catch (e) {
+                return (e as Error).message;
+            }
+        })();
+        const pyMsg = pyResolve([
+            'w = WorkState(input=Input(kind="ticket", data={}), directive_set="nope")',
+            'try:',
+            '    d.select_directive_set(w)',
+            '    sys.stdout.write("__NO_ERROR__")',
+            'except ValueError as exc:',
+            '    sys.stdout.write(str(exc))',
+        ].join('\n'));
+        expect(tsMsg).toBe(pyMsg);
+    });
+});
+
+describe('load_directive_set — real sets', () => {
+    for (const set of ['backend', 'ui', 'ui-trivial', 'mixed']) {
+        it(`${set} yields the eight-step order`, () => {
+            expect([...load_directive_set(set).keys()]).toEqual([...STEP_ORDER]);
+        });
+    }
+    it('throws ValueError on a typo', () => {
+        expect(() => load_directive_set('backendd')).toThrow(ValueError);
+    });
+});
+
+describe('assert_kind_supported — real sets', () => {
+    it('backend supports ticket + prompt', () => {
+        expect(() => assert_kind_supported('ticket', 'backend')).not.toThrow();
+        expect(() => assert_kind_supported('prompt', 'backend')).not.toThrow();
+    });
+    it('backend rejects diff', () => {
+        expect(() => assert_kind_supported('diff', 'backend')).toThrow();
+    });
+    it('ui supports all four kinds', () => {
+        for (const k of ['ticket', 'prompt', 'diff', 'file']) {
+            expect(() => assert_kind_supported(k, 'ui')).not.toThrow();
+        }
+    });
+});
+
+describeParity('assert_kind_supported — error-text parity', () => {
+    it('unsupported-kind message matches python3', () => {
+        const tsMsg = (() => {
+            try {
+                assert_kind_supported('diff', 'backend');
+                return '__NO_ERROR__';
+            } catch (e) {
+                return (e as Error).message;
+            }
+        })();
+        const pyMsg = pyResolve([
+            'try:',
+            '    d.assert_kind_supported("diff", "backend")',
+            '    sys.stdout.write("__NO_ERROR__")',
+            'except NotImplementedError as exc:',
+            '    sys.stdout.write(str(exc))',
+        ].join('\n'));
+        expect(tsMsg).toBe(pyMsg);
+    });
+});

--- a/tests/scripts/work_engine/emitters.test.ts
+++ b/tests/scripts/work_engine/emitters.test.ts
@@ -1,0 +1,172 @@
+// Golden-parity tests for work_engine/emitters.ts vs emitters.py (ADR-096
+// py2ts Phase 1 — work_engine TOP/integration layer).
+//
+// `emitters.py` imports `.delivery_state`, `.hooks`, `.state` (package-relative
+// imports through the real `work_engine` package), so the parity harness runs
+// it via sys.path + import_module. Coverage: `_emit` SUCCESS (report on stdout)
+// + halt branches ([halt] line + questions), and `_emit_halt` (stderr surface,
+// fallback `halt:` line, exit-2, halts[] persistence when the state file
+// pre-exists). The halt timestamp is wall-clock — normalised in both engines.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { _emit, _emit_halt } from '../../../src/agent-src/templates/scripts/work_engine/emitters.js';
+import { Outcome } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import { HookHalt } from '../../../src/agent-src/templates/scripts/work_engine/hooks/index.js';
+import { Input, WorkState, dump, load } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'emit-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+// ── _emit (stdout) ───────────────────────────────────────────────────────
+
+/** Run `_emit` on python3 with the given report/final/halting/questions. */
+function pyEmit(report: string, final: string, halting: string | null, questions: string[]): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine.emitters import _emit',
+        'from work_engine.delivery_state import Outcome',
+        'from work_engine.state import Input, WorkState',
+        'spec = json.loads(sys.argv[1])',
+        'w = WorkState(input=Input(kind="ticket", data={}))',
+        'w.report = spec["report"]',
+        'w.questions = spec["questions"]',
+        'final = Outcome(spec["final"])',
+        'halting = spec["halting"]',
+        '_emit(w, final, halting)',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, JSON.stringify({ report, final, halting, questions })], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+function tsEmit(report: string, final: Outcome, halting: string | null, questions: string[]): string {
+    const w = new WorkState({ input: new Input('ticket', {}) });
+    w.report = report;
+    w.questions = questions;
+    const chunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    (process.stdout.write as unknown) = (s: string) => {
+        chunks.push(s);
+        return true;
+    };
+    try {
+        _emit(w, final, halting);
+    } finally {
+        (process.stdout.write as unknown) = orig;
+    }
+    return chunks.join('');
+}
+
+describeParity('_emit — stdout parity', () => {
+    it('SUCCESS prints the report', () => {
+        expect(tsEmit('the delivery report', Outcome.SUCCESS, null, [])).toBe(
+            pyEmit('the delivery report', 'success', null, []),
+        );
+    });
+    it('BLOCKED prints the halt line + questions', () => {
+        expect(tsEmit('', Outcome.BLOCKED, 'plan', ['1. opt a', '2. opt b'])).toBe(
+            pyEmit('', 'blocked', 'plan', ['1. opt a', '2. opt b']),
+        );
+    });
+    it('PARTIAL with no halting step prints (none)', () => {
+        expect(tsEmit('', Outcome.PARTIAL, null, ['q'])).toBe(pyEmit('', 'partial', null, ['q']));
+    });
+});
+
+// ── _emit_halt (stderr + persistence) ─────────────────────────────────────
+
+describe('_emit_halt — stderr + exit code', () => {
+    it('returns 2 and writes the surface to stderr', () => {
+        const chunks: string[] = [];
+        const orig = process.stderr.write.bind(process.stderr);
+        (process.stderr.write as unknown) = (s: string) => {
+            chunks.push(s);
+            return true;
+        };
+        let rc: number;
+        try {
+            rc = _emit_halt(new HookHalt('blocked by gate', ['line 1', 'line 2']));
+        } finally {
+            (process.stderr.write as unknown) = orig;
+        }
+        expect(rc).toBe(2);
+        expect(chunks.join('')).toBe('line 1\nline 2\n');
+    });
+
+    it('falls back to `halt: <reason>` when surface is empty', () => {
+        const chunks: string[] = [];
+        const orig = process.stderr.write.bind(process.stderr);
+        (process.stderr.write as unknown) = (s: string) => {
+            chunks.push(s);
+            return true;
+        };
+        try {
+            _emit_halt(new HookHalt('no surface', null));
+        } finally {
+            (process.stderr.write as unknown) = orig;
+        }
+        expect(chunks.join('')).toBe('halt: no surface\n');
+    });
+
+    it('appends to halts[] and re-saves when the state file pre-exists', () => {
+        const stateFile = path.join(tmp, '.work-state.json');
+        const w = new WorkState({ input: new Input('ticket', { id: 'T' }) });
+        // Write it first so _emit_halt detects an existing file.
+        dump(w, stateFile);
+
+        const orig = process.stderr.write.bind(process.stderr);
+        (process.stderr.write as unknown) = () => true;
+        try {
+            _emit_halt(new HookHalt('gate halt', ['surf']), { work: w, state_file: stateFile, event: 'AFTER_LOAD' });
+        } finally {
+            (process.stderr.write as unknown) = orig;
+        }
+        const reloaded = load(stateFile);
+        expect(reloaded.halts.length).toBe(1);
+        const h = reloaded.halts[0] as Record<string, unknown>;
+        expect(h['reason']).toBe('gate halt');
+        expect(h['step']).toBe('AFTER_LOAD');
+        expect(h['surface']).toEqual(['surf']);
+        expect(typeof h['timestamp']).toBe('string');
+        // CPython aware-UTC isoformat shape: ...+00:00 with µs precision.
+        expect(h['timestamp']).toMatch(/T.*\+00:00$/);
+    });
+
+    it('does NOT write state when the file is absent (fresh-run contract)', () => {
+        const stateFile = path.join(tmp, 'absent.json');
+        const w = new WorkState({ input: new Input('ticket', {}) });
+        const orig = process.stderr.write.bind(process.stderr);
+        (process.stderr.write as unknown) = () => true;
+        try {
+            _emit_halt(new HookHalt('x', ['s']), { work: w, state_file: stateFile, event: 'BEFORE_LOAD' });
+        } finally {
+            (process.stderr.write as unknown) = orig;
+        }
+        expect(fs.existsSync(stateFile)).toBe(false);
+    });
+});

--- a/tests/scripts/work_engine/hook_bootstrap.test.ts
+++ b/tests/scripts/work_engine/hook_bootstrap.test.ts
@@ -1,0 +1,151 @@
+// Golden-parity tests for work_engine/hook_bootstrap.ts vs hook_bootstrap.py
+// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer).
+//
+// `hook_bootstrap.py` assembles a HookRegistry from `.agent-settings.yml`. The
+// registered callbacks are closures (not comparable across engines), so parity
+// is on the *per-event callback count* — the observable shape of the registry.
+// Cases: --no-hooks (empty), missing/empty settings (empty), hooks.enabled
+// with the per-hook defaults, and chat-history enabled. The Python module is
+// run through the real package on sys.path.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ParsedArgs } from '../../../src/agent-src/templates/scripts/work_engine/cli_args.js';
+import { _build_hook_registry } from '../../../src/agent-src/templates/scripts/work_engine/hook_bootstrap.js';
+import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/index.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function hasPyYaml(): boolean {
+    return spawnSync('python3', ['-c', 'import yaml'], { encoding: 'utf8' }).status === 0;
+}
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hb-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const py = hasPython3() && hasPyYaml();
+const describeParity = py ? describe : describe.skip;
+
+function baseArgs(over: Partial<ParsedArgs> = {}): ParsedArgs {
+    return {
+        state_file: '.work-state.json',
+        ticket_file: null,
+        prompt_file: null,
+        diff_file: null,
+        file_file: null,
+        persona: null,
+        no_hooks: false,
+        hooks_config: null,
+        ...over,
+    };
+}
+
+const ALL_EVENTS = Object.values(HookEvent) as HookEvent[];
+
+/** TS: per-event callback counts for the registry built from `args`. */
+function tsCounts(args: ParsedArgs): Record<string, number> {
+    const reg = _build_hook_registry(args);
+    const out: Record<string, number> = {};
+    for (const ev of ALL_EVENTS) {
+        out[ev] = reg.for_event(ev).length;
+    }
+    return out;
+}
+
+/** Python: per-event callback counts for the registry built from `args`. */
+function pyCounts(noHooks: boolean, hooksConfig: string | null): Record<string, number> {
+    const code = [
+        'import sys, json, argparse',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine.hook_bootstrap import _build_hook_registry',
+        'from work_engine.hooks import HookEvent',
+        'cfg = json.loads(sys.argv[2])',
+        'import pathlib',
+        'ns = argparse.Namespace(no_hooks=json.loads(sys.argv[1]), hooks_config=(pathlib.Path(cfg) if cfg else None))',
+        'reg = _build_hook_registry(ns)',
+        'out = {ev.value: len(reg.for_event(ev)) for ev in HookEvent}',
+        'sys.stdout.write(json.dumps(out, sort_keys=True))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, JSON.stringify(noHooks), JSON.stringify(hooksConfig)], {
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return JSON.parse(r.stdout) as Record<string, number>;
+}
+
+function sortObj(o: Record<string, number>): Record<string, number> {
+    const s: Record<string, number> = {};
+    for (const k of Object.keys(o).sort()) s[k] = o[k] as number;
+    return s;
+}
+
+describe('_build_hook_registry — local', () => {
+    it('--no-hooks yields an empty registry', () => {
+        const counts = tsCounts(baseArgs({ no_hooks: true }));
+        expect(Object.values(counts).every((n) => n === 0)).toBe(true);
+    });
+
+    it('missing settings file yields an empty registry', () => {
+        const counts = tsCounts(baseArgs({ hooks_config: path.join(tmp, 'absent.yml') }));
+        expect(Object.values(counts).every((n) => n === 0)).toBe(true);
+    });
+});
+
+describeParity('_build_hook_registry — per-event count parity', () => {
+    it('--no-hooks', () => {
+        expect(sortObj(tsCounts(baseArgs({ no_hooks: true })))).toEqual(pyCounts(true, null));
+    });
+
+    it('absent settings → empty', () => {
+        const cfg = path.join(tmp, 'absent.yml');
+        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
+    });
+
+    it('hooks.enabled: false → empty', () => {
+        const cfg = path.join(tmp, 'off.yml');
+        fs.writeFileSync(cfg, 'hooks:\n  enabled: false\n', 'utf-8');
+        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
+    });
+
+    it('hooks.enabled: true → per-hook defaults', () => {
+        const cfg = path.join(tmp, 'on.yml');
+        fs.writeFileSync(cfg, 'hooks:\n  enabled: true\n', 'utf-8');
+        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
+    });
+
+    it('hooks.enabled + chat_history enabled', () => {
+        const cfg = path.join(tmp, 'chat.yml');
+        fs.writeFileSync(
+            cfg,
+            'hooks:\n  enabled: true\n  chat_history:\n    enabled: true\n    script: scripts/chat_history.py\n',
+            'utf-8',
+        );
+        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
+    });
+
+    it('hooks.enabled + trace only (others off)', () => {
+        const cfg = path.join(tmp, 'trace.yml');
+        fs.writeFileSync(
+            cfg,
+            'hooks:\n  enabled: true\n  trace: true\n  halt_surface_audit: false\n  state_shape_validation: false\n  directive_set_guard: false\n  memory_visibility:\n    enabled: false\n',
+            'utf-8',
+        );
+        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
+    });
+});

--- a/tests/scripts/work_engine/input_builders.test.ts
+++ b/tests/scripts/work_engine/input_builders.test.ts
@@ -1,0 +1,180 @@
+// Golden-parity tests for work_engine/input_builders.ts vs input_builders.py
+// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer).
+//
+// `input_builders.py` reaches across the package (cli_args, errors, intent,
+// resolvers, state, state_io), so the parity rig runs it through the real
+// `work_engine` package on sys.path. Each builder is driven from a temp input
+// file on both engines; the resulting WorkState is serialised via
+// `state.to_dict` and compared byte-for-byte (canonical json.dumps). The
+// `_load_or_build` dispatch paths (existing state file → _load, mutual
+// exclusion, no-input, ticket non-object) are exercised for behaviour parity.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { ParsedArgs } from '../../../src/agent-src/templates/scripts/work_engine/cli_args.js';
+import { _CLIError } from '../../../src/agent-src/templates/scripts/work_engine/errors.js';
+import {
+    _build_from_diff_file,
+    _build_from_file_file,
+    _build_from_prompt_file,
+    _load_or_build,
+} from '../../../src/agent-src/templates/scripts/work_engine/input_builders.js';
+import { dump, to_dict, type WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ib-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+function baseArgs(over: Partial<ParsedArgs> = {}): ParsedArgs {
+    return {
+        state_file: path.join(tmp, '.work-state.json'),
+        ticket_file: null,
+        prompt_file: null,
+        diff_file: null,
+        file_file: null,
+        persona: null,
+        no_hooks: false,
+        hooks_config: null,
+        ...over,
+    };
+}
+
+/** Canonical v1 JSON of the WorkState a TS builder produces. */
+function tsCanonical(work: WorkState): string {
+    return JSON.stringify(to_dict(work), null, 2);
+}
+
+/**
+ * Run a builder on python3 from the same input file, returning the canonical
+ * v1 JSON of the resulting WorkState (state.to_dict). `argName` is the flag
+ * (ticket_file / prompt_file / diff_file / file_file) and `builder` the
+ * function name in input_builders.
+ */
+function pyBuild(builder: string, argName: string, inputPath: string, persona: string | null): string {
+    const code = [
+        'import sys, json, argparse, pathlib',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine import input_builders as ib',
+        'from work_engine import state as st',
+        'ns = argparse.Namespace(state_file=None, ticket_file=None, prompt_file=None, diff_file=None, file_file=None, persona=None, no_hooks=False, hooks_config=None)',
+        `setattr(ns, ${JSON.stringify(argName)}, pathlib.Path(sys.argv[1]))`,
+        'ns.persona = json.loads(sys.argv[2])',
+        `work = getattr(ib, ${JSON.stringify(builder)})(ns)`,
+        'sys.stdout.write(json.dumps(st.to_dict(work), indent=2, ensure_ascii=False))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, inputPath, JSON.stringify(persona)], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+describeParity('builders — byte parity vs python3', () => {
+    it('ticket file → v0 WorkState (via _load_or_build)', () => {
+        const tf = path.join(tmp, 'ticket.json');
+        fs.writeFileSync(tf, JSON.stringify({ id: 'T-1', title: 'Add CSV export' }), 'utf-8');
+        const [work] = _load_or_build(baseArgs().state_file, baseArgs({ ticket_file: tf }));
+
+        // Python via _load_or_build too (state file absent).
+        const code = [
+            'import sys, json, argparse, pathlib',
+            `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+            'from work_engine import input_builders as ib',
+            'from work_engine import state as st',
+            'ns = argparse.Namespace(state_file=pathlib.Path(sys.argv[2]), ticket_file=pathlib.Path(sys.argv[1]), prompt_file=None, diff_file=None, file_file=None, persona=None, no_hooks=False, hooks_config=None)',
+            'work, fmt = ib._load_or_build(pathlib.Path(sys.argv[2]), ns)',
+            'sys.stdout.write(json.dumps({"fmt": fmt, "state": st.to_dict(work)}, indent=2, ensure_ascii=False))',
+        ].join('\n');
+        const r = spawnSync('python3', ['-c', code, tf, path.join(tmp, 'absent-state.json')], { encoding: 'utf8' });
+        expect(r.status).toBe(0);
+        const pyOut = JSON.parse(r.stdout) as { fmt: string; state: unknown };
+        expect(pyOut.fmt).toBe('v0');
+        expect(tsCanonical(work)).toBe(JSON.stringify(pyOut.state, null, 2));
+    });
+
+    it('prompt file → prompt envelope', () => {
+        const pf = path.join(tmp, 'prompt.txt');
+        fs.writeFileSync(pf, 'Build a settings page with a dark-mode toggle', 'utf-8');
+        const work = _build_from_prompt_file(baseArgs({ prompt_file: pf }));
+        expect(tsCanonical(work)).toBe(pyBuild('_build_from_prompt_file', 'prompt_file', pf, null));
+    });
+
+    it('diff file → diff envelope', () => {
+        const df = path.join(tmp, 'change.diff');
+        fs.writeFileSync(df, '--- a/x.tsx\n+++ b/x.tsx\n@@ -1 +1 @@\n-old\n+new\n', 'utf-8');
+        const work = _build_from_diff_file(baseArgs({ diff_file: df }));
+        expect(tsCanonical(work)).toBe(pyBuild('_build_from_diff_file', 'diff_file', df, null));
+    });
+
+    it('file file → file envelope (first line only)', () => {
+        const ff = path.join(tmp, 'ref.txt');
+        fs.writeFileSync(ff, 'src/components/Button.tsx\nignored second line\n', 'utf-8');
+        const work = _build_from_file_file(baseArgs({ file_file: ff }));
+        expect(tsCanonical(work)).toBe(pyBuild('_build_from_file_file', 'file_file', ff, null));
+    });
+
+    it('persona override flows into the WorkState', () => {
+        const pf = path.join(tmp, 'p2.txt');
+        fs.writeFileSync(pf, 'A prompt', 'utf-8');
+        const work = _build_from_prompt_file(baseArgs({ prompt_file: pf, persona: 'qa' }));
+        expect(work.persona).toBe('qa');
+        expect(tsCanonical(work)).toBe(pyBuild('_build_from_prompt_file', 'prompt_file', pf, 'qa'));
+    });
+});
+
+describe('_load_or_build — dispatch behaviour', () => {
+    it('loads an existing state file (format-preserving)', () => {
+        // Build a v0 ticket state first, then re-load it.
+        const tf = path.join(tmp, 't.json');
+        fs.writeFileSync(tf, JSON.stringify({ id: 'T', title: 'x' }), 'utf-8');
+        const sf = path.join(tmp, '.work-state.json');
+        const [built, fmt] = _load_or_build(sf, baseArgs({ state_file: sf, ticket_file: tf }));
+        expect(fmt).toBe('v0');
+        dump(built, sf);
+        const [loaded, fmt2] = _load_or_build(sf, baseArgs({ state_file: sf }));
+        // Round-trip: a v0 file persisted via dump becomes v1 (dump always
+        // writes the v1 envelope); _load re-reads it as v1.
+        expect(fmt2).toBe('v1');
+        expect(loaded.input.kind).toBe('ticket');
+    });
+
+    it('rejects two input flags as mutually exclusive', () => {
+        const a = path.join(tmp, 'a.json');
+        const b = path.join(tmp, 'b.txt');
+        fs.writeFileSync(a, '{}', 'utf-8');
+        fs.writeFileSync(b, 'p', 'utf-8');
+        expect(() =>
+            _load_or_build(path.join(tmp, 'none.json'), baseArgs({ ticket_file: a, prompt_file: b })),
+        ).toThrow(_CLIError);
+    });
+
+    it('rejects no input when no state file exists', () => {
+        expect(() => _load_or_build(path.join(tmp, 'none.json'), baseArgs())).toThrow(_CLIError);
+    });
+
+    it('rejects a non-object ticket file', () => {
+        const tf = path.join(tmp, 'arr.json');
+        fs.writeFileSync(tf, '[1, 2, 3]', 'utf-8');
+        expect(() =>
+            _load_or_build(path.join(tmp, 'none.json'), baseArgs({ ticket_file: tf })),
+        ).toThrow(_CLIError);
+    });
+});

--- a/tests/scripts/work_engine/migration_v0_to_v1.test.ts
+++ b/tests/scripts/work_engine/migration_v0_to_v1.test.ts
@@ -1,0 +1,246 @@
+// Golden-parity tests for work_engine/migration/v0_to_v1.ts vs v0_to_v1.py
+// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer).
+//
+// `v0_to_v1.py` imports `..state` (SchemaError + the engine defaults), so the
+// direct-file importlib loader is not enough — we add
+// `src/agent-src/templates/scripts` to `sys.path` and
+// `import work_engine.migration.v0_to_v1` as a real package member (the
+// package `__init__`s pull in still-Python siblings, all present until the
+// Phase-12 sweep). The TS twin runs in-process; the Python original via a
+// python3 subprocess.
+//
+// Coverage: migrate_payload (v0 wrap, v1 idempotent deep-copy, every
+// SchemaError path), migrate_file round-trip (default destination, --no-backup,
+// backup rotation, refuse-overwrite, missing source, invalid JSON), and the
+// CLI main() success + error exit codes. Non-determinism: temp dirs are created
+// per-test and removed; on-disk bytes are compared byte-for-byte.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    BACKUP_SUFFIX,
+    DEFAULT_V0_FILENAME,
+    DEFAULT_V1_FILENAME,
+    main,
+    migrate_file,
+    migrate_payload,
+} from '../../../src/agent-src/templates/scripts/work_engine/migration/v0_to_v1.js';
+import { SchemaError } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
+
+function hasPython3(): boolean {
+    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+/** Run `migrate_payload` on python3; emit canonical JSON or `ERR:<msg>`. */
+function pyMigratePayload(payloadJson: string): string {
+    const code = [
+        'import sys, json',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine.migration.v0_to_v1 import migrate_payload',
+        'from work_engine.state import SchemaError',
+        'payload = json.loads(sys.argv[1])',
+        'try:',
+        '    out = migrate_payload(payload)',
+        '    sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
+        'except SchemaError as exc:',
+        '    sys.stdout.write("ERR:" + str(exc))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, payloadJson], { encoding: 'utf8' });
+    if (r.status !== 0) {
+        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
+    }
+    return r.stdout;
+}
+
+/** TS `migrate_payload`; emit canonical JSON or `ERR:<msg>`. */
+function tsMigratePayload(payloadJson: string): string {
+    try {
+        const out = migrate_payload(JSON.parse(payloadJson));
+        return JSON.stringify(out, null, 2);
+    } catch (exc) {
+        if (exc instanceof SchemaError) {
+            return 'ERR:' + exc.message;
+        }
+        throw exc;
+    }
+}
+
+/**
+ * Run the migration CLI on python3 in `cwd`. Emits
+ * `<exit>\n<stdout>\n--STDERR--\n<stderr>`.
+ */
+function pyCli(cwd: string, argv: string[]): { status: number; stdout: string; stderr: string } {
+    const code = [
+        'import sys',
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
+        'from work_engine.migration.v0_to_v1 import main',
+        'sys.exit(main(sys.argv[1:]))',
+    ].join('\n');
+    const r = spawnSync('python3', ['-c', code, ...argv], { encoding: 'utf8', cwd });
+    return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
+}
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'v0to1-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const py = hasPython3();
+const describeParity = py ? describe : describe.skip;
+
+describe('migrate_payload — constants', () => {
+    it('exposes the canonical filenames + suffix', () => {
+        expect(DEFAULT_V0_FILENAME).toBe('.implement-ticket-state.json');
+        expect(DEFAULT_V1_FILENAME).toBe('.work-state.json');
+        expect(BACKUP_SUFFIX).toBe('.bak');
+    });
+});
+
+const PAYLOAD_FIXTURES: Array<[string, string]> = [
+    ['minimal v0', JSON.stringify({ ticket: { id: 'T-1', title: 'Do thing' } })],
+    [
+        'full v0',
+        JSON.stringify({
+            ticket: { id: 'T-9', title: 'Big' },
+            persona: 'qa',
+            memory: [{ a: 1 }],
+            plan: 'the plan',
+            changes: [{ file: 'x.ts' }],
+            tests: 'ran',
+            verify: 'ok',
+            outcomes: { refine: 'success' },
+            questions: ['q1'],
+            report: 'done',
+        }),
+    ],
+    ['v1 idempotent', JSON.stringify({ version: 1, input: { kind: 'ticket', data: { id: 'T' } }, intent: 'backend-coding', directive_set: 'backend', persona: 'senior-engineer', memory: [], plan: null, changes: [], tests: null, verify: null, outcomes: {}, questions: [], report: '' })],
+    ['non-dict payload', JSON.stringify([1, 2, 3])],
+    ['higher version', JSON.stringify({ version: 99, ticket: {} })],
+    ['missing ticket', JSON.stringify({ persona: 'qa', plan: 'x' })],
+    ['non-dict ticket', JSON.stringify({ ticket: [1, 2] })],
+    ['unicode preserved', JSON.stringify({ ticket: { title: 'café ☕ é' } })],
+];
+
+describeParity('migrate_payload — golden parity', () => {
+    for (const [name, fixture] of PAYLOAD_FIXTURES) {
+        it(`${name} matches python3`, () => {
+            expect(tsMigratePayload(fixture)).toBe(pyMigratePayload(fixture));
+        });
+    }
+});
+
+describe('migrate_file — round-trip', () => {
+    it('writes v1 next to the source and backs up the v0 file', () => {
+        const src = path.join(tmp, DEFAULT_V0_FILENAME);
+        fs.writeFileSync(src, JSON.stringify({ ticket: { id: 'T-1', title: 'Do' } }), 'utf-8');
+        const target = migrate_file(src);
+        expect(target).toBe(path.join(tmp, DEFAULT_V1_FILENAME));
+        expect(fs.existsSync(target)).toBe(true);
+        expect(fs.existsSync(src)).toBe(false);
+        expect(fs.existsSync(src + BACKUP_SUFFIX)).toBe(true);
+        // Trailing newline contract.
+        expect(fs.readFileSync(target, 'utf-8').endsWith('\n')).toBe(true);
+    });
+
+    it('--no-backup leaves the source in place', () => {
+        const src = path.join(tmp, DEFAULT_V0_FILENAME);
+        fs.writeFileSync(src, JSON.stringify({ ticket: { id: 'T-2' } }), 'utf-8');
+        migrate_file(src, { backup: false });
+        expect(fs.existsSync(src)).toBe(true);
+    });
+
+    it('rotates the backup when .bak is taken', () => {
+        const src = path.join(tmp, DEFAULT_V0_FILENAME);
+        fs.writeFileSync(src, JSON.stringify({ ticket: { id: 'T-3' } }), 'utf-8');
+        fs.writeFileSync(src + BACKUP_SUFFIX, 'old', 'utf-8');
+        migrate_file(src);
+        expect(fs.existsSync(src + BACKUP_SUFFIX + '.1')).toBe(true);
+    });
+
+    it('refuses to overwrite an existing destination', () => {
+        const src = path.join(tmp, DEFAULT_V0_FILENAME);
+        const dst = path.join(tmp, DEFAULT_V1_FILENAME);
+        fs.writeFileSync(src, JSON.stringify({ ticket: { id: 'T-4' } }), 'utf-8');
+        fs.writeFileSync(dst, '{}', 'utf-8');
+        expect(() => migrate_file(src)).toThrow(SchemaError);
+    });
+
+    it('raises on a missing source', () => {
+        expect(() => migrate_file(path.join(tmp, 'nope.json'))).toThrow(SchemaError);
+    });
+
+    it('raises on invalid JSON', () => {
+        const src = path.join(tmp, DEFAULT_V0_FILENAME);
+        fs.writeFileSync(src, 'not json', 'utf-8');
+        expect(() => migrate_file(src)).toThrow(SchemaError);
+    });
+});
+
+describeParity('migrate_file — on-disk byte parity vs python3', () => {
+    it('produces byte-identical v1 output on both engines', () => {
+        const fixture = JSON.stringify({
+            ticket: { id: 'T-7', title: 'Parity' },
+            persona: 'qa',
+            outcomes: { refine: 'success' },
+        });
+
+        // TS engine.
+        const tsSrc = path.join(tmp, 'ts', DEFAULT_V0_FILENAME);
+        fs.mkdirSync(path.dirname(tsSrc), { recursive: true });
+        fs.writeFileSync(tsSrc, fixture, 'utf-8');
+        const tsTarget = migrate_file(tsSrc);
+        const tsBytes = fs.readFileSync(tsTarget, 'utf-8');
+
+        // Python engine, separate dir.
+        const pyDir = path.join(tmp, 'py');
+        fs.mkdirSync(pyDir, { recursive: true });
+        fs.writeFileSync(path.join(pyDir, DEFAULT_V0_FILENAME), fixture, 'utf-8');
+        const r = pyCli(pyDir, [DEFAULT_V0_FILENAME]);
+        expect(r.status).toBe(0);
+        const pyBytes = fs.readFileSync(path.join(pyDir, DEFAULT_V1_FILENAME), 'utf-8');
+
+        expect(tsBytes).toBe(pyBytes);
+    });
+});
+
+describeParity('main — CLI exit codes', () => {
+    it('exits 0 and prints the migration line on success', () => {
+        const pyDir = path.join(tmp, 'pyok');
+        fs.mkdirSync(pyDir, { recursive: true });
+        fs.writeFileSync(path.join(pyDir, DEFAULT_V0_FILENAME), JSON.stringify({ ticket: { id: 'X' } }), 'utf-8');
+        const r = pyCli(pyDir, [DEFAULT_V0_FILENAME]);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain('migrated');
+
+        // TS main() in the same shape.
+        const tsDir = path.join(tmp, 'tsok');
+        fs.mkdirSync(tsDir, { recursive: true });
+        const tsSrc = path.join(tsDir, DEFAULT_V0_FILENAME);
+        fs.writeFileSync(tsSrc, JSON.stringify({ ticket: { id: 'X' } }), 'utf-8');
+        const rc = main([tsSrc]);
+        expect(rc).toBe(0);
+    });
+
+    it('exits 2 on a missing source', () => {
+        const pyDir = path.join(tmp, 'pyerr');
+        fs.mkdirSync(pyDir, { recursive: true });
+        const r = pyCli(pyDir, ['nonexistent.json']);
+        expect(r.status).toBe(2);
+        expect(r.stderr).toContain('error:');
+
+        const rc = main([path.join(tmp, 'also-missing.json')]);
+        expect(rc).toBe(2);
+    });
+});


### PR DESCRIPTION
## What

Final work_engine wave of the Python→TypeScript migration (ADR-096): the **integration layer** that wires every already-ported work_engine module into the runnable dispatcher + CLI. 12 twins.

| Module | Role |
|---|---|
| `migration/v0_to_v1` | state v0→v1 payload + file migration |
| `directives/{,backend,ui,ui_trivial,mixed}/index.ts` | directive-set wiring (`get_steps`/`all_ambiguities`/`DIRECTIVE_SET_NAME`) — `__init__.py` → `index.ts` per the hooks convention |
| `emitters` | directive-payload + halt emission |
| `dispatcher` | advances delivery state through each directive set's phases |
| `input_builders` | builds the work-engine `Input` from diff/file/prompt |
| `hook_bootstrap` | registers builtin hooks |
| `cli` / `__main__` | work-engine CLI entrypoint |

## Parity

- 12 golden-parity test files (91 tests); **full work_engine suite 888 green** (68 files, zero regressions).
- `dispatcher` resolves directive sets via a **static module registry** (a `.ts` can't `import_module` a `.py`) + named Python-exception twins so `cli` catches `ValueError`/`NotImplementedError` faithfully; `emitters` reproduce CPython aware-UTC `isoformat`.
- `tsc` clean; ADR-051 ts==py across all 12; dist mirror regenerated.

## Milestone

This completes the **work_engine** subtree (foundation → L1 → L2 → integration). A `.ts` never imports a `.py`; all `.py` retained for the Phase-12 sweep.

## Remaining after this

Phase-11 `_cli/` (~33) + `cli/python/workspace_*` (~14) + `install`/`release`; the 5 new main tooling scripts (bench-v2 cluster, `lint_workspace_boundary`, `archive_completed_roadmaps`); then Phase-12 teardown. Base: `python2ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)