### PR TITLE
feat(fix-pr-comments): commit+push before replying, then resolve threads

### DIFF
--- a/dist/agent-src/commands/fix/pr-comments.md
+++ b/dist/agent-src/commands/fix/pr-comments.md
@@ -7,7 +7,7 @@ visibility: internal
 cluster: fix
 sub: pr-comments
 skills: [php-coder, quality-tools]
-description: Fix and reply to all open review comments (bots + human reviewers) on a GitHub PR
+description: Fix, commit+push, reply to, then resolve all open review comments (bots + human reviewers) on a GitHub PR
 suggestion:
   eligible: true
   trigger_description: "fix all PR review comments, resolve the review feedback"
@@ -131,7 +131,9 @@ Present numbered options. Always include a "leave as-is" / "skip" option.
 - Do NOT proceed until the user picks an option.
 - If the user wants a custom reply, let them dictate the text.
 - If the user asks a follow-up question, answer it before proceeding.
-- After the user chooses, apply the fix (or skip) and reply on GitHub.
+- After the user chooses, apply the fix (or skip) **locally** and record the
+  intended reply. Do NOT post the reply yet — replies + resolves happen in the
+  **Finalize** stage (after commit+push), so the change is already live.
 
 ### 4. Move to the next comment
 
@@ -141,16 +143,20 @@ Repeat until all comments are handled.
 
 ## Auto flow
 
-Process all comments without asking. For each comment:
+Process all comments without asking. For each comment, **apply the code fix
+locally and record the intended reply** — do NOT post the reply yet. All
+replies and thread resolves are posted in the **Finalize** stage below, *after*
+the fixes are committed and pushed, so every reply references code that is
+already live.
 
 **Bot comments:**
 1. Analyze whether the suggestion is valid.
-2. **If valid** — fix it and reply on GitHub.
-3. **If not valid** — reply on GitHub explaining why, do NOT change the code.
+2. **If valid** — apply the fix locally; record the reply.
+3. **If not valid** — record a reply explaining why, do NOT change the code.
 
 **Human reviewer comments:**
-1. **Clear code fix** — fix it and reply on GitHub.
-2. **Question** — reply with a concise explanation on GitHub.
+1. **Clear code fix** — apply the fix locally; record the reply.
+2. **Question** — record a concise explanation as the reply.
 3. **Ambiguous or a design decision** — do NOT guess; collect these and present
    them at the end: "These comments need your decision: …".
 
@@ -193,9 +199,32 @@ If `false` or `.agent-settings.yml` doesn't exist, do NOT add the prefix.
 Read `github.pr_reply_method` from `.agent-settings.yml` to determine the correct endpoint.
 See the `command-routing` skill → "GitHub API: Replying to PR review comments" for full details.
 
-## After all comments
+## Finalize — commit & push, THEN reply, THEN resolve
 
-1. Run a PHP syntax check (`php -l`) on all modified files to verify nothing is broken.
-2. Report a final summary: how many bot comments handled, how many reviewer
-   comments handled, how many files modified.
-3. **Do NOT commit or push.** Just apply the fixes locally and reply to all comments on GitHub.
+Run this **once**, after all comments are handled. The order is deliberate: the
+fix must be live on the PR branch *before* its reply claims it.
+
+1. **Syntax-check** the modified files (`php -l` for PHP) to verify nothing is broken.
+2. **Commit & push the fixes — before any reply.** If code was changed:
+   - Stage the review fixes and commit with a Conventional Commit subject
+     (e.g. `fix(review): address PR #<n> review comments`), per
+     `conventional-commits-writing` — no attribution footer, no emoji in the subject.
+   - Push to the PR branch so the fixes are live.
+   - **Authorization:** invoking `/fix:pr-comments` *is* the explicit authorization
+     for this commit + push (the command's contract — the `commit-policy`
+     "command invoked" exception, and the this-turn push authorization the
+     `non-destructive-by-default` Hard Floor requires). Never commit to a
+     production trunk; only the PR branch the comments are on.
+   - If **nothing** was changed (all comments were questions / explanations),
+     skip the commit + push.
+3. **Reply** to every handled comment (per the reply-style rules above), now that
+   the referenced fixes are pushed and live.
+4. **Resolve** the conversation for every handled comment — bot and human alike:
+   - Resolve each inline review thread via the GitHub GraphQL
+     `resolveReviewThread(input: {threadId: "<id>"})` mutation. Fetch the thread
+     node ids from `repository.pullRequest.reviewThreads` (GraphQL), match each
+     thread to the comment you just replied to, and resolve it.
+   - Top-level PR review comments that are not inline threads cannot be resolved
+     — the reply stands, leave them.
+5. **Final summary:** bot comments handled, reviewer comments handled, files
+   modified, the pushed commit sha (if any), and how many threads were resolved.

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -62,7 +62,7 @@
   "commands/fix/ci.md": "6b39f8b98cdd3a56e60344fd49df862f0b955e6f152ad7b29aa518495c8b5196",
   "commands/fix/comments.md": "d4503bcd626de4bdc6fb0abd164544d2b71cbc54d5aae5e5279d4c23635a12f5",
   "commands/fix/portability.md": "1cb8eaea13faf4b996841287456444d95b1f8d090eb8c6bbc1b075446dd92171",
