### PR TITLE
fix(skill-linter): accept finding_floor + declare skill field (PR #665 lint regressions)

### DIFF
--- a/dist/agent-src/skills/bug-analyzer/evals/evals.json
+++ b/dist/agent-src/skills/bug-analyzer/evals/evals.json
@@ -1,4 +1,5 @@
 {
+  "skill": "bug-analyzer",
   "_calibration": "Starter behavioral fixtures (roadmap road-to-operator-runtime-harvest, Phase 1, line 182). finding_floor `n` values are UNCALIBRATED placeholders — the real per-host floor is gated on the P0 cross-model distributions (Phase 1 lines 183-184). Do not wire these as an enforcing CI gate until calibrated.",
   "scenarios": [
     {

--- a/dist/agent-src/skills/code-review/evals/evals.json
+++ b/dist/agent-src/skills/code-review/evals/evals.json
@@ -1,4 +1,5 @@
 {
+  "skill": "code-review",
   "_calibration": "Starter behavioral fixtures (roadmap road-to-operator-runtime-harvest, Phase 1, line 182). finding_floor `n` values are UNCALIBRATED placeholders — the real per-host floor is gated on the P0 cross-model distributions (Phase 1 lines 183-184). Do not wire these as an enforcing CI gate until calibrated.",
   "scenarios": [
     {

--- a/src/scripts/skill_linter.ts
+++ b/src/scripts/skill_linter.ts
@@ -1667,7 +1667,7 @@ export function validate_evals_json(skillPath: string): Issue[] {
         );
         return issues;
     }
-    const validKinds = ['contains', 'file_exists', 'rubric'];
+    const validKinds = ['contains', 'file_exists', 'rubric', 'finding_floor'];
     const validKindsSet = new Set(validKinds);
     scenarios.forEach((scenario, idx) => {
         const loc = `scenarios[${idx}]`;
@@ -1709,15 +1709,31 @@ export function validate_evals_json(skillPath: string): Issue[] {
                 );
                 return;
             }
-            const requiredField = { contains: 'value', file_exists: 'path', rubric: 'criterion' }[kind] as string;
-            if (!(requiredField in a) || typeof a[requiredField] !== 'string') {
-                issues.push(
-                    new Issue(
-                        'warning',
-                        'evals_json_assertion_missing_field',
-                        `${aLoc} (kind=${kind}) missing required string field '${requiredField}'`,
-                    ),
-                );
+            if (kind === 'finding_floor') {
+                // finding_floor (run_skill_evals): `n` (number; runtime-defaults to
+                // 1) and `pattern` (regex string) are both OPTIONAL — validate type
+                // only when present, require neither.
+                if ('n' in a && typeof a.n !== 'number') {
+                    issues.push(
+                        new Issue('warning', 'evals_json_assertion_field_type', `${aLoc} (kind=finding_floor) 'n' must be a number`),
+                    );
+                }
+                if ('pattern' in a && typeof a.pattern !== 'string') {
+                    issues.push(
+                        new Issue('warning', 'evals_json_assertion_field_type', `${aLoc} (kind=finding_floor) 'pattern' must be a string`),
+                    );
+                }
+            } else {
+                const requiredField = { contains: 'value', file_exists: 'path', rubric: 'criterion' }[kind] as string;
+                if (!(requiredField in a) || typeof a[requiredField] !== 'string') {
+                    issues.push(
+                        new Issue(
+                            'warning',
+                            'evals_json_assertion_missing_field',
+                            `${aLoc} (kind=${kind}) missing required string field '${requiredField}'`,
+                        ),
+                    );
+                }
             }
         });
     });

--- a/src/skills/bug-analyzer/evals/evals.json
+++ b/src/skills/bug-analyzer/evals/evals.json
@@ -1,4 +1,5 @@
 {
+  "skill": "bug-analyzer",
   "_calibration": "Starter behavioral fixtures (roadmap road-to-operator-runtime-harvest, Phase 1, line 182). finding_floor `n` values are UNCALIBRATED placeholders — the real per-host floor is gated on the P0 cross-model distributions (Phase 1 lines 183-184). Do not wire these as an enforcing CI gate until calibrated.",
   "scenarios": [
     {

--- a/src/skills/code-review/evals/evals.json
+++ b/src/skills/code-review/evals/evals.json
@@ -1,4 +1,5 @@
 {
+  "skill": "code-review",
   "_calibration": "Starter behavioral fixtures (roadmap road-to-operator-runtime-harvest, Phase 1, line 182). finding_floor `n` values are UNCALIBRATED placeholders — the real per-host floor is gated on the P0 cross-model distributions (Phase 1 lines 183-184). Do not wire these as an enforcing CI gate until calibrated.",
   "scenarios": [
     {

--- a/tests/scripts/skill_linter.test.ts
+++ b/tests/scripts/skill_linter.test.ts
@@ -23,6 +23,7 @@ import {
     lint_file,
     lint_output_schema,
     parse_output_schema,
+    validate_evals_json,
     _resetRoleContractCacheForTest,
 } from '../../src/scripts/skill_linter.js';
 
@@ -51,6 +52,44 @@ function hasCode(result: LintResult, code: string): boolean {
 function hasError(result: LintResult): boolean {
     return result.issues.some((i: Issue) => i.severity === 'error');
 }
+
+describe('skill_linter — evals.json validation', () => {
+    function writeEvals(skill: string, evals: unknown): string {
+        const skillPath = writeFile(`skills/${skill}/SKILL.md`, `# ${skill}\n`);
+        writeFile(`skills/${skill}/evals/evals.json`, JSON.stringify(evals, null, 2));
+        return skillPath;
+    }
+
+    it('accepts the finding_floor assertion kind (regression: was rejected as unknown)', () => {
+        const issues = validate_evals_json(
+            writeEvals('demo', {
+                skill: 'demo',
+                scenarios: [
+                    { id: 's1', prompt: 'p', assertions: [{ kind: 'finding_floor', n: 2, pattern: '(?m)^\\s*[-*+]\\s+' }] },
+                    { id: 's2', prompt: 'p', assertions: [{ kind: 'finding_floor' }] },
+                ],
+            }),
+        );
+        expect(issues).toEqual([]);
+    });
+
+    it('flags a missing top-level skill field', () => {
+        const issues = validate_evals_json(
+            writeEvals('demo', { scenarios: [{ id: 's1', prompt: 'p', assertions: [{ kind: 'finding_floor', n: 1 }] }] }),
+        );
+        expect(issues.some((i: Issue) => i.code === 'evals_json_missing_skill')).toBe(true);
+    });
+
+    it('flags a non-numeric finding_floor n', () => {
+        const issues = validate_evals_json(
+            writeEvals('demo', {
+                skill: 'demo',
+                scenarios: [{ id: 's1', prompt: 'p', assertions: [{ kind: 'finding_floor', n: '2' }] }],
+            }),
+        );
+        expect(issues.some((i: Issue) => i.code === 'evals_json_assertion_field_type')).toBe(true);
+    });
+});
 
 describe('skill_linter — core MVP', () => {
     it('valid skill passes', () => {


### PR DESCRIPTION
Fixes the two skill-lint regressions reported on #665 for `bug-analyzer` and `code-review` evals: `evals_json_assertion_kind` and `evals_json_missing_skill`.

## Root cause

- **`evals_json_assertion_kind`** — `validate_evals_json` in `skill_linter.ts` only accepted `contains` / `file_exists` / `rubric`. The `finding_floor` primitive (added to `run_skill_evals.ts` by the operator-runtime-harvest work) was unknown to the linter, so every `finding_floor` assertion tripped a warning. The linter was stale relative to the runtime.
- **`evals_json_missing_skill`** — both `evals.json` files lacked the required top-level `skill` string.

## Fix

- Add `finding_floor` to the linter's `validKinds`, and type-check its **optional** `n` (number) / `pattern` (string) per the actual `run_skill_evals` contract (both default-tolerant at runtime).
- Declare `"skill"` in both `evals.json` (src + regenerated dist).
- Regression test added to `tests/scripts/skill_linter.test.ts` (finding_floor accepted; missing-skill caught; non-numeric `n` caught).

## Verification

- `skill_linter` on both skills (src): pass, 0 warnings.
- `tests/scripts/skill_linter.test.ts`: 122 pass / 5 skipped (incl. 3 new).
- `tests/scripts/run_skill_evals.test.ts`: green.
- `task sync` clean; pre-push hooks green.

## Note (out of scope)

The condensed `dist` `bug-analyzer/SKILL.md` carries pre-existing body warnings (`short_procedure`, `missing_runtime_debug_guidance`, `missing_backend_verification_example`) — a condensation-density artefact on the projection, not part of the reported eval-JSON regressions and not introduced here.
