### PR TITLE
feat(test): in-process CLI runner — eliminate tsx cold-start from parity rigs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,11 +212,18 @@ jobs:
         # subprocess suites spawn `./agent-config` → dist/cli/agent-config.js.
         run: npm run build --silent
 
-      - name: Vitest (shard ${{ matrix.shard }}/4, golden excluded)
+      - name: Vitest (shard ${{ matrix.shard }}/4, heavy suites excluded)
         # `--` forwards flags to vitest; each runner executes a deterministic
-        # quarter of the file set. `--exclude tests/golden/**` hands the heavy
-        # golden suite to the dedicated `golden-tests` job below.
-        run: npm run test:ts --silent -- --shard=${{ matrix.shard }}/4 --exclude 'tests/golden/**'
+        # quarter of the file set. The subprocess-heavy clusters (golden +
+        # workspace) hash-clump into one over-budget shard regardless of shard
+        # count, so they are excluded here and run in the dedicated
+        # `heavy-tests` job → each node-tests shard stays light and balanced.
+        run: >-
+          npm run test:ts --silent --
+          --shard=${{ matrix.shard }}/4
+          --exclude 'tests/golden/**'
+          --exclude 'tests/server/workspace.test.ts'
+          --exclude 'tests/scripts/cli/python/**'
 
   static-checks:
     # Whole-tree gates that have nothing to shard: ESLint, tsc --noEmit, and
@@ -251,14 +258,15 @@ jobs:
         run: node src/scripts/prepack-check.mjs
 
   golden-tests:
-    # The golden-transcript replay suite is the single heaviest test cluster —
-    # 29 scenarios that each spawn `./agent-config` (dist/cli) per cycle. It is
-    # split across 6 files (tests/golden/golden_replay*.test.ts) so vitest's
-    # fork pool runs them concurrently on a DEDICATED runner (no contention
-    # with the rest of the suite → ~25 s local, well under 2 min on CI). Kept
-    # out of the sharded `node-tests` matrix because vitest shards by file
-    # count, not duration, and would otherwise clump the golden files into one
-    # over-budget bucket (the observed 167 s shard-2 failure mode).
+    # Golden-transcript replay — 29 scenarios × `./agent-config` (dist/cli)
+    # spawn per cycle, split across 6 files (tests/golden/golden_replay*.test.ts)
+    # so vitest's fork pool runs them concurrently on a DEDICATED runner
+    # (~25 s local). Kept out of the sharded `node-tests` matrix because vitest
+    # shards by file COUNT not duration and would clump the golden files into
+    # one over-budget bucket (the observed 167 s shard-2 failure mode).
+    # Separate from `workspace-tests` on purpose: running both subprocess-heavy
+    # clusters in one job oversubscribed the fork pool and produced flaky
+    # spawn-timeout failures — each cluster gets its own runner.
     name: Golden Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     if: ${{ !startsWith(github.head_ref, 'release/') }}
@@ -286,6 +294,43 @@ jobs:
 
       - name: Vitest (tests/golden — fork-parallel)
         run: npm run test:ts --silent -- tests/golden
+
+  workspace-tests:
+    # The workspace cluster: tests/server/workspace.test.ts + the cli/python
+    # workspace suite (each spawns `tsx src/cli/python/*.ts` per assertion).
+    # These `workspace*`-named files hash-clump into one node-tests shard
+    # regardless of shard count, so they run on their own DEDICATED runner
+    # (~12 s local, ~40 s CI). Separate from `golden-tests` to avoid
+    # over-subscribing the fork pool (see the flaky-spawn note there).
+    name: Workspace Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies (hoists installer toolchain)
+        run: npm ci
+
+      - name: Build discovery manifest (gitignored; cli-e2e reads it)
+        run: ./scripts-run src/scripts/build_discovery_manifest --write --quiet
+
+      - name: Build (dist/cli + UI bundle)
+        run: npm run build --silent
+
+      - name: Vitest (workspace suite — fork-parallel)
+        run: >-
+          npm run test:ts --silent --
+          tests/server/workspace.test.ts
+          tests/scripts/cli/python
 
   # NOTE: windows-lockfile-export moved to
   # .github/workflows/windows-lockfile-export.yml in

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
     # directory. `build` script = `build:cli && build:ui`, so the
     # previous explicit build:cli + build:ui + build pair was a no-op
     # duplicate; collapsed to a single build invocation.
-    name: Node Tests (${{ matrix.os }})
+    name: Node Tests (${{ matrix.os }}, shard ${{ matrix.shard }}/4)
     runs-on: ${{ matrix.os }}
     # Release-PR skip per docs/contracts/release-pr-gating.md — release
     # PRs don't touch src/** or tests/**; ESLint, tsc, vitest,
@@ -174,7 +174,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Vitest is core-saturated on a single runner (golden-replay + the
+        # subprocess suites spawn ./agent-config / tsx heavily), so the wall
+        # clock is total-CPU-work ÷ cores. `--shard=N/4` fans the file set
+        # across 4 parallel runners per OS → ~4× the cores → the slowest
+        # shard lands well under 2 min. ESLint / typecheck / prepack are
+        # whole-tree gates with nothing to shard → shard 1 only.
         os: [ubuntu-latest, macos-latest]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
 
@@ -194,22 +201,30 @@ jobs:
         run: ./scripts-run src/scripts/build_discovery_manifest --write --quiet
 
       # ── Root TS CLI + UI ───────────────────────────────────────────
+      # Whole-tree gates — nothing to shard; run once (shard 1) to avoid 4×
+      # redundant work.
       - name: ESLint (src/**/*.ts)
+        if: ${{ matrix.shard == 1 }}
         run: npm run lint:ts --silent
 
       - name: Typecheck (tsc --noEmit)
+        if: ${{ matrix.shard == 1 }}
         run: npm run typecheck --silent
 
       - name: Build (dist/cli + UI bundle)
         # `build` = `build:cli && build:ui`; the `build:cli` step also
         # exercises the `chmod +x` hook that prepack-check.mjs asserts
-        # on `npm pack`.
+        # on `npm pack`. Every shard needs dist/ — the golden-replay suites
+        # spawn `./agent-config` → dist/cli/agent-config.js.
         run: npm run build --silent
 
-      - name: Vitest (tests/{cli,server,ui}/**/*.ts)
-        run: npm run test:ts --silent
+      - name: Vitest (shard ${{ matrix.shard }}/4)
+        # `--` forwards the shard flag to vitest; each runner executes a
+        # deterministic quarter of the file set.
+        run: npm run test:ts --silent -- --shard=${{ matrix.shard }}/4
 
       - name: prepack-check (compiled bin shape gate)
+        if: ${{ matrix.shard == 1 }}
         run: node src/scripts/prepack-check.mjs
 
   # NOTE: windows-lockfile-export moved to

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,21 +203,13 @@ jobs:
         run: ./scripts-run src/scripts/build_discovery_manifest --write --quiet
 
       # ── Root TS CLI + UI ───────────────────────────────────────────
-      # Whole-tree gates — nothing to shard; run once (shard 1) to avoid 4×
-      # redundant work.
-      - name: ESLint (src/**/*.ts)
-        if: ${{ matrix.shard == 1 }}
-        run: npm run lint:ts --silent
-
-      - name: Typecheck (tsc --noEmit)
-        if: ${{ matrix.shard == 1 }}
-        run: npm run typecheck --silent
-
+      # ESLint / typecheck / prepack are whole-tree gates with nothing to
+      # shard — they live in the dedicated `static-checks` job (runs once,
+      # not per OS × shard) so no vitest shard carries their ~40s and every
+      # shard is build + vitest only.
       - name: Build (dist/cli + UI bundle)
-        # `build` = `build:cli && build:ui`; the `build:cli` step also
-        # exercises the `chmod +x` hook that prepack-check.mjs asserts
-        # on `npm pack`. Every shard needs dist/ — the golden-replay suites
-        # spawn `./agent-config` → dist/cli/agent-config.js.
+        # `build` = `build:cli && build:ui`. Every shard needs dist/ — the
+        # subprocess suites spawn `./agent-config` → dist/cli/agent-config.js.
         run: npm run build --silent
 
       - name: Vitest (shard ${{ matrix.shard }}/4, golden excluded)
@@ -226,8 +218,36 @@ jobs:
         # golden suite to the dedicated `golden-tests` job below.
         run: npm run test:ts --silent -- --shard=${{ matrix.shard }}/4 --exclude 'tests/golden/**'
 
+  static-checks:
+    # Whole-tree gates that have nothing to shard: ESLint, tsc --noEmit, and
+    # the prepack compiled-bin shape check. Run once (ubuntu only — all three
+    # are OS-independent) instead of on every node-tests shard, so no vitest
+    # shard's wall clock carries their ~40s and the check dedups across OSes.
+    name: Static Checks (ESLint · typecheck · prepack)
+    runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies (hoists installer toolchain)
+        run: npm ci
+
+      - name: ESLint (src/**/*.ts)
+        run: npm run lint:ts --silent
+
+      - name: Typecheck (tsc --noEmit)
+        run: npm run typecheck --silent
+
+      - name: Build (dist/cli + UI bundle)
+        # prepack-check asserts the chmod +x hook applied by build:cli.
+        run: npm run build --silent
+
       - name: prepack-check (compiled bin shape gate)
-        if: ${{ matrix.shard == 1 }}
         run: node src/scripts/prepack-check.mjs
 
   golden-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,12 +174,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Vitest is core-saturated on a single runner (golden-replay + the
-        # subprocess suites spawn ./agent-config / tsx heavily), so the wall
-        # clock is total-CPU-work ÷ cores. `--shard=N/4` fans the file set
-        # across 4 parallel runners per OS → ~4× the cores → the slowest
-        # shard lands well under 2 min. ESLint / typecheck / prepack are
-        # whole-tree gates with nothing to shard → shard 1 only.
+        # Vitest is core-saturated on a single runner (the subprocess suites
+        # spawn ./agent-config / tsx heavily), so the wall clock is
+        # total-CPU-work ÷ cores. `--shard=N/4` fans the file set across 4
+        # parallel runners per OS. The golden-replay suite — the single
+        # heaviest cluster — is pulled into its OWN job (`golden-tests`) and
+        # EXCLUDED here, because vitest shards by file COUNT not duration and
+        # would otherwise clump the golden files into one > 2 min bucket.
+        # ESLint / typecheck / prepack are whole-tree gates → shard 1 only.
         os: [ubuntu-latest, macos-latest]
         shard: [1, 2, 3, 4]
     steps:
@@ -218,14 +220,52 @@ jobs:
         # spawn `./agent-config` → dist/cli/agent-config.js.
         run: npm run build --silent
 
-      - name: Vitest (shard ${{ matrix.shard }}/4)
-        # `--` forwards the shard flag to vitest; each runner executes a
-        # deterministic quarter of the file set.
-        run: npm run test:ts --silent -- --shard=${{ matrix.shard }}/4
+      - name: Vitest (shard ${{ matrix.shard }}/4, golden excluded)
+        # `--` forwards flags to vitest; each runner executes a deterministic
+        # quarter of the file set. `--exclude tests/golden/**` hands the heavy
+        # golden suite to the dedicated `golden-tests` job below.
+        run: npm run test:ts --silent -- --shard=${{ matrix.shard }}/4 --exclude 'tests/golden/**'
 
       - name: prepack-check (compiled bin shape gate)
         if: ${{ matrix.shard == 1 }}
         run: node src/scripts/prepack-check.mjs
+
+  golden-tests:
+    # The golden-transcript replay suite is the single heaviest test cluster —
+    # 29 scenarios that each spawn `./agent-config` (dist/cli) per cycle. It is
+    # split across 6 files (tests/golden/golden_replay*.test.ts) so vitest's
+    # fork pool runs them concurrently on a DEDICATED runner (no contention
+    # with the rest of the suite → ~25 s local, well under 2 min on CI). Kept
+    # out of the sharded `node-tests` matrix because vitest shards by file
+    # count, not duration, and would otherwise clump the golden files into one
+    # over-budget bucket (the observed 167 s shard-2 failure mode).
+    name: Golden Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies (hoists installer toolchain)
+        run: npm ci
+
+      - name: Build discovery manifest (gitignored; cli-e2e reads it)
+        run: ./scripts-run src/scripts/build_discovery_manifest --write --quiet
+
+      - name: Build (dist/cli + UI bundle)
+        # The golden suite spawns `./agent-config` → dist/cli/agent-config.js.
+        run: npm run build --silent
+
+      - name: Vitest (tests/golden — fork-parallel)
+        run: npm run test:ts --silent -- tests/golden
 
   # NOTE: windows-lockfile-export moved to
   # .github/workflows/windows-lockfile-export.yml in

--- a/agents/evidence/py2ts-test-layer-audit.md
+++ b/agents/evidence/py2ts-test-layer-audit.md
@@ -61,3 +61,37 @@ python-skip guards), then D3 (retire the shim + the 3 scaffolding workflows,
 soak ≥24h). Ship as small tests-only PRs per D4 (never touch
 `agents/roadmaps-progress.md`; macOS + Linux matrix for snapshot-generating
 tests).
+
+## Test-layer speed — final timing note (2026-07-06, `road-to-fast-test-layer`)
+
+The py2ts teardown replaced ~133 python-parity spawns with `tsx`-subprocess
+rigs (one `spawnSync(tsx, [script])` per assertion, ~350 ms cold-start each),
+pushing the CI Vitest step to **474 s (7m54s)** on ubuntu. Two levers fixed it:
+
+1. **In-process runner** (`tests/_lib/run_in_process.ts`) — `runInProc(main, argv)`
+   calls the script's exported `main()` directly (captures stdout/stderr,
+   mocks `process.exit`, handles the `ArgparseExit` shapes). Migrated the
+   `cmd_*` cluster, the measure/audit/lint/probe rigs, `chat_history`
+   (28→1 spawn), `cli_python/{knowledge_ingest,workspace_drive}`, the
+   `knowledge_global*` cluster, and `replay_hook`. Skipped: scripts with a
+   module-level `os.homedir()` constant (`cmd_update`, `cmd_settings_migrate`,
+   `workspace_crypto`) and fixture-copy `check_*` rigs (REPO_ROOT baked from
+   `import.meta.url`) — these stay on subprocess.
+2. **CI job topology** — CI runners are core-saturated, so single-runner wall
+   clock is total-CPU-work ÷ cores; file-level sharding inside one runner
+   barely moved it (474→447 s). Split instead:
+   - `node-tests`: `--shard=N/4` × 2 OS, **excluding** the two subprocess-heavy
+     clusters (they hash-clump into one over-budget shard regardless of shard
+     count — a 4-shard run left one bucket at 167 s).
+   - `golden-tests`: dedicated job, 6 fork-parallel `golden_replay*` files.
+   - `workspace-tests`: dedicated job (`server/workspace` + `cli/python/**`).
+     Kept **separate** from golden — combining both oversubscribed the fork
+     pool and produced flaky spawn-timeouts.
+   - `static-checks`: ESLint + tsc + prepack once (ubuntu-only, OS-independent),
+     off the per-shard critical path.
+
+**Result** (run 28769860524, all green): slowest **Vitest step 95 s (1.6 min)**
+— every test run back under 2 min (from 7m54s). Slowest **total job 137 s**
+(macos node-tests shard 1) is npm-ci + build overhead, not test code; sharding
+multiplies that fixed per-job cost, so it is the practical floor. Only required
+check `Sync + Generate Tools Consistency` is unaffected by the renamed jobs.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,41 +2,28 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 5 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/)
+> 4 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/)
 
 ## Overall
 
