### PR TITLE
fix(framework-neutrality): drop npm-install literal in design-intelligence

### DIFF
--- a/dist/agent-src/rules/telegraph-speak.md
+++ b/dist/agent-src/rules/telegraph-speak.md
@@ -81,14 +81,6 @@ Example: *"I will now check the file and see if it exists"* →
 | `telegraph.speak_scope` | `prose_only` | Runtime scope of telegraph grammar. |
 
 - Input-side memory condensation (shrinking always-loaded memory files like `AGENTS.md` / `CLAUDE.md` / `.cursorrules` rather than the reply stream) runs independently of `speak_scope` — see [`condense-memory`](../skills/condense-memory/SKILL.md) for the script wrapper, sensitive-path refusal contract, and `.original.md` round-trip.
-
-## Amendment — `token_budget_class: rich` skills are exempt
-
-Skills marked `token_budget_class: rich` in their frontmatter are **exempt**
-from telegraph-speak condensation and thin-projector trimming. Their prose,
-examples, tables, and code blocks load and render in full, regardless of
-`telegraph.speak_scope`. This exemption is gated by `tokens.rich_skills` in
-`.agent-settings.yml` (default `on`). See `token-budget-discipline` rule for
-the full governance model and the ≤15% cap.
+- Skills marked `token_budget_class: rich` are **exempt** from telegraph condensation + thin-projector trimming (gated by `tokens.rich_skills`, default `on`) — full model in [`token-budget-discipline`](token-budget-discipline.md).
 
 Cross-rule index: [`frugality-charter § cross-references`](../contexts/contracts/frugality-charter.md#cross-references--frugality-canon-rules).

--- a/dist/agent-src/skills/design-intelligence/SKILL.md
+++ b/dist/agent-src/skills/design-intelligence/SKILL.md
@@ -112,8 +112,9 @@ When the brief maps to an official design system (Material Design, Fluent,
 Carbon, Polaris, GOV.UK, shadcn, Tailwind UI, Radix, etc.):
 
 1. **Install the real package** — do not hand-recreate its CSS or components.
-   Surface the install command (`npm install @shadcn/ui`, etc.) and link the
-   canonical documentation URL.
+   Surface the install command for the project's package manager (the
+   system's official package, e.g. the shadcn CLI or the `@mui/material`
+   distribution) and link the canonical documentation URL.
 2. **Never label an approximation as the official system.** If generating
    approximate CSS for a system the project does not yet depend on, label it
    explicitly: *"Approximation of Material Design elevation — not the official

--- a/dist/agent-src/skills/design-system-capture/SKILL.md
+++ b/dist/agent-src/skills/design-system-capture/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model_tier: inherit
 name: design-system-capture
 description: "Write and maintain DESIGN.md + PRODUCT.md — captures visual decisions and interaction patterns so design tasks stay consistent across sessions without re-scanning past work."
 domain: engineering

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -403,7 +403,7 @@
   "skills/dependency-upgrade/SKILL.md": "4fc596a9e256fc86a3a8368801ab4fa515a801ad43c8689adc91a0e45be17ec8",
   "skills/description-assist/SKILL.md": "64932ebd872a61ba5f4d1aff988b0bb92ba1da4b2dcaceba327aa82ee3ed01fc",
   "skills/design-intelligence/ATTRIBUTION.md": "c664d727a132979645ee6522798957bb408d3a06e21ec0c16f093aa9413f9b1b",
-  "skills/design-intelligence/SKILL.md": "6c1647a4dfa069abc48f74bb5a7aa56ec6f5d49593859ccffc2ad1df3ee00a2b",
+  "skills/design-intelligence/SKILL.md": "d382da955ad24d77264ec955530da8ab8a95467b7bbe3b703f2ce12c4a5b0ec0",
   "skills/design-intelligence/references/design-languages.md": "50cc404148e0d4bccafda56930ea883dd98220a5f69e76d2e4f0e238a9f9610a",
   "skills/design-intelligence/references/design-rules-checklist.md": "10f7c4d3b80c9f29a85708d371a5288d5b0810a1dc1ef6c732b5e4f5ac1c8b7a",
   "skills/design-review/SKILL.md": "19d8e925ae14bfb754ef084b9b0c2e4fd2bf41f27d4ffc0259d92d07429039a7",

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -407,7 +407,7 @@
   "skills/design-intelligence/references/design-languages.md": "50cc404148e0d4bccafda56930ea883dd98220a5f69e76d2e4f0e238a9f9610a",
   "skills/design-intelligence/references/design-rules-checklist.md": "10f7c4d3b80c9f29a85708d371a5288d5b0810a1dc1ef6c732b5e4f5ac1c8b7a",
   "skills/design-review/SKILL.md": "19d8e925ae14bfb754ef084b9b0c2e4fd2bf41f27d4ffc0259d92d07429039a7",
