### PR TITLE
test(work_engine): convert 4 directives parity rigs to python-free intent tests

### DIFF
--- a/agents/roadmaps/road-to-py2ts-teardown-completion.md
+++ b/agents/roadmaps/road-to-py2ts-teardown-completion.md
@@ -136,12 +136,18 @@ stay open below — not force-marked done.
       kept); pure in-process rigs (`cli`, `directives_backend_analyze` + the 5
       `directives_backend_*`) converted to intent tests asserting the tsx
       module's own `run()` output. work_engine dir: 560 pass / 60 skip,
-      identical with python3 stubbed (python-free). **Still deferred in
-      work_engine:** `_hooks_pyloader.ts` (shared helper imported by 11
-      `hooks_*` tests — neutralise only after those consumers are converted) +
-      4 files an interrupted subagent never reached
+      identical with python3 stubbed (python-free). The 4 MIXED directives
+      files an interrupted subagent never reached
       (`directives_backend_test`, `directives_backend_verify`,
-      `directives_init`, `directives_mixed_init` — all MIXED, same purge recipe).
+      `directives_init`, `directives_mixed_init`) are now **converted**
+      (2026-06-26): each parity block → a python-free intent test asserting the
+      tsx `run()` / module contract directly (inline snapshots for the 22
+      former byte-parity assertions; `directives_init`'s python-`__all__` half
+      dropped as it asserted no TS contract beyond the kept empty-marker test).
+      work_engine dir: 582 passed / 37 skipped / 0 failed, python-free.
+      **Still deferred in work_engine:** `_hooks_pyloader.ts` (shared helper
+      imported by 11 `hooks_*` tests — neutralise only after those consumers
+      are converted) — the remaining 37 skips above.
     - **Remaining spawn-file tail after these two clusters: 108** (measured
       `git grep -lE "spawnSync\\(['\"]python3?['\"]" -- 'tests/**'`). Next
       coherent groups: `_cli/cmd_*` (~17, likely delete-candidates covered by

--- a/tests/scripts/work_engine/directives_backend_test.test.ts
+++ b/tests/scripts/work_engine/directives_backend_test.test.ts
@@ -1,58 +1,24 @@
-// Golden-parity tests for work_engine/directives/backend/test.ts vs test.py
-// (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/test.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `test.py` imports `...delivery_state` + `...persona_policy`, so it loads as a
-// real package member via `sys.path` + import. Covers persona gating (advisory
-// skip, qa widen=full), verdict validation (`{verdict!r}` repr in the malformed
-// message), and the bad-verdict halt. TS twin in-process; Python via python3
-// subprocess; byte-exact `{outcome, questions, message}` compare. Malformed-
-// verdict fixtures use only None / plain strings so the `repr()` rendering
-// (`'x'`, `None`) is unambiguous across engines. No non-determinism.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx directive's own contract directly. The TS twin is exercised
+// in-process: build a `DeliveryState` from a JSON fixture, run the directive,
+// and emit `{outcome, questions, message}` as canonical JSON for an inline
+// snapshot. Covers persona gating (advisory skip, qa widen=full), verdict
+// validation (the `{verdict!r}`-style repr in the malformed message), and the
+// bad-verdict halt. `run()` is a pure function of the fixture — no clock /
+// random / PATH — so the snapshots are deterministic.
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/test.js';
 import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function runPy(moduleName: string, stateJson: string): string {
-    const code = [
-        'import sys, json, importlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
+/** TS twin: build DeliveryState from the fixture, run, emit canonical JSON. */
 function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
     const r: StepResult = run(new DeliveryState(state));
     return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
 }
-
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 const ok = { implement: 'success' };
 
@@ -67,37 +33,155 @@ describe('directives/backend/test — AMBIGUITIES', () => {
     });
 });
 