-  "commands/fix/pr-comments.md": "2cd3ae4e8662c06e834925b41a4d9dbd246238891d54111b52f0418970fe1a85",
+  "commands/fix/pr-comments.md": "358e255ced83bb437855ecd230b5afa21b370bb58731fea9d15363a497b1c111",
   "commands/fix/refs.md": "dfd0a613a332e21478ac454b7d46194cea69b8e0d520e3fbf31a76ee14836e54",
   "commands/fix/seeder.md": "d0e998068582ff63aece19fbedc763a5027e18dca4bbf4dacd07d05850f1e48f",
   "commands/ghostwriter.md": "fe1972bddb99c2cedf3cace277f5ee9c8ce1189509337ddb0b6b6cc523fbf34e",

--- a/src/domains/engineering-base/fix/pr-comments/command.md
+++ b/src/domains/engineering-base/fix/pr-comments/command.md
@@ -7,7 +7,7 @@ visibility: internal
 cluster: fix
 sub: pr-comments
 skills: [php-coder, quality-tools]
-description: Fix and reply to all open review comments (bots + human reviewers) on a GitHub PR
+description: Fix, commit+push, reply to, then resolve all open review comments (bots + human reviewers) on a GitHub PR
 suggestion:
   eligible: true
   trigger_description: "fix all PR review comments, resolve the review feedback"
@@ -131,7 +131,9 @@ Present numbered options. Always include a "leave as-is" / "skip" option.
 - Do NOT proceed until the user picks an option.
 - If the user wants a custom reply, let them dictate the text.
 - If the user asks a follow-up question, answer it before proceeding.
-- After the user chooses, apply the fix (or skip) and reply on GitHub.
+- After the user chooses, apply the fix (or skip) **locally** and record the
+  intended reply. Do NOT post the reply yet — replies + resolves happen in the
+  **Finalize** stage (after commit+push), so the change is already live.
 
 ### 4. Move to the next comment
 
@@ -141,16 +143,20 @@ Repeat until all comments are handled.
 
 ## Auto flow
 
-Process all comments without asking. For each comment:
+Process all comments without asking. For each comment, **apply the code fix
+locally and record the intended reply** — do NOT post the reply yet. All
+replies and thread resolves are posted in the **Finalize** stage below, *after*
+the fixes are committed and pushed, so every reply references code that is
+already live.
 
 **Bot comments:**
 1. Analyze whether the suggestion is valid.
-2. **If valid** — fix it and reply on GitHub.
-3. **If not valid** — reply on GitHub explaining why, do NOT change the code.
+2. **If valid** — apply the fix locally; record the reply.
+3. **If not valid** — record a reply explaining why, do NOT change the code.
 
 **Human reviewer comments:**
-1. **Clear code fix** — fix it and reply on GitHub.
-2. **Question** — reply with a concise explanation on GitHub.
+1. **Clear code fix** — apply the fix locally; record the reply.
+2. **Question** — record a concise explanation as the reply.
 3. **Ambiguous or a design decision** — do NOT guess; collect these and present
    them at the end: "These comments need your decision: …".
 
@@ -193,9 +199,32 @@ If `false` or `.agent-settings.yml` doesn't exist, do NOT add the prefix.
 Read `github.pr_reply_method` from `.agent-settings.yml` to determine the correct endpoint.
 See the `command-routing` skill → "GitHub API: Replying to PR review comments" for full details.
 
-## After all comments
+## Finalize — commit & push, THEN reply, THEN resolve
 
