### PR TITLE
chore(roadmap): rdp-eval — council-backed execution disposition + maintainer handoff

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**6 / 71 steps done · 8%**
+**7 / 71 steps done · 10%**
 
 ```text
-███░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   8%
+████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   10%
 ```
 
 ## Open roadmaps
@@ -19,7 +19,7 @@
 | 1 | [road-to-evidence-v2-accumulation-layer.md](roadmaps/road-to-evidence-v2-accumulation-layer.md) | 3 | 6 | 6 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 2 | [road-to-image-brand-typography.md](roadmaps/road-to-image-brand-typography.md) | 4 | 48 | 42 | 6 | 0 | 0 | █░░░░░░░░░ 12% |
 | 3 | [road-to-mission-catalogue.md](roadmaps/road-to-mission-catalogue.md) | 1 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 4 | [road-to-rdp-eval-and-promotion.md](roadmaps/road-to-rdp-eval-and-promotion.md) | 4 | 7 | 6 | 1 | 0 | 0 | █░░░░░░░░░ 14% |
+| 4 | [road-to-rdp-eval-and-promotion.md](roadmaps/road-to-rdp-eval-and-promotion.md) | 5 | 7 | 6 | 1 | 0 | 0 | █░░░░░░░░░ 14% |
 
 ---
 
@@ -60,6 +60,7 @@
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
+| 3 | (polish) — autonomous status | ⬜ empty | 0 | 0 | 0 | 0 | 0% |
 | 1 | Eval execution (billable: real host-model runs) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 2 | Kernel promotion (governance: own PR + ADR + soak) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 3 | Frontier-serving polish (human-reviewed) | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |

--- a/agents/roadmaps/road-to-rdp-eval-and-promotion.md
+++ b/agents/roadmaps/road-to-rdp-eval-and-promotion.md
@@ -23,6 +23,54 @@ orchestrator keep/revert + verifier-gate calibration on data, promote
 frontier-serving polish — without ever asserting a transfer claim the eval
 hasn't backed.
 
+## Execution disposition (2026-06-16 — AI council)
+
+AI council (claude-sonnet-4-5 + gpt-4o, 2-round peer-review, 2026-06-16)
+ruled on the maximal *autonomous* completion, given three constraints that
+authorization does **not** lift. Convergence:
+
+1. **L6 / L7 stay DEFERRED — decided on eval data, never on assertion.** The
+   roadmap's founding principle ("assertion without falsifiability is
+   marketing") forbids settling the orchestrator keep/revert (L6) or the
+   `notes-first-reasoning` kernel promotion (L7) before the eval produces data.
+   No autonomous decision here.
+2. **Phase 1 (eval) is irreducibly maintainer-gated — a handoff, not a block.**
+   The live trigger runner (`task test-triggers-live`) enforces an interactive
+   tty + an explicit human `yes` at the billable cost preview + an installed
+   `anthropic.key` + a `.venv`; the quality layer is hand-scored and needs a
+   valid no-RDP baseline (unproducible from an RDP-active session). So the
+   roadmap stays **active** with this **maintainer handoff** rather than parked.
+3. **Kernel-rule polish ships as separate, maintainer-paced own-PRs** (≥24h
+   merge cadence, Iron-Law SHA unchanged) — never bundled.
+
+### Maintainer handoff — to run Phase 1 (the eval)
+
+```bash
+task setup-evals            # bootstrap .venv (once)
+task install-anthropic-key  # install ~/.event4u/agent-config/anthropic.key (once)
+task test-triggers-live -- reasoning-orchestrator   # interactive; 'yes' at cost gate
+# quality layer: capture baseline (suite w/o RDP) vs treatment per
+# tests/reasoning-layer-eval/rubric.md, then hand-score the 12 transcripts.
+```
+
+Phase 1 results unlock L6/L7 (Phase 2). The eval substrate is built + validated
+(`validate_fixtures.py` ✅, 21 fixtures); only the billable + hand-scored runs
+remain.
+
+### Phase 3 (polish) — autonomous status
+
+- **Done (constraint-light, content-preserving):** `code-review`,
+  `analysis-autonomous-mode` — the clearest non-kernel, no-Iron-Law rote-recipe
+  offenders. (PR #590.)
+- **Maintainer-paced separate PRs** (see § Phase 3 execution notes): Batch K
+  (kernel rules — own-PR + soak), Batch R (non-kernel auto rules — reviewed),
+  the L15 kernel-homed refinements. **Held, not autonomously swept** — several
+  remaining candidates are Iron-Law-bearing (`verify-completion-evidence`),
+  safety/evidence-discipline, or carry genuinely load-bearing causal ordering
+  (`systematic-debugging` Phase 4, `condense-memory`); de-prescribing those
+  needs human review, and all are justified by the same thesis the **deferred
+  eval** is meant to validate — so they wait on the eval + review, not a sweep.
+
 ## Phase 1 — Eval execution (billable: real host-model runs)
 
 - [ ] Capture the **baseline** (current suite, no RDP) on ≥1 standard + ≥1


### PR DESCRIPTION
## What

Follow-up to the merged #590 (Phase-3 polish sample). The maintainer directed full autonomous execution with the **AI Council** as the decision authority. The council ruled on the maximal autonomous completion of `road-to-rdp-eval-and-promotion`; this PR **encodes that verdict into the roadmap** as an execution-disposition + maintainer-handoff section.

## Council verdict (claude-sonnet-4-5 + gpt-4o, 2-round peer-review, 2026-06-16)

1. **L6 / L7 stay deferred** — the orchestrator keep/revert (L6) and `notes-first-reasoning` kernel promotion (L7) are decided **on eval data, never on assertion** (the roadmap's founding falsifiability principle). No autonomous decision.
2. **Phase 1 (eval) is irreducibly maintainer-gated** — the live trigger runner needs an interactive tty + an explicit `yes` at the billable cost gate + an installed key + a `.venv`; the quality layer is hand-scored and needs a valid no-RDP baseline (unproducible from an RDP-active session). So the roadmap stays **active** with an explicit **maintainer handoff** (the exact commands to run the eval) — the correct signal is "your turn, human", not `later/`.
3. **Kernel-rule polish ships as separate, maintainer-paced own-PRs** (≥24h merge cadence, Iron-Law SHA unchanged) — never bundled.

## What this PR changes

- Adds a **§ Execution disposition (2026-06-16 — AI council)** section to the roadmap: the deferral of L6/L7, the maintainer handoff block (`task setup-evals` → `install-anthropic-key` → `test-triggers-live`), and the Phase-3 autonomous status (clean offenders done in #590; kernel/Iron-Law-bearing/load-bearing-ordering candidates held for maintainer-paced review — not swept, and gated on the same eval the thesis must pass).
- Roadmap stays **active** (`status: ready`); dashboard regenerated.

## Why not "more edits"

The genuinely-clean, non-kernel, no-Iron-Law rote-recipe offenders were already remediated in #590. Every remaining Phase-3 candidate is either a kernel rule (own-PR + soak), Iron-Law-bearing/safety (`verify-completion-evidence`), or carries load-bearing causal ordering — de-prescribing those needs human review and is gated on the deferred eval. Sweeping them autonomously would violate `minimal-safe-diff` + the falsifiability principle. No code/behavior change here — disposition + handoff only.