### PR TITLE
test(py2ts): convert shipped skills UI-script parity rigs to tsx-only contracts

### DIFF
--- a/tests/scripts/skills_react_shadcn_ui_shadcn_add.test.ts
+++ b/tests/scripts/skills_react_shadcn_ui_shadcn_add.test.ts
@@ -1,18 +1,13 @@
-// Tests for src/skills/react-shadcn-ui/scripts/shadcn_add.ts (py2ts, ADR-094).
-//
-// No pytest suite exists, so this is a golden-parity suite that runs python3
-// vs tsx on synthetic fixtures and compares stdout + stderr + exit code
-// byte-for-byte. It covers the main paths (no-init guard, dry-run command
-// shape for add / add-all / overwrite, --list empty + sorted listing,
-// already-installed guard, the components.json alias-default fallback) and
-// the error paths (no components → print_help + exit 1, unrecognized flag →
-// exit 2).
+// Contract tests for src/skills/react-shadcn-ui/scripts/shadcn_add.ts (py2ts,
+// ADR-094). The tsx twin is the source of truth (the python original was
+// deleted in the teardown). Covers the main paths (no-init guard, dry-run
+// command shape for add / add-all / overwrite, --list empty + sorted listing,
+// already-installed guard, the components.json alias-default fallback) and the
+// error paths (no components → print_help + exit 1, unrecognized flag → exit 2).
 //
 // No real `npx` is ever spawned: every "would run" path uses --dry-run, and
 // the not-initialized / already-installed paths short-circuit before exec, so
 // the suite is deterministic and side-effect-free (throwaway tmp dirs only).
-// The argparse --help text is NOT byte-compared as a contract, but the
-// no-components path runs print_help → stdout and we assert exit-code parity.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -30,24 +25,12 @@ const TS_SCRIPT = path.join(
     'scripts',
     'shadcn_add.ts',
 );
-const PY_SCRIPT = path.join(
-    REPO_ROOT,
-    'src',
-    'skills',
-    'react-shadcn-ui',
-    'scripts',
-    'shadcn_add.py',
-);
 const TSX_BIN = path.join(
     REPO_ROOT,
     'node_modules',
     '.bin',
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -64,21 +47,13 @@ afterEach(() => {
     }
 });
 
-function runPy(args: string[], cwd: string) {
-    return spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
-}
 function runTs(args: string[], cwd: string) {
     return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
 }
