### PR TITLE
test(py2ts): convert the explain_last parity trio to python-free contract tests

### DIFF
--- a/tests/scripts/_cli/explain_last_build_trace.test.ts
+++ b/tests/scripts/_cli/explain_last_build_trace.test.ts
@@ -1,28 +1,13 @@
-// Golden-parity tests for the explain_last trace builder + Markdown renderer
+// Contract tests for the explain_last trace builder + Markdown renderer
 // (py2ts Phase 1, ADR-200): index.ts (build_trace), render.ts, state_loader.ts,
-// and the core slot builders (route / inputs / memory / council / assumptions /
-// halt / provider) exercised end-to-end on synthetic `.work-state.json`
-// fixtures.
-//
-// Strategy: build an isolated tmp project root (router.json + state +
-// council-responses + memory sidecar), then run the REAL python3
-// `build_trace` + `render` and the tsx twins on the SAME root with an
-// injected `now`, and assert byte-identical:
-//   - the rendered Markdown (footer + quiet), and
-//   - the trace JSON serialized with a PyFloat-aware
-//     `json.dumps(indent=2, sort_keys=True, ensure_ascii=False)` twin (so the
-//     `float()` hit_score renders `N.0` identically on both sides).
-//
-// The Python side imports the package (`scripts._cli.explain_last`) with
-// PYTHONPATH=["src", repo] — the package `__init__` pulls every sibling, so a
-// per-file importlib loader is not used here; the scrubber test covers the
-// leaf-module direct-file path. mtimes are pinned so the council ±1h window
-// and the mtime-fallback run_id are deterministic; `now` is injected.
-import { spawnSync } from 'node:child_process';
+// and the core slot builders exercised end-to-end on synthetic
+// `.work-state.json` fixtures. The tsx twins are the source of truth (the
+// python originals were deleted in the teardown); the serialized trace JSON +
+// both renders are pinned via inline snapshots. mtimes are pinned and `now`
+// is injected so every fixture is deterministic.
 import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -30,16 +15,9 @@ import { build_trace } from '../../../src/scripts/_cli/explain_last/index.js';
 import { PyFloat } from '../../../src/scripts/_cli/explain_last/memory.js';
 import { render } from '../../../src/scripts/_cli/explain_last/render.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = hasPython3();
 
 // Fixed instant injected as `now` on both sides (ms-aligned so the Python
 // `datetime` and the JS `Date` agree to the microsecond).
-const NOW_ISO = '2026-06-17T12:00:00+00:00';
 const NOW_DATE = new Date(Date.UTC(2026, 5, 17, 12, 0, 0));
 // Pinned mtimes (epoch seconds): state anchor + a council file inside the window.
 const STATE_MTIME = 1718000000.0;