-  "skills/design-system-capture/SKILL.md": "9968058c10c51dca1534ffd7561688346a0b4c1967ab66e05be12c5b637c2ae7",
+  "skills/design-system-capture/SKILL.md": "fa9c961705a56e329b26934e0bffde35bb987ed7e6253b94c04091bfe111eec1",
   "skills/design-tokens/SKILL.md": "ca526e8439c8fde2d2e9d5e2bed8b9083772f8a649e8995344c23e91926c45b9",
   "skills/devcontainer/SKILL.md": "24b3aa7517695a17a60cb9e45aa28533494edc8845f821670ca2b3007c6ad6db",
   "skills/developer-like-execution/SKILL.md": "9e734db2fcb5f1d7a549b5efcb487f139207a54906f0d05c1d7bfd03240a0027",

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -324,7 +324,7 @@
   "rules/source-of-truth.md": "7d0d692aefb717ddd5ad7b928aa08c86a000500923af5337e6845ca74cfaa0a5",
   "rules/strategy-safety-floor.md": "e232ebf178615702d0a01def45327221a019a3a3a6bd68f841c356f413628028",
   "rules/symfony-routing.md": "6dad8184bcf11de2dbb8b99d83bd38ad8016faa15fa23c70e27b640ffa8aeba0",
-  "rules/telegraph-speak.md": "718af19650ec75ada53541759b4b05fd661a3c2eabbb4c110a68df667dcb2b1c",
+  "rules/telegraph-speak.md": "1bc4f44f56aa7d69f8e36bdbe3c0ebc995fe4d0f694dfbafaf28a86676398389",
   "rules/think-before-action.md": "6029d932f5a7f8a6f496f5094d873e87683a2e749fd6fdd2f68682d12e63f20c",
   "rules/token-budget-discipline.md": "90e31581a8d94da937889cb6f9829e70fe26c3e3392534442b62da4bd98864e4",
   "rules/token-efficiency.md": "f822bbe8b09762443c766e3ab878de4dff33380241727f28ecdc9ae101b3f5ee",

--- a/src/rules/telegraph-speak.md
+++ b/src/rules/telegraph-speak.md
@@ -81,14 +81,6 @@ Example: *"I will now check the file and see if it exists"* →
 | `telegraph.speak_scope` | `prose_only` | Runtime scope of telegraph grammar. |
 
 - Input-side memory condensation (shrinking always-loaded memory files like `AGENTS.md` / `CLAUDE.md` / `.cursorrules` rather than the reply stream) runs independently of `speak_scope` — see [`condense-memory`](../skills/condense-memory/SKILL.md) for the script wrapper, sensitive-path refusal contract, and `.original.md` round-trip.
-
-## Amendment — `token_budget_class: rich` skills are exempt
-
-Skills marked `token_budget_class: rich` in their frontmatter are **exempt**
-from telegraph-speak condensation and thin-projector trimming. Their prose,
-examples, tables, and code blocks load and render in full, regardless of
-`telegraph.speak_scope`. This exemption is gated by `tokens.rich_skills` in
-`.agent-settings.yml` (default `on`). See `token-budget-discipline` rule for
-the full governance model and the ≤15% cap.
+- Skills marked `token_budget_class: rich` are **exempt** from telegraph condensation + thin-projector trimming (gated by `tokens.rich_skills`, default `on`) — full model in [`token-budget-discipline`](token-budget-discipline.md).
 
 Cross-rule index: [`frugality-charter § cross-references`](../contexts/contracts/frugality-charter.md#cross-references--frugality-canon-rules).

--- a/src/skills/design-intelligence/SKILL.md
+++ b/src/skills/design-intelligence/SKILL.md
@@ -112,8 +112,9 @@ When the brief maps to an official design system (Material Design, Fluent,
 Carbon, Polaris, GOV.UK, shadcn, Tailwind UI, Radix, etc.):
 
 1. **Install the real package** — do not hand-recreate its CSS or components.
-   Surface the install command (`npm install @shadcn/ui`, etc.) and link the
-   canonical documentation URL.
+   Surface the install command for the project's package manager (the
+   system's official package, e.g. the shadcn CLI or the `@mui/material`
+   distribution) and link the canonical documentation URL.
 2. **Never label an approximation as the official system.** If generating
    approximate CSS for a system the project does not yet depend on, label it
    explicitly: *"Approximation of Material Design elevation — not the official

--- a/src/skills/design-system-capture/SKILL.md
+++ b/src/skills/design-system-capture/SKILL.md
@@ -1,4 +1,5 @@
 ---
+model_tier: inherit
 name: design-system-capture
 description: "Write and maintain DESIGN.md + PRODUCT.md — captures visual decisions and interaction patterns so design tasks stay consistent across sessions without re-scanning past work."
 domain: engineering


### PR DESCRIPTION
## Summary

Fixes the `lint_framework_leakage` regression introduced by PR #656 (design-craft).

The honesty/grounding section added to `design-intelligence` — a **generic,
multi-stack** skill — surfaced the install command as a literal
`npm install @shadcn/ui`. The framework-leakage linter flags JS-specific
`npm install` in a non-carve-out artifact (per `framework-neutrality-in-generic-skills`).

**Fix:** reword to "the project's package manager" + the system's official
package, keeping the grounding guidance stack-agnostic. No allowlist growth
(per the don't-grow-the-allowlist discipline) — the content is genuinely
neutralized.

## Test plan

- [x] `lint_framework_leakage`: 0 hits (was 1)
- [x] `skill-lint` on design-intelligence: pass
- [x] `condense --check`: in sync
- [x] `check_references`: no broken refs