### PR TITLE
test(py2ts): de-pythonize the workspace_* + work_engine parity-rig clusters (33 files)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**62 / 136 steps done · 46%**
+**63 / 137 steps done · 46%**
 
 ```text
 ██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
@@ -16,7 +16,7 @@
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 19 | 13 | 6 | 0 | 0 | ███░░░░░░░ 32% |
+| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 20 | 13 | 7 | 0 | 0 | ████░░░░░░ 35% |
 | 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 11 | 50 | 50 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
@@ -26,12 +26,12 @@
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 
-**Road to py2ts Teardown Completion** — 6 / 19 done (32%)
+**Road to py2ts Teardown Completion** — 7 / 20 done (35%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Pre-flight gates (block Phase 1) — council-mandated | ✅ done | 0 | 2 | 0 | 0 | 100% |
-| 1 | Purge the remaining live-python test layer | 🟡 in progress | 3 | 2 | 0 | 0 | 40% |
+| 1 | Purge the remaining live-python test layer | 🟡 in progress | 3 | 3 | 0 | 0 | 50% |
 | 2 | CI + scaffolding cleanup (requires Phase 1 complete) | 🟡 in progress | 4 | 2 | 0 | 0 | 33% |
 | 2b | AI-council live-call layer (py2ts gap — transport now wired) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 3 | Consumer + merge readiness | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**63 / 137 steps done · 46%**
+**64 / 138 steps done · 46%**
 
 ```text
 ██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
@@ -16,7 +16,7 @@
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 20 | 13 | 7 | 0 | 0 | ████░░░░░░ 35% |
+| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
 | 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 11 | 50 | 50 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
@@ -26,12 +26,12 @@
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 
-**Road to py2ts Teardown Completion** — 7 / 20 done (35%)
+**Road to py2ts Teardown Completion** — 8 / 21 done (38%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Pre-flight gates (block Phase 1) — council-mandated | ✅ done | 0 | 2 | 0 | 0 | 100% |
-| 1 | Purge the remaining live-python test layer | 🟡 in progress | 3 | 3 | 0 | 0 | 50% |
+| 1 | Purge the remaining live-python test layer | 🟡 in progress | 3 | 4 | 0 | 0 | 57% |
 | 2 | CI + scaffolding cleanup (requires Phase 1 complete) | 🟡 in progress | 4 | 2 | 0 | 0 | 33% |
 | 2b | AI-council live-call layer (py2ts gap — transport now wired) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 3 | Consumer + merge readiness | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-py2ts-teardown-completion.md
+++ b/agents/roadmaps/road-to-py2ts-teardown-completion.md
@@ -118,6 +118,18 @@ stay open below — not force-marked done.
     deleting), **≈108 are sole coverage** (convert to a python-free intent
     test). Both halves still need per-file confirmation; neither is a blind
     batch.
+    - [x] **`cli/python/workspace_*` cluster converted (12 files, 2026-06-23).**
+      `workspace_hosts` (reference) + skills, secrets, roles, sessions,
+      analytics, inbox, documents, crypto, drive_health, render, explain →
+      python-free intent tests. **+346 real passing tests** (were skipped
+      parity blocks); proven python-free (whole cluster green with `python3`
+      shadowed by a failing stub) and regression-stable. Recipe: drop the
+      python side, assert the tsx contract via inline snapshots under a
+      **node-only PATH** (temp dir + lone `node` symlink → deterministic
+      host-CLI detection) + `COLUMNS`, reusing each file's `norm()` masking
+      for clock/random/mtime/tmp-path, and round-trip + structural asserts for
+      randomized crypto. **This recipe generalises to the rest of the
+      sole-coverage tail.** Remaining sole-coverage ≈96.
   - **~30 leftover-spawn files** — a python spawn survives in a now-dead helper
     the codemod did not fully prune; finish per-file.
   - **2 woven-describe files** (`validate_frontmatter`, `ai_council/events_log`)

--- a/agents/roadmaps/road-to-py2ts-teardown-completion.md
+++ b/agents/roadmaps/road-to-py2ts-teardown-completion.md
@@ -129,7 +129,22 @@ stay open below — not force-marked done.
       host-CLI detection) + `COLUMNS`, reusing each file's `norm()` masking
       for clock/random/mtime/tmp-path, and round-trip + structural asserts for
       randomized crypto. **This recipe generalises to the rest of the
-      sole-coverage tail.** Remaining sole-coverage ≈96.
+      sole-coverage tail.**
+    - [x] **`work_engine/*` cluster de-pythonized (21 files, 2026-06-23).**
+      Mixed files (parity block + real TS-side tests) had only the python parity
+      block + dead `hasPython3`/`runPy`/`PY_SCRIPT` helpers removed (coverage
+      kept); pure in-process rigs (`cli`, `directives_backend_analyze` + the 5
+      `directives_backend_*`) converted to intent tests asserting the tsx
+      module's own `run()` output. work_engine dir: 560 pass / 60 skip,
+      identical with python3 stubbed (python-free). **Still deferred in
+      work_engine:** `_hooks_pyloader.ts` (shared helper imported by 11
+      `hooks_*` tests — neutralise only after those consumers are converted) +
+      4 files an interrupted subagent never reached
+      (`directives_backend_test`, `directives_backend_verify`,
+      `directives_init`, `directives_mixed_init` — all MIXED, same purge recipe).
+    - Remaining spawn-file tail after these two clusters: ~99 (was 144 − 12
+      workspace − 21 work_engine − the 12/21 overlap already counted; recompute
+      via `git grep -lE "spawnSync\\(['\"]python3?['\"]" -- 'tests/**'`).
   - **~30 leftover-spawn files** — a python spawn survives in a now-dead helper
     the codemod did not fully prune; finish per-file.
   - **2 woven-describe files** (`validate_frontmatter`, `ai_council/events_log`)

--- a/tests/scripts/cli/python/__snapshots__/workspace_documents.test.ts.snap
+++ b/tests/scripts/cli/python/__snapshots__/workspace_documents.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`workspace_documents — argparse errors > create -h usage line 1`] = `
+"usage: workspace_documents create [-h] --type TYPE --title TITLE --body-file
+                                  BODY_FILE [--role ROLE] [--session SESSION]
+                                  [--prompt PROMPT]"
+`;
+
+exports[`workspace_documents — argparse errors > decrypt-all -h usage line 1`] = `"usage: workspace_documents decrypt-all [-h] [--root ROOT]"`;
+
+exports[`workspace_documents — argparse errors > export -h usage line 1`] = `"usage: workspace_documents export [-h] --to TO [--format FORMAT] type slug"`;
+
+exports[`workspace_documents — argparse errors > list -h usage line 1`] = `
+"usage: workspace_documents list [-h] [--type TYPE] [--role ROLE]
+                                [--limit LIMIT] [--root ROOT] [--json]"
+`;
+
+exports[`workspace_documents — argparse errors > migrate -h usage line 1`] = `"usage: workspace_documents migrate [-h] [--root ROOT]"`;
+
+exports[`workspace_documents — argparse errors > read -h usage line 1`] = `"usage: workspace_documents read [-h] type slug"`;
+
+exports[`workspace_documents — argparse errors > rekey -h usage line 1`] = `"usage: workspace_documents rekey [-h] [--root ROOT]"`;
+
+exports[`workspace_documents — argparse errors > save -h usage line 1`] = `
+"usage: workspace_documents save [-h] --body-file BODY_FILE [--actor ACTOR]
+                                type slug"
+`;

--- a/tests/scripts/cli/python/workspace_analytics.test.ts
+++ b/tests/scripts/cli/python/workspace_analytics.test.ts
@@ -1,40 +1,42 @@
-// Golden-parity tests for src/cli/python/workspace_analytics.ts (py2ts ADR-200
-// — local-only workspace analytics, local-analytics.md).
+// Intent tests for src/cli/python/workspace_analytics.ts (py2ts ADR-200 —
+// local-only workspace analytics, local-analytics.md).
 //
-// Strategy: run `python3 workspace_analytics.py` vs `tsx workspace_analytics.ts`
-// and byte-compare stdout / stderr / exit. The CLI has NO `--root`/`--path`
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. The CLI has NO `--root`/`--path`
 // flag — every subcommand reads/writes `$HOME/.event4u/.../analytics/
-// events.jsonl` — so each language runs under a SEPARATE hermetic `HOME` and
-// `norm()` masks the only nondeterministic surface (the per-record `ts` UTC
-// second). The `show` report otherwise renders deterministically (top-prompts,
-// round-half-to-even completion %, divmod session length, CSV `\r\n`, JSON
-// `indent=2`). The opt-out gate is driven from a `.agent-settings.yml` in the
-// run CWD.
+// events.jsonl` — so each case runs under a hermetic `HOME` and a neutral CWD
+// (no `.agent-settings.yml` → analytics on, encryption off). `norm()` masks the
+// only nondeterministic surface (the per-record `ts` UTC second); the `show`
+// report otherwise renders deterministically (top-prompts, round-half-to-even
+// completion %, divmod session length, CSV `\r\n`, JSON `indent=2`).
 //
-// Encryption-at-rest defaults OFF (no `.agent-settings.yml → encrypt_at_rest`
-// in the run CWD): migrate raises (exit 1 both sides), decrypt-all is a
-// crypto-free `{decrypted: 0}` — both deterministic. The `--help` BODY is NOT
-// byte-compared (only the `usage:` line); Python runs force COLUMNS=80.
+// Each case spawns with a **node-only PATH** (a temp dir holding just a `node`
+// symlink) so any host-CLI probing is deterministic, plus COLUMNS=200 so
+// arg-error/usage stderr does not re-wrap to terminal width. The `--help` BODY
+// is NOT snapshotted (only the `usage:` line). Encryption-at-rest defaults OFF:
+// migrate raises (exit 1), decrypt-all is a crypto-free `{decrypted: N}` — both
+// deterministic.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_analytics.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_analytics.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic host-CLI detection (nothing but `node` resolves).
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wsan-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    fs.rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface RunResult {
     status: number | null;
@@ -42,32 +44,14 @@ interface RunResult {
     stderr: string;
 }
 
-const COLS80 = { COLUMNS: '80' };
-
-let pyHome: string;
 let tsHome: string;
 let cwd: string;
-
-function runPy(args: string[], extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        cwd,
-        env: {
-            ...process.env,
-            HOME: pyHome,
-            PYTHONPATH: path.join(REPO_ROOT, 'src'),
-            ...COLS80,
-            ...extraEnv,
-        },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
 
 function runTs(args: string[], extraEnv: Record<string, string> = {}): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         encoding: 'utf8',
         cwd,
-        env: { ...process.env, HOME: tsHome, ...COLS80, ...extraEnv },
+        env: { ...process.env, HOME: tsHome, PATH: NODE_ONLY_DIR, COLUMNS: '200', ...extraEnv },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
@@ -77,15 +61,7 @@ function norm(text: string): string {
     return text.replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/g, '<TS>');
 }
 
-/** Byte-exact parity for deterministic surfaces (no HOME-dependent state). */
-function expectParityExact(args: string[], extraEnv: Record<string, string> = {}): void {
-    const p = runPy(args, extraEnv);
-    const t = runTs(args, extraEnv);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
-}
-
+/** Compare only the `usage:` portion of a `-h` run (help body not snapshotted). */
 function usageOnly(text: string): string {
     const out: string[] = [];
     for (const line of text.split('\n')) {
@@ -95,182 +71,316 @@ function usageOnly(text: string): string {
     return out.join('\n');
 }
 
-/** Emit the SAME event into both stores (each under its own HOME). */
-function emitBoth(event: string, data: string[]): void {
-    const args = ['emit', event, ...data.flatMap((d) => ['--data', d])];
-    runPy(args);
-    runTs(args);
+/** Emit an event into the store (under the active HOME). */
+function emit(event: string, data: string[]): void {
+    runTs(['emit', event, ...data.flatMap((d) => ['--data', d])]);
 }
 
 beforeEach(() => {
-    pyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wsan-py-'));
     tsHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wsan-ts-'));
     // A neutral CWD with NO .agent-settings.yml → analytics on, encryption off.
     cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'wsan-cwd-'));
 });
 afterEach(() => {
-    fs.rmSync(pyHome, { recursive: true, force: true });
     fs.rmSync(tsHome, { recursive: true, force: true });
     fs.rmSync(cwd, { recursive: true, force: true });
 });
 
-describe.skipIf(!py3)('workspace_analytics — emit', () => {
+describe('workspace_analytics — emit', () => {
     it('emit a valid event → exit 0, no output', () => {
-        const p = runPy(['emit', 'launcher.opened', '--data', 'role=sales']);
         const t = runTs(['emit', 'launcher.opened', '--data', 'role=sales']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout);
-        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toMatchInlineSnapshot(`0`);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(t.stderr).toMatchInlineSnapshot(`""`);
     });
 
     it('emit an unknown event → stderr + exit 1', () => {
-        const p = runPy(['emit', 'bogus.event']);
         const t = runTs(['emit', 'bogus.event']);
-        expect(t.status).toBe(p.status); // 1 / 1
-        expect(t.stdout).toBe(p.stdout);
-        expect(t.stderr).toBe(p.stderr); // names the rejected event
+        expect(t.status).toMatchInlineSnapshot(`1`);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(t.stderr).toMatchInlineSnapshot(`
+          "workspace_analytics: rejecting unknown event 'bogus.event'
+          "
+        `); // names the rejected event
     });
 
     it('emit with a bad --data (no =) → SystemExit string + exit 1', () => {
-        expectParityExact(['emit', 'launcher.opened', '--data', 'novalue']);
+        expect(runTs(['emit', 'launcher.opened', '--data', 'novalue'])).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "--data expects key=value, got 'novalue'
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('emit under env opt-out → exit 1 (no write)', () => {
-        const env = { AGENT_CONFIG_NO_LOCAL_ANALYTICS: '1' };
-        const p = runPy(['emit', 'launcher.opened'], env);
-        const t = runTs(['emit', 'launcher.opened'], env);
-        expect(t.status).toBe(p.status); // 1 / 1
-        expect(t.stdout).toBe(p.stdout);
-        expect(t.stderr).toBe(p.stderr);
+        const t = runTs(['emit', 'launcher.opened'], { AGENT_CONFIG_NO_LOCAL_ANALYTICS: '1' });
+        expect(t.status).toMatchInlineSnapshot(`1`);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(t.stderr).toMatchInlineSnapshot(`""`);
     });
 
     it('emit under settings opt-out (analytics.local: off) → exit 1', () => {
         fs.writeFileSync(path.join(cwd, '.agent-settings.yml'), 'analytics:\n  local: off\n');
-        const p = runPy(['emit', 'launcher.opened']);
         const t = runTs(['emit', 'launcher.opened']);
-        expect(t.status).toBe(p.status); // 1 / 1
+        expect(t.status).toMatchInlineSnapshot(`1`);
     });
 });
 
-describe.skipIf(!py3)('workspace_analytics — show', () => {
+describe('workspace_analytics — show', () => {
     it('markdown report (top prompts, completion %, session length)', () => {
-        emitBoth('launcher.task_launched', ['role=sales', 'task=offer']);
-        emitBoth('launcher.task_launched', ['role=sales', 'task=offer']);
-        emitBoth('launcher.task_launched', ['role=support', 'task=reply']);
-        emitBoth('session.completed', ['role=sales', 'duration_ms=90000']);
-        emitBoth('knowledge.source_clicked', ['source=docA']);
-        const p = runPy(['show', '--window', '30d']);
+        emit('launcher.task_launched', ['role=sales', 'task=offer']);
+        emit('launcher.task_launched', ['role=sales', 'task=offer']);
+        emit('launcher.task_launched', ['role=support', 'task=reply']);
+        emit('session.completed', ['role=sales', 'duration_ms=90000']);
+        emit('knowledge.source_clicked', ['source=docA']);
         const t = runTs(['show', '--window', '30d']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "# Workspace analytics — last 30d
+
+          ## Top prompts
+
+          - \`sales\` · \`offer\` — 2
+          - \`support\` · \`reply\` — 1
+
+          ## Launcher → completion rate per role
+
+          - \`sales\` — 50% (2 launched · 1 completed)
+          - \`support\` — 0% (1 launched · 0 completed)
+
+          **Average session length:** 1m 30s
+
+          **Knowledge sources clicked:** 1
+          _(docA)_
+          "
+        `);
     });
 
     it('markdown report on an empty store', () => {
-        const p = runPy(['show']);
         const t = runTs(['show']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "# Workspace analytics — last 30d
+
+          _No events recorded in this window._
+          "
+        `);
     });
 
     it('round-half-to-even completion percentage (3 launched, 2 completed → 67%)', () => {
-        for (let i = 0; i < 3; i += 1) emitBoth('launcher.task_launched', ['role=r', 'task=t']);
-        for (let i = 0; i < 2; i += 1) emitBoth('session.completed', ['role=r']);
-        const p = runPy(['show']);
+        for (let i = 0; i < 3; i += 1) emit('launcher.task_launched', ['role=r', 'task=t']);
+        for (let i = 0; i < 2; i += 1) emit('session.completed', ['role=r']);
         const t = runTs(['show']);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "# Workspace analytics — last 30d
+
+          ## Top prompts
+
+          - \`r\` · \`t\` — 3
+
+          ## Launcher → completion rate per role
+
+          - \`r\` — 67% (3 launched · 2 completed)
+
+          **Knowledge sources clicked:** 0
+          "
+        `);
     });
 
     it('csv format (\\r\\n rows, header)', () => {
-        emitBoth('launcher.task_launched', ['role=sales', 'task=offer']);
-        emitBoth('session.completed', ['role=sales', 'duration_ms=60000', 'host_tier=tier-1']);
-        const p = runPy(['show', '--format', 'csv']);
+        emit('launcher.task_launched', ['role=sales', 'task=offer']);
+        emit('session.completed', ['role=sales', 'duration_ms=60000', 'host_tier=tier-1']);
         const t = runTs(['show', '--format', 'csv']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "ts,event,role,task,host_tier,duration_ms
+          <TS>,launcher.task_launched,sales,offer,,
+          <TS>,session.completed,sales,,tier-1,60000
+          "
+        `);
         expect(t.stdout).toContain('\r\n'); // csv.writer line terminator
     });
 
     it('json format (indent=2, insertion-order keys)', () => {
-        emitBoth('launcher.task_launched', ['role=sales', 'task=offer', 'duration_ms=5']);
-        const p = runPy(['show', '--format', 'json']);
+        emit('launcher.task_launched', ['role=sales', 'task=offer', 'duration_ms=5']);
         const t = runTs(['show', '--format', 'json']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "[
+            {
+              "ts": "<TS>",
+              "event": "launcher.task_launched",
+              "data": {
+                "duration_ms": 5,
+                "role": "sales",
+                "task": "offer"
+              }
+            }
+          ]"
+        `);
     });
 
     it('--event filter', () => {
-        emitBoth('launcher.task_launched', ['role=a', 'task=x']);
-        emitBoth('session.completed', ['role=a']);
-        const p = runPy(['show', '--format', 'json', '--event', 'session.completed']);
+        emit('launcher.task_launched', ['role=a', 'task=x']);
+        emit('session.completed', ['role=a']);
         const t = runTs(['show', '--format', 'json', '--event', 'session.completed']);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "[
+            {
+              "ts": "<TS>",
+              "event": "session.completed",
+              "data": {
+                "role": "a"
+              }
+            }
+          ]"
+        `);
     });
 
     it('--role filter', () => {
-        emitBoth('launcher.task_launched', ['role=a', 'task=x']);
-        emitBoth('launcher.task_launched', ['role=b', 'task=y']);
-        const p = runPy(['show', '--format', 'csv', '--role', 'a']);
+        emit('launcher.task_launched', ['role=a', 'task=x']);
+        emit('launcher.task_launched', ['role=b', 'task=y']);
         const t = runTs(['show', '--format', 'csv', '--role', 'a']);
-        expect(norm(t.stdout)).toBe(norm(p.stdout));
+        expect(norm(t.stdout)).toMatchInlineSnapshot(`
+          "ts,event,role,task,host_tier,duration_ms
+          <TS>,launcher.task_launched,a,x,,
+          "
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_analytics — prune + encryption defaults', () => {
+describe('workspace_analytics — prune + encryption defaults', () => {
     it('prune an empty store → "pruned 0 event(s)"', () => {
-        const p = runPy(['prune']);
         const t = runTs(['prune']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout);
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "pruned 0 event(s)
+          "
+        `);
     });
 
     it('prune keeps recent events → "pruned 0 event(s)"', () => {
-        emitBoth('launcher.opened', ['role=r']);
-        const p = runPy(['prune']);
+        emit('launcher.opened', ['role=r']);
         const t = runTs(['prune']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // 0 dropped (just emitted)
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "pruned 0 event(s)
+          "
+        `); // 0 dropped (just emitted)
     });
 
-    it('migrate with encryption off → exit 1 (RuntimeError both sides)', () => {
-        emitBoth('launcher.opened', ['role=r']);
-        const p = runPy(['migrate']);
+    it('migrate with encryption off → exit 1 (RuntimeError)', () => {
+        emit('launcher.opened', ['role=r']);
         const t = runTs(['migrate']);
-        expect(t.status).toBe(p.status); // 1 / 1
+        expect(t.status).toMatchInlineSnapshot(`1`);
     });
 
-    it('decrypt-all on plaintext → {"decrypted": N} (crypto-free, same count)', () => {
-        emitBoth('launcher.opened', ['role=r']);
-        emitBoth('session.completed', ['role=r']);
-        const p = runPy(['decrypt-all']);
+    it('decrypt-all on plaintext → {"decrypted": N} (crypto-free)', () => {
+        emit('launcher.opened', ['role=r']);
+        emit('session.completed', ['role=r']);
         const t = runTs(['decrypt-all']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // {"decrypted": 2}
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "{"decrypted": 2}
+          "
+        `); // {"decrypted": 2}
     });
 });
 
-describe.skipIf(!py3)('workspace_analytics — argparse errors', () => {
+describe('workspace_analytics — argparse errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParityExact([]);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_analytics [-h]
+                                     {emit,show,prune,migrate,decrypt-all,rekey} ...
+          workspace_analytics: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParityExact(['bogus']);
+        expect(runTs(['bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_analytics [-h]
+                                     {emit,show,prune,migrate,decrypt-all,rekey} ...
+          workspace_analytics: error: argument cmd: invalid choice: 'bogus' (choose from 'emit', 'show', 'prune', 'migrate', 'decrypt-all', 'rekey')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('show bad --window → invalid choice, exit 2', () => {
-        expectParityExact(['show', '--window', '99d']);
+        expect(runTs(['show', '--window', '99d'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_analytics show [-h] [--window {24h,30d,7d}] [--event EVENT]
+                                          [--role ROLE] [--format {markdown,csv,json}]
+          workspace_analytics show: error: argument --window: invalid choice: '99d' (choose from '24h', '30d', '7d')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('show bad --format → invalid choice, exit 2', () => {
-        expectParityExact(['show', '--format', 'xml']);
+        expect(runTs(['show', '--format', 'xml'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_analytics show [-h] [--window {24h,30d,7d}] [--event EVENT]
+                                          [--role ROLE] [--format {markdown,csv,json}]
+          workspace_analytics show: error: argument --format: invalid choice: 'xml' (choose from 'markdown', 'csv', 'json')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('emit missing event → required, exit 2', () => {
-        expectParityExact(['emit']);
+        expect(runTs(['emit'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_analytics emit [-h] [--data K=V] event
+          workspace_analytics emit: error: the following arguments are required: event
+          ",
+            "stdout": "",
+          }
+        `);
     });
-    it.each([['emit'], ['show'], ['prune'], ['migrate'], ['decrypt-all'], ['rekey']])(
-        '%s -h usage line byte-matches',
-        (sub) => {
-            const p = runPy([sub, '-h']);
-            const t = runTs([sub, '-h']);
-            expect(t.status).toBe(p.status); // 0 / 0
-            expect(usageOnly(t.stdout)).toBe(usageOnly(p.stdout));
-        },
-    );
+    it('emit -h usage line', () => {
+        const t = runTs(['emit', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_analytics emit [-h] [--data K=V] event"`);
+    });
+    it('show -h usage line', () => {
+        const t = runTs(['show', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`
+          "usage: workspace_analytics show [-h] [--window {24h,30d,7d}] [--event EVENT]
+                                          [--role ROLE] [--format {markdown,csv,json}]"
+        `);
+    });
+    it('prune -h usage line', () => {
+        const t = runTs(['prune', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_analytics prune [-h]"`);
+    });
+    it('migrate -h usage line', () => {
+        const t = runTs(['migrate', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_analytics migrate [-h]"`);
+    });
+    it('decrypt-all -h usage line', () => {
+        const t = runTs(['decrypt-all', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_analytics decrypt-all [-h]"`);
+    });
+    it('rekey -h usage line', () => {
+        const t = runTs(['rekey', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_analytics rekey [-h]"`);
+    });
 });

--- a/tests/scripts/cli/python/workspace_crypto.test.ts
+++ b/tests/scripts/cli/python/workspace_crypto.test.ts
@@ -1,34 +1,26 @@
-// Golden-parity tests for src/cli/python/workspace_crypto.ts (py2ts ADR-200 —
-// the workspace encryption-at-rest CLI, ADR-062 / ADR-064).
+// Intent tests for src/cli/python/workspace_crypto.ts (py2ts ADR-200 — the
+// workspace encryption-at-rest CLI, ADR-062 / ADR-064).
 //
-// Strategy: run `python3 src/cli/python/workspace_crypto.py` vs
-// `tsx src/cli/python/workspace_crypto.ts` and byte-compare stdout / stderr /
-// exit. The CLI surfaces that DON'T need the crypto library — `status`,
-// `rotate-key` json output, `is_enabled` parsing, arg/usage errors — are pure
-// byte-parity. The argparse `--help` BODY is NOT byte-compared (only the
-// `usage:` line) per the porting contract.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. Every case spawns the tsx
+// launcher with a **node-only PATH** (a temp dir holding just a `node` symlink)
+// so the runner's installed CLIs cannot leak into behaviour, and COLUMNS=200 so
+// argparse usage/error lines never re-wrap to terminal width.
 //
-// Crypto parity is NOT a byte-equal-output assertion: the nonce is random
-// (`secrets.token_bytes(12)` / `crypto.randomBytes(12)`), so two encrypt runs
-// NEVER produce the same envelope. The real byte-parity proof for crypto is
-// cross-language ENVELOPE INTEROP: ts-encrypt then py-DECRYPT round-trips to the
-// original plaintext, AND py-encrypt then ts-decrypt round-trips — using a
-// shared `AGENT_CONFIG_WORKSPACE_KEY` env so both languages resolve the same
-// key. Plus a fixed assertion on the `AC1\0\x01` envelope header. These crypto
-// cases are GUARDED on python3 having the `cryptography` package importable;
-// when it is absent the Python encrypt/decrypt subcommands raise a RuntimeError
-// and cross-decrypt is impossible, so those cases skip (the non-crypto cases
-// still run).
-//
-// DOCUMENTED DIVERGENCE — master-key resolution. Python's order is
-// override → env → keyring → file; Node has no keyring binding (keyring branch
-// unavailable → file path). To make py and ts agree we force the explicit-key
-// path with a shared `AGENT_CONFIG_WORKSPACE_KEY`. `rotate-key` and the file
-// fallback are exercised with `HOME` pointed at a temp dir so the real
-// `~/.event4u` is never touched.
+// Determinism for crypto: AES-256-GCM uses a random 96-bit nonce
+// (`crypto.randomBytes(12)`), so two encrypt runs NEVER produce the same
+// envelope — raw ciphertext is therefore NEVER snapshotted. Crypto cases assert
+// the ROUND-TRIP contract instead (encrypt → decrypt → original plaintext) plus
+// structural invariants (exit codes, the fixed `AC1\0\x01` envelope header,
+// plaintext pass-through). A shared explicit `AGENT_CONFIG_WORKSPACE_KEY` forces
+// the same master key for encrypt and decrypt; HOME is pointed at a temp dir so
+// the real ~/.event4u key store is never touched by rotate-key / file fallback.
+// All assertions here are reproducible on any machine at any run.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import { mkdtempSync, symlinkSync } from 'node:fs';
 import * as os from 'node:os';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -45,28 +37,15 @@ const REPO_ROOT = path.resolve(
     '..',
 );
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_crypto.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_crypto.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
-
-function hasCryptography(): boolean {
-    if (!py3) return false;
-    const r = spawnSync(
-        'python3',
-        ['-c', 'from cryptography.hazmat.primitives.ciphers.aead import AESGCM'],
-        { encoding: 'utf8' },
-    );
-    return r.status === 0;
-}
-const crypto = hasCryptography();
+// node-only PATH → no installed CLI leaks into behaviour (only `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(path.join(tmpdir(), 'wscrypto-nodeonly-'));
+symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
 
 interface RunResult {
     status: number | null;
@@ -74,35 +53,13 @@ interface RunResult {
     stderr: string;
 }
 
-function runPy(args: string[], cwd: string, extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[], cwd: string, extraEnv: Record<string, string> = {}): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         cwd,
         encoding: 'utf8',
-        env: { ...process.env, ...extraEnv },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200', ...extraEnv },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
-/** Assert py and ts agree byte-for-byte + same exit, for a single invocation. */
-function expectParity(
-    args: string[],
-    cwd: string,
-    extraEnv: Record<string, string> = {},
-): void {
-    const p = runPy(args, cwd, extraEnv);
-    const t = runTs(args, cwd, extraEnv);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
 }
 
 // ---------------------------------------------------------------------------
@@ -125,187 +82,327 @@ function writeSettings(body: string): void {
     fs.writeFileSync(path.join(tmp, '.agent-settings.yml'), body);
 }
 
-const d = py3 ? describe : describe.skip;
-
 // ---------------------------------------------------------------------------
-// status — is_enabled parsing (no crypto library required)
+// status — is_enabled parsing (no crypto key required)
 // ---------------------------------------------------------------------------
 
-d('workspace_crypto — status / is_enabled', () => {
+describe('workspace_crypto — status / is_enabled', () => {
     it('no settings file → enabled false', () => {
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": false}
+          ",
+          }
+        `);
     });
 
     it('workspace.encrypt_at_rest: on → enabled true', () => {
         writeSettings('workspace:\n  encrypt_at_rest: on\n');
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 
     it('encrypt_at_rest: true → enabled true', () => {
         writeSettings('workspace:\n  encrypt_at_rest: true\n');
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 
     it('quoted yes value → enabled true', () => {
         writeSettings("workspace:\n  encrypt_at_rest: 'yes'\n");
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 
     it('encrypt_at_rest: 1 → enabled true', () => {
         writeSettings('workspace:\n  encrypt_at_rest: 1\n');
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 
     it('encrypt_at_rest: off → enabled false', () => {
         writeSettings('workspace:\n  encrypt_at_rest: off\n');
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": false}
+          ",
+          }
+        `);
     });
 
     it('key outside the workspace block is ignored → enabled false', () => {
         writeSettings('other:\n  encrypt_at_rest: on\nworkspace:\n  foo: bar\n');
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": false}
+          ",
+          }
+        `);
     });
 
     it('comments + blank lines are skipped', () => {
         writeSettings('# header\n\nworkspace:\n  # inner comment\n  encrypt_at_rest: on\n');
-        expectParity(['status'], tmp);
+        expect(runTs(['status'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 
     it('AGENT_CONFIG_NO_ENCRYPTION force-disables even when settings say on', () => {
         writeSettings('workspace:\n  encrypt_at_rest: on\n');
-        expectParity(['status'], tmp, { AGENT_CONFIG_NO_ENCRYPTION: '1' });
+        expect(runTs(['status'], tmp, { AGENT_CONFIG_NO_ENCRYPTION: '1' })).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": false}
+          ",
+          }
+        `);
     });
 
     it('AGENT_CONFIG_NO_ENCRYPTION=0 does NOT force-disable', () => {
         writeSettings('workspace:\n  encrypt_at_rest: on\n');
-        expectParity(['status'], tmp, { AGENT_CONFIG_NO_ENCRYPTION: '0' });
+        expect(runTs(['status'], tmp, { AGENT_CONFIG_NO_ENCRYPTION: '0' })).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 
     it('AGENT_CONFIG_NO_ENCRYPTION empty does NOT force-disable', () => {
         writeSettings('workspace:\n  encrypt_at_rest: on\n');
-        expectParity(['status'], tmp, { AGENT_CONFIG_NO_ENCRYPTION: '' });
+        expect(runTs(['status'], tmp, { AGENT_CONFIG_NO_ENCRYPTION: '' })).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"enabled": true}
+          ",
+          }
+        `);
     });
 });
 
 // ---------------------------------------------------------------------------
-// rotate-key — json output (no crypto library required; HOME redirected)
+// rotate-key — json output (HOME redirected so the real keyfile is untouched)
 // ---------------------------------------------------------------------------
 
-d('workspace_crypto — rotate-key', () => {
+describe('workspace_crypto — rotate-key', () => {
     it('emits {"rotated": true} and exits 0', () => {
-        expectParity(['rotate-key'], tmp, { HOME: home });
+        expect(runTs(['rotate-key'], tmp, { HOME: home })).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"rotated": true}
+          ",
+          }
+        `);
     });
 });
 
 // ---------------------------------------------------------------------------
-// arg / usage errors (no crypto library required)
+// arg / usage errors
 // ---------------------------------------------------------------------------
 
-d('workspace_crypto — arg errors', () => {
+describe('workspace_crypto — arg errors', () => {
     it('no args → required cmd', () => {
-        expectParity([], tmp);
+        expect(runTs([], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto [-h] {encrypt,decrypt,status,rotate-key} ...
+          workspace_crypto: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('invalid choice', () => {
-        expectParity(['bogus'], tmp);
+        expect(runTs(['bogus'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto [-h] {encrypt,decrypt,status,rotate-key} ...
+          workspace_crypto: error: argument cmd: invalid choice: 'bogus' (choose from 'encrypt', 'decrypt', 'status', 'rotate-key')
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('encrypt with no options → required --in, --out', () => {
-        expectParity(['encrypt'], tmp);
+        expect(runTs(['encrypt'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto encrypt [-h] --in SRC --out DST
+          workspace_crypto encrypt: error: the following arguments are required: --in, --out
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('encrypt with only --in → required --out', () => {
-        expectParity(['encrypt', '--in', 'a'], tmp);
+        expect(runTs(['encrypt', '--in', 'a'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto encrypt [-h] --in SRC --out DST
+          workspace_crypto encrypt: error: the following arguments are required: --out
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('decrypt with no options → required --in, --out', () => {
-        expectParity(['decrypt'], tmp);
+        expect(runTs(['decrypt'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto decrypt [-h] --in SRC --out DST
+          workspace_crypto decrypt: error: the following arguments are required: --in, --out
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('encrypt extra positional → unrecognized (top-level)', () => {
-        expectParity(['encrypt', '--in', 'a', '--out', 'b', 'extra'], tmp);
+        expect(runTs(['encrypt', '--in', 'a', '--out', 'b', 'extra'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto [-h] {encrypt,decrypt,status,rotate-key} ...
+          workspace_crypto: error: unrecognized arguments: extra
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('status with extra positional → unrecognized', () => {
-        expectParity(['status', 'foo'], tmp);
+        expect(runTs(['status', 'foo'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto [-h] {encrypt,decrypt,status,rotate-key} ...
+          workspace_crypto: error: unrecognized arguments: foo
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('rotate-key with extra positional → unrecognized', () => {
-        expectParity(['rotate-key', 'foo'], tmp);
+        expect(runTs(['rotate-key', 'foo'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_crypto [-h] {encrypt,decrypt,status,rotate-key} ...
+          workspace_crypto: error: unrecognized arguments: foo
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('top-level -h usage line (body NOT compared)', () => {
-        const p = runPy(['-h'], tmp);
         const t = runTs(['-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+        expect(t.status).toBe(0);
+        expect(t.stdout.split('\n')[0]).toBe(
+            'usage: workspace_crypto [-h] {encrypt,decrypt,status,rotate-key} ...',
+        );
     });
 
     it('encrypt -h usage line (body NOT compared)', () => {
-        const p = runPy(['encrypt', '-h'], tmp);
         const t = runTs(['encrypt', '-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+        expect(t.status).toBe(0);
+        expect(t.stdout.split('\n')[0]).toBe(
+            'usage: workspace_crypto encrypt [-h] --in SRC --out DST',
+        );
     });
 });
 
 // ---------------------------------------------------------------------------
-// crypto interop — cross-language envelope round-trips + envelope header.
-// GUARDED: requires python3 with the `cryptography` package.
+// crypto — round-trip + structural envelope invariants (NO ciphertext snapshot:
+// the random nonce makes raw envelopes non-reproducible).
 // ---------------------------------------------------------------------------
 
-const c = crypto ? describe : describe.skip;
-
-// A fixed, valid base64-of-32-bytes key shared by both languages so they
-// resolve the SAME master key (override the env-key path, never the keyring).
+// A fixed, valid base64-of-32-bytes key so encrypt and decrypt resolve the SAME
+// master key (override the env-key path, never the keyfile).
 const SHARED_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 
-c('workspace_crypto — crypto interop', () => {
+describe('workspace_crypto — crypto', () => {
     it('SHARED_KEY decodes to exactly 32 bytes (test invariant)', () => {
         expect(Buffer.from(SHARED_KEY, 'base64').length).toBe(32);
     });
 
-    it('ts-encrypt → py-decrypt round-trips to original plaintext', () => {
+    it('encrypt → decrypt round-trips to original plaintext', () => {
         const plain = path.join(tmp, 'plain.txt');
         const enc = path.join(tmp, 'ts.enc');
-        const back = path.join(tmp, 'ts-then-py.txt');
+        const back = path.join(tmp, 'ts-then-ts.txt');
         const data = 'cross-language secret 🔐\nline two\n';
         fs.writeFileSync(plain, data);
         const env = { AGENT_CONFIG_WORKSPACE_KEY: SHARED_KEY };
         const e = runTs(['encrypt', '--in', plain, '--out', enc], tmp, env);
-        expect(e.status).toBe(0);
-        const dres = runPy(['decrypt', '--in', enc, '--out', back], tmp, env);
-        expect(dres.status).toBe(0);
-        expect(fs.readFileSync(back, 'utf-8')).toBe(data);
-    });
-
-    it('py-encrypt → ts-decrypt round-trips to original plaintext', () => {
-        const plain = path.join(tmp, 'plain.txt');
-        const enc = path.join(tmp, 'py.enc');
-        const back = path.join(tmp, 'py-then-ts.txt');
-        const data = 'cross-language secret 🔐\nline two\n';
-        fs.writeFileSync(plain, data);
-        const env = { AGENT_CONFIG_WORKSPACE_KEY: SHARED_KEY };
-        const e = runPy(['encrypt', '--in', plain, '--out', enc], tmp, env);
         expect(e.status).toBe(0);
         const dres = runTs(['decrypt', '--in', enc, '--out', back], tmp, env);
         expect(dres.status).toBe(0);
         expect(fs.readFileSync(back, 'utf-8')).toBe(data);
     });
 
-    it('both languages emit the same AC1\\0\\x01 envelope header', () => {
+    it('emits the AC1\\0\\x01 envelope header', () => {
         const plain = path.join(tmp, 'plain.txt');
         fs.writeFileSync(plain, 'header-check');
         const env = { AGENT_CONFIG_WORKSPACE_KEY: SHARED_KEY };
-        const tsEnc = path.join(tmp, 'ts.enc');
-        const pyEnc = path.join(tmp, 'py.enc');
-        runTs(['encrypt', '--in', plain, '--out', tsEnc], tmp, env);
-        runPy(['encrypt', '--in', plain, '--out', pyEnc], tmp, env);
+        const enc = path.join(tmp, 'ts.enc');
+        const e = runTs(['encrypt', '--in', plain, '--out', enc], tmp, env);
+        expect(e.status).toBe(0);
         const header = Buffer.from([0x41, 0x43, 0x31, 0x00, 0x01]); // "AC1\0" + version 1
-        const tsHead = fs.readFileSync(tsEnc).subarray(0, 5);
-        const pyHead = fs.readFileSync(pyEnc).subarray(0, 5);
-        expect(tsHead.equals(header)).toBe(true);
-        expect(pyHead.equals(header)).toBe(true);
+        const head = fs.readFileSync(enc).subarray(0, 5);
+        expect(head.equals(header)).toBe(true);
+    });
+
+    it('two encrypt runs of the same plaintext produce different envelopes (random nonce)', () => {
+        const plain = path.join(tmp, 'plain.txt');
+        fs.writeFileSync(plain, 'nonce-uniqueness');
+        const env = { AGENT_CONFIG_WORKSPACE_KEY: SHARED_KEY };
+        const encA = path.join(tmp, 'a.enc');
+        const encB = path.join(tmp, 'b.enc');
+        expect(runTs(['encrypt', '--in', plain, '--out', encA], tmp, env).status).toBe(0);
+        expect(runTs(['encrypt', '--in', plain, '--out', encB], tmp, env).status).toBe(0);
+        expect(fs.readFileSync(encA).equals(fs.readFileSync(encB))).toBe(false);
     });
 
     it('decrypt passes a plaintext (no-magic) payload through unchanged', () => {
@@ -314,13 +411,8 @@ c('workspace_crypto — crypto interop', () => {
         const data = 'not an envelope — plaintext written when flag off\n';
         fs.writeFileSync(plain, data);
         const env = { AGENT_CONFIG_WORKSPACE_KEY: SHARED_KEY };
-        const ptres = runPy(['decrypt', '--in', plain, '--out', out], tmp, env);
-        const ptOut = fs.readFileSync(out, 'utf-8');
-        const tdres = runTs(['decrypt', '--in', plain, '--out', out], tmp, env);
-        const tOut = fs.readFileSync(out, 'utf-8');
-        expect(ptres.status).toBe(0);
-        expect(tdres.status).toBe(0);
-        expect(ptOut).toBe(data);
-        expect(tOut).toBe(data);
+        const dres = runTs(['decrypt', '--in', plain, '--out', out], tmp, env);
+        expect(dres.status).toBe(0);
+        expect(fs.readFileSync(out, 'utf-8')).toBe(data);
     });
 });

--- a/tests/scripts/cli/python/workspace_documents.test.ts
+++ b/tests/scripts/cli/python/workspace_documents.test.ts
@@ -1,42 +1,47 @@
-// Golden-parity tests for src/cli/python/workspace_documents.ts (py2ts ADR-200
+// Intent tests for src/cli/python/workspace_documents.ts (py2ts ADR-200
 // — local workspace document store, workspace-documents.md).
 //
-// Strategy: run `python3 workspace_documents.py` vs `tsx workspace_documents.ts`
-// and byte-compare stdout / stderr / exit. `create`/`save`/`read`/`export` have
-// NO `--root` flag — they write under `$HOME/.event4u/.../documents/<type>/` —
-// so each language runs under a SEPARATE hermetic `HOME`; `list`/`migrate`/
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. `create`/`save`/`read`/`export`
+// have NO `--root` flag — they write under `$HOME/.event4u/.../documents/
+// <type>/` — so each case runs under a hermetic `HOME`; `list`/`migrate`/
 // `decrypt-all`/`rekey` take an explicit `--root` (`<HOME>/.../documents`).
 // `norm()` masks the nondeterministic surfaces: the `<DAY>` slug suffix
 // (`<today>`), the `created_at`/`last_edited_at` ISO second, the `updated_at`
 // ISO-millis, the float `mtime`, and the HOME tmp root — leaving the structural
-// payload (slug, frontmatter, delta counts, body_sha256, listing shape) a true
-// byte-for-byte assertion. body_sha256 is content-derived, hence identical.
+// payload (slug, frontmatter, delta counts, body_sha256, listing shape) a
+// reproducible assertion. body_sha256 is content-derived, hence stable.
 //
 // Encryption-at-rest defaults OFF (no `.agent-settings.yml → encrypt_at_rest`
-// in the run CWD): migrate raises (exit 1 both sides), decrypt-all is a
-// crypto-free `{decrypted: 0}`. The `--help` BODY is NOT byte-compared (only
-// the `usage:` line); Python runs force COLUMNS=80. pandoc export (pdf/docx) is
+// in the run CWD — each run uses a fresh empty `cwd`): migrate raises (exit 1),
+// decrypt-all is a crypto-free `{decrypted: 0}`. pandoc export (pdf/docx) is
 // NOT exercised — only `md` export, which is pure copy.
+//
+// Every case spawns with a **node-only PATH** (a temp dir holding just a `node`
+// symlink) so the tsx launcher resolves but no host CLI / pandoc does, keeping
+// detection deterministic regardless of the runner. COLUMNS=80 stabilizes
+// usage wrapping.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_documents.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_documents.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic regardless of installed host CLIs / pandoc.
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-docs-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    fs.rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface RunResult {
     status: number | null;
@@ -44,9 +49,6 @@ interface RunResult {
     stderr: string;
 }
 
-const COLS80 = { COLUMNS: '80' };
-
-let pyHome: string;
 let tsHome: string;
 let cwd: string;
 
@@ -54,20 +56,11 @@ function docsRoot(home: string): string {
     return path.join(home, '.event4u', 'agent-config', 'workspace', 'documents');
 }
 
-function runPy(args: string[]): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        cwd,
-        env: { ...process.env, HOME: pyHome, PYTHONPATH: path.join(REPO_ROOT, 'src'), ...COLS80 },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[]): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         encoding: 'utf8',
         cwd,
-        env: { ...process.env, HOME: tsHome, ...COLS80 },
+        env: { ...process.env, HOME: tsHome, PATH: NODE_ONLY_DIR, COLUMNS: '80' },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
@@ -87,14 +80,6 @@ function norm(text: string, home: string): string {
     out = out.replace(/\d{4}-\d{2}-\d{2}/g, '<DAY>'); // slug day suffix
     out = out.replace(/"mtime": [0-9.]+/g, '"mtime": <M>'); // float mtime (if any leaks)
     return out;
-}
-
-function expectParityExact(args: string[]): void {
-    const p = runPy(args);
-    const t = runTs(args);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
 }
 
 function usageOnly(text: string): string {
@@ -118,181 +103,262 @@ function slugOf(stdout: string): string {
 }
 
 beforeEach(() => {
-    pyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wsdoc-py-'));
     tsHome = fs.mkdtempSync(path.join(os.tmpdir(), 'wsdoc-ts-'));
     cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'wsdoc-cwd-')); // no .agent-settings.yml
 });
 afterEach(() => {
-    fs.rmSync(pyHome, { recursive: true, force: true });
     fs.rmSync(tsHome, { recursive: true, force: true });
     fs.rmSync(cwd, { recursive: true, force: true });
 });
 
-describe.skipIf(!py3)('workspace_documents — create + read + save', () => {
+describe('workspace_documents — create + read + save', () => {
     it('create returns {slug, path}; slugify normalizes the title', () => {
-        const pb = bodyFile(pyHome, 'Line one\nLine two\n');
         const tb = bodyFile(tsHome, 'Line one\nLine two\n');
-        const p = runPy(['create', '--type', 'memo', '--title', 'Hello World!', '--body-file', pb, '--role', 'sales']);
         const t = runTs(['create', '--type', 'memo', '--title', 'Hello World!', '--body-file', tb, '--role', 'sales']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, tsHome)).toBe(norm(p.stdout, pyHome));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, tsHome)).toMatchInlineSnapshot(`
+          "{"path": "<H>/.event4u/agent-config/workspace/documents/memo/hello-world-<DAY>.md", "slug": "hello-world-<DAY>"}
+          "
+        `);
     });
 
     it('read returns the document body (frontmatter stripped)', () => {
-        const pb = bodyFile(pyHome, 'Alpha\nBeta\n');
         const tb = bodyFile(tsHome, 'Alpha\nBeta\n');
-        const ps = slugOf(runPy(['create', '--type', 'brief', '--title', 'Doc', '--body-file', pb]).stdout);
         const ts = slugOf(runTs(['create', '--type', 'brief', '--title', 'Doc', '--body-file', tb]).stdout);
-        const p = runPy(['read', 'brief', ps]);
         const t = runTs(['read', 'brief', ts]);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, tsHome)).toBe(norm(p.stdout, pyHome));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, tsHome)).toMatchInlineSnapshot(`
+          "Alpha
+          Beta
+
+          "
+        `);
     });
 
     it('read missing document → stderr + exit 1', () => {
-        const p = runPy(['read', 'memo', 'nope']);
         const t = runTs(['read', 'memo', 'nope']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout);
-        expect(t.stderr).toBe(p.stderr); // names the missing slug (deterministic)
+        expect(t.status).toBe(1);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(norm(t.stderr, tsHome)).toMatchInlineSnapshot(`
+          "no such document: memo/nope
+          "
+        `);
     });
 
     it('save records a revision (added/removed delta + body_sha256)', () => {
-        const pb = bodyFile(pyHome, 'A\nB\n');
         const tb = bodyFile(tsHome, 'A\nB\n');
-        const ps = slugOf(runPy(['create', '--type', 'memo', '--title', 'D', '--body-file', pb]).stdout);
         const ts = slugOf(runTs(['create', '--type', 'memo', '--title', 'D', '--body-file', tb]).stdout);
         const nb = bodyFile(cwd, 'A\nB\nC\nD\n');
-        const p = runPy(['save', 'memo', ps, '--body-file', nb, '--actor', 'user']);
         const t = runTs(['save', 'memo', ts, '--body-file', nb, '--actor', 'user']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, tsHome)).toBe(norm(p.stdout, pyHome));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, tsHome)).toMatchInlineSnapshot(`
+          "{"actor": "user", "body_sha256": "a7f5cf19fdb779272b12bed17134c60d18d464fddfda599b8a70fdc5cab185d1", "delta": {"added": 2, "removed": 0}, "kind": "save", "ts": "<TS>"}
+          "
+        `);
     });
 
     it('save shrinking body records a removed delta', () => {
-        const pb = bodyFile(pyHome, 'one\ntwo\nthree\n');
         const tb = bodyFile(tsHome, 'one\ntwo\nthree\n');
-        const ps = slugOf(runPy(['create', '--type', 'memo', '--title', 'S', '--body-file', pb]).stdout);
         const ts = slugOf(runTs(['create', '--type', 'memo', '--title', 'S', '--body-file', tb]).stdout);
         const nb = bodyFile(cwd, 'one\n');
-        const p = runPy(['save', 'memo', ps, '--body-file', nb]);
         const t = runTs(['save', 'memo', ts, '--body-file', nb]);
-        expect(norm(t.stdout, tsHome)).toBe(norm(p.stdout, pyHome));
+        expect(norm(t.stdout, tsHome)).toMatchInlineSnapshot(`
+          "{"actor": "user", "body_sha256": "2c8b08da5ce60398e1f19af0e5dccc744df274b826abe585eaba68c525434806", "delta": {"added": 0, "removed": 2}, "kind": "save", "ts": "<TS>"}
+          "
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_documents — secret guard', () => {
-    it('high-confidence secret in body → refused, exit 3, identical message', () => {
+describe('workspace_documents — secret guard', () => {
+    it('high-confidence secret in body → refused, exit 3', () => {
         const sec = bodyFile(cwd, 'aws key AKIAIOSFODNN7EXAMPLE here\n');
-        const p = runPy(['create', '--type', 'memo', '--title', 'X', '--body-file', sec]);
         const t = runTs(['create', '--type', 'memo', '--title', 'X', '--body-file', sec]);
         expect(t.status).toBe(3);
-        expect(p.status).toBe(3);
-        expect(t.stdout).toBe(p.stdout); // empty
-        expect(t.stderr).toBe(p.stderr); // "refused — high-confidence secret (aws_access_key) ..."
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(norm(t.stderr, tsHome)).toMatchInlineSnapshot(`
+          "workspace_documents: refused — high-confidence secret (aws_access_key) detected in body; redact it before saving — the document was NOT written
+          "
+        `);
     });
 
     it('fuzzy secret in body → warns on stderr, still writes (normalized)', () => {
-        const pb = bodyFile(pyHome, 'password: hunter2hunter2xx\n');
         const tb = bodyFile(tsHome, 'password: hunter2hunter2xx\n');
-        const p = runPy(['create', '--type', 'memo', '--title', 'F', '--body-file', pb]);
         const t = runTs(['create', '--type', 'memo', '--title', 'F', '--body-file', tb]);
-        expect(t.status).toBe(p.status); // 0 / 0
-        expect(t.stderr).toBe(p.stderr); // identical warning line
-        expect(norm(t.stdout, tsHome)).toBe(norm(p.stdout, pyHome));
+        expect(t.status).toBe(0);
+        expect(norm(t.stderr, tsHome)).toMatchInlineSnapshot(`
+          "workspace_documents: warning — possible secret (kv_secret) in body; review before sharing
+          "
+        `);
+        expect(norm(t.stdout, tsHome)).toMatchInlineSnapshot(`
+          "{"path": "<H>/.event4u/agent-config/workspace/documents/memo/f-<DAY>.md", "slug": "f-<DAY>"}
+          "
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_documents — list + export', () => {
+describe('workspace_documents — list + export', () => {
     it('list --json (single doc, normalized updated_at / mtime)', () => {
-        const pb = bodyFile(pyHome, 'x\n');
         const tb = bodyFile(tsHome, 'x\n');
-        runPy(['create', '--type', 'memo', '--title', 'One', '--body-file', pb, '--role', 'sales']);
         runTs(['create', '--type', 'memo', '--title', 'One', '--body-file', tb, '--role', 'sales']);
-        const p = runPy(['list', '--type', 'memo', '--root', docsRoot(pyHome), '--json']);
         const t = runTs(['list', '--type', 'memo', '--root', docsRoot(tsHome), '--json']);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, tsHome)).toBe(norm(p.stdout, pyHome));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, tsHome)).toMatchInlineSnapshot(`
+          "[{"last_edited_at": "<TS>", "path": "<H>/.event4u/agent-config/workspace/documents/memo/one-<DAY>.md", "role": "sales", "slug": "one-<DAY>", "title": "One", "type": "memo", "updated_at": "<TS>"}]
+          "
+        `);
     });
 
     it('list --role filter (per-line JSON)', () => {
-        const pb = bodyFile(pyHome, 'x\n');
         const tb = bodyFile(tsHome, 'x\n');
-        runPy(['create', '--type', 'memo', '--title', 'Sales', '--body-file', pb, '--role', 'sales']);
         runTs(['create', '--type', 'memo', '--title', 'Sales', '--body-file', tb, '--role', 'sales']);
-        const p = runPy(['list', '--role', 'support', '--root', docsRoot(pyHome)]);
         const t = runTs(['list', '--role', 'support', '--root', docsRoot(tsHome)]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // both empty (filtered out)
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`""`); // empty (filtered out)
     });
 
     it('list empty root → empty', () => {
-        const p = runPy(['list', '--root', docsRoot(pyHome)]);
         const t = runTs(['list', '--root', docsRoot(tsHome)]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout);
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
     });
 
     it('export md writes cleartext (compare exported file content)', () => {
-        const pb = bodyFile(pyHome, 'Exported body\n');
         const tb = bodyFile(tsHome, 'Exported body\n');
-        const ps = slugOf(runPy(['create', '--type', 'memo', '--title', 'E', '--body-file', pb]).stdout);
         const ts = slugOf(runTs(['create', '--type', 'memo', '--title', 'E', '--body-file', tb]).stdout);
-        const pOut = fs.mkdtempSync(path.join(os.tmpdir(), 'exp-py-'));
         const tOut = fs.mkdtempSync(path.join(os.tmpdir(), 'exp-ts-'));
-        runPy(['export', 'memo', ps, '--to', pOut, '--format', 'md']);
         runTs(['export', 'memo', ts, '--to', tOut, '--format', 'md']);
-        const pTxt = fs.readFileSync(path.join(pOut, `${ps}.md`), 'utf8');
         const tTxt = fs.readFileSync(path.join(tOut, `${ts}.md`), 'utf8');
-        expect(norm(tTxt, tsHome)).toBe(norm(pTxt, pyHome));
-        fs.rmSync(pOut, { recursive: true, force: true });
+        expect(norm(tTxt, tsHome)).toMatchInlineSnapshot(`
+          "---
+          type: memo
+          title: E
+          created_at: <TS>
+          last_edited_at: <TS>
+          schema: workspace-document/v0
+          ---
+
+          Exported body
+          "
+        `);
         fs.rmSync(tOut, { recursive: true, force: true });
     });
 });
 
-describe.skipIf(!py3)('workspace_documents — encryption-at-rest defaults (flag off)', () => {
-    it('migrate with flag off → exit 1 (RuntimeError both sides)', () => {
-        const p = runPy(['migrate', '--root', docsRoot(pyHome)]);
+describe('workspace_documents — encryption-at-rest defaults (flag off)', () => {
+    it('migrate with flag off → exit 1 (RuntimeError)', () => {
         const t = runTs(['migrate', '--root', docsRoot(tsHome)]);
-        expect(t.status).toBe(p.status); // 1 / 1
+        expect(t.status).toBe(1);
     });
 
     it('decrypt-all on plaintext store → {"decrypted": 0}', () => {
-        const pb = bodyFile(pyHome, 'x\n');
         const tb = bodyFile(tsHome, 'x\n');
-        runPy(['create', '--type', 'memo', '--title', 'D', '--body-file', pb]);
         runTs(['create', '--type', 'memo', '--title', 'D', '--body-file', tb]);
-        const p = runPy(['decrypt-all', '--root', docsRoot(pyHome)]);
         const t = runTs(['decrypt-all', '--root', docsRoot(tsHome)]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // {"decrypted": 0}
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "{"decrypted": 0}
+          "
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_documents — argparse errors', () => {
+describe('workspace_documents — argparse errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParityExact([]);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents [-h]
+                                     {create,save,list,read,export,migrate,decrypt-all,rekey}
+                                     ...
+          workspace_documents: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParityExact(['bogus']);
+        expect(runTs(['bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents [-h]
+                                     {create,save,list,read,export,migrate,decrypt-all,rekey}
+                                     ...
+          workspace_documents: error: argument cmd: invalid choice: 'bogus' (choose from 'create', 'save', 'list', 'read', 'export', 'migrate', 'decrypt-all', 'rekey')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('create missing required flags → exit 2', () => {
-        expectParityExact(['create']);
+        expect(runTs(['create'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents create [-h] --type TYPE --title TITLE --body-file
+                                            BODY_FILE [--role ROLE] [--session SESSION]
+                                            [--prompt PROMPT]
+          workspace_documents create: error: the following arguments are required: --type, --title, --body-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('save missing positionals + flag → exit 2 (type, slug, --body-file order)', () => {
-        expectParityExact(['save']);
+        expect(runTs(['save'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents save [-h] --body-file BODY_FILE [--actor ACTOR]
+                                          type slug
+          workspace_documents save: error: the following arguments are required: type, slug, --body-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('save missing slug + flag → exit 2', () => {
-        expectParityExact(['save', 'memo']);
+        expect(runTs(['save', 'memo'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents save [-h] --body-file BODY_FILE [--actor ACTOR]
+                                          type slug
+          workspace_documents save: error: the following arguments are required: slug, --body-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('read missing positionals → exit 2', () => {
-        expectParityExact(['read']);
+        expect(runTs(['read'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents read [-h] type slug
+          workspace_documents read: error: the following arguments are required: type, slug
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('export missing positionals + --to → exit 2 (type, slug, --to order)', () => {
-        expectParityExact(['export']);
+        expect(runTs(['export'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents export [-h] --to TO [--format FORMAT] type slug
+          workspace_documents export: error: the following arguments are required: type, slug, --to
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('list bad --limit int → exit 2', () => {
-        expectParityExact(['list', '--limit', 'abc']);
+        expect(runTs(['list', '--limit', 'abc'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_documents list [-h] [--type TYPE] [--role ROLE]
+                                          [--limit LIMIT] [--root ROOT] [--json]
+          workspace_documents list: error: argument --limit: invalid int value: 'abc'
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it.each([
         ['create'],
@@ -303,10 +369,9 @@ describe.skipIf(!py3)('workspace_documents — argparse errors', () => {
         ['migrate'],
         ['decrypt-all'],
         ['rekey'],
-    ])('%s -h usage line byte-matches', (sub) => {
-        const p = runPy([sub, '-h']);
+    ])('%s -h usage line', (sub) => {
         const t = runTs([sub, '-h']);
-        expect(t.status).toBe(p.status); // 0 / 0
-        expect(usageOnly(t.stdout)).toBe(usageOnly(p.stdout));
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchSnapshot();
     });
 });

--- a/tests/scripts/cli/python/workspace_drive_health.test.ts
+++ b/tests/scripts/cli/python/workspace_drive_health.test.ts
@@ -1,35 +1,39 @@
-// Golden-parity tests for src/cli/python/workspace_drive_health.ts (py2ts
-// ADR-200 — the drive-health + kill-switch CLI, ADR-073).
+// Intent tests for src/cli/python/workspace_drive_health.ts (py2ts ADR-200 —
+// the drive-health + kill-switch CLI, ADR-073).
 //
-// Strategy: run `python3 src/cli/python/workspace_drive_health.py` vs
-// `tsx src/cli/python/workspace_drive_health.ts` and byte-compare stdout /
-// stderr / exit. The CLI keeps a tiny per-host JSON cache under
-// `<root>/<host>.json`, so the two languages MUST NOT share a state dir — they
-// would race on the same files. Each parity case therefore replays the SAME
-// command sequence in a SEPARATE per-language temp root, then byte-compares the
-// final outputs.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly via normalized inline snapshots.
+//
+// The CLI keeps a tiny per-host JSON cache under `<root>/<host>.json`, so each
+// test gets its OWN per-test temp health root (beforeEach/afterEach) — no shared
+// state, no cross-test races.
 //
 // `_validate_cli_root` rejects any `--root` whose basename is not `health`, so
 // every root is a `<tmp>/workspace/health` directory.
 //
-// Nondeterminism: `killed_at` / `probe_started_at` carry epoch floats from
-// `time.time()` (py) vs `Date.now()/1000` (ts) — they WILL differ run-to-run
-// and language-to-language. The `norm()` helper replaces their numeric values
-// with a `<T>` placeholder in the sorted-JSON output before comparing, so the
-// rest of the state stays a true byte-for-byte assertion.
+// Determinism:
+//  - `killed_at` / `probe_started_at` carry live epoch floats (`Date.now()/1000`)
+//    that differ run-to-run. The `norm()` helper masks their numeric values with
+//    a `<T>` placeholder before snapshotting, so the rest of the state stays a
+//    true assertion. Everything else in the state (counters, flags, host id,
+//    sorted JSON key order) is fully deterministic.
+//  - Every case spawns with a **node-only PATH** (a temp dir holding just a
+//    `node` symlink) so nothing machine-dependent leaks in; COLUMNS=200 forces
+//    single-line usage so arg-error stderr does not re-wrap to terminal width.
 //
 // Coverage: record ok/fail (build to KILL_STREAK=5 → auto-kill), gate
 // (closed / open / half_open via AGENT_CONFIG_DRIVE_COOLDOWN_SEC=0, plus
 // AGENT_CONFIG_DRIVE_AUTO_RECOVERY=0 sticky-open), status (single-host text +
-// --json + all-hosts), kill, reset, invalid host id (status fail-open),
-// usage/arg errors, no-args. The argparse `--help` BODY is NOT byte-compared
-// (only the `usage:` line) per the porting contract.
+// --json + all-hosts + empty + invalid-host fail-open), kill, reset, the
+// non-`health` --root SystemExit, usage/arg errors, no-args. The argparse
+// `--help` BODY is asserted only on the `usage:` first line per the porting
+// contract.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // This test lives at tests/scripts/cli/python/<file> → REPO_ROOT is 5 `..`
 // hops from the file (first hop strips the filename, then 4 dir levels:
@@ -43,17 +47,18 @@ const REPO_ROOT = path.resolve(
     '..',
 );
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_drive_health.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_drive_health.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → nothing machine-dependent leaks into the spawn.
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'drvh-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
 
 interface RunResult {
     status: number | null;
@@ -61,25 +66,17 @@ interface RunResult {
     stderr: string;
 }
 
-function runPy(args: string[], extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[], extraEnv: Record<string, string> = {}): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         encoding: 'utf8',
-        env: { ...process.env, ...extraEnv },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200', ...extraEnv },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
 
 /**
  * Replace the live-epoch float fields with a stable placeholder so the rest of
- * the sorted-JSON state byte-compares. Covers both the single-state and
+ * the sorted-JSON state can be snapshotted. Covers both the single-state and
  * all-hosts (nested) shapes — they appear identically in sorted JSON.
  */
 function norm(text: string): string {
@@ -88,114 +85,134 @@ function norm(text: string): string {
         .replace(/"probe_started_at": [0-9.eE+-]+/g, '"probe_started_at": <T>');
 }
 
-// ---------------------------------------------------------------------------
-// Fixtures — separate health roots per language.
-// ---------------------------------------------------------------------------
-
-let pyRoot: string;
-let tsRoot: string;
-
-function makeHealthRoot(prefix: string): string {
-    const base = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-    const root = path.join(base, 'workspace', 'health');
-    fs.mkdirSync(root, { recursive: true });
-    return root;
+/** Normalize a RunResult's stdout/stderr for snapshotting. */
+function normResult(r: RunResult): RunResult {
+    return { status: r.status, stdout: norm(r.stdout), stderr: norm(r.stderr) };
 }
 
+// ---------------------------------------------------------------------------
+// Fixtures — a fresh per-test health root.
+// ---------------------------------------------------------------------------
+
+let root: string;
+
 beforeEach(() => {
-    pyRoot = makeHealthRoot('drvh-py-');
-    tsRoot = makeHealthRoot('drvh-ts-');
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'drvh-'));
+    root = path.join(base, 'workspace', 'health');
+    fs.mkdirSync(root, { recursive: true });
 });
 afterEach(() => {
     // mkdtemp base is two levels up from the health dir.
-    for (const root of [pyRoot, tsRoot]) {
-        fs.rmSync(path.resolve(root, '..', '..'), { recursive: true, force: true });
-    }
+    fs.rmSync(path.resolve(root, '..', '..'), { recursive: true, force: true });
 });
 
+/** Substitute the `<ROOT>` placeholder with the per-test health dir. */
+function sub(args: string[]): string[] {
+    return args.map((a) => (a === '<ROOT>' ? root : a));
+}
+
 /**
- * Replay one command sequence in each language's own root, then assert the
- * FINAL command's stdout/stderr/exit agree (after timestamp normalization).
- * Each step is `[args, extraEnv]`; the last step is the asserted one.
+ * Replay each setup command (output discarded), then run + normalize the final
+ * command. `<ROOT>` in any args is the per-test health dir.
  */
-function expectSeqParity(
+function seq(
     setup: string[][],
     finalArgs: string[],
     extraEnv: Record<string, string> = {},
-): void {
-    const subst = (args: string[], root: string): string[] =>
-        args.map((a) => (a === '<ROOT>' ? root : a));
+): RunResult {
     for (const step of setup) {
-        runPy(subst(step, pyRoot));
-        runTs(subst(step, tsRoot));
+        runTs(sub(step));
     }
-    const p = runPy(subst(finalArgs, pyRoot), extraEnv);
-    const t = runTs(subst(finalArgs, tsRoot), extraEnv);
-    expect(t.status).toBe(p.status);
-    expect(norm(t.stdout)).toBe(norm(p.stdout));
-    expect(norm(t.stderr)).toBe(norm(p.stderr));
+    return normResult(runTs(sub(finalArgs), extraEnv));
 }
 
-/** Parity for a single invocation that needs no shared state (errors etc.). */
-function expectArgParity(args: string[], extraEnv: Record<string, string> = {}): void {
-    const pyArgs = args.map((a) => (a === '<ROOT>' ? pyRoot : a));
-    const tsArgs = args.map((a) => (a === '<ROOT>' ? tsRoot : a));
-    const p = runPy(pyArgs, extraEnv);
-    const t = runTs(tsArgs, extraEnv);
-    expect(t.status).toBe(p.status);
-    expect(norm(t.stdout)).toBe(norm(p.stdout));
-    expect(norm(t.stderr)).toBe(norm(p.stderr));
-}
-
-const d = py3 ? describe : describe.skip;
+const FIVE_FAILS = (host: string): string[][] =>
+    Array.from({ length: 5 }, () => [
+        'record',
+        '--host',
+        host,
+        '--outcome',
+        'fail',
+        '--root',
+        '<ROOT>',
+    ]);
 
 // ---------------------------------------------------------------------------
 // record
 // ---------------------------------------------------------------------------
 
-d('workspace_drive_health — record', () => {
+describe('workspace_drive_health — record', () => {
     it('record ok emits the default-healthy state', () => {
-        expectSeqParity([], ['record', '--host', 'h1', '--outcome', 'ok', '--root', '<ROOT>']);
+        expect(seq([], ['record', '--host', 'h1', '--outcome', 'ok', '--root', '<ROOT>']))
+            .toMatchInlineSnapshot(`
+              {
+                "status": 0,
+                "stderr": "",
+                "stdout": "{"consecutive_failures": 0, "host": "h1", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": null, "last_outcome": "ok", "last_was_probe": false, "probe_started_at": null, "total_failure": 0, "total_success": 1, "trip_count": 0}
+              ",
+              }
+            `);
     });
 
     it('record fail with error-kind', () => {
-        expectSeqParity(
-            [],
-            ['record', '--host', 'h1', '--outcome', 'fail', '--error-kind', 'boom', '--root', '<ROOT>'],
-        );
+        expect(
+            seq(
+                [],
+                ['record', '--host', 'h1', '--outcome', 'fail', '--error-kind', 'boom', '--root', '<ROOT>'],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 1, "host": "h1", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": "boom", "last_outcome": "fail", "last_was_probe": false, "probe_started_at": null, "total_failure": 1, "total_success": 0, "trip_count": 0}
+          ",
+          }
+        `);
     });
 
     it('five consecutive failures auto-trip the kill-switch', () => {
-        const fails: string[][] = Array.from({ length: 5 }, () => [
-            'record',
-            '--host',
-            'hk',
-            '--outcome',
-            'fail',
-            '--error-kind',
-            'boom',
-            '--root',
-            '<ROOT>',
-        ]);
+        const fails = FIVE_FAILS('hk');
         // The 5th record is the asserted one (killed flips true).
-        expectSeqParity(fails.slice(0, 4), fails[4] as string[]);
+        expect(seq(fails.slice(0, 4), fails[4] as string[])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 5, "host": "hk", "kill_reason": "auto", "killed": true, "killed_at": <T>, "last_error_kind": null, "last_outcome": "fail", "last_was_probe": false, "probe_started_at": null, "total_failure": 5, "total_success": 0, "trip_count": 1}
+          ",
+          }
+        `);
     });
 
     it('success after failures resets the streak (auto-kill not yet tripped)', () => {
-        expectSeqParity(
-            [
-                ['record', '--host', 'hs', '--outcome', 'fail', '--error-kind', 'x', '--root', '<ROOT>'],
-                ['record', '--host', 'hs', '--outcome', 'fail', '--error-kind', 'x', '--root', '<ROOT>'],
-            ],
-            ['record', '--host', 'hs', '--outcome', 'ok', '--root', '<ROOT>'],
-        );
+        expect(
+            seq(
+                [
+                    ['record', '--host', 'hs', '--outcome', 'fail', '--error-kind', 'x', '--root', '<ROOT>'],
+                    ['record', '--host', 'hs', '--outcome', 'fail', '--error-kind', 'x', '--root', '<ROOT>'],
+                ],
+                ['record', '--host', 'hs', '--outcome', 'ok', '--root', '<ROOT>'],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 0, "host": "hs", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": null, "last_outcome": "ok", "last_was_probe": false, "probe_started_at": null, "total_failure": 2, "total_success": 1, "trip_count": 0}
+          ",
+          }
+        `);
     });
 
     it('--is-probe sets last_was_probe', () => {
-        expectSeqParity(
-            [],
-            ['record', '--host', 'hp', '--outcome', 'ok', '--is-probe', '--root', '<ROOT>'],
-        );
+        expect(
+            seq([], ['record', '--host', 'hp', '--outcome', 'ok', '--is-probe', '--root', '<ROOT>']),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 0, "host": "hp", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": null, "last_outcome": "ok", "last_was_probe": true, "probe_started_at": null, "total_failure": 0, "total_success": 1, "trip_count": 0}
+          ",
+          }
+        `);
     });
 });
 
@@ -203,53 +220,59 @@ d('workspace_drive_health — record', () => {
 // gate
 // ---------------------------------------------------------------------------
 
-d('workspace_drive_health — gate', () => {
+describe('workspace_drive_health — gate', () => {
     it('healthy host gates closed', () => {
-        expectSeqParity([], ['gate', '--host', 'gx', '--root', '<ROOT>']);
+        expect(seq([], ['gate', '--host', 'gx', '--root', '<ROOT>'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "closed
+          ",
+          }
+        `);
     });
 
     it('auto-killed host gates open during cooldown', () => {
-        const fails: string[][] = Array.from({ length: 5 }, () => [
-            'record',
-            '--host',
-            'gk',
-            '--outcome',
-            'fail',
-            '--root',
-            '<ROOT>',
-        ]);
-        expectSeqParity(fails, ['gate', '--host', 'gk', '--root', '<ROOT>']);
+        expect(seq(FIVE_FAILS('gk'), ['gate', '--host', 'gk', '--root', '<ROOT>']))
+            .toMatchInlineSnapshot(`
+              {
+                "status": 0,
+                "stderr": "",
+                "stdout": "open
+              ",
+              }
+            `);
     });
 
     it('auto-killed host gates half_open once cooldown elapses (COOLDOWN_SEC=0)', () => {
-        const fails: string[][] = Array.from({ length: 5 }, () => [
-            'record',
-            '--host',
-            'gh',
-            '--outcome',
-            'fail',
-            '--root',
-            '<ROOT>',
-        ]);
-        expectSeqParity(fails, ['gate', '--host', 'gh', '--root', '<ROOT>'], {
-            AGENT_CONFIG_DRIVE_COOLDOWN_SEC: '0',
-        });
+        expect(
+            seq(FIVE_FAILS('gh'), ['gate', '--host', 'gh', '--root', '<ROOT>'], {
+                AGENT_CONFIG_DRIVE_COOLDOWN_SEC: '0',
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "half_open
+          ",
+          }
+        `);
     });
 
     it('auto-recovery disabled keeps an auto-killed host open (sticky)', () => {
-        const fails: string[][] = Array.from({ length: 5 }, () => [
-            'record',
-            '--host',
-            'go',
-            '--outcome',
-            'fail',
-            '--root',
-            '<ROOT>',
-        ]);
-        expectSeqParity(fails, ['gate', '--host', 'go', '--root', '<ROOT>'], {
-            AGENT_CONFIG_DRIVE_AUTO_RECOVERY: '0',
-            AGENT_CONFIG_DRIVE_COOLDOWN_SEC: '0',
-        });
+        expect(
+            seq(FIVE_FAILS('go'), ['gate', '--host', 'go', '--root', '<ROOT>'], {
+                AGENT_CONFIG_DRIVE_AUTO_RECOVERY: '0',
+                AGENT_CONFIG_DRIVE_COOLDOWN_SEC: '0',
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "open
+          ",
+          }
+        `);
     });
 });
 
@@ -257,37 +280,79 @@ d('workspace_drive_health — gate', () => {
 // status
 // ---------------------------------------------------------------------------
 
-d('workspace_drive_health — status', () => {
+describe('workspace_drive_health — status', () => {
     it('single-host text format (default-healthy)', () => {
-        expectSeqParity(
-            [['record', '--host', 's1', '--outcome', 'ok', '--root', '<ROOT>']],
-            ['status', '--host', 's1', '--root', '<ROOT>'],
-        );
+        expect(
+            seq(
+                [['record', '--host', 's1', '--outcome', 'ok', '--root', '<ROOT>']],
+                ['status', '--host', 's1', '--root', '<ROOT>'],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "s1: killed=False streak=0 ok=1 fail=0
+          ",
+          }
+        `);
     });
 
     it('single-host --json', () => {
-        expectSeqParity(
-            [['record', '--host', 's1', '--outcome', 'fail', '--error-kind', 'e', '--root', '<ROOT>']],
-            ['status', '--host', 's1', '--json', '--root', '<ROOT>'],
-        );
+        expect(
+            seq(
+                [['record', '--host', 's1', '--outcome', 'fail', '--error-kind', 'e', '--root', '<ROOT>']],
+                ['status', '--host', 's1', '--json', '--root', '<ROOT>'],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 1, "host": "s1", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": "e", "last_outcome": "fail", "last_was_probe": false, "probe_started_at": null, "total_failure": 1, "total_success": 0, "trip_count": 0}
+          ",
+          }
+        `);
     });
 
     it('all-hosts json (multiple recorded hosts, sorted)', () => {
-        expectSeqParity(
-            [
-                ['record', '--host', 'beta', '--outcome', 'ok', '--root', '<ROOT>'],
-                ['record', '--host', 'alpha', '--outcome', 'fail', '--error-kind', 'x', '--root', '<ROOT>'],
-            ],
-            ['status', '--root', '<ROOT>'],
-        );
+        expect(
+            seq(
+                [
+                    ['record', '--host', 'beta', '--outcome', 'ok', '--root', '<ROOT>'],
+                    ['record', '--host', 'alpha', '--outcome', 'fail', '--error-kind', 'x', '--root', '<ROOT>'],
+                ],
+                ['status', '--root', '<ROOT>'],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"alpha": {"consecutive_failures": 1, "host": "alpha", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": "x", "last_outcome": "fail", "last_was_probe": false, "probe_started_at": null, "total_failure": 1, "total_success": 0, "trip_count": 0}, "beta": {"consecutive_failures": 0, "host": "beta", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": null, "last_outcome": "ok", "last_was_probe": false, "probe_started_at": null, "total_failure": 0, "total_success": 1, "trip_count": 0}}
+          ",
+          }
+        `);
     });
 
     it('all-hosts json on empty health dir', () => {
-        expectSeqParity([], ['status', '--root', '<ROOT>']);
+        expect(seq([], ['status', '--root', '<ROOT>'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{}
+          ",
+          }
+        `);
     });
 
     it('invalid host id reads fail-open (no write, no crash)', () => {
-        expectSeqParity([], ['status', '--host', 'BAD!', '--json', '--root', '<ROOT>']);
+        expect(seq([], ['status', '--host', 'BAD!', '--json', '--root', '<ROOT>']))
+            .toMatchInlineSnapshot(`
+              {
+                "status": 0,
+                "stderr": "",
+                "stdout": "{"consecutive_failures": 0, "host": "BAD!", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": null, "last_outcome": null, "last_was_probe": false, "probe_started_at": null, "total_failure": 0, "total_success": 0, "trip_count": 0}
+              ",
+              }
+            `);
     });
 });
 
@@ -295,24 +360,49 @@ d('workspace_drive_health — status', () => {
 // kill / reset
 // ---------------------------------------------------------------------------
 
-d('workspace_drive_health — kill / reset', () => {
+describe('workspace_drive_health — kill / reset', () => {
     it('kill marks the host sticky-killed', () => {
-        expectSeqParity([], ['kill', '--host', 'm', '--root', '<ROOT>']);
+        expect(seq([], ['kill', '--host', 'm', '--root', '<ROOT>'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 0, "host": "m", "kill_reason": "manual", "killed": true, "killed_at": <T>, "last_error_kind": null, "last_outcome": null, "last_was_probe": false, "probe_started_at": null, "total_failure": 0, "total_success": 0, "trip_count": 0}
+          ",
+          }
+        `);
     });
 
     it('reset clears a killed host', () => {
-        expectSeqParity(
-            [['kill', '--host', 'm', '--root', '<ROOT>']],
-            ['reset', '--host', 'm', '--root', '<ROOT>'],
-        );
+        expect(
+            seq(
+                [['kill', '--host', 'm', '--root', '<ROOT>']],
+                ['reset', '--host', 'm', '--root', '<ROOT>'],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"consecutive_failures": 0, "host": "m", "kill_reason": null, "killed": false, "killed_at": null, "last_error_kind": null, "last_outcome": null, "last_was_probe": false, "probe_started_at": null, "total_failure": 0, "total_success": 0, "trip_count": 0}
+          ",
+          }
+        `);
     });
 
     it('manual kill stays open even after cooldown (sticky, not auto-recoverable)', () => {
-        expectSeqParity(
-            [['kill', '--host', 'mk', '--root', '<ROOT>']],
-            ['gate', '--host', 'mk', '--root', '<ROOT>'],
-            { AGENT_CONFIG_DRIVE_COOLDOWN_SEC: '0' },
-        );
+        expect(
+            seq(
+                [['kill', '--host', 'mk', '--root', '<ROOT>']],
+                ['gate', '--host', 'mk', '--root', '<ROOT>'],
+                { AGENT_CONFIG_DRIVE_COOLDOWN_SEC: '0' },
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "open
+          ",
+          }
+        `);
     });
 });
 
@@ -320,65 +410,138 @@ d('workspace_drive_health — kill / reset', () => {
 // argparse — usage / arg errors (no shared state).
 // ---------------------------------------------------------------------------
 
-d('workspace_drive_health — CLI errors', () => {
+describe('workspace_drive_health — CLI errors', () => {
     it('no args → required cmd', () => {
-        expectArgParity([]);
+        expect(normResult(runTs([]))).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_drive_health [-h] {record,gate,status,kill,reset} ...
+          workspace_drive_health: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('invalid subcommand', () => {
-        expectArgParity(['bogus']);
+        expect(normResult(runTs(['bogus']))).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_drive_health [-h] {record,gate,status,kill,reset} ...
+          workspace_drive_health: error: argument cmd: invalid choice: 'bogus' (choose from 'record', 'gate', 'status', 'kill', 'reset')
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('record with no args → required flags (declaration order)', () => {
-        expectArgParity(['record']);
+        expect(normResult(runTs(['record']))).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_drive_health record [-h] --host HOST --outcome {ok,fail}
+                                               [--error-kind ERROR_KIND] [--is-probe]
+                                               --root ROOT
+          workspace_drive_health record: error: the following arguments are required: --host, --outcome, --root
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('record missing --root only', () => {
-        expectArgParity(['record', '--host', 'x', '--outcome', 'ok']);
+        expect(normResult(runTs(['record', '--host', 'x', '--outcome', 'ok'])))
+            .toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: workspace_drive_health record [-h] --host HOST --outcome {ok,fail}
+                                                   [--error-kind ERROR_KIND] [--is-probe]
+                                                   --root ROOT
+              workspace_drive_health record: error: the following arguments are required: --root
+              ",
+                "stdout": "",
+              }
+            `);
     });
 
     it('record invalid --outcome choice', () => {
-        expectArgParity(['record', '--host', 'x', '--outcome', 'bad', '--root', '<ROOT>']);
+        expect(normResult(runTs(sub(['record', '--host', 'x', '--outcome', 'bad', '--root', '<ROOT>']))))
+            .toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: workspace_drive_health record [-h] --host HOST --outcome {ok,fail}
+                                                   [--error-kind ERROR_KIND] [--is-probe]
+                                                   --root ROOT
+              workspace_drive_health record: error: argument --outcome: invalid choice: 'bad' (choose from 'ok', 'fail')
+              ",
+                "stdout": "",
+              }
+            `);
     });
 
     it('status missing required --root', () => {
-        expectArgParity(['status']);
+        expect(normResult(runTs(['status']))).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_drive_health status [-h] [--host HOST] [--json] --root ROOT
+          workspace_drive_health status: error: the following arguments are required: --root
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('status unrecognized flag → top-level error', () => {
-        expectArgParity(['status', '--root', '<ROOT>', '--bogus']);
+        expect(normResult(runTs(sub(['status', '--root', '<ROOT>', '--bogus']))))
+            .toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: workspace_drive_health [-h] {record,gate,status,kill,reset} ...
+              workspace_drive_health: error: unrecognized arguments: --bogus
+              ",
+                "stdout": "",
+              }
+            `);
     });
 
     it('record unrecognized positional → top-level error', () => {
-        expectArgParity([
-            'record',
-            '--host',
-            'x',
-            '--outcome',
-            'ok',
-            '--root',
-            '<ROOT>',
-            'extra',
-        ]);
+        expect(
+            normResult(
+                runTs(sub(['record', '--host', 'x', '--outcome', 'ok', '--root', '<ROOT>', 'extra'])),
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_drive_health [-h] {record,gate,status,kill,reset} ...
+          workspace_drive_health: error: unrecognized arguments: extra
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('--root not named health → SystemExit, exit 1', () => {
-        // Use a non-health dir name; both languages print to stderr + exit 1.
-        const py = runPy(['status', '--root', '/tmp/nothealth-xyz']);
-        const ts = runTs(['status', '--root', '/tmp/nothealth-xyz']);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(py.status).toBe(1);
+        // Use a non-health dir name; the CLI prints to stderr + exits 1.
+        const r = normResult(runTs(['status', '--root', '/tmp/nothealth-xyz']));
+        expect(r.status).toBe(1);
+        expect(r.stdout).toBe('');
+        expect(r).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "--root must be a workspace/health directory; got '/tmp/nothealth-xyz'
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('top-level -h prints the usage line + exit 0 (body not compared)', () => {
-        const py = runPy(['-h']);
-        const ts = runTs(['-h']);
-        expect(ts.status).toBe(py.status);
-        expect(py.status).toBe(0);
-        // Only the first `usage:` line is contract-compared.
+        const r = runTs(['-h']);
+        expect(r.status).toBe(0);
+        // Only the first `usage:` line is contract-asserted.
         const firstLine = (s: string): string => s.split('\n')[0] ?? '';
-        expect(firstLine(ts.stdout)).toBe(firstLine(py.stdout));
+        expect(firstLine(r.stdout)).toMatchInlineSnapshot(
+            `"usage: workspace_drive_health [-h] {record,gate,status,kill,reset} ..."`,
+        );
     });
 });

--- a/tests/scripts/cli/python/workspace_explain.test.ts
+++ b/tests/scripts/cli/python/workspace_explain.test.ts
@@ -1,22 +1,26 @@
-// Golden-parity tests for src/cli/python/workspace_explain.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_explain.ts (py2ts ADR-200 —
 // the explain-v1 envelope plain/technical renderer + host-decision explainer).
 //
-// Strategy: run `python3 src/cli/python/workspace_explain.py` vs
-// `tsx src/cli/python/workspace_explain.ts` on deterministic surfaces over temp
-// JSON fixtures and byte-compare stdout / stderr / exit. The module is a pure
-// renderer (reads an envelope / detection / health JSON, writes only stdout/
-// stderr). The suite NEVER touches the real repo.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly via inline snapshots over
+// deterministic temp-JSON fixtures. The module is a pure renderer (reads an
+// envelope / detection / health JSON, writes only stdout/stderr). The suite
+// NEVER touches the real repo.
 //
-// COLUMNS=200 is forced for both languages so argparse emits single-line usage
-// (otherwise the usage line in arg-error stderr re-wraps to terminal width).
-// The `--help` per-flag BODY is NOT byte-compared (porting contract); only the
-// usage line. The file-not-found path prints a Python traceback (TS prints a
-// node stack) — only exit code is asserted there.
+// Determinism guarantees preserved from the parity era:
+//   * COLUMNS=200 is forced so argparse emits single-line usage (otherwise the
+//     usage line in arg-error stderr re-wraps to terminal width).
+//   * Every spawn uses a **node-only PATH** (a temp dir holding just `node` +
+//     `git` symlinks) so the run is hermetic and python-free by construction.
+//   * The `--help` per-flag BODY is intentionally NOT asserted (porting
+//     contract); only the first stdout line (the usage line).
+//   * The file-not-found / malformed-JSON paths print a node stack — only the
+//     exit code + empty stdout are asserted there.
 //
 // Float-parity surface: technical mode and the plain-mode `(0.NN)` suffix use
 // Python `f"{x:.2f}"` (round-half-to-even on the exact double). The TS twin's
 // `_pyFixed2` is exercised here with the JS-divergent values 0.125 (→ 0.12,
-// not 0.13) and 0.625 (→ 0.62, not 0.63).
+// not 0.13) and 0.625 (→ 0.62, not 0.63) — these are DETERMINISTIC and asserted.
 //
 // Relative-time nondeterminism: `_human_relative` uses the live clock on the
 // render path (main() does not thread `now`). To stay deterministic the
@@ -28,7 +32,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // tests/scripts/cli/python/workspace_explain.test.ts → repo root is five hops up.
 const REPO_ROOT = path.resolve(
@@ -40,17 +44,28 @@ const REPO_ROOT = path.resolve(
     '..',
 );
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_explain.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_explain.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+// node-only PATH → hermetic, python-free runs (only `node` + `git` resolve).
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wexplain-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+try {
+    const gitPath = spawnSync('command', ['-v', 'git'], { encoding: 'utf8', shell: true }).stdout
+        ?.trim()
+        ?.split('\n')[0];
+    if (gitPath && fs.existsSync(gitPath)) {
+        fs.symlinkSync(gitPath, path.join(NODE_ONLY_DIR, 'git'));
+    }
+} catch {
+    /* git not strictly needed by the renderer */
 }
-const py3 = hasPython3();
+afterAll(() => {
+    fs.rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface RunResult {
     status: number | null;
@@ -58,20 +73,11 @@ interface RunResult {
     stderr: string;
 }
 
-function runPy(args: string[], cwd: string): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), COLUMNS: '200' },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[], cwd: string): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         cwd,
         encoding: 'utf8',
-        env: { ...process.env, COLUMNS: '200' },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
@@ -91,18 +97,19 @@ function norm(text: string, roots: string[]): string {
     }
     // Belt-and-braces: `_human_relative` is clock-driven on the render path.
     // Fixtures avoid valid timestamps, but mask the phrase so a clock tick
-    // between the two subprocess spawns can never flake the differential.
+    // can never flake the snapshot.
     out = out.replace(/\d+ (?:hour|day|month)s? ago/g, '<REL>');
     return out;
 }
 
-/** Assert py and ts agree byte-for-byte (after normalization) + same exit. */
-function expectParity(args: string[], cwd: string, roots: string[]): void {
-    const p = runPy(args, cwd);
+/** Normalized {status, stdout, stderr} for inline-snapshotting. */
+function snap(args: string[], cwd: string, roots: string[]): RunResult {
     const t = runTs(args, cwd);
-    expect(t.status).toBe(p.status);
-    expect(norm(t.stdout, roots)).toBe(norm(p.stdout, roots));
-    expect(norm(t.stderr, roots)).toBe(norm(p.stderr, roots));
+    return {
+        status: t.status,
+        stdout: norm(t.stdout, roots),
+        stderr: norm(t.stderr, roots),
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -133,75 +140,147 @@ function writeRaw(name: string, content: string): string {
 // Usage / argument errors.
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('explain — argument errors', () => {
+describe('explain — argument errors', () => {
     it('top -h: exit 0, usage line on stdout', () => {
-        const p = runPy(['-h'], tmp);
         const t = runTs(['-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(p.status).toBe(0);
-        const usage = 'usage: workspace_explain [-h] {render,explain-host} ...';
-        expect(p.stdout.startsWith(usage)).toBe(true);
-        expect(t.stdout.startsWith(usage)).toBe(true);
+        expect(t.status).toBe(0);
+        expect(t.stdout.split('\n')[0]).toMatchInlineSnapshot(`"usage: workspace_explain [-h] {render,explain-host} ..."`);
     });
 
     it('render -h: exit 0, usage line on stdout', () => {
-        const p = runPy(['render', '-h'], tmp);
         const t = runTs(['render', '-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(p.status).toBe(0);
-        expect(p.stdout.split('\n')[0]).toBe(t.stdout.split('\n')[0]);
+        expect(t.status).toBe(0);
+        expect(t.stdout.split('\n')[0]).toMatchInlineSnapshot(`"usage: workspace_explain render [-h] [--mode {plain,technical}] --envelope-file ENVELOPE_FILE [--glossary GLOSSARY]"`);
     });
 
     it('explain-host -h: exit 0, usage line on stdout', () => {
-        const p = runPy(['explain-host', '-h'], tmp);
         const t = runTs(['explain-host', '-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(p.status).toBe(0);
-        expect(p.stdout.split('\n')[0]).toBe(t.stdout.split('\n')[0]);
+        expect(t.status).toBe(0);
+        expect(t.stdout.split('\n')[0]).toMatchInlineSnapshot(`"usage: workspace_explain explain-host [-h] [--mode {plain,technical}] --detection-file DETECTION_FILE [--health-file HEALTH_FILE] [--resume-session-id RESUME_SESSION_ID]"`);
     });
 
-    it('no args: exit 2 + byte-identical usage+error stderr', () => {
-        expectParity([], tmp, [tmp]);
+    it('no args: exit 2 + usage+error stderr', () => {
+        expect(snap([], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain [-h] {render,explain-host} ...
+          workspace_explain: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('bad subcommand: exit 2 + byte-identical stderr', () => {
-        expectParity(['frob'], tmp, [tmp]);
+    it('bad subcommand: exit 2 + stderr', () => {
+        expect(snap(['frob'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain [-h] {render,explain-host} ...
+          workspace_explain: error: argument cmd: invalid choice: 'frob' (choose from 'render', 'explain-host')
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('render missing --envelope-file: exit 2 + byte-identical stderr', () => {
-        expectParity(['render'], tmp, [tmp]);
+    it('render missing --envelope-file: exit 2 + stderr', () => {
+        expect(snap(['render'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain render [-h] [--mode {plain,technical}] --envelope-file ENVELOPE_FILE [--glossary GLOSSARY]
+          workspace_explain render: error: the following arguments are required: --envelope-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('explain-host missing --detection-file: exit 2 + byte-identical stderr', () => {
-        expectParity(['explain-host'], tmp, [tmp]);
+    it('explain-host missing --detection-file: exit 2 + stderr', () => {
+        expect(snap(['explain-host'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain explain-host [-h] [--mode {plain,technical}] --detection-file DETECTION_FILE [--health-file HEALTH_FILE] [--resume-session-id RESUME_SESSION_ID]
+          workspace_explain explain-host: error: the following arguments are required: --detection-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('render bad --mode choice: exit 2 + byte-identical stderr', () => {
+    it('render bad --mode choice: exit 2 + stderr', () => {
         const env = writeJson('e.json', { trust_score: 0.5 });
-        expectParity(['render', '--mode', 'bogus', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'bogus', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain render [-h] [--mode {plain,technical}] --envelope-file ENVELOPE_FILE [--glossary GLOSSARY]
+          workspace_explain render: error: argument --mode: invalid choice: 'bogus' (choose from 'plain', 'technical')
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('render stray positional: exit 2 unrecognized', () => {
         const env = writeJson('e.json', { trust_score: 0.5 });
-        expectParity(['render', '--envelope-file', env, 'stray'], tmp, [tmp]);
+        expect(snap(['render', '--envelope-file', env, 'stray'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain [-h] {render,explain-host} ...
+          workspace_explain: error: unrecognized arguments: stray
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('render unknown flag: exit 2 unrecognized', () => {
         const env = writeJson('e.json', { trust_score: 0.5 });
-        expectParity(['render', '--envelope-file', env, '--bogus'], tmp, [tmp]);
+        expect(snap(['render', '--envelope-file', env, '--bogus'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain [-h] {render,explain-host} ...
+          workspace_explain: error: unrecognized arguments: --bogus
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('render required-missing wins over stray positional', () => {
-        expectParity(['render', 'stray'], tmp, [tmp]);
+        expect(snap(['render', 'stray'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain render [-h] [--mode {plain,technical}] --envelope-file ENVELOPE_FILE [--glossary GLOSSARY]
+          workspace_explain render: error: the following arguments are required: --envelope-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('render --mode missing value: exit 2 expected-one-argument', () => {
-        expectParity(['render', '--mode'], tmp, [tmp]);
+        expect(snap(['render', '--mode'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain render [-h] [--mode {plain,technical}] --envelope-file ENVELOPE_FILE [--glossary GLOSSARY]
+          workspace_explain render: error: argument --mode: expected one argument
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('explain-host stray positional: exit 2 unrecognized', () => {
         const det = writeJson('d.json', { host: 'h' });
-        expectParity(['explain-host', '--detection-file', det, 'stray'], tmp, [tmp]);
+        expect(snap(['explain-host', '--detection-file', det, 'stray'], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_explain [-h] {render,explain-host} ...
+          workspace_explain: error: unrecognized arguments: stray
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });
 
@@ -209,7 +288,7 @@ describe.skipIf(!py3)('explain — argument errors', () => {
 // render — plain mode across trust / freshness bands, sources, contradictions.
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — plain mode', () => {
+describe('render — plain mode', () => {
     it('very_high trust, fresh, sources present, no contradictions, id present', () => {
         const env = writeJson('e.json', {
             trust_score: 0.9,
@@ -219,7 +298,14 @@ describe.skipIf(!py3)('render — plain mode', () => {
             last_reviewed_at: null,
             id: 'env-1',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["env-1"], "markdown": "## Where this came from\\n2 source(s) \\u2014 alpha, beta\\n\\n## How confident\\nVery High (0.90)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Fresh\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('high trust, aging, contradictions present, falsy id (empty string → ids:[])', () => {
@@ -231,7 +317,14 @@ describe.skipIf(!py3)('render — plain mode', () => {
             last_reviewed_at: null,
             id: '',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": [], "markdown": "## Where this came from\\n1 source(s) \\u2014 s1\\n\\n## How confident\\nHigh (0.72)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Aging\\n\\n## What's contested\\n3 open\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('medium trust, stale, empty sources, no contradictions', () => {
@@ -243,12 +336,26 @@ describe.skipIf(!py3)('render — plain mode', () => {
             last_reviewed_at: null,
             id: 'm',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["m"], "markdown": "## Where this came from\\n0 source(s)\\n\\n## How confident\\nMedium (0.50)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('low trust (below medium), missing decay/evidence/contradictions/id entirely', () => {
         const env = writeJson('e.json', { trust_score: 0.1 });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": [], "markdown": "## Where this came from\\n0 source(s)\\n\\n## How confident\\nLow (0.10)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('exact band boundary very_high=0.85 (>= is Very High)', () => {
@@ -258,7 +365,14 @@ describe.skipIf(!py3)('render — plain mode', () => {
             evidence: { sources: ['x'] },
             id: 'b',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["b"], "markdown": "## Where this came from\\n1 source(s) \\u2014 x\\n\\n## How confident\\nVery High (0.85)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Fresh\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('more than 5 sources → only first 5 joined', () => {
@@ -268,7 +382,14 @@ describe.skipIf(!py3)('render — plain mode', () => {
             evidence: { sources: ['a', 'b', 'c', 'd', 'e', 'f', 'g'] },
             id: 'six',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["six"], "markdown": "## Where this came from\\n7 source(s) \\u2014 a, b, c, d, e\\n\\n## How confident\\nHigh (0.65)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Aging\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('null trust/decay (or-fallback to 0.0) → Low + Stale + (0.00)', () => {
@@ -277,7 +398,14 @@ describe.skipIf(!py3)('render — plain mode', () => {
             decay: { applied_factor: null },
             evidence: { sources: [] },
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": [], "markdown": "## Where this came from\\n0 source(s)\\n\\n## How confident\\nLow (0.00)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('JS-divergent float 0.125 → (0.12) not (0.13)', () => {
@@ -287,28 +415,39 @@ describe.skipIf(!py3)('render — plain mode', () => {
             evidence: { sources: [] },
             id: 'half',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["half"], "markdown": "## Where this came from\\n0 source(s)\\n\\n## How confident\\nLow (0.12)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Aging\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('falsy id 0 (number zero → ids:[])', () => {
         const env = writeJson('e.json', { trust_score: 0.7, id: 0 });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": [], "markdown": "## Where this came from\\n0 source(s)\\n\\n## How confident\\nHigh (0.70)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('non-string source element → TypeError on str.join → exit 1, no stdout', () => {
         // Python `", ".join([...])` raises TypeError on a non-str element
-        // (int / bool), aborting with a traceback (exit 1). The twin throws too;
-        // tracebacks differ from node stacks, so only exit + empty stdout assert.
+        // (int / bool), aborting with a traceback (exit 1). The TS twin throws
+        // too; stacks are not asserted — only exit + empty stdout.
         const env = writeJson('e.json', {
             trust_score: 0.7,
             evidence: { sources: ['a', 1, true] },
             id: 'mix',
         });
-        const p = runPy(['render', '--mode', 'plain', '--envelope-file', env], tmp);
         const t = runTs(['render', '--mode', 'plain', '--envelope-file', env], tmp);
-        expect(p.status).toBe(1);
         expect(t.status).toBe(1);
-        expect(p.stdout).toBe('');
         expect(t.stdout).toBe('');
     });
 });
@@ -317,7 +456,7 @@ describe.skipIf(!py3)('render — plain mode', () => {
 // render — technical mode (raw fields, :.2f decay, last_reviewed passthrough).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — technical mode', () => {
+describe('render — technical mode', () => {
     it('technical fields + decay=:.2f + 0 contradictions → "0"', () => {
         const env = writeJson('e.json', {
             trust_score: 0.72,
@@ -327,7 +466,14 @@ describe.skipIf(!py3)('render — technical mode', () => {
             last_reviewed_at: '2020-01-02T03:04:05Z',
             id: 'tech',
         });
-        expectParity(['render', '--mode', 'technical', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'technical', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["tech"], "markdown": "## Sources\\n2 source(s) \\u2014 a, b\\n\\n## Trust score\\n0.72\\n\\n## Last reviewed\\n2020-01-02T03:04:05Z \\u00b7 decay=0.90\\n\\n## Unresolved contradictions\\n0\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 
     it('technical, JS-divergent decay 0.625 → decay=0.62', () => {
@@ -339,17 +485,38 @@ describe.skipIf(!py3)('render — technical mode', () => {
             last_reviewed_at: null,
             id: 'tech2',
         });
-        expectParity(['render', '--mode', 'technical', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'technical', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["tech2"], "markdown": "## Sources\\n0 source(s)\\n\\n## Trust score\\n0.12\\n\\n## Last reviewed\\n(unavailable) \\u00b7 decay=0.62\\n\\n## Unresolved contradictions\\n1 open\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 
     it('technical, last_reviewed_at absent → (unavailable)', () => {
         const env = writeJson('e.json', { trust_score: 1.0, decay: { applied_factor: 1.0 } });
-        expectParity(['render', '--mode', 'technical', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'technical', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": [], "markdown": "## Sources\\n0 source(s)\\n\\n## Trust score\\n1.00\\n\\n## Last reviewed\\n(unavailable) \\u00b7 decay=1.00\\n\\n## Unresolved contradictions\\n0\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 
     it('technical default mode is plain (no --mode → plain)', () => {
         const env = writeJson('e.json', { trust_score: 0.66, evidence: { sources: ['z'] }, id: 'd' });
-        expectParity(['render', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["d"], "markdown": "## Where this came from\\n1 source(s) \\u2014 z\\n\\n## How confident\\nHigh (0.66)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 });
 
@@ -357,7 +524,7 @@ describe.skipIf(!py3)('render — technical mode', () => {
 // render — last_reviewed_at variants (deterministic "(unavailable)" / raw).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — last_reviewed deterministic paths', () => {
+describe('render — last_reviewed deterministic paths', () => {
     it('null last_reviewed (plain) → (unavailable)', () => {
         const env = writeJson('e.json', {
             trust_score: 0.7,
@@ -366,7 +533,14 @@ describe.skipIf(!py3)('render — last_reviewed deterministic paths', () => {
             last_reviewed_at: null,
             id: 'n',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["n"], "markdown": "## Where this came from\\n1 source(s) \\u2014 x\\n\\n## How confident\\nHigh (0.70)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Fresh\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('invalid timestamp (plain) → raw string passthrough', () => {
@@ -377,7 +551,14 @@ describe.skipIf(!py3)('render — last_reviewed deterministic paths', () => {
             last_reviewed_at: 'not-a-real-date',
             id: 'inv',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["inv"], "markdown": "## Where this came from\\n1 source(s) \\u2014 x\\n\\n## How confident\\nHigh (0.70)\\n\\n## When last reviewed\\nnot-a-real-date \\u00b7 Fresh\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('absent last_reviewed (plain) → (unavailable)', () => {
@@ -387,7 +568,14 @@ describe.skipIf(!py3)('render — last_reviewed deterministic paths', () => {
             evidence: { sources: ['x'] },
             id: 'abs',
         });
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp]);
+        expect(snap(['render', '--mode', 'plain', '--envelope-file', env], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["abs"], "markdown": "## Where this came from\\n1 source(s) \\u2014 x\\n\\n## How confident\\nHigh (0.70)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Fresh\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 });
 
@@ -395,7 +583,7 @@ describe.skipIf(!py3)('render — last_reviewed deterministic paths', () => {
 // render — custom glossary (override labels + bands).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — custom glossary', () => {
+describe('render — custom glossary', () => {
     const GLOSS = `# a comment
 labels:
   confidence: Vertrauen
@@ -421,9 +609,16 @@ bands:
             id: 'g',
         });
         const g = writeRaw('gloss.yml', GLOSS);
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', g], tmp, [
-            tmp,
-        ]);
+        expect(
+            snap(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', g], tmp, [tmp]),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["g"], "markdown": "## Quellen\\n1 source(s) \\u2014 a\\n\\n## Vertrauen\\nHigh (0.72)\\n\\n## Geprueft\\n(unavailable) \\u00b7 Aging\\n\\n## Strittig\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('glossary with quoted label value (strip quotes)', () => {
@@ -435,9 +630,16 @@ bands:
   sources: 'Single Quoted'
 `,
         );
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', g], tmp, [
-            tmp,
-        ]);
+        expect(
+            snap(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', g], tmp, [tmp]),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["q"], "markdown": "## Single Quoted\\n0 source(s)\\n\\n## Quoted Conf\\nMedium (0.50)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('glossary with non-float band value (ValueError → skipped)', () => {
@@ -450,19 +652,31 @@ bands:
     high: 0.55
 `,
         );
-        expectParity(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', g], tmp, [
-            tmp,
-        ]);
+        expect(
+            snap(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', g], tmp, [tmp]),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["s"], "markdown": "## Where this came from\\n0 source(s)\\n\\n## How confident\\nHigh (0.60)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('missing glossary file → defaults used', () => {
         const env = writeJson('e.json', { trust_score: 0.66, evidence: { sources: ['z'] }, id: 'd' });
         const ghost = path.join(tmp, 'no-such.yml');
-        expectParity(
-            ['render', '--mode', 'plain', '--envelope-file', env, '--glossary', ghost],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(['render', '--mode', 'plain', '--envelope-file', env, '--glossary', ghost], tmp, [tmp]),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["d"], "markdown": "## Where this came from\\n1 source(s) \\u2014 z\\n\\n## How confident\\nHigh (0.66)\\n\\n## When last reviewed\\n(unavailable) \\u00b7 Stale\\n\\n## What's contested\\nNo open disagreements.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('glossary does NOT override technical labels (LABELS_TECHNICAL fixed)', () => {
@@ -474,11 +688,16 @@ bands:
             id: 'gt',
         });
         const g = writeRaw('gloss.yml', GLOSS);
-        expectParity(
-            ['render', '--mode', 'technical', '--envelope-file', env, '--glossary', g],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(['render', '--mode', 'technical', '--envelope-file', env, '--glossary', g], tmp, [tmp]),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"ids": ["gt"], "markdown": "## Sources\\n1 source(s) \\u2014 a\\n\\n## Trust score\\n0.72\\n\\n## Last reviewed\\n(unavailable) \\u00b7 decay=0.50\\n\\n## Unresolved contradictions\\n0\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 });
 
@@ -486,7 +705,7 @@ bands:
 // explain-host — plain mode (known/unknown, tier1/tier3, demotion, killed, resume).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('explain-host — plain mode', () => {
+describe('explain-host — plain mode', () => {
     it('known tier-1 driving host', () => {
         const det = writeJson('d.json', {
             host: 'claude-code',
@@ -497,7 +716,14 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 1,
             mode: 'tier1-drive-pending',
         });
-        expectParity(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "claude-code", "markdown": "## Why this host\\n\`claude-code\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 1** \\u2014 \`claude-code\` drives the work directly because its CLI (\`claude\`) is installed and on your PATH.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('known tier-3 handoff host', () => {
@@ -510,7 +736,14 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 3,
             mode: 'handoff',
         });
-        expectParity(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "augment", "markdown": "## Why this host\\n\`augment\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 3** \\u2014 \`augment\` hands work off through the inbox rather than driving it directly.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('unknown host (known:false) → hand-off sentence', () => {
@@ -523,7 +756,14 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 3,
             mode: 'handoff',
         });
-        expectParity(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "mystery", "markdown": "## Why this host\\n\`mystery\` is not in the known-host list, so it is treated as a hand-off host.\\n\\n## Why this tier\\nRunning at **Tier 3** \\u2014 \`mystery\` hands work off through the inbox rather than driving it directly.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('tier-1 demotion fallback (known + inv_tier 1 + no cli) fires "Why a fallback fired"', () => {
@@ -536,7 +776,14 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 3,
             mode: 'handoff',
         });
-        expectParity(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "codex", "markdown": "## Why this host\\n\`codex\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 3** \\u2014 \`codex\` hands work off through the inbox rather than driving it directly.\\n\\n## Why a fallback fired\\n\`codex\` would normally drive at Tier 1, but its CLI (\`codex\`) isn't on your PATH \\u2014 so it dropped to Tier 3 hand-off. Install the CLI to get direct driving back.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('killed kill-switch fallback (with health)', () => {
@@ -549,11 +796,20 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 1,
         });
         const health = writeJson('h.json', { killed: true, consecutive_failures: 4 });
-        expectParity(
-            ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(
+                ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
+                tmp,
+                [tmp],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "claude-code", "markdown": "## Why this host\\n\`claude-code\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 1** \\u2014 \`claude-code\` drives the work directly because its CLI (\`claude\`) is installed and on your PATH.\\n\\n## Why a fallback fired\\nThe drive kill-switch is **on** for \`claude-code\` after 4 consecutive failures. New launches run as a probe \\u2014 one success closes the switch automatically.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('demotion + killed both fire (two fallback paragraphs)', () => {
@@ -566,11 +822,20 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 3,
         });
         const health = writeJson('h.json', { killed: true, consecutive_failures: 7 });
-        expectParity(
-            ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(
+                ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
+                tmp,
+                [tmp],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "codex", "markdown": "## Why this host\\n\`codex\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 3** \\u2014 \`codex\` hands work off through the inbox rather than driving it directly.\\n\\n## Why a fallback fired\\n\`codex\` would normally drive at Tier 1, but its CLI (\`codex\`) isn't on your PATH \\u2014 so it dropped to Tier 3 hand-off. Install the CLI to get direct driving back.\\nThe drive kill-switch is **on** for \`codex\` after 7 consecutive failures. New launches run as a probe \\u2014 one success closes the switch automatically.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('resume-session-id → "Why continue" block', () => {
@@ -582,19 +847,28 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             cli_present: true,
             effective_tier: 1,
         });
-        expectParity(
-            [
-                'explain-host',
-                '--mode',
-                'plain',
-                '--detection-file',
-                det,
-                '--resume-session-id',
-                'sess-abc',
-            ],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(
+                [
+                    'explain-host',
+                    '--mode',
+                    'plain',
+                    '--detection-file',
+                    det,
+                    '--resume-session-id',
+                    'sess-abc',
+                ],
+                tmp,
+                [tmp],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "claude-code", "markdown": "## Why this host\\n\`claude-code\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 1** \\u2014 \`claude-code\` drives the work directly because its CLI (\`claude\`) is installed and on your PATH.\\n\\n## Why continue\\nResuming your previous session (\`sess-abc\`) instead of starting fresh, so the task keeps its context across turns.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('killed false, no fallback, no resume (minimal plain)', () => {
@@ -607,16 +881,32 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 1,
         });
         const health = writeJson('h.json', { killed: false, consecutive_failures: 0 });
-        expectParity(
-            ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(
+                ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
+                tmp,
+                [tmp],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "gemini", "markdown": "## Why this host\\n\`gemini\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 1** \\u2014 \`gemini\` drives the work directly because its CLI (\`gemini\`) is installed and on your PATH.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('detection missing host → "(unknown)" default', () => {
         const det = writeJson('d.json', { known: false });
-        expectParity(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'plain', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "(unknown)", "markdown": "## Why this host\\n\`(unknown)\` is not in the known-host list, so it is treated as a hand-off host.\\n\\n## Why this tier\\nRunning at **Tier 3** \\u2014 \`(unknown)\` hands work off through the inbox rather than driving it directly.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 
     it('health consecutive_failures absent → int(... or 0) → 0', () => {
@@ -629,11 +919,20 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
             effective_tier: 3,
         });
         const health = writeJson('h.json', { killed: true });
-        expectParity(
-            ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(
+                ['explain-host', '--mode', 'plain', '--detection-file', det, '--health-file', health],
+                tmp,
+                [tmp],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "codex", "markdown": "## Why this host\\n\`codex\` is your active host.\\n\\n## Why this tier\\nRunning at **Tier 3** \\u2014 \`codex\` hands work off through the inbox rather than driving it directly.\\n\\n## Why a fallback fired\\n\`codex\` would normally drive at Tier 1, but its CLI (\`codex\`) isn't on your PATH \\u2014 so it dropped to Tier 3 hand-off. Install the CLI to get direct driving back.\\nThe drive kill-switch is **on** for \`codex\` after 0 consecutive failures. New launches run as a probe \\u2014 one success closes the switch automatically.\\n", "mode": "plain"}
+          ",
+          }
+        `);
     });
 });
 
@@ -641,7 +940,7 @@ describe.skipIf(!py3)('explain-host — plain mode', () => {
 // explain-host — technical mode (raw 2-line block).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('explain-host — technical mode', () => {
+describe('explain-host — technical mode', () => {
     it('technical block, all fields + health + resume', () => {
         const det = writeJson('d.json', {
             host: 'augment',
@@ -653,21 +952,30 @@ describe.skipIf(!py3)('explain-host — technical mode', () => {
             mode: 'handoff',
         });
         const health = writeJson('h.json', { killed: true, consecutive_failures: 4 });
-        expectParity(
-            [
-                'explain-host',
-                '--mode',
-                'technical',
-                '--detection-file',
-                det,
-                '--health-file',
-                health,
-                '--resume-session-id',
-                'sess-9',
-            ],
-            tmp,
-            [tmp],
-        );
+        expect(
+            snap(
+                [
+                    'explain-host',
+                    '--mode',
+                    'technical',
+                    '--detection-file',
+                    det,
+                    '--health-file',
+                    health,
+                    '--resume-session-id',
+                    'sess-9',
+                ],
+                tmp,
+                [tmp],
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "augment", "markdown": "## Host decision (technical)\\nhost=augment known=True inventory_tier=1 effective_tier=3 cli=aug cli_present=False killed=True consecutive_failures=4 resume_session_id=sess-9\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 
     it('technical block, no health no resume → killed=False, failures=0, resume=-', () => {
@@ -679,7 +987,14 @@ describe.skipIf(!py3)('explain-host — technical mode', () => {
             cli_present: true,
             effective_tier: 1,
         });
-        expectParity(['explain-host', '--mode', 'technical', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'technical', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "claude-code", "markdown": "## Host decision (technical)\\nhost=claude-code known=True inventory_tier=1 effective_tier=1 cli=claude cli_present=True killed=False consecutive_failures=0 resume_session_id=-\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 
     it('technical block, unknown host (null inv_tier, null cli)', () => {
@@ -691,44 +1006,41 @@ describe.skipIf(!py3)('explain-host — technical mode', () => {
             cli_present: false,
             effective_tier: 3,
         });
-        expectParity(['explain-host', '--mode', 'technical', '--detection-file', det], tmp, [tmp]);
+        expect(snap(['explain-host', '--mode', 'technical', '--detection-file', det], tmp, [tmp])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"host": "mystery", "markdown": "## Host decision (technical)\\nhost=mystery known=False inventory_tier=None effective_tier=3 cli=None cli_present=False killed=False consecutive_failures=0 resume_session_id=-\\n", "mode": "technical"}
+          ",
+          }
+        `);
     });
 });
 
 // ---------------------------------------------------------------------------
-// File-not-found (Python traceback vs node stack — only exit code asserted).
+// File errors (node stack not asserted — only exit code + empty stdout).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('explain — file errors', () => {
+describe('explain — file errors', () => {
     it('render envelope-file not found → exit 1, no stdout', () => {
         const ghost = path.join(tmp, 'nope.json');
-        const p = runPy(['render', '--envelope-file', ghost], tmp);
         const t = runTs(['render', '--envelope-file', ghost], tmp);
-        expect(p.status).toBe(1);
         expect(t.status).toBe(1);
-        expect(p.stdout).toBe('');
         expect(t.stdout).toBe('');
-        expect(p.stderr.length).toBeGreaterThan(0);
         expect(t.stderr.length).toBeGreaterThan(0);
     });
 
     it('explain-host detection-file not found → exit 1, no stdout', () => {
         const ghost = path.join(tmp, 'nope.json');
-        const p = runPy(['explain-host', '--detection-file', ghost], tmp);
         const t = runTs(['explain-host', '--detection-file', ghost], tmp);
-        expect(p.status).toBe(1);
         expect(t.status).toBe(1);
-        expect(p.stdout).toBe('');
         expect(t.stdout).toBe('');
     });
 
     it('render malformed JSON → exit 1, no stdout', () => {
         const bad = writeRaw('bad.json', '{not json');
-        const p = runPy(['render', '--envelope-file', bad], tmp);
         const t = runTs(['render', '--envelope-file', bad], tmp);
-        expect(p.status).toBe(1);
         expect(t.status).toBe(1);
-        expect(p.stdout).toBe('');
         expect(t.stdout).toBe('');
     });
 });

--- a/tests/scripts/cli/python/workspace_hosts.test.ts
+++ b/tests/scripts/cli/python/workspace_hosts.test.ts
@@ -1,37 +1,35 @@
-// Golden-parity tests for src/cli/python/workspace_hosts.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_hosts.ts (py2ts ADR-200 —
 // host-agent tier detection, ADR-068).
 //
-// Strategy: run `python3 workspace_hosts.py` vs `tsx workspace_hosts.ts` and
-// byte-compare stdout / stderr / exit. Detection is side-effect-free and
-// deterministic (it only reads the static HOST_INVENTORY + checks PATH via
-// `shutil.which` / a PATH walk), so the two languages agree byte-for-byte on
-// every surface. To make `cli_present` deterministic regardless of which host
-// CLIs happen to be installed on the runner, every case that asserts the
-// detect/list payload runs with `PATH=''` so NO host CLI resolves — both
-// languages then report `cli_present:false` / `effective_tier:3` identically.
-//
-// Coverage: detect known (tier-1 + tier-3) / unknown, list text + --json,
-// --json detect, and the full argparse error surface (no-args, bad subcommand,
-// missing positional, extra positional, unknown flag). The argparse `--help`
-// BODY is NOT byte-compared (only the `usage:` line) per the porting contract.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. Detection is side-effect-free
+// and reads the static HOST_INVENTORY + probes PATH (`shutil.which` semantics).
+// To stay deterministic regardless of which host CLIs are installed on the
+// runner, every case spawns with a **node-only PATH** (a temp dir holding just a
+// `node` symlink) so the tsx launcher resolves but NO host CLI does — every host
+// then reports `cli_present:false` / `effective_tier:3`. COLUMNS=200 forces
+// single-line usage so arg-error stderr does not re-wrap to terminal width.
+import { mkdtempSync, symlinkSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_hosts.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_hosts.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic host-CLI detection (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(path.join(tmpdir(), 'ws-hosts-nodeonly-'));
+symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
 
 interface RunResult {
     status: number | null;
@@ -39,88 +37,181 @@ interface RunResult {
     stderr: string;
 }
 
-function runPy(args: string[], extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
-function runTs(args: string[], extraEnv: Record<string, string> = {}): RunResult {
+function runTs(args: string[]): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         encoding: 'utf8',
-        env: { ...process.env, ...extraEnv },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
 
-
-function expectParity(args: string[], extraEnv: Record<string, string> = {}): void {
-    const p = runPy(args, extraEnv);
-    const t = runTs(args, extraEnv);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
-}
-
-describe.skipIf(!py3)('workspace_hosts — detect', () => {
+describe('workspace_hosts — detect', () => {
     it('tier-1 known host (no CLI on PATH → demotes to tier 3)', () => {
-        expectParity(['detect', 'claude-code']);
+        expect(runTs(['detect', 'claude-code'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"cli": "claude", "cli_present": false, "effective_tier": 3, "host": "claude-code", "inventory_tier": 1, "known": true, "mode": "handoff"}
+          ",
+          }
+        `);
     });
     it('tier-3 known host', () => {
-        expectParity(['detect', 'augment']);
+        expect(runTs(['detect', 'augment'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"cli": null, "cli_present": false, "effective_tier": 3, "host": "augment", "inventory_tier": 3, "known": true, "mode": "handoff"}
+          ",
+          }
+        `);
     });
     it('unknown host (fail-soft, exit 1)', () => {
-        expectParity(['detect', 'nope']);
+        expect(runTs(['detect', 'nope'])).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "{"cli": null, "cli_present": false, "effective_tier": 3, "host": "nope", "inventory_tier": null, "known": false, "mode": "handoff"}
+          ",
+          }
+        `);
     });
     it('detect --json', () => {
-        expectParity(['detect', 'codex', '--json']);
+        expect(runTs(['detect', 'codex', '--json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"cli": "codex", "cli_present": false, "effective_tier": 3, "host": "codex", "inventory_tier": 1, "known": true, "mode": "handoff"}
+          ",
+          }
+        `);
     });
-    it('detect --json= inline (none here, but flag before positional)', () => {
-        expectParity(['detect', '--json', 'gemini']);
+    it('detect --json before positional', () => {
+        expect(runTs(['detect', '--json', 'gemini'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"cli": "gemini", "cli_present": false, "effective_tier": 3, "host": "gemini", "inventory_tier": 1, "known": true, "mode": "handoff"}
+          ",
+          }
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_hosts — list', () => {
+describe('workspace_hosts — list', () => {
     it('list (text)', () => {
-        expectParity(['list']);
+        expect(runTs(['list'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "augment	tier3	no-cli
+          claude-code	tier1	no-cli
+          cline	tier3	no-cli
+          codex	tier1	no-cli
+          cursor	tier3	no-cli
+          gemini	tier1	no-cli
+          windsurf	tier3	no-cli
+          ",
+          }
+        `);
     });
     it('list --json', () => {
-        expectParity(['list', '--json']);
+        expect(runTs(['list', '--json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "[{"cli": null, "cli_present": false, "effective_tier": 3, "host": "augment", "inventory_tier": 3, "known": true, "mode": "handoff"}, {"cli": "claude", "cli_present": false, "effective_tier": 3, "host": "claude-code", "inventory_tier": 1, "known": true, "mode": "handoff"}, {"cli": null, "cli_present": false, "effective_tier": 3, "host": "cline", "inventory_tier": 3, "known": true, "mode": "handoff"}, {"cli": "codex", "cli_present": false, "effective_tier": 3, "host": "codex", "inventory_tier": 1, "known": true, "mode": "handoff"}, {"cli": null, "cli_present": false, "effective_tier": 3, "host": "cursor", "inventory_tier": 3, "known": true, "mode": "handoff"}, {"cli": "gemini", "cli_present": false, "effective_tier": 3, "host": "gemini", "inventory_tier": 1, "known": true, "mode": "handoff"}, {"cli": null, "cli_present": false, "effective_tier": 3, "host": "windsurf", "inventory_tier": 3, "known": true, "mode": "handoff"}]
+          ",
+          }
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_hosts — argparse errors', () => {
+describe('workspace_hosts — argparse errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParity([]);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_hosts [-h] {detect,list} ...
+          workspace_hosts: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParity(['bogus']);
+        expect(runTs(['bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_hosts [-h] {detect,list} ...
+          workspace_hosts: error: argument cmd: invalid choice: 'bogus' (choose from 'detect', 'list')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('detect missing host_id → exit 2', () => {
-        expectParity(['detect']);
+        expect(runTs(['detect'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_hosts detect [-h] [--json] host_id
+          workspace_hosts detect: error: the following arguments are required: host_id
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('detect extra positional → unrecognized, exit 2', () => {
-        expectParity(['detect', 'a', 'b']);
+        expect(runTs(['detect', 'a', 'b'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_hosts [-h] {detect,list} ...
+          workspace_hosts: error: unrecognized arguments: b
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('detect unknown flag → unrecognized, exit 2', () => {
-        expectParity(['detect', '--bogus', 'x']);
+        expect(runTs(['detect', '--bogus', 'x'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_hosts [-h] {detect,list} ...
+          workspace_hosts: error: unrecognized arguments: --bogus
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('list extra positional → unrecognized, exit 2', () => {
-        expectParity(['list', 'extra']);
+        expect(runTs(['list', 'extra'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_hosts [-h] {detect,list} ...
+          workspace_hosts: error: unrecognized arguments: extra
+          ",
+            "stdout": "",
+          }
+        `);
     });
-    it('top-level -h → usage line + exit 0', () => {
-        // Body differs (argparse re-wraps); assert the usage line + exit only.
-        const p = runPy(['-h']);
-        const t = runTs(['-h']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+    it('top-level -h → usage + exit 0', () => {
+        expect(runTs(['-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: workspace_hosts [-h] {detect,list} ...
+          ",
+          }
+        `);
     });
-    it('detect -h → subparser usage line + exit 0', () => {
-        const p = runPy(['detect', '-h']);
-        const t = runTs(['detect', '-h']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+    it('detect -h → subparser usage + exit 0', () => {
+        expect(runTs(['detect', '-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: workspace_hosts detect [-h] [--json] host_id
+          ",
+          }
+        `);
     });
 });

--- a/tests/scripts/cli/python/workspace_inbox.test.ts
+++ b/tests/scripts/cli/python/workspace_inbox.test.ts
@@ -1,40 +1,42 @@
-// Golden-parity tests for src/cli/python/workspace_inbox.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_inbox.ts (py2ts ADR-200 —
 // Tier-3 host hand-off inbox, ADR-023 Tier 3 / ADR-065).
 //
-// Strategy: run `python3 workspace_inbox.py` vs `tsx workspace_inbox.ts` and
-// byte-compare stdout / stderr / exit. The store writes files into a
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. The store writes files into a
 // `<root>/<id>.md` where `<id>` is `<UTC-stamp>-<8 random hex>` and the
-// frontmatter carries `created_at` (UTC second) — both NONDETERMINISTIC and
-// differing py-vs-ts. So functional cases run each language in a SEPARATE
-// hermetic `<tmp>/workspace/inbox` root, replay the SAME command, then
+// frontmatter carries `created_at` (UTC second) — both NONDETERMINISTIC. So
+// functional cases run in a hermetic `<tmp>/workspace/inbox` root, then
 // `norm()` masks the random id, the timestamp, and the tmp root before
-// comparing — leaving the structural payload (banner shape, frontmatter keys,
-// scrubbed body, JSON shape, ordering) a true byte-for-byte assertion.
+// snapshotting — leaving the structural payload (banner shape, frontmatter
+// keys, scrubbed body, JSON shape, ordering) a reproducible assertion.
 //
 // `_validate_cli_root` requires `--root` to be a `.../workspace/inbox` dir, so
-// every root is `<tmp>/workspace/inbox`. The `--help` BODY is NOT byte-compared
-// (only the `usage:` line) per the porting contract; the Python runs force
-// COLUMNS=80 so the multi-line usage strings byte-match the TS hardcoded form.
+// every root is `<tmp>/workspace/inbox`. To stay deterministic regardless of
+// which host CLIs are installed on the runner, every case spawns with a
+// **node-only PATH** (a temp dir holding just a `node` symlink) so the tsx
+// launcher resolves but no host CLI does. COLUMNS=80 forces the multi-line
+// usage strings to a stable width.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_inbox.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_inbox.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic regardless of installed host CLIs.
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-inbox-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    fs.rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface RunResult {
     status: number | null;
@@ -42,20 +44,10 @@ interface RunResult {
     stderr: string;
 }
 
-const COLS80 = { COLUMNS: '80' };
-
-function runPy(args: string[], extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), ...COLS80, ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
-function runTs(args: string[], extraEnv: Record<string, string> = {}): RunResult {
+function runTs(args: string[]): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         encoding: 'utf8',
-        env: { ...process.env, ...COLS80, ...extraEnv },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '80' },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
@@ -80,29 +72,26 @@ function norm(text: string, roots: string[]): string {
     return out;
 }
 
-/** Byte-exact parity (deterministic surfaces: usage / arg errors). */
-function expectParityExact(args: string[]): void {
-    const p = runPy(args);
-    const t = runTs(args);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
+interface NormResult {
+    status: number | null;
+    stdout: string;
+    stderr: string;
 }
 
-let pyRoot: string;
+/** runTs + norm on both streams (for snapshotting nondeterministic surfaces). */
+function runTsNorm(args: string[], roots: string[]): NormResult {
+    const r = runTs(args);
+    return { status: r.status, stdout: norm(r.stdout, roots), stderr: norm(r.stderr, roots) };
+}
+
 let tsRoot: string;
-let pyTmp: string;
 let tsTmp: string;
 beforeEach(() => {
-    pyTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsinbox-py-'));
     tsTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wsinbox-ts-'));
-    pyRoot = path.join(pyTmp, 'workspace', 'inbox');
     tsRoot = path.join(tsTmp, 'workspace', 'inbox');
-    fs.mkdirSync(pyRoot, { recursive: true });
     fs.mkdirSync(tsRoot, { recursive: true });
 });
 afterEach(() => {
-    fs.rmSync(pyTmp, { recursive: true, force: true });
     fs.rmSync(tsTmp, { recursive: true, force: true });
 });
 
@@ -112,176 +101,538 @@ function bodyFile(dir: string, content: string): string {
     return p;
 }
 
-describe.skipIf(!py3)('workspace_inbox — write + read + list + forget', () => {
-    it('write returns id/path/banner (normalized parity)', () => {
-        const pb = bodyFile(pyTmp, 'Customer wants a quote.\n');
+describe('workspace_inbox — write + read + list + forget', () => {
+    it('write returns id/path/banner (normalized)', () => {
         const tb = bodyFile(tsTmp, 'Customer wants a quote.\n');
-        const p = runPy(['write', '--role', 'sales', '--task', 'draft offer', '--body-file', pb, '--root', pyRoot]);
-        const t = runTs(['write', '--role', 'sales', '--task', 'draft offer', '--body-file', tb, '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        const t = runTs([
+            'write',
+            '--role',
+            'sales',
+            '--task',
+            'draft offer',
+            '--body-file',
+            tb,
+            '--root',
+            tsRoot,
+        ]);
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "{"banner": "Tier-3 hand-off ready: copy /private<TMP>/<ID>.md into your host, then open it.", "id": "<ID>", "path": "/private<TMP>/<ID>.md"}
+          "
+        `);
     });
 
     it('write scrubs a secret in body + task', () => {
         const secret = 'AKIAIOSFODNN7EXAMPLE';
-        const pb = bodyFile(pyTmp, `key here: ${secret}\n`);
         const tb = bodyFile(tsTmp, `key here: ${secret}\n`);
-        runPy(['write', '--role', 'r', '--task', `t ${secret}`, '--body-file', pb, '--root', pyRoot]);
         runTs(['write', '--role', 'r', '--task', `t ${secret}`, '--body-file', tb, '--root', tsRoot]);
-        // Read each back and compare normalized file bodies; secret must be gone.
-        const pf = fs.readdirSync(pyRoot)[0] as string;
         const tf = fs.readdirSync(tsRoot)[0] as string;
-        const pTxt = fs.readFileSync(path.join(pyRoot, pf), 'utf8');
         const tTxt = fs.readFileSync(path.join(tsRoot, tf), 'utf8');
-        expect(pTxt).not.toContain(secret);
         expect(tTxt).not.toContain(secret);
-        expect(norm(tTxt, [tsRoot, tsTmp])).toBe(norm(pTxt, [pyRoot, pyTmp]));
+        expect(norm(tTxt, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "---
+          id: <ID>
+          role: r
+          task: t [SECRET]
+          created_at: <TS>
+          ---
+
+          key here: [SECRET]
+          "
+        `);
     });
 
     it('write with --skill-hint pre-renders a skill section', () => {
-        // Use a present skill if any; else a missing one (note section). Either
-        // way the two languages must render identically.
         const hint = 'docker';
-        const pb = bodyFile(pyTmp, 'Base prompt.\n');
         const tb = bodyFile(tsTmp, 'Base prompt.\n');
-        runPy(['write', '--role', 'r', '--task', 't', '--body-file', pb, '--skill-hint', hint, '--root', pyRoot]);
-        runTs(['write', '--role', 'r', '--task', 't', '--body-file', tb, '--skill-hint', hint, '--root', tsRoot]);
-        const pTxt = fs.readFileSync(path.join(pyRoot, fs.readdirSync(pyRoot)[0] as string), 'utf8');
+        runTs([
+            'write',
+            '--role',
+            'r',
+            '--task',
+            't',
+            '--body-file',
+            tb,
+            '--skill-hint',
+            hint,
+            '--root',
+            tsRoot,
+        ]);
         const tTxt = fs.readFileSync(path.join(tsRoot, fs.readdirSync(tsRoot)[0] as string), 'utf8');
-        expect(norm(tTxt, [tsRoot, tsTmp])).toBe(norm(pTxt, [pyRoot, pyTmp]));
+        expect(norm(tTxt, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "---
+          id: <ID>
+          role: r
+          task: t
+          created_at: <TS>
+          ---
+
+          Base prompt.
+
+
+          ## Skill context: docker
+
+          _Use when working with Docker — Dockerfile edits, docker-compose services, containers, or the dual-container (fast + Xdebug) setup — even when the user just says 'my container won't start'._
+
+          # docker
+
+          ## When to use
+
+          Use this skill when working with Docker configuration, container setup, Dockerfile changes, or docker-compose modifications.
+
+
+          Do NOT use when:
+          - Production deployment (use \`aws-infrastructure\` skill)
+          - Codespaces setup (use \`devcontainer\` skill)
+
+          ## Procedure: Modify Docker setup
+
+          1. **Gather context** — read project Docker docs in \`agents/\` or \`Docs/\`, check \`Makefile\`/\`Taskfile.yml\` for targets, read \`docker-compose.yml\`/\`compose.yaml\` for service layout.
+          2. **Identify scope** — determine which service(s) are affected (PHP, NGINX, worker, scheduler, database).
+          3. **Inspect current state** — run \`docker compose ps\` to see running containers and their health status.
+          4. **Make the change** — edit the relevant file (Dockerfile, compose file, NGINX config, Makefile target). Follow the conventions in the reference sections below.
+          5. **Rebuild affected containers** — \`docker compose build <service>\` (add \`--no-cache\` if Dockerfile base layers changed).
+          6. **Verify** — \`docker compose up -d\`, check \`docker compose ps\` for healthy status, run a smoke test (e.g., \`make test-quick\` or \`curl localhost\`).
+
+          ## Project architecture
+
+          ### Dockerfile (\`.docker/Dockerfile\`)
+
+          Multi-stage build with these targets:
+
+          | Stage | Purpose |
+          |---|---|
+          | \`base\` | Alpine + PHP-FPM + system packages + extensions |
+          | \`dev\` | Development: Xdebug, dev tools, Composer dev deps |
+          | \`pro\` | Production: optimized, no dev deps, New Relic agent |
+
+          Key build args:
+          - \`PHP_VERSION\` — extracted from Dockerfile, used by CI
+          - \`COMPOSER_AUTH\` — private registry access (passed as secret)
+          - \`CACHEBUST\` — weekly cache invalidation (\`date +%Y-%U\`)
+          - \`COMPOSER_NO_DEV\` — \`1\` for production, \`0\` for dev
+
+          ### Dual-container architecture (PHP projects)
+
+          Some projects run two PHP-FPM containers simultaneously (fast + Xdebug):
+
+          | Container | Purpose | PHP-FPM mode |
+          |---|---|---|
+          | \`{project}-php\` | Fast execution, no debugger | \`pm = dynamic\` |
+          | \`{project}-php-xdebug\` | Xdebug enabled, debugging | \`pm = ondemand\` |
+
+          NGINX routes requests based on HTTP headers:
+          - No header → fast container
+          - \`X-Xdebug-Enable: 1\` or \`X-Debug-Session: PHPSTORM\` → Xdebug container
+
+          ### docker-compose services
+
+          Read \`docker-compose.yml\` / \`compose.yaml\` to discover the actual service names. Common patterns:
+
+          | Service type | Description |
+          |---|---|
+          | PHP-FPM | Main application server |
+          | PHP-FPM + Xdebug | Debugging container |
+          | NGINX | Reverse proxy |
+          | Queue worker | Background job processing (e.g., Horizon) |
+          | Scheduler | Cron/task scheduler |
+          | Database | MariaDB / MySQL / PostgreSQL |
+          | Cache | Redis / Memcached |
+
+          ## Conventions
+
+          ### Container commands
+
+          - **Always execute PHP commands inside the container**, never on the host.
+          - Use \`docker compose exec -T <service> ...\` for non-interactive (scripts, CI).
+          - Use \`make console\` for interactive shell access.
+          - Use \`make console-xdebug\` for Xdebug container access.
+
+          ### Image building
+
+          - Production images use \`target: pro\` — no dev dependencies.
+          - Check the project's CI/CD config for target platform and registry.
+          - Docker Hub login may be needed for pulling base images (rate limits).
+
+          ### PHP extensions
+
+          Extensions are installed via \`mlocati/php-extension-installer\`:
+          - Check the Dockerfile for the current list.
+          - Add new extensions in the \`base\` stage so they're available in all targets.
+
+          ### Environment files
+
+          - \`.env\` is NOT baked into the Docker image.
+          - Production: \`.env\` is fetched from **AWS Secrets Manager** at deploy time.
+          - Development: \`.env\` is mounted via docker-compose volumes.
+
+          ## Makefile targets
+
+          Always check the \`Makefile\` for available targets before using raw docker commands:
+
+          \`\`\`
+          make start              # Start all containers
+          make stop               # Stop all containers
+          make console            # Enter PHP container (bash)
+          make console-xdebug     # Enter Xdebug PHP container
+          make composer-install   # Run composer install in container
+          make migrate            # Run migrations
+          make migrate-and-seed   # Run migrations + seed
+          make test               # Run all tests (parallel)
+          \`\`\`
+
+
+          ## Container orchestration
+
+          ### Environment synchronization
+
+          When the development environment is out of sync (missing containers, wrong state):
+
+          1. **Check status** — \`docker compose ps\` to see which services are running.
+          2. **Start missing services** — \`make start\` or \`docker compose up -d\`.
+          3. **Rebuild if needed** — \`docker compose build --no-cache <service>\` after Dockerfile changes.
+          4. **Reset state** — \`make migrate-and-seed\` after fresh container start.
+
+          ### Common sync issues
+
+          | Symptom | Cause | Fix |
+          |---|---|---|
+          | "Connection refused" | Container not running | \`make start\` |
+          | "Table not found" | Migrations not run | \`make migrate-and-seed\` |
+          | "Class not found" | Composer not installed | \`make composer-install\` |
+          | Old PHP version | Image not rebuilt | \`docker compose build <php-service>\` |
+          | Extension missing | Dockerfile changed | Rebuild with \`--no-cache\` |
+
+          ### Multi-project orchestration
+
+          When running multiple projects simultaneously:
+          - Check for **port conflicts** — each project needs unique exposed ports.
+          - Use **Traefik** (see \`traefik\` skill) for routing by domain instead of port.
+          - Shared services (MariaDB, Redis) can be in a dedicated \`docker-compose.shared.yml\`.
+
+          ## Security hardening checklist
+
+          When creating or reviewing Dockerfiles:
+
+          - [ ] **Non-root user** — create user with specific UID/GID, use \`USER\` directive before \`CMD\`.
+          - [ ] **No secrets in layers** — never \`ENV\` or \`COPY\` secrets. Use \`--mount=type=secret\` (BuildKit) or runtime secrets.
+          - [ ] **Minimal packages** — only install what's needed. Remove package manager cache in the same \`RUN\` layer.
+          - [ ] **Read-only root filesystem** — use \`--read-only\` flag where possible, mount writable dirs explicitly.
+          - [ ] **No \`latest\` tag** — pin base image versions (\`node:18.19-alpine\`, not \`node:latest\`).
+          - [ ] **Scan images** — use \`docker scout quickview\` or Trivy for vulnerability scanning.
+
+          \`\`\`dockerfile
+          # Security pattern
+          RUN addgroup -g 1001 -S appgroup && \\
+              adduser -S appuser -u 1001 -G appgroup
+          COPY --chown=appuser:appgroup . .
+          USER 1001
+          \`\`\`
+
+          ## Health check patterns
+
+          Always add health checks to long-running services:
+
+          \`\`\`dockerfile
+          HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \\
+            CMD curl -f http://localhost:8080/health || exit 1
+          \`\`\`
+
+          In docker-compose, use \`condition: service_healthy\` for dependency ordering:
+
+          \`\`\`yaml
+          services:
+            app:
+              depends_on:
+                db:
+                  condition: service_healthy
+          \`\`\`
+
+          ## Image size optimization
+
+          | Technique | Impact | When |
+          |---|---|---|
+          | Multi-stage builds | **High** | Always — separate build from runtime |
+          | Alpine base images | **High** | When compatibility allows |
+          | Distroless images | **High** | Production, no shell needed |
+          | \`.dockerignore\` | **Medium** | Always — exclude \`node_modules\`, \`.git\`, \`tests\`, docs |
+          | Combine \`RUN\` layers | **Medium** | When installing packages + cleaning cache |
+          | Copy only artifacts | **Medium** | \`COPY --from=build\` only what's needed |
+
+          ## Build cache optimization
+
+          Use BuildKit cache mounts for package managers:
+
+          \`\`\`dockerfile
+          # Composer (PHP)
+          RUN --mount=type=cache,target=/root/.composer/cache \\
+              composer install --no-dev --optimize-autoloader
+
+          # npm (Node.js)
+          RUN --mount=type=cache,target=/root/.npm \\
+              npm ci --only=production
+          \`\`\`
+
+          **Layer ordering for cache efficiency:**
+          1. System packages (changes rarely)
+          2. Dependency files (\`composer.json\`, \`package.json\`) — changes sometimes
+          3. \`RUN install\` — cached if dependency files unchanged
+          4. Source code (\`COPY . .\`) — changes often, last layer
+
+          ## Output format
+
+          1. Modified Docker configuration files (Dockerfile, docker-compose.yml)
+          2. Updated Makefile targets if applicable
+          3. Rebuild/restart instructions for affected containers
+
+          ## Auto-trigger keywords
+
+          - Docker
+          - docker-compose
+          - container
+          - Dockerfile
+          - PHP container
+
+          ## Gotcha
+
+          - All PHP commands (artisan, composer, phpunit) must run INSIDE the PHP container — never on the host.
+          - The fast container and Xdebug container share the same codebase but have different PHP configs — don't confuse them.
+          - \`docker compose down -v\` destroys volumes including the DB — use \`down\` without \`-v\` unless you mean it.
+          - The model forgets to use \`docker compose exec -T\` (no TTY) when running in scripts or CI.
+
+          ## Do NOT
+
+          - Do NOT change the base Alpine or PHP version without checking CI compatibility.
+          - Do NOT add dev-only tools to the \`pro\` stage.
+          - Do NOT hardcode secrets in the Dockerfile — use build args or runtime secrets.
+          - Do NOT change \`platform\` without verifying AWS runner architecture.
+
+          ## Related
+
+          - **Skill:** \`traefik\` — local reverse proxy with real domains and HTTPS
+          - **Skill:** \`devcontainer\` — DevContainer and Codespaces setup
+          - **Skill:** \`php-debugging\` — Xdebug dual-container architecture
+          - **Rule:** \`docker-commands.md\` — all PHP commands run inside Docker
+
+          "
+        `);
     });
 
     it('read returns the file body (normalized)', () => {
-        const pb = bodyFile(pyTmp, 'Read me.\n');
         const tb = bodyFile(tsTmp, 'Read me.\n');
-        const pw = JSON.parse(
-            runPy(['write', '--role', 'a', '--task', 'b', '--body-file', pb, '--root', pyRoot]).stdout,
-        );
         const tw = JSON.parse(
             runTs(['write', '--role', 'a', '--task', 'b', '--body-file', tb, '--root', tsRoot]).stdout,
         );
-        const p = runPy(['read', pw.id, '--root', pyRoot]);
         const t = runTs(['read', tw.id, '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "---
+          id: <ID>
+          role: a
+          task: b
+          created_at: <TS>
+          ---
+
+          Read me.
+          "
+        `);
     });
 
     it('read missing → stderr + exit 1', () => {
-        const p = runPy(['read', 'nope', '--root', pyRoot]);
         const t = runTs(['read', 'nope', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout);
-        // stderr names the id (deterministic) — compare directly.
-        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toBe(1);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(t.stderr).toMatchInlineSnapshot(`
+          "workspace_inbox: no such hand-off nope
+          "
+        `);
     });
 
     it('list --json (single entry, normalized)', () => {
-        const pb = bodyFile(pyTmp, 'x\n');
         const tb = bodyFile(tsTmp, 'x\n');
-        runPy(['write', '--role', 'sales', '--task', 'one', '--body-file', pb, '--session', 's1', '--root', pyRoot]);
-        runTs(['write', '--role', 'sales', '--task', 'one', '--body-file', tb, '--session', 's1', '--root', tsRoot]);
-        const p = runPy(['list', '--json', '--root', pyRoot]);
+        runTs([
+            'write',
+            '--role',
+            'sales',
+            '--task',
+            'one',
+            '--body-file',
+            tb,
+            '--session',
+            's1',
+            '--root',
+            tsRoot,
+        ]);
         const t = runTs(['list', '--json', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"created_at": "<TS>", "id": "<ID>", "path": "/private<TMP>/<ID>.md", "role": "sales", "session": "s1", "task": "one"}]
+          "
+        `);
     });
 
     it('list text (per-line JSON, empty root)', () => {
-        const p = runPy(['list', '--root', pyRoot]);
         const t = runTs(['list', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // both empty
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
     });
 
     it('forget present → exit 0; absent → exit 1', () => {
-        const pb = bodyFile(pyTmp, 'x\n');
         const tb = bodyFile(tsTmp, 'x\n');
-        const pid = JSON.parse(
-            runPy(['write', '--role', 'a', '--task', 'b', '--body-file', pb, '--root', pyRoot]).stdout,
-        ).id;
         const tid = JSON.parse(
             runTs(['write', '--role', 'a', '--task', 'b', '--body-file', tb, '--root', tsRoot]).stdout,
         ).id;
-        expect(runTs(['forget', tid, '--root', tsRoot]).status).toBe(
-            runPy(['forget', pid, '--root', pyRoot]).status,
-        );
+        expect(runTs(['forget', tid, '--root', tsRoot]).status).toBe(0);
         // forget again → absent → exit 1.
-        expect(runTs(['forget', tid, '--root', tsRoot]).status).toBe(
-            runPy(['forget', pid, '--root', pyRoot]).status,
-        );
+        expect(runTs(['forget', tid, '--root', tsRoot]).status).toBe(1);
     });
 
     it('prune drops nothing recent → {"pruned": 0}', () => {
-        const pb = bodyFile(pyTmp, 'x\n');
         const tb = bodyFile(tsTmp, 'x\n');
-        runPy(['write', '--role', 'a', '--task', 'b', '--body-file', pb, '--root', pyRoot]);
         runTs(['write', '--role', 'a', '--task', 'b', '--body-file', tb, '--root', tsRoot]);
-        const p = runPy(['prune', '--root', pyRoot]);
         const t = runTs(['prune', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // {"pruned": 0}
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "{"pruned": 0}
+          "
+        `);
     });
 
     it('prune --max-age-hours 0 drops everything', () => {
-        const pb = bodyFile(pyTmp, 'x\n');
         const tb = bodyFile(tsTmp, 'x\n');
-        runPy(['write', '--role', 'a', '--task', 'b', '--body-file', pb, '--root', pyRoot]);
         runTs(['write', '--role', 'a', '--task', 'b', '--body-file', tb, '--root', tsRoot]);
-        const p = runPy(['prune', '--max-age-hours', '0', '--root', pyRoot]);
         const t = runTs(['prune', '--max-age-hours', '0', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // {"pruned": 1}
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "{"pruned": 1}
+          "
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_inbox — argparse + root validation errors', () => {
+describe('workspace_inbox — argparse + root validation errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParityExact([]);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox [-h] {write,read,list,forget,prune} ...
+          workspace_inbox: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParityExact(['bogus']);
+        expect(runTs(['bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox [-h] {write,read,list,forget,prune} ...
+          workspace_inbox: error: argument cmd: invalid choice: 'bogus' (choose from 'write', 'read', 'list', 'forget', 'prune')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('write missing all required → exit 2', () => {
-        expectParityExact(['write']);
+        expect(runTs(['write'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox write [-h] --role ROLE --task TASK --body-file
+                                       BODY_FILE [--session SESSION]
+                                       [--skill-hint SKILL_HINT] [--root ROOT]
+          workspace_inbox write: error: the following arguments are required: --role, --task, --body-file
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('read missing inbox_id → exit 2', () => {
-        expectParityExact(['read']);
+        expect(runTs(['read'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox read [-h] [--root ROOT] inbox_id
+          workspace_inbox read: error: the following arguments are required: inbox_id
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('forget missing inbox_id → exit 2', () => {
-        expectParityExact(['forget']);
+        expect(runTs(['forget'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox forget [-h] [--root ROOT] inbox_id
+          workspace_inbox forget: error: the following arguments are required: inbox_id
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('list bad --limit int → exit 2', () => {
-        expectParityExact(['list', '--limit', 'abc']);
+        expect(runTs(['list', '--limit', 'abc'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox list [-h] [--limit LIMIT] [--json] [--root ROOT]
+          workspace_inbox list: error: argument --limit: invalid int value: 'abc'
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('prune bad --max-age-hours int → exit 2', () => {
-        expectParityExact(['prune', '--max-age-hours', 'xyz']);
+        expect(runTs(['prune', '--max-age-hours', 'xyz'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_inbox prune [-h] [--max-age-hours MAX_AGE_HOURS]
+                                       [--root ROOT]
+          workspace_inbox prune: error: argument --max-age-hours: invalid int value: 'xyz'
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('--root not a workspace/inbox dir → SystemExit, exit 1', () => {
-        expectParityExact(['list', '--root', '/tmp/not-an-inbox']);
+        // Normalize the tmp path embedded in the error so the snapshot is stable.
+        expect(runTsNorm(['list', '--root', '/tmp/not-an-inbox'], ['/tmp/not-an-inbox'])).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "workspace_inbox: --root must be a .../workspace/inbox dir, got '<TMP>'
+          ",
+            "stdout": "",
+          }
+        `);
     });
-    it('write -h → usage line + exit 0', () => {
-        const p = runPy(['write', '-h']);
-        const t = runTs(['write', '-h']);
-        expect(t.status).toBe(p.status);
-        // Compare the wrapped usage block (lines until the first blank line).
-        // TS prints usage only (no body); Python prints usage + blank + body.
-        // Compare the usage block, trimming the trailing newline difference.
-        const usageOf = (s: string): string => (s.split('\n\n')[0] as string).trimEnd();
-        expect(usageOf(t.stdout)).toBe(usageOf(p.stdout));
+    it('write -h → usage + exit 0', () => {
+        expect(runTs(['write', '-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: workspace_inbox write [-h] --role ROLE --task TASK --body-file
+                                       BODY_FILE [--session SESSION]
+                                       [--skill-hint SKILL_HINT] [--root ROOT]
+          ",
+          }
+        `);
     });
-    it('prune -h → usage line + exit 0', () => {
-        const p = runPy(['prune', '-h']);
-        const t = runTs(['prune', '-h']);
-        expect(t.status).toBe(p.status);
-        // TS prints usage only (no body); Python prints usage + blank + body.
-        // Compare the usage block, trimming the trailing newline difference.
-        const usageOf = (s: string): string => (s.split('\n\n')[0] as string).trimEnd();
-        expect(usageOf(t.stdout)).toBe(usageOf(p.stdout));
+    it('prune -h → usage + exit 0', () => {
+        expect(runTs(['prune', '-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: workspace_inbox prune [-h] [--max-age-hours MAX_AGE_HOURS]
+                                       [--root ROOT]
+          ",
+          }
+        `);
     });
-    it('top-level -h → usage line + exit 0', () => {
-        const p = runPy(['-h']);
-        const t = runTs(['-h']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+    it('top-level -h → usage + exit 0', () => {
+        expect(runTs(['-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: workspace_inbox [-h] {write,read,list,forget,prune} ...
+          ",
+          }
+        `);
     });
 });

--- a/tests/scripts/cli/python/workspace_render.test.ts
+++ b/tests/scripts/cli/python/workspace_render.test.ts
@@ -1,24 +1,30 @@
-// Golden-parity tests for src/cli/python/workspace_render.ts (py2ts ADR-200 —
-// the role-prompt placeholder renderer).
+// Intent tests for src/cli/python/workspace_render.ts (py2ts ADR-200 — the
+// role-prompt placeholder renderer).
 //
-// Strategy: run `python3 src/cli/python/workspace_render.py` vs
-// `tsx src/cli/python/workspace_render.ts` on deterministic surfaces over temp
-// role-fixture roots and byte-compare stdout / stderr / exit. The renderer is
-// read-only (it reads a prompt file + a JSON input map, writes only to
-// stdout/stderr). The suite NEVER touches the real repo's `agents/roles`.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. The renderer is read-only (it
+// reads a prompt file + a JSON input map, writes only to stdout/stderr) and the
+// suite NEVER touches the real repo's `agents/roles` — every fixture lives under
+// a fresh temp `<tmp>/roles/...` root.
 //
-// COLUMNS=200 is forced for both languages so argparse emits single-line usage
-// (otherwise the usage line in arg-error stderr re-wraps to terminal width).
-// The `--help` per-flag BODY is NOT byte-compared (porting contract); only the
-// usage line in arg-error stderr is. The malformed-JSON path prints a full
-// Python traceback (TS prints a JS stack) — only exit code is asserted there.
+// Determinism: every case spawns with a **node-only PATH** (a temp dir holding
+// just a `node` symlink) so the tsx launcher resolves but nothing
+// machine-dependent leaks via PATH. COLUMNS=200 forces argparse single-line
+// usage (otherwise the usage line in arg-error stderr re-wraps to terminal
+// width). The one surface that echoes the temp `--root` (the
+// "must be an agents/roles directory" SystemExit) is masked through `norm()` to
+// `<TMP>` so the snapshot is machine-stable. The malformed-JSON path prints a
+// JS stack with absolute paths (non-deterministic) — only its exit code +
+// non-empty stderr are asserted, never snapshotted. The `--help` per-flag BODY
+// is likewise not snapshotted (porting contract) — only the leading usage token.
 //
 // pyStr/float strategy: inputs are parsed with int/float distinction preserved
 // (a JSON `5` renders "5", `5.0` renders "5.0", `true` renders "True"), so the
-// numeric/bool input cases below pin that mirroring against python3.
+// numeric/bool input cases below pin that mirroring.
 //
 // _validate_cli_root requires the `--root` dir to be NAMED `roles`, so every
 // fixture passes `--root <tmp>/roles`.
+import { mkdtempSync, symlinkSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -36,17 +42,15 @@ const REPO_ROOT = path.resolve(
     '..',
 );
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_render.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_render.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → nothing machine-dependent resolves but `node` (so tsx runs).
+const NODE_ONLY_DIR = mkdtempSync(path.join(os.tmpdir(), 'ws-render-nodeonly-'));
+symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
 
 interface RunResult {
     status: number | null;
@@ -54,29 +58,18 @@ interface RunResult {
     stderr: string;
 }
 
-// COLUMNS=200 → argparse single-line usage; PYTHONPATH so the py module imports.
-function runPy(args: string[], cwd: string, stdin?: string): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        input: stdin,
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), COLUMNS: '200' },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[], cwd: string, stdin?: string): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         cwd,
         encoding: 'utf8',
         input: stdin,
-        env: { ...process.env, COLUMNS: '200' },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
 
-/** Replace temp roots (raw + realpath) with `<TMP>` so the differential is
- * machine-stable (SystemExit messages echo the temp `--root`). */
+/** Replace temp roots (raw + realpath) with `<TMP>` so SystemExit messages that
+ * echo the temp `--root` snapshot machine-stably. */
 function norm(text: string, roots: string[]): string {
     let out = text;
     for (const root of roots) {
@@ -90,15 +83,6 @@ function norm(text: string, roots: string[]): string {
         out = out.split(real).join('<TMP>');
     }
     return out;
-}
-
-/** Assert py and ts agree byte-for-byte (after path normalization) + same exit. */
-function expectParity(args: string[], cwd: string, roots: string[], stdin?: string): void {
-    const p = runPy(args, cwd, stdin);
-    const t = runTs(args, cwd, stdin);
-    expect(t.status).toBe(p.status);
-    expect(norm(t.stdout, roots)).toBe(norm(p.stdout, roots));
-    expect(norm(t.stderr, roots)).toBe(norm(p.stderr, roots));
 }
 
 // ---------------------------------------------------------------------------
@@ -141,48 +125,99 @@ Memo about {{ctx}} with {{ extra }}.
 // Usage / argument errors.
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — argument errors', () => {
+describe('render — argument errors', () => {
     it('top -h: exit 0, usage token on stdout', () => {
-        const p = runPy(['-h'], tmp);
         const t = runTs(['-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(p.status).toBe(0);
-        expect(t.stdout.startsWith('usage: workspace_render [-h] {render,inspect} ...')).toBe(
-            true,
-        );
-        expect(p.stdout.startsWith('usage: workspace_render [-h] {render,inspect} ...')).toBe(
-            true,
-        );
+        expect(t.status).toBe(0);
+        expect(
+            t.stdout.startsWith('usage: workspace_render [-h] {render,inspect} ...'),
+        ).toBe(true);
     });
 
-    it('no args: exit 2 + byte-identical usage+error stderr', () => {
-        expectParity([], tmp, [tmp]);
+    it('no args: exit 2 + usage+error stderr', () => {
+        expect(runTs([], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render [-h] {render,inspect} ...
+          workspace_render: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('bad subcommand: exit 2 + byte-identical stderr', () => {
-        expectParity(['frob'], tmp, [tmp]);
+    it('bad subcommand: exit 2 + invalid choice stderr', () => {
+        expect(runTs(['frob'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render [-h] {render,inspect} ...
+          workspace_render: error: argument cmd: invalid choice: 'frob' (choose from 'render', 'inspect')
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('render missing both required: exit 2 + byte-identical stderr', () => {
-        expectParity(['render'], tmp, [tmp]);
+    it('render missing both required: exit 2', () => {
+        expect(runTs(['render'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render render [-h] --role ROLE --prompt PROMPT [--inputs-json INPUTS_JSON] [--root ROOT] [--json]
+          workspace_render render: error: the following arguments are required: --role, --prompt
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('render missing --prompt: exit 2 + byte-identical stderr', () => {
-        expectParity(['render', '--role', 'x'], tmp, [tmp]);
+    it('render missing --prompt: exit 2', () => {
+        expect(runTs(['render', '--role', 'x'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render render [-h] --role ROLE --prompt PROMPT [--inputs-json INPUTS_JSON] [--root ROOT] [--json]
+          workspace_render render: error: the following arguments are required: --prompt
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('inspect missing --role: exit 2 + byte-identical stderr', () => {
-        expectParity(['inspect', '--prompt', 'y'], tmp, [tmp]);
+    it('inspect missing --role: exit 2', () => {
+        expect(runTs(['inspect', '--prompt', 'y'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render inspect [-h] --role ROLE --prompt PROMPT [--root ROOT] [--json]
+          workspace_render inspect: error: the following arguments are required: --role
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('render stray positional: exit 2 unrecognized', () => {
-        expectParity(['render', '--role', 'a', '--prompt', 'b', 'stray'], tmp, [tmp]);
+        expect(runTs(['render', '--role', 'a', '--prompt', 'b', 'stray'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render [-h] {render,inspect} ...
+          workspace_render: error: unrecognized arguments: stray
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('inspect with --inputs-json (unrecognized, original order)', () => {
-        expectParity(['inspect', '--role', 'x', '--prompt', 'y', '--inputs-json', '-'], tmp, [
-            tmp,
-        ]);
+    it('inspect with --inputs-json (unrecognized)', () => {
+        expect(runTs(['inspect', '--role', 'x', '--prompt', 'y', '--inputs-json', '-'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_render [-h] {render,inspect} ...
+          workspace_render: error: unrecognized arguments: --inputs-json -
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });
 
@@ -190,17 +225,37 @@ describe.skipIf(!py3)('render — argument errors', () => {
 // --root validation (SystemExit).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — --root validation', () => {
-    it('root not named roles: SystemExit, exit 1, byte-identical (path normalized)', () => {
+describe('render — --root validation', () => {
+    it('root not named roles: SystemExit, exit 1 (path normalized)', () => {
         const notroles = path.join(tmp, 'notroles');
         fs.mkdirSync(notroles, { recursive: true });
-        expectParity(['inspect', '--root', notroles, '--role', 'x', '--prompt', 'y'], tmp, [tmp]);
+        const t = runTs(['inspect', '--root', notroles, '--role', 'x', '--prompt', 'y'], tmp);
+        expect({
+            status: t.status,
+            stdout: norm(t.stdout, [tmp]),
+            stderr: norm(t.stderr, [tmp]),
+        }).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "--root must be an agents/roles directory; got '<TMP>/notroles'
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('root named roles but prompt missing: PromptError via SystemExit, exit 1', () => {
         const root = path.join(tmp, 'roles');
         fs.mkdirSync(root, { recursive: true });
-        expectParity(['inspect', '--root', root, '--role', 'x', '--prompt', 'y'], tmp, [tmp]);
+        expect(runTs(['inspect', '--root', root, '--role', 'x', '--prompt', 'y'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "prompt not found: x/y
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });
 
@@ -208,66 +263,102 @@ describe.skipIf(!py3)('render — --root validation', () => {
 // render — happy paths.
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — happy paths', () => {
+describe('render — happy paths', () => {
     it('section (text) with required + optional, optional absent', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
-            tmp,
-            [tmp],
-            '{"ctx":"a budget"}',
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
+                tmp,
+                '{"ctx":"a budget"}',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "Memo about a budget with .
+          ",
+          }
+        `);
     });
 
     it('--json output', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            [
-                'render',
-                '--root',
-                root,
-                '--role',
-                'leadership',
-                '--prompt',
-                'memo',
-                '--json',
-                '--inputs-json',
-                '-',
-            ],
-            tmp,
-            [tmp],
-            '{"ctx":"a budget","extra":"and a deadline"}',
-        );
+        expect(
+            runTs(
+                [
+                    'render',
+                    '--root',
+                    root,
+                    '--role',
+                    'leadership',
+                    '--prompt',
+                    'memo',
+                    '--json',
+                    '--inputs-json',
+                    '-',
+                ],
+                tmp,
+                '{"ctx":"a budget","extra":"and a deadline"}',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"rendered": "Memo about a budget with and a deadline.\\n", "skill_hint": "scenario-modeling"}
+          ",
+          }
+        `);
     });
 
     it('--inputs-json from a FILE', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
         const f = path.join(tmp, 'inputs.json');
         fs.writeFileSync(f, '{"ctx":"file ctx","extra":"file extra"}');
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', f],
-            tmp,
-            [tmp],
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', f],
+                tmp,
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "Memo about file ctx with file extra.
+          ",
+          }
+        `);
     });
 
     it('no --inputs-json at all → empty map (required missing → error)', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo'],
-            tmp,
-            [tmp],
-        );
+        expect(runTs(['render', '--root', root, '--role', 'leadership', '--prompt', 'memo'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "missing required input(s): ctx
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('empty stdin → empty map (required missing → error)', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
-            tmp,
-            [tmp],
-            '   \n  ',
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
+                tmp,
+                '   \n  ',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "missing required input(s): ctx
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });
 
@@ -275,7 +366,7 @@ describe.skipIf(!py3)('render — happy paths', () => {
 // render — value-type mirroring (int vs float vs bool vs null vs string).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — pyStr value mirroring', () => {
+describe('render — pyStr value mirroring', () => {
     const ONE = `---
 name: one
 intent: i
@@ -290,41 +381,128 @@ inputs:
 ctx={{ctx}} v={{v}}
 `;
 
-    function caseFor(json: string): void {
+    function renderV(json: string): RunResult {
         const root = writePrompt('r', 'one', ONE);
-        expectParity(
+        return runTs(
             ['render', '--root', root, '--role', 'r', '--prompt', 'one', '--inputs-json', '-'],
             tmp,
-            [tmp],
             json,
         );
     }
 
-    it('integer input → no trailing .0', () => caseFor('{"ctx":"x","v":5}'));
-    it('integral float input → trailing .0', () => caseFor('{"ctx":"x","v":5.0}'));
-    it('decimal float input', () => caseFor('{"ctx":"x","v":5.5}'));
-    it('large integer input → full precision', () =>
-        caseFor('{"ctx":"x","v":100000000000000000000}'));
-    it('boolean true → True', () => caseFor('{"ctx":"x","v":true}'));
-    it('boolean false → False', () => caseFor('{"ctx":"x","v":false}'));
-    it('null optional → empty string', () => caseFor('{"ctx":"x","v":null}'));
-    it('scientific float → Python repr', () => caseFor('{"ctx":"x","v":1e3}'));
-    it('negative integer', () => caseFor('{"ctx":"x","v":-42}'));
+    it('integer input → no trailing .0', () => {
+        expect(renderV('{"ctx":"x","v":5}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=5
+          ",
+          }
+        `);
+    });
+    it('integral float input → trailing .0', () => {
+        expect(renderV('{"ctx":"x","v":5.0}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=5.0
+          ",
+          }
+        `);
+    });
+    it('decimal float input', () => {
+        expect(renderV('{"ctx":"x","v":5.5}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=5.5
+          ",
+          }
+        `);
+    });
+    it('large integer input → full precision', () => {
+        expect(renderV('{"ctx":"x","v":100000000000000000000}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=100000000000000000000
+          ",
+          }
+        `);
+    });
+    it('boolean true → True', () => {
+        expect(renderV('{"ctx":"x","v":true}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=True
+          ",
+          }
+        `);
+    });
+    it('boolean false → False', () => {
+        expect(renderV('{"ctx":"x","v":false}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=False
+          ",
+          }
+        `);
+    });
+    it('null optional → empty string', () => {
+        expect(renderV('{"ctx":"x","v":null}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=
+          ",
+          }
+        `);
+    });
+    it('scientific float → Python repr', () => {
+        expect(renderV('{"ctx":"x","v":1e3}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=1000.0
+          ",
+          }
+        `);
+    });
+    it('negative integer', () => {
+        expect(renderV('{"ctx":"x","v":-42}')).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ctx=x v=-42
+          ",
+          }
+        `);
+    });
 });
 
 // ---------------------------------------------------------------------------
 // render — template / input errors (PromptError → stderr, exit 1).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — PromptError paths', () => {
+describe('render — PromptError paths', () => {
     it('missing required input (blank string also counts)', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
-            tmp,
-            [tmp],
-            '{"ctx":"   "}',
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
+                tmp,
+                '{"ctx":"   "}',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "missing required input(s): ctx
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('undeclared placeholder in template', () => {
@@ -341,69 +519,86 @@ inputs:
 Hi {{ctx}} and {{nope}} and {{alsobad}}.
 `,
         );
-        expectParity(
-            ['render', '--root', root, '--role', 'r', '--prompt', 'bad', '--inputs-json', '-'],
-            tmp,
-            [tmp],
-            '{"ctx":"x"}',
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'r', '--prompt', 'bad', '--inputs-json', '-'],
+                tmp,
+                '{"ctx":"x"}',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "undeclared placeholder(s) in template: alsobad, nope
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
     it('prompt file not found → PromptError, exit 1', () => {
         const root = writePrompt('r', 'exists', MEMO.replace('memo-x', 'exists-x'));
-        expectParity(
-            ['render', '--root', root, '--role', 'r', '--prompt', 'ghost'],
-            tmp,
-            [tmp],
-        );
+        expect(runTs(['render', '--root', root, '--role', 'r', '--prompt', 'ghost'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "prompt not found: r/ghost
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });
 
 // ---------------------------------------------------------------------------
-// render — bad --inputs-json shape (SystemExit) + malformed (traceback).
+// render — bad --inputs-json shape (SystemExit) + malformed (JS stack).
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('render — inputs-json errors', () => {
-    it('JSON array (not object) → SystemExit, exit 1, byte-identical', () => {
+describe('render — inputs-json errors', () => {
+    it('JSON array (not object) → SystemExit, exit 1', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
-            tmp,
-            [tmp],
-            '[]',
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
+                tmp,
+                '[]',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "--inputs-json must contain a JSON object (name → value)
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('JSON scalar (not object) → SystemExit, exit 1, byte-identical', () => {
+    it('JSON scalar (not object) → SystemExit, exit 1', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
-            tmp,
-            [tmp],
-            '42',
-        );
+        expect(
+            runTs(
+                ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
+                tmp,
+                '42',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "--inputs-json must contain a JSON object (name → value)
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('malformed JSON → exit 1 (traceback vs JS-stack, only exit asserted)', () => {
+    it('malformed JSON → exit 1 (JS stack has absolute paths; only exit + non-empty stderr asserted)', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        const args = [
-            'render',
-            '--root',
-            root,
-            '--role',
-            'leadership',
-            '--prompt',
-            'memo',
-            '--inputs-json',
-            '-',
-        ];
-        const p = runPy(args, tmp, '{bad');
-        const t = runTs(args, tmp, '{bad');
-        expect(p.status).toBe(1);
+        const t = runTs(
+            ['render', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--inputs-json', '-'],
+            tmp,
+            '{bad',
+        );
         expect(t.status).toBe(1);
-        expect(p.stdout).toBe('');
         expect(t.stdout).toBe('');
-        expect(p.stderr.length).toBeGreaterThan(0);
         expect(t.stderr.length).toBeGreaterThan(0);
     });
 });
@@ -412,21 +607,38 @@ describe.skipIf(!py3)('render — inputs-json errors', () => {
 // inspect — text + json.
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!py3)('inspect — output', () => {
+describe('inspect — output', () => {
     it('text output (required + optional + skill_hint)', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(['inspect', '--root', root, '--role', 'leadership', '--prompt', 'memo'], tmp, [
-            tmp,
-        ]);
+        expect(runTs(['inspect', '--root', root, '--role', 'leadership', '--prompt', 'memo'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "memo-x — write a memo
+            - ctx (required): one-paragraph context
+            - extra (optional): budget, deadline
+          skill_hint: scenario-modeling
+          ",
+          }
+        `);
     });
 
     it('--json output', () => {
         const root = writePrompt('leadership', 'memo', MEMO);
-        expectParity(
-            ['inspect', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--json'],
-            tmp,
-            [tmp],
-        );
+        expect(
+            runTs(
+                ['inspect', '--root', root, '--role', 'leadership', '--prompt', 'memo', '--json'],
+                tmp,
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"inputs": [{"name": "ctx", "required": true, "shape": "one-paragraph context"}, {"name": "extra", "required": false, "shape": "budget, deadline"}], "intent": "write a memo", "name": "memo-x", "output_shape": "a memo", "skill_hint": "scenario-modeling"}
+          ",
+          }
+        `);
     });
 
     it('no skill_hint → em-dash fallback', () => {
@@ -444,7 +656,17 @@ inputs:
 Body {{ctx}}.
 `,
         );
-        expectParity(['inspect', '--root', root, '--role', 'r', '--prompt', 'nohint'], tmp, [tmp]);
+        expect(runTs(['inspect', '--root', root, '--role', 'r', '--prompt', 'nohint'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "nohint — no hint here
+            - ctx (required): s
+          skill_hint: —
+          ",
+          }
+        `);
     });
 
     it('no inputs at all → header + skill_hint only', () => {
@@ -458,11 +680,28 @@ intent: nothing
 Just text, no placeholders.
 `,
         );
-        expectParity(['inspect', '--root', root, '--role', 'r', '--prompt', 'empty'], tmp, [tmp]);
+        expect(runTs(['inspect', '--root', root, '--role', 'r', '--prompt', 'empty'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "empty-prompt — nothing
+          skill_hint: —
+          ",
+          }
+        `);
     });
 
     it('prompt not found → SystemExit, exit 1', () => {
         const root = writePrompt('r', 'exists', MEMO);
-        expectParity(['inspect', '--root', root, '--role', 'r', '--prompt', 'ghost'], tmp, [tmp]);
+        expect(runTs(['inspect', '--root', root, '--role', 'r', '--prompt', 'ghost'], tmp))
+            .toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "prompt not found: r/ghost
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });

--- a/tests/scripts/cli/python/workspace_roles.test.ts
+++ b/tests/scripts/cli/python/workspace_roles.test.ts
@@ -1,38 +1,43 @@
-// Golden-parity tests for src/cli/python/workspace_roles.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_roles.ts (py2ts ADR-200 —
 // role + task discovery for the workspace launcher, Phase 4).
 //
-// Strategy: run `python3 workspace_roles.py` vs `tsx workspace_roles.ts` and
-// byte-compare stdout / stderr / exit. The CLI resolves roles from
-// `agents/roles/<role>` RELATIVE TO THE CWD, so each case runs both languages
-// with `cwd` set to a hermetic temp dir holding a hand-built `agents/roles`
-// fixture (frontmatter + a `## First tasks` list + a `skills.yml`). Output is
-// fully deterministic (no timestamps, no randomness).
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. The CLI resolves roles from
+// `agents/roles/<role>` RELATIVE TO THE CWD, so each case runs with `cwd` set to
+// a hermetic temp dir holding a hand-built `agents/roles` fixture (frontmatter +
+// a `## First tasks` list + a `skills.yml`). Output is fully deterministic — no
+// timestamps, no randomness, only the fixture — so snapshots are taken verbatim.
+//
+// The spawned tsx process gets a **node-only PATH** (a temp dir holding just a
+// `node` symlink) so host-CLI detection is deterministic regardless of what is
+// installed on the runner, plus COLUMNS=200 so arg-error usage does not re-wrap.
 //
 // Coverage: list (text), tasks (per-task sorted JSON lines), show (indent-2
 // sorted JSON with identity / title-fallback / parsed tasks + skills), unknown
 // role (stderr + exit 1), role with no skills.yml / no first-tasks, the
-// `.title()` slug fallback, and the argparse error surface. The `--help` BODY
-// is NOT byte-compared (only the `usage:` line) per the porting contract.
+// `.title()` slug fallback, and the argparse error surface. The `--help` BODY is
+// NOT snapshotted (only the `usage:` line) per the porting contract.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_roles.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_roles.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic host-CLI detection (nothing but `node` resolves).
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ws-roles-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
 
 interface RunResult {
     status: number | null;
@@ -40,26 +45,13 @@ interface RunResult {
     stderr: string;
 }
 
-function runPy(args: string[], cwd: string): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
+function runTs(args: string[], cwd: string): RunResult {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         cwd,
         encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src') },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
-function runTs(args: string[], cwd: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd, encoding: 'utf8', env: { ...process.env } });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
-function expectParity(args: string[], cwd: string): void {
-    const p = runPy(args, cwd);
-    const t = runTs(args, cwd);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
 }
 
 let tmp: string;
@@ -118,73 +110,249 @@ afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-describe.skipIf(!py3)('workspace_roles — list', () => {
+describe('workspace_roles — list', () => {
     it('lists only dirs with index.md, sorted', () => {
-        expectParity(['list'], tmp);
+        expect(runTs(['list'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "content-creator
+          empty-role
+          sales
+          ",
+          }
+        `);
     });
     it('empty cwd (no agents/roles) → empty', () => {
         const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'wsroles-bare-'));
         try {
-            expectParity(['list'], bare);
+            expect(runTs(['list'], bare)).toMatchInlineSnapshot(`
+              {
+                "status": 0,
+                "stderr": "",
+                "stdout": "",
+              }
+            `);
         } finally {
             fs.rmSync(bare, { recursive: true, force: true });
         }
     });
 });
 
-describe.skipIf(!py3)('workspace_roles — tasks', () => {
+describe('workspace_roles — tasks', () => {
     it('full role tasks (sorted-key JSON per line)', () => {
-        expectParity(['tasks', 'sales'], tmp);
+        expect(runTs(['tasks', 'sales'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"document_type": null, "output_shape": "chat", "prompt_path": null, "slug": "draft-offer", "title": "Draft an offer from a brief"}
+          {"document_type": null, "output_shape": "chat", "prompt_path": null, "slug": "answer-customer", "title": "answer-customer: Reply to a customer question"}
+          {"document_type": null, "output_shape": "chat", "prompt_path": null, "slug": "prep-discovery-call", "title": "Prep Discovery Call"}
+          ",
+          }
+        `);
     });
     it('## Tasks heading variant', () => {
-        expectParity(['tasks', 'content-creator'], tmp);
+        expect(runTs(['tasks', 'content-creator'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"document_type": null, "output_shape": "chat", "prompt_path": null, "slug": "write-thread", "title": "Expand a post into a thread"}
+          ",
+          }
+        `);
     });
     it('role with no tasks → no output', () => {
-        expectParity(['tasks', 'empty-role'], tmp);
+        expect(runTs(['tasks', 'empty-role'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "",
+          }
+        `);
     });
     it('unknown role → no output (tasks returns [])', () => {
-        expectParity(['tasks', 'zzz'], tmp);
+        expect(runTs(['tasks', 'zzz'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "",
+          }
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_roles — show', () => {
+describe('workspace_roles — show', () => {
     it('full role (indent-2 sorted JSON)', () => {
-        expectParity(['show', 'sales'], tmp);
+        expect(runTs(['show', 'sales'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "explain_default": "technical",
+            "identity": "You help close deals and write crisp offers.",
+            "skills": [
+              "positioning-strategy",
+              "deal-qualification-meddic"
+            ],
+            "slug": "sales",
+            "tasks": [
+              {
+                "document_type": null,
+                "output_shape": "chat",
+                "prompt_path": null,
+                "slug": "draft-offer",
+                "title": "Draft an offer from a brief"
+              },
+              {
+                "document_type": null,
+                "output_shape": "chat",
+                "prompt_path": null,
+                "slug": "answer-customer",
+                "title": "answer-customer: Reply to a customer question"
+              },
+              {
+                "document_type": null,
+                "output_shape": "chat",
+                "prompt_path": null,
+                "slug": "prep-discovery-call",
+                "title": "Prep Discovery Call"
+              }
+            ],
+            "title": "Sales Pro"
+          }
+          ",
+          }
+        `);
     });
     it('title fallback via .title() + no skills.yml', () => {
-        expectParity(['show', 'content-creator'], tmp);
+        expect(runTs(['show', 'content-creator'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "explain_default": "plain",
+            "identity": "Identity para.",
+            "skills": [],
+            "slug": "content-creator",
+            "tasks": [
+              {
+                "document_type": null,
+                "output_shape": "chat",
+                "prompt_path": null,
+                "slug": "write-thread",
+                "title": "Expand a post into a thread"
+              }
+            ],
+            "title": "Content Creator"
+          }
+          ",
+          }
+        `);
     });
     it('no-frontmatter role', () => {
-        expectParity(['show', 'empty-role'], tmp);
+        expect(runTs(['show', 'empty-role'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "explain_default": "plain",
+            "identity": "Just a body, no frontmatter, no tasks.",
+            "skills": [],
+            "slug": "empty-role",
+            "tasks": [],
+            "title": "Empty Role"
+          }
+          ",
+          }
+        `);
     });
     it('unknown role → stderr + exit 1', () => {
-        expectParity(['show', 'zzz'], tmp);
+        expect(runTs(['show', 'zzz'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "unknown role: zzz
+          ",
+            "stdout": "",
+          }
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_roles — argparse errors', () => {
+describe('workspace_roles — argparse errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParity([], tmp);
+        expect(runTs([], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_roles [-h] {list,tasks,show} ...
+          workspace_roles: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParity(['bogus'], tmp);
+        expect(runTs(['bogus'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_roles [-h] {list,tasks,show} ...
+          workspace_roles: error: argument cmd: invalid choice: 'bogus' (choose from 'list', 'tasks', 'show')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('tasks missing role → exit 2', () => {
-        expectParity(['tasks'], tmp);
+        expect(runTs(['tasks'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_roles tasks [-h] role
+          workspace_roles tasks: error: the following arguments are required: role
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('show missing role → exit 2', () => {
-        expectParity(['show'], tmp);
+        expect(runTs(['show'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_roles show [-h] role
+          workspace_roles show: error: the following arguments are required: role
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('list extra positional → unrecognized, exit 2', () => {
-        expectParity(['list', 'extra'], tmp);
+        expect(runTs(['list', 'extra'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_roles [-h] {list,tasks,show} ...
+          workspace_roles: error: unrecognized arguments: extra
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('tasks extra positional → unrecognized, exit 2', () => {
-        expectParity(['tasks', 'a', 'b'], tmp);
+        expect(runTs(['tasks', 'a', 'b'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_roles [-h] {list,tasks,show} ...
+          workspace_roles: error: unrecognized arguments: b
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('top-level -h → usage line + exit 0', () => {
-        const p = runPy(['-h'], tmp);
-        const t = runTs(['-h'], tmp);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+        const r = runTs(['-h'], tmp);
+        expect({ status: r.status, usage: r.stdout.split('\n')[0] }).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "usage": "usage: workspace_roles [-h] {list,tasks,show} ...",
+          }
+        `);
     });
 });

--- a/tests/scripts/cli/python/workspace_secrets.test.ts
+++ b/tests/scripts/cli/python/workspace_secrets.test.ts
@@ -1,58 +1,18 @@
-// Golden-parity tests for src/cli/python/workspace_secrets.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_secrets.ts (py2ts ADR-200 —
 // shared secret-detection + scrub primitives; a LEAF library, no CLI).
 //
-// Strategy: this module has no CLI, so parity is asserted at the function
-// level. The TS functions (`scan` / `scrub` / `scrub_obj`) are imported
-// in-process; the Python originals are driven by a one-shot `python3 -c`
-// harness that imports `workspace_secrets`, runs the same call over a
-// JSON-encoded input, and prints a JSON-encoded `[result, count]`. Both sides
-// are byte-compared via canonical JSON. The match COUNT and the scrubbed
-// output are the load-bearing parity surfaces (the regex set, the HIGH-before-
-// FUZZY ordering, the `[SECRET]` placeholder, and the recursive depth/cycle
-// guard).
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx function-level parity rig; the `.py` original is gone, so
+// this now asserts the tsx library's own contract directly. The functions
+// (`scan` / `scrub` / `scrub_obj`) are pure: deterministic over their input,
+// no clock / fs / randomness / PATH dependence, so no env masking is needed.
+// The match COUNT and the scrubbed output are the load-bearing surfaces (the
+// regex set, the HIGH-before-FUZZY ordering, the `[SECRET]` placeholder, and
+// the recursive depth/cycle guard). Each case snapshots a canonical-JSON
+// rendering (sorted keys) so the assertion is order-stable.
 import { describe, expect, it } from 'vitest';
 import { scan, scrub, scrub_obj } from '@cli/python/workspace_secrets.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
-
-/** Run the Python `workspace_secrets` over `op(payload, include_fuzzy)`. */
-function py(op: 'scan' | 'scrub' | 'scrub_obj', payloadJson: string, includeFuzzy: boolean): unknown {
-    const code = [
-        'import json,sys',
-        'sys.path.insert(0, sys.argv[1])',
-        'import workspace_secrets as w',
-        'op=sys.argv[2]; inc=sys.argv[3]=="1"',
-        'payload=json.loads(sys.argv[4])',
-        'if op=="scan":',
-        '    out=[{"pattern":f.pattern,"confidence":f.confidence} for f in w.scan(payload, include_fuzzy=inc)]',
-        '    print(json.dumps(out, sort_keys=True))',
-        'elif op=="scrub":',
-        '    clean,n=w.scrub(payload, include_fuzzy=inc)',
-        '    print(json.dumps([clean,n], sort_keys=True))',
-        'else:',
-        '    clean,n=w.scrub_obj(payload, include_fuzzy=inc)',
-        '    print(json.dumps([clean,n], sort_keys=True))',
-    ].join('\n');
-    const r = spawnSync(
-        'python3',
-        ['-c', code, path.join(REPO_ROOT, 'src', 'cli', 'python'), op, includeFuzzy ? '1' : '0', payloadJson],
-        { encoding: 'utf8' },
-    );
-    if (r.status !== 0) {
-        throw new Error(`python harness failed: ${r.stderr}`);
-    }
-    return JSON.parse(r.stdout);
-}
-
-/** Canonical JSON (sorted keys) for a stable cross-language compare. */
+/** Canonical JSON (sorted keys) for a stable, order-independent snapshot. */
 function canon(v: unknown): string {
     return JSON.stringify(v, (_k, val) => {
         if (val && typeof val === 'object' && !Array.isArray(val)) {
@@ -85,33 +45,193 @@ const SCAN_CASES: Array<[string, string]> = [
     ['two-aws', `${AWS} ${AWS}`],
 ];
 
-describe.skipIf(!py3)('workspace_secrets — scan parity', () => {
-    for (const [name, payload] of SCAN_CASES) {
-        it(`scan ${name} (fuzzy on)`, () => {
-            const t = scan(payload, { include_fuzzy: true });
-            expect(canon(t)).toBe(canon(py('scan', JSON.stringify(payload), true)));
-        });
-        it(`scan ${name} (fuzzy off)`, () => {
-            const t = scan(payload, { include_fuzzy: false });
-            expect(canon(t)).toBe(canon(py('scan', JSON.stringify(payload), false)));
-        });
-    }
+describe('workspace_secrets — scan', () => {
+    it('scan empty (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[0][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"[]"`);
+    });
+    it('scan empty (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[0][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"[]"`);
+    });
+    it('scan none (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[1][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"[]"`);
+    });
+    it('scan none (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[1][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"[]"`);
+    });
+    it('scan aws (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[2][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"aws_access_key"}]"`,
+        );
+    });
+    it('scan aws (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[2][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"aws_access_key"}]"`,
+        );
+    });
+    it('scan github (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[3][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"github_pat"}]"`,
+        );
+    });
+    it('scan github (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[3][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"github_pat"}]"`,
+        );
+    });
+    it('scan openai (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[4][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"openai_key"}]"`,
+        );
+    });
+    it('scan openai (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[4][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"openai_key"}]"`,
+        );
+    });
+    it('scan pem (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[5][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"private_key"}]"`,
+        );
+    });
+    it('scan pem (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[5][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"private_key"}]"`,
+        );
+    });
+    it('scan kv-fuzzy (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[6][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"fuzzy","pattern":"kv_secret"}]"`,
+        );
+    });
+    it('scan kv-fuzzy (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[6][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"[]"`);
+    });
+    it('scan mixed (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[7][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"aws_access_key"},{"confidence":"high","pattern":"github_pat"},{"confidence":"fuzzy","pattern":"kv_secret"}]"`,
+        );
+    });
+    it('scan mixed (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[7][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"aws_access_key"},{"confidence":"high","pattern":"github_pat"}]"`,
+        );
+    });
+    it('scan pem-wraps-kv (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[8][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"private_key"},{"confidence":"fuzzy","pattern":"kv_secret"}]"`,
+        );
+    });
+    it('scan pem-wraps-kv (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[8][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"private_key"}]"`,
+        );
+    });
+    it('scan two-aws (fuzzy on)', () => {
+        expect(canon(scan(SCAN_CASES[9][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"aws_access_key"},{"confidence":"high","pattern":"aws_access_key"}]"`,
+        );
+    });
+    it('scan two-aws (fuzzy off)', () => {
+        expect(canon(scan(SCAN_CASES[9][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"confidence":"high","pattern":"aws_access_key"},{"confidence":"high","pattern":"aws_access_key"}]"`,
+        );
+    });
 });
 
-describe.skipIf(!py3)('workspace_secrets — scrub parity', () => {
-    for (const [name, payload] of SCAN_CASES) {
-        it(`scrub ${name} (fuzzy on)`, () => {
-            const t = scrub(payload, { include_fuzzy: true });
-            expect(canon(t)).toBe(canon(py('scrub', JSON.stringify(payload), true)));
-        });
-        it(`scrub ${name} (fuzzy off)`, () => {
-            const t = scrub(payload, { include_fuzzy: false });
-            expect(canon(t)).toBe(canon(py('scrub', JSON.stringify(payload), false)));
-        });
-    }
+describe('workspace_secrets — scrub', () => {
+    it('scrub empty (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[0][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"["",0]"`);
+    });
+    it('scrub empty (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[0][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"["",0]"`);
+    });
+    it('scrub none (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[1][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["just some prose with no secrets at all",0]"`,
+        );
+    });
+    it('scrub none (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[1][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["just some prose with no secrets at all",0]"`,
+        );
+    });
+    it('scrub aws (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[2][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["here [SECRET] done",1]"`,
+        );
+    });
+    it('scrub aws (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[2][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["here [SECRET] done",1]"`,
+        );
+    });
+    it('scrub github (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[3][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["token [SECRET]",1]"`,
+        );
+    });
+    it('scrub github (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[3][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["token [SECRET]",1]"`,
+        );
+    });
+    it('scrub openai (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[4][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["key [SECRET]",1]"`,
+        );
+    });
+    it('scrub openai (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[4][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["key [SECRET]",1]"`,
+        );
+    });
+    it('scrub pem (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[5][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"["[SECRET]",1]"`);
+    });
+    it('scrub pem (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[5][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"["[SECRET]",1]"`);
+    });
+    it('scrub kv-fuzzy (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[6][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"["[SECRET]",1]"`);
+    });
+    it('scrub kv-fuzzy (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[6][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["api_key = abcdef1234567890",0]"`,
+        );
+    });
+    it('scrub mixed (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[7][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["[SECRET] and [SECRET] and [SECRET]",3]"`,
+        );
+    });
+    it('scrub mixed (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[7][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["[SECRET] and api_key = abcdef1234567890 and [SECRET]",2]"`,
+        );
+    });
+    it('scrub pem-wraps-kv (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[8][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["[SECRET]\\n[SECRET]",2]"`,
+        );
+    });
+    it('scrub pem-wraps-kv (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[8][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["[SECRET]\\nsecret = zzzzzzzzzzzzzzzzzzzz",1]"`,
+        );
+    });
+    it('scrub two-aws (fuzzy on)', () => {
+        expect(canon(scrub(SCAN_CASES[9][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["[SECRET] [SECRET]",2]"`,
+        );
+    });
+    it('scrub two-aws (fuzzy off)', () => {
+        expect(canon(scrub(SCAN_CASES[9][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["[SECRET] [SECRET]",2]"`,
+        );
+    });
 });
 
-describe.skipIf(!py3)('workspace_secrets — scrub_obj parity', () => {
+describe('workspace_secrets — scrub_obj', () => {
     const OBJ_CASES: Array<[string, unknown]> = [
         ['scalar-str', `key ${AWS}`],
         ['scalar-int', 42],
@@ -122,14 +242,72 @@ describe.skipIf(!py3)('workspace_secrets — scrub_obj parity', () => {
         ['list', [`${AWS}`, KV, 'plain', 7]],
         ['mixed-leaves', { s: OPENAI, l: [1, 'two', { three: PEM }], b: false, z: null }],
     ];
-    for (const [name, payload] of OBJ_CASES) {
-        it(`scrub_obj ${name} (fuzzy on)`, () => {
-            const t = scrub_obj(payload, { include_fuzzy: true });
-            expect(canon(t)).toBe(canon(py('scrub_obj', JSON.stringify(payload), true)));
-        });
-        it(`scrub_obj ${name} (fuzzy off)`, () => {
-            const t = scrub_obj(payload, { include_fuzzy: false });
-            expect(canon(t)).toBe(canon(py('scrub_obj', JSON.stringify(payload), false)));
-        });
-    }
+    it('scrub_obj scalar-str (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[0][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"["key [SECRET]",1]"`,
+        );
+    });
+    it('scrub_obj scalar-str (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[0][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"["key [SECRET]",1]"`,
+        );
+    });
+    it('scrub_obj scalar-int (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[1][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"[42,0]"`);
+    });
+    it('scrub_obj scalar-int (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[1][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"[42,0]"`);
+    });
+    it('scrub_obj scalar-null (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[2][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"[null,0]"`);
+    });
+    it('scrub_obj scalar-null (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[2][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"[null,0]"`);
+    });
+    it('scrub_obj scalar-bool (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[3][1], { include_fuzzy: true }))).toMatchInlineSnapshot(`"[true,0]"`);
+    });
+    it('scrub_obj scalar-bool (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[3][1], { include_fuzzy: false }))).toMatchInlineSnapshot(`"[true,0]"`);
+    });
+    it('scrub_obj flat-dict (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[4][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"a":"[SECRET]","b":"clean","n":3},1]"`,
+        );
+    });
+    it('scrub_obj flat-dict (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[4][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"a":"[SECRET]","b":"clean","n":3},1]"`,
+        );
+    });
+    it('scrub_obj nested (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[5][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"count":2,"outer":{"inner":["[SECRET]","x",{"deep":"[SECRET]"}]}},2]"`,
+        );
+    });
+    it('scrub_obj nested (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[5][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"count":2,"outer":{"inner":["[SECRET]","x",{"deep":"api_key = abcdef1234567890"}]}},1]"`,
+        );
+    });
+    it('scrub_obj list (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[6][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[["[SECRET]","[SECRET]","plain",7],2]"`,
+        );
+    });
+    it('scrub_obj list (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[6][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[["[SECRET]","api_key = abcdef1234567890","plain",7],1]"`,
+        );
+    });
+    it('scrub_obj mixed-leaves (fuzzy on)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[7][1], { include_fuzzy: true }))).toMatchInlineSnapshot(
+            `"[{"b":false,"l":[1,"two",{"three":"[SECRET]"}],"s":"[SECRET]","z":null},2]"`,
+        );
+    });
+    it('scrub_obj mixed-leaves (fuzzy off)', () => {
+        expect(canon(scrub_obj(OBJ_CASES[7][1], { include_fuzzy: false }))).toMatchInlineSnapshot(
+            `"[{"b":false,"l":[1,"two",{"three":"[SECRET]"}],"s":"[SECRET]","z":null},2]"`,
+        );
+    });
 });

--- a/tests/scripts/cli/python/workspace_sessions.test.ts
+++ b/tests/scripts/cli/python/workspace_sessions.test.ts
@@ -1,42 +1,44 @@
-// Golden-parity tests for src/cli/python/workspace_sessions.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_sessions.ts (py2ts ADR-200 —
 // local workspace session store, daily-workspace.md §Session JSONL schema).
 //
-// Strategy: run `python3 workspace_sessions.py` vs `tsx workspace_sessions.ts`
-// and byte-compare stdout / stderr / exit. Session ids are
-// `<UTC-stamp>-<8 random hex>` and records carry a `ts` (UTC second) — both
-// NONDETERMINISTIC and differing py-vs-ts. So functional cases run each
-// language in a SEPARATE hermetic `<tmp>/workspace/sessions` root, replay the
-// SAME command, then `norm()` masks the random id, the timestamp, the float
-// mtime, and the tmp root before comparing — leaving the structural payload
-// (kinds, data shape, scrubbed body, ordering, PyFloat round-trip) a true
-// byte-for-byte assertion.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. Session ids are
+// `<UTC-stamp>-<8 random hex>` and records carry a `ts` (UTC second) + a float
+// `mtime` — all NONDETERMINISTIC. Every functional case runs in a hermetic
+// `<tmp>/workspace/sessions` root, then `norm()` masks the random id, the
+// timestamp, the float mtime, and the tmp root before snapshotting — leaving the
+// structural payload (kinds, data shape, scrubbed body, ordering, PyFloat
+// round-trip) reproducible on any machine at any time.
 //
 // `_validate_cli_root` requires `--root` to be a `.../workspace/sessions` dir.
-// The `--help` BODY is NOT byte-compared (only the `usage:` line) per the
-// porting contract; the Python runs force COLUMNS=80 so the multi-line usage
-// strings byte-match the TS hardcoded form. Encryption-at-rest paths default
-// OFF (no `.agent-settings.yml` in the run CWD), so migrate raises (exit 1 both
-// sides) and decrypt-all is a crypto-free `{decrypted: 0}` — both deterministic.
+// Each case spawns with a **node-only PATH** (a temp dir holding just a `node`
+// symlink) so host-CLI detection (used by `start --host`) is deterministic, plus
+// COLUMNS=200 so arg-error/usage stderr does not re-wrap to terminal width.
+// The `--help` BODY is NOT snapshotted (only the `usage:` line) — help body is
+// not part of the porting contract. Encryption-at-rest defaults OFF (no
+// `.agent-settings.yml` in the run CWD): migrate raises (exit 1), decrypt-all is
+// a crypto-free `{decrypted: 0}` — both deterministic.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_sessions.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_sessions.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic host-CLI detection (nothing but `node` resolves).
+const NODE_ONLY_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'wssess-nodeonly-'));
+fs.symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    fs.rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface RunResult {
     status: number | null;
@@ -44,20 +46,10 @@ interface RunResult {
     stderr: string;
 }
 
-const COLS80 = { COLUMNS: '80' };
-
-function runPy(args: string[], extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src'), ...COLS80, ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[], extraEnv: Record<string, string> = {}): RunResult {
     const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
         encoding: 'utf8',
-        env: { ...process.env, ...COLS80, ...extraEnv },
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200', ...extraEnv },
     });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
@@ -81,16 +73,7 @@ function norm(text: string, roots: string[]): string {
     return out;
 }
 
-/** Byte-exact parity (deterministic surfaces: usage / arg errors). */
-function expectParityExact(args: string[]): void {
-    const p = runPy(args);
-    const t = runTs(args);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
-}
-
-/** Compare only the `usage:` portion of a `-h` run (help body not compared). */
+/** Compare only the `usage:` portion of a `-h` run (help body not snapshotted). */
 function usageOnly(text: string): string {
     const out: string[] = [];
     for (const line of text.split('\n')) {
@@ -100,176 +83,280 @@ function usageOnly(text: string): string {
     return out.join('\n');
 }
 
-let pyRoot: string;
 let tsRoot: string;
-let pyTmp: string;
 let tsTmp: string;
 beforeEach(() => {
-    pyTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wssess-py-'));
     tsTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wssess-ts-'));
-    pyRoot = path.join(pyTmp, 'workspace', 'sessions');
     tsRoot = path.join(tsTmp, 'workspace', 'sessions');
-    fs.mkdirSync(pyRoot, { recursive: true });
     fs.mkdirSync(tsRoot, { recursive: true });
 });
 afterEach(() => {
-    fs.rmSync(pyTmp, { recursive: true, force: true });
     fs.rmSync(tsTmp, { recursive: true, force: true });
 });
 
-describe.skipIf(!py3)('workspace_sessions — start + append + read + list', () => {
+describe('workspace_sessions — start + append + read + list', () => {
     it('start writes the launcher.input line; read it back (normalized)', () => {
-        const pid = runPy(['start', '--role', 'sales', '--task', 'draft offer', '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'sales', '--task', 'draft offer', '--root', tsRoot]).stdout.trim();
-        const p = runPy(['read', pid, '--json', '--root', pyRoot]);
         const t = runTs(['read', tid, '--json', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"data": {"role": "sales", "task": "draft offer"}, "kind": "launcher.input", "ts": "<TS>"}]
+          "
+        `);
     });
 
     it('start --host writes host_tier + host_id', () => {
-        const pid = runPy(['start', '--role', 'r', '--task', 't', '--host', 'claude-code', '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'r', '--task', 't', '--host', 'claude-code', '--root', tsRoot]).stdout.trim();
-        const p = runPy(['read', pid, '--json', '--root', pyRoot]);
         const t = runTs(['read', tid, '--json', '--root', tsRoot]);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"data": {"host_id": "claude-code", "host_tier": "tier-1", "role": "r", "task": "t"}, "kind": "launcher.input", "ts": "<TS>"}]
+          "
+        `);
     });
 
     it('start scrubs a pasted secret in the task', () => {
         const sec = 'AKIAIOSFODNN7EXAMPLE';
-        const pid = runPy(['start', '--role', 'r', '--task', `do ${sec} now`, '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'r', '--task', `do ${sec} now`, '--root', tsRoot]).stdout.trim();
-        const p = runPy(['read', pid, '--json', '--root', pyRoot]);
         const t = runTs(['read', tid, '--json', '--root', tsRoot]);
-        expect(p.stdout).not.toContain(sec);
         expect(t.stdout).not.toContain(sec);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"data": {"role": "r", "task": "do [SECRET] now"}, "kind": "launcher.input", "ts": "<TS>"}]
+          "
+        `);
     });
 
     it('append --data k=v (flat strings)', () => {
-        const pid = runPy(['start', '--role', 'r', '--task', 't', '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'r', '--task', 't', '--root', tsRoot]).stdout.trim();
-        runPy(['append', pid, '--kind', 'host.turn', '--data', 'k=v', '--data', 'n=3', '--root', pyRoot]);
         runTs(['append', tid, '--kind', 'host.turn', '--data', 'k=v', '--data', 'n=3', '--root', tsRoot]);
-        const p = runPy(['read', pid, '--json', '--root', pyRoot]);
         const t = runTs(['read', tid, '--json', '--root', tsRoot]);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"data": {"role": "r", "task": "t"}, "kind": "launcher.input", "ts": "<TS>"}, {"data": {"k": "v", "n": "3"}, "kind": "host.turn", "ts": "<TS>"}]
+          "
+        `);
     });
 
     it('append --data-json preserves nested structure + PyFloat (2.0 stays 2.0)', () => {
         const dj = '{"n":3,"f":1.5,"nested":{"k":"v","arr":[1,2.0,"x"]},"b":true,"z":null,"big":2.0e3,"neg":-4.0}';
-        const pid = runPy(['start', '--role', 'r', '--task', 't', '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'r', '--task', 't', '--root', tsRoot]).stdout.trim();
-        runPy(['append', pid, '--kind', 'host.output', '--data-json', dj, '--root', pyRoot]);
         runTs(['append', tid, '--kind', 'host.output', '--data-json', dj, '--root', tsRoot]);
-        const p = runPy(['read', pid, '--json', '--root', pyRoot]);
         const t = runTs(['read', tid, '--json', '--root', tsRoot]);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"data": {"role": "r", "task": "t"}, "kind": "launcher.input", "ts": "<TS>"}, {"data": {"b": true, "big": 2000.0, "f": 1.5, "n": 3, "neg": -4.0, "nested": {"arr": [1, 2.0, "x"], "k": "v"}, "z": null}, "kind": "host.output", "ts": "<TS>"}]
+          "
+        `);
         expect(t.stdout).toContain('2.0'); // float preserved, not collapsed to 2
     });
 
     it('append --data-json scrubs a secret in a string leaf', () => {
         const dj = '{"k":"AKIAIOSFODNN7EXAMPLE here","v":2.0}';
-        const pid = runPy(['start', '--role', 'r', '--task', 't', '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'r', '--task', 't', '--root', tsRoot]).stdout.trim();
-        runPy(['append', pid, '--kind', 'host.output', '--data-json', dj, '--root', pyRoot]);
         runTs(['append', tid, '--kind', 'host.output', '--data-json', dj, '--root', tsRoot]);
-        const p = runPy(['read', pid, '--json', '--root', pyRoot]);
         const t = runTs(['read', tid, '--json', '--root', tsRoot]);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"data": {"role": "r", "task": "t"}, "kind": "launcher.input", "ts": "<TS>"}, {"data": {"k": "[SECRET] here", "v": 2.0}, "kind": "host.output", "ts": "<TS>"}]
+          "
+        `);
     });
 
     it('append rejects an unknown kind → stderr + exit 1', () => {
-        const pid = runPy(['start', '--role', 'r', '--task', 't', '--root', pyRoot]).stdout.trim();
         const tid = runTs(['start', '--role', 'r', '--task', 't', '--root', tsRoot]).stdout.trim();
-        const p = runPy(['append', pid, '--kind', 'bogus.kind', '--root', pyRoot]);
         const t = runTs(['append', tid, '--kind', 'bogus.kind', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        // stderr names the kind (deterministic).
-        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toMatchInlineSnapshot(`1`);
+        expect(t.stderr).toMatchInlineSnapshot(`
+          "workspace_sessions: rejecting unknown kind 'bogus.kind'
+          "
+        `);
     });
 
     it('append to a missing session → stderr + exit 1', () => {
-        const p = runPy(['append', '20200101T000000Z-deadbeef', '--kind', 'host.turn', '--root', pyRoot]);
         const t = runTs(['append', '20200101T000000Z-deadbeef', '--kind', 'host.turn', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout);
-        // stderr names the (same) session id — directly comparable.
-        expect(t.stderr).toBe(p.stderr);
+        expect(t.status).toMatchInlineSnapshot(`1`);
+        expect(t.stdout).toMatchInlineSnapshot(`""`);
+        expect(t.stderr).toMatchInlineSnapshot(`
+          "workspace_sessions: no session 20200101T000000Z-deadbeef
+          "
+        `);
     });
 
     it('read missing session → empty (exit 0)', () => {
-        const p = runPy(['read', '20200101T000000Z-deadbeef', '--json', '--root', pyRoot]);
         const t = runTs(['read', '20200101T000000Z-deadbeef', '--json', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // both "[]"
+        expect(t.status).toMatchInlineSnapshot(`0`);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "[]
+          "
+        `); // "[]"
     });
 
     it('list --json (single entry, normalized)', () => {
-        runPy(['start', '--role', 'sales', '--task', 'one', '--root', pyRoot]);
         runTs(['start', '--role', 'sales', '--task', 'one', '--root', tsRoot]);
-        const p = runPy(['list', '--json', '--root', pyRoot]);
         const t = runTs(['list', '--json', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(norm(t.stdout, [tsRoot, tsTmp])).toBe(norm(p.stdout, [pyRoot, pyTmp]));
+        expect(t.status).toBe(0);
+        expect(norm(t.stdout, [tsRoot, tsTmp])).toMatchInlineSnapshot(`
+          "[{"mtime": <M>, "role": "sales", "session_id": "<ID>", "started_at": "<TS>", "task": "one"}]
+          "
+        `);
     });
 
     it('list text (per-line JSON, empty root)', () => {
-        const p = runPy(['list', '--root', pyRoot]);
         const t = runTs(['list', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // both empty
+        expect(t.status).toBe(0);
+        expect(t.stdout).toMatchInlineSnapshot(`""`); // empty
     });
 });
 
-describe.skipIf(!py3)('workspace_sessions — encryption-at-rest defaults (flag off)', () => {
-    it('migrate with flag off → exit 1 (RuntimeError both sides)', () => {
-        const p = runPy(['migrate', '--root', pyRoot]);
+describe('workspace_sessions — encryption-at-rest defaults (flag off)', () => {
+    it('migrate with flag off → exit 1 (RuntimeError)', () => {
         const t = runTs(['migrate', '--root', tsRoot]);
-        expect(t.status).toBe(p.status); // 1 / 1
+        expect(t.status).toMatchInlineSnapshot(`1`);
     });
     it('decrypt-all on plaintext → {"decrypted": 0} (crypto-free)', () => {
-        runPy(['start', '--role', 'r', '--task', 't', '--root', pyRoot]);
         runTs(['start', '--role', 'r', '--task', 't', '--root', tsRoot]);
-        const p = runPy(['decrypt-all', '--root', pyRoot]);
         const t = runTs(['decrypt-all', '--root', tsRoot]);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout).toBe(p.stdout); // {"decrypted": 0}
+        expect(t.status).toMatchInlineSnapshot(`0`);
+        expect(t.stdout).toMatchInlineSnapshot(`
+          "{"decrypted": 0}
+          "
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_sessions — argparse + root validation errors', () => {
+describe('workspace_sessions — argparse + root validation errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParityExact([]);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions [-h]
+                                    {start,append,list,read,migrate,decrypt-all,rekey}
+                                    ...
+          workspace_sessions: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParityExact(['bogus']);
+        expect(runTs(['bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions [-h]
+                                    {start,append,list,read,migrate,decrypt-all,rekey}
+                                    ...
+          workspace_sessions: error: argument cmd: invalid choice: 'bogus' (choose from 'start', 'append', 'list', 'read', 'migrate', 'decrypt-all', 'rekey')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('start missing required → exit 2', () => {
-        expectParityExact(['start']);
+        expect(runTs(['start'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions start [-h] --role ROLE --task TASK [--host HOST]
+                                          [--root ROOT]
+          workspace_sessions start: error: the following arguments are required: --role, --task
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('append missing session_id → exit 2', () => {
-        expectParityExact(['append', '--kind', 'host.turn']);
+        expect(runTs(['append', '--kind', 'host.turn'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions append [-h] --kind KIND [--data DATA]
+                                           [--data-json DATA_JSON] [--root ROOT]
+                                           session_id
+          workspace_sessions append: error: the following arguments are required: session_id
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('append missing --kind → exit 2', () => {
-        expectParityExact(['append', 'sid']);
+        expect(runTs(['append', 'sid'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions append [-h] --kind KIND [--data DATA]
+                                           [--data-json DATA_JSON] [--root ROOT]
+                                           session_id
+          workspace_sessions append: error: the following arguments are required: --kind
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('read missing session_id → exit 2', () => {
-        expectParityExact(['read']);
+        expect(runTs(['read'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions read [-h] [--root ROOT] [--json] session_id
+          workspace_sessions read: error: the following arguments are required: session_id
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('list bad --limit int → exit 2', () => {
-        expectParityExact(['list', '--limit', 'abc']);
+        expect(runTs(['list', '--limit', 'abc'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_sessions list [-h] [--limit LIMIT] [--root ROOT] [--json]
+          workspace_sessions list: error: argument --limit: invalid int value: 'abc'
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('--root not a workspace/sessions dir → SystemExit, exit 1', () => {
-        expectParityExact(['list', '--root', '/tmp/not-a-sessions-dir']);
+        expect(runTs(['list', '--root', '/tmp/not-a-sessions-dir'])).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "workspace_sessions: --root must be a .../workspace/sessions dir, got '/tmp/not-a-sessions-dir'
+          ",
+            "stdout": "",
+          }
+        `);
     });
-    it.each([['start'], ['append'], ['list'], ['read'], ['migrate'], ['decrypt-all'], ['rekey']])(
-        '%s -h usage line byte-matches',
-        (sub) => {
-            const p = runPy([sub, '-h']);
-            const t = runTs([sub, '-h']);
-            expect(t.status).toBe(p.status); // 0 / 0
-            expect(usageOnly(t.stdout)).toBe(usageOnly(p.stdout));
-        },
-    );
+    it('start -h usage line', () => {
+        const t = runTs(['start', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`
+          "usage: workspace_sessions start [-h] --role ROLE --task TASK [--host HOST]
+                                          [--root ROOT]"
+        `);
+    });
+    it('append -h usage line', () => {
+        const t = runTs(['append', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`
+          "usage: workspace_sessions append [-h] --kind KIND [--data DATA]
+                                           [--data-json DATA_JSON] [--root ROOT]
+                                           session_id"
+        `);
+    });
+    it('list -h usage line', () => {
+        const t = runTs(['list', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_sessions list [-h] [--limit LIMIT] [--root ROOT] [--json]"`);
+    });
+    it('read -h usage line', () => {
+        const t = runTs(['read', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_sessions read [-h] [--root ROOT] [--json] session_id"`);
+    });
+    it('migrate -h usage line', () => {
+        const t = runTs(['migrate', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_sessions migrate [-h] [--root ROOT]"`);
+    });
+    it('decrypt-all -h usage line', () => {
+        const t = runTs(['decrypt-all', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_sessions decrypt-all [-h] [--root ROOT]"`);
+    });
+    it('rekey -h usage line', () => {
+        const t = runTs(['rekey', '-h']);
+        expect(t.status).toBe(0);
+        expect(usageOnly(t.stdout)).toMatchInlineSnapshot(`"usage: workspace_sessions rekey [-h] [--root ROOT]"`);
+    });
 });

--- a/tests/scripts/cli/python/workspace_skills.test.ts
+++ b/tests/scripts/cli/python/workspace_skills.test.ts
@@ -1,37 +1,42 @@
-// Golden-parity tests for src/cli/python/workspace_skills.ts (py2ts ADR-200 —
+// Intent tests for src/cli/python/workspace_skills.ts (py2ts ADR-200 —
 // skill-body resolution for host hand-off pre-rendering, ADR-066).
 //
-// Strategy: run `python3 workspace_skills.py` vs `tsx workspace_skills.ts` and
-// byte-compare stdout / stderr / exit. Skill resolution is deterministic: both
-// languages resolve `<repo>/.agent-src.uncondensed/skills/<id>/SKILL.md` then
-// `<repo>/dist/agent-src/skills/<id>/SKILL.md` (ROOT = parents[3] of the
-// script), strip frontmatter the same way, and cap the body at 64 KiB. The
-// resolution root is the REAL repo, so we resolve a known-present skill
-// (`docker`) for the happy path plus invalid / missing ids for the note path.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. Skill resolution is
+// deterministic: it resolves `<repo>/.agent-src.uncondensed/skills/<id>/SKILL.md`
+// then `<repo>/dist/agent-src/skills/<id>/SKILL.md` (ROOT = parents[3] of the
+// script), strips frontmatter, and caps the body at 64 KiB. The resolution root
+// is the REAL repo, so the happy path resolves whichever skill is alphabetically
+// first under one of the two SKILL_SOURCES.
 //
-// Coverage: resolve a present skill (section + --json), invalid id, missing id
-// (section + --json), `--format=json` inline form, bad --format choice, and
-// the argparse error surface. The `--help` BODY is NOT byte-compared (only the
-// `usage:` line) per the porting contract.
+// Two non-determinism sources are masked: (1) host-CLI / PATH state is removed
+// by spawning with a **node-only PATH** + COLUMNS=200 (single-line usage); (2)
+// the resolved skill's BODY + DESCRIPTION are real tracked-repo content that
+// changes under unrelated edits, so `norm()` masks them — the load-bearing
+// happy-path contract is the present/absent flag (`found` / section header), the
+// resolved id (`name`), and the output SHAPE, not the body bytes. Note-path and
+// argparse cases are fully deterministic and snapshot verbatim.
+import { mkdtempSync, readdirSync, existsSync, symlinkSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_skills.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_skills.py');
 const TSX_BIN = path.resolve(
     REPO_ROOT,
     process.env['TSX_BIN'] ??
         path.join('node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx'),
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
+// node-only PATH → deterministic host-CLI detection (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(path.join(tmpdir(), 'ws-skills-nodeonly-'));
+symlinkSync(process.execPath, path.join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
 
 /** Pick a skill id that exists under one of the two real SKILL_SOURCES. */
 function presentSkill(): string | null {
@@ -41,12 +46,12 @@ function presentSkill(): string | null {
     ]) {
         let names: string[];
         try {
-            names = fs.readdirSync(root);
+            names = readdirSync(root);
         } catch {
             continue;
         }
         for (const n of names.sort()) {
-            if (fs.existsSync(path.join(root, n, 'SKILL.md')) && /^[a-z0-9][a-z0-9-]*$/.test(n)) {
+            if (existsSync(path.join(root, n, 'SKILL.md')) && /^[a-z0-9][a-z0-9-]*$/.test(n)) {
                 return n;
             }
         }
@@ -61,74 +66,192 @@ interface RunResult {
     stderr: string;
 }
 
-function runPy(args: string[]): RunResult {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        env: { ...process.env, PYTHONPATH: path.join(REPO_ROOT, 'src') },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
-}
-
 function runTs(args: string[]): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', env: { ...process.env } });
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        encoding: 'utf8',
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
+    });
     return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
 
-function expectParity(args: string[]): void {
-    const p = runPy(args);
-    const t = runTs(args);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
+/**
+ * Mask the repo-coupled body of a resolved PRESENT skill so the snapshot pins
+ * the deterministic envelope (present-flag, id, shape) not the body bytes.
+ * - section format: keep up to the `## Skill context: <id>` header, then `<BODY>`.
+ * - json format: replace `body` + `description` string values with `<MASKED>`.
+ * Leaves note-path / argparse output untouched.
+ */
+function norm(r: RunResult): RunResult {
+    let out = r.stdout;
+    // JSON form: blank `body`/`description` values.
+    if (out.trimStart().startsWith('{') && out.includes('"body"')) {
+        out = out
+            .replace(/("body":\s*)"(?:[^"\\]|\\.)*"/, '$1"<MASKED>"')
+            .replace(/("description":\s*)"(?:[^"\\]|\\.)*"/, '$1"<MASKED>"');
+    } else {
+        // Section form for a PRESENT skill: header then a real body.
+        const m = out.match(/^([\s\S]*?## Skill context: [^\n]*\n)[\s\S]+$/);
+        if (m) {
+            out = m[1] + '<BODY>\n';
+        }
+    }
+    return { status: r.status, stdout: out, stderr: r.stderr };
 }
 
-describe.skipIf(!py3)('workspace_skills — resolve present skill', () => {
-    it.skipIf(!SKILL)('section format (full body + header)', () => {
-        expectParity(['resolve', SKILL as string]);
+describe('workspace_skills — resolve present skill', () => {
+    it.skipIf(!SKILL)('section format (header + masked body)', () => {
+        expect(norm(runTs(['resolve', SKILL as string]))).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "
+
+          ## Skill context: accessibility-auditor
+          <BODY>
+          ",
+          }
+        `);
     });
-    it.skipIf(!SKILL)('--format json (sorted keys)', () => {
-        expectParity(['resolve', SKILL as string, '--format', 'json']);
+    it.skipIf(!SKILL)('--format json (masked body + description)', () => {
+        expect(norm(runTs(['resolve', SKILL as string, '--format', 'json']))).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"body": "<MASKED>", "description": "<MASKED>", "found": true, "name": "accessibility-auditor"}
+          ",
+          }
+        `);
     });
-    it.skipIf(!SKILL)('--format=json inline form', () => {
-        expectParity(['resolve', SKILL as string, '--format=json']);
+    it.skipIf(!SKILL)('--format=json inline form (masked)', () => {
+        expect(norm(runTs(['resolve', SKILL as string, '--format=json']))).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"body": "<MASKED>", "description": "<MASKED>", "found": true, "name": "accessibility-auditor"}
+          ",
+          }
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_skills — resolve note path', () => {
+describe('workspace_skills — resolve note path', () => {
     it('invalid id (charset reject)', () => {
-        expectParity(['resolve', 'Bad Id']);
+        expect(runTs(['resolve', 'Bad Id'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "
+
+          ## Skill context
+
+          > skill \`Bad Id\` is not a valid id.
+          ",
+          }
+        `);
     });
     it('missing id (section note)', () => {
-        expectParity(['resolve', 'nonexistent-skill-xyz']);
+        expect(runTs(['resolve', 'nonexistent-skill-xyz'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "
+
+          ## Skill context
+
+          > skill \`nonexistent-skill-xyz\` not found — proceed without it.
+          ",
+          }
+        `);
     });
     it('missing id (--format json note)', () => {
-        expectParity(['resolve', 'nonexistent-skill-xyz', '--format', 'json']);
+        expect(runTs(['resolve', 'nonexistent-skill-xyz', '--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"found": false, "note": "skill \`nonexistent-skill-xyz\` not found \\u2014 proceed without it"}
+          ",
+          }
+        `);
     });
     it('empty-ish invalid id', () => {
-        expectParity(['resolve', 'UPPER']);
+        expect(runTs(['resolve', 'UPPER'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "
+
+          ## Skill context
+
+          > skill \`UPPER\` is not a valid id.
+          ",
+          }
+        `);
     });
 });
 
-describe.skipIf(!py3)('workspace_skills — argparse errors', () => {
+describe('workspace_skills — argparse errors', () => {
     it('no args → required cmd, exit 2', () => {
-        expectParity([]);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_skills [-h] {resolve} ...
+          workspace_skills: error: the following arguments are required: cmd
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('bad subcommand → invalid choice, exit 2', () => {
-        expectParity(['bogus']);
+        expect(runTs(['bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_skills [-h] {resolve} ...
+          workspace_skills: error: argument cmd: invalid choice: 'bogus' (choose from 'resolve')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('resolve missing skill_hint → exit 2', () => {
-        expectParity(['resolve']);
+        expect(runTs(['resolve'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_skills resolve [-h] [--format {section,json}] skill_hint
+          workspace_skills resolve: error: the following arguments are required: skill_hint
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('resolve bad --format choice → exit 2', () => {
-        expectParity(['resolve', 'docker', '--format', 'bogus']);
+        expect(runTs(['resolve', 'docker', '--format', 'bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_skills resolve [-h] [--format {section,json}] skill_hint
+          workspace_skills resolve: error: argument --format: invalid choice: 'bogus' (choose from 'section', 'json')
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('resolve extra positional → unrecognized, exit 2', () => {
-        expectParity(['resolve', 'a', 'b']);
+        expect(runTs(['resolve', 'a', 'b'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: workspace_skills [-h] {resolve} ...
+          workspace_skills: error: unrecognized arguments: b
+          ",
+            "stdout": "",
+          }
+        `);
     });
     it('top-level -h → usage line + exit 0', () => {
-        const p = runPy(['-h']);
-        const t = runTs(['-h']);
-        expect(t.status).toBe(p.status);
-        expect(t.stdout.split('\n')[0]).toBe(p.stdout.split('\n')[0]);
+        const r = runTs(['-h']);
+        expect({ status: r.status, usage: r.stdout.split('\n')[0] }).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "usage": "usage: workspace_skills [-h] {resolve} ...",
+          }
+        `);
     });
 });

--- a/tests/scripts/work_engine/__main__.test.ts
+++ b/tests/scripts/work_engine/__main__.test.ts
@@ -1,11 +1,12 @@
-// Golden-parity tests for work_engine/__main__.ts vs __main__.py (ADR-096 py2ts
-// Phase 1 — work_engine TOP/integration layer).
+// Intent test for work_engine/__main__.ts (py2ts ADR-096 — work_engine
+// TOP/integration layer).
 //
-// `__main__.py` is the thin `python3 -m work_engine` entry shim: it imports
-// `cli.main`, runs it, and exits with its return code. The twin sets
-// `process.exitCode = main()`. Both are run as subprocesses in identical temp
-// CWDs; the exit code + stdout + stderr are compared. The argv-passing path
-// mirrors the cli test (a runner file forwards argv into the module).
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx entry-point's own contract directly. `__main__.ts` is the thin
+// `python3 -m work_engine` entry shim twin: it imports `cli.main`, runs it with
+// `process.argv.slice(2)`, and sets `process.exitCode` to its return code. A
+// runner file imports the module after the real argv is in place — the import
+// side-effect runs the entry. With no input it exits 2 (argparse error path).
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -13,42 +14,15 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { oracle2 } from '../../_lib/parity_oracle';
-
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const MAIN_TS = path.join(SCRIPTS_ROOT, 'work_engine', '__main__.ts');
 const TSX_BIN = process.env['TSX_BIN'] ?? path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
 interface Run {
     status: number;
     stdout: string;
     stderr: string;
-}
-
-/**
- * Frozen Python-side result of `python3 -m work_engine ...argv`.
- *
- * The Python module is spawned in `cwd` (a per-test tmp dir) with
- * `PYTHONPATH=SCRIPTS_ROOT` so `work_engine` resolves. `oracle2` keys on
- * `kind:'module'` + the module name + PYTHONPATH (basename-stabilised) + argv,
- * NOT the volatile tmp `cwd` — the module's observable output here is
- * cwd-independent (BLOCKED stdout / arg-error stderr), so no `normalize` is
- * needed. Capture spawns python3 once; normal reads the frozen snapshot.
- */
-function runPy(cwd: string, argv: string[]): Run {
-    const r = oracle2({
-        kind: 'module',
-        target: 'work_engine',
-        args: argv,
-        env: { PYTHONPATH: SCRIPTS_ROOT },
-        cwd,
-    });
-    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
 }
 
 /**
@@ -67,42 +41,21 @@ function runTs(cwd: string, argv: string[]): Run {
     }
 }
 
-let tmpPy: string;
 let tmpTs: string;
 beforeEach(() => {
-    tmpPy = fs.mkdtempSync(path.join(os.tmpdir(), 'main-py-'));
     tmpTs = fs.mkdtempSync(path.join(os.tmpdir(), 'main-ts-'));
 });
 afterEach(() => {
-    fs.rmSync(tmpPy, { recursive: true, force: true });
     fs.rmSync(tmpTs, { recursive: true, force: true });
 });
 
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
-
-describeParity('__main__ — entry-point parity', () => {
-    it('no input → exit 2 + identical stderr', () => {
-        const pyR = runPy(tmpPy, ['--no-hooks']);
+describe('__main__ — entry-point contract', () => {
+    it('no input → exit 2 (argparse error path)', () => {
         const tsR = runTs(tmpTs, ['--no-hooks']);
         expect(tsR.status).toBe(2);
-        expect(pyR.status).toBe(2);
-        expect(tsR.stderr).toBe(pyR.stderr);
     });
 
-    it('fresh ticket → BLOCKED exit 1 + identical stdout', () => {
-        const fixture = JSON.stringify({ id: 'T-1', title: 'x' });
-        fs.writeFileSync(path.join(tmpPy, 'ticket.json'), fixture, 'utf-8');
-        fs.writeFileSync(path.join(tmpTs, 'ticket.json'), fixture, 'utf-8');
-        const pyR = runPy(tmpPy, ['--no-hooks', '--ticket-file', 'ticket.json']);
-        const tsR = runTs(tmpTs, ['--no-hooks', '--ticket-file', 'ticket.json']);
-        expect(tsR.status).toBe(pyR.status);
-        expect(tsR.stdout).toBe(pyR.stdout);
-    });
-});
-
-describe('__main__ — runs the entry without throwing', () => {
-    it('TS entry executes and yields a numeric exit code', () => {
+    it('runs the entry and yields a numeric exit code', () => {
         const tsR = runTs(tmpTs, ['--no-hooks']);
         expect(typeof tsR.status).toBe('number');
     });

--- a/tests/scripts/work_engine/__snapshots__/directives_backend_report.test.ts.snap
+++ b/tests/scripts/work_engine/__snapshots__/directives_backend_report.test.ts.snap
@@ -1,0 +1,423 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`directives/backend/report — rendered report > advisory persona suppresses next-commands 1`] = `
+"## Ticket
+
+R-9 — (no title)
+
+## Persona
+
+advisory
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_"
+`;
+
+exports[`directives/backend/report — rendered report > follow-ups aggregated from plan/verify/tests in order 1`] = `
+"## Ticket
+
+R-8 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+{'steps': ['x'], 'followups': [{'note': 'plan fup', 'anchor': 'P#1'}]}
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+- **verdict:** success
+- **followups:** [{'note': 'test fup'}]
+
+## Verify
+
+- **verdict:** success
+- **followups:** [{'title': 'verify fup'}]
+
+## Follow-ups
+
+- plan fup — \`P#1\`
+- verify fup
+- test fup
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > fully populated, verify success → both next-commands 1`] = `
+"## Ticket
+
+R-1 — Build the thing
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+1. **Step A** — do A
+2. plain step
+
+## Changes
+
+- \`a.ts\` (L1-L9) — add
+- \`b.ts\`
+
+## Tests
+
+- **verdict:** success
+- **targeted:** 12
+
+## Verify
+
+- **verdict:** success
+- **confidence:** high
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`
+- \`/create-pr\`"
+`;
+
+exports[`directives/backend/report — rendered report > memory all non-influential → section dropped 1`] = `
+"## Ticket
+
+R-4 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > memory that mattered drops non-influential hits 1`] = `
+"## Ticket
+
+R-3 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Memory that mattered
+
+- \`m1\` (domain-invariants) — mattered
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > minimal state (all empties / placeholders) 1`] = `
+"## Ticket
+
+(no id) — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > string plan body 1`] = `
+"## Ticket
+
+R-2 — T
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+do this thing
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > tests as a plain string (kv-block string branch) 1`] = `
+"## Ticket
+
+R-11 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+all good
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > verify not success → only /commit suggested 1`] = `
+"## Ticket
+
+R-10 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > visual preview render_ok but no paths → dropped 1`] = `
+"## Ticket
+
+R-7 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > visual preview rendered (render_ok + paths) 1`] = `
+"## Ticket
+
+R-5 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Visual preview
+
+- Screenshot: \`shot.png\`
+- DOM dump: \`dom.html\`
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;
+
+exports[`directives/backend/report — rendered report > visual preview skipped (render_ok false) → dropped 1`] = `
+"## Ticket
+
+R-6 — (no title)
+
+## Persona
+
+senior-engineer
+
+## Plan
+
+_(no plan recorded)_
+
+## Changes
+
+_(no file changes recorded)_
+
+## Tests
+
+_(no tests ran)_
+
+## Verify
+
+_(no verify verdict)_
+
+## Follow-ups
+
+_(none)_
+
+## Suggested next commands
+
+- \`/commit\`"
+`;

--- a/tests/scripts/work_engine/cli.test.ts
+++ b/tests/scripts/work_engine/cli.test.ts
@@ -1,15 +1,15 @@
-// Golden-parity tests for work_engine/cli.ts vs cli.py (ADR-096 py2ts Phase 1 —
-// work_engine TOP/integration layer).
+// Intent tests for work_engine/cli.ts (ADR-096 py2ts Phase 1 — work_engine
+// TOP/integration layer).
 //
-// `cli.py` is the work-engine CLI entry point (argparse). Both engines are
-// driven as subprocesses on identical fixtures in identical temp CWDs, and the
-// (exit code, stdout, stderr, persisted-state-file bytes) are compared
-// byte-for-byte. The argparse `--help` prose is NOT a parity surface (ADR-096);
-// only the exit code + the `usage:` token are asserted there.
-//
-// Python runs through the real `work_engine` package on sys.path; TS runs via
-// `tsx -e` importing `cli.ts::main`. Hooks are disabled (`--no-hooks`) so the
-// transport surface stays byte-stable independent of any settings file.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx CLI's own contract directly. `cli.ts::main` is the work-engine
+// entry point (argparse). It is driven via a tiny runner `.ts` written into a
+// per-test temp CWD (so trailing argv is forwarded verbatim) and the
+// (exit code, stdout, persisted-state-file bytes) are asserted. Hooks are
+// disabled (`--no-hooks`) so the transport surface stays stable independent of
+// any settings file. COLUMNS=200 forces single-line usage so argparse stderr
+// does not re-wrap to terminal width. norm() masks the volatile tmp CWD so the
+// argparse `prog` token (derived from argv[1]/the runner path) is deterministic.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -22,37 +22,19 @@ const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scri
 const CLI_TS = path.join(SCRIPTS_ROOT, 'work_engine', 'cli.ts');
 const TSX_BIN = process.env['TSX_BIN'] ?? path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
 interface Run {
     status: number;
     stdout: string;
     stderr: string;
 }
 
-/** Run the Python CLI in `cwd` with `argv`. */
-function runPy(cwd: string, argv: string[]): Run {
-    const code = [
-        'import sys',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine.cli import main',
-        'sys.exit(main(sys.argv[1:]))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, ...argv], { encoding: 'utf8', cwd });
-    return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
-}
-
 /**
  * Run the TS CLI (via tsx) in `cwd` with `argv`.
  *
- * `tsx -e <code> -- <args>` does not forward the trailing args into
- * `process.argv` (they are consumed by the `--` separator), so instead a tiny
- * runner `.ts` file is written into `cwd` and invoked with the argv directly —
- * which forwards `--help` and friends verbatim. The runner is `_`-prefixed and
- * lives only inside the per-test temp dir, so it never pollutes the state-file
- * comparison.
+ * A tiny runner `.ts` file is written into `cwd` and invoked with the argv
+ * directly — which forwards `--help` and friends verbatim into
+ * `process.argv.slice(2)`. The runner is `_`-prefixed and lives only inside the
+ * per-test temp dir, so it never pollutes the state-file comparison.
  */
 function runTs(cwd: string, argv: string[]): Run {
     const runner = path.join(cwd, '_cli_runner.ts');
@@ -64,30 +46,32 @@ function runTs(cwd: string, argv: string[]): Run {
     ].join('\n');
     fs.writeFileSync(runner, code, 'utf-8');
     try {
-        const r = spawnSync('node', [TSX_BIN, runner, ...argv], { encoding: 'utf8', cwd });
+        const r = spawnSync('node', [TSX_BIN, runner, ...argv], {
+            encoding: 'utf8',
+            cwd,
+            env: { ...process.env, COLUMNS: '200' },
+        });
         return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
     } finally {
         fs.rmSync(runner, { force: true });
     }
 }
 
-let tmpPy: string;
 let tmpTs: string;
 beforeEach(() => {
-    tmpPy = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-py-'));
     tmpTs = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-ts-'));
 });
 afterEach(() => {
-    fs.rmSync(tmpPy, { recursive: true, force: true });
     fs.rmSync(tmpTs, { recursive: true, force: true });
 });
 
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
+/** Mask the volatile per-test tmp CWD so snapshots stay deterministic. */
+function norm(r: Run): Run {
+    const mask = (s: string): string => s.split(tmpTs).join('<CWD>').replace(/_cli_runner\.ts/g, '<runner>');
+    return { status: r.status, stdout: mask(r.stdout), stderr: mask(r.stderr) };
+}
 
-/** Write the same ticket fixture into both CWDs. */
 function seedTicket(filename: string, payload: unknown): void {
-    fs.writeFileSync(path.join(tmpPy, filename), JSON.stringify(payload), 'utf-8');
     fs.writeFileSync(path.join(tmpTs, filename), JSON.stringify(payload), 'utf-8');
 }
 
@@ -96,41 +80,47 @@ function readStateMaybe(dir: string, name = '.work-state.json'): string | null {
     return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null;
 }
 
-describeParity('cli main — full transport parity', () => {
-    it('fresh ticket run halts BLOCKED at refine (exit 1) — same stdout + state', () => {
+describe('cli main — transport contract', () => {
+    it('fresh ticket run halts BLOCKED at refine (exit 1) — stable stdout + state', () => {
         // A ticket with a trivial title trips the refine deficiency gate →
         // BLOCKED at the first step. Deterministic, no agent directive needed.
         seedTicket('ticket.json', { id: 'T-1', title: 'x' });
-        const pyR = runPy(tmpPy, ['--no-hooks', '--ticket-file', 'ticket.json']);
-        const tsR = runTs(tmpTs, ['--no-hooks', '--ticket-file', 'ticket.json']);
-
-        expect(tsR.status).toBe(pyR.status);
-        expect(tsR.stdout).toBe(pyR.stdout);
-        // The persisted state file must be byte-identical (v0 wire format).
-        expect(readStateMaybe(tmpTs)).toBe(readStateMaybe(tmpPy));
+        const r = norm(runTs(tmpTs, ['--no-hooks', '--ticket-file', 'ticket.json']));
+        expect(r.status).toBe(1);
+        expect(r.stdout).toMatchInlineSnapshot(`
+          "[halt] outcome=blocked step=refine
+          > Ticket T-1 is missing: missing or trivial title; no acceptance criteria.
+          > 1. Run \`/refine-ticket T-1\` and re-invoke \`/implement-ticket\`
+          > 2. Provide the missing details in chat — I'll merge them into the ticket
+          > 3. Abandon this ticket — too vague to implement
+          "
+        `);
+        // A state file is persisted on the BLOCKED path (v0 wire format).
+        expect(readStateMaybe(tmpTs)).not.toBeNull();
     });
 
     it('missing input (no state file, no flags) → exit 2 + error on stderr', () => {
-        const pyR = runPy(tmpPy, ['--no-hooks']);
-        const tsR = runTs(tmpTs, ['--no-hooks']);
-        expect(tsR.status).toBe(2);
-        expect(pyR.status).toBe(2);
-        expect(tsR.stderr).toBe(pyR.stderr);
+        const r = norm(runTs(tmpTs, ['--no-hooks']));
+        expect(r.status).toBe(2);
+        expect(r.stderr).toMatchInlineSnapshot(`
+          "error: No state file at .work-state.json and no --ticket-file, --prompt-file, --diff-file, or --file-file given; cannot build an initial state.
+          "
+        `);
         // No state file written on the error path.
         expect(readStateMaybe(tmpTs)).toBeNull();
-        expect(readStateMaybe(tmpPy)).toBeNull();
     });
 
-    it('non-object ticket file → exit 2 + identical error text', () => {
+    it('non-object ticket file → exit 2 + error text', () => {
         seedTicket('bad.json', [1, 2, 3]);
-        const pyR = runPy(tmpPy, ['--no-hooks', '--ticket-file', 'bad.json']);
-        const tsR = runTs(tmpTs, ['--no-hooks', '--ticket-file', 'bad.json']);
-        expect(tsR.status).toBe(2);
-        expect(pyR.status).toBe(2);
-        expect(tsR.stderr).toBe(pyR.stderr);
+        const r = norm(runTs(tmpTs, ['--no-hooks', '--ticket-file', 'bad.json']));
+        expect(r.status).toBe(2);
+        expect(r.stderr).toMatchInlineSnapshot(`
+          "error: --ticket-file must carry a JSON object; got list.
+          "
+        `);
     });
 
-    it('resumes a v1 state file to SUCCESS (exit 0) — same report + state', () => {
+    it('resumes a v1 state file to SUCCESS (exit 0) — stored report + state', () => {
         // Pre-seed a v1 state file with every step already marked success so the
         // dispatcher walks straight to SUCCESS and prints the stored report.
         const v1 = {
@@ -165,31 +155,26 @@ describeParity('cli main — full transport parity', () => {
             questions: [],
             report: 'DELIVERY REPORT BODY',
         };
-        fs.writeFileSync(path.join(tmpPy, '.work-state.json'), JSON.stringify(v1, null, 2) + '\n', 'utf-8');
         fs.writeFileSync(path.join(tmpTs, '.work-state.json'), JSON.stringify(v1, null, 2) + '\n', 'utf-8');
-
-        const pyR = runPy(tmpPy, ['--no-hooks']);
-        const tsR = runTs(tmpTs, ['--no-hooks']);
-        expect(tsR.status).toBe(pyR.status);
-        expect(tsR.stdout).toBe(pyR.stdout);
-        expect(readStateMaybe(tmpTs)).toBe(readStateMaybe(tmpPy));
+        const r = norm(runTs(tmpTs, ['--no-hooks']));
+        expect(r.status).toBe(0);
+        expect(r.stdout).toMatchInlineSnapshot(`
+          "DELIVERY REPORT BODY
+          "
+        `);
+        expect(readStateMaybe(tmpTs)).not.toBeNull();
     });
 });
 
-describeParity('cli main — argparse exit codes', () => {
-    it('--help exits 0 (prose not byte-compared; usage token only)', () => {
-        const pyR = runPy(tmpPy, ['--help']);
-        const tsR = runTs(tmpTs, ['--help']);
-        expect(tsR.status).toBe(0);
-        expect(pyR.status).toBe(0);
-        expect(tsR.stdout.startsWith('usage:')).toBe(true);
-        expect(pyR.stdout.startsWith('usage:')).toBe(true);
+describe('cli main — argparse exit codes', () => {
+    it('--help exits 0 with a usage banner', () => {
+        const r = norm(runTs(tmpTs, ['--help']));
+        expect(r.status).toBe(0);
+        expect(r.stdout.startsWith('usage:')).toBe(true);
     });
 
     it('unrecognized flag exits 2', () => {
-        const pyR = runPy(tmpPy, ['--no-such-flag']);
-        const tsR = runTs(tmpTs, ['--no-such-flag']);
-        expect(tsR.status).toBe(2);
-        expect(pyR.status).toBe(2);
+        const r = norm(runTs(tmpTs, ['--no-such-flag']));
+        expect(r.status).toBe(2);
     });
 });

--- a/tests/scripts/work_engine/delivery_state.test.ts
+++ b/tests/scripts/work_engine/delivery_state.test.ts
@@ -1,15 +1,10 @@
-// Golden-parity tests for work_engine/delivery_state.ts vs delivery_state.py
-// (ADR-094 py2ts Phase 1). Covers: Outcome enum string values, StepResult /
-// DeliveryState dataclass field order + defaults via asdict, per-instance
-// mutable defaults (no shared container), agent_directive formatting (incl.
-// Python str() coercion of bool/None/int payload values + kwargs order), and
-// is_agent_directive (lstrip + prefix). Python loaded via the shared direct-file
-// importlib loader (sys.modules registered before exec for the 3.9 dataclass
-// __module__ lookup; work_engine dir + repo on sys.path).
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
+// Intent tests for work_engine/delivery_state.ts (ADR-094 py2ts Phase 1).
+// Covers: Outcome enum string values, StepResult / DeliveryState field order +
+// defaults, per-instance mutable defaults (no shared container), agent_directive
+// formatting (incl. Python str() coercion of bool/None/int payload values +
+// kwargs order), and is_agent_directive (lstrip + prefix). The python3-vs-tsx
+// parity block has been removed; the `.py` original is gone and the tsx
+// contract is asserted directly below.
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -20,36 +15,6 @@ import {
     agent_directive,
     is_agent_directive,
 } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function pyLoaderPreamble(): string {
-    return [
-        'import importlib.util, sys, json, pathlib, dataclasses',
-        `WE = pathlib.Path(${JSON.stringify(WE)})`,
-        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
-        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
-        'def _load(name):',
-        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
-        '    m = importlib.util.module_from_spec(sp)',
-        '    sys.modules[sp.name] = m',
-        '    sp.loader.exec_module(m)',
-        '    return m',
-    ].join('\n');
-}
-
-function py(body: string): string {
-    const r = spawnSync('python3', ['-c', `${pyLoaderPreamble()}\n${body}`], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr}`);
-    }
-    return r.stdout.trim();
-}
 
 describe('work_engine/delivery_state', () => {
     it('Outcome enum carries the string values', () => {
@@ -94,6 +59,15 @@ describe('work_engine/delivery_state', () => {
         expect(b.outcomes).toEqual({});
     });
 
+    it('StepResult field order matches the dataclass contract', () => {
+        const r = new StepResult({
+            outcome: Outcome.BLOCKED,
+            questions: ['q'],
+            message: 'msg',
+        });
+        expect(Object.keys(r)).toEqual(['outcome', 'questions', 'message']);
+    });
+
     it('agent_directive: name only', () => {
         expect(agent_directive('implement-plan')).toBe('@agent-directive: implement-plan');
     });
@@ -110,115 +84,21 @@ describe('work_engine/delivery_state', () => {
         );
     });
 
+    it('agent_directive: int payload values render verbatim', () => {
+        expect(agent_directive('x', { count: 0, label: 'a-b_c' })).toBe(
+            '@agent-directive: x count=0 label=a-b_c',
+        );
+    });
+
     it('is_agent_directive: lstrip then prefix match', () => {
         expect(is_agent_directive('@agent-directive: foo')).toBe(true);
         expect(is_agent_directive('   @agent-directive: foo')).toBe(true);
+        expect(is_agent_directive('\t@agent-directive: x')).toBe(true);
         expect(is_agent_directive('1. user option')).toBe(false);
+        expect(is_agent_directive('agent-directive: no-at')).toBe(false);
         expect(is_agent_directive('')).toBe(false);
         // non-string → false (Python isinstance guard).
         expect(is_agent_directive(42 as unknown)).toBe(false);
         expect(is_agent_directive(null as unknown)).toBe(false);
     });
-
-    describe.runIf(hasPython3())('python parity', () => {
-        it('Outcome values match CPython', () => {
-            const oracle = py(
-                'm=_load("delivery_state")\n' +
-                    'print(json.dumps({k: getattr(m.Outcome, k).value for k in ' +
-                    '("SUCCESS","BLOCKED","PARTIAL")}))',
-            );
-            expect(JSON.parse(oracle)).toEqual({
-                SUCCESS: 'success',
-                BLOCKED: 'blocked',
-                PARTIAL: 'partial',
-            });
-        });
-
-        it('StepResult asdict field order matches CPython', () => {
-            const oracle = py(
-                'm=_load("delivery_state")\n' +
-                    'r=m.StepResult(outcome=m.Outcome.BLOCKED, questions=["q"], message="msg")\n' +
-                    'd=dataclasses.asdict(r)\n' +
-                    'd["outcome"]=d["outcome"].value\n' +
-                    'print(json.dumps({"keys": list(d.keys()), "val": d}))',
-            );
-            const expected = JSON.parse(oracle) as { keys: string[]; val: Record<string, unknown> };
-            const r = new StepResult({
-                outcome: Outcome.BLOCKED,
-                questions: ['q'],
-                message: 'msg',
-            });
-            expect(Object.keys(r)).toEqual(expected.keys);
-            expect({ outcome: r.outcome, questions: r.questions, message: r.message }).toEqual(
-                expected.val,
-            );
-        });
-
-        it('DeliveryState asdict field order matches CPython', () => {
-            const oracle = py(
-                'm=_load("delivery_state")\n' +
-                    's=m.DeliveryState(ticket={"id":"T1"})\n' +
-                    'print(json.dumps(list(dataclasses.asdict(s).keys())))',
-            );
-            const expected = JSON.parse(oracle) as string[];
-            const s = new DeliveryState({ ticket: { id: 'T1' } });
-            expect(Object.keys(s)).toEqual(expected);
-        });
-
-        const directiveCases: Array<[string, Record<string, unknown>]> = [
-            ['implement-plan', {}],
-            ['run-tests', { scope: 'full' }],
-            ['run-tests', { scope: 'full', n: 3 }],
-            ['x', { a: true, b: false, c: null }],
-            // NB: payload keys must not collide with the `name` positional
-            // (Python `agent_directive(name, **payload)` would TypeError on a
-            // `name=` kwarg — same constraint both sides).
-            ['x', { count: 0, label: 'a-b_c' }],
-        ];
-
-        it.each(directiveCases)('agent_directive(%j, %j) matches CPython', (name, payload) => {
-            const kwargs = Object.entries(payload)
-                .map(([k, v]) => `${k}=${pyLiteral(v)}`)
-                .join(', ');
-            const oracle = py(
-                'm=_load("delivery_state")\n' +
-                    `print(m.agent_directive(${JSON.stringify(name)}${kwargs ? ', ' + kwargs : ''}))`,
-            );
-            expect(agent_directive(name, payload)).toBe(oracle);
-        });
-
-        const directiveProbes = [
-            '@agent-directive: foo',
-            '   @agent-directive: foo',
-            '\t@agent-directive: x',
-            '1. user option',
-            '',
-            'agent-directive: no-at',
-        ];
-
-        it.each(directiveProbes)('is_agent_directive(%j) matches CPython', (q) => {
-            const oracle = py(
-                'm=_load("delivery_state")\n' +
-                    `print("true" if m.is_agent_directive(${JSON.stringify(q)}) else "false")`,
-            );
-            expect(String(is_agent_directive(q))).toBe(oracle);
-        });
-    });
 });
-
-/** Render a JS payload value as a Python literal for the `-c` oracle. */
-function pyLiteral(v: unknown): string {
-    if (v === null || v === undefined) {
-        return 'None';
-    }
-    if (v === true) {
-        return 'True';
-    }
-    if (v === false) {
-        return 'False';
-    }
-    if (typeof v === 'number') {
-        return String(v);
-    }
-    return JSON.stringify(v);
-}

--- a/tests/scripts/work_engine/directives_backend_analyze.test.ts
+++ b/tests/scripts/work_engine/directives_backend_analyze.test.ts
@@ -1,67 +1,22 @@
-// Golden-parity tests for work_engine/directives/backend/analyze.ts vs
-// analyze.py (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/analyze.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `analyze.py` has intra-package imports (`from ...delivery_state import …`),
-// so the direct-file importlib loader used by state.test.ts does NOT work here.
-// Instead we add `src/agent-src/templates/scripts` to `sys.path` and
-// `import work_engine.directives.backend.analyze` as a real package member —
-// the package `__init__` imports its (still-Python) siblings, which all exist
-// in source until the Phase-12 sweep. The TS twin is exercised in-process; the
-// Python original via a python3 subprocess. Both build a `DeliveryState` from
-// the same JSON fixture and emit `{outcome, questions, message}` as
-// `json.dumps(..., indent=2, ensure_ascii=False)` for a byte-exact compare.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx directive's own contract directly. The TS twin is exercised
+// in-process: build a `DeliveryState` from a JSON fixture, run the directive,
+// and emit `{outcome, questions, message}` as canonical JSON for an inline
+// snapshot. Covers the three precondition surfaces (refine/memory upstream +
+// lost acceptance criteria) and the BLOCKED reason text.
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/analyze.js';
 import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/**
- * Drive `work_engine.directives.backend.<MODULE>.run` on python3 from a JSON
- * state fixture; emit `{outcome, questions, message}` as canonical JSON.
- */
-function runPy(moduleName: string, stateJson: string): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        `import importlib`,
-        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
 
 /** TS twin: build DeliveryState from the fixture, run, emit canonical JSON. */
 function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
     const r: StepResult = run(new DeliveryState(state));
     return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
 }
-
-/** Build the matching python fixture JSON from the same constructor args. */
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 describe('directives/backend/analyze — AMBIGUITIES', () => {
     it('declares the three precondition surfaces in order', () => {
@@ -73,69 +28,152 @@ describe('directives/backend/analyze — AMBIGUITIES', () => {
     });
 });
 
-describeParity('directives/backend/analyze — golden parity (ts == py)', () => {
-    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        [
-            'all preconditions met → SUCCESS',
-            {
+describe('directives/backend/analyze — outcome contract', () => {
+    it('all preconditions met → SUCCESS', () => {
+        expect(
+            runTs({
                 ticket: { id: 'T-1', acceptance_criteria: ['must do X'] },
                 outcomes: { refine: 'success', memory: 'success' },
-            },
-        ],
-        [
-            'refine not success → BLOCKED (single reason)',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "success",
+            "questions": [],
+            "message": ""
+          }"
+        `);
+    });
+
+    it('refine not success → BLOCKED (single reason)', () => {
+        expect(
+            runTs({
                 ticket: { id: 'T-2', acceptance_criteria: ['a'] },
                 outcomes: { memory: 'success' },
-            },
-        ],
-        [
-            'memory not success → BLOCKED',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-2 — analyze gate failed: refine step did not complete successfully.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket T-2 cannot enter the plan step: refine step did not complete successfully"
+          }"
+        `);
+    });
+
+    it('memory not success → BLOCKED', () => {
+        expect(
+            runTs({
                 ticket: { id: 'T-3', acceptance_criteria: ['a'] },
                 outcomes: { refine: 'success' },
-            },
-        ],
-        [
-            'lost acceptance criteria (empty list) → BLOCKED',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-3 — analyze gate failed: memory step did not complete successfully.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket T-3 cannot enter the plan step: memory step did not complete successfully"
+          }"
+        `);
+    });
+
+    it('lost acceptance criteria (empty list) → BLOCKED', () => {
+        expect(
+            runTs({
                 ticket: { id: 'T-4', acceptance_criteria: [] },
                 outcomes: { refine: 'success', memory: 'success' },
-            },
-        ],
-        [
-            'acceptance_criteria not a list → BLOCKED',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-4 — analyze gate failed: ticket lost its acceptance criteria.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket T-4 cannot enter the plan step: ticket lost its acceptance criteria"
+          }"
+        `);
+    });
+
+    it('acceptance_criteria not a list → BLOCKED', () => {
+        expect(
+            runTs({
                 ticket: { id: 'T-5', acceptance_criteria: 'a string not a list' },
                 outcomes: { refine: 'success', memory: 'success' },
-            },
-        ],
-        [
-            'all three missing → BLOCKED (three reasons joined)',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-5 — analyze gate failed: ticket lost its acceptance criteria.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket T-5 cannot enter the plan step: ticket lost its acceptance criteria"
+          }"
+        `);
+    });
+
+    it('all three missing → BLOCKED (three reasons joined)', () => {
+        expect(
+            runTs({
                 ticket: { id: 'T-6' },
                 outcomes: {},
-            },
-        ],
-        [
-            'no ticket id → "(no id)" in headnote',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-6 — analyze gate failed: refine step did not complete successfully; memory step did not complete successfully; ticket lost its acceptance criteria.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket T-6 cannot enter the plan step: refine step did not complete successfully; memory step did not complete successfully; ticket lost its acceptance criteria"
+          }"
+        `);
+    });
+
+    it('no ticket id → "(no id)" in headnote', () => {
+        expect(
+            runTs({
                 ticket: {},
                 outcomes: {},
-            },
-        ],
-        [
-            'empty-string ticket id falls back to "(no id)"',
-            {
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket (no id) — analyze gate failed: refine step did not complete successfully; memory step did not complete successfully; ticket lost its acceptance criteria.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket (no id) cannot enter the plan step: refine step did not complete successfully; memory step did not complete successfully; ticket lost its acceptance criteria"
+          }"
+        `);
+    });
+
+    it('empty-string ticket id falls back to "(no id)"', () => {
+        expect(
+            runTs({
                 ticket: { id: '' },
                 outcomes: { refine: 'success', memory: 'success' },
-            },
-        ],
-    ];
-
-    it.each(cases)('%s', (_label, state) => {
-        const tsOut = runTs(state);
-        const pyOut = runPy('analyze', pyFixture(state));
-        expect(tsOut).toBe(pyOut);
+            }),
+        ).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket (no id) — analyze gate failed: ticket lost its acceptance criteria.",
+              "> 1. Re-run \`/implement-ticket\` from the start — rebuild upstream state",
+              "> 2. Abort — the flow cannot continue"
+            ],
+            "message": "Ticket (no id) cannot enter the plan step: ticket lost its acceptance criteria"
+          }"
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_implement.test.ts
+++ b/tests/scripts/work_engine/directives_backend_implement.test.ts
@@ -1,56 +1,20 @@
-// Golden-parity tests for work_engine/directives/backend/implement.ts vs
-// implement.py (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/implement.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `implement.py` imports `...delivery_state` and `...persona_policy`, so it
-// loads as a real package member via `sys.path` + import. Persona gating
-// (advisory short-circuits to SUCCESS) is covered alongside the plan-gate and
-// changes-shape paths. TS twin in-process; Python via python3 subprocess;
-// byte-exact `{outcome, questions, message}` compare. No non-determinism.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx golden-parity rig; the `.py` original is gone, so this
+// now asserts the tsx module's own contract directly. `run()` is exercised
+// in-process against a `DeliveryState` built from each fixture and the full
+// `{outcome, questions, message}` result is snapshotted. The persona gate,
+// plan-gate, and changes-shape paths are all covered. No non-determinism.
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/implement.js';
 import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): Pick<StepResult, 'outcome' | 'questions' | 'message'> {
+    const r = run(new DeliveryState(state));
+    return { outcome: r.outcome, questions: r.questions, message: r.message };
 }
-
-function runPy(moduleName: string, stateJson: string): string {
-    const code = [
-        'import sys, json, importlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    const r: StepResult = run(new DeliveryState(state));
-    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
-}
-
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 const ok = { plan: 'success' };
 
@@ -64,46 +28,165 @@ describe('directives/backend/implement — AMBIGUITIES', () => {
     });
 });
 
-describeParity('directives/backend/implement — golden parity (ts == py)', () => {
-    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        [
-            'advisory persona → SUCCESS short-circuit (skip)',
-            { ticket: { id: 'I-1' }, persona: 'advisory', outcomes: ok },
-        ],
-        ['plan not success → BLOCKED precondition', { ticket: { id: 'I-2' }, outcomes: {} }],
-        ['empty changes → delegate apply-plan', { ticket: { id: 'I-3' }, outcomes: ok }],
-        [
-            'valid changes → SUCCESS',
-            { ticket: { id: 'I-4' }, changes: [{ path: 'a.ts' }, { file: 'b.ts' }], outcomes: ok },
-        ],
-        [
-            'malformed change (no path/file) → BLOCKED shape',
-            { ticket: { id: 'I-5' }, changes: [{ purpose: 'x' }], outcomes: ok },
-        ],
-        [
-            'malformed change (non-dict entry) → BLOCKED shape',
-            { ticket: { id: 'I-6' }, changes: ['not a dict'] as unknown as Array<Record<string, unknown>>, outcomes: ok },
-        ],
-        [
-            'malformed change (blank path) → BLOCKED shape',
-            { ticket: { id: 'I-7' }, changes: [{ path: '   ' }], outcomes: ok },
-        ],
-        [
-            'multiple malformed changes → BLOCKED shape (joined)',
-            { ticket: { id: 'I-8' }, changes: ['x', { why: 'y' }] as unknown as Array<Record<string, unknown>>, outcomes: ok },
-        ],
-        [
-            'qa persona behaves like senior (no skip) → delegate',
-            { ticket: { id: 'I-9' }, persona: 'qa', outcomes: ok },
-        ],
-        [
-            'path falsy falls back to file key → SUCCESS',
-            { ticket: { id: 'I-10' }, changes: [{ path: '', file: 'real.ts' }], outcomes: ok },
-        ],
-        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
-    ];
+describe('directives/backend/implement — run() contract', () => {
+    it('advisory persona → SUCCESS short-circuit', () => {
+        expect(runTs({ ticket: { id: 'I-1' }, persona: 'advisory', outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "implement skipped: persona \`advisory\` is plan-only.",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
 
-    it.each(cases)('%s', (_label, state) => {
-        expect(runTs(state)).toBe(runPy('implement', pyFixture(state)));
+    it('plan not success → BLOCKED precondition', () => {
+        expect(runTs({ ticket: { id: 'I-2' }, outcomes: {} })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-2 cannot implement: plan gate did not pass.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket I-2 — implement gate refused: \`plan\` step did not complete successfully.",
+              "> 1. Re-run \`/implement-ticket\` from the start",
+              "> 2. Abort",
+            ],
+          }
+        `);
+    });
+
+    it('empty changes → delegate apply-plan', () => {
+        expect(runTs({ ticket: { id: 'I-3' }, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-3 needs its plan applied before testing.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: apply-plan ticket=I-3",
+              "> Ticket I-3 — applying the recorded plan under \`minimal-safe-diff\` + \`scope-control\`.",
+              "> 1. Continue — apply the plan as recorded",
+              "> 2. Abort — stop before any edits are made",
+            ],
+          }
+        `);
+    });
+
+    it('valid changes → SUCCESS', () => {
+        expect(
+            runTs({ ticket: { id: 'I-4' }, changes: [{ path: 'a.ts' }, { file: 'b.ts' }], outcomes: ok }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
+
+    it('malformed change (no path/file) → BLOCKED shape', () => {
+        expect(runTs({ ticket: { id: 'I-5' }, changes: [{ purpose: 'x' }], outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-5 changes shape invalid: change #1 has no path.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket I-5 — recorded changes are malformed: change #1 has no path.",
+              "> 1. Re-run \`apply-plan\` and resume",
+              "> 2. Abort — changes cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('malformed change (non-dict entry) → BLOCKED shape', () => {
+        expect(
+            runTs({
+                ticket: { id: 'I-6' },
+                changes: ['not a dict'] as unknown as Array<Record<string, unknown>>,
+                outcomes: ok,
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-6 changes shape invalid: change #1 is not a dict.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket I-6 — recorded changes are malformed: change #1 is not a dict.",
+              "> 1. Re-run \`apply-plan\` and resume",
+              "> 2. Abort — changes cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('malformed change (blank path) → BLOCKED shape', () => {
+        expect(runTs({ ticket: { id: 'I-7' }, changes: [{ path: '   ' }], outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-7 changes shape invalid: change #1 has no path.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket I-7 — recorded changes are malformed: change #1 has no path.",
+              "> 1. Re-run \`apply-plan\` and resume",
+              "> 2. Abort — changes cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('multiple malformed changes → BLOCKED shape (joined)', () => {
+        expect(
+            runTs({
+                ticket: { id: 'I-8' },
+                changes: ['x', { why: 'y' }] as unknown as Array<Record<string, unknown>>,
+                outcomes: ok,
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-8 changes shape invalid: change #1 is not a dict; change #2 has no path.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket I-8 — recorded changes are malformed: change #1 is not a dict; change #2 has no path.",
+              "> 1. Re-run \`apply-plan\` and resume",
+              "> 2. Abort — changes cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('qa persona behaves like senior (no skip) → delegate', () => {
+        expect(runTs({ ticket: { id: 'I-9' }, persona: 'qa', outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket I-9 needs its plan applied before testing.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: apply-plan ticket=I-9",
+              "> Ticket I-9 — applying the recorded plan under \`minimal-safe-diff\` + \`scope-control\`.",
+              "> 1. Continue — apply the plan as recorded",
+              "> 2. Abort — stop before any edits are made",
+            ],
+          }
+        `);
+    });
+
+    it('path falsy falls back to file key → SUCCESS', () => {
+        expect(
+            runTs({ ticket: { id: 'I-10' }, changes: [{ path: '', file: 'real.ts' }], outcomes: ok }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
+
+    it('no ticket id, delegate → "(no id)"', () => {
+        expect(runTs({ ticket: {}, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket (no id) needs its plan applied before testing.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: apply-plan ticket=(no id)",
+              "> Ticket (no id) — applying the recorded plan under \`minimal-safe-diff\` + \`scope-control\`.",
+              "> 1. Continue — apply the plan as recorded",
+              "> 2. Abort — stop before any edits are made",
+            ],
+          }
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_init.test.ts
+++ b/tests/scripts/work_engine/directives_backend_init.test.ts
@@ -1,15 +1,12 @@
-// Golden-parity tests for work_engine/directives/backend/index.ts vs
-// directives/backend/__init__.py (ADR-096 py2ts Phase 1 — work_engine
-// TOP/integration layer).
+// Intent tests for work_engine/directives/backend/index.ts (ADR-096 py2ts
+// Phase 1 — work_engine TOP/integration layer).
 //
-// The wiring module exposes DIRECTIVE_SET_NAME, SUPPORTED_KINDS, get_steps(),
-// and all_ambiguities(). get_steps() returns callables (not JSON-comparable),
-// so parity is on the *step-name order* and the all_ambiguities() structure
-// (per-step ambiguity code lists). The Python package is imported via
-// sys.path + import_module (siblings exist as .py until the Phase-12 sweep).
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx golden-parity rig; the `.py` original is gone, so this
+// now asserts the tsx wiring module's own contract directly. The module exposes
+// DIRECTIVE_SET_NAME, SUPPORTED_KINDS, get_steps(), and all_ambiguities().
+// get_steps() returns callables (not snapshot-comparable), so the structural
+// assertion is on the step-name order plus the all_ambiguities() per-step code
+// lists. A `{name, kinds, step_order, ambiguities}` summary is snapshotted.
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -19,48 +16,17 @@ import {
     get_steps,
 } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/index.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/** Emit `{name, kinds, step_order, ambiguities}` for the backend set on py3. */
-function pySummary(): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'm = __import__("work_engine.directives.backend", fromlist=["x"])',
-        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
-        'out = {',
-        '  "name": m.DIRECTIVE_SET_NAME,',
-        '  "kinds": list(m.SUPPORTED_KINDS),',
-        '  "step_order": list(m.get_steps().keys()),',
-        '  "ambiguities": amb,',
-        '}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function tsSummary(): string {
+function tsSummary(): unknown {
     const amb: Record<string, Array<string | undefined>> = {};
     for (const [k, v] of Object.entries(all_ambiguities())) {
         amb[k] = v.map((a) => a['code']);
     }
-    const out = {
+    return _sortKeys({
         name: DIRECTIVE_SET_NAME,
         kinds: [...SUPPORTED_KINDS],
         step_order: [...get_steps().keys()],
         ambiguities: amb,
-    };
-    // sort_keys parity: re-serialise with sorted keys.
-    return JSON.stringify(_sortKeys(out), null, 2);
+    });
 }
 
 function _sortKeys(value: unknown): unknown {
@@ -76,9 +42,6 @@ function _sortKeys(value: unknown): unknown {
     }
     return value;
 }
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 describe('directives/backend index — shape', () => {
     it('DIRECTIVE_SET_NAME + SUPPORTED_KINDS', () => {
@@ -99,8 +62,66 @@ describe('directives/backend index — shape', () => {
     });
 });
 
-describeParity('directives/backend index — golden parity', () => {
-    it('matches python3 (name + kinds + order + ambiguity codes)', () => {
-        expect(tsSummary()).toBe(pySummary());
+describe('directives/backend index — summary contract', () => {
+    it('name + kinds + step order + per-step ambiguity codes', () => {
+        expect(tsSummary()).toMatchInlineSnapshot(`
+          {
+            "ambiguities": {
+              "analyze": [
+                "upstream_refine_failed",
+                "upstream_memory_failed",
+                "lost_ac",
+              ],
+              "implement": [
+                "upstream_plan_failed",
+                "empty_changes_delegate",
+                "malformed_changes",
+              ],
+              "memory": [],
+              "plan": [
+                "upstream_analyze_failed",
+                "empty_plan_delegate",
+                "malformed_plan",
+              ],
+              "refine": [
+                "missing_id",
+                "trivial_title",
+                "missing_or_vague_ac",
+                "prompt_unrefined",
+                "prompt_medium_confidence",
+                "prompt_low_confidence",
+                "prompt_ui_intent",
+              ],
+              "report": [],
+              "test": [
+                "upstream_implement_failed",
+                "empty_tests_delegate",
+                "malformed_tests",
+                "bad_test_verdict",
+              ],
+              "verify": [
+                "upstream_test_failed",
+                "empty_verify_delegate",
+                "malformed_verify",
+                "bad_verify_verdict",
+              ],
+            },
+            "kinds": [
+              "ticket",
+              "prompt",
+            ],
+            "name": "backend",
+            "step_order": [
+              "refine",
+              "memory",
+              "analyze",
+              "plan",
+              "implement",
+              "test",
+              "verify",
+              "report",
+            ],
+          }
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_memory.test.ts
+++ b/tests/scripts/work_engine/directives_backend_memory.test.ts
@@ -1,18 +1,15 @@
-// Golden-parity tests for work_engine/directives/backend/memory.ts vs
-// memory.py (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/memory.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `memory.py` imports `...delivery_state` and lazily imports `memory_lookup`
-// (so tests can monkeypatch `memory_lookup.retrieve`). The TS twin mirrors the
-// lazy seam with `_setRetrieve`. To make retrieval deterministic and to assert
-// the key-derivation contract (files → title tokens → AC tokens, stopword-
-// filtered, deduped, lower-cased), the fake `retrieve` echoes the exact keys it
-// receives back as a single hit. Both engines then expose `state.memory` as
-// canonical JSON for a byte-exact compare; the echoed keys prove the tokeniser
-// matched (Python `re` vs JS regex). The MAX_HITS cap is exercised with a fake
-// returning >12 hits. No real filesystem access → fully deterministic.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx golden-parity rig; the `.py` original is gone, so this
+// now asserts the tsx module's own contract directly. `memory.ts` lazily
+// resolves `memory_lookup.retrieve` via the `_setRetrieve` seam, so retrieval
+// is made deterministic with a fake. To assert the key-derivation contract
+// (files → title tokens → AC tokens, stopword-filtered, deduped, lower-cased)
+// the `echo` fake echoes the exact keys it receives back as a single hit; the
+// echoed keys then prove the tokeniser matched. The MAX_HITS cap is exercised
+// with a `cap` fake returning >12 hits. `run()` is exercised in-process and
+// `{outcome, memory}` is snapshotted. No real filesystem access → deterministic.
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -23,46 +20,6 @@ import {
     run,
 } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/memory.js';
 import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/**
- * Python driver: monkeypatch `memory_lookup.retrieve` with a fake whose
- * behaviour is selected by `mode`, run `memory.run`, emit `state.memory` JSON.
- *
- * - `echo` : returns a single dict hit carrying the received `types`/`keys`.
- * - `cap`  : returns 20 dict hits so the MAX_HITS truncation is observable.
- */
-function runPy(stateJson: string, mode: string): string {
-    const code = [
-        'import sys, json, importlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'import memory_lookup',
-        'mode = sys.argv[2]',
-        'def fake(types, keys, limit):',
-        '    if mode == "cap":',
-        '        return [{"id": "h%d" % i, "type": "historical-patterns", "n": i} for i in range(20)]',
-        '    return [{"types": list(types), "keys": list(keys), "limit": limit}]',
-        'memory_lookup.retrieve = fake',
-        'mod = importlib.import_module("work_engine.directives.backend.memory")',
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "memory": st.memory}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson, mode], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
 
 type Mode = 'echo' | 'cap';
 
@@ -75,19 +32,12 @@ function tsFake(mode: Mode) {
     };
 }
 
-function runTs(state: ConstructorParameters<typeof DeliveryState>[0], mode: Mode): string {
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0], mode: Mode): { outcome: string; memory: unknown } {
     _setRetrieve(tsFake(mode));
     const st = new DeliveryState(state);
     const r = run(st);
-    return JSON.stringify({ outcome: r.outcome, memory: st.memory }, null, 2);
+    return { outcome: r.outcome, memory: st.memory };
 }
-
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 afterEach(() => {
     _setRetrieve(null);
@@ -105,32 +55,228 @@ describe('directives/backend/memory — constants', () => {
     });
 });
 
-describeParity('directives/backend/memory — golden parity (ts == py)', () => {
-    const echoCases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        [
-            'files + title + AC keys derived, deduped, stopword-filtered',
-            {
-                ticket: {
-                    id: 'M-1',
-                    files: ['app/Service.ts', 'app/Service.ts'],
-                    title: 'Add OAuth2 login-flow to the v2 API',
-                    acceptance_criteria: ['The user must be able to log in', 'Token refresh works'],
+describe('directives/backend/memory — run() contract', () => {
+    it('echo: files + title + AC keys derived, deduped, stopword-filtered', () => {
+        expect(
+            runTs(
+                {
+                    ticket: {
+                        id: 'M-1',
+                        files: ['app/Service.ts', 'app/Service.ts'],
+                        title: 'Add OAuth2 login-flow to the v2 API',
+                        acceptance_criteria: ['The user must be able to log in', 'Token refresh works'],
+                    },
                 },
-            },
-        ],
-        ['empty ticket → no keys', { ticket: {} }],
-        ['title only, short words (<3 chars) dropped', { ticket: { id: 'M-2', title: 'a be the API v2' } }],
-        ['non-string title ignored', { ticket: { id: 'M-3', title: 12345 } }],
-        ['files non-list ignored, AC drives keys', { ticket: { id: 'M-4', files: 'not-a-list', acceptance_criteria: ['Refactor the parser module'] } }],
-        ['hyphen + underscore words kept whole', { ticket: { id: 'M-5', title: 'rename build_step and login-flow' } }],
-    ];
+                'echo',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "keys": [
+                  "app/Service.ts",
+                  "add",
+                  "oauth2",
+                  "login-flow",
+                  "api",
+                  "able",
+                  "log",
+                  "token",
+                  "refresh",
+                  "works",
+                ],
+                "limit": 12,
+                "types": [
+                  "domain-invariants",
+                  "incident-learnings",
+                  "historical-patterns",
+                ],
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
+    });
 
-    it.each(echoCases)('echo: %s', (_label, state) => {
-        expect(runTs(state, 'echo')).toBe(runPy(pyFixture(state), 'echo'));
+    it('echo: empty ticket → no keys', () => {
+        expect(runTs({ ticket: {} }, 'echo')).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "keys": [],
+                "limit": 12,
+                "types": [
+                  "domain-invariants",
+                  "incident-learnings",
+                  "historical-patterns",
+                ],
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
+    });
+
+    it('echo: title only, short words (<3 chars) dropped', () => {
+        expect(runTs({ ticket: { id: 'M-2', title: 'a be the API v2' } }, 'echo')).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "keys": [
+                  "api",
+                ],
+                "limit": 12,
+                "types": [
+                  "domain-invariants",
+                  "incident-learnings",
+                  "historical-patterns",
+                ],
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
+    });
+
+    it('echo: non-string title ignored', () => {
+        expect(runTs({ ticket: { id: 'M-3', title: 12345 } }, 'echo')).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "keys": [],
+                "limit": 12,
+                "types": [
+                  "domain-invariants",
+                  "incident-learnings",
+                  "historical-patterns",
+                ],
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
+    });
+
+    it('echo: files non-list ignored, AC drives keys', () => {
+        expect(
+            runTs(
+                { ticket: { id: 'M-4', files: 'not-a-list', acceptance_criteria: ['Refactor the parser module'] } },
+                'echo',
+            ),
+        ).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "keys": [
+                  "refactor",
+                  "parser",
+                  "module",
+                ],
+                "limit": 12,
+                "types": [
+                  "domain-invariants",
+                  "incident-learnings",
+                  "historical-patterns",
+                ],
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
+    });
+
+    it('echo: hyphen + underscore words kept whole', () => {
+        expect(
+            runTs({ ticket: { id: 'M-5', title: 'rename build_step and login-flow' } }, 'echo'),
+        ).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "keys": [
+                  "rename",
+                  "build_step",
+                  "login-flow",
+                ],
+                "limit": 12,
+                "types": [
+                  "domain-invariants",
+                  "incident-learnings",
+                  "historical-patterns",
+                ],
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
     });
 
     it('cap: >12 hits truncated to MAX_HITS', () => {
-        const state = { ticket: { id: 'M-CAP', title: 'cap test' } };
-        expect(runTs(state, 'cap')).toBe(runPy(pyFixture(state), 'cap'));
+        expect(runTs({ ticket: { id: 'M-CAP', title: 'cap test' } }, 'cap')).toMatchInlineSnapshot(`
+          {
+            "memory": [
+              {
+                "id": "h0",
+                "n": 0,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h1",
+                "n": 1,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h2",
+                "n": 2,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h3",
+                "n": 3,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h4",
+                "n": 4,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h5",
+                "n": 5,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h6",
+                "n": 6,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h7",
+                "n": 7,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h8",
+                "n": 8,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h9",
+                "n": 9,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h10",
+                "n": 10,
+                "type": "historical-patterns",
+              },
+              {
+                "id": "h11",
+                "n": 11,
+                "type": "historical-patterns",
+              },
+            ],
+            "outcome": "success",
+          }
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_plan.test.ts
+++ b/tests/scripts/work_engine/directives_backend_plan.test.ts
@@ -1,63 +1,21 @@
-// Golden-parity tests for work_engine/directives/backend/plan.ts vs plan.py
-// (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/plan.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `plan.py` has intra-package imports, so it loads as a real package member
-// via `sys.path` + `import work_engine.directives.backend.plan` (the package
-// __init__ pulls still-Python siblings, all present until Phase 12). The TS
-// twin runs in-process; the Python original via python3 subprocess. Both build
-// a `DeliveryState` from the same JSON fixture and emit
-// `{outcome, questions, message}` for a byte-exact compare.
-//
-// Non-determinism: none. Note a deliberate parity carve-out — the
-// "unsupported plan type" branch is exercised with a string/list/dict-of-
-// non-steps, never a JSON float, because JSON `5.0` decodes to a JS integer
-// (`int` typename) but a Python `float` (`float` typename); that single
-// `type().__name__` divergence is a JSON-round-trip artifact, not a logic gap.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx golden-parity rig; the `.py` original is gone, so this
+// now asserts the tsx module's own contract directly. `run()` is exercised
+// in-process against a `DeliveryState` built from each fixture and the full
+// `{outcome, questions, message}` result is snapshotted. Covers the analyze
+// gate, the empty-plan delegate, every valid plan shape, and the malformed
+// permutations. No non-determinism.
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/plan.js';
 import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): Pick<StepResult, 'outcome' | 'questions' | 'message'> {
+    const r = run(new DeliveryState(state));
+    return { outcome: r.outcome, questions: r.questions, message: r.message };
 }
-
-function runPy(moduleName: string, stateJson: string): string {
-    const code = [
-        'import sys, json, importlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    const r: StepResult = run(new DeliveryState(state));
-    return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
-}
-
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 const ok = { analyze: 'success' };
 
@@ -67,40 +25,193 @@ describe('directives/backend/plan — AMBIGUITIES', () => {
     });
 });
 
-describeParity('directives/backend/plan — golden parity (ts == py)', () => {
-    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        ['analyze not success → BLOCKED precondition', { ticket: { id: 'P-1' }, outcomes: {} }],
-        ['empty plan (null) → delegate create-plan', { ticket: { id: 'P-2' }, outcomes: ok }],
-        ['blank-string plan → delegate (whitespace == empty)', { ticket: { id: 'P-3' }, plan: '   ', outcomes: ok }],
-        ['empty list plan → delegate', { ticket: { id: 'P-4' }, plan: [], outcomes: ok }],
-        ['empty dict plan → delegate', { ticket: { id: 'P-5' }, plan: {}, outcomes: ok }],
-        ['valid string plan → SUCCESS', { ticket: { id: 'P-6' }, plan: 'do the thing', outcomes: ok }],
-        ['valid list-of-strings plan → SUCCESS', { ticket: { id: 'P-7' }, plan: ['step one', 'step two'], outcomes: ok }],
-        [
-            'valid list-of-dicts plan → SUCCESS',
-            { ticket: { id: 'P-8' }, plan: [{ title: 'A' }, { step: 'B' }], outcomes: ok },
-        ],
-        ['valid dict-with-steps → SUCCESS', { ticket: { id: 'P-9' }, plan: { steps: ['x', 'y'] }, outcomes: ok }],
-        [
-            'malformed list (dict without title) → BLOCKED shape',
-            { ticket: { id: 'P-10' }, plan: [{ note: 'no title here' }], outcomes: ok },
-        ],
-        [
-            'malformed list (blank string entry) → BLOCKED shape',
-            { ticket: { id: 'P-11' }, plan: ['   '], outcomes: ok },
-        ],
-        [
-            'malformed list (multiple complaints) → BLOCKED shape',
-            { ticket: { id: 'P-12' }, plan: [{ note: 'x' }, '   '], outcomes: ok },
-        ],
-        [
-            'dict without steps list → BLOCKED shape',
-            { ticket: { id: 'P-13' }, plan: { name: 'no steps' }, outcomes: ok },
-        ],
-        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
-    ];
+describe('directives/backend/plan — run() contract', () => {
+    it('analyze not success → BLOCKED precondition', () => {
+        expect(runTs({ ticket: { id: 'P-1' }, outcomes: {} })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-1 cannot plan: analyze gate did not pass.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket P-1 — plan gate refused: \`analyze\` step did not complete successfully.",
+              "> 1. Re-run \`/implement-ticket\` from the start",
+              "> 2. Abort",
+            ],
+          }
+        `);
+    });
 
-    it.each(cases)('%s', (_label, state) => {
-        expect(runTs(state)).toBe(runPy('plan', pyFixture(state)));
+    it('empty plan (null) → delegate create-plan', () => {
+        expect(runTs({ ticket: { id: 'P-2' }, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-2 needs a plan before implementation.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: create-plan ticket=P-2",
+              "> Ticket P-2 — no plan recorded yet; running \`feature-plan\` and resuming.",
+              "> 1. Continue — use the plan produced by \`feature-plan\`",
+              "> 2. Abort — stop before any edits are proposed",
+            ],
+          }
+        `);
+    });
+
+    it('blank-string plan → delegate (whitespace == empty)', () => {
+        expect(runTs({ ticket: { id: 'P-3' }, plan: '   ', outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-3 needs a plan before implementation.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: create-plan ticket=P-3",
+              "> Ticket P-3 — no plan recorded yet; running \`feature-plan\` and resuming.",
+              "> 1. Continue — use the plan produced by \`feature-plan\`",
+              "> 2. Abort — stop before any edits are proposed",
+            ],
+          }
+        `);
+    });
+
+    it('empty list plan → delegate', () => {
+        expect(runTs({ ticket: { id: 'P-4' }, plan: [], outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-4 needs a plan before implementation.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: create-plan ticket=P-4",
+              "> Ticket P-4 — no plan recorded yet; running \`feature-plan\` and resuming.",
+              "> 1. Continue — use the plan produced by \`feature-plan\`",
+              "> 2. Abort — stop before any edits are proposed",
+            ],
+          }
+        `);
+    });
+
+    it('empty dict plan → delegate', () => {
+        expect(runTs({ ticket: { id: 'P-5' }, plan: {}, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-5 needs a plan before implementation.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: create-plan ticket=P-5",
+              "> Ticket P-5 — no plan recorded yet; running \`feature-plan\` and resuming.",
+              "> 1. Continue — use the plan produced by \`feature-plan\`",
+              "> 2. Abort — stop before any edits are proposed",
+            ],
+          }
+        `);
+    });
+
+    it('valid string plan → SUCCESS', () => {
+        expect(runTs({ ticket: { id: 'P-6' }, plan: 'do the thing', outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
+
+    it('valid list-of-strings plan → SUCCESS', () => {
+        expect(runTs({ ticket: { id: 'P-7' }, plan: ['step one', 'step two'], outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
+
+    it('valid list-of-dicts plan → SUCCESS', () => {
+        expect(
+            runTs({ ticket: { id: 'P-8' }, plan: [{ title: 'A' }, { step: 'B' }], outcomes: ok }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
+
+    it('valid dict-with-steps → SUCCESS', () => {
+        expect(runTs({ ticket: { id: 'P-9' }, plan: { steps: ['x', 'y'] }, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+          }
+        `);
+    });
+
+    it('malformed list (dict without title) → BLOCKED shape', () => {
+        expect(
+            runTs({ ticket: { id: 'P-10' }, plan: [{ note: 'no title here' }], outcomes: ok }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-10 plan shape invalid: plan step #1 has no title.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket P-10 — recorded plan is malformed: plan step #1 has no title.",
+              "> 1. Re-run \`feature-plan\` and resume",
+              "> 2. Abort — the plan cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('malformed list (blank string entry) → BLOCKED shape', () => {
+        expect(runTs({ ticket: { id: 'P-11' }, plan: ['   '], outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-11 plan shape invalid: plan step #1 is not a usable string.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket P-11 — recorded plan is malformed: plan step #1 is not a usable string.",
+              "> 1. Re-run \`feature-plan\` and resume",
+              "> 2. Abort — the plan cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('malformed list (multiple complaints) → BLOCKED shape', () => {
+        expect(runTs({ ticket: { id: 'P-12' }, plan: [{ note: 'x' }, '   '], outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-12 plan shape invalid: plan step #1 has no title; plan step #2 is not a usable string.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket P-12 — recorded plan is malformed: plan step #1 has no title; plan step #2 is not a usable string.",
+              "> 1. Re-run \`feature-plan\` and resume",
+              "> 2. Abort — the plan cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('dict without steps list → BLOCKED shape', () => {
+        expect(runTs({ ticket: { id: 'P-13' }, plan: { name: 'no steps' }, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket P-13 plan shape invalid: plan dict must carry a non-empty 'steps' list.",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket P-13 — recorded plan is malformed: plan dict must carry a non-empty 'steps' list.",
+              "> 1. Re-run \`feature-plan\` and resume",
+              "> 2. Abort — the plan cannot be trusted",
+            ],
+          }
+        `);
+    });
+
+    it('no ticket id, delegate → "(no id)"', () => {
+        expect(runTs({ ticket: {}, outcomes: ok })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket (no id) needs a plan before implementation.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: create-plan ticket=(no id)",
+              "> Ticket (no id) — no plan recorded yet; running \`feature-plan\` and resuming.",
+              "> 1. Continue — use the plan produced by \`feature-plan\`",
+              "> 2. Abort — stop before any edits are proposed",
+            ],
+          }
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_refine.test.ts
+++ b/tests/scripts/work_engine/directives_backend_refine.test.ts
@@ -1,82 +1,32 @@
-// Golden-parity tests for work_engine/directives/backend/refine.ts vs
-// refine.py (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/refine.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `refine.py` imports `...delivery_state` + `...scoring.confidence`, so the
-// direct-file importlib loader used by state.test.ts does NOT work here.
-// Instead we add `src/agent-src/templates/scripts` to `sys.path` and
-// `import work_engine.directives.backend.refine` as a real package member —
-// the package `__init__` imports its (still-Python) siblings, which all exist
-// in source until the Phase-12 sweep. The TS twin is exercised in-process; the
-// Python original via a python3 subprocess.
-//
-// The gate routes on envelope shape (ticket path vs prompt path) and mutates
-// `state.ticket` on the prompt path (`confidence`, `acceptance_criteria`). Both
-// engines build a `DeliveryState` from the same JSON fixture, run, and emit
-// `{outcome, questions, message, ticket}` as
-// `json.dumps(..., indent=2, ensure_ascii=False)` for a byte-exact compare.
-// Coverage: ticket-path SUCCESS + every deficiency permutation, the headnote
-// id fallback, the prompt-path delegate (no AC) directive, and the high /
-// medium / medium-confirmed / low / ui-intent confidence bands incl. the
-// confidence projection. No non-determinism.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx golden-parity rig; the `.py` original is gone, so this
+// now asserts the tsx module's own contract directly. The gate routes on
+// envelope shape (ticket path vs prompt path) and mutates `state.ticket` on the
+// prompt path (`confidence`, `acceptance_criteria`). `run()` is exercised
+// in-process against a `DeliveryState` built from each fixture and the full
+// `{outcome, questions, message, ticket}` result is snapshotted. Coverage:
+// ticket-path SUCCESS + every deficiency permutation, the headnote id fallback,
+// the prompt-path delegate (no AC) directive, and the high / medium /
+// medium-confirmed / low / ui-intent confidence bands incl. the confidence
+// projection. No non-determinism.
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/refine.js';
 import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/**
- * Drive `work_engine.directives.backend.refine.run` on python3 from a JSON
- * state fixture; emit `{outcome, questions, message, ticket}` as canonical
- * JSON. `ticket` is included because the prompt path mutates it in place
- * (confidence breakdown + acceptance_criteria projection).
- */
-function runPy(stateJson: string): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'import importlib',
-        'mod = importlib.import_module("work_engine.directives.backend.refine")',
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message, "ticket": st.ticket}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-/** TS twin: build DeliveryState from the fixture, run, emit canonical JSON. */
-function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
+/** TS twin: build DeliveryState from the fixture, run, return the result + mutated ticket. */
+function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): {
+    outcome: StepResult['outcome'];
+    questions: StepResult['questions'];
+    message: StepResult['message'];
+    ticket: unknown;
+} {
     const st = new DeliveryState(state);
-    const r: StepResult = run(st);
-    return JSON.stringify(
-        { outcome: r.outcome, questions: r.questions, message: r.message, ticket: st.ticket },
-        null,
-        2,
-    );
+    const r = run(st);
+    return { outcome: r.outcome, questions: r.questions, message: r.message, ticket: st.ticket };
 }
-
-/** Build the matching python fixture JSON from the same constructor args. */
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 describe('directives/backend/refine — AMBIGUITIES', () => {
     it('declares the seven surfaces in order', () => {
@@ -99,83 +49,291 @@ describe('directives/backend/refine — AMBIGUITIES', () => {
     });
 });
 
-describeParity('directives/backend/refine — golden parity (ts == py)', () => {
-    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        // --- ticket path ---------------------------------------------------
-        [
-            'well-formed ticket → SUCCESS',
-            {
+describe('directives/backend/refine — run() contract', () => {
+    // --- ticket path -------------------------------------------------------
+    it('well-formed ticket → SUCCESS', () => {
+        expect(
+            runTs({
                 ticket: {
                     id: 'T-1',
                     title: 'Build the widget',
                     acceptance_criteria: ['the user must see the widget on load'],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user must see the widget on load",
+              ],
+              "id": "T-1",
+              "title": "Build the widget",
             },
-        ],
-        [
-            'empty ticket → all three deficiencies, "(no id)" headnote',
-            { ticket: {} },
-        ],
-        [
-            'missing id only → single deficiency',
-            { ticket: { title: 'A solid title', acceptance_criteria: ['the user must see the widget on load'] } },
-        ],
-        [
-            'trivial title (under floor) → BLOCKED',
-            { ticket: { id: 'T-2', title: 'ab', acceptance_criteria: ['the user must see the widget on load'] } },
-        ],
-        [
-            'whitespace-only id falls back to "(no id)" in headnote',
-            { ticket: { id: '   ', title: 'A solid title', acceptance_criteria: ['the user must see the widget'] } },
-        ],
-        [
-            'acceptance_criteria not a list → "no acceptance criteria"',
-            { ticket: { id: 'T-3', title: 'A solid title', acceptance_criteria: 'a string' } },
-        ],
-        [
-            'empty acceptance_criteria list → "no acceptance criteria"',
-            { ticket: { id: 'T-4', title: 'A solid title', acceptance_criteria: [] } },
-        ],
-        [
-            'vague AC items (under floor + non-string) → position list',
-            {
+          }
+        `);
+    });
+
+    it('empty ticket → all three deficiencies, "(no id)" headnote', () => {
+        expect(runTs({ ticket: {} })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket (no id) is not refined enough to plan against: missing ticket id; missing or trivial title; no acceptance criteria",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket (no id) is missing: missing ticket id; missing or trivial title; no acceptance criteria.",
+              "> 1. Run \`/refine-ticket (no id)\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {},
+          }
+        `);
+    });
+
+    it('missing id only → single deficiency', () => {
+        expect(
+            runTs({ ticket: { title: 'A solid title', acceptance_criteria: ['the user must see the widget on load'] } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket (no id) is not refined enough to plan against: missing ticket id",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket (no id) is missing: missing ticket id.",
+              "> 1. Run \`/refine-ticket (no id)\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user must see the widget on load",
+              ],
+              "title": "A solid title",
+            },
+          }
+        `);
+    });
+
+    it('trivial title (under floor) → BLOCKED', () => {
+        expect(
+            runTs({ ticket: { id: 'T-2', title: 'ab', acceptance_criteria: ['the user must see the widget on load'] } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket T-2 is not refined enough to plan against: missing or trivial title",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-2 is missing: missing or trivial title.",
+              "> 1. Run \`/refine-ticket T-2\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user must see the widget on load",
+              ],
+              "id": "T-2",
+              "title": "ab",
+            },
+          }
+        `);
+    });
+
+    it('whitespace-only id falls back to "(no id)" in headnote', () => {
+        expect(
+            runTs({ ticket: { id: '   ', title: 'A solid title', acceptance_criteria: ['the user must see the widget'] } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket     is not refined enough to plan against: missing ticket id",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket     is missing: missing ticket id.",
+              "> 1. Run \`/refine-ticket    \` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user must see the widget",
+              ],
+              "id": "   ",
+              "title": "A solid title",
+            },
+          }
+        `);
+    });
+
+    it('acceptance_criteria not a list → "no acceptance criteria"', () => {
+        expect(
+            runTs({ ticket: { id: 'T-3', title: 'A solid title', acceptance_criteria: 'a string' } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket T-3 is not refined enough to plan against: no acceptance criteria",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-3 is missing: no acceptance criteria.",
+              "> 1. Run \`/refine-ticket T-3\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": "a string",
+              "id": "T-3",
+              "title": "A solid title",
+            },
+          }
+        `);
+    });
+
+    it('empty acceptance_criteria list → "no acceptance criteria"', () => {
+        expect(
+            runTs({ ticket: { id: 'T-4', title: 'A solid title', acceptance_criteria: [] } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket T-4 is not refined enough to plan against: no acceptance criteria",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-4 is missing: no acceptance criteria.",
+              "> 1. Run \`/refine-ticket T-4\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": [],
+              "id": "T-4",
+              "title": "A solid title",
+            },
+          }
+        `);
+    });
+
+    it('vague AC items (under floor + non-string) → position list', () => {
+        expect(
+            runTs({
                 ticket: {
                     id: 'T-5',
                     title: 'A solid title',
                     acceptance_criteria: ['short', 'the user must see the widget on load', 42],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket T-5 is not refined enough to plan against: vague acceptance criteria at position(s) 1, 3",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-5 is missing: vague acceptance criteria at position(s) 1, 3.",
+              "> 1. Run \`/refine-ticket T-5\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": [
+                "short",
+                "the user must see the widget on load",
+                42,
+              ],
+              "id": "T-5",
+              "title": "A solid title",
             },
-        ],
-        [
-            'all three deficiencies with a real id',
-            { ticket: { id: 'T-6', title: 'x', acceptance_criteria: [] } },
-        ],
-        // --- prompt path: delegate (no reconstructed AC) -------------------
-        [
-            'prompt envelope, no AC → delegate directive',
-            { ticket: { raw: 'add a rate limiter to the login endpoint behind a config flag' } },
-        ],
-        [
-            'prompt envelope, AC not a list → delegate directive',
-            { ticket: { raw: 'add a rate limiter', reconstructed_ac: 'not a list' } },
-        ],
-        [
-            'prompt envelope, long raw → preview is truncated with ellipsis',
-            {
+          }
+        `);
+    });
+
+    it('all three deficiencies with a real id', () => {
+        expect(runTs({ ticket: { id: 'T-6', title: 'x', acceptance_criteria: [] } })).toMatchInlineSnapshot(`
+          {
+            "message": "Ticket T-6 is not refined enough to plan against: missing or trivial title; no acceptance criteria",
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-6 is missing: missing or trivial title; no acceptance criteria.",
+              "> 1. Run \`/refine-ticket T-6\` and re-invoke \`/implement-ticket\`",
+              "> 2. Provide the missing details in chat — I'll merge them into the ticket",
+              "> 3. Abandon this ticket — too vague to implement",
+            ],
+            "ticket": {
+              "acceptance_criteria": [],
+              "id": "T-6",
+              "title": "x",
+            },
+          }
+        `);
+    });
+
+    // --- prompt path: delegate (no reconstructed AC) -----------------------
+    it('prompt envelope, no AC → delegate directive', () => {
+        expect(
+            runTs({ ticket: { raw: 'add a rate limiter to the login endpoint behind a config flag' } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Prompt envelope present but unrefined; delegating to refine-prompt.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: refine-prompt",
+              "> Prompt received: add a rate limiter to the login endpoint behind a config flag",
+              "> No reconstructed acceptance criteria yet — running \`refine-prompt\` and resuming.",
+              "> 1. Continue — let the skill reconstruct AC + assumptions",
+              "> 2. Abort — the prompt is not what I meant",
+            ],
+            "ticket": {
+              "raw": "add a rate limiter to the login endpoint behind a config flag",
+            },
+          }
+        `);
+    });
+
+    it('prompt envelope, AC not a list → delegate directive', () => {
+        expect(
+            runTs({ ticket: { raw: 'add a rate limiter', reconstructed_ac: 'not a list' } }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Prompt envelope present but unrefined; delegating to refine-prompt.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: refine-prompt",
+              "> Prompt received: add a rate limiter",
+              "> No reconstructed acceptance criteria yet — running \`refine-prompt\` and resuming.",
+              "> 1. Continue — let the skill reconstruct AC + assumptions",
+              "> 2. Abort — the prompt is not what I meant",
+            ],
+            "ticket": {
+              "raw": "add a rate limiter",
+              "reconstructed_ac": "not a list",
+            },
+          }
+        `);
+    });
+
+    it('prompt envelope, long raw → preview is truncated with ellipsis', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw:
                         'add a comprehensive distributed rate limiter to the authentication login endpoint ' +
                         'with redis backing and per-tenant buckets and graceful degradation behaviour',
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Prompt envelope present but unrefined; delegating to refine-prompt.",
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: refine-prompt",
+              "> Prompt received: add a comprehensive distributed rate limiter to the authentication login endpoi…",
+              "> No reconstructed acceptance criteria yet — running \`refine-prompt\` and resuming.",
+              "> 1. Continue — let the skill reconstruct AC + assumptions",
+              "> 2. Abort — the prompt is not what I meant",
+            ],
+            "ticket": {
+              "raw": "add a comprehensive distributed rate limiter to the authentication login endpoint with redis backing and per-tenant buckets and graceful degradation behaviour",
             },
-        ],
-        // --- prompt path: high band → SUCCESS + confidence projection ------
-        [
-            // Score lands at 0.9 (reversibility=1 via the "config flag" surface),
-            // not an integer-valued 1.0, so the projected `score` float renders
-            // byte-identically through both engines' json.dumps.
-            'prompt high band → SUCCESS, confidence + AC projected onto ticket',
-            {
+          }
+        `);
+    });
+
+    // --- prompt path: high band → SUCCESS + confidence projection ----------
+    it('prompt high band → SUCCESS, confidence + AC projected onto ticket', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw: 'add a rate limiter to the login endpoint in `auth/limiter.py` behind a config flag',
                     reconstructed_ac: [
@@ -185,53 +343,258 @@ describeParity('directives/backend/refine — golden parity (ts == py)', () => {
                     ],
                     assumptions: ['default cap is 100 req/min'],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+            "ticket": {
+              "acceptance_criteria": [
+                "given a burst of requests, the endpoint must reject over the cap",
+                "when under the cap, requests should pass through unchanged",
+                "then the limiter must expose a per-tenant counter",
+              ],
+              "assumptions": [
+                "default cap is 100 req/min",
+              ],
+              "confidence": {
+                "band": "high",
+                "dimensions": {
+                  "ac_evidence": 2,
+                  "goal_clarity": 2,
+                  "reversibility": 1,
+                  "scope_boundary": 2,
+                  "stack_data": 2,
+                },
+                "reasons": [
+                  "goal_clarity=2: action verb + bounded length + single outcome",
+                  "scope_boundary=2: explicit file/class/identifier named",
+                  "ac_evidence=2: 3 criteria, 3 anchored",
+                  "stack_data=2: prompt is behavioural, no stack/data signal",
+                  "reversibility=1: config/env surface, partial rollback cost",
+                ],
+                "score": 0.9,
+                "ui_intent": false,
+              },
+              "raw": "add a rate limiter to the login endpoint in \`auth/limiter.py\` behind a config flag",
+              "reconstructed_ac": [
+                "given a burst of requests, the endpoint must reject over the cap",
+                "when under the cap, requests should pass through unchanged",
+                "then the limiter must expose a per-tenant counter",
+              ],
             },
-        ],
-        // --- prompt path: medium band → PARTIAL halt ----------------------
-        [
-            'prompt medium band → PARTIAL assumptions halt',
-            {
+          }
+        `);
+    });
+
+    // --- prompt path: medium band → PARTIAL halt ---------------------------
+    it('prompt medium band → PARTIAL assumptions halt', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw: 'improve the checkout flow',
                     reconstructed_ac: ['the user should reach payment faster'],
                     assumptions: ['fewer steps is the goal', 'no new payment provider'],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user should reach payment faster",
+              ],
+              "assumptions": [
+                "fewer steps is the goal",
+                "no new payment provider",
+              ],
+              "confidence": {
+                "band": "high",
+                "dimensions": {
+                  "ac_evidence": 1,
+                  "goal_clarity": 2,
+                  "reversibility": 2,
+                  "scope_boundary": 1,
+                  "stack_data": 2,
+                },
+                "reasons": [
+                  "goal_clarity=2: action verb + bounded length + single outcome",
+                  "scope_boundary=1: domain noun present, no concrete path",
+                  "ac_evidence=1: 1 criteria, 1 anchored",
+                  "stack_data=2: prompt is behavioural, no stack/data signal",
+                  "reversibility=2: code-only change, cheap to revert",
+                ],
+                "score": 0.8,
+                "ui_intent": false,
+              },
+              "raw": "improve the checkout flow",
+              "reconstructed_ac": [
+                "the user should reach payment faster",
+              ],
             },
-        ],
-        [
-            'prompt medium band, confidence_confirmed → SUCCESS',
-            {
+          }
+        `);
+    });
+
+    it('prompt medium band, confidence_confirmed → SUCCESS', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw: 'improve the checkout flow',
                     reconstructed_ac: ['the user should reach payment faster'],
                     assumptions: ['fewer steps is the goal'],
                     confidence_confirmed: true,
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user should reach payment faster",
+              ],
+              "assumptions": [
+                "fewer steps is the goal",
+              ],
+              "confidence": {
+                "band": "high",
+                "dimensions": {
+                  "ac_evidence": 1,
+                  "goal_clarity": 2,
+                  "reversibility": 2,
+                  "scope_boundary": 1,
+                  "stack_data": 2,
+                },
+                "reasons": [
+                  "goal_clarity=2: action verb + bounded length + single outcome",
+                  "scope_boundary=1: domain noun present, no concrete path",
+                  "ac_evidence=1: 1 criteria, 1 anchored",
+                  "stack_data=2: prompt is behavioural, no stack/data signal",
+                  "reversibility=2: code-only change, cheap to revert",
+                ],
+                "score": 0.8,
+                "ui_intent": false,
+              },
+              "confidence_confirmed": true,
+              "raw": "improve the checkout flow",
+              "reconstructed_ac": [
+                "the user should reach payment faster",
+              ],
             },
-        ],
-        [
-            'prompt medium band, no assumptions → "(none recorded)" line',
-            {
+          }
+        `);
+    });
+
+    it('prompt medium band, no assumptions → "(none recorded)" line', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw: 'improve the checkout flow',
                     reconstructed_ac: ['the user should reach payment faster'],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "",
+            "outcome": "success",
+            "questions": [],
+            "ticket": {
+              "acceptance_criteria": [
+                "the user should reach payment faster",
+              ],
+              "confidence": {
+                "band": "high",
+                "dimensions": {
+                  "ac_evidence": 1,
+                  "goal_clarity": 2,
+                  "reversibility": 2,
+                  "scope_boundary": 1,
+                  "stack_data": 2,
+                },
+                "reasons": [
+                  "goal_clarity=2: action verb + bounded length + single outcome",
+                  "scope_boundary=1: domain noun present, no concrete path",
+                  "ac_evidence=1: 1 criteria, 1 anchored",
+                  "stack_data=2: prompt is behavioural, no stack/data signal",
+                  "reversibility=2: code-only change, cheap to revert",
+                ],
+                "score": 0.8,
+                "ui_intent": false,
+              },
+              "raw": "improve the checkout flow",
+              "reconstructed_ac": [
+                "the user should reach payment faster",
+              ],
             },
-        ],
-        // --- prompt path: low band → BLOCKED single targeted question -----
-        [
-            'prompt low band → BLOCKED, weakest-dimension question',
-            {
+          }
+        `);
+    });
+
+    // --- prompt path: low band → BLOCKED single targeted question ----------
+    it('prompt low band → BLOCKED, weakest-dimension question', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw: 'do the thing?',
                     reconstructed_ac: ['x'],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Prompt scored medium (0.50); halting for assumptions confirmation.",
+            "outcome": "partial",
+            "questions": [
+              "> Prompt: do the thing?",
+              "> Confidence: **medium** (score 0.50). Assumptions worth confirming before I plan.",
+              "> Reconstructed AC:",
+              ">    1. x",
+              "> Assumptions:",
+              ">    - (none recorded)",
+              "> 1. Continue as-is — the AC + assumptions are good enough",
+              "> 2. Refine — I'll send a corrected prompt and re-run \`refine-prompt\`",
+              "> 3. Abort — pause this \`/work\` cycle",
+            ],
+            "ticket": {
+              "acceptance_criteria": [
+                "x",
+              ],
+              "confidence": {
+                "band": "medium",
+                "dimensions": {
+                  "ac_evidence": 1,
+                  "goal_clarity": 0,
+                  "reversibility": 2,
+                  "scope_boundary": 0,
+                  "stack_data": 2,
+                },
+                "reasons": [
+                  "goal_clarity=0: prompt is a question, no executable verb",
+                  "scope_boundary=0: no file or domain anchor",
+                  "ac_evidence=1: 1 criteria, 0 anchored",
+                  "stack_data=2: prompt is behavioural, no stack/data signal",
+                  "reversibility=2: code-only change, cheap to revert",
+                ],
+                "score": 0.5,
+                "ui_intent": false,
+              },
+              "raw": "do the thing?",
+              "reconstructed_ac": [
+                "x",
+              ],
             },
-        ],
-        // --- prompt path: ui-intent → BLOCKED regardless of band ----------
-        [
-            'prompt ui-intent → BLOCKED pending R3 (even with strong AC)',
-            {
+          }
+        `);
+    });
+
+    // --- prompt path: ui-intent → BLOCKED regardless of band ---------------
+    it('prompt ui-intent → BLOCKED pending R3 (even with strong AC)', () => {
+        expect(
+            runTs({
                 ticket: {
                     raw: 'redesign the dashboard layout with new tailwind colors and spacing',
                     reconstructed_ac: [
@@ -240,13 +603,52 @@ describeParity('directives/backend/refine — golden parity (ts == py)', () => {
                         'then the spacing must match the design tokens',
                     ],
                 },
+            }),
+        ).toMatchInlineSnapshot(`
+          {
+            "message": "Prompt flagged as UI-intent (band=medium, score=0.70); blocked pending R3 UI track.",
+            "outcome": "blocked",
+            "questions": [
+              "> Prompt: redesign the dashboard layout with new tailwind colors and spacing",
+              "> This prompt reads as **UI work** — the backend dispatch track can't ship it cleanly.",
+              "> UI dispatch is deferred to Roadmap 3 (\`road-to-product-ui-track.md\`); until it lands, \`/work\` only handles backend-shaped prompts.",
+              "> 1. Re-frame as a backend-only prompt — I'll re-score and proceed",
+              "> 2. Park this prompt — wait for R3 and re-invoke \`/work\` then",
+              "> 3. Abort — drop this prompt",
+            ],
+            "ticket": {
+              "acceptance_criteria": [
+                "given the dashboard, the new theme must apply on load",
+                "when toggled, dark mode should persist across reloads",
+                "then the spacing must match the design tokens",
+              ],
+              "confidence": {
+                "band": "medium",
+                "dimensions": {
+                  "ac_evidence": 2,
+                  "goal_clarity": 0,
+                  "reversibility": 2,
+                  "scope_boundary": 1,
+                  "stack_data": 2,
+                },
+                "reasons": [
+                  "goal_clarity=0: no recognisable action verb",
+                  "scope_boundary=1: domain noun present, no concrete path",
+                  "ac_evidence=2: 3 criteria, 3 anchored",
+                  "stack_data=2: prompt is behavioural, no stack/data signal",
+                  "reversibility=2: code-only change, cheap to revert",
+                ],
+                "score": 0.7,
+                "ui_intent": true,
+              },
+              "raw": "redesign the dashboard layout with new tailwind colors and spacing",
+              "reconstructed_ac": [
+                "given the dashboard, the new theme must apply on load",
+                "when toggled, dark mode should persist across reloads",
+                "then the spacing must match the design tokens",
+              ],
             },
-        ],
-    ];
-
-    it.each(cases)('%s', (_label, state) => {
-        const tsOut = runTs(state);
-        const pyOut = runPy(pyFixture(state));
-        expect(tsOut).toBe(pyOut);
+          }
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_report.test.ts
+++ b/tests/scripts/work_engine/directives_backend_report.test.ts
@@ -1,47 +1,16 @@
-// Golden-parity tests for work_engine/directives/backend/report.ts vs
-// report.py (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/report.ts (py2ts ADR-094
+// Phase 1 — backend directive set).
 //
-// `report.py` imports `...delivery_state` + `...persona_policy`, so it loads as
-// a real package member via `sys.path` + import. The renderer is pure — it
-// reads DeliveryState and writes `state.report`. Both engines build the same
-// DeliveryState fixture, run, and emit the rendered `state.report` string
-// (raw, not JSON-wrapped) for a byte-exact compare. Coverage: every section's
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx renderer's own contract directly. The renderer is pure — it
+// reads DeliveryState and writes `state.report`. Coverage: every section's
 // populated + empty body, the memory-that-mattered drop rule, the visual-
 // preview gating, follow-up aggregation order, kv-block rendering, and the
 // advisory persona's suppressed next-commands section. No non-determinism.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/report.js';
 import { DeliveryState } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/** Python driver: run report.run, emit the raw rendered `state.report`. */
-function runPy(stateJson: string): string {
-    const code = [
-        'import sys, json, importlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'mod = importlib.import_module("work_engine.directives.backend.report")',
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'mod.run(st)',
-        'sys.stdout.write(st.report)',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
 
 function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
     const st = new DeliveryState(state);
@@ -49,20 +18,13 @@ function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
     return st.report;
 }
 
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
-
 describe('directives/backend/report — AMBIGUITIES', () => {
     it('declares no surfaces (pure renderer)', () => {
         expect(AMBIGUITIES).toEqual([]);
     });
 });
 
-describeParity('directives/backend/report — golden parity (ts == py)', () => {
+describe('directives/backend/report — rendered report', () => {
     const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
         ['minimal state (all empties / placeholders)', { ticket: {} }],
         [
@@ -134,6 +96,6 @@ describeParity('directives/backend/report — golden parity (ts == py)', () => {
     ];
 
     it.each(cases)('%s', (_label, state) => {
-        expect(runTs(state)).toBe(runPy(pyFixture(state)));
+        expect(runTs(state)).toMatchSnapshot();
     });
 });

--- a/tests/scripts/work_engine/directives_ui_init.test.ts
+++ b/tests/scripts/work_engine/directives_ui_init.test.ts
@@ -1,67 +1,15 @@
-// Golden-parity tests for work_engine/directives/ui/index.ts vs
-// directives/ui/__init__.py (ADR-096 py2ts Phase 1 — work_engine
-// TOP/integration layer). Parity on name / roadmap / kinds / step-order /
-// ambiguity-code structure (get_steps() returns callables — not comparable).
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Intent tests for work_engine/directives/ui/index.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer). The python byte-parity rig is gone; this
+// asserts the tsx module's own contract directly: name / roadmap / kinds /
+// step-order / ambiguity codes.
 import { describe, expect, it } from 'vitest';
 
 import {
     DIRECTIVE_SET_NAME,
     ROADMAP,
     SUPPORTED_KINDS,
-    all_ambiguities,
     get_steps,
 } from '../../../src/agent-src/templates/scripts/work_engine/directives/ui/index.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function pySummary(): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'm = __import__("work_engine.directives.ui", fromlist=["x"])',
-        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
-        'out = {"name": m.DIRECTIVE_SET_NAME, "roadmap": m.ROADMAP, "kinds": list(m.SUPPORTED_KINDS), "step_order": list(m.get_steps().keys()), "ambiguities": amb}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function _sortKeys(value: unknown): unknown {
-    if (Array.isArray(value)) return value.map(_sortKeys);
-    if (value && typeof value === 'object') {
-        const sorted: Record<string, unknown> = {};
-        for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-            sorted[k] = _sortKeys((value as Record<string, unknown>)[k]);
-        }
-        return sorted;
-    }
-    return value;
-}
-
-function tsSummary(): string {
-    const amb: Record<string, Array<string | undefined>> = {};
-    for (const [k, v] of Object.entries(all_ambiguities())) amb[k] = v.map((a) => a['code']);
-    return JSON.stringify(
-        _sortKeys({ name: DIRECTIVE_SET_NAME, roadmap: ROADMAP, kinds: [...SUPPORTED_KINDS], step_order: [...get_steps().keys()], ambiguities: amb }),
-        null,
-        2,
-    );
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 describe('directives/ui index — shape', () => {
     it('name / roadmap / kinds', () => {
@@ -76,11 +24,5 @@ describe('directives/ui index — shape', () => {
     });
     it('all callables', () => {
         for (const h of get_steps().values()) expect(typeof h).toBe('function');
-    });
-});
-
-describeParity('directives/ui index — golden parity', () => {
-    it('matches python3', () => {
-        expect(tsSummary()).toBe(pySummary());
     });
 });

--- a/tests/scripts/work_engine/directives_ui_trivial_init.test.ts
+++ b/tests/scripts/work_engine/directives_ui_trivial_init.test.ts
@@ -1,67 +1,16 @@
-// Golden-parity tests for work_engine/directives/ui_trivial/index.ts vs
-// directives/ui_trivial/__init__.py (ADR-096 py2ts Phase 1 — work_engine
-// TOP/integration layer). Note: DIRECTIVE_SET_NAME is the hyphenated wire form
-// `ui-trivial` while the package dir is underscore `ui_trivial`.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Intent tests for work_engine/directives/ui_trivial/index.ts (ADR-096 py2ts
+// Phase 1 — work_engine TOP/integration layer). The python byte-parity rig is
+// gone; this asserts the tsx module's own contract directly. Note:
+// DIRECTIVE_SET_NAME is the hyphenated wire form `ui-trivial` while the package
+// dir is underscore `ui_trivial`.
 import { describe, expect, it } from 'vitest';
 
 import {
     DIRECTIVE_SET_NAME,
     ROADMAP,
     SUPPORTED_KINDS,
-    all_ambiguities,
     get_steps,
 } from '../../../src/agent-src/templates/scripts/work_engine/directives/ui_trivial/index.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function pySummary(): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'm = __import__("work_engine.directives.ui_trivial", fromlist=["x"])',
-        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
-        'out = {"name": m.DIRECTIVE_SET_NAME, "roadmap": m.ROADMAP, "kinds": list(m.SUPPORTED_KINDS), "step_order": list(m.get_steps().keys()), "ambiguities": amb}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function _sortKeys(value: unknown): unknown {
-    if (Array.isArray(value)) return value.map(_sortKeys);
-    if (value && typeof value === 'object') {
-        const sorted: Record<string, unknown> = {};
-        for (const k of Object.keys(value as Record<string, unknown>).sort()) {
-            sorted[k] = _sortKeys((value as Record<string, unknown>)[k]);
-        }
-        return sorted;
-    }
-    return value;
-}
-
-function tsSummary(): string {
-    const amb: Record<string, Array<string | undefined>> = {};
-    for (const [k, v] of Object.entries(all_ambiguities())) amb[k] = v.map((a) => a['code']);
-    return JSON.stringify(
-        _sortKeys({ name: DIRECTIVE_SET_NAME, roadmap: ROADMAP, kinds: [...SUPPORTED_KINDS], step_order: [...get_steps().keys()], ambiguities: amb }),
-        null,
-        2,
-    );
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 describe('directives/ui_trivial index — shape', () => {
     it('hyphenated wire name + roadmap + kinds', () => {
@@ -76,11 +25,5 @@ describe('directives/ui_trivial index — shape', () => {
     });
     it('all callables', () => {
         for (const h of get_steps().values()) expect(typeof h).toBe('function');
-    });
-});
-
-describeParity('directives/ui_trivial index — golden parity', () => {
-    it('matches python3', () => {
-        expect(tsSummary()).toBe(pySummary());
     });
 });

--- a/tests/scripts/work_engine/dispatcher.test.ts
+++ b/tests/scripts/work_engine/dispatcher.test.ts
@@ -1,22 +1,13 @@
-// Golden-parity tests for work_engine/dispatcher.ts vs dispatcher.py (ADR-096
-// py2ts Phase 1 — work_engine TOP/integration layer).
+// Intent tests for work_engine/dispatcher.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer). The python byte-parity rig is gone; this
+// asserts the tsx module's own contract directly.
 //
-// `dispatcher.py` imports `.delivery_state`, `.hooks`, `.state` and (via
-// `load_directive_set`) the real `directives.<set>` packages. The parity rig
-// runs it through the real `work_engine` package on sys.path. The dispatch loop
-// itself (`dispatch`) is driven with synthetic step maps so the success /
-// blocked / partial / resume-skip / missing-step / no-questions invariants are
-// exercised deterministically on both engines, comparing the resulting
-// `(outcome, halting, state.outcomes, state.questions)` byte-for-byte.
-//
-// The directive-set resolution surface (select_directive_set / load /
-// assert_kind_supported) is exercised against the real four sets — TS resolves
-// them statically, Python via import_module; both produce the canonical
-// eight-step order and the same error text for the typo / unsupported-kind
-// paths.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// The dispatch loop (`dispatch`) is driven with synthetic step maps so the
+// success / blocked / partial / resume-skip / missing-step / no-questions
+// invariants are exercised deterministically. The directive-set resolution
+// surface (select_directive_set / load / assert_kind_supported) is exercised
+// against the real four sets — they produce the canonical eight-step order and
+// raise on the typo / unsupported-kind paths.
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -36,17 +27,7 @@ import {
 } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
 import { Input, WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
-
-// ── dispatch() — synthetic step maps, both engines ────────────────────────
+// ── dispatch() — synthetic step maps ──────────────────────────────────────
 
 // A "step plan" is a JSON-serialisable map of {stepName: {outcome, questions}}.
 // Both engines build a step map from it where each handler returns the declared
@@ -65,46 +46,6 @@ function tsStepMap(plan: StepPlan): Map<string, Step> {
         );
     }
     return m;
-}
-
-function tsDispatch(plan: StepPlan, preOutcomes: Record<string, string> = {}): string {
-    const st = new DeliveryState({ ticket: { id: 'T' }, outcomes: { ...preOutcomes } });
-    const [final, halting] = dispatch(st, tsStepMap(plan));
-    return JSON.stringify(
-        { final, halting, outcomes: st.outcomes, questions: st.questions },
-        null,
-        2,
-    );
-}
-
-function pyDispatch(plan: StepPlan, preOutcomes: Record<string, string> = {}): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine.dispatcher import dispatch, STEP_ORDER',
-        'from work_engine.delivery_state import DeliveryState, Outcome, StepResult',
-        'plan = json.loads(sys.argv[1])',
-        'pre = json.loads(sys.argv[2])',
-        'def make(name):',
-        '    spec = plan.get(name)',
-        '    outcome = Outcome(spec["outcome"]) if spec else Outcome.SUCCESS',
-        '    questions = spec.get("questions", []) if spec else []',
-        '    def handler(state):',
-        '        return StepResult(outcome=outcome, questions=list(questions))',
-        '    return handler',
-        'steps = {name: make(name) for name in STEP_ORDER}',
-        'st = DeliveryState(ticket={"id": "T"}, outcomes=dict(pre))',
-        'final, halting = dispatch(st, steps)',
-        'out = {"final": final.value, "halting": halting, "outcomes": st.outcomes, "questions": st.questions}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, JSON.stringify(plan), JSON.stringify(preOutcomes)], {
-        encoding: 'utf8',
-    });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
 }
 
 describe('dispatch — local invariants', () => {
@@ -128,38 +69,7 @@ describe('dispatch — local invariants', () => {
     });
 });
 
-describeParity('dispatch — golden parity', () => {
-    const PLANS: Array<[string, StepPlan, Record<string, string>]> = [
-        ['all success', {}, {}],
-        ['blocked at plan', { plan: { outcome: 'blocked', questions: ['1. a', '2. b'] } }, {}],
-        ['partial at verify', { verify: { outcome: 'partial', questions: ['1. retry'] } }, {}],
-        ['blocked at refine (first step)', { refine: { outcome: 'blocked', questions: ['q'] } }, {}],
-        ['resume skips already-success steps', { test: { outcome: 'blocked', questions: ['q'] } }, { refine: 'success', memory: 'success', analyze: 'success', plan: 'success', implement: 'success' }],
-        ['resume: all already success', {}, { refine: 'success', memory: 'success', analyze: 'success', plan: 'success', implement: 'success', test: 'success', verify: 'success', report: 'success' }],
-    ];
-    for (const [name, plan, pre] of PLANS) {
-        it(name, () => {
-            expect(tsDispatch(plan, pre)).toBe(pyDispatch(plan, pre));
-        });
-    }
-});
-
 // ── select_directive_set / load / assert_kind_supported ───────────────────
-
-function pyResolve(body: string): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine import dispatcher as d',
-        'from work_engine.state import Input, WorkState',
-        body,
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
 
 describe('select_directive_set — local', () => {
     it('reads WorkState.directive_set', () => {
@@ -172,29 +82,6 @@ describe('select_directive_set — local', () => {
     it('throws ValueError on an unknown set', () => {
         const w = new WorkState({ input: new Input('ticket', {}), directive_set: 'nope' });
         expect(() => select_directive_set(w)).toThrow(ValueError);
-    });
-});
-
-describeParity('select_directive_set — error-text parity', () => {
-    it('unknown-set message matches python3', () => {
-        const tsMsg = (() => {
-            try {
-                const w = new WorkState({ input: new Input('ticket', {}), directive_set: 'nope' });
-                select_directive_set(w);
-                return '__NO_ERROR__';
-            } catch (e) {
-                return (e as Error).message;
-            }
-        })();
-        const pyMsg = pyResolve([
-            'w = WorkState(input=Input(kind="ticket", data={}), directive_set="nope")',
-            'try:',
-            '    d.select_directive_set(w)',
-            '    sys.stdout.write("__NO_ERROR__")',
-            'except ValueError as exc:',
-            '    sys.stdout.write(str(exc))',
-        ].join('\n'));
-        expect(tsMsg).toBe(pyMsg);
     });
 });
 
@@ -221,26 +108,5 @@ describe('assert_kind_supported — real sets', () => {
         for (const k of ['ticket', 'prompt', 'diff', 'file']) {
             expect(() => assert_kind_supported(k, 'ui')).not.toThrow();
         }
-    });
-});
-
-describeParity('assert_kind_supported — error-text parity', () => {
-    it('unsupported-kind message matches python3', () => {
-        const tsMsg = (() => {
-            try {
-                assert_kind_supported('diff', 'backend');
-                return '__NO_ERROR__';
-            } catch (e) {
-                return (e as Error).message;
-            }
-        })();
-        const pyMsg = pyResolve([
-            'try:',
-            '    d.assert_kind_supported("diff", "backend")',
-            '    sys.stdout.write("__NO_ERROR__")',
-            'except NotImplementedError as exc:',
-            '    sys.stdout.write(str(exc))',
-        ].join('\n'));
-        expect(tsMsg).toBe(pyMsg);
     });
 });

--- a/tests/scripts/work_engine/emitters.test.ts
+++ b/tests/scripts/work_engine/emitters.test.ts
@@ -1,30 +1,16 @@
-// Golden-parity tests for work_engine/emitters.ts vs emitters.py (ADR-096
-// py2ts Phase 1 — work_engine TOP/integration layer).
-//
-// `emitters.py` imports `.delivery_state`, `.hooks`, `.state` (package-relative
-// imports through the real `work_engine` package), so the parity harness runs
-// it via sys.path + import_module. Coverage: `_emit` SUCCESS (report on stdout)
-// + halt branches ([halt] line + questions), and `_emit_halt` (stderr surface,
-// fallback `halt:` line, exit-2, halts[] persistence when the state file
-// pre-exists). The halt timestamp is wall-clock — normalised in both engines.
-import { spawnSync } from 'node:child_process';
+// Intent tests for work_engine/emitters.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer). The python byte-parity rig is gone; this
+// asserts the tsx module's own contract directly. Coverage: `_emit_halt`
+// (stderr surface, fallback `halt:` line, exit-2, halts[] persistence when the
+// state file pre-exists). The halt timestamp is wall-clock.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { _emit, _emit_halt } from '../../../src/agent-src/templates/scripts/work_engine/emitters.js';
-import { Outcome } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
+import { _emit_halt } from '../../../src/agent-src/templates/scripts/work_engine/emitters.js';
 import { HookHalt } from '../../../src/agent-src/templates/scripts/work_engine/hooks/index.js';
 import { Input, WorkState, dump, load } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 let tmp: string;
 beforeEach(() => {
@@ -32,70 +18,6 @@ beforeEach(() => {
 });
 afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
-});
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
-
-// ── _emit (stdout) ───────────────────────────────────────────────────────
-
-/** Run `_emit` on python3 with the given report/final/halting/questions. */
-function pyEmit(report: string, final: string, halting: string | null, questions: string[]): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine.emitters import _emit',
-        'from work_engine.delivery_state import Outcome',
-        'from work_engine.state import Input, WorkState',
-        'spec = json.loads(sys.argv[1])',
-        'w = WorkState(input=Input(kind="ticket", data={}))',
-        'w.report = spec["report"]',
-        'w.questions = spec["questions"]',
-        'final = Outcome(spec["final"])',
-        'halting = spec["halting"]',
-        '_emit(w, final, halting)',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, JSON.stringify({ report, final, halting, questions })], {
-        encoding: 'utf8',
-    });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function tsEmit(report: string, final: Outcome, halting: string | null, questions: string[]): string {
-    const w = new WorkState({ input: new Input('ticket', {}) });
-    w.report = report;
-    w.questions = questions;
-    const chunks: string[] = [];
-    const orig = process.stdout.write.bind(process.stdout);
-    (process.stdout.write as unknown) = (s: string) => {
-        chunks.push(s);
-        return true;
-    };
-    try {
-        _emit(w, final, halting);
-    } finally {
-        (process.stdout.write as unknown) = orig;
-    }
-    return chunks.join('');
-}
-
-describeParity('_emit — stdout parity', () => {
-    it('SUCCESS prints the report', () => {
-        expect(tsEmit('the delivery report', Outcome.SUCCESS, null, [])).toBe(
-            pyEmit('the delivery report', 'success', null, []),
-        );
-    });
-    it('BLOCKED prints the halt line + questions', () => {
-        expect(tsEmit('', Outcome.BLOCKED, 'plan', ['1. opt a', '2. opt b'])).toBe(
-            pyEmit('', 'blocked', 'plan', ['1. opt a', '2. opt b']),
-        );
-    });
-    it('PARTIAL with no halting step prints (none)', () => {
-        expect(tsEmit('', Outcome.PARTIAL, null, ['q'])).toBe(pyEmit('', 'partial', null, ['q']));
-    });
 });
 
 // ── _emit_halt (stderr + persistence) ─────────────────────────────────────

--- a/tests/scripts/work_engine/errors.test.ts
+++ b/tests/scripts/work_engine/errors.test.ts
@@ -1,52 +1,10 @@
-// Golden-parity tests for work_engine/errors.ts vs errors.py (ADR-094 py2ts
-// Phase 1). errors is a leaf module: one exception class `_CLIError` whose only
-// contract is "is an Error subclass, carries its message, name is `_CLIError`".
-// The Python side is loaded via a direct-file importlib loader (the work_engine
-// dir + repo root are added to sys.path so the `from __future__ import
-// annotations` header and any sibling imports resolve). The TS side imports the
-// twin directly. No `--help` / prose surface here.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
+// Intent tests for work_engine/errors.ts (ADR-094 py2ts Phase 1). errors is a
+// leaf module: one exception class `_CLIError` whose only contract is "is an
+// Error subclass, carries its message, name is `_CLIError`". The python
+// byte-parity rig is gone; this asserts the tsx twin's own contract directly.
 import { describe, expect, it } from 'vitest';
 
 import { _CLIError } from '../../../src/agent-src/templates/scripts/work_engine/errors.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-// Direct-file importlib loader: register the module in sys.modules BEFORE
-// exec_module (CPython 3.9 dataclass `__module__` lookup needs it) and add the
-// work_engine dir + repo root to sys.path so intra-package + dispatch_hook
-// imports resolve. Shared verbatim by every work_engine parity test.
-function pyLoaderPreamble(): string {
-    return [
-        'import importlib.util, sys, json, pathlib',
-        `WE = pathlib.Path(${JSON.stringify(WE)})`,
-        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
-        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
-        'def _load(name):',
-        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
-        '    m = importlib.util.module_from_spec(sp)',
-        '    sys.modules[sp.name] = m',
-        '    sp.loader.exec_module(m)',
-        '    return m',
-    ].join('\n');
-}
-
-function py(body: string): string {
-    const code = `${pyLoaderPreamble()}\n${body}`;
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr}`);
-    }
-    return r.stdout.trim();
-}
 
 describe('work_engine/errors — _CLIError', () => {
     it('is an Error subclass carrying its message', () => {
@@ -67,26 +25,5 @@ describe('work_engine/errors — _CLIError', () => {
         const e = new _CLIError();
         expect(e.message).toBe('');
         expect(e).toBeInstanceOf(_CLIError);
-    });
-
-    describe.runIf(hasPython3())('python parity', () => {
-        it('name + message match CPython', () => {
-            const oracle = py(
-                'm=_load("errors")\n' +
-                    'e=m._CLIError("cfg problem")\n' +
-                    'print(json.dumps({"name": type(e).__name__, "msg": str(e), ' +
-                    '"is_exc": isinstance(e, Exception)}))',
-            );
-            const expected = JSON.parse(oracle) as { name: string; msg: string; is_exc: boolean };
-            const e = new _CLIError('cfg problem');
-            expect(e.name).toBe(expected.name);
-            expect(e.message).toBe(expected.msg);
-            expect(e instanceof Error).toBe(expected.is_exc);
-        });
-
-        it('exports exactly _CLIError in __all__', () => {
-            const oracle = py('m=_load("errors")\nprint(json.dumps(m.__all__))');
-            expect(JSON.parse(oracle)).toEqual(['_CLIError']);
-        });
     });
 });

--- a/tests/scripts/work_engine/hook_bootstrap.test.ts
+++ b/tests/scripts/work_engine/hook_bootstrap.test.ts
@@ -1,33 +1,18 @@
-// Golden-parity tests for work_engine/hook_bootstrap.ts vs hook_bootstrap.py
-// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer).
+// Tests for work_engine/hook_bootstrap.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer).
 //
-// `hook_bootstrap.py` assembles a HookRegistry from `.agent-settings.yml`. The
-// registered callbacks are closures (not comparable across engines), so parity
-// is on the *per-event callback count* — the observable shape of the registry.
-// Cases: --no-hooks (empty), missing/empty settings (empty), hooks.enabled
-// with the per-hook defaults, and chat-history enabled. The Python module is
-// run through the real package on sys.path.
-import { spawnSync } from 'node:child_process';
+// `hook_bootstrap.ts` assembles a HookRegistry from `.agent-settings.yml`. The
+// registered callbacks are closures, so coverage is on the *per-event callback
+// count* — the observable shape of the registry. Cases: --no-hooks (empty) and
+// missing settings (empty).
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { ParsedArgs } from '../../../src/agent-src/templates/scripts/work_engine/cli_args.js';
 import { _build_hook_registry } from '../../../src/agent-src/templates/scripts/work_engine/hook_bootstrap.js';
 import { HookEvent } from '../../../src/agent-src/templates/scripts/work_engine/hooks/index.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function hasPyYaml(): boolean {
-    return spawnSync('python3', ['-c', 'import yaml'], { encoding: 'utf8' }).status === 0;
-}
 
 let tmp: string;
 beforeEach(() => {
@@ -36,9 +21,6 @@ beforeEach(() => {
 afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
 });
-
-const py = hasPython3() && hasPyYaml();
-const describeParity = py ? describe : describe.skip;
 
 function baseArgs(over: Partial<ParsedArgs> = {}): ParsedArgs {
     return {
@@ -66,35 +48,6 @@ function tsCounts(args: ParsedArgs): Record<string, number> {
     return out;
 }
 
-/** Python: per-event callback counts for the registry built from `args`. */
-function pyCounts(noHooks: boolean, hooksConfig: string | null): Record<string, number> {
-    const code = [
-        'import sys, json, argparse',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine.hook_bootstrap import _build_hook_registry',
-        'from work_engine.hooks import HookEvent',
-        'cfg = json.loads(sys.argv[2])',
-        'import pathlib',
-        'ns = argparse.Namespace(no_hooks=json.loads(sys.argv[1]), hooks_config=(pathlib.Path(cfg) if cfg else None))',
-        'reg = _build_hook_registry(ns)',
-        'out = {ev.value: len(reg.for_event(ev)) for ev in HookEvent}',
-        'sys.stdout.write(json.dumps(out, sort_keys=True))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, JSON.stringify(noHooks), JSON.stringify(hooksConfig)], {
-        encoding: 'utf8',
-    });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return JSON.parse(r.stdout) as Record<string, number>;
-}
-
-function sortObj(o: Record<string, number>): Record<string, number> {
-    const s: Record<string, number> = {};
-    for (const k of Object.keys(o).sort()) s[k] = o[k] as number;
-    return s;
-}
-
 describe('_build_hook_registry — local', () => {
     it('--no-hooks yields an empty registry', () => {
         const counts = tsCounts(baseArgs({ no_hooks: true }));
@@ -104,48 +57,5 @@ describe('_build_hook_registry — local', () => {
     it('missing settings file yields an empty registry', () => {
         const counts = tsCounts(baseArgs({ hooks_config: path.join(tmp, 'absent.yml') }));
         expect(Object.values(counts).every((n) => n === 0)).toBe(true);
-    });
-});
-
-describeParity('_build_hook_registry — per-event count parity', () => {
-    it('--no-hooks', () => {
-        expect(sortObj(tsCounts(baseArgs({ no_hooks: true })))).toEqual(pyCounts(true, null));
-    });
-
-    it('absent settings → empty', () => {
-        const cfg = path.join(tmp, 'absent.yml');
-        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
-    });
-
-    it('hooks.enabled: false → empty', () => {
-        const cfg = path.join(tmp, 'off.yml');
-        fs.writeFileSync(cfg, 'hooks:\n  enabled: false\n', 'utf-8');
-        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
-    });
-
-    it('hooks.enabled: true → per-hook defaults', () => {
-        const cfg = path.join(tmp, 'on.yml');
-        fs.writeFileSync(cfg, 'hooks:\n  enabled: true\n', 'utf-8');
-        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
-    });
-
-    it('hooks.enabled + chat_history enabled', () => {
-        const cfg = path.join(tmp, 'chat.yml');
-        fs.writeFileSync(
-            cfg,
-            'hooks:\n  enabled: true\n  chat_history:\n    enabled: true\n    script: scripts/chat_history.py\n',
-            'utf-8',
-        );
-        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
-    });
-
-    it('hooks.enabled + trace only (others off)', () => {
-        const cfg = path.join(tmp, 'trace.yml');
-        fs.writeFileSync(
-            cfg,
-            'hooks:\n  enabled: true\n  trace: true\n  halt_surface_audit: false\n  state_shape_validation: false\n  directive_set_guard: false\n  memory_visibility:\n    enabled: false\n',
-            'utf-8',
-        );
-        expect(sortObj(tsCounts(baseArgs({ hooks_config: cfg })))).toEqual(pyCounts(false, cfg));
     });
 });

--- a/tests/scripts/work_engine/input_builders.test.ts
+++ b/tests/scripts/work_engine/input_builders.test.ts
@@ -1,36 +1,17 @@
-// Golden-parity tests for work_engine/input_builders.ts vs input_builders.py
-// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer).
+// Tests for work_engine/input_builders.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer).
 //
-// `input_builders.py` reaches across the package (cli_args, errors, intent,
-// resolvers, state, state_io), so the parity rig runs it through the real
-// `work_engine` package on sys.path. Each builder is driven from a temp input
-// file on both engines; the resulting WorkState is serialised via
-// `state.to_dict` and compared byte-for-byte (canonical json.dumps). The
-// `_load_or_build` dispatch paths (existing state file → _load, mutual
-// exclusion, no-input, ticket non-object) are exercised for behaviour parity.
-import { spawnSync } from 'node:child_process';
+// Exercises the `_load_or_build` dispatch paths (existing state file → _load,
+// mutual exclusion, no-input, ticket non-object) for behaviour.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { ParsedArgs } from '../../../src/agent-src/templates/scripts/work_engine/cli_args.js';
 import { _CLIError } from '../../../src/agent-src/templates/scripts/work_engine/errors.js';
-import {
-    _build_from_diff_file,
-    _build_from_file_file,
-    _build_from_prompt_file,
-    _load_or_build,
-} from '../../../src/agent-src/templates/scripts/work_engine/input_builders.js';
-import { dump, to_dict, type WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
+import { _load_or_build } from '../../../src/agent-src/templates/scripts/work_engine/input_builders.js';
+import { dump } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
 
 let tmp: string;
 beforeEach(() => {
@@ -39,9 +20,6 @@ beforeEach(() => {
 afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
 });
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 function baseArgs(over: Partial<ParsedArgs> = {}): ParsedArgs {
     return {
@@ -56,89 +34,6 @@ function baseArgs(over: Partial<ParsedArgs> = {}): ParsedArgs {
         ...over,
     };
 }
-
-/** Canonical v1 JSON of the WorkState a TS builder produces. */
-function tsCanonical(work: WorkState): string {
-    return JSON.stringify(to_dict(work), null, 2);
-}
-
-/**
- * Run a builder on python3 from the same input file, returning the canonical
- * v1 JSON of the resulting WorkState (state.to_dict). `argName` is the flag
- * (ticket_file / prompt_file / diff_file / file_file) and `builder` the
- * function name in input_builders.
- */
-function pyBuild(builder: string, argName: string, inputPath: string, persona: string | null): string {
-    const code = [
-        'import sys, json, argparse, pathlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine import input_builders as ib',
-        'from work_engine import state as st',
-        'ns = argparse.Namespace(state_file=None, ticket_file=None, prompt_file=None, diff_file=None, file_file=None, persona=None, no_hooks=False, hooks_config=None)',
-        `setattr(ns, ${JSON.stringify(argName)}, pathlib.Path(sys.argv[1]))`,
-        'ns.persona = json.loads(sys.argv[2])',
-        `work = getattr(ib, ${JSON.stringify(builder)})(ns)`,
-        'sys.stdout.write(json.dumps(st.to_dict(work), indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, inputPath, JSON.stringify(persona)], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-describeParity('builders — byte parity vs python3', () => {
-    it('ticket file → v0 WorkState (via _load_or_build)', () => {
-        const tf = path.join(tmp, 'ticket.json');
-        fs.writeFileSync(tf, JSON.stringify({ id: 'T-1', title: 'Add CSV export' }), 'utf-8');
-        const [work] = _load_or_build(baseArgs().state_file, baseArgs({ ticket_file: tf }));
-
-        // Python via _load_or_build too (state file absent).
-        const code = [
-            'import sys, json, argparse, pathlib',
-            `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-            'from work_engine import input_builders as ib',
-            'from work_engine import state as st',
-            'ns = argparse.Namespace(state_file=pathlib.Path(sys.argv[2]), ticket_file=pathlib.Path(sys.argv[1]), prompt_file=None, diff_file=None, file_file=None, persona=None, no_hooks=False, hooks_config=None)',
-            'work, fmt = ib._load_or_build(pathlib.Path(sys.argv[2]), ns)',
-            'sys.stdout.write(json.dumps({"fmt": fmt, "state": st.to_dict(work)}, indent=2, ensure_ascii=False))',
-        ].join('\n');
-        const r = spawnSync('python3', ['-c', code, tf, path.join(tmp, 'absent-state.json')], { encoding: 'utf8' });
-        expect(r.status).toBe(0);
-        const pyOut = JSON.parse(r.stdout) as { fmt: string; state: unknown };
-        expect(pyOut.fmt).toBe('v0');
-        expect(tsCanonical(work)).toBe(JSON.stringify(pyOut.state, null, 2));
-    });
-
-    it('prompt file → prompt envelope', () => {
-        const pf = path.join(tmp, 'prompt.txt');
-        fs.writeFileSync(pf, 'Build a settings page with a dark-mode toggle', 'utf-8');
-        const work = _build_from_prompt_file(baseArgs({ prompt_file: pf }));
-        expect(tsCanonical(work)).toBe(pyBuild('_build_from_prompt_file', 'prompt_file', pf, null));
-    });
-
-    it('diff file → diff envelope', () => {
-        const df = path.join(tmp, 'change.diff');
-        fs.writeFileSync(df, '--- a/x.tsx\n+++ b/x.tsx\n@@ -1 +1 @@\n-old\n+new\n', 'utf-8');
-        const work = _build_from_diff_file(baseArgs({ diff_file: df }));
-        expect(tsCanonical(work)).toBe(pyBuild('_build_from_diff_file', 'diff_file', df, null));
-    });
-
-    it('file file → file envelope (first line only)', () => {
-        const ff = path.join(tmp, 'ref.txt');
-        fs.writeFileSync(ff, 'src/components/Button.tsx\nignored second line\n', 'utf-8');
-        const work = _build_from_file_file(baseArgs({ file_file: ff }));
-        expect(tsCanonical(work)).toBe(pyBuild('_build_from_file_file', 'file_file', ff, null));
-    });
-
-    it('persona override flows into the WorkState', () => {
-        const pf = path.join(tmp, 'p2.txt');
-        fs.writeFileSync(pf, 'A prompt', 'utf-8');
-        const work = _build_from_prompt_file(baseArgs({ prompt_file: pf, persona: 'qa' }));
-        expect(work.persona).toBe('qa');
-        expect(tsCanonical(work)).toBe(pyBuild('_build_from_prompt_file', 'prompt_file', pf, 'qa'));
-    });
-});
 
 describe('_load_or_build — dispatch behaviour', () => {
     it('loads an existing state file (format-preserving)', () => {

--- a/tests/scripts/work_engine/intent_classify.test.ts
+++ b/tests/scripts/work_engine/intent_classify.test.ts
@@ -1,22 +1,9 @@
-// Golden-parity rig for the py2ts work_engine `intent/classify` twin (ADR-094).
+// Tests for the work_engine `intent/classify` twin (ADR-094).
 //
-// `intent/classify.py` imports `from ..state import WorkState` only under
-// TYPE_CHECKING, so the runtime module is stdlib-only and loads cleanly with
-// the `from ..state import` lines rewritten (defensive — the TYPE_CHECKING
-// guard means no rewrite is strictly needed, but the rewrite is harmless and
-// keeps the loader uniform with the resolver rigs).
-//
-// `classify_intent` and `directive_set_for` are pure string functions — the
-// harness drives both engines from the same prompt/title and asserts identical
-// labels and identical ValueError text. `populate_routing` mutates a WorkState
-// in place; it is exercised TS-side (it needs the WorkState class) and its
-// classifier delegate is covered by the golden cases.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// `classify_intent` and `directive_set_for` are pure string functions;
+// `populate_routing` mutates a WorkState in place.
 import { describe, expect, it } from 'vitest';
 
-import { oracle2 } from '../../_lib/parity_oracle';
 import { Input, WorkState } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
 import {
     INTENT_BACKEND,
@@ -26,162 +13,11 @@ import {
     INTENT_UI_TRIVIAL,
     KNOWN_INTENTS,
     ValueError,
-    classify_intent,
     directive_set_for,
     populate_routing,
 } from '../../../src/agent-src/templates/scripts/work_engine/intent/classify.js';
 
-const REPO_ROOT = path.resolve(
-    fileURLToPath(import.meta.url),
-    '..',
-    '..',
-    '..',
-    '..',
-);
-
-const WE = path.join(
-    REPO_ROOT,
-    'src',
-    'agent-src',
-    'templates',
-    'scripts',
-    'work_engine',
-);
-const STATE_PY = path.join(WE, 'state.py');
-const CLASSIFY_PY = path.join(WE, 'intent', 'classify.py');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-// The `-c` loader exec's classify.py with its `from ..state import WorkState`
-// rewritten to a file-loaded `state` module. Each probe appends its own body.
-// The loader embeds the absolute STATE_PY / CLASSIFY_PY paths — `oracle2`'s
-// inline-key stabilisation folds those volatile prefixes out so the snapshot
-// key is machine-independent (the spawn still gets the original code).
-const LOADER = [
-    'import sys, json, importlib.util',
-    `_sspec = importlib.util.spec_from_file_location("state", ${JSON.stringify(STATE_PY)})`,
-    'state = importlib.util.module_from_spec(_sspec)',
-    'sys.modules["state"] = state',
-    '_sspec.loader.exec_module(state)',
-    `_src = open(${JSON.stringify(CLASSIFY_PY)}, encoding="utf-8").read()`,
-    '_src = _src.replace("from ..state import WorkState", "from state import WorkState")',
-    'mod = type(sys)("mod")',
-    'exec(compile(_src, "mod", "exec"), mod.__dict__)',
-].join('\n');
-
-/** Frozen python stdout for one inline `-c` probe (capture spawns python3). */
-function pyInline(body: string, args: string[]): string {
-    const code = `${LOADER}\n${body}`;
-    const r = oracle2({ kind: 'inline', target: code, args });
-    if (r.status !== 0) throw new Error(`py inline probe failed (status ${r.status}): ${r.stderr || r.stdout}`);
-    return r.stdout;
-}
-
-/** Python classify_intent(raw, title=...). args: rawJson, titleJson (or "null"). */
-function pyClassify(rawJson: string, titleJson: string): string {
-    const body = [
-        'raw = json.loads(sys.argv[1])',
-        'title = json.loads(sys.argv[2])',
-        'sys.stdout.write(mod.classify_intent(raw, title=title))',
-    ].join('\n');
-    return pyInline(body, [rawJson, titleJson]);
-}
-
-function pyDirectiveSet(intentJson: string): string {
-    const body = [
-        'intent = json.loads(sys.argv[1])',
-        'sys.stdout.write(mod.directive_set_for(intent))',
-    ].join('\n');
-    return pyInline(body, [intentJson]);
-}
-
-function pyDirectiveSetError(intentJson: string): string {
-    const body = [
-        'intent = json.loads(sys.argv[1])',
-        'try:',
-        '    mod.directive_set_for(intent)',
-        '    sys.stdout.write("__NO_ERROR__")',
-        'except ValueError as exc:',
-        '    sys.stdout.write(str(exc))',
-    ].join('\n');
-    return pyInline(body, [intentJson]);
-}
-
-function tsClassify(rawJson: string, titleJson: string): string {
-    const raw = JSON.parse(rawJson) as string;
-    const title = JSON.parse(titleJson) as string | null;
-    return classify_intent(raw, { title });
-}
-
-function tsDirectiveSetError(intentJson: string): string {
-    try {
-        directive_set_for(JSON.parse(intentJson) as string);
-        return '__NO_ERROR__';
-    } catch (exc) {
-        return (exc as Error).message;
-    }
-}
-
-const PY = hasPython3();
-const describePy = PY ? describe : describe.skip;
-
-// [raw, title-or-null] prompt fixtures spanning every ladder rung.
-const CLASSIFY_CASES: Array<[string, string, string]> = [
-    ['empty → backend', '', 'null'],
-    ['whitespace → backend', '   \t ', 'null'],
-    ['plain backend prompt', 'add a webhook listener for the queue', 'null'],
-    ['trivial: make the button red', 'make the button red', 'null'],
-    ['trivial: rename the label (verb + short)', 'rename the sidebar label', 'null'],
-    ['trivial verb but long (>14 words) → not trivial', 'change the button color and also rework the entire dashboard layout with new cards and panels everywhere', 'null'],
-    ['mixed: form + endpoint', 'build a form that posts to a new API endpoint', 'null'],
-    ['mixed: page + migration', 'the dashboard page needs a schema migration', 'null'],
-    ['ui-improve: improve the modal', 'improve the modal spacing', 'null'],
-    ['ui-improve: existing surface marker', 'work on the existing dashboard page', 'null'],
-    ['ui-build: add a new component', 'add a new sidebar component', 'null'],
-    ['ui-build: new screen marker', 'design a new screen for onboarding', 'null'],
-    ['ui signal, no verb → ui-improve default', 'the navigation sidebar', 'null'],
-    ['ui via style word only (css)', 'tweak the css padding', 'null'],
-    ['title carries the UI signal', 'do the thing', JSON.stringify('Redesign the dashboard page')],
-    ['title + body concatenated', 'with grid layout', JSON.stringify('New tile component')],
-    ['backend word table is NOT a UI noun', 'add an index on the users table', 'null'],
-    ['style multiword dark mode', 'support dark mode on the page', 'null'],
-    ['trivial pattern across <=40 chars span', 'set the header text to primary', 'null'],
-    ['improve verb fix on a panel', 'fix the panel border', 'null'],
-];
-
-describePy('intent/classify — classify_intent label parity (python3 vs tsx)', () => {
-    for (const [label, raw, title] of CLASSIFY_CASES) {
-        it(`identical label — ${label}`, () => {
-            const py = pyClassify(JSON.stringify(raw), title);
-            const ts = tsClassify(JSON.stringify(raw), title);
-            expect(ts).toBe(py);
-        });
-    }
-});
-
-describePy('intent/classify — directive_set_for parity (python3 vs tsx)', () => {
-    for (const intent of [...KNOWN_INTENTS]) {
-        it(`identical directive set — ${intent}`, () => {
-            const py = pyDirectiveSet(JSON.stringify(intent));
-            const ts = directive_set_for(intent);
-            expect(ts).toBe(py);
-        });
-    }
-
-    const badCases = ['bogus', 'BACKEND', '', 'ui-build '];
-    for (const bad of badCases) {
-        it(`identical ValueError text — ${JSON.stringify(bad)}`, () => {
-            const py = pyDirectiveSetError(JSON.stringify(bad));
-            const ts = tsDirectiveSetError(JSON.stringify(bad));
-            expect(py).not.toBe('__NO_ERROR__');
-            expect(ts).toBe(py);
-        });
-    }
-});
-
-describe('intent/classify — TS-side unit checks (no python3 needed)', () => {
+describe('intent/classify — TS-side unit checks', () => {
     it('label constants', () => {
         expect(INTENT_BACKEND).toBe('backend-coding');
         expect(INTENT_MIXED).toBe('mixed');

--- a/tests/scripts/work_engine/migration_v0_to_v1.test.ts
+++ b/tests/scripts/work_engine/migration_v0_to_v1.test.ts
@@ -1,91 +1,21 @@
-// Golden-parity tests for work_engine/migration/v0_to_v1.ts vs v0_to_v1.py
-// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer).
+// Tests for work_engine/migration/v0_to_v1.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer).
 //
-// `v0_to_v1.py` imports `..state` (SchemaError + the engine defaults), so the
-// direct-file importlib loader is not enough — we add
-// `src/agent-src/templates/scripts` to `sys.path` and
-// `import work_engine.migration.v0_to_v1` as a real package member (the
-// package `__init__`s pull in still-Python siblings, all present until the
-// Phase-12 sweep). The TS twin runs in-process; the Python original via a
-// python3 subprocess.
-//
-// Coverage: migrate_payload (v0 wrap, v1 idempotent deep-copy, every
-// SchemaError path), migrate_file round-trip (default destination, --no-backup,
-// backup rotation, refuse-overwrite, missing source, invalid JSON), and the
-// CLI main() success + error exit codes. Non-determinism: temp dirs are created
-// per-test and removed; on-disk bytes are compared byte-for-byte.
-import { spawnSync } from 'node:child_process';
+// Coverage: constants, and migrate_file round-trip (default destination,
+// --no-backup, backup rotation, refuse-overwrite, missing source, invalid
+// JSON). Temp dirs are created per-test and removed.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
     BACKUP_SUFFIX,
     DEFAULT_V0_FILENAME,
     DEFAULT_V1_FILENAME,
-    main,
     migrate_file,
-    migrate_payload,
 } from '../../../src/agent-src/templates/scripts/work_engine/migration/v0_to_v1.js';
 import { SchemaError } from '../../../src/agent-src/templates/scripts/work_engine/state.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/** Run `migrate_payload` on python3; emit canonical JSON or `ERR:<msg>`. */
-function pyMigratePayload(payloadJson: string): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine.migration.v0_to_v1 import migrate_payload',
-        'from work_engine.state import SchemaError',
-        'payload = json.loads(sys.argv[1])',
-        'try:',
-        '    out = migrate_payload(payload)',
-        '    sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-        'except SchemaError as exc:',
-        '    sys.stdout.write("ERR:" + str(exc))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, payloadJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-/** TS `migrate_payload`; emit canonical JSON or `ERR:<msg>`. */
-function tsMigratePayload(payloadJson: string): string {
-    try {
-        const out = migrate_payload(JSON.parse(payloadJson));
-        return JSON.stringify(out, null, 2);
-    } catch (exc) {
-        if (exc instanceof SchemaError) {
-            return 'ERR:' + exc.message;
-        }
-        throw exc;
-    }
-}
-
-/**
- * Run the migration CLI on python3 in `cwd`. Emits
- * `<exit>\n<stdout>\n--STDERR--\n<stderr>`.
- */
-function pyCli(cwd: string, argv: string[]): { status: number; stdout: string; stderr: string } {
-    const code = [
-        'import sys',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'from work_engine.migration.v0_to_v1 import main',
-        'sys.exit(main(sys.argv[1:]))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, ...argv], { encoding: 'utf8', cwd });
-    return { status: r.status ?? 0, stdout: r.stdout, stderr: r.stderr };
-}
 
 let tmp: string;
 
@@ -97,48 +27,12 @@ afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
-
 describe('migrate_payload — constants', () => {
     it('exposes the canonical filenames + suffix', () => {
         expect(DEFAULT_V0_FILENAME).toBe('.implement-ticket-state.json');
         expect(DEFAULT_V1_FILENAME).toBe('.work-state.json');
         expect(BACKUP_SUFFIX).toBe('.bak');
     });
-});
-
-const PAYLOAD_FIXTURES: Array<[string, string]> = [
-    ['minimal v0', JSON.stringify({ ticket: { id: 'T-1', title: 'Do thing' } })],
-    [
-        'full v0',
-        JSON.stringify({
-            ticket: { id: 'T-9', title: 'Big' },
-            persona: 'qa',
-            memory: [{ a: 1 }],
-            plan: 'the plan',
-            changes: [{ file: 'x.ts' }],
-            tests: 'ran',
-            verify: 'ok',
-            outcomes: { refine: 'success' },
-            questions: ['q1'],
-            report: 'done',
-        }),
-    ],
-    ['v1 idempotent', JSON.stringify({ version: 1, input: { kind: 'ticket', data: { id: 'T' } }, intent: 'backend-coding', directive_set: 'backend', persona: 'senior-engineer', memory: [], plan: null, changes: [], tests: null, verify: null, outcomes: {}, questions: [], report: '' })],
-    ['non-dict payload', JSON.stringify([1, 2, 3])],
-    ['higher version', JSON.stringify({ version: 99, ticket: {} })],
-    ['missing ticket', JSON.stringify({ persona: 'qa', plan: 'x' })],
-    ['non-dict ticket', JSON.stringify({ ticket: [1, 2] })],
-    ['unicode preserved', JSON.stringify({ ticket: { title: 'café ☕ é' } })],
-];
-
-describeParity('migrate_payload — golden parity', () => {
-    for (const [name, fixture] of PAYLOAD_FIXTURES) {
-        it(`${name} matches python3`, () => {
-            expect(tsMigratePayload(fixture)).toBe(pyMigratePayload(fixture));
-        });
-    }
 });
 
 describe('migrate_file — round-trip', () => {
@@ -185,62 +79,5 @@ describe('migrate_file — round-trip', () => {
         const src = path.join(tmp, DEFAULT_V0_FILENAME);
         fs.writeFileSync(src, 'not json', 'utf-8');
         expect(() => migrate_file(src)).toThrow(SchemaError);
-    });
-});
-
-describeParity('migrate_file — on-disk byte parity vs python3', () => {
-    it('produces byte-identical v1 output on both engines', () => {
-        const fixture = JSON.stringify({
-            ticket: { id: 'T-7', title: 'Parity' },
-            persona: 'qa',
-            outcomes: { refine: 'success' },
-        });
-
-        // TS engine.
-        const tsSrc = path.join(tmp, 'ts', DEFAULT_V0_FILENAME);
-        fs.mkdirSync(path.dirname(tsSrc), { recursive: true });
-        fs.writeFileSync(tsSrc, fixture, 'utf-8');
-        const tsTarget = migrate_file(tsSrc);
-        const tsBytes = fs.readFileSync(tsTarget, 'utf-8');
-
-        // Python engine, separate dir.
-        const pyDir = path.join(tmp, 'py');
-        fs.mkdirSync(pyDir, { recursive: true });
-        fs.writeFileSync(path.join(pyDir, DEFAULT_V0_FILENAME), fixture, 'utf-8');
-        const r = pyCli(pyDir, [DEFAULT_V0_FILENAME]);
-        expect(r.status).toBe(0);
-        const pyBytes = fs.readFileSync(path.join(pyDir, DEFAULT_V1_FILENAME), 'utf-8');
-
-        expect(tsBytes).toBe(pyBytes);
-    });
-});
-
-describeParity('main — CLI exit codes', () => {
-    it('exits 0 and prints the migration line on success', () => {
-        const pyDir = path.join(tmp, 'pyok');
-        fs.mkdirSync(pyDir, { recursive: true });
-        fs.writeFileSync(path.join(pyDir, DEFAULT_V0_FILENAME), JSON.stringify({ ticket: { id: 'X' } }), 'utf-8');
-        const r = pyCli(pyDir, [DEFAULT_V0_FILENAME]);
-        expect(r.status).toBe(0);
-        expect(r.stdout).toContain('migrated');
-
-        // TS main() in the same shape.
-        const tsDir = path.join(tmp, 'tsok');
-        fs.mkdirSync(tsDir, { recursive: true });
-        const tsSrc = path.join(tsDir, DEFAULT_V0_FILENAME);
-        fs.writeFileSync(tsSrc, JSON.stringify({ ticket: { id: 'X' } }), 'utf-8');
-        const rc = main([tsSrc]);
-        expect(rc).toBe(0);
-    });
-
-    it('exits 2 on a missing source', () => {
-        const pyDir = path.join(tmp, 'pyerr');
-        fs.mkdirSync(pyDir, { recursive: true });
-        const r = pyCli(pyDir, ['nonexistent.json']);
-        expect(r.status).toBe(2);
-        expect(r.stderr).toContain('error:');
-
-        const rc = main([path.join(tmp, 'also-missing.json')]);
-        expect(rc).toBe(2);
     });
 });

--- a/tests/scripts/work_engine/persona_policy.test.ts
+++ b/tests/scripts/work_engine/persona_policy.test.ts
@@ -1,15 +1,8 @@
-// Golden-parity tests for work_engine/persona_policy.ts vs persona_policy.py
-// (ADR-094 py2ts Phase 1). Covers: every shipped persona resolves to the right
-// policy flags, the default-on-miss fallback (None / unknown / non-string), and
-// known_personas insertion order. The Python side is loaded via a direct-file
-// importlib loader (sys.modules registered before exec so the CPython-3.9
-// dataclass `__module__` lookup succeeds; work_engine dir + repo on sys.path).
-// Policy objects are compared as asdict() dicts to assert field-name + value
+// Tests for work_engine/persona_policy.ts (ADR-094 py2ts Phase 1). Covers:
+// every shipped persona resolves to the right policy flags, the default-on-miss
+// fallback (None / unknown / non-string), and known_personas insertion order.
+// Policy objects are projected to asdict() dicts to assert field-name + value
 // parity in declaration order.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { describe, expect, it } from 'vitest';
 
 import type {
@@ -19,36 +12,6 @@ import {
     known_personas,
     resolve_policy,
 } from '../../../src/agent-src/templates/scripts/work_engine/persona_policy.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const WE = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts', 'work_engine');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function pyLoaderPreamble(): string {
-    return [
-        'import importlib.util, sys, json, pathlib, dataclasses',
-        `WE = pathlib.Path(${JSON.stringify(WE)})`,
-        `REPO = pathlib.Path(${JSON.stringify(REPO_ROOT)})`,
-        'sys.path.insert(0, str(WE)); sys.path.insert(0, str(REPO))',
-        'def _load(name):',
-        '    sp = importlib.util.spec_from_file_location("we_"+name, WE / (name + ".py"))',
-        '    m = importlib.util.module_from_spec(sp)',
-        '    sys.modules[sp.name] = m',
-        '    sp.loader.exec_module(m)',
-        '    return m',
-    ].join('\n');
-}
-
-function py(body: string): string {
-    const r = spawnSync('python3', ['-c', `${pyLoaderPreamble()}\n${body}`], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr}`);
-    }
-    return r.stdout.trim();
-}
 
 /** asdict-equivalent projection of a TS PersonaPolicy, in Python field order. */
 function asdict(p: PersonaPolicy): Record<string, unknown> {
@@ -113,45 +76,5 @@ describe('work_engine/persona_policy', () => {
         expect(() => {
             (p as unknown as { widen_tests: boolean }).widen_tests = false;
         }).toThrow();
-    });
-
-    describe.runIf(hasPython3())('python parity', () => {
-        const personas = ['senior-engineer', 'qa', 'advisory', 'bogus', ''];
-
-        it.each(personas)('resolve_policy(%j) asdict matches CPython', (persona) => {
-            const oracle = py(
-                'm=_load("persona_policy")\n' +
-                    `print(json.dumps(dataclasses.asdict(m.resolve_policy(${JSON.stringify(persona)}))))`,
-            );
-            const expected = JSON.parse(oracle) as Record<string, unknown>;
-            expect(asdict(resolve_policy(persona))).toEqual(expected);
-        });
-
-        it('resolve_policy(None) asdict matches CPython', () => {
-            const oracle = py(
-                'm=_load("persona_policy")\n' +
-                    'print(json.dumps(dataclasses.asdict(m.resolve_policy(None))))',
-            );
-            expect(asdict(resolve_policy(null))).toEqual(JSON.parse(oracle));
-        });
-
-        it('known_personas matches CPython', () => {
-            const oracle = py(
-                'm=_load("persona_policy")\nprint(json.dumps(list(m.known_personas())))',
-            );
-            expect(known_personas()).toEqual(JSON.parse(oracle));
-        });
-
-        it('DEFAULT_PERSONA + __all__ match CPython', () => {
-            const oracle = py(
-                'm=_load("persona_policy")\n' +
-                    'print(json.dumps({"default": m.DEFAULT_PERSONA, "all": sorted(m.__all__)}))',
-            );
-            const expected = JSON.parse(oracle) as { default: string; all: string[] };
-            expect(DEFAULT_PERSONA).toBe(expected.default);
-            expect(expected.all).toEqual(
-                ['DEFAULT_PERSONA', 'PersonaPolicy', 'known_personas', 'resolve_policy'].sort(),
-            );
-        });
     });
 });

--- a/tests/scripts/work_engine/stack_detect.test.ts
+++ b/tests/scripts/work_engine/stack_detect.test.ts
@@ -1,128 +1,34 @@
-// Golden-parity rig for the py2ts work_engine `stack/detect` twin (ADR-094).
+// Intent tests for the py2ts work_engine `stack/detect` twin (ADR-094 / ADR-200).
 //
-// `work_engine/stack/detect.py` is a leaf module with NO intra-`work_engine`
-// imports — stdlib only. To exercise it from python3 without importing the
-// whole `work_engine` package (whose `__init__` pulls in unported siblings),
-// we load `detect.py` via a direct-file `importlib` loader, registering the
-// module in `sys.modules` BEFORE `exec_module` so the dataclass field-type
-// resolution (under `from __future__ import annotations`) finds the module.
-// This is the same loader pattern the merged `state.test.ts` uses.
+// Was a python3-vs-tsx byte-parity rig; the python side is dropped — this now
+// exercises the `.ts` module's own contract in-process. `detect.ts` is a leaf
+// module (stdlib-only, no intra-`work_engine` imports) so the detection logic
+// can be driven directly via the imported `detect_stack` / `latest_manifest_mtime`
+// without spawning anything.
 //
 // Each block builds a fake project tree (composer.json / package.json /
-// components.json) in a tmp dir, runs `detect_stack` on BOTH engines, and
-// asserts byte-identical observable output. The serialised view is
-// `{frontend, has_mtime}` rather than the raw `mtime` float: `mtime` is the
-// filesystem `st_mtime`, whose exact float byte-repr is not reproducible
-// across CPython and V8 for sub-second timestamps (see the note in
-// `detect.ts::_stat_mtime`). We assert the deterministic detection label
-// byte-for-byte, plus the `mtime == 0.0` / `mtime > 0.0` discriminator that
-// the cache-invalidation contract actually depends on.
-import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+// components.json) in a tmp dir and asserts the deterministic detection label
+// plus the `mtime == 0.0` / `mtime > 0.0` discriminator that the
+// cache-invalidation contract actually depends on. The serialised view is
+// `{frontend, has_mtime}` rather than the raw `mtime` float, whose exact
+// byte-repr is filesystem-derived and not part of the detection contract.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
     DEFAULT_STACK,
     KNOWN_STACKS,
     StackResult,
+    detect_stack,
     latest_manifest_mtime,
 } from '../../../src/agent-src/templates/scripts/work_engine/stack/detect.js';
 
-// tests/scripts/work_engine/stack_detect.test.ts → four levels up is repo root.
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-
-const DETECT_PY = path.join(
-    REPO_ROOT,
-    'src',
-    'agent-src',
-    'templates',
-    'scripts',
-    'work_engine',
-    'stack',
-    'detect.py',
-);
-
-const TSX_BIN = process.env.TSX_BIN ?? path.join('node_modules', '.bin', 'tsx');
-const DETECT_TS = path.join(
-    REPO_ROOT,
-    'src',
-    'agent-src',
-    'templates',
-    'scripts',
-    'work_engine',
-    'stack',
-    'detect.ts',
-);
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/**
- * Run a python3 snippet with `detect.py` loaded as the module `detect`
- * (direct-file importlib loader; `sys.modules` registration handles the
- * `from __future__ import annotations` dataclass type resolution). `args`
- * become `sys.argv[1:]`.
- */
-function runPyWithDetect(body: string, args: string[] = []): SpawnSyncReturns<string> {
-    const loader = [
-        'import sys, json, pathlib, importlib.util',
-        `spec = importlib.util.spec_from_file_location("detect", ${JSON.stringify(DETECT_PY)})`,
-        'detect = importlib.util.module_from_spec(spec)',
-        'sys.modules["detect"] = detect',
-        'spec.loader.exec_module(detect)',
-    ].join('\n');
-    const code = `${loader}\n${body}`;
-    return spawnSync('python3', ['-c', code, ...args], { encoding: 'utf8' });
-}
-
-/** python3: `detect_stack(root)` → `{"frontend": ..., "has_mtime": bool}`. */
-function pyDetect(root: string): string {
-    // Compact separators (`","` / `":"`) so the Python view is byte-identical
-    // to JS `JSON.stringify` — `detect` itself never serialises, so the
-    // separator choice is the harness's, not part of the twin contract.
-    const body = [
-        'root = pathlib.Path(sys.argv[1])',
-        'r = detect.detect_stack(root)',
-        'sys.stdout.write(json.dumps({"frontend": r.frontend, "has_mtime": r.mtime > 0.0}, separators=(",", ":")))',
-    ].join('\n');
-    const r = runPyWithDetect(body, [root]);
-    if (r.status !== 0) {
-        throw new Error(`python3 detect failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-/**
- * tsx: same observable view, exercised via the `.ts` module per ADR-094.
- * Root is passed via env (`tsx -e` shifts argv indices; env is unambiguous).
- */
-function tsDetect(root: string): string {
-    const code = [
-        `import { detect_stack } from ${JSON.stringify(DETECT_TS)};`,
-        'const root = process.env.P2T_ROOT as string;',
-        'const r = detect_stack(root);',
-        'process.stdout.write(JSON.stringify({ frontend: r.frontend, has_mtime: r.mtime > 0.0 }));',
-    ].join('\n');
-    const r = spawnSync(TSX_BIN, ['-e', code], {
-        encoding: 'utf8',
-        env: { ...process.env, P2T_ROOT: root },
-    });
-    if (r.status !== 0) {
-        throw new Error(`tsx detect failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-/** Assert python3 and tsx agree byte-for-byte on the observable view. */
-function expectParity(root: string): string {
-    const py = pyDetect(root);
-    const ts = tsDetect(root);
-    expect(ts).toBe(py);
-    return py;
+/** Detection result rendered to the deterministic `{frontend, has_mtime}` view. */
+function detectView(root: string): string {
+    const r = detect_stack(root);
+    return JSON.stringify({ frontend: r.frontend, has_mtime: r.mtime > 0.0 });
 }
 
 let tmp: string;
@@ -159,13 +65,10 @@ describe('stack/detect — module constants parity', () => {
     });
 });
 
-const py3 = hasPython3();
-const golden = py3 ? describe : describe.skip;
-
-golden('stack/detect — golden parity (python3 vs tsx)', () => {
+describe('stack/detect — detection logic', () => {
     it('blade-livewire-flux: composer has livewire + flux', () => {
         write('composer.json', JSON.stringify({ require: { 'livewire/livewire': '^3', 'livewire/flux': '^1' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
     });
 
     it('blade-livewire-flux: flux in require-dev still counts', () => {
@@ -173,56 +76,56 @@ golden('stack/detect — golden parity (python3 vs tsx)', () => {
             'composer.json',
             JSON.stringify({ require: { 'livewire/livewire': '^3' }, 'require-dev': { 'livewire/flux': '^1' } }),
         );
-        expect(expectParity(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
     });
 
     it('NOT blade-livewire-flux: livewire without flux falls through', () => {
         write('composer.json', JSON.stringify({ require: { 'livewire/livewire': '^3' } }));
         // No package.json → next branch fails too → plain.
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
     });
 
     it('react-shadcn: react + @radix-ui/* dependency', () => {
         write('package.json', JSON.stringify({ dependencies: { react: '^18', '@radix-ui/react-slot': '^1' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
     });
 
     it('react-shadcn: react + shadcn-ui package', () => {
         write('package.json', JSON.stringify({ dependencies: { react: '^18', 'shadcn-ui': '^0' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
     });
 
     it('react-shadcn: react + components.json marker file', () => {
         write('package.json', JSON.stringify({ dependencies: { react: '^18' } }));
         write('components.json', '{}');
-        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
     });
 
     it('NOT react-shadcn: components.json present but no react → plain', () => {
         write('package.json', JSON.stringify({ dependencies: { lodash: '^4' } }));
         write('components.json', '{}');
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
     });
 
     it('NOT react-shadcn: react alone (no radix/shadcn/components) → plain', () => {
         write('package.json', JSON.stringify({ dependencies: { react: '^18' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
     });
 
     it('vue: package lists vue, no react', () => {
         write('package.json', JSON.stringify({ dependencies: { vue: '^3' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"vue","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"vue","has_mtime":true}');
     });
 
     it('vue via devDependencies', () => {
         write('package.json', JSON.stringify({ devDependencies: { vue: '^2' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"vue","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"vue","has_mtime":true}');
     });
 
     it('precedence: blade wins over react when both manifests qualify', () => {
         write('composer.json', JSON.stringify({ require: { 'livewire/livewire': '^3', 'livewire/flux': '^1' } }));
         write('package.json', JSON.stringify({ dependencies: { react: '^18', '@radix-ui/x': '^1' } }));
-        expect(expectParity(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"blade-livewire-flux","has_mtime":true}');
     });
 
     it('precedence: react-shadcn wins over vue when both react+radix and vue present', () => {
@@ -230,43 +133,32 @@ golden('stack/detect — golden parity (python3 vs tsx)', () => {
             'package.json',
             JSON.stringify({ dependencies: { react: '^18', '@radix-ui/x': '^1', vue: '^3' } }),
         );
-        expect(expectParity(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"react-shadcn","has_mtime":true}');
     });
 
     it('greenfield: no manifests → plain, mtime 0.0', () => {
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":false}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":false}');
     });
 
     it('malformed composer.json degrades to {} (no crash) → plain', () => {
         write('composer.json', '{ this is not json');
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
     });
 
     it('non-dict JSON payload (a list) degrades to {} → plain', () => {
         write('package.json', '[1, 2, 3]');
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
     });
 
     it('non-dict dependency section (require is a string) is ignored', () => {
         write('composer.json', JSON.stringify({ require: 'not-a-dict' }));
-        expect(expectParity(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
+        expect(detectView(tmp)).toBe('{"frontend":"plain","has_mtime":true}');
     });
 
     it('latest_manifest_mtime: only composer/package count, not components.json', () => {
         // components.json carries no mtime weight; with only it present mtime
-        // stays 0.0. Assert on both engines.
+        // stays 0.0.
         write('components.json', '{}');
-        const body = [
-            'root = pathlib.Path(sys.argv[1])',
-            'sys.stdout.write(json.dumps({"zero": detect.latest_manifest_mtime(root) == 0.0}))',
-        ].join('\n');
-        const r = runPyWithDetect(body, [tmp]);
-        expect(r.status).toBe(0);
-        // Python emits spaced JSON (`": "`); compare the parsed boolean rather
-        // than byte-comparing against in-process JS `JSON.stringify` output.
-        const py = JSON.parse(r.stdout) as { zero: boolean };
-        const ts = latest_manifest_mtime(tmp) === 0.0;
-        expect(ts).toBe(py.zero);
-        expect(py.zero).toBe(true);
+        expect(latest_manifest_mtime(tmp)).toBe(0.0);
     });
 });

--- a/tests/scripts/work_engine/stack_runner.test.ts
+++ b/tests/scripts/work_engine/stack_runner.test.ts
@@ -1,30 +1,25 @@
-// Golden-parity rig for the py2ts work_engine `stack/runner` twin (ADR-094).
+// Intent tests for the py2ts work_engine `stack/runner` twin (ADR-094 / ADR-200).
 //
-// `work_engine/stack/runner.py` is a leaf module with NO intra-`work_engine`
-// imports — stdlib only. We load it from python3 via the same direct-file
-// `importlib` loader the merged `state.test.ts` / `stack_detect.test.ts` use,
-// registering the module in `sys.modules` BEFORE `exec_module` so dataclass
-// field-type resolution (under `from __future__ import annotations`) resolves.
+// Was a python3-vs-tsx byte-parity rig; the python side is dropped — this now
+// exercises the `.ts` module's own contract in-process. `runner.ts` is a leaf
+// module (stdlib-only, no intra-`work_engine` imports) so the resolver can be
+// driven directly via the imported `resolve_toolchain` / `write_config` without
+// spawning anything.
 //
 // Each block builds a fake project tree (composer.json / package.json /
 // pyproject.toml / go.mod / Cargo.toml / Makefile / Taskfile.yml) in a tmp dir
-// and asserts byte-identical observable output from python3 and tsx. Two views:
+// and asserts the observable output. Two views:
 //
-//  - `resolve_toolchain` → its `to_config()` dict, serialised compactly
-//    (`separators=(",", ":")` on the Python side, `JSON.stringify` on the JS
-//    side) with the non-deterministic `mtime` float NORMALISED to the sentinel
-//    string `"<mtime>"` on BOTH engines. `mtime` is the filesystem `st_mtime`,
-//    whose exact float byte-repr is not reproducible across CPython/V8 for
-//    sub-second timestamps (see `runner.ts::_stat_mtime`); everything else in
-//    the config IS deterministic and compared byte-for-byte.
+//  - `resolve_toolchain` → its `to_config()` dict, serialised compactly with the
+//    non-deterministic `mtime` float NORMALISED to the sentinel string
+//    `"<mtime>"` (its exact byte-repr is filesystem-derived, not part of the
+//    contract); everything else IS deterministic and asserted directly.
 //  - `write_config` → the on-disk file bytes (incl. `sort_keys=True` + the
-//    trailing `\n`), again with `mtime` normalised. This exercises the
-//    `json.dumps(..., indent=2, sort_keys=True)` serialiser directly.
-import { spawnSync } from 'node:child_process';
+//    trailing `\n`), again with `mtime` normalised — exercises the
+//    indent-2 / sort-keys serialiser directly.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -37,18 +32,9 @@ import {
     SPEED_FAST,
     SPEED_SLOW,
     ToolchainResult,
+    resolve_toolchain,
+    write_config,
 } from '../../../src/agent-src/templates/scripts/work_engine/stack/runner.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-
-const WE = ['src', 'agent-src', 'templates', 'scripts', 'work_engine', 'stack'];
-const RUNNER_PY = path.join(REPO_ROOT, ...WE, 'runner.py');
-const RUNNER_TS = path.join(REPO_ROOT, ...WE, 'runner.ts');
-const TSX_BIN = process.env.TSX_BIN ?? path.join('node_modules', '.bin', 'tsx');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 interface Flags {
     include_slow?: boolean;
@@ -57,108 +43,22 @@ interface Flags {
 }
 
 /**
- * python3: `resolve_toolchain(root, **flags).to_config()` → compact JSON with
- * `mtime` normalised to the sentinel so the float repr never enters the
- * comparison. The direct-file importlib loader registers the module first.
+ * `resolve_toolchain(root, flags).to_config()` → compact JSON with `mtime`
+ * normalised to the sentinel so the float repr never enters the comparison.
  */
-function pyConfig(root: string, flags: Flags): string {
-    const loader = [
-        'import sys, json, pathlib, importlib.util',
-        `spec = importlib.util.spec_from_file_location("runner", ${JSON.stringify(RUNNER_PY)})`,
-        'runner = importlib.util.module_from_spec(spec)',
-        'sys.modules["runner"] = runner',
-        'spec.loader.exec_module(runner)',
-    ].join('\n');
-    const body = [
-        'root = pathlib.Path(sys.argv[1])',
-        'flags = json.loads(sys.argv[2])',
-        'res = runner.resolve_toolchain(root, **flags)',
-        'cfg = res.to_config()',
-        'cfg["mtime"] = "<mtime>"',
-        'sys.stdout.write(json.dumps(cfg, separators=(",", ":")))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', `${loader}\n${body}`, root, JSON.stringify(flags)], {
-        encoding: 'utf8',
-    });
-    if (r.status !== 0) {
-        throw new Error(`python3 config failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
+function config(root: string, flags: Flags = {}): string {
+    const res = resolve_toolchain(root, flags);
+    const cfg = res.to_config() as Record<string, unknown>;
+    cfg.mtime = '<mtime>';
+    return JSON.stringify(cfg);
 }
 
-/** tsx: same observable view via the `.ts` module. Root + flags passed via env. */
-function tsConfig(root: string, flags: Flags): string {
-    const code = [
-        `import { resolve_toolchain } from ${JSON.stringify(RUNNER_TS)};`,
-        'const root = process.env.P2T_ROOT as string;',
-        'const flags = JSON.parse(process.env.P2T_FLAGS as string);',
-        'const res = resolve_toolchain(root, flags);',
-        'const cfg = res.to_config() as Record<string, unknown>;',
-        'cfg.mtime = "<mtime>";',
-        'process.stdout.write(JSON.stringify(cfg));',
-    ].join('\n');
-    const r = spawnSync(TSX_BIN, ['-e', code], {
-        encoding: 'utf8',
-        env: { ...process.env, P2T_ROOT: root, P2T_FLAGS: JSON.stringify(flags) },
-    });
-    if (r.status !== 0) {
-        throw new Error(`tsx config failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-/** python3: `write_config` → on-disk bytes, `mtime` normalised, incl. \n. */
-function pyWriteConfig(root: string): string {
-    const loader = [
-        'import sys, json, re, pathlib, importlib.util',
-        `spec = importlib.util.spec_from_file_location("runner", ${JSON.stringify(RUNNER_PY)})`,
-        'runner = importlib.util.module_from_spec(spec)',
-        'sys.modules["runner"] = runner',
-        'spec.loader.exec_module(runner)',
-    ].join('\n');
-    const body = [
-        'root = pathlib.Path(sys.argv[1])',
-        'res = runner.resolve_toolchain(root)',
-        'target = runner.write_config(root, res)',
-        'text = pathlib.Path(target).read_text(encoding="utf-8")',
-        // Normalise the single `"mtime": <float>,` line to a sentinel.
-        'text = re.sub(r\'"mtime": [0-9.]+\', \'"mtime": "<mtime>"\', text)',
-        'sys.stdout.write(text)',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', `${loader}\n${body}`, root], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 write_config failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-/** tsx: `write_config` → on-disk bytes, `mtime` normalised, incl. \n. */
-function tsWriteConfig(root: string): string {
-    const code = [
-        `import { resolve_toolchain, write_config } from ${JSON.stringify(RUNNER_TS)};`,
-        'import * as fs from "node:fs";',
-        'const root = process.env.P2T_ROOT as string;',
-        'const res = resolve_toolchain(root);',
-        'const target = write_config(root, res);',
-        'let text = fs.readFileSync(target, { encoding: "utf-8" });',
-        'text = text.replace(/"mtime": [0-9.]+/, \'"mtime": "<mtime>"\');',
-        'process.stdout.write(text);',
-    ].join('\n');
-    const r = spawnSync(TSX_BIN, ['-e', code], {
-        encoding: 'utf8',
-        env: { ...process.env, P2T_ROOT: root },
-    });
-    if (r.status !== 0) {
-        throw new Error(`tsx write_config failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
-function expectConfigParity(root: string, flags: Flags = {}): string {
-    const py = pyConfig(root, flags);
-    const ts = tsConfig(root, flags);
-    expect(ts).toBe(py);
-    return py;
+/** `write_config` → on-disk bytes, `mtime` normalised, incl. trailing `\n`. */
+function writeConfigText(root: string): string {
+    const res = resolve_toolchain(root);
+    const target = write_config(root, res);
+    const text = fs.readFileSync(target, { encoding: 'utf-8' });
+    return text.replace(/"mtime": [0-9.]+/, '"mtime": "<mtime>"');
 }
 
 let tmp: string;
@@ -217,13 +117,10 @@ describe('stack/runner — module constants parity', () => {
     });
 });
 
-const py3 = hasPython3();
-const golden = py3 ? describe : describe.skip;
-
-golden('stack/runner — golden parity (python3 vs tsx)', () => {
+describe('stack/runner — toolchain resolution', () => {
     // ── empty / no-match ─────────────────────────────────────────────────
     it('greenfield: no manifest → LOW confidence, empty inventory', () => {
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect(cfg.confidence).toBe('LOW');
         expect(cfg.runners).toEqual([]);
         expect(cfg.selected).toEqual([]);
@@ -232,31 +129,35 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
     // ── PHP branches ─────────────────────────────────────────────────────
     it('php: pest in composer require', () => {
         write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('pest');
     });
 
     it('php: vendor/bin/pest binary (no dep) wins over phpunit', () => {
         write('composer.json', JSON.stringify({ require: {} }));
         write('vendor/bin/pest', '#!/usr/bin/env php\n');
-        expectConfigParity(tmp);
+        // Exercises the binary-detection branch; assertion is the snapshot-free
+        // structural shape below.
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('pest');
     });
 
     it('php: artisan present → phpunit via php artisan test', () => {
         write('composer.json', JSON.stringify({ require: {} }));
         write('artisan', '#!/usr/bin/env php\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { command: string }[])[0]!.command).toBe('php artisan test');
     });
 
     it('php: phpunit/phpunit dependency', () => {
         write('composer.json', JSON.stringify({ 'require-dev': { 'phpunit/phpunit': '^11' } }));
-        expectConfigParity(tmp);
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
+        expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('phpunit');
     });
 
     it('php: composer.json with no runner → MEDIUM phpunit default', () => {
         write('composer.json', JSON.stringify({ require: { 'monolog/monolog': '^3' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect(cfg.confidence).toBe('MEDIUM');
         expect((cfg.runners as { confidence: string }[])[0]!.confidence).toBe('MEDIUM');
     });
@@ -266,28 +167,28 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             'composer.json',
             JSON.stringify({ 'require-dev': { 'phpstan/phpstan': '^1', 'laravel/pint': '^1' } }),
         );
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect(cfg.quality).toEqual(['vendor/bin/phpstan analyse', 'vendor/bin/pint']);
     });
 
     it('php: Makefile test wrapper wins over the direct tool', () => {
         write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
         write('Makefile', 'test:\n\t./vendor/bin/pest\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { command: string }[])[0]!.command).toBe('make test');
     });
 
     it('php: Taskfile test wrapper (no Makefile)', () => {
         write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
         write('Taskfile.yml', "version: '3'\ntasks:\n  test:\n    cmds:\n      - vendor/bin/pest\n");
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { command: string }[])[0]!.command).toBe('task test');
     });
 
     // ── JS branches ──────────────────────────────────────────────────────
     it('js: vitest beats jest when both present', () => {
         write('package.json', JSON.stringify({ devDependencies: { vitest: '^1', jest: '^29' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('vitest');
         expect((cfg.runners as { command: string }[])[0]!.command).toBe('npx vitest run');
     });
@@ -297,19 +198,19 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             'package.json',
             JSON.stringify({ devDependencies: { vitest: '^1' }, scripts: { test: 'vitest run' } }),
         );
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { command: string }[])[0]!.command).toBe('npm test');
     });
 
     it('js: jest only', () => {
         write('package.json', JSON.stringify({ devDependencies: { jest: '^29' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('jest');
     });
 
     it('js: test script with unclear runner → MEDIUM jest', () => {
         write('package.json', JSON.stringify({ scripts: { test: 'node ./run-tests.js' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { confidence: string }[])[0]!.confidence).toBe('MEDIUM');
     });
 
@@ -318,7 +219,7 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             'package.json',
             JSON.stringify({ devDependencies: { vitest: '^1', '@playwright/test': '^1' } }),
         );
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         // Inventory has both; selected (default guard) drops the e2e command.
         expect((cfg.runners as unknown[]).length).toBe(2);
         expect((cfg.selected as string[])).toEqual(['npx vitest run']);
@@ -329,7 +230,7 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             'package.json',
             JSON.stringify({ devDependencies: { vitest: '^1', '@playwright/test': '^1' } }),
         );
-        const cfg = JSON.parse(expectConfigParity(tmp, { include_e2e: true })) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp, { include_e2e: true })) as Record<string, unknown>;
         expect((cfg.selected as string[]).length).toBe(2);
     });
 
@@ -338,7 +239,7 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             'package.json',
             JSON.stringify({ devDependencies: { cypress: '^13' }, scripts: { 'test:e2e': 'cypress run' } }),
         );
-        const cfg = JSON.parse(expectConfigParity(tmp, { include_e2e: true })) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp, { include_e2e: true })) as Record<string, unknown>;
         const e2e = (cfg.runners as { runner: string; command: string }[]).find((r) => r.runner === 'cypress');
         expect(e2e?.command).toBe('npm run test:e2e');
     });
@@ -348,15 +249,15 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             'package.json',
             JSON.stringify({ devDependencies: { vitest: '^1' }, scripts: { 'test:slow': 'vitest run slow' } }),
         );
-        const def = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const def = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((def.selected as string[]).length).toBe(1);
-        const slow = JSON.parse(expectConfigParity(tmp, { include_slow: true })) as Record<string, unknown>;
+        const slow = JSON.parse(config(tmp, { include_slow: true })) as Record<string, unknown>;
         expect((slow.selected as string[]).length).toBe(2);
     });
 
     it('js quality: typescript + eslint', () => {
         write('package.json', JSON.stringify({ devDependencies: { typescript: '^5', eslint: '^9' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect(cfg.quality).toEqual(['npx tsc --noEmit', 'npx eslint .']);
     });
 
@@ -366,14 +267,14 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
             JSON.stringify({ devDependencies: { vitest: '^1' }, scripts: { test: 'vitest run' } }),
         );
         write('pnpm-lock.yaml', 'lockfileVersion: 9\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { command: string }[])[0]!.command).toBe('pnpm test');
     });
 
     // ── Python branches ──────────────────────────────────────────────────
     it('python: pyproject mentions pytest → HIGH', () => {
         write('pyproject.toml', '[tool.pytest.ini_options]\naddopts = "-q"\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { runner: string; confidence: string }[])[0]).toMatchObject({
             runner: 'pytest',
             confidence: 'HIGH',
@@ -382,27 +283,27 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
 
     it('python: requirements.txt only → MEDIUM pytest', () => {
         write('requirements.txt', 'requests\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { confidence: string }[])[0]!.confidence).toBe('MEDIUM');
     });
 
     it('python quality: ruff + mypy from pyproject text', () => {
         write('pyproject.toml', '[tool.ruff]\n[tool.mypy]\n[tool.pytest.ini_options]\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect(cfg.quality).toEqual(['ruff check', 'mypy .']);
     });
 
     // ── Go / Rust ────────────────────────────────────────────────────────
     it('go: go.mod present', () => {
         write('go.mod', 'module example.com/x\n\ngo 1.22\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('go-test');
         expect(cfg.quality).toEqual(['go vet ./...']);
     });
 
     it('rust: Cargo.toml present', () => {
         write('Cargo.toml', '[package]\nname = "x"\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect((cfg.runners as { runner: string }[])[0]!.runner).toBe('cargo-test');
         expect(cfg.quality).toEqual(['cargo clippy']);
     });
@@ -413,46 +314,26 @@ golden('stack/runner — golden parity (python3 vs tsx)', () => {
         write('package.json', JSON.stringify({ devDependencies: { vitest: '^1' } }));
         write('pyproject.toml', '[tool.pytest.ini_options]\n');
         write('go.mod', 'module x\n');
-        const cfg = JSON.parse(expectConfigParity(tmp)) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp)) as Record<string, unknown>;
         expect(cfg.ecosystems).toEqual(['php', 'js', 'python', 'go']);
     });
 
     it('monorepo: --php narrows selected to PHP only', () => {
         write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
         write('package.json', JSON.stringify({ devDependencies: { vitest: '^1' } }));
-        const cfg = JSON.parse(expectConfigParity(tmp, { php_only: true })) as Record<string, unknown>;
+        const cfg = JSON.parse(config(tmp, { php_only: true })) as Record<string, unknown>;
         // Full inventory keeps both; selected is PHP-only.
         expect((cfg.runners as unknown[]).length).toBe(2);
         expect((cfg.selected as string[])).toEqual(['vendor/bin/pest']);
     });
 
-    // ── write_config byte-parity ─────────────────────────────────────────
-    it('write_config: byte-identical on-disk file (sort_keys + trailing \\n)', () => {
+    // ── write_config byte shape ──────────────────────────────────────────
+    it('write_config: on-disk file (sort_keys + trailing \\n)', () => {
         write('composer.json', JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
         write('package.json', JSON.stringify({ devDependencies: { vitest: '^1', eslint: '^9' } }));
-        const py = pyWriteConfig(tmp);
-        // Fresh tmp for the TS write so the two don't race on the same target,
-        // but identical inputs → identical config. Re-create the same tree.
-        const tmp2 = fs.mkdtempSync(path.join(os.tmpdir(), 'p2t-runner-w-'));
-        try {
-            fs.writeFileSync(path.join(tmp2, 'composer.json'), JSON.stringify({ require: { 'pestphp/pest': '^2' } }));
-            fs.writeFileSync(
-                path.join(tmp2, 'package.json'),
-                JSON.stringify({ devDependencies: { vitest: '^1', eslint: '^9' } }),
-            );
-            const ts = (function () {
-                const saved = process.env.P2T_ROOT;
-                process.env.P2T_ROOT = tmp2;
-                const out = tsWriteConfig(tmp2);
-                process.env.P2T_ROOT = saved;
-                return out;
-            })();
-            expect(ts).toBe(py);
-            // Sanity: the file ends with a newline and sorts keys.
-            expect(py.endsWith('\n')).toBe(true);
-            expect(py.indexOf('"confidence"')).toBeLessThan(py.indexOf('"ecosystems"'));
-        } finally {
-            fs.rmSync(tmp2, { recursive: true, force: true });
-        }
+        const text = writeConfigText(tmp);
+        // The file ends with a newline and sorts keys.
+        expect(text.endsWith('\n')).toBe(true);
+        expect(text.indexOf('"confidence"')).toBeLessThan(text.indexOf('"ecosystems"'));
     });
 });


### PR DESCRIPTION
## What

De-pythonizes two coherent clusters of obsolete python3-vs-tsx parity rigs, completing the mechanical/tractable part of the py2ts teardown tail.

**`cli/python/workspace_*` (12 files)** — converted to python-free intent tests asserting the tsx CLI contract via inline snapshots under a deterministic env (node-only PATH so host-CLI detection is fixed; `COLUMNS`; reused `norm()` masking for clock/random/mtime/tmp-paths; round-trip+structural for randomized crypto). +346 real tests (were skipped parity blocks).

**`work_engine/*` (21 files)** — MIXED files had only their python parity block + dead `hasPython3`/`runPy`/`PY_SCRIPT` helpers removed (all TS-side coverage kept); pure in-process rigs converted to intent tests asserting the module's own `run()` output.

Follows the determinism approach documented in #643 (merged): a parity rig agrees byte-for-byte even when output is machine-dependent, so each conversion pins the file's determinism contract before snapshotting.

## Verification

- Every converted file passes with `python3` shadowed by a failing stub → **proven python-free by construction**, not by a skip-gate.
- Full suite: **5239 passed** (+470 real coverage over the pre-session baseline of 4769), **31 failures unchanged** (pre-existing build-artefact e2e/ui files needing `dist/cli`+UI build), no regression.
- Zero python-spawn residue in all 33 changed files.

## Scope

33 of the ~144-file spawn tail. Remaining ~108 are heterogeneous (delete-candidates covered by sibling tests, shared helper modules, singletons) and tracked in `road-to-py2ts-teardown-completion.md`; the shim + scaffolding workflows stay until they're done. Deferred within these clusters: `work_engine/_hooks_pyloader.ts` (shared helper, 11 importers) + 4 `directives_*` files an interrupted agent didn't reach.