### PR TITLE
docs(roadmap): tier-conditional discipline-rule loading lever (recovers post-merge commit from #712)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**96 / 162 steps done · 59%**
+**96 / 163 steps done · 59%**
 
 ```text
 ████████████████████████░░░░░░░░░░░░░░░░   59%
@@ -19,7 +19,7 @@
 | 1 | [road-to-final-state-and-market-readiness.md](roadmaps/road-to-final-state-and-market-readiness.md) | 4 | 33 | 22 | 11 | 0 | 0 | ███░░░░░░░ 33% |
 | 2 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
 | 3 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 34 | 11 | 21 | 0 | 2 | ███████░░░ 66% |
+| 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
 | 5 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
@@ -60,7 +60,7 @@
 
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 
-**Road to token saving — measure, then cut, at constant quality** — 21 / 32 done (66%)
+**Road to token saving — measure, then cut, at constant quality** — 21 / 33 done (64%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -70,7 +70,7 @@
 | 3 | Deterministic RTK wrap hook + install verification | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 5 | Cache-aware ordering as a CI invariant (D5) | ✅ done | 0 | 2 | 0 | 1 | 100% |
 | 8 | Always-loaded budget linter (D6) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 6 | 5 | 0 | 0 | 45% |
+| 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 7 | 5 | 0 | 0 | 42% |
 
 ### [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md)
 

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -430,10 +430,28 @@ one-off roadmaps.
       <!-- Already shipped: the always-loaded token-efficiency rule's Iron Law IS
       redirect → summary → targeted-detail; RTK is the tool that applies it. No
       separate lever. -->
+- [ ] **Tier-conditional discipline-rule loading (measured-null subset only).**
+      On strong-host tiers, omit from the always-loaded projection ONLY the
+      discipline rules whose lift is a **measured null on that tier**
+      (`docs/benchmark.md` § strong host, A6 of
+      `road-to-final-state-and-market-readiness.md`): candidates
+      `minimal-safe-diff`, `downstream-changes` (borderline:
+      `verify-before-complete`). **Eligibility fence (hard):** never a safety
+      floor (`non-destructive-by-default` — efficacy ≠ risk, both arms scored
+      0.929 not 1.0), never preference/authorization encoding (`commit-policy`,
+      `scope-control`, the one-question format of `ask-when-uncertain`), never
+      an UNmeasured rule (~35 always-on rules have no null evidence — omitting
+      them is overreach). Mechanics: reuse the `model_tier` vocabulary
+      (ADR-035) as a per-rule `min_host_tier`-style key consumed by the
+      projection/router — compile-time, no runtime. **Measure-first:** the
+      candidate subset is only ~2–4k of the ~24k+ always-on load (the A6 5× is
+      the whole footprint, not these rules) — measure the actual delta on the
+      Phase 0 rig at held quality before shipping; default-off until then.
 - [x] Triage: any further lever — capture here, promote to a phase when committed.
       <!-- Standing umbrella — intentionally open: new levers get captured here and
-      promoted to a committed phase when ready. Triage of the current candidates is
-      complete (no stale candidates). -->
+      promoted to a committed phase when ready. Current candidates triaged; the
+      tier-conditional rule-loading candidate above was added 2026-07-05 from the
+      A6 strong-host honest-null. -->
 
 **Exit:** each candidate is promoted to a phase or marked `[-]` with a reason; no
 stale candidates.


### PR DESCRIPTION
## What

One commit that was pushed into #712 during its merge window and — per the known PR-head sync lag (#710 pattern) — did not land in the merge. Recovery PR from the same branch; contains exactly this commit.

## The change

Captures the **tier-conditional discipline-rule loading** lever in `road-to-token-saving.md` Phase 10 (backlog), follow-on from the A6 strong-host honest-null (#712):

- On strong-host tiers, omit from the always-loaded projection ONLY the **measured-null discipline subset** (candidates `minimal-safe-diff`, `downstream-changes`; borderline `verify-before-complete`).
- **Hard eligibility fence:** never safety floors (`non-destructive-by-default` — efficacy ≠ risk; both arms scored 0.929, not 1.0), never preference/authorization rules (`commit-policy`, `scope-control`), never unmeasured rules.
- **Honest token math:** the subset is ~2–4k of the ~24k+ always-on load (the A6 5× is the whole footprint) — measure-first on the Phase 0 rig, default-off until measured.

Plus the dashboard regen (96/163).

## Verification

Pre-commit hooks genuinely green (marketplace sync + roadmap-progress freshness check).