-**97 / 145 steps done · 67%**
+**85 / 130 steps done · 65%**
 
 ```text
-███████████████████████████░░░░░░░░░░░░░   67%
+██████████████████████████░░░░░░░░░░░░░░   65%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md) | 5 | 16 | 3 | 12 | 1 | 0 | ████████░░ 80% |
-| 2 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 3 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
-| 5 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
+| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
+| 2 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 3 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
+| 4 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
 
 ## Per-roadmap phase breakdown
-
-### [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md)
-
-**Road to a Fast Test Layer** — 12 / 15 done (80%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | Harness + pilot | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 2 | cmd_* cluster (highest spawn count) | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 3 | check_* / lint_* / audit_* / measure_* cluster | ✅ done | 0 | 2 | 1 | 0 | 100% |
-| 4 | Heavy multi-case suites | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 5 | Measure + document | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,17 +6,17 @@
 
 ## Overall
 
-**94 / 145 steps done · 65%**
+**97 / 145 steps done · 67%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   65%
+███████████████████████████░░░░░░░░░░░░░   67%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md) | 5 | 16 | 6 | 9 | 1 | 0 | ██████░░░░ 60% |
+| 1 | [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md) | 5 | 16 | 3 | 12 | 1 | 0 | ████████░░ 80% |
 | 2 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
 | 3 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
@@ -28,14 +28,14 @@
 
 ### [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md)
 
-**Road to a Fast Test Layer** — 9 / 15 done (60%)
+**Road to a Fast Test Layer** — 12 / 15 done (80%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Harness + pilot | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 2 | cmd_* cluster (highest spawn count) | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 3 | check_* / lint_* / audit_* / measure_* cluster | ✅ done | 0 | 2 | 1 | 0 | 100% |
-| 4 | Heavy multi-case suites | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 4 | Heavy multi-case suites | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 5 | Measure + document | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,17 +6,17 @@
 
 ## Overall
 
-**92 / 146 steps done · 63%**
+**94 / 145 steps done · 65%**
 
 ```text
-█████████████████████████░░░░░░░░░░░░░░░   63%
+██████████████████████████░░░░░░░░░░░░░░   65%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md) | 5 | 16 | 9 | 7 | 0 | 0 | ████░░░░░░ 44% |
+| 1 | [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md) | 5 | 16 | 6 | 9 | 1 | 0 | ██████░░░░ 60% |
 | 2 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
 | 3 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
@@ -28,13 +28,13 @@
 
 ### [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md)
 
-**Road to a Fast Test Layer** — 7 / 16 done (44%)
+**Road to a Fast Test Layer** — 9 / 15 done (60%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Harness + pilot | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 2 | cmd_* cluster (highest spawn count) | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 3 | check_* / lint_* / audit_* / measure_* cluster | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | check_* / lint_* / audit_* / measure_* cluster | ✅ done | 0 | 2 | 1 | 0 | 100% |
 | 4 | Heavy multi-case suites | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 5 | Measure + document | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,28 +2,41 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 4 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/)
+> 5 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/)
 
 ## Overall
 
-**85 / 130 steps done · 65%**
+**92 / 146 steps done · 63%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   65%
+█████████████████████████░░░░░░░░░░░░░░░   63%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
-| 2 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 3 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
-| 4 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
+| 1 | [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md) | 5 | 16 | 9 | 7 | 0 | 0 | ████░░░░░░ 44% |
+| 2 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 13 | 8 | 0 | 0 | ████░░░░░░ 38% |
+| 3 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | ██████░░░░ 64% |
+| 5 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 11 | 56 | 0 | 0 | ████████░░ 84% |
 
 ---
 
 ## Per-roadmap phase breakdown
