### PR TITLE
chore(py2ts): teardown prep — orphan-snapshot prune + runtime_handler node fixture + completion plan

### DIFF
--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -242,6 +242,32 @@ version). Such rigs stay **LIVE python↔tsx** (`skipIf(real python3)`) until th
 - **Detection (Phase-5 gate):** before deleting any `.py`, audit each surviving frozen rig for
   generated/gitignored-state reads; re-classify manifest-dependent ones as live-parity-then-delete.
 
+### Completion plan to the final PR — council (claude-sonnet-4-5 + gpt-4o, 2026-06-18, converged)
+
+**Structure = ~3 PRs, NOT granular per-phase.** Deleting `src/**/*.py`, `tests/**/*.py`, the pytest CI
+jobs, and the dispatcher python fast-path MUST be **ATOMIC in one PR** — splitting them creates a
+"zombie test state" (surviving pytest imports / dispatcher calls reference deleted modules →
+`ModuleNotFoundError`/`FileNotFoundError`, not independently green, not independently revertible, and it
+crosses the irreversible `.py`-deletion line while python tests still need the code).
+
+- **PR-1 (prerequisites — NO `.py` deletion, each independently green):**
+  - [x] Orphan-snapshot prune (18 unreferenced goldens removed; 0 referenced touched).
+  - [x] `runtime_handler` — `python3 -c` fixtures → `node -e` (language-irrelevant subprocess; now python-independent).
+  - [ ] **Gap coverage (PR-1b, the big one):** author `.ts` tests for the ~22 full + ~6 partial GAP
+    modules (see `py2ts-teardown-coverage-audit.md`), incl. the **Golden-Transcript `replay` subsystem**
+    (largest single gap — port the harness or replace with ~3 targeted multi-rebound integration tests
+    per the earlier council Option B). These are the coverage that justifies deleting the python tests.
+  - **`config_packs` = council option (c):** do NOT refactor `packs` to committed source (that changes
+    production behaviour — rejected). The live-parity byte-check is transitional; it retires naturally
+    with python (the monkeypatched `resolve_active_*` unit tests carry the logic coverage). Its
+    `skipIf(real-python3)` block self-skips post-deletion / is dropped in PR-2. No prereq refactor.
+- **PR-2 (the FINAL atomic deletion — Hard Floor, user-authorized 2026-06-18):** delete `src/**/*.py`
+  (~586; keep the 3 `internal/` fixtures) + `tests/**/*.py` + `conftest.py`/`pytest.ini` + pytest CI
+  jobs + dispatcher python fast-path & `.py` fallback + `pyproject.toml`/`requirements*.txt` + migration
+  scaffolding, AND repoint the 8 dispatcher-coupled e2e tests + delete the 2 obsolete spikes + retire the
+  `config_packs`/`config_session_profiles` live-parity blocks — all in one atomic, independently-green PR.
+  Snapshots are already review-locked (committed). Then hand to user for `python2ts → main`.
+
 ## Risk register
 
 - **R1 — shipped consumer runtime (highest).** `dist/agent-src/**/*.py` is executed by consumers, not just dev tooling. Deleting src `.py` without resolving dist emission breaks installed consumers. **Resolved (Phase-0 council, 2026-06-18):** TS-only, Python fully removed; runtime = Node-via-`tsx` (baseline A), pre-bundled `.js` fallback (D) only if Phase-1 evidence forces it. Residual exposure = the empirical A-vs-D call; Phase-3 consumer smoke is the verification.

--- a/tests/_lib/__parity_snapshots__/compile_corpus/019a9368f1a7e8678ce54d45846ac8d3500a36e045dc856439439442a6b93db7.json
+++ b/tests/_lib/__parity_snapshots__/compile_corpus/019a9368f1a7e8678ce54d45846ac8d3500a36e045dc856439439442a6b93db7.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "corpus parse failed: corpus parse failed: heading_drift at line 1 in section 'validated' — got '### Validated', expected '## Validated'\n",
-  "status": 2
-}

