### PR TITLE
fix(hooks): roadmap-progress hook regenerates the edited file's own repo + fixes env-less resolution

### DIFF
--- a/src/scripts/roadmap_progress_hook.ts
+++ b/src/scripts/roadmap_progress_hook.ts
@@ -67,11 +67,14 @@ export const DASHBOARD_PATH = "agents/roadmaps-progress.md";
 export const REGEN_NAME = "update_roadmap_progress.ts";
 // Distributed-content script subtrees that may ship the regenerator,
 // in priority order. Project-scoped installs land it under .augment/ or
-// dist/agent-src/; the package itself carries the same projection.
+// dist/agent-src/; the package itself carries the same projection, and the
+// source checkout carries it under src/agent-src/scripts (so a standalone,
+// env-less invocation from the source tree still resolves it).
 export const DIST_SCRIPT_SUBDIRS = [
   path.join(".augment", "scripts"),
   path.join("dist/agent-src", "scripts"),
   path.join(".agent-src.uncondensed", "scripts"),
+  path.join("src/agent-src", "scripts"),
 ];
 // Set by the dispatcher (scripts/hooks/dispatch_hook) to its own resolved
 // package root, so a globally-installed binary (ADR-020 global-only) can
@@ -178,14 +181,53 @@ export function _is_roadmap_touch(p: string): boolean {
 }
 
 /**
+ * The repo root whose dashboard an edited roadmap path belongs to, or null
+ * when the path is not a roadmap touch.
+ *
+ * The dashboard the hook must regenerate is the one in the SAME repo as the
+ * edited roadmap — which is not necessarily `--project-dir`. An autonomous
+ * agent (or a monorepo dev) routinely edits `…/<worktree>/agents/roadmaps/x.md`
+ * while the session's project dir is a sibling checkout; keying off
+ * `--project-dir` alone silently skipped those edits and let the worktree's
+ * dashboard drift. So:
+ *   - an ABSOLUTE path containing `/agents/roadmaps/` resolves to the prefix
+ *     before that segment (the edited file's own repo root), wherever it is;
+ *   - a RELATIVE roadmap path resolves to `consumer_root` (the Augment
+ *     repo-relative case, where the file genuinely sits under `--project-dir`).
+ */
+export function _target_root(p: string, consumer_root: string): string | null {
+  const norm = p.replace(/\\/g, "/");
+  if (path.isAbsolute(norm)) {
+    const marker = "/" + ROADMAP_PREFIX; // "/agents/roadmaps/"
+    const idx = norm.indexOf(marker);
+    if (idx < 0) {
+      return null;
+    }
+    const rel = norm.slice(idx + 1); // "agents/roadmaps/…"
+    if (!_is_roadmap_touch(rel)) {
+      return null;
+    }
+    return norm.slice(0, idx) || "/";
+  }
+  return _is_roadmap_touch(norm) ? consumer_root : null;
+}
+
+/**
  * Package roots to search for the shipped regenerator, in priority order,
  * when the consumer carries no project-local copy.
  *
  * 1. ``AGENT_CONFIG_PACKAGE_ROOT`` — the dispatcher passes its own
  *    resolved package root.
- * 2. This hook's own location (``<pkg>/src/scripts/roadmap_progress_hook.ts``
- *    → ``<pkg>/src``) — last-resort fallback for standalone invocation.
- *    Mirrors the Python `Path(__file__).resolve().parent.parent` walk.
+ * 2. This hook's own location — last-resort fallback for a standalone
+ *    invocation the dispatcher never wrapped. The hook ships at
+ *    ``<pkg>/src/scripts/roadmap_progress_hook.ts``, so BOTH ``<pkg>/src``
+ *    (one dir up from ``scripts/``) AND ``<pkg>`` are searched: the shipped
+ *    regenerator lives under ``<pkg>/dist/agent-src/scripts`` (built /
+ *    installed) or ``<pkg>/src/agent-src/scripts`` (source), i.e. under
+ *    ``<pkg>`` — NOT under ``<pkg>/src``. The previous single
+ *    ``parent.parent`` walk stopped at ``<pkg>/src`` and therefore never
+ *    found the regenerator when the env var was unset (silent no-op → the
+ *    dashboard drifted with no signal).
  */
 export function _package_roots(): string[] {
   const roots: string[] = [];
@@ -193,7 +235,9 @@ export function _package_roots(): string[] {
   if (env_root) {
     roots.push(_expanduser(env_root));
   }
-  roots.push(path.dirname(path.dirname(path.resolve(__filename))));
+  const scriptsDir = path.dirname(path.resolve(__filename)); // <pkg>/src/scripts
+  roots.push(path.dirname(scriptsDir)); // <pkg>/src
+  roots.push(path.dirname(path.dirname(scriptsDir))); // <pkg>
   return roots;
 }
 
@@ -300,33 +344,17 @@ export function run(
     return 0;
   }
 
-  const paths = _candidate_paths(payload).map((p) => _relativize(p, consumer_root));
-  if (!paths.some((p) => _is_roadmap_touch(p))) {
-    return 0;
+  // Each touched roadmap regenerates the dashboard of ITS OWN repo (which may
+  // be a worktree/sibling of `consumer_root`, not consumer_root itself). Dedupe
+  // so N edits in one repo regenerate once.
+  const targetRoots = new Set<string>();
+  for (const p of _candidate_paths(payload)) {
+    const root = _target_root(p, consumer_root);
+    if (root !== null) {
+      targetRoots.add(root);
+    }
   }
-
-  const script = _resolve_regenerator(consumer_root);
-  if (script === null) {
-    // Phase 1 of road-to-hooks-actually-fire-in-consumers: log dispatch
-    // issue directly (this hook runs as a subprocess from the universal
-    // dispatcher; routing through the dispatcher would add latency for
-    // no benefit).
-    try {
-      log_dispatch_issue(
-        consumer_root,
-        "roadmap-progress",
-        "prerequisite_missing",
-        "update_roadmap_progress.ts not found at any of: " +
-          ".augment/scripts/, dist/agent-src/scripts/, " +
-          "src/agent-src/scripts/",
-        "./agent-config hooks:install --regen " + "(or ./agent-config init)",
-      );
-    } catch {
-      // observability never breaks the hook
-    }
-    if (verbose) {
-      process.stderr.write("roadmap-progress-hook: regenerator not found, skipping\n");
-    }
+  if (targetRoots.size === 0) {
     return 0;
   }
 
@@ -339,18 +367,48 @@ export function run(
     return 0;
   }
 
-  try {
-    // The regenerator is a `.ts` script; run it through tsx (resolved from
-    // a node_modules/.bin found by walking up from the regenerator's dir,
-    // falling back to `npx tsx`), mirroring the dispatcher's `.ts` concerns.
-    const inv = _resolve_tsx_invocation(script);
-    spawnSync(inv.command, inv.args, {
-      cwd: consumer_root,
-      stdio: ["ignore", "ignore", "ignore"],
-      timeout: 30000,
-    });
-  } catch {
-    // never propagate regenerator failures into the agent loop
+  for (const root of targetRoots) {
+    const script = _resolve_regenerator(root);
+    if (script === null) {
+      // Phase 1 of road-to-hooks-actually-fire-in-consumers: log dispatch
+      // issue directly (this hook runs as a subprocess from the universal
+      // dispatcher; routing through the dispatcher would add latency for
+      // no benefit).
+      try {
+        log_dispatch_issue(
+          root,
+          "roadmap-progress",
+          "prerequisite_missing",
+          "update_roadmap_progress.ts not found at any of: " +
+            ".augment/scripts/, dist/agent-src/scripts/, " +
+            ".agent-src.uncondensed/scripts/, src/agent-src/scripts/",
+          "./agent-config hooks:install --regen " + "(or ./agent-config init)",
+        );
+      } catch {
+        // observability never breaks the hook
+      }
+      if (verbose) {
+        process.stderr.write(
+          `roadmap-progress-hook: regenerator not found for ${root}, skipping\n`,
+        );
+      }
+      continue;
+    }
+
+    try {
+      // The regenerator is a `.ts` script; run it through tsx (resolved from
+      // a node_modules/.bin found by walking up from the regenerator's dir,
+      // falling back to `npx tsx`), mirroring the dispatcher's `.ts` concerns.
+      // `--repo-root` + cwd pin the regeneration to the edited file's own repo.
+      const inv = _resolve_tsx_invocation(script);
+      spawnSync(inv.command, [...inv.args, "--repo-root", root], {
+        cwd: root,
+        stdio: ["ignore", "ignore", "ignore"],
+        timeout: 30000,
+      });
+    } catch {
+      // never propagate regenerator failures into the agent loop
+    }
   }
 
   if (verbose) {

--- a/tests/scripts/hooks/roadmap_progress_hook.test.ts
+++ b/tests/scripts/hooks/roadmap_progress_hook.test.ts
@@ -11,11 +11,12 @@ import {
     _module,
     _package_roots,
     _relativize,
+    _resolve_regenerator,
+    _target_root,
     run,
 } from '../../../src/scripts/roadmap_progress_hook.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'roadmap_progress_hook.ts');
 const TSX_BIN = path.join(
     REPO_ROOT,
     'node_modules',
@@ -239,6 +240,68 @@ describe.skipIf(!tsx)('roadmap_progress — run()', () => {
         expect(run(stdin, { consumer_root: root })).toBe(0);
         expect(fs.existsSync(marker)).toBe(true);
     });
+
+    it("regenerates the edited roadmap's OWN repo, not --project-dir (worktree/sibling)", () => {
+        // The bug this fixes: an agent edits a roadmap in a sibling worktree
+        // while the session's --project-dir is a different checkout. Keying off
+        // --project-dir alone silently skipped the edit → the worktree's
+        // dashboard drifted. The edited file's own repo must regenerate instead.
+        const proj = consumerRoot(); // the session's --project-dir
+        const sib = consumerRoot(); // a sibling worktree, its own regenerator
+        const absInSibling = path.join(sib.root, 'agents', 'roadmaps', 'feature.md');
+        const stdin = JSON.stringify({
+            hook_event_name: 'PostToolUse',
+            tool_name: 'Edit',
+            tool_input: { file_path: absInSibling },
+        });
+        expect(run(stdin, { consumer_root: proj.root })).toBe(0);
+        expect(fs.existsSync(sib.marker)).toBe(true); // sibling regenerated
+        expect(fs.existsSync(proj.marker)).toBe(false); // project-dir untouched
+    });
+});
+
+// ── _target_root (worktree/sibling awareness) ────────────────────────
+
+describe('roadmap_progress — _target_root', () => {
+    it('absolute roadmap path → its own repo root, wherever it is', () => {
+        expect(_target_root('/a/b/repo/agents/roadmaps/x.md', '/other')).toBe('/a/b/repo');
+    });
+    it('absolute path in a sibling worktree → that worktree, not consumer_root', () => {
+        expect(_target_root('/tmp/wt/agents/roadmaps/x.md', '/tmp/proj')).toBe('/tmp/wt');
+    });
+    it('relative roadmap path → consumer_root (Augment repo-relative case)', () => {
+        expect(_target_root('agents/roadmaps/x.md', '/proj')).toBe('/proj');
+        expect(_target_root('./agents/roadmaps/x.md', '/proj')).toBe('/proj');
+    });
+    it('archive / dashboard / non-roadmap → null', () => {
+        expect(_target_root('/r/agents/roadmaps/archive/old.md', '/p')).toBeNull();
+        expect(_target_root('/r/agents/roadmaps-progress.md', '/p')).toBeNull();
+        expect(_target_root('/r/src/foo.php', '/p')).toBeNull();
+        expect(_target_root('agents/roadmaps/notes.txt', '/p')).toBeNull();
+    });
+});
+
+// ── _resolve_regenerator fallback (env-less standalone) ──────────────
+
+describe('roadmap_progress — regenerator resolution fallback', () => {
+    it('finds the shipped regenerator with no AGENT_CONFIG_PACKAGE_ROOT set', () => {
+        // Regression guard for the off-by-one package-root walk: with the env
+        // var unset, the fallback must still reach the package root that ships
+        // src/agent-src/scripts/update_roadmap_progress.ts (previously it stopped
+        // one dir short at <pkg>/src → null → silent no-op → dashboard drift).
+        const prev = process.env['AGENT_CONFIG_PACKAGE_ROOT'];
+        delete process.env['AGENT_CONFIG_PACKAGE_ROOT'];
+        try {
+            const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'rp-bare-'));
+            cleanup.push(bare);
+            const found = _resolve_regenerator(bare);
+            expect(found).not.toBeNull();
+            expect(found).toMatch(/update_roadmap_progress\.ts$/);
+        } finally {
+            if (prev === undefined) delete process.env['AGENT_CONFIG_PACKAGE_ROOT'];
+            else process.env['AGENT_CONFIG_PACKAGE_ROOT'] = prev;
+        }
+    });
 });
 
 // ── _relativize ──────────────────────────────────────────────────────
@@ -265,27 +328,3 @@ describe('roadmap_progress — _relativize', () => {
     });
 });
 
