### PR TITLE
test(py2ts): convert the templates_* parity cluster to python-free intent tests (10 files)

### DIFF
--- a/tests/scripts/templates_check_memory.test.ts
+++ b/tests/scripts/templates_check_memory.test.ts
@@ -1,18 +1,21 @@
-// Golden-parity tests for src/agent-src/templates/scripts/check_memory.ts.
+// Intent tests for src/agent-src/templates/scripts/check_memory.ts.
 //
-// CONSUMER-shipped template twin. The template `.py` is the leaner consumer
-// surface — NO `--shadow-report`, NO priority / date-discipline / critical-stale
-// / tier-0-inflation checks (those are dev-side-only). Tests differential python3
-// vs tsx on the template files. The scanned root is taken from `--path`, and
-// `str(Path)` of relative roots is CWD-relative, so both processes run with `cwd`
-// set to a tmp fixture tree and a relative `--path agents/memory`. ADR-094 parity
-// contract: byte-identical stdout/stderr/exit. argparse prog token
-// (check_memory.py vs check_memory) is filename-derived, not parity.
+// Was a python3-vs-tsx byte-parity rig; the template `.py` is gone, so this now
+// asserts the tsx template-script's own contract directly. This is the
+// CONSUMER-shipped template twin — the leaner consumer surface (NO
+// `--shadow-report`, NO priority / date-discipline / critical-stale /
+// tier-0-inflation checks; those are dev-side-only). The scanned root is taken
+// from `--path`, and `str(Path)` of relative roots is CWD-relative, so the
+// process runs with `cwd` set to a tmp fixture tree and a relative
+// `--path agents/memory`. To stay deterministic regardless of the runner's
+// installed CLIs, the tsx launcher is spawned with a **node-only PATH** (a temp
+// dir holding just a `node` symlink) and COLUMNS=200. Output is fully stable
+// (no clock / tmp-path leakage in the cases below) so it is inline-snapshotted.
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -21,12 +24,13 @@ const TSX_BIN =
         : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(DIR, 'check_memory.ts');
-const PY_SCRIPT = join(DIR, 'check_memory.py');
 
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = pythonAvailable();
+// node-only PATH → deterministic env (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(join(tmpdir(), 'tpl-cm-nodeonly-'));
+symlinkSync(process.execPath, join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface Run {
     stdout: string;
@@ -34,23 +38,19 @@ interface Run {
     status: number;
 }
 function runTs(args: readonly string[], cwd: string): Run {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        encoding: 'utf8',
+        cwd,
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
+    });
     return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
 }
