### PR TITLE
test(py2ts): Phase 4.5 oracle v2 — script/inline/module descriptor (validated)

### DIFF
--- a/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/482bc2f1ec7ebe6d47f521aa1c2776d8ec796fbdd20ede4227dda49fac7c8b02.json
+++ b/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/482bc2f1ec7ebe6d47f521aa1c2776d8ec796fbdd20ede4227dda49fac7c8b02.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "unknown intent ''; expected one of ['backend-coding', 'mixed', 'ui-build', 'ui-improve', 'ui-trivial']",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/75ed9915bef1a38644872b13ff06d9af75114b3953c94e18414235c42f6057e6.json
+++ b/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/75ed9915bef1a38644872b13ff06d9af75114b3953c94e18414235c42f6057e6.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "unknown intent 'ui-build '; expected one of ['backend-coding', 'mixed', 'ui-build', 'ui-improve', 'ui-trivial']",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/c597446d3135b33a2a823ca591e7c72210eebf64a4b422a73bfcd64d8aa9f9d3.json
+++ b/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/c597446d3135b33a2a823ca591e7c72210eebf64a4b422a73bfcd64d8aa9f9d3.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "unknown intent 'BACKEND'; expected one of ['backend-coding', 'mixed', 'ui-build', 'ui-improve', 'ui-trivial']",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/db7376c05773a4fb67948b6ea21d8b8cbdced749006bd9cc84e2858d76a12afc.json
+++ b/tests/_lib/__parity_snapshots__/inline-3fa9bc6ed9f6/db7376c05773a4fb67948b6ea21d8b8cbdced749006bd9cc84e2858d76a12afc.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "unknown intent 'bogus'; expected one of ['backend-coding', 'mixed', 'ui-build', 'ui-improve', 'ui-trivial']",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-5c9092148af1/176efeeb52ccab6db57cbf3db98a2dc96afda3df5287ce52d4cbf635d78330e7.json
+++ b/tests/_lib/__parity_snapshots__/inline-5c9092148af1/176efeeb52ccab6db57cbf3db98a2dc96afda3df5287ce52d4cbf635d78330e7.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "backend",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-5c9092148af1/29b1a27e304da496f954986807d8b30f30ee587a13f1eb73b235d7ce27b86dfe.json
+++ b/tests/_lib/__parity_snapshots__/inline-5c9092148af1/29b1a27e304da496f954986807d8b30f30ee587a13f1eb73b235d7ce27b86dfe.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-trivial",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-5c9092148af1/90ac044b0166c845b4a611f5a47b87d8ec782c89253b97c0ee61845b3c88df5d.json
+++ b/tests/_lib/__parity_snapshots__/inline-5c9092148af1/90ac044b0166c845b4a611f5a47b87d8ec782c89253b97c0ee61845b3c88df5d.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "mixed",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-5c9092148af1/b38c8b73e302a5ea2bb65ca99c92f8ec5df30466622ee0a9d33657d364afe725.json
+++ b/tests/_lib/__parity_snapshots__/inline-5c9092148af1/b38c8b73e302a5ea2bb65ca99c92f8ec5df30466622ee0a9d33657d364afe725.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-5c9092148af1/d37fd8c905926256c0763f77e862d15746fa3a57587c78fa53878d38d83392d0.json
+++ b/tests/_lib/__parity_snapshots__/inline-5c9092148af1/d37fd8c905926256c0763f77e862d15746fa3a57587c78fa53878d38d83392d0.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/051160b80ed5dcd0e4904afdd5ab6f64590b5b2ee1db530ee31715932ee157f8.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/051160b80ed5dcd0e4904afdd5ab6f64590b5b2ee1db530ee31715932ee157f8.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-trivial",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/09d8dd51e8ed7203fbcc953ff4b28be8e05cade311d579a4299eae9888a1be03.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/09d8dd51e8ed7203fbcc953ff4b28be8e05cade311d579a4299eae9888a1be03.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-improve",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/3868c9119637306803d1062dceecc38327382677d215339cc6da414506000c7f.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/3868c9119637306803d1062dceecc38327382677d215339cc6da414506000c7f.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-trivial",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/3bb67d3c13f91b8643c6c9f145d18c720d27124bdc307629d3965fe6f39482a4.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/3bb67d3c13f91b8643c6c9f145d18c720d27124bdc307629d3965fe6f39482a4.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-improve",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/4faf2e9fe51d937e2fca12b23993f68d2f3902b97b74da2506f208308dae1835.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/4faf2e9fe51d937e2fca12b23993f68d2f3902b97b74da2506f208308dae1835.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-improve",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/57a9ff4d906a7f470f3574e291b1a77366e54e4b6e6b73189a2303cede8ffd36.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/57a9ff4d906a7f470f3574e291b1a77366e54e4b6e6b73189a2303cede8ffd36.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-build",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/608441ef05861a2ecb5d749e97aa369d3b73a0beda3757ecc2cca31316a2be7f.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/608441ef05861a2ecb5d749e97aa369d3b73a0beda3757ecc2cca31316a2be7f.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "mixed",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/668d47c4faae4c74c4e23e8dc82f85d6abb376c7b6d3f28c42e15d68bde4b02b.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/668d47c4faae4c74c4e23e8dc82f85d6abb376c7b6d3f28c42e15d68bde4b02b.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "backend-coding",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/67911a5c05b4bc522fc243819e44bd0dd3c1c182815099c930099c4de32bf552.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/67911a5c05b4bc522fc243819e44bd0dd3c1c182815099c930099c4de32bf552.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "backend-coding",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/8d3970e93363f7a2a0518201c5e0ef893193f30e220b9a3aa5f97b426367105f.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/8d3970e93363f7a2a0518201c5e0ef893193f30e220b9a3aa5f97b426367105f.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-trivial",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/9e3c0a77a791e04c993e4070cea01df70458d9044db505eb2647f48fa917b6d3.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/9e3c0a77a791e04c993e4070cea01df70458d9044db505eb2647f48fa917b6d3.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-build",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/b4de6fea255a1ec5cef46b1e49dc1046a3dbf34f6b0769f5d4dfef440f788c26.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/b4de6fea255a1ec5cef46b1e49dc1046a3dbf34f6b0769f5d4dfef440f788c26.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "backend-coding",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/bc00231fb7573544c34435409744023f7f71250fbd7bb26deb9ec191856443cd.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/bc00231fb7573544c34435409744023f7f71250fbd7bb26deb9ec191856443cd.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-trivial",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/c05dd723a290d0f99cc15dcfe2c11d6243fd89c8ad46a41db1c1276ee2c70602.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/c05dd723a290d0f99cc15dcfe2c11d6243fd89c8ad46a41db1c1276ee2c70602.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-trivial",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/c3baeeeb011464ccb2262d15e75227308e50cc649fa6f2e499aeb49f1d682c78.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/c3baeeeb011464ccb2262d15e75227308e50cc649fa6f2e499aeb49f1d682c78.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "backend-coding",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/c7fb6fccc581436b6378f4edd9a732e84b929218f8a5298caf6ee159bfd03cc0.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/c7fb6fccc581436b6378f4edd9a732e84b929218f8a5298caf6ee159bfd03cc0.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "mixed",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/ca9f8ad6191bd9f7ca581524282cea383b1d437f1fc867d060aa2db78844c95c.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/ca9f8ad6191bd9f7ca581524282cea383b1d437f1fc867d060aa2db78844c95c.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-improve",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/ccd0c0484c4ccc30f651a0cbd1511b63a582c9f0e552f2ed57ce44c4d553a276.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/ccd0c0484c4ccc30f651a0cbd1511b63a582c9f0e552f2ed57ce44c4d553a276.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-improve",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/d2942ca3240018c8ccda99cf70b4fe8f1eca4ff07476da4f944b45e5fce1b5b0.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/d2942ca3240018c8ccda99cf70b4fe8f1eca4ff07476da4f944b45e5fce1b5b0.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-build",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/dc6e9b8683337764b53793516d293ccfae94a2142dc086ac08680a92f0f0a660.json
+++ b/tests/_lib/__parity_snapshots__/inline-d6d0bd872f6e/dc6e9b8683337764b53793516d293ccfae94a2142dc086ac08680a92f0f0a660.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "ui-improve",
+  "stderr": "",
+  "status": 0
+}