-1. Run a PHP syntax check (`php -l`) on all modified files to verify nothing is broken.
-2. Report a final summary: how many bot comments handled, how many reviewer
-   comments handled, how many files modified.
-3. **Do NOT commit or push.** Just apply the fixes locally and reply to all comments on GitHub.
+Run this **once**, after all comments are handled. The order is deliberate: the
+fix must be live on the PR branch *before* its reply claims it.
+
+1. **Syntax-check** the modified files (`php -l` for PHP) to verify nothing is broken.
+2. **Commit & push the fixes — before any reply.** If code was changed:
+   - Stage the review fixes and commit with a Conventional Commit subject
+     (e.g. `fix(review): address PR #<n> review comments`), per
+     `conventional-commits-writing` — no attribution footer, no emoji in the subject.
+   - Push to the PR branch so the fixes are live.
+   - **Authorization:** invoking `/fix:pr-comments` *is* the explicit authorization
+     for this commit + push (the command's contract — the `commit-policy`
+     "command invoked" exception, and the this-turn push authorization the
+     `non-destructive-by-default` Hard Floor requires). Never commit to a
+     production trunk; only the PR branch the comments are on.
+   - If **nothing** was changed (all comments were questions / explanations),
+     skip the commit + push.
+3. **Reply** to every handled comment (per the reply-style rules above), now that
+   the referenced fixes are pushed and live.
+4. **Resolve** the conversation for every handled comment — bot and human alike:
+   - Resolve each inline review thread via the GitHub GraphQL
+     `resolveReviewThread(input: {threadId: "<id>"})` mutation. Fetch the thread
+     node ids from `repository.pullRequest.reviewThreads` (GraphQL), match each
+     thread to the comment you just replied to, and resolve it.
+   - Top-level PR review comments that are not inline threads cannot be resolved
+     — the reply stands, leave them.
+5. **Final summary:** bot comments handled, reviewer comments handled, files
+   modified, the pushed commit sha (if any), and how many threads were resolved.

--- a/src/domains/meta/README.md
+++ b/src/domains/meta/README.md
@@ -45,7 +45,7 @@ Artefacts that maintain this package (agent-config itself).
 - **`fix-ci`** — Fetch CI errors from GitHub Actions and fix them
 - **`fix-comments`** — Review the code comments touched by the current branch and simplify, shorten, or remove each one
 - **`fix-portability`** — Find and fix project-specific references in shared .augment/ package files
-- **`fix-pr-comments`** — Fix and reply to all open review comments (bots + human reviewers) on a GitHub PR
+- **`fix-pr-comments`** — Fix, commit+push, reply to, then resolve all open review comments (bots + human reviewers) on a GitHub PR
 - **`fix-refs`** — Find and fix broken cross-references in .augment/ and agents/ files
 - **`fix-seeder`** — Scan seeder data files for broken foreign key references — find constants used without getReference() and fix them
 - **`ghostwriter`** — Ghostwriter cluster — fetch, write, list, show, and delete public-figure voice profiles (the third voice primitive alongside personas/ and .agent-user.md).


### PR DESCRIPTION
Reorders the `/fix:pr-comments` contract (bots + human reviewers) so a fix is **live before its reply claims it**, and the conversation is **resolved after replying**.

## New sequence

**apply fix locally → commit + push → reply → resolve** (was: fix → reply → *never commit*).

- Replies are deferred to a new **Finalize** stage. The flows (interactive + auto) now *apply the fix and record the reply*; nothing is posted until the fix is committed and pushed — so no more "fixed" replies sitting on uncommitted work.
- After replying, each inline review thread is **resolved** via the GitHub GraphQL `resolveReviewThread` mutation (bots and human reviewers alike). Top-level non-thread comments can't be resolved — the reply stands.
- The old `## After all comments` → "**Do NOT commit or push**" tail is replaced by the `## Finalize` stage.

## Authorization note

Invoking `/fix:pr-comments` is the explicit authorization for its commit + push (the `commit-policy` "command invoked" exception + the this-turn push authorization the `non-destructive-by-default` Hard Floor requires). Never the production trunk — only the PR branch the comments are on.

## Scope

- `src/domains/engineering-base/fix/pr-comments/command.md` (source) + verbatim `dist/agent-src/commands/fix/pr-comments.md` projection + `internal/.condensation-hashes.json` + the `meta` pack README catalog (regenerated description).
- Verified: `sync-check`, `sync-check-hashes`, `check_references`, `lint-command-tiers`, `lint-command-verbs` all pass.
- Pre-existing, unrelated: `lint-command-flow-coverage` / `lint-command-routing` fail on `main` for other commands (`mission/upgrade`, `analyze`, phantom `fix/pr-bot-comments`/`fix/pr-developer-comments`) — not touched here.