### PR TITLE
fix(install): global install refuses with Current package: 0.0.0 (bundle version resolution)

### DIFF
--- a/dist/install/install.mjs
+++ b/dist/install/install.mjs
@@ -7929,21 +7929,37 @@ function tuple_lt(a, b) {
   }
   return false;
 }
-function current_package_version(repo_root) {
-  let root = repo_root ?? null;
-  if (root === null) {
-    const here = path2.dirname(fileURLToPath(import.meta.url));
-    root = path2.resolve(here, "..", "..", "..");
-  }
+function _read_package_version(dir) {
   try {
-    const data = JSON.parse(fs2.readFileSync(path2.join(root, "package.json"), { encoding: "utf-8" }));
+    const data = JSON.parse(fs2.readFileSync(path2.join(dir, "package.json"), { encoding: "utf-8" }));
     const version = data.version;
     if (typeof version === "string" && version.trim()) {
       return version.trim();
     }
   } catch {
   }
-  return "0.0.0";
+  return null;
+}
+function _find_package_version_upward(start_dir) {
+  let dir = start_dir;
+  for (; ; ) {
+    const found = _read_package_version(dir);
+    if (found !== null) {
+      return found;
+    }
+    const parent = path2.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+function current_package_version(repo_root) {
+  if (repo_root != null) {
+    return _read_package_version(repo_root) ?? "0.0.0";
+  }
+  const here = path2.dirname(fileURLToPath(import.meta.url));
+  return _find_package_version_upward(here) ?? "0.0.0";
 }
 
 // src/scripts/_lib/surface_tiers.ts

--- a/src/scripts/_lib/installed_lock.ts
+++ b/src/scripts/_lib/installed_lock.ts
@@ -429,23 +429,58 @@ function tuple_lt(a: [number, number, number], b: [number, number, number]): boo
   return false;
 }
 
-/** Read `version` from the package's own `package.json`. */
-export function current_package_version(repo_root?: string | null): string {
-  let root = repo_root ?? null;
-  if (root === null) {
-    // __file__ = src/scripts/_lib/installed_lock.ts → repo root is three
-    // levels up (_lib → scripts → src → root), i.e. parents[3] in Python.
-    const here = path.dirname(fileURLToPath(import.meta.url));
-    root = path.resolve(here, "..", "..", "..");
-  }
+/** Read a string `version` from `<dir>/package.json`, or null if absent/malformed. */
+function _read_package_version(dir: string): string | null {
   try {
-    const data = JSON.parse(fs.readFileSync(path.join(root, "package.json"), { encoding: "utf-8" }));
+    const data = JSON.parse(fs.readFileSync(path.join(dir, "package.json"), { encoding: "utf-8" }));
     const version = (data as { version?: unknown }).version;
     if (typeof version === "string" && version.trim()) {
       return version.trim();
     }
   } catch {
-    // Missing / unreadable / malformed package.json → fall through.
+    // Missing / unreadable / malformed package.json → null.
   }
-  return "0.0.0";
+  return null;
+}
+
+/**
+ * Walk upward from `start_dir` to the nearest `package.json` carrying a string
+ * `version`. Layout-independent: works in the source tree
+ * (`src/scripts/_lib/`), a per-file `dist/`, AND the esbuild single-file bundle
+ * (`dist/cli/agent-config.js`) where this module's runtime location differs
+ * from its source path. Returns null at the filesystem root.
+ */
+export function _find_package_version_upward(start_dir: string): string | null {
+  let dir = start_dir;
+  for (;;) {
+    const found = _read_package_version(dir);
+    if (found !== null) {
+      return found;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return null; // reached the filesystem root
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Read `version` from the package's own `package.json`.
+ *
+ * With no `repo_root`, the version is resolved by walking **upward** from this
+ * module's runtime directory to the nearest `package.json`. A previous fixed
+ * `parents[3]` hop assumed the source layout (`src/scripts/_lib/`); in the
+ * shipped esbuild bundle the module runs from `dist/cli/`, so three hops
+ * overshot the package root → `package.json` not found → `"0.0.0"` → a
+ * spurious "downgrade" refusal on `agent-config global` (lockfile recorded a
+ * real version, current package read as `0.0.0`). The upward walk is correct
+ * in both layouts.
+ */
+export function current_package_version(repo_root?: string | null): string {
+  if (repo_root != null) {
+    return _read_package_version(repo_root) ?? "0.0.0";
+  }
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return _find_package_version_upward(here) ?? "0.0.0";
 }

--- a/tests/lib/installed_lock.test.ts
+++ b/tests/lib/installed_lock.test.ts
@@ -146,6 +146,36 @@ describe("installed_lock module", () => {
     expect(version.split(".").length - 1).toBeGreaterThanOrEqual(1);
   });
 
+  // Regression: `agent-config global` refused with "Current package: 0.0.0"
+  // because the version resolver used a fixed 3-hop (`src/scripts/_lib/`) that
+  // overshot the package root in the shipped esbuild bundle (module runs from
+  // `dist/cli/`). The upward walk must reach the package's package.json from
+  // ANY runtime depth — source layout or bundled.
+  it("upward_walk_finds_package_json_from_bundled_layout", () => {
+    const pkg_root = fs.mkdtempSync(path.join(os.tmpdir(), "pkgroot-"));
+    fs.writeFileSync(path.join(pkg_root, "package.json"), JSON.stringify({ version: "9.9.9" }));
+    // Simulate the esbuild bundle location: <pkg_root>/dist/cli/agent-config.js
+    const bundle_dir = path.join(pkg_root, "dist", "cli");
+    fs.mkdirSync(bundle_dir, { recursive: true });
+    expect(installed_lock._find_package_version_upward(bundle_dir)).toBe("9.9.9");
+    // Source layout (deeper) resolves to the same root.
+    const src_dir = path.join(pkg_root, "src", "scripts", "_lib");
+    fs.mkdirSync(src_dir, { recursive: true });
+    expect(installed_lock._find_package_version_upward(src_dir)).toBe("9.9.9");
+    fs.rmSync(pkg_root, { recursive: true, force: true });
+  });
+
+  it("upward_walk_returns_null_with_no_package_json_to_root", () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), "bare-"));
+    // No package.json anywhere up the chain inside the tmp dir; the walk must
+    // terminate at the filesystem root without looping. (A package.json may
+    // exist at an ancestor of os.tmpdir on some systems; assert it does not
+    // hang and yields a string-or-null, never throws.)
+    const result = installed_lock._find_package_version_upward(bare);
+    expect(result === null || typeof result === "string").toBe(true);
+    fs.rmSync(bare, { recursive: true, force: true });
+  });
+
   it("test_lockfile_env_override", () => {
     const custom = path.join(tmp_path, "custom.lock");
     patch_env("AGENT_CONFIG_INSTALLED_LOCK", custom);


### PR DESCRIPTION
Fixes `agent-config global` (and `npx @event4u/agent-config upgrade`) refusing every install with:

```
⚠️  Refusing global install: lockfile records a newer version.
    Recorded version:   <real>
    Current package:    0.0.0
```

## Root cause

`installed_lock.current_package_version()` resolved the package root with a fixed 3-hop (`here/../../..`) tuned for the source layout `src/scripts/_lib/`. The shipped artifact is the esbuild bundle `dist/install/install.mjs`, where the module runs from `dist/install/` — **three hops overshoot the package root**, `package.json` is not found, the resolver returns the `"0.0.0"` fallback. The lockfile’s real recorded version then classifies as a `downgrade` → install refuses.

## Fix

Resolve the version by walking **upward** from the module’s runtime directory to the nearest `package.json` carrying a string `version`. Layout-independent: correct in the source tree, a per-file `dist/`, and the bundle. The `repo_root`-override path is unchanged.

## Proof (real bundle, not just unit-sim)

Bundled an in-repo probe with esbuild to `dist/install/` (the failing artifact’s exact location):

```
RESOLVED=7.0.0      # was 0.0.0 with the 3-hop overshoot
```

Regenerated the tracked `dist/install/install.mjs` (the `Install bundle is fresh` CI gate requires the committed bundle to match source).

## Tests

- `_find_package_version_upward` regression: resolves the root `package.json` from both bundle depth (`dist/cli`/`dist/install`) and source depth (`src/scripts/_lib`); the no-`package.json` walk terminates at the filesystem root without looping.
- `installed_lock` suite 19/20; `tsc -p tsconfig.scripts.json --noEmit` + eslint clean.

## Follow-up (not in scope)

The same fixed-3-hop pattern exists in other own-package-root resolvers (e.g. `cmd_doctor._package_root`). Most `_lib` resolvers are dev-only `tsx` scripts run from source, where 3 hops is correct — so this fix targets the one resolver on the shipped bundle path. A sweep of bundle-reachable resolvers can follow separately.