+
+### [road-to-fast-test-layer.md](roadmaps/road-to-fast-test-layer.md)
+
+**Road to a Fast Test Layer** — 7 / 16 done (44%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Harness + pilot | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 2 | cmd_* cluster (highest spawn count) | ✅ done | 0 | 3 | 0 | 0 | 100% |
+| 3 | check_* / lint_* / audit_* / measure_* cluster | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 4 | Heavy multi-case suites | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 5 | Measure + document | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 

--- a/agents/roadmaps/archive/road-to-fast-test-layer.md
+++ b/agents/roadmaps/archive/road-to-fast-test-layer.md
@@ -25,7 +25,7 @@ Fix: run twins **in-process** (`main(argv)` import, stdout/exit capture).
 
 ## Phase 3 — check_* / lint_* / audit_* / measure_* cluster
 
-- [~] Migrate `check_condensation`, `check_no_conflict_markers`, `check_no_external_sources`, `check_structural_breaking`, `check_surface_tiers`, `check_trigger_evals`, `check_council_config_location`.
+- [-] Migrate `check_condensation`, `check_no_conflict_markers`, `check_no_external_sources`, `check_structural_breaking`, `check_surface_tiers`, `check_trigger_evals`, `check_council_config_location`.
 - [x] Migrate remaining measure/audit/lint rigs: `audit_likelihood`, `audit_overlap`, `measure_markitdown_lift`, `measure_projection_bytes`, `measure_patterns`, `measure_skill_reduction`, `probe_projection_fidelity`, `lint_empty_roadmaps`, `lint_marketplace`, `lint_showcase_sessions`, `lint_skill_originality`, `lint_pack_dependencies`.
 - [x] Migrate remaining one-off rigs: `apply_modules_config`, `cross_repo_retrieve`, `validate_discovery_manifest`, `validate_pack_yaml`, `inventory_frontmatter`, `check_discovery_determinism`, `plan_physical_move`, `migrate_frontmatter_defaults`, `skills_design_tokens_tokens`, `score_skill_selection`.
 
@@ -37,6 +37,6 @@ Fix: run twins **in-process** (`main(argv)` import, stdout/exit capture).
 
 ## Phase 5 — Measure + document
 
-- [ ] Confirm Node Tests ≤ 2 min on both OSes (local `time npx vitest run` over the changed files).
-- [ ] Update `agents/evidence/py2ts-test-layer-audit.md` with final timing note.
-- [ ] Open PR + merge.
+- [x] Confirm Node Tests ≤ 2 min on both OSes (local `time npx vitest run` over the changed files).
+- [x] Update `agents/evidence/py2ts-test-layer-audit.md` with final timing note.
+- [x] Open PR + merge.

--- a/agents/roadmaps/road-to-fast-test-layer.md
+++ b/agents/roadmaps/road-to-fast-test-layer.md
@@ -25,9 +25,9 @@ Fix: run twins **in-process** (`main(argv)` import, stdout/exit capture).
 
 ## Phase 3 — check_* / lint_* / audit_* / measure_* cluster
 
-- [ ] Migrate `check_condensation`, `check_no_conflict_markers`, `check_no_external_sources`, `check_structural_breaking`, `check_surface_tiers`, `check_trigger_evals`, `check_council_config_location`.
-- [ ] Migrate remaining measure/audit/lint rigs: `audit_likelihood`, `audit_overlap`, `measure_markitdown_lift`, `measure_projection_bytes`, `measure_patterns`, `measure_skill_reduction`, `probe_projection_fidelity`, `lint_empty_roadmaps`, `lint_marketplace`, `lint_showcase_sessions`, `lint_skill_originality`, `lint_pack_dependencies`.
-- [ ] Migrate remaining one-off rigs: `apply_modules_config`, `cross_repo_retrieve`, `validate_discovery_manifest`, `validate_pack_yaml`, `inventory_frontmatter`, `check_discovery_determinism`, `plan_physical_move`, `migrate_frontmatter_defaults`, `skills_design_tokens_tokens`, `score_skill_selection`.
+- [~] Migrate `check_condensation`, `check_no_conflict_markers`, `check_no_external_sources`, `check_structural_breaking`, `check_surface_tiers`, `check_trigger_evals`, `check_council_config_location`.
+- [x] Migrate remaining measure/audit/lint rigs: `audit_likelihood`, `audit_overlap`, `measure_markitdown_lift`, `measure_projection_bytes`, `measure_patterns`, `measure_skill_reduction`, `probe_projection_fidelity`, `lint_empty_roadmaps`, `lint_marketplace`, `lint_showcase_sessions`, `lint_skill_originality`, `lint_pack_dependencies`.
+- [x] Migrate remaining one-off rigs: `apply_modules_config`, `cross_repo_retrieve`, `validate_discovery_manifest`, `validate_pack_yaml`, `inventory_frontmatter`, `check_discovery_determinism`, `plan_physical_move`, `migrate_frontmatter_defaults`, `skills_design_tokens_tokens`, `score_skill_selection`.
 
 ## Phase 4 — Heavy multi-case suites
 

--- a/agents/roadmaps/road-to-fast-test-layer.md
+++ b/agents/roadmaps/road-to-fast-test-layer.md
@@ -31,9 +31,9 @@ Fix: run twins **in-process** (`main(argv)` import, stdout/exit capture).
 
 ## Phase 4 — Heavy multi-case suites
 
-- [ ] Migrate `chat_history` (28 spawn sites) — replace `runTs` helper with `runInProc(main, args, { env: { AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' } })`.
-- [ ] Migrate `cli_python/knowledge_ingest` (23) and `cli_python/workspace_drive` (24).
-- [ ] Migrate `knowledge_global_cli`, `_lib_knowledge_global_promote`, `_lib_knowledge_global`, `_lib_knowledge_global_redaction`, `injection_scan_hook`, `pack_mcp_content`, `validate_frontmatter`.
+- [x] Migrate `chat_history` (28 spawn sites) — replace `runTs` helper with `runInProc(main, args, { env: { AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' } })` (stdin-only fallback kept).`.
+- [x] Migrate `cli_python/knowledge_ingest` (23) and `cli_python/workspace_drive` (24).
+- [x] Migrate `knowledge_global_cli`, `_lib_knowledge_global_promote`, `_lib_knowledge_global`, `_lib_knowledge_global_redaction`, `injection_scan_hook`, `pack_mcp_content`, `validate_frontmatter`.
 
 ## Phase 5 — Measure + document
 

--- a/agents/roadmaps/road-to-fast-test-layer.md
+++ b/agents/roadmaps/road-to-fast-test-layer.md
@@ -1,74 +1,42 @@
 ---
-status: draft
+status: ready
 title: Road to a Fast Test Layer (in-process CLI rigs)
 owner: matze4u
 ---
 
 # Road to a Fast Test Layer
 
-> **Draft** — hidden from the dashboard until flipped to `ready`.
-
-## Problem
-
-The py2ts migration replaced the deleted Python originals with TypeScript
-twins and, in doing so, added ~90 CLI-contract test rigs that exercise each
-twin by **spawning `tsx <script>` as a subprocess**. `tsx` cold-start is
-~300–500 ms per invocation; across thousands of invocations the `Node Tests`
-job now runs **~8–11 min** (ubuntu ~10:54), where the pre-migration suite ran
-in **1–2 min**.
-
-Two aggravating factors were already addressed on `test/depythonize-remaining-parity-rigs`:
-
-- The rigs used to be `describe.runIf(hasPython3())` / `skipIf(!py3)` — **skipped**
-  in the python-free CI (0 s). Depythonizing them un-gated them, so they now run.
-- Determinism checks re-ran the twin a second time (2× spawns). **Done:**
-  collapsed to a single spawn per case (biggest lever: the `cmd_doctor`
-  `expectStable` helper, ~26 call sites).
-
-The remaining cost is the **one** `tsx` cold-start per assertion, across the
-whole migrated rig layer — the structural fix below.
-
-## Goal
-
-Restore the `Node Tests` job to ~1–2 min by running the twins **in-process**
-(import the exported `main(argv)` / functions, capture stdout/stderr/exit)
-instead of spawning `tsx` per assertion.
-
-## Why in-process is safe here
-
-- Most twins export `export function main(argv): number` and set
-  `process.exitCode` (never `process.exit()`) — directly callable.
-- Vitest runs each **file** in its own fork (`pool: forks`) and tests **within**
-  a file sequentially, so a `chdir` + restore (or an injected `cwd`) and
-  `process.env` swap in `beforeEach`/`afterEach` do **not** race.
-- A shared harness centralises the stdout/stderr capture + exit handling.
+PR #741 (py2ts depythonize) added 133 `spawnSync(TSX_BIN, …)` spawn sites.
+`tsx` cold-start ~350 ms each → Node Tests ~10–11 min (was 1–2 min).
+Fix: run twins **in-process** (`main(argv)` import, stdout/exit capture).
 
 ## Phase 1 — Harness + pilot
 
-- [ ] Build `tests/_lib/run_in_process.ts`: `runInProc(main, argv, { cwd, env }) → { status, stdout, stderr }` — capture `process.stdout/stderr.write`, snapshot+restore `process.exitCode`, `chdir`+restore, `process.env` overlay+restore.
-- [ ] Handle the argparse-error path (some `main`s throw a usage error → map to exit 2) without leaking to the runner.
-- [ ] Pilot on one small rig (e.g. `lint_agent_security` or `measure_density`); confirm identical assertions pass and the file's wall-time drops sharply.
-- [ ] Decide the fallback for `process.exit()`-using scripts (e.g. `check_condensation`): either refactor the script to return a code from `main`, or keep those few on subprocess.
+- [ ] Write `tests/_lib/run_in_process.ts`: `runInProc(mainFn, argv, opts)` — intercept `process.stdout/stderr.write`, overlay `process.env`, save/restore `process.exitCode` + `cwd`, catch `ProcessExit` for `process.exit()` scripts.
+- [ ] Pilot: migrate `tests/scripts/measure_density.test.ts` to in-process and confirm the wall-time drops (run twice, check ~1 ms vs ~350 ms).
+- [ ] Pilot: migrate `tests/scripts/lint_agent_security.test.ts` to in-process.
+- [ ] Pilot: migrate `tests/scripts/inventory_meta_layers.test.ts` to in-process.
 
-## Phase 2 — Migrate the cmd_* + check_* + lint_* clusters
+## Phase 2 — cmd_* cluster (highest spawn count)
 
-- [ ] Replace `spawnSync(tsx, [script, ...args])` with `runInProc(main, args, …)` across the `cmd_*` CLI cluster (biggest count).
-- [ ] Migrate the `check_*` / `lint_*` / `audit_*` / `measure_*` rigs.
-- [ ] Keep the fixture setup (temp trees, git-init, snapshot/restore) untouched; only the invocation changes.
+- [ ] Migrate `cmd_doctor` — 56 `runTs` calls via `expectStable`, each now in-process.
+- [ ] Migrate `cmd_export`, `cmd_migrate`, `cmd_sync`, `cmd_update`, `cmd_uninstall`.
+- [ ] Migrate `cmd_explain`, `cmd_prune`, `cmd_refresh`, `cmd_settings_check`, `cmd_settings_migrate`, `cmd_validate`, `cmd_versions`, `cmd_upgrade`.
 
-## Phase 3 — Migrate the heavy multi-case suites
+## Phase 3 — check_* / lint_* / audit_* / measure_* cluster
 
-- [ ] `chat_history` (28 spawn sites), `cli_python/*` (23–24), `knowledge_global*` (8–25) — the highest per-file spawn counts.
-- [ ] These already import the module for their in-process "Layer 2" blocks; converge the CLI blocks onto the same in-process path.
+- [ ] Migrate `check_condensation`, `check_no_conflict_markers`, `check_no_external_sources`, `check_structural_breaking`, `check_surface_tiers`, `check_trigger_evals`, `check_council_config_location`.
+- [ ] Migrate remaining measure/audit/lint rigs: `audit_likelihood`, `audit_overlap`, `measure_markitdown_lift`, `measure_projection_bytes`, `measure_patterns`, `measure_skill_reduction`, `probe_projection_fidelity`, `lint_empty_roadmaps`, `lint_marketplace`, `lint_showcase_sessions`, `lint_skill_originality`, `lint_pack_dependencies`.
+- [ ] Migrate remaining one-off rigs: `apply_modules_config`, `cross_repo_retrieve`, `validate_discovery_manifest`, `validate_pack_yaml`, `inventory_frontmatter`, `check_discovery_determinism`, `plan_physical_move`, `migrate_frontmatter_defaults`, `skills_design_tokens_tokens`, `score_skill_selection`.
 
-## Phase 4 — Measure + guard
+## Phase 4 — Heavy multi-case suites
 
-- [ ] Confirm `Node Tests` wall-time is back to ~1–2 min on both OSes.
-- [ ] Add a lightweight guard/budget (e.g. fail if the job exceeds N min) so the regression cannot silently return.
-- [ ] Decide whether the `hasPython3`-gated helper tier (`_bench_wave8d`, `_mcp_server`, `parity_oracle` capture-mode) needs the same treatment or stays as-is (already dormant under the shim).
+- [ ] Migrate `chat_history` (28 spawn sites) — replace `runTs` helper with `runInProc(main, args, { env: { AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' } })`.
+- [ ] Migrate `cli_python/knowledge_ingest` (23) and `cli_python/workspace_drive` (24).
+- [ ] Migrate `knowledge_global_cli`, `_lib_knowledge_global_promote`, `_lib_knowledge_global`, `_lib_knowledge_global_redaction`, `injection_scan_hook`, `pack_mcp_content`, `validate_frontmatter`.
 
-## Non-goals
+## Phase 5 — Measure + document
 
-- Re-introducing Python. The twin is the source of truth.
-- Changing what the rigs assert (exit codes, written artefacts, JSON shape) —
-  only *how* the twin is invoked.
+- [ ] Confirm Node Tests ≤ 2 min on both OSes (local `time npx vitest run` over the changed files).
+- [ ] Update `agents/evidence/py2ts-test-layer-audit.md` with final timing note.
+- [ ] Open PR + merge.

--- a/agents/roadmaps/road-to-fast-test-layer.md
+++ b/agents/roadmaps/road-to-fast-test-layer.md
@@ -12,16 +12,16 @@ Fix: run twins **in-process** (`main(argv)` import, stdout/exit capture).
 
 ## Phase 1 — Harness + pilot
 
-- [ ] Write `tests/_lib/run_in_process.ts`: `runInProc(mainFn, argv, opts)` — intercept `process.stdout/stderr.write`, overlay `process.env`, save/restore `process.exitCode` + `cwd`, catch `ProcessExit` for `process.exit()` scripts.
-- [ ] Pilot: migrate `tests/scripts/measure_density.test.ts` to in-process and confirm the wall-time drops (run twice, check ~1 ms vs ~350 ms).
-- [ ] Pilot: migrate `tests/scripts/lint_agent_security.test.ts` to in-process.
-- [ ] Pilot: migrate `tests/scripts/inventory_meta_layers.test.ts` to in-process.
+- [x] Write `tests/_lib/run_in_process.ts`: `runInProc(mainFn, argv, opts)` — intercept `process.stdout/stderr.write`, overlay `process.env`, save/restore `process.exitCode` + `cwd`, catch `ProcessExit` for `process.exit()` scripts.
+- [x] Pilot: migrate `tests/scripts/measure_density.test.ts` to in-process and confirm the wall-time drops (run twice, check ~1 ms vs ~350 ms).
+- [x] Pilot: migrate `tests/scripts/lint_agent_security.test.ts` to in-process.
+- [x] Pilot: migrate `tests/scripts/inventory_meta_layers.test.ts` to in-process.
 
 ## Phase 2 — cmd_* cluster (highest spawn count)
 
-- [ ] Migrate `cmd_doctor` — 56 `runTs` calls via `expectStable`, each now in-process.
-- [ ] Migrate `cmd_export`, `cmd_migrate`, `cmd_sync`, `cmd_update`, `cmd_uninstall`.
-- [ ] Migrate `cmd_explain`, `cmd_prune`, `cmd_refresh`, `cmd_settings_check`, `cmd_settings_migrate`, `cmd_validate`, `cmd_versions`, `cmd_upgrade`.
+- [x] Migrate `cmd_doctor` — 56 `runTs` calls via `expectStable`, each now in-process.
+- [x] Migrate `cmd_export`, `cmd_migrate`, `cmd_sync`, `cmd_update`, `cmd_uninstall`.
+- [x] Migrate `cmd_explain`, `cmd_prune`, `cmd_refresh`, `cmd_settings_check`, `cmd_settings_migrate`, `cmd_validate`, `cmd_versions`, `cmd_upgrade`.
 
 ## Phase 3 — check_* / lint_* / audit_* / measure_* cluster
 

--- a/tests/_lib/run_in_process.ts
+++ b/tests/_lib/run_in_process.ts
@@ -146,7 +146,7 @@ function _extractExitCode(message: string): number {
  * a mocked process.exit(). Returns a RunResult compatible with the
  * shape returned by spawnSync.
  */
-export function runInProc(mainFn: MainFn, argv: string[] = [], opts: RunOpts = {}): RunResult {
+export function runInProc(mainFn: MainFn, argv: string[] | readonly string[] = [], opts: RunOpts = {}): RunResult {
     // --- capture stdout / stderr ---
     let stdout = '';
     let stderr = '';

--- a/tests/_lib/run_in_process.ts
+++ b/tests/_lib/run_in_process.ts
@@ -90,6 +90,9 @@ export async function runInProcAsync(
             status = (e as any).code ?? _extractExitCode(e.message);
         } else if (process.exitCode !== undefined && process.exitCode !== null) {
             status = process.exitCode as number;
+        } else if (e instanceof Error) {
+            stderrBuf.push(e.message + '\n');
+            status = 1;
         } else {
             throw e;
         }
@@ -216,6 +219,11 @@ export function runInProc(mainFn: MainFn, argv: string[] = [], opts: RunOpts = {
             // Script set process.exitCode then threw a non-ProcessExit error
             // (e.g. the `process.exitCode = 2; throw new ArgExit()` pattern).
             status = process.exitCode as number;
+        } else if (e instanceof Error) {
+            // Uncaught error from main() (e.g. FileNotFoundError replica).
+            // Mirror what the CLI entry guard does: set exit 1 and emit to stderr.
+            stderrBuf.push(e.message + '\n');
+            status = 1;
         } else {
             throw e;
         }

--- a/tests/_lib/run_in_process.ts
+++ b/tests/_lib/run_in_process.ts
@@ -1,0 +1,251 @@
+/**
+ * In-process runner for TypeScript CLI twins.
+ *
+ * Replaces `spawnSync(tsx, [script, ...argv])` with a direct call to the
+ * script's exported `main(argv)` function, eliminating ~350 ms of tsx
+ * cold-start per invocation.
+ *
+ * Safety: vitest runs each test FILE in its own fork and tests within a file
+ * sequentially, so the save/restore of process globals does not race.
+ *
+ * Supported call styles:
+ *   - `main(argv)` returns a number → use it as the exit code.
+ *   - `main(argv)` sets `process.exitCode` → read it after the call.
+ *   - `process.exit(N)` inside main → caught as ProcessExit, returns N.
+ *
+ * Known limitation: module-level state in the imported script is shared
+ * across calls (constants are fine; mutable module-level vars are not).
+ * In practice all migrated scripts are stateless at module level.
+ */
+
+export interface RunResult {
+    status: number;
+    stdout: string;
+    stderr: string;
+}
+
+export interface RunOpts {
+    /** Override process.cwd() for the duration of the call. */
+    cwd?: string;
+    /** Overlay process.env keys for the duration of the call. */
+    env?: Record<string, string>;
+}
+
+/** Thrown by the mocked process.exit() to unwind the call stack. */
+export class ProcessExit extends Error {
+    constructor(public readonly code: number) {
+        super(`ProcessExit(${code})`);
+    }
+}
+
+/** Async variant for scripts whose main() returns a Promise. */
+export async function runInProcAsync(
+    mainFn: (argv: any) => Promise<number | void>,
+    argv: string[] = [],
+    opts: RunOpts = {},
+): Promise<RunResult> {
+    const stdoutBuf: string[] = [];
+    const stderrBuf: string[] = [];
+
+    const origStdoutWrite = process.stdout.write.bind(process.stdout);
+    const origStderrWrite = process.stderr.write.bind(process.stderr);
+    process.stdout.write = (s: string | Uint8Array, ...rest: any[]) => {
+        stdoutBuf.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+        return true;
+    };
+    process.stderr.write = (s: string | Uint8Array, ...rest: any[]) => {
+        stderrBuf.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+        return true;
+    };
+
+    const origExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    const origExit = process.exit.bind(process);
+    process.exit = (code?: number) => { throw new ProcessExit(code ?? 0); };
+
+    const origCwd = process.cwd();
+    if (opts.cwd) { try { process.chdir(opts.cwd); } catch {} }
+
+    const savedEnv: Record<string, string | undefined> = {};
+    if (opts.env) {
+        for (const [k, v] of Object.entries(opts.env)) {
+            savedEnv[k] = process.env[k];
+            process.env[k] = v;
+        }
+    }
+
+    let status = 0;
+    try {
+        const result = await mainFn(argv);
+        if (typeof result === 'number') {
+            status = result;
+        } else if (process.exitCode !== undefined && process.exitCode !== null) {
+            status = process.exitCode as number;
+        }
+    } catch (e) {
+        if (e instanceof ProcessExit) {
+            status = e.code;
+        } else if (e instanceof Error && _isArgparseExit(e)) {
+            status = (e as any).code ?? _extractExitCode(e.message);
+        } else if (process.exitCode !== undefined && process.exitCode !== null) {
+            status = process.exitCode as number;
+        } else {
+            throw e;
+        }
+    } finally {
+        process.stdout.write = origStdoutWrite;
+        process.stderr.write = origStderrWrite;
+        process.exitCode = origExitCode;
+        process.exit = origExit;
+        if (opts.cwd) { try { process.chdir(origCwd); } catch {} }
+        if (opts.env) {
+            for (const [k] of Object.entries(opts.env)) {
+                if (savedEnv[k] === undefined) delete process.env[k];
+                else process.env[k] = savedEnv[k] as string;
+            }
+        }
+    }
+
+    return { status, stdout: stdoutBuf.join(''), stderr: stderrBuf.join('') };
+}
+
+// Some scripts declare main(argv: string[]) (non-nullable); accept both forms.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MainFn = (argv: any) => number | void | Promise<number | void>;
+
+/** Detect the argparse "ArgparseExit" sentinel thrown by CLI scripts.
+ *  Two shapes exist in the codebase:
+ *  - `name === 'ArgparseExit'` + `.code` property (cmd_settings_check, etc.)
+ *  - message `argparse-exit-<N>` (cmd_doctor, etc.)
+ */
+function _isArgparseExit(e: Error): boolean {
+    return (
+        (e as any).name === 'ArgparseExit' ||
+        /^argparse-exit-\d+$/.test(e.message) ||
+        /^ArgparseExit\(\d+\)$/.test(e.message)
+    );
+}
+
+function _extractExitCode(message: string): number {
+    const m = message.match(/\d+/);
+    return m ? parseInt(m[0], 10) : 2;
+}
+
+/**
+ * Call `mainFn(argv)` in-process with captured stdout/stderr and
+ * a mocked process.exit(). Returns a RunResult compatible with the
+ * shape returned by spawnSync.
+ */
+export function runInProc(mainFn: MainFn, argv: string[] = [], opts: RunOpts = {}): RunResult {
+    // --- capture stdout / stderr ---
+    let stdout = '';
+    let stderr = '';
+
+    const origStdoutWrite = process.stdout.write.bind(process.stdout);
+    const origStderrWrite = process.stderr.write.bind(process.stderr);
+
+    const captureWrite =
+        (buf: string[]) =>
+        (s: string | Uint8Array, encodingOrCb?: string | ((err?: Error | null) => void)) => {
+            buf.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+            return true;
+        };
+
+    (process.stdout as NodeJS.WritableStream).write = captureWrite([stdout]) as any;
+    // Re-assign to closures that append to the same buf
+    const stdoutBuf: string[] = [];
+    const stderrBuf: string[] = [];
+    process.stdout.write = (s: string | Uint8Array, ...rest: any[]) => {
+        stdoutBuf.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+        return true;
+    };
+    process.stderr.write = (s: string | Uint8Array, ...rest: any[]) => {
+        stderrBuf.push(typeof s === 'string' ? s : Buffer.from(s).toString('utf8'));
+        return true;
+    };
+
+    // --- save / restore process.exitCode ---
+    const origExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    // --- mock process.exit ---
+    const origExit = process.exit.bind(process);
+    process.exit = (code?: number) => {
+        throw new ProcessExit(code ?? 0);
+    };
+
+    // --- save / restore cwd ---
+    const origCwd = process.cwd();
+    if (opts.cwd) {
+        try {
+            process.chdir(opts.cwd);
+        } catch {
+            /* ignore chdir failures on non-existent dirs */
+        }
+    }
+
+    // --- overlay env ---
+    const savedEnv: Record<string, string | undefined> = {};
+    if (opts.env) {
+        for (const [k, v] of Object.entries(opts.env)) {
+            savedEnv[k] = process.env[k];
+            process.env[k] = v;
+        }
+    }
+
+    let status = 0;
+    try {
+        // Pass an array (never null) so scripts that declare main(argv: string[])
+        // without a null check still work. Scripts that accept string[] | null
+        // will receive [] which they treat the same as reading process.argv.
+        const result = mainFn(argv);
+        if (typeof result === 'number') {
+            status = result;
+        } else if (process.exitCode !== undefined && process.exitCode !== null) {
+            status = process.exitCode as number;
+        }
+    } catch (e) {
+        if (e instanceof ProcessExit) {
+            status = e.code;
+        } else if (e instanceof Error && _isArgparseExit(e)) {
+            // The TypeScript argparse library throws ArgparseExit(code) for
+            // usage errors (code=2) and --help (code=0). Treat it like process.exit.
+            status = (e as any).code ?? _extractExitCode(e.message);
+        } else if (process.exitCode !== undefined && process.exitCode !== null) {
+            // Script set process.exitCode then threw a non-ProcessExit error
+            // (e.g. the `process.exitCode = 2; throw new ArgExit()` pattern).
+            status = process.exitCode as number;
+        } else {
+            throw e;
+        }
+    } finally {
+        // Restore everything — must run even on unexpected throws
+        process.stdout.write = origStdoutWrite;
+        process.stderr.write = origStderrWrite;
+        process.exitCode = origExitCode;
+        process.exit = origExit;
+        if (opts.cwd) {
+            try {
+                process.chdir(origCwd);
+            } catch {
+                /* ignore */
+            }
+        }
+        if (opts.env) {
+            for (const [k] of Object.entries(opts.env)) {
+                if (savedEnv[k] === undefined) {
+                    delete process.env[k];
+                } else {
+                    process.env[k] = savedEnv[k] as string;
+                }
+            }
+        }
+    }
+
+    return {
+        status,
+        stdout: stdoutBuf.join(''),
+        stderr: stderrBuf.join(''),
+    };
+}

--- a/tests/_lib/run_in_process.ts
+++ b/tests/_lib/run_in_process.ts
@@ -28,7 +28,7 @@ export interface RunOpts {
     /** Override process.cwd() for the duration of the call. */
     cwd?: string;
     /** Overlay process.env keys for the duration of the call. */
-    env?: Record<string, string>;
+    env?: Record<string, string | undefined>;
     /**
      * Data to make available when the script reads from stdin (fd 0).
      * Implemented by temporarily writing to a temp file and swapping fd 0.

--- a/tests/_lib/run_in_process.ts
+++ b/tests/_lib/run_in_process.ts
@@ -29,6 +29,12 @@ export interface RunOpts {
     cwd?: string;
     /** Overlay process.env keys for the duration of the call. */
     env?: Record<string, string>;
+    /**
+     * Data to make available when the script reads from stdin (fd 0).
+     * Implemented by temporarily writing to a temp file and swapping fd 0.
+     * Only supports UTF-8 string input.
+     */
+    stdin?: string;
 }
 
 /** Thrown by the mocked process.exit() to unwind the call stack. */

--- a/tests/golden/golden_replay.shard1.test.ts
+++ b/tests/golden/golden_replay.shard1.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Golden Transcript replay — shard 1 of SHARD_COUNT.
+ * See `./golden_replay.test.ts` + `./replay_shard.ts` for the shard design.
+ */
+import { defineReplayShard, SHARD_COUNT } from './replay_shard.js';
+
+defineReplayShard(1, SHARD_COUNT);

--- a/tests/golden/golden_replay.shard2.test.ts
+++ b/tests/golden/golden_replay.shard2.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Golden Transcript replay — shard 2 of SHARD_COUNT.
+ * See `./golden_replay.test.ts` + `./replay_shard.ts` for the shard design.
+ */
+import { defineReplayShard, SHARD_COUNT } from './replay_shard.js';
+
+defineReplayShard(2, SHARD_COUNT);

--- a/tests/golden/golden_replay.shard3.test.ts
+++ b/tests/golden/golden_replay.shard3.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Golden Transcript replay — shard 3 of SHARD_COUNT.
+ * See `./golden_replay.test.ts` + `./replay_shard.ts` for the shard design.
+ */
+import { defineReplayShard, SHARD_COUNT } from './replay_shard.js';
+
+defineReplayShard(3, SHARD_COUNT);

--- a/tests/golden/golden_replay.shard4.test.ts
+++ b/tests/golden/golden_replay.shard4.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Golden Transcript replay — shard 4 of SHARD_COUNT.
+ * See `./golden_replay.test.ts` + `./replay_shard.ts` for the shard design.
+ */
+import { defineReplayShard, SHARD_COUNT } from './replay_shard.js';
+
+defineReplayShard(4, SHARD_COUNT);

--- a/tests/golden/golden_replay.shard5.test.ts
+++ b/tests/golden/golden_replay.shard5.test.ts
@@ -1,0 +1,7 @@
+/**
+ * Golden Transcript replay — shard 5 of SHARD_COUNT.
+ * See `./golden_replay.test.ts` + `./replay_shard.ts` for the shard design.
+ */
+import { defineReplayShard, SHARD_COUNT } from './replay_shard.js';
+
+defineReplayShard(5, SHARD_COUNT);

--- a/tests/golden/golden_replay.test.ts
+++ b/tests/golden/golden_replay.test.ts
@@ -1,35 +1,14 @@
 /**
- * Vitest entry for the Golden Transcript replay harness (TS twin of the retired
- * `test_replay.py`). Replays each captured GT scenario against the live `.ts`
- * work_engine and asserts no structural drift versus the locked baseline under
- * `tests/golden/baseline/`. The comparison logic lives in `./harness.ts`.
+ * Golden Transcript replay — shard 0 of SHARD_COUNT.
  *
- * Coverage: the full 29-scenario matrix runs by default (deterministic, no
- * coverage regression versus the python smoke+nightly split). Set
- * `GOLDEN_SMOKE=1` for the fast PR subset — one representative per recipe
- * family covering all four comparators (exit codes, state shape, halt markers,
- * delivery report) without paying the full subprocess-per-cycle cost.
+ * The 29-scenario matrix is sharded across `golden_replay.test.ts` +
+ * `golden_replay.shard{1..N}.test.ts` so vitest's fork pool runs them
+ * concurrently (each file = its own fork). This is the fast path that keeps
+ * the FULL matrix — no coverage cut. `GOLDEN_SMOKE=1` collapses to the
+ * 6-scenario representative subset on this shard only.
+ *
+ * Shard mechanics + the smoke subset live in `./replay_shard.ts`.
  */
-import { describe, it, expect } from 'vitest';
+import { defineReplayShard, SHARD_COUNT } from './replay_shard.js';
 
-import { allGtIds, replayAndCompare, diffStr } from './harness.js';
-
-// One representative per recipe family (R1 happy + ambiguity, prompt
-// high-confidence, UI build / greenfield-resume / preview-fail).
-const SMOKE_GT_IDS = new Set(['GT-1', 'GT-2', 'GT-P1', 'GT-U1', 'GT-U10', 'GT-U15']);
-
-const ALL = allGtIds();
-const TARGETS = process.env['GOLDEN_SMOKE'] ? ALL.filter((id) => SMOKE_GT_IDS.has(id)) : ALL;
-
-describe('golden transcript replay', () => {
-    // Each scenario spawns `./agent-config` once per cycle; bump the per-test
-    // timeout above the suite default to absorb the subprocess cost.
-    it.each(TARGETS)('%s replays without structural drift', (gt_id) => {
-        const { diffs } = replayAndCompare(gt_id);
-        if (diffs.length > 0) {
-            const rendered = diffs.map((d) => `  ${diffStr(d)}`).join('\n');
-            expect.fail(`${gt_id} drifted from locked baseline (${diffs.length} diff(s)):\n${rendered}`);
-        }
-        expect(diffs).toEqual([]);
-    }, 30_000);
-});
+defineReplayShard(0, SHARD_COUNT);

--- a/tests/golden/replay_shard.ts
+++ b/tests/golden/replay_shard.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared shard driver for the Golden Transcript replay matrix.
+ *
+ * The 29-scenario matrix runs serially inside a single test FILE (~76 s),
+ * because `replayAndCompare` is synchronous (`spawnSync` per cycle) and vitest
+ * runs the cases in one `it.each` sequentially. Vitest parallelises at the
+ * FILE level (fork pool), so splitting the matrix across N shard files lets the
+ * forks run concurrently — full coverage, no async-spawn refactor.
+ *
+ * Each shard file calls `defineReplayShard(shardIndex, shardCount)`; the
+ * scenario set is partitioned deterministically by `index % shardCount`.
+ * `GOLDEN_SMOKE=1` collapses every shard to the 6-scenario representative
+ * subset run once (only shard 0 carries them; other shards become empty and
+ * are skipped) so the fast PR path stays a single cheap fork.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { allGtIds, replayAndCompare, diffStr } from './harness.js';
+
+// One representative per recipe family (R1 happy + ambiguity, prompt
+// high-confidence, UI build / greenfield-resume / preview-fail).
+export const SMOKE_GT_IDS = new Set(['GT-1', 'GT-2', 'GT-P1', 'GT-U1', 'GT-U10', 'GT-U15']);
+
+/** Deterministic scenario partition for shard `shardIndex` of `shardCount`. */
+export function shardTargets(shardIndex: number, shardCount: number): string[] {
+    const all = allGtIds();
+    if (process.env['GOLDEN_SMOKE']) {
+        // Smoke: run the representative subset once, all on shard 0.
+        return shardIndex === 0 ? all.filter((id) => SMOKE_GT_IDS.has(id)) : [];
+    }
+    return all.filter((_id, i) => i % shardCount === shardIndex);
+}
+
+/** Define the vitest suite for one shard. */
+export function defineReplayShard(shardIndex: number, shardCount: number): void {
+    const targets = shardTargets(shardIndex, shardCount);
+    const label = `golden transcript replay — shard ${shardIndex + 1}/${shardCount}`;
+
+    describe(label, () => {
+        if (targets.length === 0) {
+            it.skip('no scenarios in this shard', () => {
+                /* empty shard (e.g. GOLDEN_SMOKE collapses to shard 0) */
+            });
+            return;
+        }
+        // Each scenario spawns `./agent-config` once per cycle; bump the
+        // per-test timeout above the suite default to absorb the subprocess cost.
+        it.each(targets)('%s replays without structural drift', (gt_id) => {
+            const { diffs } = replayAndCompare(gt_id);
+            if (diffs.length > 0) {
+                const rendered = diffs.map((d) => `  ${diffStr(d)}`).join('\n');
+                expect.fail(`${gt_id} drifted from locked baseline (${diffs.length} diff(s)):\n${rendered}`);
+            }
+            expect(diffs).toEqual([]);
+        }, 30_000);
+    });
+}
+
+/** How many shard files exist — keep in sync with the `golden_replay.shardN.test.ts` set. */
+export const SHARD_COUNT = 6;

--- a/tests/scripts/_cli/cmd_doctor.test.ts
+++ b/tests/scripts/_cli/cmd_doctor.test.ts
@@ -44,6 +44,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_doctor.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_doctor.ts');
@@ -63,12 +65,7 @@ interface RunResult {
 }
 
 function runTs(args: string[], cwd: string, extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env, ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd, env: extraEnv });
 }
 
 /**

--- a/tests/scripts/_cli/cmd_explain.test.ts
+++ b/tests/scripts/_cli/cmd_explain.test.ts
@@ -26,6 +26,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_explain.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_explain.ts');
@@ -44,12 +46,7 @@ interface RunResult {
 
 
 function runTs(args: string[], projectRoot: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-        env: { ...process.env, AGENT_CONFIG_PROJECT_ROOT: projectRoot },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: projectRoot });
 }
 
 /** Strip tmp roots (raw + realpath) and ISO timestamps so the diff is stable. */

--- a/tests/scripts/_cli/cmd_export.test.ts
+++ b/tests/scripts/_cli/cmd_export.test.ts
@@ -24,6 +24,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_export.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_export.ts');
@@ -43,12 +45,7 @@ interface RunResult {
 
 
 function runTs(args: string[], cwd: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd });
 }
 
 const roots: string[] = [];

--- a/tests/scripts/_cli/cmd_migrate.test.ts
+++ b/tests/scripts/_cli/cmd_migrate.test.ts
@@ -26,6 +26,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_migrate.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_migrate.ts');
@@ -49,12 +51,7 @@ function rootEnv(root: string): Record<string, string> {
 
 
 function runTs(args: string[], root: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, ...rootEnv(root) },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: root });
 }
 
 /** Strip both the raw and realpath forms of every dynamic root. */

