### PR TITLE
feat(py2ts): Phase 12 teardown — plan of record + Phase 2 CI rewire

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -107,7 +107,7 @@ jobs:
         run: ./scripts-run src/scripts/check_references
 
       - name: No leftover conflict markers / unmerged paths
-        run: python3 src/scripts/check_no_conflict_markers.py
+        run: ./scripts-run src/scripts/check_no_conflict_markers
 
       - name: Guard — no new legacy path under src/ (ADR-051)
         # PR-scoped: pull the diff via the GitHub API (gh) instead of

--- a/agents/roadmaps/py2ts-teardown-coverage-audit.md
+++ b/agents/roadmaps/py2ts-teardown-coverage-audit.md
@@ -1,0 +1,77 @@
+# Phase-5 Coverage-Equivalence Audit (2026-06-18)
+
+Companion evidence for `road-to-py2ts-teardown.md` Phase 5. Three parallel
+read-only audits classified all **125** Python test modules: does each `.py`
+test's behavior already have a `.ts` counterpart, so the `.py` can be deleted
+without losing coverage? Prime directive: **lose nothing, no quality regression.**
+
+## Result
+
+| Batch | Modules | COVERED | GAP | OBSOLETE | FIXTURE-KEEP |
+|---|---|---|---|---|---|
+| A — work_engine | 59 | 47 | 12 | 0 | 0 |
+| B — ai_council/hooks/telemetry | 61 | 53 | 7 | 1 | 0 |
+| C — rest | 17 | 8 | 8 | 0 | 1 |
+
+A blanket `tests/**/*.py` deletion would have **silently dropped ~25 modules'
+worth of coverage.** The audit is the proof the teardown needs.
+
+## Safe to delete now (no port needed)
+
+- **OBSOLETE:** `tests/telemetry/test_cost_floor.py` — a Python import-graph
+  invariant (`work_engine.*` must not transitively import `telemetry.*`); does
+  not transfer to the TS module system.
+- All **COVERED** modules (108) — each has a confirmed `.ts` test exercising
+  the same source module (cited per-module in the audit; dominant pattern =
+  golden-parity rigs that subprocess the `.py` and byte-compare).
+
+## Never delete (fixtures / test-data)
+
+- `tests/golden/sandbox/repo/tests/test_calculator.py` — the fake-consumer
+  repo's own suite, driven as DATA by the golden harness. Plus the 63
+  fixtures/recipes/conftest `.py` (sandbox recipes `gt*.py`, `concern_*.py`,
+  `_generate.py`, etc.) — test-data representing Python projects the suite
+  analyzes, like the 3 `internal/` fixtures.
+
+## GAPs — MUST get `.ts` coverage BEFORE the `.py` is deleted
+
+### Full gaps (no `.ts` test, or a whole behavior class missing)
+
+1. `ai_council/test_pricing.py` — no `pricing.test.ts` (estimate_input_tokens, estimate_cost, load_prices bootstrap, last_monday_utc, is_stale).
+2. `hooks/test_hooks_status.py` — `hooks_status.ts` exists, **no** `hooks_status.test.ts` at all.
+3. `hooks/test_install_snapshot.py` — per-platform consumer install-output snapshots + install↔manifest binding-drift guard.
+4. `hooks/test_event_shape_contract.py` — frozen per-platform native→AC-event alias matrix (all platforms).
+5. `telemetry/test_boundary.py` — `open_boundary`/`BoundarySession` lifecycle (coalesce, exception-suppress-flush, double-flush idempotent).
+6. `cli/test_hooks_install_claude_flag.py` — `hooks:install --claude/--lifecycle/--regen` bash dispatcher e2e.
+7. `conformance/retrieval/test_fixtures.py` — v1-envelope validator + shipped fixtures + 5 rejection cases.
+8. `contracts/test_memory_visibility_redaction.py` — privacy/redaction floor (8 synthetic secrets never in output; path-separator allowlist).
+9. `contracts/test_readme_audience_order.py` — README audience-heading order contract.
+10. `contracts/test_rule_interactions.py` — behavioural 2-axis layer (structural layer IS covered by `lint_rule_interactions.test.ts`).
+11. `golden/test_replay.py` — **the entire Golden-Transcript work_engine replay system** (`tests/golden/harness.py` + baseline + recipes) has no `.ts` port. Largest single gap.
+12. `implement_ticket/test_shim.py` — package deprecation-shim contract (DeprecationWarning, `_PUBLIC_SURFACE` identity, 13 `_ALIASED_SUBMODULES`).
+13. `install/test_consumer_model_tier.py` — `finalize_claude_model_tiers` (symlink→real-dir rewrite injecting native `model:`).
+14. `work_engine/test_integration_chat_history.py` — end-to-end `main()` cycle firing append calls + heartbeat-absent.
+15. `work_engine/test_integration_full_flow.py` — scripted 4-rebound backend convergence loop + cross-loop memory keep/drop.
+16. `work_engine/test_integration_mixed_flow.py` — 5-rebound mixed convergence chain (contract-locked-before-UI).
+17. `work_engine/test_state_schema.py` — `_validate_app_spec`/`_validate_ui_scaffold` rejection paths.
+18. `work_engine/test_step_polish.py` — stack-dispatch (`ui-polish-<stack>`) + `STACK_DIRECTIVES==KNOWN_STACKS`.
+19. `work_engine/test_step_review.py` — stack-dispatch (`ui-design-review-<stack>`).
+20. `work_engine/test_cli_hooks.py` — CLI HookHalt-per-event→exit-code table via `main()`.
+21. `work_engine/test_persona_integration.py` — end-to-end persona walk through dispatch.
+22. `work_engine/test_user_type_integration.py` + `test_user_type_policy.py` — target `src/scripts/skill_linter.py` (outside work_engine port); zero `user_type` `.ts` coverage.
+
+### Partial gaps (module mostly covered; specific assertions missing)
+
+- `ai_council/test_cli.py` — `build_members`, `parse_siblings_overrides`, `resolve_rounds`, `cmd_run`/`cmd_debate` units (CLI output IS covered).
+- `hooks/test_dispatcher_feedback.py` — `session_id` path-traversal neutralisation (rest covered).
+- `work_engine/hooks/{test_decision_gate_hook,test_decision_trace_hook,test_memory_visibility_hook,test_settings}.py` — Batch A flagged specific uncovered sub-behaviors; Batch B marked covered. **Reconcile per-module before deleting** (the `.ts` test exists; confirm the specific assertions transferred).
+- `cli/explain_last/test_cli.py` — `enable_last: false → exit 0` short-circuit unasserted.
+- `migrate/test_unified_migrate.py` — v0 `.implement-ticket-state.json`→`.work-state.json` migration action absent from the TS fixture.
+
+## Design fork (→ council, per the standing mandate)
+
+`golden/test_replay.py` + `tests/golden/harness.py` is a **subsystem**, not a
+single test. Port the whole Golden-Transcript replay harness to `.ts`, or
+retire it (the `.ts` parity suite + per-step golden-parity rigs may already
+provide equivalent behavioral pinning)? This is a scope decision, not a
+mechanical port — route to the AI council.

