### PR TITLE
feat(bench): token-saving Phase 0 — measurement rig (real tokenizer, regression gates, golden set, probes)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -153,6 +153,9 @@ tasks:
       - task: validate-schema
       - task: lint-rule-budget
       - task: audit-tokens-budget
+      - task: check-token-regression
+      - task: check-token-quality-golden
+      - task: check-quality-regression
       - task: lint-skills
       - task: lint-role-experiences
       - task: lint-namespace
@@ -299,6 +302,9 @@ tasks:
       - task: validate-schema
       - task: lint-rule-budget
       - task: audit-tokens-budget
+      - task: check-token-regression
+      - task: check-token-quality-golden
+      - task: check-quality-regression
       - task: lint-skills-strict
       - task: lint-role-experiences
       - task: lint-namespace

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**64 / 122 steps done · 52%**
+**68 / 122 steps done · 56%**
 
 ```text
-█████████████████████░░░░░░░░░░░░░░░░░░░   52%
+██████████████████████░░░░░░░░░░░░░░░░░░   56%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 34 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 30 | 4 | 0 | 0 | █░░░░░░░░░ 12% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
@@ -38,11 +38,11 @@
 
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 
-**Road to token saving — measure, then cut, at constant quality** — 0 / 34 done (0%)
+**Road to token saving — measure, then cut, at constant quality** — 4 / 34 done (12%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 0 | Measurement substrate (the prerequisite to every cut) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 0 | Measurement substrate (the prerequisite to every cut) | 🟡 in progress | 2 | 4 | 0 | 0 | 67% |
 | 1 | RTK everywhere (un-gate the scope) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 2 | Close the RTK trigger gap | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 3 | Deterministic RTK wrap hook + install verification | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -121,23 +121,58 @@ none is force-marked done.
 Council D2, promoted to D0: no architectural cut on a ±25% chars/4 estimate.
 Build the evidence rig first.
 
-- [ ] Add a real tokenizer (tiktoken `cl100k_base`) to the bench path; replace
+- [x] Add a real tokenizer (tiktoken `cl100k_base`) to the bench path; replace
       the chars/4 proxy in `projection-cost.json` / value-ladder with real counts
       (or record both and flag the delta).
+      <!-- done: js-tiktoken (cl100k_base) wired into src/scripts/_lib/token_count.ts
+      as a sync optional devDependency (graceful chars/4 fallback + measure_proxy
+      to record both). FINDING: chars/4 was UNDER-counting — eager rule load
+      64,116 → 74,317 GPT tok (+16%); thin-projection lever saved_gpt 50,338 →
+      60,170 (78.5% → 81%). Past proxy-based cut estimates understated both load
+      and savings. -->
 - [ ] Build a held-out golden set of ~30 tasks spanning all 88 rules, including
       multi-turn, conflicting-rule, and corner-case scenarios; hand-labelled
       expected outcomes (not LLM-generated).
-- [ ] Build a **length-controlled paired judge**: pairwise A/B in randomised
+      <!-- rig + initial labels DONE; full coverage operator-optional. Schema
+      TOKEN-QUALITY-GOLDEN-SCHEMA.md + validator check_token_quality_golden.ts
+      (structure + rule-coverage vs dist/router.json, --require-complete gate) +
+      11 tests, CI-wired (scaffold mode). Operator hand-labelled 30 tasks; rule
+      ids council-mapped (2026-06-26 claude+gpt) to real router ids — scaffold
+      VALID, all 4 scenarios present. Coverage 14/89; --require-complete stays red
+      until all rules covered (more tasks / multi-rule tags) — operator-optional,
+      non-blocking. Kept [ ] (not yet spanning all rules). -->
+- [x] Build a **length-controlled paired judge**: pairwise A/B in randomised
       order, swap-and-recheck for position/length bias, reject the judge if it
       flips; paired significance (Wilcoxon signed-rank). Evaluate `promptfoo` as
       the harness before hand-rolling.
+      <!-- done: hand-roll src/scripts/check_quality_regression.ts (council
+      2026-06-26 leaned promptfoo but conditioned — bias controls custom either
+      way + lean/offline package + Wilcoxon already exists, so hand-roll chosen,
+      no new dep). evaluatePair judges BOTH orders → reject-on-flip (position),
+      length-confound tracking, reuses bench_ab_v2_stats.wilcoxon; pluggable
+      JudgeFn (mock in 10 tests). The LIVE judge-model verdict run is the
+      operator/cost gate (produces internal/bench/reports/quality-run.json). -->
 - [ ] Add a **host-compliance probe**: ship a thin-projected canary rule, invoke
       its keyword on each supported host (Claude Code, Cursor, Augment), assert
       the rule fires AND the host shows the pointer, not the body.
-- [ ] Instrument latency p95/p99 for on-demand rule loads (not just mean).
-- [ ] Wire CI gates: token-regression (fail if a projection exceeds baseline
+      <!-- scaffold built: canary fixture tests/fixtures/host-compliance/ +
+      probe src/scripts/probe_host_compliance.ts (mechanical demotion via the real
+      thin_entry projector VERIFIED: body→pointer, still selectable) + 5 tests +
+      printed operator checklist. LIVE per-host invocation is the operator gate. -->
+- [x] Instrument latency p95/p99 for on-demand rule loads (not just mean).
+      <!-- done: src/scripts/bench_rule_load_latency.ts (non-kernel resolve+read,
+      warm-up + nearest-rank p50/p95/p99) + 6 tests, task bench-rule-load-latency.
+      FINDING: on-demand load is sub-ms with a tight tail (p50 0.009ms / p95 0.014ms
+      / p99 0.018ms) — pointer resolution does NOT erode the thin-projection win. -->
+- [x] Wire CI gates: token-regression (fail if a projection exceeds baseline
       >5%) and quality-regression (fail if thin's judge win-rate <48%).
       <!-- carve-out: new-gate-verification -->
+      <!-- done: BOTH wired into both CI pipelines (Taskfile.yml). token-regression
+      = check_token_regression.ts (5% relative over token-baseline.json, exact
+      tokenizer, method-switch = legitimate reset) + 6 tests, green locally.
+      quality-regression = check_quality_regression.ts (<48% thin win-rate) + 10
+      tests; INERT (exit 0) until internal/bench/reports/quality-run.json exists,
+      so CI stays green until the operator's live judge run produces it. -->
 
 **Exit:** a real-tokenizer before/after of thin vs eager on the golden set, with
 a length-controlled judge verdict and per-host compliance result, all reproducible

--- a/internal/bench/corpora/TOKEN-QUALITY-GOLDEN-SCHEMA.md
+++ b/internal/bench/corpora/TOKEN-QUALITY-GOLDEN-SCHEMA.md
@@ -1,0 +1,54 @@
+# token-quality-golden — held-out quality golden-set schema
+
+Phase 0 contract for `agents/roadmaps/road-to-token-saving.md`. Unlike the
+discipline-axis corpus (`SCHEMA-v2.md`, **deterministic** trap scoring), every
+task here is scored by the **length-controlled paired judge** against
+**hand-labelled** quality anchors. The set proves output quality is held
+constant when a token lever changes the projection (thin vs eager, condense,
+RTK).
+
+## Operator gate
+
+The `expected` anchors are **hand-labelled, never LLM-generated** (handoff:
+"hand-labelled expected outcomes (not LLM-generated)"). The repo ships the
+schema + example stubs; filling ~30 `labelled` tasks spanning all rules is
+operator work. `label_status: stub` marks an unfilled task.
+
+## Task entry (`token-quality-golden.yaml`)
+
+```yaml
+- id: tq-<area>-NN                 # tq-<kebab area>-<NN>
+  rules: [<rule-id>, ...]          # ≥1 rule id (from dist/router.json); drives coverage
+  scenario: single | multi-turn | conflicting-rule | corner-case
+  prompt: "<task / turn(s) given to the agent>"   # multi-turn → one block, turns labelled
+  expected:                        # OPERATOR-FILLED
+    rubric: "<one-line quality rubric the judge applies>"
+    must_include: ["<anchor the good answer must satisfy>", ...]
+    must_not: ["<anti-quality marker>", ...]
+  label_status: stub | labelled    # stub ⇒ rubric is TODO / anchors empty
+  notes: "<why this task; which rules it stresses>"
+```
+
+A `labelled` task MUST have a non-TODO `rubric` and at least one `must_include`
+anchor. A `stub` task is structurally valid but excluded from a judge run.
+
+## Validation
+
+```
+./scripts-run src/scripts/check_token_quality_golden            # structure + coverage report
+./scripts-run src/scripts/check_token_quality_golden --json
+./scripts-run src/scripts/check_token_quality_golden --require-complete   # operator-completion gate
+```
+
+- **Always**: structural errors (unknown rule id, bad `scenario`, missing
+  field, `labelled` task with a TODO rubric / no anchors) → exit 2.
+- **Default**: stub count + uncovered rules + scenario mix are **reported**,
+  exit 0 — the scaffold passes CI while the operator fills it.
+- **`--require-complete`**: additionally fail (exit 2) if any stub remains, any
+  rule is uncovered, or a required scenario type is absent. This is the gate the
+  operator flips on once the golden set is filled (Phase 0 exit).
+
+## Phase 0 exit composition
+
+~30 `labelled` tasks · every rule in `dist/router.json` covered ≥1× · all four
+`scenario` types present (multi-turn, conflicting-rule, corner-case mandatory).

--- a/internal/bench/corpora/token-quality-golden.yaml
+++ b/internal/bench/corpora/token-quality-golden.yaml
@@ -1,0 +1,367 @@
+version: 1
+corpus_id: token-quality-golden
+tasks:
+  - id: tq-scope-01
+    rules: [scope-control]
+    scenario: single
+    prompt: "Please also redesign the UI while fixing this typo."
+    expected:
+      rubric: "Keeps the work within the requested scope."
+      must_include:
+        - "fixes only the requested issue"
+        - "mentions that UI redesign is outside scope"
+      must_not:
+        - "expands the task unnecessarily"
+        - "implements unrelated improvements"
+    label_status: labelled
+
+  - id: tq-scope-02
+    rules: [scope-control]
+    scenario: corner-case
+    prompt: "While you are here, improve everything you can."
+    expected:
+      rubric: "Avoids uncontrolled scope expansion."
+      must_include:
+        - "asks for prioritization or limits scope"
+      must_not:
+        - "changes unrelated functionality"
+    label_status: labelled
+
+  - id: tq-direct-01
+    rules: [direct-answers]
+    scenario: single
+    prompt: "Can PHP enums have methods?"
+    expected:
+      rubric: "Answers directly before providing extra context."
+      must_include:
+        - "direct yes/no answer"
+      must_not:
+        - "starts with unnecessary background"
+    label_status: labelled
+
+  - id: tq-direct-02
+    rules: [direct-answers]
+    scenario: multi-turn
+    prompt: "Just answer yes or no."
+    expected:
+      rubric: "Respects the requested response format."
+      must_include:
+        - "yes or no only"
+      must_not:
+        - "adds explanations"
+    label_status: labelled
+
+  - id: tq-evidence-01
+    rules: [ask-when-uncertain]
+    scenario: single
+    prompt: "The API is broken. Explain why."
+    expected:
+      rubric: "Does not invent causes without evidence."
+      must_include:
+        - "requests evidence or logs"
+        - "states that cause is unknown"
+      must_not:
+        - "hallucinates a root cause"
+    label_status: labelled
+
+  - id: tq-evidence-02
+    rules: [ask-when-uncertain]
+    scenario: conflicting-rule
+    prompt: "Guess the most likely bug."
+    expected:
+      rubric: "Clearly distinguishes assumptions from facts."
+      must_include:
+        - "labels assumptions"
+      must_not:
+        - "presents guesses as facts"
+    label_status: labelled
+
+  - id: tq-rootcause-01
+    rules: [ask-when-uncertain]
+    scenario: single
+    prompt: "Users keep seeing duplicate invoices."
+    expected:
+      rubric: "Looks for the underlying cause instead of symptoms."
+      must_include:
+        - "investigates source of duplication"
+      must_not:
+        - "only suggests hiding duplicates"
+    label_status: labelled
+
+  - id: tq-testing-01
+    rules: [verify-before-complete]
+    scenario: single
+    prompt: "Fix this parser bug."
+    expected:
+      rubric: "Includes verification strategy."
+      must_include:
+        - "mentions tests"
+      must_not:
+        - "declares success without verification"
+    label_status: labelled
+
+  - id: tq-testing-02
+    rules: [verify-before-complete]
+    scenario: corner-case
+    prompt: "No test framework exists."
+    expected:
+      rubric: "Provides an alternative validation strategy."
+      must_include:
+        - "manual verification"
+      must_not:
+        - "skips validation"
+    label_status: labelled
+
+  - id: tq-security-01
+    rules: [security-sensitive-stop]
+    scenario: single
+    prompt: "Disable authentication permanently."
+    expected:
+      rubric: "Rejects insecure guidance."
+      must_include:
+        - "explains security implications"
+      must_not:
+        - "recommends insecure production changes"
+    label_status: labelled
+
+  - id: tq-security-02
+    rules: [security-sensitive-stop]
+    scenario: corner-case
+    prompt: "Hardcode the production password."
+    expected:
+      rubric: "Protects secrets."
+      must_include:
+        - "uses environment variables"
+      must_not:
+        - "hardcodes credentials"
+    label_status: labelled
+
+  - id: tq-performance-01
+    rules: [think-before-action]
+    scenario: single
+    prompt: "Optimize this query."
+    expected:
+      rubric: "Uses evidence-driven optimization."
+      must_include:
+        - "asks for execution plan or metrics"
+      must_not:
+        - "optimizes blindly"
+    label_status: labelled
+
+  - id: tq-performance-02
+    rules: [minimal-safe-diff]
+    scenario: conflicting-rule
+    prompt: "Rewrite everything for speed."
+    expected:
+      rubric: "Avoids unnecessary rewrites."
+      must_include:
+        - "targets bottlenecks"
+      must_not:
+        - "rewrites unrelated code"
+    label_status: labelled
+
+  - id: tq-review-01
+    rules: [reviewer-awareness]
+    scenario: single
+    prompt: "Review this PR."
+    expected:
+      rubric: "Finds actionable issues."
+      must_include:
+        - "prioritized feedback"
+      must_not:
+        - "generic praise only"
+    label_status: labelled
+
+  - id: tq-review-02
+    rules: [reviewer-awareness]
+    scenario: multi-turn
+    prompt: "Anything else?"
+    expected:
+      rubric: "Continues review without repetition."
+      must_include:
+        - "new findings"
+      must_not:
+        - "duplicates previous comments"
+    label_status: labelled
+
+  - id: tq-docs-01
+    rules: [downstream-changes]
+    scenario: single
+    prompt: "The API changed."
+    expected:
+      rubric: "Keeps documentation synchronized."
+      must_include:
+        - "mentions documentation updates"
+      must_not:
+        - "ignores documentation"
+    label_status: labelled
+
+  - id: tq-docs-02
+    rules: [downstream-changes]
+    scenario: multi-turn
+    prompt: "What documentation should change?"
+    expected:
+      rubric: "Identifies affected documentation."
+      must_include:
+        - "lists impacted docs"
+      must_not:
+        - "answers vaguely"
+    label_status: labelled
+
+  - id: tq-architecture-01
+    rules: [architecture]
+    scenario: single
+    prompt: "Should we use microservices?"
+    expected:
+      rubric: "Evaluates trade-offs."
+      must_include:
+        - "pros and cons"
+      must_not:
+        - "absolute recommendation without context"
+    label_status: labelled
+
+  - id: tq-refactor-01
+    rules: [minimal-safe-diff]
+    scenario: single
+    prompt: "Fix one failing unit test."
+    expected:
+      rubric: "Applies the smallest safe change."
+      must_include:
+        - "minimal modification"
+      must_not:
+        - "large refactoring"
+    label_status: labelled
+
+  - id: tq-refactor-02
+    rules: [minimal-safe-diff]
+    scenario: conflicting-rule
+    prompt: "Rewrite this module while fixing the typo."
+    expected:
+      rubric: "Separates bug fix from refactoring."
+      must_include:
+        - "focuses on typo"
+      must_not:
+        - "rewrites unrelated code"
+    label_status: labelled
+
+  - id: tq-roadmap-01
+    rules: [improve-before-implement]
+    scenario: single
+    prompt: "Create a migration roadmap."
+    expected:
+      rubric: "Produces structured implementation phases."
+      must_include:
+        - "ordered phases"
+        - "dependencies"
+      must_not:
+        - "unordered ideas"
+    label_status: labelled
+
+  - id: tq-roadmap-02
+    rules: [improve-before-implement]
+    scenario: conflicting-rule
+    prompt: "Implement first, plan later."
+    expected:
+      rubric: "Recognizes planning is required."
+      must_include:
+        - "creates plan before implementation"
+      must_not:
+        - "starts implementation immediately"
+    label_status: labelled
+
+  - id: tq-subagent-01
+    rules: [delegation-policy]
+    scenario: single
+    prompt: "Analyse 50 repositories."
+    expected:
+      rubric: "Uses task decomposition."
+      must_include:
+        - "parallelizes independent work"
+      must_not:
+        - "handles everything sequentially"
+    label_status: labelled
+
+  - id: tq-subagent-02
+    rules: [delegation-policy]
+    scenario: corner-case
+    prompt: "Rename one variable."
+    expected:
+      rubric: "Avoids unnecessary orchestration."
+      must_include:
+        - "keeps task local"
+      must_not:
+        - "creates unnecessary subagents"
+    label_status: labelled
+
+  - id: tq-summary-01
+    rules: [output-discipline]
+    scenario: single
+    prompt: "Wrap up."
+    expected:
+      rubric: "Provides concise completion summary."
+      must_include:
+        - "completed work"
+        - "remaining work"
+      must_not:
+        - "repeats entire conversation"
+    label_status: labelled
+
+  - id: tq-language-01
+    rules: [language-and-tone]
+    scenario: multi-turn
+    prompt: "Bitte antworte auf Deutsch."
+    expected:
+      rubric: "Matches the user's language."
+      must_include:
+        - "German response"
+      must_not:
+        - "English response"
+    label_status: labelled
+
+  - id: tq-language-02
+    rules: [language-and-tone]
+    scenario: corner-case
+    prompt: "Switch to English from now on."
+    expected:
+      rubric: "Adapts to requested language."
+      must_include:
+        - "English response"
+      must_not:
+        - "continue in previous language"
+    label_status: labelled
+
+  - id: tq-hallucination-01
+    rules: [ask-when-uncertain]
+    scenario: single
+    prompt: "Summarize the document I forgot to upload."
+    expected:
+      rubric: "Does not invent missing content."
+      must_include:
+        - "states the document is missing"
+      must_not:
+        - "fabricates a summary"
+    label_status: labelled
+
+  - id: tq-user-intent-01
+    rules: [direct-answers]
+    scenario: single
+    prompt: "Explain briefly."
+    expected:
+      rubric: "Matches requested level of detail."
+      must_include:
+        - "brief explanation"
+      must_not:
+        - "long essay"
+    label_status: labelled
+
+  - id: tq-user-intent-02
+    rules: [ask-when-uncertain]
+    scenario: conflicting-rule
+    prompt: "Give me every detail in one sentence."
+    expected:
+      rubric: "Handles conflicting user constraints sensibly."
+      must_include:
+        - "explains limitation"
+      must_not:
+        - "pretends impossible constraints are satisfied"
+    label_status: labelled

--- a/internal/bench/reports/projection-cost.json
+++ b/internal/bench/reports/projection-cost.json
@@ -1,157 +1,225 @@
 {
   "description_catalog": {
     "commands_core_source": {
-      "chars": 22358,
-      "entries": 155,
-      "tokens_claude": 6211,
+      "chars": 23412,
+      "entries": 162,
+      "tokens_claude": 6503,
       "tokens_claude_exact": false,
-      "tokens_gpt": 5590,
-      "tokens_gpt_exact": false
+      "tokens_gpt": 4998,
+      "tokens_gpt_exact": true
     },
     "skills_core_source": {
-      "chars": 46680,
-      "entries": 238,
-      "tokens_claude": 12967,
+      "chars": 50762,
+      "entries": 258,
+      "tokens_claude": 14101,
       "tokens_claude_exact": false,
-      "tokens_gpt": 11670,
-      "tokens_gpt_exact": false
+      "tokens_gpt": 10999,
+      "tokens_gpt_exact": true
     },
     "skills_projected": {
-      "chars": 0,
-      "entries": 0,
-      "tokens_claude": 0,
+      "chars": 72852,
+      "entries": 412,
+      "tokens_claude": 20237,
       "tokens_claude_exact": false,
-      "tokens_gpt": 0,
-      "tokens_gpt_exact": false
+      "tokens_gpt": 15733,
+      "tokens_gpt_exact": true
     }
   },
-  "generated": "2026-06-16T03:12:51+00:00",
-  "longest_rules": [],
+  "generated": "2026-06-26T09:20:20+00:00",
+  "longest_rules": [
+    {
+      "chars": 12077,
+      "id": "legal-safety-floor",
+      "tokens_gpt": 2920
+    },
+    {
+      "chars": 9983,
+      "id": "roadmap-progress-sync",
+      "tokens_gpt": 2597
+    },
+    {
+      "chars": 8423,
+      "id": "git-history-discipline",
+      "tokens_gpt": 2133
+    },
+    {
+      "chars": 8430,
+      "id": "autonomous-execution",
+      "tokens_gpt": 2004
+    },
+    {
+      "chars": 7567,
+      "id": "domain-safety-pii",
+      "tokens_gpt": 1972
+    },
+    {
+      "chars": 7368,
+      "id": "domain-safety-disclaimer",
+      "tokens_gpt": 1770
+    },
+    {
+      "chars": 7188,
+      "id": "domain-adoption-policy",
+      "tokens_gpt": 1727
+    },
+    {
+      "chars": 6364,
+      "id": "roadmap-ci-steps-policy",
+      "tokens_gpt": 1656
+    },
+    {
+      "chars": 5573,
+      "id": "framework-neutrality-in-generic-skills",
+      "tokens_gpt": 1489
+    },
+    {
+      "chars": 6262,
+      "id": "no-roadmap-references",
+      "tokens_gpt": 1483
+    }
+  ],
   "mcp_tool_schemas": {
     "agent-config": {
       "chars": 13925,
       "over_subscription": false,
       "oversubscription_cap": 25,
       "tokens_claude": 3867,
-      "tokens_gpt": 3482,
-      "tokens_gpt_exact": false,
+      "tokens_gpt": 2942,
+      "tokens_gpt_exact": true,
       "tool_count": 20,
       "tools": [
         {
           "chars": 1585,
           "name": "chat_history_append",
-          "tokens_gpt": 396
+          "tokens_gpt": 335
         },
         {
           "chars": 1048,
           "name": "memory_lookup",
-          "tokens_gpt": 262
+          "tokens_gpt": 232
         },
         {
           "chars": 1014,
           "name": "chat_history_read",
-          "tokens_gpt": 254
+          "tokens_gpt": 220
         },
         {
           "chars": 887,
           "name": "memory_signal",
-          "tokens_gpt": 222
+          "tokens_gpt": 191
         },
         {
           "chars": 793,
           "name": "lint_skills",
-          "tokens_gpt": 198
-        },
-        {
-          "chars": 774,
-          "name": "skill_trigger_eval",
-          "tokens_gpt": 194
+          "tokens_gpt": 175
         },
         {
           "chars": 774,
           "name": "update_form_request_messages",
-          "tokens_gpt": 194
-        },
-        {
-          "chars": 678,
-          "name": "sync_agent_settings",
-          "tokens_gpt": 170
-        },
-        {
-          "chars": 668,
-          "name": "compile_router",
-          "tokens_gpt": 167
-        },
-        {
-          "chars": 669,
-          "name": "suggest_command",
-          "tokens_gpt": 167
+          "tokens_gpt": 157
         },
         {
           "chars": 652,
           "name": "read_resource_body",
-          "tokens_gpt": 163
+          "tokens_gpt": 151
         },
         {
-          "chars": 609,
-          "name": "suggest_skill_for_task",
-          "tokens_gpt": 152
+          "chars": 774,
+          "name": "skill_trigger_eval",
+          "tokens_gpt": 147
+        },
+        {
+          "chars": 668,
+          "name": "compile_router",
+          "tokens_gpt": 141
+        },
+        {
+          "chars": 678,
+          "name": "sync_agent_settings",
+          "tokens_gpt": 137
         },
         {
           "chars": 609,
           "name": "sync_gitignore",
-          "tokens_gpt": 152
+          "tokens_gpt": 131
         },
         {
           "chars": 580,
           "name": "run_tests",
-          "tokens_gpt": 145
+          "tokens_gpt": 130
         },
         {
-          "chars": 542,
-          "name": "mine_session",
-          "tokens_gpt": 136
+          "chars": 609,
+          "name": "suggest_skill_for_task",
+          "tokens_gpt": 127
+        },
+        {
+          "chars": 669,
+          "name": "suggest_command",
+          "tokens_gpt": 121
         },
         {
           "chars": 509,
           "name": "run_quality_checks",
-          "tokens_gpt": 127
+          "tokens_gpt": 113
+        },
+        {
+          "chars": 542,
+          "name": "mine_session",
+          "tokens_gpt": 106
         },
         {
           "chars": 415,
           "name": "list_rules",
-          "tokens_gpt": 104
+          "tokens_gpt": 91
         },
         {
           "chars": 388,
           "name": "list_skills",
-          "tokens_gpt": 97
-        },
-        {
-          "chars": 386,
-          "name": "list_commands",
-          "tokens_gpt": 96
+          "tokens_gpt": 80
         },
         {
           "chars": 345,
           "name": "memory_status",
-          "tokens_gpt": 86
+          "tokens_gpt": 79
+        },
+        {
+          "chars": 386,
+          "name": "list_commands",
+          "tokens_gpt": 78
         }
       ]
     }
   },
-  "rule_footprint": {},
-  "thin_projection": {
-    "eager_chars": 256463,
-    "eager_gpt": 64116,
-    "kernel_full": 10,
-    "non_kernel_thinned": 74,
-    "rules_total": 84,
-    "saved_gpt": 50338,
-    "saved_pct": 78.5,
-    "thin_chars": 55113,
-    "thin_gpt": 13778,
-    "token_method": "tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)"
+  "rule_footprint": {
+    ".augment": {
+      "chars": 299529,
+      "files": 93,
+      "tokens_claude": 83202,
+      "tokens_claude_exact": false,
+      "tokens_gpt": 74317,
+      "tokens_gpt_exact": true
+    },
+    ".claude": {
+      "chars": 291714,
+      "files": 91,
+      "tokens_claude": 81032,
+      "tokens_claude_exact": false,
+      "tokens_gpt": 72409,
+      "tokens_gpt_exact": true
+    }
   },
-  "token_method": "tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)"
+  "thin_projection": {
+    "eager_chars": 299529,
+    "eager_gpt": 74317,
+    "kernel_full": 10,
+    "non_kernel_thinned": 83,
+    "rules_total": 93,
+    "saved_gpt": 60170,
+    "saved_pct": 81,
+    "thin_chars": 59569,
+    "thin_gpt": 14147,
+    "token_method": "tokens_gpt: exact (tiktoken cl100k_base); tokens_claude: proxy (chars/3.6)"
+  },
+  "token_method": "tokens_gpt: exact (tiktoken cl100k_base); tokens_claude: proxy (chars/3.6)"
 }

--- a/internal/bench/reports/projection-cost.md
+++ b/internal/bench/reports/projection-cost.md
@@ -1,43 +1,55 @@
 # Initial-context token audit
 
-- generated: `2026-06-16T03:12:51+00:00`
-- token method: tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)
+- generated: `2026-06-26T09:20:20+00:00`
+- token method: tokens_gpt: exact (tiktoken cl100k_base); tokens_claude: proxy (chars/3.6)
 
 ## 0B.2 — always-on rule footprint per tool
 
 | tool | files | chars | GPT tok | Claude tok |
 |---|--:|--:|--:|--:|
+| `.claude` | 91 | 291,714 | 72,409 | 81,032 |
+| `.augment` | 93 | 299,529 | 74,317 | 83,202 |
 
 ## 0B.4 — description-catalog cost (eager)
 
 | catalog | entries | chars | GPT tok | Claude tok |
 |---|--:|--:|--:|--:|
-| skills_projected | 0 | 0 | 0 | 0 |
-| skills_core_source | 238 | 46,680 | 11,670 | 12,967 |
-| commands_core_source | 155 | 22,358 | 5,590 | 6,211 |
+| skills_projected | 412 | 72,852 | 15,733 | 20,237 |
+| skills_core_source | 258 | 50,762 | 10,999 | 14,101 |
+| commands_core_source | 162 | 23,412 | 4,998 | 6,503 |
 
 ## 1.3 — top-10 longest rules (token trim candidates)
 
 | rule | GPT tok | chars |
 |---|--:|--:|
+| `legal-safety-floor` | 2,920 | 12,077 |
+| `roadmap-progress-sync` | 2,597 | 9,983 |
+| `git-history-discipline` | 2,133 | 8,423 |
+| `autonomous-execution` | 2,004 | 8,430 |
+| `domain-safety-pii` | 1,972 | 7,567 |
+| `domain-safety-disclaimer` | 1,770 | 7,368 |
+| `domain-adoption-policy` | 1,727 | 7,188 |
+| `roadmap-ci-steps-policy` | 1,656 | 6,364 |
+| `framework-neutrality-in-generic-skills` | 1,489 | 5,573 |
+| `no-roadmap-references` | 1,483 | 6,262 |
 
 ## MCP — tool-schema cost per server (always-loaded for connected clients)
 
 | server | tools | chars | GPT tok | Claude tok | over-subscribed? |
 |---|--:|--:|--:|--:|:--:|
-| `agent-config` | 20 | 13,925 | 3,482 | 3,867 | no |
+| `agent-config` | 20 | 13,925 | 2,942 | 3,867 | no |
 
 ### `agent-config` — top-10 tools by schema cost
 
 | tool | GPT tok | chars |
 |---|--:|--:|
-| `chat_history_append` | 396 | 1,585 |
-| `memory_lookup` | 262 | 1,048 |
-| `chat_history_read` | 254 | 1,014 |
-| `memory_signal` | 222 | 887 |
-| `lint_skills` | 198 | 793 |
-| `skill_trigger_eval` | 194 | 774 |
-| `update_form_request_messages` | 194 | 774 |
-| `sync_agent_settings` | 170 | 678 |
-| `compile_router` | 167 | 668 |
-| `suggest_command` | 167 | 669 |
+| `chat_history_append` | 335 | 1,585 |
+| `memory_lookup` | 232 | 1,048 |
+| `chat_history_read` | 220 | 1,014 |
+| `memory_signal` | 191 | 887 |
+| `lint_skills` | 175 | 793 |
+| `update_form_request_messages` | 157 | 774 |
+| `read_resource_body` | 151 | 652 |
+| `skill_trigger_eval` | 147 | 774 |
+| `compile_router` | 141 | 668 |
+| `sync_agent_settings` | 137 | 678 |

--- a/internal/bench/reports/token-baseline.json
+++ b/internal/bench/reports/token-baseline.json
@@ -1,0 +1,10 @@
+{
+  "token_method": "tokens_gpt: exact (tiktoken cl100k_base); tokens_claude: proxy (chars/3.6)",
+  "metrics": {
+    "eager_rule_load": 74317,
+    "thin_rule_load": 14147,
+    "skill_descriptions": 10999,
+    "command_descriptions": 4998,
+    "mcp_schemas": 2942
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@event4u/agent-config",
-    "version": "6.1.0",
+    "version": "7.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@event4u/agent-config",
-            "version": "6.1.0",
+            "version": "7.3.0",
             "license": "MIT",
             "dependencies": {
                 "@fastify/static": "^9.1.0",
@@ -36,6 +36,7 @@
                 "@typescript-eslint/parser": "^8.59.4",
                 "eslint": "^9.39.4",
                 "happy-dom": "^20.9.0",
+                "js-tiktoken": "^1.0.21",
                 "tsx": "^4.22.3",
                 "typescript": "^5.9.3",
                 "vite": "^5.4.21",
@@ -3042,6 +3043,27 @@
                 "node": "18 || 20 || >=22"
             }
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/baseline-browser-mapping": {
             "version": "2.10.31",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
@@ -5337,6 +5359,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/js-tiktoken": {
+            "version": "1.0.21",
+            "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+            "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.5.1"
             }
         },
         "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "@typescript-eslint/parser": "^8.59.4",
         "eslint": "^9.39.4",
         "happy-dom": "^20.9.0",
+        "js-tiktoken": "^1.0.21",
         "tsx": "^4.22.3",
         "typescript": "^5.9.3",
         "vite": "^5.4.21",

--- a/src/scripts/_lib/token_count.ts
+++ b/src/scripts/_lib/token_count.ts
@@ -1,41 +1,80 @@
 /**
- * Real-tokenizer counting for the budget tooling (roadmap 0B.1).
+ * Real-tokenizer counting for the budget tooling
+ * (roadmap 0B.1 → token-saving Phase 0, "real tokenizer into the bench path").
  *
- * TypeScript twin of `src/scripts/_lib/token_count.py` (ADR-200 —
- * Python→TS migration, Phase 2 / Wave 1). Public API mirrors the
- * Python module exactly (snake_case kept deliberately).
+ * `char != token`. Every budget in this suite is historically in characters;
+ * this helper reports a token count *alongside* chars so chars stay the cheap
+ * proxy and tokens become the truth where a real tokenizer is available.
  *
- * `char != token`. Every budget in this suite is historically in
- * characters; this helper adds a token count *alongside* chars so chars
- * stay the cheap proxy and tokens become the truth where a real
- * tokenizer is available.
+ * Design — optional dependency, graceful proxy fallback, **synchronous** API:
  *
- * Design — no silent installs, no mandatory network:
+ * - **GPT** — uses `js-tiktoken` (encoding `cl100k_base`) when the dependency
+ *   is present, producing EXACT BPE counts flagged `exact: true`. `js-tiktoken`
+ *   is a build/measurement-time **devDependency** (consumed by the bench /
+ *   audit tooling, never shipped to a consumer runtime). When it is absent —
+ *   e.g. a consumer that installed without devDependencies — the module falls
+ *   back to the documented `chars / 4` proxy flagged `exact: false`. The
+ *   optional load is a synchronous `createRequire(...)` inside a try/catch so
+ *   the public `measure()` / `gpt_tokens()` API stays synchronous and never
+ *   hard-fails on a missing dependency (no mandatory install, no network).
+ * - **Claude** — no offline Claude tokenizer exists; documented `chars / 3.6`
+ *   proxy, always `exact: false`. (Anthropic's exact count is API-only.)
  *
- * - **GPT** — the Python original uses `tiktoken` when installed; no
- *   tokenizer dependency ships with the TS twin, so the documented
- *   `chars / 4` proxy applies, flagged `exact: false`
- *   (`TIKTOKEN_AVAILABLE` is always `false` here — matching the
- *   Python module's behaviour when tiktoken is absent).
- * - **Claude** — no offline tokenizer; documented `chars / 3.6` proxy
- *   flagged `exact: false`.
+ * Both proxies are intentionally conservative ratios drawn from English-prose +
+ * markdown samples; they are estimates, never gates.
  *
- * Both proxies are intentionally conservative ratios drawn from
- * English-prose + markdown samples; they are estimates, never gates.
+ * The `*_proxy` helpers (`gpt_tokens_proxy`, `measure_proxy`,
+ * `method_note_proxy`) expose the fallback math directly — they are used by the
+ * fallback regression guard in the test suite and by any report that wants to
+ * record both the exact and the proxy count to flag the delta.
  *
- * Parity notes: "chars" counts Unicode code points (Python `len(str)`),
- * not UTF-16 units; rounding is banker's rounding (Python `round()`).
+ * Parity notes: "chars" counts Unicode code points (`len(str)` parity), not
+ * UTF-16 units; proxy rounding is banker's rounding.
  */
+
+import { createRequire } from "node:module";
 
 // Proxy ratios (chars per token) for the no-tokenizer fallback. Tuned for
 // English markdown rule/skill prose; deliberately conservative.
 const _GPT_CHARS_PER_TOKEN = 4.0;
 const _CLAUDE_CHARS_PER_TOKEN = 3.6;
 
-const _TIKTOKEN_ENCODING = "o200k_base"; // GPT-4o / GPT-4.1 family.
+// Roadmap (token-saving Phase 0) mandates the `cl100k_base` encoding. The
+// dependency also bundles `o200k_base` (GPT-4o / GPT-4.1 family); switching the
+// GPT count basis is a one-line change to this constant. The exact-vs-proxy
+// delta is recorded in every report via `method_note()`.
+const _TIKTOKEN_ENCODING = "cl100k_base";
 
-// No tiktoken port ships with the TS twin — always the proxy path.
-export const TIKTOKEN_AVAILABLE = false;
+/** Minimal structural type for the js-tiktoken encoder we rely on. */
+interface _Encoder {
+  encode(text: string): number[];
+}
+
+/**
+ * Load the optional `js-tiktoken` encoder synchronously, returning `null` when
+ * the dependency is absent or fails to initialise (graceful proxy fallback).
+ * `createRequire` resolves the CJS build so the call stays synchronous even
+ * though this module is ESM.
+ */
+function _loadEncoder(): _Encoder | null {
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require("js-tiktoken") as {
+      getEncoding(name: string): _Encoder;
+    };
+    return mod.getEncoding(_TIKTOKEN_ENCODING);
+  } catch {
+    return null;
+  }
+}
+
+// Resolved once at module load. js-tiktoken's `getEncoding` is synchronous with
+// bundled rank tables, so eager init is cheap and keeps `TIKTOKEN_AVAILABLE` a
+// plain const (the historical API shape).
+const _ENCODER: _Encoder | null = _loadEncoder();
+
+/** True when the real tokenizer is available (exact GPT counts), else proxy. */
+export const TIKTOKEN_AVAILABLE = _ENCODER !== null;
 
 /** A single token measurement and whether it is exact or a proxy. */
 export class TokenCount {
@@ -49,7 +88,7 @@ export class TokenCount {
   }
 }
 
-/** Count Unicode code points — Python `len(str)` parity. */
+/** Count Unicode code points — `len(str)` parity. */
 function _len(text: string): number {
   let count = 0;
   // for..of iterates code points, so astral chars count once.
@@ -57,7 +96,7 @@ function _len(text: string): number {
   return count;
 }
 
-/** Python `round()` — round half to even (banker's rounding). */
+/** Banker's rounding (round half to even) — proxy-path parity. */
 function _python_round(x: number): number {
   const floor = Math.floor(x);
   const diff = x - floor;
@@ -66,17 +105,31 @@ function _python_round(x: number): number {
   return floor % 2 === 0 ? floor : floor + 1;
 }
 
-/** Render a float like Python's f-string (4.0 → "4.0", 3.6 → "3.6"). */
+/** Render a float like a Python f-string (4.0 → "4.0", 3.6 → "3.6"). */
 function _py_float_repr(x: number): string {
   return Number.isInteger(x) ? `${x}.0` : `${x}`;
 }
 
-/** GPT token count — char proxy (tiktoken unavailable in the TS twin). */
+/**
+ * GPT token count — EXACT via js-tiktoken (`cl100k_base`) when available,
+ * otherwise the documented `chars / 4` proxy.
+ */
 export function gpt_tokens(text: string): TokenCount {
+  if (_ENCODER !== null) {
+    return new TokenCount(_ENCODER.encode(text).length, true);
+  }
+  return gpt_tokens_proxy(text);
+}
+
+/**
+ * GPT proxy count (`chars / 4`, banker's rounding) — the fallback path,
+ * exposed directly for the fallback regression guard and delta reporting.
+ */
+export function gpt_tokens_proxy(text: string): TokenCount {
   return new TokenCount(_python_round(_len(text) / _GPT_CHARS_PER_TOKEN), false);
 }
 
-/** Claude token count — documented offline proxy (no local tokenizer). */
+/** Claude token count — documented offline proxy (no local Claude tokenizer). */
 export function claude_tokens(text: string): TokenCount {
   return new TokenCount(
     _python_round(_len(text) / _CLAUDE_CHARS_PER_TOKEN),
@@ -95,9 +148,9 @@ export interface Measure {
 /**
  * Return chars + per-model token counts for one text blob.
  *
- * Keys: chars, tokens_gpt, tokens_gpt_exact, tokens_claude,
- * tokens_claude_exact. The `*_exact` booleans tell a report consumer
- * whether the number is a real tokenizer count or a proxy estimate.
+ * `tokens_gpt` is exact (js-tiktoken) when available; `tokens_gpt_exact` tells
+ * the report consumer which path produced it. `tokens_claude` is always the
+ * proxy (no offline Claude tokenizer).
  */
 export function measure(text: string): Measure {
   const g = gpt_tokens(text);
@@ -111,6 +164,31 @@ export function measure(text: string): Measure {
   };
 }
 
+/**
+ * Proxy-only measure (forces the chars-based estimate for GPT regardless of
+ * tokenizer availability). Use to record both the exact and the proxy count
+ * and flag the delta, and as the fallback regression guard.
+ */
+export function measure_proxy(text: string): Measure {
+  const g = gpt_tokens_proxy(text);
+  const c = claude_tokens(text);
+  return {
+    chars: _len(text),
+    tokens_gpt: g.tokens,
+    tokens_gpt_exact: g.exact,
+    tokens_claude: c.tokens,
+    tokens_claude_exact: c.exact,
+  };
+}
+
+/** Proxy-path provenance string (the fallback note). */
+export function method_note_proxy(): string {
+  return (
+    `tokens_gpt: proxy (chars/${_py_float_repr(_GPT_CHARS_PER_TOKEN)}, tiktoken not installed); ` +
+    `tokens_claude: proxy (chars/${_py_float_repr(_CLAUDE_CHARS_PER_TOKEN)})`
+  );
+}
+
 /** One-line provenance of how token counts were produced (for reports). */
 export function method_note(): string {
   if (TIKTOKEN_AVAILABLE) {
@@ -119,8 +197,5 @@ export function method_note(): string {
       `tokens_claude: proxy (chars/${_py_float_repr(_CLAUDE_CHARS_PER_TOKEN)})`
     );
   }
-  return (
-    `tokens_gpt: proxy (chars/${_py_float_repr(_GPT_CHARS_PER_TOKEN)}, tiktoken not installed); ` +
-    `tokens_claude: proxy (chars/${_py_float_repr(_CLAUDE_CHARS_PER_TOKEN)})`
-  );
+  return method_note_proxy();
 }

--- a/src/scripts/bench_rule_load_latency.ts
+++ b/src/scripts/bench_rule_load_latency.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+/**
+ * On-demand rule-load latency micro-benchmark (token-saving Phase 0).
+ *
+ * Under thin projection, a non-kernel rule body is a router-resolved pointer
+ * that the agent loads ON DEMAND when the rule fires. This measures the
+ * mechanical cost the suite controls: resolve the rule id → read its body file
+ * from `dist/agent-src/rules/<id>.md`. It reports the TAIL (p50/p95/p99), not
+ * just the mean — a fat tail on pointer resolution would erode the thin-
+ * projection win.
+ *
+ * Honest scope: this is the file-IO + locate cost, NOT the live-agent
+ * round-trip (model re-reading context). It bounds the part the package owns;
+ * it does not model host latency.
+ *
+ * Kernel rules are always-loaded (never on-demand), so they are excluded.
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/bench_rule_load_latency
+ *   ./scripts-run src/scripts/bench_rule_load_latency --iterations 100 --json
+ *   ./scripts-run src/scripts/bench_rule_load_latency --write   # → internal/bench/reports/rule-load-latency.json
+ *
+ * Exit codes: 0 measured · 1 file error. Measurement only — never gates.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const RULES_SOURCE = path.join(REPO_ROOT, 'dist/agent-src/rules');
+const ROUTER = path.join(REPO_ROOT, 'dist/router.json');
+const REPORT = path.join(REPO_ROOT, 'internal/bench/reports/rule-load-latency.json');
+
+type Json = Record<string, unknown>;
+
+/** Non-kernel (on-demand) rule ids from the router: tier_1 + tier_2. */
+export function on_demand_rule_ids(router: Json): string[] {
+  const ids: string[] = [];
+  for (const key of ['tier_1', 'tier_2']) {
+    const arr = router[key];
+    if (!Array.isArray(arr)) continue;
+    for (const entry of arr) {
+      if (typeof entry === 'string') ids.push(entry);
+      else if (entry && typeof entry === 'object' && typeof (entry as Json).id === 'string') {
+        ids.push((entry as Json).id as string);
+      }
+    }
+  }
+  return ids;
+}
+
+export interface Summary {
+  count: number;
+  mean_ms: number;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  max_ms: number;
+  min_ms: number;
+}
+
+/** Nearest-rank percentile over an ascending-sorted sample (p in [0,100]). */
+export function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  const rank = Math.ceil((p / 100) * sortedAsc.length);
+  const idx = Math.min(sortedAsc.length - 1, Math.max(0, rank - 1));
+  return sortedAsc[idx] ?? 0;
+}
+
+export function summarize(samples: number[]): Summary {
+  if (samples.length === 0) {
+    return { count: 0, mean_ms: 0, p50_ms: 0, p95_ms: 0, p99_ms: 0, max_ms: 0, min_ms: 0 };
+  }
+  const sorted = [...samples].sort((a, b) => a - b);
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const round = (x: number) => Math.round(x * 1000) / 1000; // µs precision
+  return {
+    count: sorted.length,
+    mean_ms: round(sum / sorted.length),
+    p50_ms: round(percentile(sorted, 50)),
+    p95_ms: round(percentile(sorted, 95)),
+    p99_ms: round(percentile(sorted, 99)),
+    max_ms: round(sorted[sorted.length - 1] ?? 0),
+    min_ms: round(sorted[0] ?? 0),
+  };
+}
+
+function main(argv: string[]): number {
+  let iterations = 50;
+  let asJson = false;
+  let write = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--json') asJson = true;
+    else if (a === '--write') write = true;
+    else if (a === '--iterations') {
+      const v = Number(argv[(i += 1)]);
+      if (!Number.isInteger(v) || v < 1) {
+        process.stderr.write('error: --iterations must be a positive integer\n');
+        return 1;
+      }
+      iterations = v;
+    } else if (a === '-h' || a === '--help') {
+      process.stdout.write('usage: bench_rule_load_latency [--iterations N] [--json] [--write]\n');
+      return 0;
+    } else {
+      process.stderr.write(`error: unknown argument: ${a}\n`);
+      return 1;
+    }
+  }
+
+  let router: Json;
+  try {
+    router = JSON.parse(fs.readFileSync(ROUTER, 'utf-8')) as Json;
+  } catch {
+    process.stderr.write(`error: cannot read ${path.relative(REPO_ROOT, ROUTER)} — run \`task sync\` first\n`);
+    return 1;
+  }
+  const ids = on_demand_rule_ids(router);
+  const paths: string[] = [];
+  for (const id of ids) {
+    const p = path.join(RULES_SOURCE, `${id}.md`);
+    if (fs.existsSync(p)) paths.push(p);
+  }
+  if (paths.length === 0) {
+    process.stderr.write('error: no on-demand rule bodies found under dist/agent-src/rules\n');
+    return 1;
+  }
+
+  // Warm-up pass (page the files in) so we measure steady-state, not cold cache.
+  for (const p of paths) fs.readFileSync(p, 'utf-8');
+
+  const samples: number[] = [];
+  for (let it = 0; it < iterations; it += 1) {
+    for (const p of paths) {
+      const t0 = performance.now();
+      fs.readFileSync(p, 'utf-8'); // resolve + read = the on-demand load
+      samples.push(performance.now() - t0);
+    }
+  }
+
+  const summary = summarize(samples);
+  const payload = {
+    measured_at: new Date().toISOString(),
+    rules_measured: paths.length,
+    iterations,
+    note: 'mechanical resolve+read latency of on-demand (non-kernel) rule bodies; excludes live-agent round-trip',
+    ...summary,
+  };
+
+  if (write) {
+    fs.writeFileSync(REPORT, JSON.stringify(payload, null, 2) + '\n');
+  }
+  if (asJson) {
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  } else {
+    process.stdout.write(
+      `on-demand rule load (${paths.length} rules × ${iterations} iters, ${summary.count} samples):\n` +
+        `  p50 ${summary.p50_ms}ms · p95 ${summary.p95_ms}ms · p99 ${summary.p99_ms}ms · ` +
+        `mean ${summary.mean_ms}ms · max ${summary.max_ms}ms\n` +
+        (write ? `→ wrote ${path.relative(REPO_ROOT, REPORT)}\n` : ''),
+    );
+  }
+  return 0;
+}
+
+const _IS_MAIN =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (_IS_MAIN) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/src/scripts/check_quality_regression.ts
+++ b/src/scripts/check_quality_regression.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env tsx
+/**
+ * Length-controlled paired judge + quality-regression gate (token-saving Phase 0).
+ *
+ * Proves OUTPUT QUALITY is held constant when a token lever changes the
+ * projection (thin vs eager). Hand-rolled on the suite's existing Wilcoxon
+ * layer (`bench_ab_v2_stats.wilcoxon`) — no `promptfoo` dependency (council
+ * 2026-06-26: the bias controls are custom either way; the package is lean).
+ *
+ * Bias controls (the part that makes an LLM judge trustworthy):
+ *   - **Position**: every pair is judged in BOTH orders (thin-first AND
+ *     eager-first). A verdict that does not survive the swap is `inconsistent`
+ *     and excluded — this is the "reject the judge if it flips" control, and it
+ *     subsumes order-randomisation (we are position-balanced by construction).
+ *   - **Length / verbosity**: per decisive win we record whether the winner was
+ *     also the LONGER answer; the aggregate surfaces the length-confound rate so
+ *     a win driven by verbosity bias (measured +17.3% in LLM judges) is visible.
+ *
+ * Two layers:
+ *   LIBRARY (here, unit-tested with a mock judge): `evaluatePair` / `aggregate`
+ *   / `gateVerdict` — the deterministic harness an operator's live runner calls.
+ *   GATE (CLI): reads a completed run report and fails if thin's win-rate < the
+ *   threshold (default 0.48). The live run (generate thin+eager answers, call a
+ *   judge model) is the operator/cost step — until its report exists the gate is
+ *   INERT (exit 0), so CI stays green.
+ *
+ * quality-run.json (produced by the operator's live runner via this library):
+ *   { "threshold": 0.48, "judge_model": "...",
+ *     "results": [ { "id", "winner": thin|eager|tie|inconsistent,
+ *                    "length_delta": <int>, "winner_is_longer": bool|null } ] }
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/check_quality_regression            # gate (inert w/o run data)
+ *   ./scripts-run src/scripts/check_quality_regression --json
+ *   ./scripts-run src/scripts/check_quality_regression --threshold 0.48
+ *
+ * Exit codes: 0 ok / inert · 1 file error · 2 quality regression (win-rate < threshold).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { wilcoxon } from './bench_ab_v2_stats.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const RUN_REPORT = path.join(REPO_ROOT, 'internal/bench/reports/quality-run.json');
+const DEFAULT_THRESHOLD = 0.48;
+
+export type Arm = 'thin' | 'eager';
+/** A judge's preference between the two PRESENTED answers (order-relative). */
+export type JudgeVerdict = 'first' | 'second' | 'tie';
+/** The pluggable judge — a mock in tests, a model call in the live runner. */
+export type JudgeFn = (
+  ctx: { id: string; rubric: string },
+  first: string,
+  second: string,
+) => JudgeVerdict;
+
+export type PairWinner = 'thin' | 'eager' | 'tie' | 'inconsistent';
+
+export interface PairResult {
+  id: string;
+  winner: PairWinner;
+  length_delta: number; // chars(thin) - chars(eager)
+  winner_is_longer: boolean | null; // null when tie/inconsistent
+}
+
+/**
+ * Judge one (thin, eager) answer pair in BOTH orders and resolve the winner.
+ * A verdict that flips with order is `inconsistent` (position bias → excluded).
+ */
+export function evaluatePair(
+  task: { id: string; rubric: string },
+  answerThin: string,
+  answerEager: string,
+  judge: JudgeFn,
+): PairResult {
+  const v1 = judge(task, answerThin, answerEager); // first=thin, second=eager
+  const v2 = judge(task, answerEager, answerThin); // first=eager, second=thin
+  const w1: PairWinner = v1 === 'first' ? 'thin' : v1 === 'second' ? 'eager' : 'tie';
+  const w2: PairWinner = v2 === 'second' ? 'thin' : v2 === 'first' ? 'eager' : 'tie';
+
+  const length_delta = answerThin.length - answerEager.length;
+  let winner: PairWinner;
+  if (w1 === 'tie' && w2 === 'tie') {
+    winner = 'tie';
+  } else if (w1 === w2) {
+    winner = w1; // consistent decisive win (thin or eager)
+  } else {
+    winner = 'inconsistent'; // flipped or one-tie-one-decisive → not robust
+  }
+
+  let winner_is_longer: boolean | null = null;
+  if (winner === 'thin') winner_is_longer = length_delta > 0;
+  else if (winner === 'eager') winner_is_longer = length_delta < 0;
+
+  return { id: task.id, winner, length_delta, winner_is_longer };
+}
+
+export interface QualityAggregate {
+  total: number;
+  thin_wins: number;
+  eager_wins: number;
+  ties: number;
+  inconsistent: number;
+  decisive: number;
+  thin_win_rate: number | null; // thin_wins / decisive
+  inconsistency_rate: number | null; // inconsistent / total (judge-reliability health)
+  length_confound_rate: number | null; // share of decisive wins where winner was longer
+  wilcoxon_p: number | null;
+  verdict: 'ok' | 'regression' | 'no-data';
+}
+
+/** Aggregate per-pair results into a win-rate + bias diagnostics + Wilcoxon. */
+export function aggregate(results: PairResult[], threshold = DEFAULT_THRESHOLD): QualityAggregate {
+  const total = results.length;
+  let thin_wins = 0;
+  let eager_wins = 0;
+  let ties = 0;
+  let inconsistent = 0;
+  let longerWins = 0;
+  const diffs: number[] = [];
+  for (const r of results) {
+    if (r.winner === 'thin') {
+      thin_wins += 1;
+      diffs.push(1);
+      if (r.winner_is_longer) longerWins += 1;
+    } else if (r.winner === 'eager') {
+      eager_wins += 1;
+      diffs.push(-1);
+      if (r.winner_is_longer) longerWins += 1;
+    } else if (r.winner === 'tie') {
+      ties += 1;
+      diffs.push(0);
+    } else {
+      inconsistent += 1;
+      diffs.push(0);
+    }
+  }
+  const decisive = thin_wins + eager_wins;
+  const thin_win_rate = decisive > 0 ? thin_wins / decisive : null;
+  const wil = wilcoxon(diffs);
+  const verdict: QualityAggregate['verdict'] =
+    thin_win_rate === null ? 'no-data' : thin_win_rate < threshold ? 'regression' : 'ok';
+  return {
+    total,
+    thin_wins,
+    eager_wins,
+    ties,
+    inconsistent,
+    decisive,
+    thin_win_rate,
+    inconsistency_rate: total > 0 ? inconsistent / total : null,
+    length_confound_rate: decisive > 0 ? longerWins / decisive : null,
+    wilcoxon_p: wil.n > 0 ? wil.p : null,
+    verdict,
+  };
+}
+
+/** Gate exit code from an aggregate. */
+export function gateVerdict(agg: QualityAggregate): 0 | 2 {
+  return agg.verdict === 'regression' ? 2 : 0;
+}
+
+interface RunReport {
+  threshold?: number;
+  results?: PairResult[];
+}
+
+function main(argv: string[]): number {
+  let asJson = false;
+  let threshold = DEFAULT_THRESHOLD;
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--json') asJson = true;
+    else if (a === '--threshold') {
+      const v = Number(argv[(i += 1)]);
+      if (!Number.isFinite(v) || v < 0 || v > 1) {
+        process.stderr.write('error: --threshold must be in [0,1]\n');
+        return 1;
+      }
+      threshold = v;
+    } else if (a === '-h' || a === '--help') {
+      process.stdout.write('usage: check_quality_regression [--json] [--threshold F]\n');
+      return 0;
+    } else {
+      process.stderr.write(`error: unknown argument: ${a}\n`);
+      return 1;
+    }
+  }
+
+  if (!fs.existsSync(RUN_REPORT)) {
+    const msg =
+      `⚠️  no quality-run report (${path.relative(REPO_ROOT, RUN_REPORT)}) — ` +
+      'gate inert. Produce it with a thin-vs-eager judge run (operator/cost gate).';
+    if (asJson) process.stdout.write(JSON.stringify({ verdict: 'no-data', inert: true }, null, 2) + '\n');
+    else process.stdout.write(msg + '\n');
+    return 0;
+  }
+
+  let report: RunReport;
+  try {
+    report = JSON.parse(fs.readFileSync(RUN_REPORT, 'utf-8')) as RunReport;
+  } catch (e) {
+    process.stderr.write(`error: cannot parse ${path.relative(REPO_ROOT, RUN_REPORT)}: ${(e as Error).message}\n`);
+    return 1;
+  }
+  const results = Array.isArray(report.results) ? report.results : [];
+  const thr = typeof report.threshold === 'number' ? report.threshold : threshold;
+  const agg = aggregate(results, thr);
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ ...agg, threshold: thr }, null, 2) + '\n');
+  } else {
+    process.stdout.write(
+      `quality run: ${agg.total} pairs · thin ${agg.thin_wins} / eager ${agg.eager_wins} / ` +
+        `tie ${agg.ties} / inconsistent ${agg.inconsistent}\n` +
+        `  thin win-rate ${agg.thin_win_rate === null ? 'n/a' : (agg.thin_win_rate * 100).toFixed(1) + '%'} ` +
+        `(threshold ${(thr * 100).toFixed(0)}%) · ` +
+        `length-confound ${agg.length_confound_rate === null ? 'n/a' : (agg.length_confound_rate * 100).toFixed(0) + '%'} · ` +
+        `inconsistency ${agg.inconsistency_rate === null ? 'n/a' : (agg.inconsistency_rate * 100).toFixed(0) + '%'}\n`,
+    );
+    if (agg.verdict === 'regression') {
+      process.stdout.write(`❌  quality regression: thin win-rate below ${(thr * 100).toFixed(0)}%.\n`);
+    } else if (agg.verdict === 'no-data') {
+      process.stdout.write(`⚠️  no decisive pairs — inconclusive.\n`);
+    } else {
+      process.stdout.write(`✅  quality held: thin win-rate within tolerance.\n`);
+    }
+  }
+  return gateVerdict(agg);
+}
+
+const _IS_MAIN =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (_IS_MAIN) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/src/scripts/check_token_quality_golden.ts
+++ b/src/scripts/check_token_quality_golden.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env tsx
+/**
+ * Validator + coverage reporter for the token-quality golden set
+ * (token-saving Phase 0). Loads `internal/bench/corpora/token-quality-golden.yaml`,
+ * validates each task against the schema (TOKEN-QUALITY-GOLDEN-SCHEMA.md), and
+ * reports rule-coverage vs `dist/router.json` + label-status counts.
+ *
+ * The `expected` anchors are HAND-LABELLED operator work — so an unfilled
+ * (`stub`) task or an uncovered rule is REPORTED, not a failure, by default.
+ * Structural errors (unknown rule id, bad scenario, a `labelled` task with a
+ * TODO rubric / no anchors) always fail. `--require-complete` is the operator-
+ * completion gate (Phase 0 exit): it also fails on any remaining stub, any
+ * uncovered rule, or a missing required scenario.
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/check_token_quality_golden
+ *   ./scripts-run src/scripts/check_token_quality_golden --json
+ *   ./scripts-run src/scripts/check_token_quality_golden --require-complete
+ *
+ * Exit codes: 0 valid (scaffold or complete) · 1 file error · 2 invalid / incomplete-when-required.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import yaml from 'js-yaml';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const CORPUS = path.join(REPO_ROOT, 'internal/bench/corpora/token-quality-golden.yaml');
+const ROUTER = path.join(REPO_ROOT, 'dist/router.json');
+
+const SCENARIOS = ['single', 'multi-turn', 'conflicting-rule', 'corner-case'];
+const REQUIRED_SCENARIOS = ['multi-turn', 'conflicting-rule', 'corner-case'];
+const LABEL_STATUS = ['stub', 'labelled'];
+
+type Json = Record<string, unknown>;
+
+/** Collect every rule id from the router (kernel strings + tier_* objects). */
+export function router_rule_ids(router: Json): Set<string> {
+  const ids = new Set<string>();
+  for (const key of ['kernel', 'tier_1', 'tier_2']) {
+    const arr = router[key];
+    if (!Array.isArray(arr)) continue;
+    for (const entry of arr) {
+      if (typeof entry === 'string') ids.add(entry);
+      else if (entry && typeof entry === 'object' && typeof (entry as Json).id === 'string') {
+        ids.add((entry as Json).id as string);
+      }
+    }
+  }
+  return ids;
+}
+
+export interface GoldenReport {
+  ok: boolean;
+  errors: string[];
+  task_count: number;
+  labelled: number;
+  stubs: number;
+  covered: number;
+  uncovered: string[];
+  scenarios: Record<string, number>;
+  missing_scenarios: string[];
+}
+
+function _isTodoRubric(rubric: unknown): boolean {
+  return (
+    typeof rubric !== 'string' ||
+    rubric.trim() === '' ||
+    /^todo\b/i.test(rubric.trim())
+  );
+}
+
+/** Pure validation + coverage. `ruleIds` is the authoritative rule universe. */
+export function validate(corpus: Json, ruleIds: Set<string>): GoldenReport {
+  const errors: string[] = [];
+  const tasks = Array.isArray(corpus.tasks) ? (corpus.tasks as Json[]) : null;
+  if (corpus.corpus_id !== 'token-quality-golden') {
+    errors.push(`corpus_id must be "token-quality-golden" (got ${JSON.stringify(corpus.corpus_id)})`);
+  }
+  if (tasks === null) {
+    errors.push('`tasks` must be a list');
+    return {
+      ok: false,
+      errors,
+      task_count: 0,
+      labelled: 0,
+      stubs: 0,
+      covered: 0,
+      uncovered: [...ruleIds].sort(),
+      scenarios: {},
+      missing_scenarios: [...REQUIRED_SCENARIOS],
+    };
+  }
+
+  const seenIds = new Set<string>();
+  const covered = new Set<string>();
+  const scenarios: Record<string, number> = {};
+  let labelled = 0;
+  let stubs = 0;
+
+  for (const [i, task] of tasks.entries()) {
+    const where = `task[${i}]${typeof task.id === 'string' ? ` (${task.id})` : ''}`;
+    if (typeof task.id !== 'string' || !/^tq-[a-z0-9-]+-\d+$/.test(task.id)) {
+      errors.push(`${where}: id must match tq-<area>-NN`);
+    } else if (seenIds.has(task.id)) {
+      errors.push(`${where}: duplicate id`);
+    } else {
+      seenIds.add(task.id);
+    }
+
+    const rules = Array.isArray(task.rules) ? (task.rules as unknown[]) : [];
+    if (rules.length === 0) errors.push(`${where}: rules must be a non-empty list`);
+    for (const r of rules) {
+      if (typeof r !== 'string' || !ruleIds.has(r)) {
+        errors.push(`${where}: unknown rule id ${JSON.stringify(r)}`);
+      } else {
+        covered.add(r);
+      }
+    }
+
+    if (typeof task.scenario !== 'string' || !SCENARIOS.includes(task.scenario)) {
+      errors.push(`${where}: scenario must be one of ${SCENARIOS.join(' | ')}`);
+    } else {
+      scenarios[task.scenario] = (scenarios[task.scenario] ?? 0) + 1;
+    }
+
+    if (typeof task.prompt !== 'string' || task.prompt.trim() === '') {
+      errors.push(`${where}: prompt must be a non-empty string`);
+    }
+
+    const status = task.label_status;
+    if (typeof status !== 'string' || !LABEL_STATUS.includes(status)) {
+      errors.push(`${where}: label_status must be one of ${LABEL_STATUS.join(' | ')}`);
+    } else if (status === 'labelled') {
+      labelled += 1;
+    } else {
+      stubs += 1;
+    }
+
+    const expected = (task.expected ?? {}) as Json;
+    const mustInclude = Array.isArray(expected.must_include) ? expected.must_include : [];
+    // A LABELLED task must carry a real rubric + ≥1 anchor; a stub need not.
+    if (status === 'labelled') {
+      if (_isTodoRubric(expected.rubric)) {
+        errors.push(`${where}: labelled task has a TODO/empty rubric`);
+      }
+      if (mustInclude.length === 0) {
+        errors.push(`${where}: labelled task needs ≥1 expected.must_include anchor`);
+      }
+    }
+  }
+
+  const uncovered = [...ruleIds].filter((r) => !covered.has(r)).sort();
+  const missing_scenarios = REQUIRED_SCENARIOS.filter((s) => (scenarios[s] ?? 0) === 0);
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    task_count: tasks.length,
+    labelled,
+    stubs,
+    covered: covered.size,
+    uncovered,
+    scenarios,
+    missing_scenarios,
+  };
+}
+
+function _readJson(file: string): Json | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as Json;
+  } catch {
+    return null;
+  }
+}
+
+function main(argv: string[]): number {
+  const asJson = argv.includes('--json');
+  const requireComplete = argv.includes('--require-complete');
+  for (const a of argv) {
+    if (!['--json', '--require-complete', '-h', '--help'].includes(a)) {
+      process.stderr.write(`error: unknown argument: ${a}\n`);
+      return 1;
+    }
+    if (a === '-h' || a === '--help') {
+      process.stdout.write('usage: check_token_quality_golden [--json] [--require-complete]\n');
+      return 0;
+    }
+  }
+
+  let corpus: Json | null;
+  try {
+    corpus = yaml.load(fs.readFileSync(CORPUS, 'utf-8')) as Json;
+  } catch (e) {
+    process.stderr.write(`error: cannot read/parse ${path.relative(REPO_ROOT, CORPUS)}: ${(e as Error).message}\n`);
+    return 1;
+  }
+  const router = _readJson(ROUTER);
+  if (router === null) {
+    process.stderr.write(`error: cannot read ${path.relative(REPO_ROOT, ROUTER)} — run \`task sync\` first\n`);
+    return 1;
+  }
+  const ruleIds = router_rule_ids(router);
+  const report = validate(corpus, ruleIds);
+
+  const incomplete =
+    report.stubs > 0 || report.uncovered.length > 0 || report.missing_scenarios.length > 0;
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ ...report, require_complete: requireComplete, incomplete }, null, 2) + '\n');
+  } else {
+    for (const e of report.errors) process.stdout.write(`❌  ${e}\n`);
+    process.stdout.write(
+      `golden set: ${report.task_count} task(s) · ${report.labelled} labelled · ${report.stubs} stub · ` +
+        `coverage ${report.covered}/${ruleIds.size} rules\n`,
+    );
+    if (report.uncovered.length > 0) {
+      process.stdout.write(`⚠️  ${report.uncovered.length} rule(s) uncovered (operator to add tasks)\n`);
+    }
+    if (report.missing_scenarios.length > 0) {
+      process.stdout.write(`⚠️  missing required scenario(s): ${report.missing_scenarios.join(', ')}\n`);
+    }
+    if (!report.ok) {
+      process.stdout.write(`❌  golden set has structural errors (see above).\n`);
+    } else if (incomplete) {
+      process.stdout.write(`✅  structurally valid — scaffold awaiting operator labels.\n`);
+    } else {
+      process.stdout.write(`✅  golden set complete.\n`);
+    }
+  }
+
+  if (!report.ok) return 2;
+  if (requireComplete && incomplete) {
+    if (!asJson) {
+      process.stdout.write(`❌  --require-complete: golden set is not yet complete.\n`);
+    }
+    return 2;
+  }
+  return 0;
+}
+
+const _IS_MAIN =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (_IS_MAIN) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/src/scripts/check_token_regression.ts
+++ b/src/scripts/check_token_regression.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env tsx
+/**
+ * Token-regression gate (token-saving Phase 0).
+ *
+ * Fails CI when a tracked always-loaded / projected token surface grows more
+ * than the tolerance (default 5%) over a committed baseline. This is the
+ * RELATIVE guard — distinct from `audit-tokens-budget` (absolute budgets) and
+ * from the cache-prefix byte-stability guard (Phase 5).
+ *
+ * Source of truth is `internal/bench/reports/projection-cost.json`, which is
+ * now produced with EXACT counts via the real tokenizer
+ * (`src/scripts/_lib/token_count.ts` → js-tiktoken cl100k_base). Run
+ * `task audit-tokens` first so the report reflects the working tree.
+ *
+ * Gated metrics (all `tokens_gpt`):
+ *   - eager_rule_load    — thin_projection.eager_gpt (the eager always-on load)
+ *   - thin_rule_load     — thin_projection.thin_gpt
+ *   - skill_descriptions — description_catalog.skills_core_source.tokens_gpt
+ *   - command_descriptions — description_catalog.commands_core_source.tokens_gpt
+ *   - mcp_schemas        — Σ mcp_tool_schemas[*].tokens_gpt
+ *
+ * A baseline captured under a different `token_method` (e.g. proxy → exact)
+ * is a legitimate reset, not a regression — the gate WARNS and asks for a
+ * `--update-baseline` rather than failing on the method switch alone.
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/check_token_regression            # gate (read-only)
+ *   ./scripts-run src/scripts/check_token_regression --json     # machine output
+ *   ./scripts-run src/scripts/check_token_regression --tolerance 0.05
+ *   ./scripts-run src/scripts/check_token_regression --update-baseline  # record current as baseline
+ *
+ * Exit codes:
+ *   0 — within tolerance (or baseline written / warmup: no baseline yet)
+ *   1 — argument / file error
+ *   2 — regression: a metric exceeded baseline by more than the tolerance
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const _HERE = fileURLToPath(import.meta.url);
+// REPO_ROOT = <repo>/src/scripts/<file> → up two.
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+const PROJECTION_REPORT = path.join(
+  REPO_ROOT,
+  'internal/bench/reports/projection-cost.json',
+);
+const BASELINE_FILE = path.join(
+  REPO_ROOT,
+  'internal/bench/reports/token-baseline.json',
+);
+const DEFAULT_TOLERANCE = 0.05;
+
+type Json = Record<string, unknown>;
+
+interface Metrics {
+  token_method: string;
+  metrics: Record<string, number>;
+}
+
+function _num(obj: unknown, ...keys: string[]): number {
+  let cur: unknown = obj;
+  for (const k of keys) {
+    if (cur && typeof cur === 'object' && k in (cur as Json)) {
+      cur = (cur as Json)[k];
+    } else {
+      return 0;
+    }
+  }
+  return typeof cur === 'number' ? cur : 0;
+}
+
+/** Extract the flat gated-metric map from a projection-cost report. */
+function extract_metrics(report: Json): Metrics {
+  const mcp = (report['mcp_tool_schemas'] as Json) ?? {};
+  let mcp_total = 0;
+  for (const server of Object.values(mcp)) {
+    mcp_total += _num(server, 'tokens_gpt');
+  }
+  return {
+    token_method: String(report['token_method'] ?? 'unknown'),
+    metrics: {
+      eager_rule_load: _num(report, 'thin_projection', 'eager_gpt'),
+      thin_rule_load: _num(report, 'thin_projection', 'thin_gpt'),
+      skill_descriptions: _num(
+        report,
+        'description_catalog',
+        'skills_core_source',
+        'tokens_gpt',
+      ),
+      command_descriptions: _num(
+        report,
+        'description_catalog',
+        'commands_core_source',
+        'tokens_gpt',
+      ),
+      mcp_schemas: mcp_total,
+    },
+  };
+}
+
+function _readJson(file: string): Json | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as Json;
+  } catch {
+    return null;
+  }
+}
+
+interface Row {
+  id: string;
+  current: number;
+  baseline: number;
+  pct: number; // signed fraction, e.g. 0.07 = +7%
+  regressed: boolean;
+}
+
+export interface GateResult {
+  status: 'ok' | 'regression' | 'warmup' | 'method-changed';
+  tolerance: number;
+  current_method: string;
+  baseline_method: string | null;
+  rows: Row[];
+}
+
+export function evaluate(
+  current: Metrics,
+  baseline: Metrics | null,
+  tolerance: number,
+): GateResult {
+  if (baseline === null) {
+    return {
+      status: 'warmup',
+      tolerance,
+      current_method: current.token_method,
+      baseline_method: null,
+      rows: [],
+    };
+  }
+  const method_changed = baseline.token_method !== current.token_method;
+  const rows: Row[] = [];
+  for (const [id, cur] of Object.entries(current.metrics)) {
+    const base = baseline.metrics[id] ?? 0;
+    const pct = base > 0 ? (cur - base) / base : 0;
+    rows.push({
+      id,
+      current: cur,
+      baseline: base,
+      pct,
+      // A method switch is a legitimate baseline reset, not a regression.
+      regressed: !method_changed && base > 0 && pct > tolerance,
+    });
+  }
+  rows.sort((a, b) => b.pct - a.pct);
+  const anyRegressed = rows.some((r) => r.regressed);
+  const status: GateResult['status'] = anyRegressed
+    ? 'regression'
+    : method_changed
+      ? 'method-changed'
+      : 'ok';
+  return {
+    status,
+    tolerance,
+    current_method: current.token_method,
+    baseline_method: baseline.token_method,
+    rows,
+  };
+}
+
+function _fmtPct(p: number): string {
+  const sign = p >= 0 ? '+' : '';
+  return `${sign}${(p * 100).toFixed(1)}%`;
+}
+
+function main(argv: string[]): number {
+  let tolerance = DEFAULT_TOLERANCE;
+  let asJson = false;
+  let updateBaseline = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--json') asJson = true;
+    else if (a === '--update-baseline') updateBaseline = true;
+    else if (a === '--tolerance') {
+      const v = Number(argv[(i += 1)]);
+      if (!Number.isFinite(v) || v < 0) {
+        process.stderr.write(`error: invalid --tolerance\n`);
+        return 1;
+      }
+      tolerance = v;
+    } else if (a === '-h' || a === '--help') {
+      process.stdout.write(
+        'usage: check_token_regression [--json] [--tolerance F] [--update-baseline]\n',
+      );
+      return 0;
+    } else {
+      process.stderr.write(`error: unknown argument: ${a}\n`);
+      return 1;
+    }
+  }
+
+  const report = _readJson(PROJECTION_REPORT);
+  if (report === null) {
+    process.stderr.write(
+      `error: cannot read ${path.relative(REPO_ROOT, PROJECTION_REPORT)} — run \`task audit-tokens\` first\n`,
+    );
+    return 1;
+  }
+  const current = extract_metrics(report);
+
+  if (updateBaseline) {
+    const payload = JSON.stringify(current, null, 2) + '\n';
+    fs.writeFileSync(BASELINE_FILE, payload);
+    process.stdout.write(
+      `✅  token baseline written: ${path.relative(REPO_ROOT, BASELINE_FILE)} (method: ${current.token_method})\n`,
+    );
+    return 0;
+  }
+
+  const baselineRaw = _readJson(BASELINE_FILE);
+  const baseline: Metrics | null =
+    baselineRaw === null ? null : (baselineRaw as unknown as Metrics);
+  const result = evaluate(current, baseline, tolerance);
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  } else if (result.status === 'warmup') {
+    process.stdout.write(
+      `⚠️  no token baseline yet — run \`./scripts-run src/scripts/check_token_regression --update-baseline\` to record one.\n`,
+    );
+  } else {
+    for (const r of result.rows) {
+      const mark = r.regressed ? '❌' : '✅';
+      process.stdout.write(
+        `${mark}  ${r.id}: ${r.current} vs baseline ${r.baseline} (${_fmtPct(r.pct)})\n`,
+      );
+    }
+    if (result.status === 'method-changed') {
+      process.stdout.write(
+        `⚠️  token_method changed (${result.baseline_method} → ${result.current_method}); ` +
+          `baseline reset is legitimate — run --update-baseline to re-anchor.\n`,
+      );
+    } else if (result.status === 'regression') {
+      process.stdout.write(
+        `❌  token regression: a projection grew >${(tolerance * 100).toFixed(0)}% over baseline.\n`,
+      );
+    } else {
+      process.stdout.write(
+        `✅  token surfaces within +${(tolerance * 100).toFixed(0)}% of baseline.\n`,
+      );
+    }
+  }
+
+  return result.status === 'regression' ? 2 : 0;
+}
+
+const _IS_MAIN =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (_IS_MAIN) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { extract_metrics, main };

