### PR TITLE
feat(bench): thin-vs-eager quality-run producer (Phase 0 EXIT judge runner)

### DIFF
--- a/src/scripts/bench_quality_run.ts
+++ b/src/scripts/bench_quality_run.ts
@@ -1,0 +1,253 @@
+#!/usr/bin/env tsx
+/**
+ * Thin-vs-eager quality-run producer (token-saving Phase 0 EXIT).
+ *
+ * The missing RUNNER that produces `internal/bench/reports/quality-run.json` —
+ * the report the `check_quality_regression` gate consumes. For each labelled
+ * golden task it generates the agent's answer under the THIN rule context
+ * (kernel bodies + non-kernel pointers) and the EAGER context (all rule bodies),
+ * then judges the pair with the length-controlled paired judge
+ * (`evaluatePair`: both orders → reject-on-flip).
+ *
+ * Model calls (answer generation + judging) go through the proven council
+ * `AnthropicClient` (synchronous curl → Anthropic Messages API) — so this is
+ * **API-gated**: a real run needs an Anthropic key and costs money proportional
+ * to (golden tasks × 2 arms + 2 judge calls) × the rule-context size. Use
+ * `--dry-run` (deterministic mock, no API) to prove the pipeline + see the
+ * output shape first, and `--limit N` to bound a live run.
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/bench_quality_run --dry-run            # mock, no API
+ *   ./scripts-run src/scripts/bench_quality_run --limit 5            # live, first 5 tasks
+ *   ./scripts-run src/scripts/bench_quality_run --model claude-sonnet-4-5
+ * Then gate on it: ./scripts-run src/scripts/check_quality_regression
+ *
+ * Exit codes: 0 wrote report · 1 error.
+ */
+import { createRequire } from 'node:module';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import yaml from 'js-yaml';
+
+import { build_thin, RULES_SOURCE } from './project_thin_rules.js';
+import { evaluatePair, type JudgeFn, type JudgeVerdict, type PairResult } from './check_quality_regression.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const GOLDEN = path.join(REPO_ROOT, 'internal/bench/corpora/token-quality-golden.yaml');
+const OUT = path.join(REPO_ROOT, 'internal/bench/reports/quality-run.json');
+const DEFAULT_THRESHOLD = 0.48;
+
+export interface GoldenTask {
+  id: string;
+  rubric: string;
+  prompt: string;
+  must_include: string[];
+  must_not: string[];
+}
+
+/** Load the labelled golden tasks (stubs are skipped — they have no real rubric). */
+export function load_golden(file = GOLDEN): GoldenTask[] {
+  const doc = yaml.load(fs.readFileSync(file, 'utf-8')) as { tasks?: unknown[] };
+  const tasks = Array.isArray(doc?.tasks) ? doc.tasks : [];
+  const out: GoldenTask[] = [];
+  for (const t of tasks as Array<Record<string, unknown>>) {
+    if (t.label_status !== 'labelled') continue;
+    const exp = (t.expected ?? {}) as Record<string, unknown>;
+    out.push({
+      id: String(t.id),
+      rubric: String(exp.rubric ?? ''),
+      prompt: String(t.prompt ?? ''),
+      must_include: Array.isArray(exp.must_include) ? exp.must_include.map(String) : [],
+      must_not: Array.isArray(exp.must_not) ? exp.must_not.map(String) : [],
+    });
+  }
+  return out;
+}
+
+/** Assemble the always-loaded rule context for each arm (eager bodies vs thin pointers). */
+export function assemble_contexts(rulesDir = RULES_SOURCE): { eager: string; thin: string } {
+  const thinMap = build_thin(rulesDir);
+  const thin = [...thinMap.values()].join('\n\n');
+  const eager = fs
+    .readdirSync(rulesDir)
+    .filter((n) => n.endsWith('.md'))
+    .sort()
+    .map((n) => fs.readFileSync(path.join(rulesDir, n), 'utf-8'))
+    .join('\n\n');
+  return { eager, thin };
+}
+
+/** A model that answers a task under a given rule context. */
+export type AnswerFn = (armContext: string, task: GoldenTask) => string;
+
+/** A judge that, given the FULL task (rubric + anchors) + two presented answers,
+ * returns the order-relative verdict. Wrapped into evaluatePair's narrow JudgeFn. */
+export type ModelJudgeFn = (task: GoldenTask, first: string, second: string) => JudgeVerdict;
+
+/** Build the judge user-prompt — length-controlled (ignore verbosity). */
+export function judge_prompt(task: GoldenTask, first: string, second: string): string {
+  return (
+    `Rubric: ${task.rubric}\n` +
+    (task.must_include.length ? `Must satisfy: ${task.must_include.join('; ')}\n` : '') +
+    (task.must_not.length ? `Must avoid: ${task.must_not.join('; ')}\n` : '') +
+    `\nTwo answers to the same request. Judge ONLY which better satisfies the rubric —\n` +
+    `IGNORE length and verbosity (a longer answer is not better).\n\n` +
+    `--- ANSWER A ---\n${first}\n\n--- ANSWER B ---\n${second}\n\n` +
+    `Reply with exactly one line: "VERDICT: A", "VERDICT: B", or "VERDICT: TIE".`
+  );
+}
+
+/** Parse a judge reply into the order-relative verdict (default tie = inconclusive). */
+export function parse_verdict(reply: string): JudgeVerdict {
+  const m = /VERDICT:\s*(A|B|TIE)/i.exec(reply);
+  if (!m) return 'tie';
+  const v = (m[1] as string).toUpperCase();
+  return v === 'A' ? 'first' : v === 'B' ? 'second' : 'tie';
+}
+
+/** Run every task through both arms + the paired judge. Pure given the injected fns. */
+export function run_golden_judge(
+  tasks: GoldenTask[],
+  contexts: { eager: string; thin: string },
+  answer: AnswerFn,
+  judge: ModelJudgeFn,
+): PairResult[] {
+  return tasks.map((task) => {
+    const thinAnswer = answer(contexts.thin, task);
+    const eagerAnswer = answer(contexts.eager, task);
+    // evaluatePair calls its JudgeFn with the narrow {id,rubric} ctx; capture
+    // the full task here so the model judge gets the rubric + anchors.
+    const judgeFn: JudgeFn = (_ctx, first, second) => judge(task, first, second);
+    return evaluatePair(task, thinAnswer, eagerAnswer, judgeFn);
+  });
+}
+
+// ── Mock model (--dry-run): deterministic, no API ───────────────────────────
+function mock_answer(_ctx: string, task: GoldenTask): string {
+  return `Answer to ${task.id}: ${(task.must_include[0] ?? 'addresses the request')}.`;
+}
+const mock_judge: ModelJudgeFn = () => 'tie'; // dry-run can't truly compare → all ties
+
+interface Args {
+  dryRun: boolean;
+  model: string;
+  limit: number | null;
+  output: string;
+}
+
+function parse_args(argv: string[]): Args | number {
+  const a: Args = { dryRun: false, model: 'claude-sonnet-4-5', limit: null, output: OUT };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') a.dryRun = true;
+    else if (arg === '--model') a.model = String(argv[(i += 1)] ?? a.model);
+    else if (arg === '--output') a.output = String(argv[(i += 1)] ?? a.output);
+    else if (arg === '--limit') {
+      const v = Number(argv[(i += 1)]);
+      if (!Number.isInteger(v) || v < 1) {
+        process.stderr.write('error: --limit must be a positive integer\n');
+        return 1;
+      }
+      a.limit = v;
+    } else if (arg === '-h' || arg === '--help') {
+      process.stdout.write('usage: bench_quality_run [--dry-run] [--model M] [--limit N] [--output PATH]\n');
+      return 0;
+    } else {
+      process.stderr.write(`error: unknown argument: ${arg}\n`);
+      return 1;
+    }
+  }
+  return a;
+}
+
+function main(argv: string[]): number {
+  const parsed = parse_args(argv);
+  if (typeof parsed === 'number') return parsed;
+  const args = parsed;
+
+  let tasks = load_golden();
+  if (tasks.length === 0) {
+    process.stderr.write('error: no labelled golden tasks — fill internal/bench/corpora/token-quality-golden.yaml\n');
+    return 1;
+  }
+  if (args.limit !== null) tasks = tasks.slice(0, args.limit);
+  const contexts = assemble_contexts();
+
+  let answer: AnswerFn;
+  let judge: ModelJudgeFn;
+  let modelLabel: string;
+
+  if (args.dryRun) {
+    answer = mock_answer;
+    judge = mock_judge;
+    modelLabel = 'dry-run-mock';
+    process.stdout.write(`⚠️  --dry-run: deterministic mock, no API. Output shape only.\n`);
+  } else {
+    // Live path — reuse the proven council AnthropicClient (sync curl). API-gated.
+    let client: { ask(system: string, user: string): { text: string } };
+    try {
+      // Lazy import so --dry-run + tests never touch the council key path.
+      const require = createRequire(import.meta.url);
+      const clients = require('./ai_council/clients.js') as {
+        AnthropicClient: new (o: { model: string; api_key: string }) => { ask(s: string, u: string): { text: string } };
+        load_anthropic_key: () => string;
+      };
+      client = new clients.AnthropicClient({ model: args.model, api_key: clients.load_anthropic_key() });
+    } catch (e) {
+      process.stderr.write(
+        `error: live model unavailable (${(e as Error).message}). ` +
+          `Set an Anthropic key (see install-anthropic-key) or use --dry-run.\n`,
+      );
+      return 1;
+    }
+    const SYS =
+      'You are an AI coding agent governed by the following always-loaded package rules. ' +
+      'Answer the user request as that agent would, honouring these rules:\n\n';
+    answer = (ctx, task) => client.ask(SYS + ctx, task.prompt).text;
+    judge = (task, first, second) =>
+      parse_verdict(
+        client.ask('You are a strict, length-neutral answer judge.', judge_prompt(task, first, second)).text,
+      );
+    modelLabel = args.model;
+    process.stdout.write(
+      `Live run: ${tasks.length} tasks × 2 arms + 2 judge calls each via ${args.model}. This costs API $.\n`,
+    );
+  }
+
+  let results: PairResult[];
+  try {
+    results = run_golden_judge(tasks, contexts, answer, judge);
+  } catch (e) {
+    process.stderr.write(`error: run failed: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  const payload = {
+    generated_by: 'bench_quality_run',
+    judge_model: modelLabel,
+    dry_run: args.dryRun,
+    threshold: DEFAULT_THRESHOLD,
+    results,
+  };
+  fs.writeFileSync(args.output, JSON.stringify(payload, null, 2) + '\n');
+  const thinWins = results.filter((r) => r.winner === 'thin').length;
+  const eagerWins = results.filter((r) => r.winner === 'eager').length;
+  process.stdout.write(
+    `→ wrote ${path.relative(REPO_ROOT, args.output)} (${results.length} pairs; ` +
+      `thin ${thinWins} / eager ${eagerWins}). Gate: \`check_quality_regression\`.\n`,
+  );
+  return 0;
+}
+
+const _IS_MAIN =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_IS_MAIN) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main, mock_answer };

