### PR TITLE
fix(council): config lives in .ai-council.yml, not .agent-settings.yml

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -199,6 +199,7 @@ tasks:
       # in taskfiles/ci-fast.yml above test:ts).
       - task: check-roadmap-trackable
       - task: check-council-layout
+      - task: check-council-config-location
       - task: lint-agents-layout
       - task: check-role-doc-links
       - task: roadmap-progress-check
@@ -338,6 +339,7 @@ tasks:
       - task: build-ts
       - task: check-roadmap-trackable
       - task: check-council-layout
+      - task: check-council-config-location
       - task: lint-agents-layout-strict
       - task: check-role-doc-links
       - task: roadmap-progress-check

--- a/dist/agent-src/commands/council/default.md
+++ b/dist/agent-src/commands/council/default.md
@@ -52,8 +52,8 @@ the host translates that to `--depth deep` on the CLI. If multiple
 active artefacts disagree, **deep wins** (max policy). Explicit
 `rounds:N` overrides depth.
 
-The default comes from `ai_council.min_rounds` in
-`.agent-settings.yml` (default `2` so members critique each other at
+The default comes from `defaults.min_rounds` in the resolved
+`.ai-council.yml` (default `2` so members critique each other at
 least once before convergence). **Do NOT ask the user "how many
 rounds?"** when `rounds:N` is unset or `N <= min_rounds` — proceed
 with the settings default. Ask only when the artefact is genuinely
@@ -88,16 +88,40 @@ Neutrality — context-handoff).
 
 ### 2. Check the council is configured + price table fresh
 
-Read `.agent-settings.yml` → `ai_council`:
+Council config lives in **`.ai-council.yml`**, NOT in `.agent-settings.yml`.
+The CLI (`scripts/ai_council/config.py:resolve_config_path`, per
+[ADR-093](../../../docs/decisions/ADR-093-ai-council-config-user-global.md))
+resolves it — first hit wins:
 
-- If `ai_council.enabled` is false → state that and offer to flip it
-  on. Do not flip it autonomously.
-- If no member has `enabled: true` → list the install commands
-  (`./agent-config keys:install-anthropic`, `./agent-config keys:install-openai`)
-  and stop.
-- If a member is enabled but its `*.key` file is missing or has the
-  wrong mode → tell the user which key to install. Do not fall back
-  to env vars. Ever.
+1. Project-local `<project_root>/agents/settings/.ai-council.yml` (if present).
+2. User-global `~/.event4u/agent-config/settings/.ai-council.yml` — default
+   home; one global config serves every project.
+
+Keys are **top-level** (`enabled`, `defaults:`, `members:`). No `ai_council:`
+parent block; the legacy `ai_council.*` block under `.agent-settings.yml` was
+removed in ADR-093 — never read or recommend that path for council config.
+
+```
+NEVER claim the council "needs `.agent-settings.yml` set up" or an
+`ai_council` block. The CLI's `resolve_config_path` is authoritative:
+run `council:estimate` (Step 3) and read its exit code + message before
+making any "not configured" claim. A user-global `.ai-council.yml` with
+`enabled: true` works from EVERY project, including consumer repos that
+have no project-local config.
+```
+
+CLI is the single source of truth for the configured-check — do not hand-parse
+the YAML to second-guess it. Map its outcomes (Step 4 exit codes + the
+**CLI exits 2** cases below):
+
+- `enabled: false` (top-level in resolved `.ai-council.yml`) → CLI exits 2 with
+  `ai_council.enabled is false`. State that, offer to flip it on. Do not flip
+  it autonomously.
+- No member has `enabled: true` (under top-level `members:`) → list install
+  commands (`./agent-config keys:install-anthropic`,
+  `./agent-config keys:install-openai`) and stop.
+- A member is enabled but its `*.key` file is missing or wrong-mode → tell the
+  user which key to install. Do not fall back to env vars. Ever.
 
 Load the price table via `scripts.ai_council.pricing.load_prices()`
 (auto-bootstraps `agents/runtime/.agent-prices.md` from defaults if missing). Run