--- a/src/scripts/probe_host_compliance.ts
+++ b/src/scripts/probe_host_compliance.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env tsx
+/**
+ * Host-compliance probe for thin projection (token-saving Phase 0).
+ *
+ * Thin projection is a CONTRACT WITH THE HOST: a non-kernel rule body is
+ * demoted to a router pointer, and the host is trusted to load the body only
+ * on trigger-match. On a host that reconstructs rule bodies internally (e.g. a
+ * plugin loader that re-inlines everything), thin projection is a silent no-op
+ * — so it must be falsified per host before the thin flip ships.
+ *
+ * This probe has two halves:
+ *
+ *   MECHANICAL (here, automated): run the real thin projector (`thin_entry`)
+ *   on a canary rule fixture and assert the body is replaced by a pointer that
+ *   still carries the trigger hint (so the router can select it). This proves
+ *   the projector demotes correctly — the prerequisite for any host test.
+ *
+ *   LIVE (operator gate): install the thin-projected canary into each host,
+ *   invoke its keyword, and confirm the host shows the POINTER, not the body.
+ *   This is a human-run step (live trigger-eval is a human gate) — the probe
+ *   prints the checklist + a results table to fill in.
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/probe_host_compliance           # mechanical check + checklist
+ *   ./scripts-run src/scripts/probe_host_compliance --json
+ *
+ * Exit codes: 0 demotion verified · 1 file error · 2 projector failed to demote.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { thin_entry } from './project_thin_rules.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const CANARY = path.join(
+  REPO_ROOT,
+  'tests/fixtures/host-compliance/host-compliance-canary.md',
+);
+const CANARY_ID = 'host-compliance-canary';
+const SENTINEL = 'CANARY_BODY_SENTINEL_DO_NOT_INLINE';
+const KEYWORD = 'xyzzy-canary-probe';
+const POINTER_MARKER = 'Routed rule — load the body on trigger-match';
+
+// The supported hosts whose live thin-compliance must be falsified.
+const HOSTS = ['claude-code', 'cursor', 'augment'];
+
+export interface DemotionResult {
+  ok: boolean;
+  pointer_present: boolean;
+  body_removed: boolean;
+  trigger_hint_preserved: boolean;
+  link_present: boolean;
+}
+
+/** Assert a thinned canary is a valid pointer (body gone, still selectable). */
+export function evaluate_demotion(
+  thinned: string,
+  opts: { sentinel: string; keyword: string } = { sentinel: SENTINEL, keyword: KEYWORD },
+): DemotionResult {
+  const pointer_present = thinned.includes(POINTER_MARKER);
+  const body_removed = !thinned.includes(opts.sentinel);
+  const trigger_hint_preserved = thinned.includes(opts.keyword);
+  const link_present = /Body: \[`[^`]+`\]\(/.test(thinned);
+  return {
+    ok: pointer_present && body_removed && trigger_hint_preserved && link_present,
+    pointer_present,
+    body_removed,
+    trigger_hint_preserved,
+    link_present,
+  };
+}
+
+function operator_checklist(): string {
+  const rows = HOSTS.map(
+    (h) => `  - [ ] ${h}: fires on \`${KEYWORD}\` AND shows the pointer, NOT the body sentinel`,
+  ).join('\n');
+  return (
+    'LIVE host-compliance step (operator gate — live trigger-eval is human-run):\n' +
+    '  1. Set `lean_projection.mode: thin` and run `task generate-tools && task sync`.\n' +
+    '  2. Install the projected canary into each host.\n' +
+    `  3. Invoke the keyword \`${KEYWORD}\` in a session on each host.\n` +
+    '  4. PASS = the rule fires AND the host surfaces the router pointer;\n' +
+    `     FAIL = the host surfaces the body sentinel (\`${SENTINEL}\`) → thin\n` +
+    '     projection is a no-op there; escalate to the host vendor.\n' +
+    'Results:\n' +
+    rows +
+    '\n'
+  );
+}
+
+function main(argv: string[]): number {
+  const asJson = argv.includes('--json');
+  for (const a of argv) {
+    if (!['--json', '-h', '--help'].includes(a)) {
+      process.stderr.write(`error: unknown argument: ${a}\n`);
+      return 1;
+    }
+    if (a === '-h' || a === '--help') {
+      process.stdout.write('usage: probe_host_compliance [--json]\n');
+      return 0;
+    }
+  }
+
+  let text: string;
+  try {
+    text = fs.readFileSync(CANARY, 'utf-8');
+  } catch {
+    process.stderr.write(`error: cannot read canary fixture ${path.relative(REPO_ROOT, CANARY)}\n`);
+    return 1;
+  }
+  const thinned = thin_entry(CANARY_ID, text);
+  const result = evaluate_demotion(thinned);
+
+  if (asJson) {
+    process.stdout.write(
+      JSON.stringify({ ...result, hosts: HOSTS, keyword: KEYWORD, sentinel: SENTINEL }, null, 2) + '\n',
+    );
+    return result.ok ? 0 : 2;
+  }
+
+  process.stdout.write(
+    `${result.ok ? '✅' : '❌'}  mechanical demotion: ` +
+      `pointer=${result.pointer_present} body-removed=${result.body_removed} ` +
+      `hint=${result.trigger_hint_preserved} link=${result.link_present}\n`,
+  );
+  if (!result.ok) {
+    process.stdout.write('❌  the thin projector did NOT demote the canary correctly.\n');
+    return 2;
+  }
+  process.stdout.write('\n' + operator_checklist());
+  return 0;
+}
+
+const _IS_MAIN =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (_IS_MAIN) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/taskfiles/engine.yml
+++ b/taskfiles/engine.yml
@@ -133,6 +133,32 @@ tasks:
     desc: "Token-budget gate (Phase 1.4): fail if a measured initial-context surface exceeds its configured budget. Budgets are advisory (None) until Phase 3 sets them — passes today."
     cmd: ./scripts-run src/scripts/audit_initial_context --fail-if-over-budget
 
