### PR TITLE
test(py2ts): convert the 4 all-parity CLI rigs to python-free intent tests

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,17 +6,17 @@
 
 ## Overall
 
-**59 / 134 steps done · 44%**
+**61 / 135 steps done · 45%**
 
 ```text
-██████████████████░░░░░░░░░░░░░░░░░░░░░░   44%
+██████████████████░░░░░░░░░░░░░░░░░░░░░░   45%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 17 | 14 | 3 | 0 | 0 | ██░░░░░░░░ 18% |
+| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 18 | 13 | 5 | 0 | 0 | ███░░░░░░░ 28% |
 | 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 11 | 50 | 50 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
@@ -26,13 +26,13 @@
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 
-**Road to py2ts Teardown Completion** — 3 / 17 done (18%)
+**Road to py2ts Teardown Completion** — 5 / 18 done (28%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Pre-flight gates (block Phase 1) — council-mandated | ✅ done | 0 | 2 | 0 | 0 | 100% |
-| 1 | Purge the remaining live-python test layer | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 2 | CI + scaffolding cleanup (requires Phase 1 complete) | 🟡 in progress | 4 | 1 | 0 | 0 | 20% |
+| 1 | Purge the remaining live-python test layer | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
+| 2 | CI + scaffolding cleanup (requires Phase 1 complete) | 🟡 in progress | 4 | 2 | 0 | 0 | 33% |
 | 2b | AI-council live-call layer (py2ts gap — transport now wired) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 3 | Consumer + merge readiness | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/road-to-py2ts-teardown-completion.md
+++ b/agents/roadmaps/road-to-py2ts-teardown-completion.md
@@ -99,8 +99,8 @@ stay open below — not force-marked done.
 > escalate to manual review. Full python-free `vitest run` green is the Phase-1
 > exit gate.
 
-- [ ] **269 oracle-backed `runIf(py3)` files — mechanical classification, not
-  judgement** (council B1). Per file: if the `runIf(py3)` block calls
+- [x] **269 oracle-backed `runIf(py3)` files — mechanical classification, not
+  judgement** (council B1). <!-- DONE 2026-06-23: 0 runIf(py3)/runIf(PY) blocks remain repo-wide (21 purged #639 + 4 all-parity CLI rigs converted to python-free intent tests). The "269" was a stale count; the real gated surface was 25 files. --> Per file: if the `runIf(py3)` block calls
   `readOracleSnapshot(...)` with **no** `captureSnapshot(...)` in the same block
   → **stale** (the gate is vestigial; drop it so the block runs python-free).
   If the block *captures* a snapshot that any other file reads (corpus
@@ -139,11 +139,18 @@ stay open below — not force-marked done.
   time-limited-buffer divergence — see review): `no-python-in-src.yml` fails the
   build if `git ls-files 'src/**/*.py'` is non-empty. Survives post-merge; not
   time-limited. <!-- done 2026-06-23: .github/workflows/no-python-in-src.yml -->
-- [ ] **Purge the 21 mixed python-gated test files** (dead `runIf(py3)` /
-  `it.runIf(PY)` golden-parity blocks + plumbing) — **DONE 2026-06-23** (231
-  passed / 0 failed across the 25 run together; `compile_corpus` edge cases
-  converted to python-free TS). The 4 all-parity CLI rigs + shim removal are the
-  coupled continuation (see Disposition). <!-- partial: 21/25 -->
+- [x] **Eliminate all 25 python-gated test files** — **DONE 2026-06-23.** 21
+  mixed files purged of dead `runIf(py3)` / `it.runIf(PY)` golden-parity blocks
+  (#639); the 4 remaining *all-parity* CLI rigs (`council_cli`, `council_prune`,
+  `implement_ticket_main`, `update_roadmap_progress`) **converted** to python-free
+  intent tests (47 passed) — they assert the tsx twins' own contract directly
+  instead of byte-comparing the deleted python CLI. `compile_corpus` edge cases
+  likewise converted, not deleted. **0 `runIf(py3)` / `runIf(PY)` repo-wide.**
+- [ ] **Retire the shim + the live-python3 harness sites** — coupled tail:
+  `tests/scripts/lint_regression.test.ts` still drives the python-spawning
+  `lint_regression.ts` baseline harness; resolve that + `parity/replay.ts` FIRST,
+  then remove `tests/_lib/python-free-env.ts`, proven green-by-construction with a
+  full python-free `vitest run` (see Phase 1 "Retire" item below + Phase 2).
 - [ ] Confirm remote CI green on `python2ts` with the new guard in place.
 
 ## Phase 2b — AI-council live-call layer (py2ts gap — transport now wired)

--- a/tests/scripts/council_cli.test.ts
+++ b/tests/scripts/council_cli.test.ts
@@ -5,9 +5,11 @@
 // cluster (orchestrator, clients, config, consensus, replay, solo_dispatch,
 // necessity, advisors, …).
 //
-// Golden parity: run the REAL python3 script and the tsx twin with identical
-// argv and assert byte-identical stdout/stderr/exit for the SIDE-EFFECT-FREE,
-// NON-SPENDING surfaces:
+// These were originally golden-parity tests against the python twin. The
+// python `council_cli.py` is DELETED (py2ts teardown), so the parity blocks
+// are now python-free INTENT tests: they spawn the tsx twin with the same
+// argv the parity cases exercised and assert the tsx CLI's OWN contract
+// (exit code + the load-bearing output marker) directly. Coverage preserved:
 //   - render / replay / quota / shadow-report on fixtures
 //   - the argparse error / exit paths
 //   - the output-path validator
@@ -15,14 +17,13 @@
 //
 // LIVE-SPEND paths (run / debate dispatch, the orchestrator transport) NEVER
 // make real API calls here. `estimate` would construct API members from the
-// real config; the TS `AnthropicClient` ctor throws without an injected SDK
-// (a pre-existing clients.ts divergence — Python defers the SDK import to call
-// time). So `estimate` byte-parity is driven through a harness that INJECTS
-// mock members on both sides via the `members=` kwarg, bypassing member
+// real config; the TS `AnthropicClient` ctor throws without an injected SDK.
+// So the `estimate` cost-output cases drive `cmd_estimate` through a harness
+// that INJECTS mock members via the `members=` option, bypassing member
 // construction. Static pricing makes the cost math deterministic.
 //
-// Per the migration convention we do NOT byte-compare the full --help prose —
-// only the exit code + the usage line.
+// Per the migration convention we do NOT assert the full --help prose — only
+// the exit code + the usage line.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -31,10 +32,7 @@ import { fileURLToPath } from 'node:url';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { oracle2, oracleFile } from '../_lib/parity_oracle.js';
-import { hasPython3, runPyScript, runTsScript } from './ai_council/_harness.js';
-
-const py3 = hasPython3();
+import { runTsScript } from './ai_council/_harness.js';
 
 // tests/scripts/council_cli.test.ts → two levels up is the repo root.
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
@@ -46,53 +44,11 @@ interface Run {
     status: number;
     stdout: string;
     stderr: string;
-    // v3 file-sink — frozen python file side-effects, present only when the
-    // call declared `outputs`. Decode with `oracleFile(run, name)`.
-    files?: Record<string, string | null>;
 }
 
-function pyEnv(): NodeJS.ProcessEnv {
-    const src = path.join(REPO_ROOT, 'src');
-    const existing = process.env.PYTHONPATH;
-    const parts = [src, REPO_ROOT];
-    if (existing) {
-        parts.push(existing);
-    }
-    return { ...process.env, PYTHONPATH: parts.join(path.delimiter) };
-}
-
-interface RunOpts {
-    // Volatile abs paths passed in argv → collapsed to a stable `<scratch:i>`
-    // token in the snapshot KEY (oracle side) so capture/replay resolve to the
-    // same golden. The spawn still receives the real path.
-    scratch?: string[];
-    // Symmetric normalize: applied to the python golden (oracle, capture+replay)
-    // AND to the live `.ts` twin output before comparison. Strips volatile path
-    // text that the command echoes into stdout/stderr.
-    normalize?: (s: string) => string;
-    // v3 file-sink — python file side-effects to freeze (logical name → path).
-    outputs?: Record<string, string>;
-}
-
-function runPy(args: string[], opts: RunOpts = {}): Run {
-    const r = runPyScript('council_cli', args, {
-        cwd: REPO_ROOT,
-        ...(opts.scratch !== undefined ? { scratch: opts.scratch } : {}),
-        ...(opts.normalize !== undefined ? { normalize: opts.normalize } : {}),
-        ...(opts.outputs !== undefined ? { outputs: opts.outputs } : {}),
-    });
-    return {
-        status: r.status ?? -1,
-        stdout: r.stdout,
-        stderr: r.stderr,
-        ...(r.files !== undefined ? { files: r.files } : {}),
-    };
-}
-
-function runTs(args: string[], opts: RunOpts = {}): Run {
+function runTs(args: string[]): Run {
     const r = runTsScript('council_cli', args, { cwd: REPO_ROOT });
-    const norm = opts.normalize ?? ((s: string): string => s);
-    return { status: r.status ?? -1, stdout: norm(r.stdout), stderr: norm(r.stderr) };
+    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
 }
 
 // ── fixtures ────────────────────────────────────────────────────────
@@ -121,51 +77,10 @@ const RESP_PLAIN_PAYLOAD = {
     ],
 };
 
-// Injected-member estimate harness. Identical mock-member set on both sides;
-// a fake settings dict (council enabled, real provider names) plus the real
-// static price table → deterministic cost output without constructing API
-// clients. argv: <question-file> <rounds-or-empty> <debate-flag "1"|"">.
-//
-// rounds/debate are read from argv (NOT env) so the oracle folds them into the
-// snapshot key — the single-shot and the --debate --rounds-2 case resolve to
-// distinct frozen goldens. The PY side runs through the inline oracle
-// (kind:inline) so no live python3 in normal mode; the TS twin is spawned live.
-const PY_HARNESS = `import sys
-import scripts.council_cli as cc
-from scripts.ai_council.clients import ExternalAIClient, CouncilResponse
-from scripts.ai_council.pricing import load_prices
-
-
-class Mock(ExternalAIClient):
-    def __init__(self, name, model, billable=True):
-        self.name = name
-        self.model = model
-        self.billable = billable
-
-    def ask(self, system_prompt, user_prompt, max_tokens=2048):
-        return CouncilResponse(self.name, self.model, "x")
-
-
-members = [Mock("anthropic", "claude-sonnet-4-5"), Mock("openai", "gpt-4o")]
-settings = {
-    "ai_council": {
-        "enabled": True,
-        "members": {"anthropic": {"enabled": True}, "openai": {"enabled": True}},
-    }
-}
-qfile = sys.argv[1]
-rounds_arg = sys.argv[2] if len(sys.argv) > 2 else ""
-debate_arg = sys.argv[3] if len(sys.argv) > 3 else ""
-ns_args = ["estimate", qfile]
-if debate_arg == "1":
-    ns_args.append("--debate")
-if rounds_arg:
-    ns_args += ["--rounds", rounds_arg]
-args = cc.build_parser().parse_args(ns_args)
-rc = cc.cmd_estimate(args, settings=settings, members=members, table=load_prices())
-sys.exit(rc)
-`;
-
+// Injected-member estimate harness. A fixed mock-member set + a fake settings
+// dict (council enabled, real provider names) + the real static price table →
+// deterministic cost output without constructing API clients (no spend).
+// argv: <question-file> <rounds-or-empty> <debate-flag "1"|"">.
 function tsHarness(root: string): string {
     return `import { cmd_estimate } from ${JSON.stringify(path.join(root, 'src/scripts/council_cli.ts'))};
 import { ExternalAIClient, CouncilResponse } from ${JSON.stringify(
@@ -231,37 +146,8 @@ process.exitCode = rc;
 `;
 }
 
-// Symmetric normalize: the question file is a volatile per-test tmp path. The
-// estimate cost output does not echo it, but normalising it on both sides keeps
-// the frozen golden machine-independent even if a future cost line surfaces it.
-function makeHarnessNormalize(qfile: string): (s: string) => string {
-    return (s: string): string => s.split(qfile).join('<qfile>');
-}
-
-// PY side → inline oracle (kind:inline). The injected harness code is the inline
-// `-c` target; rounds/debate ride in argv so they fold into the snapshot key.
-// `scratch:[qfile]` collapses the volatile question path in the key; the spawn
-// (capture only) still receives the real path. Normal mode replays the frozen
-// golden — no live python3.
-function runHarnessPy(qfile: string, rounds: string, debate: string): Run {
-    const normalize = makeHarnessNormalize(qfile);
-    const r = oracle2({
-        kind: 'inline',
-        target: PY_HARNESS,
-        args: [qfile, rounds, debate],
-        env: { PYTHONPATH: pyEnv().PYTHONPATH as string },
-        cwd: REPO_ROOT,
-        scratch: [qfile],
-        normalize,
-    });
-    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
-}
-
-// TS side → spawn the real tsx twin (live). Apply the SAME normalize before
-// comparing against the frozen-and-normalized python golden (oracle normalize
-// contract — symmetry is the caller's responsibility).
+// Spawn the real tsx estimate harness (live, no spend — members are injected).
 function runHarnessTs(qfile: string, rounds: string, debate: string): Run {
-    const normalize = makeHarnessNormalize(qfile);
     const r = spawnSync(TSX_BIN, [HARNESS_TS, qfile, rounds, debate], {
         cwd: REPO_ROOT,
         encoding: 'utf8',
@@ -269,8 +155,8 @@ function runHarnessTs(qfile: string, rounds: string, debate: string): Run {
     });
     return {
         status: r.status ?? -1,
-        stdout: normalize(r.stdout ?? ''),
-        stderr: normalize(r.stderr ?? ''),
+        stdout: r.stdout ?? '',
+        stderr: r.stderr ?? '',
     };
 }
 
@@ -292,177 +178,185 @@ afterAll(() => {
 
 const TOP_USAGE = 'usage: agent-config council [-h]';
 
-// ── argparse / dispatch error parity (no member construction) ───────
+// ── argparse / dispatch error intent (no member construction) ───────
 
-describe.runIf(py3)('council_cli CLI — argparse parity with python3', () => {
-    for (const [label, args] of [
-        ['no subcommand', []],
-        ['bad subcommand', ['bogus']],
-    ] as const) {
-        it(`exit 2 + identical usage/error lines — ${label}`, () => {
-            const py = runPy([...args]);
-            const ts = runTs([...args]);
-            expect(ts.status, 'exit code').toBe(2);
-            expect(py.status, 'exit code').toBe(2);
-            expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-            expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
-            expect(ts.stderr.split('\n')[0]).toBe(TOP_USAGE);
-        });
-    }
-
-    it('--help: exit 0 + top usage line (prose not byte-compared)', () => {
-        const py = runPy(['--help']);
-        const ts = runTs(['--help']);
-        expect(ts.status).toBe(0);
-        expect(py.status).toBe(0);
-        expect(ts.stdout.split('\n')[0]).toBe(TOP_USAGE);
-        expect(py.stdout.split('\n')[0]).toBe(TOP_USAGE);
+describe('council_cli CLI — argparse intent', () => {
+    it('no subcommand: exit 2 + usage + missing-cmd error', () => {
+        const ts = runTs([]);
+        expect(ts.status, 'exit code').toBe(2);
+        expect(ts.stderr.split('\n')[0]).toBe(TOP_USAGE);
+        expect(ts.stderr).toContain('error: the following arguments are required: cmd');
     });
 
-    // Group A — FULL stderr byte-parity. These errors either route through
-    // the fixed top-level usage (unrecognized args bubble to the top parser,
-    // matching argparse) or are caught in `main()` as ArgumentTypeError /
-    // ValueError → a `❌ council:<cmd>:` line with no usage block.
-    for (const [label, args] of [
-        ['estimate bad --model shape (main-caught)', ['estimate', '__Q__', '--model', 'badshape']],
-        ['estimate empty --model member (main-caught)', ['estimate', '__Q__', '--model', '=x']],
-        ['estimate bad --siblings (1 model, main-caught)', ['estimate', '__Q__', '--siblings', 'anthropic=only-one']],
-        ['run unrecognized flag (top usage)', ['run', '__Q__', '--output', 'x', '--bogus']],
-        ['estimate unrecognized flag (top usage)', ['estimate', '__Q__', '--bogus']],
+    it('bad subcommand: exit 2 + usage + invalid-choice error', () => {
+        const ts = runTs(['bogus']);
+        expect(ts.status, 'exit code').toBe(2);
+        expect(ts.stderr.split('\n')[0]).toBe(TOP_USAGE);
+        expect(ts.stderr).toContain("error: argument cmd: invalid choice: 'bogus'");
+    });
+
+    it('--help: exit 0 + top usage line (prose not asserted)', () => {
+        const ts = runTs(['--help']);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout.split('\n')[0]).toBe(TOP_USAGE);
+    });
+
+    // Group A — main-caught validation (ArgumentTypeError / ValueError) →
+    // a `❌ council:<cmd>:` line with no usage block — and the two
+    // unrecognized-flag cases that bubble to the fixed top-level usage.
+    for (const [label, args, marker] of [
+        [
+            'estimate bad --model shape (main-caught)',
+            ['estimate', '__Q__', '--model', 'badshape'],
+            "❌  council:estimate: --model expects '<member>=<model-id>', got 'badshape'.",
+        ],
+        [
+            'estimate empty --model member (main-caught)',
+            ['estimate', '__Q__', '--model', '=x'],
+            "❌  council:estimate: --model member and model-id must both be non-empty: '=x'.",
+        ],
+        [
+            'estimate bad --siblings (1 model, main-caught)',
+            ['estimate', '__Q__', '--siblings', 'anthropic=only-one'],
+            "❌  council:estimate: --siblings requires ≥ 2 distinct models for 'anthropic', got ['only-one'].",
+        ],
+        [
+            'run unrecognized flag (top usage)',
+            ['run', '__Q__', '--output', 'x', '--bogus'],
+            'error: unrecognized arguments: --bogus',
+        ],
+        [
+            'estimate unrecognized flag (top usage)',
+            ['estimate', '__Q__', '--bogus'],
+            'error: unrecognized arguments: --bogus',
+        ],
     ] as const) {
-        it(`arg error: exit 2 + byte-identical stderr — ${label}`, () => {
+        it(`arg error: exit 2 + error line — ${label}`, () => {
             const concrete = (args as readonly string[]).map((a) =>
                 a === '__Q__' ? QUESTION : a === '__R__' ? RESP_PLAIN : a,
             );
-            const py = runPy(concrete);
             const ts = runTs(concrete);
             expect(ts.status, 'exit code').toBe(2);
-            expect(py.status, 'exit code').toBe(2);
-            expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-            expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+            expect(ts.stderr).toContain(marker);
         });
     }
 
     // Group B — subparser validation errors (choices / required). argparse
-    // prints the full per-subcommand usage block (wrapped flag list) before
-    // the `error:` line. Per the migration convention we do NOT byte-compare
-    // usage prose — assert exit 2, the first usage line, and the final
-    // `prog: error: …` line (the load-bearing semantics).
+    // prints the full per-subcommand usage block before the `error:` line.
+    // Per the migration convention we do NOT assert usage prose — assert
+    // exit 2, the subcommand usage prefix, and the final `prog: error: …`
+    // line (the load-bearing semantics).
     function lastLine(s: string): string {
         const lines = s.replace(/\n$/, '').split('\n');
         return lines[lines.length - 1] ?? '';
     }
-    for (const [label, args] of [
-        ['run missing --output (required)', ['run', '__Q__']],
-        ['run bad --depth choice', ['run', '__Q__', '--depth', 'bogus']],
-        ['render bad --prompt-mode choice', ['render', '__R__', '--prompt-mode', 'nope']],
-        ['estimate bad --input-mode choice', ['estimate', '__Q__', '--input-mode', 'nope']],
+    for (const [label, args, errLine] of [
+        [
+            'run missing --output (required)',
+            ['run', '__Q__'],
+            'agent-config council run: error: the following arguments are required: --output',
+        ],
+        [
+            'run bad --depth choice',
+            ['run', '__Q__', '--depth', 'bogus'],
+            "agent-config council run: error: argument --depth: invalid choice: 'bogus' (choose from 'standard', 'deep')",
+        ],
+        [
+            'render bad --prompt-mode choice',
+            ['render', '__R__', '--prompt-mode', 'nope'],
+            "agent-config council render: error: argument --prompt-mode: invalid choice: 'nope' (choose from 'default', 'pr', 'design', 'optimize', 'analysis', 'prompt', 'roadmap', 'diff', 'files')",
+        ],
+        [
+            'estimate bad --input-mode choice',
+            ['estimate', '__Q__', '--input-mode', 'nope'],
+            "agent-config council estimate: error: argument --input-mode: invalid choice: 'nope' (choose from 'prompt', 'roadmap')",
+        ],
     ] as const) {
-        it(`arg error: exit 2 + identical error line + usage prefix — ${label}`, () => {
+        it(`arg error: exit 2 + error line + usage prefix — ${label}`, () => {
             const concrete = (args as readonly string[]).map((a) =>
                 a === '__Q__' ? QUESTION : a === '__R__' ? RESP_PLAIN : a,
             );
-            const py = runPy(concrete);
             const ts = runTs(concrete);
             expect(ts.status, 'exit code').toBe(2);
-            expect(py.status, 'exit code').toBe(2);
-            expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-            // The trailing `prog: error: …` line is byte-identical.
-            expect(lastLine(ts.stderr), 'error line byte-parity').toBe(lastLine(py.stderr));
-            // Both start with the subcommand usage prefix.
+            expect(lastLine(ts.stderr), 'error line').toBe(errLine);
             const cmd = concrete[0] as string;
             const prefix = `usage: agent-config council ${cmd} [-h]`;
-            expect(ts.stderr.startsWith(prefix), 'ts usage prefix').toBe(true);
-            expect(py.stderr.startsWith(prefix), 'py usage prefix').toBe(true);
+            expect(ts.stderr.startsWith(prefix), 'usage prefix').toBe(true);
         });
     }
 });
 
 // ── quota / shadow-report (read-only, no member construction) ───────
 
-describe.runIf(py3)('council_cli quota + shadow-report — byte-parity', () => {
-    it('quota (no configured caps in user-global config)', () => {
-        const py = runPy(['quota']);
+describe('council_cli quota + shadow-report — intent', () => {
+    it('quota (no configured caps in user-global config) → exit 0', () => {
         const ts = runTs(['quota']);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toContain('council:quota · no providers have a configured cli_call_budget.max_calls_per_day cap.');
     });
 
     it('quota --reset openai without --confirm → exit 2', () => {
-        const py = runPy(['quota', '--reset', 'openai']);
         const ts = runTs(['quota', '--reset', 'openai']);
         expect(ts.status, 'exit code').toBe(2);
-        expect(py.status, 'exit code').toBe(2);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.stderr).toContain('❌  council:quota: --reset openai requires --confirm.');
     });
 
-    it('shadow-report with an empty / missing log', () => {
+    it('shadow-report with an empty / missing log → exit 0', () => {
         // Point at a non-existent log so the result is deterministic
         // regardless of the developer's local shadow-log.jsonl.
         const missing = path.join(TMP, 'no-such-shadow.jsonl');
-        const py = runPy(['shadow-report', '--log', missing]);
         const ts = runTs(['shadow-report', '--log', missing]);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toContain('[shadow SLO] no samples yet');
     });
 });
 
 // ── render (re-render a saved responses JSON) ───────────────────────
 
-describe.runIf(py3)('council_cli render — byte-parity', () => {
+describe('council_cli render — intent', () => {
     it('render to stdout (default decision-lens template)', () => {
-        const py = runPy(['render', RESP_PLAIN]);
         const ts = runTs(['render', RESP_PLAIN]);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
         expect(ts.status).toBe(0);
+        // The saved member response is echoed, then the analysis-lens summary.
+        expect(ts.stdout).toContain('## anthropic · claude-sonnet-4-5');
+        expect(ts.stdout).toContain('Hello world finding.');
+        expect(ts.stdout).toContain('## Convergence / Divergence');
+        expect(ts.stdout).toContain('analysis-lens shape');
     });
 
     it('render --prompt-mode pr (lens override)', () => {
-        const py = runPy(['render', RESP_PLAIN, '--prompt-mode', 'pr']);
         const ts = runTs(['render', RESP_PLAIN, '--prompt-mode', 'pr']);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toContain('## Convergence / Divergence');
+        // The PR lens swaps in the PR-review shape.
+        expect(ts.stdout).toContain('PR-review shape');
     });
 
     it('render --prose-synthesis (R4 Q4 escape hatch)', () => {
-        const py = runPy(['render', RESP_PLAIN, '--prose-synthesis']);
         const ts = runTs(['render', RESP_PLAIN, '--prose-synthesis']);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toContain('## Convergence / Divergence');
+        // The escape hatch defers synthesis to the host agent.
+        expect(ts.stdout).toContain('*to be summarised by the host agent*');
     });
 });
 
 // ── replay (decision-replay re-render + low-impact stats) ───────────
 
-describe.runIf(py3)('council_cli replay — byte-parity', () => {
+describe('council_cli replay — intent', () => {
     it('replay on a payload with no consensus block → exit 2', () => {
-        const py = runPy(['replay', RESP_PLAIN]);
         const ts = runTs(['replay', RESP_PLAIN]);
         expect(ts.status, 'exit code').toBe(2);
-        expect(py.status, 'exit code').toBe(2);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.stderr).toContain('❌  council:replay: payload has no `consensus` block');
     });
 
-    it('replay --low-impact-stats with no resolutions log alongside', () => {
-        // The "no low-impact-resolutions.md alongside <RESP_PLAIN>" line echoes
-        // the volatile tmp path. Collapse it symmetrically (oracle golden + live
-        // ts twin) to a stable token, and key the snapshot via scratch.
-        const norm = (s: string): string => s.split(RESP_PLAIN).join('<resp>');
-        const opts = { scratch: [RESP_PLAIN], normalize: norm };
-        const py = runPy(['replay', RESP_PLAIN, '--low-impact-stats'], opts);
-        const ts = runTs(['replay', RESP_PLAIN, '--low-impact-stats'], opts);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+    it('replay --low-impact-stats with no resolutions log alongside → exit 0', () => {
+        const ts = runTs(['replay', RESP_PLAIN, '--low-impact-stats']);
         expect(ts.status).toBe(0);
+        // The line echoes the volatile RESP_PLAIN path; assert the stable prefix
+        // + suffix that frame it instead of the full path.
+        expect(ts.stdout).toContain('council:replay · no low-impact-resolutions.md alongside');
+        expect(ts.stdout).toContain('session had no fast-path entries.');
     });
 });
 
@@ -473,19 +367,16 @@ describe.runIf(py3)('council_cli replay — byte-parity', () => {
 // path with a non-canonical absolute target so no spend / member
 // construction happens.
 
-describe.runIf(py3)('council_cli output-path validation — byte-parity', () => {
-    it('render --output outside agents/runtime/council/sessions → exit 2', () => {
+describe('council_cli output-path validation — intent', () => {
+    it('render --output outside agents/runtime/council/sessions → exit 2, nothing written', () => {
         const badOut = path.join(TMP, 'not-canonical.md');
-        // The validator error echoes the volatile `--output` abs path; collapse
-        // it symmetrically and key the snapshot on it via scratch.
-        const norm = (s: string): string => s.split(badOut).join('<badout>');
-        const opts = { scratch: [badOut], normalize: norm };
-        const py = runPy(['render', RESP_PLAIN, '--output', badOut], opts);
-        const ts = runTs(['render', RESP_PLAIN, '--output', badOut], opts);
+        const ts = runTs(['render', RESP_PLAIN, '--output', badOut]);
         expect(ts.status, 'exit code').toBe(2);
-        expect(py.status, 'exit code').toBe(2);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
+        expect(ts.stderr).toContain(
+            'council:render --output must live under agents/runtime/council/sessions/',
+        );
+        // The error echoes the rejected --output path.
+        expect(ts.stderr).toContain(badOut);
         // Sanity: nothing written.
         expect(fs.existsSync(badOut)).toBe(false);
     });
@@ -493,56 +384,35 @@ describe.runIf(py3)('council_cli output-path validation — byte-parity', () => 
 
 // ── render --output to the canonical (gitignored) dir, snapshot+restore ─
 
-describe.runIf(py3)('council_cli render --output (canonical dir) — byte-parity', () => {
+describe('council_cli render --output (canonical dir) — intent', () => {
     const SESSIONS_REL = 'agents/runtime/council/sessions';
 
-    function snapshot(dir: string): { existed: boolean; entries: Set<string> } {
+    function snapshot(dir: string): { existed: boolean } {
         const abs = path.join(REPO_ROOT, dir);
-        if (!fs.existsSync(abs)) {
-            return { existed: false, entries: new Set() };
-        }
-        return { existed: true, entries: new Set(fs.readdirSync(abs)) };
+        return { existed: fs.existsSync(abs) };
     }
 
-    it('render --output writes byte-identical files + identical stdout', () => {
+    it('render --output writes the rendered file under the canonical dir', () => {
         const abs = path.join(REPO_ROOT, SESSIONS_REL);
         const before = snapshot(SESSIONS_REL);
-        const pyRel = `${SESSIONS_REL}/__cc_test_py.md`;
         const tsRel = `${SESSIONS_REL}/__cc_test_ts.md`;
-        const created: string[] = [];
+        const tsAbs = path.join(REPO_ROOT, tsRel);
         try {
-            // PY side is a file-sink: the observable is the WRITTEN file, not
-            // stdout. `outputs: { rendered: pyRel }` freezes the written bytes
-            // into the snapshot (capture, while .py exists) and replays them in
-            // normal mode — python is NOT spawned, so the file is never written
-            // to the repo on replay. The TS twin still writes its file live.
-            const py = runPy(['render', RESP_PLAIN, '--output', pyRel], {
-                outputs: { rendered: pyRel },
-            });
             const ts = runTs(['render', RESP_PLAIN, '--output', tsRel]);
-            created.push(path.join(REPO_ROOT, tsRel));
-            expect(py.status).toBe(0);
             expect(ts.status).toBe(0);
-            // stdout differs only in the echoed filename; normalise it.
-            const pyOut = py.stdout.replace('__cc_test_py.md', '__OUT__');
-            const tsOut = ts.stdout.replace('__cc_test_ts.md', '__OUT__');
-            expect(tsOut, 'stdout byte-parity (filename normalised)').toBe(pyOut);
-            expect(ts.stderr).toBe(py.stderr);
-            // Written file bodies must be byte-identical. The python body is the
-            // frozen golden (oracleFile); the ts body is the live-written file.
-            const pyBytes = oracleFile(py, 'rendered');
-            expect(pyBytes, 'frozen python render must exist').not.toBeNull();
-            const pyBody = (pyBytes as Buffer).toString('utf8');
-            const tsBody = fs.readFileSync(path.join(REPO_ROOT, tsRel), 'utf8');
-            expect(tsBody, 'written file byte-parity').toBe(pyBody);
+            // stdout confirms the write to the canonical relative path.
+            expect(ts.stdout).toContain(`council:render · wrote ${tsRel}`);
+            // The written body is the rendered template (member + summary).
+            expect(fs.existsSync(tsAbs), 'file written').toBe(true);
+            const body = fs.readFileSync(tsAbs, 'utf8');
+            expect(body).toContain('## anthropic · claude-sonnet-4-5');
+            expect(body).toContain('Hello world finding.');
+            expect(body).toContain('## Convergence / Divergence');
         } finally {
-            // Restore: delete only the files we created (the ts twin's file;
-            // python's was frozen, never written on replay). If the dir did not
-            // exist before and is now empty, remove it too.
-            for (const f of created) {
-                if (fs.existsSync(f)) {
-                    fs.rmSync(f, { force: true });
-                }
+            // Restore: delete the file we created. If the dir did not exist
+            // before and is now empty, remove it too.
+            if (fs.existsSync(tsAbs)) {
+                fs.rmSync(tsAbs, { force: true });
             }
             if (!before.existed && fs.existsSync(abs) && fs.readdirSync(abs).length === 0) {
                 fs.rmdirSync(abs);
@@ -552,29 +422,26 @@ describe.runIf(py3)('council_cli render --output (canonical dir) — byte-parity
 });
 
 // ── estimate / debate-estimate cost output (injected mock members) ──
-// Both sides inject the SAME mock member set + the real static price
-// table → deterministic cost math (the `:.4f` round-half-even f-strings).
-// No API client is constructed → no spend.
+// The injected mock member set + the real static price table → deterministic
+// cost math (the `:.4f` round-half-even formatting). No API client is
+// constructed → no spend.
 
-describe.runIf(py3)('council_cli estimate cost-output — byte-parity (injected members)', () => {
+describe('council_cli estimate cost-output — intent (injected members)', () => {
     it('estimate · single-shot cost preview', () => {
-        const py = runHarnessPy(QUESTION, '', '');
         const ts = runHarnessTs(QUESTION, '', '');
-        expect(ts.status, 'exit code').toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
-        expect(ts.status).toBe(0);
-        // Anchor: the cost lines + TOTAL must be present (round-half-even).
+        expect(ts.status, 'exit code').toBe(0);
         expect(ts.stdout).toContain('council:estimate · mode=prompt · members=2 (billable=2)');
-        expect(ts.stdout).toContain('TOTAL:  $');
+        // Per-member cost lines (round-half-even, 4 decimals) + the TOTAL.
+        expect(ts.stdout).toMatch(/anthropic\/claude-sonnet-4-5: ~\d+ in \+ \d+ out\s+=\s+\$\d+\.\d{4}/);
+        expect(ts.stdout).toMatch(/TOTAL:\s+\$\d+\.\d{4}/);
     });
 
     it('estimate --debate --rounds 2 · round-by-round projection', () => {
-        const py = runHarnessPy(QUESTION, '2', '1');
         const ts = runHarnessTs(QUESTION, '2', '1');
-        expect(ts.status, 'exit code').toBe(py.status);
-        expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-        expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
-        expect(ts.stdout).toContain('PROJECTED TOTAL (2 rounds):  $');
+        expect(ts.status, 'exit code').toBe(0);
+        expect(ts.stdout).toContain('council:estimate · mode=debate · members=2 (billable=2) · rounds=2 (cap=4)');
+        expect(ts.stdout).toContain('Round 1 of 2:');
+        expect(ts.stdout).toContain('Round 2 of 2:');
+        expect(ts.stdout).toMatch(/PROJECTED TOTAL \(2 rounds\):\s+\$\d+\.\d{4}/);
     });
 });

--- a/tests/scripts/council_prune.test.ts
+++ b/tests/scripts/council_prune.test.ts
@@ -1,80 +1,96 @@
-// Tests for src/scripts/council_prune.ts (py2ts Phase 1, ADR-094).
+// Intent tests for src/scripts/council_prune.ts (py2ts Phase 1, ADR-094).
 //
-// council_prune is the manual CLI wrapper around session.prune_all_council_
-// artifacts. Exit code is always 0 for the operational paths; arg errors exit
-// 2 with the argparse-shaped usage + error lines.
-//
-// Golden parity: run the REAL python3 script and the tsx twin with identical
-// argv and assert byte-identical stdout/stderr + exit code for the
-// side-effect-free paths (--days 0 → disabled, --dry-run, bad args). Per the
-// migration convention we do NOT byte-compare the full --help prose — only the
-// exit code and the usage line. The default (no --days) path is intentionally
-// not exercised here because it prunes the real working tree; the prune logic
-// itself is covered by session.test.ts against tmp fixtures.
+// council_prune is the manual CLI wrapper around the council artefact pruner.
+// The python twin is gone (py2ts teardown), so these assert the tsx twin's OWN
+// contract directly — the same surface the former byte-parity rig exercised:
+//   - operational paths exit 0 with their deterministic status lines
+//     (--days <=0 → disabled, --dry-run → cutoff banner),
+//   - --help exits 0 with the argparse usage line,
+//   - arg errors exit 2 with the usage line + a `prog: error: …` line.
+// The default (no --days) path is intentionally not exercised here because it
+// prunes the real working tree; the prune logic itself is covered by
+// session.test.ts against tmp fixtures.
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
-
-import { hasPython3, runPyScript, runTsScript } from './ai_council/_harness.js';
-
-const py3 = hasPython3();
 
 // tests/scripts/council_prune.test.ts → two levels up is the repo root.
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-
-function runPy(args: string[]): { status: number; stdout: string; stderr: string } {
-    const r = runPyScript('council_prune', args, { cwd: REPO_ROOT });
-    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
-}
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'council_prune.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
 
 function runTs(args: string[]): { status: number; stdout: string; stderr: string } {
-    const r = runTsScript('council_prune', args, { cwd: REPO_ROOT });
+    const r: SpawnSyncReturns<string> = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+    });
     return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
 }
 
 const USAGE = 'usage: council_prune.py [-h] [--days DAYS] [--dry-run]';
 
-describe.runIf(py3)('council_prune CLI — byte-parity with python3', () => {
-    for (const [label, args] of [
-        ['--days 0 (pruning disabled)', ['--days', '0']],
-        ['--days -1 (pruning disabled)', ['--days', '-1']],
-        ['--days 7 --dry-run', ['--days', '7', '--dry-run']],
-        ['--days=7 --dry-run (=-form)', ['--days=7', '--dry-run']],
+describe('council_prune CLI — intent', () => {
+    for (const [label, args, expectedLines] of [
+        [
+            '--days 0 (pruning disabled)',
+            ['--days', '0'],
+            ['council-prune: retention_days=0 → pruning disabled.'],
+        ],
+        [
+            '--days -1 (pruning disabled)',
+            ['--days', '-1'],
+            ['council-prune: retention_days=-1 → pruning disabled.'],
+        ],
+        [
+            '--days 7 --dry-run',
+            ['--days', '7', '--dry-run'],
+            [
+                'council-prune: dry-run, cutoff = retention_days=7',
+                'council-prune: actual deletion requires omitting --dry-run',
+            ],
+        ],
+        [
+            '--days=7 --dry-run (=-form)',
+            ['--days=7', '--dry-run'],
+            [
+                'council-prune: dry-run, cutoff = retention_days=7',
+                'council-prune: actual deletion requires omitting --dry-run',
+            ],
+        ],
     ] as const) {
-        it(`exit + stdout + stderr identical — ${label}`, () => {
-            const py = runPy([...args]);
+        it(`operational path exits 0 with its status line — ${label}`, () => {
             const ts = runTs([...args]);
-            expect(ts.status, 'exit code').toBe(py.status);
-            expect(ts.stdout, 'stdout byte-parity').toBe(py.stdout);
-            expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
             // Operational paths always exit 0.
-            expect(ts.status).toBe(0);
+            expect(ts.status, 'exit code').toBe(0);
+            const out = ts.stdout.split('\n').filter((l) => l.length > 0);
+            expect(out, 'stdout lines').toEqual([...expectedLines]);
         });
     }
 
-    it('--help: exit 0 + usage line (prose not byte-compared per convention)', () => {
-        const py = runPy(['--help']);
+    it('--help: exit 0 + usage line', () => {
         const ts = runTs(['--help']);
         expect(ts.status).toBe(0);
-        expect(py.status).toBe(0);
         expect(ts.stdout.split('\n')[0]).toBe(USAGE);
-        expect(py.stdout.split('\n')[0]).toBe(USAGE);
     });
 
-    for (const [label, args] of [
-        ['unrecognized arg', ['--bogus']],
-        ['bad --days int value', ['--days', 'abc']],
-        ['--days missing value', ['--days']],
+    for (const [label, args, errFragment] of [
+        ['unrecognized arg', ['--bogus'], 'unrecognized arguments: --bogus'],
+        ['bad --days int value', ['--days', 'abc'], "argument --days: invalid int value: 'abc'"],
+        ['--days missing value', ['--days'], 'argument --days: expected one argument'],
     ] as const) {
-        it(`arg error: exit 2 + identical usage/error lines — ${label}`, () => {
-            const py = runPy([...args]);
+        it(`arg error: exit 2 + usage/error lines — ${label}`, () => {
             const ts = runTs([...args]);
             expect(ts.status, 'exit code').toBe(2);
-            expect(py.status, 'exit code').toBe(2);
             // argparse writes usage + a `prog: error: …` line to stderr.
-            expect(ts.stderr, 'stderr byte-parity').toBe(py.stderr);
             expect(ts.stderr.split('\n')[0]).toBe(USAGE);
+            expect(ts.stderr).toContain(`council_prune.py: error: ${errFragment}`);
         });
     }
 });

--- a/tests/scripts/implement_ticket_main.test.ts
+++ b/tests/scripts/implement_ticket_main.test.ts
@@ -1,25 +1,20 @@
-// Golden-parity tests for the py2ts `implement_ticket/__main__` entry shim
-// (ADR-200, Python→TypeScript migration).
+// Intent tests for the py2ts `implement_ticket/__main__` entry shim (ADR-200).
 //
-// `implement_ticket/__main__.py` is a 15-line deprecated entry point: it
-// imports `main` from `work_engine.cli`, runs it, and exits with the returned
-// code (`sys.exit(main())`). The twin sets `process.exitCode = main()` from the
-// shipped `work_engine` CLI twin. This test exercises the ENTRYPOINT contract —
-// it imports, runs, and propagates the exit code / stdout / stderr of the
-// delegated `cli.main` 1:1 — by running BOTH in identical clean temp cwds:
-//   - `python3 -m implement_ticket [argv]` (the pinned Golden-Transcript
-//     invocation; the package `__init__` deprecation aliases are import-time
-//     side effects with no observable `-m` stdout/stderr),
-//   - `tsx implement_ticket/__main__.ts [argv]`,
-// comparing exit + stdout + stderr byte-for-byte (mirrors the sibling
-// `work_engine/__main__.test.ts` model).
+// `implement_ticket/__main__.ts` is the deprecated entry point: it imports
+// `main` from the shipped `work_engine` CLI twin, runs it, and propagates the
+// returned exit code. The python twin is gone (py2ts teardown), so these assert
+// the tsx twin's OWN delegate-and-propagate contract directly — the same
+// surface the former byte-parity rig exercised:
+//   - it forwards argv to `cli.main` and propagates its exit code 1:1,
+//   - with no state file and no input flag, cli.main fails (exit 2),
+//   - with `--prompt-file`, cli.main builds the initial `.work-state.json`,
+//     halts at refine, and the shim forwards the non-zero (exit 1).
 //
-// Scope: only the entry-shim's delegate-and-propagate behaviour. The argument
-// PARSING / `--help` banner lives in the `work_engine/cli` twin (covered by
-// `work_engine/cli.test.ts`), not here — so the cases below drive argv that
-// the shim forwards verbatim and that `cli.main` resolves deterministically
-// (a clean cwd has no `.work-state.json`, so the error / halt outputs are
-// stable). COLUMNS pinned to 80; no real repo state is touched.
+// Scope: only the entry-shim's delegate-and-propagate behaviour. Argument
+// PARSING / `--help` lives in the `work_engine/cli` twin (covered by
+// `work_engine/cli.test.ts`), not here — so the cases drive argv the shim
+// forwards verbatim and that `cli.main` resolves deterministically (a clean cwd
+// has no `.work-state.json`). COLUMNS pinned to 80; no real repo state touched.
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -35,17 +30,8 @@ const TSX_BIN =
     process.env['TSX_BIN'] ??
     path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
 function env(): NodeJS.ProcessEnv {
-    return { ...process.env, COLUMNS: '80', PYTHONPATH: SCRIPTS_ROOT };
-}
-
-/** `python3 -m implement_ticket` semantics in `cwd` with `argv`. */
-function runPy(cwd: string, argv: string[]): SpawnSyncReturns<string> {
-    return spawnSync('python3', ['-m', 'implement_ticket', ...argv], { cwd, env: env(), encoding: 'utf8' });
+    return { ...process.env, COLUMNS: '80' };
 }
 
 /** `tsx implement_ticket/__main__.ts` in `cwd` with `argv`. */
@@ -53,56 +39,44 @@ function runTs(cwd: string, argv: string[]): SpawnSyncReturns<string> {
     return spawnSync(TSX_BIN, [MAIN_TS, ...argv], { cwd, env: env(), encoding: 'utf8' });
 }
 
-const py3 = hasPython3();
-
-describe.runIf(py3)('implement_ticket/__main__ — entry-shim golden parity (python3 vs tsx)', () => {
+describe('implement_ticket/__main__ — entry-shim intent', () => {
     let cwd: string;
     beforeEach(() => {
         // A pristine cwd → no `.work-state.json`, so cli.main's initial-state
-        // resolution is deterministic on both engines.
+        // resolution is deterministic.
         cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'it-main-'));
     });
     afterEach(() => {
         fs.rmSync(cwd, { recursive: true, force: true });
     });
 
-    /** Compare exit + stdout + stderr of the two delegated runs in the SAME argv. */
-    function expectMatch(argv: string[]): { status: number | null } {
-        const py = runPy(cwd, argv);
-        const ts = runTs(cwd, argv);
-        const label = JSON.stringify(argv);
-        expect(ts.status, `exit ${label}`).toBe(py.status);
-        expect(ts.stdout, `stdout ${label}`).toBe(py.stdout);
-        expect(ts.stderr, `stderr ${label}`).toBe(py.stderr);
-        return { status: py.status };
-    }
-
-    it('no args: delegates to cli.main → exit 2 + identical "no state file" error', () => {
-        const { status } = expectMatch([]);
-        // Sanity: the shim really propagated cli.main's failure code, not 0.
-        expect(status).toBe(2);
+    it('no args: delegates to cli.main → propagates exit 2 + "no state file" error', () => {
+        const ts = runTs(cwd, []);
+        // The shim forwarded cli.main's failure code, not 0.
+        expect(ts.status, 'exit').toBe(2);
+        expect(ts.stderr, 'stderr').toContain('No state file at .work-state.json');
+        expect(ts.stderr, 'stderr').toContain('cannot build an initial state');
     });
 
-    it('--prompt-file: delegates, builds initial state, propagates the halt exit identically', () => {
+    it('--prompt-file: delegates, builds initial state, propagates the halt exit (1)', () => {
         fs.writeFileSync(path.join(cwd, 'p.txt'), 'improve the thing\n', 'utf-8');
-        const { status } = expectMatch(['--prompt-file', 'p.txt']);
+        const ts = runTs(cwd, ['--prompt-file', 'p.txt']);
         // cli.main halts at refine and returns a non-zero code; the shim forwards it.
-        expect(status).toBe(1);
-        // Both engines wrote the SAME initial state file via the delegated cli.
-        // (The py run wrote it last — re-run TS into a fresh cwd to compare bytes.)
-        const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'it-state-'));
-        try {
-            fs.writeFileSync(path.join(fresh, 'p.txt'), 'improve the thing\n', 'utf-8');
-            const pyRun = runPy(fresh, ['--prompt-file', 'p.txt']);
-            expect(pyRun.status).toBe(1);
-            const pyState = fs.readFileSync(path.join(fresh, '.work-state.json'), 'utf-8');
-            fs.rmSync(path.join(fresh, '.work-state.json'));
-            const tsRun = runTs(fresh, ['--prompt-file', 'p.txt']);
-            expect(tsRun.status).toBe(1);
-            const tsState = fs.readFileSync(path.join(fresh, '.work-state.json'), 'utf-8');
-            expect(tsState, 'delegated .work-state.json bytes').toBe(pyState);
-        } finally {
-            fs.rmSync(fresh, { recursive: true, force: true });
-        }
+        expect(ts.status, 'exit').toBe(1);
+        expect(ts.stdout, 'stdout').toContain('[halt] outcome=blocked step=refine');
+        expect(ts.stdout, 'stdout').toContain('@agent-directive: refine-prompt');
+
+        // The delegated cli wrote the initial state file with the expected shape.
+        const statePath = path.join(cwd, '.work-state.json');
+        expect(fs.existsSync(statePath), '.work-state.json written').toBe(true);
+        const state = JSON.parse(fs.readFileSync(statePath, 'utf-8')) as {
+            version: number;
+            input: { kind: string; data: { raw: string } };
+            outcomes: Record<string, string>;
+        };
+        expect(state.version).toBe(1);
+        expect(state.input.kind).toBe('prompt');
+        expect(state.input.data.raw).toBe('improve the thing\n');
+        expect(state.outcomes['refine']).toBe('blocked');
     });
 });

--- a/tests/scripts/update_roadmap_progress.test.ts
+++ b/tests/scripts/update_roadmap_progress.test.ts
@@ -1,26 +1,23 @@
-// Golden-parity rig for the py2ts `update_roadmap_progress` twin (ADR-200).
+// Intent tests for the py2ts `update_roadmap_progress` twin (ADR-200).
 //
-// `update_roadmap_progress.{py,ts}` is the roadmap dashboard generator — the
-// script CI runs with `--check`, so byte-identical parity is load-bearing.
-// Both engines accept `--repo-root <dir>` (default cwd), so each case builds a
-// throwaway `<tmp>/agents/roadmaps/` fixture tree and drives BOTH scripts as a
-// direct CLI invocation (`python3 …py` vs `tsx …ts`), then compares:
-//   - the generated `agents/roadmaps-progress.md` bytes,
-//   - stdout + stderr,
-//   - exit code,
-// all byte-for-byte. argparse `--help` PROSE is not byte-compared (only the
-// exit code + the `usage:` token); the unknown-arg error path IS compared in
-// full (it is a one-line deterministic banner, not multi-line help prose).
+// `update_roadmap_progress.ts` is the roadmap dashboard generator — the script
+// CI runs with `--check`. The python twin is gone (py2ts teardown), so these
+// assert the tsx twin's OWN contract directly — the same surface the former
+// byte-parity rig exercised: the dashboard sections/markers a regen renders,
+// the exclusion rules, the frontmatter (draft/ready) gating, the
+// complete-unarchived stderr warning, the `--check` exit codes (stale → 1,
+// fresh → 0, no dir → 0), and the unknown-arg / `--help` usage banner.
+//
+// The twin accepts `--repo-root <dir>` (default cwd), so each case builds a
+// throwaway `<tmp>/proj/agents/roadmaps/` fixture tree and drives the script as
+// a direct CLI invocation. COLUMNS pinned to 80.
 //
 // Fixtures: phases always carry a NAME (or a blank line follows the heading).
-// `## Phase 1` immediately followed by `- [ ] x` is a PHASE_RE quirk shared by
-// both engines — the `[\s:—-]+(.*?)` name group swallows the next line, so the
-// checkbox is consumed into the heading and not counted. That divergence is a
-// property of the shared regex (identical py vs tsx), not a twin defect; real
-// roadmaps always name their phases, so the fixtures do too.
-//
-// No env mutation, no real repo / real roadmaps touched — every fixture lives
-// under a fresh mkdtemp dir cleaned in afterEach. COLUMNS pinned to 80.
+// `## Phase 1` immediately followed by `- [ ] x` is a PHASE_RE quirk — the name
+// group swallows the next line, so the checkbox is consumed into the heading
+// and not counted. Real roadmaps always name their phases, so the fixtures do
+// too. No env mutation, no real repo touched — every fixture lives under a
+// fresh mkdtemp dir cleaned in afterEach.
 import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -30,7 +27,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // tests/scripts/update_roadmap_progress.test.ts → two levels up is the repo root.
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'agent-src', 'scripts', 'update_roadmap_progress.py');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'agent-src', 'scripts', 'update_roadmap_progress.ts');
 const TSX_BIN = path.join(
     REPO_ROOT,
@@ -39,37 +35,21 @@ const TSX_BIN = path.join(
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-// PYTHONPATH=src + the script dir so the `import update_roadmap_progress`
-// sibling resolution + any `src/` packages are importable when run directly.
 function childEnv(): NodeJS.ProcessEnv {
-    return {
-        ...process.env,
-        COLUMNS: '80',
-        PYTHONPATH: `${path.join(REPO_ROOT, 'src')}:${path.dirname(PY_SCRIPT)}`,
-    };
-}
-
-function runPy(args: string[], cwd: string): SpawnSyncReturns<string> {
-    return spawnSync('python3', [PY_SCRIPT, ...args], { cwd, env: childEnv(), encoding: 'utf8' });
+    return { ...process.env, COLUMNS: '80' };
 }
 
 function runTs(args: string[], cwd: string): SpawnSyncReturns<string> {
     return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd, env: childEnv(), encoding: 'utf8' });
 }
 
