### PR TITLE
fix(hooks): drop legacy-path mention from roadmap-hook not-found message (ADR-051)

### DIFF
--- a/src/scripts/roadmap_progress_hook.ts
+++ b/src/scripts/roadmap_progress_hook.ts
@@ -381,7 +381,7 @@ export function run(
           "prerequisite_missing",
           "update_roadmap_progress.ts not found at any of: " +
             ".augment/scripts/, dist/agent-src/scripts/, " +
-            ".agent-src.uncondensed/scripts/, src/agent-src/scripts/",
+            "src/agent-src/scripts/",
           "./agent-config hooks:install --regen " + "(or ./agent-config init)",
         );
       } catch {


### PR DESCRIPTION
## Follow-up hygiene to #724

#724 (roadmap-progress hook worktree-awareness + fallback fix) merged with one CI nit outstanding: the `prerequisite_missing` hint string in `roadmap_progress_hook.ts` lists `.agent-src.uncondensed/scripts/`, which the **no-new-legacy-path guard (ADR-051)** flags as a fresh reference to the legacy tree — that's the `Sync + Generate Tools Consistency` failure on #724.

This drops the legacy-path name from the human-readable message only. `.agent-src.uncondensed/scripts` remains a grandfathered entry in `DIST_SCRIPT_SUBDIRS` (real search path, unchanged) — so resolution behaviour is identical; only the log wording changes.

Verified: `check_no_new_legacy_path` guard passes locally (`No new .agent-src.uncondensed/ references added under src/`). One-line diff, no behaviour change.