@@ -172,8 +196,8 @@ Once the user picks `1`, invoke the same arguments with `run` plus
     [--original-ask "<framing sentence>"]
 ```
 
-`--rounds` defaults to `ai_council.min_rounds` from
-`.agent-settings.yml` (or `2` if unset). Pass `--rounds N` only when
+`--rounds` defaults to `defaults.min_rounds` from the resolved
+`.ai-council.yml` (or `2` if unset). Pass `--rounds N` only when
 the user explicitly asked for a different count or a complex
 artefact justifies more depth — do not pass `--rounds 1` to "save
 money" by default; the settings owner already chose `min_rounds`.
@@ -181,15 +205,15 @@ money" by default; the settings owner already chose `min_rounds`.
 `--depth` defaults to `standard`. Set `--depth deep` when the
 active rule, skill, or command declares `council_depth: deep` in
 its frontmatter; the floor becomes
-`max(ai_council.deep_min_rounds, ai_council.min_rounds)` (default
+`max(defaults.deep_min_rounds, defaults.min_rounds)` (default
 `3`). If `--rounds N` is also passed, `--rounds` wins.
 
 The CLI:
 
 - bundles the artefact via `scripts.ai_council.bundler` (redaction +
   size guard — `BundleTooLarge` exits 2 with the byte count),
-- builds members from `.agent-settings.yml` (refusing if
-  `ai_council.enabled` is false or no member is wired up),
+- builds members from the resolved `.ai-council.yml` (refusing if
+  top-level `enabled` is false or no member is wired up),
 - detects project context via `detect_project_context()`,
 - calls `orchestrator.consult(...)` with the `cost_budget` from
   settings,
@@ -253,8 +277,11 @@ council can act on the project directly.
 
 ## Failure modes
 
-- **CLI exits 2, "ai_council.enabled is false"** → tell the user how
-  to flip it on; do not flip it autonomously.
+- **CLI exits 2, "ai_council.enabled is false"** → tell the user to set
+  top-level `enabled: true` in the resolved `.ai-council.yml` (user-global
+  `~/.event4u/agent-config/settings/.ai-council.yml`, or project-local
+  `<project_root>/agents/settings/.ai-council.yml`) — never in
+  `.agent-settings.yml`. Do not flip it autonomously.
 - **CLI exits 2, "no council member has `enabled: true`"** → list the
   install commands (`./agent-config keys:install-anthropic`,
   `./agent-config keys:install-openai`) and stop.

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -262,7 +262,7 @@ is invoked.
   tier. The two-tier split reconciles "Council always active when
   enabled" with "skip trivial agent-side requests": user-typed
   `/council` calls proceed by default, agent-initiated dispatches keep
-  `educate` behaviour. Override via `.agent-settings.yml`.
+  `educate` behaviour. Override via the resolved `.ai-council.yml`.
 - `lens_overrides.necessity_classifier_mode.<lens>` — per-lens override.
   Wins over the global `mode` for the matching invocation tier (agent
   vs user_explicit follow the same lens map). Typical use: leave the
@@ -433,26 +433,26 @@ Worked example — opt the Anthropic and OpenAI members in, leave the
 others off, and switch the `low_impact` class to `council`:
 
 ```yaml
-ai_council:
-  members:
-    anthropic:
-      enabled: true
-      model: claude-sonnet-4-5
-      api_key_ref: file:anthropic.key
-      participate_low_impact: true   # eligible for fast-path
-    openai:
-      enabled: true
-      model: gpt-4o
-      api_key_ref: file:openai.key
-      participate_low_impact: true   # eligible for fast-path
-    gemini:
-      enabled: false                  # disabled — opt-in ignored even if set
+# In the resolved .ai-council.yml — keys are top-level (no `ai_council:` wrapper).
+members:
+  anthropic:
+    enabled: true
+    model: claude-sonnet-4-5
+    api_key_ref: file:anthropic.key
+    participate_low_impact: true   # eligible for fast-path
+  openai:
+    enabled: true
+    model: gpt-4o
+    api_key_ref: file:openai.key
+    participate_low_impact: true   # eligible for fast-path
+  gemini:
+    enabled: false                  # disabled — opt-in ignored even if set
 