--- a/tests/_lib/__parity_snapshots__/module-work_engine/94ef932a6ac0eda5e5a130d8e914614092b7c01cf7017d63a74319983ac63e74.json
+++ b/tests/_lib/__parity_snapshots__/module-work_engine/94ef932a6ac0eda5e5a130d8e914614092b7c01cf7017d63a74319983ac63e74.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "",
+  "stderr": "error: No state file at .work-state.json and no --ticket-file, --prompt-file, --diff-file, or --file-file given; cannot build an initial state.\n",
+  "status": 2
+}

--- a/tests/_lib/__parity_snapshots__/module-work_engine/bb9c9183f2a4e960491be9b5495da733660b756aa85cfc15c1042cbb9f539af9.json
+++ b/tests/_lib/__parity_snapshots__/module-work_engine/bb9c9183f2a4e960491be9b5495da733660b756aa85cfc15c1042cbb9f539af9.json
@@ -1,0 +1,5 @@
+{
+  "stdout": "[halt] outcome=blocked step=refine\n> Ticket T-1 is missing: missing or trivial title; no acceptance criteria.\n> 1. Run `/refine-ticket T-1` and re-invoke `/implement-ticket`\n> 2. Provide the missing details in chat — I'll merge them into the ticket\n> 3. Abandon this ticket — too vague to implement\n",
+  "stderr": "",
+  "status": 1
+}

