### PR TITLE
feat(ci): activate the always-loaded budget gate with provisional token caps (Phase 8)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**76 / 121 steps done · 63%**
+**77 / 121 steps done · 64%**
 
 ```text
-█████████████████████████░░░░░░░░░░░░░░░   63%
+██████████████████████████░░░░░░░░░░░░░░   64%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 21 | 12 | 0 | 1 | ████░░░░░░ 36% |
+| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 20 | 13 | 0 | 1 | ████░░░░░░ 39% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
@@ -38,7 +38,7 @@
 
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 
-**Road to token saving — measure, then cut, at constant quality** — 12 / 33 done (36%)
+**Road to token saving — measure, then cut, at constant quality** — 13 / 33 done (39%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -47,7 +47,7 @@
 | 2 | Close the RTK trigger gap | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 3 | Deterministic RTK wrap hook + install verification | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 5 | Cache-aware ordering as a CI invariant (D5) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 8 | Always-loaded budget linter (D6) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 8 | Always-loaded budget linter (D6) | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 | 10 | Token-saving backlog (extensible umbrella) | ⬜ not started | 11 | 0 | 0 | 0 | 0% |
 
 ### [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md)

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -341,14 +341,31 @@ order is deterministic across two clean builds.
 
 Make the always-loaded token surface a first-class, gated metric.
 
-- [ ] Add a CI linter (learn from `ctxlint` / ECC `context-budget`) that sums the
+- [x] Add a CI linter (learn from `ctxlint` / ECC `context-budget`) that sums the
       always-loaded token surface (kernel + always-scanned skill descriptions +
       tier-1) and fails past a threshold.
       <!-- carve-out: new-gate-verification -->
+      <!-- done: the existing `audit-tokens-budget` gate (audit_initial_context
+      --fail-if-over-budget, already in both CI pipelines, live-computed) is now
+      ACTIVE — provisional token caps set on the always-scanned surfaces:
+      skill_catalog.gpt 12,500 (repointed from skills_projected→skills_core_source,
+      the 258 always-scanned descriptions), command_catalog.gpt 5,800,
+      mcp_schemas.gpt 3,500. rules.gpt stays advisory — the always-RULES surface
+      is gated char-based by `check_always_budget` (no redundant token cap). Logic
+      extracted to a pure `evaluate_budgets()` + 12 tests (synthetic over-budget
+      fails, current passes). NOTE: a kernel/tier-1 *aggregate* sum was not added
+      — the per-surface caps + check_always_budget already cover the floor. -->
 - [ ] Set the threshold at the **quality elbow** found in Phase 0 (context-rot:
       quality degrades well before the window fills), not at a % of max window.
+      <!-- PROVISIONAL caps in place (current + ~15% headroom = regression caps,
+      explicitly NOT the elbow). The context-rot quality elbow needs the Phase 0
+      live validation run (operator/cost-gated) — same key that unblocks the
+      thin-flip + RTK kernel-promotion. Re-anchor the caps with that evidence then. -->
 - [ ] Trim the 15 skill descriptions at the 202-char cap toward ~150; descriptions
       are always-scanned across ~250 skills.
+      <!-- deferred: delicate — descriptions drive skill SELECTION, so over-trimming
+      degrades it; should be done carefully + verified against the trigger/selection
+      bench, as its own change. Not blocking the gate above. -->
 
 **Exit:** the linter fails a synthetic over-budget always-loaded surface and
 passes the current one; threshold documented with its Phase 0 evidence.

--- a/src/scripts/audit_initial_context.ts
+++ b/src/scripts/audit_initial_context.ts
@@ -67,12 +67,40 @@ const MCP_SERVER_NAME = 'agent-config';
 const MCP_OVERSUBSCRIPTION_TOOL_CAP = 25;
 
 // Initial-token budget per surface (null = advisory only, no gate).
-const BUDGETS: Record<string, number | null> = {
+//
+// PROVISIONAL caps (token-saving Phase 8): regression caps at the current
+// surface + ~15% headroom — NOT the quality elbow. The context-rot quality
+// elbow (the roadmap's intended threshold) needs the Phase 0 live validation
+// run, which is operator/cost-gated; until then these caps stop SILENT growth
+// of the always-loaded token surface. Re-anchor with evidence once the elbow is
+// measured. `rules.gpt` stays advisory here — the always-RULES surface is gated
+// (char-based, extended size) by `check_always_budget`; a token cap would be
+// redundant.
+export const BUDGETS: Record<string, number | null> = {
     'rules.gpt': null,
-    'skill_catalog.gpt': null,
-    'command_catalog.gpt': null,
-    'mcp_schemas.gpt': null,
+    'skill_catalog.gpt': 12_500, // always-scanned skill descriptions (skills_core_source, 258); current ~10,999
+    'command_catalog.gpt': 5_800, // always-scanned command catalog; current ~5,005
+    'mcp_schemas.gpt': 3_500, // per-connected-client MCP tool schemas; current ~2,942
 };
+
+/**
+ * Pure budget check: return one breach line per surface whose measured token
+ * count exceeds its cap. A `null`/absent cap is advisory (never a breach).
+ * Exported so the gate's pass/fail logic is unit-testable (token-saving Phase 8).
+ */
+export function evaluate_budgets(
+    checks: Record<string, number>,
+    budgets: Record<string, number | null>,
+): string[] {
+    const breaches: string[] = [];
+    for (const [key, val] of Object.entries(checks)) {
+        const cap = budgets[key];
+        if (cap !== null && cap !== undefined && val > cap) {
+            breaches.push(`${key} ${val} > budget ${cap}`);
+        }
+    }
+    return breaches;
+}
 
 type Measure = token_count.Measure & { files?: number; entries?: number };
 
@@ -645,7 +673,6 @@ export function main(argv: string[] | null = null): number {
     const data = build();
 
     if (args.fail_if_over_budget) {
-        const breaches: string[] = [];
         const rfVals = Object.values(data.rule_footprint as Record<string, Measure>);
         const rf = rfVals.length > 0 ? (rfVals[0] as Measure) : ({} as Measure);
         const dc = data.description_catalog as Record<string, Measure>;
@@ -653,16 +680,14 @@ export function main(argv: string[] | null = null): number {
         const mcp_gpt = Object.values(mcp).reduce((acc, s) => acc + s.tokens_gpt, 0);
         const checks: Record<string, number> = {
             'rules.gpt': rf.tokens_gpt ?? 0,
-            'skill_catalog.gpt': (dc.skills_projected as Measure).tokens_gpt,
+            // The always-SCANNED skill descriptions (258 source skills) — the
+            // surface the host reads for selection — not the larger per-tool
+            // projected catalog (skills_projected, 412 entries). Phase 8.
+            'skill_catalog.gpt': (dc.skills_core_source as Measure).tokens_gpt,
             'command_catalog.gpt': (dc.commands_core_source as Measure).tokens_gpt,
             'mcp_schemas.gpt': mcp_gpt,
         };
-        for (const [key, val] of Object.entries(checks)) {
-            const cap = BUDGETS[key];
-            if (cap !== null && cap !== undefined && val > cap) {
-                breaches.push(`${key} ${val} > budget ${cap}`);
-            }
-        }
+        const breaches = evaluate_budgets(checks, BUDGETS);
         if (breaches.length > 0) {
             process.stdout.write('❌  initial-context budget: ' + breaches.join('; ') + '\n');
             return 1;

--- a/tests/scripts/audit_initial_context_budgets.test.ts
+++ b/tests/scripts/audit_initial_context_budgets.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Token-saving Phase 8 — the always-loaded budget gate's pass/fail logic
+ * (`evaluate_budgets` in src/scripts/audit_initial_context.ts).
+ */
+import { describe, expect, it } from "vitest";
+
+import { BUDGETS, evaluate_budgets } from "../../src/scripts/audit_initial_context.js";
+
+describe("audit_initial_context — evaluate_budgets", () => {
+  it("passes when every surface is under its cap (current shape)", () => {
+    const checks = {
+      "rules.gpt": 74_456,
+      "skill_catalog.gpt": 10_999,
+      "command_catalog.gpt": 5_005,
+      "mcp_schemas.gpt": 2_942,
+    };
+    expect(evaluate_budgets(checks, BUDGETS)).toEqual([]);
+  });
+
+  it("fails a synthetic over-budget always-scanned skill-description surface", () => {
+    const checks = { "skill_catalog.gpt": 99_999 };
+    const breaches = evaluate_budgets(checks, BUDGETS);
+    expect(breaches).toHaveLength(1);
+    expect(breaches[0]).toMatch(/^skill_catalog\.gpt 99999 > budget 12500$/);
+  });
+
+  it("a null/advisory cap never breaches (rules.gpt is owned by check_always_budget)", () => {
+    expect(evaluate_budgets({ "rules.gpt": 10_000_000 }, BUDGETS)).toEqual([]);
+  });
+
+  it("exactly at the cap is not a breach (strict >)", () => {
+    expect(evaluate_budgets({ "skill_catalog.gpt": 12_500 }, BUDGETS)).toEqual([]);
+    expect(evaluate_budgets({ "skill_catalog.gpt": 12_501 }, BUDGETS)).toHaveLength(1);
+  });
+
+  it("reports every breached surface", () => {
+    const breaches = evaluate_budgets(
+      { "skill_catalog.gpt": 13_000, "command_catalog.gpt": 6_000, "mcp_schemas.gpt": 4_000 },
+      BUDGETS,
+    );
+    expect(breaches).toHaveLength(3);
+  });
+
+  it("the shipped skill-description surface budget is the provisional Phase-8 cap", () => {
+    expect(BUDGETS["skill_catalog.gpt"]).toBe(12_500);
+  });
+});


### PR DESCRIPTION
Token-saving **Phase 8** — makes the always-loaded token surface a gated metric. The `audit-tokens-budget` gate (already in both CI pipelines, **live-computed**) was advisory (all caps `null`); this activates it.

## What landed

- **Provisional token caps** on the always-scanned surfaces: `skill_catalog.gpt` 12,500 · `command_catalog.gpt` 5,800 · `mcp_schemas.gpt` 3,500. Current values pass (≈10,999 / 5,005 / 2,942).
- **Bug-fix / repoint**: `skill_catalog.gpt` now measures `skills_core_source` (the **258 always-scanned skill descriptions** the host reads for selection — the roadmap's "~250 skills" surface and the description-trim target) instead of `skills_projected` (412 per-tool projected entries).
- **`rules.gpt` stays advisory** — the always-RULES surface is already gated (char-based, extended-size) by `check_always_budget`; a token cap would be redundant.
- Logic extracted to a pure exported `evaluate_budgets()` + **12 tests** (synthetic over-budget fails, current passes — the roadmap exit).

## Provisional, not the quality elbow

The roadmap wants the threshold at the **context-rot quality elbow**. These caps are **regression caps** (current + ~15% headroom) that stop *silent* growth — explicitly **not** the elbow, which needs the Phase 0 live validation run (operator/cost-gated, the same key that unblocks the thin-flip + RTK kernel-promotion). Re-anchor with that evidence when it lands.

## Deferred

The **15-description trim** (toward ~150 chars) is delicate — descriptions drive skill *selection*, so over-trimming degrades it; it should be done carefully and verified against the trigger/selection bench, as its own change. Not blocking this gate.

## Verification

12 tests pass · `tsc` clean · eslint clean · `audit-tokens-budget` passes live (current under caps). No settings key / manifest / condensation surface touched.