-function runPy(args: readonly string[], cwd: string): Run {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
-}
-function normProg(s: string): string {
-    return s.replace(/check_memory\.py/g, 'check_memory').trimEnd();
-}
-// Python argparse prefixes a `usage:` block whose line-wrapping is
-// terminal-width-dependent — NOT a stable parity contract. The byte-identical
+// Python argparse used a terminal-width-dependent `usage:` block; the stable
 // contract is the trailing `<prog>: error: <msg>` line.
 function errorLine(stderr: string): string {
-    const lines = normProg(stderr).split('\n');
+    const lines = stderr.trimEnd().split('\n');
     const found = lines.find((l) => /^check_memory: error:/.test(l));
-    return found ?? normProg(stderr);
+    return found ?? stderr.trimEnd();
 }
 
 const REQUIRED = [
@@ -64,7 +64,7 @@ const REQUIRED = [
     'review_after_days: 180',
 ];
 
-describe.skipIf(!HAVE_PYTHON)('templates/check_memory — golden parity', () => {
+describe('templates/check_memory — intent', () => {
     let tmp: string;
     beforeEach(() => {
         tmp = mkdtempSync(join(tmpdir(), 'tpl-cm-'));
@@ -80,59 +80,132 @@ describe.skipIf(!HAVE_PYTHON)('templates/check_memory — golden parity', () => 
         writeFileSync(full, body);
     }
 
-    function bothEqual(args: readonly string[]): void {
-        const ts = runTs(args, tmp);
-        const py = runPy(args, tmp);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-    }
-
-    it('missing path parity (info, exit 0)', () => {
-        bothEqual(['--path', 'agents/memory/nope']);
+    it('missing path (info, exit 0)', () => {
+        expect(runTs(['--path', 'agents/memory/nope'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "ℹ️  agents/memory/nope not found — nothing to validate
+          ",
+          }
+        `);
     });
 
-    it('missing path JSON parity', () => {
-        bothEqual(['--path', 'agents/memory/nope', '--format', 'json']);
+    it('missing path JSON', () => {
+        expect(runTs(['--path', 'agents/memory/nope', '--format', 'json'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"findings": [], "note": "agents/memory/nope not found"}
+          ",
+          }
+        `);
     });
 
-    it('valid entries parity (clean)', () => {
+    it('valid entries (clean)', () => {
         writeYml('domain-invariants/d.yml', `entries:\n  - ${REQUIRED.join('\n    ')}\n`);
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "
+          Summary: 0 error(s), 0 warning(s), 0 info
+          ",
+          }
+        `);
     });
 
-    it('missing required fields parity (errors, sorted)', () => {
+    it('missing required fields (errors, sorted)', () => {
         writeYml('domain-invariants/bad.yml', 'entries:\n  - id: x\n    status: active\n');
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "  ❌  agents/memory/domain-invariants/bad.yml [x]  missing required field: confidence
+            ❌  agents/memory/domain-invariants/bad.yml [x]  missing required field: last_validated
+            ❌  agents/memory/domain-invariants/bad.yml [x]  missing required field: owner
+            ❌  agents/memory/domain-invariants/bad.yml [x]  missing required field: review_after_days
+            ❌  agents/memory/domain-invariants/bad.yml [x]  missing required field: source
+            ❌  agents/memory/domain-invariants/bad.yml [x]  source must be a list with ≥1 entry
+
+          Summary: 6 error(s), 0 warning(s), 0 info
+          ",
+          }
+        `);
     });
 
-    it('redaction leak parity (inline credential + internal ip)', () => {
+    it('redaction leak (inline credential + internal ip)', () => {
         writeYml(
             'incident-learnings/leak.yml',
             ['entries:', '  - id: y', '    note: "api_key=ABCDEFGH12345678"', '    host: 10.0.0.5'].join('\n') + '\n',
         );
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "  ❌  agents/memory/incident-learnings/leak.yml:3  possible leak: inline credential
+            ❌  agents/memory/incident-learnings/leak.yml:4  possible leak: internal ipv4 range
+            ❌  agents/memory/incident-learnings/leak.yml [y]  missing required field: confidence
+            ❌  agents/memory/incident-learnings/leak.yml [y]  missing required field: last_validated
+            ❌  agents/memory/incident-learnings/leak.yml [y]  missing required field: owner
+            ❌  agents/memory/incident-learnings/leak.yml [y]  missing required field: review_after_days
+            ❌  agents/memory/incident-learnings/leak.yml [y]  missing required field: source
+            ❌  agents/memory/incident-learnings/leak.yml [y]  missing required field: status
+            ❌  agents/memory/incident-learnings/leak.yml [y]  source must be a list with ≥1 entry
+
+          Summary: 9 error(s), 0 warning(s), 0 info
+          ",
+          }
+        `);
     });
 
-    it('unknown memory type parity (warning)', () => {
+    it('unknown memory type (warning)', () => {
         writeYml('weird-type/w.yml', 'entries: []\n');
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  ⚠️  agents/memory/weird-type/w.yml  unknown memory type 'weird-type'
+
+          Summary: 0 error(s), 1 warning(s), 0 info
+          ",
+          }
+        `);
     });
 
-    it('duplicate id parity (error)', () => {
+    it('duplicate id (error)', () => {
         writeYml(
             'product-rules/dup.yml',
             `entries:\n  - ${REQUIRED.join('\n    ')}\n  - ${REQUIRED.join('\n    ')}\n`,
         );
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "  ❌  agents/memory/product-rules/dup.yml [own-1]  duplicate id 'own-1'
+
+          Summary: 1 error(s), 0 warning(s), 0 info
+          ",
+          }
+        `);
     });
 
-    it('missing top-level entries parity (error)', () => {
+    it('missing top-level entries (error)', () => {
         writeYml('architecture-decisions/noentries.yml', 'id: z\nfoo: bar\n');
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "  ⚠️  agents/memory/architecture-decisions/noentries.yml  unknown memory type 'architecture-decisions'
+            ❌  agents/memory/architecture-decisions/noentries.yml  missing top-level 'entries' key
+
+          Summary: 1 error(s), 1 warning(s), 0 info
+          ",
+          }
+        `);
     });
 
-    it('stale entry parity (info)', () => {
+    it('stale entry (info)', () => {
         writeYml(
             'domain-invariants/stale.yml',
             [
@@ -147,27 +220,91 @@ describe.skipIf(!HAVE_PYTHON)('templates/check_memory — golden parity', () => 
                 '    review_after_days: 1',
             ].join('\n') + '\n',
         );
-        bothEqual(['--path', 'agents/memory']);
+        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  ℹ️  agents/memory/domain-invariants/stale.yml [old-1]  stale: last_validated 9676 days ago (limit 1)
+
+          Summary: 0 error(s), 0 warning(s), 1 info
+          ",
+          }
+        `);
     });
 
-    it('JSON format parity over mixed findings', () => {
+    it('JSON format over mixed findings', () => {
         writeYml('domain-invariants/bad.yml', 'entries:\n  - id: x\n    status: nope\n');
-        bothEqual(['--path', 'agents/memory', '--format', 'json']);
+        expect(runTs(['--path', 'agents/memory', '--format', 'json'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "{
+            "findings": [
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "missing required field: confidence",
+                "entry_id": "x"
+              },
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "missing required field: last_validated",
+                "entry_id": "x"
+              },
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "missing required field: owner",
+                "entry_id": "x"
+              },
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "missing required field: review_after_days",
+                "entry_id": "x"
+              },
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "missing required field: source",
+                "entry_id": "x"
+              },
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "invalid status 'nope'",
+                "entry_id": "x"
+              },
+              {
+                "file": "agents/memory/domain-invariants/bad.yml",
+                "line": 0,
+                "severity": "error",
+                "message": "source must be a list with \\u22651 entry",
+                "entry_id": "x"
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('unrecognized arg parity (exit 2)', () => {
+    it('unrecognized arg (exit 2)', () => {
         const ts = runTs(['--bogus'], tmp);
-        const py = runPy(['--bogus'], tmp);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(2);
-        expect(errorLine(ts.stderr)).toBe(errorLine(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"check_memory: error: unrecognized arguments: --bogus"`);
     });
 
-    it('invalid --format choice parity (exit 2)', () => {
+    it('invalid --format choice (exit 2)', () => {
         const ts = runTs(['--format', 'xml'], tmp);
-        const py = runPy(['--format', 'xml'], tmp);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(2);
-        expect(errorLine(ts.stderr)).toBe(errorLine(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"check_memory: error: argument --format: invalid choice: 'xml' (choose from 'text', 'json')"`);
     });
 });

--- a/tests/scripts/templates_check_memory_proposal.test.ts
+++ b/tests/scripts/templates_check_memory_proposal.test.ts
@@ -1,17 +1,19 @@
-// Golden-parity tests for src/agent-src/templates/scripts/check_memory_proposal.ts.
+// Intent tests for src/agent-src/templates/scripts/check_memory_proposal.ts.
 //
-// CONSUMER-shipped template twin. The template `.py` differs from the dev-side
-// only by lacking the `--quiet` flag, so this twin drops `--quiet` and its
-// gate-passed line always prints. Tests differential python3 vs tsx on the
-// template files. INTAKE_ROOT is `agents/memory/intake` relative to CWD, so both
-// processes run with `cwd` set to a tmp fixture tree. ADR-094 parity contract:
-// byte-identical stdout/stderr/exit. argparse prog token (check_memory_proposal.py
-// vs check_memory_proposal) is filename-derived, not parity — normalized away.
+// Was a python3-vs-tsx byte-parity rig; the template `.py` is gone, so this now
+// asserts the tsx template-script's own contract directly. This is the
+// CONSUMER-shipped template twin — it differs from the dev-side only by lacking
+// the `--quiet` flag, so the gate-passed line always prints. INTAKE_ROOT is
+// `agents/memory/intake` relative to CWD, so the process runs with `cwd` set to
+// a tmp fixture tree. To stay deterministic regardless of the runner's installed
+// CLIs, the tsx launcher is spawned with a **node-only PATH** (a temp dir holding
+// just a `node` symlink) and COLUMNS=200. All fixture references are CWD-relative
+// (e.g. `--proposal p.yml`), so no absolute tmp path leaks into a snapshot.
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -20,12 +22,13 @@ const TSX_BIN =
         : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(DIR, 'check_memory_proposal.ts');
-const PY_SCRIPT = join(DIR, 'check_memory_proposal.py');
 
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = pythonAvailable();
+// node-only PATH → deterministic env (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(join(tmpdir(), 'tpl-cmp-nodeonly-'));
+symlinkSync(process.execPath, join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface Run {
     stdout: string;
@@ -33,27 +36,22 @@ interface Run {
     status: number;
 }
 function runTs(args: readonly string[], cwd: string): Run {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        encoding: 'utf8',
+        cwd,
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
+    });
     return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
 }
-function runPy(args: readonly string[], cwd: string): Run {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
-}
-function normProg(s: string): string {
-    return s.replace(/check_memory_proposal\.py/g, 'check_memory_proposal').trimEnd();
-}
-// Python argparse prefixes a `usage:` block whose line-wrapping is
-// terminal-width-dependent (COLUMNS / shutil.get_terminal_size) — NOT a stable
-// parity contract, like the filename-derived prog token. The byte-identical
-// contract is the trailing `<prog>: error: <msg>` line; extract just that.
+// Python argparse used a terminal-width-dependent `usage:` block; the stable
+// contract is the trailing `<prog>: error: <msg>` line.
 function errorLine(stderr: string): string {
-    const lines = normProg(stderr).split('\n');
+    const lines = stderr.trimEnd().split('\n');
     const found = lines.find((l) => /^check_memory_proposal: error:/.test(l));
-    return found ?? normProg(stderr);
+    return found ?? stderr.trimEnd();
 }
 
-describe.skipIf(!HAVE_PYTHON)('templates/check_memory_proposal — golden parity', () => {
+describe('templates/check_memory_proposal — intent', () => {
     let tmp: string;
     beforeEach(() => {
         tmp = mkdtempSync(join(tmpdir(), 'tpl-cmp-'));
@@ -63,15 +61,7 @@ describe.skipIf(!HAVE_PYTHON)('templates/check_memory_proposal — golden parity
         rmSync(tmp, { recursive: true, force: true });
     });
 
-    function bothEqual(args: readonly string[]): void {
-        const ts = runTs(args, tmp);
-        const py = runPy(args, tmp);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-    }
-
-    it('--proposal gate pass parity (line always prints — no --quiet)', () => {
+    it('--proposal gate pass (line always prints — no --quiet)', () => {
         const p = join(tmp, 'p.yml');
         writeFileSync(
             p,
@@ -86,34 +76,71 @@ describe.skipIf(!HAVE_PYTHON)('templates/check_memory_proposal — golden parity
                 '  - {decision: c, expected_by: 2026-01-03, owner: me}',
             ].join('\n') + '\n',
         );
-        bothEqual(['--proposal', 'p.yml']);
+        expect(runTs(['--proposal', 'p.yml'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "✅  p.yml — gate passed
+          ",
+          }
+        `);
     });
 
-    it('--proposal gate fail parity (missing fields + bad type + weak fds)', () => {
+    it('--proposal gate fail (missing fields + bad type + weak fds)', () => {
         const p = join(tmp, 'bad.yml');
         writeFileSync(p, ['id: x', 'entry_type: not-a-type', 'body: y'].join('\n') + '\n');
-        bothEqual(['--proposal', 'bad.yml']);
+        expect(runTs(['--proposal', 'bad.yml'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "❌  bad.yml — gate failed:
+            🔴 missing field: \`path\`
+            🔴 entry_type \`not-a-type\` not in ['domain-invariants', 'historical-patterns', 'incident-learnings', 'ownership', 'product-rules']
+            🔴 weak pattern evidence (0 sibling path(s)) and future_decisions insufficient:
+            🔴   - future_decisions: missing or not a list
+          ",
+          }
+        `);
     });
 
-    it('--proposal gate fail JSON parity', () => {
+    it('--proposal gate fail JSON', () => {
         const p = join(tmp, 'bad.yml');
         writeFileSync(p, ['id: x', 'entry_type: bogus'].join('\n') + '\n');
-        bothEqual(['--proposal', 'bad.yml', '--format', 'json']);
+        expect(runTs(['--proposal', 'bad.yml', '--format', 'json'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "",
+            "stdout": "{
+            "source": "bad.yml",
+            "failures": [
+              "missing field: \`path\`",
+              "missing field: \`body\`",
+              "entry_type \`bogus\` not in ['domain-invariants', 'historical-patterns', 'incident-learnings', 'ownership', 'product-rules']",
+              "weak pattern evidence (0 sibling path(s)) and future_decisions insufficient:",
+              "  - future_decisions: missing or not a list"
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('--proposal non-mapping parity (exit 1)', () => {
+    it('--proposal non-mapping (exit 1)', () => {
         const p = join(tmp, 'list.yml');
         writeFileSync(p, '- a\n- b\n');
         const ts = runTs(['--proposal', 'list.yml'], tmp);
-        const py = runPy(['--proposal', 'list.yml'], tmp);
-        // stderr contains the absolute proposal path; normalize CWD-relative.
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(1);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "error: list.yml is not a YAML mapping
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('--intake-id found parity (pattern via ≥2 sibling paths)', () => {
+    it('--intake-id found (pattern via ≥2 sibling paths)', () => {
         const intake = join(tmp, 'agents', 'memory', 'intake', 'a.jsonl');
         writeFileSync(
             intake,
@@ -122,28 +149,38 @@ describe.skipIf(!HAVE_PYTHON)('templates/check_memory_proposal — golden parity
                 JSON.stringify({ id: 'i-2', entry_type: 'ownership', path: 'app/B', body: 'shared' }),
             ].join('\n') + '\n',
         );
-        bothEqual(['--intake-id', 'i-1']);
+        expect(runTs(['--intake-id', 'i-1'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "✅  intake:i-1 — gate passed
+          ",
+          }
+        `);
     });
 
-    it('--intake-id not-found parity (exit 1)', () => {
-        bothEqual(['--intake-id', 'does-not-exist']);
+    it('--intake-id not-found (exit 1)', () => {
+        expect(runTs(['--intake-id', 'does-not-exist'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "error: no intake entry with id=does-not-exist
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('mutually-exclusive args parity (exit 2)', () => {
+    it('mutually-exclusive args (exit 2)', () => {
         const p = join(tmp, 'p.yml');
         writeFileSync(p, 'id: x\n');
         const ts = runTs(['--proposal', 'p.yml', '--intake-id', 'z'], tmp);
-        const py = runPy(['--proposal', 'p.yml', '--intake-id', 'z'], tmp);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(2);
-        expect(errorLine(ts.stderr)).toBe(errorLine(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"check_memory_proposal: error: argument --intake-id: not allowed with argument --proposal"`);
     });
 
-    it('no required group parity (exit 2)', () => {
+    it('no required group (exit 2)', () => {
         const ts = runTs([], tmp);
-        const py = runPy([], tmp);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(2);
-        expect(errorLine(ts.stderr)).toBe(errorLine(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"check_memory_proposal: error: one of the arguments --intake-id --proposal is required"`);
     });
 });

--- a/tests/scripts/templates_memory_hash.test.ts
+++ b/tests/scripts/templates_memory_hash.test.ts
@@ -1,13 +1,13 @@
-// Golden-parity tests for src/agent-src/templates/scripts/memory_hash.ts.
+// Intent tests for src/agent-src/templates/scripts/memory_hash.ts.
 //
-// The CONSUMER-shipped template twin. Its template `.py` is byte-identical to
-// the dev-side `src/scripts/memory_hash.py`, so this twin reuses the dev-side
-// logic verbatim. These tests differential python3 vs tsx on the template files
-// directly (distinct `templates_` prefix to avoid colliding with the dev-side
-// `tests/scripts/memory_hash.test.ts`). ADR-094 parity contract: byte-identical
-// stdout/stderr/exit. argparse derives the prog token from the script basename
-// (`memory_hash.py` vs `memory_hash`), so usage/error prog tokens are NOT a
-// parity contract — normalized away before comparing.
+// Was a python3-vs-tsx byte-parity rig; the template `.py` is gone, so this now
+// asserts the tsx template-script's own contract directly. This is the
+// CONSUMER-shipped template twin (its template `.py` was byte-identical to the
+// dev-side `src/scripts/memory_hash.py`). The script is a pure stdin/file ->
+// canonical-hash transform with no clock / random / host-CLI dependency, so its
+// output is fully deterministic. Each case is inline-snapshotted. (Inline
+// snapshots can't be written per-iteration inside `it.each`, so the former
+// json-stdin parametrization is unrolled into one `it` per fixture.)
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -21,12 +21,6 @@ const TSX_BIN =
         : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(DIR, 'memory_hash.ts');
-const PY_SCRIPT = join(DIR, 'memory_hash.py');
-
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = pythonAvailable();
 
 interface Run {
     stdout: string;
@@ -40,19 +34,15 @@ function runTs(args: readonly string[], input?: string): Run {
     });
     return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
 }
-function runPy(args: readonly string[], input?: string): Run {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], {
-        encoding: 'utf8',
-        ...(input !== undefined ? { input } : {}),
-    });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
-}
-// Prog token is filename-derived (memory_hash.py vs memory_hash) — not parity.
-function normProg(s: string): string {
-    return s.replace(/memory_hash\.py/g, 'memory_hash').trimEnd();
+// Python argparse used a terminal-width-dependent `usage:` block; the stable
+// contract is the trailing `<prog>: error: <msg>` line.
+function errorLine(stderr: string): string {
+    const lines = stderr.trimEnd().split('\n');
+    const found = lines.find((l) => /^memory_hash: error:/.test(l));
+    return found ?? stderr.trimEnd();
 }
 
-describe.skipIf(!HAVE_PYTHON)('templates/memory_hash — golden parity', () => {
+describe('templates/memory_hash — intent', () => {
     let tmp: string;
     beforeEach(() => {
         tmp = mkdtempSync(join(tmpdir(), 'tpl-memhash-'));
@@ -61,68 +51,119 @@ describe.skipIf(!HAVE_PYTHON)('templates/memory_hash — golden parity', () => {
         rmSync(tmp, { recursive: true, force: true });
     });
 
-    const jsonCases: ReadonlyArray<unknown> = [
-        { id: 'x', body: 'b', tags: ['z', 'a'] },
-        { id: 'café ☕', nested: { z: 1, a: 2 }, list: [3, 2, 1] },
-        ['a', 'b', { k: 'v' }],
-        { bool: true, none: null, num: 42, flt: 3.14 },
-        { unicode: 'naïve — résumé', emoji: '🎯' },
-    ];
-
-    it.each(jsonCases.map((c) => [JSON.stringify(c)]))('--json-stdin parity for %s', (input) => {
-        const ts = runTs(['--json-stdin'], input);
-        const py = runPy(['--json-stdin'], input);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('--json-stdin: simple object with tags', () => {
+        const input = JSON.stringify({ id: 'x', body: 'b', tags: ['z', 'a'] });
+        expect(runTs(['--json-stdin'], input)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "dbbf67c86322
+          ",
+          }
+        `);
     });
 
-    it('--json-stdin scalar error parity (exit 1)', () => {
-        const input = '"justastring"';
-        const ts = runTs(['--json-stdin'], input);
-        const py = runPy(['--json-stdin'], input);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('--json-stdin: nested + unicode keys', () => {
+        const input = JSON.stringify({ id: 'café ☕', nested: { z: 1, a: 2 }, list: [3, 2, 1] });
+        expect(runTs(['--json-stdin'], input)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "5de6f31b72ed
+          ",
+          }
+        `);
+    });
+
+    it('--json-stdin: top-level array', () => {
+        const input = JSON.stringify(['a', 'b', { k: 'v' }]);
+        expect(runTs(['--json-stdin'], input)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "59ad89063886
+          ",
+          }
+        `);
+    });
+
+    it('--json-stdin: scalar mix (bool/null/num/float)', () => {
+        const input = JSON.stringify({ bool: true, none: null, num: 42, flt: 3.14 });
+        expect(runTs(['--json-stdin'], input)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "d00deb460a0a
+          ",
+          }
+        `);
+    });
+
+    it('--json-stdin: unicode + emoji values', () => {
+        const input = JSON.stringify({ unicode: 'naïve — résumé', emoji: '🎯' });
+        expect(runTs(['--json-stdin'], input)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "5c29887aa641
+          ",
+          }
+        `);
+    });
+
+    it('--json-stdin scalar error (exit 1)', () => {
+        const ts = runTs(['--json-stdin'], '"justastring"');
         expect(ts.status).toBe(1);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "error: expected object/array, got str
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('--yaml date scalar parity', () => {
+    it('--yaml date scalar', () => {
         const p = join(tmp, 'entry.yml');
         writeFileSync(
             p,
             ['id: own-01', 'status: active', 'last_validated: 2026-01-01', 'review_after_days: 180', 'path: "app/Http/**"'].join('\n') + '\n',
         );
         const ts = runTs(['--yaml', p]);
-        const py = runPy(['--yaml', p]);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.status).toBe(py.status);
+        expect({ stdout: ts.stdout, status: ts.status }).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stdout": "a224605f1eb0
+          ",
+          }
+        `);
     });
 
-    it('--yaml datetime scalar parity', () => {
+    it('--yaml datetime scalar', () => {
         const p = join(tmp, 'dt.yml');
         writeFileSync(p, 'id: y\nts: 2026-01-01T13:45:30Z\n');
         const ts = runTs(['--yaml', p]);
-        const py = runPy(['--yaml', p]);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.status).toBe(py.status);
+        expect({ stdout: ts.stdout, status: ts.status }).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stdout": "fc33f764a48c
+          ",
+          }
+        `);
     });
 
-    it('mutually-exclusive args parity (exit 2)', () => {
+    it('mutually-exclusive args (exit 2)', () => {
         const p = join(tmp, 'm.yml');
         writeFileSync(p, 'id: x\n');
         const ts = runTs(['--yaml', p, '--json-stdin']);
-        const py = runPy(['--yaml', p, '--json-stdin']);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(2);
-        expect(normProg(ts.stderr)).toBe(normProg(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"memory_hash: error: argument --json-stdin: not allowed with argument --yaml"`);
     });
 
-    it('no-arg required-group parity (exit 2)', () => {
+    it('no-arg required-group (exit 2)', () => {
         const ts = runTs([]);
-        const py = runPy([]);
-        expect(ts.status).toBe(py.status);
         expect(ts.status).toBe(2);
-        expect(normProg(ts.stderr)).toBe(normProg(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"memory_hash: error: one of the arguments --yaml --json-stdin is required"`);
     });
 });

--- a/tests/scripts/templates_memory_lookup.test.ts
+++ b/tests/scripts/templates_memory_lookup.test.ts
@@ -1,18 +1,19 @@
-// Golden-parity tests for src/agent-src/templates/scripts/memory_lookup.ts.
+// Intent tests for src/agent-src/templates/scripts/memory_lookup.ts.
 //
-// CONSUMER-shipped template twin. Retrieval is entirely file-backed (no
-// external backend); the template `.py` is byte-identical to the dev-side
-// `src/scripts/memory_lookup.py` and supports `knowledge` / `cross-repo`
-// types. Tests differential python3 vs tsx on the template files.
-// MEMORY_ROOT / INTAKE_ROOT are `agents/memory[/intake]` relative to CWD, so
-// both processes run with `cwd` set to a tmp fixture tree. ADR-094 parity
-// contract: byte-identical stdout/stderr/exit. argparse prog token
-// (memory_lookup.py vs memory_lookup) is filename-derived, not parity.
+// Was a python3-vs-tsx byte-parity rig; the template `.py` is gone, so this now
+// asserts the tsx template-script's own contract directly. This is the
+// CONSUMER-shipped template twin — retrieval is entirely file-backed (no
+// external backend) and supports `knowledge` / `cross-repo` types.
+// MEMORY_ROOT / INTAKE_ROOT are `agents/memory[/intake]` relative to CWD, so the
+// process runs with `cwd` set to a tmp fixture tree. To stay deterministic
+// regardless of the runner's installed CLIs, the tsx launcher is spawned with a
+// **node-only PATH** (a temp dir holding just a `node` symlink) and COLUMNS=200.
+// Output is fully stable (no clock / tmp-path leakage) so it is inline-snapshotted.
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -21,12 +22,13 @@ const TSX_BIN =
         : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(DIR, 'memory_lookup.ts');
-const PY_SCRIPT = join(DIR, 'memory_lookup.py');
 
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = pythonAvailable();
+// node-only PATH → deterministic env (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(join(tmpdir(), 'tpl-ml-nodeonly-'));
+symlinkSync(process.execPath, join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    rmSync(NODE_ONLY_DIR, { recursive: true, force: true });
+});
 
 interface Run {
     stdout: string;
@@ -34,25 +36,19 @@ interface Run {
     status: number;
 }
 function runTs(args: readonly string[], cwd: string): Run {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        encoding: 'utf8',
+        cwd,
+        env: { ...process.env, PATH: NODE_ONLY_DIR, COLUMNS: '200' },
+    });
     return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
 }
-function runPy(args: readonly string[], cwd: string): Run {
-    // Plain python3 — retrieval is entirely file-backed, so the .py and .ts
-    // twins produce identical output over the same fixture tree.
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? -1 };
-}
-function normProg(s: string): string {
-    return s.replace(/memory_lookup\.py/g, 'memory_lookup').trimEnd();
-}
-// Python argparse prefixes a `usage:` block whose line-wrapping is
-// terminal-width-dependent — NOT a stable parity contract. The byte-identical
+// Python argparse used a terminal-width-dependent `usage:` block; the stable
 // contract is the trailing `<prog>: error: <msg>` line.
 function errorLine(stderr: string): string {
-    const lines = normProg(stderr).split('\n');
+    const lines = stderr.trimEnd().split('\n');
     const found = lines.find((l) => /^memory_lookup: error:/.test(l));
-    return found ?? normProg(stderr);
+    return found ?? stderr.trimEnd();
 }
 
 const CURATED_ENTRY = [
@@ -67,7 +63,7 @@ const CURATED_ENTRY = [
     '    path: "app/Http/Controllers/Billing"',
 ];
 
-describe.skipIf(!HAVE_PYTHON)('templates/memory_lookup — golden parity', () => {
+describe('templates/memory_lookup — intent', () => {
     let tmp: string;
     beforeEach(() => {
         tmp = mkdtempSync(join(tmpdir(), 'tpl-ml-'));
@@ -83,24 +79,30 @@ describe.skipIf(!HAVE_PYTHON)('templates/memory_lookup — golden parity', () =>
         writeFileSync(full, body);
     }
 
-    function bothEqual(args: readonly string[]): void {
-        const ts = runTs(args, tmp);
-        const py = runPy(args, tmp);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-    }
-
-    it('no memory tree → no hits parity (text)', () => {
-        bothEqual(['--types', 'ownership', '--key', 'billing']);
+    it('no memory tree → no hits (text)', () => {
+        expect(runTs(['--types', 'ownership', '--key', 'billing'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  (no hits)
+          ",
+          }
+        `);
     });
 
-    it('curated single-file layout parity (text)', () => {
+    it('curated single-file layout (text)', () => {
         writeMem('ownership.yml', `entries:\n${CURATED_ENTRY.join('\n')}\n`);
-        bothEqual(['--types', 'ownership', '--key', 'Billing']);
+        expect(runTs(['--types', 'ownership', '--key', 'Billing'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  [curated] ownership  score=0.80  id=own-1  path=agents/memory/ownership.yml
+          ",
+          }
+        `);
     });
 
-    it('curated content-addressed layout parity (text)', () => {
+    it('curated content-addressed layout (text)', () => {
         writeMem(
             'domain-invariants/abc123.yml',
             [
@@ -110,10 +112,17 @@ describe.skipIf(!HAVE_PYTHON)('templates/memory_lookup — golden parity', () =>
                 'rule: "amounts are integers"',
             ].join('\n') + '\n',
         );
-        bothEqual(['--types', 'domain-invariants', '--key', 'money']);
+        expect(runTs(['--types', 'domain-invariants', '--key', 'money'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  [curated] domain-invariants  score=0.80  id=inv-1  path=agents/memory/domain-invariants/abc123.yml
+          ",
+          }
+        `);
     });
 
-    it('intake supersede-chain parity (json)', () => {
+    it('intake supersede-chain (json)', () => {
         const intake = join(tmp, 'agents', 'memory', 'intake', 'a.jsonl');
         writeFileSync(
             intake,
@@ -123,25 +132,137 @@ describe.skipIf(!HAVE_PYTHON)('templates/memory_lookup — golden parity', () =>
                 JSON.stringify({ type: 'supersede', supersedes: 'k-1' }),
             ].join('\n') + '\n',
         );
-        bothEqual(['--types', 'ownership', '--key', 'billing', '--format', 'json']);
+        expect(runTs(['--types', 'ownership', '--key', 'billing', '--format', 'json'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "hits": [
+              {
+                "id": "k-2",
+                "type": "ownership",
+                "source": "intake",
+                "path": "agents/memory/intake/a.jsonl",
+                "score": 0.7200000000000001,
+                "entry": {
+                  "id": "k-2",
+                  "entry_type": "ownership",
+                  "path": "app/Billing",
+                  "body": "billing owner"
+                }
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('json format parity over curated + intake', () => {
+    it('json format over curated + intake', () => {
         writeMem('ownership.yml', `entries:\n${CURATED_ENTRY.join('\n')}\n`);
         const intake = join(tmp, 'agents', 'memory', 'intake', 'b.jsonl');
         writeFileSync(
             intake,
             JSON.stringify({ id: 'k-9', entry_type: 'ownership', path: 'app/Http', body: 'b' }) + '\n',
         );
-        bothEqual(['--types', 'ownership', '--key', 'app/Http', '--format', 'json']);
+        expect(runTs(['--types', 'ownership', '--key', 'app/Http', '--format', 'json'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "hits": [
+              {
+                "id": "own-1",
+                "type": "ownership",
+                "source": "curated",
+                "path": "agents/memory/ownership.yml",
+                "score": 0.8,
+                "entry": {
+                  "id": "own-1",
+                  "status": "active",
+                  "confidence": "high",
+                  "source": [
+                    "ADR-1"
+                  ],
+                  "owner": "team",
+                  "last_validated": "2026-01-01",
+                  "review_after_days": 180,
+                  "path": "app/Http/Controllers/Billing"
+                }
+              },
+              {
+                "id": "k-9",
+                "type": "ownership",
+                "source": "intake",
+                "path": "agents/memory/intake/b.jsonl",
+                "score": 0.7200000000000001,
+                "entry": {
+                  "id": "k-9",
+                  "entry_type": "ownership",
+                  "path": "app/Http",
+                  "body": "b"
+                }
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('v1 envelope parity (known + unknown type)', () => {
+    it('v1 envelope (known + unknown type)', () => {
         writeMem('ownership.yml', `entries:\n${CURATED_ENTRY.join('\n')}\n`);
-        bothEqual(['--types', 'ownership,bogus-type', '--key', 'billing', '--envelope', 'v1']);
+        expect(runTs(['--types', 'ownership,bogus-type', '--key', 'billing', '--envelope', 'v1'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "contract_version": 1,
+            "status": "partial",
+            "entries": [
+              {
+                "id": "own-1",
+                "type": "ownership",
+                "source": "repo",
+                "confidence": 0.8,
+                "body": {
+                  "id": "own-1",
+                  "status": "active",
+                  "confidence": "high",
+                  "source": [
+                    "ADR-1"
+                  ],
+                  "owner": "team",
+                  "last_validated": "2026-01-01",
+                  "review_after_days": 180,
+                  "path": "app/Http/Controllers/Billing"
+                }
+              }
+            ],
+            "slices": {
+              "ownership": {
+                "status": "ok",
+                "count": 1
+              },
+              "bogus-type": {
+                "status": "unknown_type",
+                "count": 0
+              }
+            },
+            "errors": [
+              {
+                "type": "bogus-type",
+                "code": "unknown_type",
+                "message": "file-backed backend does not know type 'bogus-type'"
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('limit clamps result count parity', () => {
+    it('limit clamps result count', () => {
         writeMem(
             'ownership.yml',
             'entries:\n' +
@@ -150,22 +271,63 @@ describe.skipIf(!HAVE_PYTHON)('templates/memory_lookup — golden parity', () =>
                     .join('\n') +
                 '\n',
         );
-        bothEqual(['--types', 'ownership', '--key', 'app/Http', '--limit', '2', '--format', 'json']);
+        expect(runTs(['--types', 'ownership', '--key', 'app/Http', '--limit', '2', '--format', 'json'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "hits": [
+              {
+                "id": "own-0",
+                "type": "ownership",
+                "source": "curated",
+                "path": "agents/memory/ownership.yml",
+                "score": 0.8,
+                "entry": {
+                  "id": "own-0",
+                  "path": "app/Http/0",
+                  "status": "active"
+                }
+              },
+              {
+                "id": "own-1",
+                "type": "ownership",
+                "source": "curated",
+                "path": "agents/memory/ownership.yml",
+                "score": 0.8,
+                "entry": {
+                  "id": "own-1",
+                  "path": "app/Http/1",
+                  "status": "active"
+                }
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('no hits text branch parity (empty key, no entries)', () => {
-        bothEqual(['--types', 'incident-learnings']);
+    it('no hits text branch (empty key, no entries)', () => {
+        expect(runTs(['--types', 'incident-learnings'], tmp)).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  (no hits)
+          ",
+          }
+        `);
     });
 
-    it('missing --types parity (exit 2)', () => {
-        bothEqual(['--key', 'x']);
-    });
-
-    it('unrecognized arg parity (exit 2)', () => {
-        const ts = runTs(['--bogus'], tmp);
-        const py = runPy(['--bogus'], tmp);
-        expect(ts.status).toBe(py.status);
+    it('missing --types (exit 2)', () => {
+        const ts = runTs(['--key', 'x'], tmp);
         expect(ts.status).toBe(2);
-        expect(errorLine(ts.stderr)).toBe(errorLine(py.stderr));
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"error: --types is required"`);
+    });
+
+    it('unrecognized arg (exit 2)', () => {
+        const ts = runTs(['--bogus'], tmp);
+        expect(ts.status).toBe(2);
+        expect(errorLine(ts.stderr)).toMatchInlineSnapshot(`"memory_lookup: error: unrecognized arguments: --bogus"`);
     });
 });

--- a/tests/scripts/templates_memory_report.test.ts
+++ b/tests/scripts/templates_memory_report.test.ts
@@ -1,17 +1,26 @@
-// Tests for src/agent-src/templates/scripts/memory_report.ts — observability report.
+// Intent tests for src/agent-src/templates/scripts/memory_report.ts —
+// observability report (ADR-200, consumer-template memory).
 //
-// Golden-parity harness (ADR-094): runs python3 + tsx on the consumer-template
-// twin against tmp `agents/memory` fixtures and asserts byte-identical
-// stdout/stderr/exit for the text + `--format json` paths and the error paths.
-// The backend probe is neutralised with an isolated PATH (node + python3 only,
-// no `memory`-family CLI) so the `backend` block is the deterministic `absent`
-// shape on both sides. Skipped without python3.
+// Was a python3-vs-tsx byte-parity rig; the `.py` twin is gone, so this asserts
+// the tsx CLI's own contract directly against tmp `agents/memory` fixtures, for
+// the text and `--format json` paths plus the argparse error paths.
+//
+// Determinism: the backend is a hard-coded `file` constant; the fixture dates
+// (2000-01-01 = always overdue, 2999-01-01 = never overdue) keep the overdue
+// COUNT, staleness-rate and quarter buckets date-independent. The only value
+// that drifts with wall-clock is the overdue DAY count (`+Nd` in text,
+// `overdue_days` in json) — masked via `norm()` before snapshotting. The
+// role-mode scan dirs (`agents/sessions`, …) don't exist in the tmp tree, so
+// `files_scanned` is a stable 0. Every case spawns with a node-only PATH (a
+// temp dir holding just a `node` symlink) so the tsx launcher resolves but no
+// `memory`-family CLI does, and COLUMNS=200 forces single-line usage so
+// arg-error stderr does not re-wrap to terminal width.
 
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const _TSX_ENV = process.env['TSX_BIN'];
@@ -20,110 +29,235 @@ const TSX_BIN = _TSX_ENV
     : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const SCRIPTS_DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(SCRIPTS_DIR, 'memory_report.ts');
-const PY_SCRIPT = join(SCRIPTS_DIR, 'memory_report.py');
 
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+// node-only PATH → deterministic absent backend (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(join(tmpdir(), 'tpl-memrep-nodeonly-'));
+symlinkSync(process.execPath, join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
+
+interface RunResult {
+    status: number | null;
+    stdout: string;
+    stderr: string;
 }
-const HAVE_PYTHON = pythonAvailable();
 
-describe.skipIf(!HAVE_PYTHON)('templates/memory_report — golden parity', () => {
-    let goldenTmp: string;
-    let emptyPathDir: string;
+let goldenTmp: string;
+beforeEach(() => {
+    goldenTmp = mkdtempSync(join(tmpdir(), 'tpl-memrep-gold-'));
+});
+afterEach(() => {
+    rmSync(goldenTmp, { recursive: true, force: true });
+});
 
-    beforeEach(() => {
-        goldenTmp = mkdtempSync(join(tmpdir(), 'tpl-memrep-gold-'));
-        emptyPathDir = mkdtempSync(join(tmpdir(), 'tpl-memrep-path-'));
-        const nodeBin = process.execPath;
-        const py = spawnSync('which', ['python3'], { encoding: 'utf8' }).stdout.trim();
-        spawnSync('ln', ['-s', nodeBin, join(emptyPathDir, 'node')]);
-        if (py) {
-            spawnSync('ln', ['-s', py, join(emptyPathDir, 'python3')]);
-        }
+function runTs(args: string[]): RunResult {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        cwd: goldenTmp,
+        encoding: 'utf8',
+        env: { HOME: process.env['HOME'] ?? '', PATH: NODE_ONLY_DIR, COLUMNS: '200', AGENT_MEMORY_STATUS: '' },
     });
-    afterEach(() => {
-        rmSync(goldenTmp, { recursive: true, force: true });
-        rmSync(emptyPathDir, { recursive: true, force: true });
-    });
+    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
 
-    function envParity(args: readonly string[]): { ts: ReturnType<typeof spawnSync>; py: ReturnType<typeof spawnSync> } {
-        // Empty PATH (no `memory` CLI) + cleared cache → deterministic absent backend.
-        const env = { HOME: process.env['HOME'] ?? '', PATH: emptyPathDir, AGENT_MEMORY_STATUS: '' };
-        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: goldenTmp, encoding: 'utf8', env });
-        const py = spawnSync('python3', [PY_SCRIPT, ...args], { cwd: goldenTmp, encoding: 'utf8', env });
-        return { ts, py };
-    }
+// The overdue DAY count drifts with wall clock; mask it (the COUNT, rate and
+// buckets are date-independent and stay asserted).
+function normOverdue(s: string): string {
+    return s.replace(/\+\d+d/g, '+Nd').replace(/"overdue_days": \d+/g, '"overdue_days": N');
+}
 
-    function seedMemoryTree(): void {
-        const memRoot = join(goldenTmp, 'agents', 'memory');
-        const intake = join(memRoot, 'intake');
-        mkdirSync(intake, { recursive: true });
-        // Intake JSONL: 2 active (one ownership, one historical), 1 supersede.
-        const lines = [
-            JSON.stringify({ entry_type: 'ownership', path: 'app/A.php', body: 'team-a' }),
-            JSON.stringify({ entry_type: 'historical-patterns', path: 'app/B.php', body: 'flake' }),
-            JSON.stringify({ type: 'supersede', id: 'old-1' }),
-            '', // blank line — must be skipped
-            'not-json', // malformed — must be skipped
-        ];
-        writeFileSync(join(intake, 'signals-2026-05.jsonl'), `${lines.join('\n')}\n`, 'utf-8');
+function seedMemoryTree(): void {
+    const memRoot = join(goldenTmp, 'agents', 'memory');
+    const intake = join(memRoot, 'intake');
+    mkdirSync(intake, { recursive: true });
+    // Intake JSONL: 2 active (one ownership, one historical), 1 supersede,
+    // a blank line + a malformed line (both must be skipped).
+    const lines = [
+        JSON.stringify({ entry_type: 'ownership', path: 'app/A.php', body: 'team-a' }),
+        JSON.stringify({ entry_type: 'historical-patterns', path: 'app/B.php', body: 'flake' }),
+        JSON.stringify({ type: 'supersede', id: 'old-1' }),
+        '',
+        'not-json',
+    ];
+    writeFileSync(join(intake, 'signals-2026-05.jsonl'), `${lines.join('\n')}\n`, 'utf-8');
 
-        // Curated single-file layout with an overdue + a current entry.
-        const ownership = [
-            'entries:',
-            '  - id: own-overdue',
-            '    last_validated: 2000-01-01',
-            '    review_after_days: 30',
-            '  - id: own-current',
-            '    last_validated: 2999-01-01',
-            '    review_after_days: 30',
-            '  - id: own-no-review',
-            '    last_validated: 2000-01-01',
-        ].join('\n');
-        writeFileSync(join(memRoot, 'ownership.yml'), `${ownership}\n`, 'utf-8');
-    }
+    // Curated single-file layout: an overdue + a current + a no-review entry.
+    const ownership = [
+        'entries:',
+        '  - id: own-overdue',
+        '    last_validated: 2000-01-01',
+        '    review_after_days: 30',
+        '  - id: own-current',
+        '    last_validated: 2999-01-01',
+        '    review_after_days: 30',
+        '  - id: own-no-review',
+        '    last_validated: 2000-01-01',
+    ].join('\n');
+    writeFileSync(join(memRoot, 'ownership.yml'), `${ownership}\n`, 'utf-8');
+}
 
-    it('text output parity (populated tree)', () => {
+describe('templates/memory_report — populated tree', () => {
+    it('text output (overdue-days masked)', () => {
         seedMemoryTree();
-        const { ts, py } = envParity([]);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+        const r = runTs([]);
+        expect({ status: r.status, stderr: r.stderr, stdout: normOverdue(r.stdout) }).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "Backend:   file (backend=file)
+                     reason: file-backed memory (no external backend)
+          Intake:    2 active, 1 superseded
+            - historical-patterns: 1
+            - ownership: 1
+          Staleness: 1 entrie(s) overdue
+            - own-overdue (ownership)  +Nd  agents/memory/ownership.yml
+          Quarterly: staleness-rate=33.3% (1/3)
+            accepted: 2000Q1:2, 2999Q1:1
+          ",
+          }
+        `);
     });
 
-    it('json output parity (populated tree)', () => {
+    it('json output (overdue-days masked)', () => {
         seedMemoryTree();
-        const { ts, py } = envParity(['--format', 'json']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+        const r = runTs(['--format', 'json']);
+        expect({ status: r.status, stderr: r.stderr, stdout: normOverdue(r.stdout) }).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "backend": {
+              "status": "file",
+              "backend": "file",
+              "reason": "file-backed memory (no external backend)"
+            },
+            "intake": {
+              "total_active": 2,
+              "superseded": 1,
+              "by_type": {
+                "ownership": 1,
+                "historical-patterns": 1
+              },
+              "by_month": {
+                "2026-05": 2
+              }
+            },
+            "staleness": [
+              {
+                "file": "agents/memory/ownership.yml",
+                "type": "ownership",
+                "id": "own-overdue",
+                "overdue_days": N
+              }
+            ],
+            "quarterly": {
+              "accepted_by_quarter": {
+                "2000Q1": 2,
+                "2999Q1": 1
+              },
+              "retired_by_quarter": {},
+              "staleness_rate": 0.333,
+              "curated_total": 3,
+              "curated_overdue": 1
+            },
+            "role_modes": {
+              "total_markers": 0,
+              "files_scanned": 0,
+              "by_mode": {},
+              "unknown_modes": []
+            }
+          }
+          ",
+          }
+        `);
+    });
+});
+
+describe('templates/memory_report — empty tree', () => {
+    it('text output (fully deterministic)', () => {
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "Backend:   file (backend=file)
+                     reason: file-backed memory (no external backend)
+          Intake:    0 active, 0 superseded
+          Staleness: no curated entries past review_after_days
+          Quarterly: staleness-rate=0.0% (0/0)
+          ",
+          }
+        `);
     });
 
-    it('text output parity (empty tree)', () => {
-        const { ts, py } = envParity([]);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('json output (fully deterministic)', () => {
+        expect(runTs(['--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "backend": {
+              "status": "file",
+              "backend": "file",
+              "reason": "file-backed memory (no external backend)"
+            },
+            "intake": {
+              "total_active": 0,
+              "superseded": 0,
+              "by_type": {},
+              "by_month": {}
+            },
+            "staleness": [],
+            "quarterly": {
+              "accepted_by_quarter": {},
+              "retired_by_quarter": {},
+              "staleness_rate": 0.0,
+              "curated_total": 0,
+              "curated_overdue": 0
+            },
+            "role_modes": {
+              "total_markers": 0,
+              "files_scanned": 0,
+              "by_mode": {},
+              "unknown_modes": []
+            }
+          }
+          ",
+          }
+        `);
     });
+});
 
-    it('json output parity (empty tree)', () => {
-        const { ts, py } = envParity(['--format', 'json']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+describe('templates/memory_report — argparse errors', () => {
+    it('bad --format choice → exit 2', () => {
+        expect(runTs(['--format', 'xml'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: memory_report.py [-h] [--format {text,json}]
+          memory_report.py: error: argument --format: invalid choice: 'xml' (choose from 'text', 'json')
+          ",
+            "stdout": "",
+          }
+        `);
     });
-
-    it('bad --format choice (exit 2) parity', () => {
-        const { ts, py } = envParity(['--format', 'xml']);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(2);
+    it('unrecognized argument → exit 2', () => {
+        expect(runTs(['--bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: memory_report.py [-h] [--format {text,json}]
+          memory_report.py: error: unrecognized arguments: --bogus
+          ",
+            "stdout": "",
+          }
+        `);
     });
-
-    it('unrecognized argument (exit 2) parity', () => {
-        const { ts, py } = envParity(['--bogus']);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(2);
+    it('-h → usage + exit 0', () => {
+        expect(runTs(['-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: memory_report.py [-h] [--format {text,json}]
+          ",
+          }
+        `);
     });
 });

--- a/tests/scripts/templates_memory_signal.test.ts
+++ b/tests/scripts/templates_memory_signal.test.ts
@@ -1,18 +1,21 @@
-// Tests for src/agent-src/templates/scripts/memory_signal.ts — write-side helper.
+// Intent tests for src/agent-src/templates/scripts/memory_signal.ts —
+// write-side helper (ADR-200, consumer-template memory).
 //
-// Golden-parity harness (ADR-094): runs python3 + tsx on the consumer-template
-// twin and asserts byte-identical behaviour. The generated `id` (secrets.token_hex)
+// Was a python3-vs-tsx byte-parity rig; the `.py` twin is gone, so this asserts
+// the tsx CLI's own contract directly. The generated `id` (crypto.randomBytes)
 // and `ts` (wall clock) are non-deterministic, so the emit-success stdout is
-// compared with id normalised, and the written-record key set + non-id/ts
-// values are asserted equal. Error paths are byte-compared directly. The
-// template `memory_signal.py` always writes the JSONL trail (it has no backend
-// skip path), so no backend stub is needed. Skipped without python3.
+// snapshotted with `id` masked, and the written JSONL record is asserted via
+// its key set + its non-id/ts values (which ARE deterministic). Error paths are
+// snapshotted directly. The script always writes the JSONL trail (no backend
+// skip path), so no backend stub is needed; a node-only PATH keeps the launcher
+// resolvable and COLUMNS=200 pins usage-line wrapping out of the picture (the
+// usage block is a hard-coded 80-col constant in the script either way).
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const _TSX_ENV = process.env['TSX_BIN'];
@@ -21,63 +24,84 @@ const TSX_BIN = _TSX_ENV
     : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const SCRIPTS_DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(SCRIPTS_DIR, 'memory_signal.ts');
-const PY_SCRIPT = join(SCRIPTS_DIR, 'memory_signal.py');
 
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+// node-only PATH → deterministic launcher resolution (nothing else resolves).
+const NODE_ONLY_DIR = mkdtempSync(join(tmpdir(), 'tpl-memsig-nodeonly-'));
+symlinkSync(process.execPath, join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
+
+interface RunResult {
+    status: number | null;
+    stdout: string;
+    stderr: string;
 }
-const HAVE_PYTHON = pythonAvailable();
 
-describe.skipIf(!HAVE_PYTHON)('templates/memory_signal — golden parity', () => {
-    function run(bin: 'py' | 'ts', cwd: string, args: string[]): ReturnType<typeof spawnSync> {
-        const env = { ...process.env, AGENT_MEMORY_STATUS: '' };
-        if (bin === 'py') {
-            return spawnSync('python3', [PY_SCRIPT, ...args], { cwd, encoding: 'utf8', env });
-        }
-        return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd, encoding: 'utf8', env });
-    }
+function runTs(cwd: string, args: string[]): RunResult {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        cwd,
+        encoding: 'utf8',
+        env: { HOME: process.env['HOME'] ?? '', PATH: NODE_ONLY_DIR, COLUMNS: '200', AGENT_MEMORY_STATUS: '' },
+    });
+    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
 
-    function writtenRecordKeys(dir: string): string[] {
-        const root = join(dir, 'agents', 'memory', 'intake');
-        const f = readdirSync(root).find((n) => n.endsWith('.jsonl')) as string;
-        const obj = JSON.parse(readFileSync(join(root, f), 'utf-8').trim()) as Record<string, unknown>;
-        return Object.keys(obj).sort();
-    }
+// id=sig-<hex> in stdout is non-deterministic; mask it for the snapshot.
+function normId(s: string): string {
+    return s.replace(/id=sig-[0-9a-f]+/g, 'id=sig-XXX');
+}
 
-    function nonVolatileValues(dir: string): Record<string, unknown> {
-        const root = join(dir, 'agents', 'memory', 'intake');
-        const f = readdirSync(root).find((n) => n.endsWith('.jsonl')) as string;
-        const obj = JSON.parse(readFileSync(join(root, f), 'utf-8').trim()) as Record<string, unknown>;
-        // id + ts are non-deterministic (token_hex + wall clock).
-        delete obj['id'];
-        delete obj['ts'];
-        return obj;
-    }
+function writtenRecord(dir: string): Record<string, unknown> {
+    const root = join(dir, 'agents', 'memory', 'intake');
+    const f = readdirSync(root).find((n) => n.endsWith('.jsonl')) as string;
+    return JSON.parse(readFileSync(join(root, f), 'utf-8').trim()) as Record<string, unknown>;
+}
 
-    it('emit stdout shape parity (id normalised)', () => {
-        const pyDir = mkdtempSync(join(tmpdir(), 'tpl-memsig-py-'));
-        const tsDir = mkdtempSync(join(tmpdir(), 'tpl-memsig-ts-'));
+describe('templates/memory_signal — emit', () => {
+    it('emit stdout shape (id masked)', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-emit-'));
         try {
-            const args = ['--type', 'historical-patterns', '--path', 'app/Foo.php', '--body', 'null deref'];
-            const py = run('py', pyDir, args);
-            const ts = run('ts', tsDir, args);
-            const norm = (s: string): string => s.replace(/id=sig-[0-9a-f]+/g, 'id=sig-XXX');
-            expect(norm(String(ts.stdout))).toBe(norm(String(py.stdout)));
-            expect(ts.stderr).toBe(py.stderr);
-            expect(ts.status).toBe(py.status);
-            expect(writtenRecordKeys(tsDir)).toEqual(writtenRecordKeys(pyDir));
-            expect(nonVolatileValues(tsDir)).toEqual(nonVolatileValues(pyDir));
+            const r = runTs(dir, ['--type', 'historical-patterns', '--path', 'app/Foo.php', '--body', 'null deref']);
+            expect({ status: r.status, stderr: r.stderr, stdout: normId(r.stdout) }).toMatchInlineSnapshot(`
+              {
+                "status": 0,
+                "stderr": "",
+                "stdout": "  ✅  signal emitted: id=sig-XXX type=historical-patterns path=app/Foo.php
+              ",
+              }
+            `);
+            // Written record: deterministic key set + non-volatile values.
+            const rec = writtenRecord(dir);
+            expect(Object.keys(rec).sort()).toMatchInlineSnapshot(`
+              [
+                "body",
+                "entry_type",
+                "id",
+                "origin",
+                "path",
+                "ts",
+              ]
+            `);
+            delete rec['id'];
+            delete rec['ts'];
+            expect(rec).toMatchInlineSnapshot(`
+              {
+                "body": "null deref",
+                "entry_type": "historical-patterns",
+                "origin": "agent",
+                "path": "app/Foo.php",
+              }
+            `);
         } finally {
-            rmSync(pyDir, { recursive: true, force: true });
-            rmSync(tsDir, { recursive: true, force: true });
+            rmSync(dir, { recursive: true, force: true });
         }
     });
 
-    it('emit with extra preserves extra keys (id normalised)', () => {
-        const pyDir = mkdtempSync(join(tmpdir(), 'tpl-memsig-py-'));
-        const tsDir = mkdtempSync(join(tmpdir(), 'tpl-memsig-ts-'));
+    it('emit with --extra preserves extra keys (id masked)', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-extra-'));
         try {
-            const args = [
+            const r = runTs(dir, [
                 '--type',
                 'ownership',
                 '--path',
@@ -86,39 +110,137 @@ describe.skipIf(!HAVE_PYTHON)('templates/memory_signal — golden parity', () =>
                 'team-x',
                 '--extra',
                 '{"symptom":"flaky","owner":"team-x"}',
-            ];
-            const py = run('py', pyDir, args);
-            const ts = run('ts', tsDir, args);
-            const norm = (s: string): string => s.replace(/id=sig-[0-9a-f]+/g, 'id=sig-XXX');
-            expect(norm(String(ts.stdout))).toBe(norm(String(py.stdout)));
-            expect(ts.status).toBe(py.status);
-            expect(writtenRecordKeys(tsDir)).toEqual(writtenRecordKeys(pyDir));
-            expect(nonVolatileValues(tsDir)).toEqual(nonVolatileValues(pyDir));
+            ]);
+            expect({ status: r.status, stdout: normId(r.stdout) }).toMatchInlineSnapshot(`
+              {
+                "status": 0,
+                "stdout": "  ✅  signal emitted: id=sig-XXX type=ownership path=app/Bill
+              ",
+              }
+            `);
+            const rec = writtenRecord(dir);
+            expect(Object.keys(rec).sort()).toMatchInlineSnapshot(`
+              [
+                "body",
+                "entry_type",
+                "id",
+                "origin",
+                "owner",
+                "path",
+                "symptom",
+                "ts",
+              ]
+            `);
+            delete rec['id'];
+            delete rec['ts'];
+            expect(rec).toMatchInlineSnapshot(`
+              {
+                "body": "team-x",
+                "entry_type": "ownership",
+                "origin": "agent",
+                "owner": "team-x",
+                "path": "app/Bill",
+                "symptom": "flaky",
+              }
+            `);
         } finally {
-            rmSync(pyDir, { recursive: true, force: true });
-            rmSync(tsDir, { recursive: true, force: true });
+            rmSync(dir, { recursive: true, force: true });
         }
     });
+});
 
-    it('error-path stderr/exit parity', () => {
-        const cases: string[][] = [
-            ['--type', 'bogus', '--path', 'x', '--body', 'y'], // invalid choice
-            ['--path', 'x'], // missing required
-            ['--type', 'ownership', '--path', 'x', '--body', 'y', '--bogus'], // unrecognized
-            ['--type', 'ownership', '--path', 'x', '--body', 'y', '--extra', '[1,2]'], // --extra not an object
-            [], // no args → required-args error
-        ];
-        for (const args of cases) {
-            const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-err-'));
-            try {
-                const py = run('py', dir, args);
-                const ts = run('ts', dir, args);
-                expect(ts.stdout, `stdout ${args.join(' ')}`).toBe(py.stdout);
-                expect(ts.stderr, `stderr ${args.join(' ')}`).toBe(py.stderr);
-                expect(ts.status, `exit ${args.join(' ')}`).toBe(py.status);
-            } finally {
-                rmSync(dir, { recursive: true, force: true });
-            }
+describe('templates/memory_signal — error paths', () => {
+    it('invalid --type choice → exit 2', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-err-'));
+        try {
+            expect(runTs(dir, ['--type', 'bogus', '--path', 'x', '--body', 'y'])).toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: memory_signal.py [-h] --type
+                                      {domain-invariants,historical-patterns,incident-learnings,ownership,product-rules}
+                                      --path PATH --body BODY [--origin ORIGIN]
+                                      [--extra EXTRA] [--force]
+              memory_signal.py: error: argument --type: invalid choice: 'bogus' (choose from 'domain-invariants', 'historical-patterns', 'incident-learnings', 'ownership', 'product-rules')
+              ",
+                "stdout": "",
+              }
+            `);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it('missing required args → exit 2', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-err-'));
+        try {
+            expect(runTs(dir, ['--path', 'x'])).toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: memory_signal.py [-h] --type
+                                      {domain-invariants,historical-patterns,incident-learnings,ownership,product-rules}
+                                      --path PATH --body BODY [--origin ORIGIN]
+                                      [--extra EXTRA] [--force]
+              memory_signal.py: error: the following arguments are required: --type, --body
+              ",
+                "stdout": "",
+              }
+            `);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it('unrecognized argument → exit 2', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-err-'));
+        try {
+            expect(runTs(dir, ['--type', 'ownership', '--path', 'x', '--body', 'y', '--bogus']))
+                .toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: memory_signal.py [-h] --type
+                                      {domain-invariants,historical-patterns,incident-learnings,ownership,product-rules}
+                                      --path PATH --body BODY [--origin ORIGIN]
+                                      [--extra EXTRA] [--force]
+              memory_signal.py: error: unrecognized arguments: --bogus
+              ",
+                "stdout": "",
+              }
+            `);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it('--extra not a JSON object → exit 2', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-err-'));
+        try {
+            expect(runTs(dir, ['--type', 'ownership', '--path', 'x', '--body', 'y', '--extra', '[1,2]']))
+                .toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "error: --extra must be a JSON object
+              ",
+                "stdout": "",
+              }
+            `);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it('no args → required-args error, exit 2', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'tpl-memsig-err-'));
+        try {
+            expect(runTs(dir, [])).toMatchInlineSnapshot(`
+              {
+                "status": 2,
+                "stderr": "usage: memory_signal.py [-h] --type
+                                      {domain-invariants,historical-patterns,incident-learnings,ownership,product-rules}
+                                      --path PATH --body BODY [--origin ORIGIN]
+                                      [--extra EXTRA] [--force]
+              memory_signal.py: error: the following arguments are required: --type, --path, --body
+              ",
+                "stdout": "",
+              }
+            `);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
         }
     });
 });

--- a/tests/scripts/templates_memory_status.test.ts
+++ b/tests/scripts/templates_memory_status.test.ts
@@ -1,18 +1,20 @@
-// Tests for src/agent-src/templates/scripts/memory_status.ts — backend probe.
+// Intent tests for src/agent-src/templates/scripts/memory_status.ts — backend
+// probe (ADR-200, consumer-template memory; byte-identical to the dev-side
+// src/scripts/memory_status.ts apart from the header doc-comment path).
 //
-// Golden-parity harness (ADR-094): runs python3 + tsx on the consumer-template
-// twin against a deterministic `absent` probe (isolated PATH with node +
-// python3 only, no `memory`-family CLI) and asserts byte-identical
-// stdout/stderr/exit. The template `.ts` is byte-identical to the dev-side
-// `src/scripts/memory_status.ts` apart from the header doc-comment path, so the
-// behavioural contract is identical; this suite re-verifies it at the template
-// path. Skipped without python3.
+// Was a python3-vs-tsx byte-parity rig; the `.py` twin is gone, so this asserts
+// the tsx CLI's own contract directly. The backend is a hard-coded `file`
+// constant (no clock, no tmp paths, no external probe), so output is fully
+// deterministic. Every case spawns with a node-only PATH (a temp dir holding
+// just a `node` symlink) so the tsx launcher resolves but NO `memory`-family
+// CLI does, and COLUMNS=200 forces single-line usage so arg-error stderr does
+// not re-wrap to terminal width.
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join, resolve } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const _TSX_ENV = process.env['TSX_BIN'];
@@ -21,79 +23,92 @@ const TSX_BIN = _TSX_ENV
     : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const SCRIPTS_DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(SCRIPTS_DIR, 'memory_status.ts');
-const PY_SCRIPT = join(SCRIPTS_DIR, 'memory_status.py');
 
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
+// node-only PATH → deterministic absent backend (nothing but `node` resolves).
+const NODE_ONLY_DIR = mkdtempSync(join(tmpdir(), 'tpl-memstat-nodeonly-'));
+symlinkSync(process.execPath, join(NODE_ONLY_DIR, 'node'));
+afterAll(() => {
+    // temp dir is left for the OS to reap; nothing sensitive.
+});
+
+interface RunResult {
+    status: number | null;
+    stdout: string;
+    stderr: string;
 }
-const HAVE_PYTHON = pythonAvailable();
 
-describe.skipIf(!HAVE_PYTHON)('templates/memory_status — golden parity', () => {
-    let goldenTmp: string;
-    let emptyPathDir: string;
-    beforeEach(() => {
-        goldenTmp = mkdtempSync(join(tmpdir(), 'tpl-memstat-gold-'));
-        // A PATH dir with node + python3 symlinks but NO `memory`-family CLI,
-        // so both implementations resolve the deterministic `absent` probe.
-        emptyPathDir = mkdtempSync(join(tmpdir(), 'tpl-memstat-path-'));
-        const nodeBin = process.execPath;
-        const py = spawnSync('which', ['python3'], { encoding: 'utf8' }).stdout.trim();
-        spawnSync('ln', ['-s', nodeBin, join(emptyPathDir, 'node')]);
-        if (py) {
-            spawnSync('ln', ['-s', py, join(emptyPathDir, 'python3')]);
-        }
+function runTs(args: string[]): RunResult {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        encoding: 'utf8',
+        env: { HOME: process.env['HOME'] ?? '', PATH: NODE_ONLY_DIR, COLUMNS: '200', AGENT_MEMORY_STATUS: '' },
     });
-    afterEach(() => {
-        rmSync(goldenTmp, { recursive: true, force: true });
-        rmSync(emptyPathDir, { recursive: true, force: true });
+    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('templates/memory_status — status', () => {
+    it('text output (absent)', () => {
+        expect(runTs(['--refresh'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  ℹ️  backend=file  status=file  reason=file-backed memory (no external backend)
+          ",
+          }
+        `);
     });
-
-    function envParity(args: readonly string[]): { ts: ReturnType<typeof spawnSync>; py: ReturnType<typeof spawnSync> } {
-        // Empty PATH (no `memory` CLI) + cleared cache env → deterministic absent.
-        const env = { HOME: process.env['HOME'] ?? '', PATH: emptyPathDir, AGENT_MEMORY_STATUS: '' };
-        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: goldenTmp, encoding: 'utf8', env });
-        const py = spawnSync('python3', [PY_SCRIPT, ...args], { cwd: goldenTmp, encoding: 'utf8', env });
-        return { ts, py };
-    }
-
-    it('text output (absent) parity', () => {
-        const { ts, py } = envParity(['--refresh']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('json output (absent)', () => {
+        expect(runTs(['--refresh', '--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"status": "file", "backend": "file", "reason": "file-backed memory (no external backend)", "elapsed_ms": 0}
+          ",
+          }
+        `);
     });
-
-    it('json output (absent) parity', () => {
-        const { ts, py } = envParity(['--refresh', '--format', 'json']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('--health (absent)', () => {
+        expect(runTs(['--health', '--refresh'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{"contract_version": 1, "status": "ok", "backend_version": "0.0.0-file", "features": ["file-fallback"]}
+          ",
+          }
+        `);
     });
+});
 
-    it('--health (absent) parity', () => {
-        const { ts, py } = envParity(['--health', '--refresh']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+describe('templates/memory_status — argparse errors', () => {
+    it('bad --format choice → exit 2', () => {
+        expect(runTs(['--format', 'xml'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: memory_status.py [-h] [--format {text,json}] [--refresh] [--health]
+          memory_status.py: error: argument --format: invalid choice: 'xml' (choose from 'text', 'json')
+          ",
+            "stdout": "",
+          }
+        `);
     });
-
-    // Argparse error-path divergence (KNOWN, pre-existing in the dev-side
-    // src/scripts/memory_status.ts which this template twin is byte-identical
-    // to): the Python twin emits the full argparse block — a `usage:` line plus
-    // `memory_status.py: error: …`; the TS twin emits only `memory_status:
-    // error: …` (no usage line, prog `memory_status`, not `.py`). Exit code (2)
-    // and the error wording match. These cases therefore assert exit-code
-    // parity only, mirroring the dev twin's own golden test, not stderr bytes.
-    // Re-flagged as a divergence candidate by this port, not introduced by it.
-    it('bad --format choice (exit 2) parity', () => {
-        const { ts, py } = envParity(['--format', 'xml']);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(2);
+    it('unrecognized argument → exit 2', () => {
+        expect(runTs(['--bogus'])).toMatchInlineSnapshot(`
+          {
+            "status": 2,
+            "stderr": "usage: memory_status.py [-h] [--format {text,json}] [--refresh] [--health]
+          memory_status.py: error: unrecognized arguments: --bogus
+          ",
+            "stdout": "",
+          }
+        `);
     });
-
-    it('unrecognized argument (exit 2) parity', () => {
-        const { ts, py } = envParity(['--bogus']);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(2);
+    it('-h → usage + exit 0', () => {
+        expect(runTs(['-h'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "usage: memory_status.py [-h] [--format {text,json}] [--refresh] [--health]
+          ",
+          }
+        `);
     });
 });

--- a/tests/scripts/templates_telemetry_record.test.ts
+++ b/tests/scripts/templates_telemetry_record.test.ts
@@ -1,10 +1,13 @@
-// Tests for src/agent-src/templates/scripts/telemetry_record.ts (ADR-094).
+// Intent tests for src/agent-src/templates/scripts/telemetry_record.ts (ADR-094).
 //
-// Template-only entry point over the telemetry/ package. Golden-parity:
-// python3 vs tsx on tmp fixtures, byte-identical stdout / stderr / exit AND
-// the written JSONL line. Timestamps are pinned via --ts so the byte
-// comparison is deterministic; the no--ts path is covered by a unit assertion
-// that does not compare the wall-clock token. argparse --help is not compared.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx template-script's own contract directly. The script is
+// default-off (silent exit 0, zero file IO when disabled), validates the
+// schema (exit 1), and rejects bad argparse choices (exit 2). Timestamps are
+// pinned via --ts so the written JSONL line is deterministic; the no--ts path
+// is not snapshotted (wall-clock token). The written log embeds NO tmp path
+// (ids only), so no path masking is needed. Each case runs with COLUMNS=200 so
+// any argparse usage text does not re-wrap to terminal width.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -16,14 +19,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const S = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = path.join(S, 'telemetry_record.ts');
-const PY_SCRIPT = path.join(S, 'telemetry_record.py');
 const TSX_BIN = process.env.TSX_BIN
     ? path.resolve(REPO_ROOT, process.env.TSX_BIN)
     : path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -56,149 +54,153 @@ interface Run {
     log: string;
 }
 
-function run(bin: string, script: string, args: string[], logPath: string): Run {
-    const r = spawnSync(bin, [script, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
+function runTs(script: string, args: string[], logPath: string): Run {
+    const r = spawnSync(TSX_BIN, [script, ...args], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, COLUMNS: '200' },
+    });
     let log = ' MISSING ';
     try {
         log = fs.readFileSync(logPath, 'utf8');
     } catch {
         log = ' MISSING ';
     }
-    return { status: r.status, stdout: r.stdout, stderr: r.stderr, log };
+    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '', log };
 }
 
-describe.runIf(hasPython3())('telemetry_record — golden parity (python3 vs tsx)', () => {
+describe('telemetry_record — template contract', () => {
     it('disabled (default) → silent exit 0 and zero file IO', () => {
         const dir = mkTmp();
         const settings = settingsFile(dir, false);
         const logPath = path.join(dir, 'eng.jsonl');
         const args = ['--settings', settings, '--task-id', 't', '--consulted', 'skills:x'];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        expect(fs.existsSync(logPath)).toBe(false);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(0);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stdout).toBe('');
+        expect(ts.stderr).toBe('');
         expect(fs.existsSync(logPath)).toBe(false);
     });
 
-    it('enabled CLI args → byte-identical JSONL line', () => {
-        const args = (settings: string): string[] => [
-            '--settings', settings, '--ts', '2026-01-02T03:04:05Z',
+    it('enabled CLI args → canonical JSONL line', () => {
+        const dir = mkTmp();
+        const logPath = path.join(dir, 'eng.jsonl');
+        const args = [
+            '--settings', settingsFile(dir, true), '--ts', '2026-01-02T03:04:05Z',
             '--task-id', 'ticket-1', '--boundary', 'task',
             '--consulted', 'skills:php-coder', '--consulted', 'rules:scope-control',
             '--applied', 'skills:php-coder',
             '--outcome', 'verification_failed', '--outcome', 'stop_rule_triggered',
         ];
-        const pyDir = mkTmp();
-        const tsDir = mkTmp();
-        const pyLog = path.join(pyDir, 'eng.jsonl');
-        const tsLog = path.join(tsDir, 'eng.jsonl');
-        const py = run('python3', PY_SCRIPT, args(settingsFile(pyDir, true)), pyLog);
-        const ts = run(TSX_BIN, TS_SCRIPT, args(settingsFile(tsDir, true)), tsLog);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.log).toBe(py.log);
+        const ts = runTs(TS_SCRIPT, args, logPath);
+        expect(ts.status).toBe(0);
+        expect(ts.log).toMatchInlineSnapshot(`
+          "{"applied":{"skills":["php-coder"]},"boundary_kind":"task","consulted":{"rules":["scope-control"],"skills":["php-coder"]},"outcomes":["verification_failed","stop_rule_triggered"],"schema_version":1,"task_id":"ticket-1","ts":"2026-01-02T03:04:05Z"}
+          "
+        `);
     });
 
     it('--force bypasses the disabled flag', () => {
-        const pyDir = mkTmp();
-        const tsDir = mkTmp();
-        const a = (settings: string): string[] => [
-            '--force', '--settings', settings, '--ts', '2026-05-05T05:05:05Z',
+        const dir = mkTmp();
+        const logPath = path.join(dir, 'eng.jsonl');
+        const args = [
+            '--force', '--settings', settingsFile(dir, false), '--ts', '2026-05-05T05:05:05Z',
             '--task-id', 'forced', '--consulted', 'guidelines:g1',
         ];
-        const pyLog = path.join(pyDir, 'eng.jsonl');
-        const tsLog = path.join(tsDir, 'eng.jsonl');
-        const py = run('python3', PY_SCRIPT, a(settingsFile(pyDir, false)), pyLog);
-        const ts = run(TSX_BIN, TS_SCRIPT, a(settingsFile(tsDir, false)), tsLog);
-        expect(ts.status).toBe(py.status);
-        expect(ts.log).toBe(py.log);
+        const ts = runTs(TS_SCRIPT, args, logPath);
+        expect(ts.status).toBe(0);
+        expect(ts.log).toMatchInlineSnapshot(`
+          "{"applied":{},"boundary_kind":"task","consulted":{"guidelines":["g1"]},"schema_version":1,"task_id":"forced","ts":"2026-05-05T05:05:05Z"}
+          "
+        `);
     });
 
-    it('JSON payload via --stdin → byte-identical JSONL line', () => {
-        const pyDir = mkTmp();
-        const tsDir = mkTmp();
+    it('JSON payload via --stdin → canonical JSONL line', () => {
+        const dir = mkTmp();
+        const logPath = path.join(dir, 'eng.jsonl');
         const payload = '{"task_id":"p1","boundary_kind":"phase-step","consulted":{"rules":["r1","r2"]},"applied":{"rules":["r1"]},"ts":"2026-03-03T03:03:03Z"}';
-        const pyLog = path.join(pyDir, 'eng.jsonl');
-        const tsLog = path.join(tsDir, 'eng.jsonl');
-        const pyR = spawnSync('python3', [PY_SCRIPT, '--settings', settingsFile(pyDir, true), '--stdin'], { cwd: REPO_ROOT, encoding: 'utf8', input: payload });
-        const tsR = spawnSync(TSX_BIN, [TS_SCRIPT, '--settings', settingsFile(tsDir, true), '--stdin'], { cwd: REPO_ROOT, encoding: 'utf8', input: payload });
-        expect(tsR.status).toBe(pyR.status);
-        expect(tsR.stderr).toBe(pyR.stderr);
-        expect(fs.readFileSync(tsLog, 'utf8')).toBe(fs.readFileSync(pyLog, 'utf8'));
+        const r = spawnSync(TSX_BIN, [TS_SCRIPT, '--settings', settingsFile(dir, true), '--stdin'], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+            input: payload,
+            env: { ...process.env, COLUMNS: '200' },
+        });
+        expect(r.status).toBe(0);
+        expect(fs.readFileSync(logPath, 'utf8')).toMatchInlineSnapshot(`
+          "{"applied":{"rules":["r1"]},"boundary_kind":"phase-step","consulted":{"rules":["r1","r2"]},"schema_version":1,"task_id":"p1","ts":"2026-03-03T03:03:03Z"}
+          "
+        `);
     });
 
-    it('bad artefact kind → byte-identical schema error + exit 1', () => {
+    it('bad artefact kind → schema error + exit 1', () => {
         const dir = mkTmp();
-        const settings = settingsFile(dir, true);
         const logPath = path.join(dir, 'eng.jsonl');
-        const args = ['--settings', settings, '--task-id', 't', '--consulted', 'badkind:x'];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const args = ['--settings', settingsFile(dir, true), '--task-id', 't', '--consulted', 'badkind:x'];
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(1);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "❌  schema validation failed: consulted.'badkind' is not an allowed artefact kind (allowed: ('skills', 'rules', 'commands', 'guidelines', 'personas'))
+          "
+        `);
     });
 
-    it('redaction floor (slash in id) → byte-identical error + exit 1', () => {
+    it('redaction floor (slash in id) → error + exit 1', () => {
         const dir = mkTmp();
-        const settings = settingsFile(dir, true);
         const logPath = path.join(dir, 'eng.jsonl');
-        const args = ['--settings', settings, '--task-id', 't', '--consulted', 'skills:a/b'];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const args = ['--settings', settingsFile(dir, true), '--task-id', 't', '--consulted', 'skills:a/b'];
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(1);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "❌  schema validation failed: consulted.skills contains forbidden character '/'; id fields must be repository-internal artefact ids only (no paths, no free-text)
+          "
+        `);
     });
 
-    it('--consulted without a colon → byte-identical error + exit 1', () => {
+    it('--consulted without a colon → error + exit 1', () => {
         const dir = mkTmp();
-        const settings = settingsFile(dir, true);
         const logPath = path.join(dir, 'eng.jsonl');
-        const args = ['--settings', settings, '--task-id', 't', '--consulted', 'noColonHere'];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const args = ['--settings', settingsFile(dir, true), '--task-id', 't', '--consulted', 'noColonHere'];
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(1);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "❌  --consulted/--applied must be 'kind:id', got 'noColonHere'
+          "
+        `);
     });
 
-    it('missing --task-id with no payload → byte-identical error + exit 1', () => {
+    it('missing --task-id with no payload → error + exit 1', () => {
         const dir = mkTmp();
-        const settings = settingsFile(dir, true);
         const logPath = path.join(dir, 'eng.jsonl');
-        const args = ['--settings', settings];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const args = ['--settings', settingsFile(dir, true)];
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(1);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "❌  --task-id required (or pass --payload-file/--stdin)
+          "
+        `);
     });
 
-    it('duplicate outcome → byte-identical schema error + exit 1', () => {
+    it('duplicate outcome → schema error + exit 1', () => {
         const dir = mkTmp();
-        const settings = settingsFile(dir, true);
         const logPath = path.join(dir, 'eng.jsonl');
-        const args = ['--settings', settings, '--task-id', 't', '--consulted', 'skills:x', '--outcome', 'blocked', '--outcome', 'blocked'];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const args = ['--settings', settingsFile(dir, true), '--task-id', 't', '--consulted', 'skills:x', '--outcome', 'blocked', '--outcome', 'blocked'];
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(1);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "❌  schema validation failed: outcomes contains duplicate 'blocked'
+          "
+        `);
     });
 
-    it('invalid --boundary choice → exit 2 on both (usage text not compared)', () => {
+    it('invalid --boundary choice → exit 2', () => {
         const dir = mkTmp();
-        const settings = settingsFile(dir, true);
         const logPath = path.join(dir, 'eng.jsonl');
-        const args = ['--settings', settings, '--task-id', 't', '--boundary', 'bogus'];
-        const py = run('python3', PY_SCRIPT, args, logPath);
-        const ts = run(TSX_BIN, TS_SCRIPT, args, logPath);
-        expect(ts.status).toBe(py.status);
+        const args = ['--settings', settingsFile(dir, true), '--task-id', 't', '--boundary', 'bogus'];
+        const ts = runTs(TS_SCRIPT, args, logPath);
         expect(ts.status).toBe(2);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "error: argument --boundary: invalid choice: 'bogus' (choose from 'task', 'phase-step', 'tool-call')
+          "
+        `);
     });
 });

--- a/tests/scripts/templates_telemetry_status.test.ts
+++ b/tests/scripts/templates_telemetry_status.test.ts
@@ -1,10 +1,12 @@
-// Tests for src/agent-src/templates/scripts/telemetry_status.ts (ADR-094).
+// Intent tests for src/agent-src/templates/scripts/telemetry_status.ts (ADR-094).
 //
-// Template-only entry point over the telemetry/ package. Golden-parity:
-// python3 vs tsx on tmp fixtures, byte-identical stdout / stderr / exit for
-// text and JSON formats. The log path embedded in the output is pinned to an
-// absolute tmp path passed via the settings file, so it normalises naturally
-// (both interpreters read the same fixed path). argparse --help not compared.
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx template-script's own contract directly (text + json status
+// for the disabled-defaults, enabled-not-created, populated, and
+// no-trailing-newline paths, plus the bad --format exit-2 path). The status
+// output embeds the absolute settings/log tmp path, so `norm()` collapses the
+// per-run tmp dir to `<TMP>` (and the macOS `/private` realpath prefix) so the
+// snapshots are stable on Linux CI. COLUMNS=200 keeps argparse usage stable.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -16,14 +18,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const S = path.join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = path.join(S, 'telemetry_status.ts');
-const PY_SCRIPT = path.join(S, 'telemetry_status.py');
 const TSX_BIN = process.env.TSX_BIN
     ? path.resolve(REPO_ROOT, process.env.TSX_BIN)
     : path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -46,29 +43,76 @@ interface Run {
     stderr: string;
 }
 
-function run(bin: string, script: string, args: string[]): Run {
-    const r = spawnSync(bin, [script, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
-    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+// Mask the per-run tmp dir → `<TMP>`, collapsing the macOS `/private` realpath
+// prefix so snapshots match on Linux CI.
+function norm(s: string, dir: string): string {
+    let out = s.split(`/private${dir}`).join('<TMP>');
+    out = out.split(dir).join('<TMP>');
+    return out;
 }
 
-function assertParity(args: string[]): void {
-    const py = run('python3', PY_SCRIPT, args);
-    const ts = run(TSX_BIN, TS_SCRIPT, args);
-    expect(ts.status).toBe(py.status);
-    expect(ts.stdout).toBe(py.stdout);
-    expect(ts.stderr).toBe(py.stderr);
+function runTs(dir: string, args: string[]): Run {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: { ...process.env, COLUMNS: '200' },
+    });
+    return {
+        status: r.status,
+        stdout: norm(r.stdout ?? '', dir),
+        stderr: norm(r.stderr ?? '', dir),
+    };
 }
 
-describe.runIf(hasPython3())('telemetry_status — golden parity (python3 vs tsx)', () => {
-    it('no settings section → disabled-with-defaults note (text + json)', () => {
+describe('telemetry_status — template contract', () => {
+    it('no settings section → disabled-with-defaults note (text)', () => {
         const dir = mkTmp();
         const settings = path.join(dir, 'settings.yml');
         fs.writeFileSync(settings, 'other: {}\n');
-        assertParity(['--settings', settings]);
-        assertParity(['--settings', settings, '--format', 'json']);
+        expect(runTs(dir, ['--settings', settings])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  artifact-engagement: ⛔  disabled (no telemetry section in .agent-settings.yml — using defaults)
+            granularity:         task
+            record:              consulted=True applied=True
+            log path:            .agent-engagement.jsonl
+            log:                 not yet created
+          ",
+          }
+        `);
     });
 
-    it('enabled, log not yet created → "not yet created" / exists:false', () => {
+    it('no settings section → disabled-with-defaults note (json)', () => {
+        const dir = mkTmp();
+        const settings = path.join(dir, 'settings.yml');
+        fs.writeFileSync(settings, 'other: {}\n');
+        expect(runTs(dir, ['--settings', settings, '--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "enabled": false,
+            "granularity": "task",
+            "log": {
+              "exists": false,
+              "last_event_ts": null,
+              "line_count": 0,
+              "path": ".agent-engagement.jsonl",
+              "size_bytes": 0
+            },
+            "record": {
+              "applied": true,
+              "consulted": true
+            },
+            "section_present": false
+          }
+          ",
+          }
+        `);
+    });
+
+    it('enabled, log not yet created → "not yet created" (text)', () => {
         const dir = mkTmp();
         const settings = path.join(dir, 'settings.yml');
         const logPath = path.join(dir, 'eng.jsonl');
@@ -76,11 +120,54 @@ describe.runIf(hasPython3())('telemetry_status — golden parity (python3 vs tsx
             settings,
             `telemetry:\n  artifact_engagement:\n    enabled: true\n    granularity: phase-step\n    output:\n      path: ${logPath}\n`,
         );
-        assertParity(['--settings', settings]);
-        assertParity(['--settings', settings, '--format', 'json']);
+        expect(runTs(dir, ['--settings', settings])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  artifact-engagement: ✅  enabled
+            granularity:         phase-step
+            record:              consulted=True applied=True
+            log path:            <TMP>/eng.jsonl
+            log:                 not yet created
+          ",
+          }
+        `);
     });
 
-    it('enabled with a populated log → size + line_count + last_event_ts', () => {
+    it('enabled, log not yet created → exists:false (json)', () => {
+        const dir = mkTmp();
+        const settings = path.join(dir, 'settings.yml');
+        const logPath = path.join(dir, 'eng.jsonl');
+        fs.writeFileSync(
+            settings,
+            `telemetry:\n  artifact_engagement:\n    enabled: true\n    granularity: phase-step\n    output:\n      path: ${logPath}\n`,
+        );
+        expect(runTs(dir, ['--settings', settings, '--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "enabled": true,
+            "granularity": "phase-step",
+            "log": {
+              "exists": false,
+              "last_event_ts": null,
+              "line_count": 0,
+              "path": "<TMP>/eng.jsonl",
+              "size_bytes": 0
+            },
+            "record": {
+              "applied": true,
+              "consulted": true
+            },
+            "section_present": true
+          }
+          ",
+          }
+        `);
+    });
+
+    it('enabled with a populated log → size + line_count + last_event_ts (text)', () => {
         const dir = mkTmp();
         const settings = path.join(dir, 'settings.yml');
         const logPath = path.join(dir, 'eng.jsonl');
@@ -94,11 +181,61 @@ describe.runIf(hasPython3())('telemetry_status — golden parity (python3 vs tsx
             'malformed-tail-line-ignored',
         ];
         fs.writeFileSync(logPath, `${lines.join('\n')}\n`);
-        assertParity(['--settings', settings]);
-        assertParity(['--settings', settings, '--format', 'json']);
+        expect(runTs(dir, ['--settings', settings])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "  artifact-engagement: ✅  enabled
+            granularity:         task
+            record:              consulted=False applied=True
+            log path:            <TMP>/eng.jsonl
+            log size:            296 bytes (3 events)
+            last event ts:       2026-02-02T02:02:02Z
+          ",
+          }
+        `);
     });
 
-    it('log with no trailing newline still counts the final line', () => {
+    it('enabled with a populated log → size + line_count + last_event_ts (json)', () => {
+        const dir = mkTmp();
+        const settings = path.join(dir, 'settings.yml');
+        const logPath = path.join(dir, 'eng.jsonl');
+        fs.writeFileSync(
+            settings,
+            `telemetry:\n  artifact_engagement:\n    enabled: true\n    record:\n      consulted: false\n    output:\n      path: ${logPath}\n`,
+        );
+        const lines = [
+            '{"schema_version":1,"ts":"2026-01-01T00:00:00Z","task_id":"a","boundary_kind":"task","consulted":{"skills":["x"]},"applied":{}}',
+            '{"schema_version":1,"ts":"2026-02-02T02:02:02Z","task_id":"b","boundary_kind":"task","consulted":{"rules":["y"]},"applied":{"rules":["y"]}}',
+            'malformed-tail-line-ignored',
+        ];
+        fs.writeFileSync(logPath, `${lines.join('\n')}\n`);
+        expect(runTs(dir, ['--settings', settings, '--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "enabled": true,
+            "granularity": "task",
+            "log": {
+              "exists": true,
+              "last_event_ts": "2026-02-02T02:02:02Z",
+              "line_count": 3,
+              "path": "<TMP>/eng.jsonl",
+              "size_bytes": 296
+            },
+            "record": {
+              "applied": true,
+              "consulted": false
+            },
+            "section_present": true
+          }
+          ",
+          }
+        `);
+    });
+
+    it('log with no trailing newline still counts the final line (json)', () => {
         const dir = mkTmp();
         const settings = path.join(dir, 'settings.yml');
         const logPath = path.join(dir, 'eng.jsonl');
@@ -110,17 +247,40 @@ describe.runIf(hasPython3())('telemetry_status — golden parity (python3 vs tsx
             logPath,
             '{"schema_version":1,"ts":"2026-01-01T00:00:00Z","task_id":"a","boundary_kind":"task","consulted":{"skills":["x"]},"applied":{}}',
         );
-        assertParity(['--settings', settings, '--format', 'json']);
+        expect(runTs(dir, ['--settings', settings, '--format', 'json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "enabled": true,
+            "granularity": "task",
+            "log": {
+              "exists": true,
+              "last_event_ts": "2026-01-01T00:00:00Z",
+              "line_count": 1,
+              "path": "<TMP>/eng.jsonl",
+              "size_bytes": 127
+            },
+            "record": {
+              "applied": true,
+              "consulted": true
+            },
+            "section_present": true
+          }
+          ",
+          }
+        `);
     });
 
-    it('invalid --format choice → exit 2 on both (usage text not compared)', () => {
+    it('invalid --format choice → exit 2', () => {
         const dir = mkTmp();
         const settings = path.join(dir, 'settings.yml');
         fs.writeFileSync(settings, 'telemetry: {}\n');
-        const args = ['--settings', settings, '--format', 'bogus'];
-        const py = run('python3', PY_SCRIPT, args);
-        const ts = run(TSX_BIN, TS_SCRIPT, args);
-        expect(ts.status).toBe(py.status);
+        const ts = runTs(dir, ['--settings', settings, '--format', 'bogus']);
         expect(ts.status).toBe(2);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "error: argument --format: invalid choice: 'bogus' (choose from 'text', 'json')
+          "
+        `);
     });
 });

--- a/tests/scripts/templates_tier_usage_report.test.ts
+++ b/tests/scripts/templates_tier_usage_report.test.ts
@@ -1,49 +1,66 @@
-// Tests for src/agent-src/templates/scripts/tier_usage_report.ts — tier-usage report.
+// Intent tests for src/agent-src/templates/scripts/tier_usage_report.ts.
 //
-// Golden-parity harness (ADR-094): runs python3 + tsx on the consumer-template
-// twin against tmp `.agent-tier-usage.jsonl` + `.agent-settings.yml` fixtures and
-// asserts byte-identical stdout/stderr/exit for the table, `--json`,
-// disabled-telemetry, privacy-floor-refusal (exit 1), missing-log (exit 2), and
-// CLI-error (exit 2) paths. Output is fully deterministic (no backend probe,
-// no id/ts generation) so a `--window-days 0` (full-log) window avoids any
-// wall-clock dependence. Skipped without python3.
-
+// Was a python3-vs-tsx byte-parity rig; the `.py` original is gone, so this now
+// asserts the tsx template-script's own contract directly: the table + `--json`
+// happy paths, the privacy floor (drop leaked/invalid records; refuse with
+// exit 1 when none survive), disabled-telemetry, enabled-with-absent-log,
+// missing-log-path, and the two argparse exit-2 paths. Output is fully
+// deterministic (no backend probe, no id/ts generation) so `--window-days 0`
+// (full log) avoids any wall-clock dependence. The `--json` output embeds the
+// absolute `--log-path`, so `norm()` collapses the per-run tmp dir to `<TMP>`
+// (and the macOS `/private` realpath prefix) for Linux-CI-stable snapshots.
+// COLUMNS=200 keeps argparse usage from re-wrapping.
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { isAbsolute, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const _TSX_ENV = process.env['TSX_BIN'];
 const TSX_BIN = _TSX_ENV
-    ? (isAbsolute(_TSX_ENV) ? _TSX_ENV : resolve(REPO_ROOT, _TSX_ENV))
+    ? resolve(REPO_ROOT, _TSX_ENV)
     : join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 const SCRIPTS_DIR = join(REPO_ROOT, 'src', 'agent-src', 'templates', 'scripts');
 const TS_SCRIPT = join(SCRIPTS_DIR, 'tier_usage_report.ts');
-const PY_SCRIPT = join(SCRIPTS_DIR, 'tier_usage_report.py');
-
-function pythonAvailable(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = pythonAvailable();
 
 // A 16-char user_hash (the privacy floor requires exactly 16 chars).
 const UH = (n: number): string => `u${String(n).padStart(15, '0')}`;
 
-describe.skipIf(!HAVE_PYTHON)('templates/tier_usage_report — golden parity', () => {
+interface Run {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+describe('templates/tier_usage_report — template contract', () => {
     let tmp: string;
     beforeEach(() => {
-        tmp = mkdtempSync(join(tmpdir(), 'tpl-tier-gold-'));
+        tmp = mkdtempSync(join(tmpdir(), 'tpl-tier-'));
     });
     afterEach(() => {
         rmSync(tmp, { recursive: true, force: true });
     });
 
-    function envParity(args: readonly string[]): { ts: ReturnType<typeof spawnSync>; py: ReturnType<typeof spawnSync> } {
-        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: tmp, encoding: 'utf8' });
-        const py = spawnSync('python3', [PY_SCRIPT, ...args], { cwd: tmp, encoding: 'utf8' });
-        return { ts, py };
+    // Mask the per-run tmp dir → `<TMP>`, collapsing the macOS `/private`
+    // realpath prefix so snapshots match on Linux CI.
+    function norm(s: string): string {
+        let out = s.split(`/private${tmp}`).join('<TMP>');
+        out = out.split(tmp).join('<TMP>');
+        return out;
+    }
+
+    function runTs(args: readonly string[]): Run {
+        const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+            cwd: tmp,
+            encoding: 'utf8',
+            env: { ...process.env, COLUMNS: '200' },
+        });
+        return {
+            status: r.status,
+            stdout: norm(r.stdout ?? ''),
+            stderr: norm(r.stderr ?? ''),
+        };
     }
 
     function writeLog(name: string, records: Record<string, unknown>[], trailing = true): string {
@@ -63,26 +80,64 @@ describe.skipIf(!HAVE_PYTHON)('templates/tier_usage_report — golden parity', (
         ];
     }
 
-    it('table output parity (--log-path, full window)', () => {
+    it('table output (--log-path, full window)', () => {
         const log = writeLog('usage.jsonl', validRecords());
-        const { ts, py } = envParity(['--log-path', log, '--window-days', '0']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(0);
+        expect(runTs(['--log-path', log, '--window-days', '0'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "Tier  Command                            Calls   Users
+          ------------------------------------------------------
+          0     help                                   1       1
+          1     commit                                 3       2
+          2     review                                 1       1
+
+          (window:(full log))
+          ",
+          }
+        `);
     });
 
-    it('json output parity (--log-path, full window)', () => {
+    it('json output (--log-path, full window)', () => {
         const log = writeLog('usage.jsonl', validRecords());
-        const { ts, py } = envParity(['--log-path', log, '--window-days', '0', '--json']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+        expect(runTs(['--log-path', log, '--window-days', '0', '--json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "window_days": 0,
+            "log_path": "<TMP>/usage.jsonl",
+            "records_total": 5,
+            "records_kept": 5,
+            "rows": [
+              {
+                "tier": 0,
+                "command": "help",
+                "count": 1,
+                "distinct_users": 1
+              },
+              {
+                "tier": 1,
+                "command": "commit",
+                "count": 3,
+                "distinct_users": 2
+              },
+              {
+                "tier": 2,
+                "command": "review",
+                "count": 1,
+                "distinct_users": 1
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
     it('privacy floor drops leaked/invalid records (--json)', () => {
         // Mix valid records with floor violations: extra field, bad tier, bad
-        // outcome, short hash, command with a slash, non-string ts_bucket.
+        // outcome, short hash, command with a slash.
         const recs: Record<string, unknown>[] = [
             ...validRecords(),
             { ts_bucket: '2026-05-01T00:00:00+00:00', command: 'commit', tier: 1, outcome: 'success', user_hash: UH(1), leak: 'oops' },
@@ -92,33 +147,70 @@ describe.skipIf(!HAVE_PYTHON)('templates/tier_usage_report — golden parity', (
             { ts_bucket: '2026-05-01T00:00:00+00:00', command: 'a/b', tier: 1, outcome: 'success', user_hash: UH(1) },
         ];
         const log = writeLog('usage.jsonl', recs);
-        const { ts, py } = envParity(['--log-path', log, '--window-days', '0', '--json']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+        expect(runTs(['--log-path', log, '--window-days', '0', '--json'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "{
+            "window_days": 0,
+            "log_path": "<TMP>/usage.jsonl",
+            "records_total": 10,
+            "records_kept": 5,
+            "rows": [
+              {
+                "tier": 0,
+                "command": "help",
+                "count": 1,
+                "distinct_users": 1
+              },
+              {
+                "tier": 1,
+                "command": "commit",
+                "count": 3,
+                "distinct_users": 2
+              },
+              {
+                "tier": 2,
+                "command": "review",
+                "count": 1,
+                "distinct_users": 1
+              }
+            ]
+          }
+          ",
+          }
+        `);
     });
 
-    it('all-records-dropped → exit 1 parity', () => {
+    it('all-records-dropped → exit 1', () => {
         // Every record violates the floor → total>0, kept==0 → exit 1.
         const recs: Record<string, unknown>[] = [
             { ts_bucket: '2026-05-01T00:00:00+00:00', command: 'x', tier: 9, outcome: 'success', user_hash: UH(1) },
             { ts_bucket: '2026-05-01T00:00:00+00:00', command: 'x', tier: 1, outcome: 'nope', user_hash: UH(1) },
         ];
         const log = writeLog('usage.jsonl', recs);
-        const { ts, py } = envParity(['--log-path', log, '--window-days', '0']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+        const ts = runTs(['--log-path', log, '--window-days', '0']);
         expect(ts.status).toBe(1);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "status": 1,
+            "stderr": "❌  2 record(s) read; 0 survived the privacy floor — report refused
+          ",
+            "stdout": "",
+          }
+        `);
     });
 
-    it('telemetry disabled (no --log-path, no settings) parity', () => {
+    it('telemetry disabled (no --log-path, no settings)', () => {
         // No settings file → disabled → single header line, exit 0.
-        const { ts, py } = envParity([]);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(0);
+        expect(runTs([])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "(tier-usage telemetry disabled; set \`telemetry.tier_usage.enabled: true\` in .agent-settings.yml)
+          ",
+          }
+        `);
     });
 
     it('telemetry enabled via settings, default log absent → empty table', () => {
@@ -128,34 +220,49 @@ describe.skipIf(!HAVE_PYTHON)('templates/tier_usage_report — golden parity', (
             'telemetry:\n  tier_usage:\n    enabled: true\n',
             'utf-8',
         );
-        const { ts, py } = envParity(['--window-days', '0']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(0);
+        expect(runTs(['--window-days', '0'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "(no tier-usage records (full log))
+          ",
+          }
+        `);
     });
 
-    it('missing --log-path file → exit 2 parity', () => {
+    it('missing --log-path file → empty table, exit 0', () => {
         // --log-path provided (bypasses the disabled check) but file is missing.
-        // Python: aggregate returns ({},0,0) for a non-existent path → exit 0,
-        // empty table. Assert both sides agree on whatever that contract is.
-        const { ts, py } = envParity(['--log-path', join(tmp, 'nope.jsonl'), '--window-days', '0']);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+        expect(runTs(['--log-path', join(tmp, 'nope.jsonl'), '--window-days', '0'])).toMatchInlineSnapshot(`
+          {
+            "status": 0,
+            "stderr": "",
+            "stdout": "(no tier-usage records (full log))
+          ",
+          }
+        `);
     });
 
-    it('bad --window-days int (exit 2) parity', () => {
-        const { ts, py } = envParity(['--window-days', 'abc']);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('bad --window-days int → exit 2', () => {
+        const ts = runTs(['--window-days', 'abc']);
         expect(ts.status).toBe(2);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "usage: tier_usage_report.py [-h] [--window-days WINDOW_DAYS] [--json]
+                                      [--log-path LOG_PATH]
+                                      [--settings-file SETTINGS_FILE]
+          tier_usage_report.py: error: argument --window-days: invalid int value: 'abc'
+          "
+        `);
     });
 
-    it('unrecognized argument (exit 2) parity', () => {
-        const { ts, py } = envParity(['--bogus']);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.status).toBe(py.status);
+    it('unrecognized argument → exit 2', () => {
+        const ts = runTs(['--bogus']);
         expect(ts.status).toBe(2);
+        expect(ts.stderr).toMatchInlineSnapshot(`
+          "usage: tier_usage_report.py [-h] [--window-days WINDOW_DAYS] [--json]
+                                      [--log-path LOG_PATH]
+                                      [--settings-file SETTINGS_FILE]
+          tier_usage_report.py: error: unrecognized arguments: --bogus
+          "
+        `);
     });
 });


### PR DESCRIPTION
Next wave of the py2ts post-merge test-layer cleanup (per the 2026-06-29 council finish strategy, #695).

Converts the 10 `templates_*` parity rigs (check_memory, check_memory_proposal, memory_hash, memory_lookup, memory_report, memory_signal, memory_status, telemetry_record, telemetry_status, tier_usage_report) from obsolete python3-vs-tsx byte-parity rigs into **python-free intent tests** that assert each TS template-script's own contract via inline snapshots.

**CONVERT-by-default** (no deletes — the council's coverage-degradation guard: a delete needs the Phase-0 3-tier audit + assertion-strength sample-check, not done here). Coverage preserved 1:1; several argparse-error paths *strengthened* from exit-code-only to full stderr-byte snapshots. Determinism via per-file `norm()` masking (ids / overdue-days / tmp paths, incl. the macOS `/private` realpath collapse so Linux CI matches).

## Verification
- 111 tests pass; green with `python3` shadowed by a failing stub → python-free by construction (zero spawn residue in all 10 files).
- `tsc -p tsconfig.scripts.json --noEmit` clean (the CI Typecheck gate that vitest doesn't cover).
- Tests-only PR — never touches `agents/roadmaps-progress.md`, so no dashboard merge-conflict / merge-ref suppression (the #646 failure mode).

Tail: 103 → 93. Remaining clusters (`_cli/cmd_*` audit, singletons, shim-retire) tracked in the re-scoped roadmap (#695).