### PR TITLE
test: de-pythonize 4 mixed parity files + D1 audit of the test-layer purge

### DIFF
--- a/agents/evidence/py2ts-test-layer-audit.md
+++ b/agents/evidence/py2ts-test-layer-audit.md
@@ -1,0 +1,63 @@
+# py2ts test-layer purge — D1 audit (2026-07-05)
+
+> Phase-0/D1 audit for `road-to-py2ts-teardown-completion.md` (Finish
+> strategy 2026-06-29). Classifies the remaining test files that still spawn
+> live `python3` via vestigial parity blocks the shim (`tests/_lib/python-free-env.ts`)
+> force-skips. `python2ts` is long merged (release 7.5.0, `src` has 0 `.py`),
+> so every `python3 <script>.py` parity spawn targets a **deleted** twin and is
+> a permanently-skipped no-op today.
+
+## Current surface
+
+- **93** test files spawn live `python3` (`git grep -lE "spawnSync\(['\"]python3?['\"]" -- 'tests/**'`).
+- **2** non-vestigial live-python harness sites remain (D2): `src/scripts/lint_regression.ts` (baseline ref may be a pre-migration `.py`) and `src/scripts/parity/replay.ts:212` (`runOnce({command:"python3",...})`).
+- Shim still wired: `vitest.config.ts` `setupFiles: ['./tests/_lib/python-free-env.ts']`.
+
+## Classification (the D1 matrix)
+
+Two shapes, distinguished by whether a real (non-parity) `describe` exists
+outside the `describe.runIf(hasPython3())(...)` block:
+
+| Tier | Meaning | Action | Count |
+|---|---|---|---:|
+| **MIXED** | real TS unit tests + a vestigial parity block | **drop the parity block + dead helpers** (zero coverage loss — the TS tests remain) | 4 |
+| **PURE-PARITY** | the whole file is the `runIf` parity block; the TS module has **no** other test | **CONVERT** to a python-free intent test (council D1 default — deleting leaves the module untested) | ~79 |
+| **HARNESS/helper** | shared python-spawn helpers (`tests/_lib/parity_oracle.ts`, `_bench_*.ts`, `_mcp_server.ts`) — no `describe` | resolve **last**, after their consumers are de-pythonized | 10 |
+
+**No pure-parity file is covered by a sibling test or by `tests/cli/cli-e2e.test.ts`**
+(those exercise `versions` / `doctor-shell` / `commands`, not these scripts), so
+the council **coverage-degradation guard** forbids blind deletion: sole-coverage
+files must be CONVERTed, not deleted.
+
+## Done this wave (MIXED — safe drop)
+
+`confidence_gate`, `events_log`, `modes` (ai_council) + `skills_corpus_grounding_bm25_search`
+— removed the `describe.runIf(hasPython3())('… golden parity vs CPython twin')`
+block + the now-dead python helpers (`hasPython3`, `py`/`runPy`/`pyAppend`,
+`PY_MOD`/`PY_SCRIPT`, the `node:child_process` import). Each stays green
+python-free by construction (41 tests total; 0 python residue).
+
+**Recipe (proven, reusable for the remaining MIXED tail if any surfaces):**
+1. Delete the parity `describe.runIf(...)` block (title contains "golden parity"/"CPython"/"python3 vs tsx").
+2. Delete the python helpers only that block used.
+3. Delete now-unused imports (only if `spawnSync` no longer appears).
+4. Keep every non-parity test. Verify `vitest run <file>` > 0 tests + 0 python residue.
+
+## Remaining (the CONVERT bulk — delicate, multi-wave)
+
+~79 pure-parity files → convert to python-free intent tests asserting the tsx
+module's own contract. **Not a codemod / not a blind snapshot** — each file
+must first establish its determinism contract before snapshotting (documented
+traps: **PATH**-dependent host-CLI resolution, **float round-half-to-even**,
+**relative-time**/wall-clock, seeded-**random** sims, and corpus-over-real-repo
+output that bakes the runner's state into the golden → CI-flaky). Use the
+`cli/python/workspace_*` recipe: node-only fixture PATH + `norm()` masking +
+inline snapshots on pinned inputs.
+
+Coherent next clusters: `_cli/cmd_*` (17, rich `--json`/error-path assertions),
+`measure_*` (5, corpus-over-repo — mask/pin), `prediction-pool_*` (3, seeded
+random — pin the seed), `inventory_*` (2). Then D2 (the 2 harness sites → local
+python-skip guards), then D3 (retire the shim + the 3 scaffolding workflows,
+soak ≥24h). Ship as small tests-only PRs per D4 (never touch
+`agents/roadmaps-progress.md`; macOS + Linux matrix for snapshot-generating
+tests).

--- a/tests/scripts/ai_council/confidence_gate.test.ts
+++ b/tests/scripts/ai_council/confidence_gate.test.ts
@@ -1,10 +1,6 @@
 // Tests for src/scripts/ai_council/confidence_gate.ts (py2ts Phase 1).
 //
-// Heuristics are regex + length only. Golden-parity against the Python twin
-// via direct-file import (registered in sys.modules so the frozen dataclass
-// + `float | None` annotations resolve under Python 3.9).
-import { spawnSync } from 'node:child_process';
-
+// Heuristics are regex + length only.
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -13,31 +9,6 @@ import {
     is_split_response,
     should_escalate,
 } from '../../../src/scripts/ai_council/confidence_gate.js';
-
-const PY_MOD = 'src/scripts/ai_council/confidence_gate.py';
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-function pyLoadPreamble(): string[] {
-    return [
-        'import importlib.util, sys, json',
-        `spec = importlib.util.spec_from_file_location("cg", ${JSON.stringify(PY_MOD)})`,
-        'cg = importlib.util.module_from_spec(spec)',
-        'sys.modules["cg"] = cg',
-        'spec.loader.exec_module(cg)',
-    ];
-}
-
-function py(snippet: string): string {
-    const code = [...pyLoadPreamble(), snippet].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr}`);
-    }
-    return r.stdout.trim();
-}
 
 // Representative response corpus exercising every branch + edge.
 const CORPUS: Record<string, string> = {
@@ -106,39 +77,4 @@ describe('confidence_gate — should_escalate ordering', () => {
         expect(d.escalate).toBe(false);
         expect(d.reason).toBe('ok');
     });
-});
-
-describe.runIf(hasPython3())('confidence_gate — golden parity vs CPython twin', () => {
-    const floors = [0.0, 0.5, 0.7, 0.9];
-    const keys = Object.keys(CORPUS);
-
-    // Parse both sides so Python's float repr (`1.0`) compares equal to JS's
-    // single number type (`1`) — the documented ADR-094 number divergence.
-    it.each(keys)('extract_confidence(%s) matches', (key) => {
-        const text = CORPUS[key] as string;
-        const expected = py(`print(json.dumps(cg.extract_confidence(${JSON.stringify(text)})))`);
-        expect(extract_confidence(text)).toEqual(JSON.parse(expected));
-    });
-
-    it.each(keys)('is_refusal / is_split(%s) match', (key) => {
-        const text = CORPUS[key] as string;
-        const expected = py(
-            `print(json.dumps([cg.is_refusal(${JSON.stringify(text)}), cg.is_split_response(${JSON.stringify(text)})]))`,
-        );
-        expect([is_refusal(text), is_split_response(text)]).toEqual(JSON.parse(expected));
-    });
-
-    for (const floor of floors) {
-        it.each(keys)(`should_escalate(%s, floor=${floor}) matches`, (key) => {
-            const text = CORPUS[key] as string;
-            const expected = py(
-                `d = cg.should_escalate(${JSON.stringify(text)}, floor=${floor})\n` +
-                    'print(json.dumps({"escalate": d.escalate, "reason": d.reason, "confidence": d.confidence}))',
-            );
-            const d = should_escalate(text, floor);
-            expect({ escalate: d.escalate, reason: d.reason, confidence: d.confidence }).toEqual(
-                JSON.parse(expected),
-            );
-        });
-    }
 });

--- a/tests/scripts/ai_council/events_log.test.ts
+++ b/tests/scripts/ai_council/events_log.test.ts
@@ -2,10 +2,7 @@
 //
 // Appends one JSON line per council event. The only non-determinism is
 // `ts_utc` (wall-clock); the TS twin accepts an injectable `now` for unit
-// tests, and the golden-parity check strips `ts_utc` from BOTH sides before
-// comparing the JSON line byte-for-byte (the timestamp format itself is
-// asserted separately).
-import { spawnSync } from 'node:child_process';
+// tests.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -17,30 +14,6 @@ import {
     appendEvent,
     defaultLogPath,
 } from '../../../src/scripts/ai_council/events_log.js';
-
-const PY_MOD = 'src/scripts/ai_council/events_log.py';
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/** Append `event` (Python literal) to `logPath` via the Python twin; return the line. */
-function pyAppend(eventPyLiteral: string, logPath: string): string {
-    const code = [
-        'import importlib.util, sys',
-        `spec = importlib.util.spec_from_file_location("el", ${JSON.stringify(PY_MOD)})`,
-        'el = importlib.util.module_from_spec(spec)',
-        'sys.modules["el"] = el',
-        'spec.loader.exec_module(el)',
-        `el.append_event(${eventPyLiteral}, log_path=el.Path(${JSON.stringify(logPath)}))`,
-        `print(open(${JSON.stringify(logPath)}, encoding="utf-8").read(), end="")`,
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr}`);
-    }
-    return r.stdout;
-}
 
 const created: string[] = [];
 function tmpDir(): string {
@@ -54,13 +27,6 @@ afterEach(() => {
         fs.rmSync(created.pop()!, { recursive: true, force: true });
     }
 });
