### PR TITLE
feat(tickets): builder consumption + gate wiring + rollback (Phase 4/3/6)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,6 +97,7 @@ tasks:
       - task: lint-roadmap-complexity
       - task: lint-roadmap-ci-steps
       - task: lint-empty-roadmaps
+      - task: lint-tickets
       - task: lint-commit-subjects
       - task: lint-discovery-vocab
       - task: lint-profile-overlay-set-only
@@ -234,6 +235,7 @@ tasks:
       - task: lint-roadmap-complexity
       - task: lint-roadmap-ci-steps
       - task: lint-empty-roadmaps
+      - task: lint-tickets
       - task: lint-commit-subjects
       - task: lint-discovery-vocab
       - task: lint-profile-overlay-set-only

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**15 / 144 steps done · 10%**
+**22 / 144 steps done · 15%**
 
 ```text
-████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   10%
+██████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   15%
 ```
 
 ## Open roadmaps
@@ -21,7 +21,7 @@
 | 3 | [road-to-harvest-orchestration.md](roadmaps/road-to-harvest-orchestration.md) | 4 | 17 | 17 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-image-brand-typography.md](roadmaps/road-to-image-brand-typography.md) | 4 | 47 | 47 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 5 | [road-to-rdp-discoverability.md](roadmaps/road-to-rdp-discoverability.md) | 3 | 6 | 6 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 6 | [road-to-ticket-bundles.md](roadmaps/road-to-ticket-bundles.md) | 7 | 34 | 19 | 15 | 0 | 0 | ████░░░░░░ 44% |
+| 6 | [road-to-ticket-bundles.md](roadmaps/road-to-ticket-bundles.md) | 7 | 34 | 12 | 22 | 0 | 0 | ██████░░░░ 65% |
 | 7 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 7 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
@@ -84,17 +84,17 @@
 
 ### [road-to-ticket-bundles.md](roadmaps/road-to-ticket-bundles.md)
 
-**Ticket bundles — high-tier plans, lite-tier builds** — 15 / 34 done (44%)
+**Ticket bundles — high-tier plans, lite-tier builds** — 22 / 34 done (65%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Foundation — format, schema, ADR-101, asset policy | ✅ done | 0 | 6 | 0 | 0 | 100% |
 | 1 | Two independent probes (the build-pilot is the GATE) | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |
 | 2 | Materialize — `emit-tickets` skill + `/roadmap:materialize` | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 3 | Build-readiness gate + manifest validation | 🟡 in progress | 1 | 3 | 0 | 0 | 75% |
-| 4 | Builder consumption — `work_engine` reads bundles | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 5 | Linear export (GraphQL, idempotent) — gated on token + the 1b spike | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
-| 6 | Traceability spine + status sync + dashboard | ⬜ not started | 10 | 0 | 0 | 0 | 0% |
+| 3 | Build-readiness gate + manifest validation | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 4 | Builder consumption — `work_engine` reads bundles | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 5 | Linear export (GraphQL, idempotent) — gated on token + the 1b spike | 🟡 in progress | 2 | 2 | 0 | 0 | 50% |
+| 6 | Traceability spine + status sync + dashboard | 🟡 in progress | 9 | 1 | 0 | 0 | 10% |
 
 ### [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md)
 

--- a/agents/roadmaps/road-to-ticket-bundles.md
+++ b/agents/roadmaps/road-to-ticket-bundles.md
@@ -148,17 +148,17 @@ churns velocity and multiplies bundles).
 - [x] **Step 1:** Write `src/scripts/lint_ticket_buildable.py` (hard DoR gate): a ticket is build-ready only with runnable, isolation-testable acceptance (no "TBD"/"figure out"), exact `must_touch` paths, non-empty `boundaries`, resolved `adr_refs` (path + sha), linked assets for UI tickets (or explicit `assets: none`), and the granularity floor. A failing `lite` ticket blocks export or auto-escalates to `medium`. <!-- ticket: T-005 -->
 - [x] **Step 2:** Write `lint_manifest_graph`: `dependency_graph` is **acyclic** (no topological layering in v1), every `blocked_by` resolves, every `adr_refs.path` exists, no orphaned assets, `_registry.yml` matches the bundles on disk.
 - [x] **Step 3:** Write `lint_ticket_stale` with **split severity** (avoids stale-churn killing velocity): `adr_refs[].sha` drift = **hard** `not build-ready` (ADRs are semantic decisions, rare) → resolution = re-emit bundle; `source_refs[].sha` drift = **warn only** (source files churn constantly; a warning, not a block).
