### PR TITLE
feat(subagent): subagent-v1 determinism lint (A1)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -171,6 +171,7 @@ tasks:
       - task: lint-ghostwriter-source
       - task: lint-media-policy-linkage
       - task: lint-persona-governance
+      - task: lint-subagent-determinism
       - task: lint-handoffs
       - task: lint-hook-manifest
       - task: lint-marketplace-install
@@ -323,6 +324,7 @@ tasks:
       - task: lint-ghostwriter-source
       - task: lint-media-policy-linkage
       - task: lint-persona-governance
+      - task: lint-subagent-determinism
       - task: lint-handoffs
       - task: lint-hook-manifest
       - task: lint-marketplace-install

--- a/src/scripts/lint_subagent_determinism.ts
+++ b/src/scripts/lint_subagent_determinism.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+/**
+ * Lint subagent determinism — the ADR-109 guarantees the schema mini-validator
+ * cannot express.
+ *
+ * `validate_frontmatter` (the schema gate) covers type / enum / required /
+ * pattern, but its mini-validator ignores JSON-Schema `const` and `uniqueItems`.
+ * This lint closes that gap for `src/subagents/*.md`:
+ *
+ *   1. `schema_version` MUST equal `subagent-v1` (schema `const`).
+ *   2. `discovery.visible` MUST be exactly `false` — default-off (schema `const`).
+ *   3. `tools` MUST have no duplicate entries (schema `uniqueItems`).
+ *   4. `name` MUST match the filename stem (addressable-handle invariant).
+ *   5. `name` MUST be globally unique across the subagent category
+ *      (projection-path collision guard — two units would overwrite each other
+ *      in `.claude/agents/`).
+ *
+ * Exit codes: 0 clean, 1 any violation.
+ *
+ * See ADR-109 (§ 6 determinism) and `src/scripts/schemas/subagent.schema.json`.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { parse_frontmatter } from './validate_frontmatter.js';
+
+const QUIET = process.argv.includes('--quiet');
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO = path.resolve(path.dirname(_HERE), '..', '..');
+const SUBAGENT_DIR = path.join(REPO, 'src', 'subagents');
+
+function _listSubagents(dir: string): string[] {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    return fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith('.md'))
+        .sort()
+        .map((f) => path.join(dir, f));
+}
+
+function main(dir: string = SUBAGENT_DIR): number {
+    const findings: string[] = [];
+    const namesSeen = new Map<string, string>();
+
+    for (const file of _listSubagents(dir)) {
+        const rel = path.relative(REPO, file);
+        const stem = path.basename(file, '.md');
+        const text = fs.readFileSync(file, 'utf-8');
+        const [data] = parse_frontmatter(text);
+        if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+            findings.push(`${rel}: no parseable frontmatter`);
+            continue;
+        }
+        const fm = data as Record<string, unknown>;
+
+        if (fm.schema_version !== 'subagent-v1') {
+            findings.push(`${rel}: schema_version must be 'subagent-v1' (got ${JSON.stringify(fm.schema_version)})`);
+        }
+
+        const discovery = fm.discovery;
+        const visible =
+            discovery !== null && typeof discovery === 'object' && !Array.isArray(discovery)
+                ? (discovery as Record<string, unknown>).visible
+                : undefined;
+        if (visible !== false) {
+            findings.push(`${rel}: discovery.visible must be exactly false (default-off; got ${JSON.stringify(visible)})`);
+        }
+
+        const tools = fm.tools;
+        if (Array.isArray(tools)) {
+            const seen = new Set<unknown>();
+            const dupes = new Set<unknown>();
+            for (const t of tools) {
+                if (seen.has(t)) {
+                    dupes.add(t);
+                }
+                seen.add(t);
+            }
+            if (dupes.size > 0) {
+                findings.push(`${rel}: tools has duplicate entr(y/ies): ${[...dupes].map((d) => JSON.stringify(d)).join(', ')}`);
+            }
+        }
+
+        const name = fm.name;
+        if (typeof name !== 'string' || name !== stem) {
+            findings.push(`${rel}: name must match the filename stem '${stem}' (got ${JSON.stringify(name)})`);
+        } else {
+            const prior = namesSeen.get(name);
+            if (prior !== undefined) {
+                findings.push(`${rel}: duplicate subagent name '${name}' (also in ${prior}) — projection-path collision`);
+            } else {
+                namesSeen.set(name, rel);
+            }
+        }
+    }
+
+    if (findings.length > 0) {
+        process.stdout.write('❌ subagent determinism:\n');
+        for (const f of findings.sort()) {
+            process.stdout.write(`  - ${f}\n`);
+        }
+        return 1;
+    }
+
+    if (!QUIET) {
+        process.stdout.write(
+            `✅  subagent determinism: ${namesSeen.size} subagent(s) clean.\n`,
+        );
+    }
+    return 0;
+}
+
+const _isCliEntry =
+    process.argv[1] !== undefined &&
+    import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (_isCliEntry) {
+    process.exit(main());
+}
+
+export { main };

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -215,6 +215,11 @@ tasks:
     desc: "Enforce per-domain specialist cap (≤ 2) from .agent-src.uncondensed/rules/persona-governance.md; citation floor surfaced as warning (see scripts/lint_persona_governance.py)"
     cmd: ./scripts-run src/scripts/lint_persona_governance {{.QUIET_FLAG}}
 
+  lint-subagent-determinism:
+    silent: true
+    desc: "Enforce the ADR-109 subagent-v1 guarantees the schema mini-validator cannot express (schema_version / discovery.visible const, tools uniqueItems, name↔stem match + global uniqueness) over src/subagents/*.md"
+    cmd: ./scripts-run src/scripts/lint_subagent_determinism {{.QUIET_FLAG}}
+
   lint-rule-budget:
     silent: true
     desc: Enforce kernel-bucket + per-rule size caps (Council R2 amendments) — see road-to-kernel-and-router.md P5.1

--- a/tests/scripts/lint_subagent_determinism.test.ts
+++ b/tests/scripts/lint_subagent_determinism.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for `src/scripts/lint_subagent_determinism.ts` (ADR-109 § 6).
+ *
+ * Exercises the guarantees the schema mini-validator cannot express
+ * (`const` / `uniqueItems` / stem-match / global-uniqueness) by pointing the
+ * lint at fixture dirs and asserting its exit code.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { main } from '../../src/scripts/lint_subagent_determinism.js';
+
+const _tmpDirs: string[] = [];
+
+function _fixtureDir(files: Record<string, string>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sabdet-'));
+    _tmpDirs.push(dir);
+    for (const [name, body] of Object.entries(files)) {
+        fs.writeFileSync(path.join(dir, name), body, 'utf-8');
+    }
+    return dir;
+}
+
+function _unit(overrides: Partial<Record<string, string>> = {}): string {
+    const fm: Record<string, string> = {
+        schema_version: 'subagent-v1',
+        name: 'good-agent',
+        'discovery.visible': 'false',
+        tools: '[Read, Grep]',
+        ...overrides,
+    };
+    // Build minimal frontmatter the lint reads (schema_version, name, tools, discovery.visible).
+    return [
+        '---',
+        `schema_version: ${fm.schema_version}`,
+        `name: ${fm.name}`,
+        'description: fixture',
+        'model_tier: inherit',
+        `tools: ${fm.tools}`,
+        'discovery:',
+        `  visible: ${fm['discovery.visible']}`,
+        '  requires_capability: claude_subagents',
+        'source: package',
+        '---',
+        '',
+        'body',
+        '',
+    ].join('\n');
+}
+
+afterEach(() => {
+    for (const d of _tmpDirs.splice(0)) {
+        fs.rmSync(d, { recursive: true, force: true });
+    }
+});
+
+describe('lint_subagent_determinism', () => {
+    it('passes a clean subagent', () => {
+        const dir = _fixtureDir({ 'good-agent.md': _unit() });
+        expect(main(dir)).toBe(0);
+    });
+
+    it('passes an empty dir (no subagents)', () => {
+        const dir = _fixtureDir({});
+        expect(main(dir)).toBe(0);
+    });
+
+    it('fails when discovery.visible is true (default-off breached)', () => {
+        const dir = _fixtureDir({ 'good-agent.md': _unit({ 'discovery.visible': 'true' }) });
+        expect(main(dir)).toBe(1);
+    });
+
+    it('fails on a wrong schema_version', () => {
+        const dir = _fixtureDir({ 'good-agent.md': _unit({ schema_version: 'subagent-v2' }) });
+        expect(main(dir)).toBe(1);
+    });
+
+    it('fails when name does not match the filename stem', () => {
+        const dir = _fixtureDir({ 'good-agent.md': _unit({ name: 'other-name' }) });
+        expect(main(dir)).toBe(1);
+    });
+
+    it('fails on duplicate tool entries', () => {
+        const dir = _fixtureDir({ 'good-agent.md': _unit({ tools: '[Read, Read]' }) });
+        expect(main(dir)).toBe(1);
+    });
+
+    it('fails on a duplicate name across two files', () => {
+        // Two files whose stems differ but whose `name` collides — the lint's
+        // stem-match catches the mismatch on the second file, and the
+        // uniqueness guard would catch a true collision. Here we assert the
+        // stem-match failure path returns non-zero.
+        const dir = _fixtureDir({
+            'good-agent.md': _unit(),
+            'second-agent.md': _unit({ name: 'good-agent' }),
+        });
+        expect(main(dir)).toBe(1);
+    });
+});


### PR DESCRIPTION
Track A / A1 continuation. Adds the determinism lint the schema mini-validator
cannot provide (ADR-109 § 6).

## What
`src/scripts/lint_subagent_determinism.ts` scans `src/subagents/*.md` and enforces
the guarantees `validate_frontmatter`'s mini-validator ignores (`const`,
`uniqueItems`):

1. `schema_version === subagent-v1`
2. `discovery.visible === false` (default-off)
3. `tools` has no duplicates
4. `name` matches the filename stem
5. `name` globally unique across the category (projection-path collision guard)

Wired into `task lint-subagent-determinism` + both root CI aggregation lists.
`tests/scripts/lint_subagent_determinism.test.ts` — 7 fixture cases (1 clean,
1 empty-dir, 5 negative).

## Gates (fresh)
- `task lint-subagent-determinism` ✅ (1 clean) · `npm run typecheck` ✅ 0 errors ·
  contract + determinism tests ✅ 12/12.

## Not in this PR (routed to council)
The literal "5th discovery-manifest category" step hit a real gap: the manifest's
`_classify` requires `workspaces`/`packs`/`install`, which ADR-109's deliberately
minimal schema omits. Whether subagents join the manifest (schema-extend vs.
classify-branch) or stay out of it (option C) is a design fork now in the AI
council; the manifest wiring + the `generate-tools` native-CC projection to
`.claude/agents/` follow that decision.