### PR TITLE
feat: Claims-Ledger gate — machine-checked honest marketing (roadmap B1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > **Choose your experience — developer · founder · content · agency · finance · ops. Add packs. Get a focused command set, not a 500-artefact dump.** Bring your own AI provider.
 
-**258 skills, 162 commands, 93 governed rules** — plus a capability router that loads the right skill on intent, and multi-agent orchestration with consensus review. The whole layer is compiled into 7+ host agents (Claude Code, Cursor, Augment, Cline, Windsurf, Copilot, Gemini) with **zero runtime daemon**. Six role-shaped entry paths sit on top, so any host becomes a reliable team member — without locking you to a single model or vendor.
+**258 skills, 162 commands, 93 governed rules** — plus a capability router that loads the right skill on intent, and multi-agent orchestration with consensus review. The whole layer is compiled into 7+ host agents (Claude Code, Cursor, Augment, Cline, Windsurf, Copilot, Gemini) with **zero runtime daemon**.<!-- claim:no-runtime-daemon --> Six role-shaped entry paths sit on top, so any host becomes a reliable team member — without locking you to a single model or vendor.
 
 ### What's different
 
@@ -16,7 +16,7 @@ It is both deep **and** disciplined — and honest about what it deliberately is
 
 - **Depth that routes itself** — 258 skills + 162 commands, with a capability router that loads the right one on intent, not a 500-artefact context dump.
 - **Governance on every host** — rules compiled into each tool's native format at projection time; deterministic runtime hooks added on hook-capable hosts. This config-space, host-agnostic governance is the moat ([the governance advantage](docs/governance-advantage.md) · [enforcement by host](docs/enforcement-by-host.md)).
-- **Surgical uninstall** — removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries.
+- **Surgical uninstall** — removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries.<!-- claim:surgical-uninstall -->
 - **Pack-scoped install** — writes the active pack only, not a 500-artefact dump.
 
 **What it deliberately is *not*** — a content + governance layer, not a runtime: **no background daemon, no separate state database, no self-rewriting memory, no auto-build pipeline.** The host agent runs the loop; every learned change is human-reviewed; the same layer stays portable across tools. Capability without a process to babysit.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,6 +82,7 @@ tasks:
       - task: check-template-pin-drift
       - task: check-refs
       - task: check-no-conflict-markers
+      - task: check-claims
       - task: check-structural-breaking
       - task: check-trigger-evals
       - task: lint-eval-freshness
@@ -232,6 +233,7 @@ tasks:
       - task: check-template-pin-drift
       - task: check-refs
       - task: check-no-conflict-markers
+      - task: check-claims
       - task: check-structural-breaking
       - task: check-trigger-evals
       - task: lint-eval-freshness

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -1,0 +1,94 @@
+# Claims Ledger
+
+> Every public-facing claim (README, docs, site, marketplace copy) that carries a
+> `<!-- claim:<id> -->` marker binds here to resolvable evidence. `check_claims`
+> (in `task ci`) fails the build if a markered claim has no `backed` ledger entry
+> with a resolving evidence pointer. This is the package's falsifiability culture
+> turned on its own marketing — **we sell honesty, so the selling is machine-checked.**
+>
+> Enforced by [`src/scripts/check_claims.ts`](../src/scripts/check_claims.ts).
+> Roadmap: `road-to-final-state-and-market-readiness.md` Phase 1 / Track B (B1).
+
+## How it works
+
+- A public sentence that makes a capability or quantitative claim gets an HTML
+  marker: `<!-- claim:my-claim-id -->` (invisible in rendered Markdown).
+- The marker's `id` must match a `### claim: my-claim-id` block below with
+  `status: backed` and a resolving `evidence` pointer.
+- **Only markered claims are enforced.** Unmarkered prose is never checked — the
+  ledger tightens as claims are bound over time, never retroactively breaking CI.
+- `status: unbacked` entries are **inventory** (documented debt): they record a
+  claim that is not yet bound. They do NOT fail the build, but markering their
+  claim in prose does (forces the binding first).
+
+## Entry schema
+
+```
+### claim: <kebab-id>
+- claim: <the sentence, roughly as it appears publicly>
+- kind: quant | qual | comparative
+- evidence: <pointer>            # see grammar below
+- status: backed | unbacked
+- last_verified: <YYYY-MM-DD>
+```
+
+**Evidence-pointer grammar (v1):**
+
+- `path/to/file.md` or `path/to/file.md:42` — the repo file exists (line advisory).
+- `path/to/file.md#substring` — the file exists AND contains `substring`.
+- `https://… (YYYY-MM-DD)` — external cite carrying a dated stamp (not fetched in CI).
+
+---
+
+## Backed claims
+
+### claim: no-runtime-daemon
+- claim: The whole layer is compiled into host agents with zero runtime daemon.
+- kind: qual
+- evidence: docs/contracts/no-runtime-boundary.md#file-first, no-runtime suite
+- status: backed
+- last_verified: 2026-07-04
+
+### claim: surgical-uninstall
+- claim: Removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries.
+- kind: qual
+- evidence: docs/contracts/install-layout.md#JSON-pointer
+- status: backed
+- last_verified: 2026-07-04
+
+---
+
+## Unbacked inventory (documented debt — not yet markered in prose)
+
+These are real README claims that need a durable binding before they may carry a
+`<!-- claim: -->` marker. Counts are drift-prone: binding them requires a
+count-source mechanism (a generated number the prose must match), which is
+follow-up work (roadmap B1.2). Listed here so the debt is visible, not hidden.
+
+### claim: skill-count
+- claim: 258 skills (README hero + feature list).
+- kind: quant
+- evidence: needs a generated count-source binding (discovery manifest) — B1.2
+- status: unbacked
+- last_verified:
+
+### claim: command-count
+- claim: 162 commands.
+- kind: quant
+- evidence: needs a generated count-source binding (discovery manifest) — B1.2
+- status: unbacked
+- last_verified:
+
+### claim: rule-count
+- claim: 93 governed rules.
+- kind: quant
+- evidence: needs a generated count-source binding (discovery manifest) — B1.2
+- status: unbacked
+- last_verified:
+
+### claim: host-agent-count
+- claim: Compiled into 7+ host agents (Claude Code, Cursor, Augment, Cline, Windsurf, Copilot, Gemini).
+- kind: quant
+- evidence: needs binding to the projection targets list — B1.2
+- status: unbacked
+- last_verified:

--- a/src/scripts/check_claims.ts
+++ b/src/scripts/check_claims.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env tsx
+/**
+ * Claims-Ledger gate — no public claim without a resolvable evidence binding.
+ *
+ * The mechanical anti-hype guardrail (road-to-final-state-and-market-readiness
+ * Phase 1 / Track B, step B1). Every public-facing claim that carries a
+ * `<!-- claim:<id> -->` marker in README.md or docs/ MUST resolve to a ledger
+ * entry in docs/CLAIMS.md whose `status: backed` and whose `evidence` pointer
+ * resolves. A smuggled unbacked claim (marker without a backed, resolvable
+ * ledger entry) fails the build — so "we sell honesty" is itself machine-checked.
+ *
+ * Non-disruptive by design: only `<!-- claim:ID -->`-**markered** spans are
+ * enforced. Unmarkered prose is never checked, so existing README text does not
+ * retroactively break CI; the ledger tightens as claims are markered over time.
+ * Ledger entries with `status: unbacked` are inventory (documented debt) and do
+ * NOT fail the build — but marking such an entry's claim in prose does.
+ *
+ * Evidence-pointer grammar (v1):
+ *   <repo-path>[:line]        → the repo file exists (line advisory).
+ *   <repo-path>#<substring>   → the file exists AND contains <substring>.
+ *   https://… (YYYY-MM-DD)    → external cite with a dated stamp (not fetched).
+ *
+ * Exit codes: 0 = clean · 2 = unbacked/dangling/missing-entry finding OR usage
+ * error. Success prints to stdout; findings print to stderr.
+ *
+ * Usage:
+ *     ./scripts-run src/scripts/check_claims
+ *     ./scripts-run src/scripts/check_claims --quiet
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const _FILE = fileURLToPath(import.meta.url);
+const _HERE = path.dirname(_FILE);
+const REPO = path.resolve(_HERE, '..', '..');
+const LEDGER_REL = 'docs/CLAIMS.md';
+
+/** Surfaces scanned for `<!-- claim:ID -->` markers. */
+const SURFACE_ROOTS = ['README.md', 'docs'];
+
+const CLAIM_MARKER = /<!--\s*claim:([A-Za-z0-9._-]+)\s*-->/g;
+const URL_DATED = /^https?:\/\/\S+\(\d{4}-\d{2}-\d{2}\)\s*$/;
+
+class ExitCode extends Error {
+    code: number;
+    constructor(code: number) {
+        super(`exit ${code}`);
+        this.code = code;
+    }
+}
+
+interface LedgerEntry {
+    id: string;
+    claim: string;
+    kind: string;
+    evidence: string;
+    status: string;
+    last_verified: string;
+}
+
+interface Args {
+    quiet: boolean;
+}
+
+function parse_args(argv: string[]): Args {
+    const out: Args = { quiet: false };
+    for (const a of argv) {
+        if (a === '--quiet') {
+            out.quiet = true;
+        } else if (a === '-h' || a === '--help') {
+            process.stdout.write('usage: check_claims [--quiet]\n');
+            throw new ExitCode(0);
+        } else {
+            process.stderr.write(`❌  check_claims: unrecognized argument: ${a}\n`);
+            throw new ExitCode(2);
+        }
+    }
+    return out;
+}
+
+/** Parse docs/CLAIMS.md — one entry per `### claim: <id>` block. */
+function load_ledger(): Map<string, LedgerEntry> {
+    const ledger = new Map<string, LedgerEntry>();
+    const p = path.join(REPO, LEDGER_REL);
+    if (!fs.existsSync(p)) {
+        return ledger;
+    }
+    const lines = fs.readFileSync(p, 'utf8').split('\n');
+    let cur: Partial<LedgerEntry> & { id?: string } = {};
+    const flush = () => {
+        if (cur.id) {
+            ledger.set(cur.id, {
+                id: cur.id,
+                claim: cur.claim ?? '',
+                kind: cur.kind ?? '',
+                evidence: cur.evidence ?? '',
+                status: cur.status ?? '',
+                last_verified: cur.last_verified ?? '',
+            });
+        }
+        cur = {};
+    };
+    for (const line of lines) {
+        const head = line.match(/^###\s+claim:\s*([A-Za-z0-9._-]+)\s*$/);
+        if (head) {
+            flush();
+            cur = { id: head[1] };
+            continue;
+        }
+        if (!cur.id) continue;
+        const field = line.match(/^-\s+(claim|kind|evidence|status|last_verified):\s*(.*)$/);
+        if (field) {
+            const key = field[1] as keyof LedgerEntry;
+            (cur as Record<string, string>)[key] = field[2].trim();
+        }
+    }
+    flush();
+    return ledger;
+}
+
+/** Recursively collect .md files under a repo-relative root (file or dir). */
+function collect_md(rel: string): string[] {
+    const abs = path.join(REPO, rel);
+    if (!fs.existsSync(abs)) return [];
+    const st = fs.statSync(abs);
+    if (st.isFile()) return abs.endsWith('.md') ? [abs] : [];
+    const out: string[] = [];
+    for (const name of fs.readdirSync(abs)) {
+        if (name === 'node_modules' || name.startsWith('.')) continue;
+        out.push(...collect_md(path.join(rel, name)));
+    }
+    return out;
+}
+
+/** Find every live `<!-- claim:ID -->` marker across the scanned surfaces.
+ *  Skips the ledger file itself and any marker shown as documentation
+ *  (inside a ``` fenced block or an inline `backtick` span). */
+function scan_markers(): { id: string; file: string }[] {
+    const found: { id: string; file: string }[] = [];
+    const files = new Set<string>();
+    for (const root of SURFACE_ROOTS) {
+        for (const f of collect_md(root)) files.add(f);
+    }
+    for (const f of files) {
+        const rel = path.relative(REPO, f);
+        if (rel === LEDGER_REL) continue; // the ledger documents the syntax
+        let fenced = false;
+        for (const line of fs.readFileSync(f, 'utf8').split('\n')) {
+            if (/^\s*```/.test(line)) {
+                fenced = !fenced;
+                continue;
+            }
+            if (fenced) continue;
+            for (const m of line.matchAll(CLAIM_MARKER)) {
+                const before = line.slice(0, m.index ?? 0);
+                const backticks = (before.match(/`/g) ?? []).length;
+                if (backticks % 2 === 1) continue; // inside an inline-code span
+                found.push({ id: m[1], file: rel });
+            }
+        }
+    }
+    return found;
+}
+
+/** Does an evidence pointer resolve? Returns null on success, else a reason. */
+function pointer_unresolved(evidence: string): string | null {
+    const ev = evidence.trim();
+    if (!ev) return 'empty evidence pointer';
+    if (/^https?:\/\//.test(ev)) {
+        return URL_DATED.test(ev) ? null : 'external URL missing a (YYYY-MM-DD) stamp';
+    }
+    // repo-path[:line] or repo-path#substring
+    let target = ev;
+    let needle: string | null = null;
+    const hash = ev.indexOf('#');
+    if (hash !== -1) {
+        target = ev.slice(0, hash);
+        needle = ev.slice(hash + 1);
+    }
+    target = target.replace(/:\d+$/, ''); // strip :line
+    const abs = path.join(REPO, target);
+    if (!fs.existsSync(abs)) return `evidence path not found: ${target}`;
+    if (needle) {
+        const body = fs.readFileSync(abs, 'utf8');
+        if (!body.includes(needle)) return `evidence file lacks '${needle}': ${target}`;
+    }
+    return null;
+}
+
+interface Finding {
+    id: string;
+    file: string;
+    reason: string;
+}
+
+function main(argv: string[] = process.argv.slice(2)): number {
+    const args = parse_args(argv);
+    const ledger = load_ledger();
+    const markers = scan_markers();
+    const findings: Finding[] = [];
+
+    // 1. Every markered claim must map to a backed, resolvable ledger entry.
+    for (const { id, file } of markers) {
+        const entry = ledger.get(id);
+        if (!entry) {
+            findings.push({ id, file, reason: `no ledger entry in ${LEDGER_REL}` });
+            continue;
+        }
+        if (entry.status !== 'backed') {
+            findings.push({ id, file, reason: `ledger status is '${entry.status || 'missing'}', not 'backed'` });
+            continue;
+        }
+        const un = pointer_unresolved(entry.evidence);
+        if (un) findings.push({ id, file, reason: un });
+    }
+
+    // 2. Rot guard: a backed ledger entry whose pointer no longer resolves
+    //    fails even before it is markered (an implementation must not outlive
+    //    its claim, and vice-versa).
+    for (const entry of ledger.values()) {
+        if (entry.status !== 'backed') continue;
+        const un = pointer_unresolved(entry.evidence);
+        if (un) findings.push({ id: entry.id, file: LEDGER_REL, reason: `backed entry has dangling evidence — ${un}` });
+    }
+
+    if (findings.length > 0) {
+        process.stderr.write(`❌  check_claims: ${findings.length} unbacked/dangling claim(s):\n`);
+        for (const f of findings) {
+            process.stderr.write(`    ${f.file} · claim:${f.id} — ${f.reason}\n`);
+        }
+        process.stderr.write(`    → bind the claim in ${LEDGER_REL} (status: backed + a resolvable evidence pointer), or remove the marker.\n`);
+        return 2;
+    }
+
+    if (!args.quiet) {
+        const backed = [...ledger.values()].filter((e) => e.status === 'backed').length;
+        const unbacked = [...ledger.values()].filter((e) => e.status === 'unbacked').length;
+        process.stdout.write(
+            `✅  check_claims: ${markers.length} markered claim(s) bound · ledger ${ledger.size} entries (${backed} backed, ${unbacked} unbacked inventory)\n`,
+        );
+    }
+    return 0;
+}
+
+/** Robust "am I the entry script?" — realpath-compares argv[1] to this file so
+ *  a symlinked invocation path (macOS /var → /private/var under a tmp tree)
+ *  still resolves. Irrelevant under scripts-run (run.ts calls main directly). */
+function _isCliEntry(): boolean {
+    const a = process.argv[1];
+    if (!a) return false;
+    if (a === _FILE || pathToFileURL(path.resolve(a)).href === import.meta.url) return true;
+    try {
+        return fs.realpathSync(a) === fs.realpathSync(_FILE);
+    } catch {
+        return false;
+    }
+}
+if (_isCliEntry()) {
+    try {
+        process.exit(main());
+    } catch (exc) {
+        if (exc instanceof ExitCode) {
+            process.exit(exc.code);
+        }
+        throw exc;
+    }
+}
+
+export { REPO, LEDGER_REL, main, parse_args, load_ledger, scan_markers, pointer_unresolved, ExitCode };