--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -110,9 +110,23 @@ not the "~25 gap ports" the audit alone implied. Evidence: `PY_SCRIPT = …X.py`
 and 475 others. CI would go red on deletion (visible, not silent) — but the path
 to green is the rig-conversion, not the deletion.
 
-**Decision required (test-teardown strategy):** convert all rigs to standalone /
-keep `.py` as a test-only anchor / hybrid / phased. Routed to AI council; reshapes
-the migration endgame, so surfaced to the user.
+**Decision (council 2026-06-18, claude-sonnet-4-5 + gpt-4o, 2 rounds; split A↔C → host-synthesised hybrid):**
+- **A — snapshot-conversion** for the ~450 COVERED parity rigs: capture each rig's
+  `python3` output once as a committed snapshot, rewrite the rig to compare the
+  `.ts` output against it, drop the live `python3` spawn. They share one
+  `spawnSync('python3', …)` pattern → drive via a **codemod + verification**, not
+  450 hand-edits. Preserves the migration's byte-verified contract (the `.ts` is
+  intentionally byte-identical to `.py`, so the snapshot just freezes the
+  already-verified state).
+- **C — fresh intent-based standalone tests** for the ~25 GAP modules (no rig to
+  snapshot; must be written anyway) — covers the round-2 intent concern exactly
+  where it matters (security, contracts, convergence-loops).
+- **B rejected** (both members, both rounds — fails "end Python").
+
+This is the new Phase 4.5. Execution: (1) codemod the rigs A-style + verify green;
+(2) write the ~25 C-style gap tests; (3) THEN the deletion waves (4/5/6).
+
+**Decision required (test-teardown strategy):** RESOLVED above.
 
 ## Risk register
 

