### PR TITLE
test(py2ts): convert the prediction-pool parity trio to python-free contract tests

### DIFF
--- a/tests/scripts/prediction-pool_poisson_sim.test.ts
+++ b/tests/scripts/prediction-pool_poisson_sim.test.ts
@@ -1,16 +1,11 @@
-// Tests for src/scripts/prediction-pool/poisson_sim.ts (py2ts Phase 1).
+// Contract tests for src/scripts/prediction-pool/poisson_sim.ts (py2ts Phase 1).
 //
-// No pytest suite exists, so this is a golden-parity suite that runs python3
-// vs tsx and asserts byte-identical stdout + stderr + exit code. The sim uses
-// `random.Random(seed)`, so with a FIXED `--seed` the runs are fully
-// deterministic across runtimes (PyRandom reproduces CPython MT19937
-// bit-for-bit) — nothing needs normalisation; there are no wall-clock fields.
-//
-// The no-config argparse error wraps its usage block to the terminal width,
-// which is environment-dependent (lesson #8: argparse error PROSE is
-// Python-version / COLUMNS-dependent), so the no-args case asserts exit code 2
-// and the stable error LINE, not the full byte stream. Likewise `-h` full help
-// is COLUMNS-dependent and is not byte-asserted.
+// The sim uses `random.Random(seed)`, so with a FIXED `--seed` the tsx run is
+// fully deterministic (PyRandom reproduces CPython MT19937 bit-for-bit). The
+// tsx twin is the source of truth (the python original was deleted in the
+// teardown); its output is pinned via an inline snapshot. Argparse usage prose
+// is COLUMNS-dependent, so error cases assert exit 2 + a stable token, not the
+// full byte stream.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -21,14 +16,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'poisson_sim.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'poisson_sim.py');
 const TSX_BIN =
     process.env.TSX_BIN ??
     path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpDirs: string[] = [];
 function writeTmp(name: string, content: string): string {
@@ -51,11 +42,6 @@ interface RunOut {
     stdout: string;
     stderr: string;
     status: number | null;
-}
-
-function runPy(args: string[]): RunOut {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8' });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
 }
 
 function runTs(args: string[]): RunOut {
@@ -87,7 +73,7 @@ const NO_GROUPS = JSON.stringify({
     teams: { A: { att: 1.2, def: 0.9 }, B: { att: 0.9, def: 1.1 }, C: { att: 1.0, def: 1.0 } },
 });
 
-describe.runIf(hasPython3())('poisson_sim — golden parity (python3 vs tsx)', () => {
+describe('poisson_sim — CLI contract (deterministic seed)', () => {
     const cases: Array<{ label: string; seed: string; runs: string; fixture: string }> = [
         { label: 'groups runs=500 seed=0', seed: '0', runs: '500', fixture: TEAMS },
         { label: 'groups runs=500 seed=1', seed: '1', runs: '500', fixture: TEAMS },
@@ -97,45 +83,167 @@ describe.runIf(hasPython3())('poisson_sim — golden parity (python3 vs tsx)', (
         { label: 'no-groups runs=600 seed=8', seed: '8', runs: '600', fixture: NO_GROUPS },
     ];
 
-    it.each(cases)('$label', ({ seed, runs, fixture }) => {
-        const cfg = writeTmp('config.json', fixture);
-        const args = [cfg, '--runs', runs, '--seed', seed];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+    it('deterministic sim output across seeds (pinned)', () => {
+        const results = Object.fromEntries(
+            cases.map(({ label, seed, runs, fixture }) => {
+                const cfg = writeTmp('config.json', fixture);
+                const ts = runTs([cfg, '--runs', runs, '--seed', seed]);
+                expect(ts.status, ts.stderr).toBe(0);
+                return [label, JSON.parse(ts.stdout)];
+            }),
+        );
+        expect(results).toMatchInlineSnapshot(`
+          {
+            "groups runs=1000 seed=999": {
+              "advance_pct": {
+                "Albania": 10.1,
+                "Croatia": 41.9,
+                "Germany": 83.8,
+                "Hungary": 42.4,
+                "Italy": 65.6,
+                "Scotland": 15.7,
+                "Spain": 82.4,
+                "Switzerland": 58.1,
+              },
+              "runs": 1000,
+              "seed": 999,
+              "title_pct": {
+                "Croatia": 4,
+                "Germany": 29.9,
+                "Hungary": 2.4,
+                "Italy": 13,
+                "Scotland": 0.3,
+                "Spain": 42,
+                "Switzerland": 8.4,
+              },
+            },
+            "groups runs=300 seed=42": {
+              "advance_pct": {
+                "Albania": 16,
+                "Croatia": 44.67,
+                "Germany": 83.33,
+                "Hungary": 38.33,
+                "Italy": 62,
+                "Scotland": 18.33,
+                "Spain": 77.33,
+                "Switzerland": 60,
+              },
+              "runs": 300,
+              "seed": 42,
+              "title_pct": {
+                "Albania": 0.33,
+                "Croatia": 3.33,
+                "Germany": 31.67,
+                "Hungary": 2,
+                "Italy": 11.67,
+                "Scotland": 0.33,
+                "Spain": 42.67,
+                "Switzerland": 8,
+              },
+            },
+            "groups runs=500 seed=0": {
+              "advance_pct": {
+                "Albania": 10.2,
+                "Croatia": 44.6,
+                "Germany": 83.6,
+                "Hungary": 43.4,
+                "Italy": 62.8,
+                "Scotland": 18.8,
+                "Spain": 82.4,
+                "Switzerland": 54.2,
+              },
+              "runs": 500,
+              "seed": 0,
+              "title_pct": {
+                "Albania": 0.2,
+                "Croatia": 4,
+                "Germany": 29.6,
+                "Hungary": 2.8,
+                "Italy": 16.4,
+                "Scotland": 0.2,
+                "Spain": 41,
+                "Switzerland": 5.8,
+              },
+            },
+            "groups runs=500 seed=1": {
+              "advance_pct": {
+                "Albania": 9.4,
+                "Croatia": 41.6,
+                "Germany": 84.4,
+                "Hungary": 42,
+                "Italy": 66,
+                "Scotland": 17,
+                "Spain": 83,
+                "Switzerland": 56.6,
+              },
+              "runs": 500,
+              "seed": 1,
+              "title_pct": {
+                "Croatia": 3.4,
+                "Germany": 29,
+                "Hungary": 2.2,
+                "Italy": 12.8,
+                "Scotland": 0.2,
+                "Spain": 45,
+                "Switzerland": 7.4,
+              },
+            },
+            "groups runs=500 seed=7": {
+              "advance_pct": {
+                "Albania": 8.2,
+                "Croatia": 46.6,
+                "Germany": 85.4,
+                "Hungary": 43,
+                "Italy": 64.8,
+                "Scotland": 18.6,
+                "Spain": 80.4,
+                "Switzerland": 53,
+              },
+              "runs": 500,
+              "seed": 7,
+              "title_pct": {
+                "Albania": 0.2,
+                "Croatia": 4,
+                "Germany": 35.4,
+                "Hungary": 2.4,
+                "Italy": 14.2,
+                "Scotland": 0.2,
+                "Spain": 38,
+                "Switzerland": 5.6,
+              },
+            },
+            "no-groups runs=600 seed=8": {
+              "advance_pct": {},
+              "runs": 600,
+              "seed": 8,
+              "title_pct": {
+                "A": 59.33,
+                "B": 14.33,
+                "C": 26.33,
+              },
+            },
+          }
+        `);
     });
 
-    it('missing config file → exit 2, byte-identical', () => {
-        const args = [path.join(os.tmpdir(), 'definitely-missing-poisson.json'), '--seed', '1'];
-        const py = runPy(args);
-        const ts = runTs(args);
+    it('missing config file → exit 2', () => {
+        const ts = runTs([path.join(os.tmpdir(), 'definitely-missing-poisson.json'), '--seed', '1']);
         expect(ts.status).toBe(2);
-        expect(py.status).toBe(2);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toContain('config not found:');
     });
 
-    it("config without 'teams' → exit 2, byte-identical", () => {
+    it("config without 'teams' → exit 2", () => {
         const cfg = writeTmp('noteams.json', JSON.stringify({ base_goals: 1.3 }));
-        const args = [cfg, '--seed', '1'];
-        const py = runPy(args);
-        const ts = runTs(args);
+        const ts = runTs([cfg, '--seed', '1']);
         expect(ts.status).toBe(2);
-        expect(py.status).toBe(2);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toContain("config needs a 'teams' object");
     });
 
     it('no args → exit 2 with the stable required-config error line', () => {
-        const py = runPy([]);
         const ts = runTs([]);
-        expect(py.status).toBe(2);
         expect(ts.status).toBe(2);
         // The usage block wraps to terminal width (env-dependent); assert the
-        // stable error line both runtimes emit.
+        // stable error line.
         expect(ts.stderr).toContain('the following arguments are required: config');
-        expect(py.stderr).toContain('the following arguments are required: config');
     });
 });

--- a/tests/scripts/prediction-pool_pool_winsim.test.ts
+++ b/tests/scripts/prediction-pool_pool_winsim.test.ts
@@ -1,17 +1,11 @@
-// Tests for src/scripts/prediction-pool/pool_winsim.ts (py2ts Phase 1).
+// Contract tests for src/scripts/prediction-pool/pool_winsim.ts (py2ts Phase 1).
 //
-// No pytest suite exists, so this is a golden-parity suite that runs python3
-// vs tsx and asserts byte-identical stdout + stderr + exit code across the
-// text and --json output paths. The sim uses `random.Random(seed)`, so with a
-// FIXED `--seed` the runs are fully deterministic across runtimes (PyRandom
-// reproduces CPython MT19937 bit-for-bit, and `round()` is replicated
-// half-to-even on the exact IEEE-754 value) — nothing needs normalisation;
-// there are no wall-clock fields.
-//
-// The no-config argparse error wraps to terminal width (lesson #8: argparse
-// PROSE is Python-version / COLUMNS-dependent), so the no-args case asserts
-// exit code 2 + the stable error LINE; `-h` full help is likewise not
-// byte-asserted.
+// The sim uses `random.Random(seed)` with half-to-even `round()`, so with a
+// FIXED `--seed` the tsx run is fully deterministic (PyRandom reproduces
+// CPython MT19937 bit-for-bit). The tsx twin is the source of truth (the python
+// original was deleted in the teardown); its text/json output is pinned via
+// inline snapshots. Argparse usage prose is COLUMNS-dependent, so error cases
+// assert exit 2 + a stable token.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -22,14 +16,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'pool_winsim.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'pool_winsim.py');
 const TSX_BIN =
     process.env.TSX_BIN ??
     path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpDirs: string[] = [];
 function writeTmp(name: string, content: string): string {
@@ -52,11 +42,6 @@ interface RunOut {
     stdout: string;
     stderr: string;
     status: number | null;
-}
-
-function runPy(args: string[]): RunOut {
-    const r = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8' });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
 }
 
 function runTs(args: string[]): RunOut {
@@ -90,89 +75,451 @@ const POOL_NEG = JSON.stringify({
     ],
 });
 
-describe.runIf(hasPython3())('pool_winsim — golden parity (python3 vs tsx)', () => {
+describe('pool_winsim — CLI contract (deterministic seed)', () => {
     const seeds = ['1', '2', '3', '7', '42', '99', '12345'];
 
-    it.each(seeds)('text — seed=%s runs=800 max-flips=2', (seed) => {
-        const cfg = writeTmp('pool.json', POOL);
-        const args = [cfg, '--runs', '800', '--max-flips', '2', '--seed', seed];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+    it('text output across the seed sweep (pinned)', () => {
+        const out = Object.fromEntries(
+            seeds.map((seed) => {
+                const cfg = writeTmp('pool.json', POOL);
+                const ts = runTs([cfg, '--runs', '800', '--max-flips', '2', '--seed', seed]);
+                expect(ts.status, ts.stderr).toBe(0);
+                return [seed, ts.stdout];
+            }),
+        );
+        expect(out).toMatchInlineSnapshot(`
+          {
+            "1": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0200
+          suggested flips (greedy, each raises P(win) most):
+            flip B -> 0:2  (EV cost +0.016)  P(win) 0.0213
+            flip A -> 2:1  (EV cost +0.081)  P(win) 0.0312
+          P(win) after flips: 0.0312  (+0.0112)
+          ",
+            "12345": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0175
+          suggested flips (greedy, each raises P(win) most):
+            flip C -> 1:2  (EV cost +0.030)  P(win) 0.0262
+            flip B -> 0:2  (EV cost +0.016)  P(win) 0.0312
+          P(win) after flips: 0.0312  (+0.0137)
+          ",
+            "2": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0238
+          suggested flips (greedy, each raises P(win) most):
+            flip D -> 2:1  (EV cost +0.002)  P(win) 0.0300
+            flip A -> 2:0  (EV cost +0.044)  P(win) 0.0325
+          P(win) after flips: 0.0325  (+0.0087)
+          ",
+            "3": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0250
+          suggested flips (greedy, each raises P(win) most):
+            flip A -> 2:1  (EV cost +0.081)  P(win) 0.0300
+          P(win) after flips: 0.0300  (+0.0050)
+          ",
+            "42": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0387
+          suggested flips (greedy, each raises P(win) most):
+            flip D -> 2:1  (EV cost +0.002)  P(win) 0.0425
+          P(win) after flips: 0.0425  (+0.0038)
+          ",
+            "7": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0138
+          suggested flips (greedy, each raises P(win) most):
+            flip C -> 2:1  (EV cost +0.030)  P(win) 0.0288
+          P(win) after flips: 0.0288  (+0.0150)
+          ",
+            "99": "participants 120 (modelled 119)  runs 800  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.0262
+          suggested flips (greedy, each raises P(win) most):
+            flip B -> 0:2  (EV cost +0.016)  P(win) 0.0362
+            flip D -> 2:0  (EV cost +0.091)  P(win) 0.0450
+          P(win) after flips: 0.0450  (+0.0188)
+          ",
+          }
+        `);
     });
 
-    it.each(seeds)('json — seed=%s runs=800 max-flips=2', (seed) => {
-        const cfg = writeTmp('pool.json', POOL);
-        const args = [cfg, '--runs', '800', '--max-flips', '2', '--seed', seed, '--json'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+    it('json output across the seed sweep (pinned)', () => {
+        const out = Object.fromEntries(
+            seeds.map((seed) => {
+                const cfg = writeTmp('pool.json', POOL);
+                const ts = runTs([
+                    cfg, '--runs', '800', '--max-flips', '2', '--seed', seed, '--json',
+                ]);
+                expect(ts.status, ts.stderr).toBe(0);
+                return [seed, JSON.parse(ts.stdout)];
+            }),
+        );
+        expect(out).toMatchInlineSnapshot(`
+          {
+            "1": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.016,
+                  "match": "B",
+                  "p_win_after": 0.0213,
+                  "to": "0:2",
+                },
+                {
+                  "ev_cost": 0.081,
+                  "match": "A",
+                  "p_win_after": 0.0312,
+                  "to": "2:1",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0312,
+              "p_win_ev_max": 0.02,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+            "12345": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.03,
+                  "match": "C",
+                  "p_win_after": 0.0262,
+                  "to": "1:2",
+                },
+                {
+                  "ev_cost": 0.016,
+                  "match": "B",
+                  "p_win_after": 0.0312,
+                  "to": "0:2",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0312,
+              "p_win_ev_max": 0.0175,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+            "2": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.002,
+                  "match": "D",
+                  "p_win_after": 0.03,
+                  "to": "2:1",
+                },
+                {
+                  "ev_cost": 0.044,
+                  "match": "A",
+                  "p_win_after": 0.0325,
+                  "to": "2:0",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0325,
+              "p_win_ev_max": 0.0238,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+            "3": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.081,
+                  "match": "A",
+                  "p_win_after": 0.03,
+                  "to": "2:1",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.03,
+              "p_win_ev_max": 0.025,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+            "42": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.002,
+                  "match": "D",
+                  "p_win_after": 0.0425,
+                  "to": "2:1",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0425,
+              "p_win_ev_max": 0.0387,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+            "7": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.03,
+                  "match": "C",
+                  "p_win_after": 0.0288,
+                  "to": "2:1",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0288,
+              "p_win_ev_max": 0.0138,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+            "99": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.016,
+                  "match": "B",
+                  "p_win_after": 0.0362,
+                  "to": "0:2",
+                },
+                {
+                  "ev_cost": 0.091,
+                  "match": "D",
+                  "p_win_after": 0.045,
+                  "to": "2:0",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.045,
+              "p_win_ev_max": 0.0262,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 800,
+            },
+          }
+        `);
     });
 
-    it('default args (seed=1 runs=4000) json', () => {
-        const cfg = writeTmp('pool.json', POOL);
-        const args = [cfg, '--json'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+    it('flag variants + negative-lead float rendering (pinned)', () => {
+        const runStdout = (fixtureName: string, fixture: string, args: string[]): string => {
+            const cfg = writeTmp(fixtureName, fixture);
+            const ts = runTs([cfg, ...args]);
+            expect(ts.status, ts.stderr).toBe(0);
+            return ts.stdout;
+        };
+        const variants = {
+            'default json (seed=1 runs=4000)': JSON.parse(runStdout('pool.json', POOL, ['--json'])),
+            'small field max-opponents=3 text': runStdout('pool.json', POOL, [
+                '--runs', '1000', '--max-opponents', '3', '--seed', '3',
+            ]),
+            'top-flip=6 json seed=9': JSON.parse(runStdout('pool.json', POOL, [
+                '--runs', '1500', '--top-flip', '6', '--seed', '9', '--json',
+            ])),
+            'neg-lead temp1.0 text': runStdout('pool-neg.json', POOL_NEG, [
+                '--runs', '1000', '--seed', '4',
+            ]),
+            'neg-lead temp1.0 json': JSON.parse(runStdout('pool-neg.json', POOL_NEG, [
+                '--runs', '1000', '--seed', '4', '--json',
+            ])),
+        };
+        expect(variants).toMatchInlineSnapshot(`
+          {
+            "default json (seed=1 runs=4000)": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.044,
+                  "match": "A",
+                  "p_win_after": 0.018,
+                  "to": "2:0",
+                },
+                {
+                  "ev_cost": 0,
+                  "match": "C",
+                  "p_win_after": 0.0248,
+                  "to": "1:0",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0248,
+              "p_win_ev_max": 0.0168,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 4000,
+            },
+            "neg-lead temp1.0 json": {
+              "ev_max_set": [
+                "X=2:1",
+                "Y=0:0",
+              ],
+              "field_temperature": 1,
+              "flips": [],
+              "my_lead": -3,
+              "opponents_modelled": 49,
+              "p_win_after_flips": 0,
+              "p_win_ev_max": 0,
+              "participants": 50,
+              "rule": {
+                "diff": 3,
+                "exact": 4,
+                "tendency": 2,
+              },
+              "runs": 1000,
+            },
+            "neg-lead temp1.0 text": "participants 50 (modelled 49)  runs 1000  my_lead -3.0  field_temp 1.0
+          EV-max set: X=2:1, Y=0:0
+          P(win) all-EV-max : 0.0000
+          greedy flips: none improved P(win) — EV-max is already best (small/easy field).
+          ",
+            "small field max-opponents=3 text": "participants 120 (modelled 3)  runs 1000  my_lead 0.0  field_temp 0.6
+          EV-max set: A=1:0, B=0:1, C=0:1, D=1:0
+          P(win) all-EV-max : 0.2390
+          suggested flips (greedy, each raises P(win) most):
+            flip C -> 1:0  (EV cost +0.000)  P(win) 0.2590
+          P(win) after flips: 0.2590  (+0.0200)
+          ",
+            "top-flip=6 json seed=9": {
+              "ev_max_set": [
+                "A=1:0",
+                "B=0:1",
+                "C=0:1",
+                "D=1:0",
+              ],
+              "field_temperature": 0.6,
+              "flips": [
+                {
+                  "ev_cost": 0.091,
+                  "match": "C",
+                  "p_win_after": 0.022,
+                  "to": "1:1",
+                },
+                {
+                  "ev_cost": 0.185,
+                  "match": "B",
+                  "p_win_after": 0.0227,
+                  "to": "0:3",
+                },
+              ],
+              "my_lead": 0,
+              "opponents_modelled": 119,
+              "p_win_after_flips": 0.0227,
+              "p_win_ev_max": 0.014,
+              "participants": 120,
+              "rule": {
+                "diff": 3,
+                "exact": 5,
+                "tendency": 2,
+              },
+              "runs": 1500,
+            },
+          }
+        `);
     });
 
-    it('small field (max-opponents=3) text — flips often none', () => {
+    it('invalid int for --runs → exit 2', () => {
         const cfg = writeTmp('pool.json', POOL);
-        const args = [cfg, '--runs', '1000', '--max-opponents', '3', '--seed', '3'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-    });
-
-    it('top-flip=6 json — seed=9', () => {
-        const cfg = writeTmp('pool.json', POOL);
-        const args = [cfg, '--runs', '1500', '--top-flip', '6', '--seed', '9', '--json'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-    });
-
-    it.each([
-        ['text', false],
-        ['json', true],
-    ] as Array<[string, boolean]>)('negative float lead + temp 1.0 — %s', (_label, asJson) => {
-        const cfg = writeTmp('pool-neg.json', POOL_NEG);
-        const args = [cfg, '--runs', '1000', '--seed', '4', ...(asJson ? ['--json'] : [])];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-    });
-
-    it('invalid int for --runs → exit 2, byte-identical', () => {
-        const cfg = writeTmp('pool.json', POOL);
-        const args = [cfg, '--runs', 'abc'];
-        const py = runPy(args);
-        const ts = runTs(args);
+        const ts = runTs([cfg, '--runs', 'abc']);
         expect(ts.status).toBe(2);
-        expect(py.status).toBe(2);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.stderr).toContain('invalid int value');
     });
 
     it('no args → exit 2 with the stable required-config error line', () => {
-        const py = runPy([]);
         const ts = runTs([]);
-        expect(py.status).toBe(2);
         expect(ts.status).toBe(2);
         expect(ts.stderr).toContain('the following arguments are required: config');
-        expect(py.stderr).toContain('the following arguments are required: config');
     });
 });

--- a/tests/scripts/prediction-pool_score_ev.test.ts
+++ b/tests/scripts/prediction-pool_score_ev.test.ts
@@ -1,18 +1,10 @@
-// Tests for src/scripts/prediction-pool/score_ev.ts (py2ts Phase 8).
+// Contract tests for src/scripts/prediction-pool/score_ev.ts (py2ts Phase 8).
 //
-// No pytest suite exists, so this is a golden-parity suite that runs python3
-// vs tsx and asserts byte-identical stdout + stderr + exit code across the
-// text and --json output paths, single-lambda and JSON-batch inputs, and the
-// error paths.
-//
-// score_ev is a pure deterministic computation (Poisson grid, NO RNG — its
-// siblings poisson_sim / pool_winsim use RNG and are out of scope), so the
-// output is fully reproducible cross-runtime; nothing needs normalisation.
-//
-// The no-input argparse error wraps its usage block to the terminal width,
-// which is environment-dependent (lesson #8: argparse error PROSE is
-// Python-version / COLUMNS-dependent) — so the error case asserts exit code 2
-// and that the stable error LINE is present, not the full byte stream.
+// score_ev is a pure deterministic computation (Poisson grid, NO RNG), so its
+// output is fully reproducible. The tsx twin is the source of truth (the python
+// original was deleted in the teardown); its text/json output is pinned via
+// inline snapshots. Argparse usage prose is COLUMNS-dependent, so the no-input
+// case asserts exit 2 + a stable token.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -23,7 +15,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'score_ev.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'prediction-pool', 'score_ev.py');
 const TSX_BIN = path.join(
     REPO_ROOT,
     'node_modules',
@@ -31,9 +22,6 @@ const TSX_BIN = path.join(
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpFiles: string[] = [];
 function writeTmp(name: string, content: string): string {
@@ -52,67 +40,371 @@ afterEach(() => {
     }
 });
 
-describe.runIf(hasPython3())('score_ev — golden parity (python3 vs tsx)', () => {
-    const cases: Array<{ label: string; args: string[] }> = [
-        { label: 'text — moderate favourite', args: ['--lh', '2.0', '--la', '0.7'] },
-        { label: 'text — kicktipp 2/3/5 underdog', args: ['--lh', '0.6', '--la', '2.1', '--tendency', '2', '--diff', '3', '--exact', '5'] },
-        { label: 'text — even draw-likely', args: ['--lh', '1.5', '--la', '1.5'] },
-        { label: 'text — zero rates', args: ['--lh', '0', '--la', '0'] },
-        { label: 'text — custom top + max-tip', args: ['--lh', '2.3', '--la', '1.1', '--top', '3', '--max-tip', '4'] },
-        { label: 'json — moderate favourite', args: ['--lh', '2.0', '--la', '0.7', '--json'] },
-        { label: 'json — kicktipp config', args: ['--lh', '0.6', '--la', '2.1', '--tendency', '2', '--diff', '3', '--exact', '5', '--json'] },
-        { label: 'json — fractional lambdas, top 2', args: ['--lh', '1.234', '--la', '0.876', '--top', '2', '--json'] },
-    ];
-    for (const { label, args } of cases) {
-        it(`byte-identical: ${label}`, () => {
-            const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
-            const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
-            expect(ts.status).toBe(py.status);
-            expect(ts.stdout).toBe(py.stdout);
-            expect(ts.stderr).toBe(py.stderr);
-        });
-    }
+function runTs(args: string[]): { stdout: string; stderr: string; status: number | null } {
+    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
 
-    it('byte-identical: JSON batch input (text mode)', () => {
-        const matches = JSON.stringify([
-            { match: 'Senegal-Iraq', lh: 2.0, la: 0.7 },
-            { match: 'Qatar-Switzerland', lh: 0.6, la: 2.1 },
-        ]);
-        const file = writeTmp('m.json', matches);
-        const args = [file, '--tendency', '2', '--diff', '3', '--exact', '5'];
-        const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
-        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+describe('score_ev — CLI contract (deterministic)', () => {
+    it('all lambda/flag cases, text + json (pinned)', () => {
+        const cases: Array<{ label: string; args: string[] }> = [
+            { label: 'text — moderate favourite', args: ['--lh', '2.0', '--la', '0.7'] },
+            { label: 'text — kicktipp 2/3/5 underdog', args: ['--lh', '0.6', '--la', '2.1', '--tendency', '2', '--diff', '3', '--exact', '5'] },
+            { label: 'text — even draw-likely', args: ['--lh', '1.5', '--la', '1.5'] },
+            { label: 'text — zero rates', args: ['--lh', '0', '--la', '0'] },
+            { label: 'text — custom top + max-tip', args: ['--lh', '2.3', '--la', '1.1', '--top', '3', '--max-tip', '4'] },
+            { label: 'json — moderate favourite', args: ['--lh', '2.0', '--la', '0.7', '--json'] },
+            { label: 'json — kicktipp config', args: ['--lh', '0.6', '--la', '2.1', '--tendency', '2', '--diff', '3', '--exact', '5', '--json'] },
+            { label: 'json — fractional lambdas, top 2', args: ['--lh', '1.234', '--la', '0.876', '--top', '2', '--json'] },
+        ];
+        const out = Object.fromEntries(
+            cases.map(({ label, args }) => {
+                const ts = runTs(args);
+                expect(ts.status, ts.stderr).toBe(0);
+                return [label, args.includes('--json') ? JSON.parse(ts.stdout) : ts.stdout];
+            }),
+        );
+        expect(out).toMatchInlineSnapshot(`
+          {
+            "json — fractional lambdas, top 2": [
+              {
+                "ev_max": {
+                  "ev": 1.286,
+                  "tip": "1:0",
+                },
+                "lambda": [
+                  1.234,
+                  0.876,
+                ],
+                "modal_result": {
+                  "prob": 0.15,
+                  "score": "1:0",
+                },
+                "p_draw": 0.292,
+                "ranked": [
+                  {
+                    "ev": 1.286,
+                    "tip": "1:0",
+                  },
+                  {
+                    "ev": 1.217,
+                    "tip": "2:1",
+                  },
+                ],
+                "rule": {
+                  "diff": 3,
+                  "exact": 4,
+                  "tendency": 2,
+                },
+              },
+            ],
+            "json — kicktipp config": [
+              {
+                "ev_max": {
+                  "ev": 1.981,
+                  "tip": "0:1",
+                },
+                "lambda": [
+                  0.6,
+                  2.1,
+                ],
+                "modal_result": {
+                  "prob": 0.148,
+                  "score": "0:2",
+                },
+                "p_draw": 0.183,
+                "ranked": [
+                  {
+                    "ev": 1.981,
+                    "tip": "0:1",
+                  },
+                  {
+                    "ev": 1.965,
+                    "tip": "0:2",
+                  },
+                  {
+                    "ev": 1.876,
+                    "tip": "1:2",
+                  },
+                  {
+                    "ev": 1.796,
+                    "tip": "0:3",
+                  },
+                  {
+                    "ev": 1.793,
+                    "tip": "1:3",
+                  },
+                  {
+                    "ev": 1.736,
+                    "tip": "2:3",
+                  },
+                ],
+                "rule": {
+                  "diff": 3,
+                  "exact": 5,
+                  "tendency": 2,
+                },
+              },
+            ],
+            "json — moderate favourite": [
+              {
+                "ev_max": {
+                  "ev": 1.747,
+                  "tip": "1:0",
+                },
+                "lambda": [
+                  2,
+                  0.7,
+                ],
+                "modal_result": {
+                  "prob": 0.134,
+                  "score": "1:0",
+                },
+                "p_draw": 0.2,
+                "ranked": [
+                  {
+                    "ev": 1.747,
+                    "tip": "1:0",
+                  },
+                  {
+                    "ev": 1.706,
+                    "tip": "2:1",
+                  },
+                  {
+                    "ev": 1.703,
+                    "tip": "2:0",
+                  },
+                  {
+                    "ev": 1.634,
+                    "tip": "3:2",
+                  },
+                  {
+                    "ev": 1.631,
+                    "tip": "3:1",
+                  },
+                  {
+                    "ev": 1.615,
+                    "tip": "4:3",
+                  },
+                ],
+                "rule": {
+                  "diff": 3,
+                  "exact": 4,
+                  "tendency": 2,
+                },
+              },
+            ],
+            "text — custom top + max-tip": "lambda 2.3:1.1  rule exact=4.0 diff=3.0 tendency=2.0
+          EV-max tip : 2:1  (EV 1.607)
+          modal score: 2:1  (P 0.097)  P(draw) 0.189
+          ranked by EV:
+              2:1  EV 1.607  <- EV-max
+              1:0  EV 1.586
+              2:0  EV 1.564
+          ",
+            "text — even draw-likely": "lambda 1.5:1.5  rule exact=4.0 diff=3.0 tendency=2.0
+          EV-max tip : 2:1  (EV 1.038)
+          modal score: 1:1  (P 0.112)  P(draw) 0.243
+          ranked by EV:
+              2:1  EV 1.038  <- EV-max
+              1:2  EV 1.038
+              1:0  EV 1.029
+              0:1  EV 1.029
+              2:3  EV 0.985
+              3:2  EV 0.985
+          ",
+            "text — kicktipp 2/3/5 underdog": "lambda 0.6:2.1  rule exact=5.0 diff=3.0 tendency=2.0
+          EV-max tip : 0:1  (EV 1.981)
+          modal score: 0:2  (P 0.148)  P(draw) 0.183
+          ranked by EV:
+              0:1  EV 1.981  <- EV-max
+              0:2  EV 1.965
+              1:2  EV 1.876
+              0:3  EV 1.796
+              1:3  EV 1.793
+              2:3  EV 1.736
+          ",
+            "text — moderate favourite": "lambda 2.0:0.7  rule exact=4.0 diff=3.0 tendency=2.0
+          EV-max tip : 1:0  (EV 1.747)
+          modal score: 1:0  (P 0.134)  P(draw) 0.2
+          ranked by EV:
+              1:0  EV 1.747  <- EV-max
+              2:1  EV 1.706
+              2:0  EV 1.703
+              3:2  EV 1.634
+              3:1  EV 1.631
+              4:3  EV 1.615
+          ",
+            "text — zero rates": "lambda 0.0:0.0  rule exact=4.0 diff=3.0 tendency=2.0
+          EV-max tip : 0:0  (EV 4.0)
+          modal score: 0:0  (P 1.0)  P(draw) 1.0
+          ranked by EV:
+              0:0  EV 4.000  <- EV-max
+              1:1  EV 3.000
+              2:2  EV 3.000
+              3:3  EV 3.000
+              4:4  EV 3.000
+              5:5  EV 3.000
+          ",
+          }
+        `);
     });
 
-    it('byte-identical: JSON batch input (--json mode)', () => {
-        const matches = JSON.stringify([
-            { match: 'A-B', lh: 1.8, la: 1.1 },
-            { match: 'C-D', lh: 0.9, la: 0.9 },
-        ]);
-        const file = writeTmp('m.json', matches);
-        const args = [file, '--json'];
-        const py = spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
-        const ts = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+    it('JSON batch input — text mode (pinned)', () => {
+        const file = writeTmp(
+            'm.json',
+            JSON.stringify([
+                { match: 'Senegal-Iraq', lh: 2.0, la: 0.7 },
+                { match: 'Qatar-Switzerland', lh: 0.6, la: 2.1 },
+            ]),
+        );
+        const ts = runTs([file, '--tendency', '2', '--diff', '3', '--exact', '5']);
+        expect(ts.status, ts.stderr).toBe(0);
+        expect(ts.stdout).toMatchInlineSnapshot(`
+          "
+          ## Senegal-Iraq
+          lambda 2.0:0.7  rule exact=5.0 diff=3.0 tendency=2.0
+          EV-max tip : 1:0  (EV 1.881)
+          modal score: 1:0  (P 0.134)  P(draw) 0.2
+          ranked by EV:
+              1:0  EV 1.881  <- EV-max
+              2:0  EV 1.837
+              2:1  EV 1.800
+              3:1  EV 1.694
+              3:0  EV 1.664
+              3:2  EV 1.656
+
+          ## Qatar-Switzerland
+          lambda 0.6:2.1  rule exact=5.0 diff=3.0 tendency=2.0
+          EV-max tip : 0:1  (EV 1.981)
+          modal score: 0:2  (P 0.148)  P(draw) 0.183
+          ranked by EV:
+              0:1  EV 1.981  <- EV-max
+              0:2  EV 1.965
+              1:2  EV 1.876
+              0:3  EV 1.796
+              1:3  EV 1.793
+              2:3  EV 1.736
+          "
+        `);
     });
 
-    // Error path: no input. argparse wraps the usage block to terminal width
-    // (env-dependent), so assert exit 2 + the stable error line, not the full
-    // byte stream.
-    it('no input → exit 2 with the same error line on stderr', () => {
-        const py = spawnSync('python3', [PY_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
-        const ts = spawnSync(TSX_BIN, [TS_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+    it('JSON batch input — --json mode (pinned)', () => {
+        const file = writeTmp(
+            'm.json',
+            JSON.stringify([
+                { match: 'A-B', lh: 1.8, la: 1.1 },
+                { match: 'C-D', lh: 0.9, la: 0.9 },
+            ]),
+        );
+        const ts = runTs([file, '--json']);
+        expect(ts.status, ts.stderr).toBe(0);
+        expect(JSON.parse(ts.stdout)).toMatchInlineSnapshot(`
+          [
+            {
+              "ev_max": {
+                "ev": 1.41,
+                "tip": "1:0",
+              },
+              "lambda": [
+                1.8,
+                1.1,
+              ],
+              "match": "A-B",
+              "modal_result": {
+                "prob": 0.109,
+                "score": "1:1",
+              },
+              "p_draw": 0.231,
+              "ranked": [
+                {
+                  "ev": 1.41,
+                  "tip": "1:0",
+                },
+                {
+                  "ev": 1.409,
+                  "tip": "2:1",
+                },
+                {
+                  "ev": 1.343,
+                  "tip": "3:2",
+                },
+                {
+                  "ev": 1.329,
+                  "tip": "2:0",
+                },
+                {
+                  "ev": 1.316,
+                  "tip": "4:3",
+                },
+                {
+                  "ev": 1.311,
+                  "tip": "5:4",
+                },
+              ],
+              "rule": {
+                "diff": 3,
+                "exact": 4,
+                "tendency": 2,
+              },
+            },
+            {
+              "ev_max": {
+                "ev": 1.152,
+                "tip": "0:0",
+              },
+              "lambda": [
+                0.9,
+                0.9,
+              ],
+              "match": "C-D",
+              "modal_result": {
+                "prob": 0.165,
+                "score": "0:0",
+              },
+              "p_draw": 0.329,
+              "ranked": [
+                {
+                  "ev": 1.152,
+                  "tip": "0:0",
+                },
+                {
+                  "ev": 1.121,
+                  "tip": "1:1",
+                },
+                {
+                  "ev": 1.038,
+                  "tip": "0:1",
+                },
+                {
+                  "ev": 1.038,
+                  "tip": "1:0",
+                },
+                {
+                  "ev": 1.014,
+                  "tip": "2:2",
+                },
+                {
+                  "ev": 0.989,
+                  "tip": "3:3",
+                },
+              ],
+              "rule": {
+                "diff": 3,
+                "exact": 4,
+                "tendency": 2,
+              },
+            },
+          ]
+        `);
+    });
+
+    // Error path: no input. Argparse usage prose is COLUMNS-dependent, so
+    // assert exit 2 + the stable error line, not the full byte stream.
+    it('no input → exit 2 with the stable error line', () => {
+        const ts = runTs([]);
         expect(ts.status).toBe(2);
-        expect(py.status).toBe(2);
         expect(ts.stdout).toBe('');
-        expect(py.stdout).toBe('');
-        const line = 'score_ev.py: error: provide either a matches JSON file or --lh and --la';
-        expect(ts.stderr).toContain(line);
-        expect(py.stderr).toContain(line);
+        expect(ts.stderr).toContain('provide either a matches JSON file or --lh and --la');
     });
 });


### PR DESCRIPTION
## What

Wave 3 of the py2ts test-layer purge (`road-to-py2ts-teardown-completion`).
Converts the **prediction-pool parity trio** — `poisson_sim`, `pool_winsim`,
`score_ev` — from whole-file `python3 vs tsx` byte-parity suites into
python-free contract tests.

## Why

Each was a PURE-PARITY rig against a now-**deleted** `.py` twin → permanently
shim-skipped, so the tsx CLIs had **zero live coverage**. Per the D1 council
default (CONVERT, not blind-delete), the tsx twin is now the source of truth,
its text/json output pinned via inline snapshots.

## Determinism

- `poisson_sim` / `pool_winsim` — `random.Random(seed)` with a FIXED `--seed`
  (`PyRandom` reproduces CPython MT19937 bit-for-bit).
- `score_ev` — pure Poisson grid, no RNG.

Verified by filling snapshots (`-u`) then re-running without `-u`: **no drift**.
`it.each` seed sweeps are collapsed into one combined object snapshot per group
(vitest can't inline-snapshot inside a loop). Argparse usage prose is
COLUMNS-dependent, so error cases assert exit 2 + a stable token.

## Changes

- `poisson_sim` — 4 tests (6-seed sweep + config-error paths)
- `pool_winsim` — 5 tests (text+json seed sweeps, flag variants, errors)
- `score_ev` — 4 tests (lambda/flag cases text+json, JSON batch, no-input)

13 tests pass python-free; 0 python residue; `tsc --noEmit` clean. Test-layer
python-spawn count 86 → 83.

## Scope (D4)

Small tests-only PR, inline snapshots (no `__snapshots__` dir). Does not touch
`agents/roadmaps-progress.md` or roadmap checkboxes. Branch named off the
`py2ts-` prefix so the obsolete `py2ts-base-guard` doesn't false-fire.
