### PR TITLE
test(py2ts): gap coverage — ~230 .ts tests for python-only behaviors (PR-1b)

### DIFF
--- a/agents/roadmaps/road-to-py2ts-teardown.md
+++ b/agents/roadmaps/road-to-py2ts-teardown.md
@@ -253,10 +253,20 @@ crosses the irreversible `.py`-deletion line while python tests still need the c
 - **PR-1 (prerequisites — NO `.py` deletion, each independently green):**
   - [x] Orphan-snapshot prune (18 unreferenced goldens removed; 0 referenced touched).
   - [x] `runtime_handler` — `python3 -c` fixtures → `node -e` (language-irrelevant subprocess; now python-independent).
-  - [ ] **Gap coverage (PR-1b, the big one):** author `.ts` tests for the ~22 full + ~6 partial GAP
-    modules (see `py2ts-teardown-coverage-audit.md`), incl. the **Golden-Transcript `replay` subsystem**
-    (largest single gap — port the harness or replace with ~3 targeted multi-rebound integration tests
-    per the earlier council Option B). These are the coverage that justifies deleting the python tests.
+  - [ ] **Gap coverage (PR-1b) — authoring done 2026-06-18, closes when merged:** 23 gap modules now have `.ts` tests
+    (~230 new tests, all green python-shadowed + bite-checked): batch 1 = pricing, telemetry/boundary,
+    council_cli units, hooks_status, event_shape_contract, dispatcher_feedback traversal, contracts
+    (memory-visibility-redaction / readme-audience-order / rule-interactions behavioural),
+    install/consumer_model_tier, retrieval fixtures, migrate v0-state, explain disabled-short-circuit;
+    batch 2 = work_engine state validators / ui-polish / ui-review dispatch / cli-hooks exit table /
+    integration chat-history + full-flow (4-rebound) + mixed-flow (5-rebound) + persona + user-type, and
+    install_snapshot (per-platform + drift guard). The **Golden-Transcript `replay` subsystem is retired**
+    per council Option B — its coverage is the full-flow + mixed-flow integration tests; `tests/golden/
+    test_replay.py` + `harness.py` + recipes are slated for deletion in PR-2. **Found + fixed a real bug**
+    in `install.ts` (`finalize_claude_model_tiers` passed file-contents not path → auto model-tier switch
+    rendered 0 skills). **Justified skips:** `implement_ticket/test_shim.py` (python import-system shim,
+    no TS equivalent — dies with `__init__.py`); `cli/test_hooks_install_claude_flag.py` (bash-dispatcher
+    e2e — Phase-6-coupled, handled in PR-2). Partials reconciled per-module.
   - **`config_packs` = council option (c):** do NOT refactor `packs` to committed source (that changes
     production behaviour — rejected). The live-parity byte-check is transitional; it retires naturally
     with python (the monkeypatched `resolve_active_*` unit tests carry the logic coverage). Its