-const py3 = hasPython3();
-
-describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)', () => {
+describe('update_roadmap_progress — intent', () => {
     let tmp: string;
     let root: string;
     let roadmaps: string;
 
     beforeEach(() => {
-        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'urp-parity-'));
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'urp-intent-'));
         root = path.join(tmp, 'proj');
         roadmaps = path.join(root, 'agents', 'roadmaps');
         fs.mkdirSync(roadmaps, { recursive: true });
@@ -86,44 +66,15 @@ describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)'
 
     const DASH = path.join('agents', 'roadmaps-progress.md');
 
-    /** Run the regen (write) path on both engines into two sibling repo roots and compare. */
-    function expectRegenMatch(): void {
-        // Clone the fixture roadmaps tree into a py-root and a ts-root so each
-        // engine writes its own dashboard without clobbering the other.
-        const pyRoot = path.join(tmp, 'py-root');
-        const tsRoot = path.join(tmp, 'ts-root');
-        fs.cpSync(root, pyRoot, { recursive: true });
-        fs.cpSync(root, tsRoot, { recursive: true });
-
-        const py = runPy(['--repo-root', pyRoot], tmp);
-        const ts = runTs(['--repo-root', tsRoot], tmp);
-
-        expect(ts.status, 'exit').toBe(py.status);
-        // stdout names the repo-relative target only — root-name differs, so
-        // normalize the two root basenames to a placeholder before comparing.
-        const norm = (s: string): string => s.split('py-root').join('R').split('ts-root').join('R');
-        expect(norm(ts.stdout), 'stdout').toBe(norm(py.stdout));
-        expect(norm(ts.stderr), 'stderr').toBe(norm(py.stderr));
-
-        const pyDash = fs.readFileSync(path.join(pyRoot, DASH), 'utf-8');
-        const tsDash = fs.readFileSync(path.join(tsRoot, DASH), 'utf-8');
-        expect(tsDash, 'dashboard bytes').toBe(pyDash);
+    /** Run a regen against `root` and return the written dashboard + run result. */
+    function regen(): { result: SpawnSyncReturns<string>; dashboard: string } {
+        const result = runTs(['--repo-root', root], tmp);
+        const dashPath = path.join(root, DASH);
+        const dashboard = fs.existsSync(dashPath) ? fs.readFileSync(dashPath, 'utf-8') : '';
+        return { result, dashboard };
     }
 
-    /** Run `--check` on both engines against the SAME root (read-only) and compare. */
-    function expectCheckMatch(preRegen: boolean): void {
-        if (preRegen) {
-            // Write a fresh dashboard first so `--check` sees an up-to-date file.
-            runPy(['--repo-root', root], tmp);
-        }
-        const py = runPy(['--repo-root', root, '--check'], tmp);
-        const ts = runTs(['--repo-root', root, '--check'], tmp);
-        expect(ts.status, 'check exit').toBe(py.status);
-        expect(ts.stdout, 'check stdout').toBe(py.stdout);
-        expect(ts.stderr, 'check stderr').toBe(py.stderr);
-    }
-
-    it('regen: mixed states (done/open/deferred/cancelled) byte-identical', () => {
+    it('regen: mixed states (done/open/deferred/cancelled) render the expected sections', () => {
         mkRoadmap(
             'road-to-alpha.md',
             [
@@ -144,10 +95,25 @@ describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)'
             'road-to-beta.md',
             ['# Roadmap: Beta', '', '## Phase A — Track', '- [ ] beta open', ''].join('\n'),
         );
-        expectRegenMatch();
+        const { result, dashboard } = regen();
+        expect(result.status, 'exit').toBe(0);
+        // Generic header (auto-generated banner) is always present.
+        expect(dashboard).toContain('# Roadmap Progress');
+        expect(dashboard).toContain('> Auto-generated — do not edit.');
+        expect(dashboard).toContain('2 open roadmaps');
+        // Overall tally: 2 done of 4 counted steps (50%).
+        expect(dashboard).toContain('**2 / 4 steps done · 50%**');
+        // Both roadmaps listed in the open-roadmaps table.
+        expect(dashboard).toContain('[road-to-alpha.md](roadmaps/road-to-alpha.md)');
+        expect(dashboard).toContain('[road-to-beta.md](roadmaps/road-to-beta.md)');
+        // Per-roadmap phase breakdown reflects the per-phase states.
+        expect(dashboard).toContain('## Per-roadmap phase breakdown');
+        expect(dashboard).toContain('🟡 in progress');
+        expect(dashboard).toContain('✅ done');
+        expect(dashboard).toContain('⬜ not started');
     });
 
-    it('regen: excluded dirs (archive/later/skipped/stubs) + excluded names ignored identically', () => {
+    it('regen: excluded dirs + excluded names never appear in the dashboard', () => {
         mkRoadmap('road-to-live.md', ['# Live', '', '## Phase 1 — Go', '- [x] a', '- [ ] b', ''].join('\n'));
         // None of these may appear in the dashboard.
         mkRoadmap('archive/road-to-old.md', ['# Old', '', '## Phase 1 — X', '- [x] z', ''].join('\n'));
@@ -157,10 +123,25 @@ describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)'
         mkRoadmap('README.md', ['# Readme', '', '## Phase 1 — N', '- [ ] no', ''].join('\n'));
         mkRoadmap('template.md', ['# Template', '', '## Phase 1 — T', '- [ ] tpl', ''].join('\n'));
         mkRoadmap('open-questions.md', ['# OQ', '', '## Phase 1 — O', '- [ ] oq', ''].join('\n'));
-        expectRegenMatch();
+        const { result, dashboard } = regen();
+        expect(result.status, 'exit').toBe(0);
+        // Only the live roadmap is listed.
+        expect(dashboard).toContain('1 open roadmap ');
+        expect(dashboard).toContain('road-to-live.md');
+        for (const excluded of [
+            'road-to-old.md',
+            'road-to-parked.md',
+            'road-to-dropped.md',
+            'road-to-stub.md',
+            'README.md',
+            'template.md',
+            'open-questions.md',
+        ]) {
+            expect(dashboard, `excluded: ${excluded}`).not.toContain(excluded);
+        }
     });
 
-    it('regen: draft frontmatter hidden, ready frontmatter listed — byte-identical', () => {
+    it('regen: draft frontmatter hidden, ready frontmatter listed', () => {
         mkRoadmap(
             'road-to-draft.md',
             ['---', 'status: draft', '---', '# Draft', '', '## Phase 1 — D', '- [ ] hidden', ''].join('\n'),
@@ -169,10 +150,14 @@ describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)'
             'road-to-ready.md',
             ['---', 'status: ready', '---', '# Ready', '', '## Phase 1 — R', '- [x] shown', ''].join('\n'),
         );
-        expectRegenMatch();
+        const { result, dashboard } = regen();
+        expect(result.status, 'exit').toBe(0);
+        expect(dashboard).toContain('1 open roadmap ');
+        expect(dashboard).toContain('road-to-ready.md');
+        expect(dashboard).not.toContain('road-to-draft.md');
     });
 
-    it('regen: roman + letter + numeric-sub phase ids round-trip identically', () => {
+    it('regen: roman + letter + numeric-sub phase ids round-trip into the breakdown', () => {
         mkRoadmap(
             'road-to-ids.md',
             [
@@ -192,10 +177,16 @@ describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)'
                 '',
             ].join('\n'),
         );
-        expectRegenMatch();
+        const { result, dashboard } = regen();
+        expect(result.status, 'exit').toBe(0);
+        // All four phase ids appear in the per-roadmap phase breakdown rows.
+        expect(dashboard).toContain('| 0 | Zero |');
+        expect(dashboard).toContain('| III | Roman |');
+        expect(dashboard).toContain('| 2a | Sub |');
+        expect(dashboard).toContain('| B1 | Letter track |');
     });
 
-    it('regen: merge-gated open item surfaces in dashboard identically', () => {
+    it('regen: merge-gated open item still surfaces as an open step', () => {
         mkRoadmap(
             'road-to-gated.md',
             [
@@ -207,77 +198,88 @@ describe.runIf(py3)('update_roadmap_progress — golden parity (python3 vs tsx)'
                 '',
             ].join('\n'),
         );
-        expectRegenMatch();
+        const { result, dashboard } = regen();
+        expect(result.status, 'exit').toBe(0);
+        expect(dashboard).toContain('road-to-gated.md');
+        // 1 done + 1 open = the gated item counts as open work (not complete).
+        expect(dashboard).toContain('**1 / 2 steps done · 50%**');
     });
 
-    it('regen: no open roadmaps (only excluded) → "_No open roadmaps._" identically', () => {
+    it('regen: no open roadmaps (only excluded) → "_No open roadmaps._"', () => {
         mkRoadmap('archive/road-to-old.md', ['# Old', '', '## Phase 1 — X', '- [x] z', ''].join('\n'));
-        expectRegenMatch();
+        const { result, dashboard } = regen();
+        expect(result.status, 'exit').toBe(0);
+        expect(dashboard).toContain('0 open roadmaps');
+        expect(dashboard).toContain('_No open roadmaps._');
     });
 
-    it('regen: complete-unarchived roadmap emits stderr warning identically', () => {
+    it('regen: complete-unarchived roadmap emits the stderr warning', () => {
         mkRoadmap('road-to-complete.md', ['# Complete', '', '## Phase 1 — All', '- [x] all done', ''].join('\n'));
-        expectRegenMatch();
+        const { result } = regen();
+        expect(result.status, 'exit').toBe(0);
+        // The "Completed — pending archival" banner goes to stderr.
+        expect(result.stderr).toContain('Completed roadmaps not yet archived');
+        expect(result.stderr).toContain('road-to-complete.md');
     });
 
-    it('--check: stale (no dashboard yet) + complete + deferred → exit 1, stderr identical', () => {
+    it('--check: stale (no dashboard yet) + complete + deferred → exit 1 with the markers', () => {
         mkRoadmap('road-to-complete.md', ['# Complete', '', '## Phase 1 — All', '- [x] all done', ''].join('\n'));
         mkRoadmap(
             'road-to-deferred.md',
             ['# Deferred', '', '## Phase 1 — Wait', '- [x] done', '- [~] later', ''].join('\n'),
         );
-        expectCheckMatch(false);
+        const ts = runTs(['--repo-root', root, '--check'], tmp);
+        expect(ts.status, 'check exit').toBe(1);
+        // `--check` diagnostics are written to stderr.
+        expect(ts.stderr, 'stale marker').toContain('is stale');
+        expect(ts.stderr, 'complete-unarchived marker').toContain(
+            'Completed roadmaps are still in `agents/roadmaps/`',
+        );
+        expect(ts.stderr, 'Iron Law 3 marker').toContain('Iron Law 3');
+        expect(ts.stderr).toContain('road-to-complete.md');
+        expect(ts.stderr).toContain('road-to-deferred.md');
     });
 
-    it('--check: up-to-date dashboard (open work) → exit 0 identically', () => {
+    it('--check: up-to-date dashboard (open work) → exit 0', () => {
         mkRoadmap(
             'road-to-active.md',
             ['# Active', '', '## Phase 1 — Go', '- [x] done', '- [ ] todo', ''].join('\n'),
         );
-        expectCheckMatch(true);
+        // Write a fresh dashboard first so `--check` sees an up-to-date file.
+        runTs(['--repo-root', root], tmp);
+        const ts = runTs(['--repo-root', root, '--check'], tmp);
+        expect(ts.status, 'check exit').toBe(0);
+        expect(ts.stdout, 'fresh marker').toContain('is up to date');
     });
 
-    it('--check: no roadmaps directory → exit 0 silent identically', () => {
-        // Point both engines at a root WITHOUT agents/roadmaps.
+    it('--check: no roadmaps directory → exit 0 silent', () => {
         const bare = path.join(tmp, 'bare');
         fs.mkdirSync(bare, { recursive: true });
-        const py = runPy(['--repo-root', bare, '--check'], tmp);
         const ts = runTs(['--repo-root', bare, '--check'], tmp);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(py.status).toBe(0);
+        expect(ts.status, 'check exit').toBe(0);
+        expect(ts.stdout, 'silent stdout').toBe('');
     });
 
-    it('regen: no roadmaps directory → "No roadmaps directory" stdout identically', () => {
+    it('regen: no roadmaps directory → "No roadmaps directory" stdout', () => {
         const bare = path.join(tmp, 'bare2');
         fs.mkdirSync(bare, { recursive: true });
-        const py = runPy(['--repo-root', bare], tmp);
         const ts = runTs(['--repo-root', bare], tmp);
-        expect(ts.status).toBe(py.status);
-        // stdout names the absolute roadmap_root path — normalize the tmp prefix.
-        const norm = (s: string): string => s.split(bare).join('ROOT');
-        expect(norm(ts.stdout)).toBe(norm(py.stdout));
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.status, 'exit').toBe(0);
+        expect(ts.stdout).toContain('No roadmaps directory');
     });
 
-    it('unknown arg → exit 2, usage banner byte-identical', () => {
-        const py = runPy(['--bogus'], tmp);
+    it('unknown arg → exit 2, usage banner on stderr', () => {
         const ts = runTs(['--bogus'], tmp);
-        expect(ts.status, 'exit').toBe(py.status);
-        expect(py.status).toBe(2);
-        expect(ts.stderr, 'stderr').toBe(py.stderr);
-        expect(ts.stdout, 'stdout').toBe(py.stdout);
+        expect(ts.status, 'exit').toBe(2);
+        expect(ts.stderr.split('\n')[0]).toBe(
+            'usage: update_roadmap_progress.py [-h] [--check] [--repo-root REPO_ROOT]',
+        );
+        expect(ts.stderr).toContain('unrecognized arguments: --bogus');
     });
 
-    it('--help → exit 0, usage token present (prose not byte-compared)', () => {
-        const py = runPy(['--help'], tmp);
+    it('--help → exit 0, usage token present', () => {
         const ts = runTs(['--help'], tmp);
-        expect(ts.status, 'exit').toBe(py.status);
-        expect(py.status).toBe(0);
-        // argparse renders a multi-line help body; the twin emits only the
-        // usage line. Assert the exit + the shared usage token, not the prose.
-        expect(py.stdout.includes('usage: update_roadmap_progress.py')).toBe(true);
+        expect(ts.status, 'exit').toBe(0);
         expect(ts.stdout.includes('usage: update_roadmap_progress.py')).toBe(true);
     });
 });


### PR DESCRIPTION
Finishes the python-gated **test-layer elimination** for `road-to-py2ts-teardown-completion`. After #639 purged 21 mixed files, the 4 remaining were *all-parity* (every block byte-compared the tsx CLI vs the **deleted** python CLI; no python-free tests), so a purge would have emptied them and lost all CLI coverage. Per the AI-council ruling (`py2ts-boundary-2026-06-23`): **convert, don't delete** — preserve the contract coverage.

## Converted (47 tests, all green)
- **council_cli.test.ts** — 7 `describe.runIf(py3)` byte-parity blocks → plain python-free intent describes (24 tests): usage/exit-2 on bad args, `--help` exit 0, `estimate` cost-output shape, `render`/`replay`/`quota`/output-path validation. Expected values captured by running the tsx CLI live, not invented.
- **council_prune** (8), **implement_ticket_main** (2), **update_roadmap_progress** (13): single parity blocks → intent tests asserting exit codes, output markers, state-file shape, and (update_roadmap_progress) dashboard sections + `--check` exit codes against the real twin.
- All python plumbing removed. **0 `runIf(py3)` / `runIf(PY)` repo-wide.** (2 parallel subagents, each self-verified.)

## Coupled tail — still open in the roadmap, NOT claimed done
Retire the `python-free-env.ts` shim + the 2 live-`python3` harness sites (`lint_regression.ts`, `parity/replay.ts` — `lint_regression.test.ts` still drives the python baseline harness) + the 3 scaffolding workflows. These need a full python-free `vitest run` as the green-by-construction gate and are deliberately the next focused step, not rushed.

Docs: roadmap Phase-1 reconciled (all 25 gated files eliminated) + dashboard. `check-refs` / `roadmap-progress-check` green; branch name avoids the stale `py2ts-base-guard`.