--- a/tests/_lib/__parity_snapshots__/compile_corpus/4495825a221282b75c6802e078afcb27b080e1369f469533db7f8c275b0ea6d5.json
+++ b/tests/_lib/__parity_snapshots__/compile_corpus/4495825a221282b75c6802e078afcb27b080e1369f469533db7f8c275b0ea6d5.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/compile_corpus/70d3245a43187e9de6a19d96a39f73283f104308fe9274b3b632958af32bbde4.json
+++ b/tests/_lib/__parity_snapshots__/compile_corpus/70d3245a43187e9de6a19d96a39f73283f104308fe9274b3b632958af32bbde4.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/compile_corpus/8e2360dbe217abac7c300502e2c3c22f68fdd7fce75f08c58349937727b6c8c4.json
+++ b/tests/_lib/__parity_snapshots__/compile_corpus/8e2360dbe217abac7c300502e2c3c22f68fdd7fce75f08c58349937727b6c8c4.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/compile_corpus/af7b75a53233d56c7668e4d74d253073baf93d35f467c8f16c932bb8be2f4cf4.json
+++ b/tests/_lib/__parity_snapshots__/compile_corpus/af7b75a53233d56c7668e4d74d253073baf93d35f467c8f16c932bb8be2f4cf4.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-1e7713e34ceb/2553dde75891b4cc91b128d072e070260f4de3cf4fedd3a210840fc2d78f54c5.json
+++ b/tests/_lib/__parity_snapshots__/inline-1e7713e34ceb/2553dde75891b4cc91b128d072e070260f4de3cf4fedd3a210840fc2d78f54c5.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "{\n  \"date\": \"2026-06-18\",\n  \"counts\": {\n    \"anthropic\": 2,\n    \"\\u00f6penai\": 1\n  }\n}",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-5aa94ac9ccec/d2e3e71404670f50bce056abdd52149a701cc405f7ef456946612bb483f388e2.json
+++ b/tests/_lib/__parity_snapshots__/inline-5aa94ac9ccec/d2e3e71404670f50bce056abdd52149a701cc405f7ef456946612bb483f388e2.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "2 1 1\n",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-80c5a3138c00/81e7d5e999f05a6bc87bbcad8627f7466f666dbfa9891390c761f0aa5a7b63db.json
+++ b/tests/_lib/__parity_snapshots__/inline-80c5a3138c00/81e7d5e999f05a6bc87bbcad8627f7466f666dbfa9891390c761f0aa5a7b63db.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-80c5a3138c00/bf78d6c59bf71fd1bcd52d20ea61b3de863a5ac1595de8c7b4e3cbf2bc0dd91f.json
+++ b/tests/_lib/__parity_snapshots__/inline-80c5a3138c00/bf78d6c59bf71fd1bcd52d20ea61b3de863a5ac1595de8c7b4e3cbf2bc0dd91f.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "sessions: 2020-01-01T00-00-00Z\nsessions: report-old.json\nsessions: not-a-timestamp\nquestions: q-old.md\nresponses: r-old.json",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b15a22bde7d6/2f9432d1b307a701967efd946c0a356f5bb5845b78a3a81698bd29d0a5d3890e.json
+++ b/tests/_lib/__parity_snapshots__/inline-b15a22bde7d6/2f9432d1b307a701967efd946c0a356f5bb5845b78a3a81698bd29d0a5d3890e.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b15a22bde7d6/b5f21b395708f30518b4ef7bee5ba3995216ab5dff87f9ab78392b4d5f754fbb.json
+++ b/tests/_lib/__parity_snapshots__/inline-b15a22bde7d6/b5f21b395708f30518b4ef7bee5ba3995216ab5dff87f9ab78392b4d5f754fbb.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b15a22bde7d6/d7861e7d7573ef103f4ff0860fff4b8a1779845c0becc660059c8d4008134278.json
+++ b/tests/_lib/__parity_snapshots__/inline-b15a22bde7d6/d7861e7d7573ef103f4ff0860fff4b8a1779845c0becc660059c8d4008134278.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/18b9abdaed4809ac8554f649ed1dc739026a288aedc73a06c3ff802d0552abc5.json
+++ b/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/18b9abdaed4809ac8554f649ed1dc739026a288aedc73a06c3ff802d0552abc5.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "[\"duplicate_validated\", \"what port does the app use\", \"2026-06-02\", \"already learned\"]\n",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/32ffb4b400784fc7c3ffcc1d7709078c6f26a02ef2244bdee9e386c3a7526ba1.json
+++ b/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/32ffb4b400784fc7c3ffcc1d7709078c6f26a02ef2244bdee9e386c3a7526ba1.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "[\"noop\", \"how do i run tests\", \"2026-05-01\", \"already seen today\"]\n",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/a8206c4e2a60bb024d8f8b25aa3c4bf9d051d89bbd160571eff5f40cdbdbd376.json
+++ b/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/a8206c4e2a60bb024d8f8b25aa3c4bf9d051d89bbd160571eff5f40cdbdbd376.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "[\"appended_seen\", \"How do I run tests?\", \"2026-06-02\", \"\"]\n",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/cd93bb17e18b848ea2a913a19134f4797d57ef289f68199bfe998de4428430ac.json
+++ b/tests/_lib/__parity_snapshots__/inline-b1de53e938eb/cd93bb17e18b848ea2a913a19134f4797d57ef289f68199bfe998de4428430ac.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "[\"new_probation\", \"A brand-new, punctuated question!\", \"2026-06-03\", \"\"]\n",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-eaec9b17aa72/957092fc75007c6750043ca686f2e19181905bfa69f3522d0667fcbdea5883e6.json
+++ b/tests/_lib/__parity_snapshots__/inline-eaec9b17aa72/957092fc75007c6750043ca686f2e19181905bfa69f3522d0667fcbdea5883e6.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "{\"timestamp\": \"<TS>\", \"query_hash\": \"f887dccff067a81a\", \"solo_verdict\": \"yes\", \"full_verdict\": \"no\", \"agreed\": false, \"escalated\": true, \"escalation_reason\": \"low-conf\"}\n",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/_lib/__parity_snapshots__/inline-f424bd0993df/2bcd47e0e5241aa34106e5b18b3a90a9489d3fc4dee00c8193bed8310edb734e.json
+++ b/tests/_lib/__parity_snapshots__/inline-f424bd0993df/2bcd47e0e5241aa34106e5b18b3a90a9489d3fc4dee00c8193bed8310edb734e.json
@@ -1,5 +1,0 @@
-{
-  "stdout": "",
-  "stderr": "",
-  "status": 0
-}

