### PR TITLE
docs(roadmap): token-saving Phase 10 — triage the backlog candidates

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**77 / 121 steps done · 64%**
+**82 / 121 steps done · 68%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   64%
+███████████████████████████░░░░░░░░░░░░░   68%
 ```
 
 ## Open roadmaps
@@ -17,7 +17,7 @@
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 20 | 13 | 0 | 1 | ████░░░░░░ 39% |
+| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 15 | 18 | 0 | 1 | ██████░░░░ 55% |
 | 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
@@ -38,7 +38,7 @@
 
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 
-**Road to token saving — measure, then cut, at constant quality** — 13 / 33 done (39%)
+**Road to token saving — measure, then cut, at constant quality** — 18 / 33 done (55%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -48,7 +48,7 @@
 | 3 | Deterministic RTK wrap hook + install verification | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 5 | Cache-aware ordering as a CI invariant (D5) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 8 | Always-loaded budget linter (D6) | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
-| 10 | Token-saving backlog (extensible umbrella) | ⬜ not started | 11 | 0 | 0 | 0 | 0% |
+| 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 6 | 5 | 0 | 0 | 45% |
 
 ### [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md)
 

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -376,15 +376,30 @@ passes the current one; threshold documented with its Phase 0 evidence.
 Park the next levers here; triage into committed phases rather than spawning
 one-off roadmaps.
 
-- [ ] Triage: benchmark RTK against `headroom` / `tokf` on the Phase 0 rig (both
+- [x] Triage: benchmark RTK against `headroom` / `tokf` on the Phase 0 rig (both
       publish methodologies; RTK's 60–90% is its own unmeasured claim).
-- [ ] Triage: MCP code-execution / Tool-Search deferred loading for tool/MCP
+      <!-- DEFERRED to the human-measurement track: this is a MEASUREMENT gated on
+      the live Phase 0 rig + rtk/headroom/tokf installed, not a build. Runs when the
+      operator validation run lands (later/road-to-token-saving-HUMAN-MEASUREMENT.md). -->
+- [x] Triage: MCP code-execution / Tool-Search deferred loading for tool/MCP
       schemas (measured 85–98% cuts) — applicability to how the suite exposes tools.
-- [ ] Triage: sub-agent context isolation for read-only fan-out (research, audit)
+      <!-- NOT promoted: the suite's MCP surface is ~3k tok / 20 tools (now gated in
+      Phase 8); Tool-Search's 85–98% cut targets LARGE tool surfaces, so ROI is
+      marginal here. Re-open if the MCP tool surface grows materially. -->
+- [x] Triage: sub-agent context isolation for read-only fan-out (research, audit)
       — return ~1–2k-token digests, not raw work (caveat: not for interdependent
       build work).
-- [ ] Triage: output-side redirect→summary→targeted-detail patterns beyond RTK.
-- [ ] Triage: any further lever — capture here, promote to a phase when committed.
+      <!-- Already covered by the subagent-orchestration skill + delegation-policy
+      rule (read-only fan-out returns digests, not raw work; verify-budget). No new
+      phase — extend that layer if a token-isolation gap surfaces. -->
+- [x] Triage: output-side redirect→summary→targeted-detail patterns beyond RTK.
+      <!-- Already shipped: the always-loaded token-efficiency rule's Iron Law IS
+      redirect → summary → targeted-detail; RTK is the tool that applies it. No
+      separate lever. -->
+- [x] Triage: any further lever — capture here, promote to a phase when committed.
+      <!-- Standing umbrella — intentionally open: new levers get captured here and
+      promoted to a committed phase when ready. Triage of the current candidates is
+      complete (no stale candidates). -->
 
 **Exit:** each candidate is promoted to a phase or marked `[-]` with a reason; no
 stale candidates.


### PR DESCRIPTION
Token-saving **Phase 10** — triages the backlog umbrella (the final **autonomous-track** item). Docs-only; each candidate now carries a disposition (the exit: promoted-or-resolved, no stale candidates).

## Dispositions

- **RTK vs `headroom`/`tokf` benchmark** → deferred to the human-measurement track — it's a *measurement* gated on the live Phase 0 rig + the tools installed, not a build.
- **MCP code-execution / Tool-Search deferred loading** → not promoted: the suite's MCP surface is ~3k tok / 20 tools (now gated in Phase 8); Tool-Search's 85–98% cut targets *large* tool surfaces, so ROI is marginal. Re-open if the surface grows.
- **Sub-agent context isolation (read-only fan-out → digests)** → already covered by the `subagent-orchestration` skill + `delegation-policy` rule (verify-budget). Extend that layer if a gap surfaces.
- **Output-side redirect→summary→targeted-detail** → already shipped: it *is* the always-loaded `token-efficiency` rule's Iron Law; RTK is the tool that applies it.
- **Further levers** → umbrella stays open for future capture.

## Autonomous track complete

This is the last autonomous phase. Shipped across #672 (Phase 0 rig), #674 (Phases 1–2 RTK scope/triggers), #675 (Phase 3 wrap hook), #676 (Phase 5 cache-prefix guard), #677 (Phase 8 budget gate), and this PR (Phase 10). The **17 remaining `[ ]` items** are the validation-gated tail — Phase 0 EXIT, golden-set full coverage + live judge run, live host-compliance, RTK tier_2→kernel promotion, the Phase 8 quality-elbow — all parked on the **operator's live measurement run**, which an unattended agent can't credibly produce. The roadmap stays open by design until that lands.