### PR TITLE
test(py2ts): convert validator/generator parity rigs to drift-free contract tests

### DIFF
--- a/tests/scripts/build_mcp_registry_manifest.test.ts
+++ b/tests/scripts/build_mcp_registry_manifest.test.ts
@@ -20,7 +20,6 @@ import * as mcp from '../../src/scripts/build_mcp_registry_manifest.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'build_mcp_registry_manifest.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'build_mcp_registry_manifest.py');
 const MCP_DIR = path.join(REPO_ROOT, 'dist', 'mcp');
 const DISCOVERY = path.join(REPO_ROOT, 'dist', 'discovery', 'discovery-manifest.json');
 const TSX_BIN = path.join(
@@ -59,13 +58,9 @@ describe('build_mcp_registry_manifest.pyJsonDumps — Python json.dumps parity',
 
 // --- Layer 2: golden parity on the REAL REPO -------------------------------
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py3 = hasPython3();
-// Requires the HARD discovery prereq + the two on-disk inputs.
-const runnable =
-    py3 &&
+// Requires the discovery prereq + the two on-disk inputs (dist/discovery is
+// gitignored/generated — the layer skips when they are absent).
+const buildable =
     fs.existsSync(DISCOVERY) &&
     fs.existsSync(path.join(REPO_ROOT, 'internal', 'workers', 'mcp', 'content.json')) &&
     fs.existsSync(path.join(REPO_ROOT, '.github', 'topics.yml'));
@@ -73,7 +68,12 @@ const runnable =
 const big = { maxBuffer: 64 * 1024 * 1024, cwd: REPO_ROOT, encoding: 'utf8' as const };
 const FILES = ['registry-manifest.json', 'awesome-mcp-servers.row.md', 'mcp-cloudflare-catalogue.json'];
 
-describe.skipIf(!runnable)('build_mcp_registry_manifest — golden parity (python3 vs tsx)', () => {
+// The tsx twin is the source of truth (the python original was deleted in the
+// teardown). The manifest content is repo-derived (would drift in a snapshot),
+// so this asserts the writer contract structurally: exit 0, ensure_ascii
+// escaping, valid JSON outputs, and DETERMINISM (a second --write reproduces
+// byte-identical files).
+describe.skipIf(!buildable)('build_mcp_registry_manifest — writer contract', () => {
     let mcpDirExisted: boolean;
     let snapshot: Record<string, string>;
     afterEach(() => {
@@ -97,36 +97,35 @@ describe.skipIf(!runnable)('build_mcp_registry_manifest — golden parity (pytho
         }
     }
 
-    it('stdout (no --write) is byte-identical, with \\u2014 escaping', () => {
+    it('no --write emits the manifest with ensure_ascii escaping (exit 0)', () => {
         snap();
-        const py = spawnSync('python3', [PY_SCRIPT], big);
         const ts = spawnSync(TSX_BIN, [TS_SCRIPT], big);
-        expect(py.status).toBe(0);
-        expect(ts.status).toBe(0);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-        expect(ts.stdout).toContain('\\u2014');
+        expect(ts.status, ts.stderr).toBe(0);
+        expect(ts.stdout).toContain('\\u2014'); // em-dash escaped, not raw —
+        expect(ts.stdout).not.toContain('—');
+        expect(ts.stdout.length).toBeGreaterThan(100);
     });
 
-    it('--write produces byte-identical files py vs tsx', () => {
+    it('--write emits the three files, valid + deterministic', () => {
         snap();
-        const work = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-gp-'));
-        try {
-            // python3 --write, capture the three files.
-            const py = spawnSync('python3', [PY_SCRIPT, '--write'], big);
-            expect(py.status).toBe(0);
-            const pyCopies: Record<string, string> = {};
-            for (const f of FILES) pyCopies[f] = fs.readFileSync(path.join(MCP_DIR, f), 'utf-8');
-            // Clear dist/mcp, then tsx --write, capture again.
-            fs.rmSync(MCP_DIR, { recursive: true, force: true });
-            const ts = spawnSync(TSX_BIN, [TS_SCRIPT, '--write'], big);
-            expect(ts.status).toBe(0);
-            for (const f of FILES) {
-                const tsBody = fs.readFileSync(path.join(MCP_DIR, f), 'utf-8');
-                expect(tsBody).toBe(pyCopies[f]);
-            }
-        } finally {
-            fs.rmSync(work, { recursive: true, force: true });
+        const run1 = spawnSync(TSX_BIN, [TS_SCRIPT, '--write'], big);
+        expect(run1.status, run1.stderr).toBe(0);
+        const first: Record<string, string> = {};
+        for (const f of FILES) {
+            const p = path.join(MCP_DIR, f);
+            expect(fs.existsSync(p), f).toBe(true);
+            first[f] = fs.readFileSync(p, 'utf-8');
+        }
+        expect(() => JSON.parse(first['registry-manifest.json'] as string)).not.toThrow();
+        expect(() => JSON.parse(first['mcp-cloudflare-catalogue.json'] as string)).not.toThrow();
+        expect((first['awesome-mcp-servers.row.md'] as string).length).toBeGreaterThan(0);
+
+        // Deterministic: a second --write reproduces byte-identical files.
+        fs.rmSync(MCP_DIR, { recursive: true, force: true });
+        const run2 = spawnSync(TSX_BIN, [TS_SCRIPT, '--write'], big);
+        expect(run2.status).toBe(0);
+        for (const f of FILES) {
+            expect(fs.readFileSync(path.join(MCP_DIR, f), 'utf-8'), f).toBe(first[f]);
         }
     });
 });

--- a/tests/scripts/print_required_checks.test.ts
+++ b/tests/scripts/print_required_checks.test.ts
@@ -13,7 +13,6 @@ import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'print_required_checks.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'print_required_checks.py');
 const TSX_BIN = path.join(
     REPO_ROOT,
     'node_modules',
@@ -21,32 +20,112 @@ const TSX_BIN = path.join(
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py = hasPython3();
-const runPy = (args: string[]) =>
-    spawnSync('python3', [PY_SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
 const runTs = (args: string[]) =>
     spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
 
-describe.skipIf(!py)('print_required_checks — golden parity (python3 vs tsx)', () => {
-    const cases: string[][] = [
-        ['--branch', 'feat/x', '--base', 'HEAD'],
-        ['--branch', 'release/1.2.3', '--base', 'HEAD'],
-        ['--branch', 'docs/x', '--base', 'HEAD'],
-        ['--base', 'HEAD'],
-        ['--branch=feat/y', '--base=HEAD'],
-        ['--bogus'],
-        ['--branch'],
-    ];
-    for (const args of cases) {
-        it(`[${args.join(' ')}] matches`, () => {
-            const p = runPy(args);
-            const t = runTs(args);
-            expect(t.status).toBe(p.status);
-            expect(t.stdout).toBe(p.stdout);
-            expect(t.stderr).toBe(p.stderr);
-        });
-    }
+// `--base HEAD` makes the diff empty (HEAD..HEAD) in any checkout, so the
+// required-check set is the shape-based default — deterministic. The tsx twin
+// is the source of truth (the python original was deleted in the teardown);
+// output is pinned via an inline snapshot (updates only on an intentional
+// required-checks matrix change).
+describe('print_required_checks — CLI contract', () => {
+    it('required checks per PR shape (pinned)', () => {
+        const shapes: Record<string, string[]> = {
+            feature: ['--branch', 'feat/x', '--base', 'HEAD'],
+            release: ['--branch', 'release/1.2.3', '--base', 'HEAD'],
+            'docs-only': ['--branch', 'docs/x', '--base', 'HEAD'],
+            'no-branch': ['--base', 'HEAD'],
+            'eq-joined': ['--branch=feat/y', '--base=HEAD'],
+        };
+        const out = Object.fromEntries(
+            Object.entries(shapes).map(([label, args]) => {
+                const t = runTs(args);
+                expect(t.status, `${label}: ${t.stderr}`).toBe(0);
+                return [label, t.stdout];
+            }),
+        );
+        expect(out).toMatchInlineSnapshot(`
+          {
+            "docs-only": "Branch: docs/x
+          Base:   HEAD
+          PR shape: feature  (0 file(s) in diff)
+          Required checks (8):
+            - Consistency
+            - Smoke Contracts
+            - Skill Lint
+            - Tests / install-tests
+            - Tests / install-aux-tests
+            - Tests / python-tests
+            - Tests / node-tests
+            - Public Install Smoke / smoke
+
+          Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
+          ",
+            "eq-joined": "Branch: feat/y
+          Base:   HEAD
+          PR shape: feature  (0 file(s) in diff)
+          Required checks (8):
+            - Consistency
+            - Smoke Contracts
+            - Skill Lint
+            - Tests / install-tests
+            - Tests / install-aux-tests
+            - Tests / python-tests
+            - Tests / node-tests
+            - Public Install Smoke / smoke
+
+          Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
+          ",
+            "feature": "Branch: feat/x
+          Base:   HEAD
+          PR shape: feature  (0 file(s) in diff)
+          Required checks (8):
+            - Consistency
+            - Smoke Contracts
+            - Skill Lint
+            - Tests / install-tests
+            - Tests / install-aux-tests
+            - Tests / python-tests
+            - Tests / node-tests
+            - Public Install Smoke / smoke
+
+          Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
+          ",
+            "no-branch": "Branch: main
+          Base:   HEAD
+          PR shape: feature  (0 file(s) in diff)
+          Required checks (8):
+            - Consistency
+            - Smoke Contracts
+            - Skill Lint
+            - Tests / install-tests
+            - Tests / install-aux-tests
+            - Tests / python-tests
+            - Tests / node-tests
+            - Public Install Smoke / smoke
+
+          Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
+          ",
+            "release": "Branch: release/1.2.3
+          Base:   HEAD
+          PR shape: release  (0 file(s) in diff)
+          Required checks (7):
+            - Consistency
+            - Smoke Contracts
+            - Migration Dry-Run
+            - Release Validation / release-shape
+            - Release Validation / changelog-entry
+            - Release Validation / version-consistency
+            - Release Guard (post-tag)
+
+          Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
+          ",
+          }
+        `);
+    });
+
+    it('argparse errors exit 2', () => {
+        expect(runTs(['--bogus']).status).toBe(2);
+        expect(runTs(['--branch']).status).toBe(2);
+    });
 });

--- a/tests/scripts/print_required_checks.test.ts
+++ b/tests/scripts/print_required_checks.test.ts
@@ -1,11 +1,10 @@
-// Tests for src/scripts/print_required_checks.ts (py2ts Phase 8 / Wave 8g).
+// Contract tests for src/scripts/print_required_checks.ts (py2ts Phase 8).
 //
-// No pytest suite existed — focused differential (python3 vs tsx, byte-exact)
-// over deterministic `--branch`/`--base` invocations covering the three PR
-// shapes (feature / release / docs-only), the release-out-of-shape fallback,
-// `=`-joined flags, and the argparse error paths. `--base HEAD` keeps the diff
-// deterministic in any checkout. Read-only, no git drift. Skipped without
-// python3.
+// Covers the PR shapes (feature / release / docs-only), `=`-joined flags, and
+// the argparse error paths over deterministic `--branch`/`--base HEAD`
+// invocations (`--base HEAD` → empty diff in any checkout). Read-only, no git
+// drift. The tsx twin is the source of truth (the python original was deleted
+// in the teardown).
 import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -30,11 +29,13 @@ const runTs = (args: string[]) =>
 // required-checks matrix change).
 describe('print_required_checks — CLI contract', () => {
     it('required checks per PR shape (pinned)', () => {
+        // Every case passes an explicit --branch: the no-flag path auto-detects
+        // the current git branch (env-dependent — differs local vs CI), so it is
+        // intentionally excluded from the pinned snapshot.
         const shapes: Record<string, string[]> = {
             feature: ['--branch', 'feat/x', '--base', 'HEAD'],
             release: ['--branch', 'release/1.2.3', '--base', 'HEAD'],
             'docs-only': ['--branch', 'docs/x', '--base', 'HEAD'],
-            'no-branch': ['--base', 'HEAD'],
             'eq-joined': ['--branch=feat/y', '--base=HEAD'],
         };
         const out = Object.fromEntries(
@@ -77,21 +78,6 @@ describe('print_required_checks — CLI contract', () => {
           Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
           ",
             "feature": "Branch: feat/x
-          Base:   HEAD
-          PR shape: feature  (0 file(s) in diff)
-          Required checks (8):
-            - Consistency
-            - Smoke Contracts
-            - Skill Lint
-            - Tests / install-tests
-            - Tests / install-aux-tests
-            - Tests / python-tests
-            - Tests / node-tests
-            - Public Install Smoke / smoke
-
-          Contract: docs/contracts/branch-protection-policy.md (per-PR-shape matrix)
-          ",
-            "no-branch": "Branch: main
           Base:   HEAD
           PR shape: feature  (0 file(s) in diff)
           Required checks (8):

--- a/tests/scripts/propose_modules_config.test.ts
+++ b/tests/scripts/propose_modules_config.test.ts
@@ -1,10 +1,9 @@
-// Tests for src/scripts/propose_modules_config.ts (py2ts Phase 8 / Wave 8g).
+// Contract tests for src/scripts/propose_modules_config.ts (py2ts Phase 8).
 //
-// No pytest suite existed — focused differential (python3 vs tsx, byte-exact)
-// over the JSON envelope and the interactive TTY block, on a no-modules root,
-// a crafted root with a real `app/Modules/<Module>` dir (exercises the
-// candidate-detection path + suggested-block render), and the argparse error
-// paths. Pure read-only scan; never writes. Skipped without python3.
+// Covers the JSON envelope + interactive TTY block on a no-modules root, a
+// crafted root with a real `app/Modules/<Module>` dir (candidate-detection +
+// suggested-block render), and the argparse error paths. Pure read-only scan;
+// never writes.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -14,7 +13,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'propose_modules_config.ts');
-const PY_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'propose_modules_config.py');
 const TSX_BIN = path.join(
     REPO_ROOT,
     'node_modules',
@@ -22,12 +20,6 @@ const TSX_BIN = path.join(
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
 
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
-const py = hasPython3();
-const runPy = (args: string[]) =>
-    spawnSync('python3', [PY_SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
 const runTs = (args: string[]) =>
     spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
 
@@ -48,44 +40,115 @@ afterEach(() => {
     }
 });
 
-function assertSame(args: string[]): void {
-    const p = runPy(args);
-    const t = runTs(args);
-    expect(t.status).toBe(p.status);
-    expect(t.stdout).toBe(p.stdout);
-    expect(t.stderr).toBe(p.stderr);
+/** Mask a temp root so a fixture snapshot is host-independent. Masks the
+ *  realpath form FIRST (longest match — macOS resolves /var → /private/var),
+ *  then the raw form, then collapses any residual macOS `/private` prefix so
+ *  the snapshot is identical on macOS and Linux. */
+function mask(s: string, d: string): string {
+    let real = d;
+    try {
+        real = fs.realpathSync(d);
+    } catch {
+        // dir already gone — nothing to resolve
+    }
+    return s
+        .split(real).join('<TMP>')
+        .split(d).join('<TMP>')
+        .split('/private<TMP>').join('<TMP>');
 }
 
-describe.skipIf(!py)('propose_modules_config — golden parity (python3 vs tsx)', () => {
-    it('json on the package root matches', () => {
-        assertSame(['--project', REPO_ROOT, '--json']);
-    });
-    it('interactive on the package root matches', () => {
-        assertSame(['--project', REPO_ROOT]);
-    });
-    it('json on a no-modules temp root matches', () => {
-        assertSame(['--project', mkTmp(), '--json']);
-    });
-    it('interactive on a no-modules temp root matches', () => {
-        assertSame(['--project', mkTmp()]);
+// The tsx twin is the source of truth (the python original was deleted in the
+// teardown). Package-root runs scan the real repo → structural only (drift-free);
+// temp-root runs are fully controlled → pinned via masked inline snapshots.
+describe('propose_modules_config — CLI contract', () => {
+    it('package root: --json is valid, interactive runs (exit 0)', () => {
+        const j = runTs(['--project', REPO_ROOT, '--json']);
+        expect(j.status, j.stderr).toBe(0);
+        expect(() => JSON.parse(j.stdout)).not.toThrow();
+        expect(runTs(['--project', REPO_ROOT]).status).toBe(0);
     });
 
-    it('json on a root with a laravel module dir matches', () => {
+    it('no-modules temp root (pinned)', () => {
         const d = mkTmp();
-        fs.mkdirSync(path.join(d, 'app', 'Modules', 'Billing'), { recursive: true });
-        assertSame(['--project', d, '--json']);
-    });
-    it('interactive on a root with a laravel module dir matches', () => {
-        const d = mkTmp();
-        fs.mkdirSync(path.join(d, 'app', 'Modules', 'Billing'), { recursive: true });
-        assertSame(['--project', d]);
+        const j = runTs(['--project', d, '--json']);
+        expect(j.status, j.stderr).toBe(0);
+        expect(mask(j.stdout, d)).toMatchInlineSnapshot(`
+          "{
+            "project_root": "<TMP>",
+            "candidates": [],
+            "proposed_block": {
+              "enabled": false,
+              "root_paths": [],
+              "namespace_template": "",
+              "agent_folder": "agents",
+              "skip_dirs": [
+                ".module-template",
+                ".example"
+              ]
+            }
+          }
+          "
+        `);
+        expect(mask(runTs(['--project', d]).stdout, d)).toMatchInlineSnapshot(`
+          "⚠️  No module roots detected.
+
+          Skipping \`modules:\` config. Re-run after adding a module directory (app/Modules/, src/Module/, packages/, internal/, ...).
+          "
+        `);
     });
 
-    it('bad flag exits 2 identically', () => {
-        assertSame(['--bogus']);
+    it('root with a laravel module dir (pinned)', () => {
+        const d = mkTmp();
+        fs.mkdirSync(path.join(d, 'app', 'Modules', 'Billing'), { recursive: true });
+        const j = runTs(['--project', d, '--json']);
+        expect(j.status, j.stderr).toBe(0);
+        expect(mask(j.stdout, d)).toMatchInlineSnapshot(`
+          "{
+            "project_root": "<TMP>",
+            "candidates": [
+              {
+                "path": "app/Modules",
+                "stack": "laravel-hmvc",
+                "namespace_template_guess": "App\\\\Modules\\\\{ModuleName}",
+                "confidence": "high"
+              }
+            ],
+            "proposed_block": {
+              "enabled": true,
+              "root_paths": [
+                "app/Modules"
+              ],
+              "namespace_template": "App\\\\Modules\\\\{ModuleName}",
+              "agent_folder": "agents",
+              "skip_dirs": [
+                ".module-template",
+                ".example"
+              ]
+            }
+          }
+          "
+        `);
+        expect(mask(runTs(['--project', d]).stdout, d)).toMatchInlineSnapshot(`
+          "📦 Detected module-root candidates:
+
+            #  Path              Stack            Confidence  Namespace template
+            ─  ────────────────  ───────────────  ──────────  ────────────────────
+            1  app/Modules       laravel-hmvc     high        App\\Modules\\{ModuleName}
+
+          Suggested \`modules:\` block (paste into .agent-project-settings.yml):
+
+          modules:
+            enabled: true
+            root_paths: [app/Modules]
+            namespace_template: 'App\\Modules\\{ModuleName}'
+            agent_folder: agents
+            skip_dirs: [.module-template, .example]
+          "
+        `);
     });
-    it('unreachable project root exits 2 identically', () => {
-        const missing = path.join(mkTmp(), 'does-not-exist');
-        assertSame(['--project', missing]);
+
+    it('bad flag + unreachable project root exit 2', () => {
+        expect(runTs(['--bogus']).status).toBe(2);
+        expect(runTs(['--project', path.join(mkTmp(), 'does-not-exist')]).status).toBe(2);
     });
 });


### PR DESCRIPTION
## What

Wave 6 of the py2ts test-layer purge (`road-to-py2ts-teardown-completion`).
Converts three CLI/generator rigs (`print_required_checks`,
`propose_modules_config`, `build_mcp_registry_manifest`) from `python3`-vs-`tsx`
parity to tsx-only contracts.

## Recipes applied

- **`print_required_checks`** — `--base HEAD` → empty diff → deterministic
  shape-based required-check set → combined inline snapshot (updates only on an
  intentional matrix change); argparse errors exit 2.
- **`propose_modules_config`** — package-root run → structural (valid JSON, exit
  0, drift-free); temp-root fixtures (no-modules / laravel module dir) → masked
  inline snapshots. The mask collapses the macOS `/private` realpath prefix so
  the snapshot is **identical on macOS + Linux** (the D4 `/private` lesson —
  would otherwise fail on the Linux runner).
- **`build_mcp_registry_manifest`** — keeps the python-free Layer-1 `pyJsonDumps`
  units; the parity layer becomes a writer contract: `ensure_ascii` escaping,
  valid JSON outputs, and deterministic `--write`. `dist/mcp` restored
  (gitignored).

12 tests pass python-free; 0 python residue; `tsc --noEmit` clean. Test-layer
python-spawn count 79 → 76.

## Scope (D4)

Tests-only PR; no `agents/roadmaps-progress.md` / roadmap-checkbox touch; branch
off the `py2ts-` prefix (obsolete `py2ts-base-guard` won't false-fire).

## Deferred

`validate_discovery_manifest` — its committed manifest is stale (validator exits
1 on drift) and gitignored; deferred to a targeted follow-up rather than pinning
a stale/absent artifact.