--- a/tests/scripts/runtime_handler.test.ts
+++ b/tests/scripts/runtime_handler.test.ts
@@ -53,7 +53,7 @@ function skill(
 
 describe('runtime_handler — handler in isolation', () => {
     it('test_execute_shell_success', () => {
-        const result = execute_shell(skill(['python3', '-c', "print('ok')"]), tmp);
+        const result = execute_shell(skill(['node', '-e', "console.log('ok')"]), tmp);
         expect(result.status).toBe('success');
         expect(result.exit_code).toBe(0);
         expect(result.stdout).toContain('ok');
@@ -63,7 +63,7 @@ describe('runtime_handler — handler in isolation', () => {
     });
 
     it('test_execute_shell_non_zero_is_failure', () => {
-        const result = execute_shell(skill(['python3', '-c', 'import sys; sys.exit(3)']), tmp);
+        const result = execute_shell(skill(['node', '-e', 'process.exit(3)']), tmp);
         expect(result.status).toBe('failure');
         expect(result.exit_code).toBe(3);
         expect(result.is_success).toBe(false);
@@ -71,7 +71,7 @@ describe('runtime_handler — handler in isolation', () => {
 
     it('test_execute_shell_captures_stderr', () => {
         const result = execute_shell(
-            skill(['python3', '-c', "import sys; sys.stderr.write('boom'); sys.exit(1)"]),
+            skill(['node', '-e', "process.stderr.write('boom'); process.exit(1)"]),
             tmp,
         );
         expect(result.status).toBe('failure');
@@ -79,7 +79,7 @@ describe('runtime_handler — handler in isolation', () => {
     });
 
     it('test_execute_shell_timeout', () => {
-        const result = execute_shell(skill(['python3', '-c', 'import time; time.sleep(5)'], 'shell', 1), tmp);
+        const result = execute_shell(skill(['node', '-e', 'setTimeout(() => {}, 5000)'], 'shell', 1), tmp);
         expect(result.status).toBe('timeout');
         expect(result.timed_out).toBe(true);
         expect(result.exit_code).toBe(-1);
@@ -127,7 +127,7 @@ describe('runtime_handler — handler in isolation', () => {
     });
 
     it('execute_shell returns an ExecutionResult instance', () => {
-        const result = execute_shell(skill(['python3', '-c', 'pass']), tmp);
+        const result = execute_shell(skill(['node', '-e', '0']), tmp);
         expect(result).toBeInstanceOf(ExecutionResult);
     });
 });


### PR DESCRIPTION
First prerequisite wave toward the final atomic-deletion PR. **No `.py` deleted here** — all changes keep the suite green and python-independent where possible. Targets `python2ts`.

## Changes
- **Prune 18 orphan golden snapshots** left by this session's re-captures / key changes. Verified safe: a full-suite run produced **0 missing-snapshot THROWs** — no referenced golden was touched. 236 live goldens remain (they are NOT garbage — they are the frozen parity fixtures that let the `.py` be deleted).
- **`runtime_handler`** — its `execute_shell` tests used `python3 -c` only as a *generic subprocess fixture* (no `.py` twin); swapped to `node -e` (language-irrelevant). The rig is now python-independent (9/9 green with python3 shadowed) — a deletion-phase prerequisite.
- **Completion plan recorded** in `road-to-py2ts-teardown.md` from the AI-council verdict (claude-sonnet-4-5 + gpt-4o, converged).

## Council-converged completion plan (for reviewers)
- **~3 PRs, not granular.** Deleting `src/**/*.py` + `tests/**/*.py` + pytest CI + the dispatcher python fast-path MUST be **atomic** — splitting them creates a zombie test state (surviving pytest imports / dispatcher calls reference deleted modules → not independently green, crosses the irreversible `.py`-deletion line while python tests still need the code).
- **PR-1 (this + next):** prerequisites, no deletion. Remaining = **PR-1b gap coverage** (~22 full + ~6 partial GAP modules incl. the Golden-Transcript `replay` subsystem — the coverage that justifies deleting the python tests).
- **`config_packs` = option (c):** the live-parity byte-check is transitional and retires with python (monkeypatched unit tests carry the logic); no production-behaviour refactor.
- **PR-2 = the final atomic deletion** (Hard Floor, user-authorized): `src`/`tests` `.py` + pytest CI + dispatcher fast-path + toolchain + scaffolding + repoint the 8 dispatcher-coupled e2e tests, all in one independently-green PR. Then `python2ts → main`.

## Verification
Typecheck clean; `runtime_handler` 9/9 green python-shadowed; orphan prune verified by 0 missing-snapshot THROWs across the full suite.