--- a/tests/scripts/_cli/cmd_prune.test.ts
+++ b/tests/scripts/_cli/cmd_prune.test.ts
@@ -31,6 +31,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_prune.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_prune.ts');
@@ -54,12 +56,7 @@ function rootEnv(root: string): Record<string, string> {
 
 
 function runTs(args: string[], root: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, ...rootEnv(root) },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: root });
 }
 
 function norm(text: string, roots: string[]): string {

--- a/tests/scripts/_cli/cmd_refresh.test.ts
+++ b/tests/scripts/_cli/cmd_refresh.test.ts
@@ -23,6 +23,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_refresh.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_refresh.ts');
@@ -44,12 +46,7 @@ interface RunResult {
 // safe for both sides.
 
 function runTs(args: string[], cwd: string, extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env, ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd, env: extraEnv });
 }
 
 function norm(text: string, roots: string[]): string {

--- a/tests/scripts/_cli/cmd_settings_check.test.ts
+++ b/tests/scripts/_cli/cmd_settings_check.test.ts
@@ -23,6 +23,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_settings_check.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_settings_check.ts');
@@ -46,12 +48,7 @@ function rootEnv(root: string): Record<string, string> {
 
 
 function runTs(args: string[], root: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, COLUMNS: '80', ...rootEnv(root) },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: root, env: { COLUMNS: '80', ...rootEnv(root) } });
 }
 
 const roots: string[] = [];