--- a/tests/_lib/parity_oracle.ts
+++ b/tests/_lib/parity_oracle.ts
@@ -9,15 +9,30 @@
 // twin and asserts `ts === oracle(...)` byte-for-byte.
 //
 // Modes (env `PY2TS_CAPTURE`):
-//   - "1"  → CAPTURE: spawn `python3 <stem>.py`, write the snapshot, return it.
-//            Run once with the `.py` present to freeze the goldens.
+//   - "1"  → CAPTURE: spawn the python3 invocation, write the snapshot,
+//            return it. Run once with the `.py` present to freeze the goldens.
 //   - else → NORMAL: read the snapshot and return it. A missing snapshot
 //            THROWS loudly — never silently skips or passes.
 //
-// Snapshot layout (keyed by a stable hash of stem+args+input so the same
-// invocation always resolves to the same file, and any change to the
+// ─── v1 vs v2 ────────────────────────────────────────────────────────────
+// v1 (`oracle(stem, args, input)`) modelled ONLY `python3 <stem>.py args`
+// — the "script" invocation kind. ~38% of rigs invoke python3 differently:
+//   - inline  → `python3 -c "<code>" args`  (often code that itself inserts
+//               `src` onto sys.path or loads sibling modules by abs path).
+//   - module  → `python3 -m <module> args` with `PYTHONPATH=<repo>/src`
+//               (and sometimes other env, e.g. a frozen clock).
+//
+// v2 (`oracle2({ kind, target, args?, input?, env?, normalize? })`) models
+// all three. v1 `oracle(...)` is kept as a thin wrapper over
+// `oracle2({ kind: 'script', target: stem, args, input })`, so already-
+// converted rigs (e.g. templates_telemetry_report.test.ts) keep passing
+// against their EXISTING snapshots — the v1 key scheme is preserved exactly
+// for `kind: 'script'` with no `env`/`normalize` (see snapshotKey).
+//
+// Snapshot layout (keyed by a stable hash of kind+target+args+input(+env) so
+// the same invocation always resolves to the same file, and any change to the
 // invocation surfaces as a new key rather than overwriting a golden):
-//   tests/_lib/__parity_snapshots__/<basename(stem)>/<sha256>.json
+//   tests/_lib/__parity_snapshots__/<bucket>/<sha256>.json
 //
 // This package is ESM ("type":"module"); a bare `require` throws under tsx,
 // so everything below uses top-level `import`.