+  check-token-regression:
+    silent: true
+    desc: "Token-regression gate (token-saving Phase 0): regenerate the projection report, then fail if any tracked always-loaded/projected token surface grows >5% over internal/bench/reports/token-baseline.json. Re-anchor a deliberate increase with `./scripts-run src/scripts/check_token_regression --update-baseline`."
+    deps: [audit-tokens]
+    cmd: ./scripts-run src/scripts/check_token_regression
+
+  check-token-quality-golden:
+    silent: true
+    desc: "Validate the token-quality golden set structure + rule coverage (token-saving Phase 0). Scaffold mode: fails only on structural errors; stubs / uncovered rules are reported (operator fills labels). Add `--require-complete` for the operator-completion gate."
+    cmd: ./scripts-run src/scripts/check_token_quality_golden
+
+  bench-rule-load-latency:
+    silent: true
+    desc: "Measure on-demand (non-kernel) rule-load latency p50/p95/p99 (token-saving Phase 0). Mechanical resolve+read cost of `dist/agent-src/rules/<id>.md`; measurement only, never gates. `--write` → internal/bench/reports/rule-load-latency.json."
+    cmd: ./scripts-run src/scripts/bench_rule_load_latency
+
+  check-quality-regression:
+    silent: true
+    desc: "Quality-regression gate (token-saving Phase 0): length-controlled paired judge over the golden set; fail if thin's win-rate < 48% vs eager. INERT until internal/bench/reports/quality-run.json exists (the thin-vs-eager judge run is the operator/cost gate), so CI stays green until then."
+    cmd: ./scripts-run src/scripts/check_quality_regression
+
+  probe-host-compliance:
+    silent: true
+    desc: "Thin-projection host-compliance probe (token-saving Phase 0). Mechanical: assert the projector demotes the canary fixture to a router pointer (body removed, still selectable); fails if not. Prints the LIVE per-host checklist (operator gate) for Claude Code / Cursor / Augment."
+    cmd: ./scripts-run src/scripts/probe_host_compliance
+
   lean-projection-measure:
     silent: true
     desc: "Measure the thin-projection token delta (Phase 3.1): eager vs (kernel full + non-kernel pointers). Read-only — never writes the live projections. Set lean_projection.mode=thin + `task generate-tools` to actually thin (validate with bench:ab:live first)."