@@ -92,45 +70,6 @@ function dumpSorted(v: unknown, depth: number): string {
     return `{\n${keys
         .map((k) => `${pad}${pyJsonStr(k)}: ${dumpSorted(o[k], depth + 1)}`)
         .join(',\n')}\n${close}}`;
-}
-
-interface PyOut {
-    status: number;
-    json: string;
-    footer: string;
-    quiet: string;
-    stderr: string;
-}
-
-/** Run the python3 build_trace + render on `projectRoot` with the pinned now. */
-function runPy(projectRoot: string, stateRel = '.work-state.json'): PyOut {
-    const code = [
-        'import json, sys, datetime, pathlib',
-        'from scripts._cli.explain_last import build_trace',
-        'from scripts._cli.explain_last.render import render',
-        `root = pathlib.Path(${JSON.stringify(projectRoot)})`,
-        'now = datetime.datetime(2026,6,17,12,0,0, tzinfo=datetime.timezone.utc)',
-        `trace = build_trace(root, root / ${JSON.stringify(stateRel)}, now=now)`,
-        'parts = {',
-        '  "json": json.dumps(trace, indent=2, sort_keys=True, ensure_ascii=False),',
-        '  "footer": render(trace, with_footer=True),',
-        '  "quiet": render(trace, with_footer=False),',
-        '}',
-        'sys.stdout.write(json.dumps(parts, ensure_ascii=False))',
-    ].join('\n');
-    const res = spawnSync('python3', ['-c', code], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-        env: {
-            ...process.env,
-            PYTHONPATH: [path.join(REPO_ROOT, 'src'), REPO_ROOT].join(path.delimiter),
-        },
-    });
-    if (res.status !== 0) {
-        return { status: res.status ?? -1, json: '', footer: '', quiet: '', stderr: res.stderr };
-    }
-    const parsed = JSON.parse(res.stdout) as { json: string; footer: string; quiet: string };
-    return { status: 0, ...parsed, stderr: res.stderr };
 }
 
 function writeJson(p: string, obj: unknown): void {
@@ -194,37 +133,285 @@ function buildRichFixture(): void {
     utimesSync(councilFile, COUNCIL_MTIME, COUNCIL_MTIME);
 }
 
-describe('explain_last build_trace + render — golden parity', () => {
-    it.runIf(HAVE_PYTHON)('rich fixture: trace JSON + both renders are byte-identical', () => {
+describe('explain_last build_trace + render — contract', () => {
+    it('rich fixture: trace JSON + both renders (pinned)', () => {
         buildRichFixture();
-        const py = runPy(root);
-        expect(py.status, py.stderr).toBe(0);
         const stateFile = path.join(root, '.work-state.json');
         const trace = build_trace(root, stateFile, { now: NOW_DATE });
-        expect(dumpSorted(trace, 0)).toBe(py.json);
-        expect(render(trace, { with_footer: true })).toBe(py.footer);
-        expect(render(trace, { with_footer: false })).toBe(py.quiet);
+        const json = dumpSorted(trace, 0);
+        expect(json).toMatchInlineSnapshot(`
+          "{
+            "assumptions": [
+              {
+                "accepted": true,
+                "id": "first assumption",
+                "source": "refine"
+              },
+              {
+                "accepted": false,
+                "id": "a2",
+                "source": "halt"
+              }
+            ],
+            "council": [
+              {
+                "citations": [
+                  "c1",
+                  "note about <host>"
+                ],
+                "member_id": "anthropic/sonnet",
+                "verdict": "Verdict line one"
+              },
+              {
+                "citations": [],
+                "member_id": "solo",
+                "verdict": "only model"
+              }
+            ],
+            "generated_at": "2026-06-17T12:00:00+00:00",
+            "halt": {
+              "reason": "needs review",
+              "step": "refine",
+              "surface": [
+                "line A",
+                "line B"
+              ]
+            },
+            "inputs": {
+              "preset": "balanced",
+              "profile": "developer",
+              "rule_loading_tier": "balanced",
+              "source_per_knob": {
+                "preset": "profile",
+                "profile": "default",
+                "rule_loading_tier": "default"
+              }
+            },
+            "memory": [
+              {
+                "entry_id": "s-mem",
+                "hit_score": 1.25,
+                "used_in": "plan"
+              },
+              {
+                "entry_id": "m1",
+                "hit_score": 2.0,
+                "used_in": "refine"
+              },
+              {
+                "entry_id": "m2",
+                "hit_score": 0.5,
+                "used_in": "unspecified"
+              }
+            ],
+            "pack": null,
+            "provider": null,
+            "route": {
+              "kernel_rules": [
+                "k-one",
+                "k-two"
+              ],
+              "matched_rules": [
+                "t-a",
+                "t-b"
+              ],
+              "persona": "developer"
+            },
+            "run_id": "TICK-1",
+            "subject": "implement-ticket",
+            "version": 1
+          }"
+        `);
+        expect(render(trace, { with_footer: true })).toMatchInlineSnapshot(`
+          "# explain last — run TICK-1
+
+          **Subject:** /implement-ticket · **Started:** 2026-06-17T12:00:00+00:00
+
+          ## Why this route?
+
+          - Active rules: t-a, t-b
+          - Kernel rules: 2
+          - Persona: developer
+
+          ## Why this profile / preset?
+
+          | knob | value | source |
+          |---|---|---|
+          | profile.id | developer | default |
+          | preset.id | balanced | profile |
+          | rule_loading_tier | balanced | default |
+
+          ## Memory hits influencing this run
+
+          - s-mem (score 1.25) — used in plan
+          - m1 (score 2.00) — used in refine
+          - m2 (score 0.50) — used in unspecified
+
+          ## Council
+
+          ### anthropic/sonnet
+
+          > Verdict line one
+
+          Citations:
+          - c1
+          - note about <host>
+
+          ### solo
+
+          > only model
+
+          ## Why halted?
+
+          - **Reason:** \`needs review\`
+          - **Hook event:** \`refine\`
+
+          Surface emitted to the user:
+
+            line A
+            line B
+
+          ## Assumptions
+
+          - [x] first assumption  — recorded in step \`refine\`
+          - [ ] a2  — recorded in step \`halt\`
+
+          _tip: pass \`--json\` to emit machine-readable trace; \`--quiet\` to drop this footer._
+          "
+        `);
+        expect(render(trace, { with_footer: false })).toMatchInlineSnapshot(`
+          "# explain last — run TICK-1
+
+          **Subject:** /implement-ticket · **Started:** 2026-06-17T12:00:00+00:00
+
+          ## Why this route?
+
+          - Active rules: t-a, t-b
+          - Kernel rules: 2
+          - Persona: developer
+
+          ## Why this profile / preset?
+
+          | knob | value | source |
+          |---|---|---|
+          | profile.id | developer | default |
+          | preset.id | balanced | profile |
+          | rule_loading_tier | balanced | default |
+
+          ## Memory hits influencing this run
+
+          - s-mem (score 1.25) — used in plan
+          - m1 (score 2.00) — used in refine
+          - m2 (score 0.50) — used in unspecified
+
+          ## Council
+
+          ### anthropic/sonnet
+
+          > Verdict line one
+
+          Citations:
+          - c1
+          - note about <host>
+
+          ### solo
+
+          > only model
+
+          ## Why halted?
+
+          - **Reason:** \`needs review\`
+          - **Hook event:** \`refine\`
+
+          Surface emitted to the user:
+
+            line A
+            line B
+
+          ## Assumptions
+
+          - [x] first assumption  — recorded in step \`refine\`
+          - [ ] a2  — recorded in step \`halt\`
+          "
+        `);
         // spot-checks: PyFloat carries the int-valued float; scrubber fired.
         const mem = trace.memory as Array<Record<string, unknown>>;
         expect(mem[1]?.hit_score).toBeInstanceOf(PyFloat);
-        expect(py.json).toContain('"hit_score": 2.0');
-        expect(py.json).toContain('<host>'); // srv.local citation scrubbed
+        expect(json).toContain('"hit_score": 2.0');
+        expect(json).toContain('<host>'); // srv.local citation scrubbed
     });
 
-    it.runIf(HAVE_PYTHON)('empty/minimal state: every slot degrades to null/placeholder', () => {
+    it('empty/minimal state: every slot degrades to null/placeholder', () => {
         const state = { version: 1, input: { kind: 'prompt', data: {} } };
         const stateFile = path.join(root, '.work-state.json');
         writeJson(stateFile, state);
         utimesSync(stateFile, STATE_MTIME, STATE_MTIME);
-        const py = runPy(root);
-        expect(py.status, py.stderr).toBe(0);
         const trace = build_trace(root, stateFile, { now: NOW_DATE });
-        expect(dumpSorted(trace, 0)).toBe(py.json);
-        expect(render(trace, { with_footer: true })).toBe(py.footer);
+        expect(dumpSorted(trace, 0)).toMatchInlineSnapshot(`
+          "{
+            "assumptions": [],
+            "council": null,
+            "generated_at": "2026-06-17T12:00:00+00:00",
+            "halt": null,
+            "inputs": {
+              "preset": "balanced",
+              "profile": "developer",
+              "rule_loading_tier": "balanced",
+              "source_per_knob": {
+                "preset": "profile",
+                "profile": "default",
+                "rule_loading_tier": "default"
+              }
+            },
+            "memory": null,
+            "pack": null,
+            "provider": null,
+            "route": null,
+            "run_id": "2024-06-10T06:13:20+00:00",
+            "subject": "work",
+            "version": 1
+          }"
+        `);
+        expect(render(trace, { with_footer: true })).toMatchInlineSnapshot(`
+          "# explain last — run 2024-06-10T06:13:20+00:00
+
+          **Subject:** /work · **Started:** 2026-06-17T12:00:00+00:00
+
+          ## Why this route?
+
+          - (none) — router.json missing or unreadable
+
+          ## Why this profile / preset?
+
+          | knob | value | source |
+          |---|---|---|
+          | profile.id | developer | default |
+          | preset.id | balanced | profile |
+          | rule_loading_tier | balanced | default |
+
+          ## Memory hits influencing this run
+
+          - (none)
+
+          ## Council
+
+          (none recorded for this run)
+
+          ## Why halted?
+
+          (clean run — no halt recorded)
+
+          ## Assumptions
+
+          - (none captured)
+
+          _tip: pass \`--json\` to emit machine-readable trace; \`--quiet\` to drop this footer._
+          "
+        `);
         expect(trace.run_id).toBe('2024-06-10T06:13:20+00:00'); // mtime fallback, no µs
     });
 
-    it.runIf(HAVE_PYTHON)('video subject: provider slot + section populate and scrub', () => {
+    it('video subject: provider slot + section populate and scrub', () => {
         const state = {
             version: 1,
             directive_set: 'video',
@@ -234,18 +421,81 @@ describe('explain_last build_trace + render — golden parity', () => {
         const stateFile = path.join(root, '.work-state.json');
         writeJson(stateFile, state);
         utimesSync(stateFile, 1718000000.5, 1718000000.5); // fractional → µs in run_id
-        const py = runPy(root);
-        expect(py.status, py.stderr).toBe(0);
         const trace = build_trace(root, stateFile, { now: NOW_DATE });
-        expect(dumpSorted(trace, 0)).toBe(py.json);
-        expect(render(trace, { with_footer: false })).toBe(py.quiet);
+        expect(dumpSorted(trace, 0)).toMatchInlineSnapshot(`
+          "{
+            "assumptions": [],
+            "council": null,
+            "generated_at": "2026-06-17T12:00:00+00:00",
+            "halt": null,
+            "inputs": {
+              "preset": "balanced",
+              "profile": "developer",
+              "rule_loading_tier": "balanced",
+              "source_per_knob": {
+                "preset": "profile",
+                "profile": "default",
+                "rule_loading_tier": "default"
+              }
+            },
+            "memory": null,
+            "pack": null,
+            "provider": {
+              "id": "sora",
+              "selection_reason": "budget on <host> <money>/m"
+            },
+            "route": null,
+            "run_id": "2024-06-10T06:13:20.500000+00:00",
+            "subject": "video",
+            "version": 1
+          }"
+        `);
+        expect(render(trace, { with_footer: false })).toMatchInlineSnapshot(`
+          "# explain last — run 2024-06-10T06:13:20.500000+00:00
+
+          **Subject:** /video · **Started:** 2026-06-17T12:00:00+00:00
+
+          ## Why this route?
+
+          - (none) — router.json missing or unreadable
+
+          ## Why this profile / preset?
+
+          | knob | value | source |
+          |---|---|---|
+          | profile.id | developer | default |
+          | preset.id | balanced | profile |
+          | rule_loading_tier | balanced | default |
+
+          ## Memory hits influencing this run
+
+          - (none)
+
+          ## Council
+
+          (none recorded for this run)
+
+          ## Why halted?
+
+          (clean run — no halt recorded)
+
+          ## Why this provider?
+
+          - **Provider:** \`sora\`
+          - **Selection reason:** budget on <host> <money>/m
+
+          ## Assumptions
+
+          - (none captured)
+          "
+        `);
         expect(trace.run_id).toBe('2024-06-10T06:13:20.500000+00:00');
         expect((trace.provider as Record<string, unknown>).selection_reason).toBe(
             'budget on <host> <money>/m',
         );
     });
 
-    it.runIf(HAVE_PYTHON)('council out of ±1h window → null', () => {
+    it('council out of ±1h window → null', () => {
         mkdirSync(path.join(root, 'agents', 'runtime', 'council', 'sessions', 's9'), {
             recursive: true,
         });
@@ -258,15 +508,37 @@ describe('explain_last build_trace + render — golden parity', () => {
         writeJson(stateFile, state);
         utimesSync(stateFile, STATE_MTIME, STATE_MTIME);
         utimesSync(cf, STATE_MTIME + 99999, STATE_MTIME + 99999); // outside window
-        const py = runPy(root);
-        expect(py.status, py.stderr).toBe(0);
         const trace = build_trace(root, stateFile, { now: NOW_DATE });
-        expect(dumpSorted(trace, 0)).toBe(py.json);
+        expect(dumpSorted(trace, 0)).toMatchInlineSnapshot(`
+          "{
+            "assumptions": [],
+            "council": null,
+            "generated_at": "2026-06-17T12:00:00+00:00",
+            "halt": null,
+            "inputs": {
+              "preset": "balanced",
+              "profile": "developer",
+              "rule_loading_tier": "balanced",
+              "source_per_knob": {
+                "preset": "profile",
+                "profile": "default",
+                "rule_loading_tier": "default"
+              }
+            },
+            "memory": null,
+            "pack": null,
+            "provider": null,
+            "route": null,
+            "run_id": "spaced",
+            "subject": "work",
+            "version": 1
+          }"
+        `);
         expect(trace.council).toBe(null);
         expect(trace.run_id).toBe('spaced'); // raw_id.strip() then scrub
     });
 
-    it.runIf(HAVE_PYTHON)('subject derivation: council/video override, kind map, unknown', () => {
+    it('subject derivation: council/video override, kind map, unknown', () => {
         const cases: Array<[Record<string, unknown>, string]> = [
             [{ directive_set: 'council', input: { kind: 'ticket', data: {} } }, 'council'],
             [{ directive_set: 'video', input: { kind: 'ticket', data: {} } }, 'video'],
@@ -280,14 +552,9 @@ describe('explain_last build_trace + render — golden parity', () => {
             const stateFile = path.join(root, '.work-state.json');
             writeJson(stateFile, { version: 1, ...extra });
             utimesSync(stateFile, STATE_MTIME, STATE_MTIME);
-            const py = runPy(root);
-            expect(py.status, py.stderr).toBe(0);
             const trace = build_trace(root, stateFile, { now: NOW_DATE });
             expect(trace.subject).toBe(expectedSubject);
-            expect(dumpSorted(trace, 0)).toBe(py.json);
         }
     });
 });
 
-// keep NOW_ISO referenced (documents the injected instant for readers)
-void NOW_ISO;

--- a/tests/scripts/_cli/explain_last_scrubber.test.ts
+++ b/tests/scripts/_cli/explain_last_scrubber.test.ts
@@ -1,56 +1,16 @@
-// Golden-parity tests for src/scripts/_cli/explain_last/scrubber.ts (py2ts
+// Contract tests for src/scripts/_cli/explain_last/scrubber.ts (py2ts
 // Phase 1, ADR-200). The scrubber is the leaf dependency of the whole
 // explain_last subtree — every other module's free-form output passes
-// through it, so its redaction classes are pinned here byte-for-byte.
+// through it, so its redaction classes are pinned here.
 //
-// Strategy: run the REAL python3 scrubber and the tsx twin over an identical
-// corpus and assert byte-identical results per string. The Python side is
-// loaded via a DIRECT-FILE importlib loader (scrubber.py has no sibling
-// imports, so no sys.modules registration is needed for this module). The TS
-// side is imported directly through tsx. Covers every redaction class
-// (secret / api_key / email / url / path / internal-host / money), the
-// long-string summary, idempotence, the non-string passthrough, and the
-// Unicode `\w`/`\b` behaviour of Python's `re`.
-import { spawnSync } from 'node:child_process';
-import * as path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-
+// Covers every redaction class (secret / api_key / email / url / path /
+// internal-host / money), the long-string summary, idempotence, the
+// non-string passthrough, and the Unicode `\w`/`\b` behaviour. The tsx twin
+// is the source of truth (the python original was deleted in the py2ts
+// teardown); the redaction output is pinned via inline snapshots.
 import { describe, expect, it } from 'vitest';
 
 import { scrub_string } from '../../../src/scripts/_cli/explain_last/scrubber.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const SCRUBBER_PY = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'explain_last', 'scrubber.py');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = hasPython3();
-
-/**
- * Run the Python scrubber over a JSON array of strings via a direct-file
- * importlib loader and return its per-string `scrub_string` output as a JSON
- * array of strings. No PYTHONPATH needed — scrubber.py imports nothing local.
- */
-function pyScrub(inputs: string[]): string[] {
-    const code = [
-        'import importlib.util, json, sys',
-        `spec = importlib.util.spec_from_file_location("scrubmod", ${JSON.stringify(SCRUBBER_PY)})`,
-        'mod = importlib.util.module_from_spec(spec)',
-        'spec.loader.exec_module(mod)',
-        'data = json.loads(sys.stdin.read())',
-        'out = [mod.scrub_string(s) for s in data]',
-        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
-    ].join('\n');
-    const res = spawnSync('python3', ['-c', code], {
-        encoding: 'utf8',
-        input: JSON.stringify(inputs),
-    });
-    if (res.status !== 0) {
-        throw new Error(`python scrubber failed: ${res.stderr}`);
-    }
-    return JSON.parse(res.stdout) as string[];
-}
 
 const CORPUS: string[] = [
     // secrets
@@ -60,7 +20,7 @@ const CORPUS: string[] = [
     'api_key = ABCDEFGHIJKL123',
     'API-KEY: ZZZZZZZZZZZZ99',
     'api_key: short', // below the 12-char floor → untouched
-    // emails (incl. Unicode local/host parts — Python `\w` is Unicode-aware)
+    // emails (incl. Unicode local/host parts — `\w` is Unicode-aware)
     'a@b.co',
     'x.y+z@host-1.io',
     'café@exämple.com',
@@ -93,21 +53,47 @@ const CORPUS: string[] = [
     'normal text with no secrets',
 ];
 
-describe('explain_last/scrubber — golden parity', () => {
-    it.runIf(HAVE_PYTHON)('matches python3 scrub_string on the full corpus', () => {
-        const expected = pyScrub(CORPUS);
-        const actual = CORPUS.map((s) => scrub_string(s));
-        expect(actual).toEqual(expected);
+describe('explain_last/scrubber — contract', () => {
+    it('scrub_string over the full corpus (pinned redaction output)', () => {
+        expect(CORPUS.map((s) => scrub_string(s))).toMatchInlineSnapshot(`
+          [
+            "<secret> then more",
+            "token <secret> here",
+            "<secret>",
+            "api_key=<secret>",
+            "api_key=<secret>",
+            "api_key: short",
+            "<email>",
+            "<email>",
+            "<email>",
+            "<email>",
+            "<path> and more",
+            "<path>",
+            "<path>",
+            "see <path> done",
+            "<path>",
+            "visit https://example.com/… end",
+            "ftp://h.io/…",
+            "ws://a/… and wss://c/…",
+            "<host>",
+            "<host>",
+            "a.localx",
+            "<host>:8080",
+            "<money> and <money> plus <money>",
+            "total <money> spent",
+            "no-money $ alone",
+            "mix <path> https://h.io/… <email> <money> <host> end",
+            "<250 chars>",
+            "",
+            "normal text with no secrets",
+          ]
+        `);
     });
 
-    it.runIf(HAVE_PYTHON)('is idempotent — scrubbing twice equals scrubbing once', () => {
+    it('is idempotent — scrubbing twice equals scrubbing once', () => {
         const once = CORPUS.map((s) => scrub_string(s) as string);
         const twice = once.map((s) => scrub_string(s));
-        const pyOnce = pyScrub(CORPUS);
-        const pyTwice = pyScrub(pyOnce);
-        expect(once).toEqual(pyOnce);
-        expect(twice).toEqual(pyTwice);
-        expect(twice).toEqual(once); // idempotence holds on both sides
+        expect(twice).toEqual(once);
     });
 
     it('returns non-string inputs unchanged (isinstance guard)', () => {
@@ -117,20 +103,22 @@ describe('explain_last/scrubber — golden parity', () => {
         expect(scrub_string('')).toBe('');
     });
 
-    it.runIf(HAVE_PYTHON)('long-string summary uses the POST-mask code-point length', () => {
+    it('long-string summary uses the POST-mask code-point length', () => {
         // `aaa…` (250) → "<250 chars>"; a 199-char clean string is untouched;
-        // a 201-char clean string is summarized. All three pinned to python.
+        // a 201-char clean string is summarized.
         const probes = ['a'.repeat(199), 'a'.repeat(201), 'b'.repeat(250)];
-        expect(probes.map((s) => scrub_string(s))).toEqual(pyScrub(probes));
+        expect(probes.map((s) => scrub_string(s))).toMatchInlineSnapshot(`
+          [
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "<201 chars>",
+            "<250 chars>",
+          ]
+        `);
     });
 
-    it.runIf(HAVE_PYTHON)('emits a Unicode code-point count (not UTF-16 units)', () => {
-        // Astral chars count as ONE code point in Python `len`; a string of
-        // 201 emoji must summarize to "<201 chars>", not "<402 chars>".
-        const s = '😀'.repeat(201);
-        expect(scrub_string(s)).toEqual(pyScrub([s])[0]);
+    it('emits a Unicode code-point count (not UTF-16 units)', () => {
+        // Astral chars count as ONE code point; a string of 201 emoji must
+        // summarize to "<201 chars>", not "<402 chars>".
+        expect(scrub_string('😀'.repeat(201))).toMatchInlineSnapshot(`"<201 chars>"`);
     });
 });
-
-// touch import so unused-var lints stay quiet when python is absent
-void pathToFileURL;

--- a/tests/scripts/_cli/explain_last_sections.test.ts
+++ b/tests/scripts/_cli/explain_last_sections.test.ts
@@ -1,26 +1,11 @@
-// Golden-parity tests for the 9 explain_last SECTION renderers + the
-// state_loader failure paths (py2ts Phase 1, ADR-200).
-//
-// The section renderers are pure `render(trace) -> str` functions (no I/O,
-// no scrubbing — masking happens in the builders), so they are driven here
-// over hand-built trace dicts and compared byte-for-byte against the REAL
-// python3 renderers. The Python side uses a DIRECT-FILE importlib loader
-// that registers a stub `explast` package in `sys.modules` so each section
-// (and any `from ..` sibling it touches) loads WITHOUT triggering the real
-// package `__init__` (which would pull config/_lib siblings). state_loader
-// is loaded the same way to pin the version-skew / not-found messages +
-// exit codes.
-//
-// Coverage: every section's populated AND empty/placeholder branch, the
-// hit_score `:.2f` formatting (incl. banker's rounding + non-numeric n/a),
-// the double-space before the assumptions em-dash, the 2-space halt-surface
-// indent, the provider/pack empty-string skip, and the council citations
-// sub-block.
-import { spawnSync } from 'node:child_process';
+// Contract tests for the 9 explain_last SECTION renderers + the
+// state_loader failure paths (py2ts Phase 1, ADR-200). The tsx twins are the
+// source of truth (the python originals were deleted in the teardown); the
+// pure render(trace)->str output + the state_loader failure messages are
+// pinned via inline snapshots.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -31,52 +16,6 @@ import {
     StateLoadError,
     load_state,
 } from '../../../src/scripts/_cli/explain_last/state_loader.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const BASE = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'explain_last');
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const HAVE_PYTHON = hasPython3();
-
-// Python preamble: register a stub `explast` package so direct-file loads of
-// `explast.sections.<name>` resolve their relative imports without the real
-// package __init__.
-const PY_PREAMBLE = [
-    'import importlib.util, sys, types, json',
-    `BASE = ${JSON.stringify(BASE)}`,
-    "pkg = types.ModuleType('explast'); pkg.__path__ = [BASE]; pkg.__package__ = 'explast'",
-    "sys.modules['explast'] = pkg",
-    "spkg = types.ModuleType('explast.sections'); spkg.__path__ = [BASE + '/sections']; spkg.__package__ = 'explast.sections'",
-    "sys.modules['explast.sections'] = spkg",
-    'def _load(name, rel):',
-    '    spec = importlib.util.spec_from_file_location(name, BASE + "/" + rel)',
-    '    m = importlib.util.module_from_spec(spec); sys.modules[name] = m; spec.loader.exec_module(m); return m',
-    "_load('explast.scrubber', 'scrubber.py')",
-].join('\n');
-
-/**
- * Render `section` over each trace in `traces` with the python3 twin and
- * return the per-trace output strings.
- */
-function pyRenderSection(section: string, traces: unknown[]): string[] {
-    const code = [
-        PY_PREAMBLE,
-        `mod = _load('explast.sections.${section}', 'sections/${section}.py')`,
-        'data = json.loads(sys.stdin.read())',
-        'out = [mod.render(t) for t in data]',
-        'sys.stdout.write(json.dumps(out, ensure_ascii=False))',
-    ].join('\n');
-    const res = spawnSync('python3', ['-c', code], {
-        encoding: 'utf8',
-        input: JSON.stringify(traces),
-    });
-    if (res.status !== 0) {
-        throw new Error(`python section ${section} failed: ${res.stderr}`);
-    }
-    return JSON.parse(res.stdout) as string[];
-}
 
 type Renderer = (trace: Record<string, unknown>) => string;
 
@@ -172,7 +111,7 @@ const SECTION_CASES: Record<string, Array<Record<string, unknown>>> = {
     ],
 };
 
-describe('explain_last sections — golden parity', () => {
+describe('explain_last sections — render contract', () => {
     const renderers: Record<string, Renderer> = {
         header: sections.header.render,
         route: sections.route.render,
@@ -185,66 +124,185 @@ describe('explain_last sections — golden parity', () => {
         pack: sections.pack.render,
     };
 
-    for (const [name, cases] of Object.entries(SECTION_CASES)) {
-        it.runIf(HAVE_PYTHON)(`${name}.render matches python3 across all branches`, () => {
-            // Python receives plain numbers for hit_score; its `float()` was
-            // already applied by the builder in production, but the section
-            // only does `:.2f`/isinstance, so a plain JSON number is faithful.
-            const pyTraces = cases.map((t) => stripPyFloatMarker(t));
-            const expected = pyRenderSection(name, pyTraces);
-            const actual = tsRender(renderers[name] as Renderer, cases);
-            expect(actual).toEqual(expected);
-        });
-    }
+    it('every section renders each branch (pinned output)', () => {
+        const rendered = Object.fromEntries(
+            Object.entries(SECTION_CASES).map(([name, cases]) => [
+                name,
+                tsRender(renderers[name] as Renderer, cases),
+            ]),
+        );
+        expect(rendered).toMatchInlineSnapshot(`
+          {
+            "assumptions": [
+              "## Assumptions
+
+          - [x] a1  — recorded in step \`refine\`
+          - [ ] a2  — recorded in step \`halt\`
+          - [x] (unknown)  — recorded in step \`unspecified\`
+          ",
+              "## Assumptions
+
+          - (none captured)
+          ",
+              "## Assumptions
+
+          - (none captured)
+          ",
+            ],
+            "council": [
+              "## Council
+
+          ### a/b
+
+          > looks fine
+
+          Citations:
+          - c1
+          - c2
+
+          ### solo
+
+          > ok
+
+          ### (unknown)
+
+          > (no verdict)
+          ",
+              "## Council
+
+          (none recorded for this run)
+          ",
+              "## Council
+
+          (none recorded for this run)
+          ",
+            ],
+            "halt": [
+              "## Why halted?
+
+          - **Reason:** \`blocked\`
+          - **Hook event:** \`plan\`
+
+          Surface emitted to the user:
+
+            x
+            y
+          ",
+              "## Why halted?
+
+          - **Reason:** \`blocked\`
+          - **Hook event:** \`(unspecified)\`
+          ",
+              "## Why halted?
+
+          (clean run — no halt recorded)
+          ",
+            ],
+            "header": [
+              "# explain last — run TICK-1
+
+          **Subject:** /implement-ticket · **Started:** 2026-06-17T12:00:00+00:00
+          ",
+              "# explain last — run (unknown)
+
+          **Subject:** (unknown) · **Started:** 
+          ",
+              "# explain last — run R
+
+          **Subject:** mystery · **Started:** 
+          ",
+            ],
+            "inputs": [
+              "## Why this profile / preset?
+
+          | knob | value | source |
+          |---|---|---|
+          | profile.id | developer | user |
+          | preset.id | balanced | profile |
+          | rule_loading_tier | strict | user |
+          ",
+              "## Why this profile / preset?
+
+          | knob | value | source |
+          |---|---|---|
+          | profile.id | (none) | default |
+          | preset.id | balanced | default |
+          | rule_loading_tier | x | default |
+          ",
+              "## Why this profile / preset?
+
+          - (none) — settings could not be resolved
+          ",
+            ],
+            "memory": [
+              "## Memory hits influencing this run
+
+          - m1 (score 1.25) — used in plan
+          - m2 (score 2.00) — used in refine
+          - m3 (score 0.01) — used in x
+          - m4 (score 0.01) — used in y
+          ",
+              "## Memory hits influencing this run
+
+          - mx (score n/a) — used in z
+          ",
+              "## Memory hits influencing this run
+
+          - (none)
+          ",
+              "## Memory hits influencing this run
+
+          - (none)
+          ",
+            ],
+            "pack": [
+              "## Active pack
+
+          - finance — declared
+          ",
+              "## Active pack
+
+          - core
+          ",
+              "",
+            ],
+            "provider": [
+              "## Why this provider?
+
+          - **Provider:** \`sora\`
+          - **Selection reason:** cheap
+          ",
+              "## Why this provider?
+
+          - **Provider:** \`(unknown)\`
+          - **Selection reason:** (no reason recorded)
+          ",
+              "",
+            ],
+            "route": [
+              "## Why this route?
+
+          - Active rules: a, b
+          - Kernel rules: 3
+          - Persona: dev
+          ",
+              "## Why this route?
+
+          - Active rules: (none)
+          - Kernel rules: 0
+          - Persona: (none)
+          ",
+              "## Why this route?
+
+          - (none) — router.json missing or unreadable
+          ",
+            ],
+          }
+        `);
+    });
 });
 
-/** Convert `__pyfloat__: n` markers to a plain `hit_score: n` for the py side. */
-function stripPyFloatMarker(trace: Record<string, unknown>): unknown {
-    if (!Array.isArray(trace.memory)) {
-        return trace;
-    }
-    const memory = (trace.memory as Array<Record<string, unknown>>).map((e) => {
-        if (e && typeof e === 'object' && '__pyfloat__' in e) {
-            const { __pyfloat__, ...rest } = e;
-            return { ...rest, hit_score: __pyfloat__ };
-        }
-        return e;
-    });
-    return { ...trace, memory };
-}
-
-describe('explain_last state_loader — golden parity (importlib direct-file)', () => {
-    function pyLoad(stateJson: string | null): {
-        ok: boolean; msg?: string; exit?: number;
-    } {
-        const code = [
-            'import importlib.util, sys, types, json, tempfile, os',
-            `BASE = ${JSON.stringify(BASE)}`,
-            'spec = importlib.util.spec_from_file_location("sl", BASE + "/state_loader.py")',
-            'sl = importlib.util.module_from_spec(spec); spec.loader.exec_module(sl)',
-            'from pathlib import Path',
-            'arg = sys.stdin.read()',
-            'd = tempfile.mkdtemp(); p = Path(d) / "s.json"',
-            'present = arg != "__MISSING__"',
-            'if present: p.write_text(arg, encoding="utf-8")',
-            'try:',
-            '    sl.load_state(p)',
-            '    sys.stdout.write(json.dumps({"ok": True}))',
-            'except sl.StateLoadError as e:',
-            // normalize the tmp path out of the message so it is deterministic.
-            '    msg = str(e).replace(str(p), "<state>")',
-            '    sys.stdout.write(json.dumps({"ok": False, "msg": msg, "exit": e.exit_code}))',
-        ].join('\n');
-        const res = spawnSync('python3', ['-c', code], {
-            encoding: 'utf8',
-            input: stateJson === null ? '__MISSING__' : stateJson,
-        });
-        if (res.status !== 0) {
-            throw new Error(`python state_loader failed: ${res.stderr}`);
-        }
-        return JSON.parse(res.stdout) as { ok: boolean; msg?: string; exit?: number };
-    }
-
+describe('explain_last state_loader — failure paths', () => {
     function tsLoad(stateJson: string | null): { ok: boolean; msg?: string; exit?: number } {
         const d = fs.mkdtempSync(path.join(os.tmpdir(), 'sl-'));
         const p = path.join(d, 's.json');
@@ -264,38 +322,61 @@ describe('explain_last state_loader — golden parity (importlib direct-file)', 
         }
     }
 
-    it.runIf(HAVE_PYTHON)('version skew (v0) → exit 0 + byte-identical message', () => {
-        const py = pyLoad(JSON.stringify({ version: 0 }));
+    it('version skew (v0) → exit 0 + pinned message', () => {
         const ts = tsLoad(JSON.stringify({ version: 0 }));
-        expect(ts).toEqual(py);
         expect(ts.exit).toBe(0);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "exit": 0,
+            "msg": "trace format upgraded; rerun the upstream command on this branch to regenerate (found version=0, expected 1)",
+            "ok": false,
+          }
+        `);
     });
 
-    it.runIf(HAVE_PYTHON)('missing version (legacy) → same skew message (version=None)', () => {
-        const py = pyLoad(JSON.stringify({ foo: 1 }));
+    it('missing version (legacy) → version=None skew message', () => {
         const ts = tsLoad(JSON.stringify({ foo: 1 }));
-        expect(ts).toEqual(py);
         expect(ts.msg).toContain('version=None');
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "exit": 0,
+            "msg": "trace format upgraded; rerun the upstream command on this branch to regenerate (found version=None, expected 1)",
+            "ok": false,
+          }
+        `);
     });
 
-    it.runIf(HAVE_PYTHON)('not found → exit 1', () => {
-        const py = pyLoad(null);
+    it('not found → exit 1', () => {
         const ts = tsLoad(null);
-        expect(ts.exit).toBe(py.exit);
         expect(ts.exit).toBe(1);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "exit": 1,
+            "msg": "state file not found: <state>",
+            "ok": false,
+          }
+        `);
     });
 
-    it.runIf(HAVE_PYTHON)('non-object JSON → must-contain-object message', () => {
-        const py = pyLoad(JSON.stringify([1, 2, 3]));
+    it('non-object JSON → must-contain-object message', () => {
         const ts = tsLoad(JSON.stringify([1, 2, 3]));
-        expect(ts).toEqual(py);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "exit": 2,
+            "msg": "state file <state> must contain a JSON object",
+            "ok": false,
+          }
+        `);
     });
 
-    it.runIf(HAVE_PYTHON)('valid v1 → ok', () => {
-        const py = pyLoad(JSON.stringify({ version: 1, x: 1 }));
+    it('valid v1 → ok', () => {
         const ts = tsLoad(JSON.stringify({ version: 1, x: 1 }));
-        expect(ts).toEqual(py);
         expect(ts.ok).toBe(true);
+        expect(ts).toMatchInlineSnapshot(`
+          {
+            "ok": true,
+          }
+        `);
     });
 
     it('EXPECTED_VERSION is pinned to 1', () => {


### PR DESCRIPTION
## What

Wave 2 of the py2ts test-layer purge (`road-to-py2ts-teardown-completion`).
Converts the **explain_last parity trio** — `scrubber`, `sections`, `build_trace`
— from whole-file `python3 vs tsx` byte-parity suites into python-free
contract tests.

## Why

Each was a PURE-PARITY rig: its only tests spawned `python3 <mod>.py` (now a
**deleted** twin) and byte-compared against tsx → permanently shim-skipped, so
the tsx modules had **zero live coverage**. Per the D1 council default
(CONVERT, don't blind-delete — deleting leaves the module untested), these are
converted: the tsx twin is now the source of truth, its output pinned via
inline snapshots.

## Determinism

All three are deterministic by construction — pure `scrub_string`, fixture-built
traces, injected `now` (`NOW_DATE`) + pinned mtimes. Verified by running each
with `-u` then again without: **no snapshot drift** (the roadmap's
determinism-trap guard).

## Changes

- `scrubber` — 5 tests (redaction classes, idempotence, unicode code-point length)
- `sections` — 7 tests (all 9 section renderers via one pinned object snapshot + state_loader failure paths)
- `build_trace` — 5 tests (trace JSON + footer/quiet renders + run_id/subject/scrub spot-checks)

17 tests pass python-free; 0 python residue; `tsc --noEmit` clean. Test-layer
python-spawn count 89 → 86.

## Scope (D4)

Small tests-only PR, inline snapshots (no `__snapshots__` dir). Does not touch
`agents/roadmaps-progress.md` or the roadmap checkboxes. Branch named off the
`py2ts-` prefix so the obsolete `py2ts-base-guard` doesn't false-fire.