--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -51,9 +51,9 @@ parent_roadmap: null
 
 ## Phase 2 — Rewire callers to `.ts` (before any deletion)
 
-- [ ] `hook_manifest.yaml`: flip `.py` handler paths to `.ts` (or extension-less dispatcher form). Verify each hook fires green.
-- [ ] CI workflows: rewire each real `python3 .../*.py` call to the `.ts`/dispatcher form. Distinguish migration-scaffolding workflows (`py2ts-*`, `migration-gates`, `migration-dry-run`) from production workflows (`tests`, `consistency`, `release-*`, `smoke-*`) — the scaffolding workflows are removed in Phase 6, not rewired.
-- [ ] Verify each rewired caller green individually before proceeding (narrow probe, not full pipeline).
+- [x] `hook_manifest.yaml`: **N/A** — no `.py` handler paths; handlers resolve extension-less via the dispatcher (`.ts`-wins).
+- [x] CI workflows — non-pytest direct invocation rewired: `consistency.yml` `python3 src/scripts/check_no_conflict_markers.py` → `./scripts-run src/scripts/check_no_conflict_markers` (job already has `npm ci`; verified locally: dispatcher resolves `.ts`, exit 0, byte-identical to `.py`). The remaining executed-python surface is **all pytest** (`tests.yml` python-tests, `python-version-sweep.yml`, `freeze-guard.yml` golden capture, `windows-lockfile-export.yml`, `consistency.yml:184` readme_linter) — these are removed **atomically with the `tests/**/*.py` deletion in Phase 5**, not here. Migration-scaffolding workflows (`py2ts-*`, `migration-gates`) removed in Phase 6.
+- [x] Verified the one rewired caller green individually (byte-parity probe).
 
 ## Phase 3 — dist mirror resolution (council verdict: TS-only, Node runtime)
 

--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -91,6 +91,29 @@ parent_roadmap: null
 - [ ] Full CI green on `python2ts`.
 - [ ] Hand back to user: `python2ts → main` final merge is the user's Hard-Floor decision (out of scope).
 
+## R6 — Parity-rig dependency (CRITICAL, discovered 2026-06-18, blocks teardown-as-planned)
+
+```
+479 of 541 .test.ts (88%) are golden-parity rigs that spawn `python3 <original.py>`
+and byte-compare .py-output vs .ts-output. Deleting the src .py removes their
+comparison anchor → they fail / assert nothing. "COVERED" in the audit is largely
+parity-rig coverage that does NOT survive deletion.
+```
+
+The parity rigs are the **migration's verification mechanism** (prove `.ts == .py`),
+not a standalone permanent suite. "Delete all `.py`" therefore requires first
+**converting ~479 rigs to standalone `.ts` tests** (inline/snapshot the expected
+values, drop the `python3` spawn) — an effort comparable to the migration itself,
+not the "~25 gap ports" the audit alone implied. Evidence: `PY_SCRIPT = …X.py` +
+`spawnSync('python3', …)` in `directives_backend_analyze.test.ts`,
+`ai_council/config.test.ts`, `templates_telemetry_report.test.ts`, `_cli/cmd_migrate.test.ts`,
+and 475 others. CI would go red on deletion (visible, not silent) — but the path
+to green is the rig-conversion, not the deletion.
+
+**Decision required (test-teardown strategy):** convert all rigs to standalone /
+keep `.py` as a test-only anchor / hybrid / phased. Routed to AI council; reshapes
+the migration endgame, so surfaced to the user.
+
 ## Risk register
 
 - **R1 — shipped consumer runtime (highest).** `dist/agent-src/**/*.py` is executed by consumers, not just dev tooling. Deleting src `.py` without resolving dist emission breaks installed consumers. **Resolved (Phase-0 council, 2026-06-18):** TS-only, Python fully removed; runtime = Node-via-`tsx` (baseline A), pre-bundled `.js` fallback (D) only if Phase-1 evidence forces it. Residual exposure = the empirical A-vs-D call; Phase-3 consumer smoke is the verification.