-// ── Golden parity vs python3 ─────────────────────────────────────────
-
-interface RunResult {
-    status: number | null;
-    stdout: string;
-    stderr: string;
-    markerExists: boolean;
-}
-
-// Build a consumer dir with a sentinel .py regenerator whose marker lives
-// INSIDE the consumer dir (so the two parity dirs stay isolated).
-function makeParityDir(prefix: string): { dir: string; marker: string } {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-    const scriptsDir = path.join(dir, '.augment', 'scripts');
-    fs.mkdirSync(scriptsDir, { recursive: true });
-    const marker = path.join(dir, 'regen.marker');
-    fs.writeFileSync(
-        path.join(scriptsDir, 'update_roadmap_progress.py'),
-        'import pathlib, sys\n' +
-            `pathlib.Path('regen.marker').write_text('ok')\n` +
-            'sys.exit(0)\n',
-    );
-    return { dir, marker };
-}


### PR DESCRIPTION
## Problem — the roadmap dashboard drifts silently

`agents/roadmaps-progress.md` is meant to stay current automatically via the `roadmap_progress_hook` PostToolUse hook ("without depending on agent self-discipline"). In practice it drifts, with **no user-visible signal**. Reproduced two independent silent-no-op paths:

**1. Worktree / sibling / monorepo edits (the main cause).** The hook regenerates only the dashboard under `--project-dir`. When a roadmap is edited in a *different* checkout than the session's project dir — e.g. an autonomous agent editing `…/<worktree>/agents/roadmaps/x.md` while `$CLAUDE_PROJECT_DIR` is a sibling — the edit is relativised against the wrong root, fails the `agents/roadmaps/` prefix check, and the hook no-ops. That worktree's dashboard never regenerates. Verified end-to-end: an edit in a sibling dir left its dashboard at `STALE-SENTINEL`.