--- a/taskfiles/engine.yml
+++ b/taskfiles/engine.yml
@@ -149,6 +149,11 @@ tasks:
     desc: "Measure on-demand (non-kernel) rule-load latency p50/p95/p99 (token-saving Phase 0). Mechanical resolve+read cost of `dist/agent-src/rules/<id>.md`; measurement only, never gates. `--write` → internal/bench/reports/rule-load-latency.json."
     cmd: ./scripts-run src/scripts/bench_rule_load_latency
 
+  bench-quality-run:
+    silent: true
+    desc: "Produce internal/bench/reports/quality-run.json — the thin-vs-eager length-controlled judge run that activates the check-quality-regression gate (Phase 0 EXIT). API-GATED: a live run needs an Anthropic key + costs $ (golden tasks × 2 arms + 2 judge calls). `--dry-run` proves the pipeline with no API; `--limit N` bounds a live run; then run `check-quality-regression`."
+    cmd: ./scripts-run src/scripts/bench_quality_run {{.CLI_ARGS}}
+
   check-quality-regression:
     silent: true
     desc: "Quality-regression gate (token-saving Phase 0): length-controlled paired judge over the golden set; fail if thin's win-rate < 48% vs eager. INERT until internal/bench/reports/quality-run.json exists (the thin-vs-eager judge run is the operator/cost gate), so CI stays green until then."