--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -67,11 +67,14 @@ parent_roadmap: null
 - [ ] Delete `src/**/*.py` (keep the 3 residual fixtures).
 - [ ] Verify: full parity suite + `npm run typecheck` + dispatcher resolution green; grep `src/` for any remaining non-fixture `.py` → zero.
 
-## Phase 5 — Delete `tests/**/*.py` Python suite (Hard Floor)
+## Phase 5 — Delete `tests/**/*.py` Python suite (Hard Floor) — NOT a blanket delete
 
-- [ ] Coverage-gap check: confirm `.ts` golden tests cover every behavior the 207 Python tests asserted (no silent loss). Surface any gap before deleting.
-- [ ] Surface the deletion diff and obtain explicit confirmation.
-- [ ] Delete `tests/**/*.py` + `conftest.py` + `pytest.ini`.
+- [x] Coverage-equivalence audit DONE (2026-06-18, 3 parallel agents, 125 modules) → `py2ts-teardown-coverage-audit.md`. Result: **108 COVERED, ~25 GAP, 1 OBSOLETE, fixtures KEEP.** A blanket delete would have silently dropped ~25 modules of coverage — audit vindicated the stop.
+- [ ] **Phase 4.5 (NEW precursor) — port the ~25 GAP modules' missing assertions to `.ts`** before any test deletion. Full list in the audit doc. Includes real security asserts (path-traversal, secret-redaction), `hooks_status` (no `.ts` at all), pricing primitives, per-platform install snapshots, 3 work_engine convergence-loop integrations, contract tests.
+- [ ] **Council fork — Golden-Transcript replay harness.** `golden/test_replay.py` + `tests/golden/harness.py` + recipes is a Python-only subsystem with no `.ts` port. Port it, or retire it (the per-step golden-parity rigs may already pin equivalent behavior)? Scope decision → AI council.
+- [ ] Reconcile the 4 `work_engine/hooks` partial-gap modules (Batch A deep-gap vs Batch B covered) per-module before deleting those.
+- [ ] Only after gaps closed: delete the COVERED + OBSOLETE `.py` test modules + `conftest.py` + `pytest.ini` (Hard Floor diff). **KEEP** all fixtures/recipes (`sandbox/`, `fixtures/`, `gt*.py`, `concern_*.py`, `test_calculator.py`).
+- [ ] Atomically remove the pytest CI jobs/steps (`tests.yml` python-tests, `python-version-sweep.yml`, `freeze-guard.yml`, `windows-lockfile-export.yml`, `consistency.yml:184`) in the same diff.
 - [ ] Verify: full `.ts` test suite green.
 
 ## Phase 6 — Remove Python toolchain + dead fast-paths (Hard Floor)