-  fast_path:
-    max_members: 2          # 1 or 2 only
-    max_rounds: 1           # LOCKED
-    max_tokens: 2500
-    max_cost_usd: 0.05
+fast_path:
+  max_members: 2          # 1 or 2 only
+  max_rounds: 1           # LOCKED
+  max_tokens: 2500
+  max_cost_usd: 0.05
 
 decision_resolution:
   classes:

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -39,7 +39,7 @@
   "commands/council.md": "933676b0ee20198a5ca4bc42fe7f4df7e44e22748820fbd48d3f5f7e254c87f3",
   "commands/council/analysis.md": "73deb32b3e416985bb372c82d52097c31809120b9c059f1f6f684a219b46731b",
   "commands/council/debate.md": "6bd6263922a319ef053274950dba0d6d1a7d815fd1cfcef7759ad37f93484a29",
-  "commands/council/default.md": "5e31c8c8900c3df7b1202c6ac209757c211f50662146a0f56bede5765601c8d9",
+  "commands/council/default.md": "cd3a205899cd9ebe1a0794e1663003f6120fb5e49332b81e0dea8101c4b8c355",
   "commands/council/design.md": "e59bd2a717b5fd4ca0a8f33c0d50c4928cf67f5e507f898705814a35fc929525",
   "commands/council/optimize.md": "ee1e16f92bc8f4d85bffeba8e89288d4bd5b2407c14c2fd823e7ba2cdcad5ffa",
   "commands/council/pr.md": "d348cf45584a846b2f63a58050d9ae49b7dd1627c0d30d13b721a8eb4c2eeaeb",

--- a/src/domains/meta/council/default/command.md
+++ b/src/domains/meta/council/default/command.md
@@ -52,8 +52,8 @@ the host translates that to `--depth deep` on the CLI. If multiple
 active artefacts disagree, **deep wins** (max policy). Explicit
 `rounds:N` overrides depth.
 
-The default comes from `ai_council.min_rounds` in
-`.agent-settings.yml` (default `2` so members critique each other at
+The default comes from `defaults.min_rounds` in the resolved
+`.ai-council.yml` (default `2` so members critique each other at
 least once before convergence). **Do NOT ask the user "how many
 rounds?"** when `rounds:N` is unset or `N <= min_rounds` — proceed
 with the settings default. Ask only when the artefact is genuinely
@@ -88,16 +88,41 @@ Neutrality — context-handoff).
 
 ### 2. Check the council is configured + price table fresh
 
-Read `.agent-settings.yml` → `ai_council`:
+Council config lives in **`.ai-council.yml`**, NOT in `.agent-settings.yml`.
+The CLI (`scripts/ai_council/config.py:resolve_config_path`, per
+[ADR-093](../../../docs/decisions/ADR-093-ai-council-config-user-global.md))
+resolves it in this order — first hit wins:
 