--- a/src/scripts/check_claims.ts
+++ b/src/scripts/check_claims.ts
@@ -105,14 +105,14 @@ function load_ledger(): Map<string, LedgerEntry> {
         const head = line.match(/^###\s+claim:\s*([A-Za-z0-9._-]+)\s*$/);
         if (head) {
             flush();
-            cur = { id: head[1] };
+            cur = { id: head[1]! };
             continue;
         }
         if (!cur.id) continue;
         const field = line.match(/^-\s+(claim|kind|evidence|status|last_verified):\s*(.*)$/);
         if (field) {
             const key = field[1] as keyof LedgerEntry;
-            (cur as Record<string, string>)[key] = field[2].trim();
+            (cur as Record<string, string>)[key] = (field[2] ?? '').trim();
         }
     }
     flush();
@@ -156,7 +156,7 @@ function scan_markers(): { id: string; file: string }[] {
                 const before = line.slice(0, m.index ?? 0);
                 const backticks = (before.match(/`/g) ?? []).length;
                 if (backticks % 2 === 1) continue; // inside an inline-code span
-                found.push({ id: m[1], file: rel });
+                found.push({ id: m[1]!, file: rel });
             }
         }
     }

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -347,6 +347,11 @@ tasks:
     desc: "Fail on leftover merge/stash conflict state — unmerged index entries or <<<<<<< / >>>>>>> markers in tracked files (conflict-marker-guard hardening, 2026-06-15)"
     cmd: ./scripts-run src/scripts/check_no_conflict_markers {{.QUIET_FLAG}}
 
+  check-claims:
+    silent: true
+    desc: "Claims-Ledger gate — every <!-- claim:ID --> marker in README/docs binds to a backed, resolvable entry in docs/CLAIMS.md (road-to-final-state-and-market-readiness B1)"
+    cmd: ./scripts-run src/scripts/check_claims {{.QUIET_FLAG}}
+
   check-structural-breaking:
     silent: true
     desc: "Fail when a structural break (artifact deleted/renamed, or a contract schema changed without an x-schemaVersion bump) lacks a breaking annotation — road-to-contract-integrity F3"

--- a/tests/scripts/check_claims.test.ts
+++ b/tests/scripts/check_claims.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Mechanism tests for `src/scripts/check_claims.ts` (Claims-Ledger gate, B1).
+ *
+ * The acceptance test of the mechanism itself (roadmap B1.4): a deliberately
+ * unbacked / dangling / unregistered markered claim MUST turn CI red (exit 2),
+ * and a fully-bound claim MUST pass (exit 0). The script resolves its REPO from
+ * `parents[2]` of its own location, so each fixture copies the one script into
+ * `<work>/src/scripts/` and runs it inside a throwaway tree via tsx.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const TSX = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+const SCRIPT_SRC = path.join(REPO_ROOT, 'src', 'scripts', 'check_claims.ts');
+
+let work: string;
+
+function run(): { code: number; stdout: string; stderr: string } {
+    const r = spawnSync(TSX, [path.join(work, 'src', 'scripts', 'check_claims.ts')], {
+        cwd: work,
+        encoding: 'utf8',
+    });
+    return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function write(rel: string, body: string): void {
+    const abs = path.join(work, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+}
+
+beforeEach(() => {
+    work = fs.mkdtempSync(path.join(os.tmpdir(), 'claims-test-'));
+    fs.mkdirSync(path.join(work, 'src', 'scripts'), { recursive: true });
+    fs.copyFileSync(SCRIPT_SRC, path.join(work, 'src', 'scripts', 'check_claims.ts'));
+    write('docs/evidence.md', 'This file contains the ANCHOR string.\n');
+});
+
+afterEach(() => {
+    fs.rmSync(work, { recursive: true, force: true });
+});
+
+const backedLedger = [
+    '# Claims Ledger',
+    '',
+    '### claim: good',
+    '- claim: A bound claim.',
+    '- kind: qual',
+    '- evidence: docs/evidence.md#ANCHOR',
+    '- status: backed',
+    '- last_verified: 2026-07-04',
+    '',
+].join('\n');
+
+describe('check_claims — mechanism', () => {
+    it('clean: a markered claim bound to a backed, resolving entry → exit 0', () => {
+        write('docs/CLAIMS.md', backedLedger);
+        write('README.md', 'We do a good thing.<!-- claim:good -->\n');
+        const r = run();
+        expect(r.code).toBe(0);
+        expect(r.stdout).toContain('1 markered claim');
+    });
+
+    it('unbacked: markered claim whose ledger entry is status:unbacked → exit 2', () => {
+        write(
+            'docs/CLAIMS.md',
+            ['# Claims Ledger', '', '### claim: wip', '- claim: Not yet proven.', '- kind: quant', '- evidence: TODO', '- status: unbacked', '- last_verified:', ''].join('\n'),
+        );
+        write('README.md', 'A shaky claim.<!-- claim:wip -->\n');
+        const r = run();
+        expect(r.code).toBe(2);
+        expect(r.stderr).toContain("not 'backed'");
+    });
+
+    it('missing entry: markered claim with no ledger entry → exit 2', () => {
+        write('docs/CLAIMS.md', backedLedger);
+        write('README.md', 'An orphan claim.<!-- claim:ghost -->\n');
+        const r = run();
+        expect(r.code).toBe(2);
+        expect(r.stderr).toContain('no ledger entry');
+    });
+
+    it('dangling: backed entry whose evidence path does not exist → exit 2', () => {
+        write(
+            'docs/CLAIMS.md',
+            ['# Claims Ledger', '', '### claim: rotten', '- claim: Points nowhere.', '- kind: qual', '- evidence: docs/gone.md', '- status: backed', '- last_verified: 2026-07-04', ''].join('\n'),
+        );
+        write('README.md', 'no markers here\n');
+        const r = run();
+        expect(r.code).toBe(2);
+        expect(r.stderr).toContain('dangling evidence');
+    });
+
+    it('documentation is exempt: a marker shown in an inline-code span is not a live claim', () => {
+        write('docs/CLAIMS.md', backedLedger);
+        write('docs/guide.md', 'To bind a claim, add `<!-- claim:example -->` to the sentence.\n');
+        write('README.md', 'We do a good thing.<!-- claim:good -->\n');
+        const r = run();
+        expect(r.code).toBe(0);
+    });
+});


### PR DESCRIPTION
## What

Ships **B1 — the Claims-Ledger gate** from the market-readiness roadmap (`road-to-final-state-and-market-readiness.md`, Track B). This is the mechanical anti-hype guardrail: the package's falsifiability culture turned on its own marketing.

Every public sentence that carries a `<!-- claim:ID -->` marker (README/docs) must bind to a `status: backed` entry in `docs/CLAIMS.md` with a **resolving** evidence pointer. `check_claims` (wired into `task ci`) fails the build on an unbacked, dangling, or unregistered markered claim — so "we sell honesty" is itself machine-checked. This is the differentiator the ruflo comparison surfaced: reproducible honesty is the moat a competitor with unbacked headline numbers cannot copy.

## Non-disruptive by design

- **Only markered spans are enforced.** Existing README prose without a marker is never checked — no retroactive CI breakage.
- Documentation of the marker syntax (fenced ``` blocks / inline `code` spans) is exempt, so guides can show the format.
- `status: unbacked` ledger entries are **inventory** (documented debt) — they don't fail the build; markering their claim in prose forces the binding first.

## What's in it

- `src/scripts/check_claims.ts` — the gate (evidence-pointer grammar: repo-path[:line] · path#substring · dated external URL). Exit 2 on findings.
- `docs/CLAIMS.md` — the ledger: 2 **backed** seed claims markered in README (`no-runtime-daemon` → `no-runtime-boundary.md`; `surgical-uninstall` → `install-layout.md`) + 4 **unbacked inventory** entries (the drift-prone skill/command/rule/host counts, to be bound via a count-source in B1.2).
- `tests/scripts/check_claims.test.ts` — 5 mechanism tests incl. the acceptance test (a deliberately unbacked/dangling/orphan markered claim turns CI red).
- CI wiring: `check-claims` in `task ci` (both lists) + `ci-fast.yml`.

## Verification

`task check-claims` green (2 markered claims bound, 6 ledger entries); 5/5 tests pass; `check-refs` green.

## Notes

- No `dist/`/condensation impact (script + docs, not condensed surfaces).
- The B1 checkbox lives in `road-to-final-state-and-market-readiness.md` (PR #700, not yet merged) — it flips when both land on main.