--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -1,0 +1,97 @@
+---
+status: draft
+slug: py2ts-teardown
+title: "Python → TypeScript migration: Phase 12 teardown"
+parent_roadmap: null
+---
+
+# Road to Python → TypeScript Teardown (Phase 12)
+
+> **Draft — review before activation.** The dev-side migration is complete:
+> every port-target `.py` has a byte-identical, CI-green `.ts` twin (PRs up to
+> #604 on `python2ts`). This roadmap plans the **removal** of the Python
+> originals. It is a bulk deletion: every deletion phase is a Hard-Floor gate
+> (`non-destructive-by-default`) — the agent surfaces the diff and waits for
+> explicit confirmation. Nothing is deleted on `draft`/`ready` alone.
+>
+> **Out of scope:** the final `python2ts → main` merge. That is the user's
+> Hard-Floor decision and is not a roadmap step.
+
+## Inventory (evidence, `git ls-files` on `python2ts` HEAD)
+
+| Class | Count | Disposition |
+|---|---|---|
+| `src/**/*.py` (port-targets) | 586 | DELETE (Phase 4) — all twinned |
+| `tests/**/*.py` (Python suite) | 207 | DELETE (Phase 5) — replaced by `.ts` golden tests |
+| `dist/agent-src/**/*.py` (shipped mirror) | 110 | RESOLVE (Phase 3) — consumer runtime, council-gated |
+| `pyproject.toml`, `requirements*.txt`, `conftest.py`, `pytest.ini` | ~7 | DELETE (Phase 6) |
+| Residual fixtures (`internal/.../user_model.py`, `retry.py`, `internal/glama/smoke.py`) | 3 | **KEEP** — test/fixture data representing Python projects the suite analyzes, not scripts |
+
+## Phase 0 — Pre-teardown gates
+
+- [ ] Confirm PR #604 merged into `python2ts`; full parity suite green on `python2ts` HEAD (baseline evidence).
+- [x] **Council decision — consumer dist runtime.** Council (claude-sonnet-4-5 + gpt-4o, 2 rounds, 2026-06-18) **converged**: remove Python from `dist/` entirely; no TS→py transpile (both members independently rejected Option B as vaporware — no production-grade TS→Python transpiler exists; dual-maintenance defeats the migration). Single-TS source, consumer runtime = **Node**. Host tie-break on the residual A-vs-D split (`tsx`-at-runtime vs pre-bundled `.js`): **baseline = A** — the dispatcher (`scripts-run`/`run.ts`) already runs `node_modules/.bin/tsx` and the package already depends on it, so no new bundler infra and no consumer dependency beyond what the installed package ships. **Fallback = D** (pre-bundle the shipped skill-scripts to plain `.js`) IF Phase-1 evidence shows consumers invoke `dist/` skill-scripts standalone without access to the package's `tsx` — decided empirically in Phase 3, not up front.
+- [ ] Decide whether `python2ts` is synced with latest `main` one final time before teardown (avoid a late big-bang conflict).
+
+## Phase 1 — Caller discovery (no deletion) — DONE 2026-06-18
+
+- [x] Sweep done across dispatcher, `hook_manifest.yaml`, `Taskfile.yml`, all `.github/workflows/*.yml`, `package.json`, docs.
+- [x] Caller map produced (see findings below).
+- [x] Orphan check: **0 active port-targets are orphan.** Every live script has a `.ts` twin.
+
+### Findings (caller map)
+
+- **Orphans (twin-less `.py`) = all dead/markers, 0 runtime callers:** 7 `src/scripts/_archive/`, 21 `ai_council/one_off_archive/2026-05/`, 4 `_`-prefix one-offs (`_emit_domain_table`, `_phase4_bucket`, `_pilot_measure`, `_tmp_scan_framework_leakage` — only prose/README refs; `_pilot_measure` is a docstring xref in `iron_law_sha.ts`, not a call), 27 `__init__.py` package markers (content absorbed into `.ts` module structure; `work_engine` 66 `.py`/60 `.ts` gap = exactly these markers, every logic file twinned). All delete without a twin.
+- **hook_manifest.yaml — no `.py` handler paths** (R2 dissolved): handlers resolve extension-less via the dispatcher (`.ts`-wins). No rewiring needed.
+- **Dispatcher** (`scripts-run` lines 15–19 + `run.ts` `.py` fallback): dead-but-harmless once `.py` gone → removed in Phase 6.
+- **CI surface (the real Phase-2 weight):** ~20 PRODUCTION workflows do `setup-python` + `pip install pytest` + `python3 -m pytest tests/` and/or trigger on `src/scripts/*.py` paths — `tests.yml`, `python-version-sweep.yml`, `freeze-guard.yml`, `consistency.yml`, `smoke.yml`, `skill-lint.yml`, `check-visibility-drift.yml`, `migration-dry-run.yml`, `windows-lockfile-export.yml`, `release-validation.yml`, `release-drift.yml`, `cloud-release.yml`, `publish-npm.yml`, `deploy-mcp-worker.yml`, `adoption-snapshot.yml`, `sync-visibility.yml`, `bench-drift.yml`, `release-guard.yml`, `commit-subjects.yml`, `smoke-public-install.yml`.
+- **Migration scaffolding workflows (remove in Phase 6, do NOT rewire):** `py2ts-drift.yml`, `migration-gates.yml`, `py2ts-base-guard.yml`, `py2ts-main-sync.yml`, `migration-dry-run.yml`(?-verify).
+- **KEYSTONE (re-checked — already satisfied):** `tests.yml` already has a `node-tests` job running `npm run test:ts` (= `vitest run`), and `vitest.config.ts` `include: ['tests/**/*.test.{ts,tsx}', ...]` collects the **entire** parity suite (3116 in `tests/scripts`, plus `tests/cli/python`, `tests/spikes`, …) — NOT just cli/server/ui (the job comment is stale). So vitest is **already the production gate**; deleting `tests/**/*.py` will not remove CI coverage. Phase 2 is therefore mostly **removing** redundant Python jobs/steps, not promoting vitest.
+- **Phase-2 work = remove/rewire Python invocations:** `tests.yml` `python-tests` job (pytest + golden-replay-pytest; the `runtime_dispatcher` E2E already uses `./scripts-run` = `.ts`-first), `python-version-sweep.yml` (pytest sweep), `freeze-guard.yml` (golden pytest in toy repo), and any workflow calling `python3 src/scripts/*.py` directly rather than via `./scripts-run`. Most `./scripts-run` callers already resolve `.ts`-first and need no change.
+
+## Phase 2 — Rewire callers to `.ts` (before any deletion)
+
+- [ ] `hook_manifest.yaml`: flip `.py` handler paths to `.ts` (or extension-less dispatcher form). Verify each hook fires green.
+- [ ] CI workflows: rewire each real `python3 .../*.py` call to the `.ts`/dispatcher form. Distinguish migration-scaffolding workflows (`py2ts-*`, `migration-gates`, `migration-dry-run`) from production workflows (`tests`, `consistency`, `release-*`, `smoke-*`) — the scaffolding workflows are removed in Phase 6, not rewired.
+- [ ] Verify each rewired caller green individually before proceeding (narrow probe, not full pipeline).
+
+## Phase 3 — dist mirror resolution (council verdict: TS-only, Node runtime)
+
+- [ ] Condense pipeline emits `.ts` twins (not `.py`) for `dist/agent-src/**/*.py`; no `.py` in the shipped tree.
+- [ ] Consumer smoke (baseline A): install into a sandbox consumer and run a shipped skill-script (`corpus-grounding/bm25_search`, `design-tokens/tokens`) + roadmap-progress via the installed package's `tsx`. Confirm end-to-end.
+- [ ] **A-vs-D empirical gate:** if the smoke shows consumers invoke `dist/` skill-scripts standalone without reachable `tsx`, switch the shipped skill-scripts to fallback D (pre-bundled `.js`, node-only) and re-smoke. Otherwise stay on A.
+
+## Phase 4 — Delete `src/**/*.py` port-targets (Hard Floor)
+
+- [ ] Surface the deletion diff (586 files) and obtain explicit user confirmation.
+- [ ] Delete `src/**/*.py` (keep the 3 residual fixtures).
+- [ ] Verify: full parity suite + `npm run typecheck` + dispatcher resolution green; grep `src/` for any remaining non-fixture `.py` → zero.
+
+## Phase 5 — Delete `tests/**/*.py` Python suite (Hard Floor)
+
+- [ ] Coverage-gap check: confirm `.ts` golden tests cover every behavior the 207 Python tests asserted (no silent loss). Surface any gap before deleting.
+- [ ] Surface the deletion diff and obtain explicit confirmation.
+- [ ] Delete `tests/**/*.py` + `conftest.py` + `pytest.ini`.
+- [ ] Verify: full `.ts` test suite green.
+
+## Phase 6 — Remove Python toolchain + dead fast-paths (Hard Floor)
+
+- [ ] Remove `pyproject.toml`, `requirements*.txt`, `python-version-sweep.yml`, the `migration-gates.yml` python-parity-dep step, and the migration scaffolding workflows once parity is no longer being tested.
+- [ ] Remove the dispatcher Python fast-path (`scripts-run` lines 15–19) and the `run.ts` `.py` fallback.
+- [ ] Surface the diff (infra + bulk) and obtain explicit confirmation.
+- [ ] Verify: full CI green; dispatcher still resolves `.ts` from any cwd.
+
+## Phase 7 — Final sweep + close
+
+- [ ] `git ls-files '*.py'` returns only the 3 kept fixtures.
+- [ ] `grep -rn 'python3'` across tracked files returns zero invocation sites (fixtures/docs prose excluded).
+- [ ] Full CI green on `python2ts`.
+- [ ] Hand back to user: `python2ts → main` final merge is the user's Hard-Floor decision (out of scope).
+
+## Risk register
+
+- **R1 — shipped consumer runtime (highest).** `dist/agent-src/**/*.py` is executed by consumers, not just dev tooling. Deleting src `.py` without resolving dist emission breaks installed consumers. **Resolved (Phase-0 council, 2026-06-18):** TS-only, Python fully removed; runtime = Node-via-`tsx` (baseline A), pre-bundled `.js` fallback (D) only if Phase-1 evidence forces it. Residual exposure = the empirical A-vs-D call; Phase-3 consumer smoke is the verification.
+- **R2 — hook handlers point at `.py`.** Deleting before rewiring `hook_manifest.yaml` silently disables hooks. Gated by Phase-2-before-Phase-4 ordering.
+- **R3 — coverage loss.** Deleting the Python test suite could drop assertions the `.ts` tests don't replicate. Gated by Phase-5 coverage-gap check.
+- **R4 — dispatcher orphan.** A `.py` with no `.ts` twin becomes unresolvable after deletion. Gated by Phase-1 orphan check.
+- **R5 — CI scaffolding vs production confusion.** Removing a production workflow thinking it was migration scaffolding. Gated by Phase-2 classification.


### PR DESCRIPTION
Phase 12 of the Python→TypeScript migration: plan the removal of the Python originals.

## What's in this PR (waves 0–2, no deletion)
- **Phase 0 — council (R1 resolved).** Council (claude-sonnet-4-5 + gpt-4o, 2 rounds, 2026-06-18) converged: remove Python from `dist/` entirely, single-TS source, consumer runtime = Node (baseline A = `tsx`; fallback D = pre-bundled `.js` only if Phase-1 evidence forces it). No TS→py transpile (rejected as vaporware).
- **Phase 1 — caller discovery.** 0 active port-targets are orphan; the 59 twin-less `.py` are all dead/markers (`_archive`, `one_off_archive`, `_`-one-offs, `__init__.py`). `hook_manifest` has no `.py` handler paths. **vitest is already the production test gate** (`tests.yml` `node-tests` runs the full `tests/**` parity suite).
- **Phase 2 — CI rewire (this diff).** The only non-pytest direct python invocation (`consistency.yml` conflict-marker check) rewired to the dispatcher; verified byte-identical.

## Not in this PR (Hard-Floor gated)
Phases 4/5/6 are bulk deletions (`src/**/*.py`, `tests/**/*.py`, Python toolchain) — each surfaces its diff and waits for explicit confirmation. The `python2ts → main` final merge is the user's decision.

Roadmap of record: `agents/roadmaps/road-to-py2ts-teardown.md`.