### PR TITLE
feat(audit): MCP tool-schema token accounting (context-load-budget)

### DIFF
--- a/agents/roadmaps/archive/road-to-mcp-token-accounting.md
+++ b/agents/roadmaps/archive/road-to-mcp-token-accounting.md
@@ -1,16 +1,15 @@
 ---
 complexity: lightweight
-status: draft
+status: ready
 parent_roadmap: harvest-small-enhancements
 ---
 
 # Roadmap: MCP tool-schema token accounting (context-load-budget)
 
-> **Status: draft (trigger-gated).** Spawned from
+> **Status: ready (trigger fired 2026-06-16).** Spawned from
 > `road-to-harvest-small-enhancements` Phase 3a so the parent stays clean
 > (council 2026-06-15: 3a is "a deferred item with no clear owner" — give it an
-> open target + a trigger instead of folding it). Hidden from the dashboard until
-> flipped to `ready`.
+> open target + a trigger instead of folding it).
 
 ## Trigger (flip to `ready` when this holds)
 
@@ -19,15 +18,26 @@ This work belongs *inside* that budget surface — it is the MCP slice of the sa
 "what is this context costing?" question — and must not be built before the budget
 mechanism it extends exists.
 
+**Trigger met (2026-06-16):** `road-to-capability-discoverability` is archived
+(complete) and its `context-load-budget` tool `src/scripts/audit_initial_context.py`
+exists — the MCP accounting folds into it as a new surface, not a new tool.
+
 ## Phase 1 — MCP tool-schema accounting (only when the trigger fires)
 
-- [ ] In `audit_initial_context.py` (the context-load-budget tool), price MCP
+- [x] In `audit_initial_context.py` (the context-load-budget tool), price MCP
       **tool schemas** ~per-tool (each connected MCP server's tool definitions add
       to the always-loaded budget) and **flag over-subscription** (many tools, few
       used). Fold into the existing `context-load-budget` accounting — NOT a new
       surface.
-- [ ] Surface the per-server token cost so a maintainer can decide which MCP
+      <!-- done 2026-06-16: mcp_tool_schemas() prices each tool's client-facing
+      triple (name + description + input_schema) from consumer_tool_catalog.json,
+      aggregated per server (keyed for multi-server generality), with a count-based
+      over_subscription heuristic + mcp_schemas.gpt advisory budget. -->
+- [x] Surface the per-server token cost so a maintainer can decide which MCP
       servers earn their context cost.
+      <!-- done 2026-06-16: render_md adds an "MCP — tool-schema cost per server"
+      table (tools/chars/GPT/Claude/over-subscribed?) + top-10 tools-by-cost +
+      an over-subscription advisory; JSON carries the full per-tool breakdown. -->
 
 ## Provenance
 