--- a/src/scripts/install.ts
+++ b/src/scripts/install.ts
@@ -4224,7 +4224,7 @@ function finalize_claude_model_tiers(project_root: string): number {
         const src_md = path.join(src_dir, 'SKILL.md');
         let tier: string | null;
         try {
-            tier = read_model_tier(readText(src_md));
+            tier = read_model_tier(src_md);
         } catch {
             tier = null;
         }
@@ -4465,6 +4465,9 @@ export {
     SystemExitError,
     ArgparseExit,
     state,
+    // ADR-200 py2ts: re-exported for test_consumer_model_tier.ts twin
+    // (Python test imports `install.finalize_claude_model_tiers` directly).
+    finalize_claude_model_tiers,
     SUPPORTED_PROFILES,
     DEFAULT_PROFILE,
     _VALID_TOOLS,

--- a/src/scripts/install.ts
+++ b/src/scripts/install.ts
@@ -4485,5 +4485,14 @@ export {
     KIRO_MARKER,
     ROOCODE_MARKER,
     ZED_MARKER,
+    // ADR-200 py2ts: re-exported for test_install_snapshot.ts twin
+    CURSOR_DISPATCHER_BINDINGS,
+    CLINE_DISPATCHER_BINDINGS,
+    WINDSURF_DISPATCHER_BINDINGS,
+    GEMINI_DISPATCHER_BINDINGS,
+    ensure_cursor_bridge,
+    ensure_cline_bridge,
+    ensure_windsurf_bridge,
+    ensure_gemini_bridge,
 };
 export type { Options };

--- a/tests/conformance/retrieval/fixtures.test.ts
+++ b/tests/conformance/retrieval/fixtures.test.ts
@@ -1,0 +1,297 @@
+// TypeScript twin of tests/conformance/retrieval/test_fixtures.py +
+// tests/conformance/retrieval/validator.py (ADR-200 py2ts).
+//
+// Conformance: every shipped fixture validates against the v1 envelope.
+//
+// The Python validator lives test-side (no `src/` twin) and IS the spec, so
+// the hand-written shape validator is ported inline here — a faithful 1:1 of
+// `validator.py`, mirroring `internal/schemas/retrieval-v1.schema.json` with
+// zero third-party runtime dependency. The fixtures and schema are unchanged.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Ported validator (validator.py 1:1).
+// ---------------------------------------------------------------------------
+
+const _SLICE_STATUSES = new Set(['ok', 'timeout', 'unknown_type', 'misconfigured', 'internal']);
+const _ERROR_CODES = new Set(['timeout', 'unknown_type', 'misconfigured', 'internal']);
+const _ENVELOPE_STATUSES = new Set(['ok', 'partial', 'error']);
+const _HEALTH_STATUSES = new Set(['ok', 'degraded', 'error']);
+const _DT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+\-]\d{2}:\d{2})$/;
+
+/** Raised with a dotted `.path` showing where the envelope failed. */
+class ValidationError extends Error {}
+
+function _fail(p: string, msg: string): never {
+    throw new ValidationError(`${p}: ${msg}`);
+}
+
+function _isObject(v: unknown): v is Record<string, unknown> {
+    return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function _repr(v: unknown): string {
+    // Python `!r` for str → 'value'; for others → str(). Good-enough parity for
+    // the assertions below (which match on substrings, not exact repr).
+    if (typeof v === 'string') return `'${v}'`;
+    return String(v);
+}
+
+function _require(payload: Record<string, unknown>, p: string, ...keys: string[]): void {
+    for (const k of keys) {
+        if (!(k in payload)) _fail(p, `missing required key \`${k}\``);
+    }
+}
+
+function _noExtras(payload: Record<string, unknown>, p: string, ...allowed: string[]): void {
+    const allow = new Set(allowed);
+    const extra = Object.keys(payload).filter((k) => !allow.has(k)).sort();
+    if (extra.length > 0) _fail(p, `unexpected keys ${JSON.stringify(extra)}`);
+}
+
+function _entry(entry: unknown, p: string): void {
+    if (!_isObject(entry)) _fail(p, 'entry must be object');
+    const e = entry as Record<string, unknown>;
+    _require(e, p, 'id', 'type', 'source', 'confidence', 'body');
+    _noExtras(e, p, 'id', 'type', 'source', 'confidence', 'body', 'last_validated');
+    if (typeof e['id'] !== 'string' || !e['id']) _fail(`${p}.id`, 'must be non-empty string');
+    if (typeof e['type'] !== 'string' || !e['type']) _fail(`${p}.type`, 'must be non-empty string');
+    if (e['source'] !== 'repo') _fail(`${p}.source`, `got ${_repr(e['source'])}`);
+    const conf = e['confidence'];
+    if (typeof conf !== 'number' || !(conf >= 0 && conf <= 1)) {
+        _fail(`${p}.confidence`, `must be in [0,1], got ${_repr(conf)}`);
+    }
+    if (!_isObject(e['body'])) _fail(`${p}.body`, 'must be object');
+    if ('last_validated' in e) {
+        const lv = e['last_validated'];
+        if (typeof lv !== 'string' || !_DT_RE.test(lv)) {
+            _fail(`${p}.last_validated`, `must be RFC3339, got ${_repr(lv)}`);
+        }
+    }
+}
+
+function _sliceStatus(slc: unknown, p: string): void {
+    if (!_isObject(slc)) _fail(p, 'slice must be object');
+    const s = slc as Record<string, unknown>;
+    _require(s, p, 'status', 'count');
+    _noExtras(s, p, 'status', 'count');
+    if (typeof s['status'] !== 'string' || !_SLICE_STATUSES.has(s['status'])) {
+        _fail(`${p}.status`, `got ${_repr(s['status'])}`);
+    }
+    if (typeof s['count'] !== 'number' || !Number.isInteger(s['count']) || s['count'] < 0) {
+        _fail(`${p}.count`, `must be non-negative int, got ${_repr(s['count'])}`);
+    }
+}
+
+function _error(err: unknown, p: string): void {
+    if (!_isObject(err)) _fail(p, 'error must be object');
+    const e = err as Record<string, unknown>;
+    _require(e, p, 'type', 'code', 'message');
+    _noExtras(e, p, 'type', 'code', 'message');
+    if (typeof e['type'] !== 'string' || !e['type']) _fail(`${p}.type`, 'must be non-empty string');
+    if (typeof e['code'] !== 'string' || !_ERROR_CODES.has(e['code'])) {
+        _fail(`${p}.code`, `got ${_repr(e['code'])}`);
+    }
+    if (typeof e['message'] !== 'string') _fail(`${p}.message`, 'must be string');
+}
+
+/** Validate a `retrieve()` response envelope against v1. */
+function validateRetrieve(envelope: unknown): void {
+    if (!_isObject(envelope)) _fail('$', 'envelope must be object');
+    const env = envelope as Record<string, unknown>;
+    _require(env, '$', 'contract_version', 'status', 'entries', 'slices');
+    _noExtras(env, '$', 'contract_version', 'status', 'entries', 'slices', 'errors');
+    if (env['contract_version'] !== 1) {
+        _fail('$.contract_version', `expected 1, got ${_repr(env['contract_version'])}`);
+    }
+    if (typeof env['status'] !== 'string' || !_ENVELOPE_STATUSES.has(env['status'])) {
+        _fail('$.status', `got ${_repr(env['status'])}`);
+    }
+    if (!Array.isArray(env['entries'])) _fail('$.entries', 'must be array');
+    (env['entries'] as unknown[]).forEach((e, i) => _entry(e, `$.entries[${i}]`));
+    if (!_isObject(env['slices'])) _fail('$.slices', 'must be object');
+    for (const [name, slc] of Object.entries(env['slices'] as Record<string, unknown>)) {
+        _sliceStatus(slc, `$.slices['${name}']`);
+    }
+    const errors = (env['errors'] as unknown[] | undefined) ?? [];
+    errors.forEach((err, i) => _error(err, `$.errors[${i}]`));
+}
+
+/** Validate a `health()` response envelope against v1. */
+function validateHealth(envelope: unknown): void {
+    if (!_isObject(envelope)) _fail('$', 'health envelope must be object');
+    const env = envelope as Record<string, unknown>;
+    _require(env, '$', 'contract_version', 'status', 'backend_version', 'features');
+    _noExtras(env, '$', 'contract_version', 'status', 'backend_version', 'features');
+    if (env['contract_version'] !== 1) {
+        _fail('$.contract_version', `expected 1, got ${_repr(env['contract_version'])}`);
+    }
+    if (typeof env['status'] !== 'string' || !_HEALTH_STATUSES.has(env['status'])) {
+        _fail('$.status', `got ${_repr(env['status'])}`);
+    }
+    if (typeof env['backend_version'] !== 'string' || !env['backend_version']) {
+        _fail('$.backend_version', 'must be non-empty string');
+    }
+    const feats = env['features'];
+    if (!Array.isArray(feats) || new Set(feats).size !== feats.length) {
+        _fail('$.features', 'must be unique string array');
+    }
+    (feats as unknown[]).forEach((f, i) => {
+        if (typeof f !== 'string' || !f) _fail(`$.features[${i}]`, 'must be non-empty string');
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Conformance suite (test_fixtures.py 1:1).
+// ---------------------------------------------------------------------------
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// test_fixtures.py: parents[2] / "fixtures" / "retrieval"
+// (tests/conformance/retrieval → tests → fixtures/retrieval).
+const FIXTURES_DIR = path.resolve(HERE, '..', '..', 'fixtures', 'retrieval');
+
+const RETRIEVE_FIXTURES = [
+    '01-empty.json',
+    '02-single-type-hit.json',
+    '03-multi-type-partial.json',
+    '04-error-all-slices.json',
+];
+const HEALTH_FIXTURES = ['06-health-ok.json'];
+
+function _load(name: string): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf-8'));
+}
+
+describe('retrieval v1 conformance', () => {
+    it.each(RETRIEVE_FIXTURES)('retrieve fixture %s passes validation', (name) => {
+        expect(() => validateRetrieve(_load(name))).not.toThrow();
+    });
+
+    it.each(HEALTH_FIXTURES)('health fixture %s passes validation', (name) => {
+        expect(() => validateHealth(_load(name))).not.toThrow();
+    });
+
+    it('envelope status matches slice outcomes', () => {
+        // every slice ok → envelope `ok`; every slice failed → `error`;
+        // mix of ok + failed → `partial`.
+        for (const name of RETRIEVE_FIXTURES) {
+            const env = _load(name);
+            const slices = env['slices'] as Record<string, { status: string }>;
+            const vals = Object.values(slices);
+            const oks = vals.filter((s) => s.status === 'ok');
+            const fails = vals.filter((s) => s.status !== 'ok');
+            const expected = fails.length === 0 ? 'ok' : oks.length === 0 ? 'error' : 'partial';
+            expect(env['status'], `${name}: envelope status mismatch`).toBe(expected);
+        }
+    });
+
+    it('every fixture on disk is wired to a test', () => {
+        // Guards against a fixture file landing without being wired to a test.
+        const shipped = new Set(
+            fs
+                .readdirSync(FIXTURES_DIR)
+                .filter((n) => fs.statSync(path.join(FIXTURES_DIR, n)).isFile() && n.endsWith('.json')),
+        );
+        const declared = new Set([...RETRIEVE_FIXTURES, ...HEALTH_FIXTURES]);
+        const missing = [...shipped].filter((n) => !declared.has(n)).sort();
+        expect(missing, `fixture(s) on disk but not covered by a test: ${JSON.stringify(missing)}`).toEqual([]);
+    });
+
+    it('shadowed_by is non-null only for an operational source', () => {
+        // Repo entries never get `shadowed_by` set — only operational losers do.
+        for (const name of RETRIEVE_FIXTURES) {
+            const env = _load(name);
+            (env['entries'] as Record<string, unknown>[]).forEach((e, i) => {
+                if (e['shadowed_by']) {
+                    expect(e['source'], `${name} entry[${i}] id=${e['id']}: shadowed_by set`).toBe(
+                        'operational',
+                    );
+                }
+            });
+        }
+    });
+
+    // ---- 5 rejection cases — validator actually catches drift ----
+
+    it('rejects an unknown top-level key', () => {
+        const env = _load('01-empty.json');
+        env['unexpected_field'] = 'drift';
+        let msg = '';
+        expect(() => {
+            try {
+                validateRetrieve(env);
+            } catch (err) {
+                msg = (err as Error).message;
+                throw err;
+            }
+        }).toThrow(ValidationError);
+        expect(msg.includes('unexpected_field') || msg.includes('unexpected keys')).toBe(true);
+    });
+
+    it('rejects a wrong contract version', () => {
+        const env = _load('01-empty.json');
+        env['contract_version'] = 2;
+        let msg = '';
+        expect(() => {
+            try {
+                validateRetrieve(env);
+            } catch (err) {
+                msg = (err as Error).message;
+                throw err;
+            }
+        }).toThrow(ValidationError);
+        expect(msg).toContain('contract_version');
+    });
+
+    it('rejects confidence out of range', () => {
+        const env = _load('02-single-type-hit.json');
+        (env['entries'] as Record<string, unknown>[])[0]!['confidence'] = 1.5;
+        let msg = '';
+        expect(() => {
+            try {
+                validateRetrieve(env);
+            } catch (err) {
+                msg = (err as Error).message;
+                throw err;
+            }
+        }).toThrow(ValidationError);
+        expect(msg).toContain('confidence');
+    });
+
+    it('rejects an operational source', () => {
+        const env = _load('02-single-type-hit.json');
+        (env['entries'] as Record<string, unknown>[])[0]!['source'] = 'operational';
+        let msg = '';
+        expect(() => {
+            try {
+                validateRetrieve(env);
+            } catch (err) {
+                msg = (err as Error).message;
+                throw err;
+            }
+        }).toThrow(ValidationError);
+        expect(msg).toContain('source');
+    });
+
+    // 5th rejection: health envelope rejects a duplicate feature (the
+    // unique-string-array guard) — exercises the `validateHealth` failure path
+    // that the happy-path health fixture cannot.
+    it('health rejects a non-unique feature array', () => {
+        const env = _load('06-health-ok.json');
+        env['features'] = ['file-fallback', 'file-fallback'];
+        let msg = '';
+        expect(() => {
+            try {
+                validateHealth(env);
+            } catch (err) {
+                msg = (err as Error).message;
+                throw err;
+            }
+        }).toThrow(ValidationError);
+        expect(msg).toContain('features');
+    });
+});

--- a/tests/contracts/readme_audience_order.test.ts
+++ b/tests/contracts/readme_audience_order.test.ts
@@ -1,0 +1,65 @@
+// README audience-heading order contract (PURE-TS port of
+// tests/contracts/test_readme_audience_order.py).
+//
+// The README must open with three audience-focused `##` headings in the fixed
+// order `Use it in your project` → `Prove it` → `Contribute` so consumer-side
+// readers can self-route by role, all before `## Quickstart`. AI Council is a
+// maintainer-only surface and MUST NOT appear in the user-facing branches.
+//
+// No python, no oracle: the "twin" is the README itself — read it and assert.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const README = path.join(REPO_ROOT, 'README.md');
+
+const AUDIENCE_HEADINGS = [
+    '## Use it in your project',
+    '## Prove it',
+    '## Contribute',
+] as const;
+
+function readmeText(): string {
+    return fs.readFileSync(README, 'utf-8');
+}
+
+describe('README audience-heading contract', () => {
+    it('all three audience headings are present', () => {
+        const text = readmeText();
+        for (const heading of AUDIENCE_HEADINGS) {
+            expect(text, `missing audience heading: ${JSON.stringify(heading)}`).toContain(heading);
+        }
+    });
+
+    it('headings appear in Use → Prove → Contribute order', () => {
+        const text = readmeText();
+        const positions = AUDIENCE_HEADINGS.map((h) => text.indexOf(h));
+        const sorted = [...positions].sort((a, b) => a - b);
+        expect(positions).toEqual(sorted);
+    });
+
+    it('all audience headings appear before `## Quickstart`', () => {
+        const text = readmeText();
+        const quickstartIdx = text.indexOf('## Quickstart');
+        expect(quickstartIdx).toBeGreaterThanOrEqual(0);
+        for (const heading of AUDIENCE_HEADINGS) {
+            expect(
+                text.indexOf(heading),
+                `${JSON.stringify(heading)} must appear before '## Quickstart'`,
+            ).toBeLessThan(quickstartIdx);
+        }
+    });
+
+    it('no AI Council / /council references in the user-facing branches', () => {
+        const text = readmeText();
+        const start = text.indexOf(AUDIENCE_HEADINGS[0]);
+        const end = text.indexOf(AUDIENCE_HEADINGS[2]);
+        const userFacing = text.slice(start, end);
+        // (?i)\b(?:ai[\s-]?council|/council)\b
+        const pattern = /\b(?:ai[\s-]?council|\/council)\b/gi;
+        const matches = userFacing.match(pattern) ?? [];
+        expect(matches).toEqual([]);
+    });
+});

--- a/tests/contracts/rule_interactions_behavioural.test.ts
+++ b/tests/contracts/rule_interactions_behavioural.test.ts
@@ -1,0 +1,120 @@
+// Behavioural 2-axis contract for docs/contracts/rule-interactions.yml
+// (PURE-TS port of the BEHAVIOURAL layer of
+// tests/contracts/test_rule_interactions.py).
+//
+// The STRUCTURAL layer (constants + golden-parity of the linter) is already
+// covered by tests/scripts/lint_rule_interactions.test.ts. This file ports
+// ONLY the behavioural gap: the four roadmap-mandated 2-axis cases
+// (autonomy×scope, autonomy×commit, scope×verify, memory×commit) must be
+// present and assert the dominant (senior) rule's Iron Law fires when both
+// rules could trigger.
+//
+// "memory" in roadmap shorthand = standing instructions; the on-disk surface
+// is `autonomous-execution`, so memory-x-commit maps to the same YAML pair as
+// autonomy-x-commit. This indirection is intentional — the package has no
+// standalone `agent-memory` rule slug.
+//
+// No python, no oracle: parse the YAML directly and assert.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const MATRIX_PATH = path.join(REPO_ROOT, 'docs', 'contracts', 'rule-interactions.yml');
+
+interface Pair {
+    id: string;
+    rules: string[];
+    relation: string;
+    conflict: string;
+    resolution: string;
+    evidence: string[];
+}
+
+// Roadmap-mandated 2-axis cases: roadmap label → YAML pair-id + senior/junior.
+// The senior rule is the one whose Iron Law fires when both could trigger.
+const ROADMAP_AXIS_CASES: Record<string, { pair_id: string; senior: string; junior: string }> = {
+    'autonomy-x-scope': {
+        pair_id: 'autonomy-x-scope-control',
+        senior: 'scope-control',
+        junior: 'autonomous-execution',
+    },
+    'autonomy-x-commit': {
+        pair_id: 'autonomy-x-commit-policy',
+        senior: 'commit-policy',
+        junior: 'autonomous-execution',
+    },
+    'scope-x-verify': {
+        pair_id: 'scope-x-verify-before-complete',
+        senior: 'verify-before-complete',
+        junior: 'scope-control',
+    },
+    // "memory" shorthand = standing instructions → on-disk `autonomous-execution`.
+    'memory-x-commit': {
+        pair_id: 'autonomy-x-commit-policy',
+        senior: 'commit-policy',
+        junior: 'autonomous-execution',
+    },
+};
+
+function loadMatrix(): { version?: number; rules?: string[]; pairs: Pair[] } {
+    return parseYaml(fs.readFileSync(MATRIX_PATH, 'utf-8'), { version: '1.1' });
+}
+
+function pairsById(): Record<string, Pair> {
+    const out: Record<string, Pair> = {};
+    for (const p of loadMatrix().pairs) {
+        out[p.id] = p;
+    }
+    return out;
+}
+
+// Sorted labels mirror `params=sorted(ROADMAP_AXIS_CASES)` so the parametrized
+// case set is identical to the python spec.
+const AXIS_LABELS = Object.keys(ROADMAP_AXIS_CASES).sort();
+
+describe('rule-interactions behavioural 2-axis cases', () => {
+    for (const label of AXIS_LABELS) {
+        const spec = ROADMAP_AXIS_CASES[label];
+
+        describe(label, () => {
+            const byId = pairsById();
+            const pair = byId[spec.pair_id];
+
+            it('roadmap axis maps to an existing matrix pair', () => {
+                expect(
+                    pair,
+                    `roadmap axis ${label} expects pair ${spec.pair_id} but matrix has none`,
+                ).toBeDefined();
+            });
+
+            it('case present and well-oriented: senior first, both rules listed', () => {
+                const rules = pair.rules;
+                expect(rules).toContain(spec.senior);
+                expect(rules).toContain(spec.junior);
+                // Senior rule must be first in pair.rules.
+                expect(rules[0]).toBe(spec.senior);
+            });
+
+            it('resolution invokes the senior rule (or its Iron Law)', () => {
+                const resolution = pair.resolution.toLowerCase();
+                expect(
+                    resolution.includes(spec.senior) || resolution.includes('iron law'),
+                    `${label}: resolution does not invoke senior rule ${spec.senior} or its Iron Law`,
+                ).toBe(true);
+            });
+
+            it('evidence anchors the senior rule', () => {
+                const seniorEvidence = pair.evidence.filter((citation) =>
+                    citation.includes(`/rules/${spec.senior}.md`),
+                );
+                expect(
+                    seniorEvidence.length,
+                    `${label}: evidence for pair ${spec.pair_id} cites no anchor on senior rule ${spec.senior}`,
+                ).toBeGreaterThan(0);
+            });
+        });
+    }
+});

--- a/tests/install/consumer_model_tier.test.ts
+++ b/tests/install/consumer_model_tier.test.ts
@@ -1,0 +1,105 @@
+// TypeScript twin of tests/install/test_consumer_model_tier.py (ADR-200 py2ts).
+//
+// Step 19b — consumer model-tier auto-switch reaches the installed tree.
+// `install.finalize_claude_model_tiers` rewrites the payload-synced
+// `.claude/skills/<skill>` symlinks so model-tier-bearing skills carry a native
+// Claude `model:` key when the consumer opted into `model.auto_switch: auto`.
+// Mirrors the repo generator (`condense generate_claude_skills`).
+//
+// Regression guard: 5.10.0 shipped `~/.claude/skills/` with raw `model_tier:`
+// and zero native `model:`, so Claude Code never performed the per-turn switch.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as install from '../../src/scripts/install.js';
+
+let tmp: string;
+
+beforeEach(() => {
+    // Python monkeypatches install.QUIET = True; the TS twin exposes QUIET on
+    // the mutable `state` global. Cache + restore around each test.
+    install.state.QUIET = true;
+    tmp = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'consumer-model-tier-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// Stage a consumer with two augment skills (one model-tier, one inherit),
+// each symlinked into .claude/skills/ exactly as install.sh does.
+function stageConsumer(root: string, autoSwitch: string): void {
+    const settings = path.join(root, 'agents', 'settings', '.agent-settings.yml');
+    fs.mkdirSync(path.dirname(settings), { recursive: true });
+    fs.writeFileSync(settings, `model:\n  auto_switch: ${autoSwitch}\n`, 'utf-8');
+
+    const augment = path.join(root, '.augment', 'skills');
+    const claude = path.join(root, '.claude', 'skills');
+    fs.mkdirSync(augment, { recursive: true });
+    fs.mkdirSync(claude, { recursive: true });
+
+    const skill = (name: string, tierLine: string): void => {
+        const sdir = path.join(augment, name);
+        fs.mkdirSync(sdir, { recursive: true });
+        fs.writeFileSync(
+            path.join(sdir, 'SKILL.md'),
+            `---\nname: ${name}\n${tierLine}\n---\n\n# ${name}\n\nbody\n`,
+            'utf-8',
+        );
+        fs.writeFileSync(path.join(sdir, 'reference.md'), 'ref\n', 'utf-8');
+        // install.sh shape: .claude/skills/<name> -> ../../.augment/skills/<name>
+        fs.symlinkSync(path.join('../../.augment/skills', name), path.join(claude, name));
+    };
+
+    skill('tiered-skill', 'model_tier: medium');
+    skill('inherit-skill', 'model_tier: inherit');
+}
+
+describe('finalize_claude_model_tiers', () => {
+    it('auto_switch renders native model', () => {
+        stageConsumer(tmp, 'auto');
+
+        const rendered = install.finalize_claude_model_tiers(tmp);
+        expect(rendered).toBe(1); // only the model-tier skill
+
+        const claude = path.join(tmp, '.claude', 'skills');
+        // The model-tier skill is now a REAL dir with a rendered SKILL.md.
+        const tiered = path.join(claude, 'tiered-skill');
+        expect(fs.statSync(tiered).isDirectory()).toBe(true);
+        expect(fs.lstatSync(tiered).isSymbolicLink()).toBe(false);
+        const skillMd = fs.readFileSync(path.join(tiered, 'SKILL.md'), 'utf-8');
+        expect(skillMd).toContain('model: sonnet');
+        expect(skillMd).not.toContain('model_tier:');
+        // Non-SKILL.md files stay symlinks into .augment/skills.
+        expect(fs.lstatSync(path.join(tiered, 'reference.md')).isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(path.join(tiered, 'reference.md'))).toBe(
+            '../../../.augment/skills/tiered-skill/reference.md',
+        );
+
+        // The inherit skill is untouched (still a symlink, raw frontmatter).
+        const inherit = path.join(claude, 'inherit-skill');
+        expect(fs.lstatSync(inherit).isSymbolicLink()).toBe(true);
+    });
+
+    it('suggest is a no-op', () => {
+        stageConsumer(tmp, 'suggest');
+
+        const rendered = install.finalize_claude_model_tiers(tmp);
+        expect(rendered).toBe(0);
+        // Both skills remain pure symlinks — no native model: injected.
+        expect(
+            fs.lstatSync(path.join(tmp, '.claude', 'skills', 'tiered-skill')).isSymbolicLink(),
+        ).toBe(true);
+        expect(
+            fs.lstatSync(path.join(tmp, '.claude', 'skills', 'inherit-skill')).isSymbolicLink(),
+        ).toBe(true);
+    });
+
+    it('missing trees is a no-op', () => {
+        // No .claude/.augment trees at all → silent 0, never throws.
+        expect(install.finalize_claude_model_tiers(tmp)).toBe(0);
+    });
+});

--- a/tests/scripts/_cli/cmd_explain_disabled.test.ts
+++ b/tests/scripts/_cli/cmd_explain_disabled.test.ts
@@ -1,0 +1,92 @@
+// Pure-TS coverage for the `explain.enable_last: false` short-circuit of
+// `agent-config explain last` (ADR-200 py2ts). The golden-parity suite in
+// `cmd_explain.test.ts` exercises happy-path / quiet / json / missing-state /
+// v0-skew but NOT the disabled-by-settings exit gate; this twin closes that
+// gap, porting tests/cli/explain_last/test_cli.py
+// (`test_disabled_by_settings_exits_zero` + `test_disabled_via_in_process_returns_zero`).
+//
+// Drives the exported `main(argv)` directly and captures `process.stdout`
+// (the command's `print` helper writes there) — no python, no subprocess.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { main } from '../../../src/scripts/_cli/cmd_explain.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+let tmp: string;
+
+// Minimal seeded project root (router + preset + profile) — same shape the
+// explain_last conftest builds, so the resolvers don't fall over before the
+// disabled gate fires.
+const ROUTER = JSON.stringify({
+    schema_version: 1,
+    kernel: ['direct-answers', 'no-cheap-questions'],
+    tier_1: [{ id: 'architecture', triggers: [{ keyword: 'controller' }] }],
+    tier_2: [],
+});
+
+function seedProject(root: string): void {
+    fs.mkdirSync(path.join(root, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'dist', 'router.json'), ROUTER, 'utf-8');
+    const presets = path.join(root, '.agent-src.uncondensed', 'presets');
+    fs.mkdirSync(presets, { recursive: true });
+    fs.writeFileSync(
+        path.join(presets, 'balanced.yml'),
+        'preset:\n  id: balanced\n  cost: {daily_max_usd: 10, weekly_max_usd: 50, monthly_max_usd: 150}\n  autonomy: {default: auto}\n',
+        'utf-8',
+    );
+    const profiles = path.join(root, '.agent-src.uncondensed', 'profiles');
+    fs.mkdirSync(profiles, { recursive: true });
+    fs.writeFileSync(
+        path.join(profiles, 'developer.yml'),
+        'profile:\n  id: developer\n  preset: balanced\n',
+        'utf-8',
+    );
+}
+
+/** Copy a canonical `.work-state.json` fixture into the project root by name. */
+function copyState(root: string, name: string): void {
+    const src = path.resolve(HERE, '..', '..', 'fixtures', 'explain_last', name);
+    fs.copyFileSync(src, path.join(root, '.work-state.json'));
+}
+
+let stdoutSpy: { mockRestore: () => void };
+let captured: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'explain-disabled-'));
+    seedProject(tmp);
+    captured = '';
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+        captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8');
+        return true;
+    });
+});
+
+afterEach(() => {
+    stdoutSpy.mockRestore();
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('cmd_explain — explain.enable_last: false short-circuit', () => {
+    it('disabled-by-settings exits 0 with the disabled-by-settings message', () => {
+        copyState(tmp, 'work-state.success.json');
+        fs.writeFileSync(
+            path.join(tmp, '.agent-settings.yml'),
+            'explain:\n  enable_last: false\n',
+            'utf-8',
+        );
+
+        const rc = main(['last', '--project', tmp]);
+        expect(rc).toBe(0);
+        // Same surface the python CLI test asserts: "disabled by settings"
+        // wording + the `explain.enable_last` key name, both on stdout.
+        expect(captured).toContain('disabled by settings');
+        expect(captured).toContain('explain.enable_last');
+    });
+});

--- a/tests/scripts/_cli/cmd_migrate_v0_state.test.ts
+++ b/tests/scripts/_cli/cmd_migrate_v0_state.test.ts
@@ -1,0 +1,126 @@
+// Pure-TS coverage for the v0 `.implement-ticket-state.json` →
+// `.work-state.json` migration action of `agent-config migrate`
+// (ADR-200 py2ts). The golden-parity suite in `cmd_migrate.test.ts` does NOT
+// exercise the v0 state-file migration; this twin closes that gap, porting the
+// state-migration assertions of tests/migrate/test_unified_migrate.py
+// (`test_full_apply_sweeps_every_signal` + `test_dry_run_does_not_mutate_filesystem`).
+//
+// Drives the exported `main(argv, { cwd, out })` directly — no python, no
+// subprocess. The v0→v1 migrator is the shipped engine under
+// `dist/agent-src/templates/scripts/work_engine/migration`, resolved by the
+// command relative to its own module location.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { main } from '../../../src/scripts/_cli/cmd_migrate.js';
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'acmig-v0state-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Capturing OutSink (mirrors `m.main(out=io.StringIO())`). */
+function capture(): { sink: { write: (t: string) => void }; text: () => string } {
+    let buf = '';
+    return { sink: { write: (t: string) => (buf += t) }, text: () => buf };
+}
+
+/** Stage a v0 `.implement-ticket-state.json` (the python fixture's signal #4). */
+function makeV0State(project: string): void {
+    fs.writeFileSync(
+        path.join(project, '.implement-ticket-state.json'),
+        JSON.stringify(
+            {
+                ticket: {
+                    id: 'PROJ-123',
+                    title: 'fixture ticket',
+                    body: 'fixture body',
+                    acceptance_criteria: ['AC-1'],
+                },
+            },
+            null,
+            2,
+        ) + '\n',
+        'utf-8',
+    );
+}
+
+/** Snapshot every regular file + symlink content under `root` (dry-run guard). */
+function snapshot(root: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    const walk = (dir: string): void => {
+        for (const name of fs.readdirSync(dir).sort()) {
+            const p = path.join(dir, name);
+            const rel = path.relative(root, p);
+            const st = fs.lstatSync(p);
+            if (st.isSymbolicLink()) {
+                out[rel] = `symlink:${fs.readlinkSync(p)}`;
+            } else if (st.isDirectory()) {
+                out[rel] = '<dir>';
+                walk(p);
+            } else {
+                out[rel] = fs.readFileSync(p, 'utf-8');
+            }
+        }
+    };
+    walk(root);
+    return out;
+}
+
+describe('cmd_migrate — v0 .implement-ticket-state.json migration', () => {
+    it('apply migrates v0 state → .work-state.json, preserves .bak, removes v0', () => {
+        makeV0State(tmp);
+        const cap = capture();
+        const rc = main([], { cwd: tmp, out: cap.sink, err: cap.sink });
+        const stdout = cap.text();
+        expect(rc, stdout).toBe(0);
+
+        // v0 state migrated; .bak preserved; v0 source gone.
+        const v1 = path.join(tmp, '.work-state.json');
+        expect(fs.statSync(v1).isFile()).toBe(true);
+        expect(fs.existsSync(path.join(tmp, '.implement-ticket-state.json.bak'))).toBe(true);
+        expect(fs.existsSync(path.join(tmp, '.implement-ticket-state.json'))).toBe(false);
+
+        // v1 payload shape: version 1, ticket wrapped under input.kind/input.data.
+        const v1Payload = JSON.parse(fs.readFileSync(v1, 'utf-8'));
+        expect(v1Payload.version).toBe(1);
+        expect(v1Payload.input.kind).toBe('ticket');
+        expect(v1Payload.input.data.id).toBe('PROJ-123');
+
+        // Summary lists the migration action by verb.
+        expect(stdout).toContain('migrated .implement-ticket-state.json');
+    });
+
+    it('dry-run describes the migration in `would …` voice and mutates nothing', () => {
+        makeV0State(tmp);
+        const before = snapshot(tmp);
+        const cap = capture();
+        const rc = main(['--dry-run'], { cwd: tmp, out: cap.sink, err: cap.sink });
+        const stdout = cap.text();
+        expect(rc).toBe(0);
+        // Byte-for-byte identical — no migration applied, no .bak written.
+        expect(snapshot(tmp)).toEqual(before);
+        expect(stdout).toContain('would migrate .implement-ticket-state.json');
+    });
+
+    it('--check on a v0-state legacy repo exits 2 + reports a pending action, no writes', () => {
+        makeV0State(tmp);
+        const before = snapshot(tmp);
+        const cap = capture();
+        const rc = main(['--check'], { cwd: tmp, out: cap.sink, err: cap.sink });
+        const stdout = cap.text();
+        expect(rc).toBe(2);
+        expect(stdout).toContain('legacy install detected');
+        expect(stdout).toContain('pending action(s)');
+        // Probe must not mutate the filesystem.
+        expect(snapshot(tmp)).toEqual(before);
+    });
+});

--- a/tests/scripts/ai_council/council_cli.test.ts
+++ b/tests/scripts/ai_council/council_cli.test.ts
@@ -1,0 +1,431 @@
+// Pure-TS behaviour test for the council CLI twin (`src/scripts/council_cli.ts`).
+//
+// PARTIAL port of `tests/ai_council/test_cli.py` — covers the units the task
+// scopes (`build_members`, `_parse_siblings_overrides`, the rounds-resolution
+// reachable via the exported surface, and `cmd_run` / `cmd_debate` unit paths)
+// that are cleanly testable against the twin's EXPORTED surface without
+// modifying it. No existing `.ts` test covers `council_cli`, so this is the
+// first.
+//
+// Scope notes (faithful-port limits, all driven by the twin's export surface,
+// not by dropping coverage):
+//   • `_resolve_rounds` is module-private (not exported) and `REPO_ROOT` is not
+//     monkeypatchable from TS, so the Python `cmd_run --confirm` rounds-payload
+//     tests (which write under a monkeypatched REPO_ROOT/agents/runtime/council/
+//     responses/) cannot run without editing the twin. The rounds chain's
+//     reachable surface — `cmd_run` without `--confirm` returns 0 before any
+//     output write — is covered here; the confirm-write variants are noted as
+//     blocked-by-export, not silently skipped.
+//   • `build_members` siblings POSITIVE fan-out (constructs N real API clients)
+//     needs the `AnthropicClient` ctor to accept a key; the Python test
+//     monkeypatches `council_cli.AnthropicClient`, which in TS is an import
+//     binding only replaceable via a full clients-module mock. The
+//     CLI-specific VALIDATION logic (unknown / disabled / conflict / manual
+//     guards, all of which throw before construction) is covered; the positive
+//     construction path is exercised by the existing `clients` twin tests.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    CouncilResponse,
+    ExternalAIClient,
+} from '../../../src/scripts/ai_council/clients.js';
+import type { Price, PriceTable } from '../../../src/scripts/ai_council/pricing.js';
+import {
+    CouncilDisabledError,
+    build_members,
+    cmd_debate,
+    cmd_run,
+    _parse_siblings_overrides,
+} from '../../../src/scripts/council_cli.js';
+
+// ── stubs (mirror the Python _StubMember / _ManualStub / _fake_table) ──
+
+class StubMember extends ExternalAIClient {
+    private _response: CouncilResponse;
+    constructor(name: string, model: string, response: CouncilResponse) {
+        super();
+        this.name = name;
+        this.model = model;
+        this.billable = true;
+        this._response = response;
+    }
+    override ask(): CouncilResponse {
+        return this._response;
+    }
+}
+
+function fakeTable(): PriceTable {
+    const prices = new Map<string, Price>();
+    prices.set('anthropic claude-x', {
+        provider: 'anthropic',
+        model: 'claude-x',
+        input_per_1m_usd: 3.0,
+        output_per_1m_usd: 15.0,
+    });
+    prices.set('openai gpt-x', {
+        provider: 'openai',
+        model: 'gpt-x',
+        input_per_1m_usd: 2.5,
+        output_per_1m_usd: 10.0,
+    });
+    return {
+        last_updated: '2026-01-01',
+        currency: 'USD',
+        unit: 'per_1M_tokens',
+        source: 'test-fixture',
+        prices,
+    };
+}
+
+const _tmpDirs: string[] = [];
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'council-cli-'));
+    _tmpDirs.push(d);
+    return d;
+}
+afterEach(() => {
+    while (_tmpDirs.length > 0) {
+        const d = _tmpDirs.pop();
+        if (d) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+// `cmd_run` / `cmd_debate` take a structural `args` object; build the minimal
+// shape each path reads. Cast through unknown — the twin uses `_getattr`, so
+// only the named fields are inspected.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Args = any;
+
+// ── _parse_siblings_overrides ─────────────────────────────────────────
+
+describe('_parse_siblings_overrides', () => {
+    it('accepts two models', () => {
+        const out = _parse_siblings_overrides(['anthropic=claude-sonnet-4-5,claude-opus-4-1']);
+        expect(out).toEqual({ anthropic: ['claude-sonnet-4-5', 'claude-opus-4-1'] });
+    });
+
+    it('rejects a single model', () => {
+        expect(() => _parse_siblings_overrides(['anthropic=claude-sonnet-4-5'])).toThrow(/≥ 2 distinct/);
+    });
+
+    it('rejects duplicate models', () => {
+        expect(() =>
+            _parse_siblings_overrides(['anthropic=claude-sonnet-4-5,claude-sonnet-4-5']),
+        ).toThrow(/≥ 2 distinct/);
+    });
+
+    it('rejects a repeated provider', () => {
+        expect(() =>
+            _parse_siblings_overrides(['anthropic=a,b', 'anthropic=c,d']),
+        ).toThrow(/repeated/);
+    });
+
+    it('rejects a missing equals', () => {
+        expect(() => _parse_siblings_overrides(['anthropic-a-b'])).toThrow(/expects/);
+    });
+});
+
+// ── build_members guards ──────────────────────────────────────────────
+
+describe('build_members guards', () => {
+    it('raises when council is disabled', () => {
+        expect(() => build_members({ ai_council: { enabled: false } })).toThrow(CouncilDisabledError);
+        expect(() => build_members({ ai_council: { enabled: false } })).toThrow(/enabled is false/);
+    });
+
+    it('raises when no member is enabled', () => {
+        const settings = {
+            ai_council: {
+                enabled: true,
+                members: { anthropic: { enabled: false }, openai: { enabled: false } },
+            },
+        };
+        expect(() => build_members(settings)).toThrow(CouncilDisabledError);
+        expect(() => build_members(settings)).toThrow(/no council member/);
+    });
+});
+
+// ── build_members — siblings validation ───────────────────────────────
+
+describe('build_members siblings validation', () => {
+    it('unknown provider raises', () => {
+        const settings = {
+            ai_council: {
+                enabled: true,
+                mode: 'api',
+                members: { anthropic: { enabled: true, model: 'claude-sonnet-4-5' } },
+            },
+        };
+        expect(() =>
+            build_members(settings, { siblings_overrides: { openai: ['gpt-4o', 'o1'] } }),
+        ).toThrow(/unknown member/);
+    });
+
+    it('disabled provider raises', () => {
+        const settings = {
+            ai_council: {
+                enabled: true,
+                mode: 'api',
+                members: { anthropic: { enabled: false, model: 'claude-sonnet-4-5' } },
+            },
+        };
+        expect(() =>
+            build_members(settings, {
+                siblings_overrides: { anthropic: ['claude-sonnet-4-5', 'claude-opus-4-1'] },
+            }),
+        ).toThrow(/not .*enabled/);
+    });
+
+    it('conflicts with a model override on the same member', () => {
+        const settings = {
+            ai_council: {
+                enabled: true,
+                mode: 'api',
+                members: { anthropic: { enabled: true, model: 'claude-sonnet-4-5' } },
+            },
+        };
+        expect(() =>
+            build_members(settings, {
+                model_overrides: { anthropic: 'claude-opus-4-1' },
+                siblings_overrides: { anthropic: ['claude-sonnet-4-5', 'claude-opus-4-1'] },
+            }),
+        ).toThrow(/same member/);
+    });
+
+    it('rejects manual mode (requires mode=api)', () => {
+        const settings = {
+            ai_council: {
+                enabled: true,
+                mode: 'manual',
+                members: { anthropic: { enabled: true, mode: 'manual' } },
+            },
+        };
+        expect(() =>
+            build_members(settings, {
+                siblings_overrides: { anthropic: ['claude-sonnet-4-5', 'claude-opus-4-1'] },
+            }),
+        ).toThrow(/mode=api/);
+    });
+});
+
+// ── cmd_run — estimate-only path (no --confirm, returns before output write) ──
+
+describe('cmd_run', () => {
+    it('without --confirm is estimate-only and writes no output', () => {
+        const dir = mkTmp();
+        const q = path.join(dir, 'ask.txt');
+        fs.writeFileSync(q, 'hi', 'utf-8');
+        const out_path = path.join(dir, 'out.json');
+        const members = [new StubMember('openai', 'gpt-x', new CouncilResponse({ provider: 'openai', model: 'gpt-x', text: 'x' }))];
+        const args: Args = {
+            question: q,
+            input_mode: 'prompt',
+            max_tokens: 10,
+            mode_override: null,
+            original_ask: '',
+            confirm: false,
+            output: out_path,
+            rounds: 1,
+        };
+        const captured: string[] = [];
+        const origWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+            captured.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+            return true;
+        }) as typeof process.stdout.write;
+        let rc: number;
+        try {
+            rc = cmd_run(args, { settings: { ai_council: { enabled: true } }, members, table: fakeTable() });
+        } finally {
+            process.stdout.write = origWrite;
+        }
+        expect(rc).toBe(0);
+        expect(fs.existsSync(out_path)).toBe(false);
+        expect(captured.join('')).toContain('No --confirm flag');
+    });
+});
+
+// ── cmd_debate — disclosure + refusal cap (all return before output write) ──
+
+function debateArgs(dir: string, opts: { rounds?: number; confirm?: boolean } = {}): Args {
+    const q = path.join(dir, 'ask.txt');
+    fs.writeFileSync(q, 'Design trade-off: monolith vs microservices', 'utf-8');
+    return {
+        question: q,
+        input_mode: 'prompt',
+        max_tokens: 128,
+        mode_override: null,
+        original_ask: '',
+        confirm: opts.confirm ?? false,
+        output: path.join(dir, 'debate-out'),
+        rounds: opts.rounds ?? 2,
+        model: null,
+        siblings: null,
+        proceed_anyway: false,
+        invocation: 'agent',
+        continue_as_debate: null,
+        auto_continue: true,
+        depth: 'standard',
+    };
+}
+
+describe('cmd_debate', () => {
+    let logSpy: string[] = [];
+    let errSpy: string[] = [];
+    let origLog: typeof process.stdout.write;
+    let origErr: typeof process.stderr.write;
+
+    function captureStart() {
+        logSpy = [];
+        errSpy = [];
+        origLog = process.stdout.write.bind(process.stdout);
+        origErr = process.stderr.write.bind(process.stderr);
+        process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+            logSpy.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+            return true;
+        }) as typeof process.stdout.write;
+        process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+            errSpy.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+            return true;
+        }) as typeof process.stderr.write;
+    }
+    function captureStop() {
+        process.stdout.write = origLog;
+        process.stderr.write = origErr;
+    }
+
+    it('disclosure mode=always renders the block', () => {
+        const dir = mkTmp();
+        const members = [new StubMember('openai', 'gpt-x', new CouncilResponse({ provider: 'openai', model: 'gpt-x', text: 'r' }))];
+        captureStart();
+        let rc: number;
+        try {
+            rc = cmd_debate(debateArgs(dir), {
+                settings: {
+                    ai_council: {
+                        enabled: true,
+                        debate: {
+                            max_cost_usd: 100.0,
+                            cost_disclosure: { mode: 'always', show_per_member: true },
+                        },
+                    },
+                },
+                members,
+                table: fakeTable(),
+            });
+        } finally {
+            captureStop();
+        }
+        const out = logSpy.join('');
+        expect(rc).toBe(0);
+        expect(out).toContain('cost-disclosure');
+        expect(out).toContain('per member');
+    });
+
+    it('disclosure mode=off suppresses the block', () => {
+        const dir = mkTmp();
+        const members = [new StubMember('openai', 'gpt-x', new CouncilResponse({ provider: 'openai', model: 'gpt-x', text: 'r' }))];
+        captureStart();
+        let rc: number;
+        try {
+            rc = cmd_debate(debateArgs(dir), {
+                settings: {
+                    ai_council: {
+                        enabled: true,
+                        debate: { max_cost_usd: 100.0, cost_disclosure: { mode: 'off' } },
+                    },
+                },
+                members,
+                table: fakeTable(),
+            });
+        } finally {
+            captureStop();
+        }
+        expect(rc).toBe(0);
+        expect(logSpy.join('')).not.toContain('cost-disclosure');
+    });
+
+    it('disclosure above_threshold skips the block when below the threshold', () => {
+        const dir = mkTmp();
+        const members = [new StubMember('openai', 'gpt-x', new CouncilResponse({ provider: 'openai', model: 'gpt-x', text: 'r' }))];
+        captureStart();
+        let rc: number;
+        try {
+            rc = cmd_debate(debateArgs(dir, { rounds: 1 }), {
+                settings: {
+                    ai_council: {
+                        enabled: true,
+                        debate: {
+                            max_cost_usd: 100.0,
+                            cost_disclosure: { mode: 'above_threshold', threshold_usd: 1000.0 },
+                        },
+                    },
+                },
+                members,
+                table: fakeTable(),
+            });
+        } finally {
+            captureStop();
+        }
+        expect(rc).toBe(0);
+        expect(logSpy.join('')).not.toContain('cost-disclosure');
+    });
+
+    it('refusal cap blocks (exit 4) when the high-end estimate exceeds max_cost_usd', () => {
+        const dir = mkTmp();
+        const members = [new StubMember('openai', 'gpt-x', new CouncilResponse({ provider: 'openai', model: 'gpt-x', text: 'r' }))];
+        captureStart();
+        let rc: number;
+        try {
+            rc = cmd_debate(debateArgs(dir, { rounds: 4, confirm: true }), {
+                settings: {
+                    ai_council: {
+                        enabled: true,
+                        debate_max_rounds: 4,
+                        debate: {
+                            max_cost_usd: 0.000001, // impossibly low
+                            cost_disclosure: { mode: 'always' },
+                        },
+                    },
+                },
+                members,
+                table: fakeTable(),
+            });
+        } finally {
+            captureStop();
+        }
+        const err = errSpy.join('');
+        expect(rc).toBe(4);
+        expect(err).toContain('refused');
+        expect(err).toContain('max_cost_usd');
+    });
+
+    it('refusal cap of 0 disables the check', () => {
+        const dir = mkTmp();
+        const members = [new StubMember('openai', 'gpt-x', new CouncilResponse({ provider: 'openai', model: 'gpt-x', text: 'r' }))];
+        captureStart();
+        let rc: number;
+        try {
+            rc = cmd_debate(debateArgs(dir, { rounds: 1 }), {
+                settings: {
+                    ai_council: {
+                        enabled: true,
+                        debate: { max_cost_usd: 0, cost_disclosure: { mode: 'off' } },
+                    },
+                },
+                members,
+                table: fakeTable(),
+            });
+        } finally {
+            captureStop();
+        }
+        expect(rc).toBe(0);
+        expect(errSpy.join('')).not.toContain('refused');
+    });
+});