-
-/** Strip the wall-clock `ts_utc` field from a JSON line for stable comparison. */
-function stripTs(line: string): unknown {
-    const rec = JSON.parse(line.trim()) as Record<string, unknown>;
-    delete rec.ts_utc;
-    return rec;
-}
 
 const FIXED = new Date(Date.UTC(2026, 5, 14, 8, 30, 15));
 
@@ -157,56 +123,3 @@ describe('events_log — write + schema', () => {
     });
 });
 
-describe.runIf(hasPython3())('events_log — golden parity vs CPython twin', () => {
-    const cases: Array<{ desc: string; tsEvent: () => Record<string, unknown>; pyLiteral: string }> =
-        [
-            {
-                desc: 'full record with non-ASCII ask + pass-through',
-                tsEvent: () => ({
-                    lens: 'security',
-                    invocation: '/council',
-                    action: 'skip_necessity',
-                    verdict: 'no',
-                    provider_caps: { api: true, cli: false },
-                    original_ask: 'Why skip? äöü ümlaut',
-                    category: 'extra',
-                    rationale: 'quota',
-                }),
-                pyLiteral:
-                    "{'lens':'security','invocation':'/council','action':'skip_necessity','verdict':'no','provider_caps':{'api':True,'cli':False},'original_ask':'Why skip? äöü ümlaut','category':'extra','rationale':'quota'}",
-            },
-            {
-                desc: 'minimal proceed (defaults + sentinel hash)',
-                tsEvent: () => ({ action: 'proceed' }),
-                pyLiteral: "{'action':'proceed'}",
-            },
-            {
-                desc: 'block_quota with empty caps',
-                tsEvent: () => ({ action: 'block_quota', lens: 'cost', original_ask: 'long ask here' }),
-                pyLiteral: "{'action':'block_quota','lens':'cost','original_ask':'long ask here'}",
-            },
-        ];
-
-    it.each(cases)('$desc — line matches (sans ts_utc)', ({ tsEvent, pyLiteral }) => {
-        const tsLog = path.join(tmpDir(), 'ts.log');
-        const pyLog = path.join(tmpDir(), 'py.log');
-        appendEvent(tsEvent(), { logPath: tsLog, now: FIXED });
-        const tsLine = fs.readFileSync(tsLog, 'utf-8');
-        const pyLine = pyAppend(pyLiteral, pyLog);
-
-        // ts_utc differs (wall-clock) — strip and compare the parsed record.
-        expect(stripTs(tsLine)).toEqual(stripTs(pyLine));
-
-        // Byte-parity of everything except the ts_utc value: replace the
-        // ts_utc value in both with a placeholder and compare the raw line.
-        const norm = (l: string): string => l.trim().replace(/"ts_utc":"[^"]*"/, '"ts_utc":"X"');
-        expect(norm(tsLine)).toBe(norm(pyLine));
-    });
-
-    it('Python ts_utc format is YYYY-MM-DDTHH:MM:SSZ (matches TS shape)', () => {
-        const pyLog = path.join(tmpDir(), 'fmt.log');
-        const line = pyAppend("{'action':'proceed'}", pyLog);
-        const rec = JSON.parse(line.trim()) as Record<string, unknown>;
-        expect(rec.ts_utc).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
-    });
-});