@@ -27,11 +42,57 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-/** Captured / frozen result of one script invocation. */
+/** Captured / frozen result of one invocation. */
 export interface OracleResult {
     stdout: string;
     stderr: string;
     status: number;
+}
+
+/** The three python3 invocation kinds v2 models. */
+export type OracleKind = 'script' | 'inline' | 'module';
+
+/**
+ * Descriptor for one python3 invocation.
+ *
+ * - `script`: spawn `python3 <target>.py ...args`. `target` is a repo-relative
+ *   path WITHOUT the `.py` extension (e.g. `src/.../telemetry_report`).
+ * - `inline`: spawn `python3 -c <target> ...args`. `target` is the literal
+ *   code string handed to `-c`.
+ * - `module`: spawn `python3 -m <target> ...args`. `target` is the module name
+ *   (e.g. `work_engine`); pass `env: { PYTHONPATH: ... }` so the module
+ *   resolves. CWD is always REPO_ROOT (see resolveCwd note below).
+ *
+ * `env` is merged over `process.env` for BOTH capture and normal modes —
+ * but env is NEVER stored in the snapshot beyond its effect on the output.
+ * (For `module`, PYTHONPATH is part of the key — see keying note below.)
+ *
+ * `normalize`, when given, is applied to stdout AND stderr symmetrically
+ * BEFORE the snapshot is written (capture) and BEFORE the result is returned
+ * (normal). It strips volatile noise (tmp paths, clock text) so the frozen
+ * golden is machine-independent.
+ *
+ * ── normalize contract (READ THIS) ──────────────────────────────────────
+ * The oracle applies `normalize` to its OWN (python) output. The caller's
+ * `.ts` side compares against `oracle2(...).stdout`. Therefore the CALLER
+ * MUST apply the SAME `normalize` to the `.ts` stdout/stderr before
+ * `expect(tsOut).toBe(oracle2(...).stdout)`. The oracle cannot reach into the
+ * rig's tsx spawn — symmetry is the caller's responsibility. Keep one shared
+ * `normalize` fn in the rig and pass it both here and to the tsx side.
+ *
+ * `cwd` overrides the spawn working directory (default REPO_ROOT). Volatile
+ * absolute `cwd` values (a per-test `os.tmpdir()` dir) are NOT part of the key
+ * — pass a `normalize` if the cwd leaks into the output, and keep the
+ * invocation's *observable* output cwd-independent.
+ */
+export interface OracleSpec {
+    kind: OracleKind;
+    target: string;
+    args?: string[];
+    input?: string;
+    env?: Record<string, string>;
+    normalize?: (s: string) => string;
+    cwd?: string;
 }
 
 // tests/_lib/parity_oracle.ts → repo root is two levels up.