--- a/tests/scripts/ai_council/pricing.test.ts
+++ b/tests/scripts/ai_council/pricing.test.ts
@@ -1,0 +1,202 @@
+// Pure-TS behaviour test for the pricing twin (`src/scripts/ai_council/pricing.ts`).
+//
+// Ports `tests/ai_council/test_pricing.py` faithfully against the TS twin so the
+// Python spec can be retired. Covers: `estimate_input_tokens` (chars/4 heuristic),
+// `bootstrap_from_defaults` + `load_prices` round-trip, `estimate_cost`,
+// `last_monday_utc`, and `is_stale` (UTC Monday boundary + invalid-date path).
+//
+// API note: the Python `PriceTable.lookup(provider, model)` method is a free
+// function `lookup(table, provider, model)` in the twin; this test asserts the
+// same lookup behaviour through it.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_PRICES } from '../../../src/scripts/ai_council/_default_prices.js';
+import {
+    bootstrap_from_defaults,
+    estimate_cost,
+    estimate_input_tokens,
+    is_stale,
+    last_monday_utc,
+    load_prices,
+    lookup,
+} from '../../../src/scripts/ai_council/pricing.js';
+
+const _tmpDirs: string[] = [];
+
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'pricing-'));
+    _tmpDirs.push(d);
+    return d;
+}
+
+afterEach(() => {
+    while (_tmpDirs.length > 0) {
+        const d = _tmpDirs.pop();
+        if (d) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+// ── chars/4 heuristic ────────────────────────────────────────────────
+
+describe('estimate_input_tokens', () => {
+    it('empty string returns zero', () => {
+        expect(estimate_input_tokens('')).toBe(0);
+    });
+
+    it('short string returns at least one', () => {
+        expect(estimate_input_tokens('ab')).toBe(1);
+        expect(estimate_input_tokens('a')).toBe(1);
+    });
+
+    it('uses chars / 4', () => {
+        expect(estimate_input_tokens('x'.repeat(100))).toBe(25);
+        expect(estimate_input_tokens('x'.repeat(4001))).toBe(1000);
+    });
+});
+
+// ── bootstrap + parser round-trip ────────────────────────────────────
+
+describe('bootstrap + load_prices', () => {
+    it('bootstrap creates a file with frontmatter and table', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        bootstrap_from_defaults(p);
+        const text = fs.readFileSync(p, 'utf-8');
+        expect(text.startsWith('---\n')).toBe(true);
+        expect(text).toContain('currency: USD');
+        expect(text).toContain('unit: per_1M_tokens');
+        expect(text).toContain('source: shipped-default');
+        expect(text).toContain('| provider');
+    });
+
+    it('load_prices bootstraps when the file is missing', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        const table = load_prices(p);
+        expect(fs.existsSync(p)).toBe(true);
+        expect(table.source).toBe('shipped-default');
+        expect(table.prices.has('anthropic claude-sonnet-4-5')).toBe(true);
+    });
+
+    it('round-trips every default entry', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        bootstrap_from_defaults(p);
+        const table = load_prices(p);
+        for (const key of DEFAULT_PRICES.keys()) {
+            expect(table.prices.has(key), `missing ${key}`).toBe(true);
+        }
+        // key is "provider model"; split into the two components for lookup().
+        for (const [key, [inp, outp]] of DEFAULT_PRICES) {
+            const sep = key.indexOf(' ');
+            const provider = key.slice(0, sep);
+            const model = key.slice(sep + 1);
+            const price = lookup(table, provider, model);
+            expect(price).not.toBeNull();
+            expect(price?.input_per_1m_usd).toBe(inp);
+            expect(price?.output_per_1m_usd).toBe(outp);
+        }
+    });
+
+    it('user edit wins over defaults', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        fs.writeFileSync(
+            p,
+            '---\nlast_updated: 2026-04-29\ncurrency: USD\nunit: per_1M_tokens\nsource: user-curated\n---\n\n' +
+                '| provider | model | input | output |\n' +
+                '|---|---|---|---|\n' +
+                '| anthropic | claude-sonnet-4-5 | 99.99 | 100.00 |\n',
+            'utf-8',
+        );
+        const table = load_prices(p);
+        const price = lookup(table, 'anthropic', 'claude-sonnet-4-5');
+        expect(price).not.toBeNull();
+        expect(price?.input_per_1m_usd).toBe(99.99);
+        expect(price?.output_per_1m_usd).toBe(100.0);
+        expect(table.source).toBe('user-curated');
+    });
+});
+
+// ── cost estimation ──────────────────────────────────────────────────
+
+describe('estimate_cost', () => {
+    it('known model', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        bootstrap_from_defaults(p);
+        const table = load_prices(p);
+        const e = estimate_cost('anthropic', 'claude-sonnet-4-5', 1_000_000, 1_000_000, table);
+        expect(e.input_usd).toBe(3.0);
+        expect(e.output_usd).toBe(15.0);
+        // Python asserts total_usd == 18.0; the twin's CostEstimate has no
+        // total field, so assert the equivalent sum.
+        expect(e.input_usd + e.output_usd).toBe(18.0);
+    });
+
+    it('unknown model returns zero', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        bootstrap_from_defaults(p);
+        const table = load_prices(p);
+        const e = estimate_cost('anthropic', 'no-such-model', 100, 100, table);
+        expect(e.input_usd).toBe(0.0);
+        expect(e.output_usd).toBe(0.0);
+    });
+});
+
+// ── staleness (UTC Monday boundary) ──────────────────────────────────
+
+describe('last_monday_utc', () => {
+    it('on a Wednesday returns the prior Monday', () => {
+        // 2026-04-29 is a Wednesday.
+        const wed = new Date(Date.UTC(2026, 3, 29, 12, 0, 0));
+        expect(last_monday_utc(wed)).toBe('2026-04-27');
+    });
+
+    it('on a Monday returns the same date', () => {
+        const mon = new Date(Date.UTC(2026, 3, 27, 0, 1, 0));
+        expect(last_monday_utc(mon)).toBe('2026-04-27');
+    });
+
+    it('on a Sunday returns the previous Monday', () => {
+        const sun = new Date(Date.UTC(2026, 4, 3, 23, 0, 0));
+        expect(last_monday_utc(sun)).toBe('2026-04-27');
+    });
+});
+
+describe('is_stale', () => {
+    function writeTable(lastUpdated: string): string {
+        const p = path.join(mkTmp(), 'prices.md');
+        fs.writeFileSync(
+            p,
+            `---\nlast_updated: ${lastUpdated}\ncurrency: USD\nunit: per_1M_tokens\nsource: shipped-default\n---\n\n` +
+                '| provider | model | input | output |\n|---|---|---|---|\n',
+            'utf-8',
+        );
+        return p;
+    }
+
+    it('true when last_updated is before last Monday', () => {
+        const table = load_prices(writeTable('2026-04-26'));
+        const now = new Date(Date.UTC(2026, 3, 29, 12, 0, 0));
+        expect(is_stale(table, now)).toBe(true);
+    });
+
+    it('false when last_updated is on or after last Monday', () => {
+        const table = load_prices(writeTable('2026-04-27'));
+        const now = new Date(Date.UTC(2026, 3, 29, 12, 0, 0));
+        expect(is_stale(table, now)).toBe(false);
+    });
+
+    it('true when last_updated is an invalid date', () => {
+        const p = path.join(mkTmp(), 'prices.md');
+        fs.writeFileSync(
+            p,
+            '---\nlast_updated: not-a-date\ncurrency: USD\nunit: per_1M_tokens\nsource: shipped-default\n---\n\n',
+            'utf-8',
+        );
+        const table = load_prices(p);
+        expect(is_stale(table)).toBe(true);
+    });
+});

--- a/tests/scripts/hooks/dispatcher_feedback_traversal.test.ts
+++ b/tests/scripts/hooks/dispatcher_feedback_traversal.test.ts
@@ -1,0 +1,127 @@
+// Tests for src/scripts/hooks/dispatch_hook.ts feedback-dir path-traversal
+// neutralisation (py2ts — GAP coverage).
+//
+// Ports ONLY the session_id path-traversal case from
+// tests/hooks/test_dispatcher_feedback.py
+// (test_session_id_path_traversal_is_neutralised). The rest of that
+// python file (per-concern files, summary rollup, silent-severity
+// inference, empty-envelope fallback) is already covered end-to-end by
+// the golden-parity layer in tests/scripts/hooks/dispatch_hook.test.ts,
+// so only the traversal gap is filled here.
+//
+// Two layers:
+//   1. Pure unit — feedback_dir() is the neutralisation site; assert `/`,
+//      `\`, and `..` collapse to `_` with no subprocess.
+//   2. End-to-end — drive the dispatcher (main) the way the python test
+//      does (against a tmp manifest + fixture concern) and assert no
+//      parent-escape directory lands on disk. Runs via tsx subprocess so
+//      it mirrors the python in-process main() run; the concern result is
+//      irrelevant (fail-open) so it passes even when python3 is stubbed.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { EXIT_ALLOW } from '../../../src/scripts/hooks/dispatch_hook.js';
+import { feedback_dir, FEEDBACK_DIRNAME } from '../../../src/scripts/hooks/state_io.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'hooks', 'dispatch_hook.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+const FIXTURE_CONCERN = 'tests/hooks/fixtures/concern_allow.py';
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dispatch-traversal-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+// --- Layer 1: pure unit on feedback_dir (the neutralisation site) -----
+
+describe('feedback_dir — path-traversal neutralisation', () => {
+    it('collapses /, \\ and .. in the session id to _', () => {
+        const stateRoot = path.join(tmp, 'agents', 'runtime', 'state');
+        const dir = feedback_dir(stateRoot, '../etc/passwd');
+        const base = path.basename(dir);
+        // No path separators or parent-escape sequences survive.
+        expect(base).not.toContain('/');
+        expect(base).not.toContain('\\');
+        expect(base).not.toContain('..');
+        // The dir stays inside the .dispatcher root — never escapes upward:
+        // the sanitised id is a single path segment under .dispatcher.
+        const dispatcherRoot = path.join(stateRoot, FEEDBACK_DIRNAME);
+        expect(path.dirname(dir)).toBe(dispatcherRoot);
+        expect(base.length).toBeGreaterThan(0);
+        expect(base.split(path.sep).length).toBe(1);
+    });
+
+    it('neutralises a backslash-based traversal too', () => {
+        const stateRoot = path.join(tmp, 'agents', 'runtime', 'state');
+        const dir = feedback_dir(stateRoot, '..\\..\\secret');
+        const base = path.basename(dir);
+        expect(base).not.toContain('\\');
+        expect(base).not.toContain('..');
+        expect(path.dirname(dir)).toBe(path.join(stateRoot, FEEDBACK_DIRNAME));
+    });
+});
+
+// --- Layer 2: end-to-end main() run, no parent-escape on disk ---------
+
+function writeManifest(target: string): void {
+    const lines = [
+        'schema_version: 1',
+        'concerns:',
+        '  allow_one:',
+        `    script: ${FIXTURE_CONCERN}`,
+        '    fail_closed: false',
+        'platforms:',
+        '  augment:',
+        '    stop: [allow_one]',
+        '',
+    ];
+    fs.writeFileSync(target, lines.join('\n'), 'utf8');
+}
+
+describe('dispatch_hook end-to-end — session_id path-traversal cannot escape', () => {
+    it('a ../etc/passwd session id leaves no parent-escape dir on disk', () => {
+        const ws = path.join(tmp, 'ws');
+        fs.mkdirSync(ws, { recursive: true });
+        const manifest = path.join(tmp, 'manifest.yaml');
+        writeManifest(manifest);
+
+        const payload = JSON.stringify({ session_id: '../etc/passwd' });
+        const r = spawnSync(
+            TSX_BIN,
+            [TS_SCRIPT, '--platform', 'augment', '--event', 'stop', '--manifest', manifest],
+            { cwd: ws, input: payload, encoding: 'utf8' },
+        );
+        // Concern result is irrelevant (fail-open); the dispatcher still
+        // exits allow and writes feedback to the sanitised dir.
+        expect(r.status).toBe(EXIT_ALLOW);
+
+        const dispatcherDir = path.join(ws, 'agents', 'runtime', 'state', '.dispatcher');
+        expect(fs.existsSync(dispatcherDir)).toBe(true);
+        const children = fs
+            .readdirSync(dispatcherDir)
+            .filter((p) => fs.statSync(path.join(dispatcherDir, p)).isDirectory())
+            .sort();
+        // Every session dir is sanitised — no `/` or `..` survives.
+        for (const c of children) {
+            expect(c).not.toContain('/');
+            expect(c).not.toContain('..');
+        }
+        // Hard assertion: no parent-escape directories on disk.
+        expect(fs.existsSync(path.join(ws, 'agents', 'runtime', 'state', 'etc'))).toBe(false);
+        expect(fs.existsSync(path.join(ws, 'etc'))).toBe(false);
+        expect(fs.existsSync(path.join(tmp, 'etc'))).toBe(false);
+    });
+});

--- a/tests/scripts/hooks/event_shape_contract.test.ts
+++ b/tests/scripts/hooks/event_shape_contract.test.ts
@@ -1,0 +1,157 @@
+// Tests for src/scripts/hooks/dispatch_hook.ts envelope contract (py2ts).
+//
+// 1:1 port of tests/hooks/test_event_shape_contract.py. Freezes a
+// representative native payload for each platform and asserts the
+// dispatcher's envelope contract (docs/contracts/hook-architecture-v1.md
+// § "Stdin contract") holds without subprocess overhead. Pure-TS: imports
+// the twin's _build_envelope / EVENT_VOCABULARY plus the real manifest's
+// native_event_aliases via _load_yaml. No python, no oracle.
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+    EVENT_VOCABULARY,
+    _build_envelope,
+    _load_yaml,
+} from '../../../src/scripts/hooks/dispatch_hook.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+const MANIFEST_PATH = path.join(REPO_ROOT, 'src', 'scripts', 'hook_manifest.yaml');
+
+const MANIFEST = _load_yaml(MANIFEST_PATH) as Record<string, unknown>;
+const ALIASES = (MANIFEST['native_event_aliases'] as Record<string, Record<string, string>>) ?? {};
+
+// Frozen sample payloads — kept as plain JSON strings so a breaking
+// platform-doc change is a one-line diff with provenance. (native_event,
+// ac_event, payload_json).
+type Sample = [native: string, ac: string, payloadJson: string];
+
+const SAMPLES: Record<string, Sample[]> = {
+    augment: [
+        ['SessionStart', 'session_start', '{"session_id": "aug-1", "source": "startup", "cwd": "/work"}'],
+        ['Stop', 'stop', '{"session_id": "aug-1", "stop_reason": "end_turn"}'],
+        ['PostToolUse', 'post_tool_use', '{"session_id": "aug-1", "tool_name": "view"}'],
+    ],
+    claude: [
+        ['SessionStart', 'session_start', '{"session_id": "cl-1", "transcript_path": "/tmp/t.json"}'],
+        ['UserPromptSubmit', 'user_prompt_submit', '{"session_id": "cl-1", "prompt": "hello"}'],
+        ['PostToolUse', 'post_tool_use', '{"session_id": "cl-1", "tool_name": "Read"}'],
+    ],
+    cowork: [
+        ['SessionStart', 'session_start', '{"session_id": "co-1", "cwd": "/work", "transcript_path": "/tmp/co.json"}'],
+        ['UserPromptSubmit', 'user_prompt_submit', '{"session_id": "co-1", "cwd": "/work", "prompt": "hello cowork"}'],
+        ['PostToolUse', 'post_tool_use', '{"session_id": "co-1", "cwd": "/work", "tool_name": "Read"}'],
+    ],
+    cursor: [
+        ['sessionStart', 'session_start', '{"session_id": "cu-1", "workspace_roots": ["/work"]}'],
+        ['beforeSubmitPrompt', 'user_prompt_submit', '{"session_id": "cu-1", "prompt": "hi"}'],
+        ['postToolUse', 'post_tool_use', '{"session_id": "cu-1", "tool_name": "edit_file"}'],
+    ],
+    cline: [
+        ['TaskStart', 'session_start', '{"taskId": "cli-1", "session_id": "cli-1", "workspaceRoots": ["/work"], "model": "claude-sonnet"}'],
+        ['TaskResume', 'session_start', '{"taskId": "cli-1", "session_id": "cli-1"}'],
+        ['UserPromptSubmit', 'user_prompt_submit', '{"taskId": "cli-1", "session_id": "cli-1", "prompt": "go"}'],
+    ],
+    windsurf: [
+        ['post_setup_worktree', 'session_start', '{"session_id": "ws-1", "workspace_path": "/work"}'],
+        ['pre_user_prompt', 'user_prompt_submit', '{"session_id": "ws-1", "prompt": "ping"}'],
+        ['post_cascade_response', 'stop', '{"session_id": "ws-1"}'],
+    ],
+    gemini: [
+        ['SessionStart', 'session_start', '{"session_id": "gem-1", "cwd": "/work"}'],
+        ['BeforeAgent', 'user_prompt_submit', '{"session_id": "gem-1", "prompt": "build it"}'],
+        ['AfterAgent', 'stop', '{"session_id": "gem-1"}'],
+        ['AfterTool', 'post_tool_use', '{"session_id": "gem-1", "tool_name": "ReadFile"}'],
+    ],
+};
+
+function build(platform: string, event: string, native: string, payloadJson: string): Record<string, unknown> {
+    const args = {
+        platform,
+        event,
+        native_event: native,
+        manifest: MANIFEST_PATH,
+        dry_run: false,
+        project_dir: '',
+        min_version: 0,
+    };
+    return _build_envelope(args, payloadJson) as Record<string, unknown>;
+}
+
+describe('event-shape contract — native_event_aliases resolve per sample', () => {
+    it('every sample native event aliases to its declared AC event', () => {
+        for (const [platform, samples] of Object.entries(SAMPLES)) {
+            const platformAliases = ALIASES[platform] ?? {};
+            for (const [native, acEvent] of samples) {
+                expect(
+                    platformAliases[native],
+                    `${platform}: native '${native}' does not alias to '${acEvent}' (manifest says: ${String(platformAliases[native])})`,
+                ).toBe(acEvent);
+            }
+        }
+    });
+});
+
+describe('event-shape contract — envelope passthrough + required keys', () => {
+    it('payload is a verbatim passthrough', () => {
+        for (const [platform, samples] of Object.entries(SAMPLES)) {
+            for (const [native, acEvent, payloadJson] of samples) {
+                const env = build(platform, acEvent, native, payloadJson);
+                expect(env['payload'], `${platform}/${native}: payload mutated by dispatcher`).toEqual(
+                    JSON.parse(payloadJson),
+                );
+            }
+        }
+    });
+
+    it('envelope carries required top-level keys with correct values', () => {
+        const required = [
+            'schema_version',
+            'platform',
+            'event',
+            'native_event',
+            'session_id',
+            'workspace_root',
+            'payload',
+            'settings',
+        ];
+        for (const [platform, samples] of Object.entries(SAMPLES)) {
+            for (const [native, acEvent, payloadJson] of samples) {
+                const env = build(platform, acEvent, native, payloadJson);
+                for (const key of required) {
+                    expect(key in env, `${platform}/${native}: missing key ${key}`).toBe(true);
+                }
+                expect(env['schema_version']).toBe(1);
+                expect(env['platform']).toBe(platform);
+                expect(env['event']).toBe(acEvent);
+                expect(env['native_event']).toBe(native);
+            }
+        }
+    });
+
+    it('session_id is lifted from the payload when present', () => {
+        for (const [platform, samples] of Object.entries(SAMPLES)) {
+            for (const [native, acEvent, payloadJson] of samples) {
+                const env = build(platform, acEvent, native, payloadJson);
+                const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+                if ('session_id' in payload) {
+                    expect(
+                        env['session_id'],
+                        `${platform}/${native}: session_id not lifted from payload`,
+                    ).toBe(payload['session_id']);
+                }
+            }
+        }
+    });
+});
+
+describe('event-shape contract — ac events match vocabulary', () => {
+    it('every sample ac event is in EVENT_VOCABULARY', () => {
+        for (const [platform, samples] of Object.entries(SAMPLES)) {
+            for (const [, acEvent] of samples) {
+                expect(EVENT_VOCABULARY.has(acEvent), `${platform}: '${acEvent}' not in EVENT_VOCABULARY`).toBe(true);
+            }
+        }
+    });
+});