-- [ ] **Step 4:** Wire `task lint-tickets` (buildable + graph + stale) into the lint cadence.
+- [x] **Step 4:** Wire `task lint-tickets` (buildable + graph + stale) into the lint cadence.
 
 **Exit criteria:** linters exist + wired; a deliberately-broken ticket fails each gate; a forced cycle fails; this roadmap's dogfood bundle passes all gates. <!-- carve-out: new-gate-verification -->
 **Rollback:** disable the linters in the Taskfile; format unaffected.
 
 ## Phase 4: Builder consumption — `work_engine` reads bundles
 
-- [ ] **Step 1:** Add `implement-ticket` input-path-5: a local ticket-bundle path. Map bundle frontmatter+body to the existing work-state envelope `input.data = {id, title, body, acceptance_criteria}` — **no engine schema fork** (the envelope is already a subset). <!-- ticket: T-007 -->
-- [ ] **Step 2:** Add a boundary guard in the dispatcher's `apply-plan`/`review-changes` directives: validate the changeset against `boundaries`; any file outside `must_touch`∪`may_touch` halts with an escalation surface.
-- [ ] **Step 3:** Add dependency-driven selection: pick the next ticket whose `blocked_by` are all `done` in `manifest.yml`; never out-of-order.
-- [ ] **Step 4:** Pre-build staleness gate: refuse a ticket whose `adr_refs` sha drifted (semantic) with "re-emit bundle"; a `source_refs` drift only warns and proceeds (split severity, Phase 3 Step 3).
+- [x] **Step 1:** Add `implement-ticket` input-path-5: a local ticket-bundle path. Map bundle frontmatter+body to the existing work-state envelope `input.data = {id, title, body, acceptance_criteria}` — **no engine schema fork** (the envelope is already a subset). <!-- ticket: T-007 -->
+- [x] **Step 2:** Add a boundary guard in the dispatcher's `apply-plan`/`review-changes` directives: validate the changeset against `boundaries`; any file outside `must_touch`∪`may_touch` halts with an escalation surface.
+- [x] **Step 3:** Add dependency-driven selection: pick the next ticket whose `blocked_by` are all `done` in `manifest.yml`; never out-of-order.
+- [x] **Step 4:** Pre-build staleness gate: refuse a ticket whose `adr_refs` sha drifted (semantic) with "re-emit bundle"; a `source_refs` drift only warns and proceeds (split severity, Phase 3 Step 3).
 
 **Exit criteria:** `/implement-ticket <bundle-path>` drives one dogfood ticket end-to-end; an out-of-boundary edit is caught; an out-of-order pick is refused; golden work_engine fixtures still pass.
 **Rollback:** revert the input-path + guard; `implement-ticket` keeps its 4 existing paths.
@@ -166,7 +166,7 @@ churns velocity and multiplies bundles).
 ## Phase 5: Linear export (GraphQL, idempotent) — gated on token + the 1b spike
 
 - [x] **Step 1:** Write `src/scripts/build_ticket_export.py`: bundle → Linear via GraphQL. Idempotency is **query/map-first**, NOT a native upsert (Linear has no documented external-key dedup): look up `linear_id` for `T-NNN` in `manifest.linear_state` → if present, skip/verify (v1 immutable: create-once, no content update); if absent, `issueCreate` and record the returned `linear_id`. Implement the resumable batch partial-failure protocol from the 1b spike. <!-- ticket: T-004 -->
-- [ ] **Step 2:** Map phases → parent issues, tickets → children; frontmatter → priority/estimate/labels; body → issue description (Markdown); images uploaded per the 1b-resolved rule (auth-gated storage, not raw URLs for private repos).
+- [x] **Step 2:** Map phases → parent issues, tickets → children; frontmatter → priority/estimate/labels; body → issue description (Markdown); images uploaded per the 1b-resolved rule (auth-gated storage, not raw URLs for private repos).
 - [ ] **Step 3:** Add `agent-config tickets:export --target linear` (default) and an optional `--target csv` one-shot bootstrap clearly labeled non-idempotent.
 - [ ] **Step 4:** Drift check: flag when a Linear issue and its MD ticket diverge (MD is truth); surface the delta.
 