@@ -59,7 +120,7 @@ function isCaptureMode(): boolean {
  * Rig contract this assumes: the invocation's *output* must not depend on the
  * absolute path text (only on basename + contents). Rigs whose stdout/stderr
  * echoes an absolute path are NOT key-stable under this scheme and need a
- * different normalisation (see fan-out obstacles in the report).
+ * `normalize` hook (see fan-out obstacles in the report).
  */
 function normalizeArgForKey(arg: string): string {
     if (!path.isAbsolute(arg)) {
@@ -79,20 +140,92 @@ function normalizeArgForKey(arg: string): string {
 }
 
 /**
- * Stable key for one invocation. The NUL separators keep the three fields
- * unambiguous (no field can contain a NUL byte in practice), so distinct
- * (stem, args, input) triples never collide on a single key.
+ * Stabilise an inline `-c` code string for KEYING. The code commonly embeds
+ * volatile absolute paths (a JSON-quoted `/Users/.../foo.py` injected via
+ * `JSON.stringify(ABS)`) or a `sys.path.insert(..., 'src')` line. Hashing the
+ * raw literal would make the key machine-dependent. So for the key we:
+ *   - replace every absolute-path-looking run with a stable placeholder, then
+ *   - hash the result.
+ * The spawn still receives the ORIGINAL code unchanged. The placeholder keeps
+ * two genuinely-different code bodies distinct while folding out the volatile
+ * dir prefix that differs per machine / per checkout.
  */
-function snapshotKey(scriptStem: string, args: string[], input: string): string {
+function stableInlineKeyMaterial(code: string): string {
+    // Collapse POSIX + Windows absolute paths to a placeholder for the key.
+    // (Common shapes: "/Users/...", "/home/...", "/private/...", "C:\\...".)
+    const stabilised = code
+        .replace(/(["'`])(?:\/[^"'`\s]+)\1/g, '$1<abspath>$1')
+        .replace(/(["'`])[A-Za-z]:\\[^"'`]+\1/g, '$1<abspath>$1');
+    return createHash('sha256').update(stabilised, 'utf8').digest('hex').slice(0, 24);
+}
+
+/**
+ * Stable key for one invocation.
+ *
+ * v1 compatibility: for `kind: 'script'` with no env, the material is exactly
+ * `<target>\0<keyArgs>\0<input>` — byte-identical to the v1 scheme — so
+ * existing `kind: 'script'` snapshots resolve unchanged. v2 adds the `kind`
+ * tag and (for module) the PYTHONPATH only for NON-script kinds, so no
+ * existing script key shifts.
+ *
+ * - inline: `target` is hashed via `stableInlineKeyMaterial` (NOT treated as a
+ *   path), so the key stays stable across machines even when the code embeds
+ *   absolute paths.
+ * - module: PYTHONPATH (basename-stabilised) joins the material so two runs
+ *   with different module-search roots can't collide.
+ *
+ * The NUL separators keep fields unambiguous (no field contains a NUL byte in
+ * practice), so distinct invocations never collide on a single key.
+ */
+function snapshotKey(spec: OracleSpec): string {
+    const args = spec.args ?? [];
+    const input = spec.input ?? '';
     const keyArgs = args.map(normalizeArgForKey);
-    const material = `${scriptStem}\0${JSON.stringify(keyArgs)}\0${input}`;
+
+    if (spec.kind === 'script' && !spec.env) {
+        // v1-identical material — keeps existing script snapshots resolving.
+        const material = `${spec.target}\0${JSON.stringify(keyArgs)}\0${input}`;
+        return createHash('sha256').update(material, 'utf8').digest('hex');
+    }
+
+    let targetForKey: string;
+    if (spec.kind === 'inline') {
+        targetForKey = `inline:${stableInlineKeyMaterial(spec.target)}`;
+    } else {
+        targetForKey = `${spec.kind}:${spec.target}`;
+    }
+
+    // Fold PYTHONPATH into the key for module runs (basename-stabilised so the
+    // volatile checkout prefix drops out but a different search root still
+    // produces a distinct key).
+    const pythonPath = spec.env?.['PYTHONPATH'];
+    const envMaterial =
+        spec.kind === 'module' && pythonPath
+            ? `\0PYTHONPATH=${pythonPath.split(path.sep).slice(-2).join('/')}`
+            : '';
+
+    const material = `${spec.kind}\0${targetForKey}\0${JSON.stringify(keyArgs)}\0${input}${envMaterial}`;
     return createHash('sha256').update(material, 'utf8').digest('hex');
 }
 
-function snapshotPath(scriptStem: string, args: string[], input: string): string {
-    const base = path.basename(scriptStem);
-    const key = snapshotKey(scriptStem, args, input);
-    return path.join(SNAPSHOT_ROOT, base, `${key}.json`);
+/**
+ * Bucket directory for the snapshot. Script: basename of the stem (v1 layout).
+ * Inline / module: the kind plus a short stable tag, so the snapshot tree is
+ * navigable and the inline code literal never becomes a path.
+ */
+function snapshotBucket(spec: OracleSpec): string {
+    if (spec.kind === 'script') {
+        return path.basename(spec.target);
+    }
+    if (spec.kind === 'module') {
+        return `module-${spec.target.replace(/[^A-Za-z0-9._-]/g, '_')}`;
+    }
+    // inline: stable short tag from the code body.
+    return `inline-${stableInlineKeyMaterial(spec.target).slice(0, 12)}`;
+}
+
+function snapshotPath(spec: OracleSpec): string {
+    return path.join(SNAPSHOT_ROOT, snapshotBucket(spec), `${snapshotKey(spec)}.json`);
 }
 
 /** Absolute path to the script (stem given relative to REPO_ROOT). */
@@ -100,41 +233,60 @@ function resolveStem(scriptStem: string): string {
     return path.isAbsolute(scriptStem) ? scriptStem : path.join(REPO_ROOT, scriptStem);
 }
 
-function capture(scriptStem: string, args: string[], input: string): OracleResult {
-    const pyScript = `${resolveStem(scriptStem)}.py`;
-    if (!fs.existsSync(pyScript)) {
-        throw new Error(
-            `parity_oracle CAPTURE: python source not found at ${pyScript} ` +
-                `(scriptStem="${scriptStem}"). Capture must run while the .py original exists.`,
-        );
+/** Build the argv + spawn options for one invocation kind. */
+function buildSpawn(spec: OracleSpec): { argv: string[]; cwd: string } {
+    const args = spec.args ?? [];
+    const cwd = spec.cwd ?? REPO_ROOT;
+    if (spec.kind === 'script') {
+        const pyScript = `${resolveStem(spec.target)}.py`;
+        if (!fs.existsSync(pyScript)) {
+            throw new Error(
+                `parity_oracle CAPTURE: python source not found at ${pyScript} ` +
+                    `(target="${spec.target}"). Capture must run while the .py original exists.`,
+            );
+        }
+        return { argv: [pyScript, ...args], cwd };
     }
-    const r = spawnSync('python3', [pyScript, ...args], {
-        cwd: REPO_ROOT,
-        input,
+    if (spec.kind === 'inline') {
+        return { argv: ['-c', spec.target, ...args], cwd };
+    }
+    // module
+    return { argv: ['-m', spec.target, ...args], cwd };
+}
+
+function capture(spec: OracleSpec): OracleResult {
+    const { argv, cwd } = buildSpawn(spec);
+    const env = spec.env ? { ...process.env, ...spec.env } : process.env;
+    const r = spawnSync('python3', argv, {
+        cwd,
+        input: spec.input ?? '',
         encoding: 'utf8',
+        env,
     });
     if (r.error) {
         throw new Error(`parity_oracle CAPTURE: spawning python3 failed: ${r.error.message}`);
     }
+    const norm = spec.normalize ?? ((s: string): string => s);
     const result: OracleResult = {
-        stdout: r.stdout ?? '',
-        stderr: r.stderr ?? '',
+        stdout: norm(r.stdout ?? ''),
+        stderr: norm(r.stderr ?? ''),
         // spawnSync reports status `null` when the process was killed by a
         // signal; -1 is a deterministic, JSON-serialisable stand-in.
         status: r.status ?? -1,
     };
-    const target = snapshotPath(scriptStem, args, input);
+    const target = snapshotPath(spec);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, `${JSON.stringify(result, null, 2)}\n`);
     return result;
 }
 
-function readSnapshot(scriptStem: string, args: string[], input: string): OracleResult {
-    const target = snapshotPath(scriptStem, args, input);
+function readSnapshot(spec: OracleSpec): OracleResult {
+    const target = snapshotPath(spec);
     if (!fs.existsSync(target)) {
         throw new Error(
-            `parity_oracle: no snapshot for scriptStem="${scriptStem}" args=${JSON.stringify(args)} ` +
-                `(expected ${target}). Re-run capture with PY2TS_CAPTURE=1 while the .py original exists. ` +
+            `parity_oracle: no snapshot for kind="${spec.kind}" target="${spec.target}" ` +
+                `args=${JSON.stringify(spec.args ?? [])} (expected ${target}). ` +
+                `Re-run capture with PY2TS_CAPTURE=1 while the .py original exists. ` +
                 `Refusing to pass without a frozen golden.`,
         );
     }
@@ -151,7 +303,22 @@ function readSnapshot(scriptStem: string, args: string[], input: string): Oracle
 }
 
 /**
- * Resolve the frozen Python-side result for one script invocation.
+ * Resolve the frozen Python-side result for one invocation descriptor (v2).
+ *
+ * Capture mode spawns python3 per `spec.kind`, applies `spec.normalize` to
+ * stdout/stderr, writes the snapshot, and returns it. Normal mode reads the
+ * frozen snapshot (a missing one throws — never silently passes).
+ *
+ * The caller MUST apply the same `spec.normalize` to the `.ts` twin's output
+ * before comparing — see the normalize contract on `OracleSpec`.
+ */
+export function oracle2(spec: OracleSpec): OracleResult {
+    return isCaptureMode() ? capture(spec) : readSnapshot(spec);
+}
+
+/**
+ * v1 entry point — kept as a thin wrapper so already-converted `kind: 'script'`
+ * rigs keep passing against their existing snapshots.
  *
  * @param scriptStem  Path to the script WITHOUT extension, relative to the
  *                    repo root (e.g. `src/agent-src/templates/scripts/telemetry_report`).
@@ -160,7 +327,5 @@ function readSnapshot(scriptStem: string, args: string[], input: string): Oracle
  * @param input       stdin fed to the script (use `''` when the script reads no stdin).
  */
 export function oracle(scriptStem: string, args: string[], input: string): OracleResult {
-    return isCaptureMode()
-        ? capture(scriptStem, args, input)
-        : readSnapshot(scriptStem, args, input);
+    return oracle2({ kind: 'script', target: scriptStem, args, input });
 }

--- a/tests/scripts/work_engine/__main__.test.ts
+++ b/tests/scripts/work_engine/__main__.test.ts
@@ -13,6 +13,8 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { oracle2 } from '../../_lib/parity_oracle';
+
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const MAIN_TS = path.join(SCRIPTS_ROOT, 'work_engine', '__main__.ts');
@@ -28,15 +30,25 @@ interface Run {
     stderr: string;
 }
 
-/** Run `python3 -m work_engine` semantics in `cwd` with `argv`. */
+/**
+ * Frozen Python-side result of `python3 -m work_engine ...argv`.
+ *
+ * The Python module is spawned in `cwd` (a per-test tmp dir) with
+ * `PYTHONPATH=SCRIPTS_ROOT` so `work_engine` resolves. `oracle2` keys on
+ * `kind:'module'` + the module name + PYTHONPATH (basename-stabilised) + argv,
+ * NOT the volatile tmp `cwd` — the module's observable output here is
+ * cwd-independent (BLOCKED stdout / arg-error stderr), so no `normalize` is
+ * needed. Capture spawns python3 once; normal reads the frozen snapshot.
+ */
 function runPy(cwd: string, argv: string[]): Run {
-    // `python3 -m work_engine` runs the package's __main__ with sys.argv set.
-    const r = spawnSync('python3', ['-m', 'work_engine', ...argv], {
-        encoding: 'utf8',
+    const r = oracle2({
+        kind: 'module',
+        target: 'work_engine',
+        args: argv,
+        env: { PYTHONPATH: SCRIPTS_ROOT },
         cwd,
-        env: { ...process.env, PYTHONPATH: SCRIPTS_ROOT },
     });
-    return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
+    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
 }
 
 /**

--- a/tests/scripts/work_engine/intent_classify.test.ts
+++ b/tests/scripts/work_engine/intent_classify.test.ts
@@ -11,11 +11,12 @@
 // labels and identical ValueError text. `populate_routing` mutates a WorkState
 // in place; it is exercised TS-side (it needs the WorkState class) and its
 // classifier delegate is covered by the golden cases.
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { oracle2 } from '../../_lib/parity_oracle';
 import { Input, WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
 import {
     INTENT_BACKEND,
@@ -53,21 +54,29 @@ function hasPython3(): boolean {
     return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
 }
 
-function runPy(body: string, args: string[] = []): SpawnSyncReturns<string> {
-    const loader = [
-        'import sys, json, importlib.util',
-        `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
-        'state = importlib.util.module_from_spec(_sspec)',
-        'sys.modules["state"] = state',
-        '_sspec.loader.exec_module(state)',
-        `_src = open(${JSON.stringify(CLASSIFY_PY)}, encoding="utf-8").read()`,
-        '_src = _src.replace("from ..state import WorkState", "from state import WorkState")',
-        'mod = type(sys)("mod")',
-        'exec(compile(_src, "mod", "exec"), mod.__dict__)',
-    ].join('\n');
-    return spawnSync('python3', ['-c', `${loader}\n${body}`, ...args], {
-        encoding: 'utf8',
-    });
+// The `-c` loader exec's classify.py with its `from ..state import WorkState`
+// rewritten to a file-loaded `state` module. Each probe appends its own body.
+// The loader embeds the absolute STATE_PY / CLASSIFY_PY paths — `oracle2`'s
+// inline-key stabilisation folds those volatile prefixes out so the snapshot
+// key is machine-independent (the spawn still gets the original code).
+const LOADER = [
+    'import sys, json, importlib.util',
+    `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
+    'state = importlib.util.module_from_spec(_sspec)',
+    'sys.modules["state"] = state',
+    '_sspec.loader.exec_module(state)',
+    `_src = open(${JSON.stringify(CLASSIFY_PY)}, encoding="utf-8").read()`,
+    '_src = _src.replace("from ..state import WorkState", "from state import WorkState")',
+    'mod = type(sys)("mod")',
+    'exec(compile(_src, "mod", "exec"), mod.__dict__)',
+].join('\n');
+
+/** Frozen python stdout for one inline `-c` probe (capture spawns python3). */
+function pyInline(body: string, args: string[]): string {
+    const code = `${LOADER}\n${body}`;
+    const r = oracle2({ kind: 'inline', target: code, args });
+    if (r.status !== 0) throw new Error(`py inline probe failed (status ${r.status}): ${r.stderr || r.stdout}`);
+    return r.stdout;
 }
 
 /** Python classify_intent(raw, title=...). args: rawJson, titleJson (or "null"). */
@@ -77,9 +86,7 @@ function pyClassify(rawJson: string, titleJson: string): string {
         'title = json.loads(sys.argv[2])',
         'sys.stdout.write(mod.classify_intent(raw, title=title))',
     ].join('\n');
-    const r = runPy(body, [rawJson, titleJson]);
-    if (r.status !== 0) throw new Error(`py classify failed: ${r.stderr || r.stdout}`);
-    return r.stdout;
+    return pyInline(body, [rawJson, titleJson]);
 }
 
 function pyDirectiveSet(intentJson: string): string {
@@ -87,9 +94,7 @@ function pyDirectiveSet(intentJson: string): string {
         'intent = json.loads(sys.argv[1])',
         'sys.stdout.write(mod.directive_set_for(intent))',
     ].join('\n');
-    const r = runPy(body, [intentJson]);
-    if (r.status !== 0) throw new Error(`py directive_set failed: ${r.stderr || r.stdout}`);
-    return r.stdout;
+    return pyInline(body, [intentJson]);
 }
 
 function pyDirectiveSetError(intentJson: string): string {
@@ -101,9 +106,7 @@ function pyDirectiveSetError(intentJson: string): string {
         'except ValueError as exc:',
         '    sys.stdout.write(str(exc))',
     ].join('\n');
-    const r = runPy(body, [intentJson]);
-    if (r.status !== 0) throw new Error(`py directive_set error-probe failed: ${r.stderr || r.stdout}`);
-    return r.stdout;
+    return pyInline(body, [intentJson]);
 }
 
 function tsClassify(rawJson: string, titleJson: string): string {


### PR DESCRIPTION
Extends the snapshot-oracle to cover the ~38% of rigs that aren't plain `script` invocations, unblocking the bulk conversion.

## v2
`oracle2({kind:'script'|'inline'|'module', target, args?, input?, env?, normalize?, cwd?})`; v1 `oracle()` kept as a script-kind wrapper (telemetry rig unchanged).
- **inline** (`python3 -c`): key hashes the code body, folding embedded abs-paths for machine-independence.
- **module** (`python3 -m`): PYTHONPATH folded into key + env passthrough (capture == normal).
- **normalize** hook: strips tmp/clock noise from stdout+stderr symmetrically on capture + read (caller applies the same fn to the tsx side).

## Validation (one rig per kind, regression-proof)
- script `templates_telemetry_report` 8/8 (v1 wrapper, unchanged).
- inline `work_engine/intent_classify` 37/37 + 29 snapshots.
- module `work_engine/__main__` 3/3 + 2 snapshots.
- All green with python3 OFF PATH; each goes RED on an injected twin regression then green on revert; `npm run typecheck` clean.

## Next
Bulk conversion: 2 shared harnesses (21 rigs) → ~400 rigs (parallel) with the ~35 path-normalizers + ~4 clock-freezes from the classification doc → bulk capture + review-lock → 25 C-gap tests → deletion 4/5/6 (Hard Floor).