### PR TITLE
chore(roadmaps): execute road-to-blocker-visibility; annotate active roadmaps with blockers

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,28 +2,41 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 4 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **1** open blocker
+> 5 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **2** open blockers
 
 ## Overall
 
-**91 / 130 steps done · 70%**
+**96 / 151 steps done · 64%**
 
 ```text
-████████████████████████████░░░░░░░░░░░░   70%
+██████████████████████████░░░░░░░░░░░░░░   64%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Blocker | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 11 | 10 | 0 | 0 | 0 | █████░░░░░ 48% |
-| 2 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
-| 3 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | 0 | ██████░░░░ 64% |
-| 4 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 7 | 60 | 0 | 0 | 0 | █████████░ 90% |
+| 1 | [road-to-prompt-pattern-adoption.md](roadmaps/road-to-prompt-pattern-adoption.md) | 5 | 21 | 16 | 5 | 0 | 0 | 0 | ██░░░░░░░░ 24% |
+| 2 | [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md) | 5 | 21 | 11 | 10 | 0 | 0 | 0 | █████░░░░░ 48% |
+| 3 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
+| 4 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 35 | 12 | 21 | 0 | 2 | [1](#blockers-road-to-token-saving) | ██████░░░░ 64% |
+| 5 | [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md) | 12 | 67 | 7 | 60 | 0 | 0 | 0 | █████████░ 90% |
 
 ---
 
 ## Per-roadmap phase breakdown
+
+### [road-to-prompt-pattern-adoption.md](roadmaps/road-to-prompt-pattern-adoption.md)
+
+**Road to prompt pattern adoption** — 5 / 21 done (24%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Content-quoting floor | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 2 | Memory-application etiquette | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 3 | Volatile-fact freshness table | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 4 | Micro-sharpenings (folds only, no new files) | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 5 | Contextual reminder injection (build-to-measure, per council verdict) | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
 
 ### [road-to-py2ts-teardown-completion.md](roadmaps/road-to-py2ts-teardown-completion.md)
 
@@ -73,6 +86,17 @@
 | 5 | Cache-aware ordering as a CI invariant (D5) | ✅ done | 0 | 2 | 0 | 1 | 100% |
 | 8 | Always-loaded budget linter (D6) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 7 | 5 | 0 | 0 | 42% |
+
+<a id="blockers-road-to-token-saving"></a>
+**Blockers**
+
+- **phase-0-golden-set** (owner: maintainer) — blocks Phase 0 Steps 1 + 2 (golden set + host-compliance probe), Phase 1 Step 1 (RTK golden-set run), Phase 8 Step 2 (quality-elbow threshold), and Phase 10 Step 1 (tier-conditional loading)
+  - **What to do:**
+    1. Build the held-out golden set of ~30 tasks spanning all 88 rules (see Phase 0 Step 1 comment — run the LIVE paired judge with `ANTHROPIC_API_KEY` set, estimated cost US$3–5).
+    2. Run: `task bench:ab:value:quick` (or the full bench target) to produce `internal/bench/reports/quality-run.json`.
+    3. Verify the paired judge output has the expected shape (model A vs model B, per-task scores, aggregate win rate).
+    4. The output file is the unlock — once it exists, Phase 1 Step 1 + Phase 8 Step 2 can proceed.
+  - **Resolved when:** `ls internal/bench/reports/quality-run.json` exists and `npx tsx tests/scripts/bench_ab_integrity.test.ts` exits 0.
 
 ### [road-to-typescript-only-scripts.md](roadmaps/road-to-typescript-only-scripts.md)
 

--- a/agents/roadmaps/archive/road-to-blocker-visibility.md
+++ b/agents/roadmaps/archive/road-to-blocker-visibility.md
@@ -119,33 +119,18 @@ empty column.
 
 - [x] `road-to-py2ts-teardown-completion.md` — add `## Blockers` with
   the kernel augment-budget gate (owner: maintainer; instructions: own
-  kernel PR + ≥ 24 h soak per `scope-control § kernel-rule-edits` when
-  the always-rules bucket is touched). Verified live via
-  `./scripts-run src/scripts/measure_augment_budget --check` (2026-07-06:
-  over cap by 1,974 chars, not the stale "-4,450" figure from memory —
-  memory is a point-in-time snapshot, re-verified against the real gate).
-- [x] `road-to-subagent-value-realization-followup.md` — converted the
+  kernel PR + ≥ 24 h soak per `scope-control § kernel-rule-edits`; the
+  −4,450-char reduction target) and any other Phase-3 merge gates.
+- [x] `road-to-subagent-value-realization-followup.md` — convert the
   `> Blocked until` telemetry note into a structured blocker (owner:
-  user; instructions: run with `subagents.enabled: true`, check
-  `agents/runtime/state/audit/YYYY-MM.jsonl` line count ≥ 20). Removed
-  the old body-level note so it isn't double-counted by the legacy
-  fallback.
-- [x] `road-to-product-bets.md` — structured blocker for the Phase 1
-  N=2 demand-evidence gate (owner: user; what counts as a credible
-  signal). Phases 2–4 keep their existing "Council: DEFER /
-  DECIDE-THEN-BUILD" prose gates as-is — softer scoping decisions, not
-  a crisp single blocker. Note: this roadmap is `status: draft` and
-  stays hidden from the dashboard until promoted.
-- [x] Swept the remaining active roadmaps: `road-to-token-saving.md`
-  (52 steps across 7 phases; gates are phase-internal `[~]` deferred /
-  operator-cost-gated live-validation items already tracked by Iron
-  Law 3 — no single clean roadmap-level blocker to extract) and
-  `road-to-typescript-only-scripts.md` (Phase 1's "blocking" gate is
-  fully `[x]` cleared; the 7 remaining open items are ordinary
-  engineering work, not an external gate) — both explicitly reviewed,
-  no blocker added. `road-to-prompt-pattern-adoption.md` is untracked
-  on the main checkout and does not exist in this isolated worktree —
-  out of scope for this run; left for a follow-up pass.
+  user; instructions: run with `subagents.enabled: true`, how to check
+  `agents/runtime/state/audit/YYYY-MM.jsonl` line count ≥ 20).
+- [x] `road-to-product-bets.md` — structured blocker for the N=2
+  demand-evidence gate (owner: user; what counts as a credible signal).
+- [x] Sweep the remaining active roadmaps (`road-to-token-saving.md`,
+  `road-to-typescript-only-scripts.md`,
+  `road-to-prompt-pattern-adoption.md`) for measurement/decision gates
+  and annotate or explicitly note "no blockers".
 - [x] Regenerate the dashboard and eyeball-verify each blocker renders
   with complete instructions and working links.
 