--- a/tests/scripts/_cli/cmd_sync.test.ts
+++ b/tests/scripts/_cli/cmd_sync.test.ts
@@ -22,6 +22,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_sync.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_sync.ts');
@@ -45,12 +47,7 @@ function rootEnv(root: string): Record<string, string> {
 
 
 function runTs(args: string[], root: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, COLUMNS: '80', ...rootEnv(root) },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: root });
 }
 
 const roots: string[] = [];

--- a/tests/scripts/_cli/cmd_uninstall.test.ts
+++ b/tests/scripts/_cli/cmd_uninstall.test.ts
@@ -33,6 +33,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_uninstall.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_uninstall.ts');
@@ -60,12 +62,7 @@ function baseEnv(root: string, lock: string): Record<string, string> {
 
 
 function runTs(args: string[], root: string, lock: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, ...baseEnv(root, lock) },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: root, env: { ...baseEnv(root, lock) } });
 }
 
 function norm(text: string, roots: string[]): string {

--- a/tests/scripts/_cli/cmd_validate.test.ts
+++ b/tests/scripts/_cli/cmd_validate.test.ts
@@ -16,6 +16,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_validate.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_validate.ts');
@@ -40,12 +42,7 @@ interface RunResult {
 // imported `_lib` twins while still pinning the read to the temp fixture.
 
 function runTs(args: string[], projectRoot: string, extraEnv: Record<string, string> = {}): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-        env: { ...process.env, AGENT_CONFIG_PROJECT_ROOT: projectRoot, ...extraEnv },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: projectRoot, env: extraEnv });
 }
 
 /** Strip machine-specific tmp roots (raw + realpath) so the diff stays stable. */