--- a/tests/scripts/bench_quality_run.test.ts
+++ b/tests/scripts/bench_quality_run.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the thin-vs-eager quality-run producer
+ * (`src/scripts/bench_quality_run.ts`). The model is mocked — the live
+ * Anthropic path is exercised only by an operator with an API key.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  type AnswerFn,
+  type GoldenTask,
+  type ModelJudgeFn,
+  assemble_contexts,
+  judge_prompt,
+  load_golden,
+  parse_verdict,
+  run_golden_judge,
+} from "../../src/scripts/bench_quality_run.js";
+
+describe("parse_verdict", () => {
+  it("maps VERDICT: A/B/TIE to order-relative verdicts", () => {
+    expect(parse_verdict("reasoning…\nVERDICT: A")).toBe("first");
+    expect(parse_verdict("VERDICT: B")).toBe("second");
+    expect(parse_verdict("VERDICT: tie")).toBe("tie"); // case-insensitive
+  });
+  it("defaults to tie when no verdict line is present (inconclusive)", () => {
+    expect(parse_verdict("I cannot decide.")).toBe("tie");
+  });
+});
+
+describe("judge_prompt", () => {
+  it("includes the rubric, anchors, both answers, and the length-neutral instruction", () => {
+    const task: GoldenTask = {
+      id: "t",
+      rubric: "answer directly",
+      prompt: "q",
+      must_include: ["direct"],
+      must_not: ["waffle"],
+    };
+    const p = judge_prompt(task, "AAA", "BBB");
+    expect(p).toContain("answer directly");
+    expect(p).toContain("direct");
+    expect(p).toContain("AAA");
+    expect(p).toContain("BBB");
+    expect(p).toMatch(/IGNORE length/i);
+  });
+});
+
+const task = (id: string): GoldenTask => ({ id, rubric: "r", prompt: "p", must_include: [], must_not: [] });
+
+describe("run_golden_judge", () => {
+  const contexts = { thin: "THIN-CTX", eager: "EAGER-CTX" };
+  const answer: AnswerFn = (ctx) => (ctx.includes("THIN") ? "thin-answer" : "eager-answer");
+
+  it("records a consistent thin win (survives the swap)", () => {
+    const judge: ModelJudgeFn = (_t, first) => (first === "thin-answer" ? "first" : "second");
+    const res = run_golden_judge([task("a")], contexts, answer, judge);
+    expect(res[0]?.winner).toBe("thin");
+  });
+
+  it("records a consistent eager win", () => {
+    const judge: ModelJudgeFn = (_t, first) => (first === "eager-answer" ? "first" : "second");
+    expect(run_golden_judge([task("a")], contexts, answer, judge)[0]?.winner).toBe("eager");
+  });
+
+  it("a position-biased judge (always picks first) → inconsistent (rejected)", () => {
+    const judge: ModelJudgeFn = () => "first";
+    expect(run_golden_judge([task("a")], contexts, answer, judge)[0]?.winner).toBe("inconsistent");
+  });
+
+  it("passes the FULL task to the model judge (rubric/anchors available)", () => {
+    let seenRubric = "";
+    const judge: ModelJudgeFn = (t) => {
+      seenRubric = t.rubric;
+      return "tie";
+    };
+    run_golden_judge([{ ...task("a"), rubric: "be concise" }], contexts, answer, judge);
+    expect(seenRubric).toBe("be concise");
+  });
+});
+
+describe("load_golden + assemble_contexts (against the real repo files)", () => {
+  it("loads only labelled golden tasks with rubric + prompt", () => {
+    const tasks = load_golden();
+    expect(tasks.length).toBeGreaterThan(0);
+    for (const t of tasks) {
+      expect(t.id).toMatch(/^tq-/);
+      expect(t.rubric.length).toBeGreaterThan(0);
+      expect(t.prompt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("the eager context is larger than the thin context (bodies vs pointers)", () => {
+    const { eager, thin } = assemble_contexts();
+    expect(eager.length).toBeGreaterThan(thin.length);
+    expect(thin).toContain("Routed rule"); // thin uses pointers
+  });
+});


### PR DESCRIPTION
The missing **runner** that produces `internal/bench/reports/quality-run.json` — the report the `check_quality_regression` gate (Phase 3) consumes but which nothing wrote. This gives the operator a **button** for the Phase 0 EXIT measurement.

## What it does

`bench_quality_run` — for each labelled golden task:
1. generates the agent's answer under the **THIN** rule context (kernel bodies + non-kernel pointers) and the **EAGER** context (all bodies),
2. judges the pair with the length-controlled paired judge (`evaluatePair`: both orders → reject-on-flip, length-neutral prompt),
3. writes `quality-run.json` → then `check-quality-regression` gates on thin's win-rate.

## API-gated, with a verifiable dry-run

Model calls reuse the proven council `AnthropicClient` (sync curl). A **live run needs an Anthropic key and costs $** (golden tasks × 2 arms + 2 judge calls × the rule-context size). 

- `task bench-quality-run -- --dry-run` — deterministic mock, **no API**: proves the runner→report→gate pipeline end-to-end + shows the output shape.
- `task bench-quality-run -- --limit 5` — bound a first live run.

## How the operator runs the Phase 0 EXIT (now possible)

```
# (golden set already has 30 labelled tasks committed; expand coverage optionally)
task bench-quality-run -- --limit 5      # live, needs Anthropic key; costs $
./scripts-run src/scripts/check_quality_regression   # gate on the result
```

## Verification

`tsc` clean · eslint clean · **9 tests** (parse_verdict, judge_prompt, run_golden_judge thin/eager/inconsistent paths, golden loader, context assembly) · dry-run pipeline verified (runner → report → gate). The live model path reuses the council clients that ran successfully earlier this session; its first live run is the operator's (I can't exercise the API here). No settings/schema/manifest surface touched.