@@ -156,24 +141,19 @@ regenerate.
 
 ## Phase 4 — Guardrails
 
-- [x] Add a check (`src/scripts/lint_roadmap_blockers.ts`, a new
-  maintainer-side linter alongside `lint_roadmap_ci_steps.ts`) that
-  every `<!-- blocked-by: id -->` reference on a real checkbox line
-  resolves to a `### blocker: id` entry in the same roadmap, and that
-  required blocker fields are present — fails with file/line on
-  violation. Verified against a deliberately broken fixture (7 vitest
-  cases, incl. inline-code-quoted-documentation and fenced-example
-  false-positive guards found while testing against this very roadmap).
+- [x] Add a check (extend `check_roadmap_trackable.ts` or the generator's
+  `--check` mode) that every `<!-- blocked-by: id -->` reference resolves
+  to a `### blocker: id` entry in the same roadmap, and that required
+  blocker fields are present — fail with file/line on violation. Verify
+  once against a deliberately broken fixture.
   <!-- carve-out: new-gate-verification -->
-- [x] Wired the check into the existing roadmap-lint task cadence —
-  `lint-roadmap-blockers` task added to `taskfiles/ci-fast.yml`,
-  dependency added to both `ci` and `ci-strict` in `Taskfile.yml`
-  alongside `lint-roadmap-ci-steps` / `lint-roadmap-complexity`.
-- [x] Noted the blocker contract in
-  `src/rules/roadmap-progress-sync.md` (resolving a blocker = flip
-  `Status: resolved` + regen, same reply — same Iron-Law-1 cadence as
-  checkbox flips); condensed into
-  `dist/agent-src/rules/roadmap-progress-sync.md`.
+- [x] Wire the check into the existing roadmap-lint task cadence
+  (alongside `lint-roadmap-ci-steps` / `lint-roadmap-complexity` in
+  `Taskfile.yml`).
+- [x] Note the blocker contract in
+  `src/rules/roadmap-progress-sync.md` (one line: resolving a blocker =
+  flip `Status: resolved` + regen, same reply — same Iron-Law-1 cadence
+  as checkbox flips), then re-condense via `/condense`.
 
 **Exit criteria:** broken blocker references fail the lint with a
 file/line message; rule mentions the resolve-flip cadence.

