### PR TITLE
feat(hooks): deterministic RTK-wrap PreToolUse nudge (token-saving Phase 3)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**70 / 121 steps done · 58%**
+**74 / 121 steps done · 61%**
 
 ```text
-███████████████████████░░░░░░░░░░░░░░░░░   58%
+████████████████████████░░░░░░░░░░░░░░░░   61%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 27 | 6 | 0 | 1 | ██░░░░░░░░ 18% |
+| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 23 | 10 | 0 | 1 | ███░░░░░░░ 30% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
@@ -38,14 +38,14 @@
 
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 
-**Road to token saving — measure, then cut, at constant quality** — 6 / 33 done (18%)
+**Road to token saving — measure, then cut, at constant quality** — 10 / 33 done (30%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Measurement substrate (the prerequisite to every cut) | 🟡 in progress | 2 | 4 | 0 | 0 | 67% |
 | 1 | RTK everywhere (un-gate the scope) | ⬜ not started | 3 | 0 | 0 | 1 | 0% |
 | 2 | Close the RTK trigger gap | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 3 | Deterministic RTK wrap hook + install verification | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 3 | Deterministic RTK wrap hook + install verification | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 5 | Cache-aware ordering as a CI invariant (D5) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 8 | Always-loaded budget linter (D6) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 10 | Token-saving backlog (extensible umbrella) | ⬜ not started | 11 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -256,19 +256,42 @@ The rule fires only on `git/phpstan/rector/phpunit/composer`; the skill's
 
 Convert RTK from advisory to deterministic; stop trusting the self-reported flag.
 
-- [ ] Add a runtime `which rtk` probe; key wrapping decisions off the live probe,
+- [x] Add a runtime `which rtk` probe; key wrapping decisions off the live probe,
       not `personal.n`. Mismatch (flag vs reality) surfaces once; absent rtk →
       silent plain-command fallback, no nag.
-- [ ] Implement a `pre_tool_use` wrap hook modeled on `block_no_verify.py`: parse
+      <!-- done: rtk_available() scans PATH for an executable rtk (cross-platform).
+      Simplified vs the spec: the hook keys PURELY off the live probe and ignores
+      the self-reported flag entirely (the cleanest "stop trusting the flag"), so
+      there is no flag-vs-reality "mismatch surfaces once" notice — the flag is now
+      irrelevant. rtk absent → silent no-op (exit 0), no nag. -->
+- [x] Implement a `pre_tool_use` wrap hook modeled on `block_no_verify.py`: parse
       Bash, no-op when rtk absent, **denylist completeness-critical** (`git diff`,
       `rtk read`, already-piped, short commands), fail-open on parse error.
       Mechanism: deny-and-instruct (cross-platform exit-code envelope) where
       rewrite is unsupported; `updatedInput` rewrite where the host supports it.
-- [ ] Wire into `hook_manifest.yaml` for every supporting platform; respect
+      <!-- done: src/scripts/hooks/rtk_wrap_hook.ts reuses block_no_verify's
+      shlexSplit / _split_subcommands / _is_env_assignment. classify() denylists
+      git diff, rtk-wrapped, piped/compound, non-verbose programs; fail-OPEN on
+      parse error (never break a command). MECHANISM CORRECTION: the v1 dispatcher
+      contract (docs/contracts/hook-architecture-v1.md) is allow/block/warn ONLY —
+      there is NO transparent `updatedInput` rewrite (that field is Claude-native,
+      not in this contract). So the hook WARNS (exit 2, decision:warn) "re-run
+      wrapped: rtk <cmd>" — like the sibling injection_scan_hook (surface, don't
+      block); appropriate for a token optimization vs a safety floor. -->
+- [x] Wire into `hook_manifest.yaml` for every supporting platform; respect
       `lint_hook_concern_budget`; add a settings toggle (conservative default).
-- [ ] Snapshot tests under `tests/hooks/`: eligible wrapped/flagged, denylisted
+      <!-- done: rtk-wrap concern + pre_tool_use wiring for augment/claude/cowork
+      (matches block-no-verify's platform set — the only platforms with
+      pre_tool_use). Settings toggle hooks.rtk_wrap.enabled (default false).
+      lint-hook-manifest + lint-hook-concern-budget pass. -->
+- [x] Snapshot tests under `tests/hooks/`: eligible wrapped/flagged, denylisted
       untouched, rtk-absent no-op, parse-error fail-open.
       <!-- carve-out: new-gate-verification -->
+      <!-- done: tests/scripts/hooks/rtk_wrap_hook.test.ts (13 tests — classify
+      eligible/denylist/compound/parse-error/env-prefix + rtk_available probe).
+      End-to-end smoke confirmed: enabled+rtk+`git status`→warn exit 2;
+      `git diff`→no-op; disabled→no-op. (Location is tests/scripts/hooks/, the
+      block_no_verify test's convention, not tests/hooks/.) -->
 
 **Exit:** hook fires on an eligible command, leaves denylisted commands untouched,
 proven by snapshot tests run locally.

--- a/src/config/agent-settings.template.yml
+++ b/src/config/agent-settings.template.yml
@@ -722,6 +722,15 @@ hooks:
   injection_scan:
     enabled: false
 
+  # PreToolUse RTK-wrap nudge (token-saving Phase 3). Default-OFF. When enabled
+  # AND `rtk` is on PATH (a live probe — not a self-reported flag), warns (exit
+  # 2, never blocks) "re-run wrapped with rtk" before a single verbose CLI
+  # command (git/npm/cargo/docker/…), so verbose output is filtered for 60–90%
+  # token saving. Skips completeness-critical / piped / compound commands and
+  # `git diff`. No-op when rtk is absent. Opt in once you have rtk installed.
+  rtk_wrap:
+    enabled: false
+
 # --- Decision engine ---
 #
 # Controllable gates layered over the observability surface. Absent

--- a/src/scripts/hook_manifest.yaml
+++ b/src/scripts/hook_manifest.yaml
@@ -64,6 +64,18 @@ concerns:
     script: src/scripts/hooks/block_no_verify.ts
     args: []
     fail_closed: true
+  # token-saving Phase 3 — PreToolUse RTK-wrap nudge. DETERMINISTIC: keys off a
+  # live `which rtk` probe (not the self-reported flag). When rtk is installed
+  # and the agent is about to run a single verbose CLI command that is NOT
+  # completeness-critical, warns "re-run wrapped with rtk" (60–90% fewer output
+  # tokens). Warn only — never blocks (the v1 contract has no transparent
+  # rewrite); never fires when rtk is absent (silent plain-command fallback).
+  # Default-OFF (hooks.rtk_wrap.enabled). fail_closed: false — never break a
+  # command for a token optimization.
+  rtk-wrap:
+    script: src/scripts/hooks/rtk_wrap_hook.ts
+    args: []
+    fail_closed: false
   # Phase 2 of road-to-hooks-actually-fire-in-consumers — session_start
   # gate that surfaces the marketplace-install-but-unscaffolded shape.
   # Writes .augment/.first-run-action-needed.md + one stderr line so
@@ -96,7 +108,7 @@ platforms:
     session_start:    [chat-history, first-run-gate, onboarding-gate, verify-before-complete, minimal-safe-diff, profile-staleness, wrapper-freshness]
     session_end:      [chat-history]
     stop:             [chat-history, verify-before-complete]
-    pre_tool_use:     [block-no-verify]
+    pre_tool_use:     [block-no-verify, rtk-wrap]
     post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
 
   claude:
@@ -104,7 +116,7 @@ platforms:
     session_end:      [chat-history]
     stop:             [chat-history, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    pre_tool_use:     [block-no-verify]
+    pre_tool_use:     [block-no-verify, rtk-wrap]
     post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
 
   # Cowork — the Claude desktop app's local-agent-mode runtime, built
@@ -126,7 +138,7 @@ platforms:
     session_end:      [chat-history]
     stop:             [chat-history, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    pre_tool_use:     [block-no-verify]
+    pre_tool_use:     [block-no-verify, rtk-wrap]
     post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
 
   # Phase 7.5 — Cursor. `.cursor/hooks.json` (project) is read by the

--- a/src/scripts/hooks/rtk_wrap_hook.ts
+++ b/src/scripts/hooks/rtk_wrap_hook.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env tsx
+/**
+ * PreToolUse RTK-wrap nudge — deterministic, warn-in-context
+ * (token-saving Phase 3).
+ *
+ * Converts RTK from advisory to DETERMINISTIC: instead of trusting a
+ * self-reported flag, this hook keys off a live `which rtk` probe. When rtk is
+ * actually installed AND the agent is about to run a single verbose CLI command
+ * that is NOT completeness-critical, it surfaces (warn) "re-run wrapped with
+ * rtk" so the 60–90% output-token saving is captured. It NEVER blocks (the v1
+ * dispatcher contract is allow/block/warn — there is no transparent
+ * `updatedInput` rewrite — and, like `injection_scan_hook`, warn preserves
+ * agency). It NEVER fires when rtk is absent (silent plain-command fallback,
+ * no nag).
+ *
+ * Default-OFF. Fires only when `hooks.rtk_wrap.enabled: true` in
+ * `.agent-settings.yml`. Disabled / missing / rtk-absent → no-op exit 0.
+ * fail_closed: false — any parse/probe error returns allow (never break a
+ * command for a token optimization).
+ *
+ * Denylist (never nudged — completeness-critical or already-handled):
+ *   - `git diff` / `rtk read` (silent truncation risk — see the rtk skill)
+ *   - already `rtk …` wrapped, or piped / compound (`|`, `&&`, `||`, `;`)
+ *   - any program not in the verbose-CLI allowlist
+ *
+ * Exit codes (dispatcher contract): 0 allow · 2 warn (+ JSON reason on stdout).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  shlexSplit,
+  ShlexError,
+  _split_subcommands,
+  _is_env_assignment,
+} from "./block_no_verify.js";
+
+const SETTINGS_FILE = ".agent-settings.yml";
+const EXIT_ALLOW = 0;
+const EXIT_WARN = 2;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+type JsonObject = { [k: string]: JsonValue };
+
+// Verbose-CLI programs worth wrapping — mirrors the cli-output-handling rule
+// triggers + the rtk skill's "✅ Always" table. Kept in sync with
+// src/rules/cli-output-handling.md.
+const _RTK_PROGRAMS: ReadonlySet<string> = new Set([
+  "git", "phpstan", "rector", "phpunit", "composer",
+  "npm", "pnpm", "yarn", "eslint", "tsc", "vitest", "jest",
+  "pytest", "ruff", "mypy", "pyright", "cargo", "go",
+  "golangci-lint", "docker", "kubectl", "terraform",
+]);
+
+function _isObject(v: unknown): v is JsonObject {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** `hooks.rtk_wrap.enabled: true` mini-parser (mirrors injection_scan_hook). */
+function _enabled(root: string): boolean {
+  const f = path.join(root, SETTINGS_FILE);
+  try {
+    if (!fs.statSync(f).isFile()) return false;
+  } catch {
+    return false;
+  }
+  let text: string;
+  try {
+    text = fs.readFileSync(f, "utf-8");
+  } catch {
+    return false;
+  }
+  let in_hooks = false;
+  let in_rw = false;
+  const lines = text.split(/\r\n|\r|\n/);
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, "");
+    if (!line || line.replace(/^\s+/, "").startsWith("#")) continue;
+    if (!(line.startsWith(" ") || line.startsWith("\t"))) {
+      in_hooks = /^hooks\s*:\s*$/.test(line);
+      in_rw = false;
+      continue;
+    }
+    if (in_hooks) {
+      if (/^\s+rtk_wrap\s*:\s*$/.test(line)) {
+        in_rw = true;
+        continue;
+      }
+      if (in_rw && /^\s{0,3}\S/.test(line)) in_rw = false;
+    }
+    if (in_rw && /^\s+enabled\s*:\s*true\b/.test(line)) return true;
+  }
+  return false;
+}
+
+/** Live `which rtk` — scan PATH for an executable `rtk` (cross-platform). */
+export function rtk_available(env: NodeJS.ProcessEnv = process.env): boolean {
+  const pathVar = env.PATH ?? env.Path ?? "";
+  if (!pathVar) return false;
+  const dirs = pathVar.split(path.delimiter).filter(Boolean);
+  // On Windows the launcher is rtk.exe / rtk.cmd / rtk.bat.
+  const exts = process.platform === "win32" ? ["", ".exe", ".cmd", ".bat"] : [""];
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = path.join(dir, `rtk${ext}`);
+      try {
+        const st = fs.statSync(candidate);
+        if (st.isFile()) {
+          // POSIX: require an executable bit; Windows: extension is enough.
+          if (process.platform === "win32" || (st.mode & 0o111) !== 0) return true;
+        }
+      } catch {
+        /* not here — keep scanning */
+      }
+    }
+  }
+  return false;
+}
+
+function _extract_command(envelope: JsonObject): string | null {
+  const payload = (_isObject(envelope["payload"]) ? envelope["payload"] : {}) as JsonObject;
+  const tool_input = (_isObject(payload["tool_input"]) ? payload["tool_input"] : {}) as JsonObject;
+  for (const src of [tool_input["command"], payload["command"], envelope["command"]]) {
+    if (typeof src === "string") return src;
+  }
+  return null;
+}
+
+export interface Eligibility {
+  eligible: boolean;
+  program?: string;
+  reason_skip?: string;
+}
+
+/**
+ * A command is eligible for an rtk-wrap nudge iff it is a SINGLE simple command
+ * (no pipe / compound separators), whose program is a known verbose CLI, and is
+ * not a completeness-critical / already-wrapped case.
+ */
+export function classify(command: string): Eligibility {
+  const cmd = command.trim();
+  if (!cmd) return { eligible: false, reason_skip: "empty" };
+
+  let tokens: string[];
+  try {
+    tokens = shlexSplit(cmd);
+  } catch (e) {
+    if (e instanceof ShlexError) return { eligible: false, reason_skip: "parse-error" };
+    throw e;
+  }
+
+  // Compound / piped → don't wrap (rtk wraps a single command). `_split_subcommands`
+  // splits on && || ; | — more than one group means a pipeline/chain.
+  const groups = _split_subcommands(tokens);
+  if (groups.length !== 1) return { eligible: false, reason_skip: "compound-or-piped" };
+
+  const sub = groups[0] as string[];
+  let i = 0;
+  while (i < sub.length && _is_env_assignment(sub[i] as string)) i += 1;
+  const program = sub[i];
+  if (!program) return { eligible: false, reason_skip: "no-program" };
+  if (program === "rtk") return { eligible: false, reason_skip: "already-rtk" };
+  if (!_RTK_PROGRAMS.has(program)) return { eligible: false, program, reason_skip: "not-verbose-cli" };
+  // `git diff` is completeness-critical (silent truncation) — never wrap.
+  if (program === "git" && sub[i + 1] === "diff") {
+    return { eligible: false, program, reason_skip: "git-diff-denylisted" };
+  }
+  return { eligible: true, program };
+}
+
+function _readStdin(): string {
+  try {
+    if (process.stdin.isTTY) return "";
+    return fs.readFileSync(0, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+function _jsonReason(reason: string): string {
+  return JSON.stringify({ decision: "warn", reason });
+}
+
+export function main(): number {
+  let envelope: JsonValue;
+  try {
+    const raw = _readStdin();
+    envelope = raw.trim() ? (JSON.parse(raw) as JsonValue) : {};
+  } catch {
+    return EXIT_ALLOW; // never break a command on a malformed envelope
+  }
+  if (!_isObject(envelope)) return EXIT_ALLOW;
+
+  const cwd = envelope["cwd"];
+  const projectRoot = envelope["workspace_root"] ?? envelope["project_root"];
+  const root =
+    typeof cwd === "string" && cwd
+      ? cwd
+      : typeof projectRoot === "string" && projectRoot
+        ? projectRoot
+        : ".";
+  if (!_enabled(root)) return EXIT_ALLOW;
+
+  // Deterministic gate: the live probe, NOT a self-reported flag.
+  if (!rtk_available()) return EXIT_ALLOW;
+
+  const command = _extract_command(envelope);
+  if (!command) return EXIT_ALLOW;
+
+  const verdict = classify(command);
+  if (!verdict.eligible) return EXIT_ALLOW;
+
+  const reason =
+    `rtk is installed and wraps verbose CLI output (60–90% fewer output tokens). ` +
+    `Re-run wrapped: \`rtk ${command.trim()}\`. ` +
+    `(Skip for completeness-critical output like \`git diff\`.)`;
+  process.stdout.write(`${_jsonReason(reason)}\n`);
+  return EXIT_WARN;
+}
+
+const _isCliEntry =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_isCliEntry) {
+  process.exit(main());
+}

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -362,6 +362,11 @@ export const settingsSchema = z.object({
                 'PostToolUse prompt-injection scanner (road-to-security-pillar.md P3.2). Default off. When on, scans tool output (file reads, web fetches, MCP responses) for injection signatures and WARNS in context (never blocks). Runtime backstop on top of the always-on untrusted-input-defense rule; detection is probabilistic.',
             ),
         }).default({}),