--- a/internal/bench/reports/projection-cost.json
+++ b/internal/bench/reports/projection-cost.json
@@ -1,111 +1,156 @@
 {
   "description_catalog": {
     "commands_core_source": {
-      "chars": 20912,
-      "entries": 149,
-      "tokens_claude": 5809,
+      "chars": 22358,
+      "entries": 155,
+      "tokens_claude": 6211,
       "tokens_claude_exact": false,
-      "tokens_gpt": 5228,
+      "tokens_gpt": 5590,
       "tokens_gpt_exact": false
     },
     "skills_core_source": {
-      "chars": 42133,
-      "entries": 214,
-      "tokens_claude": 11704,
+      "chars": 46680,
+      "entries": 238,
+      "tokens_claude": 12967,
       "tokens_claude_exact": false,
-      "tokens_gpt": 10533,
+      "tokens_gpt": 11670,
       "tokens_gpt_exact": false
     },
     "skills_projected": {
-      "chars": 62371,
-      "entries": 359,
-      "tokens_claude": 17325,
+      "chars": 0,
+      "entries": 0,
+      "tokens_claude": 0,
       "tokens_claude_exact": false,
-      "tokens_gpt": 15593,
+      "tokens_gpt": 0,
       "tokens_gpt_exact": false
     }
   },
-  "generated": "2026-06-05T03:13:10+00:00",
-  "longest_rules": [
-    {
-      "chars": 7771,
-      "id": "roadmap-progress-sync",
-      "tokens_gpt": 1943
-    },
-    {
-      "chars": 7556,
-      "id": "autonomous-execution",
-      "tokens_gpt": 1889
-    },
-    {
-      "chars": 7314,
-      "id": "domain-safety-disclaimer",
-      "tokens_gpt": 1828
-    },
-    {
-      "chars": 7184,
-      "id": "domain-adoption-policy",
-      "tokens_gpt": 1796
-    },
-    {
-      "chars": 6364,
-      "id": "roadmap-ci-steps-policy",
-      "tokens_gpt": 1591
-    },
-    {
-      "chars": 6278,
-      "id": "no-roadmap-references",
-      "tokens_gpt": 1570
-    },
-    {
-      "chars": 6255,
-      "id": "domain-safety-pii",
-      "tokens_gpt": 1564
-    },
-    {
-      "chars": 5779,
-      "id": "persona-governance",
-      "tokens_gpt": 1445
-    },
-    {
-      "chars": 5573,
-      "id": "framework-neutrality-in-generic-skills",
-      "tokens_gpt": 1393
-    },
-    {
-      "chars": 5565,
-      "id": "context-hygiene",
-      "tokens_gpt": 1391
-    }
-  ],
-  "rule_footprint": {
-    ".augment": {
-      "chars": 239131,
-      "files": 79,
-      "tokens_claude": 66425,
-      "tokens_claude_exact": false,
-      "tokens_gpt": 59783,
-      "tokens_gpt_exact": false
-    },
-    ".claude": {
-      "chars": 239131,
-      "files": 79,
-      "tokens_claude": 66425,
-      "tokens_claude_exact": false,
-      "tokens_gpt": 59783,
-      "tokens_gpt_exact": false
+  "generated": "2026-06-16T03:12:51+00:00",
+  "longest_rules": [],
+  "mcp_tool_schemas": {
+    "agent-config": {
+      "chars": 13925,
+      "over_subscription": false,
+      "oversubscription_cap": 25,
+      "tokens_claude": 3867,
+      "tokens_gpt": 3482,
+      "tokens_gpt_exact": false,
+      "tool_count": 20,
+      "tools": [
+        {
+          "chars": 1585,
+          "name": "chat_history_append",
+          "tokens_gpt": 396
+        },
+        {
+          "chars": 1048,
+          "name": "memory_lookup",
+          "tokens_gpt": 262
+        },
+        {
+          "chars": 1014,
+          "name": "chat_history_read",
+          "tokens_gpt": 254
+        },
+        {
+          "chars": 887,
+          "name": "memory_signal",
+          "tokens_gpt": 222
+        },
+        {
+          "chars": 793,
+          "name": "lint_skills",
+          "tokens_gpt": 198
+        },
+        {
+          "chars": 774,
+          "name": "skill_trigger_eval",
+          "tokens_gpt": 194
+        },
+        {
+          "chars": 774,
+          "name": "update_form_request_messages",
+          "tokens_gpt": 194
+        },
+        {
+          "chars": 678,
+          "name": "sync_agent_settings",
+          "tokens_gpt": 170
+        },
+        {
+          "chars": 668,
+          "name": "compile_router",
+          "tokens_gpt": 167
+        },
+        {
+          "chars": 669,
+          "name": "suggest_command",
+          "tokens_gpt": 167
+        },
+        {
+          "chars": 652,
+          "name": "read_resource_body",
+          "tokens_gpt": 163
+        },
+        {
+          "chars": 609,
+          "name": "suggest_skill_for_task",
+          "tokens_gpt": 152
+        },
+        {
+          "chars": 609,
+          "name": "sync_gitignore",
+          "tokens_gpt": 152
+        },
+        {
+          "chars": 580,
+          "name": "run_tests",
+          "tokens_gpt": 145
+        },
+        {
+          "chars": 542,
+          "name": "mine_session",
+          "tokens_gpt": 136
+        },
+        {
+          "chars": 509,
+          "name": "run_quality_checks",
+          "tokens_gpt": 127
+        },
+        {
+          "chars": 415,
+          "name": "list_rules",
+          "tokens_gpt": 104
+        },
+        {
+          "chars": 388,
+          "name": "list_skills",
+          "tokens_gpt": 97
+        },
+        {
+          "chars": 386,
+          "name": "list_commands",
+          "tokens_gpt": 96
+        },
+        {
+          "chars": 345,
+          "name": "memory_status",
+          "tokens_gpt": 86
+        }
+      ]
     }
   },
+  "rule_footprint": {},
   "thin_projection": {
-    "eager_chars": 239131,
-    "eager_gpt": 59783,
+    "eager_chars": 256463,
+    "eager_gpt": 64116,
     "kernel_full": 10,
-    "non_kernel_thinned": 69,
-    "rules_total": 79,
-    "saved_gpt": 46222,
-    "saved_pct": 77.3,
-    "thin_chars": 54245,
-    "thin_gpt": 13561,
+    "non_kernel_thinned": 74,
+    "rules_total": 84,
+    "saved_gpt": 50338,
+    "saved_pct": 78.5,
+    "thin_chars": 55113,
+    "thin_gpt": 13778,
     "token_method": "tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)"
   },
   "token_method": "tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)"

--- a/internal/bench/reports/projection-cost.md
+++ b/internal/bench/reports/projection-cost.md
@@ -1,34 +1,43 @@
 # Initial-context token audit
 
-- generated: `2026-06-05T03:13:10+00:00`
+- generated: `2026-06-16T03:12:51+00:00`
 - token method: tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)
 
 ## 0B.2 — always-on rule footprint per tool
 
 | tool | files | chars | GPT tok | Claude tok |
 |---|--:|--:|--:|--:|
-| `.claude` | 79 | 239,131 | 59,783 | 66,425 |
-| `.augment` | 79 | 239,131 | 59,783 | 66,425 |
 
 ## 0B.4 — description-catalog cost (eager)
 
 | catalog | entries | chars | GPT tok | Claude tok |
 |---|--:|--:|--:|--:|
-| skills_projected | 359 | 62,371 | 15,593 | 17,325 |
-| skills_core_source | 214 | 42,133 | 10,533 | 11,704 |
-| commands_core_source | 149 | 20,912 | 5,228 | 5,809 |
+| skills_projected | 0 | 0 | 0 | 0 |
+| skills_core_source | 238 | 46,680 | 11,670 | 12,967 |
+| commands_core_source | 155 | 22,358 | 5,590 | 6,211 |
 
 ## 1.3 — top-10 longest rules (token trim candidates)
 
 | rule | GPT tok | chars |
 |---|--:|--:|
-| `roadmap-progress-sync` | 1,943 | 7,771 |
-| `autonomous-execution` | 1,889 | 7,556 |
-| `domain-safety-disclaimer` | 1,828 | 7,314 |
-| `domain-adoption-policy` | 1,796 | 7,184 |
-| `roadmap-ci-steps-policy` | 1,591 | 6,364 |
-| `no-roadmap-references` | 1,570 | 6,278 |
-| `domain-safety-pii` | 1,564 | 6,255 |
-| `persona-governance` | 1,445 | 5,779 |
-| `framework-neutrality-in-generic-skills` | 1,393 | 5,573 |
-| `context-hygiene` | 1,391 | 5,565 |
+
+## MCP — tool-schema cost per server (always-loaded for connected clients)
+
+| server | tools | chars | GPT tok | Claude tok | over-subscribed? |
+|---|--:|--:|--:|--:|:--:|
+| `agent-config` | 20 | 13,925 | 3,482 | 3,867 | no |
+
+### `agent-config` — top-10 tools by schema cost
+
+| tool | GPT tok | chars |
+|---|--:|--:|
+| `chat_history_append` | 396 | 1,585 |
+| `memory_lookup` | 262 | 1,048 |
+| `chat_history_read` | 254 | 1,014 |
+| `memory_signal` | 222 | 887 |
+| `lint_skills` | 198 | 793 |
+| `skill_trigger_eval` | 194 | 774 |
+| `update_form_request_messages` | 194 | 774 |
+| `sync_agent_settings` | 170 | 678 |
+| `compile_router` | 167 | 668 |
+| `suggest_command` | 167 | 669 |

--- a/src/scripts/audit_initial_context.py
+++ b/src/scripts/audit_initial_context.py
@@ -60,6 +60,20 @@ DIR_RULE_TOOLS = (".claude", ".augment", ".cursor")
 # Tools whose always-on surface is a single monolithic file.
 MONOLITH_TOOLS = (".windsurfrules",)
 
+# MCP tool-schema accounting (road-to-mcp-token-accounting). Every connected
+# MCP server's tool definitions (name + description + input schema) are
+# always-loaded context for an MCP client — the same "what is this context
+# costing?" question as the rule/description surfaces, for the MCP slice. The
+# source-of-truth catalog is the one shipped by this package's MCP server.
+MCP_CATALOG = REPO_ROOT / "src" / "scripts" / "mcp_server" / "consumer_tool_catalog.json"
+# This package ships a single MCP server; the accounting is keyed by server so
+# a multi-server consumer surface generalises without a shape change.
+MCP_SERVER_NAME = "agent-config"
+# Soft advisory ceiling on tool count per server. "Few used" cannot be known at
+# audit time (no runtime call data), so over-subscription is a count-based
+# heuristic: many tools => maintainer should review which earn their cost.
+MCP_OVERSUBSCRIPTION_TOOL_CAP = 25
+
 # Initial-token budget per surface (None = advisory only, no gate). These are
 # soft ceilings the audit can enforce once a baseline is agreed (1.4). Set
 # generously now; tighten as Phase 3 lands.
@@ -67,6 +81,7 @@ BUDGETS: dict[str, int | None] = {
     "rules.gpt": None,
     "skill_catalog.gpt": None,
     "command_catalog.gpt": None,
+    "mcp_schemas.gpt": None,
 }
 
 
@@ -158,6 +173,63 @@ def thin_projection() -> dict:
         return {}
 
 
+def _measure_tool_schema(tool: dict) -> dict:
+    """Token cost of one MCP tool definition as a client loads it.
+
+    An MCP ``tools/list`` entry carries ``name`` + ``description`` +
+    ``inputSchema``; that triple is what lands in an MCP client's always-on
+    context. Price the serialized triple, not the whole catalog record (the
+    catalog's bookkeeping fields — ``side_effect``, ``implemented_on`` — are
+    not sent to the client).
+    """
+    payload = json.dumps(
+        {
+            "name": tool.get("name", ""),
+            "description": tool.get("description", ""),
+            "inputSchema": tool.get("input_schema", {}),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    m = token_count.measure(payload)
+    m["name"] = tool.get("name", "")
+    return m
+
+
+def mcp_tool_schemas() -> dict:
+    """Per-server MCP tool-schema footprint (road-to-mcp-token-accounting).
+
+    Prices each tool definition the package's MCP server exposes and folds the
+    result into the same initial-context budget surface as rules/descriptions
+    (NOT a new surface). Returns an empty dict when the catalog is absent so the
+    audit never hard-fails on it. Shape is keyed by server name so a
+    multi-server consumer generalises without a change here.
+    """
+    if not MCP_CATALOG.is_file():
+        return {}
+    try:
+        catalog = json.loads(MCP_CATALOG.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):  # pragma: no cover — defensive
+        return {}
+    tools = catalog.get("tools") or []
+    priced = [_measure_tool_schema(t) for t in tools if isinstance(t, dict)]
+    priced.sort(key=lambda r: (-int(r["tokens_gpt"]), str(r["name"])))
+    server = {
+        "tool_count": len(priced),
+        "chars": sum(int(r["chars"]) for r in priced),
+        "tokens_gpt": sum(int(r["tokens_gpt"]) for r in priced),
+        "tokens_claude": sum(int(r["tokens_claude"]) for r in priced),
+        "tokens_gpt_exact": all(bool(r["tokens_gpt_exact"]) for r in priced) if priced else True,
+        "over_subscription": len(priced) > MCP_OVERSUBSCRIPTION_TOOL_CAP,
+        "oversubscription_cap": MCP_OVERSUBSCRIPTION_TOOL_CAP,
+        "tools": [
+            {"name": r["name"], "tokens_gpt": r["tokens_gpt"], "chars": r["chars"]}
+            for r in priced
+        ],
+    }
+    return {MCP_SERVER_NAME: server}
+
+
 def build() -> dict:
     return {
         "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
@@ -166,6 +238,7 @@ def build() -> dict:
         "thin_projection": thin_projection(),
         "description_catalog": description_catalog(),
         "longest_rules": longest_rules(),
+        "mcp_tool_schemas": mcp_tool_schemas(),
     }
 
 
@@ -187,6 +260,31 @@ def render_md(d: dict) -> str:
           "| rule | GPT tok | chars |", "|---|--:|--:|"]
     for r in d["longest_rules"]:
         L.append(f"| `{r['id']}` | {r['tokens_gpt']:,} | {r['chars']:,} |")
+    mcp = d.get("mcp_tool_schemas") or {}
+    if mcp:
+        L += ["", "## MCP — tool-schema cost per server (always-loaded for connected clients)", "",
+              "| server | tools | chars | GPT tok | Claude tok | over-subscribed? |",
+              "|---|--:|--:|--:|--:|:--:|"]
+        for server, m in mcp.items():
+            flag = "⚠️ yes" if m["over_subscription"] else "no"
+            L.append(
+                f"| `{server}` | {m['tool_count']} | {m['chars']:,} | "
+                f"{m['tokens_gpt']:,} | {m['tokens_claude']:,} | {flag} |"
+            )
+        for server, m in mcp.items():
+            if m["over_subscription"]:
+                L += ["",
+                      f"> ⚠️  `{server}` exposes {m['tool_count']} tools "
+                      f"(> {m['oversubscription_cap']} soft cap). Every tool schema is "
+                      f"always-loaded for connected MCP clients — review which tools earn "
+                      f"their context cost. (\"Few used\" needs runtime call data, not "
+                      f"available at audit time; this is a count-based heuristic.)"]
+            top = m["tools"][:10]
+            if top:
+                L += ["", f"### `{server}` — top-{len(top)} tools by schema cost", "",
+                      "| tool | GPT tok | chars |", "|---|--:|--:|"]
+                for t in top:
+                    L.append(f"| `{t['name']}` | {t['tokens_gpt']:,} | {t['chars']:,} |")
     L.append("")
     return "\n".join(L)
 
@@ -204,10 +302,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.fail_if_over_budget:
         breaches = []
         rf = next(iter(data["rule_footprint"].values()), {})
+        mcp = data.get("mcp_tool_schemas") or {}
+        mcp_gpt = sum(int(s["tokens_gpt"]) for s in mcp.values())
         checks = {
             "rules.gpt": rf.get("tokens_gpt", 0),
             "skill_catalog.gpt": data["description_catalog"]["skills_projected"]["tokens_gpt"],
             "command_catalog.gpt": data["description_catalog"]["commands_core_source"]["tokens_gpt"],
+            "mcp_schemas.gpt": mcp_gpt,
         }
         for key, val in checks.items():
             cap = BUDGETS.get(key)

--- a/tests/test_audit_initial_context_mcp.py
+++ b/tests/test_audit_initial_context_mcp.py
@@ -1,0 +1,94 @@
+"""Tests for the MCP tool-schema accounting in `scripts/audit_initial_context.py`
+(road-to-mcp-token-accounting)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src" / "scripts"))
+
+import audit_initial_context as aic  # noqa: E402
+
+
+def _write_catalog(path: Path, tools: list[dict]) -> None:
+    path.write_text(
+        json.dumps({"schema_version": 1, "tools": tools}, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+
+def test_measure_tool_schema_prices_only_client_facing_triple() -> None:
+    """side_effect / implemented_on are catalog bookkeeping, not sent to the
+    client — two tools differing only there must price identically."""
+    base = {
+        "name": "do_thing",
+        "description": "Does a thing.",
+        "input_schema": {"type": "object", "properties": {"x": {"type": "string"}}},
+    }
+    a = aic._measure_tool_schema({**base, "side_effect": "ro", "implemented_on": ["stdio"]})
+    b = aic._measure_tool_schema({**base, "side_effect": "rw", "implemented_on": ["worker"]})
+    assert a["tokens_gpt"] == b["tokens_gpt"]
+    assert a["tokens_gpt"] > 0
+    assert a["name"] == "do_thing"
+
+
+def test_real_catalog_priced_per_server() -> None:
+    """The shipped catalog prices into a single keyed server entry."""
+    out = aic.mcp_tool_schemas()
+    assert set(out) == {aic.MCP_SERVER_NAME}
+    server = out[aic.MCP_SERVER_NAME]
+    catalog = json.loads(aic.MCP_CATALOG.read_text(encoding="utf-8"))
+    assert server["tool_count"] == len(catalog["tools"])
+    assert server["tokens_gpt"] > 0
+    assert server["chars"] > 0
+    # per-tool list is sorted by descending GPT tokens
+    toks = [t["tokens_gpt"] for t in server["tools"]]
+    assert toks == sorted(toks, reverse=True)
+    # aggregate equals the sum of the per-tool prices
+    assert server["tokens_gpt"] == sum(t["tokens_gpt"] for t in server["tools"])
+    assert isinstance(server["over_subscription"], bool)
+    assert server["oversubscription_cap"] == aic.MCP_OVERSUBSCRIPTION_TOOL_CAP
+
+
+def test_over_subscription_flag(tmp_path, monkeypatch) -> None:
+    """Count-based heuristic flips when tool count exceeds the soft cap."""
+    cat = tmp_path / "catalog.json"
+    tools = [
+        {"name": f"t{i}", "description": "d", "input_schema": {"type": "object"}}
+        for i in range(3)
+    ]
+    _write_catalog(cat, tools)
+    monkeypatch.setattr(aic, "MCP_CATALOG", cat)
+
+    monkeypatch.setattr(aic, "MCP_OVERSUBSCRIPTION_TOOL_CAP", 5)
+    assert aic.mcp_tool_schemas()[aic.MCP_SERVER_NAME]["over_subscription"] is False
+
+    monkeypatch.setattr(aic, "MCP_OVERSUBSCRIPTION_TOOL_CAP", 2)
+    assert aic.mcp_tool_schemas()[aic.MCP_SERVER_NAME]["over_subscription"] is True
+
+
+def test_missing_catalog_returns_empty(tmp_path, monkeypatch) -> None:
+    """Absent catalog → empty dict; the audit never hard-fails on MCP."""
+    monkeypatch.setattr(aic, "MCP_CATALOG", tmp_path / "does-not-exist.json")
+    assert aic.mcp_tool_schemas() == {}
+
+
+def test_render_md_includes_mcp_section() -> None:
+    md = aic.render_md(aic.build())
+    assert "## MCP — tool-schema cost per server" in md
+    assert f"`{aic.MCP_SERVER_NAME}`" in md
+    assert "over-subscribed?" in md
+
+
+def test_render_md_omits_mcp_section_when_absent(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(aic, "MCP_CATALOG", tmp_path / "missing.json")
+    md = aic.render_md(aic.build())
+    assert "## MCP — tool-schema cost per server" not in md
+
+
+def test_budget_gate_passes_when_advisory() -> None:
+    """mcp_schemas.gpt budget is advisory (None) → gate stays green."""
+    assert aic.main(["--fail-if-over-budget"]) == 0


### PR DESCRIPTION
Implements `agents/roadmaps/road-to-mcp-token-accounting.md` (both Phase-1 steps). The roadmap's trigger fired — `road-to-capability-discoverability` is archived and its `context-load-budget` tool (`src/scripts/audit_initial_context.py`) exists — so the MCP slice folds **into** that budget surface rather than a new tool.

## What changed

- **`mcp_tool_schemas()`** prices each MCP tool's client-facing triple (`name` + `description` + `inputSchema`) from the server's `consumer_tool_catalog.json`, aggregated **per server** (keyed so a multi-server consumer generalises without a shape change). Carries a count-based `over_subscription` heuristic (a soft tool-count cap — "few used" needs runtime call data not available at audit time, so it's an honest count-based signal) and a new advisory `mcp_schemas.gpt` budget entry.
- **`render_md`** surfaces a per-server table (tools / chars / GPT / Claude / over-subscribed?) + the top-10 tools by schema cost + an over-subscription advisory; `--json` carries the full per-tool breakdown.
- Regenerated the tracked `internal/bench/reports/projection-cost.{json,md}` snapshot (adds the MCP section; also catches up pre-existing drift, since the generator changed).
- New `tests/test_audit_initial_context_mcp.py` (7 cases): pricing ignores catalog bookkeeping fields, per-server shape + sorted/aggregated totals, over-subscription flag flips on the cap, missing-catalog safety, render section present/absent, advisory budget gate stays green.

Current reading: the `agent-config` server's 20 tool schemas cost **~3,482 GPT tokens** always-loaded for connected clients; not over-subscribed (≤ 25-tool soft cap).

## Verification

- `tests/test_audit_initial_context_mcp.py` — 7 passed
- `tests/test_check_context_paths.py` + audit subset — green
- consumers (`value_report` / `value_ladder`) still parse `projection-cost.json` (additive key)
- `lint_marketplace.py` + roadmap dashboard `--check` — pass (pre-commit hooks green)

Completed roadmap archived in-PR via the PR-gate sweep.