### PR TITLE
feat(bench): checkpoint/resume for the ab-v2 sweep runner

### DIFF
--- a/src/scripts/bench_ab_v2_run.ts
+++ b/src/scripts/bench_ab_v2_run.ts
@@ -32,8 +32,18 @@
  * Cost controls inherited: --model pin (sonnet), --max-budget-usd cap. Cheap-by-
  * construction: the v2 fixtures are tiny, so per-run tokens are far below the v1
  * big-repo tasks.
+ *
+ * Checkpoint / resume (2026-07): every completed run (task × arm × seed) is
+ * appended to a JSONL checkpoint under reports/ab-v2/checkpoints/, keyed by a
+ * hash of the run configuration. A killed sweep restarted with the SAME flags
+ * resumes from the checkpoint instead of re-spending the completed runs (a
+ * 117/180 kill previously burned the whole sweep — results lived only in
+ * memory until the final report write). The checkpoint is deleted after the
+ * paired report is written, so a finished sweep leaves no residue. Opt out
+ * with --no-checkpoint; force a from-scratch run with --fresh.
  */
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -55,6 +65,7 @@ const RULES_DIR = path.join(REPO_ROOT, 'dist', 'agent-src', 'rules');
 const CORPUS_PATH = path.join(REPO_ROOT, 'internal', 'bench', 'corpora', 'ab-trackb-v2.yaml');
 const FIXTURES_ROOT = path.join(REPO_ROOT, 'internal', 'bench', 'ab');
 const REPORTS_DIR = path.join(REPO_ROOT, 'internal', 'bench', 'reports', 'ab-v2');
+const CHECKPOINTS_DIR = path.join(REPORTS_DIR, 'checkpoints');
 // CRITICAL (2026-06-15): clones MUST live OUTSIDE the agent-config repo. A clone
 // under the repo lets Claude discover the repo's own project surface (CLAUDE.md /
 // AGENTS.md / .claude/rules+skills) walking up from the cwd — so the `vanilla`
@@ -610,6 +621,192 @@ export function run_one_recursive(
     };
 }
 