+        rtk_wrap: z.object({
+            enabled: z.boolean().default(false).describe(
+                'PreToolUse RTK-wrap nudge (token-saving Phase 3). Default off. When on AND rtk is on PATH (a live probe — not a self-reported flag), warns (never blocks) "re-run wrapped with rtk" before a single verbose CLI command (git/npm/cargo/docker/…) for 60–90% token saving. Skips completeness-critical / piped / compound commands and git diff. No-op when rtk is absent.',
+            ),
+        }).default({}),
     }),
     decision_engine: z.object({
         surface_traces: z.boolean().default(false).describe(

--- a/tests/scripts/hooks/rtk_wrap_hook.test.ts
+++ b/tests/scripts/hooks/rtk_wrap_hook.test.ts
@@ -1,0 +1,91 @@
+// Tests for src/scripts/hooks/rtk_wrap_hook.ts (token-saving Phase 3).
+//
+// Unit tests over the exported pure logic: `classify` (eligibility +
+// denylist) and `rtk_available` (the live PATH probe). The hook is warn-only
+// and fail-open; the dispatcher integration (settings gate + stdin envelope)
+// is covered by the manifest/lint gates.
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { classify, rtk_available } from "../../../src/scripts/hooks/rtk_wrap_hook.js";
+
+describe("rtk_wrap — classify (eligibility)", () => {
+  it("flags a single verbose CLI command", () => {
+    for (const cmd of ["git status", "npm run build", "cargo test", "docker compose logs", "phpunit", "pytest -q"]) {
+      const r = classify(cmd);
+      expect(r.eligible, cmd).toBe(true);
+    }
+  });
+
+  it("strips leading env assignments to find the program", () => {
+    const r = classify("FOO=1 BAR=2 npm test");
+    expect(r.eligible).toBe(true);
+    expect(r.program).toBe("npm");
+  });
+
+  it("denylists `git diff` (completeness-critical)", () => {
+    const r = classify("git diff --stat");
+    expect(r.eligible).toBe(false);
+    expect(r.reason_skip).toBe("git-diff-denylisted");
+  });
+
+  it("skips an already-rtk-wrapped command", () => {
+    expect(classify("rtk git log").reason_skip).toBe("already-rtk");
+  });
+
+  it("skips piped commands (already filtered / composed)", () => {
+    expect(classify("git log | grep fix").reason_skip).toBe("compound-or-piped");
+  });
+
+  it("skips compound commands (&&, ;, ||)", () => {
+    expect(classify("npm ci && npm test").reason_skip).toBe("compound-or-piped");
+    expect(classify("git add . ; git status").reason_skip).toBe("compound-or-piped");
+  });
+
+  it("ignores non-verbose programs", () => {
+    expect(classify("ls -la").reason_skip).toBe("not-verbose-cli");
+    expect(classify("echo hi").reason_skip).toBe("not-verbose-cli");
+  });
+
+  it("fails open on an unparseable command (unterminated quote)", () => {
+    const r = classify("git commit -m 'unterminated");
+    expect(r.eligible).toBe(false);
+    expect(r.reason_skip).toBe("parse-error");
+  });
+
+  it("treats empty input as ineligible", () => {
+    expect(classify("   ").eligible).toBe(false);
+  });
+});
+
+describe("rtk_wrap — rtk_available (live PATH probe)", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "rtk-probe-"));
+  afterAll(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  it("returns false when PATH has no rtk", () => {
+    expect(rtk_available({ PATH: tmp })).toBe(false);
+  });
+
+  it("returns true when an executable rtk is on PATH (POSIX)", () => {
+    if (process.platform === "win32") return; // exec-bit semantics differ
+    const bin = path.join(tmp, "rtk");
+    fs.writeFileSync(bin, "#!/bin/sh\n");
+    fs.chmodSync(bin, 0o755);
+    expect(rtk_available({ PATH: tmp })).toBe(true);
+  });
+
+  it("returns false for a non-executable rtk file (POSIX)", () => {
+    if (process.platform === "win32") return;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rtk-noexec-"));
+    fs.writeFileSync(path.join(dir, "rtk"), "x");
+    fs.chmodSync(path.join(dir, "rtk"), 0o644);
+    expect(rtk_available({ PATH: dir })).toBe(false);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns false on an empty PATH", () => {
+    expect(rtk_available({ PATH: "" })).toBe(false);
+  });
+});


### PR DESCRIPTION
Token-saving **Phase 3** — converts RTK from advisory to **deterministic** by keying off a live probe instead of a self-reported flag. Default-OFF, warn-only.

## What it does

A `pre_tool_use` concern (`src/scripts/hooks/rtk_wrap_hook.ts`) that, when `hooks.rtk_wrap.enabled: true` **and** `rtk` is on PATH (a live `which rtk` scan), warns before a single verbose CLI command (`git/npm/cargo/docker/pytest/…`): *"re-run wrapped: `rtk <cmd>`"* — capturing 60–90% fewer output tokens.

- Reuses `block_no_verify`'s shlex parser. `classify()` denylists `git diff` (silent-truncation risk), already-`rtk`-wrapped, piped/compound, and non-verbose programs. **Fail-open** on parse error — never breaks a command.
- **No-op when rtk is absent** (silent plain-command fallback, no nag) — the determinism the council asked for ("stop trusting the self-reported flag").

## Mechanism correction (vs the roadmap's wording)

The roadmap proposed "`updatedInput` rewrite where the host supports it." The v1 dispatcher contract (`docs/contracts/hook-architecture-v1.md`) is **allow/block/warn only** — there is no transparent `updatedInput` rewrite (that field is Claude-native, outside this contract). So the hook **warns** (exit 2, `decision: warn`), matching the sibling `injection_scan_hook`'s "surface, don't block" pattern — the right call for a token optimization rather than a safety floor. It never blocks a command. Recorded in the roadmap notes.

Also simplified: the hook keys *purely* off the live probe and ignores the self-reported flag entirely, so there's no "flag-vs-reality mismatch" notice — the flag is now irrelevant.

## Scope & verification

`rtk_wrap_hook.ts` + its 13-test suite + `hook_manifest.yaml` (concern + `pre_tool_use` wiring for augment/claude/cowork) + the `hooks.rtk_wrap.enabled: false` settings toggle. All `.ts`/`.yaml` source (ships directly; no condensation).

Verified: 13 tests pass · `tsc` clean · eslint clean · `lint-hook-manifest` + `lint-hook-concern-budget` pass · `check_references` clean · end-to-end smoke (enabled+rtk+`git status`→warn exit 2; `git diff`→no-op; disabled→no-op).

Pre-existing/unrelated: `validate-agent-settings` flags `tokens.rich_skills: on` (YAML parses `on`→bool) on `main` — not touched here.