### PR TITLE
docs(governance): document the compile-time governance moat (road-to-governance-moat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 It is both deep **and** disciplined — and honest about what it deliberately is not:
 
 - **Depth that routes itself** — 258 skills + 162 commands, with a capability router that loads the right one on intent, not a 500-artefact context dump.
-- **Governance on every host** — rules compiled into each tool's native format at projection time; deterministic runtime hooks added on hook-capable hosts ([enforcement by host](docs/enforcement-by-host.md)).
+- **Governance on every host** — rules compiled into each tool's native format at projection time; deterministic runtime hooks added on hook-capable hosts. This config-space, host-agnostic governance is the moat ([the governance advantage](docs/governance-advantage.md) · [enforcement by host](docs/enforcement-by-host.md)).
 - **Surgical uninstall** — removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries.
 - **Pack-scoped install** — writes the active pack only, not a 500-artefact dump.
 

--- a/agents/roadmaps/archive/road-to-governance-moat.md
+++ b/agents/roadmaps/archive/road-to-governance-moat.md
@@ -1,0 +1,109 @@
+---
+complexity: structural
+status: ready
+parent_roadmap: road-to-positioning-and-enforcement
+---
+
+# Road to the governance moat — exploit the advantage we already have, don't build measurement theater
+
+**Trigger:** External reviewer proposed 5 moves to make AC provably superior to an
+external operator-runtime reference ("Source R"): per-skill capability registry,
+public cross-model routing benchmark, README benchmark + host matrix, 5 showcase
+flows, council/judge model. An AI-council pass critically reframed the proposals.
+
+**Mode:** Positioning + documentation plate. The decisive finding is **not** "build
+the registry/benchmark" — it is "exploit the compile-time governance moat that
+already ships, and explicitly do NOT build the theater." Source referenced
+source-anonymously per `source-confidentiality`.
+
+- **Source R** — the same external operator-runtime / Claude-Code reference as the
+  sibling roadmaps (runtime-first: deterministic hooks, more raw skills).
+
+## Council convergence (inline per `no-roadmap-references`)
+
+Council (claude-sonnet-4-5 + gpt-4o, 2026-06-25, 2 rounds) converged **against**
+most of the proposals:
+
+1. **Per-skill capability registry → DO NOT BUILD.** Maintainability theater with no
+   consumer: maintainers read the skill file + `dist/router.json` (88 intent→skill);
+   host integrators project rules, they do not parse per-skill I/O; end users never
+   see it. `confidenceHints`/`best_for` are qualitative human judgments → perpetual
+   drift tax for a single maintainer. `CAPABILITIES.yaml` (area-level) + `router.json`
+   already cover the real need.
+2. **Public routing-precision benchmark → DO NOT PUBLISH (category error).**
+   `skill_trigger_eval` measures AC's OWN trigger-matching (config quality), NOT
+   end-to-end skill-invocation inside a real host (Cline/Roo have their own routing
+   that may ignore AC's `router.json`). A "95% accuracy" headline that a user then
+   sees as 60% in-host is false-advertising. It is also Anthropic-only
+   (`DEFAULT_MODEL=claude-sonnet-4-5`), cross-model is credential-gated, and "proves
+   superiority" needs a comparative baseline (vs host-native, vs Source R) that does
+   not exist. And the governance-effect axis already measured honest-null — do not
+   build a public "governance works" story on it.
+3. **Real leverage = exploit the EXISTING compile-time governance moat** (a structural
+   property already shipped — NOT the behaviour-change claim that measured null):
+   rules/constraints travel in config space, are un-strippable without forking, and
+   reach ALL hosts (runtime hooks reach <30%). Position AC as **"the governance layer
+   for host agents that lack one."**
+4. **Positioning honesty:** "Source R has many skills; AC proves when which skill
+   fires" OVERCLAIMS. The honest, deliverable claim is the host-agnostic compile-time
+   governance moat.
+
+## Phase 1 — Document & surface the moat (highest leverage, cheap)
+
+- [x] `docs/governance-advantage.md` — the moat (config-space, host-agnostic
+  governance; reaches all hosts vs runtime hooks <30%). Structural-property claim
+  only; explicit honesty boundary (honest-null A/B cited, "un-strippable" avoided
+  as overclaim). Adversarial subagent review → 1 minor overclaim ("always reads")
+  fixed. Done 2026-06-25.
+- [x] **Governance-in-action examples** — folded into `governance-advantage.md`
+  (3 traces: safety-floor surviving static-host projection; intent routing vs
+  500-artefact dump; the two-layer spectrum). `docs/flows.md` is generator-touched
+  (`generate_command_flows.ts`), so the examples live in the new hand-authored doc
+  rather than hand-editing a generated surface.
+- [x] **Per-surface / MCP view** — added an honest "Where MCP fits" note to the
+  hand-authored `docs/enforcement-by-host.md` (MCP = transport, not a 3rd
+  enforcement layer) pointing at the authoritative `capability-matrix.md`. The
+  generated matrix (`generate_capability_matrix.ts`, reflection-from-`condense` +
+  coverage-guard + byte-`--check`) was deliberately NOT force-fitted with invented
+  per-host columns — avoiding a drift/over-claim trap.
+- [x] Verify: `check_references` clean; `generate_capability_matrix --check` green
+  (untouched); `readme_linter`/size/jargon green. Done 2026-06-25.
+
+## Phase 2 — Positioning honesty
+
+- [x] README positioning: the "proves when which skill fires" overclaim was never
+  in the README (only the reviewer's proposal), so nothing to drop. Surfaced the
+  moat instead — the "Governance on every host" bullet now names it the moat and
+  links `docs/governance-advantage.md`. Done 2026-06-25.
+- [x] Verify: `readme_linter` + `lint_readme_size` (441/750) + `lint_readme_jargon`
+  (2/3) + `update_counts --check` green. Done 2026-06-25.
+
+## Phase 3 — Gated / explicitly deferred (do NOT start without the gate)
+
+- [-] **Cross-model routing eval** — **moved out** (Iron Law 3 resolution,
+  2026-06-25) to `agents/roadmaps/later/road-to-cross-model-routing-eval.md`
+  (`status: later`), blocked on credentials + an in-host end-to-end harness +
+  baselines. Parked, not dropped.
+- [-] **Public routing benchmark** — **moved out** with the cross-model eval to the
+  same `later/` follow-up; gated behind the harness above.
+
+## Do NOT build (council "no" list — positioning asset)
+
+- Per-skill capability registry (inputs/outputs/confidenceHints) — no consumer,
+  perpetual maintenance tax.
+- Public Anthropic-only routing benchmark — weak/wrong-layer evidence.
+- A separate "council/judge model" artefact — already shipped (`judge-*` skills +
+  `ai-council` + `/implement-ticket` review-judges); surface in flows, do not rebuild.
+
+## Acceptance criteria
+
+- The moat is documented and surfaced; positioning drops the overclaim.
+- Nothing on the "Do NOT build" list is built.
+- Phase 3 items stay deferred until their gates (credentials + in-host harness +
+  baselines) clear.
+- Source R stays anonymized in every tracked artifact.
+
+## Provenance
+
+- Source R link: `ENC1:` token — maintainer to fill via `link_crypto.ts`.
+- Siblings: `road-to-positioning-and-enforcement.md` (archived), `road-to-operator-runtime-harvest.md`.

--- a/agents/roadmaps/later/road-to-cross-model-routing-eval.md
+++ b/agents/roadmaps/later/road-to-cross-model-routing-eval.md
@@ -1,0 +1,48 @@
+---
+complexity: structural
+status: later
+parent_roadmap: road-to-governance-moat
+---
+
+# Road to cross-model routing eval — the falsifiability lever, parked behind its gates
+
+**Trigger:** Spun out of `road-to-governance-moat` (Iron Law 3 resolution,
+2026-06-25). That roadmap's P1/P2 shipped; its P3 (cross-model routing eval +
+public benchmark) is real but blocked, so it is parked here rather than dropped.
+
+> **Blocked until** all three gates clear: (a) OpenAI **and** Gemini API
+> credentials are available to the eval env; (b) an **in-host end-to-end**
+> skill-invocation harness exists (measuring what the host actually invokes, NOT
+> AC's own trigger-matching — the current `skill_trigger_eval` measures the wrong
+> layer per the 2026-06-25 council); (c) a comparative **baseline** (host-native
+> routing and/or the external operator-runtime reference) is defined.
+
+## Why parked, not cancelled
+
+Council (claude-sonnet-4-5 + gpt-4o, 2026-06-25) flagged routing-precision
+measured *correctly* (end-to-end in-host, with baselines, across models) as a
+genuine falsifiability lever for the multi-host claim — but warned the naive
+version is a category error (measures config trigger-matching, not in-host
+invocation) and is credential-gated. So the work is worth keeping, gated on the
+harness + credentials, not shipped as a single-model trigger-match table.
+
+## Phase 1 — In-host end-to-end harness (the prerequisite)
+
+- [ ] Build a harness that measures **what the host actually invokes** for a
+  prompt (not AC's trigger-match), with a host-native baseline. Anthropic first,
+  then OpenAI/Gemini once credentialled.
+- [ ] Define the baseline + the comparison (host-native routing; optionally the
+  external operator-runtime reference) so "precision" is comparative, not absolute.
+
+## Phase 2 — Cross-model run + honest publication
+
+- [ ] Run cross-model once credentials land; report precision per model with the
+  baseline. Honest-null allowed.
+- [ ] Only if the result is comparative and survives review: a public benchmark.
+  A single-model, wrong-layer table must never ship as positioning evidence.
+
+## Acceptance criteria
+
+- Measures in-host end-to-end invocation, not config trigger-matching.
+- Cross-model with a stated baseline; honest-null is a valid outcome.
+- No public benchmark until the above holds.

--- a/docs/enforcement-by-host.md
+++ b/docs/enforcement-by-host.md
@@ -31,5 +31,14 @@ it a two-tier experience — strong on Claude, absent on Cursor/Windsurf/Copilot
 So the universal lever is the compile-time layer; runtime hooks are an opt-in
 **bonus** on the hosts that can run them, never the floor.
 
+**Where MCP fits.** MCP is a *transport* surface, not a third enforcement layer.
+On a host that runs MCP servers, MCP is one path by which a tool lifecycle (and
+therefore the runtime-hook column above) can become available — but MCP presence
+does not by itself add enforcement. Which hosts consume which surface is tracked
+authoritatively, per artifact type, in
+[`capability-matrix.md`](capability-matrix.md) (derived from the projection
+dispatcher, drift-checked in CI) — we do not restate per-host surface facts here,
+to avoid drift between two hand-maintained tables.
+
 See also the artifact-projection view: [`capability-matrix.md`](capability-matrix.md)
 (its `hooks` row already shows hooks are native to the Claude plugin only).

--- a/docs/governance-advantage.md
+++ b/docs/governance-advantage.md
@@ -1,0 +1,72 @@
+# The governance advantage — why compile-time, config-space governance is the moat
+
+Most agent-config packages are a pile of skills. This one's defensible edge is
+not skill *count* — it is **where the governance lives**: compiled into every
+host's own instruction layer at projection time, so it travels with the config
+and is present on every host by construction. Runtime-hook systems can only
+enforce where the host exposes a tool lifecycle — a minority of hosts.
+
+This is a **structural** claim, not a behaviour claim. See the honesty boundary
+at the end.
+
+## The two enforcement layers (and their reach)
+
+| Layer | How it works | Reach |
+|---|---|---|
+| **Compile-time (config space)** | Rules + Iron Laws are compiled into each host's native instruction format at projection time (`.cursorrules`, `.windsurfrules`, `copilot-instructions.md`, `GEMINI.md`, Claude/Augment native rule dirs). | **Every projection target.** |
+| **Runtime hooks** | On hosts exposing a tool lifecycle (`PreToolUse`/`PostToolUse`/`Stop`), a guard can deterministically block a call (e.g. `block_no_verify`). | **Hook-capable hosts only** (~2 of the supported set). |
+
+Full per-host breakdown: [`enforcement-by-host.md`](enforcement-by-host.md).
+
+The point: a runtime-first competitor's strongest enforcement simply **does not
+exist** on a host that has no hook surface. The compile-time layer is there on
+*that same host* because it rides in the config the host already reads.
+
+## Governance in action — three concrete traces
+
+### 1. A safety-floor rule survives projection into a static host
+`commit-policy` (`tier: safety-floor`) is compiled into Cursor's `.cursorrules`
+and Copilot's `copilot-instructions.md`. The host has no hook to block a
+`git commit`, but the constraint is **in the instruction file the host loads at
+session start** — present by construction, not dependent on a runtime primitive
+the host lacks (a static host gives it no runtime attention guarantee, but a
+runtime-only system gives it nothing at all here). A runtime-only system contributes *nothing* on these hosts.
+
+### 2. Intent routing, not a 500-artefact dump
+A prompt does not load all 258 skills. `dist/router.json` (88 rules, intent →
+skill, keyword/phrase/path triggers) carries the right skill on intent. The
+governance value is *selection discipline* — the host gets the relevant rule
+set, not the whole catalogue as context ballast.
+
+### 3. The enforcement spectrum is explicit, not implied
+On Claude Code / Cline (MCP) the safety-floor constraints get **both** layers:
+compile-time instruction **and** a deterministic runtime block. On Cursor /
+Windsurf / Copilot / Gemini they get the compile-time layer alone. We state
+which host gets which — we never imply "deterministic everywhere".
+
+## What this is NOT (honesty boundary)
+
+- **Not "un-strippable".** A human can edit any projected file. The claim is
+  *present-by-construction on every host* — a host's runtime cannot selectively
+  ignore it the way it ignores an absent runtime hook.
+- **Not a measured behaviour-change claim.** A length-controlled A/B
+  (hardened-constraint blocks vs a length-matched placebo) measured **honest-null
+  at the discipline ceiling** — the cooperative rules already catch the test
+  traps, so *adding emphasis* changed nothing measurable. The moat is that
+  governance is **present and portable across hosts**, not that more governance
+  prose provably changes a model's behaviour.
+- **Not deterministic on static hosts.** Compile-time governance is
+  model-cooperative; only hook-capable hosts get a hard block.
+
+## Why it's hard to copy
+
+A runtime-first system would have to re-author its governance to live in
+config space and project into every host's native format — i.e. become a
+content+governance layer — to match the reach. That is a different architecture,
+not a feature bolt-on. Meanwhile this package adds runtime hooks as an opt-in
+*superset* where hosts allow it, without depending on them for the floor.
+
+## See also
+
+- [`enforcement-by-host.md`](enforcement-by-host.md) — per-host enforcement mechanism.
+- [`capability-matrix.md`](capability-matrix.md) — which artifact type projects to which host.


### PR DESCRIPTION
Executes `road-to-governance-moat` — the roadmap built from an AI-council pass on external feedback about catching up to a runtime-first operator suite.

## The decision (council convergence)

The reviewer proposed a per-skill capability registry + a public cross-model routing benchmark. The council (2 independent models, 2 rounds) **rejected both**:
- **Per-skill registry** — maintainability theater, no consumer (maintainers use the skill file + `router.json`; host integrators project rules; end users never see it).
- **Public routing benchmark** — category error: the trigger eval measures AC's *own* trigger-matching (config quality), **not** end-to-end skill-invocation inside a real host. Also Anthropic-only and credential-gated, with no comparative baseline.

Redirect: **exploit the compile-time governance moat that already ships** — governance compiled into every host's instruction layer (config space), present on every host vs runtime hooks (<30% of hosts).

## What this PR ships

- **`docs/governance-advantage.md`** — the moat, with three governance-in-action traces and an explicit honesty boundary (cites the honest-null A/B; a *structural* claim, not a behaviour-change claim; "un-strippable" deliberately avoided as an overclaim). Adversarial-review-checked (one minor overclaim, "always reads", fixed).
- **`docs/enforcement-by-host.md`** — adds a "Where MCP fits" note (MCP = transport, not a third enforcement layer); defers per-host surface facts to the authoritative generated matrix rather than duplicating them.
- **README** — the "Governance on every host" bullet now names the moat and links the doc.

## Deliberately NOT built (council "no" list)

- Per-skill capability registry · public Anthropic-only routing benchmark · a separate council/judge artefact (already shipped: `judge-*` + `ai-council`).
- The strict generated `capability-matrix` was not force-fitted with invented per-host columns; `flows.md` (generator-touched) was not hand-edited — examples live in the new doc.

## Roadmap lifecycle

`road-to-governance-moat` is **complete** (P1/P2 done) and archived. Its P3 (cross-model routing eval + public benchmark) is genuinely blocked (vendor credentials + an in-host end-to-end harness + baselines), so per Iron Law 3 it is **parked** in `agents/roadmaps/later/road-to-cross-model-routing-eval.md` (`status: later`) — not dropped.

## Verification

`readme_linter`/size/jargon · `update_counts --check` · `check_references` · `generate_capability_matrix --check` — all green. Pre-commit/push hooks green.
