### PR TITLE
feat(subagent): native-CC projection to .claude/agents/ (A1 final piece)

### DIFF
--- a/src/scripts/condense.ts
+++ b/src/scripts/condense.ts
@@ -250,6 +250,8 @@ interface ModuleState {
     PERSONAS_SOURCE: string;
     USER_TYPES_SOURCE: string;
     CLAUDE_SKILLS_DIR: string;
+    CLAUDE_AGENTS_DIR: string;
+    SUBAGENTS_SOURCE: string;
     PLUGIN_SKILLS_DIR: string;
     // Injectable multi-root helpers (monkeypatch seam).
     iter_all_sources: () => Iterable<[string, string]>;
@@ -271,6 +273,12 @@ function _deriveState(root: string): ModuleState {
         PERSONAS_SOURCE: path.join(root, 'dist/agent-src', 'personas'),
         USER_TYPES_SOURCE: path.join(root, 'dist/agent-src', 'user-types'),
         CLAUDE_SKILLS_DIR: path.join(root, '.claude', 'skills'),
+        // ADR-109: subagents project from src/ directly (NOT dist/) — a subagent
+        // is an executable system prompt Claude Code runs verbatim; telegraph
+        // condensation would alter its behaviour, and it is not routed through the
+        // pack/discovery condensation flow.
+        CLAUDE_AGENTS_DIR: path.join(root, '.claude', 'agents'),
+        SUBAGENTS_SOURCE: path.join(root, 'src', 'subagents'),
         PLUGIN_SKILLS_DIR: path.join(root, '.claude-plugin', 'skills'),
         iter_all_sources: _agent_src_iter_all_sources,
         resolve_logical: _agent_src_resolve_logical,
@@ -1475,6 +1483,89 @@ export function generate_claude_commands(active_command_slugs: ReadonlySet<strin
     return count;
 }
 
+/**
+ * Project `src/subagents/*.md` (subagent-v1, ADR-109) → `.claude/agents/*.md`
+ * in Claude Code's native subagent format.
+ *
+ * The source frontmatter carries governance metadata (schema_version, trust,
+ * lifecycle, discovery, source) that Claude Code does not understand; the native
+ * `.claude/agents/` format wants only `{name, description, tools, model}` + the
+ * system-prompt body. This is a **frontmatter transform**, not a symlink:
+ *
+ *  - `model_tier` → native `model:` via `_TIER_TO_CLAUDE_MODEL` (ADR-034/035);
+ *    the `inherit` sentinel passes through to `model: inherit`.
+ *  - `tools` (a YAML list) → the comma-joined form Claude Code accepts.
+ *  - the body (everything after the closing `---`) is copied verbatim.
+ *
+ * Static projection only — Claude Code (or the user via `@<name>`) decides
+ * dispatch; nothing here runs an agent. Reads from `src/` directly (subagent
+ * prompts are not telegraph-condensed). Reaps stale generated `.claude/agents/`
+ * files whose source no longer exists.
+ */
+export function generate_claude_subagents(): number {
+    if (!_isDir(MODULE_STATE.SUBAGENTS_SOURCE)) {
+        return 0;
+    }
+    _mkdirp(MODULE_STATE.CLAUDE_AGENTS_DIR);
+
+    const sources = _rglobSorted(MODULE_STATE.SUBAGENTS_SOURCE, '*.md').filter((p) => _isFile(p));
+    const current = new Set<string>();
+    let count = 0;
+
+    for (const src of sources) {
+        const stem = path.basename(src, '.md');
+        const text = _readText(src);
+        if (!text.startsWith('---\n')) {
+            continue;
+        }
+        const end = text.indexOf('\n---\n', 4);
+        if (end === -1) {
+            continue;
+        }
+        const fmBlock = text.slice(4, end);
+        const body = text.slice(end + 5);
+        const fm = _yamlParse(fmBlock) as Record<string, unknown> | null;
+        if (fm === null) {
+            continue;
+        }
+        const name = typeof fm['name'] === 'string' ? (fm['name'] as string) : stem;
+        const description = typeof fm['description'] === 'string' ? (fm['description'] as string) : '';
+        const toolsRaw = fm['tools'];
+        const tools = Array.isArray(toolsRaw) ? toolsRaw.map((t) => String(t)).join(', ') : String(toolsRaw ?? '');
+        const tier = typeof fm['model_tier'] === 'string' ? (fm['model_tier'] as string) : 'inherit';
+        const model = tier === 'inherit' ? 'inherit' : (_TIER_TO_CLAUDE_MODEL[tier] ?? 'inherit');
+
+        const out =
+            '---\n' +
+            `name: ${name}\n` +
+            `description: ${description}\n` +
+            `tools: ${tools}\n` +
+            `model: ${model}\n` +
+            '---\n' +
+            body;
+
+        const target = path.join(MODULE_STATE.CLAUDE_AGENTS_DIR, `${name}.md`);
+        _writeText(target, out);
+        current.add(`${name}.md`);
+        count += 1;
+    }
+
+    // Reap stale generated agent files (source removed). Only touch plain .md
+    // files we would have generated; never follow into unrelated content.
+    for (const item of _iterdirSorted(MODULE_STATE.CLAUDE_AGENTS_DIR)) {
+        const base = path.basename(item);
+        if (base === 'README.md' || current.has(base)) {
+            continue;
+        }
+        if (_isFile(item) && base.endsWith('.md') && !_isSymlink(item)) {
+            fs.unlinkSync(item);
+        }
+    }
+
+    info(`  ✅  Created ${count} subagent entries in .claude/agents/`);
+    return count;
+}
+
 export function generate_plugin_command_skills(): number {
     if (!_isDir(path.join(MODULE_STATE.PROJECT_ROOT, 'src', 'domains'))) {
         return 0;
@@ -1713,6 +1804,7 @@ function _generate_tools_inner(
     }
     const skills = _tool_active('claude-code') ? generate_claude_skills(skill_names) : 0;
     const commands = _tool_active('claude-code') ? generate_claude_commands(cmd_slugs) : 0;
+    const subagents = _tool_active('claude-code') ? generate_claude_subagents() : 0;
     const plugin_cmd_skills = _tool_active('claude-code') ? generate_plugin_command_skills() : 0;
     const plugin_hooks = _tool_active('claude-code') ? generate_plugin_hooks() : 0;
     const personas = generate_persona_symlinks();
@@ -1723,7 +1815,7 @@ function _generate_tools_inner(
     const windsurf_wf = _tool_active('windsurf') ? generate_windsurf_workflows(cmd_slugs) : 0;
     const summary =
         `✅  generate-tools — rules=${rules} skills=${skills} ` +
-        `commands=${commands} plugin_cmd_skills=${plugin_cmd_skills} ` +
+        `commands=${commands} subagents=${subagents} plugin_cmd_skills=${plugin_cmd_skills} ` +
         `plugin_hooks=${plugin_hooks} ` +
         `personas=${personas} user_types=${user_types} ` +
         `cursor_mdc=${cursor_mdc} windsurf_rules=${windsurf_modern} ` +

--- a/tests/scripts/generate_claude_subagents.test.ts
+++ b/tests/scripts/generate_claude_subagents.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for `condense.generate_claude_subagents` (ADR-109 — native-CC projection).
+ *
+ * Verifies the subagent-v1 → Claude Code `.claude/agents/` frontmatter transform:
+ * model_tier→model mapping (incl. the `inherit` passthrough), tools list→comma
+ * form, body preserved verbatim, and stale-file reaping. Isolated via the
+ * condense test-state seam so it never touches the real tree.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import * as condense from '../../src/scripts/condense.js';
+
+const _UNIT = (overrides: { name?: string; model_tier?: string; tools?: string } = {}): string => {
+    const name = overrides.name ?? 'demo-agent';
+    const tier = overrides.model_tier ?? 'inherit';
+    const tools = overrides.tools ?? '[Read, Grep]';
+    return [
+        '---',
+        'schema_version: subagent-v1',
+        `name: ${name}`,
+        'description: A demo subagent.',
+        `model_tier: ${tier}`,
+        `tools: ${tools}`,
+        'trust:',
+        '  level: core',
+        '  confidence: high',
+        '  human_review_required: false',
+        'lifecycle: active',
+        'discovery:',
+        '  visible: false',
+        '  requires_capability: claude_subagents',
+        'source: package',
+        '---',
+        '',
+        'You are the demo agent. Do the demo thing.',
+        '',
+    ].join('\n');
+};
+
+function _fm(file: string): Record<string, string> {
+    const text = fs.readFileSync(file, 'utf-8');
+    const block = text.slice(4, text.indexOf('\n---\n', 4));
+    const out: Record<string, string> = {};
+    for (const line of block.split('\n')) {
+        const m = /^([a-z_]+):\s*(.*)$/.exec(line);
+        if (m) out[m[1] as string] = (m[2] as string).trim();
+    }
+    return out;
+}
+
+describe('generate_claude_subagents', () => {
+    let saved: ReturnType<typeof condense._getStateForTest>;
+    let tmp: string;
+    let srcDir: string;
+    let agentsDir: string;
+
+    beforeEach(() => {
+        saved = condense._getStateForTest();
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sabgen-'));
+        srcDir = path.join(tmp, 'subagents');
+        agentsDir = path.join(tmp, 'agents');
+        fs.mkdirSync(srcDir, { recursive: true });
+        condense.MODULE_STATE.SUBAGENTS_SOURCE = srcDir;
+        condense.MODULE_STATE.CLAUDE_AGENTS_DIR = agentsDir;
+    });
+
+    afterEach(() => {
+        condense._setStateForTest(saved);
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('projects a subagent to CC format with inherit passthrough', () => {
+        fs.writeFileSync(path.join(srcDir, 'demo-agent.md'), _UNIT(), 'utf-8');
+        expect(condense.generate_claude_subagents()).toBe(1);
+        const out = path.join(agentsDir, 'demo-agent.md');
+        expect(fs.existsSync(out)).toBe(true);
+        const fm = _fm(out);
+        expect(fm.name).toBe('demo-agent');
+        expect(fm.description).toBe('A demo subagent.');
+        expect(fm.tools).toBe('Read, Grep');
+        expect(fm.model).toBe('inherit');
+        // Governance fields must NOT leak into the CC file.
+        expect(fm.schema_version).toBeUndefined();
+        expect(fm.discovery).toBeUndefined();
+        // Body preserved verbatim.
+        expect(fs.readFileSync(out, 'utf-8')).toContain('You are the demo agent. Do the demo thing.');
+    });
+
+    it('maps model_tier high→opus, medium→sonnet, lite→haiku', () => {
+        for (const [tier, model] of [['high', 'opus'], ['medium', 'sonnet'], ['lite', 'haiku']] as const) {
+            fs.writeFileSync(path.join(srcDir, 'demo-agent.md'), _UNIT({ model_tier: tier }), 'utf-8');
+            condense.generate_claude_subagents();
+            expect(_fm(path.join(agentsDir, 'demo-agent.md')).model).toBe(model);
+        }
+    });
+
+    it('reaps a stale generated agent whose source was removed', () => {
+        fs.writeFileSync(path.join(srcDir, 'demo-agent.md'), _UNIT(), 'utf-8');
+        condense.generate_claude_subagents();
+        // Simulate a previously-generated agent with no current source.
+        fs.writeFileSync(path.join(agentsDir, 'gone.md'), '---\nname: gone\n---\nold', 'utf-8');
+        condense.generate_claude_subagents();
+        expect(fs.existsSync(path.join(agentsDir, 'gone.md'))).toBe(false);
+        expect(fs.existsSync(path.join(agentsDir, 'demo-agent.md'))).toBe(true);
+    });
+
+    it('returns 0 when the source dir is absent', () => {
+        condense.MODULE_STATE.SUBAGENTS_SOURCE = path.join(tmp, 'nope');
+        expect(condense.generate_claude_subagents()).toBe(0);
+    });
+});


### PR DESCRIPTION
Track A / A1 — the last A1 piece: native Claude Code projection. With this, A1's
deliverables (schema, validate, determinism lint, 5th discovery category,
**native-CC translation**) are all implemented.

## What
`condense.generate_claude_subagents()` projects `src/subagents/*.md` (subagent-v1,
ADR-109) into Claude Code's `.claude/agents/` format via a **frontmatter
transform**:
- Governance fields (`schema_version`, `trust`, `lifecycle`, `discovery`,
  `source`) drop; the CC agent keeps `{name, description, tools, model}` + body.
- `model_tier` → `model` reuses `TIER_TO_CLAUDE_MODEL` (ADR-034/035); the
  `inherit` sentinel passes through to `model: inherit`.
- `tools` list → comma form; body verbatim; stale generated agents reaped.
- Wired into `generate-tools` (claude-code-gated) + a summary counter.

## Design notes
- **Reads from `src/` directly, not `dist/`:** a subagent is an executable system
  prompt Claude Code runs verbatim — telegraph condensation would alter its
  behaviour, and it is not routed through the pack/discovery condensation flow.
- The `.claude/` tree is a **generated, uncommitted** projection (CI regenerates),
  so this is a generator change, not committed data.

## Verified
- `generate_claude_subagents()` produces `.claude/agents/production-validator.md`
  in exact CC format (verified against the real unit).
- `tests/scripts/generate_claude_subagents.test.ts` — 4 cases (transform incl.
  `inherit`, model_tier→opus/sonnet/haiku, reaping, absent-source no-op).
- `npm run typecheck` ✅ 0 errors · `condense.test.ts` + `condense_memory.test.ts`
  ✅ 102/110 · condense hash sync ✅.

## Deferred (documented limitation, ADR-109 cross-host)
The non-CC loadable-context-file degradation — subagents are CC-native today;
other hosts get no projection yet. Small follow-on, not blocking A1/A2/A3.

## Note
The roadmap A1 checkbox flip is intentionally **not** in this PR: the shared
working tree currently carries a parallel session's uncommitted gap-hunt work
(A6/A7 bench + roadmap edits), which this PR does not touch or absorb.