--- a/tests/scripts/ai_council/modes.test.ts
+++ b/tests/scripts/ai_council/modes.test.ts
@@ -1,11 +1,6 @@
 // Tests for src/scripts/ai_council/modes.ts (py2ts Phase 1).
 //
-// Pure resolver — no I/O, no env. Golden-parity against the Python twin via a
-// direct-file import (the package `__init__.py` pulls in networked client
-// deps, so we exec the single module file with the name registered in
-// sys.modules so its dataclass / `X | None` annotations resolve).
-import { spawnSync } from 'node:child_process';
-
+// Pure resolver — no I/O, no env.
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -15,29 +10,6 @@ import {
     resolve_mode,
     resolve_modes,
 } from '../../../src/scripts/ai_council/modes.js';
-
-const PY_MOD = 'src/scripts/ai_council/modes.py';
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/** Run a python snippet with `modes` loaded as the direct-file twin. */
-function py(snippet: string): string {
-    const code = [
-        'import importlib.util, sys, json',
-        `spec = importlib.util.spec_from_file_location("modes", ${JSON.stringify(PY_MOD)})`,
-        'm = importlib.util.module_from_spec(spec)',
-        'sys.modules["modes"] = m',
-        'spec.loader.exec_module(m)',
-        snippet,
-    ].join('\n');
-    const r = spawnSync('python3', ['-c', code], { encoding: 'utf8' });
-    if (r.status !== 0) {
-        throw new Error(`python3 failed: ${r.stderr}`);
-    }
-    return r.stdout.trim();
-}
 
 describe('modes — constants', () => {
     it('VALID_MODES and DEFAULT_MODE match the Python contract', () => {
@@ -118,53 +90,3 @@ describe('modes — resolve_modes batch', () => {
     });
 });
 
-describe.runIf(hasPython3())('modes — golden parity vs CPython twin', () => {
-    const cases: Array<{ desc: string; tsCall: () => unknown; pyExpr: string }> = [
-        {
-            desc: 'invocation flag normalised',
-            tsCall: () => resolve_mode('anthropic', { invocationMode: '  API ' }),
-            pyExpr: "m.resolve_mode('anthropic', invocation_mode='  API ')",
-        },
-        {
-            desc: 'member beats global',
-            tsCall: () => resolve_mode('o', { memberSettings: { mode: 'CLI' }, globalMode: 'api' }),
-            pyExpr: "m.resolve_mode('o', member_settings={'mode':'CLI'}, global_mode='api')",
-        },
-        {
-            desc: 'default fallthrough',
-            tsCall: () => resolve_mode('o'),
-            pyExpr: "m.resolve_mode('o')",
-        },
-        {
-            desc: 'batch resolve',
-            tsCall: () =>
-                resolve_modes(['a', 'b', 'c'], {
-                    membersSettings: { a: { mode: 'cli' }, b: {} },
-                    globalMode: 'api',
-                }),
-            pyExpr:
-                "m.resolve_modes(['a','b','c'], members_settings={'a':{'mode':'cli'},'b':{}}, global_mode='api')",
-        },
-    ];
-
-    it.each(cases)('$desc', ({ tsCall, pyExpr }) => {
-        const expected = py(`print(json.dumps(${pyExpr}))`);
-        expect(tsCall()).toEqual(JSON.parse(expected));
-    });
-
-    it('invalid-mode error message matches CPython', () => {
-        const expected = py(
-            "import traceback\n" +
-                "try:\n" +
-                "    m.resolve_mode('x', invocation_mode='bogus')\n" +
-                "except m.InvalidModeError as e:\n" +
-                "    print(str(e))",
-        );
-        try {
-            resolve_mode('x', { invocationMode: 'bogus' });
-            throw new Error('expected throw');
-        } catch (e) {
-            expect((e as Error).message).toBe(expected);
-        }
-    });
-});

--- a/tests/scripts/skills_corpus_grounding_bm25_search.test.ts
+++ b/tests/scripts/skills_corpus_grounding_bm25_search.test.ts
@@ -1,51 +1,14 @@
 // Tests for src/skills/corpus-grounding/scripts/bm25_search.ts (ADR-094 py2ts).
 //
-// No pytest suite exists for the skill scripts, so this is a differential
-// suite: TS unit tests over the BM25 math / CSV parsing / filters, PLUS a
-// golden-parity layer that runs the Python module's functions (via a direct
-// importlib loader, since the skill scripts are not an importable package)
-// and the TS twin on identical inputs and asserts byte-identical JSON. The
-// CLI-level end-to-end parity (which exercises search_rows through ground.py)
-// lives in skills_corpus_grounding_ground.test.ts.
+// TS unit tests over the BM25 math / CSV parsing / filters.
 //
 // Float parity is the load-bearing concern here: BM25 produces tf-idf floats
 // whose exact bit pattern (and the descending-with-stable-ties sort) must
-// match CPython. Determinism: pure functions over inline fixtures, no clock,
+// be correct. Determinism: pure functions over inline fixtures, no clock,
 // no network, no git drift.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import { describe, expect, it } from 'vitest';
 
 import * as bm from '../../src/skills/corpus-grounding/scripts/bm25_search.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const SCRIPTS = path.join(REPO_ROOT, 'src', 'skills', 'corpus-grounding', 'scripts');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-
-/** Run a python snippet that imports the .py module by file path (importlib). */
-function py(modAttr: string, snippet: string): string {
-    const loader = `
-import importlib.util, json, sys
-def _load(name):
-    spec = importlib.util.spec_from_file_location(name, ${JSON.stringify(SCRIPTS)} + "/" + name + ".py")
-    m = importlib.util.module_from_spec(spec)
-    sys.modules[name] = m
-    spec.loader.exec_module(m)
-    return m
-${modAttr}
-${snippet}
-`;
-    const r = spawnSync('python3', ['-c', loader], { encoding: 'utf8', cwd: REPO_ROOT });
-    if (r.status !== 0) {
-        throw new Error(`python failed: ${r.stderr}`);
-    }
-    return r.stdout;
-}
 
 describe('bm25_search — tokenize parity', () => {
     it('lowercases, strips punctuation, drops <3-char tokens (code-point length)', () => {
@@ -127,34 +90,5 @@ describe('bm25_search — search_rows', () => {
         expect(r.count).toBe(0);
         expect(r.results).toEqual([]);
         expect('scores' in r).toBe(false);
-    });
-});
-
-describe.runIf(hasPython3())('bm25_search — golden parity (python3 importlib)', () => {
-    it('BM25.score floats match CPython bit-for-bit', () => {
-        const docs = [
-            'Muted Palette muted calm soft A restrained low-saturation palette',
-            'Vibrant Palette vibrant bold bright High-saturation energetic colors',
-            'Fintech Blue fintech trust blue Conservative blue trust palette',
-        ];
-        const out = py(
-            'bm = _load("bm25_search")',
-            `b = bm.BM25(); b.fit(${JSON.stringify(docs)})
-print(json.dumps([repr(s) for _, s in b.score("muted calm palette")]))`,
-        );
-        const pyScores = JSON.parse(out.trim()) as string[];
-        const tsB = new bm.BM25();
-        tsB.fit(docs);
-        const tsScores = tsB.score('muted calm palette').map(([, s]) => String(s));
-        expect(tsScores).toEqual(pyScores);
-    });
-
-    it('tokenize parity on a tricky unicode string', () => {
-        const sample = 'Über-Café 123 a_b naïve €5 你好世界 ab abc';
-        const out = py(
-            'bm = _load("bm25_search")',
-            `print(json.dumps(bm.BM25.tokenize(${JSON.stringify(sample)})))`,
-        );
-        expect(bm.BM25.tokenize(sample)).toEqual(JSON.parse(out.trim()));
     });
 });


### PR DESCRIPTION
## What

First wave of the py2ts test-layer purge (`road-to-py2ts-teardown-completion`,
Finish strategy 2026-06-29): de-pythonize the **4 MIXED** parity test files +
land the **D1 audit** that scopes the whole remainder.

## Why now / context

`python2ts` is long merged (release 7.5.0, `src` has 0 `.py`), so every
`python3 <script>.py` parity spawn targets a **deleted** twin and is a
permanently-skipped no-op. 93 test files still carry such vestigial blocks.
This wave clears the safe subset and maps the rest.

## Changes

**`test:` — 4 MIXED files de-pythonized** (real TS unit tests + a vestigial
`describe.runIf(hasPython3())('… golden parity vs CPython twin')` block):
`ai_council/{confidence_gate,events_log,modes}` + `skills_corpus_grounding_bm25_search`.
Removed the parity block + dead python helpers; the real TS tests remain →
**zero coverage loss**. 41 tests pass python-free; 0 python residue.

**`docs(evidence):` — D1 audit** (`agents/evidence/py2ts-test-layer-audit.md`):
classifies all 93 spawn files → **4 MIXED** (done), **~79 PURE-PARITY**
(CONVERT — sole coverage, council forbids blind delete), **10 harness** (last).
Records the proven drop recipe, the per-module determinism traps, and the
remaining wave plan (D2 harness sites, D3 shim + scaffolding retire).

## Scope discipline (D4)

Small tests-only + evidence PR. Does **not** touch `agents/roadmaps-progress.md`
(the #646 merge-ref failure mode) or the roadmap checkboxes — those ride a
separate doc PR post-wave, and no single open step is fully closed by this
wave (partial progress on the test-layer purge).

## Not in this PR (the delicate bulk, per the audit)

The ~79 PURE-PARITY files need per-module CONVERT (determinism analysis:
PATH / float round-half-even / relative-time / seeded-random / corpus-over-repo)
— not a blind batch, not a codemod. Deleting them would leave the TS module
untested (council coverage-degradation guard). Tracked as follow-up waves.

## Verification

`vitest run` on the 4 changed files → 41 passed, 0 python residue; `tsc --noEmit`
clean on the changed set. Full pipeline is the authoritative remote-CI gate.
