### PR TITLE
fix: make memory tests clock-robust (unblocks main Node Tests)

### DIFF
--- a/tests/scripts/memory_lookup.test.ts
+++ b/tests/scripts/memory_lookup.test.ts
@@ -18,6 +18,11 @@ import * as ml from '../../src/scripts/memory_lookup.js';
 
 type Hit = InstanceType<typeof ml.Hit>;
 
+// Freshness fixtures must be relative to the real clock — a hardcoded date
+// silently expires past `review_after_days` and flips retrieve() to 0 hits
+// (memory-test clock-drift, 2026-07-04). Use today so the entry is always fresh.
+const TODAY_ISO = new Date().toISOString().slice(0, 10);
+
 // dedent helper mirroring textwrap.dedent.
 function dedent(s: string): string {
     const lines = s.replace(/^\n/, '').split('\n');
@@ -76,7 +81,7 @@ describe('memory_lookup.ts — retrieve()', () => {
             confidence: high
             source: ["docs/teams.md"]
             owner: team-payments
-            last_validated: 2026-01-01
+            last_validated: ${TODAY_ISO}
             review_after_days: 180
             path: "app/Http/Controllers/Billing/**"
     `,
@@ -98,7 +103,7 @@ describe('memory_lookup.ts — retrieve()', () => {
         confidence: high
         source: ["docs/domain.md"]
         owner: team-x
-        last_validated: 2026-01-01
+        last_validated: ${TODAY_ISO}
         review_after_days: 180
         rule: "invoice total equals sum of line items"
         feature: "billing"

--- a/tests/scripts/templates_check_memory.test.ts
+++ b/tests/scripts/templates_check_memory.test.ts
@@ -53,6 +53,11 @@ function errorLine(stderr: string): string {
     return found ?? stderr.trimEnd();
 }
 
+// Freshness must be relative to the real clock — a hardcoded date silently
+// crosses review_after_days and adds an unexpected "stale" info line, breaking
+// the clean/duplicate snapshots (memory-test clock-drift, 2026-07-04).
+const TODAY_ISO = new Date().toISOString().slice(0, 10);
+
 const REQUIRED = [
     'id: own-1',
     'status: active',
@@ -60,7 +65,7 @@ const REQUIRED = [
     'source:',
     '  - ADR-1',
     'owner: team',
-    'last_validated: 2026-01-01',
+    `last_validated: ${TODAY_ISO}`,
     'review_after_days: 180',
 ];
 
@@ -220,16 +225,16 @@ describe('templates/check_memory — intent', () => {
                 '    review_after_days: 1',
             ].join('\n') + '\n',
         );
-        expect(runTs(['--path', 'agents/memory'], tmp)).toMatchInlineSnapshot(`
-          {
-            "status": 0,
-            "stderr": "",
-            "stdout": "  ℹ️  agents/memory/domain-invariants/stale.yml [old-1]  stale: last_validated 9676 days ago (limit 1)
-
-          Summary: 0 error(s), 0 warning(s), 1 info
-          ",
-          }
-        `);
+        // The "days ago" count drifts with the real clock, so assert the shape
+        // (stale detected + info summary) rather than a hardcoded day number —
+        // an inline snapshot of the exact count is a time-bomb.
+        const r = runTs(['--path', 'agents/memory'], tmp);
+        expect(r.status).toBe(0);
+        expect(r.stderr).toBe('');
+        expect(r.stdout).toMatch(
+            /ℹ️ {2}agents\/memory\/domain-invariants\/stale\.yml \[old-1] {2}stale: last_validated \d+ days ago \(limit 1\)/,
+        );
+        expect(r.stdout).toContain('Summary: 0 error(s), 0 warning(s), 1 info');
     });
 
     it('JSON format over mixed findings', () => {


### PR DESCRIPTION
## What

Makes two memory tests clock-robust. They turned `main`'s **Node Tests** red on a **date rollover**, not a code change — a latent time-bomb, unrelated to any feature work (it currently blocks every open PR).

## Root cause

- `tests/scripts/memory_lookup.test.ts` and `tests/scripts/templates_check_memory.test.ts` hardcoded `last_validated: 2026-01-01` with `review_after_days: 180`. That freshness window closed around **2026-06-30**, so as of 2026-07-04 the fixtures are stale:
  - `retrieve()` filters the stale entry → `expected 1, got 0` hits.
  - `check_memory` emits an unexpected `stale` info line → the clean/duplicate snapshots break.
- The stale-entry test also inline-snapshotted `stale: last_validated 9676 days ago` — a count that **drifts daily**.

## Fix (test-only, no source change)

- Fresh fixtures use **today's real date** (`TODAY_ISO`) so they never expire — mirrors the pattern an existing test in the same file already used (`iso(today)`).
- The intentionally-stale test asserts the message **shape via regex** (`stale: last_validated \d+ days ago (limit 1)`) instead of a hardcoded day count.

## Not touched

`tests/scripts/check_memory.test.ts` also has `2026-01-01` fixtures but passes — its assertions are freshness-independent (they check schema/error findings, not the clean summary), so it is not a bomb. Left as-is (minimal diff).

## Verification

`tsc --noEmit` clean; the three memory test files pass (48/48). This unblocks the Node Tests gate on `main` and on the open feature PRs (#701, #702).