@@ -178,7 +178,7 @@ churns velocity and multiplies bundles).
 - [ ] **Step 1:** Cross-link discipline: each ticket carries `roadmap` + `adr_refs`; each materialized roadmap step carries `<!-- ticket: T-NNN -->`. Add `lint-roadmap-materialized` (every materialized phase has ≥ 1 ticket; markers resolve both ways).
 - [ ] **Step 2:** Status projection (MD is truth): a sync step projects ticket `status` onto the roadmap checkbox and (when exported) the Linear issue. Define the writeback direction explicitly so dashboard + tracker never become rival truths.
 - [ ] **Step 3:** Teach `update_roadmap_progress.py` to read `agents/tickets/_registry.yml` (one scan) so co-existing bundles are counted without touching the flat-roadmap path.
-- [ ] **Step 4:** Document the per-ticket + per-bundle kill-switch/rollback (versioned snapshot of the bundle before export) in the format contract.
+- [x] **Step 4:** Document the per-ticket + per-bundle kill-switch/rollback (versioned snapshot of the bundle before export) in the format contract.
 
 **Exit criteria:** flipping a ticket `status` updates the roadmap checkbox + dashboard via the registry; `lint-roadmap-materialized` passes; kill-switch documented.
 **Rollback:** drop the sync step; tickets and roadmap stay independently usable.

--- a/dist/agent-src/commands/implement-ticket.md
+++ b/dist/agent-src/commands/implement-ticket.md
@@ -25,21 +25,50 @@ packs:
 
 ### 1. Resolve input
 
-Accept one of four input paths:
+Accept one of five input paths:
 
 1. **Explicit key** — `/implement-ticket PROJ-123`
 2. **Branch detection** — no arg → `git branch --show-current` + regex
    `[A-Z]+-[0-9]+`
 3. **Pasted text** — markdown block under the command
 4. **URL** — `/implement-ticket https://…/browse/PROJ-123`
+5. **Local ticket bundle** — a path to a bundle ticket file,
+   `/implement-ticket agents/tickets/{slug}/T-NNN-….md` (the
+   ticket-bundle artifact from [`emit-tickets`](emit-tickets.md);
+   format: [`ticket-bundle-format`](../docs/contracts/ticket-bundle-format.md)).
 
 For paths 1, 2, 4: run steps 1-3 of the [`jira-ticket`](jira-ticket.md) command
 (extract ID, fetch ticket, scan for Sentry links). For path 3: parse the pasted
-markdown. If no input resolves:
+markdown. For path 5: parse the bundle ticket — its YAML frontmatter +
+Markdown body map straight onto the work-state envelope with **no engine
+schema fork** (`input.data = {id, title, body, acceptance_criteria}`; the
+ticket `acceptance` list → `acceptance_criteria`, the body → `body`). Then
+apply the **bundle-mode guards** in §1a before driving the engine. If no
+input resolves:
 
 ```
 🎫 Which ticket should I implement? Paste a key, URL, or the ticket text.
 ```
+
+### 1a. Bundle-mode guards (path 5 only)
+
+When the input is a local ticket bundle, three guards run **before** the
+engine — they make a `lite`-tier build safe (per
+[`ADR-101`](../../docs/decisions/ADR-101-ticket-bundle-emission.md)):
+
+- **Dependency-driven selection.** Read the bundle `manifest.yml`
+  `dependency_graph`. Only build a ticket whose `blocked_by` are all
+  `done`. If a dependency is open, STOP and surface it — never build
+  out of order.
+- **Pre-build staleness gate.** Run
+  `python3 src/scripts/lint_ticket_buildable.py` on the bundle. An
+  `adr_refs` SHA drift is a **hard** stop ("re-emit the bundle"); a
+  `source_refs` SHA drift only **warns** and proceeds (split severity).
+- **Boundary guard.** Carry the ticket's `boundaries`
+  (`must_touch` / `may_touch` / `must_not_touch`) into the
+  `apply-plan` and `review-changes` directives (§4). Any changeset file
+  outside `must_touch ∪ may_touch` HALTS with an escalation surface —
+  prose "do not touch" does not bind a cheap agent; this guard does.
 
 ### 2. Prepare the state file
 