-- If `ai_council.enabled` is false → state that and offer to flip it
-  on. Do not flip it autonomously.
-- If no member has `enabled: true` → list the install commands
-  (`./agent-config keys:install-anthropic`, `./agent-config keys:install-openai`)
-  and stop.
-- If a member is enabled but its `*.key` file is missing or has the
-  wrong mode → tell the user which key to install. Do not fall back
-  to env vars. Ever.
+1. Project-local `<project_root>/agents/settings/.ai-council.yml` (if present).
+2. User-global `~/.event4u/agent-config/settings/.ai-council.yml` — the
+   default home; one global config serves every project.
+
+Keys are **top-level** in that file (`enabled`, `defaults:`, `members:`).
+There is no `ai_council:` parent block, and the legacy `ai_council.*` block
+under `.agent-settings.yml` was removed in ADR-093 — never read or recommend
+that path for council config.
+
+```
+NEVER claim the council "needs `.agent-settings.yml` set up" or an
+`ai_council` block. The CLI's `resolve_config_path` is authoritative:
+run `council:estimate` (Step 3) and read its exit code + message before
+making any "not configured" claim. A user-global `.ai-council.yml` with
+`enabled: true` works from EVERY project, including consumer repos that
+have no project-local config.
+```
+
+The CLI is the single source of truth for the configured-check — do not
+hand-parse the YAML to second-guess it. Map its outcomes (Step 4 exit
+codes, plus the **CLI exits 2** cases below):
+
+- `enabled: false` (top-level in the resolved `.ai-council.yml`) → CLI exits 2
+  with `ai_council.enabled is false`. State that and offer to flip it on. Do
+  not flip it autonomously.
+- No member has `enabled: true` (under top-level `members:`) → list the
+  install commands (`./agent-config keys:install-anthropic`,
+  `./agent-config keys:install-openai`) and stop.
+- A member is enabled but its `*.key` file is missing or has the wrong mode
+  → tell the user which key to install. Do not fall back to env vars. Ever.
 
 Load the price table via `scripts.ai_council.pricing.load_prices()`
 (auto-bootstraps `agents/runtime/.agent-prices.md` from defaults if missing). Run
