### PR TITLE
feat(bench): pair-capture seam for recursion arm (human-preference pretest)

### DIFF
--- a/src/scripts/bench_ab_v2_run.ts
+++ b/src/scripts/bench_ab_v2_run.ts
@@ -211,6 +211,7 @@ export function run_one(task: Dict, arm: string, opts: RunOneOpts): Dict {
 export interface RecursiveAttempt {
     run: Dict;
     score: scoring.ScoreResultV2;
+    output?: string; // pair-capture: changed-file contents at this depth (for human-preference judging)
 }
 
 /**
@@ -235,6 +236,7 @@ export function run_one_recursive(
     task: Dict,
     opts: RunOneOpts,
     attemptFn?: (depth: number, priorVerdict: string | null) => RecursiveAttempt,
+    onAttempt?: (depth: number, attempt: RecursiveAttempt) => void,
 ): Dict {
     const maxDepth = Math.max(0, opts.max_depth ?? 1);
     const makeAttempt =
@@ -257,7 +259,19 @@ export function run_one_recursive(
                 clone_root: clone,
                 transcript: String(run['transcript'] ?? ''),
             });
-            return { run, score };
+            // Capture the attempt's output (changed-file contents) for the
+            // human-preference pair, before the next depth resets the clone.
+            const output = score.files_changed
+                .map((f: string) => {
+                    try {
+                        return `--- ${f} ---\n${fs.readFileSync(path.join(clone, f), 'utf-8')}`;
+                    } catch {
+                        return `--- ${f} --- (unreadable)`;
+                    }
+                })
+                .join('\n\n')
+                .slice(0, 4000);
+            return { run, score, output };
         });
 
     const accepts = (s: scoring.ScoreResultV2): boolean => Boolean(s.capability_pass) && Boolean(s.discipline_pass);
@@ -265,6 +279,7 @@ export function run_one_recursive(
     let depth = 0;
     let prior: RecursiveAttempt | null = null;
     let attempt = makeAttempt(0, null);
+    onAttempt?.(0, attempt);
     let stop_reason: string;
     let last_verdict_len = 0;
     for (;;) {
@@ -293,6 +308,7 @@ export function run_one_recursive(
         last_verdict_len = verdict.length;
         prior = attempt;
         attempt = makeAttempt(depth, verdict);
+        onAttempt?.(depth, attempt);
     }
 
     const { run, score } = attempt;

--- a/tests/scripts/bench_ab_v2_run_recursive.test.ts
+++ b/tests/scripts/bench_ab_v2_run_recursive.test.ts
@@ -72,6 +72,22 @@ describe('run_one_recursive — loop control flow (ADR-106, mocked seam)', () =>
         expect(r.depth_reached).toBe(1);
     });
 
+    it('onAttempt fires once per attempt with depth + output (pair capture)', () => {
+        const seen: Array<{ depth: number; output: string | undefined }> = [];
+        const af = (depth: number): RecursiveAttempt => ({
+            run: mkRun(),
+            score: (depth === 0
+                ? mkScore(true, false, 0.5)
+                : mkScore(true, true, 1.0)) as unknown as RecursiveAttempt['score'],
+            output: `output-depth-${depth}`,
+        });
+        run_one_recursive({} as Record<string, unknown>, opts(1), af, (d, a) => seen.push({ depth: d, output: a.output }));
+        expect(seen).toEqual([
+            { depth: 0, output: 'output-depth-0' },
+            { depth: 1, output: 'output-depth-1' },
+        ]);
+    });
+
     it('max_depth 0 → single attempt, never re-attempts even if failing', () => {
         const log: Array<{ depth: number; verdict: string | null }> = [];
         const r = run_one_recursive(


### PR DESCRIPTION
## What

Enables the ADR-106 **human-preference pre-test** (Phase 3a-pre of
`road-to-recursive-verification`) by letting the recursion arm emit judgeable
`attempt₀` vs `attempt_final` output pairs.

- `run_one_recursive` gains an optional `output` per attempt (changed-file
  contents, capped) and an `onAttempt(depth, attempt)` callback.
- A pair generator can collect depth-0 vs depth-final outputs via `onAttempt`.
- Both are **optional** — the default benchmark arm path is unchanged.
- Capture-seam control flow unit-tested (6 tests); `npm run typecheck` clean. No live spend.

## Next (separate, supervised — needs spend + humans)

A small live pair-gen run on `claude-haiku-4-5` (~$5–10, bounded) produces
~10 pairs → 3 blind human judges → the ADR-106 ≥60% gate decides whether the
expensive three-baseline benchmark runs at all.