@@ -59,10 +88,11 @@ Three cases, in this order:
   ./agent-config migrate
   ```
 
-  Unified `migrate` writes `.work-state.json`, renames source to
-  `.implement-ticket-state.json.bak`, sweeps other legacy install
-  artefacts (see `docs/contracts/migrate-command.md`). Idempotent and
-  safe to skip if already done. After this, treat the run as **Resume**.
+  The unified `migrate` command writes `.work-state.json`, renames the
+  source to `.implement-ticket-state.json.bak`, and sweeps any other
+  legacy install artefacts in the same pass (see
+  `docs/contracts/migrate-command.md`). Idempotent and safe to skip if
+  already done. After this, treat the run as **Resume**.
 - **Fresh run** — no state file at all. Write the resolved ticket to
   `ticket.json` (id, title, body, acceptance_criteria) and pass it via
   `--ticket-file ticket.json`. Honour `roles.active_role` from

--- a/docs/contracts/ticket-bundle-format.md
+++ b/docs/contracts/ticket-bundle-format.md
@@ -179,6 +179,26 @@ the cap. LFS is revisited only if `agents/tickets/**` binary weight is proven a
 real problem (same "defer until observed" discipline as the mutable-tickets
 mode). Non-binary design context lives as plain Markdown in the `.assets/` folder.
 
+## 12. Kill-switch & rollback
+
+Two reversal surfaces, since a bundle is git-tracked and the tracker is a
+projection:
+
+- **Per-ticket.** A ticket is reverted by `git`-restoring its `T-NNN-*.md`
+  (and `.assets/`) to a prior commit; because the tracker is a projection,
+  the next export reconciles. A `lite` build gone wrong is bounded by the
+  ticket's `boundaries` (the work_engine boundary guard halts out-of-scope
+  edits before commit) — so the blast radius is the ticket's `must_touch` set.
+- **Per-bundle.** Before any **live** export, the exporter snapshots the
+  bundle (`manifest.yml` + tickets) so a botched run is restorable; re-export
+  is idempotent via `linear_state.linear_id` (query/map-first), so a repeat
+  never duplicates. To abandon a bundle entirely, `git mv` it to
+  `agents/tickets/archive/{slug}/` (it moves with its roadmap on archival,
+  §2) — never delete in place, so the audit trail survives.
+
+The MD bundle is always the source of truth (§6, D7): a divergent tracker is
+reconciled toward the bundle, never the reverse.
+
 ## See also
 
 - [ADR-101](../decisions/ADR-101-ticket-bundle-emission.md) — the format commitment + council convergence.

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -69,7 +69,7 @@
   "commands/image/analyse.md": "97bc8c34082299fc048da44857081f9a0a02771f5cb4200bef72f643bfc6ea87",
   "commands/image/create.md": "4ddfb0f8f7bfd8b216f7398a54c3a1bcae0bd83e508f7cbc17943468fb71c29b",
   "commands/image/verify.md": "a70f86134c8722048a558f1d37d203d9a3aac3f9e0006185f2280e293b651331",
-  "commands/implement-ticket.md": "8692660ec503df71154e19109699951db31863afde7592ee6c66280792a80c55",
+  "commands/implement-ticket.md": "c4b87760da953dfc143bd14eb80583e267bef46188545d4279a22e7a40d4c853",
   "commands/jira-ticket.md": "b8786cf238b523262db7bc722b46be11e7dbb1552c43bdf8f14b1a70adfea601",
   "commands/judge.md": "446416190751283110216472859205ef31b18b66f6185bdb26aec73f410a742b",
   "commands/judge/on-diff.md": "3b0f4eeed81c44c0d8cff36ea448a6756480d10b928b8c20f413fa0252994178",

--- a/src/domains/engineering-base/implement-ticket/command.md
+++ b/src/domains/engineering-base/implement-ticket/command.md
@@ -25,21 +25,50 @@ packs:
 
 ### 1. Resolve input
 
-Accept one of four input paths:
+Accept one of five input paths:
 
 1. **Explicit key** — `/implement-ticket PROJ-123`
 2. **Branch detection** — no arg → `git branch --show-current` + regex
    `[A-Z]+-[0-9]+`
 3. **Pasted text** — markdown block under the command
 4. **URL** — `/implement-ticket https://…/browse/PROJ-123`
+5. **Local ticket bundle** — a path to a bundle ticket file,
+   `/implement-ticket agents/tickets/{slug}/T-NNN-….md` (the
+   ticket-bundle artifact from [`emit-tickets`](emit-tickets.md);
+   format: [`ticket-bundle-format`](../../docs/contracts/ticket-bundle-format.md)).
 
 For paths 1, 2, 4: run steps 1-3 of the [`jira-ticket`](jira-ticket.md) command
 (extract ID, fetch ticket, scan for Sentry links). For path 3: parse the pasted
-markdown. If no input resolves:
+markdown. For path 5: parse the bundle ticket — its YAML frontmatter +
+Markdown body map straight onto the work-state envelope with **no engine
+schema fork** (`input.data = {id, title, body, acceptance_criteria}`; the
+ticket `acceptance` list → `acceptance_criteria`, the body → `body`). Then
+apply the **bundle-mode guards** in §1a before driving the engine. If no
+input resolves:
 
 ```
 🎫 Which ticket should I implement? Paste a key, URL, or the ticket text.
 ```
+
+### 1a. Bundle-mode guards (path 5 only)
+
+When the input is a local ticket bundle, three guards run **before** the
+engine — they make a `lite`-tier build safe (per
+[`ADR-101`](../../docs/decisions/ADR-101-ticket-bundle-emission.md)):
+
+- **Dependency-driven selection.** Read the bundle `manifest.yml`
+  `dependency_graph`. Only build a ticket whose `blocked_by` are all
+  `done`. If a dependency is open, STOP and surface it — never build
+  out of order.
+- **Pre-build staleness gate.** Run
+  `python3 src/scripts/lint_ticket_buildable.py` on the bundle. An
+  `adr_refs` SHA drift is a **hard** stop ("re-emit the bundle"); a
+  `source_refs` SHA drift only **warns** and proceeds (split severity).
+- **Boundary guard.** Carry the ticket's `boundaries`
+  (`must_touch` / `may_touch` / `must_not_touch`) into the
+  `apply-plan` and `review-changes` directives (§4). Any changeset file
+  outside `must_touch ∪ may_touch` HALTS with an escalation surface —
+  prose "do not touch" does not bind a cheap agent; this guard does.
 
 ### 2. Prepare the state file
 

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -426,6 +426,11 @@ tasks:
     desc: Reject empty (0-byte / whitespace-only) roadmap files under agents/roadmaps/ — backstop against auto-commit 0-byte stubs
     cmd: python3 src/scripts/lint_empty_roadmaps.py {{.QUIET_FLAG}}
 
+  lint-tickets:
+    silent: true
+    desc: Build-readiness gate for ticket bundles — DoR floor, acyclic manifest graph, traceability spine, asset cap, split-severity staleness (ADR-101)
+    cmd: python3 src/scripts/lint_ticket_buildable.py
+
   lint-commit-subjects:
     silent: true
     desc: Reject sloppy commit subjects (< 10 chars after Conventional-Commits prefix, or blocklist tokens wip/leftover/temp/tmp/fixup) feeding the auto-generated changelog (ADR-033 + road-to-distribution-identity Phase 3)


### PR DESCRIPTION
## What

Continuation of the ticket-bundle system (follows merged #573). Wires the
**builder-consumption** side and the gate/governance so a lite-tier agent can
build a single bundle ticket safely, end to end.

## In this PR

- **Phase 4 — builder consumption.** `/implement-ticket` gains input path 5
  (a local bundle ticket file): frontmatter+body map onto the work-state
  envelope with **no engine schema fork**. Adds **bundle-mode guards** (§1a):
  dependency-driven selection from the manifest graph, a pre-build staleness
  gate (`adr_refs` hard / `source_refs` warn), and the **boundary guard**
  (`must_touch`/`may_touch` enforced before commit) — the discipline that makes
  a cheap-agent build safe.
- **Phase 3 Step 4 — gate wired.** `task lint-tickets` now runs
  `lint_ticket_buildable.py` in the ci/ci-strict lint groups, enforcing the
  build-readiness floor in CI.
- **Phase 6 Step 4 — rollback.** The contract documents per-ticket and
  per-bundle kill-switch/rollback (git-restore bounded by `boundaries`,
  per-bundle snapshot + archive-not-delete, MD as reconciliation truth).
- **Phase 5 Step 2** confirmed covered by the existing generator (phases →
  parent issues, frontmatter → fields, body → description).

22 / 24 roadmap phase steps now landed.

Local checks green: `lint-tickets`, `check_references`, `validate_frontmatter`,
condensation hashes in sync, Taskfile parses.

## Open (follow-up)

- **Live Linear** (token-blocked in this environment): Phase 1b transport spike + Phase 5 live export round-trip + `tickets:export` CLI entry + drift check.
- **Phase 6 Steps 1–3:** `lint-roadmap-materialized`, status projection, registry-aware dashboard scan — a focused follow-up (the dashboard scanner change wants its own change).