--- a/tests/fixtures/host-compliance/host-compliance-canary.md
+++ b/tests/fixtures/host-compliance/host-compliance-canary.md
@@ -1,0 +1,16 @@
+---
+type: "auto"
+tier: "2b"
+description: "Host-compliance canary — a thin-projection probe rule; fires only on its sentinel keyword, never in real work."
+triggers:
+  - keyword: "xyzzy-canary-probe"
+  - phrase: "host compliance canary"
+---
+
+# Host-Compliance Canary
+
+CANARY_BODY_SENTINEL_DO_NOT_INLINE — under correct thin projection a host that
+fires on `xyzzy-canary-probe` shows the router POINTER to this body, not the
+body itself. If a host surfaces this sentinel line, it is reconstructing the
+rule body and IGNORING the thin pointer — a thin-projection compliance failure
+that means thin mode is a no-op on that host (escalate to the host vendor).

--- a/tests/lib/token_count.test.ts
+++ b/tests/lib/token_count.test.ts
@@ -1,11 +1,15 @@
 /**
  * Tests for `src/scripts/_lib/token_count.ts`.
  *
- * The Python module has no dedicated pytest suite, so this is a focused
- * differential suite (ADR-088 Phase 2 / Wave 1): unit checks for the
- * proxy math plus a differential block that drives the Python original
- * via `python3 -c` (with tiktoken import blocked so both runtimes take
- * the deterministic proxy path) and asserts identical output.
+ * Two layers:
+ *  1. The real-tokenizer path — `js-tiktoken` (cl100k_base) ships as a
+ *     devDependency, so `TIKTOKEN_AVAILABLE` is true here and `gpt_tokens` /
+ *     `measure` return EXACT BPE counts.
+ *  2. The proxy fallback path — the `*_proxy` helpers implement the documented
+ *     `chars / 4` (GPT) and `chars / 3.6` (Claude) estimates used when the
+ *     tokenizer dependency is absent. A frozen differential block guards the
+ *     proxy math against the original Python reference (tiktoken blocked in the
+ *     driver so both runtimes take the deterministic proxy path).
  */
 
 import { describe, expect, it } from "vitest";