--- a/tests/scripts/_cli/cmd_versions.test.ts
+++ b/tests/scripts/_cli/cmd_versions.test.ts
@@ -24,6 +24,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../../src/scripts/_cli/cmd_versions.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', '_cli', 'cmd_versions.ts');
@@ -58,12 +60,7 @@ function baseEnv(root: string): Record<string, string> {
 
 
 function runTs(args: string[], root: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, COLUMNS: '80', ...baseEnv(root) },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(main, args, { cwd: root });
 }
 
 const roots: string[] = [];

--- a/tests/scripts/_lib_knowledge_global.test.ts
+++ b/tests/scripts/_lib_knowledge_global.test.ts
@@ -10,6 +10,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main as mainKg } from '../../src/scripts/_lib/knowledge_global.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -37,8 +39,7 @@ function env(): NodeJS.ProcessEnv {
 }
 
 function runTs(args: readonly string[]): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf8', env: env() });
-    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+    return runInProc(mainKg, args, { env: env() });
 }
 
 /** Replace the resolved $HOME store path so the two runs are comparable. */

--- a/tests/scripts/_lib_knowledge_global_promote.test.ts
+++ b/tests/scripts/_lib_knowledge_global_promote.test.ts
@@ -10,6 +10,8 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main as mainKgp } from '../../src/scripts/_lib/knowledge_global_promote.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -42,8 +44,7 @@ function env(): NodeJS.ProcessEnv {
 }
 
 function runTs(args: readonly string[]): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: repo, encoding: 'utf8', env: env() });
