### PR TITLE
fix: release-gate hardening — template-pin, legal-ref resolution, release verification

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -178,3 +178,12 @@ jobs:
             exit 1
           fi
           echo "✅  Every version reference agrees on $pkg"
+
+      - name: Check project-template pin matches package.json.version
+        run: |
+          set -euo pipefail
+          # The project-settings example template (src + dist twin) carries an
+          # `agent_config_version` pin that must equal package.json.version, or a
+          # fresh `init` bootstraps onto a stale pin. release.ts set_template_pin
+          # keeps it in lockstep; this gate is the backstop on the release PR.
+          ./scripts-run src/scripts/check_template_pin_drift

--- a/agents/roadmaps/archive/road-to-release-gate-hardening.md
+++ b/agents/roadmaps/archive/road-to-release-gate-hardening.md
@@ -1,0 +1,83 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to release-gate hardening — turn reactive catches into pre-merge gates
+
+> Distilled from the 7.5.0 (PR #694) external review round. Six independent
+> reviewers converged on one structural theme: **too much is caught reactively
+> that should have been a blocking gate** — the LEGAL_NOTICE path bug, the
+> condense-hash drift, and a template version-pin that shipped one release
+> behind. This roadmap closes that class. It deliberately does **not** add new
+> product surface (connectors, employee mode, knowledge layer) — those are
+> already tracked, council-deferred, and demand-gated in
+> `road-to-product-bets`. The single highest-leverage move per the reviewers is
+> "a more comprehensive pre-merge verification net", not another feature.
+
+## Why these and not the bigger asks
+
+The review's P0/P1 strategic items — knowledge connectors, employee mode,
+consumer-install smoke, mission-success analytics — are **already** captured in
+`road-to-product-bets` (draft, council-deferred behind demand signals and
+`domain-adoption-policy`). Re-opening them here would duplicate a deliberate
+deferral. The design-feature refinements (anti-slop configurable rule-sets,
+judge-synthesis minority dissent, design-system.json schema hardening, golden
+tasks) are genuine but are feature work that needs its own scoping round, not an
+autonomous hygiene sweep. What remains — and what every reviewer flagged as the
+recurring failure mode — is gate-hardening. That is this roadmap.
+
+## Phase 1 — Template version-pin: fix the live drift and wire the guard into CI
+
+> Root cause confirmed on `main`: `package.json` is `7.5.0` but both
+> `agent-project-settings.example.yml` twins are pinned `7.4.0`, so
+> `check_template_pin_drift` is **red inside `task ci`** today. It merged anyway
+> because that guard is wired into **no** GitHub workflow — it only runs in the
+> local `task ci` meta-task. A fresh install on 7.5.0 therefore starts with a
+> 7.4.0-pinned example. The example template is also the one hand-maintained pin
+> outside the `generate_pack_manifests` generator, which is why it alone drifts.
+
+- [x] **1.1 — Bump both template twins to the current `package.json` version** — `src/agent-src/templates/agents/agent-project-settings.example.yml` and the `dist/agent-src/` twin, `agent_config_version: "7.5.0"`. Verify `./scripts-run src/scripts/check_template_pin_drift` exits 0.
+- [x] **1.2 — Make the bump automatic for future releases** — add `set_template_pin()` to `src/scripts/release.ts`, called from the bump step alongside `set_package_version`/`set_marketplace_version` (the src twin; `task release-prepare` regenerates the dist twin). Add it to the preview print and export it for tests. Mirror the embedded patch from the review.
+- [x] **1.3 — Allowlist the template in the release-PR-shape guard** — add both template paths to `ALLOWLIST_GLOBS` in `src/scripts/check_release_pr_shape.ts`, so the legitimate release-time bump is not rejected. Without this, 1.1+1.2 deadlock against the shape guard.
+- [x] **1.4 — Wire `check-template-pin-drift` into a GitHub gate** — add the guard to the release-gating workflow (`release-validation.yml` / `release-guard.yml`, whichever gates release PRs) so a future pin drift fails the PR at the source instead of being caught a release later. This is the actual root-cause fix; 1.1 is only the symptom.
+- [x] **1.5 — Verify** — `./scripts-run src/scripts/check_template_pin_drift` green, `check_release_pr_shape` green, and the `release.ts` test suite green over the new `set_template_pin`.
+
+## Phase 2 — Legal-pack reference-resolution gate
+
+> The 7.5.0 changelog carries `correct LEGAL_NOTICE.md relative path in
+> legal-safety-floor rule` — a broken path shipped in the one pack whose
+> disclaimer is the liability shield. From `src/rules/legal-safety-floor.md` the
+> `../../../LEGAL_NOTICE.md` link still does not resolve (it points above the
+> repo root); the path is only correct from the `dist/agent-src/rules/`
+> projection. `lint_legal_pack.ts` exists but let the break through. A
+> projection-aware resolution check is the missing gate.
+
+- [x] **2.1 — Inventory the references** — enumerate every path/link reference in `legal-safety-floor` (LEGAL_NOTICE, disclaimer paths, cross-linked skills) and record, per reference, whether it resolves from the `src/` location, the `dist/agent-src/` projection, or both. Establish the intended resolution root.
+- [x] **2.2 — Add the resolution gate** — extend `lint_legal_pack.ts` (or add a focused check it calls) to assert every reference in the legal-safety-floor rule resolves from its shipped projection. Fail on any unresolvable reference.
+- [x] **2.3 — Negative fixture** — add a test that points the gate at a deliberately broken reference and asserts it fails, so the gate itself is covered.
+- [x] **2.4 — Fix any reference the new gate flags** — including the `LEGAL_NOTICE.md` link if it is still wrong from any shipped projection. Verify the gate is green afterward.
+
+## Phase 3 — Close the two open release-verification questions
+
+> Two merged-but-unverified claims from the 7.5.0 cycle the reviewers flagged as
+> 10-second checks. Record the evidence rather than re-litigate.
+
+- [x] **3.1 — `rubric:score` drop semver check** — confirm the dropped `rubric:score` was a judge/council-internal surface (Minor-safe), not a consumed public surface. Record the evidence in the roadmap or a short note.
+- [x] **3.2 — Trigger-evals over the 15 trimmed descriptions** — confirm the trigger-evals pass over the 15 at-cap skill descriptions trimmed in 7.5.0, so the token-saving trim did not regress routing. Record the result.
+
+## Out of scope — already tracked or needs its own round
+
+- **Knowledge connectors, simple/expert (employee) mode, subagent explainability, consumer-install smoke** — `road-to-product-bets` (draft, council-deferred, demand-gated). Do not duplicate.
+- **Condense-hash drift as a blocking gate** — already enforced in `consistency.yml` (`sync-check-hashes` + `check_condensation`). No new work; the 7.5.0 "pre-existing drift" was refreshed reactively but the gate exists.
+- **Design capability-boundary contract** (a `design-capability-boundary` doc under `docs/contracts/`) — a genuine reviewer follow-up, but a 2-member AI council (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2026-06-29) found it is **not gate-hardening**: a documentation artefact blocks none of the three cited mechanical defects (template drift, broken legal path, missing release verification). It belongs in its own design-governance round, not this roadmap.
+- **Design-feature refinements** (anti-slop configurable rule-sets, judge-synthesis minority dissent, design-system.json schema hardening + good/bad/migration examples, design-quality golden tasks, mission-success analytics) — real, but feature work needing its own scoping/council round, not a hygiene sweep.
+- **Branch protection** — repo-admin action, not a code change; tracked separately and needs a human with admin rights.
+
+## Acceptance criteria
+
+- `./scripts-run src/scripts/check_template_pin_drift` exits 0 and the guard runs in a GitHub release gate.
+- A future release bump moves the template pin automatically (covered by a `release.ts` test).
+- Every reference in the legal-safety-floor rule is gate-verified to resolve from its shipped projection, with a negative fixture.
+- The two release-verification questions are answered with recorded evidence.
+- No new product surface added; the strategic asks remain in `road-to-product-bets`.

--- a/dist/agent-src/templates/agents/agent-project-settings.example.yml
+++ b/dist/agent-src/templates/agents/agent-project-settings.example.yml
@@ -39,7 +39,7 @@ schema_version: 1
 # CI guard: a release bump of `package.json` must update this value
 # in lockstep — see scripts/check_template_pin_drift.py (road-to-
 # portable-runtime-and-update-check P3.3).
-agent_config_version: "7.4.0"
+agent_config_version: "7.5.0"
 
 # --- Project identity ---
 project:

--- a/src/agent-src/templates/agents/agent-project-settings.example.yml
+++ b/src/agent-src/templates/agents/agent-project-settings.example.yml
@@ -39,7 +39,7 @@ schema_version: 1
 # CI guard: a release bump of `package.json` must update this value
 # in lockstep — see scripts/check_template_pin_drift.py (road-to-
 # portable-runtime-and-update-check P3.3).
-agent_config_version: "7.4.0"
+agent_config_version: "7.5.0"
 
 # --- Project identity ---
 project:

--- a/src/scripts/check_release_pr_shape.ts
+++ b/src/scripts/check_release_pr_shape.ts
@@ -31,6 +31,10 @@ const ALLOWLIST_GLOBS = [
     'src/domains/*/pack.yaml',
     'src/domains/*/README.md',
     'docs/archive/CHANGELOG-pre-*.md',
+    // Project-settings template pin — bumped by release.ts set_template_pin and
+    // its regenerated dist twin (kept in lockstep with package.json.version).
+    'src/agent-src/templates/agents/agent-project-settings.example.yml',
+    'dist/agent-src/templates/agents/agent-project-settings.example.yml',
 ] as const;
 
 /**

--- a/src/scripts/lint_legal_pack.ts
+++ b/src/scripts/lint_legal_pack.ts
@@ -74,6 +74,62 @@ export function legalPromotionViolations(packsYml: string, legalNotice: string):
     return [];
 }
 
+// D7 — reference-resolution gate for the floor rule itself. The
+// `legal-safety-floor` rule is authored in `src/rules/` but SHIPS/PROJECTS to
+// `dist/agent-src/rules/`; its relative links must resolve from that SHIPPED
+// projection root (7.5.0 shipped a `LEGAL_NOTICE.md` path that only resolved
+// from the projection — correct by design, but nothing asserted it, so a wrong
+// depth could silently regress). `check_references` does not catch this: it
+// only scans `dist/agent-src/` + `agents/` (never `src/`), and its PATH_PATTERN
+// matches only directory-rooted paths (`skills/…`, `docs/…`), so a bare
+// `../../../LEGAL_NOTICE.md` filename link is invisible to it. This gate is the
+// complementary backstop — every markdown link target in the floor rule must
+// resolve from the projected `dist/agent-src/rules/` location.
+const PROJECTED_FLOOR_DIR = path.join(REPO, 'dist', 'agent-src', 'rules');
+// Markdown inline link: [text](target). Captures the target.
+const MD_LINK_RE = /\[[^\]]*\]\(([^)]+)\)/g;
+
+/**
+ * Pure reference-resolution check for the floor rule. `ruleText` is the floor
+ * rule body (read from `src/rules/legal-safety-floor.md`); every relative
+ * markdown link target it contains MUST resolve from `projectedDir` (the
+ * shipped `dist/agent-src/rules/` location). External (http/anchor/mailto) and
+ * absolute targets are skipped. Returns a Violation per unresolvable link.
+ */
+export function legalFloorReferenceViolations(
+    ruleText: string,
+    projectedDir: string,
+    floorRel: string,
+): Violation[] {
+    const out: Violation[] = [];
+    const seen = new Set<string>();
+    MD_LINK_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = MD_LINK_RE.exec(ruleText)) !== null) {
+        let target = (m[1] ?? '').trim();
+        // Strip a fragment/anchor and any title (`path "Title"`).
+        const titleSplit = target.match(/^(\S+)\s+["'(]/);
+        if (titleSplit) target = titleSplit[1] ?? target;
+        const hashIdx = target.indexOf('#');
+        if (hashIdx >= 0) target = target.slice(0, hashIdx);
+        if (!target) continue;
+        // Skip non-path targets: external URLs, mailto, in-page anchors,
+        // absolute paths (resolution root is the projection, not the FS root).
+        if (/^([a-z][a-z0-9+.-]*:|#|\/)/i.test(target)) continue;
+        if (seen.has(target)) continue;
+        seen.add(target);
+        const resolved = path.resolve(projectedDir, target);
+        if (!fs.existsSync(resolved)) {
+            out.push({
+                file: floorRel,
+                rule: 'floor-reference',
+                msg: `link target "${target}" does not resolve from the shipped projection (dist/agent-src/rules/) — fix the relative depth so it resolves from the projected rule location`,
+            });
+        }
+    }
+    return out;
+}
+
 // D4 — definitive-legal-language blocklist (the floor bans these; this is the
 // deterministic backstop over skill bodies). Narrow on purpose; the floor's
 // prompt layer is the primary enforcement.
@@ -174,6 +230,17 @@ export function lintLegalPack(skillsDir: string = SKILLS_DIR): Violation[] {
         // D6 — promotion gate (real-run only).
         if (fs.existsSync(PACKS_YML) && fs.existsSync(PACK_NOTICE)) {
             violations.push(...legalPromotionViolations(_readText(PACKS_YML), _readText(PACK_NOTICE)));
+        }
+        // D7 — floor-rule reference gate: every link in the floor rule must
+        // resolve from its SHIPPED projection (dist/agent-src/rules/).
+        if (fs.existsSync(PROJECTED_FLOOR_DIR)) {
+            violations.push(
+                ...legalFloorReferenceViolations(
+                    _readText(FLOOR_RULE),
+                    PROJECTED_FLOOR_DIR,
+                    path.relative(REPO, FLOOR_RULE),
+                ),
+            );
         }
     }
     return violations;

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -151,6 +151,18 @@ class CalledProcessError extends Error {
 const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
 const PACKAGE_JSON = path.join(REPO_ROOT, 'package.json');
 const MARKETPLACE_JSON = path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
+// Source-of-truth project-settings template. Carries an `agent_config_version`
+// pin that check_template_pin_drift requires to equal package.json.version. We
+// bump the src twin here; `task release-prepare` (run right after the bump)
+// regenerates the dist/agent-src/ twin from it.
+const PROJECT_TEMPLATE = path.join(
+    REPO_ROOT,
+    'src',
+    'agent-src',
+    'templates',
+    'agents',
+    'agent-project-settings.example.yml',
+);
 const CHANGELOG = path.join(REPO_ROOT, 'CHANGELOG.md');
 const MAIN_BRANCH = 'main';
 const REMOTE = 'origin';
@@ -879,6 +891,29 @@ function set_marketplace_version(p: string, version: string): void {
     fs.writeFileSync(p, jsonDumpsIndent(data, 2) + '\n', 'utf-8');
 }
 
+function set_template_pin(p: string, version: string): void {
+    // Rewrite the single `agent_config_version:` line in place, preserving the
+    // rest of the YAML byte-for-byte. Quoted value to match the existing pin
+    // style and check_template_pin_drift's tolerant parse.
+    const text = fs.readFileSync(p, 'utf-8');
+    const lines = text.split('\n');
+    let found = false;
+    for (let i = 0; i < lines.length; i += 1) {
+        if (/^\s*agent_config_version\s*:/.test(lines[i]!)) {
+            lines[i] = lines[i]!.replace(
+                /^(\s*agent_config_version\s*:\s*).*/,
+                `$1"${version}"`,
+            );
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        die(`set_template_pin: no \`agent_config_version:\` line in ${p}`);
+    }
+    fs.writeFileSync(p, lines.join('\n'), 'utf-8');
+}
+
 // ─── preflight ────────────────────────────────────────────────────────────────
 
 /**
@@ -982,6 +1017,7 @@ function print_preview(plan: Plan): void {
     process.stdout.write('Files to change:\n');
     process.stdout.write(`  · ${path.relative(REPO_ROOT, PACKAGE_JSON)}\n`);
     process.stdout.write(`  · ${path.relative(REPO_ROOT, MARKETPLACE_JSON)}\n`);
+    process.stdout.write(`  · ${path.relative(REPO_ROOT, PROJECT_TEMPLATE)}\n`);
     process.stdout.write(`  · ${path.relative(REPO_ROOT, CHANGELOG)}\n`);
     process.stdout.write('  · regenerated derived files via `task release-prepare`\n');
     process.stdout.write(
@@ -1204,9 +1240,10 @@ function execute(
         if (resume && current_pkg === plan.target) {
             _step(2, total, `Files already at ${plan.target} — skip bump`);
         } else {
-            _step(2, total, 'Bump package.json + marketplace.json, prepend CHANGELOG');
+            _step(2, total, 'Bump package.json + marketplace.json + template pin, prepend CHANGELOG');
             set_package_version(PACKAGE_JSON, plan.target);
             set_marketplace_version(MARKETPLACE_JSON, plan.target);
+            set_template_pin(PROJECT_TEMPLATE, plan.target);
             prepend_changelog(CHANGELOG, plan.changelog_entry);
         }
 
@@ -1727,6 +1764,7 @@ export {
     prepend_changelog,
     set_package_version,
     set_marketplace_version,
+    set_template_pin,
     resolve_bump,
     _detect_in_flight_target,
     print_preview,

--- a/tests/scripts/lint_legal_pack.test.ts
+++ b/tests/scripts/lint_legal_pack.test.ts
@@ -7,7 +7,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { lintLegalPack, legalPromotionViolations } from '../../src/scripts/lint_legal_pack.js';
+import {
+    lintLegalPack,
+    legalPromotionViolations,
+    legalFloorReferenceViolations,
+} from '../../src/scripts/lint_legal_pack.js';
 
 const LAB_PACK = '- id: legal-review-prep\n  surface_tier: lab\n  trust_level_default: experimental\n  default_install: false\n';
 const PROMOTED_PACK = '- id: legal-review-prep\n  surface_tier: core\n  trust_level_default: professional\n  default_install: true\n';
@@ -24,6 +28,59 @@ describe('lint_legal_pack — promotion gate', () => {
     });
     it('promoted pack WITH a recorded framing review passes', () => {
         expect(legalPromotionViolations(PROMOTED_PACK, REVIEWED)).toEqual([]);
+    });
+});
+
+describe('lint_legal_pack — floor reference gate (D7)', () => {
+    // Build a tiny shipped-projection tree: <root>/dist/agent-src/rules is the
+    // resolution base; LEGAL_NOTICE.md sits at <root> (../../../ from rules),
+    // and a sibling skill at <root>/dist/agent-src/skills/.
+    function makeProjection(): { root: string; projectedDir: string } {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'legal-ref-'));
+        tmpDirs.push(root);
+        const projectedDir = path.join(root, 'dist', 'agent-src', 'rules');
+        fs.mkdirSync(projectedDir, { recursive: true });
+        fs.writeFileSync(path.join(root, 'LEGAL_NOTICE.md'), 'notice', 'utf-8');
+        const skillDir = path.join(root, 'dist', 'agent-src', 'skills', 'contracts-cognition');
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# skill', 'utf-8');
+        return { root, projectedDir };
+    }
+
+    it('passes when every link resolves from the shipped projection', () => {
+        const { projectedDir } = makeProjection();
+        const text =
+            'See [`LEGAL_NOTICE.md`](../../../LEGAL_NOTICE.md) and ' +
+            '[`contracts-cognition`](../skills/contracts-cognition/SKILL.md).';
+        expect(legalFloorReferenceViolations(text, projectedDir, 'rules/floor.md')).toEqual([]);
+    });
+
+    it('flags a link with the wrong relative depth (the 7.5.0 bug shape)', () => {
+        const { projectedDir } = makeProjection();
+        // `../../LEGAL_NOTICE.md` would NOT resolve from the projection (only
+        // `../../../` does) — exactly the broken-path class this gate guards.
+        const text = 'See [`LEGAL_NOTICE.md`](../../LEGAL_NOTICE.md).';
+        const v = legalFloorReferenceViolations(text, projectedDir, 'rules/floor.md');
+        expect(v.some((x) => x.rule === 'floor-reference')).toBe(true);
+    });
+
+    it('flags an entirely missing target', () => {
+        const { projectedDir } = makeProjection();
+        const text = '[gone](../skills/does-not-exist/SKILL.md)';
+        const v = legalFloorReferenceViolations(text, projectedDir, 'rules/floor.md');
+        expect(v.some((x) => x.rule === 'floor-reference')).toBe(true);
+    });
+
+    it('skips external URLs and in-page anchors', () => {
+        const { projectedDir } = makeProjection();
+        const text = '[web](https://example.com) and [anchor](#section) and [mail](mailto:a@b.c)';
+        expect(legalFloorReferenceViolations(text, projectedDir, 'rules/floor.md')).toEqual([]);
+    });
+
+    it('ignores a fragment suffix on an otherwise-valid path', () => {
+        const { projectedDir } = makeProjection();
+        const text = '[s](../skills/contracts-cognition/SKILL.md#anchor)';
+        expect(legalFloorReferenceViolations(text, projectedDir, 'rules/floor.md')).toEqual([]);
     });
 });
 


### PR DESCRIPTION
## Why

Distilled from the 7.5.0 (PR #694) external review round. Six independent reviewers converged on one structural theme: **too much is caught reactively that should have been a blocking gate** — a broken `LEGAL_NOTICE.md` path shipped in the legal-safety-floor rule, a template version-pin shipped one release behind, condense-hash drift accumulated. This PR closes that class. It deliberately adds **no new product surface** — connectors, employee mode, knowledge layer, consumer-install smoke are already tracked, council-deferred and demand-gated in `road-to-product-bets`.

Scope validated by a 2-member AI council (anthropic/claude-sonnet-4-5 + openai/gpt-4o). The council confirmed the gate-hardening phases are root-cause-correct and **rejected** a planned design-capability-boundary doc as scope-creep (a documentation artefact blocks none of the cited mechanical defects) — it was moved to out-of-scope.

## What

### Phase 1 — Template version-pin gate (root cause: guard ran nowhere)
`package.json` was `7.5.0` but both `agent-project-settings.example.yml` twins were pinned `7.4.0`, so `check_template_pin_drift` was **red inside `task ci`** yet merged — because that guard was wired into **no** GitHub workflow.
- Bump both template twins (src + dist) to `7.5.0`.
- Add `set_template_pin()` to `release.ts` so the pin moves in lockstep on every future release (src twin; `release-prepare` regenerates the dist twin).
- Allowlist both template paths in `check_release_pr_shape` (otherwise the legitimate release bump deadlocks against the shape guard).
- Wire `check-template-pin-drift` into the `release-validation` `version-consistency` job — the actual fix, so future drift fails the release PR at source.

This implements the patch embedded in the review feedback, plus the missing CI-wiring (1.4) the patch did not cover.

### Phase 2 — Legal-pack reference-resolution gate (root cause: no path gate)
The 7.5.0 `LEGAL_NOTICE.md` path bug shipped because `check_references` never scans `src/` and its pattern ignores bare-filename relative links. Added `legalFloorReferenceViolations()` to `lint_legal_pack.ts`: every markdown link in the legal-safety-floor rule must resolve from its shipped `dist/agent-src/rules/` projection. Covered by 5 tests including the exact 7.5.0 bug shape and a missing-target case. No live path bug remained; this is regression-prevention.

### Phase 3 — Two release-verification questions closed (evidence)
- **`rubric:score` drop = minor-safe.** It was never shipped: the AI council rejected the planned companion; commit `a0c3d126a` only *adds* `judge-synthesis` and deletes nothing. Zero references in commands/skills/contracts/README/marketplace. No public surface → minor-safe.
- **Trigger-evals pass over the 15 trimmed descriptions.** `check_trigger_evals` → `40 trigger set(s) fresh + valid`, exit 0. Of the 15 trimmed skills, the 4 carrying a `triggers.json` each score 10/10 (precision 1.0, recall 1.0). No routing regression.

## Out of scope (tracked / needs own round)
Knowledge connectors, employee mode, subagent explainability, consumer-install smoke (`road-to-product-bets`); condense-hash drift (already gated in `consistency.yml`); design capability-boundary doc (council: not gate scope); design-feature refinements; branch protection (repo-admin).

## Verification (fresh)
- `check_template_pin_drift` ✅ exit 0 · `lint_legal_pack` ✅ · `check_references` ✅ · `check_condensation` ✅ · `check_trigger_evals` ✅ 40 fresh+valid
- `vitest` release + check_release_pr_shape + lint_legal_pack → **84 passed**
- `tsc --noEmit` → exit 0

Roadmap `road-to-release-gate-hardening` delivered in full and archived per the PR-gate.
