### PR TITLE
docs(recursive-verification): council follow-up disposition — terminal

### DIFF
--- a/agents/roadmaps/archive/road-to-recursive-verification.md
+++ b/agents/roadmaps/archive/road-to-recursive-verification.md
@@ -235,7 +235,7 @@ ELSE off.
 
 ## Phase 4 — cross-vendor recursive pool (most expensive, gated last)
 
-- [-] Cross-vendor critic inside the recursion. <!-- cancelled: gated on Phase 3 passing, which it did not. A model/cross-vendor critic might fire more often than the deterministic scorer-as-critic — the one un-explored lever — but pursuing it is a new design (more spend) and out of scope for this honest-null closure. Captured for a future roadmap if revisited. -->
+- [-] Cross-vendor critic inside the recursion. <!-- cancelled: gated on Phase 3 passing, which it did not. The model/cross-vendor critic was the one un-explored lever, but a follow-up AI council (anthropic + openai, 2026-06-24, deep) converged TERMINAL — cost scales with all tasks, benefit only on the ~28% tail; a model-critic would mostly fire more often for more null-lift at higher cost. NO follow-up roadmap. The real lever is refining the rules on the failure tail. See docs/benchmark.md § Follow-up disposition. -->
 - [-] Iron Law / net-value gate for the cross-vendor critic. <!-- cancelled with the step above. -->
 
 ## Deferred (auditable-orchestration differentiator — reconsider after Phase 3)

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -109,3 +109,13 @@ Cost axis: each recursion run is up to 2× the host calls of a single pass, for 
 - Roadmap: `agents/roadmaps/archive/road-to-recursive-verification.md` (closed honest-null).
 - Gate logic: `recursiveGateVerdict` / `resolveRecursiveDefault` (`orchestration_gate.ts`); on a
   falsified gate `resolveRecursiveDefault` resolves `off` — no shipped-default flip.
+
+**Follow-up disposition — TERMINAL** (AI council, anthropic/claude-sonnet-4-5 +
+openai/gpt-4o, 2026-06-24, deep tier). Both members converged: do **not** pursue a
+model-critic / cross-vendor variant. The 72% first-pass rate shows recursion solves the
+wrong problem — cost scales with *all* tasks, benefit only on the ~28% tail (best-case
+~4–6% lift, would need n≥200 to detect); a model-critic would mostly fire more often and
+produce more null-lift re-attempts at higher cost. The real lever is **refining the rules
+on the 28% failure tail** (applies to 100% of tasks at zero marginal cost), not recursion.
+Recursion-as-a-class is closed; the model-critic's contextual-quality angle, if ever
+wanted, is a *different* (quality-review) product, not a recursion follow-up.


### PR DESCRIPTION
Records the AI-council verdict (anthropic + openai, 2026-06-24, deep) on the one open question after the recursive-verification honest-null: **terminal — no model-critic / cross-vendor follow-up roadmap.** Cost scales with all tasks, benefit only on the ~28% tail; the real lever is refining the rules on the failure tail. Durably answers it so it is not re-litigated. Docs-only (benchmark.md + the archived roadmap note).