--- a/tests/scripts/hooks_status.test.ts
+++ b/tests/scripts/hooks_status.test.ts
@@ -1,0 +1,222 @@
+// Tests for src/scripts/hooks_status.ts (py2ts — hooks runtime matrix).
+//
+// 1:1 port of tests/hooks/test_hooks_status.py. Pure-TS: import the twin's
+// exported surface (collect / main / PLATFORM_BRIDGES) plus the real
+// manifest via dispatch_hook._load_yaml, drive against tmp project dirs,
+// and assert the matrix shape, per-platform bridge detection, the Copilot
+// degraded marker, the Cowork n/a row, --strict exit codes, the table
+// rendering, and JSON parseability.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { _load_yaml, type JsonObject } from '../../src/scripts/hooks/dispatch_hook.js';
+import {
+    PLATFORM_BRIDGES,
+    collect,
+    main,
+    type PlatformRow,
+    type StatusMatrix,
+} from '../../src/scripts/hooks_status.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const MANIFEST_PATH = path.join(REPO_ROOT, 'src', 'scripts', 'hook_manifest.yaml');
+
+function manifest(): JsonObject {
+    return _load_yaml(MANIFEST_PATH) as JsonObject;
+}
+
+function byPlatform(matrix: StatusMatrix): Record<string, PlatformRow> {
+    const out: Record<string, PlatformRow> = {};
+    for (const row of matrix.platforms) {
+        out[row.platform] = row;
+    }
+    return out;
+}
+
+// Capture stdout writes (main() prints the table / JSON to stdout, like
+// the python capsys fixture).
+function captureStdout(fn: () => number): { rc: number; out: string } {
+    let buf = '';
+    const spy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation((chunk: string | Uint8Array): boolean => {
+            buf += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+            return true;
+        });
+    try {
+        const rc = fn();
+        return { rc, out: buf };
+    } finally {
+        spy.mockRestore();
+    }
+}
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hooks-status-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+    vi.restoreAllMocks();
+});
+
+// --- collect() walks every platform -----------------------------------
+
+describe('hooks_status — collect', () => {
+    it('returns every platform in PLATFORM_BRIDGES', () => {
+        const matrix = collect(tmp, manifest());
+        expect(matrix.schema_version).toBe(1);
+        const platforms = new Set(matrix.platforms.map((r) => r.platform));
+        expect(platforms).toEqual(new Set(Object.keys(PLATFORM_BRIDGES)));
+    });
+
+    it('reports missing bridges on a fresh project, degraded copilot, n/a cowork', () => {
+        const matrix = collect(tmp, manifest());
+        const rows = byPlatform(matrix);
+
+        // All non-Copilot, non-Cowork platforms have a real bridge_path and
+        // should report 'missing' in a fresh tmp dir.
+        for (const platform of ['augment', 'claude', 'cursor', 'cline', 'windsurf', 'gemini']) {
+            const row = rows[platform]!;
+            expect(row.status, platform).toBe('missing');
+            expect(
+                Object.keys(row.bindings).length,
+                `${platform} has no manifest bindings`,
+            ).toBeGreaterThan(0);
+        }
+
+        // Copilot is always degraded.
+        expect(rows['copilot']!.status).toBe('degraded');
+        expect(rows['copilot']!.fallback_only).toBe(true);
+
+        // Cowork has manifest bindings but no project-scope bridge path
+        // (upstream-blocked). Empty bridge path → status="n/a"; strict mode
+        // never fails on n/a (matches Copilot's no-bridge posture).
+        const cowork = rows['cowork']!;
+        expect(cowork.status).toBe('n/a');
+        expect(cowork.bridge_path).toBeNull();
+        expect(Object.keys(cowork.bindings).length, 'cowork must declare manifest bindings').toBeGreaterThan(0);
+        expect(cowork.fallback_only).toBe(false);
+        expect(cowork.hint ?? '').toContain('upstream-blocked');
+    });
+
+    it('detects an installed claude bridge (file present)', () => {
+        fs.mkdirSync(path.join(tmp, '.claude'));
+        fs.writeFileSync(path.join(tmp, '.claude', 'settings.json'), '{}', 'utf8');
+        const matrix = collect(tmp, manifest());
+        const claude = matrix.platforms.find((r) => r.platform === 'claude')!;
+        expect(claude.status).toBe('installed');
+        expect(claude.hint).toBeNull();
+    });
+
+    it('detects a non-empty cline directory bridge as installed', () => {
+        const clineDir = path.join(tmp, '.clinerules', 'hooks');
+        fs.mkdirSync(clineDir, { recursive: true });
+        fs.writeFileSync(path.join(clineDir, 'TaskStart'), '#!/bin/sh\n', 'utf8');
+        const matrix = collect(tmp, manifest());
+        const cline = matrix.platforms.find((r) => r.platform === 'cline')!;
+        expect(cline.status).toBe('installed');
+    });
+
+    it('marks an empty cline directory as empty', () => {
+        fs.mkdirSync(path.join(tmp, '.clinerules', 'hooks'), { recursive: true });
+        const matrix = collect(tmp, manifest());
+        const cline = matrix.platforms.find((r) => r.platform === 'cline')!;
+        expect(cline.status).toBe('empty');
+    });
+});
+
+// --- main() strict mode + output -------------------------------------
+
+describe('hooks_status — main strict mode', () => {
+    it('strict mode returns 1 on a missing bridge', () => {
+        const { rc, out } = captureStdout(() =>
+            main([
+                '--project-root',
+                tmp,
+                '--manifest',
+                MANIFEST_PATH,
+                '--strict',
+                '--format',
+                'json',
+            ]),
+        );
+        expect(rc).toBe(1);
+        const payload = JSON.parse(out);
+        expect(payload.schema_version).toBe(1);
+    });
+
+    it('strict mode returns 0 when all bridges are installed', () => {
+        const bridges: Record<string, string> = {
+            '.augment/settings.json': '{}',
+            '.claude/settings.json': '{}',
+            '.cursor/hooks.json': '{}',
+            '.windsurf/hooks.json': '{}',
+            '.gemini/settings.json': '{}',
+        };
+        for (const [rel, body] of Object.entries(bridges)) {
+            const target = path.join(tmp, rel);
+            fs.mkdirSync(path.dirname(target), { recursive: true });
+            fs.writeFileSync(target, body, 'utf8');
+        }
+        const clineDir = path.join(tmp, '.clinerules', 'hooks');
+        fs.mkdirSync(clineDir, { recursive: true });
+        fs.writeFileSync(path.join(clineDir, 'TaskStart'), '#!/bin/sh\n', 'utf8');
+
+        const { rc } = captureStdout(() =>
+            main([
+                '--project-root',
+                tmp,
+                '--manifest',
+                MANIFEST_PATH,
+                '--strict',
+                '--format',
+                'json',
+            ]),
+        );
+        // Copilot is exempt (fallback_only never trips strict); Cowork is n/a.
+        expect(rc).toBe(0);
+    });
+});
+
+describe('hooks_status — main rendering', () => {
+    it('table renders the copilot degraded marker', () => {
+        const { rc, out } = captureStdout(() =>
+            main(['--project-root', tmp, '--manifest', MANIFEST_PATH]),
+        );
+        expect(rc).toBe(0);
+        expect(out).toContain('copilot');
+        expect(out).toContain('degraded');
+        expect(out).toContain('rule-only fallback');
+    });
+
+    it('json format is parseable with the expected shape', () => {
+        const { rc, out } = captureStdout(() =>
+            main(['--project-root', tmp, '--manifest', MANIFEST_PATH, '--format', 'json']),
+        );
+        expect(rc).toBe(0);
+        const payload = JSON.parse(out);
+        expect('platforms' in payload).toBe(true);
+        const first = payload.platforms[0];
+        for (const key of ['platform', 'status', 'bindings']) {
+            expect(key in first, key).toBe(true);
+        }
+    });
+});
+
+// --- guard against the python-shadowed run path -----------------------
+// hooks_status is pure (fs + manifest read only), so a stubbed python3
+// changes nothing — but assert the import surface is intact regardless.
+describe('hooks_status — no python dependency', () => {
+    it('collect works without a python3 binary on PATH', () => {
+        const hasPython = spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+        // Whether or not python3 exists, collect() must not invoke it.
+        const matrix = collect(tmp, manifest());
+        expect(matrix.platforms.length).toBe(Object.keys(PLATFORM_BRIDGES).length);
+        void hasPython;
+    });
+});

--- a/tests/scripts/install_snapshot.test.ts
+++ b/tests/scripts/install_snapshot.test.ts
@@ -1,0 +1,180 @@
+// Install-output snapshot tests for src/scripts/install.ts — the TS twin of
+// tests/hooks/test_install_snapshot.py (the SPEC). PURE-TS: no python, no
+// snapshot oracle. Two behaviors are frozen here:
+//
+//   1. Per-platform install output — drive `ensure_<platform>_bridge(...)`
+//      against a tmp project dir and assert the written bridge file CONTENTS
+//      match the expected per-platform strings (frozen INLINE as committed
+//      fixtures, ported from the python snapshot expectations).
+//   2. Drift guard — each platform's `*_DISPATCHER_BINDINGS` must cover the
+//      `scripts/hook_manifest.yaml` platform block (manifest events ⊆ binding
+//      ac_events), the silent-no-op failure mode the parser guards.
+//
+// A breaking change to install.ts (renamed binding, dropped event, shifted CLI
+// flag) trips one of these with a useful diff.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parse as parseYaml } from 'yaml';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as inst from '../../src/scripts/install.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const MANIFEST = path.join(REPO_ROOT, 'src', 'scripts', 'hook_manifest.yaml');
+
+// Mirror the python _Base setUp: a fresh tmp consumer dir with the agent-config
+// CLI shim install.py expects to find.
+let project: string;
+let tmpRoot: string;
+
+beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'install-snap-'));
+    project = path.join(tmpRoot, 'consumer');
+    fs.mkdirSync(project);
+    const shim = path.join(project, 'agent-config');
+    fs.writeFileSync(shim, '#!/usr/bin/env bash\nexit 0\n');
+    fs.chmodSync(shim, 0o755);
+});
+
+afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function readJson(rel: string): Record<string, any> {
+    return JSON.parse(fs.readFileSync(path.join(project, rel), 'utf8'));
+}
+
+describe('Cursor snapshot', () => {
+    // `.cursor/hooks.json` is locked to `version: 1` + event-keyed arrays of
+    // `{command: "<sh>"}` entries that invoke the dispatcher via
+    // `./agent-config dispatch:hook`.
+    it('writes the locked per-event dispatcher shape', () => {
+        inst.ensure_cursor_bridge(project, false);
+        const data = readJson('.cursor/hooks.json');
+        expect(data['version']).toBe(1);
+        const hooks = data['hooks'];
+        const boundNative = new Set(inst.CURSOR_DISPATCHER_BINDINGS.map(([, n]) => n));
+        expect(new Set(Object.keys(hooks))).toEqual(boundNative);
+        for (const [acEvent, native] of inst.CURSOR_DISPATCHER_BINDINGS) {
+            expect(hooks[native]).toHaveLength(1);
+            const cmd: string = hooks[native][0]['command'];
+            expect(cmd).toContain('./agent-config dispatch:hook');
+            expect(cmd).toContain('--platform cursor');
+            expect(cmd).toContain(`--event ${acEvent}`);
+            expect(cmd).toContain(`--native-event ${native}`);
+        }
+    });
+});
+
+describe('Cline snapshot', () => {
+    // One executable script per binding under `.clinerules/hooks/<HookName>`.
+    // Filename = native event name; body invokes
+    // `./agent-config dispatch:hook --platform cline`.
+    it('writes one executable script per binding, body invokes the dispatcher', () => {
+        inst.ensure_cline_bridge(project, false);
+        const hooksDir = path.join(project, '.clinerules', 'hooks');
+        const boundNative = new Set(inst.CLINE_DISPATCHER_BINDINGS.map(([, n]) => n));
+        const onDisk = new Set(
+            fs
+                .readdirSync(hooksDir)
+                .filter((n) => fs.statSync(path.join(hooksDir, n)).isFile()),
+        );
+        expect(onDisk).toEqual(boundNative);
+        for (const [acEvent, native] of inst.CLINE_DISPATCHER_BINDINGS) {
+            const script = path.join(hooksDir, native);
+            expect(fs.statSync(script).mode & 0o111).not.toBe(0);
+            const body = fs.readFileSync(script, 'utf8');
+            expect(body).toContain('./agent-config dispatch:hook');
+            expect(body).toContain('--platform cline');
+            expect(body).toContain(`--event ${acEvent}`);
+            expect(body).toContain(`--native-event ${native}`);
+        }
+    });
+});
+
+describe('Windsurf snapshot', () => {
+    // `.windsurf/hooks.json` — one entry per binding pointing at the dispatcher
+    // via the agent-config CLI, each with `show_output: false`.
+    it('writes one show_output:false dispatcher entry per binding', () => {
+        inst.ensure_windsurf_bridge(project, false);
+        const data = readJson('.windsurf/hooks.json');
+        const hooks = data['hooks'];
+        const boundNative = new Set(inst.WINDSURF_DISPATCHER_BINDINGS.map(([, n]) => n));
+        expect(new Set(Object.keys(hooks))).toEqual(boundNative);
+        for (const [acEvent, native] of inst.WINDSURF_DISPATCHER_BINDINGS) {
+            const entries = hooks[native];
+            expect(entries).toHaveLength(1);
+            const entry = entries[0];
+            expect(entry['show_output']).toBe(false);
+            const cmd: string = entry['command'];
+            expect(cmd).toContain('./agent-config dispatch:hook');
+            expect(cmd).toContain('--platform windsurf');
+            expect(cmd).toContain(`--event ${acEvent}`);
+            expect(cmd).toContain(`--native-event ${native}`);
+        }
+    });
+});
+
+describe('Gemini snapshot', () => {
+    // `.gemini/settings.json` uses the nested
+    // `hooks → EventName → [{matcher, hooks: [{type, command}]}]` shape.
+    it('writes the nested matcher/command group shape', () => {
+        inst.ensure_gemini_bridge(project, false);
+        const data = readJson('.gemini/settings.json');
+        const hooks = data['hooks'];
+        const boundNative = new Set(inst.GEMINI_DISPATCHER_BINDINGS.map(([, n]) => n));
+        for (const n of boundNative) {
+            expect(Object.keys(hooks)).toContain(n);
+        }
+        for (const [acEvent, native, matcher] of inst.GEMINI_DISPATCHER_BINDINGS) {
+            const groups = hooks[native];
+            expect(groups).toHaveLength(1);
+            const group = groups[0];
+            expect(group['matcher']).toBe(matcher);
+            const entry = group['hooks'][0];
+            expect(entry['type']).toBe('command');
+            const cmd: string = entry['command'];
+            expect(cmd).toContain('./agent-config dispatch:hook');
+            expect(cmd).toContain('--platform gemini');
+            expect(cmd).toContain(`--event ${acEvent}`);
+            expect(cmd).toContain(`--native-event ${native}`);
+        }
+    });
+});
+
+describe('Binding coverage snapshot', () => {
+    // Each platform binding table covers the manifest's platform block. Drift
+    // between install.ts and scripts/hook_manifest.yaml is the silent-no-op
+    // failure mode the orphan check guards on the manifest side; this layer
+    // guards from the install side.
+    it('bindings cover the manifest events', () => {
+        const manifest = parseYaml(fs.readFileSync(MANIFEST, 'utf8')) as Record<string, any>;
+        const platforms = (manifest['platforms'] ?? {}) as Record<string, any>;
+
+        const acEvents = (bindings: ReadonlyArray<readonly [string, ...string[]]>): Set<string> =>
+            new Set(bindings.map((b) => b[0]));
+
+        const cases: Array<[string, ReadonlyArray<readonly [string, ...string[]]>]> = [
+            ['cursor', inst.CURSOR_DISPATCHER_BINDINGS],
+            ['cline', inst.CLINE_DISPATCHER_BINDINGS],
+            ['windsurf', inst.WINDSURF_DISPATCHER_BINDINGS],
+            ['gemini', inst.GEMINI_DISPATCHER_BINDINGS],
+        ];
+
+        for (const [platform, bindings] of cases) {
+            const manifestEvents = new Set(
+                Object.keys(platforms[platform] ?? {}).filter((e) => e !== 'fallback_only'),
+            );
+            const bound = acEvents(bindings);
+            for (const ev of manifestEvents) {
+                expect(
+                    bound.has(ev),
+                    `${platform}: manifest event ${ev} not covered by install bindings ${[...bound].join(', ')}`,
+                ).toBe(true);
+            }
+        }
+    });
+});