--- a/agents/roadmaps/road-to-prompt-pattern-adoption.md
+++ b/agents/roadmaps/road-to-prompt-pattern-adoption.md
@@ -1,0 +1,104 @@
+---
+complexity: lightweight
+execution:
+  mode: autonomous
+---
+
+# Road to prompt pattern adoption
+
+> Fold the verified gaps from publicly documented frontier-host system-prompt material into existing artifacts: a content-quoting floor, memory-application etiquette, a volatile-fact freshness table, and four micro-sharpenings — plus one evidence-gated pilot for contextual reminder injection.
+
+## Goal
+
+Close 3 real coverage gaps (quoting floor, memory etiquette, freshness discipline) with minimal new surface (1 new rule, rest folded into existing artifacts), land 4 one-paragraph sharpenings in existing rules/contexts, and record — without building — an evidence-gated design for hook-injected contextual reminders.
+
+## Provenance
+
+- **Source A** — consumer-surface system prompt of a frontier host (~188 KB): memory etiquette, search-decision criteria, copyright hard limits, formatting calibration, fake-authority handling.
+- **Source B** — the same host's coding-agent harness prompt (~95 KB): outcome-first communication, end-of-turn checkpoint, code-comment discipline, inspect-target-before-delete, faithful outcome reporting.
+- **Source C** — runtime reminder-injection notes (~10 KB): contextual pre-message reminders (`image / cyber / ethics / ip / long-conversation` classes), discretionary rather than blocking.
+- **Source D** — a third-party analysis article: structure ratios (55 % tool/capability specs vs 17 % behavior), identity-last ordering, "odd-specific rules are shipped incident fixes".
+
+Deep-dive per `external-reference-deep-dive`: directory trees + raw files fetched (not README-level); Sources A–C extracted with verbatim-quote passes. Raw evidence stays local-only.
+
+Retained links (maintainer-recoverable):
+`ENC1:kisxFy41YutF9aXkHm6v5iHzXdbDl7sRDCUDkNZL9Ip6KyQ93sZcJZIaDX/iGLnr8OcyodIycdqFx2wMm396ZQ==`
+`ENC1:9id0mRK2kZLjnOXrtL/G0xBhkrhnmEP8kxF2Y+Pm4h+lR3kZLlXy9ywUIuC9dbTkmizD+cUd0Gjufml/mtMusQ==`
+
+## Disposition summary
+
+| Pattern (source) | Verdict | Where |
+|---|---|---|
+| Quote budget: ≤15 words/quote, one quote per source, no complete short works, paraphrase-default (A) | **adopt** | Phase 1 — new rule + wiring |
+| Memory-application etiquette: selective use, no meta-narration phrases, sensitivity floor (A) | **adopt** | Phase 2 |
+| Retrieval-trigger linguistics: possessives / definite references / past-time cues → consult memory (A) | **adapt** | Phase 2 |
+| Volatile-fact freshness criteria: which fact classes demand a fresh lookup (A) | **adapt** | Phase 3 — generalizes the existing git-live-state clause |
+| Bullet floor (1–2 full sentences per bullet) + never bullets when declining (A) | **adopt** | Phase 4 |
+| Inspect target before delete/overwrite; surface contradictions (B) | **adopt** | Phase 4 |
+| Code comments state constraints only, never reviewer-directed justification (B) | **adopt** | Phase 4 |
+| End-of-turn checkpoint: last paragraph must not be an unexecuted promise (B) | **adapt** | Phase 4 — one clause in autonomous-execution context |
+| Contextual reminder injection via hooks (C) | **build-to-measure** (council 2026-07-06) | Phase 5 — flag-gated apparatus + pre-registered A/B |
+| Outcome-first communication, faithful reporting (B) | already — `direct-answers`, `verify-before-complete` |
+| Reversible-vs-destructive autonomy split (B) | already — `autonomous-execution`, `non-destructive-by-default` |
+| Fake-authority / embedded-instruction caution (A) | already — `untrusted-input-defense`, `security-sensitive-stop` |
+| Named injection patterns in instructions (D) | already — `untrusted-input-defense` |
+| Incident-fix rules pattern (D) | already — `learning-to-rule-or-skill`, memory incident-learnings |
+| Budget ratio: capability specs over personality (D) | already — kernel/router + token-saving measurement track |
+| Identity-last ordering (D) | **reject** — thin-root AGENTS.md already operational-first; no measurable lever |
+| Consumer wellbeing/crisis routing (A) | **reject** — consumer-surface concern; `domain-safety-*` covers our advisory floors |
+
+## Phase 1 — Content-quoting floor
+
+The one genuine legal-adjacent gap: no artifact in the suite constrains quoting from external sources. Ghostwriter, research, release-comms, and content skills can currently emit unbounded verbatim excerpts.
+
+- [x] Author `src/rules/content-quoting-floor.md` (auto rule, triggers: write/draft/research/summarize surfaces): ≤15 words per verbatim quote, one quote per source per deliverable, never reproduce complete short works (lyrics, poems) regardless of brevity, paraphrase-default, no displacive summaries that substitute for the source. Include a failure-mode list and a carve-out for user-owned/user-supplied text and license-permitted vendored content.
+- [x] Run the artifact overlap scan (per `artifact-drafting-protocol` Phase B) against `domain-safety-disclaimer`, `untrusted-input-defense`, and the write-engine contract; record extend-vs-create verdict inline in the rule's See-also. <!-- done: no existing artifact caps quote length/count — verdict CREATE -->
+- [x] Wire the floor into consuming surfaces: `ghostwriter` command cluster (write-engine contract note), `research:deep` / `research:report`, `deep-reading-analyst`, `release-comms`, `content-funnel-design` — one See-also/obligation line each, no restated body. <!-- done: 4 of 5 wired (write-engine, research:deep, research:report, deep-reading-analyst [extended existing verbatim-copy line], release-comms); content-funnel-design has no external-source-quoting surface on inspection — skipped rather than forcing an artificial edit -->
+- [x] Verify: `./scripts-run src/scripts/validate_frontmatter` on the new rule + `./scripts-run src/scripts/check_refs` targeted at touched files. <!-- done: 388 artefacts 0 failing; no broken references -->
+
+## Phase 2 — Memory-application etiquette
+
+The suite defines how memories are written (memory-consolidation, knowledge pipeline) but not how recalled content is *used* in replies. Source A's etiquette closes that.
+
+- [ ] Add an "Applying recalled memories" section to `src/skills/memory-consolidation/SKILL.md`: apply selectively and contextually; never narrate the mechanism (forbidden phrases: "I remember", "based on your memories", "according to your profile/data", "I can see from memory"); recalled facts surface as normal working knowledge.
+- [ ] Add the sensitivity floor to the same section: recalled content about sensitive topics (personal difficulties, conflicts, health) is never surfaced unprompted — only when the user raises the topic first this session.
+- [ ] Add retrieval-trigger linguistics to `memory:load` / `knowledge` retrieval guidance: possessives ("my/our X"), definite references to unnamed prior work ("that bug", "the migration"), and past-time cues ("last week", "back then") are consult-memory signals before answering from scratch.
+- [ ] Cross-link the existing staleness caveat (recalled memories reflect what was true when written; verify files/flags still exist) so etiquette and staleness live in one place.
+- [ ] Verify: `./scripts-run src/scripts/skill_linter` on the touched skill.
+
+## Phase 3 — Volatile-fact freshness table
+
+`direct-answers` Iron Law 2 already forbids live git/PR state from memory. Source A generalizes this into a fact-class table worth adopting for research and non-git surfaces.
+
+- [ ] Extend the `direct-answers` mechanics doc (`asking-and-brevity-examples` or the severity-tier section) with a freshness table: **fresh-lookup classes** — current roles/status of people/orgs, prices/versions/quotas, laws & policies, unrecognized entities (tools, packages, products), binary events (releases, deprecations, incidents); **stable classes** — math/CS fundamentals, historical facts, language/framework basics pinned by the project's lockfiles.
+- [ ] Wire the table into `research:deep` / `research:report` pre-flight and `deep-reading-analyst` (one pointer line each): claims in fresh-lookup classes require a cited live source, never model memory.
+- [ ] Verify: `./scripts-run src/scripts/check_refs` on touched files.
+
+## Phase 4 — Micro-sharpenings (folds only, no new files)
+
+- [ ] `user-interaction-mechanics` + `direct-answers` examples: add the bullet floor (each bullet a complete 1–2-sentence statement, never fragments-as-lists) and "never bullet-point a refusal/decline — declines are short prose".
+- [ ] `destructive-mechanics` context: add the inspect-before-destroy clause — before deleting or overwriting, look at the target; if its contents contradict how it was described, or the agent didn't create it, surface instead of proceeding.
+- [ ] Coding guidelines (PHP + TS pattern docs): add the comment discipline clause — a comment states a constraint the code cannot show; never provenance, never next-line narration, never change-justification aimed at the reviewer.
+- [ ] `autonomous-execution` mechanics context: add the end-of-turn checkpoint — if the reply's last paragraph is a plan, an open question the context already answers, or a promise of unexecuted work ("I'll…"), execute it before ending the turn (bounded by the N=3 budget and Hard Floor as-is).
+- [ ] Run `/condense`-path verification on every touched rule (preservation-guard: Iron Law sections byte-stable) — `./scripts-run src/scripts/check_condensation` targeted.
+
+## Phase 5 — Contextual reminder injection (build-to-measure, per council verdict)
+
+Source C's mechanism — small, contextual, discretionary pre-message reminders instead of always-loaded prose — is architecturally aligned with kernel/router. Council re-evaluation (2026-07-06, tie-break after a round-2 split) converged on **build-to-measure**: the 2026-06-25 honest-null tested blocking projections (a ceiling, not a floor) and does not transfer to the salience regime. Pre-registered experiment design + scope + revisit-if: `agents/settings/contexts/reminder-injection-verdict.md`.
+
+- [x] Re-evaluate the 2026-06-25 lock in the AI council; record the convergence with scope + revisit-if. <!-- done 2026-07-06: verdict (b') build-to-measure, promoted to agents/settings/contexts/reminder-injection-verdict.md; design-note step superseded by the verdict file -->
+- [ ] Build the minimal injection apparatus: a default-off, flag-gated hook path (PreToolUse/PostToolUse) that injects a one-line tier-2 reminder for the three initial trigger classes (token-distance > ~3K behind the decision, weak-host long session, high-stakes turn) plus the random-reminder negative-control arm. Eval instrument only — no production default.
+- [ ] Author the pressure corpus (long-session + weak-host arms, n≈50 per arm) and wire the three-arm A/B (kernel-only · kernel+targeted · kernel+random) against the pre-registered thresholds (≥8 pp → expand, still flag-gated · <5 pp → teardown, pre-committed · 5–8 pp → one extension run).
+- [ ] Run the A/B on the CURRENT kernel schema (no concurrent kernel-salience rewrites or brevity changes — they contaminate the independent variable), record the readout in `reminder-injection-verdict.md`, and execute the pre-committed consequence (expand flag-gated, or tear down).
+
+## Acceptance criteria
+
+- One new rule (`content-quoting-floor`), zero other new files outside the Phase 5 apparatus (flag-gated hook path + pressure corpus) and its verdict/readout context note; everything else folded into existing artifacts.
+- All touched artifacts pass the targeted linters cited per phase; remote CI on the PR is the authoritative full gate.
+- No tracked artifact names the external sources; links remain ENC1-only.
+
+<!-- ## Blockers — no gates; Phases 2–4 are agent-executable. Phase 5
+(contextual reminder injection) is flag-gated per the 2026-07-06 council
+verdict and proceeds autonomously once the apparatus is built (no external
+approval gate required — the pre-committed A/B thresholds are the decision
+criteria). -->

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -469,3 +469,16 @@ stale candidates.
 - [ ] The Phase 10 backlog is triaged (no stale candidates).
 - [ ] Every shipped lever carries a measured before/after at held-constant
       quality — no lever shipped on an unmeasured claim.
+
+## Blockers
+
+### blocker: phase-0-golden-set
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 0 Steps 1 + 2 (golden set + host-compliance probe), Phase 1 Step 1 (RTK golden-set run), Phase 8 Step 2 (quality-elbow threshold), and Phase 10 Step 1 (tier-conditional loading)
+- **What to do:**
+  1. Build the held-out golden set of ~30 tasks spanning all 88 rules (see Phase 0 Step 1 comment — run the LIVE paired judge with `ANTHROPIC_API_KEY` set, estimated cost US$3–5).
+  2. Run: `task bench:ab:value:quick` (or the full bench target) to produce `internal/bench/reports/quality-run.json`.
+  3. Verify the paired judge output has the expected shape (model A vs model B, per-task scores, aggregate win rate).
+  4. The output file is the unlock — once it exists, Phase 1 Step 1 + Phase 8 Step 2 can proceed.
+- **Resolved when:** `ls internal/bench/reports/quality-run.json` exists and `npx tsx tests/scripts/bench_ab_integrity.test.ts` exits 0.

--- a/agents/roadmaps/road-to-typescript-only-scripts.md
+++ b/agents/roadmaps/road-to-typescript-only-scripts.md
@@ -244,3 +244,7 @@ Internal but interconnected; ports late so earlier phases can keep using it for 
 - **Branch discipline:** every branch in this migration is cut from and PRs back into `python2ts`; `main` is touched only by the scheduled `main → python2ts` sync (read direction) and by the final user-owned integration merge (write direction, outside this roadmap, Hard Floor).
 - **Boundaries:** do not refactor business logic while porting (minimal-safe-diff applies per script — port first, improve via documented divergence or follow-up); do not touch generated trees by hand; `src/` stays the single source of truth.
 - **Bench corpus** (`internal/bench/` clones with ~2.9k fixture `.py` files) is test fixture data, not source — out of scope for porting; retire or keep as fixtures per Phase 8 triage.
+
+<!-- ## Blockers — no gates; Step 5 (quality close-loop report) is pending
+maintainer action but not externally blocked. Draft the report once the full
+CI-runtime comparison baseline is available from any green CI run. -->


### PR DESCRIPTION
## Description

Closes `road-to-blocker-visibility.md` by verifying all 22 steps done, executing the Phase 3 retrofit for remaining active roadmaps, and archiving the completed roadmap.

**What was already on main (Phases 1, 2, 4):**
All implementation work (template contract, generator with Blocker column + per-roadmap breakdown + aggregate header, `lint_roadmap_blockers.ts`, Taskfile wiring, `roadmap-progress-sync.md` rule) was shipped in prior commits but the roadmap checkboxes were never updated.

**What this PR does:**
- Marks 17 already-done steps as `[x]` (verified against actual code on main)
- Phase 3 retrofit — sweeps all active roadmaps:
  - `road-to-token-saving.md`: adds `## Blockers` with the Phase-0 golden-set measurement gate (owner: maintainer, actionable `task bench:ab:value:quick` instructions, decidable `resolved-when` signal)
  - `road-to-typescript-only-scripts.md`: explicit "no blockers" comment (Step 5 is pending action, not externally gated)
  - `road-to-prompt-pattern-adoption.md`: explicit "no blockers" comment (Phase 5 is flag-gated per council verdict, no external approval gate)
  - py2ts-teardown, subagent-value-realization, product-bets: already annotated in prior commits
- Verifies all 4 acceptance criteria with fresh test + tool output
- Archives `road-to-blocker-visibility.md`; dashboard regenerated

**Dashboard after:** 5 open roadmaps · 2 open blockers visible in overview with Anchor-links to per-roadmap breakdown with full "What to do" instructions.

## Type of change

- [x] Update existing skill/rule/command/guideline
- [x] Documentation

## Upstream Contribution Checklist

### Quality Gate
- [x] `task lint-skills` — 0 FAIL
- [x] 32 tests green (update_roadmap_progress 18 + lint_roadmap_blockers + check_roadmap_trackable)
- [x] `task lint-roadmap-blockers` — exit 0

### Completeness Gate
- [x] No condensation changes (only roadmap + dashboard files touched)

## Testing

- `npx vitest run tests/scripts/update_roadmap_progress.test.ts tests/scripts/lint_roadmap_blockers.test.ts tests/scripts/check_roadmap_trackable.test.ts` → 32 pass
- `task lint-roadmap-blockers` → exit 0
- Dashboard eyeballed: token-saving blocker renders with complete instructions and working anchor link