-describeParity('directives/backend/test — golden parity (ts == py)', () => {
-    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        ['advisory persona → SUCCESS short-circuit', { ticket: { id: 'T-1' }, persona: 'advisory', outcomes: ok }],
-        ['implement not success → BLOCKED precondition', { ticket: { id: 'T-2' }, outcomes: {} }],
-        ['empty tests, senior → delegate targeted', { ticket: { id: 'T-3' }, outcomes: ok }],
-        ['empty tests, qa → delegate full (widen)', { ticket: { id: 'T-4' }, persona: 'qa', outcomes: ok }],
-        ['success verdict → SUCCESS', { ticket: { id: 'T-5' }, tests: { verdict: 'success' }, outcomes: ok }],
-        [
-            'failed verdict → BLOCKED bad verdict',
-            { ticket: { id: 'T-6' }, tests: { verdict: 'failed' }, outcomes: ok },
-        ],
-        [
-            'mixed verdict → BLOCKED bad verdict',
-            { ticket: { id: 'T-7' }, tests: { verdict: 'mixed' }, outcomes: ok },
-        ],
-        [
-            'tests not a dict → BLOCKED malformed (typename)',
-            { ticket: { id: 'T-8' }, tests: ['list not dict'], outcomes: ok },
-        ],
-        [
-            'unknown verdict string → BLOCKED malformed (repr)',
-            { ticket: { id: 'T-9' }, tests: { verdict: 'weird' }, outcomes: ok },
-        ],
-        [
-            'missing verdict key (None) → BLOCKED malformed (repr None)',
-            { ticket: { id: 'T-10' }, tests: { duration_ms: 5 }, outcomes: ok },
-        ],
-        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
-    ];
+describe('directives/backend/test — outcome contract', () => {
+    it('advisory persona → SUCCESS short-circuit', () => {
+        expect(runTs({ ticket: { id: 'T-1' }, persona: 'advisory', outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "success",
+            "questions": [],
+            "message": "test skipped: persona \`advisory\` is plan-only."
+          }"
+        `);
+    });
 
-    it.each(cases)('%s', (_label, state) => {
-        expect(runTs(state)).toBe(runPy('test', pyFixture(state)));
+    it('implement not success → BLOCKED precondition', () => {
+        expect(runTs({ ticket: { id: 'T-2' }, outcomes: {} })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-2 — test gate refused: \`implement\` step did not complete successfully.",
+              "> 1. Re-run \`/implement-ticket\` from the start",
+              "> 2. Abort"
+            ],
+            "message": "Ticket T-2 cannot test: implement gate did not pass."
+          }"
+        `);
+    });
+
+    it('empty tests, senior → delegate targeted', () => {
+        expect(runTs({ ticket: { id: 'T-3' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: run-tests ticket=T-3 scope=targeted",
+              "> Ticket T-3 — running tests: targeted first (\`--filter\` on the changed paths), full suite only if targeted passes.",
+              "> 1. Continue — run targeted tests now",
+              "> 2. Abort — skip testing (NOT recommended)"
+            ],
+            "message": "Ticket T-3 needs its tests run before verification."
+          }"
+        `);
+    });
+
+    it('empty tests, qa → delegate full (widen)', () => {
+        expect(runTs({ ticket: { id: 'T-4' }, persona: 'qa', outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: run-tests ticket=T-4 scope=full",
+              "> Ticket T-4 — running tests: full suite (qa persona widens to catch regressions outside the changed paths).",
+              "> 1. Continue — run full tests now",
+              "> 2. Abort — skip testing (NOT recommended)"
+            ],
+            "message": "Ticket T-4 needs its tests run before verification."
+          }"
+        `);
+    });
+
+    it('success verdict → SUCCESS', () => {
+        expect(runTs({ ticket: { id: 'T-5' }, tests: { verdict: 'success' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "success",
+            "questions": [],
+            "message": ""
+          }"
+        `);
+    });
+
+    it('failed verdict → BLOCKED bad verdict', () => {
+        expect(runTs({ ticket: { id: 'T-6' }, tests: { verdict: 'failed' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-6 — tests reported \`failed\`. Verification cannot proceed on a non-success verdict.",
+              "> 1. Fix the failing tests and re-run \`run-tests\`",
+              "> 2. Continue anyway — override (NOT recommended)",
+              "> 3. Abort"
+            ],
+            "message": "Ticket T-6 test verdict was \`failed\`, not success."
+          }"
+        `);
+    });
+
+    it('mixed verdict → BLOCKED bad verdict', () => {
+        expect(runTs({ ticket: { id: 'T-7' }, tests: { verdict: 'mixed' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-7 — tests reported \`mixed\`. Verification cannot proceed on a non-success verdict.",
+              "> 1. Fix the failing tests and re-run \`run-tests\`",
+              "> 2. Continue anyway — override (NOT recommended)",
+              "> 3. Abort"
+            ],
+            "message": "Ticket T-7 test verdict was \`mixed\`, not success."
+          }"
+        `);
+    });
+
+    it('tests not a dict → BLOCKED malformed (typename)', () => {
+        expect(runTs({ ticket: { id: 'T-8' }, tests: ['list not dict'], outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-8 — recorded test output is malformed: state.tests must be a dict, got list.",
+              "> 1. Re-run tests and resume",
+              "> 2. Abort — test verdict cannot be trusted"
+            ],
+            "message": "Ticket T-8 tests shape invalid: state.tests must be a dict, got list."
+          }"
+        `);
+    });
+
+    it('unknown verdict string → BLOCKED malformed (repr)', () => {
+        expect(runTs({ ticket: { id: 'T-9' }, tests: { verdict: 'weird' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-9 — recorded test output is malformed: state.tests['verdict'] must be one of success, failed, mixed; got 'weird'.",
+              "> 1. Re-run tests and resume",
+              "> 2. Abort — test verdict cannot be trusted"
+            ],
+            "message": "Ticket T-9 tests shape invalid: state.tests['verdict'] must be one of success, failed, mixed; got 'weird'."
+          }"
+        `);
+    });
+
+    it('missing verdict key (None) → BLOCKED malformed (repr None)', () => {
+        expect(runTs({ ticket: { id: 'T-10' }, tests: { duration_ms: 5 }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket T-10 — recorded test output is malformed: state.tests['verdict'] must be one of success, failed, mixed; got None.",
+              "> 1. Re-run tests and resume",
+              "> 2. Abort — test verdict cannot be trusted"
+            ],
+            "message": "Ticket T-10 tests shape invalid: state.tests['verdict'] must be one of success, failed, mixed; got None."
+          }"
+        `);
+    });
+
+    it('no ticket id, delegate → "(no id)"', () => {
+        expect(runTs({ ticket: {}, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: run-tests ticket=(no id) scope=targeted",
+              "> Ticket (no id) — running tests: targeted first (\`--filter\` on the changed paths), full suite only if targeted passes.",
+              "> 1. Continue — run targeted tests now",
+              "> 2. Abort — skip testing (NOT recommended)"
+            ],
+            "message": "Ticket (no id) needs its tests run before verification."
+          }"
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_backend_verify.test.ts
+++ b/tests/scripts/work_engine/directives_backend_verify.test.ts
@@ -1,58 +1,24 @@
-// Golden-parity tests for work_engine/directives/backend/verify.ts vs
-// verify.py (ADR-094 py2ts Phase 1 — backend directive set).
+// Intent tests for work_engine/directives/backend/verify.ts (ADR-094 py2ts
+// Phase 1 — backend directive set).
 //
-// `verify.py` imports `...delivery_state` + `...persona_policy`, so it loads as
-// a real package member via `sys.path` + import. Covers persona gating
-// (advisory skip), verdict validation (`{verdict!r}` repr in the malformed
-// message), and the bad-verdict halt (`blocked` / `partial`). TS twin
-// in-process; Python via python3 subprocess; byte-exact compare. Malformed-
-// verdict fixtures use only None / plain strings for unambiguous repr. No
-// non-determinism.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx directive's own contract directly. The TS twin is exercised
+// in-process: build a `DeliveryState` from a JSON fixture, run the directive,
+// and emit `{outcome, questions, message}` as canonical JSON for an inline
+// snapshot. Covers persona gating (advisory skip), verdict validation (the
+// `{verdict!r}`-style repr in the malformed message), and the bad-verdict halt
+// (`blocked` / `partial`). `run()` is a pure function of the fixture — no
+// clock / random / PATH — so the snapshots are deterministic.
 import { describe, expect, it } from 'vitest';
 
 import { AMBIGUITIES, run } from '../../../src/agent-src/templates/scripts/work_engine/directives/backend/verify.js';
 import { DeliveryState, type StepResult } from '../../../src/agent-src/templates/scripts/work_engine/delivery_state.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function runPy(moduleName: string, stateJson: string): string {
-    const code = [
-        'import sys, json, importlib',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        `mod = importlib.import_module("work_engine.directives.backend.${moduleName}")`,
-        'from work_engine.delivery_state import DeliveryState',
-        'payload = json.loads(sys.argv[1])',
-        'st = DeliveryState(**payload)',
-        'r = mod.run(st)',
-        'out = {"outcome": r.outcome.value, "questions": r.questions, "message": r.message}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code, stateJson], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
-
+/** TS twin: build DeliveryState from the fixture, run, emit canonical JSON. */
 function runTs(state: ConstructorParameters<typeof DeliveryState>[0]): string {
     const r: StepResult = run(new DeliveryState(state));
     return JSON.stringify({ outcome: r.outcome, questions: r.questions, message: r.message }, null, 2);
 }
-
-function pyFixture(state: ConstructorParameters<typeof DeliveryState>[0]): string {
-    return JSON.stringify(state);
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 const ok = { test: 'success' };
 
@@ -67,30 +33,140 @@ describe('directives/backend/verify — AMBIGUITIES', () => {
     });
 });
 
-describeParity('directives/backend/verify — golden parity (ts == py)', () => {
-    const cases: Array<[string, ConstructorParameters<typeof DeliveryState>[0]]> = [
-        ['advisory persona → SUCCESS short-circuit', { ticket: { id: 'V-1' }, persona: 'advisory', outcomes: ok }],
-        ['test not success → BLOCKED precondition', { ticket: { id: 'V-2' }, outcomes: {} }],
-        ['empty verify → delegate review-changes', { ticket: { id: 'V-3' }, outcomes: ok }],
-        ['success verdict → SUCCESS', { ticket: { id: 'V-4' }, verify: { verdict: 'success' }, outcomes: ok }],
-        ['blocked verdict → BLOCKED bad verdict', { ticket: { id: 'V-5' }, verify: { verdict: 'blocked' }, outcomes: ok }],
-        ['partial verdict → BLOCKED bad verdict', { ticket: { id: 'V-6' }, verify: { verdict: 'partial' }, outcomes: ok }],
-        [
-            'verify not a dict → BLOCKED malformed (typename)',
-            { ticket: { id: 'V-7' }, verify: 'a string', outcomes: ok },
-        ],
-        [
-            'unknown verdict string → BLOCKED malformed (repr)',
-            { ticket: { id: 'V-8' }, verify: { verdict: 'failed' }, outcomes: ok },
-        ],
-        [
-            'missing verdict key (None) → BLOCKED malformed (repr None)',
-            { ticket: { id: 'V-9' }, verify: { confidence: 'high' }, outcomes: ok },
-        ],
-        ['no ticket id, delegate → "(no id)"', { ticket: {}, outcomes: ok }],
-    ];
+describe('directives/backend/verify — outcome contract', () => {
+    it('advisory persona → SUCCESS short-circuit', () => {
+        expect(runTs({ ticket: { id: 'V-1' }, persona: 'advisory', outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "success",
+            "questions": [],
+            "message": "verify skipped: persona \`advisory\` is plan-only."
+          }"
+        `);
+    });
 
-    it.each(cases)('%s', (_label, state) => {
-        expect(runTs(state)).toBe(runPy('verify', pyFixture(state)));
+    it('test not success → BLOCKED precondition', () => {
+        expect(runTs({ ticket: { id: 'V-2' }, outcomes: {} })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket V-2 — verify gate refused: \`test\` step did not complete successfully.",
+              "> 1. Re-run \`/implement-ticket\` from the start",
+              "> 2. Abort"
+            ],
+            "message": "Ticket V-2 cannot verify: test gate did not pass."
+          }"
+        `);
+    });
+
+    it('empty verify → delegate review-changes', () => {
+        expect(runTs({ ticket: { id: 'V-3' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: review-changes ticket=V-3",
+              "> Ticket V-3 — running the four-judge review (bugs, security, tests, code quality) before the delivery report is written.",
+              "> 1. Continue — run \`review-changes\` now",
+              "> 2. Abort — skip review (NOT recommended)"
+            ],
+            "message": "Ticket V-3 needs \`review-changes\` before the report."
+          }"
+        `);
+    });
+
+    it('success verdict → SUCCESS', () => {
+        expect(runTs({ ticket: { id: 'V-4' }, verify: { verdict: 'success' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "success",
+            "questions": [],
+            "message": ""
+          }"
+        `);
+    });
+
+    it('blocked verdict → BLOCKED bad verdict', () => {
+        expect(runTs({ ticket: { id: 'V-5' }, verify: { verdict: 'blocked' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket V-5 — \`review-changes\` reported \`blocked\`. The delivery report cannot claim completion on a non-success verdict (see \`verify-before-complete\`).",
+              "> 1. Address the findings and re-run \`review-changes\`",
+              "> 2. Continue anyway — override (NOT recommended)",
+              "> 3. Abort"
+            ],
+            "message": "Ticket V-5 verify verdict was \`blocked\`, not success."
+          }"
+        `);
+    });
+
+    it('partial verdict → BLOCKED bad verdict', () => {
+        expect(runTs({ ticket: { id: 'V-6' }, verify: { verdict: 'partial' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket V-6 — \`review-changes\` reported \`partial\`. The delivery report cannot claim completion on a non-success verdict (see \`verify-before-complete\`).",
+              "> 1. Address the findings and re-run \`review-changes\`",
+              "> 2. Continue anyway — override (NOT recommended)",
+              "> 3. Abort"
+            ],
+            "message": "Ticket V-6 verify verdict was \`partial\`, not success."
+          }"
+        `);
+    });
+
+    it('verify not a dict → BLOCKED malformed (typename)', () => {
+        expect(runTs({ ticket: { id: 'V-7' }, verify: 'a string', outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket V-7 — recorded verify output is malformed: state.verify must be a dict, got str.",
+              "> 1. Re-run \`review-changes\` and resume",
+              "> 2. Abort — verify verdict cannot be trusted"
+            ],
+            "message": "Ticket V-7 verify shape invalid: state.verify must be a dict, got str."
+          }"
+        `);
+    });
+
+    it('unknown verdict string → BLOCKED malformed (repr)', () => {
+        expect(runTs({ ticket: { id: 'V-8' }, verify: { verdict: 'failed' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket V-8 — recorded verify output is malformed: state.verify['verdict'] must be one of success, blocked, partial; got 'failed'.",
+              "> 1. Re-run \`review-changes\` and resume",
+              "> 2. Abort — verify verdict cannot be trusted"
+            ],
+            "message": "Ticket V-8 verify shape invalid: state.verify['verdict'] must be one of success, blocked, partial; got 'failed'."
+          }"
+        `);
+    });
+
+    it('missing verdict key (None) → BLOCKED malformed (repr None)', () => {
+        expect(runTs({ ticket: { id: 'V-9' }, verify: { confidence: 'high' }, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "> Ticket V-9 — recorded verify output is malformed: state.verify['verdict'] must be one of success, blocked, partial; got None.",
+              "> 1. Re-run \`review-changes\` and resume",
+              "> 2. Abort — verify verdict cannot be trusted"
+            ],
+            "message": "Ticket V-9 verify shape invalid: state.verify['verdict'] must be one of success, blocked, partial; got None."
+          }"
+        `);
+    });
+
+    it('no ticket id, delegate → "(no id)"', () => {
+        expect(runTs({ ticket: {}, outcomes: ok })).toMatchInlineSnapshot(`
+          "{
+            "outcome": "blocked",
+            "questions": [
+              "@agent-directive: review-changes ticket=(no id)",
+              "> Ticket (no id) — running the four-judge review (bugs, security, tests, code quality) before the delivery report is written.",
+              "> 1. Continue — run \`review-changes\` now",
+              "> 2. Abort — skip review (NOT recommended)"
+            ],
+            "message": "Ticket (no id) needs \`review-changes\` before the report."
+          }"
+        `);
     });
 });

--- a/tests/scripts/work_engine/directives_init.test.ts
+++ b/tests/scripts/work_engine/directives_init.test.ts
@@ -1,41 +1,15 @@
-// Parity test for work_engine/directives/index.ts vs directives/__init__.py
-// (ADR-096 py2ts Phase 1 — work_engine TOP/integration layer). The Python
-// `__init__` declares `__all__ = []` (no re-exports); the TS twin is the empty
-// package-marker module. Parity is the empty public surface.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Intent test for work_engine/directives/index.ts (ADR-096 py2ts Phase 1 —
+// work_engine TOP/integration layer). Was a python3-vs-tsx parity rig asserting
+// the python `__init__.__all__ = []` matched the TS empty package-marker module;
+// the `.py` original is gone, so the python-internal half is dropped. The TS
+// contract — an empty public surface — is asserted directly below.
 import { describe, expect, it } from 'vitest';
 
 import * as directives from '../../../src/agent-src/templates/scripts/work_engine/directives/index.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
 
 describe('directives/index — empty package marker', () => {
     it('exposes no runtime members (mirrors __all__ = [])', () => {
         // `export {}` yields a module object with no own enumerable members.
         expect(Object.keys(directives)).toEqual([]);
-    });
-});
-
-describeParity('directives/__init__ — __all__ parity', () => {
-    it('python __all__ is empty', () => {
-        const code = [
-            'import sys, json',
-            `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-            'm = __import__("work_engine.directives", fromlist=["x"])',
-            'sys.stdout.write(json.dumps(getattr(m, "__all__", None)))',
-        ].join('\n');
-        const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-        expect(r.status).toBe(0);
-        expect(r.stdout).toBe('[]');
     });
 });

--- a/tests/scripts/work_engine/directives_mixed_init.test.ts
+++ b/tests/scripts/work_engine/directives_mixed_init.test.ts
@@ -1,11 +1,11 @@
-// Golden-parity tests for work_engine/directives/mixed/index.ts vs
-// directives/mixed/__init__.py (ADR-096 py2ts Phase 1 — work_engine
-// TOP/integration layer). The mixed set reuses five backend handlers by
-// reference; parity is on name / roadmap / kinds / step-order / ambiguity-code
-// structure.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+// Intent tests for work_engine/directives/mixed/index.ts (ADR-096 py2ts Phase 1
+// — work_engine TOP/integration layer). Was a python3-vs-tsx byte-parity rig;
+// the `.py` original is gone, so this asserts the tsx directive-set's own
+// contract directly. The mixed set reuses five backend handlers by reference;
+// the shape block covers name / roadmap / kinds / step-order / callables, and
+// the summary snapshot additionally freezes the ambiguity-code structure
+// (`all_ambiguities()`). The summary is a pure read of static module state —
+// deterministic, so the inline snapshot is stable.
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -15,29 +15,6 @@ import {
     all_ambiguities,
     get_steps,
 } from '../../../src/agent-src/templates/scripts/work_engine/directives/mixed/index.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRIPTS_ROOT = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function pySummary(): string {
-    const code = [
-        'import sys, json',
-        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_ROOT)})`,
-        'm = __import__("work_engine.directives.mixed", fromlist=["x"])',
-        'amb = {k: [a.get("code") for a in v] for k, v in m.all_ambiguities().items()}',
-        'out = {"name": m.DIRECTIVE_SET_NAME, "roadmap": m.ROADMAP, "kinds": list(m.SUPPORTED_KINDS), "step_order": list(m.get_steps().keys()), "ambiguities": amb}',
-        'sys.stdout.write(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True))',
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr || r.stdout}`);
-    }
-    return r.stdout;
-}
 
 function _sortKeys(value: unknown): unknown {
     if (Array.isArray(value)) return value.map(_sortKeys);
@@ -61,9 +38,6 @@ function tsSummary(): string {
     );
 }
 
-const py = hasPython3();
-const describeParity = py ? describe : describe.skip;
-
 describe('directives/mixed index — shape', () => {
     it('name / roadmap / kinds', () => {
         expect(DIRECTIVE_SET_NAME).toBe('mixed');
@@ -80,8 +54,69 @@ describe('directives/mixed index — shape', () => {
     });
 });
 
-describeParity('directives/mixed index — golden parity', () => {
-    it('matches python3', () => {
-        expect(tsSummary()).toBe(pySummary());
+describe('directives/mixed index — full directive-set summary', () => {
+    it('name / roadmap / kinds / step-order / ambiguity-code structure', () => {
+        expect(tsSummary()).toMatchInlineSnapshot(`
+          "{
+            "ambiguities": {
+              "analyze": [
+                "upstream_refine_failed",
+                "upstream_memory_failed",
+                "lost_ac"
+              ],
+              "implement": [
+                "upstream_contract_failed",
+                "contract_sentinel_missing",
+                "ui_track_not_started",
+                "ui_track_review_unclean"
+              ],
+              "memory": [],
+              "plan": [
+                "upstream_analyze_failed",
+                "contract_missing",
+                "contract_incomplete",
+                "contract_unconfirmed"
+              ],
+              "refine": [
+                "missing_id",
+                "trivial_title",
+                "missing_or_vague_ac",
+                "prompt_unrefined",
+                "prompt_medium_confidence",
+                "prompt_low_confidence",
+                "prompt_ui_intent"
+              ],
+              "report": [],
+              "test": [
+                "upstream_ui_failed",
+                "empty_stitch_delegate",
+                "malformed_stitch",
+                "bad_stitch_verdict"
+              ],
+              "verify": [
+                "upstream_test_failed",
+                "empty_verify_delegate",
+                "malformed_verify",
+                "bad_verify_verdict"
+              ]
+            },
+            "kinds": [
+              "ticket",
+              "prompt"
+            ],
+            "name": "mixed",
+            "roadmap": "agents/roadmaps/road-to-product-ui-track.md",
+            "step_order": [
+              "refine",
+              "memory",
+              "analyze",
+              "plan",
+              "implement",
+              "test",
+              "verify",
+              "report"
+            ]
+          }"
+        `);
     });
 });


### PR DESCRIPTION
**py2ts-teardown-completion · Phase 1.** The 4 MIXED `directives_*` test files an interrupted subagent never reached (`directives_backend_test`, `directives_backend_verify`, `directives_init`, `directives_mixed_init`) still carried a dead `python3↔tsx` byte-parity block (`describeParity` + `hasPython3`/`runPy`/`pySummary` + `spawnSync`). The `.py` originals are gone, so each is **converted to assert the tsx contract directly** — the proven `directives_backend_analyze` recipe, not a blind delete.

> Re-opened from `test/work-engine-directives-parity` (was `chore/py2ts-teardown-directives-parity`, PR #681). The old name tripped the stale `py2ts-base-guard`, which forces `*/py2ts-*` branches to target `python2ts` — but `python2ts` is already merged into `main` (27/0), so post-merge teardown lands on `main`. Same diff; retiring that scaffolding workflow is Phase 2, out of scope here.

## Per file
- **backend/test** + **backend/verify** — parity `it.each` unrolled into per-case intent tests asserting `run()`'s own `{outcome, questions, message}` via inline snapshots (22 former byte-parity assertions). `run()` is a pure function of the fixture (no clock/random/PATH) → deterministic; the AMBIGUITIES describe is kept verbatim.
- **directives/index** — the parity block only asserted a *python-internal* fact (`__init__.__all__ == []`); dropped, since the kept empty-package-marker test already covers the TS contract (council N2 sibling-coverage check).
- **directives/mixed** — parity → inline snapshot of the full directive-set summary; it uniquely covers the **ambiguity-code structure** (`all_ambiguities()`) the shape block omits.

## Verification
- No python residue — no `spawnSync` / `hasPython3` / `runPy` / `node:child_process` / `describeParity`; only documentary header comments remain (matching the already-converted siblings).
- `work_engine` dir: **582 passed / 37 skipped / 0 failed**, python-free. The 37 skips are the separate `hooks_*` + `_hooks_pyloader` coupling (next batch, per the roadmap).
- `tsc --noEmit` clean · `eslint` clean.

No deletion, no conversion-determinism trap, no Hard-Floor surface. The roadmap's work_engine note is updated to reflect the 4 conversions and the remaining `hooks_*` deferral.