**2. Env-less standalone resolution.** `_package_roots()`'s fallback walked `dirname(dirname(__filename))` → `<pkg>/src`, then searched `<pkg>/src/{.augment,dist/agent-src,…}/scripts`. But the shipped regenerator lives under **`<pkg>`** (`dist/agent-src/scripts` built/installed, `src/agent-src/scripts` in source) — one level up. So with `AGENT_CONFIG_PACKAGE_ROOT` unset, `_resolve_regenerator` returned `null` → `prerequisite_missing` → no-op. (Verified: running the hook against a real consumer with the env unset printed `regenerator not found, skipping`.)

## Fix

- **Derive the target repo from each edited roadmap's own path** (the prefix before `/agents/roadmaps/`), not blindly `--project-dir`; regenerate each distinct touched repo (`--repo-root` + `cwd`). Repo-relative paths still resolve to `--project-dir` (Augment case). New `_target_root()` helper.
- **Correct the `_package_roots()` fallback** to also reach `<pkg>`, and add `src/agent-src/scripts` to the search subdirs — so env-less/standalone invocation resolves the regenerator in both built and source layouts.

Both changes are pure robustness: the dispatcher's normal flow (which *does* set `AGENT_CONFIG_PACKAGE_ROOT`) is unaffected; these make the documented fallbacks actually work and stop the silent worktree drift.

## Verification

- `tests/scripts/hooks/roadmap_progress_hook.test.ts`: **31 passed** (25 existing + 6 new) — a worktree/sibling `run()` case (edit in a sibling regenerates the sibling, not `--project-dir`), `_target_root` unit cases, and an env-less `_resolve_regenerator` regression guard.
- End-to-end with the real `update_roadmap_progress.ts`: a sibling edit now regenerates the sibling's dashboard (`STALE-SENTINEL` → real) while `--project-dir` is left untouched.
- `eslint` (0 errors), `tsc -p tsconfig.scripts.json`, `tsc -p tsconfig.test.json` clean.
- Also removed dead py2ts-parity orphans (`TS_SCRIPT`, `RunResult`, `makeParityDir`) that were already flagged unused by eslint in this file, so it lints green.

## Impact

Consumers whose roadmaps are edited in worktrees (the default for autonomous agents) will now keep their `roadmaps-progress.md` in sync automatically, and the standalone fallback no longer silently fails when the dispatcher env isn't set.
