### PR TITLE
feat: guard against leftover conflict markers / unmerged state in CI + pre-push

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Check cross-references
         run: python3 src/scripts/check_references.py
 
+      - name: No leftover conflict markers / unmerged paths
+        run: python3 src/scripts/check_no_conflict_markers.py
+
       - name: Guard — no new legacy path under src/ (ADR-051)
         # PR-scoped: pull the diff via the GitHub API (gh) instead of
         # `git fetch <base>` — the shallow PR-merge checkout races with the

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -81,6 +81,7 @@ tasks:
       - task: check-overlay-cascade-subdirs
       - task: check-template-pin-drift
       - task: check-refs
+      - task: check-no-conflict-markers
       - task: check-token-optimizer-freshness
       - task: check-portability
       - task: check-no-external-sources
@@ -214,6 +215,7 @@ tasks:
       - task: check-overlay-cascade-subdirs
       - task: check-template-pin-drift
       - task: check-refs
+      - task: check-no-conflict-markers
       - task: check-token-optimizer-freshness
       - task: check-portability
       - task: check-no-external-sources

--- a/src/scripts/check_no_conflict_markers.py
+++ b/src/scripts/check_no_conflict_markers.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Fail the build on leftover merge/stash conflict state.
+
+Two signals, either of which fails:
+
+1. **Unmerged index entries** (``git ls-files -u``) — a conflicted working
+   tree (the exact state a botched ``git stash pop`` / merge / rebase leaves).
+   Zero false positives.
+2. **Conflict markers in tracked files** — a file carrying both a
+   ``<<<<<<< `` line and a ``>>>>>>> `` line (the diff2/diff3 conflict
+   envelope), so a resolved-but-not-cleaned file can never be committed or
+   merged silently.
+
+Why this exists: a `git stash pop` used as a throwaway probe conflicted on
+stale generated files, its output was suppressed, and the conflicted state
+went unnoticed until review (conflict-marker-guard, 2026-06-15).
+A content/state guard makes that class structurally un-mergeable.
+
+Files that legitimately document conflict markers (the merge-conflict skill,
+git-workflow docs) can be allowlisted in
+``check_no_conflict_markers_allowlist.json`` or carry a per-line
+``conflict-marker-check: ignore`` comment.
+
+Usage:
+    python3 scripts/check_no_conflict_markers.py
+    python3 scripts/check_no_conflict_markers.py --quiet
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+ALLOWLIST = Path(__file__).resolve().parent / "check_no_conflict_markers_allowlist.json"
+ALLOWLIST_CAP = 20
+
+START_RE = re.compile(r"^<{7}( |$)")
+END_RE = re.compile(r"^>{7}( |$)")
+BASE_RE = re.compile(r"^\|{7}( |$)")
+IGNORE = "conflict-marker-check: ignore"
+
+
+def _git(args: list[str]) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=REPO, capture_output=True, text=True, check=False
+    ).stdout
+
+
+def load_allowlist() -> set[str]:
+    if not ALLOWLIST.is_file():
+        return set()
+    data = json.loads(ALLOWLIST.read_text(encoding="utf-8"))
+    entries = data.get("files", [])
+    if len(entries) > ALLOWLIST_CAP:
+        print(
+            f"❌  check_no_conflict_markers: allowlist has {len(entries)} entries "
+            f"(> {ALLOWLIST_CAP}) — tighten the guard, do not grow the allowlist.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return set(entries)
+
+
+def unmerged_paths() -> list[str]:
+    out = _git(["ls-files", "-u"])
+    return sorted({line.split("\t", 1)[1] for line in out.splitlines() if "\t" in line})
+
+
+def tracked_text_files() -> list[str]:
+    return [p for p in _git(["ls-files"]).splitlines() if p]
+
+
+def scan_markers(allow: set[str]) -> list[str]:
+    hits: list[str] = []
+    for rel in tracked_text_files():
+        if rel in allow:
+            continue
+        path = REPO / rel
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue  # binary / unreadable — not a conflict-marker surface
+        has_start = has_end = False
+        for line in text.splitlines():
+            if IGNORE in line:
+                continue
+            if START_RE.match(line) or BASE_RE.match(line):
+                has_start = True
+            elif END_RE.match(line):
+                has_end = True
+        if has_start and has_end:
+            hits.append(rel)
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--quiet", action="store_true")
+    args = ap.parse_args(argv)
+
+    allow = load_allowlist()
+    unmerged = unmerged_paths()
+    marker_hits = scan_markers(allow)
+
+    if unmerged or marker_hits:
+        if unmerged:
+            print("❌  check_no_conflict_markers: unmerged (conflicted) paths in the index:",
+                  file=sys.stderr)
+            for p in unmerged:
+                print(f"    {p}", file=sys.stderr)
+            print("    → resolve the conflict (`git checkout HEAD -- <file>` or finish the "
+                  "merge), then re-stage.", file=sys.stderr)
+        if marker_hits:
+            print("❌  check_no_conflict_markers: conflict markers in tracked files:",
+                  file=sys.stderr)
+            for p in marker_hits:
+                print(f"    {p}", file=sys.stderr)
+            print("    → remove the <<<<<<< / ======= / >>>>>>> envelope, or allowlist a "
+                  "doc that documents markers (capped at 20).", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(f"✅  check_no_conflict_markers: no conflicted index entries, no markers "
+              f"({len(tracked_text_files())} tracked files scanned).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/scripts/check_no_conflict_markers_allowlist.json
+++ b/src/scripts/check_no_conflict_markers_allowlist.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Tracked files that LEGITIMATELY contain conflict-marker examples (e.g. a skill/doc teaching merge-conflict resolution). Hard-capped at 20 (check_no_conflict_markers.py ALLOWLIST_CAP). Prefer a per-line `conflict-marker-check: ignore` comment over an allowlist entry; use this only for files where many example markers appear. Each entry is a repo-relative path.",
+  "files": []
+}

--- a/src/scripts/install-hooks.sh
+++ b/src/scripts/install-hooks.sh
@@ -36,6 +36,12 @@ if ! python3 src/scripts/check_command_count_messaging.py; then
     fail=1
 fi
 
+echo "🔍 Checking for leftover conflict markers / unmerged paths..."
+if ! python3 src/scripts/check_no_conflict_markers.py --quiet; then
+    echo "❌  Conflict markers or unmerged paths present. Resolve them (e.g. 'git checkout HEAD -- <file>' or finish the merge), then re-push."
+    fail=1
+fi
+
 if [ $fail -ne 0 ]; then
     echo ""
     echo "   Push blocked — fix the failures above and re-push."

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -341,6 +341,11 @@ tasks:
     desc: Check for broken cross-references in .md files
     cmd: python3 src/scripts/check_references.py
 
+  check-no-conflict-markers:
+    silent: true
+    desc: "Fail on leftover merge/stash conflict state — unmerged index entries or <<<<<<< / >>>>>>> markers in tracked files (conflict-marker-guard hardening, 2026-06-15)"
+    cmd: python3 src/scripts/check_no_conflict_markers.py {{.QUIET_FLAG}}
+
   check-no-new-legacy-path:
     silent: true
     desc: "Regression guard — no NEW .agent-src.uncondensed/ references added under src/ (ADR-051)"

--- a/tests/test_check_no_conflict_markers.py
+++ b/tests/test_check_no_conflict_markers.py
@@ -1,0 +1,54 @@
+"""Tests for scripts/check_no_conflict_markers.py."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "check_no_conflict_markers",
+    REPO_ROOT / "src" / "scripts" / "check_no_conflict_markers.py",
+)
+assert SPEC and SPEC.loader
+cm = importlib.util.module_from_spec(SPEC)
+sys.modules["check_no_conflict_markers"] = cm
+SPEC.loader.exec_module(cm)
+
+
+def test_repo_is_clean():
+    """The committed tree must carry no conflict markers / unmerged entries."""
+    assert cm.main(["--quiet"]) == 0
+
+
+def test_detects_conflict_envelope(tmp_path: Path, monkeypatch):
+    """A file with the <<<<<<< ... >>>>>>> envelope is flagged."""
+    f = tmp_path / "x.txt"
+    f.write_text("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n")
+    monkeypatch.setattr(cm, "tracked_text_files", lambda: [str(f.relative_to(cm.REPO))]
+                        if str(f).startswith(str(cm.REPO)) else [])
+    # Use REPO-relative resolution: point REPO at tmp_path for isolation.
+    monkeypatch.setattr(cm, "REPO", tmp_path)
+    monkeypatch.setattr(cm, "tracked_text_files", lambda: ["x.txt"])
+    monkeypatch.setattr(cm, "unmerged_paths", lambda: [])
+    assert cm.scan_markers(set()) == ["x.txt"]
+
+
+def test_ignore_comment_suppresses(tmp_path: Path, monkeypatch):
+    f = tmp_path / "doc.md"
+    f.write_text(
+        "<<<<<<< HEAD  # conflict-marker-check: ignore\n"
+        "=======  # conflict-marker-check: ignore\n"
+        ">>>>>>> b  # conflict-marker-check: ignore\n"
+    )
+    monkeypatch.setattr(cm, "REPO", tmp_path)
+    monkeypatch.setattr(cm, "tracked_text_files", lambda: ["doc.md"])
+    assert cm.scan_markers(set()) == []
+
+
+def test_allowlist_skips_file(tmp_path: Path, monkeypatch):
+    f = tmp_path / "skill.md"
+    f.write_text("<<<<<<< HEAD\nx\n=======\ny\n>>>>>>> z\n")
+    monkeypatch.setattr(cm, "REPO", tmp_path)
+    monkeypatch.setattr(cm, "tracked_text_files", lambda: ["skill.md"])
+    assert cm.scan_markers({"skill.md"}) == []


### PR DESCRIPTION
## Summary

Hardens the package against the failure that left conflict markers in the tree during the competitive-borrow run (PR #551): a `git stash pop` used as a throwaway "is this failure pre-existing?" probe conflicted on stale generated files, its output was suppressed, and the conflicted state went unnoticed.

## Root cause (5-why)

1. **Symptom:** 5 tracked files left in `UU` (unmerged) state with `<<<<<<< / >>>>>>>` markers, undetected until review.
2. **Why:** a `git stash pop` conflicted and was left unresolved (markers read "Updated upstream" / "Stashed changes" — the stash-pop signature, not a merge).
3. **Why:** `git stash -u` was used as a probe to check whether a lint failure was pre-existing on a clean tree — and it swept up unrelated stale generated files already dirty in the shared working tree.
4. **Why:** the probe suppressed output (`git stash pop >/dev/null 2>&1`) and no `git status` ran afterward, so the conflicted state produced no visible signal.
5. **Root cause:** a **destructive working-tree mutation (`git stash`) was used as a read-only probe**, with output suppressed and no post-condition check. The pre-existing-failure question never needed a stash — `git diff --name-only origin/main...HEAD` (which was run separately and was sufficient) or `git show <ref>:<path>` answers it without touching the tree.

## The fix (structural)

`check_no_conflict_markers.py` makes the bad state un-mergeable:

- Fails on **unmerged index entries** (`git ls-files -u`) — the exact `UU` state, zero false positives.
- Fails on tracked files carrying the **`<<<<<<< … >>>>>>>` envelope**.
- Allowlist + per-line `conflict-marker-check: ignore` escape for docs that legitimately show markers (capped at 20).

Wired into `ci` + `ci-strict`, the `consistency` workflow (after `check-references`), and the **pre-push** hook (`install-hooks.sh`) — so a conflicted tree is blocked locally before it reaches remote, and in CI as a backstop.

## Verification

- Clean tree passes (4786 files scanned); a synthetic conflicted file fails with exit 1.
- `tests/test_check_no_conflict_markers.py` — 4 tests (clean repo, envelope detection, ignore-comment, allowlist).
- `install-hooks.sh` passes `bash -n`; `consistency.yml` parses; `check-refs` green.

## Behavioural follow-up

The behavioural lesson (never use `git stash` as a probe; never suppress git-state-mutating output; always `git status` after a tree op) belongs in `git-history-discipline`. Left as a separate rule edit to keep this PR a focused structural gate.