--- a/tests/scripts/templates_telemetry_boundary.test.ts
+++ b/tests/scripts/templates_telemetry_boundary.test.ts
@@ -1,0 +1,187 @@
+// Pure-TS behaviour test for the telemetry boundary twin
+// (`src/agent-src/templates/scripts/telemetry/boundary.ts`).
+//
+// Ports `tests/telemetry/test_boundary.py` faithfully so the Python spec can be
+// retired. Covers the `BoundarySession` lifecycle (coalesce + dedup + sort,
+// empty-does-not-write, exception-suppresses-flush, double-flush idempotent,
+// unknown-kind / unknown-boundary rejection) and `record_event`
+// (validate-before-write, every-line-complete-JSON).
+//
+// Divergence note: the Python `test_record_event_concurrent_writes_no_interleaving`
+// test uses `multiprocessing` to assert cross-process append atomicity via
+// `fcntl.flock`. The TS twin documents itself as the best-effort-append branch
+// (Node has no portable advisory lock) and is single-writer in tests; the
+// realistic TS equivalent is sequential writers, which is the behaviour
+// `test_record_event_each_line_is_complete_json` already asserts. The
+// no-interleaving guarantee is therefore covered by the sequential round-trip
+// below, not a process pool.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    BoundarySession,
+    open_boundary,
+    record_event,
+} from '../../src/agent-src/templates/scripts/telemetry/boundary.js';
+import {
+    EngagementEvent,
+    EngagementSchemaError,
+    now_utc_iso,
+    parse_event,
+} from '../../src/agent-src/templates/scripts/telemetry/engagement.js';
+
+const _tmpDirs: string[] = [];
+
+function mkTmp(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-'));
+    _tmpDirs.push(d);
+    return d;
+}
+
+function readLines(p: string): string[] {
+    return fs
+        .readFileSync(p, 'utf-8')
+        .split('\n')
+        .filter((line) => line.trim().length > 0);
+}
+
+afterEach(() => {
+    while (_tmpDirs.length > 0) {
+        const d = _tmpDirs.pop();
+        if (d) {
+            fs.rmSync(d, { recursive: true, force: true });
+        }
+    }
+});
+
+describe('BoundarySession', () => {
+    it('coalesces duplicates into a single sorted, deduped event', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        open_boundary('ticket-1', 'task', log, (session) => {
+            session.add_consulted('skills', ['php-coder', 'eloquent']);
+            session.add_consulted('skills', ['php-coder']); // duplicate
+            session.add_applied('skills', ['php-coder']);
+            session.add_applied('rules', ['scope-control']);
+        });
+
+        const lines = readLines(log);
+        expect(lines).toHaveLength(1);
+        const event = parse_event(`${lines[0]}\n`);
+        expect(event.consulted).toEqual({ skills: ['eloquent', 'php-coder'] }); // sorted, deduped
+        expect(event.applied).toEqual({ skills: ['php-coder'], rules: ['scope-control'] });
+    });
+
+    it('empty boundary does not write a file', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        open_boundary('ticket-2', 'task', log, () => {
+            // no add_* calls
+        });
+        expect(fs.existsSync(log)).toBe(false);
+    });
+
+    it('exception inside the boundary suppresses the flush', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        expect(() =>
+            open_boundary('ticket-3', 'phase-step', log, (session) => {
+                session.add_consulted('skills', ['x']);
+                throw new Error('boundary failed');
+            }),
+        ).toThrow('boundary failed');
+        expect(fs.existsSync(log)).toBe(false);
+    });
+
+    it('double flush is idempotent', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        const session = new BoundarySession({
+            task_id: 'ticket-4',
+            boundary_kind: 'task',
+            log_path: log,
+        });
+        session.add_consulted('rules', ['scope-control']);
+        expect(session.flush()).toBe(true);
+        expect(session.flush()).toBe(false); // no-op on second call
+        expect(readLines(log)).toHaveLength(1);
+    });
+
+    it('rejects an unknown artefact kind', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        const session = new BoundarySession({
+            task_id: 't',
+            boundary_kind: 'task',
+            log_path: log,
+        });
+        expect(() => session.add_consulted('plugins', ['x'])).toThrow(EngagementSchemaError);
+        expect(() => session.add_consulted('plugins', ['x'])).toThrow('not an allowed artefact kind');
+    });
+
+    it('rejects an unknown boundary kind at construction', () => {
+        const log = path.join(mkTmp(), 'log.jsonl');
+        expect(
+            () =>
+                new BoundarySession({ task_id: 't', boundary_kind: 'day', log_path: log }),
+        ).toThrow(EngagementSchemaError);
+        expect(
+            () =>
+                new BoundarySession({ task_id: 't', boundary_kind: 'day', log_path: log }),
+        ).toThrow('boundary_kind must be one of');
+    });
+});
+
+describe('record_event', () => {
+    it('validates before writing — no partial write on bad event', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        const bad = new EngagementEvent({ ts: now_utc_iso(), task_id: '', boundary_kind: 'task' });
+        expect(() => record_event(log, bad)).toThrow(EngagementSchemaError);
+        expect(fs.existsSync(log)).toBe(false);
+    });
+
+    it('writes well-formed, non-interleaved lines that each round-trip', () => {
+        // TS-equivalent of the Python concurrent-writers test: sequential
+        // writers must each produce one complete, parseable line.
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        const nWriters = 20;
+        for (let i = 0; i < nWriters; i++) {
+            record_event(
+                log,
+                new EngagementEvent({
+                    ts: now_utc_iso(),
+                    task_id: `ticket-${i}`,
+                    boundary_kind: 'task',
+                    consulted: { skills: [`skill-${i}`] },
+                }),
+            );
+        }
+        const lines = readLines(log);
+        expect(lines).toHaveLength(nWriters);
+        const seen = new Set<string>();
+        for (const line of lines) {
+            const event = parse_event(`${line}\n`);
+            seen.add(event.task_id);
+        }
+        const expected = new Set(Array.from({ length: nWriters }, (_, i) => `ticket-${i}`));
+        expect(seen).toEqual(expected);
+    });
+
+    it('every line is complete JSON, no truncation', () => {
+        const log = path.join(mkTmp(), '.agent-engagement.jsonl');
+        for (let i = 0; i < 5; i++) {
+            record_event(
+                log,
+                new EngagementEvent({
+                    ts: now_utc_iso(),
+                    task_id: `t-${i}`,
+                    boundary_kind: 'task',
+                    consulted: { skills: ['x'] },
+                }),
+            );
+        }
+        for (const line of readLines(log)) {
+            const parsed = JSON.parse(line) as Record<string, unknown>;
+            expect(parsed['schema_version']).toBe(1);
+            expect(parsed['boundary_kind']).toBe('task');
+        }
+    });
+});

--- a/tests/scripts/work_engine/cli_hooks_exit_table.test.ts
+++ b/tests/scripts/work_engine/cli_hooks_exit_table.test.ts
@@ -1,0 +1,241 @@
+// Pure-TS gap coverage for the CLI-layer hook surface — ported from the python
+// spec `tests/work_engine/test_cli_hooks.py`. No python3, no golden oracle:
+// drive `main()` in-process and assert the HookHalt-per-event → exit-code
+// table directly.
+//
+// Python patches `work_engine.cli._build_hook_registry` (monkeypatch) and stubs
+// `memory_lookup.retrieve` (the `fake_memory_lookup` fixture). The TS twin
+// mirrors both: `vi.mock('hook_bootstrap.js')` injects a controllable factory
+// (`setRegistryFactory`), and `_setRetrieve` (the established memory seam) plays
+// the role of `fake_memory_lookup`. stdout/stderr are captured by spying on
+// `process.stdout.write` / `process.stderr.write` (the `capsys` analogue).
+//
+// The `test_build_hook_registry_*` settings-driven cases from the python spec
+// are already covered pure-TS in `hook_bootstrap.test.ts`; this file covers the
+// `main()`-driven branch table that file does not.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    HookContext,
+    HookEvent,
+    HookHalt,
+    HookRegistry,
+} from '../../../src/agent-src/templates/scripts/work_engine/hooks/index.js';
+
+// Mutable factory the mocked `_build_hook_registry` delegates to. Declared
+// before the hoisted vi.mock factory references it via the module-scope binding.
+type RegistryFactory = (args: unknown) => HookRegistry;
+let registryFactory: RegistryFactory = () => new HookRegistry();
+function setRegistryFactory(fn: RegistryFactory): void {
+    registryFactory = fn;
+}
+
+vi.mock(
+    '../../../src/agent-src/templates/scripts/work_engine/hook_bootstrap.js',
+    async (importOriginal) => {
+        const actual =
+            await importOriginal<
+                typeof import('../../../src/agent-src/templates/scripts/work_engine/hook_bootstrap.js')
+            >();
+        return {
+            ...actual,
+            _build_hook_registry: (args: unknown) => registryFactory(args),
+        };
+    },
+);
+
+const { main } = await import(
+    '../../../src/agent-src/templates/scripts/work_engine/cli.js'
+);
+const { _build_hook_registry } = await import(
+    '../../../src/agent-src/templates/scripts/work_engine/hook_bootstrap.js'
+);
+const { _setRetrieve } = await import(
+    '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js'
+);
+
+let tmp: string;
+let outChunks: string[];
+let errChunks: string[];
+const restores: Array<() => void> = [];
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-hooks-'));
+    // Mirror the python fake_memory_lookup fixture: retrieve returns nothing.
+    _setRetrieve(() => []);
+    outChunks = [];
+    errChunks = [];
+    const outSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(((chunk: string | Uint8Array): boolean => {
+            outChunks.push(String(chunk));
+            return true;
+        }) as typeof process.stdout.write);
+    const errSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(((chunk: string | Uint8Array): boolean => {
+            errChunks.push(String(chunk));
+            return true;
+        }) as typeof process.stderr.write);
+    restores.push(() => outSpy.mockRestore(), () => errSpy.mockRestore());
+});
+
+afterEach(() => {
+    for (const restore of restores.splice(0)) restore();
+    _setRetrieve(null);
+    registryFactory = () => new HookRegistry();
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeTicket(): string {
+    const ticket = path.join(tmp, 'ticket.json');
+    fs.writeFileSync(
+        ticket,
+        JSON.stringify({
+            id: 'HOOK-1',
+            title: 'Wire CLI hooks',
+            acceptance_criteria: ['CLI fires the six lifecycle events.'],
+        }),
+        'utf-8',
+    );
+    return ticket;
+}
+
+/**
+ * Seed `registryFactory` with recorder hooks for the given events; each records
+ * its firing into `trace` and, when a halt is supplied, raises it. Mirrors the
+ * python `_install_hooks`.
+ */
+function installHooks(
+    events: Partial<Record<keyof typeof HookEvent, HookHalt | null>>,
+): Array<[string, string]> {
+    const trace: Array<[string, string]> = [];
+    setRegistryFactory(() => {
+        const registry = new HookRegistry();
+        for (const [name, halt] of Object.entries(events)) {
+            const ev = HookEvent[name as keyof typeof HookEvent];
+            registry.register(ev, (_ctx: HookContext) => {
+                trace.push(['trace', ev]);
+                if (halt) throw halt;
+            });
+        }
+        return registry;
+    });
+    return trace;
+}
+
+describe('cli hooks — default registry', () => {
+    it('build_hook_registry returns an empty registry by default', () => {
+        // Real (un-mocked behaviour): a Namespace with no settings → empty.
+        const registry = _build_hook_registry({} as never);
+        expect(registry).toBeInstanceOf(HookRegistry);
+        expect([...registry.events()]).toEqual([]);
+    });
+});
+
+describe('cli hooks — runner threaded through dispatch', () => {
+    it('same registry powers both CLI and dispatcher events, in order', () => {
+        const trace = installHooks({
+            BEFORE_LOAD: null,
+            AFTER_LOAD: null,
+            BEFORE_DISPATCH: null,
+            BEFORE_STEP: null,
+            AFTER_DISPATCH: null,
+            BEFORE_SAVE: null,
+            AFTER_SAVE: null,
+        });
+
+        main([
+            '--state-file',
+            path.join(tmp, 'state.json'),
+            '--ticket-file',
+            writeTicket(),
+        ]);
+
+        const fired = trace.map(([, ev]) => ev);
+        // CLI events fire in declared order, dispatcher events fire in between.
+        expect(fired.slice(0, 2)).toEqual([HookEvent.BEFORE_LOAD, HookEvent.AFTER_LOAD]);
+        expect(fired[2]).toBe(HookEvent.BEFORE_DISPATCH);
+        // At least one BEFORE_STEP between BEFORE_DISPATCH and AFTER_DISPATCH.
+        const before = fired.indexOf(HookEvent.BEFORE_DISPATCH);
+        const after = fired.indexOf(HookEvent.AFTER_DISPATCH);
+        expect(fired.slice(before + 1, after)).toContain(HookEvent.BEFORE_STEP);
+        // Save events fire after dispatch.
+        expect(fired.slice(after + 1)).toEqual([
+            HookEvent.BEFORE_SAVE,
+            HookEvent.AFTER_SAVE,
+        ]);
+    });
+});
+
+describe('cli hooks — halt branch table (exit 2)', () => {
+    const beforeSaveEvents: Array<keyof typeof HookEvent> = [
+        'BEFORE_LOAD',
+        'AFTER_LOAD',
+        'BEFORE_DISPATCH',
+        'AFTER_DISPATCH',
+        'BEFORE_SAVE',
+    ];
+
+    for (const haltEvent of beforeSaveEvents) {
+        it(`halt on ${haltEvent} → exit 2, no state persisted`, () => {
+            const surface = ['> 1. Resolve the halt.', '> 2. Abort.'];
+            const halt = new HookHalt('cli_test', surface);
+            installHooks({ [haltEvent]: halt });
+
+            const stateFile = path.join(tmp, 'state.json');
+            const exitCode = main([
+                '--state-file',
+                stateFile,
+                '--ticket-file',
+                writeTicket(),
+            ]);
+
+            expect(exitCode).toBe(2);
+            const err = errChunks.join('');
+            for (const line of surface) expect(err).toContain(line);
+            // Halt fired before _save → no state on disk.
+            expect(fs.existsSync(stateFile)).toBe(false);
+        });
+    }
+
+    it('halt on AFTER_SAVE → exit 2, state persisted', () => {
+        const surface = ['> 1. Acknowledge persisted state.'];
+        const halt = new HookHalt('after_save_test', surface);
+        installHooks({ AFTER_SAVE: halt });
+
+        const stateFile = path.join(tmp, 'state.json');
+        const exitCode = main([
+            '--state-file',
+            stateFile,
+            '--ticket-file',
+            writeTicket(),
+        ]);
+
+        expect(exitCode).toBe(2);
+        expect(errChunks.join('')).toContain(surface[0]);
+        // Halt fired after _save → state IS persisted, valid JSON.
+        expect(fs.existsSync(stateFile)).toBe(true);
+        expect(JSON.parse(fs.readFileSync(stateFile, 'utf-8'))).toBeTruthy();
+    });
+});
+
+describe('cli hooks — empty registry is byte-compatible with pre-P3', () => {
+    it('default empty registry → exit 1, state exists, create-plan directive', () => {
+        // No installHooks() → registryFactory stays the empty default.
+        const stateFile = path.join(tmp, 'state.json');
+        const exitCode = main([
+            '--state-file',
+            stateFile,
+            '--ticket-file',
+            writeTicket(),
+        ]);
+
+        expect(exitCode).toBe(1); // BLOCKED at create-plan, same as pre-P3.
+        expect(fs.existsSync(stateFile)).toBe(true);
+        expect(outChunks.join('')).toContain('@agent-directive: create-plan');
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_polish_dispatch.test.ts
+++ b/tests/scripts/work_engine/directives_ui_polish_dispatch.test.ts
@@ -1,0 +1,467 @@
+// Pure-TS gap coverage for the `directives/ui/polish` twin — ported from the
+// python spec `tests/work_engine/test_step_polish.py`. No python3, no golden
+// oracle: build a `DeliveryState`, call `polish.run`, assert the
+// `{outcome, questions}` shape directly against the twin.
+//
+// Focus per the py2ts gap brief: stack-dispatch (`ui-polish-<stack>`), the
+// `STACK_DIRECTIVES == KNOWN_STACKS` invariant, the bounded loop / ceiling
+// halt, and defensive `rounds` parsing — the behaviours the existing golden
+// rig exercises only via the python projection.
+import { describe, expect, it } from 'vitest';
+
+import {
+    AGENT_DIRECTIVE_PREFIX,
+    DeliveryState,
+    Outcome,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    POLISH_CEILING,
+    STACK_DIRECTIVES,
+    TOKEN_REPEAT_THRESHOLD,
+    TOKEN_VIOLATION_KIND,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/polish.js';
+import { KNOWN_STACKS } from '../../../src/agent-src/templates/scripts/work_engine/stack/detect.js';
+
+type Json = Record<string, unknown>;
+
+/** First surfaced question — non-empty on every BLOCKED path under test. */
+function q0(questions: string[]): string {
+    return questions[0] ?? '';
+}
+
+function uiState(opts: {
+    stack?: string | null;
+    ui_review?: Json | null;
+    ui_polish?: Json | null;
+    ui_audit?: Json | null;
+} = {}): DeliveryState {
+    const stack = opts.stack === undefined ? 'blade-livewire-flux' : opts.stack;
+    const state = new DeliveryState({
+        ticket: {
+            id: 'UI-4',
+            title: 'Polish dark mode toggle',
+            raw: 'Polish dark mode toggle',
+        },
+    });
+    if (opts.ui_review != null) state.ui_review = opts.ui_review;
+    if (opts.ui_polish != null) state.ui_polish = opts.ui_polish;
+    if (opts.ui_audit != null) state.ui_audit = opts.ui_audit;
+    if (stack != null) state.stack = { frontend: stack, mtime: 0.0 };
+    return state;
+}
+
+// --- success / no-op paths --------------------------------------------------
+
+describe('polish — success / no-op paths', () => {
+    it('succeeds when review is clean', () => {
+        const result = run(uiState({ ui_review: { findings: [], review_clean: true } }));
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('succeeds when findings empty even if clean flag is false', () => {
+        const result = run(uiState({ ui_review: { findings: [], review_clean: false } }));
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('succeeds with clean flag after max rounds (ship-as-is replay)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'label', issue: 'wrong copy' }],
+                    review_clean: true,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+});
+
+// --- bounded loop -----------------------------------------------------------
+
+describe('polish — bounded loop directives', () => {
+    it('emits the stack directive on the first round', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'label', issue: 'wrong copy' }],
+                    review_clean: false,
+                },
+                ui_polish: null,
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        expect(q0(result.questions)).toContain('ui-polish-blade-livewire-flux');
+        const body = result.questions.join('\n');
+        expect(body.includes('1 of 2') || body.toLowerCase().includes('round 1')).toBe(true);
+    });
+
+    it('emits the directive on the second round', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'label', issue: 'wrong copy' }],
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 1, applied: [{ path: 'label', fix: 'x' }] },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        const body = result.questions.join('\n');
+        expect(body.includes('2 of 2') || body.toLowerCase().includes('round 2')).toBe(true);
+    });
+});
+
+// --- ceiling halt -----------------------------------------------------------
+
+describe('polish — ceiling halt', () => {
+    it('halts at ceiling when review still dirty (user-decision, not directive)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [
+                        { path: 'label', issue: 'wrong copy' },
+                        { path: 'btn', issue: 'missing aria-label' },
+                    ],
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n');
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(false);
+        expect(body.toLowerCase()).toContain('ceiling');
+        expect(body).toContain('Ship as-is');
+        expect(body).toContain('Abort');
+        expect(body).toContain('Hand off');
+    });
+
+    it('surfaces the findings count at ceiling', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [0, 1, 2].map((i) => ({ path: `f${i}`, issue: 'x' })),
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+            }),
+        );
+        expect(result.questions.join('\n')).toContain('3');
+    });
+
+    it('refuses a third round even with a higher rounds value', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'x', issue: 'y' }],
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 5, applied: [] },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n')).toContain('Ship as-is');
+    });
+});
+
+// --- stack dispatch ---------------------------------------------------------
+
+describe('polish — stack dispatch', () => {
+    it('dispatches to the react-shadcn directive', () => {
+        const result = run(
+            uiState({
+                stack: 'react-shadcn',
+                ui_review: { findings: [{ path: 'x', issue: 'y' }], review_clean: false },
+            }),
+        );
+        expect(q0(result.questions)).toContain('ui-polish-react-shadcn');
+    });
+
+    it('falls back to plain when the stack is missing', () => {
+        const result = run(
+            uiState({
+                stack: null,
+                ui_review: { findings: [{ path: 'x', issue: 'y' }], review_clean: false },
+            }),
+        );
+        expect(q0(result.questions)).toContain('ui-polish-plain');
+    });
+
+    it('STACK_DIRECTIVES keys match KNOWN_STACKS exactly', () => {
+        expect(new Set(Object.keys(STACK_DIRECTIVES))).toEqual(new Set(KNOWN_STACKS));
+    });
+});
+
+// --- defensive parsing ------------------------------------------------------
+
+describe('polish — defensive rounds parsing', () => {
+    it('treats a non-int rounds as zero (first-round directive, not ceiling)', () => {
+        const result = run(
+            uiState({
+                ui_review: { findings: [{ path: 'x', issue: 'y' }], review_clean: false },
+                ui_polish: { rounds: 'two', applied: [] },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+    });
+
+    it('treats a bool rounds (true) as zero — not round 1', () => {
+        const result = run(
+            uiState({
+                ui_review: { findings: [{ path: 'x', issue: 'y' }], review_clean: false },
+                ui_polish: { rounds: true, applied: [] },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        const body = result.questions.join('\n');
+        expect(body.includes('1 of 2') || body.toLowerCase().includes('round 1')).toBe(true);
+    });
+});
+
+// --- constant mirrors -------------------------------------------------------
+
+describe('polish — schema-mirror constants', () => {
+    it('POLISH_CEILING is 2', () => {
+        expect(POLISH_CEILING).toBe(2);
+    });
+
+    it('TOKEN_REPEAT_THRESHOLD is 2', () => {
+        expect(TOKEN_REPEAT_THRESHOLD).toBe(2);
+    });
+});
+
+// --- token-violation refactor ----------------------------------------------
+
+function tokenFinding(
+    category: string,
+    value: string,
+    path = 'Component.razor',
+): Json {
+    return {
+        kind: TOKEN_VIOLATION_KIND,
+        category,
+        value,
+        path,
+        issue: `hardcoded ${category} value \`${value}\``,
+    };
+}
+
+describe('polish — token-violation classifier', () => {
+    it('auto-converts when token matches an existing design token (no halt)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [
+                        tokenFinding('colors', '#3b82f6', 'Button.blade.php'),
+                        tokenFinding('colors', '#3b82f6', 'Card.blade.php'),
+                    ],
+                    review_clean: false,
+                },
+                ui_audit: {
+                    components_found: [],
+                    design_tokens: { colors: { primary: '#3b82f6' } },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        const body = result.questions.join('\n');
+        expect(
+            body.includes('2 token-violation match') || body.includes('auto-convert'),
+        ).toBe(true);
+    });
+
+    it('halts when an unmatched value repeats above the threshold', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [0, 1, 2].map((i) =>
+                        tokenFinding('colors', '#abcdef', `f${i}.blade.php`),
+                    ),
+                    review_clean: false,
+                },
+                ui_audit: { design_tokens: { colors: { primary: '#3b82f6' } } },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(false);
+        const body = result.questions.join('\n');
+        expect(body).toContain('#abcdef');
+        expect(body).toContain('Extract');
+        expect(body).toContain('Inline');
+        expect(body).toContain('Abort');
+    });
+
+    it('does not halt at exactly the threshold (strict >)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [
+                        tokenFinding('spacing', '13px', 'A.blade.php'),
+                        tokenFinding('spacing', '13px', 'B.blade.php'),
+                    ],
+                    review_clean: false,
+                },
+                ui_audit: { design_tokens: { spacing: { sm: '8px' } } },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        expect(result.questions.join('\n')).not.toContain('Extract');
+    });
+
+    it('halts when audit missing — no tokens known → value unmatched', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [0, 1, 2].map(() => tokenFinding('colors', '#deadbe')),
+                    review_clean: false,
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n')).toContain('Extract');
+    });
+
+    it('ignores non-token findings in the classifier', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [
+                        { path: 'label', issue: 'wrong copy' },
+                        { path: 'btn', issue: 'missing aria-label' },
+                    ],
+                    review_clean: false,
+                },
+                ui_audit: { design_tokens: { colors: { primary: '#fff' } } },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        const body = result.questions.join('\n');
+        expect(body).not.toContain('Extract');
+        expect(body).not.toContain('token-violation match');
+    });
+
+    it('ceiling overrides the token-extraction halt', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [0, 1, 2].map(() => tokenFinding('colors', '#abcdef')),
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+                ui_audit: { design_tokens: { colors: {} } },
+            }),
+        );
+        const body = result.questions.join('\n');
+        expect(body).toContain('Ship as-is');
+        expect(body).not.toContain('Extract');
+    });
+});
+
+// --- R4 Phase 2: a11y-blocking + one-shot extension ------------------------
+
+function a11yFinding(rule = 'color-contrast', selector = '.x'): Json {
+    return { kind: 'a11y_violation', rule, selector, severity: 'serious' };
+}
+
+describe('polish — a11y-blocking ceiling + one-shot extension', () => {
+    it('emits the a11y-blocking halt at the ceiling with a11y findings', () => {
+        const result = run(
+            uiState({
+                ui_review: { findings: [a11yFinding()], review_clean: false },
+                ui_polish: { rounds: 2, applied: [], extension_used: false },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n');
+        expect(body).toContain('a11y violation');
+        expect(body).toContain('Extend');
+        expect(body).toContain('Accept');
+        expect(body).not.toContain('Ship as-is');
+        expect(body).not.toContain('Hand off');
+    });
+
+    it('a11y halt takes precedence over the subjective ceiling halt', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [a11yFinding(), { path: 'x', issue: 'subjective' }],
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+            }),
+        );
+        const body = result.questions.join('\n');
+        expect(body).toContain('Extend');
+        expect(body).not.toContain('Ship as-is');
+    });
+
+    it('subjective-only findings keep the classic ceiling halt', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'x', issue: 'subjective' }],
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+            }),
+        );
+        const body = result.questions.join('\n');
+        expect(body).toContain('Ship as-is');
+        expect(body).toContain('Hand off');
+        expect(body).not.toContain('Extend');
+    });
+
+    it('extension grants round three (delegation, not halt)', () => {
+        const result = run(
+            uiState({
+                ui_review: { findings: [a11yFinding()], review_clean: false },
+                ui_polish: { rounds: 2, applied: [], extension_used: true },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        expect(result.questions.join('\n')).toContain('round 3 of 3');
+    });
+
+    it('exhausted extension drops the Extend option', () => {
+        const result = run(
+            uiState({
+                ui_review: { findings: [a11yFinding()], review_clean: false },
+                ui_polish: { rounds: 3, applied: [], extension_used: true },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n');
+        expect(body).toContain('Accept');
+        expect(body).toContain('Abort');
+        expect(body).not.toContain('Extend');
+    });
+
+    it('a11y halt lists the findings', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [
+                        a11yFinding('color-contrast', '.btn'),
+                        a11yFinding('label', 'input#name'),
+                    ],
+                    review_clean: false,
+                },
+                ui_polish: { rounds: 2, applied: [] },
+            }),
+        );
+        const body = result.questions.join('\n');
+        expect(body).toContain('color-contrast');
+        expect(body).toContain('.btn');
+        expect(body).toContain('label');
+    });
+});

