### PR TITLE
test(py2ts): convert corpus-generator parity rigs to drift-free contract tests

### DIFF
--- a/tests/scripts/build_rule_trigger_matrix.test.ts
+++ b/tests/scripts/build_rule_trigger_matrix.test.ts
@@ -1,12 +1,13 @@
-// Tests for src/scripts/build_rule_trigger_matrix.ts (py2ts Phase 8 / Wave 8g).
+// Contract test for src/scripts/build_rule_trigger_matrix.ts (py2ts Phase 8).
 //
-// No pytest suite existed — focused differential (python3 vs tsx) for this
-// generator. It writes to a FIXED live path
-// (agents/settings/contexts/rule-trigger-matrix.md), so the test snapshots
-// that file, runs each generator (capturing stdout / stderr / written bytes),
-// then restores the snapshot — never leaving repo drift. py and ts must
-// produce byte-identical stdout, stderr, written file, and exit code on the
-// same rule inputs. Skipped without python3.
+// The generator writes a FIXED committed artifact
+// (agents/settings/contexts/rule-trigger-matrix.md). The tsx twin is the source
+// of truth (the python original was deleted in the teardown). A full-output
+// snapshot would drift whenever a rule's triggers or byte counts change, so
+// this asserts the generator contract structurally: exit 0, a well-formed
+// matrix (header + methodology + table), and DETERMINISM (a second run
+// reproduces byte-identical output). The live file is snapshotted + restored
+// so the test never leaves repo drift.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -15,7 +16,6 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'build_rule_trigger_matrix.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'build_rule_trigger_matrix.py');
 const OUT = path.join(REPO_ROOT, 'agents', 'settings', 'contexts', 'rule-trigger-matrix.md');
 const TSX_BIN = path.join(
     REPO_ROOT,
@@ -24,16 +24,10 @@ const TSX_BIN = path.join(
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py = hasPython3();
-
 let snapshot: string | null = null;
-const outExisted = fs.existsSync(OUT);
 
 beforeAll(() => {
-    if (outExisted) {
+    if (fs.existsSync(OUT)) {
         snapshot = fs.readFileSync(OUT, 'utf-8');
     }
 });
@@ -47,17 +41,24 @@ afterAll(() => {
     }
 });
 
-describe.skipIf(!py)('build_rule_trigger_matrix — golden parity (python3 vs tsx)', () => {
-    it('stdout, stderr, written file, and exit code match', () => {
-        const pyRun = spawnSync('python3', [PY_SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' });
-        const pyFile = fs.readFileSync(OUT, 'utf-8');
+describe('build_rule_trigger_matrix — generator contract', () => {
+    it('writes a well-formed matrix, deterministically', () => {
+        const run1 = spawnSync(TSX_BIN, [TS_SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' });
+        // exit 0 when every rule is classified, 2 when some are not — both are
+        // valid outcomes; the unclassified count is repo state, not a bug, so
+        // the exact code is not pinned (it would drift as rules are added).
+        expect([0, 2]).toContain(run1.status);
 
-        const tsRun = spawnSync(TSX_BIN, [TS_SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' });
-        const tsFile = fs.readFileSync(OUT, 'utf-8');
+        const first = fs.readFileSync(OUT, 'utf-8');
+        // Well-formed structure (drift-free — asserts shape, not rule content).
+        expect(first.startsWith('# Rule Trigger Matrix')).toBe(true);
+        expect(first).toContain('## Methodology');
+        expect(first).toContain('| Column | Meaning |');
+        expect(first.length).toBeGreaterThan(1000);
 
-        expect(tsRun.status).toBe(pyRun.status);
-        expect(tsRun.stdout).toBe(pyRun.stdout);
-        expect(tsRun.stderr).toBe(pyRun.stderr);
-        expect(tsFile).toBe(pyFile);
+        // Deterministic: a second run reproduces byte-identical output + exit.
+        const run2 = spawnSync(TSX_BIN, [TS_SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' });
+        expect(run2.status).toBe(run1.status);
+        expect(fs.readFileSync(OUT, 'utf-8')).toBe(first);
     });
 });

--- a/tests/scripts/compile_router.test.ts
+++ b/tests/scripts/compile_router.test.ts
@@ -18,7 +18,6 @@ import * as cr from '../../src/scripts/compile_router.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'compile_router.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'compile_router.py');
 const ROUTER = path.join(REPO_ROOT, 'dist', 'router.json');
 const ROUTER_PRETTY = path.join(REPO_ROOT, 'dist', 'router.pretty.json');
 const TSX_BIN = path.join(
@@ -76,13 +75,9 @@ describe('compile_router.build — shape', () => {
 
 // --- Layer 2: golden parity on the REAL REPO -------------------------------
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
-const runnable = py3 && fs.existsSync(ROUTER);
+const routerExists = fs.existsSync(ROUTER);
 
-describe.skipIf(!runnable)('compile_router — golden parity (python3 vs tsx)', () => {
+describe.skipIf(!routerExists)('compile_router — writer reproduces the committed artifact', () => {
     let routerBak: string;
     let prettyBak: string | null;
     afterEach(() => {
@@ -98,43 +93,26 @@ describe.skipIf(!runnable)('compile_router — golden parity (python3 vs tsx)', 
         prettyBak = fs.existsSync(ROUTER_PRETTY) ? fs.readFileSync(ROUTER_PRETTY, 'utf-8') : null;
     }
 
-    it('router.json (minified) is byte-identical py vs tsx AND zero-drift vs committed', () => {
+    it('regenerating router.json reproduces the committed file byte-for-byte + exit 0', () => {
         snapshot();
         const committed = routerBak;
-        const py = spawnSync('python3', [PY_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(py.status).toBe(0);
-        const pyOut = fs.readFileSync(ROUTER, 'utf-8');
-        fs.writeFileSync(ROUTER, committed, 'utf-8');
         const ts = spawnSync(TSX_BIN, [TS_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(ts.status).toBe(0);
-        const tsOut = fs.readFileSync(ROUTER, 'utf-8');
-        expect(tsOut).toBe(pyOut);
-        // Zero drift: the writer reproduces the committed file byte-for-byte.
-        expect(tsOut).toBe(committed);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.status, ts.stderr).toBe(0);
+        // Zero drift: the writer reproduces the committed file byte-for-byte
+        // (the committed router.json is kept current — see the --check test).
+        expect(fs.readFileSync(ROUTER, 'utf-8')).toBe(committed);
     });
 
-    it('router.pretty.json is byte-identical py vs tsx (--pretty)', () => {
+    it('--pretty writes JSON that parses to the same object as router.json', () => {
         snapshot();
-        const py = spawnSync('python3', [PY_SCRIPT, '--pretty'], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(py.status).toBe(0);
-        const pyOut = fs.readFileSync(ROUTER_PRETTY, 'utf-8');
         const ts = spawnSync(TSX_BIN, [TS_SCRIPT, '--pretty'], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(ts.status).toBe(0);
-        const tsOut = fs.readFileSync(ROUTER_PRETTY, 'utf-8');
-        expect(tsOut).toBe(pyOut);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+        expect(ts.status, ts.stderr).toBe(0);
+        const pretty = JSON.parse(fs.readFileSync(ROUTER_PRETTY, 'utf-8'));
+        expect(pretty).toEqual(JSON.parse(routerBak));
     });
 
-    it('--check is byte-identical py vs tsx (up-to-date)', () => {
-        const py = spawnSync('python3', [PY_SCRIPT, '--check'], { encoding: 'utf8', cwd: REPO_ROOT });
+    it('--check passes: the committed router.json is current + reproducible (exit 0)', () => {
         const ts = spawnSync(TSX_BIN, [TS_SCRIPT, '--check'], { encoding: 'utf8', cwd: REPO_ROOT });
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        // The committed router.json is current → exit 0.
-        expect(ts.status).toBe(0);
+        expect(ts.status, ts.stderr).toBe(0);
     });
 });


### PR DESCRIPTION
## What

Wave 4 of the py2ts test-layer purge (`road-to-py2ts-teardown-completion`).
Converts the two **corpus-generator** parity rigs — `build_rule_trigger_matrix`
and `compile_router` — to drift-free contract tests.

## Why this needs a different recipe

Unlike the earlier waves (deterministic fixture/pure functions → inline
snapshots), these generators run over the **real repo** and write committed
artifacts. A full-output snapshot would drift on every rule/router change → CI
flake. So the contract is expressed drift-free:

- **`build_rule_trigger_matrix`** — the committed matrix is *stale* (44
  unclassified rules), so "reproduces committed" can't be asserted. Instead:
  exit ∈ {0,2} (0 = all rules classified, 2 = some not — a repo-state signal,
  not a bug, so the exact code isn't pinned), a **well-formed** matrix (header
  + methodology + table), and **determinism** (a second run is byte-identical).
- **`compile_router`** — keeps its python-free Layer-1 `build()` shape units;
  the parity layer becomes "the tsx writer **reproduces the committed
  `dist/router.json` byte-for-byte** + `--check` exits 0" (router.json *is* kept
  current) and "`--pretty` parses to the same object". `--check` passing is the
  strongest drift-free guard: committed == generated.

Both snapshot + restore the live files (no repo drift left behind).

## Result

8 tests pass python-free (1 + 7); 0 python residue; `tsc --noEmit` clean.
Test-layer python-spawn count 83 → 81.

## Scope (D4)

Tests-only PR; no `agents/roadmaps-progress.md` / roadmap-checkbox touch; branch
off the `py2ts-` prefix (obsolete `py2ts-base-guard` won't false-fire).

## Note

Establishes the **corpus-generator recipe** for the remaining tail: generators
that write a *current* committed artifact → "reproduces committed + `--check`";
generators whose artifact is stale or content-volatile → structure +
idempotence. The `cmd_*` CLI cluster (masked temp-dir output) and the
`bench_*` shared-harness cluster remain for later waves.