-    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+    return runInProc(mainKgp, args, { cwd: repo, env: env() });
 }
 
 // The tsx twin is the source of truth (the python original was deleted in the

--- a/tests/scripts/_lib_knowledge_global_redaction.test.ts
+++ b/tests/scripts/_lib_knowledge_global_redaction.test.ts
@@ -7,6 +7,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main as mainKgr } from '../../src/scripts/_lib/knowledge_global_redaction.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -36,8 +38,7 @@ function write(name: string, body: string): string {
 }
 
 function runTs(args: readonly string[]): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
-    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+    return runInProc(mainKgr, args);
 }
 
 /** Both implementations on the same card+tier — byte-identical contract. */

--- a/tests/scripts/audit_likelihood.test.ts
+++ b/tests/scripts/audit_likelihood.test.ts
@@ -22,6 +22,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { tokens } from '../../src/scripts/audit_likelihood.js';
 import { acquireGlobalStateLock } from './_global_state_lock.js';
+import { main as mainLikelihood } from '../../src/scripts/audit_likelihood.js';
+import { main as mainAudit } from '../../src/scripts/audit_auto_rules.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_LIKELIHOOD = path.join(REPO_ROOT, 'src', 'scripts', 'audit_likelihood.ts');
@@ -38,8 +41,8 @@ const AUDIT_MD = path.join(REPORT_DIR, 'auto-rules-audit.md');
 const LIKELIHOOD_JSON = path.join(REPORT_DIR, 'auto-rules-likelihood.json');
 
 function ts(script: string, args: string[]): { stdout: string; stderr: string; status: number | null } {
-    const r = spawnSync(TSX_BIN, [script, ...args], { cwd: REPO_ROOT, encoding: 'utf8' });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+    const mainFn = script.includes('audit_likelihood') ? mainLikelihood : mainAudit;
+    return runInProc(mainFn, args);
 }
 
 describe('audit_likelihood — unit helpers', () => {

--- a/tests/scripts/audit_overlap.test.ts
+++ b/tests/scripts/audit_overlap.test.ts
@@ -11,6 +11,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/audit_overlap.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'audit_overlap.ts');
@@ -51,7 +53,7 @@ function readMaybe(p: string): Buffer | null {
     return fs.existsSync(p) ? fs.readFileSync(p) : null;
 }
 function runTs() {
-    return spawnSync(TSX_BIN, [TS_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, []);
 }
 
 describe.runIf(inputPresent())('audit_overlap — CLI contract', () => {

--- a/tests/scripts/chat_history.test.ts
+++ b/tests/scripts/chat_history.test.ts
@@ -29,6 +29,8 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import * as ch from '../../src/scripts/chat_history.js';
+import { main } from '../../src/scripts/chat_history.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'chat_history.ts');
@@ -70,14 +72,18 @@ function runPy(file: string, args: string[], stdin = ''): RunResult {
 
 /** Run tsx chat_history.ts with $AGENT_CHAT_HISTORY_FILE pinned + COLUMNS=80. */
 function runTs(file: string, args: string[], stdin = ''): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        encoding: 'utf8',
-        cwd: REPO_ROOT,
-        input: stdin,
-        env: { ...process.env, AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' },
-        maxBuffer: 64 * 1024 * 1024,
-    });
-    return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    if (stdin) {
+        // stdin redirect requires subprocess — rare path (only reset --entries-stdin)
+        const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+            encoding: 'utf8',
+            cwd: REPO_ROOT,
+            input: stdin,
+            env: { ...process.env, AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' },
+            maxBuffer: 64 * 1024 * 1024,
+        });
+        return { status: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    }
+    return runInProc(main, args, { env: { AGENT_CHAT_HISTORY_FILE: file, COLUMNS: '80' } });
 }
 
 /** Normalise the two wall-clock fields so file/stdout comparisons stay deterministic. */

--- a/tests/scripts/cli_python/knowledge_ingest.test.ts
+++ b/tests/scripts/cli_python/knowledge_ingest.test.ts
@@ -17,6 +17,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { _cli as mainKi } from '../../../src/cli/python/knowledge_ingest.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'knowledge_ingest.ts');
@@ -35,12 +37,7 @@ interface RunResult {
 
 
 function runTs(args: string[], cwd: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(mainKi, args, { cwd });
 }
 
 const roots: string[] = [];

--- a/tests/scripts/cli_python/workspace_drive.test.ts
+++ b/tests/scripts/cli_python/workspace_drive.test.ts
@@ -14,6 +14,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main as mainWd } from '../../../src/cli/python/workspace_drive.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'cli', 'python', 'workspace_drive.ts');
@@ -33,12 +35,7 @@ interface RunResult {
 
 
 function runTs(args: string[], cwd: string): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
-        cwd,
-        encoding: 'utf8',
-        env: { ...process.env, COLUMNS: '80' },
-    });
-    return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    return runInProc(mainWd, args, { cwd, env: { COLUMNS: '80' } });
 }
 
 const roots: string[] = [];

--- a/tests/scripts/hooks/replay_hook.test.ts
+++ b/tests/scripts/hooks/replay_hook.test.ts
@@ -5,18 +5,17 @@
 // bare-event-name resolution, invalid-payload exit 2, --dry-run plan). The
 // python3-vs-tsx golden-parity layer was retired with the Python→TS final
 // deletion (the Python replay driver no longer exists).
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main as replayMain } from '../../../src/scripts/hooks/replay_hook.js';
+import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
-const TS_REPLAY = path.join(REPO_ROOT, 'src', 'scripts', 'hooks', 'replay_hook.ts');
 const FIXTURE_DIR = path.join(REPO_ROOT, 'tests', 'fixtures', 'hooks');
 const MANIFEST = path.join(REPO_ROOT, 'src', 'scripts', 'hook_manifest.yaml');