-function assertParity(args: string[], cwd: string, expectedStatus?: number) {
-    const py = runPy(args, cwd);
+/** Run tsx, assert the exit code, return the result. */
+function run(args: string[], cwd: string, expectedStatus: number) {
     const ts = runTs(args, cwd);
-    expect(ts.status).toBe(py.status);
-    if (expectedStatus !== undefined) {
-        expect(ts.status).toBe(expectedStatus);
-    }
-    expect(ts.stdout).toBe(py.stdout);
-    expect(ts.stderr).toBe(py.stderr);
+    expect(ts.status, ts.stderr).toBe(expectedStatus);
     return ts;
 }
 
@@ -98,79 +73,62 @@ function seed(installed: string[] | null, componentsJson = '{"aliases":{"compone
     return d;
 }
 
-describe.runIf(hasPython3())('shadcn_add — golden parity (python3 vs tsx)', () => {
+describe('shadcn_add — CLI contract', () => {
     it('--list with no components.json → "shadcn not initialized" + exit 1', () => {
-        const d = mkTmp();
-        assertParity(['--list'], d, 1);
+        const ts = run(['--list'], mkTmp(), 1);
+        expect(ts.stdout).toContain('shadcn not initialized');
     });
 
     it('add a component with no components.json → init-required + exit 1', () => {
-        const d = mkTmp();
-        const ts = assertParity(['button'], d, 1);
+        const ts = run(['button'], mkTmp(), 1);
         expect(ts.stdout).toContain("shadcn not initialized. Run 'npx shadcn@latest init' first");
     });
 
     it('dry-run add (initialized) → "Would run: npx shadcn@latest add …" + exit 0', () => {
-        const d = seed(null);
-        const ts = assertParity(['button', 'card', '--dry-run'], d, 0);
+        const ts = run(['button', 'card', '--dry-run'], seed(null), 0);
         expect(ts.stdout).toBe('Would run: npx shadcn@latest add button card\n');
     });
 
     it('dry-run --all (initialized) → add --all command shape + exit 0', () => {
-        const d = seed(null);
-        const ts = assertParity(['--all', '--dry-run'], d, 0);
+        const ts = run(['--all', '--dry-run'], seed(null), 0);
         expect(ts.stdout).toBe('Would run: npx shadcn@latest add --all\n');
     });
 
     it('dry-run --overwrite appends the --overwrite flag', () => {
-        const d = seed(['button']);
-        const ts = assertParity(['button', '--overwrite', '--dry-run'], d, 0);
+        const ts = run(['button', '--overwrite', '--dry-run'], seed(['button']), 0);
         expect(ts.stdout).toBe('Would run: npx shadcn@latest add button --overwrite\n');
     });
 
     it('--list (initialized, empty ui dir) → "No components installed" + exit 0', () => {
-        const d = seed(null);
-        assertParity(['--list'], d, 0);
+        const ts = run(['--list'], seed(null), 0);
+        expect(ts.stdout).toContain('No components installed');
     });
 
     it('--list emits a sorted "- name" listing of installed *.tsx stems', () => {
-        const d = seed(['button', 'card', 'alert-dialog']);
-        const ts = assertParity(['--list'], d, 0);
+        const ts = run(['--list'], seed(['button', 'card', 'alert-dialog']), 0);
         expect(ts.stdout).toBe('Installed components:\n  - alert-dialog\n  - button\n  - card\n');
     });
 
     it('already-installed component without --overwrite → guard message + exit 1', () => {
-        const d = seed(['button']);
-        const ts = assertParity(['button', 'dialog'], d, 1);
+        const ts = run(['button', 'dialog'], seed(['button']), 1);
         expect(ts.stdout).toContain('Components already installed: button. Use --overwrite to reinstall');
     });
 
     it('components.json without an aliases key falls back to the default "components" dir', () => {
-        const d = seed(['button', 'card', 'alert-dialog'], '{}');
-        const ts = assertParity(['--list'], d, 0);
+        const ts = run(['--list'], seed(['button', 'card', 'alert-dialog'], '{}'), 0);
         expect(ts.stdout).toBe('Installed components:\n  - alert-dialog\n  - button\n  - card\n');
     });
 
     it('no components (and no --all/--list) → print_help to stdout + exit 1', () => {
-        const d = seed(null);
-        // print_help emits argparse usage prose, which is COLUMNS- and
-        // Python-version-dependent (width wrapping) — NOT a byte contract
-        // (passed on local python3, diverged on the CI runner's). Assert the
-        // exit code + the stdout/stderr split (help → stdout, empty stderr) +
-        // a stable usage-line token, not byte-identical prose. Convention:
-        // run_skill_evals / score_ev / airgap twins.
-        const ts = runTs([], d);
-        const py = runPy([], d);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(1);
-        expect(ts.stderr).toBe(py.stderr);
+        // print_help emits argparse usage prose (COLUMNS-dependent), so assert
+        // the exit code + stdout/stderr split + a stable usage-line token, not
+        // byte-identical prose.
+        const ts = run([], seed(null), 1);
         expect(ts.stdout).toMatch(/usage:\s+shadcn_add/u);
-        expect(py.stdout).toMatch(/usage:\s+shadcn_add/u);
     });
 
-    it('unrecognized flag → byte-identical usage + error + exit 2', () => {
-        const d = mkTmp();
-        const ts = assertParity(['--bogus'], d, 2);
+    it('unrecognized flag → usage + error + exit 2', () => {
+        const ts = run(['--bogus'], mkTmp(), 2);
         expect(ts.stderr).toContain('unrecognized arguments: --bogus');
     });
 });

--- a/tests/scripts/skills_tailwind_engineer_tailwind_config_gen.test.ts
+++ b/tests/scripts/skills_tailwind_engineer_tailwind_config_gen.test.ts
@@ -1,17 +1,11 @@
-// Tests for src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts (py2ts, ADR-094).
-//
-// No pytest suite exists, so this is a golden-parity suite that runs python3
-// vs tsx on fixtures and compares stdout + stderr + exit code byte-for-byte,
-// plus a byte-identical check on the WRITTEN config file (.ts and .js). It
-// covers the main generation paths (validate-only default react, full
-// option matrix with --js/--colors/--fonts/--spacing/--breakpoints/--plugins
-// on nextjs, the file-write path) and the error paths (bad color/font/spacing/
-// breakpoint spec → exit 1, argparse invalid framework choice → exit 2).
-//
-// The argparse --help text is intentionally NOT byte-compared (an argparse
-// internal detail); the invalid-choice usage block IS compared because the
-// twin pins it as a fixed-width-80 constant. Everything is deterministic —
-// the write path uses throwaway tmp dirs, so there is zero git drift.
+// Contract tests for src/skills/tailwind-engineer/scripts/tailwind_config_gen.ts
+// (py2ts, ADR-094). The tsx twin is the source of truth (the python original
+// was deleted in the teardown). Covers the generation paths (validate-only
+// default react, the full option matrix on nextjs, vue/svelte frameworks, the
+// file-write path for .ts and .js) and the error paths (bad
+// color/font/spacing/breakpoint spec → exit 1, invalid framework → exit 2).
+// Everything is deterministic — the write path uses throwaway tmp dirs, so
+// there is zero git drift; generated output is pinned via inline snapshots.
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -29,24 +23,12 @@ const TS_SCRIPT = path.join(
     'scripts',
     'tailwind_config_gen.ts',
 );
-const PY_SCRIPT = path.join(
-    REPO_ROOT,
-    'src',
-    'skills',
-    'tailwind-engineer',
-    'scripts',
-    'tailwind_config_gen.py',
-);
 const TSX_BIN = path.join(
     REPO_ROOT,
     'node_modules',
     '.bin',
     process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
 );
-
-function hasPython3(): boolean {
-    return spawnSync('python3', ['--version'], { encoding: 'utf8' }).status === 0;
-}
 
 const tmpDirs: string[] = [];
 function mkTmp(): string {
@@ -63,88 +45,205 @@ afterEach(() => {
     }
 });
 
-function runPy(args: string[], cwd: string = REPO_ROOT) {
-    return spawnSync('python3', [PY_SCRIPT, ...args], { encoding: 'utf8', cwd });
-}
 function runTs(args: string[], cwd: string = REPO_ROOT) {
     return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd });
 }
 
-describe.runIf(hasPython3())('tailwind_config_gen — golden parity (python3 vs tsx)', () => {
-    it('--validate-only default (react) prints a byte-identical config + exit 0', () => {
-        const args = ['--validate-only'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(0);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+describe('tailwind_config_gen — CLI contract', () => {
+    it('generated config across frameworks + the full option matrix (pinned)', () => {
+        const cases: Record<string, string[]> = {
+            'react default (--validate-only)': ['--validate-only'],
+            'full matrix (nextjs, --js)': [
+                '--validate-only', '--js', '--framework', 'nextjs',
+                '--colors', 'brand:#3b82f6', 'accent:#8b5cf6',
+                '--fonts', 'sans:Inter,system-ui,sans-serif', "display:'Playfair Display',serif",
+                '--spacing', 'navbar:4rem',
+                '--breakpoints', '3xl:1920px',
+                '--plugins',
+            ],
+            vue: ['--validate-only', '--framework', 'vue'],
+            svelte: ['--validate-only', '--framework', 'svelte'],
+        };
+        const out = Object.fromEntries(
+            Object.entries(cases).map(([label, args]) => {
+                const ts = runTs(args);
+                expect(ts.status, `${label}: ${ts.stderr}`).toBe(0);
+                return [label, ts.stdout];
+            }),
+        );
+        expect(out).toMatchInlineSnapshot(`
+          {
+            "full matrix (nextjs, --js)": "Added recommended plugins: tailwindcss-animate, @tailwindcss/typography
+
+          Install with:
+            npm install -D tailwindcss-animate @tailwindcss/typography
+          Configuration valid
+
+          Generated config:
+          /** @type {import('tailwindcss').Config} */
+          module.exports = {
+              "darkMode": [
+                "class"
+              ],
+              "content": [
+                "./app/**/*.{js,ts,jsx,tsx}",
+                "./pages/**/*.{js,ts,jsx,tsx}",
+                "./components/**/*.{js,ts,jsx,tsx}"
+              ],
+              "theme": {
+                "extend": {
+                  "colors": {
+                    "brand": "#3b82f6",
+                    "accent": "#8b5cf6"
+                  },
+                  "fontFamily": {
+                    "sans": [
+                      "Inter",
+                      "system-ui",
+                      "sans-serif"
+                    ],
+                    "display": [
+                      "Playfair Display",
+                      "serif"
+                    ]
+                  },
+                  "spacing": {
+                    "navbar": "4rem"
+                  },
+                  "screens": {
+                    "3xl": "1920px"
+                  }
+                }
+              }
+            plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')],
+          }
+
+          ",
+            "react default (--validate-only)": "Warning: No theme extensions defined
+          Configuration valid
+
+          Generated config:
+          import type { Config } from 'tailwindcss'
+
+          const config: Config = {
+              "darkMode": [
+                "class"
+              ],
+              "content": [
+                "./src/**/*.{js,jsx,ts,tsx}",
+                "./index.html"
+              ],
+              "theme": {
+                "extend": {}
+              }
+            plugins: [],
+          }
+
+          export default config
+
+          ",
+            "svelte": "Warning: No theme extensions defined
+          Configuration valid
+
+          Generated config:
+          import type { Config } from 'tailwindcss'
+
+          const config: Config = {
+              "darkMode": [
+                "class"
+              ],
+              "content": [
+                "./src/**/*.{svelte,js,ts}",
+                "./src/app.html"
+              ],
+              "theme": {
+                "extend": {}
+              }
+            plugins: [],
+          }
+
+          export default config
+
+          ",
+            "vue": "Warning: No theme extensions defined
+          Configuration valid
+
+          Generated config:
+          import type { Config } from 'tailwindcss'
+
+          const config: Config = {
+              "darkMode": [
+                "class"
+              ],
+              "content": [
+                "./src/**/*.{vue,js,ts,jsx,tsx}",
+                "./index.html"
+              ],
+              "theme": {
+                "extend": {}
+              }
+            plugins: [],
+          }
+
+          export default config
+
+          ",
+          }
+        `);
     });
 
-    it('full option matrix (--js nextjs + colors/fonts/spacing/breakpoints/plugins) matches', () => {
-        const args = [
-            '--validate-only',
-            '--js',
-            '--framework',
-            'nextjs',
-            '--colors',
-            'brand:#3b82f6',
-            'accent:#8b5cf6',
-            '--fonts',
-            'sans:Inter,system-ui,sans-serif',
-            "display:'Playfair Display',serif",
-            '--spacing',
-            'navbar:4rem',
-            '--breakpoints',
-            '3xl:1920px',
-            '--plugins',
-        ];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(0);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
+    it('writes a tailwind.config.ts (file-write path, pinned)', () => {
+        const outPath = path.join(mkTmp(), 'tailwind.config.ts');
+        const ts = runTs(['--colors', 'brand:#3b82f6', '--output', outPath]);
+        expect(ts.status, ts.stderr).toBe(0);
+        expect(fs.readFileSync(outPath, 'utf8')).toMatchInlineSnapshot(`
+          "import type { Config } from 'tailwindcss'
+
+          const config: Config = {
+              "darkMode": [
+                "class"
+              ],
+              "content": [
+                "./src/**/*.{js,jsx,ts,tsx}",
+                "./index.html"
+              ],
+              "theme": {
+                "extend": {
+                  "colors": {
+                    "brand": "#3b82f6"
+                  }
+                }
+              }
+            plugins: [],
+          }
+
+          export default config
+          "
+        `);
     });
 
-    it.each([
-        ['vue'],
-        ['svelte'],
-    ])('--validate-only --framework %s matches', (fw) => {
-        const args = ['--validate-only', '--framework', fw];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
-    });
-
-    it('writes a byte-identical tailwind.config.ts (the file-write path)', () => {
-        const pyDir = mkTmp();
-        const tsDir = mkTmp();
-        const pyOut = path.join(pyDir, 'tailwind.config.ts');
-        const tsOut = path.join(tsDir, 'tailwind.config.ts');
-        const py = runPy(['--colors', 'brand:#3b82f6', '--output', pyOut]);
-        const ts = runTs(['--colors', 'brand:#3b82f6', '--output', tsOut]);
-        expect(ts.status).toBe(py.status);
-        expect(ts.status).toBe(0);
-        // stdout embeds the absolute output path; normalise that one token.
-        expect(ts.stdout.replace(tsOut, 'OUT')).toBe(py.stdout.replace(pyOut, 'OUT'));
-        expect(ts.stderr).toBe(py.stderr);
-        expect(fs.readFileSync(tsOut, 'utf8')).toBe(fs.readFileSync(pyOut, 'utf8'));
-    });
-
-    it('writes a byte-identical tailwind.config.js (--js write path)', () => {
-        const pyDir = mkTmp();
-        const tsDir = mkTmp();
-        const pyOut = path.join(pyDir, 'tailwind.config.js');
-        const tsOut = path.join(tsDir, 'tailwind.config.js');
-        const py = runPy(['--js', '--plugins', '--framework', 'nextjs', '--output', pyOut]);
-        const ts = runTs(['--js', '--plugins', '--framework', 'nextjs', '--output', tsOut]);
-        expect(ts.status).toBe(py.status);
-        expect(ts.stdout.replace(tsOut, 'OUT')).toBe(py.stdout.replace(pyOut, 'OUT'));
-        expect(ts.stderr).toBe(py.stderr);
-        expect(fs.readFileSync(tsOut, 'utf8')).toBe(fs.readFileSync(pyOut, 'utf8'));
+    it('writes a tailwind.config.js (--js write path, pinned)', () => {
+        const outPath = path.join(mkTmp(), 'tailwind.config.js');
+        const ts = runTs(['--js', '--plugins', '--framework', 'nextjs', '--output', outPath]);
+        expect(ts.status, ts.stderr).toBe(0);
+        expect(fs.readFileSync(outPath, 'utf8')).toMatchInlineSnapshot(`
+          "/** @type {import('tailwindcss').Config} */
+          module.exports = {
+              "darkMode": [
+                "class"
+              ],
+              "content": [
+                "./app/**/*.{js,ts,jsx,tsx}",
+                "./pages/**/*.{js,ts,jsx,tsx}",
+                "./components/**/*.{js,ts,jsx,tsx}"
+              ],
+              "theme": {
+                "extend": {}
+              }
+            plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')],
+          }
+          "
+        `);
     });
 
     it.each([
@@ -152,25 +251,15 @@ describe.runIf(hasPython3())('tailwind_config_gen — golden parity (python3 vs 
         ['--fonts', 'Invalid font spec: nocolon'],
         ['--spacing', 'Invalid spacing spec: nocolon'],
         ['--breakpoints', 'Invalid breakpoint spec: nocolon'],
-    ])('bad %s spec → byte-identical error + exit 1', (flag, marker) => {
-        const args = [flag, 'nocolon'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
+    ])('bad %s spec → error + exit 1', (flag, marker) => {
+        const ts = runTs([flag, 'nocolon']);
         expect(ts.status).toBe(1);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
         expect(ts.stderr).toContain(marker);
     });
 
-    it('invalid --framework choice → byte-identical usage + error + exit 2', () => {
-        const args = ['--framework', 'angular'];
-        const py = runPy(args);
-        const ts = runTs(args);
-        expect(ts.status).toBe(py.status);
+    it('invalid --framework choice → usage + error + exit 2', () => {
+        const ts = runTs(['--framework', 'angular']);
         expect(ts.status).toBe(2);
-        expect(ts.stdout).toBe(py.stdout);
-        expect(ts.stderr).toBe(py.stderr);
         expect(ts.stderr).toContain("invalid choice: 'angular'");
     });
 });


### PR DESCRIPTION
## What

Wave 7 of the py2ts test-layer purge (`road-to-py2ts-teardown-completion`).
Converts two shipped skill-scripts (`react-shadcn-ui/shadcn_add`,
`tailwind-engineer/tailwind_config_gen`) from `python3`-vs-`tsx` parity to
tsx-only contracts.

- **`shadcn_add`** — most cases already asserted the exact tsx stdout, so the
  python comparison was pure redundancy; dropped it and kept the explicit
  `toBe`/`toContain` asserts (no-init guard, dry-run add/add-all/overwrite
  command shape, sorted `--list`, already-installed guard, alias fallback,
  `print_help` exit 1, bad flag exit 2).
- **`tailwind_config_gen`** — deterministic config generation → combined inline
  snapshot across frameworks + the full option matrix; written `.ts`/`.js`
  files pinned via inline snapshots (config content only — no paths); bad-spec →
  exit 1, invalid framework → exit 2 via stable tokens.

19 tests pass python-free; 0 python residue; `tsc --noEmit` clean. Fixture
output carries no tmp paths or env-dependence (the wave-6 `/private` +
branch-autodetect CI traps don't apply here). Test-layer python-spawn count
74 (post-merge of the prior waves).

## Scope (D4)

Tests-only PR; no `agents/roadmaps-progress.md` / roadmap-checkbox touch; branch
off the `py2ts-` prefix.
