### PR TITLE
fix(release): measure accumulated era body in the split gate

### DIFF
--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -94,7 +94,7 @@ import type {
     SplitPlan} from './_lib/changelog_eras.js';
 import {
     CURRENT_ERA_BODY_CAP,
-    current_era_body_size,
+    current_era_accumulated_body_size,
     current_era_insertion_point,
     perform_split,
     plan_split,
@@ -1596,12 +1596,18 @@ function main(argv: readonly string[] | null = null): number {
         test_trend_line,
     });
 
-    // Era-split planning: only crosses the gate when the current era body
-    // has grown past the drift cap AND the release crosses a minor/major
-    // boundary. Patch overflow is caught by the drift test (red CI), not
-    // by an auto-split into a nonsensical "pre-X.Y.Z" archive.
+    // Era-split planning: only crosses the gate when the current era's
+    // *accumulated* body (prior releases, excluding the newest section) has
+    // grown past the drift cap AND the release crosses a minor/major boundary.
+    // The newest release is exempt — a single large catch-up release forces
+    // the split on the *next* minor/major once it has become a prior entry,
+    // not on the patch that immediately follows it. This is the same quantity
+    // the drift test enforces (current_era_accumulated_body_size); measuring
+    // the raw total here would re-fire the gate the exemption exists to clear.
+    // Patch overflow that genuinely accumulates is caught by the drift test
+    // (red CI), not by an auto-split into a nonsensical "pre-X.Y.Z" archive.
     let split: SplitPlan | null = null;
-    const body_size = current_era_body_size();
+    const body_size = current_era_accumulated_body_size();
     if (body_size > CURRENT_ERA_BODY_CAP) {
         const candidate = plan_split(target);
         if (candidate === null) {

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -44,6 +44,12 @@ import {
     _RELEASE_BRANCH_RE,
     confirmGate,
 } from '../../src/scripts/release.js';
+import {
+    CURRENT_ERA_BODY_CAP,
+    current_era_accumulated_body_size,
+    current_era_body_size,
+    read_changelog_lines,
+} from '../../src/scripts/_lib/changelog_eras.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'release.ts');
@@ -506,5 +512,30 @@ describe.runIf(hasPython3())('release CLI — golden parity (python3 vs tsx)', (
         expect(ts.status).toBe(0);
         expect(normalizeDryRun(ts.stdout)).toBe(normalizeDryRun(py.stdout));
         expect(ts.stderr).toBe(py.stderr);
+    });
+});
+
+// ─── era-split gate — newest-release exemption (regression) ───────────────────
+// The gate in main() must measure the *accumulated* era body (newest release
+// exempt), the same quantity the drift test enforces — NOT the raw total. A
+// single large catch-up release (e.g. 7.0.0 in its own era, ~414 lines) busts
+// the raw cap, but its body is exempt and forces the split on the *next*
+// minor/major, never on the patch immediately after. Reverting the gate to
+// current_era_body_size re-fires the die() the exemption exists to clear, which
+// is exactly the `task release` failure this guards against (exit 2 on a patch).
+describe('release --dry-run — era gate honours the newest-release exemption', () => {
+    it('does not die when the era total busts the cap but the accumulated body is under it', () => {
+        const lines = read_changelog_lines();
+        const total = current_era_body_size(lines);
+        const accumulated = current_era_accumulated_body_size(lines);
+        // Only meaningful while the exemption is load-bearing — the current
+        // era's newest release alone exceeds the cap. After a genuine era split
+        // the precondition lapses and the guard is moot (skip, don't assert).
+        if (!(total > CURRENT_ERA_BODY_CAP && accumulated <= CURRENT_ERA_BODY_CAP)) {
+            return;
+        }
+        const ts = runTs(['--dry-run']);
+        expect(ts.status, ts.stderr).toBe(0);
+        expect(ts.stderr).not.toContain('split needs a minor/major bump');
     });
 });


### PR DESCRIPTION
## Problem

`task release` for **7.0.1** dies on the era-split gate:

```
error: current era body is 414 lines (cap 250) but release 7.0.1 is a patch
within the same era — split needs a minor/major bump.
```

The gate in `src/scripts/release.ts` measured `current_era_body_size` (the raw total, **including** the newest release section), while the drift test it mirrors (`tests/lib/changelog_eras.test.ts`) measures `current_era_accumulated_body_size` (newest release **exempt**).

After `0dfa3a23` split 7.0.0 into its own era, the gate counted all 414 lines of the 7.0.0 section and refused the next 7.0.1 patch — the exact failure the newest-release exemption was added to clear, just never propagated from the test to the gate. The two disagreed:

| measure | value | cap | verdict |
|---|---|---|---|
| drift test — accumulated (newest exempt) | 6 | 250 | green |
| release gate — raw total | 414 | 250 | **died** |

## Fix

Point the gate at `current_era_accumulated_body_size`, the same quantity the CI drift test enforces. A single large catch-up release is exempt and forces the era split on the **next** minor/major once it becomes a prior entry — never on the patch immediately after it.

## Verification

- `release --dry-run` now renders the 7.0.1 patch preview instead of dying.
- New regression test in `tests/scripts/release.test.ts` runs `--dry-run` while the exemption is load-bearing (era total > cap, accumulated ≤ cap) and asserts the gate does not die — fails (exit 2) if the gate is ever reverted to the raw total.
- `release.test.ts` (60) + `changelog_eras.test.ts` (18) green.