### PR TITLE
feat(design-review): deterministic anti-slop detector + design/taste harvest roadmaps

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,27 +2,53 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 3 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/)
+> 7 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/)
 
 ## Overall
 
-**85 / 120 steps done · 71%**
+**85 / 159 steps done · 53%**
 
 ```text
-████████████████████████████░░░░░░░░░░░░   71%
+█████████████████████░░░░░░░░░░░░░░░░░░░   53%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 2 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 11 | 21 | 0 | 2 | ███████░░░ 66% |
-| 3 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
+| 1 | [road-to-design-canon-grounding.md](roadmaps/road-to-design-canon-grounding.md) | 4 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 2 | [road-to-design-system-extraction-contract.md](roadmaps/road-to-design-system-extraction-contract.md) | 4 | 8 | 8 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 3 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
+| 4 | [road-to-shadcn-registry-awareness.md](roadmaps/road-to-shadcn-registry-awareness.md) | 5 | 10 | 10 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 5 | [road-to-taste-dials-and-locks.md](roadmaps/road-to-taste-dials-and-locks.md) | 5 | 11 | 11 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 6 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 11 | 21 | 0 | 2 | ███████░░░ 66% |
+| 7 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
 
 ## Per-roadmap phase breakdown
+
+### [road-to-design-canon-grounding.md](roadmaps/road-to-design-canon-grounding.md)
+
+**Road to Design-Canon Grounding** — 0 / 10 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | The canon index | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Wire into design-intelligence (lazy) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | Cross-link the craft skills | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Verify | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+
+### [road-to-design-system-extraction-contract.md](roadmaps/road-to-design-system-extraction-contract.md)
+
+**Road to a Design-System Extraction Contract** — 0 / 8 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Define the import contract | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 1 | Import into design-system-capture | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | Bridge to existing-ui-audit | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 3 | Verify | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 
@@ -35,6 +61,30 @@
 | 2 | CI + scaffolding cleanup (requires Phase 1 complete) | 🟡 in progress | 4 | 2 | 0 | 0 | 33% |
 | 2b | AI-council live-call layer (py2ts gap — transport now wired) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 3 | Consumer + merge readiness | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+
+### [road-to-shadcn-registry-awareness.md](roadmaps/road-to-shadcn-registry-awareness.md)
+
+**Road to shadcn Registry & MCP Awareness** — 0 / 10 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Registry model + JSON schema literacy | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 1 | `shadcn info --json` handshake (opt-in) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | Token-aware scaffolding | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 3 | Optional shadcn MCP path | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 4 | Verify | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+
+### [road-to-taste-dials-and-locks.md](roadmaps/road-to-taste-dials-and-locks.md)
+
+**Road to Taste Dials & Consistency Locks** — 0 / 11 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Dials in DESIGN.md | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Dials drive generation | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | Consistency Locks (within-project) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 3 | Layout-repetition caps (deterministic flags) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 4 | Verify | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 

--- a/agents/roadmaps/archive/road-to-anti-slop-detector.md
+++ b/agents/roadmaps/archive/road-to-anti-slop-detector.md
@@ -1,0 +1,78 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to an Anti-Slop Detector (deterministic aesthetic-tell layer)
+
+> Turn our PROSE anti-slop catalog into a zero-runtime-token deterministic detector that flags AI-generated "tells" (cream-palette, side-stripe border, icon-tile-stack, em-dash-overuse, gradient-text) — feeding structured findings into `design-review` instead of reloading a 12 KB catalog every invocation.
+
+## Goal
+
+Ship a deterministic anti-slop **detector** (a linter, not loaded prose) that catches the *aesthetic-provenance* tells our `lint_design_quality.ts` does not — the patterns that make a UI "look like an AI made it." The detector emits structured `{rule-id, severity P0–P3, file:line, context-gate}` findings; `design-review` cites those findings instead of re-deriving them from the prose catalog. **Flags, never hard blocks.**
+
+This is the highest-leverage harvest axis (council 2026-06-28 ranked it #1). It also *resolves* the token tension: the knowledge lives in code (zero context tokens) rather than always-loaded text.
+
+## Context
+
+**What we have:**
+- `docs/guidelines/design-antipatterns.md` — the AI-slop catalog as PROSE (Visual V1–V7, Layout L1–L8, Typography/Color tells, originality self-test), lazy-loaded.
+- `src/scripts/lint_design_quality.ts` — deterministic CI floor, but **objective only** (Q1–Q6: WCAG contrast, font-size, line-length, reduced-motion, heading hierarchy, focus).
+- `design-review` skill — cites the catalog by ID, pass/flag/fail originality self-test, severity triage. No mechanical detector backing it.
+- `design-system-capture` — writes consumer `DESIGN.md`/`PRODUCT.md` (the context-gate source).
+
+**What the Source A reference adds (deep-dived 2026-06-28):** a 62-rule deterministic anti-slop detector that names aesthetic-provenance tells a human reviewer recognises (side-stripe border = "the most recognizable tell of AI-generated UIs"; cream/beige "tasteful AI" surface; icon-tile-stack feature-card template; purple/cyan gradient; copy-cadence tells: em-dash-overuse, marketing-buzzword), API-key-free, with per-model gated rules and a severity model. Plus a session-bootstrap gate that reads the consumer's design spec as ground truth.
+
+**Council verdict (claude-sonnet-4-5 + gpt-4o, 2026-06-28):** ADOPT as the top axis, in **hybrid** shape — detector produces structured rule-ID output, `design-review` interprets/cites it. Detector is a **rebuttable presumption** (flag + DESIGN.md context-gate to suppress), not a replacement for judgment, and **never a hard block**. Use real parsers (postcss / `@babel/parser` / Tailwind resolver) as ~200–300 LOC of glue, not from-scratch parsers. ~8% false-positive rate is acceptable *because they are flags*. The pre-edit BLOCK belongs as a linter/CI gate (universal across hosts); a pre-edit hook is OPTIONAL only (host-limited, ~2/7 hosts) and must carry anti-loop deny→allow degradation.
+
+## Token-optimization stance
+
+The detector costs **zero context tokens at runtime** — it runs in Node (CI / pre-commit / optional hook), not in the model's context. `design-review` loads only a thin pointer + the structured findings, never the full catalog. This is the canonical "knowledge → deterministic script" move the council validated; it is *better* than loading prose on low-context hosts (where a 12 KB catalog × N review iterations dominates the window). No `token_budget_class: rich` change is needed here — the win is moving prose OUT of context.
+
+## Prerequisites
+
+- `lint_design_quality.ts` stays the objective floor; the new detector is a sibling, not a rewrite.
+- Rule definitions live in a data registry (one entry per tell) so adding a tell is data, not code.
+
+## Phase 0 — Rule registry + parser substrate
+
+- [x] Define the rule-registry schema: `{ id, category (slop|quality), severity (P0–P3), engines[], context_gates[], message }`. One JSON/TS module, additive. <!-- done: src/scripts/design_slop_rules.ts — SlopRule interface + SLOP_RULES (14 rules) -->
+- [x] Port the highest-confidence tells from `design-antipatterns.md` into registry entries (start with the unambiguous ones: side-stripe border, gradient-clip text, icon-tile-stack, repeating-gradient stripes, identical 3-card grid, per-section uppercase eyebrow, em-dash-overuse, marketing-buzzword). Each entry cites its catalog ID (V*/L*/T*/C*) so prose ↔ rule stay traceable. <!-- done: 14 rules, each carries catalogId (V1/V3/V6/C2/C5/T4/T6/T7/L4/L8/M2/M4/CP1/CP2). icon-tile-stack(T3) + 3-card-grid(L2) deferred — need DOM-structure analysis, too FP-prone for deterministic v0; left to design-review judgment -->
+- [x] Stand up the parser substrate. <!-- ADAPTED: postcss/@babel/tailwind are ABSENT and the existing lint_design_quality is dependency-free BY DESIGN (ships via npx, frugality). Built dependency-free pattern matchers (cssBlocks/visibleText helpers) matching lint_design_quality's proven approach. Council assumed those libs present; for THIS package pattern-based is the correct frugal adaptation. Recorded in design_slop_rules.ts header. -->
+- [x] Write the cross-stack adapter contract so the same rule fires regardless of stack. <!-- done: enginesForExt() maps css/scss/less + html/vue/svelte/astro + jsx/tsx + md/mdx to engine-classes {css,html,jsx,copy}. Blade (.blade.php) deferred to a follow-up; CSS + Tailwind classes + inline style + HTML/JSX/MD covered. -->
+
+## Phase 1 — Context gates (rebuttable presumptions, not blocks)
+
+- [x] Read consumer `DESIGN.md`/`PRODUCT.md` (via `design-system-capture` output) as the gate source: a declared palette/font/radius/style keyword (e.g. `brutalist`) suppresses the correlated flag. A tell is a *presumption the project can rebut by documenting intent*. <!-- done: loadDesignContext() reads DESIGN.md (scan dir → cwd → parent); each rule's gated(ctx) suppresses on keyword match. Smoke-verified: declaring Inter suppresses T7. -->
+- [x] Add semantic-element exceptions (e.g. `border-left` on `<blockquote>` is not a side-stripe). <!-- done: V1 detect excludes blockquote/quote selectors. -->
+- [x] Add density/co-occurrence thresholds (cream alone ≠ flag; cream + beige + brass together = flag; em-dash density > N per 100 words, not absolute presence) — the council's explicit precision lever. <!-- done: C5 requires cream+brass co-occurrence; CP1 uses em-dash density (>2 per 500 words, ≥80-word floor); T4 eyebrow count vs ceil(sections/3). -->
+
+## Phase 2 — Wire into the linter + design-review (the hybrid)
+
+- [x] Add the detector as a new mode of `lint_design_quality.ts` (or a sibling `lint_design_slop.ts`) — exit non-zero only on P0; P1–P3 are reported flags. Slop tells default to flag severity, never CI-fail, to honour "flags not blocks." <!-- done: sibling src/scripts/lint_design_slop.ts. Default exit 0 (flags only); CI opts in via --fail-on <P0|P1|P2|P3>. --json emits structured findings. Smoke-verified. -->
+- [x] Update `design-review` to **consume the structured findings** (cite rule-id + file:line + the catalog ID) instead of re-deriving from prose. Keep the human originality self-test for the judgment the detector cannot make. This is the AND architecture, not XOR. <!-- done: src/skills/design-review/SKILL.md "Anti-slop scan" — detector-first (lint_design_slop --json), cite verbatim, then judge T3/L2/V2 + originality self-test. -->
+- [x] Update `design-antipatterns.md` to note which catalog entries now have a deterministic detector backing (traceability both directions). <!-- done: added Detection row + "Deterministic detector backing" para listing V1/V3/V6/C2/C5/T4/T6/T7/L4/L8/M2/M4/CP1/CP2; T3/L2/V2 explicitly judgment-only. -->
+
+## Phase 3 — Optional pre-edit hook (host-limited)
+
+- [x] Wire an OPTIONAL pre-edit hook (only on hosts with the surface) that runs the detector on proposed UI content and surfaces P0/P1 flags before the write. Default OFF; opt-in via `.agent-settings.yml`. <!-- done: src/scripts/hooks/design_slop_hook.ts (PreToolUse, warn exit-2, never block); concern `design-slop` registered in hook_manifest.yaml + bound to pre_tool_use on augment/claude/cowork (the ~2-3 hosts with the surface); hooks.design_slop.enabled default false in template + schema. Smoke-verified: OFF→exit0, ON→exit2 warn. -->
+- [x] Implement anti-loop degradation: after N repeated flags on the same file+finding signature, downgrade surface→silent (mirrors the reference's deny→allow defuse) so the hook never traps the agent. This is the safety valve the council required. <!-- done: DEGRADE_AFTER=3, state at agents/runtime/state/design-slop-hook.json keyed file::rule. Smoke-verified: runs 1-3 warn (exit2), run 4 silent (exit0). -->
+- [x] Document that the hook is a convenience layer; the linter/CI gate is the universal source of truth. <!-- done: stated in the hook header docstring, the hook_manifest concern comment, and the template + schema describe strings. -->
+
+## Phase 4 — Calibration + guard
+
+- [x] Build a small fixture corpus (slop exemplars + intentional-design counter-examples) and measure false-positive rate per rule; demote/ tighten any rule above the agreed FP ceiling. Record the corpus so re-calibration is mechanical. <!-- done: FIXTURES in design_slop_rules.test.ts — 1 positive (must fire) + 1 negative (must be clean = zero-FP on the counter-example) per rule. Negative cases ARE the per-rule FP guard. -->
+- [x] Add a CI guard that every registry rule has at least one positive + one negative fixture (no untested tell). <!-- done: test asserts every SLOP_RULES id has a fixture + no orphan fixtures; 20 tests green. -->
+- [x] Run `task lint-skills` / relevant gates green; confirm `design-review` cites detector output in a smoke run. <!-- done: skill_linter design-review = PASS (0 issues); design_slop_rules.test.ts 20/20; condensation hashes in sync (check ✅); manifest lint exit 0; lint_design_slop --json smoke produced the structured findings design-review now cites. Note: .claude/.cursor tool-projection of design-review left stale (documented tools:[] generate-tools friction); src/ + dist/ correct + .augment symlinked. -->
+
+## Explicitly out of scope (council hard-rejects)
+
+- No in-browser "live carbonization" direct-manipulation loop (runtime-heavy, fragile across 7 hosts).
+- No numeric aesthetic SCORE or trend-over-time engine (Phase B; see `road-to-design-canon-grounding` note) — flags + severity only.
+- No model-fingerprint guessing as a hard dependency; per-model gated rules are an optional refinement, not Phase 0.
+
+## Provenance
+
+Source link retained encrypted per `source-confidentiality` (decrypt with the maintainer key via `src/scripts/_lib/link_crypto`):
+
+- Source A — an external anti-slop design skill pack — `ENC1:JWOLqw8iyvW1nEYHT3ysChDMUWA4zPyR2i97KKe65v+V6zAesWogJ0F+JgPRDSK/YfzlRv4PdDIKw5IqkI6Frw==`

--- a/agents/roadmaps/road-to-design-canon-grounding.md
+++ b/agents/roadmaps/road-to-design-canon-grounding.md
@@ -1,0 +1,67 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to Design-Canon Grounding
+
+> Add a thin, lazy-loaded `design-canon.md` reference — named design systems (Material, Apple HIG, Fluent, Carbon, Ant) + typography foundries/theory + colour tools (incl. culturally-specific palettes + a11y contrast) with one-line summaries — so `design-intelligence` can ground a brief against published canon and lazy-load a full spec only when the brief signals it.
+
+## Goal
+
+Give the design cluster a **canon index**: the named, published design systems and craft references a serious designer grounds against, as a compact lookup (names + one-line summaries + when-to-pull). The big specs are NOT loaded — `design-intelligence` lazy-loads one only when the brief or `components.json` signals it (e.g. "Material-inspired", or `@mui/material` present).
+
+## Context
+
+**What we have:**
+- `design-intelligence` (rich) grounds from an internal corpus (84 styles, 73 font pairings, WCAG colour sets) — strong on *generated* style knowledge, lighter on *named published canon*.
+- `corpus-grounding` skill + the "audit findings outrank corpus" principle.
+- `brand-source-of-truth` / `brand-consistency` rules (ground against the consumer's brand, not improvise).
+- `typography-system`, `iconography` skills.
+
+**What the Source C reference adds (deep-dived 2026-06-28):** a curated 16-category design-knowledge taxonomy whose highest-signal section is **Styleguide & Branding** — an index of the actual published canon (Apple HIG, Material, Fluent, Carbon, Ant, plus brand books) — alongside typography foundries/theory (Butterick, Typewolf, real foundries) and colour tools including *culturally-specific* palettes (Nippon/Chinese Colors) and a11y contrast checkers. The signal is structural: design competence is grounded in named systems + treats typography/colour as crafts with canon, not as CSS properties.
+
+**Council verdict (2026-06-28):** ADOPT as enrichment, but **lazy-load** — a `design-canon.md` with NAMES + one-line summaries + a pull-trigger; the multi-megabyte specs are fetched only on signal. "This is ALREADY your model" (mirrors how `design-antipatterns.md` is a lazy-loaded prose catalog). Ranked mid (#4) — lower leverage than detector/dials, but cheap and reinforces the existing brand-source-of-truth posture.
+
+## Token-optimization stance
+
+The whole point is frugality: `design-canon.md` is a thin index (names + one-liners + a `load_context`-style pull trigger), not a corpus. It loads only when `design-intelligence` is already active AND the brief names a system. The actual spec content is never baked into the package — at most an encrypted/neutral pointer or a "fetch when signalled" instruction. No `token_budget_class: rich` change; the index is small enough for standard budget.
+
+## Prerequisites
+
+- `design-intelligence` is the consumer of the canon index.
+- Aligns with `brand-source-of-truth` (consumer brand > canon > generated corpus).
+
+## Phase 0 — The canon index
+
+- [ ] Author `docs/guidelines/design-canon.md`: a compact table of named design systems (Material 3, Apple HIG, Fluent, Carbon, Ant, Atlassian) — each a one-line summary (token model, motion stance, signature traits) + a "pull this when" trigger (brief keyword or `components.json` dependency).
+- [ ] Add a typography-craft sub-section: foundry/theory references as a one-line index (point `typography-system` at it; do not inline the content).
+- [ ] Add a colour sub-section: tool classes incl. accessibility-contrast and culturally-specific palettes — names + when-to-use, not the palettes themselves.
+
+## Phase 1 — Wire into design-intelligence (lazy)
+
+- [ ] Add a "canon grounding" step to `design-intelligence`: if the brief names a system OR `components.json`/deps signal one (`@mui/material`, `antd`, `@fluentui/*`, `@carbon/*`), surface the matching canon one-liner and offer to pull the full spec (lazy fetch / pointer), rather than improvising.
+- [ ] Make the precedence explicit and consistent with `brand-source-of-truth`: consumer brand tokens > confirmed session decisions > named canon > generated corpus. Canon is a gap-filler, never an override of a registered brand value.
+
+## Phase 2 — Cross-link the craft skills
+
+- [ ] `typography-system` references the typography-craft sub-section for foundry/theory grounding.
+- [ ] `iconography` / `icon-consistency` reference the icon-system canon entries.
+- [ ] Note the colour-canon entries from `design-tokens` / `brand-to-tokens` where culturally-aware or a11y-contrast grounding helps.
+
+## Phase 3 — Verify
+
+- [ ] Smoke: a "Material-inspired dashboard" brief surfaces the Material canon one-liner + offers the lazy pull; a generic brief does NOT load any canon spec (frugality check).
+- [ ] Confirm `design-canon.md` is lazy-loaded (not always-on) and stays a thin index. Run gates green.
+
+## Explicitly out of scope
+
+- No bundling of multi-megabyte design-system specs into the tracked tree.
+- No always-loaded canon prose — index + pull-trigger only.
+- No re-implementation of the source's link collection; we take the *taxonomy/structure* (named-canon-as-grounding), not the link list.
+
+## Provenance
+
+Source link retained encrypted per `source-confidentiality` (decrypt with the maintainer key via `src/scripts/_lib/link_crypto`):
+
+- Source C — an external curated design-knowledge taxonomy — `ENC1:wOAdrwJg3Zzz1Mau9lCSQ1Dkm6F3g7JxmNgdMNnJFWUE/+QBAdu0/l2rsCsIqKO+305oTNDnCB4xaI40E08upA==`

--- a/agents/roadmaps/road-to-design-system-extraction-contract.md
+++ b/agents/roadmaps/road-to-design-system-extraction-contract.md
@@ -1,0 +1,65 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to a Design-System Extraction Contract
+
+> Teach `design-system-capture` to CONSUME an extracted `design-system.json` (tokens, fonts, spacing, motion, components) produced by any external static-extraction tool — so a consumer can reverse-engineer an existing site/repo's look-and-feel and our skill grounds against it. We define the consumer-side contract only; we do NOT build the Playwright/screenshot extraction engine in-package.
+
+## Goal
+
+Add an **import contract**: a documented `design-system.json` schema that `design-system-capture` can read to seed/merge a consumer's `DESIGN.md`. This lets a team extract a design system from a live URL, a git repo, or a local dir using whatever standalone tool they like, then hand the artifact to our skill — closing the "we can author a design system but can't capture an existing one from a target" gap, without dragging a heavy runtime extraction engine into the package.
+
+## Context
+
+**What we have:**
+- `design-system-capture` (rich) — writes/maintains `DESIGN.md`/`PRODUCT.md` (cross-session design memory: radius/shadow/motion/spacing/colour decisions); `design-intelligence` reads it and lets it override the corpus.
+- `design-tokens` / `brand-to-tokens` — author a DTCG `.tokens.json` source of truth.
+- `existing-ui-audit` — inventories an existing *codebase's* components/tokens into `state.ui_audit`.
+
+**What the Source E reference adds (deep-dived 2026-06-28):** a static-analysis CLI that reverse-engineers a design system from a live URL / git repo / local dir (zero AI, zero API key) — extracts colours, fonts, spacing, animations, components — and emits a `SKILL.md` + a `DESIGN.md`, auto-copied into the agent's skills dir. The interesting capability is **extraction from an arbitrary target**; the heavy parts are a Playwright "ultra" mode (runtime introspection: detect GSAP/Lottie from `window`, walk `styleSheets` keyframes, scroll screenshots) and local font bundling.
+
+**Council verdict (2026-06-28):** This is the **wrong package** to host the extraction engine — "build-time extraction tool, not agent guidance," runtime-heavy, fragile across 7 hosts (sonnet, explicit). ADOPT the **consumer-side contract only**: teach `design-system-capture` to *read* an extracted `design-system.json`; "let consumers generate that artifact however they want." gpt ranked the capability high but the council's shared resolution is: own the contract, not the crawler. Ranked #5 (after detector/dials/shadcn/canon) — real value, narrow scope.
+
+## Token-optimization stance
+
+The contract is a JSON schema + a thin import step in `design-system-capture` (already `rich`, no budget change). The extracted artifact is a consumer file (read transiently, merged into `DESIGN.md`), never loaded into always-on context. By refusing the extraction engine we also avoid shipping Playwright/screenshot machinery — keeping the package lean and host-portable. The frugal move here is *scoping out* the runtime, not adding budget.
+
+## Prerequisites
+
+- `design-system-capture` is the consumer of the contract.
+- Reuse the DTCG `.tokens.json` shape from `design-tokens`/`brand-to-tokens` where the extracted tokens map cleanly (don't invent a parallel token format).
+
+## Phase 0 — Define the import contract
+
+- [ ] Specify `design-system.json`: `colors` (with light/dark), `typography` (families + scale; note when fonts are bundled locally), `spacing`, `radius`, `shadow`, `motion` (durations/easings, detected libs as metadata), `components` (name + observed class/prop patterns), `source` (url|repo|dir + a captured-at stamp). Map fields to DTCG where possible; mark extraction-only metadata clearly.
+- [ ] Document trust posture: an extracted artifact is *observed*, not *authoritative* — it seeds `DESIGN.md` as a proposal the human confirms (mirrors `source-discovery` evidence-vs-authoritative discipline). Never let an import silently override a confirmed brand token (`brand-source-of-truth`).
+
+## Phase 1 — Import into design-system-capture
+
+- [ ] Add an "import extracted design system" path to `design-system-capture`: read `design-system.json`, diff against the current `DESIGN.md`, surface a confirm/merge proposal (per-field accept), then persist. Conflicts with a registered brand value are flagged, never auto-applied.
+- [ ] Hand mapped tokens to `design-tokens`/`brand-to-tokens` to materialise `.tokens.json` where the consumer wants a token source of truth.
+
+## Phase 2 — Bridge to existing-ui-audit
+
+- [ ] Where the target is the *current* repo (not an external site), prefer `existing-ui-audit` (we already inventory the codebase) and let it emit the same `design-system.json` shape, so the import path is uniform whether the source is "our repo" or "an external artifact."
+- [ ] Document the two sources clearly: external target → external tool emits the artifact; current repo → `existing-ui-audit` emits it.
+
+## Phase 3 — Verify
+
+- [ ] Smoke: feed a hand-authored `design-system.json` → `design-system-capture` proposes a `DESIGN.md` merge with per-field confirm; a field conflicting with a registered brand token is flagged not applied.
+- [ ] Confirm no Playwright / browser-runtime dependency entered the package. Run gates green.
+
+## Explicitly out of scope (council hard-rejects)
+
+- No in-package Playwright "ultra" runtime introspection (GSAP/Lottie detection, styleSheet-keyframe walking, scroll screenshots) — that is a standalone build-time tool, not agent guidance.
+- No `.skill`=zip auto-install-to-`~/.claude/skills/` mechanism — we have our own distribution.
+- No local font-download/bundling pipeline in-package.
+- We OWN the import contract; we do NOT own the crawler.
+
+## Provenance
+
+Source link retained encrypted per `source-confidentiality` (decrypt with the maintainer key via `src/scripts/_lib/link_crypto`):
+
+- Source E — an external static design-system reverse-engineering CLI — `ENC1:TQo27fraMUOfQEYI/k/W5Dy5NkrSOkgVBcWF//sZo8K7KERevyAUBIN+Utb4BEAmCiiP7bFfXccyvH4jTBfhvg==`

--- a/agents/roadmaps/road-to-shadcn-registry-awareness.md
+++ b/agents/roadmaps/road-to-shadcn-registry-awareness.md
@@ -1,0 +1,68 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to shadcn Registry & MCP Awareness
+
+> Teach `react-shadcn-ui` the modern shadcn distribution model — the JSON registry, namespaced `@registry/component` resolution, the `shadcn info --json` project-context handshake, token-carrying `registry-item.json`, and the optional shadcn MCP server — so the skill grounds in the real project + registry instead of only driving the legacy `npx shadcn add` CLI.
+
+## Goal
+
+Close the registry/MCP gap in `react-shadcn-ui`. Today it knows `npx shadcn@latest add` + reads `components.json`, but has **no** awareness of: the registry-as-JSON model, namespaced registries (`@acme/button` → URL), the self-describing `registry-item.json` (deps graph + OKLCH `cssVars` light/dark/theme), the `shadcn info --json` handshake, or the shadcn MCP server. Add these as an **opt-in enhancement** — the existing CLI path keeps working.
+
+## Context
+
+**What we have (verified):**
+- `react-shadcn-ui` — bundles `scripts/shadcn_add.ts` wrapping `npx shadcn@latest add`; reads `components.json` for detection + post-run sanity; gated `assisted`/`strict`, `allowed_tools:[npx]`, propose-never-silent-run, `--dry-run`. Anti-slop hooks at polish. Validated vs shadcn 2.1 / Tailwind 3.x / React 18+.
+- `existing-ui-audit` writes `state.ui_audit.shadcn_inventory` (a project-context handshake of our own).
+- This skill is on the `source-confidentiality` skip-list (integrating shadcn the tool is explicitly allowed; naming the tool is fine).
+
+**What the Source D reference adds (deep-dived 2026-06-28):** the *decoupled* pattern — a skill that TEACHES the agent to drive a CLI + MCP + a self-describing namespaced JSON registry, rather than embedding component knowledge. Key mechanisms: `shadcn info --json` reads the project's `components.json` (framework, aliases, installed components, icon lib) before acting; `registry-item.json` encodes `dependencies`/`registryDependencies` (dependency graph) + `cssVars` (OKLCH, light/dark/theme scopes) so the agent scaffolds + themes without guessing; namespaced resolution maps `@ns/name` → URL via the `registries` key; the shadcn MCP server exposes the same surface (browse/search/install-with-NL) over MCP.
+
+**Council verdict (2026-06-28):** ADOPT — but as an **opt-in enhancement, not a mandatory per-operation gate**. Sonnet's round-2 walk-back: the current skill "works on 90%+ of shadcn projects"; do not add 2–3 round-trips (`info` → parse → decide) to *every* component op. Make registry awareness opt-in; make `shadcn info --json` the handshake when the project uses custom/namespaced registries or when theme-alignment matters. gpt ranked it high. Net: real gap, adopt deliberately, don't over-gate.
+
+## Token-optimization stance
+
+This is mostly *executor* knowledge (CLI/MCP/registry mechanics), not loaded prose — `react-shadcn-ui` is `model_tier: medium`, not `rich`. The registry/MCP reference detail lives in the skill's bundled `scripts/` + a reference file lazy-loaded only on the registry path, not in always-loaded context. No budget change. The handshake (`shadcn info --json`) returns structured JSON the agent reads transiently — zero persistent context cost.
+
+## Prerequisites
+
+- `react-shadcn-ui` is the sole edit surface (skip-listed for source-confidentiality).
+- Keep the existing `shadcn_add.ts` CLI path intact and default.
+
+## Phase 0 — Registry model + JSON schema literacy
+
+- [ ] Add a lazy-loaded reference (skill-local) describing `registry-item.json`: the `type` enum (`registry:ui|block|component|hook|lib|theme|style|page|file`), `dependencies`/`devDependencies` (npm), `registryDependencies` (built-in / `@ns/x` / GitHub / URL / local), `files[]` (path + type + target placeholders), `cssVars` (theme/light/dark, OKLCH), `css` (raw `@layer`/`@utility`). Loaded only on the registry path.
+- [ ] Document namespaced resolution: `components.json` `registries` map (`@acme-ui` → URL template with `{name}`/`{style}`), the resolution regex, and per-registry `headers` with `${ENV_VAR}` for auth registries.
+
+## Phase 1 — `shadcn info --json` handshake (opt-in)
+
+- [ ] Teach the skill to run `shadcn info --json` to read framework / aliases / installed components / icon lib / base settings — used as the grounding handshake **when** the project declares custom/namespaced registries OR theme-alignment is in scope. NOT a forced first action on every add.
+- [ ] Reconcile with our own `state.ui_audit.shadcn_inventory` — prefer the live `info --json` when present; fall back to the audit. Document the precedence.
+
+## Phase 2 — Token-aware scaffolding
+
+- [ ] When a `registry-item.json` carries `cssVars`, align additions to the project's existing theme tokens (read from `info --json` / `components.json`) instead of injecting the default shadcn neutral theme — directly reinforces our anti-slop posture (default shadcn theme + Inter fallback is a flagged tell).
+- [ ] Honour `registryDependencies` (install the graph) and surface version-pinned GitHub deps; keep propose-never-silent-run + `--dry-run`.
+
+## Phase 3 — Optional shadcn MCP path
+
+- [ ] Document the shadcn MCP server as an alternative discovery/install surface (browse / search-across-registries / install-with-NL). Reference our `mcp` skill for wiring; keep it OPT-IN (a user who has the MCP configured), never a hard dependency.
+- [ ] Add a decision note: CLI path = default + universal; MCP path = opt-in when configured; registry-JSON literacy underpins both.
+
+## Phase 4 — Verify
+
+- [ ] Smoke on a project with a custom namespaced registry: skill runs `info --json`, resolves `@ns/x` → URL, installs the dep graph, aligns to project `cssVars`, stays propose-only.
+- [ ] Smoke on a vanilla project: existing CLI path unchanged, no extra round-trips (the opt-in stays off). Run gates green; confirm `react-shadcn-ui` still passes the skill linter.
+
+## Explicitly out of scope
+
+- No making `shadcn info --json` a mandatory gate on every component operation (council: over-gating, low ROI on vanilla projects).
+- No bundling the registry catalog into the package — the registry is fetched live.
+
+## Provenance
+
+Source link retained encrypted per `source-confidentiality` (decrypt with the maintainer key via `src/scripts/_lib/link_crypto`):
+
+- Source D — an external component-library "skill" (decoupled CLI/MCP/registry pattern) — `ENC1:ftPyTVUQGLup+hwroy0QSrGuRTFbRp1BpB3VWcMwlx/3hDgFowp9XOUe9bfL0/Y7NjAX9IXpwT2L3AnelMrUaw==`

--- a/agents/roadmaps/road-to-taste-dials-and-locks.md
+++ b/agents/roadmaps/road-to-taste-dials-and-locks.md
@@ -1,0 +1,74 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to Taste Dials & Consistency Locks
+
+> Give `design-intelligence` three quantified, brief-inferred taste dials (variance / motion / density), within-project consistency Locks (theme / colour / shape), and hard layout-repetition caps — so "taste" becomes a tunable, checkable configuration instead of an implicit vibe. Reject the gimmicks (seeded randomization, cross-run anti-repetition).
+
+## Goal
+
+Add a small, legible taste-parameterization layer to the design cluster:
+1. **Three dials** — `DESIGN_VARIANCE`, `MOTION_INTENSITY`, `VISUAL_DENSITY` (1–10), inferred from the brief and persisted to `DESIGN.md`.
+2. **Consistency Locks** — one theme, one accent, one corner-radius scale per project, enforced within-project.
+3. **Layout-repetition caps** — zigzag-alternation cap, section-layout-repetition floor, eyebrow-count cap — as deterministic flags.
+
+## Context
+
+**What we have:**
+- `design-intelligence` (rich, corpus-grounded) already does brief→style inference *implicitly* and emits a "Design Read" + brand/product register decision.
+- `design-system-capture` persists `DESIGN.md`/`PRODUCT.md` (the natural home for dial values + locks).
+- Two-register model (brand vs product) already exists.
+- `lint_design_quality.ts` deterministic floor (objective metrics).
+
+**What the Source B reference adds (deep-dived 2026-06-28):** quantified taste dials with a "Dial Inference Table" (brief signal → dial values, e.g. *minimalist→low variance/motion/density*; *Awwwards/playful→high*), named consistency Locks (theme/colour/shape), layout-repetition caps as hard fail conditions (max 2 consecutive zigzag sections, ≥4 distinct layout families across 8 sections, eyebrow count ≤ ceil(sections/3)), plus hex-level palette bans and a "why models default" grounding essay.
+
+**Council verdict (2026-06-28):** ADOPT dials + locks + layout-repetition caps (high leverage, consumer-legible, prevents within-project drift). **HARD-REJECT** cross-run anti-repetition ("differ from last project" = novelty-for-novelty, "its own form of slop") and deterministic seeded randomization ("astrology" — randomness serving novelty, not taste). The hex-level palette bans are valuable but belong in the detector registry (see `road-to-anti-slop-detector`), not as new loaded prose.
+
+## Token-optimization stance
+
+Dials + locks are a handful of values written to `DESIGN.md` (consumer file, not context) and a thin guidance block in `design-intelligence` (already `token_budget_class: rich`, no budget change). The layout-repetition caps are deterministic checks → fold into the anti-slop detector registry (zero runtime tokens). The Dial Inference Table is a compact lookup, not a corpus — it fits in the existing rich budget. No new always-loaded prose blobs.
+
+## Prerequisites
+
+- `road-to-anti-slop-detector` Phase 0 (rule registry) — the layout-repetition caps register there.
+- `design-system-capture` is the persistence layer for dial values + lock declarations.
+
+## Phase 0 — Dials in DESIGN.md
+
+- [ ] Extend the `DESIGN.md` schema (owned by `design-system-capture`) with a `## Taste Dials` block: `variance`, `motion`, `density` (1–10) + a one-line rationale each. Absent = unset (design-intelligence infers).
+- [ ] Add the Dial Inference Table to `design-intelligence` as a compact lookup: brief-signal keywords → dial ranges (minimal/editorial/calm → low; playful/expressive/awards → high; trust/regulated/public-sector → low variance + low motion + mid density). Emit the inferred dials in the "Design Read" line so the user can correct them.
+- [ ] On confirmation, persist the dials to `DESIGN.md` via `design-system-capture`.
+
+## Phase 1 — Dials drive generation
+
+- [ ] Map each dial to concrete downstream levers (documented in `design-intelligence`): variance → layout-family spread + asymmetry tolerance; motion → animation budget + reduced-motion posture; density → spacing scale + information-per-viewport. Keep the mapping a table, not prose.
+- [ ] Ensure dial values are surfaced to the stack executors (`tailwind-engineer`, `react-shadcn-ui`, `blade-ui`, `flux`) so generation honours them.
+
+## Phase 2 — Consistency Locks (within-project)
+
+- [ ] Define three Locks persisted in `DESIGN.md`: Theme Lock (no mid-page light/dark inversion), Colour Lock (one accent family across the surface), Shape Lock (one corner-radius scale). These are *invariants*, derived from the confirmed design system.
+- [ ] Add Lock-violation detection to the anti-slop detector registry (Phase 0 of the detector roadmap): a second accent family, a mid-surface theme inversion, mixed radius scales → flag with the Lock id.
+
+## Phase 3 — Layout-repetition caps (deterministic flags)
+
+- [ ] Add to the detector registry: zigzag-alternation cap (>2 consecutive "image-left + text-right" = flag), section-layout-repetition floor (<4 distinct layout families across ≥8 sections = flag), eyebrow-count cap (count > ceil(sections/3) = flag). All arithmetic, all deterministic, zero runtime tokens.
+- [ ] Gate each by the consumer's declared style (a deliberately repetitive brutalist grid can rebut via `DESIGN.md`, per the detector's context-gate model).
+
+## Phase 4 — Verify
+
+- [ ] Smoke: a brief with "minimal, calm, editorial" infers low dials; a brief with "bold, playful" infers high; both persist to `DESIGN.md` and survive a second session (no re-inference drift).
+- [ ] Detector fixtures cover each new Lock + layout cap (positive + negative). Run gates green.
+
+## Explicitly out of scope (council hard-rejects)
+
+- No cross-run anti-repetition / palette-rotation memory ("differ from last project").
+- No deterministic seeded randomization (prompt-char-count seed → architecture pick).
+- No "why models default" theory essay as loaded prose — at most a one-line pointer; the discipline lives in the dials + detector, not in an essay.
+
+## Provenance
+
+Source link retained encrypted per `source-confidentiality` (decrypt with the maintainer key via `src/scripts/_lib/link_crypto`):
+
+- Source B — an external anti-slop frontend "taste" framework — `ENC1:+mDpIGrhUsbMavsmrg1aIN0w3YddiRd4u7gYuMWuEOafB3SVHC2YVQq+ireV6JoDJt65yoakxJ1gl+pxiUCw1g==`

--- a/dist/agent-src/skills/design-review/SKILL.md
+++ b/dist/agent-src/skills/design-review/SKILL.md
@@ -287,17 +287,29 @@ This is especially useful when the user provides a screenshot or Figma export as
 
 ## Anti-slop scan
 
-During any design review, load
-[`docs/guidelines/design-antipatterns.md`](../../../docs/guidelines/design-antipatterns.md)
-as a reference. After the structured review phases, add an explicit
-**Anti-Slop Check** section to the review output:
+Hybrid: a deterministic detector does the mechanical pattern-matching (zero
+token cost, no catalog reload); you do the judgment it cannot. After the
+structured phases, add an **Anti-Slop Check** section:
 
-1. List any patterns from the catalog that appear in the reviewed UI (cite by
-   entry ID, e.g. V1, T2, C1).
-2. For each finding: note whether an override condition is in effect (if yes,
-   verify it is stated in the design brief; if not, flag as a finding).
-3. Run the AI-slop originality self-test on the overall aesthetic direction.
-   Report the result (pass / flag / fail) with one sentence of evidence.
+1. **Run the detector first** — catches pattern-detectable tells so you don't
+   eyeball or re-derive:
+   ```
+   npx tsx src/scripts/lint_design_slop.ts --dir <consumer-ui-path> --json
+   ```
+   Each finding: `rule` (`slop-v1-side-stripe`), `catalogId` (`V1`), `severity`
+   (`P0`–`P3`), `file:line`, `message`. **Cite verbatim** — don't re-describe
+   from the catalog. Findings are *rebuttable presumptions*: a `DESIGN.md`-gated
+   finding is already filtered; a remaining one means intent not declared.
+   `lint_design_slop` is **flags, never a block** (default exit 0; CI opts in via
+   `--fail-on`).
+2. **Judge what the detector cannot** — load
+   [`docs/guidelines/design-antipatterns.md`](../../../docs/guidelines/design-antipatterns.md)
+   for tells needing structural/aesthetic judgment (T3 icon-tile stack, L2
+   three-identical-card grid, V2 glassmorphism intent). List any, cite by entry
+   ID, check the override.
+3. Run the AI-slop originality self-test on the overall direction. Report
+   pass / flag / fail + one sentence of evidence — the judgment the detector
+   does not make.
 
 For the **objective quality floors** (WCAG contrast, font-size, line-length,
 reduced-motion, heading hierarchy, focus indicator), do NOT eyeball them —

--- a/docs/guidelines/design-antipatterns.md
+++ b/docs/guidelines/design-antipatterns.md
@@ -26,6 +26,7 @@ hierarchy, reduced-motion, focus indicator) is in `lint_design_quality`
 |---|---|---|
 | **Guidance** | Subjective taste — Visual / Typography / Color / Layout / Copy patterns, override judgment, the originality self-test | this catalog |
 | **Enforcement** | Objective floors — Q1–Q6 (WCAG contrast, font-size, line-length, reduced-motion, heading hierarchy, focus indicator) as exit-code-2 CI | `lint_design_quality` |
+| **Detection** | Deterministic *aesthetic-tell* flags (P0–P3, rebuttable via DESIGN.md) — the pattern-detectable subset of the entries below | `lint_design_slop` |
 | **Audit method** | HOW to test WCAG (keyboard nav, ARIA, screen-reader procedures) | `accessibility-auditor` |
 | **Stack manifestation** | Concrete Tailwind class / hex bans, shadcn defaults | `tailwind-engineer`, `react-shadcn-ui` (per `framework-neutrality-in-generic-skills`) |
 | **Register** | Brand mode vs product mode — which patterns apply | `docs/guidelines/design-modes.md` |
@@ -33,6 +34,17 @@ hierarchy, reduced-motion, focus indicator) is in `lint_design_quality`
 This catalog is the canonical *index*; it states the pattern stack-agnostically.
 The stack-specific bans live in the apply skills and link back here by entry ID.
 The objective floors are cited from the linter, never re-eyeballed by an agent.
+
+**Deterministic detector backing** (`lint_design_slop`, dependency-free, zero
+runtime token cost): a pattern-detectable subset of these entries now has a
+deterministic rule that `design-review` cites instead of re-deriving — `V1`,
+`V3`, `V6`, `C2`, `C5`, `T4`, `T6`, `T7`, `L4`, `L8`, `M2`, `M4`, `CP1`, `CP2`
+(rule ids `slop-<id>-*`, registry in `src/scripts/design_slop_rules.ts`). These
+are **flags / rebuttable presumptions**, never hard blocks — a consumer
+`DESIGN.md` that declares the pattern as intentional suppresses the flag. The
+entries needing structural or aesthetic judgment (e.g. `T3` icon-tile stack,
+`L2` three-identical-card grid, `V2` glassmorphism intent) stay
+agent-judgment-only and are deliberately **not** in the detector.
 
 ---
 

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -406,7 +406,7 @@
   "skills/design-intelligence/SKILL.md": "d382da955ad24d77264ec955530da8ab8a95467b7bbe3b703f2ce12c4a5b0ec0",
   "skills/design-intelligence/references/design-languages.md": "50cc404148e0d4bccafda56930ea883dd98220a5f69e76d2e4f0e238a9f9610a",
   "skills/design-intelligence/references/design-rules-checklist.md": "10f7c4d3b80c9f29a85708d371a5288d5b0810a1dc1ef6c732b5e4f5ac1c8b7a",
-  "skills/design-review/SKILL.md": "19d8e925ae14bfb754ef084b9b0c2e4fd2bf41f27d4ffc0259d92d07429039a7",
+  "skills/design-review/SKILL.md": "02adcda0e9837a46e22be422b925ea59808cb6272664c1d7b8acf9497b7f11ca",
   "skills/design-system-capture/SKILL.md": "fa9c961705a56e329b26934e0bffde35bb987ed7e6253b94c04091bfe111eec1",
   "skills/design-tokens/SKILL.md": "ca526e8439c8fde2d2e9d5e2bed8b9083772f8a649e8995344c23e91926c45b9",
   "skills/devcontainer/SKILL.md": "24b3aa7517695a17a60cb9e45aa28533494edc8845f821670ca2b3007c6ad6db",

--- a/internal/bench/reports/quality-run.json
+++ b/internal/bench/reports/quality-run.json
@@ -1,0 +1,38 @@
+{
+  "generated_by": "bench_quality_run",
+  "judge_model": "claude-sonnet-4-5",
+  "dry_run": false,
+  "threshold": 0.48,
+  "results": [
+    {
+      "id": "tq-scope-01",
+      "winner": "eager",
+      "length_delta": -786,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-scope-02",
+      "winner": "thin",
+      "length_delta": -1771,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-direct-01",
+      "winner": "tie",
+      "length_delta": -327,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-direct-02",
+      "winner": "tie",
+      "length_delta": 0,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-evidence-01",
+      "winner": "eager",
+      "length_delta": 2139,
+      "winner_is_longer": false
+    }
+  ]
+}

--- a/src/config/agent-settings.template.yml
+++ b/src/config/agent-settings.template.yml
@@ -731,6 +731,18 @@ hooks:
   rtk_wrap:
     enabled: false
 
+  # PreToolUse anti-slop nudge (road-to-anti-slop-detector Phase 3). Default-OFF.
+  # When enabled, runs the lint_design_slop registry against about-to-be-written
+  # UI content (html/css/jsx/…) and WARNS (exit 2, never blocks) on P0/P1
+  # aesthetic tells — the side-stripe signature, gradient-text, magic z-index,
+  # etc. Flags are rebuttable: declare intent in DESIGN.md, design-slop-disable,
+  # or proceed. Anti-loop: a file::rule signature surfaced 3x goes silent so it
+  # never traps the agent. The universal gate is the lint_design_slop linter/CI;
+  # this hook is a host-limited convenience layer (pre_tool_use fires on ~2-3
+  # hosts). Opt in once you trust the signal-to-noise on your UI.
+  design_slop:
+    enabled: false
+
 # --- Decision engine ---
 #
 # Controllable gates layered over the observability surface. Absent

--- a/src/scripts/design_slop_rules.test.ts
+++ b/src/scripts/design_slop_rules.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { SLOP_RULES, type DesignContext } from "./design_slop_rules.ts";
+import { scanFile } from "./lint_design_slop.ts";
+
+// Context with no DESIGN.md → all gates OFF, every rule active.
+const NO_CTX: DesignContext = { raw: "", has: () => false };
+const ctxWith = (raw: string): DesignContext => ({
+  raw: raw.toLowerCase(),
+  has: (...ks: string[]) => ks.some((k) => raw.toLowerCase().includes(k.toLowerCase())),
+});
+
+/**
+ * Calibration corpus (Phase 4). One positive (must fire) + one negative (must be
+ * clean) per rule. `ext` drives the engine class. No untested tell — the guard
+ * below asserts every registry rule appears here.
+ */
+const FIXTURES: Record<string, { ext: string; positive: string; negative: string }> = {
+  "slop-v1-side-stripe": {
+    ext: "css",
+    positive: ".card { border-left: 4px solid #6c5ce7; padding: 16px; }",
+    negative: ".card { border-left: 1px solid #eee; padding: 16px; }",
+  },
+  "slop-v3-ghost-card": {
+    ext: "css",
+    positive: ".card { border: 1px solid #ddd; box-shadow: 0 8px 24px rgba(0,0,0,.1); }",
+    negative: ".card { box-shadow: 0 2px 4px rgba(0,0,0,.1); }",
+  },
+  "slop-v6-diagonal-stripes": {
+    ext: "css",
+    positive: ".bg { background: repeating-linear-gradient(45deg,#000,#000 10px,#111 10px,#111 20px); }",
+    negative: ".bg { background: linear-gradient(#fff,#eee); }",
+  },
+  "slop-c2-gradient-text": {
+    ext: "css",
+    positive: ".h { background: linear-gradient(90deg,#f00,#00f); -webkit-background-clip: text; color: transparent; }",
+    negative: ".h { color: #111; }",
+  },
+  "slop-c5-cream-palette": {
+    ext: "css",
+    positive: "body { background: #f5f1ea; } .a { color: #b08947; }",
+    negative: "body { background: #ffffff; } .a { color: #111111; }",
+  },
+  "slop-t4-eyebrow-overuse": {
+    ext: "html",
+    positive:
+      '<section><span class="uppercase">Features</span></section><section><span class="uppercase">Pricing</span></section><section><h2>Contact</h2></section>',
+    negative:
+      '<section><span class="uppercase">Features</span></section><section><h2>Pricing</h2></section><section><h2>Contact</h2></section>',
+  },
+  "slop-t6-crushed-tracking": {
+    ext: "css",
+    positive: ".display { letter-spacing: -0.05em; }",
+    negative: ".display { letter-spacing: -0.02em; }",
+  },
+  "slop-t7-default-fonts": {
+    ext: "css",
+    positive: "body { font-family: 'Inter', sans-serif; }",
+    negative: "body { font-family: 'Söhne', sans-serif; }",
+  },
+  "slop-l4-numbered-markers": {
+    ext: "html",
+    positive: "<div>01</div><div>02</div><div>03</div>",
+    negative: "<div>Discover</div><div>Build</div><div>Ship</div>",
+  },
+  "slop-l8-zindex-magic": {
+    ext: "css",
+    positive: ".modal { z-index: 9999; }",
+    negative: ".modal { z-index: 400; }",
+  },
+  "slop-m4-transition-all": {
+    ext: "css",
+    positive: ".x { transition: all 200ms ease-out; }",
+    negative: ".x { transition: transform 200ms ease-out; }",
+  },
+  "slop-m2-animate-layout": {
+    ext: "css",
+    positive: ".x { transition: width 200ms ease; }",
+    negative: ".x { transition: transform 200ms, opacity 200ms; }",
+  },
+  "slop-cp1-em-dash": {
+    ext: "md",
+    // ≥80 words is the rule floor; positive carries 4 em-dashes (well over the
+    // ~2-per-500 density), negative carries one across the same length.
+    positive:
+      "We build tools — fast, focused tools — that teams genuinely love using every single day of the working week. " +
+      "The product is calm and clear and useful, and people return to it daily because it respects their time — and their attention — and never wastes a single click of effort or a moment of their busy day, and that quiet reliability is the whole point of the thing we set out to make together, and the team keeps shipping the small improvements that matter most to the people who rely on it.",
+    negative:
+      "We build tools, fast and focused tools, that teams genuinely love using every single day of the working week. " +
+      "The product is calm and clear and useful, and people return to it daily because it respects their time and their attention and never wastes a single click of effort or a moment of their busy day — and that quiet reliability is the whole point of the thing we set out to make together, and the team keeps shipping the small improvements that matter most to the people who rely on it.",
+  },
+  "slop-cp2-buzzword": {
+    ext: "md",
+    positive: "We streamline and empower your robust, world-class workflow.",
+    negative: "We cut page load by 40% and remove three steps from checkout.",
+  },
+};
+
+function findingsFor(ruleId: string, content: string, ext: string, ctx = NO_CTX) {
+  return scanFile(content, `fixture.${ext}`, ctx).filter((f) => f.rule === ruleId);
+}
+
+describe("design-slop rule registry", () => {
+  it("every rule has a unique id + a catalog id", () => {
+    const ids = SLOP_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const r of SLOP_RULES) {
+      expect(r.id).toMatch(/^slop-/);
+      expect(r.catalogId).toMatch(/^[A-Z]+\d+$/);
+      expect(r.engines.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("no untested tell — every registry rule has a +/- fixture", () => {
+    for (const r of SLOP_RULES) {
+      expect(FIXTURES[r.id], `missing fixture for ${r.id}`).toBeDefined();
+    }
+    // and no orphan fixtures
+    const ids = new Set(SLOP_RULES.map((r) => r.id));
+    for (const k of Object.keys(FIXTURES)) {
+      expect(ids.has(k), `orphan fixture ${k}`).toBe(true);
+    }
+  });
+
+  describe("positive fixtures fire, negative fixtures are clean", () => {
+    for (const r of SLOP_RULES) {
+      const fx = FIXTURES[r.id];
+      if (!fx) continue;
+      it(`${r.id} (${r.catalogId})`, () => {
+        expect(findingsFor(r.id, fx.positive, fx.ext).length, "positive must fire").toBeGreaterThan(0);
+        expect(findingsFor(r.id, fx.negative, fx.ext).length, "negative must be clean").toBe(0);
+      });
+    }
+  });
+});
+
+describe("context gates suppress when DESIGN.md declares intent", () => {
+  it("t7 default-font is suppressed when DESIGN.md adopts Inter", () => {
+    const fx = FIXTURES["slop-t7-default-fonts"]!;
+    expect(findingsFor("slop-t7-default-fonts", fx.positive, "css", NO_CTX).length).toBeGreaterThan(0);
+    expect(
+      findingsFor("slop-t7-default-fonts", fx.positive, "css", ctxWith("Body font: Inter (chosen for variable metrics in a data-dense dashboard)")).length,
+    ).toBe(0);
+  });
+
+  it("c5 cream-palette is suppressed under a declared warm-neutral language", () => {
+    const fx = FIXTURES["slop-c5-cream-palette"]!;
+    expect(findingsFor("slop-c5-cream-palette", fx.positive, "css", NO_CTX).length).toBeGreaterThan(0);
+    expect(
+      findingsFor("slop-c5-cream-palette", fx.positive, "css", ctxWith("Palette: warm-neutral, first-party")).length,
+    ).toBe(0);
+  });
+});
+
+describe("inline-ignore", () => {
+  it("design-slop-disable-next-line suppresses the next line", () => {
+    const css = "/* design-slop-disable-next-line slop-m4-transition-all */\n.x { transition: all 200ms; }";
+    expect(findingsFor("slop-m4-transition-all", css, "css").length).toBe(0);
+  });
+
+  it("file-scope design-slop-disable suppresses the whole file", () => {
+    const css = "/* design-slop-disable slop-l8-zindex-magic */\n.a{z-index:9999}\n.b{z-index:999}";
+    expect(findingsFor("slop-l8-zindex-magic", css, "css").length).toBe(0);
+  });
+});

--- a/src/scripts/design_slop_rules.test.ts
+++ b/src/scripts/design_slop_rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { SLOP_RULES, type DesignContext } from "./design_slop_rules.ts";
-import { scanFile } from "./lint_design_slop.ts";
+import { SLOP_RULES, type DesignContext } from "./design_slop_rules.js";
+import { scanFile } from "./lint_design_slop.js";
 
 // Context with no DESIGN.md → all gates OFF, every rule active.
 const NO_CTX: DesignContext = { raw: "", has: () => false };

--- a/src/scripts/design_slop_rules.ts
+++ b/src/scripts/design_slop_rules.ts
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/**
+ * design_slop_rules — the deterministic anti-slop rule registry.
+ *
+ * Data + matchers for the aesthetic-PROVENANCE tells that make a UI "look like
+ * an AI made it" — the layer `lint_design_quality` deliberately does NOT cover
+ * (it owns the OBJECTIVE floors: contrast, font-size, line-length, reduced-motion,
+ * heading hierarchy, focus). This registry is the deterministic backing for the
+ * PROSE catalog in `docs/guidelines/design-antipatterns.md`; every rule cites its
+ * catalog id (V1, C2, …) so prose ↔ rule stay traceable.
+ *
+ * DESIGN CONSTRAINT (why no postcss/@babel): this package ships to consumers via
+ * `npx` and is dependency-free by design (see lint_design_quality header). Heavy
+ * parsers (postcss/@babel/tailwind resolver) would bloat the install and break
+ * portability. The Phase-0 tells are all detectable by pattern analysis on
+ * CSS/HTML/JSX text without a cascade — we follow lint_design_quality's proven
+ * dependency-free approach. Council 2026-06-28 assumed those libs were present;
+ * for THIS package, pattern-based is the correct, frugal adaptation.
+ *
+ * Severity is a REBUTTABLE PRESUMPTION, never a hard block:
+ *   P0 — objective failure (none here; those live in lint_design_quality)
+ *   P1 — high-confidence tell (e.g. the side-stripe signature)
+ *   P2 — confident tell
+ *   P3 — co-occurrence / lower-confidence heuristic
+ * A rule is suppressed when the consumer's DESIGN.md declares the pattern as
+ * intentional (the context gate), via inline-ignore, or via .design-quality.json.
+ */
+
+export type Severity = "P0" | "P1" | "P2" | "P3";
+export type Engine = "css" | "html" | "jsx" | "copy";
+
+export interface RawHit {
+  line: number;
+  snippet: string;
+}
+
+export interface DesignContext {
+  /** lowercased DESIGN.md text, or "" when absent */
+  raw: string;
+  /** true when DESIGN.md mentions any of the given keywords */
+  has(...keywords: string[]): boolean;
+}
+
+export interface RuleInput {
+  content: string;
+  lines: string[];
+  ext: string; // e.g. ".css"
+  ctx: DesignContext;
+}
+
+export interface SlopRule {
+  id: string; // e.g. "slop-v1-side-stripe"
+  catalogId: string; // e.g. "V1"
+  severity: Severity;
+  engines: Engine[];
+  description: string;
+  /** human-facing note on what to do — printed with the finding */
+  message: string;
+  /** suppress the rule entirely for this file when DESIGN.md declares intent */
+  gated?: (ctx: DesignContext) => boolean;
+  detect: (input: RuleInput) => RawHit[];
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers (pattern-based, dependency-free)
+// ---------------------------------------------------------------------------
+
+/** Split CSS-ish text into naive `selector { body }` blocks with the line of `{`. */
+export function cssBlocks(content: string): Array<{ selector: string; body: string; line: number }> {
+  const blocks: Array<{ selector: string; body: string; line: number }> = [];
+  const re = /([^{}]+)\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const before = content.slice(0, m.index);
+    const line = (before.match(/\n/g) ?? []).length + 1;
+    blocks.push({ selector: (m[1] ?? "").trim(), body: m[2] ?? "", line });
+  }
+  return blocks;
+}
+
+function lineOf(content: string, index: number): number {
+  return (content.slice(0, index).match(/\n/g) ?? []).length + 1;
+}
+
+/** Visible text from HTML/JSX/Markdown: strip tags, code fences, attributes. */
+export function visibleText(content: string, ext: string): string {
+  let t = content;
+  if (ext === ".md" || ext === ".mdx") {
+    t = t.replace(/```[\s\S]*?```/g, " ").replace(/`[^`]*`/g, " ");
+  }
+  // strip HTML/JSX tags and JSX expression braces
+  t = t.replace(/<[^>]+>/g, " ").replace(/\{[^}]*\}/g, " ");
+  return t;
+}
+
+const DEFAULT_FONTS = [
+  "inter",
+  "roboto",
+  "dm sans",
+  "geist",
+  "space grotesk",
+  "instrument serif",
+];
+
+const BUZZWORDS = [
+  "streamline",
+  "empower",
+  "supercharge",
+  "world-class",
+  "enterprise-grade",
+  "seamlessly",
+  "robust",
+  "leverage",
+];
+
+// ---------------------------------------------------------------------------
+// The registry
+// ---------------------------------------------------------------------------
+
+export const SLOP_RULES: SlopRule[] = [
+  {
+    id: "slop-v1-side-stripe",
+    catalogId: "V1",
+    severity: "P1",
+    engines: ["css"],
+    description: "Colored side-stripe border (border-left/right > 1px) — the #1 AI-UI signature",
+    message:
+      "Side-stripe accent border reads as scaffold-default. Remove it, or declare an intentional stripe in DESIGN.md (V1).",
+    gated: (ctx) => ctx.has("side stripe", "side-stripe", "stripe accent", "accent border"),
+    detect: ({ content }) =>
+      cssBlocks(content)
+        // a side-stripe is a left/right border with a width > 1px and a color;
+        // exclude semantic blockquote/quote selectors (legitimate left rule)
+        .filter((b) => !/blockquote|\bquote\b|<q>/i.test(b.selector))
+        .filter((b) =>
+          /border-(?:left|right)\s*:\s*(?:[2-9]|\d{2,})px\s+\w+\s+(?:#|rgb|hsl|oklch|var\(|[a-z])/i.test(
+            b.body,
+          ),
+        )
+        .map((b) => ({ line: b.line, snippet: b.selector.slice(0, 80) })),
+  },
+  {
+    id: "slop-v3-ghost-card",
+    catalogId: "V3",
+    severity: "P2",
+    engines: ["css"],
+    description: "Ghost card: 1px border AND a ≥16px box-shadow on the same surface",
+    message:
+      "Border + heavy shadow together signal no confident depth decision. Choose one (V3).",
+    detect: ({ content }) =>
+      cssBlocks(content)
+        .filter(
+          (b) =>
+            /border\s*:\s*1px\s+solid/i.test(b.body) &&
+            /box-shadow\s*:[^;]*?(?:1[6-9]|[2-9]\d)px/i.test(b.body),
+        )
+        .map((b) => ({ line: b.line, snippet: b.selector.slice(0, 80) })),
+  },
+  {
+    id: "slop-v6-diagonal-stripes",
+    catalogId: "V6",
+    severity: "P2",
+    engines: ["css"],
+    description: "repeating-linear-gradient stripes as a background texture",
+    message: "Repeating diagonal stripes are a generated-CSS-art cliché (V6).",
+    gated: (ctx) => ctx.has("pattern background", "pattern-background", "stripe texture"),
+    detect: ({ lines }) =>
+      lines.flatMap((l, i) =>
+        /background[^;]*repeating-linear-gradient\s*\(/i.test(l)
+          ? [{ line: i + 1, snippet: l.trim().slice(0, 90) }]
+          : [],
+      ),
+  },
+  {
+    id: "slop-c2-gradient-text",
+    catalogId: "C2",
+    severity: "P2",
+    engines: ["css"],
+    description: "Gradient text via background-clip: text",
+    message:
+      "Gradient text via background-clip:text is overused and has cross-platform rendering edges (C2).",
+    gated: (ctx) => ctx.has("gradient identity", "gradient-identity", "gradient logo"),
+    detect: ({ content }) =>
+      cssBlocks(content)
+        .filter(
+          (b) =>
+            /background-clip\s*:\s*text|-webkit-background-clip\s*:\s*text/i.test(b.body) &&
+            /linear-gradient|radial-gradient|conic-gradient/i.test(b.body),
+        )
+        .map((b) => ({ line: b.line, snippet: b.selector.slice(0, 80) })),
+  },
+  {
+    id: "slop-c5-cream-palette",
+    catalogId: "C5",
+    severity: "P3",
+    engines: ["css"],
+    description: "Cream/sand background + brass/clay/oxblood accent — the 2025 'premium-consumer' AI palette",
+    message:
+      "Warm cream/sand + brass/clay is the default 'tasteful AI' surface. Confirm it is first-party in DESIGN.md (C5).",
+    gated: (ctx) => ctx.has("warm neutral", "warm-neutral", "cream", "sand", "premium consumer"),
+    detect: ({ content }) => {
+      const cream = /#f[5-9bdf][f0-9a-f]e[0-9a-f]|#fbf8f1|#f7f5f1|#f5f1ea/i.test(content);
+      const brass = /#b08947|#b6553a|#9a2436|brass|oxblood|terracotta|clay/i.test(content);
+      if (!cream || !brass) return [];
+      const idx = content.search(/#f[5-9bdf][f0-9a-f]e[0-9a-f]|#fbf8f1|#f7f5f1|#f5f1ea/i);
+      return [{ line: lineOf(content, Math.max(0, idx)), snippet: "cream/sand bg + warm accent co-occur" }];
+    },
+  },
+  {
+    id: "slop-t4-eyebrow-overuse",
+    catalogId: "T4",
+    severity: "P2",
+    engines: ["html", "jsx", "css"],
+    description: "More than one ALL-CAPS eyebrow per 3 sections",
+    message:
+      "Eyebrow/ALL-CAPS labels above every section collapse emphasis; cap is 1 per 3 sections (T4).",
+    detect: ({ content }) => {
+      const sections = (content.match(/<section\b|<Section\b/gi) ?? []).length;
+      const eyebrows =
+        (content.match(/text-transform\s*:\s*uppercase/gi) ?? []).length +
+        (content.match(/(?:class|className)=["'][^"']*\buppercase\b/gi) ?? []).length;
+      const cap = Math.max(1, Math.ceil(sections / 3));
+      if (sections >= 3 && eyebrows > cap) {
+        return [
+          {
+            line: 1,
+            snippet: `${eyebrows} uppercase eyebrows across ${sections} sections (cap ${cap})`,
+          },
+        ];
+      }
+      return [];
+    },
+  },
+  {
+    id: "slop-t6-crushed-tracking",
+    catalogId: "T6",
+    severity: "P2",
+    engines: ["css"],
+    description: "Crushed display letter-spacing below −0.04em",
+    message: "letter-spacing tighter than −0.04em makes glyphs collide optically (T6/Q7).",
+    detect: ({ lines }) =>
+      lines.flatMap((l, i) => {
+        const m = /letter-spacing\s*:\s*(-?\d*\.?\d+)\s*em/i.exec(l);
+        if (m && m[1] && parseFloat(m[1]) < -0.04) {
+          return [{ line: i + 1, snippet: l.trim().slice(0, 80) }];
+        }
+        return [];
+      }),
+  },
+  {
+    id: "slop-t7-default-fonts",
+    catalogId: "T7",
+    severity: "P2",
+    engines: ["css"],
+    description: "Default AI font (Inter/Roboto/DM Sans/Geist/Space Grotesk/Instrument Serif) without a brand reason",
+    message:
+      "This is a default AI-coding-tool font pick. Declare it in DESIGN.md with a reason, or choose deliberately (T7).",
+    gated: (ctx) => DEFAULT_FONTS.some((f) => ctx.has(f)),
+    detect: ({ lines }) =>
+      lines.flatMap((l, i) => {
+        if (!/font-family\s*:/i.test(l)) return [];
+        const lower = l.toLowerCase();
+        const hit = DEFAULT_FONTS.find((f) => lower.includes(f));
+        return hit ? [{ line: i + 1, snippet: l.trim().slice(0, 80) }] : [];
+      }),
+  },
+  {
+    id: "slop-l4-numbered-markers",
+    catalogId: "L4",
+    severity: "P3",
+    engines: ["html", "jsx"],
+    description: "Numbered section markers (01 / 02 / 03) as a decorative order device",
+    message:
+      "Numbered 01/02/03 section markers are a universal generated-landing-page tell (L4).",
+    detect: ({ content, ext }) => {
+      const text = visibleText(content, ext);
+      const markers = text.match(/(?<![\d/.])0[1-9](?![\d%])/g) ?? [];
+      const distinct = new Set(markers.map((s) => s.trim()));
+      if (distinct.has("01") && distinct.has("02") && distinct.has("03")) {
+        return [{ line: 1, snippet: "decorative 01/02/03 section markers" }];
+      }
+      return [];
+    },
+  },
+  {
+    id: "slop-l8-zindex-magic",
+    catalogId: "L8",
+    severity: "P2",
+    engines: ["css"],
+    description: "Magic z-index values (99 / 999 / 9999) with no semantic scale",
+    message: "Magic z-index breaks the first time two elements compete. Use a named scale (L8).",
+    detect: ({ lines }) =>
+      lines.flatMap((l, i) =>
+        /z-index\s*:\s*(?:99|999|9999)\b/i.test(l) ? [{ line: i + 1, snippet: l.trim().slice(0, 80) }] : [],
+      ),
+  },
+  {
+    id: "slop-m4-transition-all",
+    catalogId: "M4",
+    severity: "P2",
+    engines: ["css"],
+    description: "transition: all shorthand",
+    message: "transition:all animates layout/color/opacity together — unpredictable + expensive (M4).",
+    detect: ({ lines }) =>
+      lines.flatMap((l, i) =>
+        /transition\s*:\s*all\b/i.test(l) ? [{ line: i + 1, snippet: l.trim().slice(0, 80) }] : [],
+      ),
+  },
+  {
+    id: "slop-m2-animate-layout",
+    catalogId: "M2",
+    severity: "P2",
+    engines: ["css"],
+    description: "Transitioning layout properties (width/height/top/left/margin/padding)",
+    message: "Animating layout props forces reflow; use transform instead (M2).",
+    detect: ({ lines }) =>
+      lines.flatMap((l, i) =>
+        /transition\s*:\s*(?:[^;]*\b)?(?:width|height|top|left|right|bottom|margin|padding)\b[^;]*\d/i.test(l)
+          ? [{ line: i + 1, snippet: l.trim().slice(0, 80) }]
+          : [],
+      ),
+  },
+  {
+    id: "slop-cp1-em-dash",
+    catalogId: "CP1",
+    severity: "P2",
+    engines: ["copy"],
+    description: "Em-dash overuse in visible copy (> 2 per 500 words)",
+    message: "Em-dash density above ~2 per 500 words is the #1 LLM syntactic tell (CP1).",
+    detect: ({ content, ext }) => {
+      const text = visibleText(content, ext);
+      const words = (text.match(/\S+/g) ?? []).length;
+      const dashes = (text.match(/—/g) ?? []).length;
+      if (words >= 80 && dashes > Math.max(2, Math.round((words / 500) * 2))) {
+        return [{ line: 1, snippet: `${dashes} em-dashes in ~${words} words` }];
+      }
+      return [];
+    },
+  },
+  {
+    id: "slop-cp2-buzzword",
+    catalogId: "CP2",
+    severity: "P2",
+    engines: ["copy"],
+    description: "Marketing buzzwords (streamline/empower/supercharge/world-class/…)",
+    message: "These words carry no information — delete-test each one (CP2).",
+    detect: ({ content, ext }) => {
+      const text = visibleText(content, ext);
+      const lower = text.toLowerCase();
+      const hits = BUZZWORDS.filter((w) => new RegExp(`\\b${w}\\b`, "i").test(lower));
+      if (hits.length > 0) {
+        return [{ line: 1, snippet: `buzzwords: ${hits.join(", ")}` }];
+      }
+      return [];
+    },
+  },
+];

--- a/src/scripts/external_sources_denylist.json
+++ b/src/scripts/external_sources_denylist.json
@@ -48,7 +48,13 @@
     "agency-agents",
     "msitarzewski",
     "610ClaudeSubagents",
-    "ChrisRoyse"
+    "ChrisRoyse",
+    "pbakaus",
+    "leonxlnx",
+    "gztchan",
+    "amaancoderx",
+    "npxskillui",
+    "\\bskillui\\b"
   ],
   "skip_paths": [
     "src/scripts/check_no_external_sources.py",

--- a/src/scripts/hook_manifest.yaml
+++ b/src/scripts/hook_manifest.yaml
@@ -76,6 +76,17 @@ concerns:
     script: src/scripts/hooks/rtk_wrap_hook.ts
     args: []
     fail_closed: false
+  # road-to-anti-slop-detector Phase 3 — OPTIONAL PreToolUse anti-slop nudge.
+  # Runs the lint_design_slop registry against about-to-be-written UI content
+  # and WARNS (exit 2) on P0/P1 aesthetic tells. Never blocks (flags, not
+  # blocks). Default-OFF (hooks.design_slop.enabled). Anti-loop degradation: a
+  # file::rule signature surfaced >=3x goes silent so it never traps the agent.
+  # The universal source of truth is the lint_design_slop linter/CI; this hook
+  # is a host-limited convenience layer. fail_closed: false.
+  design-slop:
+    script: src/scripts/hooks/design_slop_hook.ts
+    args: []
+    fail_closed: false
   # Phase 2 of road-to-hooks-actually-fire-in-consumers — session_start
   # gate that surfaces the marketplace-install-but-unscaffolded shape.
   # Writes .augment/.first-run-action-needed.md + one stderr line so
@@ -108,7 +119,7 @@ platforms:
     session_start:    [chat-history, first-run-gate, onboarding-gate, verify-before-complete, minimal-safe-diff, profile-staleness, wrapper-freshness]
     session_end:      [chat-history]
     stop:             [chat-history, verify-before-complete]
-    pre_tool_use:     [block-no-verify, rtk-wrap]
+    pre_tool_use:     [block-no-verify, rtk-wrap, design-slop]
     post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
 
   claude:
@@ -116,7 +127,7 @@ platforms:
     session_end:      [chat-history]
     stop:             [chat-history, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    pre_tool_use:     [block-no-verify, rtk-wrap]
+    pre_tool_use:     [block-no-verify, rtk-wrap, design-slop]
     post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
 
   # Cowork — the Claude desktop app's local-agent-mode runtime, built
@@ -138,7 +149,7 @@ platforms:
     session_end:      [chat-history]
     stop:             [chat-history, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    pre_tool_use:     [block-no-verify, rtk-wrap]
+    pre_tool_use:     [block-no-verify, rtk-wrap, design-slop]
     post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
 
   # Phase 7.5 — Cursor. `.cursor/hooks.json` (project) is read by the

--- a/src/scripts/hooks/design_slop_hook.ts
+++ b/src/scripts/hooks/design_slop_hook.ts
@@ -22,8 +22,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { type DesignContext } from "../design_slop_rules.ts";
-import { loadDesignContext, scanFile } from "../lint_design_slop.ts";
+import { type DesignContext } from "../design_slop_rules.js";
+import { loadDesignContext, scanFile } from "../lint_design_slop.js";
 
 const SETTINGS_FILE = ".agent-settings.yml";
 const EXIT_ALLOW = 0;

--- a/src/scripts/hooks/design_slop_hook.ts
+++ b/src/scripts/hooks/design_slop_hook.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse anti-slop nudge — surfaces high-severity aesthetic tells in
+ * proposed UI content BEFORE the write (road-to-anti-slop-detector Phase 3).
+ *
+ * OPTIONAL, host-limited (pre_tool_use fires on ~2–3 hosts). The universal
+ * source of truth is the `lint_design_slop` linter / CI gate; this hook is a
+ * convenience layer that runs the same registry against the about-to-be-written
+ * content. Default-OFF: no-ops unless `hooks.design_slop.enabled: true` in
+ * `.agent-settings.yml`. fail_closed: false (never break a write for a flag).
+ *
+ * FLAGS, NEVER A BLOCK. On a P0/P1 finding it WARNS (exit 2 + reason); it never
+ * returns block (exit 1). Mirrors the injection-scan "warn, don't block" shape.
+ *
+ * Anti-loop degradation (council-required safety valve): a `file::rule`
+ * signature surfaced ≥ DEGRADE_AFTER times is downgraded to silent, so a
+ * deliberate-but-undeclared pattern the agent keeps re-writing never traps it.
+ * State: <root>/agents/runtime/state/design-slop-hook.json.
+ *
+ * Exit codes (dispatcher contract): 0 allow · 2 warn (+ JSON reason on stdout).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { SLOP_RULES, type DesignContext } from "../design_slop_rules.ts";
+import { loadDesignContext, scanFile } from "../lint_design_slop.ts";
+
+const SETTINGS_FILE = ".agent-settings.yml";
+const EXIT_ALLOW = 0;
+const EXIT_WARN = 2;
+const DEGRADE_AFTER = 3; // surfaces of the same file::rule signature before going silent
+const UI_EXT = /\.(html|htm|css|scss|sass|less|vue|svelte|astro|jsx|tsx)$/i;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+type JsonObject = { [k: string]: JsonValue };
+
+function isObject(v: unknown): v is JsonObject {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Minimal `.agent-settings.yml` reader for hooks.design_slop.enabled (mirrors injection-scan). */
+function enabled(root: string): boolean {
+  const f = path.join(root, SETTINGS_FILE);
+  let text: string;
+  try {
+    if (!fs.statSync(f).isFile()) return false;
+    text = fs.readFileSync(f, "utf-8");
+  } catch {
+    return false;
+  }
+  let inHooks = false;
+  let inDs = false;
+  for (const raw of text.split(/\r\n|\r|\n/)) {
+    const line = raw.replace(/\s+$/, "");
+    if (!line || line.replace(/^\s+/, "").startsWith("#")) continue;
+    if (!(line.startsWith(" ") || line.startsWith("\t"))) {
+      inHooks = /^hooks\s*:\s*$/.test(line);
+      inDs = false;
+      continue;
+    }
+    if (inHooks) {
+      if (/^\s+design_slop\s*:\s*$/.test(line)) {
+        inDs = true;
+        continue;
+      }
+      if (inDs && /^\s{0,3}\S/.test(line)) inDs = false;
+    }
+    if (inDs && /^\s+enabled\s*:\s*true\b/.test(line)) return true;
+  }
+  return false;
+}
+
+/** Best-effort: pull (toolName, filePath, proposedContent) from the PreToolUse envelope. */
+function extract(envelope: JsonObject): { file: string; content: string } | null {
+  const ti = envelope["tool_input"] ?? envelope["toolInput"] ?? envelope["input"];
+  if (!isObject(ti)) return null;
+  const fileVal = ti["file_path"] ?? ti["path"] ?? ti["filePath"];
+  const file = typeof fileVal === "string" ? fileVal : "";
+  // Edit → new_string/new_str; Write → content; some hosts → text
+  for (const key of ["content", "new_string", "new_str", "text", "newText"]) {
+    const v = ti[key];
+    if (typeof v === "string" && v.length > 0) return { file, content: v };
+  }
+  return null;
+}
+
+function stateFile(root: string): string {
+  return path.join(root, "agents", "runtime", "state", "design-slop-hook.json");
+}
+
+function readState(root: string): Record<string, number> {
+  try {
+    const t = fs.readFileSync(stateFile(root), "utf-8");
+    const parsed = JSON.parse(t);
+    return isObject(parsed) ? (parsed as Record<string, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeState(root: string, state: Record<string, number>): void {
+  try {
+    const sf = stateFile(root);
+    fs.mkdirSync(path.dirname(sf), { recursive: true });
+    fs.writeFileSync(sf, JSON.stringify(state, null, 2) + "\n");
+  } catch {
+    /* fail-open: never break a write because state could not persist */
+  }
+}
+
+function readStdin(): string {
+  try {
+    return fs.readFileSync(0, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+export function main(): number {
+  let envelope: JsonValue;
+  try {
+    const raw = readStdin();
+    envelope = raw.trim() ? (JSON.parse(raw) as JsonValue) : {};
+  } catch {
+    return EXIT_ALLOW;
+  }
+  if (!isObject(envelope)) return EXIT_ALLOW;
+
+  const rootVal = envelope["cwd"] ?? envelope["project_root"] ?? ".";
+  const root = typeof rootVal === "string" && rootVal ? rootVal : ".";
+  if (!enabled(root)) return EXIT_ALLOW;
+
+  const ex = extract(envelope);
+  if (!ex || !ex.file || !UI_EXT.test(ex.file)) return EXIT_ALLOW;
+
+  let ctx: DesignContext;
+  try {
+    ctx = loadDesignContext(path.dirname(path.resolve(root, ex.file)));
+  } catch {
+    ctx = { raw: "", has: () => false };
+  }
+
+  let findings;
+  try {
+    findings = scanFile(ex.content, ex.file, ctx).filter(
+      (f) => f.severity === "P0" || f.severity === "P1",
+    );
+  } catch {
+    return EXIT_ALLOW;
+  }
+  if (findings.length === 0) return EXIT_ALLOW;
+
+  // Anti-loop degradation: drop any signature already surfaced DEGRADE_AFTER times.
+  const state = readState(root);
+  const surfaced = findings.filter((f) => {
+    const sig = `${ex.file}::${f.rule}`;
+    const seen = state[sig] ?? 0;
+    if (seen >= DEGRADE_AFTER) return false; // gone silent — never trap the agent
+    state[sig] = seen + 1;
+    return true;
+  });
+  writeState(root, state);
+
+  if (surfaced.length === 0) return EXIT_ALLOW;
+
+  const lines = surfaced
+    .map((f) => `${f.catalogId} (${f.rule}) ${f.file}:${f.line} — ${f.message}`)
+    .join("; ");
+  const reason =
+    "⚠️ Anti-slop: high-severity aesthetic tell(s) in the proposed UI — " +
+    lines +
+    ". Rebuttable: declare intent in DESIGN.md, add design-slop-disable-next-line, " +
+    "or proceed if deliberate (this is a flag, not a block).";
+  process.stdout.write(JSON.stringify({ decision: "warn", reason }) + "\n");
+  return EXIT_WARN;
+}
+
+const isCliEntry =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isCliEntry) process.exit(main());

--- a/src/scripts/hooks/design_slop_hook.ts
+++ b/src/scripts/hooks/design_slop_hook.ts
@@ -22,7 +22,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { SLOP_RULES, type DesignContext } from "../design_slop_rules.ts";
+import { type DesignContext } from "../design_slop_rules.ts";
 import { loadDesignContext, scanFile } from "../lint_design_slop.ts";
 
 const SETTINGS_FILE = ".agent-settings.yml";

--- a/src/scripts/lint_design_slop.ts
+++ b/src/scripts/lint_design_slop.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * lint_design_slop — deterministic anti-slop DETECTOR for consumer projects.
+ *
+ * The aesthetic-PROVENANCE layer that `lint_design_quality` deliberately omits.
+ * It scans HTML/CSS/JSX/Markdown for the "AI tells" catalogued in
+ * `docs/guidelines/design-antipatterns.md` and emits structured findings
+ * (rule-id + catalog-id + severity P0–P3 + file:line). The rule registry lives
+ * in `design_slop_rules.ts`.
+ *
+ * FLAGS, NEVER A HARD BLOCK. Default exit is 0 regardless of findings — slop
+ * tells are rebuttable presumptions, not failures. CI opts into failing with
+ * `--fail-on <P0|P1|P2|P3>` (fails when any finding at or above that severity
+ * remains). This honours the council 2026-06-28 "flags not blocks" verdict.
+ *
+ * Zero runtime token cost: this runs in Node (CI / pre-commit / optional hook),
+ * never in the model's context. `design-review` cites the structured `--json`
+ * output instead of reloading the 12 KB prose catalog.
+ *
+ * Dependency-free pattern analysis (no postcss/@babel) — see the design note in
+ * design_slop_rules.ts. Same posture as lint_design_quality.
+ *
+ * Usage:
+ *   npx tsx lint_design_slop.ts --dir src/ [--json] [--fail-on P1] [--quiet]
+ *
+ * Context gate: a consumer DESIGN.md (project root or scan dir) that declares a
+ * pattern as intentional suppresses the matching rule (e.g. "warm-neutral" →
+ * C5 cream-palette is not flagged). Inline-ignore (eslint-style):
+ *   design-slop-disable <rule-id>            (file scope, top of file)
+ *   design-slop-disable-next-line <rule-id>
+ *   design-slop-disable-line <rule-id>
+ * Per-project config (.design-quality.json, shared with lint_design_quality):
+ *   { "ignoreRules": ["slop-c5-cream-palette"], "ignoreFiles": ["src/legacy/**"] }
+ *
+ * Exit codes: 0 = clean OR findings-below-threshold, 2 = findings at/above
+ * --fail-on threshold, 1 = internal error.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  SLOP_RULES,
+  type DesignContext,
+  type Engine,
+  type Severity,
+} from "./design_slop_rules.ts";
+
+interface Finding {
+  rule: string;
+  catalogId: string;
+  severity: Severity;
+  file: string;
+  line: number;
+  snippet: string;
+  message: string;
+}
+
+interface ProjectConfig {
+  ignoreRules?: string[];
+  ignoreFiles?: string[];
+}
+
+const SEVERITY_ORDER: Severity[] = ["P3", "P2", "P1", "P0"];
+const sevRank = (s: Severity): number => SEVERITY_ORDER.indexOf(s);
+
+// ext → which engine-classes a file of that type can contain
+function enginesForExt(ext: string): Set<Engine> {
+  if (/\.(css|scss|sass|less)$/i.test(ext)) return new Set<Engine>(["css"]);
+  if (/\.(html|htm|vue|svelte|astro)$/i.test(ext)) return new Set<Engine>(["css", "html", "copy"]);
+  if (/\.(jsx|tsx)$/i.test(ext)) return new Set<Engine>(["css", "jsx", "copy"]);
+  if (/\.(md|mdx)$/i.test(ext)) return new Set<Engine>(["copy"]);
+  return new Set<Engine>();
+}
+
+function* walkDir(dir: string, ext: RegExp): Generator<string> {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    if (entry.isDirectory()) yield* walkDir(full, ext);
+    else if (ext.test(entry.name)) yield full;
+  }
+}
+
+function loadConfig(dir: string): ProjectConfig {
+  const p = path.join(dir, ".design-quality.json");
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf-8")) as ProjectConfig;
+  } catch {
+    return {};
+  }
+}
+
+/** Read DESIGN.md (scan dir, then project root) as the context-gate source. */
+export function loadDesignContext(scanDir: string): DesignContext {
+  const candidates = [
+    path.join(scanDir, "DESIGN.md"),
+    path.join(process.cwd(), "DESIGN.md"),
+    path.join(scanDir, "..", "DESIGN.md"),
+  ];
+  let raw = "";
+  for (const c of candidates) {
+    if (fs.existsSync(c)) {
+      raw = fs.readFileSync(c, "utf-8").toLowerCase();
+      break;
+    }
+  }
+  return {
+    raw,
+    has: (...keywords: string[]) => keywords.some((k) => raw.includes(k.toLowerCase())),
+  };
+}
+
+function parseIgnores(lines: string[]): Map<string, Set<number>> {
+  const ignores = new Map<string, Set<number>>();
+  const add = (rule: string, line: number) => {
+    const set = ignores.get(rule) ?? new Set<number>();
+    set.add(line);
+    ignores.set(rule, set);
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const file = /design-slop-disable\s+([\w-]+)/i.exec(line);
+    if (file && file[1] && !/-line|-next-line/.test(line)) {
+      ignores.set(file[1].toLowerCase(), new Set([...Array(99999).keys()].map((n) => n + 1)));
+    }
+    const next = /design-slop-disable-next-line\s+([\w-]+)/i.exec(line);
+    if (next && next[1]) add(next[1].toLowerCase(), i + 2);
+    const cur = /design-slop-disable-line\s+([\w-]+)/i.exec(line);
+    if (cur && cur[1]) add(cur[1].toLowerCase(), i + 1);
+  }
+  return ignores;
+}
+
+export function scanFile(
+  content: string,
+  relPath: string,
+  ctx: DesignContext,
+): Finding[] {
+  const lines = content.split("\n");
+  const ext = path.extname(relPath).toLowerCase();
+  const fileEngines = enginesForExt(ext);
+  if (fileEngines.size === 0) return [];
+  const ignores = parseIgnores(lines);
+
+  const out: Finding[] = [];
+  for (const rule of SLOP_RULES) {
+    if (!rule.engines.some((e) => fileEngines.has(e))) continue;
+    if (rule.gated && rule.gated(ctx)) continue; // DESIGN.md declares intent → suppress
+    let hits;
+    try {
+      hits = rule.detect({ content, lines, ext, ctx });
+    } catch {
+      continue; // a single rule throwing never kills the scan
+    }
+    for (const h of hits) {
+      const ruleIgnore = ignores.get(rule.id.toLowerCase());
+      if (ruleIgnore && ruleIgnore.has(h.line)) continue;
+      out.push({
+        rule: rule.id,
+        catalogId: rule.catalogId,
+        severity: rule.severity,
+        file: relPath,
+        line: h.line,
+        snippet: h.snippet,
+        message: rule.message,
+      });
+    }
+  }
+  return out;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const jsonMode = args.includes("--json");
+  const quiet = args.includes("--quiet");
+  const dirIdx = args.indexOf("--dir");
+  const scanDir = dirIdx >= 0 && args[dirIdx + 1] ? path.resolve(args[dirIdx + 1]!) : path.resolve(process.cwd(), "src");
+  const failIdx = args.indexOf("--fail-on");
+  const failOn = (failIdx >= 0 ? args[failIdx + 1] : undefined) as Severity | undefined;
+
+  if (!fs.existsSync(scanDir)) {
+    if (!quiet) {
+      process.stderr.write(`[lint_design_slop] scan directory not found: ${scanDir}\n`);
+      process.stderr.write("Opt-in for consumer projects. Run with --dir <path> at your UI source.\n");
+    }
+    process.exit(0);
+  }
+
+  const ctx = loadDesignContext(scanDir);
+  const config = loadConfig(process.cwd());
+  const ignoreRules = new Set((config.ignoreRules ?? []).map((r) => r.toLowerCase()));
+  const ignoreGlobs = config.ignoreFiles ?? [];
+
+  const files: string[] = [];
+  for (const f of walkDir(scanDir, /\.(html|htm|css|scss|sass|less|vue|svelte|astro|jsx|tsx|md|mdx)$/i)) {
+    if (!ignoreGlobs.some((g) => f.includes(g.replace("**", "")))) files.push(f);
+  }
+
+  const findings: Finding[] = [];
+  for (const fp of files) {
+    const rel = path.relative(process.cwd(), fp);
+    try {
+      const fileFindings = scanFile(fs.readFileSync(fp, "utf-8"), rel, ctx).filter(
+        (f) => !ignoreRules.has(f.rule.toLowerCase()),
+      );
+      findings.push(...fileFindings);
+    } catch (err) {
+      if (!quiet) process.stderr.write(`[lint_design_slop] error: ${fp}: ${err}\n`);
+    }
+  }
+
+  findings.sort((a, b) => sevRank(b.severity) - sevRank(a.severity));
+
+  const overThreshold = failOn
+    ? findings.filter((f) => sevRank(f.severity) >= sevRank(failOn))
+    : [];
+
+  if (jsonMode) {
+    process.stdout.write(JSON.stringify({ findings, failOn: failOn ?? null, overThreshold: overThreshold.length }, null, 2) + "\n");
+    process.exit(overThreshold.length > 0 ? 2 : 0);
+  }
+
+  if (findings.length === 0) {
+    if (!quiet) process.stdout.write(`✅  lint_design_slop: no anti-slop tells in ${files.length} file(s).\n`);
+    process.exit(0);
+  }
+
+  for (const f of findings) {
+    const icon = f.severity === "P0" || f.severity === "P1" ? "⚠️ " : "•";
+    process.stdout.write(`${icon} [${f.severity} ${f.catalogId}] ${f.file}:${f.line} (${f.rule}) — ${f.message}\n     ${f.snippet}\n`);
+  }
+  process.stdout.write(
+    `\nlint_design_slop: ${findings.length} tell(s) flagged (rebuttable — declare intent in DESIGN.md, ` +
+      `design-slop-disable-next-line <rule>, or .design-quality.json).` +
+      (failOn ? ` ${overThreshold.length} at/above ${failOn}.` : " Flags only; no CI failure (pass --fail-on to gate).") +
+      "\n",
+  );
+  process.exit(overThreshold.length > 0 ? 2 : 0);
+}
+
+// Run only when invoked directly (not when imported by the test guard).
+const invokedDirectly =
+  process.argv[1] !== undefined && /lint_design_slop\.ts$/.test(process.argv[1]);
+if (invokedDirectly) main();

--- a/src/scripts/lint_design_slop.ts
+++ b/src/scripts/lint_design_slop.ts
@@ -42,7 +42,7 @@ import {
   type DesignContext,
   type Engine,
   type Severity,
-} from "./design_slop_rules.ts";
+} from "./design_slop_rules.js";
 
 interface Finding {
   rule: string;

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -367,6 +367,11 @@ export const settingsSchema = z.object({
                 'PreToolUse RTK-wrap nudge (token-saving Phase 3). Default off. When on AND rtk is on PATH (a live probe — not a self-reported flag), warns (never blocks) "re-run wrapped with rtk" before a single verbose CLI command (git/npm/cargo/docker/…) for 60–90% token saving. Skips completeness-critical / piped / compound commands and git diff. No-op when rtk is absent.',
             ),
         }).default({}),
+        design_slop: z.object({
+            enabled: z.boolean().default(false).describe(
+                'PreToolUse anti-slop nudge (road-to-anti-slop-detector Phase 3). Default off. When on, runs the lint_design_slop registry against about-to-be-written UI content and WARNS (never blocks) on P0/P1 aesthetic tells (side-stripe, gradient-text, magic z-index, …). Flags are rebuttable via DESIGN.md / design-slop-disable. Anti-loop: a file::rule signature surfaced 3x goes silent. Host-limited convenience layer; the universal gate is the lint_design_slop linter/CI.',
+            ),
+        }).default({}),
     }),
     decision_engine: z.object({
         surface_traces: z.boolean().default(false).describe(

--- a/src/skills/design-review/SKILL.md
+++ b/src/skills/design-review/SKILL.md
@@ -287,17 +287,31 @@ This is especially useful when the user provides a screenshot or Figma export as
 
 ## Anti-slop scan
 
-During any design review, load
-[`docs/guidelines/design-antipatterns.md`](../../../docs/guidelines/design-antipatterns.md)
-as a reference. After the structured review phases, add an explicit
-**Anti-Slop Check** section to the review output:
+Hybrid: a deterministic detector does the mechanical pattern-matching (zero
+token cost, no catalog reload); you do the judgment it cannot. After the
+structured review phases, add an explicit **Anti-Slop Check** section:
 
-1. List any patterns from the catalog that appear in the reviewed UI (cite by
-   entry ID, e.g. V1, T2, C1).
-2. For each finding: note whether an override condition is in effect (if yes,
-   verify it is stated in the design brief; if not, flag as a finding).
+1. **Run the deterministic detector first** — it catches the pattern-detectable
+   tells so you don't eyeball or re-derive them:
+   ```
+   npx tsx src/scripts/lint_design_slop.ts --dir <consumer-ui-path> --json
+   ```
+   Each finding carries `rule` (e.g. `slop-v1-side-stripe`), `catalogId`
+   (`V1`), `severity` (`P0`–`P3`), `file:line`, and a `message`. **Cite these
+   verbatim** (rule-id + catalogId + file:line) — do not re-describe them from
+   the prose catalog. Findings are *rebuttable presumptions*: a finding the
+   consumer's `DESIGN.md` gate suppresses is already filtered out; a remaining
+   finding means the project has not declared the pattern as intentional.
+   `lint_design_slop` is **flags, never a block** (default exit 0; CI opts into
+   failure via `--fail-on`).
+2. **Judge what the detector cannot** — load
+   [`docs/guidelines/design-antipatterns.md`](../../../docs/guidelines/design-antipatterns.md)
+   for the tells that need structural/aesthetic judgment (e.g. T3 icon-tile
+   stack, L2 three-identical-card grid, V2 glassmorphism intent). List any that
+   appear, cite by entry ID, and check the override condition.
 3. Run the AI-slop originality self-test on the overall aesthetic direction.
-   Report the result (pass / flag / fail) with one sentence of evidence.
+   Report the result (pass / flag / fail) with one sentence of evidence — this
+   is the human judgment the detector deliberately does not make.
 
 For the **objective quality floors** (WCAG contrast, font-size, line-length,
 reduced-motion, heading hierarchy, focus indicator), do NOT eyeball them —

--- a/tests/test_frontmatter_strict_yaml.py
+++ b/tests/test_frontmatter_strict_yaml.py
@@ -1,0 +1,74 @@
+"""Strict-YAML gate for artefact frontmatter.
+
+Regression guard for the Zed "invalid yaml formatter" class: the lenient
+subset parser in ``validate_frontmatter._parse_yaml_block`` strips matching
+outer quotes without checking the inner content, so malformed frontmatter
+sailed through schema validation and only broke in stricter consumers
+(Zed, any PyYAML-based reader). ``strict_yaml_error`` closes that gap.
+
+Both code paths are exercised: the PyYAML path (source of truth, same parser
+real consumers use) and the stdlib structural fallback (so the gate never
+silently no-ops when PyYAML is absent).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src" / "scripts"))
+
+import validate_frontmatter as V  # noqa: E402
+
+# Each case: (label, frontmatter-body-text, expect_error)
+BROKEN_INNER_QUOTES = '---\nname: x\ndescription: "say "hi" now"\n---\nbody\n'
+BROKEN_BARE_COLON = "---\nname: x\ndescription: outside DE:/EN: blocks\n---\nbody\n"
+OK_ESCAPED_QUOTES = '---\nname: x\ndescription: "say \\"hi\\" now"\n---\nbody\n'
+OK_QUOTED_COLON = '---\nname: x\ndescription: "outside DE:/EN: blocks"\n---\nbody\n'
+OK_PLAIN = "---\nname: x\ndescription: a plain description\n---\nbody\n"
+
+CASES = [
+    ("broken_inner_quotes", BROKEN_INNER_QUOTES, True),
+    ("broken_bare_colon", BROKEN_BARE_COLON, True),
+    ("ok_escaped_quotes", OK_ESCAPED_QUOTES, False),
+    ("ok_quoted_colon", OK_QUOTED_COLON, False),
+    ("ok_plain", OK_PLAIN, False),
+]
+
+
+@pytest.mark.parametrize("label,text,expect_error", CASES, ids=[c[0] for c in CASES])
+def test_strict_yaml_error_pyyaml_path(label, text, expect_error):
+    if V._yaml is None:
+        pytest.skip("PyYAML not importable in this environment")
+    err = V.strict_yaml_error(text)
+    assert (err is not None) is expect_error, f"{label}: {err!r}"
+
+
+@pytest.mark.parametrize("label,text,expect_error", CASES, ids=[c[0] for c in CASES])
+def test_strict_yaml_error_stdlib_fallback(monkeypatch, label, text, expect_error):
+    # Force the no-PyYAML branch so the structural fallback is covered even
+    # where PyYAML is installed.
+    monkeypatch.setattr(V, "_yaml", None)
+    err = V.strict_yaml_error(text)
+    assert (err is not None) is expect_error, f"{label}: {err!r}"
+
+
+def test_missing_frontmatter_is_not_an_error():
+    assert V.strict_yaml_error("no frontmatter here\n") is None
+
+
+def test_live_artefacts_all_parse_strictly():
+    """Every shipped artefact frontmatter must pass the strict gate."""
+    sys.path.insert(0, str(REPO_ROOT / "src" / "scripts"))
+    from _lib.agent_src import artefact_roots  # noqa: E402
+    from validate_frontmatter import _iter_artefacts  # noqa: E402
+
+    offenders = []
+    for root in artefact_roots():
+        for _type, path in _iter_artefacts(root):
+            err = V.strict_yaml_error(path.read_text(encoding="utf-8"))
+            if err is not None:
+                offenders.append(f"{path}: {err}")
+    assert not offenders, "Frontmatter fails strict YAML:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary

Ships the **deterministic anti-slop detector** (the #1-ranked axis from a
design/taste/anti-slop reference analysis + AI-council session) and the four
remaining harvest roadmaps it sits alongside.

The detector turns the prose anti-slop catalog into a **dependency-free linter**
with **zero runtime token cost** (runs in Node/CI, not in model context) — the
council-validated resolution to the token-frugality tension.

### Detector (Phase 0–4, complete)

- `src/scripts/design_slop_rules.ts` — 14-rule registry, each citing a catalog
  id (`V1/V3/V6/C2/C5/T4/T6/T7/L4/L8/M2/M4/CP1/CP2`). Pattern-based matchers —
  no postcss/@babel (this package is dependency-free by design and ships via
  `npx`; the assumed parser libs are absent, so the approach was adapted to
  match the existing `lint_design_quality`).
- `src/scripts/lint_design_slop.ts` — sibling linter. **Flags, never blocks**:
  default exit 0; CI opts into failure via `--fail-on <P0..P3>`. `--json`,
  `DESIGN.md` context gates, `design-slop-disable` inline-ignore.
- `src/scripts/design_slop_rules.test.ts` — 20 tests; one positive + one
  negative fixture per rule (no untested tell; negatives are the per-rule
  false-positive guard).
- `design-review` "Anti-slop scan" now runs the detector first and cites the
  structured findings, then judges what it cannot (`T3`/`L2`/`V2` +
  originality self-test). Re-condensed to `dist/`; hashes in sync.
- `design-antipatterns.md` — Detection row + traceability of backed catalog ids.
- `src/scripts/hooks/design_slop_hook.ts` — **OPTIONAL** PreToolUse nudge (warn
  exit-2, never block; anti-loop degradation after 3 repeats). Concern
  `design-slop` bound to `pre_tool_use` on augment/claude/cowork;
  `hooks.design_slop.enabled` default **false** in template + schema.

### Harvest roadmaps (ready)

Four anonymized roadmaps (Source A–E, encrypted provenance per
`source-confidentiality`): taste-dials-and-locks, design-canon-grounding,
shadcn-registry-awareness, design-system-extraction-contract.
`road-to-anti-slop-detector` is the one implemented here, archived.

## Test plan

- `npx vitest run src/scripts/design_slop_rules.test.ts` → 20/20.
- `skill_linter src/skills/design-review/SKILL.md` → PASS (0 issues).
- `lint_hook_manifest` → exit 0; `condense --check` → in sync.
- Hook smoke: OFF→exit0, ON→exit2 warn, anti-loop→silent after 3.
- CLI smoke: detects tells, `DESIGN.md` gate suppresses, `--fail-on P1`→exit2.

## Notes / caveats

- The `.claude/` + `.cursor/` tool-projection of `design-review` is **stale**
  (`task generate-tools` reported 0 — the known `tools:[]` projection
  friction); `src/`, `dist/`, and `.augment/` (symlinked) are correct. A clean
  tool-gen pass will propagate it.
- The third commit (`chore: …`) holds **two pre-existing untracked files** that
  predate this work (`internal/bench/reports/quality-run.json`,
  `tests/test_frontmatter_strict_yaml.py`) — included per request to commit all
  uncommitted files, isolated so they can be dropped if unwanted.
