### PR TITLE
fix(subagent): register generate_claude_subagents in the capability matrix (unbreak main)

### DIFF
--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -15,6 +15,7 @@ transform — `.mdc`, workflow, or an aggregated single file) · **— none**
 | `rules` | ✅ native | — none | ✅ native | 🔁 adapter | 🔁 adapter | ✅ native | 🔁 adapter | 🔁 adapter † | — none |
 | `skills` | ✅ native | ✅ native | ✅ native | — none | — none | — none | — none | — none | — none |
 | `commands` | ✅ native | — none | ✅ native | 🔁 adapter | 🔁 adapter | — none | — none | — none | — none |
+| `subagents` | ✅ native | — none | — none | — none | — none | — none | — none | — none | — none |
 | `personas` | ✅ native | — none | ✅ native | ✅ native | — none | — none | — none | — none | — none |
 | `user-types` | ✅ native | — none | ✅ native | ✅ native | — none | — none | — none | — none | — none |
 | `hooks` | — none | ✅ native | — none | — none | — none | — none | — none | — none | — none |

--- a/src/scripts/generate_capability_matrix.ts
+++ b/src/scripts/generate_capability_matrix.ts
@@ -65,7 +65,7 @@ const HOSTS = [
     'windsurf', 'cline', 'gemini', 'copilot', 'claude-desktop',
 ];
 
-const ARTIFACTS = ['rules', 'skills', 'commands', 'personas', 'user-types', 'hooks'];
+const ARTIFACTS = ['rules', 'skills', 'commands', 'subagents', 'personas', 'user-types', 'hooks'];
 
 interface FnSpec {
     artifact: string;
@@ -108,6 +108,10 @@ const _FN_SPEC: Record<string, FnSpec> = {
     generate_claude_commands: {
         artifact: 'commands',
         cells: { 'claude-code': 'native', augment: 'native' },
+    },
+    generate_claude_subagents: {
+        artifact: 'subagents',
+        cells: { 'claude-code': 'native' },
     },
     generate_plugin_command_skills: {
         artifact: 'skills', cells: { 'claude-plugin': 'native' },


### PR DESCRIPTION
**Unbreaks main.** PR #710 merged the native-CC projection commit
(`3e3a92d2`) but — due to a GitHub PR-head sync glitch — **not** its follow-up
fix commit (`30a3e4de`). So `main` has `generate_claude_subagents` in
`condense.ts` `_generate_tools_inner`, but `generate_capability_matrix._FN_SPEC`
does not list it → the `coverage_guard` test fails on `main`
(`tests/scripts/generate_capability_matrix.test.ts`).

This cherry-picks the missing fix:
- `generate_capability_matrix.ts`: add the `subagents` row to `ARTIFACTS` + a
  `generate_claude_subagents` `_FN_SPEC` entry (`claude-code: native`).
- `docs/capability-matrix.md`: regenerated.

## Verified
- `generate_capability_matrix.test.ts` ✅ 4/4 (coverage_guard empty) ·
  `generate_capability_matrix --check` ✅ · `npm run typecheck` ✅ 0 errors.

Pure follow-up to #710; no new behaviour.