-const TSX_BIN = path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
 
 const EVENTS = [
     'session_start',
@@ -46,7 +45,6 @@ function runTsReplay(
 ): { stdout: string; stderr: string; status: number } {
     fs.mkdirSync(workspace, { recursive: true });
     const cmd = [
-        TS_REPLAY,
         '--platform',
         platform,
         '--event',
@@ -57,8 +55,7 @@ function runTsReplay(
         MANIFEST,
         ...extra,
     ];
-    const r = spawnSync(TSX_BIN, cmd, { cwd: workspace, encoding: 'utf8' });
-    return { stdout: r.stdout, stderr: r.stderr, status: r.status ?? 0 };
+    return runInProc(replayMain, cmd, { cwd: workspace });
 }
 
 function snapshotState(workspace: string): Set<string> {
@@ -115,7 +112,6 @@ describe('replay_hook — summary + resolution', () => {
 
     it('resolves a bare event name', () => {
         const cmd = [
-            TS_REPLAY,
             '--platform',
             'augment',
             '--event',
@@ -126,7 +122,7 @@ describe('replay_hook — summary + resolution', () => {
             MANIFEST,
             '--json',
         ];
-        const r = spawnSync(TSX_BIN, cmd, { cwd: tmp, encoding: 'utf8' });
+        const r = runInProc(replayMain, cmd, { cwd: tmp });
         expect(r.status, r.stderr).toBe(0);
         const summary = JSON.parse(r.stdout);
         expect(String(summary['payload']).endsWith('post_tool_use.json')).toBe(true);
@@ -134,7 +130,6 @@ describe('replay_hook — summary + resolution', () => {
 
     it('rejects an invalid payload path with exit 2', () => {
         const cmd = [
-            TS_REPLAY,
             '--platform',
             'augment',
             '--event',
@@ -144,7 +139,7 @@ describe('replay_hook — summary + resolution', () => {
             '--manifest',
             MANIFEST,
         ];
-        const r = spawnSync(TSX_BIN, cmd, { cwd: tmp, encoding: 'utf8' });
+        const r = runInProc(replayMain, cmd, { cwd: tmp });
         expect(r.status).toBe(2);
         expect(r.stderr.toLowerCase()).toContain('not found');
     });

--- a/tests/scripts/inventory_frontmatter.test.ts
+++ b/tests/scripts/inventory_frontmatter.test.ts
@@ -8,6 +8,8 @@ import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/inventory_frontmatter.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'inventory_frontmatter.ts');
@@ -19,7 +21,7 @@ const TSX_BIN = path.join(
 );
 
 function runTs() {
-    return spawnSync(TSX_BIN, [TS_SCRIPT], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, []);
 }
 
 describe('inventory_frontmatter — CLI contract', () => {

--- a/tests/scripts/inventory_meta_layers.test.ts
+++ b/tests/scripts/inventory_meta_layers.test.ts
@@ -19,28 +19,22 @@
 // in a deterministic (sorted) order and matches the Python output byte-for-byte.
 //
 // Skipped without python3.
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { main } from '../../src/scripts/inventory_meta_layers.js';
 import { acquireGlobalStateLock } from './_global_state_lock.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'inventory_meta_layers.ts');
-const TSX_BIN = path.join(
-    REPO_ROOT,
-    'node_modules',
-    '.bin',
-    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
 const EVIDENCE_DIR = path.join(REPO_ROOT, 'agents', 'evidence', 'analysis');
 const MD = path.join(EVIDENCE_DIR, 'meta-layer-inventory.md');
 const CSV = path.join(EVIDENCE_DIR, 'meta-layer-inventory.csv');
 
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 describe('inventory_meta_layers — CLI contract', () => {

--- a/tests/scripts/knowledge_global_cli.test.ts
+++ b/tests/scripts/knowledge_global_cli.test.ts
@@ -11,6 +11,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main as mainKgc } from '../../src/scripts/knowledge_global_cli.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..', '..');
 const TSX_BIN =
@@ -43,8 +45,7 @@ function env(): NodeJS.ProcessEnv {
 }
 
 function runTs(args: readonly string[]): RunResult {
-    const r = spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd: repo, encoding: 'utf8', env: env() });
-    return { status: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+    return runInProc(mainKgc, args, { cwd: repo, env: env() });
 }
 
 /** Normalize ISO dates + the resolved store path for deterministic compares. */

--- a/tests/scripts/lint_agent_security.test.ts
+++ b/tests/scripts/lint_agent_security.test.ts
@@ -5,25 +5,20 @@
 // --quiet) on the REAL src/ tree: defined exit + determinism + the written
 // SARIF file. The umbrella runner shells out to the child linters, so it
 // observes the real repo. The SARIF file is written under a tmp dir so the
-// test leaves zero git drift.
-import { spawnSync } from 'node:child_process';
+// test leaves zero git drift. Runs in-process (no tsx cold-start).
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { main } from '../../src/scripts/lint_agent_security.js';
+import { runInProc } from '../_lib/run_in_process.js';
+
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'lint_agent_security.ts');
-const TSX_BIN = path.join(
-    REPO_ROOT,
-    'node_modules',
-    '.bin',
-    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
 
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 describe('lint_agent_security — CLI contract', () => {

--- a/tests/scripts/lint_marketplace.test.ts
+++ b/tests/scripts/lint_marketplace.test.ts
@@ -11,6 +11,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/lint_marketplace.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'lint_marketplace.ts');
@@ -22,7 +24,7 @@ const TSX_BIN = path.join(
 );
 
 function runTs(cwd: string) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT], { cwd, encoding: 'utf8' });
+    return runInProc(main, [], { cwd });
 }
 
 /** Run the tsx linter and return its result for the fixture's assertions. */

--- a/tests/scripts/lint_pack_dependencies.test.ts
+++ b/tests/scripts/lint_pack_dependencies.test.ts
@@ -9,6 +9,8 @@ import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/lint_pack_dependencies.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'lint_pack_dependencies.ts');
@@ -20,7 +22,7 @@ const TSX_BIN = path.join(
 );
 
 function runTs() {
-    return spawnSync(TSX_BIN, [TS_SCRIPT], { cwd: REPO_ROOT, encoding: 'utf8' });
+    return runInProc(main, []);
 }
 
 describe('lint_pack_dependencies — CLI contract', () => {

--- a/tests/scripts/measure_density.test.ts
+++ b/tests/scripts/measure_density.test.ts
@@ -3,28 +3,20 @@
 // The script reads the whole artifact corpus and prints a report (default) or
 // deterministic JSON (--json); --snapshot writes JSONL to the gitignored
 // agents/runtime/density/snapshot.jsonl. The tsx twin is the source of truth
-// (the python original was deleted in the teardown). Its output is
-// corpus-derived (would drift in a fixed snapshot), so this asserts the
-// contract structurally: exit 0, non-empty output, valid JSON(L), and
-// DETERMINISM (a second run is byte-identical).
-import { spawnSync } from 'node:child_process';
+// (the python original was deleted in the teardown). Runs in-process via
+// runInProc (no tsx cold-start per call) for speed.
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { main } from '../../src/scripts/measure_density.js';
+import { runInProc } from '../_lib/run_in_process.js';
+
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'measure_density.ts');
-const TSX_BIN = path.join(
-    REPO_ROOT,
-    'node_modules',
-    '.bin',
-    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
 const SNAPSHOT = path.join(REPO_ROOT, 'agents', 'runtime', 'density', 'snapshot.jsonl');
 
-const runTs = (args: string[]) =>
-    spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+const runTs = (args: string[]) => runInProc(main, args);
 
 describe('measure_density — CLI contract', () => {
     it('default + --json run deterministically over the repo (exit 0)', () => {

--- a/tests/scripts/measure_markitdown_lift.test.ts
+++ b/tests/scripts/measure_markitdown_lift.test.ts
@@ -9,6 +9,8 @@ import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/measure_markitdown_lift.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'measure_markitdown_lift.ts');
@@ -25,7 +27,7 @@ function hasMarkitdown(): boolean {
     }).status === 0;
 }
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 describe('measure_markitdown_lift — CLI contract', () => {

--- a/tests/scripts/measure_patterns.test.ts
+++ b/tests/scripts/measure_patterns.test.ts
@@ -15,6 +15,8 @@ import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/measure_patterns.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'measure_patterns.ts');
@@ -26,7 +28,7 @@ const TSX_BIN = path.join(
 );
 
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 // The tsx twin is the source of truth (the python original was deleted in the

--- a/tests/scripts/measure_projection_bytes.test.ts
+++ b/tests/scripts/measure_projection_bytes.test.ts
@@ -10,6 +10,8 @@ import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/measure_projection_bytes.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'measure_projection_bytes.ts');
@@ -21,7 +23,7 @@ const TSX_BIN = path.join(
 );
 
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 describe('measure_projection_bytes — CLI contract', () => {

--- a/tests/scripts/measure_skill_reduction.test.ts
+++ b/tests/scripts/measure_skill_reduction.test.ts
@@ -17,6 +17,8 @@ import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/measure_skill_reduction.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'measure_skill_reduction.ts');
@@ -28,7 +30,7 @@ const TSX_BIN = path.join(
 );
 
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 // The tsx twin is the source of truth (the python original was deleted in the

--- a/tests/scripts/plan_physical_move.test.ts
+++ b/tests/scripts/plan_physical_move.test.ts
@@ -6,21 +6,15 @@
 // teardown); only the default DRY-RUN (writes the plan JSON, no FS moves) is
 // asserted. The plan file is written to an in-tree temp path and removed
 // afterwards, so the test leaves zero git drift.
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/plan_physical_move.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'plan_physical_move.ts');
 const TMP_DIR = path.join(REPO_ROOT, 'dist', 'migration');
-const TSX_BIN = path.join(
-    REPO_ROOT,
-    'node_modules',
-    '.bin',
-    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
 
 // The tsx twin is the source of truth (the python original was deleted in the
 // teardown). --apply mutates the tree via `git mv` → NEVER exercised; only the
@@ -38,8 +32,7 @@ describe('plan_physical_move — dry-run contract', () => {
 
     it('dry-run writes a valid plan JSON, deterministically', () => {
         fs.mkdirSync(TMP_DIR, { recursive: true });
-        const runTs = () =>
-            spawnSync(TSX_BIN, [TS_SCRIPT, '--out', tsOut], { encoding: 'utf8', cwd: REPO_ROOT });
+        const runTs = () => runInProc(main, ['--out', tsOut]);
         const a = runTs();
         // 0 = clean, 1 = conflicts — both are valid dry-run verdicts (repo state).
         expect([0, 1]).toContain(a.status);

--- a/tests/scripts/probe_projection_fidelity.test.ts
+++ b/tests/scripts/probe_projection_fidelity.test.ts
@@ -12,6 +12,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { main } from '../../src/scripts/probe_projection_fidelity.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'probe_projection_fidelity.ts');
@@ -41,8 +43,8 @@ afterEach(() => {
 });
 
 function runTs(reportRel?: string) {
-    const args = reportRel ? [TS_SCRIPT, '--report', reportRel] : [TS_SCRIPT];
-    return spawnSync(TSX_BIN, args, { encoding: 'utf8', cwd: REPO_ROOT });
+    const args = reportRel ? ['--report', reportRel] : [];
+    return runInProc(main, args);
 }
 
 describe.runIf(fs.existsSync(FIXTURE))('probe_projection_fidelity — CLI contract', () => {

--- a/tests/scripts/score_skill_selection.test.ts
+++ b/tests/scripts/score_skill_selection.test.ts
@@ -29,6 +29,8 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { acquireGlobalStateLock } from './_global_state_lock.js';
+import { main } from '../../src/scripts/score_skill_selection.js';
+import { runInProc } from '../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'score_skill_selection.ts');
@@ -45,7 +47,7 @@ function clustersPresent(): boolean {
     return fs.existsSync(CLUSTERS);
 }
 function runTs(args: string[]) {
-    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { encoding: 'utf8', cwd: REPO_ROOT });
+    return runInProc(main, args);
 }
 
 describe('score_skill_selection — CLI contract', () => {


### PR DESCRIPTION
## What

Restores the CI test suite to the ~1-2 min range it ran in before the py2ts
teardown. The teardown replaced ~133 python-parity spawns with tsx-subprocess
rigs (a fresh \`tsx\` cold-start per assertion), pushing the CI **Vitest step to
474 s (7m54s)** on ubuntu.

## Two levers

### 1. In-process runner — `tests/_lib/run_in_process.ts`

\`runInProc(main, argv, opts)\` calls a script's exported \`main()\` directly
(captures stdout/stderr, mocks \`process.exit\`, handles both \`ArgparseExit\`
shapes + the \`exitCode\`-then-throw pattern; \`runInProcAsync\` for async mains)
instead of \`spawnSync(tsx, [script])\`.

Migrated: the \`cmd_*\` cluster (13/17), the measure/audit/lint/probe rigs,
\`chat_history\` (28→1 spawn), \`cli_python/{knowledge_ingest,workspace_drive}\`,
the \`knowledge_global*\` cluster, and \`replay_hook\`.
Kept on subprocess (module-level \`os.homedir()\` const / fixture-copy REPO_ROOT):
\`cmd_update\`, \`cmd_settings_migrate\`, \`workspace_crypto\`, the \`check_*\` rigs.

### 2. CI job topology

CI runners are core-saturated → single-runner wall clock is total-CPU-work ÷
cores; file-level sharding inside one runner barely moved it (474→447 s). Split:

- **node-tests**: \`--shard=N/4\` × 2 OS, **excluding** the two subprocess-heavy
  clusters (they hash-clump into one > 2 min shard regardless of shard count).
- **golden-tests**: dedicated job, 6 fork-parallel \`golden_replay*\` files
  (the 29-scenario matrix is split across files, full coverage — no cut).
- **workspace-tests**: dedicated job (\`server/workspace\` + \`cli/python/**\`).
  Separate from golden — combining both oversubscribed the fork pool → flaky
  spawn-timeouts.
- **static-checks**: ESLint + tsc + prepack once (ubuntu-only), off the
  per-shard critical path.

## Result (run 28769860524 — all green)

| Metric | Before | After |
|---|---|---|
| Slowest **Vitest step** | 474 s (7m54s) | **95 s (1.6 min)** |
| Slowest **total job** | ~9 min | 137 s (macos, npm-ci-bound) |

Every test run is back under 2 min. The 137 s total-job floor is npm-ci + build
overhead (sharding multiplies fixed per-job cost), not test code.

Only required check \`Sync + Generate Tools Consistency\` is unaffected by the
renamed Node Tests jobs.

Completes + archives \`road-to-fast-test-layer\`.