+// ── checkpoint / resume ─────────────────────────────────────────────────────
+//
+// A sweep of tasks × arms × seeds can run for hours; without a checkpoint, a
+// kill (manual stop, harness timeout, machine sleep) loses EVERY completed run
+// because results only exist in memory until the single final report write.
+// The checkpoint is a JSONL file (one line per completed run) so each write is
+// a single atomic-enough append and a truncated tail line (killed mid-write)
+// is simply skipped on load. The file is keyed by a hash of the run config —
+// a restart with different flags gets a different checkpoint and never mixes
+// results from an incompatible sweep.
+
+/** Stable id key for one run inside a sweep. */
+export function run_key(task_id: string, arm: string, seed: number): string {
+    return `${task_id}|${arm}|${seed}`;
+}
+
+/**
+ * Hash of the sweep configuration — everything that changes what a run means.
+ * Same flags → same key → resume; any config change → fresh checkpoint file.
+ */
+export function checkpoint_key(cfg: {
+    corpus: string;
+    model: string;
+    seeds: number;
+    arms: string[];
+    budget: number;
+    timeout: number;
+    host: string;
+    task_ids: string[];
+}): string {
+    const stable = JSON.stringify([
+        cfg.corpus,
+        cfg.model,
+        cfg.seeds,
+        cfg.arms,
+        cfg.budget,
+        cfg.timeout,
+        cfg.host,
+        cfg.task_ids,
+    ]);
+    return createHash('sha256').update(stable).digest('hex').slice(0, 16);
+}
+
+/**
+ * JSON round-trip loses the PyFloat wrapper (1.0 parses back as 1), which
+ * would break the byte-parity float rendering of the final report on resume.
+ * freeze/thaw make the checkpoint lossless: PyFloat → {"__pyfloat__": n} on
+ * write, restored to PyFloat on load.
+ */
+export function freeze_result(v: unknown): unknown {
+    if (v instanceof PyFloat) {
+        return { __pyfloat__: v.value };
+    }
+    if (Array.isArray(v)) {
+        return v.map((x) => freeze_result(x));
+    }
+    if (v && typeof v === 'object') {
+        const out: Record<string, unknown> = {};
+        for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+            out[k] = freeze_result(val);
+        }
+        return out;
+    }
+    return v;
+}
+
+export function thaw_result(v: unknown): unknown {
+    if (Array.isArray(v)) {
+        return v.map((x) => thaw_result(x));
+    }
+    if (v && typeof v === 'object') {
+        const o = v as Record<string, unknown>;
+        const keys = Object.keys(o);
+        if (keys.length === 1 && keys[0] === '__pyfloat__' && typeof o['__pyfloat__'] === 'number') {
+            return new PyFloat(o['__pyfloat__']);
+        }
+        const out: Record<string, unknown> = {};
+        for (const [k, val] of Object.entries(o)) {
+            out[k] = thaw_result(val);
+        }
+        return out;
+    }
+    return v;
+}
+
+/**
+ * Load completed runs from a checkpoint file. Tolerant by design: a missing
+ * file → empty map; an unparseable line (truncated tail from a mid-write
+ * kill) → skipped; a duplicate key → last line wins.
+ */
+export function load_checkpoint(file: string): Map<string, Dict> {
+    const map = new Map<string, Dict>();
+    let raw: string;
+    try {
+        raw = fs.readFileSync(file, 'utf-8');
+    } catch {
+        return map;
+    }
+    for (const line of raw.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+            continue;
+        }
+        let entry: unknown;
+        try {
+            entry = JSON.parse(trimmed);
+        } catch {
+            continue; // truncated tail — the run it held simply re-executes
+        }
+        if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+            const e = entry as Record<string, unknown>;
+            if (typeof e['key'] === 'string' && e['result'] && typeof e['result'] === 'object') {
+                map.set(e['key'], thaw_result(e['result']) as Dict);
+            }
+        }
+    }
+    return map;
+}
+
+/** Append one completed run to the checkpoint (single-line atomic append). */
+export function append_checkpoint(file: string, key: string, result: Dict): void {
+    fs.appendFileSync(file, JSON.stringify({ key, result: freeze_result(result) }) + '\n', {
+        encoding: 'utf-8',
+    });
+}
+
+export interface CheckpointIO {
+    /** Checkpoint file to append completed runs to (created on first append). */
+    path: string;
+    /** Runs already completed by a prior (killed) sweep — reused, not re-run. */
+    completed: Map<string, Dict>;
+}
+
+/**
+ * The sweep loop, extracted from main() with an injectable run function so the
+ * resume behaviour is testable without live model calls. Semantics with no
+ * checkpoint are byte-identical to the pre-checkpoint loop (same stderr
+ * progress lines, same record shape).
+ */
+export function collect_records(
+    tasks: Dict[],
+    arms: string[],
+    seeds: number,
+    run_fn: (task: Dict, arm: string, seed: number) => Dict,
+    ckpt: CheckpointIO | null = null,
+    log: (msg: string) => void = (m) => process.stderr.write(m),
+): { records: Dict[]; executed: number; reused: number } {
+    const total = tasks.length * arms.length * seeds;
+    let done = 0;
+    let executed = 0;
+    let reused = 0;
+    const records: Dict[] = [];
+    for (const task of tasks) {
+        const per_arm: Record<string, Dict[]> = {};
+        for (const arm of arms) {
+            const seed_runs: Dict[] = [];
+            for (let seed = 0; seed < seeds; seed += 1) {
+                done += 1;
+                const key = run_key(String(task['id']), arm, seed);
+                const cached = ckpt?.completed.get(key);
+                if (cached) {
+                    reused += 1;
+                    seed_runs.push(cached);
+                    continue;
+                }
+                log(`[${done}/${total}] ${String(task['id'])} · ${arm} · seed ${seed}\n`);
+                const r = run_fn(task, arm, seed);
+                r['seed'] = seed;
+                executed += 1;
+                if (ckpt) {
+                    append_checkpoint(ckpt.path, key, r);
+                }
+                seed_runs.push(r);
+            }
+            per_arm[arm] = seed_runs;
+        }
+        records.push({
+            id: task['id'],
+            archetype: task['archetype'],
+            rule: task['rule'],
+            arms: per_arm,
+        });
+    }
+    return { records, executed, reused };
+}
+
 export function main(argv: string[] | null = null): number {
     const args = parse_args(argv ?? process.argv.slice(2));
 
@@ -666,35 +863,49 @@ export function main(argv: string[] | null = null): number {
     const placebo_chars = Math.max(rdp_text.length, 2000);
 
     const total = tasks.length * arms.length * args.seeds;
-    let done = 0;
-    const records: Dict[] = [];
-    for (const task of tasks) {
-        const per_arm: Record<string, Dict[]> = {};
-        for (const arm of arms) {
-            const seed_runs: Dict[] = [];
-            for (let seed = 0; seed < args.seeds; seed += 1) {
-                done += 1;
-                process.stderr.write(`[${done}/${total}] ${String(task['id'])} · ${arm} · seed ${seed}\n`);
-                const r = run_one(task, arm, {
-                    model: args.model,
-                    max_budget,
-                    timeout: args.timeout,
-                    placebo_chars,
-                    sp_dir,
-                    host: args.host,
-                });
-                r['seed'] = seed;
-                seed_runs.push(r);
-            }
-            per_arm[arm] = seed_runs;
-        }
-        records.push({
-            id: task['id'],
-            archetype: task['archetype'],
-            rule: task['rule'],
-            arms: per_arm,
+
+    let ckpt: CheckpointIO | null = null;
+    if (args.checkpoint) {
+        const key = checkpoint_key({
+            corpus: 'ab-trackb-v2',
+            model: args.model,
+            seeds: args.seeds,
+            arms,
+            budget: args.budget,
+            timeout: args.timeout,
+            host: args.host,
+            task_ids: tasks.map((t) => String(t['id'])),
         });
+        const ckpt_path = path.join(CHECKPOINTS_DIR, `${key}.jsonl`);
+        fs.mkdirSync(CHECKPOINTS_DIR, { recursive: true });
+        if (args.fresh && fs.existsSync(ckpt_path)) {
+            fs.rmSync(ckpt_path);
+        }
+        const completed = load_checkpoint(ckpt_path);
+        if (completed.size > 0) {
+            process.stderr.write(
+                `bench_ab_v2: resuming — ${completed.size}/${total} runs already complete ` +
+                    `(checkpoint ${_relToRootPosix(ckpt_path)}; use --fresh to discard)\n`,
+            );
+        }
+        ckpt = { path: ckpt_path, completed };
     }
+
+    const { records } = collect_records(
+        tasks,
+        arms,
+        args.seeds,
+        (task, _arm, _seed) =>
+            run_one(task, _arm, {
+                model: args.model,
+                max_budget,
+                timeout: args.timeout,
+                placebo_chars,
+                sp_dir,
+                host: args.host,
+            }),
+        ckpt,
+    );
 
     const stamp = v1.utc_stamp();
     const payload: Dict = {
@@ -711,6 +922,11 @@ export function main(argv: string[] | null = null): number {
     };
     const out = path.join(REPORTS_DIR, `${stamp}-ab-v2-paired.json`);
     fs.writeFileSync(out, _jsonDumps(_toJson(payload), 2) + '\n');
+    // The paired report now holds everything — retire the checkpoint so a
+    // finished sweep leaves no residue and a later identical sweep starts fresh.
+    if (ckpt && fs.existsSync(ckpt.path)) {
+        fs.rmSync(ckpt.path);
+    }
     process.stdout.write(
         `bench_ab_v2: wrote ${_relToRootPosix(out)} ` + `(${records.length} tasks, ${total} runs)\n`,
     );
@@ -729,6 +945,8 @@ interface ParsedArgs {
     timeout: number;
     mode: string;
     host: string;
+    checkpoint: boolean;
+    fresh: boolean;
 }
 
 class ArgExit extends Error {}
@@ -745,8 +963,10 @@ function parse_args(argv: string[]): ParsedArgs {
         timeout: 180,
         mode: 'live',
         host: 'claude',
+        checkpoint: true,
+        fresh: false,
     };
-    const usage = `usage: ${prog} [-h] [--arms ARMS] [--seeds SEEDS] [--tasks TASKS] [--limit LIMIT] [--model MODEL] [--budget BUDGET] [--timeout TIMEOUT] [--mode {live,dry-run}] [--host {claude,codex}]\n`;
+    const usage = `usage: ${prog} [-h] [--arms ARMS] [--seeds SEEDS] [--tasks TASKS] [--limit LIMIT] [--model MODEL] [--budget BUDGET] [--timeout TIMEOUT] [--mode {live,dry-run}] [--host {claude,codex}] [--no-checkpoint] [--fresh]\n`;
     const argErr = (msg: string): never => {
         process.stderr.write(usage);
         process.stderr.write(`${prog}: error: ${msg}\n`);
@@ -809,6 +1029,10 @@ function parse_args(argv: string[]): ParsedArgs {
             out.host = _choice(a.slice('--host='.length), '--host', ['claude', 'codex'], argErr);
         } else if (a.startsWith('--mode=')) {
             out.mode = _choice(a.slice('--mode='.length), '--mode', ['live', 'dry-run'], argErr);
+        } else if (a === '--no-checkpoint') {
+            out.checkpoint = false;
+        } else if (a === '--fresh') {
+            out.fresh = true;
         } else {
             argErr(`unrecognized arguments: ${a}`);
         }
@@ -909,7 +1133,7 @@ function _pyNumStr(x: number): string {
 
 // ── JSON byte-parity (json.dumps(payload, indent=2)) ──────────────────────
 
-class PyFloat {
+export class PyFloat {
     constructor(readonly value: number) {}
 }
 

--- a/taskfiles/bench-ab.yml
+++ b/taskfiles/bench-ab.yml
@@ -150,6 +150,9 @@ tasks:
       Cost-bearing & quota-aware: pins sonnet, caps per-run spend (--budget).
       WARNING the full 15×4×3=180-run pilot is ~60-90M tokens — use --tasks /
       --seeds to bound it. See agents/roadmaps/road-to-discipline-axis-benchmark.md.
+      Crash-safe: every completed run is checkpointed (reports/ab-v2/checkpoints/);
+      a killed sweep restarted with the SAME flags resumes instead of re-spending
+      (--fresh discards the checkpoint, --no-checkpoint disables it).
       Pass flags through, e.g.:
         task bench:ab:v2 -- --tasks trapA-overeng-01,trapB-regress-01 --seeds 1 --budget 3.5
     cmd: ./scripts-run src/scripts/bench_ab_v2_run {{.CLI_ARGS}}

--- a/tests/scripts/bench_ab_v2_run.test.ts
+++ b/tests/scripts/bench_ab_v2_run.test.ts
@@ -21,16 +21,28 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { placebo_prose, status_bucket, trajectory_metrics, injected_text, hardened_blocks_text } from '../../src/scripts/bench_ab_v2_run.js';
+import {
+    placebo_prose,
+    status_bucket,
+    trajectory_metrics,
+    injected_text,
+    hardened_blocks_text,
+    checkpoint_key,
+    run_key,
+    freeze_result,
+    thaw_result,
+    load_checkpoint,
+    append_checkpoint,
+    collect_records,
+    PyFloat,
+    type CheckpointIO,
+} from '../../src/scripts/bench_ab_v2_run.js';
 import type { ScoreResultV2 } from '../../src/scripts/_lib/bench_ab_scoring_v2.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const SCRIPTS = path.join(REPO_ROOT, 'src', 'scripts');
 const TS_SCRIPT = path.join(SCRIPTS, 'bench_ab_v2_run.ts');
-const REPORTS_DIR = path.join(REPO_ROOT, 'internal', 'bench', 'reports', 'ab-v2');
-const CORPUS = path.join(REPO_ROOT, 'internal', 'bench', 'corpora', 'ab-trackb-v2.yaml');
 const TSX_BIN = path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
-const HAVE_CORPUS = fs.existsSync(CORPUS);
 
 interface RunOut {
     stdout: string;
@@ -133,5 +145,152 @@ describe('bench_ab_v2_run — --help', () => {
         const ts = runTs(['--help']);
         expect(ts.status).toBe(0);
         expect(ts.stdout.startsWith('usage: bench_ab_v2_run.py')).toBe(true);
+    });
+
+    it('accepts the checkpoint flags without an arg error', () => {
+        // dry-run returns before any checkpoint IO — this asserts parse only.
+        const ts = runTs(['--mode', 'dry-run', '--no-checkpoint', '--fresh', '--limit', '1']);
+        expect(ts.status).toBe(0);
+        expect(ts.stdout).toContain('DRY');
+    });
+});
+
+describe('bench_ab_v2_run — checkpoint / resume', () => {
+    const mkTmp = (): string => {
+        const d = fs.mkdtempSync(path.join(os.tmpdir(), 'ab-v2-ckpt-'));
+        tmpDirs.push(d);
+        return d;
+    };
+
+    it('checkpoint_key is deterministic and sensitive to every config field', () => {
+        const cfg = {
+            corpus: 'ab-trackb-v2',
+            model: 'gpt-5-mini',
+            seeds: 3,
+            arms: ['vanilla', 'placebo'],
+            budget: 1.0,
+            timeout: 180,
+            host: 'codex',
+            task_ids: ['t1', 't2'],
+        };
+        const base = checkpoint_key(cfg);
+        expect(checkpoint_key({ ...cfg })).toBe(base);
+        expect(checkpoint_key({ ...cfg, model: 'other' })).not.toBe(base);
+        expect(checkpoint_key({ ...cfg, seeds: 2 })).not.toBe(base);
+        expect(checkpoint_key({ ...cfg, arms: ['vanilla'] })).not.toBe(base);
+        expect(checkpoint_key({ ...cfg, task_ids: ['t1'] })).not.toBe(base);
+        expect(checkpoint_key({ ...cfg, host: 'claude' })).not.toBe(base);
+    });
+
+    it('freeze/thaw round-trips PyFloat losslessly (the 1.0-vs-1 report parity)', () => {
+        const result: Record<string, unknown> = {
+            errored: false,
+            discipline_score: new PyFloat(1),
+            metrics: { wall_time_seconds: new PyFloat(0), ask_vs_act_ratio: 0, num_turns: 3 },
+            seed: 2,
+        };
+        const thawed = thaw_result(JSON.parse(JSON.stringify(freeze_result(result)))) as Record<string, unknown>;
+        expect(thawed['discipline_score']).toBeInstanceOf(PyFloat);
+        expect((thawed['discipline_score'] as PyFloat).value).toBe(1);
+        const metrics = thawed['metrics'] as Record<string, unknown>;
+        expect(metrics['wall_time_seconds']).toBeInstanceOf(PyFloat);
+        // the int-0 ask ratio must stay a plain number, NOT become a PyFloat
+        expect(metrics['ask_vs_act_ratio']).toBe(0);
+        expect(thawed['seed']).toBe(2);
+    });
+
+    it('load_checkpoint skips a truncated tail line and lets later duplicates win', () => {
+        const dir = mkTmp();
+        const file = path.join(dir, 'ckpt.jsonl');
+        append_checkpoint(file, run_key('t1', 'vanilla', 0), { errored: false, v: 1 });
+        append_checkpoint(file, run_key('t1', 'vanilla', 1), { errored: false, v: 2 });
+        append_checkpoint(file, run_key('t1', 'vanilla', 0), { errored: false, v: 3 }); // dup → wins
+        fs.appendFileSync(file, '{"key":"t1|vanilla|2","result":{"err'); // killed mid-write
+        const map = load_checkpoint(file);
+        expect(map.size).toBe(2);
+        expect((map.get('t1|vanilla|0') as Record<string, unknown>)['v']).toBe(3);
+        expect(map.has('t1|vanilla|2')).toBe(false);
+        // missing file → empty map, no throw
+        expect(load_checkpoint(path.join(dir, 'nope.jsonl')).size).toBe(0);
+    });
+
+    it('collect_records resumes: a killed sweep re-runs ONLY the missing runs', () => {
+        const dir = mkTmp();
+        const ckptPath = path.join(dir, 'ckpt.jsonl');
+        const tasks = [
+            { id: 't1', archetype: 'a', rule: 'r' },
+            { id: 't2', archetype: 'a', rule: 'r' },
+        ];
+        const arms = ['vanilla', 'placebo'];
+        const seeds = 2; // 2 tasks × 2 arms × 2 seeds = 8 runs
+        const mkResult = (task: Record<string, unknown>, arm: string, seed: number): Record<string, unknown> => ({
+            errored: false,
+            reason: null,
+            discipline_score: new PyFloat(1),
+            marker: `${String(task['id'])}-${arm}-${seed}`,
+        });
+
+        // First sweep: the run function dies on call #4 (simulated kill at 3/8).
+        let calls1 = 0;
+        const dying = (task: Record<string, unknown>, arm: string, seed: number): Record<string, unknown> => {
+            calls1 += 1;
+            if (calls1 > 3) {
+                throw new Error('killed');
+            }
+            return mkResult(task, arm, seed);
+        };
+        const ckpt1: CheckpointIO = { path: ckptPath, completed: new Map() };
+        expect(() => collect_records(tasks, arms, seeds, dying, ckpt1, () => {})).toThrow('killed');
+        expect(load_checkpoint(ckptPath).size).toBe(3); // 3 completed runs survived the kill
+
+        // Second sweep, same config: resume from the checkpoint.
+        let calls2 = 0;
+        const counting = (task: Record<string, unknown>, arm: string, seed: number): Record<string, unknown> => {
+            calls2 += 1;
+            return mkResult(task, arm, seed);
+        };
+        const ckpt2: CheckpointIO = { path: ckptPath, completed: load_checkpoint(ckptPath) };
+        const logs: string[] = [];
+        const { records, executed, reused } = collect_records(tasks, arms, seeds, counting, ckpt2, (m) => logs.push(m));
+        expect(reused).toBe(3);
+        expect(executed).toBe(5);
+        expect(calls2).toBe(5); // the 3 completed runs were NOT re-spent
+        // progress lines only for executed runs, with the GLOBAL run index
+        expect(logs).toHaveLength(5);
+        expect(logs[0]).toContain('[4/8]');
+
+        // The assembled report is complete and ordered as a fresh full run.
+        expect(records).toHaveLength(2);
+        for (const [ti, task] of tasks.entries()) {
+            const perArm = (records[ti] as Record<string, unknown>)['arms'] as Record<string, Record<string, unknown>[]>;
+            for (const arm of arms) {
+                expect(perArm[arm]).toHaveLength(seeds);
+                for (let seed = 0; seed < seeds; seed += 1) {
+                    const r = perArm[arm]![seed] as Record<string, unknown>;
+                    expect(r['marker']).toBe(`${task.id}-${arm}-${seed}`);
+                    expect(r['seed']).toBe(seed);
+                    // PyFloat survives the checkpoint round-trip on reused runs too
+                    expect(r['discipline_score']).toBeInstanceOf(PyFloat);
+                }
+            }
+        }
+    });
+
+    it('collect_records without a checkpoint keeps the pre-checkpoint semantics', () => {
+        const tasks = [{ id: 't1', archetype: 'a', rule: 'r' }];
+        const logs: string[] = [];
+        const { records, executed, reused } = collect_records(
+            tasks,
+            ['vanilla'],
+            2,
+            (_t, _a, seed) => ({ errored: false, s: seed }),
+            null,
+            (m) => logs.push(m),
+        );
+        expect(executed).toBe(2);
+        expect(reused).toBe(0);
+        expect(logs).toEqual(['[1/2] t1 · vanilla · seed 0\n', '[2/2] t1 · vanilla · seed 1\n']);
+        const perArm = (records[0] as Record<string, unknown>)['arms'] as Record<string, unknown[]>;
+        expect(perArm['vanilla']).toHaveLength(2);
     });
 });


### PR DESCRIPTION
## Problem

A killed `bench:ab:v2` sweep loses **every** completed run: the runner collects all results in memory and writes the paired report as one JSON file only at the very end. A recent 180-run sweep was killed at run 117/180 — all 117 results (and their API spend) were gone, and the restart had to begin at run 1.

## Fix

Per-run checkpointing with automatic resume:

- After each completed run (task × arm × seed), the result is appended as one JSONL line to `internal/bench/reports/ab-v2/checkpoints/<config-hash>.jsonl` (single atomic-enough append; a kill costs at most the in-flight run).
- The file is keyed by a sha256 hash over the sweep config (corpus, model, seeds, arms, budget, timeout, host, resolved task ids) — a restart with the **same flags** resumes automatically and re-runs only the missing runs; any config change gets a fresh checkpoint and never mixes results.
- After the paired report is written, the checkpoint is deleted — a finished sweep leaves no residue (the directory is already gitignored via `reports/ab-v2/`).
- `--no-checkpoint` disables the mechanism; `--fresh` discards a stale checkpoint and starts over.

## Design notes

- **Report byte-parity preserved on resume**: `PyFloat` wrappers (the `1.0`-vs-`1` json.dumps parity) don't survive a naive JSON round-trip, so checkpoint entries are frozen (`PyFloat → {"__pyfloat__": n}`) and thawed on load. Verified in the smoke run: a resumed run renders `"discipline_score": 1.0`.
- **Tolerant load**: a truncated tail line (killed mid-append) is skipped — that run simply re-executes; duplicate keys → last wins.
- **Fresh runs unchanged**: without a prior checkpoint, stdout/stderr and the written report are byte-identical to the pre-checkpoint behaviour (only the checkpoint file write is new). The sweep loop was extracted as `collect_records()` with an injectable run seam so resume is testable without live model calls.
- Taskfile `bench:ab:v2` description documents the new behaviour next to the 180-run cost warning.

## Verification

- `tsc --noEmit` green, `eslint` green on touched files (also removed two pre-existing unused consts in the touched test file)
- `vitest`: 19/19 across `bench_ab_v2_run.test.ts` (6 new checkpoint tests incl. a simulated kill-at-3/8 + resume asserting only the 5 missing runs execute) and the recursive-loop suite
- Fake-`CLAUDE_CLI` end-to-end smoke (no live spend): sweep killed at run 2/2 → checkpoint holds 1 run → restart prints the resume notice, executes only the missing run, writes the complete report, deletes the checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)