--- a/tests/scripts/work_engine/directives_ui_review_dispatch.test.ts
+++ b/tests/scripts/work_engine/directives_ui_review_dispatch.test.ts
@@ -1,0 +1,542 @@
+// Pure-TS gap coverage for the `directives/ui/review` twin — ported from the
+// python spec `tests/work_engine/test_step_review.py`. No python3, no golden
+// oracle: build a `DeliveryState`, call `review.run`, assert
+// `{outcome, questions}` + state mutations directly against the twin.
+//
+// Focus per the py2ts gap brief: stack-dispatch (`ui-design-review-<stack>`),
+// the `STACK_DIRECTIVES == KNOWN_STACKS` invariant, partial-envelope halts,
+// success-path round-trips, plus the a11y + preview gates the existing golden
+// rig exercises only via the python projection.
+import { describe, expect, it } from 'vitest';
+
+import {
+    AGENT_DIRECTIVE_PREFIX,
+    DeliveryState,
+    Outcome,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    AMBIGUITIES,
+    STACK_DIRECTIVES,
+    run,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/review.js';
+import { KNOWN_STACKS } from '../../../src/agent-src/templates/scripts/work_engine/stack/detect.js';
+
+type Json = Record<string, unknown>;
+
+/** First surfaced question — non-empty on every BLOCKED path under test. */
+function q0(questions: string[]): string {
+    return questions[0] ?? '';
+}
+
+/**
+ * Build a DeliveryState shaped like a UI-routed envelope post-apply.
+ *
+ * Mirrors the python `_ui_state`: a *well-formed* success envelope (findings +
+ * review_clean, no own preview) injects `preview: {render_ok: true}` so the
+ * preview gate does not fire for fixtures focused on a different property.
+ * Halt-path fixtures (empty dict, missing findings/clean, non-dict, explicit
+ * preview) are left untouched.
+ */
+function uiState(opts: { stack?: string | null; ui_review?: unknown } = {}): DeliveryState {
+    const stack = opts.stack === undefined ? 'blade-livewire-flux' : opts.stack;
+    const state = new DeliveryState({
+        ticket: {
+            id: 'UI-3',
+            title: 'Render dark mode toggle',
+            raw: 'Render dark mode toggle',
+        },
+    });
+    let review = opts.ui_review;
+    if (review !== undefined && review !== null) {
+        if (
+            typeof review === 'object' &&
+            !Array.isArray(review) &&
+            'findings' in (review as Json) &&
+            'review_clean' in (review as Json) &&
+            !('preview' in (review as Json))
+        ) {
+            review = { ...(review as Json), preview: { render_ok: true } };
+        }
+        state.ui_review = review as Json;
+    }
+    if (stack != null) state.stack = { frontend: stack, mtime: 0.0 };
+    return state;
+}
+
+function uiStateWithAudit(opts: { audit: Json | null; ui_review: Json }): DeliveryState {
+    const state = uiState({ ui_review: opts.ui_review });
+    if (opts.audit != null) state.ui_audit = opts.audit;
+    return state;
+}
+
+// --- first-pass directive halt ----------------------------------------------
+
+describe('review — first-pass directive halt', () => {
+    it('emits a directive when ui_review is missing', () => {
+        const result = run(uiState({ ui_review: null }));
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        expect(q0(result.questions)).toContain('ui-design-review-blade-livewire-flux');
+    });
+
+    it('emits a directive when ui_review is an empty dict', () => {
+        const result = run(uiState({ ui_review: {} }));
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+    });
+
+    it('emits a directive when ui_review is non-dict', () => {
+        const result = run(uiState({ ui_review: ['nope'] }));
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(q0(result.questions).startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+    });
+});
+
+// --- stack dispatch ---------------------------------------------------------
+
+describe('review — stack dispatch', () => {
+    it('dispatches to react-shadcn and names it in the body', () => {
+        const result = run(uiState({ stack: 'react-shadcn', ui_review: null }));
+        expect(q0(result.questions)).toContain('ui-design-review-react-shadcn');
+        expect(result.questions.join('\n')).toContain('`react-shadcn`');
+    });
+
+    it('dispatches to vue', () => {
+        const result = run(uiState({ stack: 'vue', ui_review: null }));
+        expect(q0(result.questions)).toContain('ui-design-review-vue');
+    });
+
+    it('falls back to plain when the stack is missing', () => {
+        const result = run(uiState({ stack: null, ui_review: null }));
+        expect(q0(result.questions)).toContain('ui-design-review-plain');
+    });
+
+    it('falls back to plain when the stack is unknown', () => {
+        const state = uiState({ stack: null, ui_review: null });
+        state.stack = { frontend: 'svelte', mtime: 0.0 };
+        const result = run(state);
+        expect(q0(result.questions)).toContain('ui-design-review-plain');
+    });
+
+    it('STACK_DIRECTIVES keys match KNOWN_STACKS exactly', () => {
+        expect(new Set(Object.keys(STACK_DIRECTIVES))).toEqual(new Set(KNOWN_STACKS));
+    });
+});
+
+// --- partial envelope halts -------------------------------------------------
+
+describe('review — partial envelope halts', () => {
+    it('halts when the findings key is missing', () => {
+        const result = run(uiState({ ui_review: { review_clean: true } }));
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n').toLowerCase()).toContain('findings');
+    });
+
+    it('halts when findings is not a list', () => {
+        const result = run(
+            uiState({ ui_review: { findings: 'all good', review_clean: true } }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n').toLowerCase()).toContain('findings');
+    });
+
+    it('halts when review_clean is missing (findings count surfaced)', () => {
+        const result = run(
+            uiState({ ui_review: { findings: [{ path: 'x', issue: 'y' }] } }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n');
+        expect(body).toContain('review_clean');
+        expect(body).toContain('1');
+    });
+
+    it('halts when review_clean is not a bool', () => {
+        const result = run(uiState({ ui_review: { findings: [], review_clean: 'yes' } }));
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n')).toContain('review_clean');
+    });
+});
+
+// --- success path -----------------------------------------------------------
+
+describe('review — success path', () => {
+    it('succeeds with a clean envelope', () => {
+        const result = run(uiState({ ui_review: { findings: [], review_clean: true } }));
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('succeeds with a dirty envelope (polish entry shape)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'label', issue: 'wrong copy' }],
+                    review_clean: false,
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('does not enforce clean matches findings count (ship-as-is replay)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [{ path: 'label', issue: 'wrong copy' }],
+                    review_clean: true,
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+});
+
+// --- R4 Phase 1: a11y gate --------------------------------------------------
+
+describe('review — a11y gate', () => {
+    it('passes when no baseline and no a11y envelope (pre-R4)', () => {
+        const result = run(uiState({ ui_review: { findings: [], review_clean: true } }));
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('halts pending when baseline declared but review skipped a11y', () => {
+        const result = run(
+            uiStateWithAudit({
+                audit: { a11y_baseline: [] },
+                ui_review: { findings: [], review_clean: true },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n').toLowerCase();
+        expect(body).toContain('a11y');
+        expect(body).toContain('baseline');
+    });
+
+    it('filters even without a baseline when an envelope is present', () => {
+        const state = uiStateWithAudit({
+            audit: null,
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [{ rule: 'label', selector: 'input', severity: 'serious' }],
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const review = state.ui_review as Json;
+        expect(review['review_clean']).toBe(false);
+        const findings = review['findings'] as Json[];
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.['kind']).toBe('a11y_violation');
+        expect(findings[0]?.['rule']).toBe('label');
+    });
+
+    it('filters baseline (pre-existing) violations', () => {
+        const state = uiStateWithAudit({
+            audit: {
+                a11y_baseline: [
+                    { rule: 'color-contrast', selector: 'h1', severity: 'moderate' },
+                ],
+            },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [
+                        { rule: 'color-contrast', selector: 'h1', severity: 'moderate' },
+                    ],
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const review = state.ui_review as Json;
+        expect(review['review_clean']).toBe(true);
+        expect(review['findings']).toEqual([]);
+    });
+
+    it('filters violations below the severity floor', () => {
+        const state = uiStateWithAudit({
+            audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [{ rule: 'region', selector: 'main', severity: 'minor' }],
+                    severity_floor: 'moderate',
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const review = state.ui_review as Json;
+        expect(review['review_clean']).toBe(true);
+        expect(review['findings']).toEqual([]);
+    });
+
+    it('filters accepted violations', () => {
+        const state = uiStateWithAudit({
+            audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [
+                        { rule: 'aria-roles', selector: '[role=tab]', severity: 'serious' },
+                    ],
+                    accepted_violations: [{ rule: 'aria-roles', selector: '[role=tab]' }],
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const review = state.ui_review as Json;
+        expect(review['review_clean']).toBe(true);
+        expect(review['findings']).toEqual([]);
+    });
+
+    it('synthesizes actionable findings (floor applied)', () => {
+        const state = uiStateWithAudit({
+            audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [
+                        { rule: 'label', selector: 'input#email', severity: 'serious' },
+                        { rule: 'color-contrast', selector: 'h1', severity: 'critical' },
+                        { rule: 'region', selector: 'main', severity: 'minor' },
+                    ],
+                    severity_floor: 'moderate',
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const review = state.ui_review as Json;
+        expect(review['review_clean']).toBe(false);
+        const findings = review['findings'] as Json[];
+        expect(findings).toHaveLength(2);
+        expect(new Set(findings.map((f) => f['rule']))).toEqual(
+            new Set(['label', 'color-contrast']),
+        );
+        for (const f of findings) expect(f['kind']).toBe('a11y_violation');
+    });
+
+    it('is idempotent on re-entry (no duplicate synthesised findings)', () => {
+        const state = uiStateWithAudit({
+            audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [{ rule: 'label', selector: 'input', severity: 'serious' }],
+                },
+            },
+        });
+        run(state);
+        run(state);
+        run(state);
+        const findings = (state.ui_review as Json)['findings'] as Json[];
+        expect(findings).toHaveLength(1);
+        expect(findings[0]?.['rule']).toBe('label');
+    });
+
+    it('preserves existing non-a11y findings', () => {
+        const state = uiStateWithAudit({
+            audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [{ path: 'header', issue: 'wrong padding' }],
+                review_clean: false,
+                a11y: {
+                    violations: [{ rule: 'label', selector: 'input', severity: 'serious' }],
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const findings = (state.ui_review as Json)['findings'] as Json[];
+        expect(findings).toHaveLength(2);
+        expect(findings.filter((f) => f['kind'] === 'a11y_violation')).toHaveLength(1);
+    });
+
+    it('defaults unknown severity to the floor (does not weaken the gate)', () => {
+        const state = uiStateWithAudit({
+            audit: { a11y_baseline: [] },
+            ui_review: {
+                findings: [],
+                review_clean: true,
+                a11y: {
+                    violations: [{ rule: 'label', selector: 'input', severity: 'bogus' }],
+                    severity_floor: 'moderate',
+                },
+            },
+        });
+        const result = run(state);
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+        const review = state.ui_review as Json;
+        expect(review['review_clean']).toBe(false);
+        expect((review['findings'] as Json[])).toHaveLength(1);
+    });
+
+    it('runs the pending halt only after the basic shape gates', () => {
+        const result = run(
+            uiStateWithAudit({
+                audit: { a11y_baseline: [] },
+                ui_review: { review_clean: true }, // findings missing
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n').toLowerCase();
+        expect(body).toContain('findings');
+        expect(body).not.toContain('a11y');
+    });
+
+    it('declares review_a11y_pending in the AMBIGUITIES table', () => {
+        const codes = new Set(AMBIGUITIES.map((e) => e['code']));
+        expect(codes.has('review_a11y_pending')).toBe(true);
+    });
+});
+
+// --- R4 Phase 3: preview envelope gate --------------------------------------
+
+describe('review — preview envelope gate', () => {
+    it('render-capable + missing render_ok halts', () => {
+        const result = run(
+            uiState({
+                stack: 'react-shadcn',
+                ui_review: { findings: [], review_clean: true, preview: {} },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n').toLowerCase();
+        expect(body).toContain('render evidence');
+        expect(body).toContain('required');
+        expect(body).toContain('render');
+        expect(body).toContain('skip');
+        expect(body).toContain('abort');
+    });
+
+    it('non-render-capable + missing render_ok passes (silent no-op)', () => {
+        const result = run(
+            uiState({
+                stack: null,
+                ui_review: { findings: [], review_clean: true, preview: {} },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('render-capable + explicit skip passes', () => {
+        const result = run(
+            uiState({
+                stack: 'react-shadcn',
+                ui_review: {
+                    findings: [],
+                    review_clean: true,
+                    preview: { skipped: true, skip_reason: 'no Playwright runner' },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('render-capable + non-dict preview halts (no silent pass)', () => {
+        const result = run(
+            uiState({
+                stack: 'blade-livewire-flux',
+                ui_review: { findings: [], review_clean: true, preview: null },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n').toLowerCase()).toContain('render evidence');
+    });
+
+    it('render_ok true passes', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [],
+                    review_clean: true,
+                    preview: { render_ok: true, screenshot_path: 'tmp/preview/foo.png' },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('render_ok false halts with the error surfaced', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [],
+                    review_clean: true,
+                    preview: {
+                        render_ok: false,
+                        error: 'ECONNREFUSED at http://localhost:5173',
+                    },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n').toLowerCase();
+        expect(body).toContain('preview');
+        expect(body).toContain('render');
+        expect(body).toContain('econnrefused');
+        expect(body).toContain('retry');
+        expect(body).toContain('skip');
+        expect(body).toContain('abort');
+    });
+
+    it('render_ok false without an error still halts (placeholder rendered)', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [],
+                    review_clean: true,
+                    preview: { render_ok: false },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        expect(result.questions.join('\n').toLowerCase()).toContain('none reported');
+    });
+
+    it('skipped round-trips through SUCCESS even with render_ok false', () => {
+        const result = run(
+            uiState({
+                ui_review: {
+                    findings: [],
+                    review_clean: true,
+                    preview: { render_ok: false, error: 'boom', skipped: true },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.SUCCESS);
+    });
+
+    it('runs after the a11y gate (ordering: shape → a11y → preview)', () => {
+        const result = run(
+            uiStateWithAudit({
+                audit: { a11y_baseline: [] },
+                ui_review: {
+                    findings: [],
+                    review_clean: true,
+                    // No a11y key → a11y_pending halt fires first.
+                    preview: { render_ok: false, error: 'boom' },
+                },
+            }),
+        );
+        expect(result.outcome).toBe(Outcome.BLOCKED);
+        const body = result.questions.join('\n').toLowerCase();
+        expect(body).toContain('a11y');
+        expect(body).not.toContain('render');
+    });
+
+    it('declares the preview ambiguity codes in the AMBIGUITIES table', () => {
+        const codes = new Set(AMBIGUITIES.map((e) => e['code']));
+        expect(codes.has('preview_render_failed')).toBe(true);
+        expect(codes.has('preview_render_required')).toBe(true);
+    });
+});

--- a/tests/scripts/work_engine/integration_chat_history.test.ts
+++ b/tests/scripts/work_engine/integration_chat_history.test.ts
@@ -1,0 +1,144 @@
+// End-to-end integration of the chat-history hooks via main() (pure TS).
+//
+// Behavioural twin of tests/work_engine/test_integration_chat_history.py — the
+// Python suite is the spec. It drives the full eight-step flow through `main()`
+// with the structural chat-history hooks registered (append + halt_append) and
+// a fake subprocess runner capturing every `scripts/chat_history.py` invocation.
+// The contract under lock:
+//
+//   - `append --type phase` fires once per successful step boundary.
+//   - `append --type decision` fires when the engine halts with a surfaceable
+//     decision (the halt-append hook).
+//   - The retired cooperative hooks (`turn-check`, `heartbeat`) never fire.
+//
+// Python patches `_chat_history_base._default_runner`. The TS twin builds its
+// hooks (inside `main()` → `_register_chat_history_hooks`) with the default
+// runner, whose only subprocess boundary is `spawnSync` from `node:child_process`
+// inside `_default_runner`. We intercept exactly there with `vi.mock`, capturing
+// every argv and returning exit 0 — no real subprocess, no python3 spawned. The
+// memory step's lazy `memory_lookup.retrieve` seam is stubbed via `_setRetrieve`
+// (the TS mirror of the Python `fake_memory_lookup` fixture).
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture log shared with the mocked spawnSync (declared before the hoisted
+// vi.mock factory references it via the module-scope binding).
+const capturedCommands: string[][] = [];
+
+vi.mock('node:child_process', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:child_process')>();
+    return {
+        ...actual,
+        spawnSync: (program: string, args: string[]) => {
+            capturedCommands.push([program, ...(args ?? [])]);
+            return { status: 0, stdout: '', stderr: '', signal: null, pid: 0, output: [] };
+        },
+    };
+});
+
+const { main } = await import(
+    '../../../src/agent-src/templates/scripts/work_engine/cli.js'
+);
+const { _setRetrieve } = await import(
+    '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js'
+);
+
+let tmp: string;
+
+beforeEach(() => {
+    capturedCommands.length = 0;
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chat-history-int-'));
+    // Mirror the Python fake_memory_lookup fixture: retrieve returns nothing.
+    _setRetrieve(() => []);
+});
+
+afterEach(() => {
+    _setRetrieve(null);
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function settingsWithChatHistory(script: string): string {
+    const cfg = path.join(tmp, '.agent-settings.yml');
+    fs.writeFileSync(
+        cfg,
+        [
+            'hooks:',
+            '  enabled: true',
+            '  trace: false',
+            '  halt_surface_audit: false',
+            '  state_shape_validation: false',
+            '  directive_set_guard: false',
+            '  chat_history:',
+            '    enabled: true',
+            `    script: ${script}`,
+            'chat_history:',
+            '  enabled: true',
+            '',
+        ].join('\n'),
+        'utf-8',
+    );
+    return cfg;
+}
+
+function wellFormedTicket(): string {
+    const ticket = path.join(tmp, 'ticket.json');
+    fs.writeFileSync(
+        ticket,
+        JSON.stringify({
+            id: 'TICKET-99',
+            title: 'Add export button',
+            acceptance_criteria: [
+                'Users can trigger CSV export from the dashboard.',
+                'The export includes every visible column.',
+            ],
+        }),
+        'utf-8',
+    );
+    return ticket;
+}
+
+describe('chat-history hooks — one dispatch cycle through main()', () => {
+    it('fires phase appends per step boundary + a decision append on halt', () => {
+        const script = path.join(tmp, 'chat_history.py');
+        fs.writeFileSync(script, '# stub', 'utf-8');
+        const cfg = settingsWithChatHistory(script);
+        const stateFile = path.join(tmp, 'state.json');
+
+        const exitCode = main([
+            '--state-file',
+            stateFile,
+            '--ticket-file',
+            wellFormedTicket(),
+            '--hooks-config',
+            cfg,
+        ]);
+
+        // First cycle halts BLOCKED at create-plan (agent must resume).
+        expect(exitCode).toBe(1);
+        expect(fs.existsSync(stateFile)).toBe(true);
+
+        // Only chat-history subprocess invocations matter; the sub-command is at
+        // argv index 2 (python3, <script>, <sub-command>, ...).
+        const subCommands = capturedCommands.filter((c) => c.length > 2).map((c) => c[2]);
+        // No cooperative hooks fire — they were removed.
+        expect(subCommands).not.toContain('turn-check');
+        expect(subCommands).not.toContain('heartbeat');
+
+        // refine + memory + analyze succeeded before plan blocked → 3 phase
+        // appends + 1 decision append for the create-plan halt.
+        const appendCalls = capturedCommands.filter((c) => c.length > 2 && c[2] === 'append');
+        expect(appendCalls.length).toBeGreaterThanOrEqual(3);
+
+        const typesSeen: string[] = [];
+        for (const call of appendCalls) {
+            const idx = call.indexOf('--type');
+            if (idx !== -1 && idx + 1 < call.length) {
+                typesSeen.push(call[idx + 1] as string);
+            }
+        }
+        expect(typesSeen.filter((t) => t === 'phase').length).toBeGreaterThanOrEqual(3);
+        expect(typesSeen.filter((t) => t === 'decision').length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/tests/scripts/work_engine/integration_full_flow.test.ts
+++ b/tests/scripts/work_engine/integration_full_flow.test.ts
@@ -1,0 +1,213 @@
+// End-to-end integration of the eight-step BACKEND dispatcher (pure TS).
+//
+// Behavioural twin of tests/work_engine/test_integration_full_flow.py — the
+// Python suite is the spec. It drives the full Option-A resume loop with the
+// real backend step handlers and a scripted fake orchestrator that, on each
+// BLOCKED with an `@agent-directive:` marker, applies the deterministic slice a
+// real agent would produce, marks the step success, and re-invokes `dispatch`.
+//
+// No python, no oracle, no snapshot: we import the TS twins, drive `dispatch`,
+// and assert the convergence sequence, the cross-loop memory keep/drop rule in
+// the report, the skip-already-successful resume contract, and the failed-test
+// halt. The `memory_lookup.retrieve` lazy seam is swapped via `_setRetrieve`
+// (the TS mirror of the Python `fake_memory_lookup` monkeypatch fixture).
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    AGENT_DIRECTIVE_PREFIX,
+    DeliveryState,
+    Outcome,
+    is_agent_directive,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    STEP_ORDER,
+    dispatch,
+} from '../../../src/agent-src/templates/scripts/work_engine/dispatcher.js';
+import {
+    get_steps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/index.js';
+import {
+    _setRetrieve,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js';
+
+const REAL_STEPS = get_steps();
+
+// `void AGENT_DIRECTIVE_PREFIX` — imported to mirror the Python spec's import
+// surface; used indirectly via `is_agent_directive`.
+void AGENT_DIRECTIVE_PREFIX;
+
+type Hit = Record<string, unknown>;
+
+/**
+ * Install the influential-hit fake: a single `changed_outcome=True` hit, like
+ * the Python `fake_memory_lookup` fixture. Mirrors the lazy-import monkeypatch.
+ */
+function installInfluentialMemory(): void {
+    _setRetrieve(
+        (): Hit[] => [
+            {
+                id: 'dec-option-a',
+                type: 'architecture-decisions',
+                note: 'Option A delegation chosen for implement/test/verify',
+                changed_outcome: true,
+            },
+        ],
+    );
+}
+
+afterEach(() => {
+    _setRetrieve(null);
+});
+
+function extractDirectiveVerb(questions: string[]): string {
+    expect(questions.length).toBeGreaterThan(0);
+    expect(is_agent_directive(questions[0])).toBe(true);
+    // Shape: "@agent-directive: <verb> key=value key=value"
+    const payload = (questions[0] as string).split(':').slice(1).join(':').trim();
+    return payload.split(' ', 1)[0] as string;
+}
+
+/** Apply the deterministic slice a real agent would produce for `verb`. */
+function resumeAsAgent(state: DeliveryState, verb: string): void {
+    if (verb === 'create-plan') {
+        state.plan = [
+            { title: 'Add export endpoint', detail: 'GET /api/exports' },
+            { title: 'Wire frontend download button' },
+        ];
+        state.outcomes['plan'] = Outcome.SUCCESS;
+    } else if (verb === 'apply-plan') {
+        state.changes = [
+            { path: 'app/Http/Controllers/Export.php', purpose: 'new endpoint' },
+            { path: 'resources/views/exports.blade.php', purpose: 'download button' },
+        ];
+        state.outcomes['implement'] = Outcome.SUCCESS;
+    } else if (verb === 'run-tests') {
+        state.tests = { verdict: 'success', targeted: 'all green', duration_ms: 1420 };
+        state.outcomes['test'] = Outcome.SUCCESS;
+    } else if (verb === 'review-changes') {
+        state.verify = { verdict: 'success', confidence: 'high', findings: [] };
+        state.outcomes['verify'] = Outcome.SUCCESS;
+    } else {
+        throw new Error(`unknown directive verb: ${verb}`);
+    }
+}
+
+/** Run dispatch+resume until SUCCESS, returning the verbs seen in order. */
+function driveLoop(state: DeliveryState, maxIterations = 10): string[] {
+    const seen: string[] = [];
+    for (let i = 0; i < maxIterations; i++) {
+        const [final, halting] = dispatch(state, REAL_STEPS);
+        if (final === Outcome.SUCCESS) {
+            return seen;
+        }
+        expect(final, `unexpected halt at ${halting}: outcome=${final}`).toBe(Outcome.BLOCKED);
+        const verb = extractDirectiveVerb(state.questions);
+        seen.push(verb);
+        resumeAsAgent(state, verb);
+    }
+    throw new Error('dispatch did not converge within max_iterations');
+}
+
+function wellFormedTicket(): Record<string, unknown> {
+    return {
+        id: 'TICKET-42',
+        title: 'Add export button',
+        acceptance_criteria: [
+            'Users can trigger a CSV export from the dashboard within two clicks.',
+            'The exported file includes every visible column.',
+        ],
+    };
+}
+
+describe('full backend flow — four-rebound convergence', () => {
+    it('converges with the create-plan → apply-plan → run-tests → review-changes chain', () => {
+        installInfluentialMemory();
+        const state = new DeliveryState({ ticket: wellFormedTicket() });
+
+        const verbs = driveLoop(state);
+
+        expect(verbs).toEqual(['create-plan', 'apply-plan', 'run-tests', 'review-changes']);
+        for (const name of STEP_ORDER) {
+            expect(state.outcomes[name], JSON.stringify(state.outcomes)).toBe(Outcome.SUCCESS);
+        }
+    });
+
+    it('produces a delivery report ending the run (Markdown header + ticket id)', () => {
+        installInfluentialMemory();
+        const state = new DeliveryState({ ticket: wellFormedTicket() });
+
+        driveLoop(state);
+
+        expect(typeof state.report).toBe('string');
+        expect(state.report.trim().startsWith('#')).toBe(true);
+        expect(state.report).toContain('TICKET-42');
+    });
+
+    it('keeps the memory section when a hit changed the outcome', () => {
+        installInfluentialMemory();
+        const state = new DeliveryState({ ticket: wellFormedTicket() });
+
+        driveLoop(state);
+
+        expect(state.report).toContain('Memory that mattered');
+        expect(state.report).toContain('dec-option-a');
+    });
+
+    it('drops the memory section when no hit changed the outcome', () => {
+        _setRetrieve(
+            (): Hit[] => [
+                {
+                    id: 'dec-irrelevant',
+                    type: 'historical-patterns',
+                    note: 'not applied',
+                    changed_outcome: false,
+                },
+            ],
+        );
+        const state = new DeliveryState({ ticket: wellFormedTicket() });
+
+        driveLoop(state);
+
+        expect(state.report).not.toContain('Memory that mattered');
+    });
+
+    it('skips already-successful steps on resume', () => {
+        installInfluentialMemory();
+        const state = new DeliveryState({ ticket: wellFormedTicket() });
+        state.outcomes['refine'] = Outcome.SUCCESS;
+        state.outcomes['memory'] = Outcome.SUCCESS;
+        state.memory = [];
+
+        const verbs = driveLoop(state);
+
+        expect(verbs).toEqual(['create-plan', 'apply-plan', 'run-tests', 'review-changes']);
+    });
+
+    it('halts BLOCKED at test when the test verdict is failed', () => {
+        installInfluentialMemory();
+        const state = new DeliveryState({ ticket: wellFormedTicket() });
+
+        // Resume through plan + implement, then populate a failed verdict.
+        for (const expectedVerb of ['create-plan', 'apply-plan']) {
+            const [final] = dispatch(state, REAL_STEPS);
+            expect(final).toBe(Outcome.BLOCKED);
+            expect(extractDirectiveVerb(state.questions)).toBe(expectedVerb);
+            resumeAsAgent(state, expectedVerb);
+        }
+
+        let [final] = dispatch(state, REAL_STEPS);
+        expect(final).toBe(Outcome.BLOCKED);
+        expect(extractDirectiveVerb(state.questions)).toBe('run-tests');
+        // Agent ran the tests, captured the verdict, re-dispatches. It does NOT
+        // forge outcomes.test = success — the gate decides that on the rebound.
+        state.tests = { verdict: 'failed', targeted: '3 failures in ExportTest' };
+
+        let halting: string | null;
+        [final, halting] = dispatch(state, REAL_STEPS);
+        expect(final).toBe(Outcome.BLOCKED);
+        expect(halting).toBe('test');
+        expect(state.outcomes['test']).toBe(Outcome.BLOCKED);
+        expect(state.outcomes['verify']).toBeUndefined();
+        expect(state.outcomes['report']).toBeUndefined();
+    });
+});

--- a/tests/scripts/work_engine/integration_mixed_flow.test.ts
+++ b/tests/scripts/work_engine/integration_mixed_flow.test.ts
@@ -1,0 +1,245 @@
+// End-to-end integration of the MIXED (backend + UI) directive set (pure TS).
+//
+// Behavioural twin of tests/work_engine/test_integration_mixed_flow.py — the
+// Python suite is the spec. Two mixed fixtures are driven through the eight-step
+// dispatcher with a fake orchestrator that resumes the three mixed-specific
+// directives (`contract-plan`, `ui-track`, `integration-test`), the
+// backend-shared `review-changes`, and the user-confirmation halt (no directive)
+// between contract draft and UI delegation.
+//
+// Fixture A — form + endpoint: SavedSearch persistence (POST + GET).
+// Fixture B — table + list endpoint with filtering: order list with filters.
+//
+// No python, no oracle: import the TS twins, drive `dispatch(state, mixed
+// get_steps())`, assert the five-rebound chain, the contract-locked-before-UI
+// ordering, and the recorded smoke scenarios. `memory_lookup.retrieve` is
+// stubbed empty via `_setRetrieve` (the TS mirror of `fake_memory_lookup`).
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    DeliveryState,
+    Outcome,
+    is_agent_directive,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    STEP_ORDER,
+    dispatch,
+} from '../../../src/agent-src/templates/scripts/work_engine/dispatcher.js';
+import {
+    get_steps as mixedSteps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/mixed/index.js';
+import {
+    _setRetrieve,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js';
+
+const MIXED_STEPS = mixedSteps();
+
+afterEach(() => {
+    _setRetrieve(null);
+});
+
+/** Stub `memory_lookup.retrieve` empty so the memory step is deterministic. */
+function installEmptyMemory(): void {
+    _setRetrieve(() => []);
+}
+
+/** Return the directive verb, or `null` if the halt is user-facing. */
+function extractDirectiveVerb(questions: string[]): string | null {
+    if (questions.length === 0 || !is_agent_directive(questions[0])) {
+        return null;
+    }
+    const payload = (questions[0] as string).split(':').slice(1).join(':').trim();
+    return payload.split(' ', 1)[0] as string;
+}
+
+/**
+ * Apply the slice a real orchestrator would produce; returns a label so the
+ * caller can record the rebound sequence. The user-confirmation halt (no
+ * directive) is encoded as `"confirm-contract"`.
+ */
+function resumeAsAgent(
+    state: DeliveryState,
+    verb: string | null,
+    contract: Record<string, unknown>,
+): string {
+    if (verb === null) {
+        // Contract draft is in place, awaiting user confirmation.
+        expect(state.contract).not.toBeNull();
+        (state.contract as Record<string, unknown>)['contract_confirmed'] = true;
+        return 'confirm-contract';
+    }
+    if (verb === 'contract-plan') {
+        state.contract = { ...contract };
+        return verb;
+    }
+    if (verb === 'ui-track') {
+        state.ui_review = { review_clean: true, findings: [] };
+        state.outcomes['implement'] = Outcome.SUCCESS;
+        return verb;
+    }
+    if (verb === 'integration-test') {
+        state.stitch = {
+            verdict: 'success',
+            scenarios: [{ id: 'S-1' }, { id: 'S-2' }],
+        };
+        state.outcomes['test'] = Outcome.SUCCESS;
+        return verb;
+    }
+    if (verb === 'review-changes') {
+        state.verify = { verdict: 'success', confidence: 'high', findings: [] };
+        state.outcomes['verify'] = Outcome.SUCCESS;
+        return verb;
+    }
+    throw new Error(`unknown directive verb: ${verb}`);
+}
+
+/** Run dispatch + resume until SUCCESS, returning the rebound labels. */
+function driveMixedLoop(
+    state: DeliveryState,
+    contract: Record<string, unknown>,
+    maxIterations = 12,
+): string[] {
+    const seen: string[] = [];
+    for (let i = 0; i < maxIterations; i++) {
+        const [final, halting] = dispatch(state, MIXED_STEPS);
+        if (final === Outcome.SUCCESS) {
+            return seen;
+        }
+        expect(final, `unexpected halt at ${halting}: outcome=${final}`).toBe(Outcome.BLOCKED);
+        const verb = extractDirectiveVerb(state.questions);
+        seen.push(resumeAsAgent(state, verb, contract));
+    }
+    throw new Error('mixed dispatch did not converge within max_iterations');
+}
+
+// --- Fixture A: form + endpoint --------------------------------------------
+
+function formEndpointTicket(): Record<string, unknown> {
+    return {
+        id: 'MIX-A-1',
+        title: 'Saved-search form + persistence endpoint',
+        acceptance_criteria: [
+            'Users can save a named search from the search-results screen.',
+            'POST /saved-searches persists name + query JSON; GET returns them.',
+            'Form validates name (required, <=80 chars) and query (non-empty JSON).',
+        ],
+    };
+}
+
+function formEndpointContract(): Record<string, unknown> {
+    return {
+        data_model: [{ name: 'SavedSearch', fields: ['id', 'name', 'query', 'owner_id'] }],
+        api_surface: [
+            { method: 'POST', path: '/saved-searches' },
+            { method: 'GET', path: '/saved-searches' },
+        ],
+    };
+}
+
+// --- Fixture B: table + list endpoint with filtering -----------------------
+
+function tableFilterTicket(): Record<string, unknown> {
+    return {
+        id: 'MIX-B-1',
+        title: 'Order list table with status + date-range filters',
+        acceptance_criteria: [
+            'Operators see a paginated table of orders with status, customer, total, created_at columns.',
+            'GET /orders accepts `status` (enum) and `created_from` / `created_to` (ISO date) query params; returns paginated JSON.',
+            'Empty filter result shows the empty-state message; applied filters survive page navigation.',
+        ],
+    };
+}
+
+function tableFilterContract(): Record<string, unknown> {
+    return {
+        data_model: [
+            { name: 'Order', fields: ['id', 'status', 'customer_id', 'total', 'created_at'] },
+        ],
+        api_surface: [
+            {
+                method: 'GET',
+                path: '/orders',
+                query: ['status', 'created_from', 'created_to', 'page'],
+                response: 'paginated list of Order',
+            },
+        ],
+    };
+}
+
+const FIVE_REBOUND_CHAIN = [
+    'contract-plan',
+    'confirm-contract',
+    'ui-track',
+    'integration-test',
+    'review-changes',
+];
+
+describe('mixed flow — Fixture A (form + endpoint)', () => {
+    it('converges with the five-rebound contract → ui → stitch chain', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: formEndpointTicket() });
+
+        const seen = driveMixedLoop(state, formEndpointContract());
+
+        expect(seen).toEqual(FIVE_REBOUND_CHAIN);
+        for (const name of STEP_ORDER) {
+            expect(state.outcomes[name], JSON.stringify(state.outcomes)).toBe(Outcome.SUCCESS);
+        }
+    });
+
+    it('locks the contract before the UI track is reachable', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: formEndpointTicket() });
+        const contract = formEndpointContract();
+
+        // Step 1 — first halt must be contract-plan at the plan slot.
+        let [final, halting] = dispatch(state, MIXED_STEPS);
+        expect(final).toBe(Outcome.BLOCKED);
+        expect(halting).toBe('plan');
+        expect(extractDirectiveVerb(state.questions)).toBe('contract-plan');
+
+        // Step 2 — agent fills contract; next halt is the user-confirmation
+        // screen (no directive). UI track is NOT yet reachable.
+        resumeAsAgent(state, 'contract-plan', contract);
+        [final, halting] = dispatch(state, MIXED_STEPS);
+        expect(final).toBe(Outcome.BLOCKED);
+        expect(halting).toBe('plan');
+        expect(extractDirectiveVerb(state.questions)).toBeNull();
+        expect(state.outcomes['implement']).not.toBe(Outcome.SUCCESS);
+
+        // Step 3 — only after contract_confirmed flips does ui-track fire.
+        resumeAsAgent(state, null, contract);
+        [final, halting] = dispatch(state, MIXED_STEPS);
+        expect(final).toBe(Outcome.BLOCKED);
+        expect(halting).toBe('implement');
+        expect(extractDirectiveVerb(state.questions)).toBe('ui-track');
+    });
+});
+
+describe('mixed flow — Fixture B (table + filtered list endpoint)', () => {
+    it('converges with the same five-rebound chain', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: tableFilterTicket() });
+
+        const seen = driveMixedLoop(state, tableFilterContract());
+
+        expect(seen).toEqual(FIVE_REBOUND_CHAIN);
+        for (const name of STEP_ORDER) {
+            expect(state.outcomes[name], JSON.stringify(state.outcomes)).toBe(Outcome.SUCCESS);
+        }
+    });
+
+    it('records the two smoke scenarios the integration-test rebound ran', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: tableFilterTicket() });
+
+        driveMixedLoop(state, tableFilterContract());
+
+        expect(state.stitch).not.toBeNull();
+        const stitch = state.stitch as Record<string, unknown>;
+        expect(stitch['verdict']).toBe('success');
+        const scenarios = (stitch['scenarios'] ?? []) as Array<{ id: string }>;
+        expect(scenarios.length).toBe(2);
+        expect(new Set(scenarios.map((s) => s.id))).toEqual(new Set(['S-1', 'S-2']));
+    });
+});

--- a/tests/scripts/work_engine/integration_persona.test.ts
+++ b/tests/scripts/work_engine/integration_persona.test.ts
@@ -1,0 +1,147 @@
+// Persona-policy integration across the backend step handlers (pure TS).
+//
+// Behavioural twin of tests/work_engine/test_persona_integration.py — the
+// Python suite is the spec. test_integration_full_flow covers the default
+// `senior-engineer` persona end-to-end; this file exercises the two remaining
+// shipped personas — `qa` and `advisory` — under the same scripted-orchestrator
+// pattern, driving the real backend `dispatch`.
+//
+// No python, no oracle: import the TS twins, drive `dispatch`, assert the QA
+// scope widening, the advisory plan-only convergence (implement/test/verify
+// auto-succeed), and the advisory report shape (no next-commands, persona in
+// header, core sections kept). `memory_lookup.retrieve` is stubbed empty via
+// `_setRetrieve` (the TS mirror of `fake_memory_lookup`).
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+    AGENT_DIRECTIVE_PREFIX,
+    DeliveryState,
+    Outcome,
+    is_agent_directive,
+} from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import {
+    dispatch,
+} from '../../../src/agent-src/templates/scripts/work_engine/dispatcher.js';
+import {
+    get_steps,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/index.js';
+import {
+    _setRetrieve,
+} from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js';
+
+const REAL_STEPS = get_steps();
+
+afterEach(() => {
+    _setRetrieve(null);
+});
+
+function installEmptyMemory(): void {
+    _setRetrieve(() => []);
+}
+
+function ticket(): Record<string, unknown> {
+    return {
+        id: 'TICKET-9001',
+        title: 'Add invoice export',
+        acceptance_criteria: [
+            'User can download invoices as CSV from the invoices page.',
+            'Filename includes the selected date range.',
+        ],
+    };
+}
+
+function directiveVerb(questions: string[]): string {
+    expect(questions.length).toBeGreaterThan(0);
+    expect(is_agent_directive(questions[0])).toBe(true);
+    const payload = (questions[0] as string).split(':').slice(1).join(':').trim();
+    return payload.split(' ', 1)[0] as string;
+}
+
+describe('persona integration — qa', () => {
+    it('widens the run-tests directive to scope=full', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: ticket(), persona: 'qa' });
+
+        // Walk to the test step — plan + implement still delegate normally.
+        dispatch(state, REAL_STEPS);
+        state.plan = [{ title: 'Add export button' }];
+        state.outcomes['plan'] = Outcome.SUCCESS;
+
+        dispatch(state, REAL_STEPS);
+        state.changes = [{ path: 'app/Exports/InvoiceCsvExport.php' }];
+        state.outcomes['implement'] = Outcome.SUCCESS;
+
+        const [final, halting] = dispatch(state, REAL_STEPS);
+        expect(final).toBe(Outcome.BLOCKED);
+        expect(halting).toBe('test');
+        const directive = state.questions[0] as string;
+        expect(directive.startsWith(AGENT_DIRECTIVE_PREFIX)).toBe(true);
+        expect(directive).toContain('scope=full');
+        // Human-facing option line mirrors the widened scope.
+        expect(state.questions.some((q) => q.includes('run full tests'))).toBe(true);
+    });
+});
+
+describe('persona integration — advisory', () => {
+    it('converges with only the create-plan rebound (implement/test/verify auto-succeed)', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: ticket(), persona: 'advisory' });
+        const verbsSeen: string[] = [];
+
+        let converged = false;
+        for (let i = 0; i < 6; i++) {
+            const [final] = dispatch(state, REAL_STEPS);
+            if (final === Outcome.SUCCESS) {
+                converged = true;
+                break;
+            }
+            expect(final).toBe(Outcome.BLOCKED);
+            const verb = directiveVerb(state.questions);
+            verbsSeen.push(verb);
+            // Advisory only rebounds on create-plan; implement/test/verify
+            // auto-succeed so no other directive should ever appear.
+            expect(verb).toBe('create-plan');
+            state.plan = [{ title: 'Propose a CSV export on the invoice page' }];
+            state.outcomes['plan'] = Outcome.SUCCESS;
+        }
+        expect(converged, 'advisory flow did not converge').toBe(true);
+
+        expect(verbsSeen).toEqual(['create-plan']);
+        for (const name of ['implement', 'test', 'verify', 'report']) {
+            expect(state.outcomes[name]).toBe(Outcome.SUCCESS);
+        }
+    });
+
+    it('drops the next-commands section from the report (nothing was changed)', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: ticket(), persona: 'advisory' });
+
+        for (let i = 0; i < 4; i++) {
+            const [final] = dispatch(state, REAL_STEPS);
+            if (final === Outcome.SUCCESS) break;
+            state.plan = [{ title: 'Advisory-only outline' }];
+            state.outcomes['plan'] = Outcome.SUCCESS;
+        }
+
+        expect(state.report).not.toContain('Suggested next commands');
+        expect(state.report).not.toContain('/commit');
+        // But the persona itself shows up in the report header.
+        expect(state.report).toContain('advisory');
+    });
+
+    it('still renders the core Ticket/Persona/Plan sections', () => {
+        installEmptyMemory();
+        const state = new DeliveryState({ ticket: ticket(), persona: 'advisory' });
+
+        for (let i = 0; i < 4; i++) {
+            const [final] = dispatch(state, REAL_STEPS);
+            if (final === Outcome.SUCCESS) break;
+            state.plan = 'Outline only';
+            state.outcomes['plan'] = Outcome.SUCCESS;
+        }
+
+        for (const heading of ['## Ticket', '## Persona', '## Plan']) {
+            expect(state.report).toContain(heading);
+        }
+    });
+});

--- a/tests/scripts/work_engine/integration_user_type.test.ts
+++ b/tests/scripts/work_engine/integration_user_type.test.ts
@@ -1,0 +1,277 @@
+// User-type axis integration + schema lint (pure TS).
+//
+// Behavioural twin of tests/work_engine/test_user_type_integration.py +
+// tests/work_engine/test_user_type_policy.py — the Python suites are the spec.
+// User-types are CLI-only review lenses (no engine policy module —
+// docs/contracts/user-type-schema.md § 1); the surface under lock is the
+// linter's user-type classifier plus the refine-ticket CLI/skill composition
+// contract, which the TS twin `src/scripts/skill_linter.ts` and `resolve_logical`
+// own. This is the only `.ts` coverage of the linter's user_type logic.
+//
+// No python, no oracle: import `lint_file` + `resolve_logical`, lint files
+// written under `.agent-src.uncondensed/user-types/`, and read the real
+// refine-ticket command + skill.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    type LintResult,
+    lint_file,
+} from '../../../src/scripts/skill_linter.js';
+import { resolve_logical } from '../../../src/scripts/_lib/agent_src.js';
+
+let tmp: string;
+
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'user-type-int-'));
+});
+
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeFile(relative: string, content: string): string {
+    const p = path.join(tmp, relative);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content, 'utf-8');
+    return p;
+}
+
+function hasError(result: LintResult): boolean {
+    return result.issues.some((i) => i.severity === 'error');
+}
+
+const USER_TYPE_BODY = `---
+id: test-lens
+kind: user-type
+description: "Test review lens."
+version: "1.0"
+source: project
+---
+
+# Test Lens
+
+## Focus
+
+Review-lens only, never operational instruction source.
+
+## Daily Workflow
+
+- 06:00 brief
+- 15:00 proof
+
+## Vocabulary
+
+- term
+
+## Operational Constraints
+
+- gloves + cold
+- offline + dead zones
+- timestamped photo proof
+
+## Unique Questions
+
+- Question one.
+- Question two.
+- Question three.
+
+## Ticket Red Flags
+
+- Missing offline-queue spec
+
+## Anti-Patterns
+
+- Review-only, never operational instruction.
+- No trade-execution instructions.
+`;
+
+const PERSONA_BODY = `---
+id: test-reviewer
+role: Test Reviewer
+description: "Methodology lens for tests."
+tier: core
+mode: developer
+version: "1.0"
+source: package
+---
+
+# Test Reviewer
+
+## Focus
+
+One paragraph framing the methodology.
+
+## Mindset
+
+- Default assumption.
+
+## Unique Questions
+
+- Question one.
+- Question two.
+- Question three.
+
+## Output Expectations
+
+Short bullets.
+
+## Anti-Patterns
+
+- Do NOT skip evidence.
+`;
+
+// --- Schema / lint template (test_user_type_policy.py spec) -----------------
+
+const USER_TYPE_TEMPLATE = (id: string, kind: string, extra: string): string => `---
+id: ${id}
+kind: ${kind}
+description: "Test review lens for the user-type axis."
+version: "1.0"
+source: project
+---
+
+# Test User-Type
+
+## Focus
+
+One paragraph framing the lens. Review-lens only, never operational
+instruction source.
+
+## Daily Workflow
+
+- 06:00 morning brief
+- 10:00 execution
+- 15:00 end-of-day proof
+
+## Vocabulary
+
+- term-one
+- term-two
+
+## Operational Constraints
+
+- gloves + capacitive touch fail at 4 °C
+- no signal in cellar yards
+- end-of-day proof = photo + signature + GPS
+
+## Unique Questions
+
+- Question one — falsifiable against the ticket.
+- Question two — falsifiable against the ticket.
+- Question three — falsifiable against the ticket.
+
+## Ticket Red Flags
+
+- Missing offline-queue spec
+- No proof-of-work artefact
+
+## Anti-Patterns
+
+- Review-only, never operational instruction.
+- No trade-execution instructions (welding, electrical, structural).
+- No dangerous how-to.
+${extra}
+`;
+
+function body(opts: { id?: string; kind?: string; extra?: string } = {}): string {
+    return USER_TYPE_TEMPLATE(opts.id ?? 'test-user-type', opts.kind ?? 'user-type', opts.extra ?? '');
+}
+
+// --- Integration surface (test_user_type_integration.py spec) ---------------
+
+describe('user-type axis — loading + composition', () => {
+    it('a well-formed user-type file lints clean (no errors)', () => {
+        const p = writeFile('.agent-src.uncondensed/user-types/test-lens.md', USER_TYPE_BODY);
+        const result = lint_file(p);
+        expect(result.artifact_type).toBe('user-type');
+        expect(hasError(result)).toBe(false);
+    });
+
+    it('a user-type and a persona compose without cross-contamination', () => {
+        const ut = writeFile('.agent-src.uncondensed/user-types/test-lens.md', USER_TYPE_BODY);
+        const pe = writeFile('.agent-src.uncondensed/personas/test-reviewer.md', PERSONA_BODY);
+        const utResult = lint_file(ut);
+        const peResult = lint_file(pe);
+
+        expect(utResult.artifact_type).toBe('user-type');
+        expect(peResult.artifact_type).toBe('persona');
+        expect(hasError(utResult)).toBe(false);
+        expect(hasError(peResult)).toBe(false);
+    });
+
+    it('the refine-ticket command declares the --user-type flag alongside --personas', () => {
+        const p = resolve_logical('commands/refine-ticket.md');
+        expect(p, 'commands/refine-ticket.md not found in any pack').not.toBeNull();
+        const cmd = fs.readFileSync(p as string, 'utf-8');
+        expect(cmd).toContain('--user-type=');
+        expect(cmd).toContain('--personas=');
+    });
+
+    it('the refine-ticket skill documents the persona=methodology, user-type=end-user contract', () => {
+        const p = resolve_logical('skills/refine-ticket/SKILL.md');
+        expect(p, 'skills/refine-ticket/SKILL.md not found in any pack').not.toBeNull();
+        const skill = fs.readFileSync(p as string, 'utf-8');
+        expect(skill).toContain('--user-type=');
+        expect(skill.toLowerCase()).toContain('methodology');
+        expect(skill.toLowerCase()).toContain('end-user');
+    });
+});
+
+// --- Schema / lint surface (test_user_type_policy.py spec) ------------------
+
+describe('user-type axis — schema / lint enforcement', () => {
+    it('a valid user-type passes', () => {
+        const p = writeFile('.agent-src.uncondensed/user-types/test-user-type.md', body());
+        const result = lint_file(p);
+        expect(['pass', 'pass_with_warnings']).toContain(result.status);
+        expect(hasError(result)).toBe(false);
+    });
+
+    it('dropping a spine section fails (section-spine enforcement)', () => {
+        const content = body().replace('## Anti-Patterns', '## Notes');
+        const p = writeFile('.agent-src.uncondensed/user-types/test-user-type.md', content);
+        const result = lint_file(p);
+        const missing = result.issues
+            .filter((i) => i.code === 'missing_section')
+            .map((i) => i.message);
+        expect(missing.some((m) => m.includes('Anti-Patterns'))).toBe(true);
+    });
+
+    it('too few unique questions warns', () => {
+        const content = body().replace(
+            '- Question three — falsifiable against the ticket.\n',
+            '',
+        );
+        const p = writeFile('.agent-src.uncondensed/user-types/test-user-type.md', content);
+        const result = lint_file(p);
+        expect(result.issues.some((i) => i.code === 'too_few_unique_questions')).toBe(true);
+    });
+
+    it('an invalid kind fails', () => {
+        const p = writeFile(
+            '.agent-src.uncondensed/user-types/test-user-type.md',
+            body({ kind: 'persona' }),
+        );
+        const result = lint_file(p);
+        expect(result.issues.some((i) => i.code === 'invalid_kind')).toBe(true);
+    });
+
+    it('id must match the filename stem', () => {
+        const p = writeFile(
+            '.agent-src.uncondensed/user-types/test-user-type.md',
+            body({ id: 'other-id' }),
+        );
+        const result = lint_file(p);
+        expect(result.issues.some((i) => i.code === 'id_filename_mismatch')).toBe(true);
+    });
+
+    it('the size budget warns above 120 lines', () => {
+        const content = body() + '\n<!-- pad -->'.repeat(100);
+        const p = writeFile('.agent-src.uncondensed/user-types/test-user-type.md', content);
+        const result = lint_file(p);
+        expect(result.issues.some((i) => i.code === 'size_budget')).toBe(true);
+    });
+});

--- a/tests/scripts/work_engine/scoring_memory_visibility_redaction.test.ts
+++ b/tests/scripts/work_engine/scoring_memory_visibility_redaction.test.ts
@@ -1,0 +1,159 @@
+// Privacy-floor regression for work_engine/scoring/memory_visibility.ts.
+//
+// PURE-TS port of tests/contracts/test_memory_visibility_redaction.py — the
+// privacy-floor SPEC for `docs/contracts/memory-visibility-v1.md`. The sibling
+// scoring_memory_visibility.test.ts covers the FUNCTIONAL surface (parity of
+// summarise/format/diff/should_emit); this file covers the REDACTION floor only:
+// the visibility line and its summary must never carry entry bodies, summaries,
+// quoted snippets, secrets, tokens, env values, or paths outside the allowlist.
+//
+// Three layers, faithfully ported:
+//   1. Allowlisted summary keys — summarise_visibility returns exactly
+//      {asks, hits, ids}.
+//   2. Rendered-line whitelist — grammar regex; no path separators outside the
+//      allowlist; the 8 synthetic secrets never appear in the line OR in any
+//      summary value's serialized form.
+//   3. Synthetic-secret + unknown-id-typed payload drops.
+//
+// No python, no oracle: imports the TS twin and asserts directly.
+import { describe, expect, it } from 'vitest';
+
+import {
+    format_line,
+    summarise_visibility,
+} from '../../../src/agent-src/templates/scripts/work_engine/scoring/memory_visibility.js';
+
+const ALLOWED_SUMMARY_KEYS = ['asks', 'hits', 'ids'];
+
+// Ported verbatim from SYNTHETIC_SECRETS in the python spec.
+const SYNTHETIC_SECRETS: readonly string[] = [
+    'AKIAFAKEFAKEFAKEFAKE',
+    'ghp_FAKE_PERSONAL_ACCESS_TOKEN_1234567890',
+    'Bearer eyJhbGciFAKEHEADER.FAKEPAYLOAD.FAKESIGNATURE',
+    '/etc/passwd',
+    '/var/log/prod.log',
+    '/Users/operator/.ssh/id_rsa',
+    'DROP TABLE customers',
+    'user@example.com password=hunter2',
+];
+
+/** Build a memory hit dict that crams every dangerous field in (mirror `_payload`). */
+function payload(extras: Record<string, unknown>): Record<string, unknown> {
+    return {
+        id: 'mem_safe_42',
+        type: 'domain-invariants',
+        score: 0.91,
+        ...extras,
+    };
+}
+
+/**
+ * Python `repr(value)` surface used by the secret-absence assertion. The python
+ * test does `assert secret not in repr(value)` for every summary value. The
+ * summary values are: two ints and a list of id strings — so a deterministic
+ * JSON serialization is a faithful, equivalent "serialized form" surface for
+ * the substring check (no secret may hide in any of them).
+ */
+function serializeValue(value: unknown): string {
+    return JSON.stringify(value ?? null);
+}
+
+/**
+ * Stable, non-negative synthetic id derived from the secret string, mirroring
+ * the python `abs(hash(secret)) % 9999` shape — the exact int is irrelevant
+ * (it is a *safe* id), only that it is a stable mem_safe_<n> id.
+ */
+function safeIdFor(secret: string): string {
+    let h = 0;
+    for (let i = 0; i < secret.length; i += 1) {
+        h = (h * 31 + secret.charCodeAt(i)) | 0;
+    }
+    return `mem_safe_${Math.abs(h) % 9999}`;
+}
+
+describe('memory_visibility redaction floor — summary key allowlist', () => {
+    it('summary only exposes the allowlisted keys', () => {
+        const summary = summarise_visibility([
+            payload({
+                entry: {
+                    body: 'secret onboarding text',
+                    summary: 'do not leak',
+                    path: '/etc/secrets/credentials',
+                },
+                source: 'operational',
+                path: 'agents/memory/intake/2026-05-04.jsonl',
+                snippet: 'do not leak',
+                raw: SYNTHETIC_SECRETS[0],
+            }),
+        ]);
+        expect(new Set(Object.keys(summary))).toEqual(new Set(ALLOWED_SUMMARY_KEYS));
+        expect(summary['ids']).toEqual(['mem_safe_42']);
+    });
+});
+
+describe('memory_visibility redaction floor — secret value never surfaces', () => {
+    for (const secret of SYNTHETIC_SECRETS) {
+        it(`secret ${JSON.stringify(secret)} never appears in line or summary values`, () => {
+            const memory = [
+                payload({
+                    id: safeIdFor(secret),
+                    entry: { body: secret, summary: secret },
+                    raw_text: secret,
+                    path: secret,
+                    source: secret,
+                }),
+            ];
+            const summary = summarise_visibility(memory);
+            const line = format_line(summary);
+            expect(line).not.toBeNull();
+            expect(line as string).not.toContain(secret);
+            for (const value of Object.values(summary)) {
+                expect(serializeValue(value)).not.toContain(secret);
+            }
+        });
+    }
+});
+
+describe('memory_visibility redaction floor — contract grammar', () => {
+    it('line matches the contract grammar whitelist', () => {
+        const memory = [
+            { id: 'mem_a', type: 'domain-invariants' },
+            { id: 'mem_b', type: 'architecture-decisions' },
+            { id: 'mem_c', type: 'incident-learnings' },
+        ];
+        const line = format_line(summarise_visibility(memory));
+        expect(line).not.toBeNull();
+        // ^🧠 Memory: \d+/\d+ · ids=[<id-list>]$  (ids: alnum, _, comma, space, …, +)
+        const pattern = /^\u{1F9E0} Memory: \d+\/\d+ · ids=\[[a-zA-Z0-9_,\s…+]*\]$/u;
+        expect(pattern.test(line as string)).toBe(true);
+    });
+});
+
+describe('memory_visibility redaction floor — path separators outside allowlist', () => {
+    it('line never leaks path fragments outside the allowlist', () => {
+        const memory = [
+            payload({
+                id: 'mem_safe_path_1',
+                path: '/var/log/billing/prod.log',
+                entry: { file: '/etc/passwd' },
+            }),
+        ];
+        const line = format_line(summarise_visibility(memory));
+        expect(line).not.toBeNull();
+        const l = line as string;
+        expect(l).not.toContain('/var/');
+        expect(l).not.toContain('/etc/');
+        expect(l.toLowerCase()).not.toContain('log');
+    });
+});
+
+describe('memory_visibility redaction floor — id typing', () => {
+    it('drops payloads with missing / non-string-or-int ids; stringifies int ids', () => {
+        const summary = summarise_visibility([
+            { type: 'domain-invariants', body: 'no id here' }, // no id → dropped
+            { id: ['not', 'a', 'string'], type: 'x' }, // list id → dropped
+            { id: 42, type: 'x' }, // int id → "42"
+        ]);
+        expect(summary['ids']).toEqual(['42']);
+    });
+});

--- a/tests/scripts/work_engine/state_app_spec_ui_scaffold.test.ts
+++ b/tests/scripts/work_engine/state_app_spec_ui_scaffold.test.ts
@@ -1,0 +1,154 @@
+// Pure-TS gap coverage for the `state` twin's `_validate_app_spec` and
+// `_validate_ui_scaffold` rejection paths — ported from the python spec
+// `tests/work_engine/test_state_schema.py` (TestAppSpecEnvelope +
+// TestUiScaffoldEnvelope). No python3, no golden oracle: build a payload,
+// call `from_dict`, assert the round-trip or the SchemaError message.
+//
+// The existing `state.test.ts` golden rig covers `app_spec` / `ui_scaffold`
+// only via the populated FULL_ENVELOPE round-trip; the per-field rejection
+// branches below are otherwise untested on the TS side.
+import { describe, expect, it } from 'vitest';
+
+import {
+    DEFAULT_DIRECTIVE_SET,
+    DEFAULT_INTENT,
+    type JsonValue,
+    SCHEMA_VERSION,
+    SchemaError,
+    from_dict,
+    to_dict,
+} from '../../../src/agent-src/templates/scripts/work_engine/state.js';
+
+type JsonObject = Record<string, unknown>;
+
+/** Build a minimal v1 payload with an optional extra slot merged in. */
+function payload(extra: JsonObject = {}): JsonValue {
+    return {
+        version: SCHEMA_VERSION,
+        input: { kind: 'ticket', data: {} },
+        intent: DEFAULT_INTENT,
+        directive_set: DEFAULT_DIRECTIVE_SET,
+        ...extra,
+    } as JsonValue;
+}
+
+describe('work_engine/state — _validate_app_spec rejection + round-trip', () => {
+    it('default app_spec is null and serialises as null', () => {
+        const state = from_dict(payload());
+        expect(state.app_spec).toBeNull();
+        expect(to_dict(state)['app_spec']).toBeNull();
+    });
+
+    it('round-trips a fully-populated app_spec', () => {
+        const spec = {
+            pages: ['Dashboard', 'Board'],
+            entity_model: ['Board', 'Task'],
+            flow_map: { Dashboard: ['Board'] },
+            confirmed: true,
+            bypassed: false,
+        };
+        const rebuilt = from_dict(to_dict(from_dict(payload({ app_spec: spec }))));
+        expect(rebuilt.app_spec).toEqual(spec);
+    });
+
+    it('accepts flow_map as a list', () => {
+        const rebuilt = from_dict(
+            payload({ app_spec: { pages: ['Home'], flow_map: [] } }),
+        );
+        expect((rebuilt.app_spec as JsonObject)['flow_map']).toEqual([]);
+    });
+
+    it('rejects non-list pages', () => {
+        expect(() => from_dict(payload({ app_spec: { pages: 'Home' } }))).toThrow(
+            /state\.app_spec\.pages must be a list/,
+        );
+    });
+
+    it('rejects non-bool confirmed', () => {
+        expect(() =>
+            from_dict(payload({ app_spec: { pages: ['Home'], confirmed: 'yes' } })),
+        ).toThrow(/state\.app_spec\.confirmed/);
+    });
+
+    it('rejects a bad flow_map (string is neither list nor object)', () => {
+        expect(() =>
+            from_dict(
+                payload({ app_spec: { pages: ['Home'], flow_map: 'linear' } }),
+            ),
+        ).toThrow(/state\.app_spec\.flow_map/);
+    });
+
+    it('rejects app_spec that is not an object', () => {
+        expect(() =>
+            from_dict(payload({ app_spec: ['not', 'an', 'object'] })),
+        ).toThrow(/state\.app_spec must be a JSON object/);
+    });
+
+    it('throws SchemaError (not a generic Error) on a bad app_spec', () => {
+        expect(() => from_dict(payload({ app_spec: { pages: 'Home' } }))).toThrow(
+            SchemaError,
+        );
+    });
+});
+
+describe('work_engine/state — _validate_ui_scaffold rejection + round-trip', () => {
+    it('default ui_scaffold is null and serialises as null', () => {
+        const state = from_dict(payload());
+        expect(state.ui_scaffold).toBeNull();
+        expect(to_dict(state)['ui_scaffold']).toBeNull();
+    });
+
+    it('round-trips a fully-populated ui_scaffold', () => {
+        const plan = {
+            pages: ['Dashboard', 'Board'],
+            routes: ['/', '/board/:id'],
+            layout_strategy: 'sidebar-shell',
+            component_manifest: ['AppShell', 'BoardGrid'],
+            token_seed: { radius: '0.5rem', primary: '#2563eb' },
+            scaffolded: true,
+            artifacts: ['src/App.tsx'],
+        };
+        const rebuilt = from_dict(
+            to_dict(from_dict(payload({ ui_scaffold: plan }))),
+        );
+        expect(rebuilt.ui_scaffold).toEqual(plan);
+    });
+
+    it('rejects non-list routes', () => {
+        expect(() =>
+            from_dict(payload({ ui_scaffold: { routes: '/' } })),
+        ).toThrow(/state\.ui_scaffold\.routes must be a list/);
+    });
+
+    it('rejects non-string layout_strategy', () => {
+        expect(() =>
+            from_dict(payload({ ui_scaffold: { layout_strategy: ['sidebar'] } })),
+        ).toThrow(/layout_strategy must be a string/);
+    });
+
+    it('rejects non-object token_seed', () => {
+        expect(() =>
+            from_dict(payload({ ui_scaffold: { token_seed: ['primary'] } })),
+        ).toThrow(/token_seed must be a JSON object/);
+    });
+
+    it('rejects non-bool scaffolded', () => {
+        expect(() =>
+            from_dict(
+                payload({ ui_scaffold: { routes: ['/'], scaffolded: 'yes' } }),
+            ),
+        ).toThrow(/state\.ui_scaffold\.scaffolded/);
+    });
+
+    it('rejects ui_scaffold that is not an object', () => {
+        expect(() =>
+            from_dict(payload({ ui_scaffold: ['not', 'an', 'object'] })),
+        ).toThrow(/state\.ui_scaffold must be a JSON object/);
+    });
+
+    it('throws SchemaError (not a generic Error) on a bad ui_scaffold', () => {
+        expect(() =>
+            from_dict(payload({ ui_scaffold: { routes: '/' } })),
+        ).toThrow(SchemaError);
+    });
+});


### PR DESCRIPTION
Second prerequisite wave toward the final atomic-deletion PR. Authors `.ts` tests for the behaviors the python suite covered but the `.ts` suite did not — the coverage that justifies deleting the python tests. **No `.py` deleted here.** All new tests are pure-TS (no python, no snapshot oracle), verified green with python3 shadowed, and bite-checked (break the twin → RED → revert → green). Targets `python2ts`.

## Coverage authored (23 gap modules, ~230 tests)
**Batch 1** — pricing, telemetry/boundary, council_cli units, hooks_status, hooks/event_shape_contract, hooks dispatcher_feedback traversal, contracts (memory-visibility-redaction / readme-audience-order / rule-interactions behavioural), install/consumer_model_tier, conformance/retrieval fixtures, migrate v0-state, explain disabled-short-circuit.

**Batch 2** — work_engine: state app_spec/ui_scaffold validators, ui-polish & ui-review stack-dispatch, CLI hook exit-code table, integration flows (chat-history e2e, 4-rebound full backend convergence, 5-rebound mixed contract-locked-before-UI, persona walk, user-type/skill_linter axis); per-platform install_snapshot + manifest binding-drift guard.

## Notable
- **Real bug found + fixed:** `install.ts` `finalize_claude_model_tiers` passed `read_model_tier` the file *contents* instead of the *path* → `existsSync(<contents>)` always false → the auto native-`model:` tier switch rendered **0 skills** (silently defeating the exact regression it guards). The missing `.ts` test hid it.
- **Golden-Transcript `replay` subsystem retired** per council Option B — its coverage is the full-flow + mixed-flow integration tests; `tests/golden/test_replay.py` + `harness.py` + recipes are slated for deletion in PR-2.
- **Justified skips:** `implement_ticket/test_shim.py` (python import-system shim, no TS equivalent — dies with `__init__.py`); `cli/test_hooks_install_claude_flag.py` (bash-dispatcher e2e — Phase-6-coupled, handled in PR-2).

## Next
PR-2 = the final atomic deletion (Hard Floor, user-authorized): `src`/`tests` `.py` + pytest CI + dispatcher python fast-path + toolchain + scaffolding + repoint the 8 dispatcher-coupled e2e tests + retire the live-parity blocks (config_packs / config_session_profiles) + delete the replay harness + spikes. Then `python2ts → main`.

## Verification
Global typecheck clean; all ~230 new tests green python-shadowed; `install.test.ts` 30/30 (the install.ts bug-fix + exports don't regress it); each module bite-checked.