### PR TITLE
chore(roadmap): defer Phase 2 (won't-build-speculatively) + roadmap end-state

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**77 / 159 steps done · 48%**
+**77 / 157 steps done · 49%**
 
 ```text
-███████████████████░░░░░░░░░░░░░░░░░░░░░   48%
+████████████████████░░░░░░░░░░░░░░░░░░░░   49%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-auto-subagent-orchestration-followup.md](roadmaps/road-to-auto-subagent-orchestration-followup.md) | 1 | 5 | 5 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 2 | [road-to-operator-runtime-harvest.md](roadmaps/road-to-operator-runtime-harvest.md) | 6 | 20 | 3 | 13 | 4 | 0 | ████████░░ 81% |
+| 2 | [road-to-operator-runtime-harvest.md](roadmaps/road-to-operator-runtime-harvest.md) | 6 | 20 | 1 | 13 | 6 | 0 | █████████░ 93% |
 | 3 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
 | 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 11 | 50 | 50 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 5 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
@@ -36,14 +36,14 @@
 
 ### [road-to-operator-runtime-harvest.md](roadmaps/road-to-operator-runtime-harvest.md)
 
-**Road to operator-runtime harvest — cross-model parity is the keystone; gate the rest on it** — 13 / 16 done (81%)
+**Road to operator-runtime harvest — cross-model parity is the keystone; gate the rest on it** — 13 / 14 done (93%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Cross-model e2e parity (keystone; everything downstream gates on it) | ✅ done | 0 | 7 | 0 | 0 | 100% |
 | 0b | Output-format governance (decision-gated on P0 evidence; NOT a first-class P2) | ✅ done | 0 | 1 | 0 | 0 | 100% |
 | 1 | `finding_floor` eval kind (after Phase 0; calibrated, not guessed) | ✅ done | 0 | 3 | 2 | 0 | 100% |
-| 2 | size-budget undershoot-floor + audited override (after Phase 1) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | size-budget undershoot-floor + audited override (after Phase 1) | ⏭️ skipped | 0 | 0 | 2 | 0 | 0% |
 | G | (GATED) — model-overlays — open ONLY on a Phase-0 RDP failure | ✅ done | 0 | 1 | 1 | 0 | 100% |
 | 3 | (parallel track) — product surface: QA-orchestration skill + lifecycle packaging | 🟡 in progress | 1 | 1 | 1 | 0 | 50% |
 

--- a/agents/roadmaps/road-to-operator-runtime-harvest.md
+++ b/agents/roadmaps/road-to-operator-runtime-harvest.md
@@ -190,8 +190,8 @@ it is not an Anthropic-only false baseline.
 Goal: catch suspicious skill *shrinkage*, distinguishable from legitimate small
 skills only once `finding_floor` exists.
 
-- [ ] <!-- open — not in this push: buildable + autonomous, but off-theme (budget discipline, not cross-model) and council-rated lowest/last. Quick follow-up on request. --> Extend `check_always_budget` / `measure_augment_budget` with an undershoot floor (skill below expected size = suspect truncation) and an override that requires a logged reason (`*_OVERRIDE_REASON` → audit log). <!-- carve-out: new-gate-verification -->
-- [ ] <!-- open — with the undershoot-floor item above (same Phase 2 follow-up) --> Add the catalog-token target (sum of always-on descriptions ≤ threshold) if not already covered — directly addresses the historical always-on-budget pressure.
+- [~] <!-- WON'T-BUILD-SPECULATIVELY (user-confirmed 2026-06-25): no truncation incident has occurred, so this would be a guard against a problem the evidence does not show — exactly the speculative governance this roadmap's ethos (honest-null; don't fix what isn't broken) rejects. The natural host scripts are delicate (check_always_budget = CI-tuned overshoot gate; measure_augment_budget = faithful-twin with golden tests), and for the always-budget a *drop* is normally desirable, not suspect. Reopen on a real truncation incident. --> Extend `check_always_budget` / `measure_augment_budget` with an undershoot floor (skill below expected size = suspect truncation) and an override that requires a logged reason (`*_OVERRIDE_REASON` → audit log).
+- [~] <!-- ~ALREADY-COVERED: `measure_augment_budget` already gates the whole always-on prompt against a 49,512-char cap, and that total already counts always-rule bodies AND auto-rule stubs *including their descriptions*. A separate description-sum cap would be largely redundant. Deferred unless a distinct, evidenced need appears. --> Add the catalog-token target (sum of always-on descriptions ≤ threshold) if not already covered — directly addresses the historical always-on-budget pressure.
 
 ## Phase G (GATED) — model-overlays — open ONLY on a Phase-0 RDP failure
 


### PR DESCRIPTION
## What

Roadmap-closure decision for `road-to-operator-runtime-harvest` Phase 2 (size-budget). Doc-only — no code.

## Decision (user-confirmed): don't build speculatively

Grounding the two Phase-2 items showed they don't warrant a build:

- **Catalog-token target (sum of always-on descriptions ≤ threshold)** → **~already covered.** `measure_augment_budget` already gates the entire always-on prompt against a 49,512-char cap, and that total already counts always-rule bodies + auto-rule stubs *including their descriptions*. A separate description-sum cap would be largely redundant.
- **Undershoot floor (suspect truncation)** → **speculative.** No truncation incident has occurred — this would guard a problem the evidence doesn't show. The natural host scripts are delicate (`check_always_budget` = CI-tuned overshoot gate; `measure_augment_budget` = faithful-twin with golden tests), and for the always-budget a *drop* is normally desirable, not suspect.

Building it would be exactly the speculative governance this roadmap's ethos (honest-null; don't fix what isn't broken) rejects — the same discipline we applied to gstack's overlays. Deferred `[~]`; **reopen on a real truncation incident**.

## Roadmap end state

**13 done / 1 open / 6 deferred.** The autonomous core (cross-model keystone, Phase 0/0b, finding_floor mechanism, canary) is complete. Residuals all need a human/external trigger: finding_floor calibration (human gold set), Phase G overlays (gated on a real behavior gap), repositioning (parallel-owned), Phase 2 (reopen on incident). The 1 open item (QA orchestration skill) is user-driven future work (needs the drafting protocol).

## Verification

Doc-only; dashboard regenerated; no source-name leak; parallel tree work (README, draft positioning roadmap) left unstaged.