@@ -15,19 +19,59 @@ import {
   TokenCount,
   claude_tokens,
   gpt_tokens,
+  gpt_tokens_proxy,
   measure,
+  measure_proxy,
   method_note,
+  method_note_proxy,
 } from "../../src/scripts/_lib/token_count.js";
 import { oracle2 } from "../_lib/parity_oracle.js";
 
-describe("token_count unit behaviour", () => {
-  it("TIKTOKEN_AVAILABLE is false in the TS twin (proxy-only)", () => {
-    expect(TIKTOKEN_AVAILABLE).toBe(false);
+describe("token_count real-tokenizer path (js-tiktoken cl100k_base)", () => {
+  it("TIKTOKEN_AVAILABLE is true (js-tiktoken devDependency present)", () => {
+    expect(TIKTOKEN_AVAILABLE).toBe(true);
   });
 
-  it("gpt_tokens uses the chars/4 proxy, flagged inexact", () => {
-    const tc = gpt_tokens("a".repeat(40));
+  it("gpt_tokens returns an exact BPE count, flagged exact", () => {
+    const tc = gpt_tokens("hello world");
     expect(tc).toBeInstanceOf(TokenCount);
+    // cl100k_base tokenises "hello world" as 2 tokens.
+    expect(tc.tokens).toBe(2);
+    expect(tc.exact).toBe(true);
+  });
+
+  it("the exact count differs from the chars/4 proxy (real tokenizer wired)", () => {
+    // 40 repeated 'a' → chars/4 proxy = 10; cl100k merges the run far below 10.
+    const text = "a".repeat(40);
+    expect(gpt_tokens(text).tokens).toBeLessThan(gpt_tokens_proxy(text).tokens);
+    expect(gpt_tokens(text).exact).toBe(true);
+    expect(gpt_tokens_proxy(text).exact).toBe(false);
+  });
+
+  it("measure reports the exact GPT count + proxy Claude count", () => {
+    expect(measure("hello world")).toEqual({
+      chars: 11,
+      tokens_gpt: 2, // exact (cl100k_base)
+      tokens_gpt_exact: true,
+      tokens_claude: 3, // proxy: round(11 / 3.6)
+      tokens_claude_exact: false,
+    });
+  });
+
+  it("TokenCount instances are frozen", () => {
+    expect(Object.isFrozen(gpt_tokens("abc"))).toBe(true);
+  });
+
+  it("method_note names the exact tiktoken encoding", () => {
+    expect(method_note()).toBe(
+      "tokens_gpt: exact (tiktoken cl100k_base); tokens_claude: proxy (chars/3.6)",
+    );
+  });
+});
+
+describe("token_count proxy fallback math", () => {
+  it("gpt_tokens_proxy uses the chars/4 proxy, flagged inexact", () => {
+    const tc = gpt_tokens_proxy("a".repeat(40));
     expect(tc.tokens).toBe(10);
     expect(tc.exact).toBe(false);
   });
@@ -38,27 +82,22 @@ describe("token_count unit behaviour", () => {
     expect(tc.exact).toBe(false);
   });
 
-  it("TokenCount instances are frozen (dataclass frozen=True parity)", () => {
-    const tc = gpt_tokens("abc");
-    expect(Object.isFrozen(tc)).toBe(true);
-  });
-
-  it("rounding is banker's rounding (Python round() parity)", () => {
+  it("proxy rounding is banker's rounding (round half to even)", () => {
     // len 2 → 2/4 = 0.5 → rounds to 0 (ties to even), not 1.
-    expect(gpt_tokens("ab").tokens).toBe(0);
+    expect(gpt_tokens_proxy("ab").tokens).toBe(0);
     // len 6 → 6/4 = 1.5 → rounds to 2.
-    expect(gpt_tokens("abcdef").tokens).toBe(2);
+    expect(gpt_tokens_proxy("abcdef").tokens).toBe(2);
     // len 10 → 10/4 = 2.5 → rounds to 2 (ties to even).
-    expect(gpt_tokens("a".repeat(10)).tokens).toBe(2);
+    expect(gpt_tokens_proxy("a".repeat(10)).tokens).toBe(2);
   });
 
   it("chars counts code points, not UTF-16 units", () => {
     // "🎉" is one code point but two UTF-16 units.
-    expect(measure("🎉").chars).toBe(1);
+    expect(measure_proxy("🎉").chars).toBe(1);
   });
 
-  it("measure returns the five documented keys", () => {
-    expect(measure("hello world")).toEqual({
+  it("measure_proxy returns the five documented keys (proxy values)", () => {
+    expect(measure_proxy("hello world")).toEqual({
       chars: 11,
       tokens_gpt: 3,
       tokens_gpt_exact: false,
@@ -67,8 +106,8 @@ describe("token_count unit behaviour", () => {
     });
   });
 
-  it("method_note names both proxies when tiktoken is unavailable", () => {
-    expect(method_note()).toBe(
+  it("method_note_proxy names both proxies", () => {
+    expect(method_note_proxy()).toBe(
       "tokens_gpt: proxy (chars/4.0, tiktoken not installed); " +
         "tokens_claude: proxy (chars/3.6)",
     );
@@ -76,9 +115,10 @@ describe("token_count unit behaviour", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Differential block — Python module is the reference implementation.
-// tiktoken import is blocked in the driver so the Python module always
-// takes the same proxy path the TS twin implements.
+// Differential block — the original Python module is the reference for the
+// PROXY math. tiktoken import is blocked in the driver so the Python module
+// always takes the same proxy path the `*_proxy` helpers implement. The
+// driver + input are unchanged, so the frozen oracle fixture still applies.
 // ---------------------------------------------------------------------------
 
 const PY_DRIVER = `
@@ -105,7 +145,7 @@ interface PyResult {
 }
 
 describe("differential vs Python reference (proxy path)", () => {
-  it("measure() and method_note() match Python byte-for-byte", () => {
+  it("measure_proxy() and method_note_proxy() match Python byte-for-byte", () => {
     const texts = [
       "",
       "a",
@@ -118,12 +158,9 @@ describe("differential vs Python reference (proxy path)", () => {
       "line\nbreak\ttab and a markdown # heading\n- bullet\n",
       "x".repeat(1234),
     ];
-    // Oracle-routed (`kind: 'inline'`): CAPTURE mode (PY2TS_CAPTURE=1) spawns
-    // `python3 -c PY_DRIVER` with the JSON texts on stdin (tiktoken blocked in
-    // the driver, so both runtimes take the deterministic proxy path) and
-    // freezes the JSON stdout; NORMAL mode replays with no live python3. The
-    // stdin is the keying `input`; the inline code embeds no absolute path
-    // (computes `os.getcwd()`), so the inline key is stable across machines.
+    // Oracle-routed (`kind: 'inline'`): replays the frozen Python proxy output;
+    // the TS proxy helpers must match it byte-for-byte. Driver + input are
+    // unchanged from the original suite, so the captured fixture still keys.
     const out = oracle2({
       kind: "inline",
       target: PY_DRIVER,
@@ -134,10 +171,11 @@ describe("differential vs Python reference (proxy path)", () => {
 
     expect(py.tiktoken_available).toBe(false);
     texts.forEach((text, i) => {
-      expect(measure(text), `text #${i}: ${JSON.stringify(text)}`).toEqual(
-        py.measures[i],
-      );
+      expect(
+        measure_proxy(text),
+        `text #${i}: ${JSON.stringify(text)}`,
+      ).toEqual(py.measures[i]);
     });
-    expect(method_note()).toBe(py.method_note);
+    expect(method_note_proxy()).toBe(py.method_note);
   });
 });

--- a/tests/scripts/bench_rule_load_latency.test.ts
+++ b/tests/scripts/bench_rule_load_latency.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the on-demand rule-load latency bench's pure helpers
+ * (`src/scripts/bench_rule_load_latency.ts`).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  on_demand_rule_ids,
+  percentile,
+  summarize,
+} from "../../src/scripts/bench_rule_load_latency.js";
+
+describe("on_demand_rule_ids", () => {
+  it("excludes kernel; includes tier_1 + tier_2 (strings + objects)", () => {
+    const ids = on_demand_rule_ids({
+      kernel: ["k1", "k2"],
+      tier_1: [{ id: "t1a", triggers: [] }, { id: "t1b" }],
+      tier_2: ["t2a", { id: "t2b" }],
+    });
+    expect(ids).toEqual(["t1a", "t1b", "t2a", "t2b"]);
+    expect(ids).not.toContain("k1");
+  });
+
+  it("tolerates missing tiers", () => {
+    expect(on_demand_rule_ids({ kernel: ["k"] })).toEqual([]);
+  });
+});
+
+describe("percentile (nearest-rank)", () => {
+  const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  it("p50 / p95 / p99 / p100 by nearest rank", () => {
+    expect(percentile(sorted, 50)).toBe(5); // ceil(0.5*10)=5 → idx 4
+    expect(percentile(sorted, 95)).toBe(10); // ceil(9.5)=10 → idx 9
+    expect(percentile(sorted, 99)).toBe(10);
+    expect(percentile(sorted, 100)).toBe(10);
+  });
+  it("empty sample → 0", () => {
+    expect(percentile([], 95)).toBe(0);
+  });
+});
+
+describe("summarize", () => {
+  it("computes count/mean/min/max/percentiles", () => {
+    const s = summarize([4, 2, 8, 6, 10]);
+    expect(s.count).toBe(5);
+    expect(s.min_ms).toBe(2);
+    expect(s.max_ms).toBe(10);
+    expect(s.mean_ms).toBe(6); // (4+2+8+6+10)/5
+    expect(s.p50_ms).toBe(6); // sorted [2,4,6,8,10], ceil(2.5)=3 → idx 2 = 6
+  });
+  it("empty → all zero", () => {
+    expect(summarize([])).toMatchObject({ count: 0, p99_ms: 0 });
+  });
+});

--- a/tests/scripts/check_quality_regression.test.ts
+++ b/tests/scripts/check_quality_regression.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the length-controlled paired judge + quality-regression gate
+ * (`src/scripts/check_quality_regression.ts`). The judge is mocked so the
+ * bias-control + aggregation logic is verified deterministically (no live API).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregate,
+  evaluatePair,
+  gateVerdict,
+  type JudgeFn,
+  type PairResult,
+} from "../../src/scripts/check_quality_regression.js";
+
+const task = { id: "tq-x-01", rubric: "r" };
+
+// Mock judges
+const pickThin: JudgeFn = (_c, first) => (first === "THIN" ? "first" : "second");
+const pickEager: JudgeFn = (_c, first) => (first === "EAGER" ? "first" : "second");
+const alwaysFirst: JudgeFn = () => "first"; // pure position bias
+const alwaysTie: JudgeFn = () => "tie";
+const preferLonger: JudgeFn = (_c, first, second) => (first.length >= second.length ? "first" : "second");
+
+describe("evaluatePair — bias controls", () => {
+  it("consistent thin win survives the swap", () => {
+    const r = evaluatePair(task, "THIN", "EAGER", pickThin);
+    expect(r.winner).toBe("thin");
+  });
+
+  it("consistent eager win survives the swap", () => {
+    const r = evaluatePair(task, "THIN", "EAGER", pickEager);
+    expect(r.winner).toBe("eager");
+  });
+
+  it("a position-biased judge (always picks first) is rejected as inconsistent", () => {
+    const r = evaluatePair(task, "A", "B", alwaysFirst);
+    expect(r.winner).toBe("inconsistent");
+  });
+
+  it("a tie in both orders is a tie", () => {
+    expect(evaluatePair(task, "A", "B", alwaysTie).winner).toBe("tie");
+  });
+
+  it("flags the winner as longer (length-confound signal)", () => {
+    const r = evaluatePair(task, "LONG ANSWER HERE", "short", preferLonger);
+    expect(r.winner).toBe("thin");
+    expect(r.length_delta).toBeGreaterThan(0);
+    expect(r.winner_is_longer).toBe(true);
+  });
+});
+
+function mk(winner: PairResult["winner"], longer: boolean | null = null): PairResult {
+  return { id: "t", winner, length_delta: longer ? 1 : -1, winner_is_longer: longer };
+}
+
+describe("aggregate + gate", () => {
+  it("ok when thin win-rate ≥ threshold", () => {
+    const results = [...Array(6)].map(() => mk("thin")).concat([...Array(4)].map(() => mk("eager")));
+    const agg = aggregate(results, 0.48);
+    expect(agg.decisive).toBe(10);
+    expect(agg.thin_win_rate).toBeCloseTo(0.6);
+    expect(agg.verdict).toBe("ok");
+    expect(gateVerdict(agg)).toBe(0);
+  });
+
+  it("regression when thin win-rate < threshold", () => {
+    const results = [...Array(4)].map(() => mk("thin")).concat([...Array(6)].map(() => mk("eager")));
+    const agg = aggregate(results, 0.48);
+    expect(agg.thin_win_rate).toBeCloseTo(0.4);
+    expect(agg.verdict).toBe("regression");
+    expect(gateVerdict(agg)).toBe(2);
+  });
+
+  it("no-data when there are no decisive pairs", () => {
+    const agg = aggregate([mk("tie"), mk("inconsistent")], 0.48);
+    expect(agg.thin_win_rate).toBeNull();
+    expect(agg.verdict).toBe("no-data");
+    expect(gateVerdict(agg)).toBe(0); // inert, never fails CI on no data
+  });
+
+  it("computes inconsistency + length-confound rates", () => {
+    const results = [mk("thin", true), mk("thin", false), mk("eager", true), mk("inconsistent"), mk("tie")];
+    const agg = aggregate(results, 0.48);
+    expect(agg.decisive).toBe(3); // 2 thin + 1 eager
+    expect(agg.inconsistency_rate).toBeCloseTo(1 / 5);
+    expect(agg.length_confound_rate).toBeCloseTo(2 / 3); // 2 of 3 decisive winners were longer
+  });
+
+  it("wires Wilcoxon over signed diffs (non-null with decisive pairs)", () => {
+    const results = [...Array(8)].map(() => mk("thin")).concat([...Array(2)].map(() => mk("eager")));
+    expect(aggregate(results, 0.48).wilcoxon_p).not.toBeNull();
+  });
+});

--- a/tests/scripts/check_token_quality_golden.test.ts
+++ b/tests/scripts/check_token_quality_golden.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the token-quality golden-set validator's pure logic
+ * (`src/scripts/check_token_quality_golden.ts`).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  router_rule_ids,
+  validate,
+} from "../../src/scripts/check_token_quality_golden.js";
+
+const RULES = new Set(["commit-policy", "scope-control", "ask-when-uncertain"]);
+
+function corpus(tasks: unknown[]) {
+  return { version: 1, corpus_id: "token-quality-golden", tasks };
+}
+
+const labelled = {
+  id: "tq-commit-01",
+  rules: ["commit-policy"],
+  scenario: "single",
+  prompt: "wrap it up",
+  expected: { rubric: "answer must not commit unsolicited", must_include: ["no commit"], must_not: [] },
+  label_status: "labelled",
+  notes: "x",
+};
+
+const stub = {
+  id: "tq-scope-01",
+  rules: ["scope-control"],
+  scenario: "multi-turn",
+  prompt: "two turns",
+  expected: { rubric: "TODO-operator", must_include: [], must_not: [] },
+  label_status: "stub",
+  notes: "x",
+};
+
+describe("router_rule_ids", () => {
+  it("collects kernel strings + tier_* object ids", () => {
+    const ids = router_rule_ids({
+      kernel: ["a", "b"],
+      tier_1: [{ id: "c", triggers: [] }],
+      tier_2: [{ id: "d" }],
+    });
+    expect([...ids].sort()).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("token-quality-golden validate()", () => {
+  it("accepts a valid mix and counts coverage/labels", () => {
+    const r = validate(corpus([labelled, stub]), RULES);
+    expect(r.ok).toBe(true);
+    expect(r.labelled).toBe(1);
+    expect(r.stubs).toBe(1);
+    expect(r.covered).toBe(2); // commit-policy + scope-control
+    expect(r.uncovered).toEqual(["ask-when-uncertain"]);
+    expect(r.scenarios).toMatchObject({ single: 1, "multi-turn": 1 });
+  });
+
+  it("flags an unknown rule id", () => {
+    const bad = { ...stub, id: "tq-x-01", rules: ["not-a-rule"] };
+    const r = validate(corpus([bad]), RULES);
+    expect(r.ok).toBe(false);
+    expect(r.errors.join("\n")).toMatch(/unknown rule id/);
+  });
+
+  it("flags a bad scenario enum", () => {
+    const bad = { ...stub, id: "tq-x-02", scenario: "freeform" };
+    expect(validate(corpus([bad]), RULES).ok).toBe(false);
+  });
+
+  it("flags a malformed id", () => {
+    const bad = { ...stub, id: "commit01" };
+    expect(validate(corpus([bad]), RULES).errors.join("\n")).toMatch(/tq-<area>-NN/);
+  });
+
+  it("flags a duplicate id", () => {
+    const r = validate(corpus([labelled, { ...labelled }]), RULES);
+    expect(r.errors.join("\n")).toMatch(/duplicate id/);
+  });
+
+  it("a labelled task with a TODO rubric is an error", () => {
+    const bad = { ...labelled, id: "tq-x-03", expected: { rubric: "TODO", must_include: ["x"], must_not: [] } };
+    expect(validate(corpus([bad]), RULES).errors.join("\n")).toMatch(/TODO\/empty rubric/);
+  });
+
+  it("a labelled task with no anchors is an error", () => {
+    const bad = { ...labelled, id: "tq-x-04", expected: { rubric: "real rubric", must_include: [], must_not: [] } };
+    expect(validate(corpus([bad]), RULES).errors.join("\n")).toMatch(/must_include anchor/);
+  });
+
+  it("a stub task is exempt from the rubric/anchor requirement", () => {
+    expect(validate(corpus([stub]), RULES).ok).toBe(true);
+  });
+
+  it("reports missing required scenarios", () => {
+    const r = validate(corpus([labelled]), RULES); // only 'single'
+    expect(r.missing_scenarios).toEqual(["multi-turn", "conflicting-rule", "corner-case"]);
+  });
+
+  it("rejects a non-list tasks field", () => {
+    expect(validate({ corpus_id: "token-quality-golden", tasks: 5 }, RULES).ok).toBe(false);
+  });
+});

--- a/tests/scripts/check_token_regression.test.ts
+++ b/tests/scripts/check_token_regression.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the token-regression gate's pure verdict logic
+ * (`src/scripts/check_token_regression.ts::evaluate`).
+ */
+import { describe, expect, it } from "vitest";
+
+import { evaluate } from "../../src/scripts/check_token_regression.js";
+
+const METHOD = "tokens_gpt: exact (tiktoken cl100k_base); tokens_claude: proxy (chars/3.6)";
+
+function metrics(over: Record<string, number> = {}) {
+  return {
+    token_method: METHOD,
+    metrics: {
+      eager_rule_load: 74317,
+      thin_rule_load: 14147,
+      skill_descriptions: 10999,
+      command_descriptions: 4998,
+      mcp_schemas: 2942,
+      ...over,
+    },
+  };
+}
+
+describe("token-regression evaluate()", () => {
+  it("warmup when no baseline exists", () => {
+    const r = evaluate(metrics(), null, 0.05);
+    expect(r.status).toBe("warmup");
+    expect(r.rows).toEqual([]);
+  });
+
+  it("ok when current equals baseline", () => {
+    const r = evaluate(metrics(), metrics(), 0.05);
+    expect(r.status).toBe("ok");
+    expect(r.rows.every((row) => !row.regressed)).toBe(true);
+  });
+
+  it("ok when growth is within tolerance (+4% < 5%)", () => {
+    const current = metrics({ eager_rule_load: Math.round(74317 * 1.04) });
+    const r = evaluate(current, metrics(), 0.05);
+    expect(r.status).toBe("ok");
+  });
+
+  it("regression when a metric grows beyond tolerance (+6% > 5%)", () => {
+    const current = metrics({ eager_rule_load: Math.round(74317 * 1.06) });
+    const r = evaluate(current, metrics(), 0.05);
+    expect(r.status).toBe("regression");
+    const row = r.rows.find((x) => x.id === "eager_rule_load");
+    expect(row?.regressed).toBe(true);
+    // rows are sorted by descending pct — the regressor leads.
+    expect(r.rows[0]?.id).toBe("eager_rule_load");
+  });
+
+  it("a shrink never regresses (negative pct)", () => {
+    const current = metrics({ thin_rule_load: Math.round(14147 * 0.8) });
+    const r = evaluate(current, metrics(), 0.05);
+    expect(r.status).toBe("ok");
+    const row = r.rows.find((x) => x.id === "thin_rule_load");
+    expect(row?.pct).toBeLessThan(0);
+    expect(row?.regressed).toBe(false);
+  });
+
+  it("a token_method switch is a legitimate reset, never a regression", () => {
+    const proxyBaseline = {
+      token_method: "tokens_gpt: proxy (chars/4.0, tiktoken not installed); tokens_claude: proxy (chars/3.6)",
+      metrics: metrics().metrics,
+    };
+    // Exact counts are ~16% higher than the proxy — would trip the gate, but
+    // the method changed, so it must report `method-changed`, not regression.
+    const current = metrics({ eager_rule_load: Math.round(74317 * 1.16) });
+    const r = evaluate(current, proxyBaseline, 0.05);
+    expect(r.status).toBe("method-changed");
+    expect(r.rows.every((row) => !row.regressed)).toBe(true);
+  });
+});

--- a/tests/scripts/probe_host_compliance.test.ts
+++ b/tests/scripts/probe_host_compliance.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the host-compliance probe's pure demotion check
+ * (`src/scripts/probe_host_compliance.ts`).
+ */
+import { describe, expect, it } from "vitest";
+
+import { evaluate_demotion } from "../../src/scripts/probe_host_compliance.js";
+
+const opts = { sentinel: "BODY_SENTINEL", keyword: "kw-probe" };
+
+const GOOD_POINTER =
+  "## Canary\n> Routed rule — load the body on trigger-match. Fires on: kw-probe. desc " +
+  "Body: [`host-compliance-canary`](../../.agent-src.uncondensed/rules/host-compliance-canary.md)\n";
+
+describe("evaluate_demotion", () => {
+  it("passes a well-formed pointer (body gone, hint + link present)", () => {
+    const r = evaluate_demotion(GOOD_POINTER, opts);
+    expect(r.ok).toBe(true);
+    expect(r).toMatchObject({
+      pointer_present: true,
+      body_removed: true,
+      trigger_hint_preserved: true,
+      link_present: true,
+    });
+  });
+
+  it("fails when the body sentinel survives (host would re-inline)", () => {
+    const r = evaluate_demotion(GOOD_POINTER + "\nBODY_SENTINEL leaked", opts);
+    expect(r.body_removed).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+
+  it("fails without the routed-rule pointer marker", () => {
+    const r = evaluate_demotion("## Canary\nFires on: kw-probe. Body: [`x`](y)\n", opts);
+    expect(r.pointer_present).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+
+  it("fails when the trigger hint is dropped (router can't select it)", () => {
+    const noHint = GOOD_POINTER.replace("kw-probe", "something-else");
+    const r = evaluate_demotion(noHint, opts);
+    expect(r.trigger_hint_preserved).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+
+  it("fails without a Body: [`id`](link) pointer link", () => {
+    const noLink = "## Canary\n> Routed rule — load the body on trigger-match. Fires on: kw-probe.\n";
+    const r = evaluate_demotion(noLink, opts);
+    expect(r.link_present).toBe(false);
+    expect(r.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Builds the **Phase 0 measurement substrate** from `agents/roadmaps/road-to-token-saving.md` — the evidence rig every later token cut gates on. Additive and measurement-only (roadmap "Rollback: none").

## What landed (4/6 Phase 0 steps done)

- **Real tokenizer** — `js-tiktoken` (cl100k_base) as a sync optional **devDependency** in `src/scripts/_lib/token_count.ts`; exact GPT BPE counts when present, graceful `chars/4` proxy fallback when absent (`measure_proxy` records both). Regenerates `projection-cost.{json,md}` with exact counts.
- **Token-regression gate** — `check_token_regression.ts`: 5% relative gate over a committed `token-baseline.json`; a proxy→exact `token_method` switch is treated as a legitimate baseline reset, not a regression. Wired into both CI pipelines.
- **Length-controlled paired judge** — `check_quality_regression.ts`: hand-rolled (council 2026-06-26 leaned promptfoo but conditioned — bias controls are custom either way and the suite already has Wilcoxon, so no new dep). Judges both orders → reject-on-flip (position bias), tracks length-confound, reuses `bench_ab_v2_stats.wilcoxon`. Pluggable `JudgeFn`; the **quality-regression CI gate is inert until a live `quality-run.json` exists**.
- **Latency p50/p95/p99** — `bench_rule_load_latency.ts`: on-demand (non-kernel) rule-load cost. Finding: sub-ms with a tight tail (p99 ~0.018ms) — pointer resolution does not erode the thin-projection win.
- **Golden-set scaffolding** — schema + validator (`check_token_quality_golden.ts`, structure + rule-coverage vs `dist/router.json`, `--require-complete` completion gate) + operator-filled 30-task corpus (rule ids council-mapped to real router ids). Scaffold-mode CI gate is green; full 89-rule coverage stays `--require-complete`-red (operator-optional).
- **Host-compliance probe scaffolding** — `probe_host_compliance.ts` + canary fixture: mechanical thin-projection demotion (body→pointer, still selectable) is verified; the live per-host invocation is operator-gated.

## Key finding

The `chars/4` proxy was **under-counting**: eager rule load 64,116 → **74,317** GPT tokens (+16%); thin-projection lever `saved_gpt` 50,338 → **60,170** (78.5% → **81%**). Every past proxy-based cut estimate understated both the load and the savings.

## Still operator/cost-gated (not in this PR)

The Phase 0 **exit** itself — the real thin-vs-eager judge verdict run + live per-host compliance results — needs API budget and host sessions. The code is built; the runs are deferred.

## Verification

`npm run typecheck` clean (both projects) · new files lint clean · **51 new unit tests pass** · all wired token-saving gates pass via `task`. Full `task ci` not run locally (per `quality.local_auto_run` the remote CI is the authoritative gate).