@@ -172,8 +197,8 @@ Once the user picks `1`, invoke the same arguments with `run` plus
     [--original-ask "<framing sentence>"]
 ```
 
-`--rounds` defaults to `ai_council.min_rounds` from
-`.agent-settings.yml` (or `2` if unset). Pass `--rounds N` only when
+`--rounds` defaults to `defaults.min_rounds` from the resolved
+`.ai-council.yml` (or `2` if unset). Pass `--rounds N` only when
 the user explicitly asked for a different count or a complex
 artefact justifies more depth — do not pass `--rounds 1` to "save
 money" by default; the settings owner already chose `min_rounds`.
@@ -181,15 +206,15 @@ money" by default; the settings owner already chose `min_rounds`.
 `--depth` defaults to `standard`. Set `--depth deep` when the
 active rule, skill, or command declares `council_depth: deep` in
 its frontmatter; the floor becomes
-`max(ai_council.deep_min_rounds, ai_council.min_rounds)` (default
+`max(defaults.deep_min_rounds, defaults.min_rounds)` (default
 `3`). If `--rounds N` is also passed, `--rounds` wins.
 
 The CLI:
 
 - bundles the artefact via `scripts.ai_council.bundler` (redaction +
   size guard — `BundleTooLarge` exits 2 with the byte count),
-- builds members from `.agent-settings.yml` (refusing if
-  `ai_council.enabled` is false or no member is wired up),
+- builds members from the resolved `.ai-council.yml` (refusing if
+  top-level `enabled` is false or no member is wired up),
 - detects project context via `detect_project_context()`,
 - calls `orchestrator.consult(...)` with the `cost_budget` from
   settings,
@@ -253,8 +278,12 @@ council can act on the project directly.
 
 ## Failure modes
 
-- **CLI exits 2, "ai_council.enabled is false"** → tell the user how
-  to flip it on; do not flip it autonomously.
+- **CLI exits 2, "ai_council.enabled is false"** → tell the user to set
+  top-level `enabled: true` in the resolved `.ai-council.yml` (user-global
+  `~/.event4u/agent-config/settings/.ai-council.yml`, or a project-local
+  `<project_root>/agents/settings/.ai-council.yml`) — never in
+  `.agent-settings.yml`. Do not
+  flip it autonomously.
 - **CLI exits 2, "no council member has `enabled: true`"** → list the
   install commands (`./agent-config keys:install-anthropic`,
   `./agent-config keys:install-openai`) and stop.

--- a/src/scripts/check_council_config_location.py
+++ b/src/scripts/check_council_config_location.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""CI guard: council config lives in `.ai-council.yml`, never `.agent-settings.yml`.
+
+Per [ADR-093](docs/decisions/ADR-093-ai-council-config-user-global.md) the
+council reads a dedicated `.ai-council.yml` — resolved project-local
+(`agents/settings/.ai-council.yml`) first, else user-global
+(`~/.event4u/agent-config/settings/.ai-council.yml`). Keys are **top-level**
+in that file; the legacy `ai_council.*` block under `.agent-settings.yml` was
+removed in Phase 0.
+
+When agent-facing surfaces still tell the model to "read `.agent-settings.yml`
+→ `ai_council`", the agent inspects the wrong file, finds nothing, and tells
+the user the council "needs `.agent-settings.yml` set up" — even though a
+user-global `.ai-council.yml` with `enabled: true` is present and works from
+every project. This guard makes that drift fail CI.
+
+What it flags, in the council command/skill surfaces + the config contract:
+
+  1. A `.agent-settings.yml` reference that is NOT negated — i.e. an
+     instruction to read/use it for council config. Corrective mentions
+     ("NOT in `.agent-settings.yml`", "was removed", "never read") carry a
+     negation marker on the same line and are allowed.
+  2. A bare `ai_council:` YAML parent-block declaration — post-ADR-093 the
+     keys are top-level in `.ai-council.yml`; there is no `ai_council:`
+     namespace to nest under.
+
+Escape hatch: a line carrying `<!-- council-config-allowed -->` is exempt
+(for a legitimate non-council `.agent-settings.yml` reference, e.g.
+`personal.autonomy`).
+
+Exit codes:
+  0 — clean.
+  1 — at least one violation; details printed to stdout.
+
+Invocation (from project root):
+  python3 src/scripts/check_council_config_location.py [--quiet]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+QUIET = "--quiet" in sys.argv
+
+# Agent-facing surfaces where council config must resolve to `.ai-council.yml`.
+# Globs are relative to the repo root; non-existent paths are skipped silently.
+SCAN_GLOBS = (
+    "src/domains/meta/council/**/*.md",
+    "src/domains/product-basic/roadmap/ai-council/**/*.md",
+    "src/skills/ai-council/**/*.md",
+    "docs/contracts/ai-council-config.md",
+)
+
+AGENT_SETTINGS_RE = re.compile(r"\.agent-settings\.yml")
+# A negation marker on the same line marks a corrective reference (allowed).
+NEGATION_RE = re.compile(
+    r"\b(not|never|removed|no\s+longer|neither|instead)\b", re.IGNORECASE
+)
+# A YAML parent-block declaration: `ai_council:` alone (optionally indented,
+# optional trailing comment). Inline-code mentions like `under \`ai_council:\``
+# do not match because the line does not START with the key.
+AI_COUNCIL_BLOCK_RE = re.compile(r"^\s*ai_council:\s*(#.*)?$")
+ALLOW_PRAGMA = "<!-- council-config-allowed -->"
+
+
+def iter_files(root: Path):
+    seen: set[Path] = set()
+    for pattern in SCAN_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                yield path
+
+
+def find_violations(root: Path) -> list[str]:
+    findings: list[str] = []
+    for path in iter_files(root):
+        rel = path.relative_to(root)
+        in_fence = False
+        for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = raw.lstrip()
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                in_fence = not in_fence
+                continue
+            if ALLOW_PRAGMA in raw:
+                continue
+            if AGENT_SETTINGS_RE.search(raw) and not NEGATION_RE.search(raw):
+                findings.append(
+                    f"{rel}:{lineno}: council config referenced via "
+                    f"`.agent-settings.yml` without a negation marker — council "
+                    f"config lives in `.ai-council.yml` (ADR-093). Point at the "
+                    f"resolved `.ai-council.yml`, or add a negation / "
+                    f"`{ALLOW_PRAGMA}` if this is a non-council reference."
+                )
+            if AI_COUNCIL_BLOCK_RE.match(raw):
+                where = "fenced YAML" if in_fence else "prose"
+                findings.append(
+                    f"{rel}:{lineno}: `ai_council:` parent block ({where}) — "
+                    f"post-ADR-093 the keys are top-level in `.ai-council.yml` "
+                    f"(no `ai_council:` wrapper)."
+                )
+    return findings
+
+
+def main() -> int:
+    root = Path.cwd()
+    findings = find_violations(root)
+    if findings:
+        print("❌  Council config-location violations:\n")
+        for f in findings:
+            print(f"  - {f}")
+        print(
+            "\nRule: council config lives in `.ai-council.yml` "
+            "(docs/contracts/ai-council-config.md + ADR-093), never in "
+            "`.agent-settings.yml`."
+        )
+        return 1
+    if not QUIET:
+        print("✅  Council config-location clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -206,6 +206,11 @@ tasks:
     desc: Fail if council-* artefacts are placed outside the canonical agents/runtime/council/{questions,responses,sessions}/ dirs (ai-council § Output path convention)
     cmd: python3 src/scripts/check_council_layout.py {{.QUIET_FLAG}}
 
+  check-council-config-location:
+    silent: true
+    desc: Fail if council surfaces tie config to .agent-settings.yml instead of .ai-council.yml (ADR-093)
+    cmd: python3 src/scripts/check_council_config_location.py {{.QUIET_FLAG}}
+
   lint-agents-layout:
     silent: true
     desc: Fail on unknown flat files at agents/ root; warn on legacy entries scheduled for migration (see scripts/lint_agents_layout.py)


### PR DESCRIPTION
## Problem

In consumer projects the agent kept telling the user it would *"need to set up `.agent-settings.yml` with an `ai_council` block + API keys"* — even though a working, `enabled: true` council config exists user-global at `~/.event4u/agent-config/settings/.ai-council.yml`.

**Root cause:** the `/council` command (Step 2 + Step 4) and the config contract still instructed the agent to read council config from `.agent-settings.yml` → `ai_council`. That is stale from before **ADR-093**, which moved council config to a dedicated `.ai-council.yml` with **top-level** keys and removed the `ai_council.*` block from `.agent-settings.yml`. The CLI (`resolve_config_path`) already reads the right file — only the agent-facing guidance lagged. So the agent inspected the wrong file, found nothing, and reported "not configured". The contract's own ADR-093 note describes exactly this failure.

## Fix

- **`src/domains/meta/council/default/command.md`** (master orchestrator; the `pr`/`design`/`optimize`/`analysis` wrappers inherit):
  - Step 2 rewritten — names `.ai-council.yml` + the resolution order (project-local → user-global), makes the **CLI authoritative** for the configured-check (no hand-parsing YAML), and forbids ever claiming `.agent-settings.yml` is needed.
  - `min_rounds` / `deep_min_rounds` / "builds members" / failure-mode pointers corrected to the right file + top-level key paths (`defaults.min_rounds`, top-level `enabled`/`members`).
- **`docs/contracts/ai-council-config.md`** — fixed the stale "Override via `.agent-settings.yml`" note and de-nested the low-impact worked example out of the removed `ai_council:` wrapper to the real top-level shape.
- **`dist/agent-src/commands/council/default.md`** + **`internal/.condensation-hashes.json`** — regenerated via the condense flow (hashes in sync).

## Hardening

New CI guard **`check_council_config_location.py`** (wired into both CI lists in `Taskfile.yml`, task def in `taskfiles/content.yml`): scans the council command/skill surfaces + the contract and fails if any `.agent-settings.yml` reference is **not** negated, or if a bare `ai_council:` YAML parent block reappears. Corrective mentions (NOT/never/removed) and a per-line `<!-- council-config-allowed -->` escape hatch are honored. Negative-tested.

## Verification

- `condense.sh --check` ✅ (hashes in sync) · `check_condensation.py` ✅ · `check_references.py` exit 0 ✅
- `check_council_config_location.py` ✅ (and fails on a stubbed regression)
- All 4 YAML fences in the contract parse OK