### PR TITLE
feat(commit-policy): one-shot authorization is not a standing license

### DIFF
--- a/dist/agent-src/rules/commit-policy.md
+++ b/dist/agent-src/rules/commit-policy.md
@@ -31,6 +31,16 @@ Exactly four:
 
 Anything else → no commit. Hard Floor (bulk deletions, infra changes) still fires on top of any exception — see [`commit-mechanics`](../contexts/authority/commit-mechanics.md) for diff triggers and roadmap-authorized commit flow.
 
+## One-shot authorization is not a standing license
+
+```
+A ONE-OFF AUTHORIZATION IS SPENT ON EXACTLY THAT OPERATION, ONCE.
+IT NEVER BECOMES A STANDING LICENSE FOR LATER COMMITS OR PUSHES.
+EACH FURTHER COMMIT / PUSH NEEDS ITS OWN FRESH, EXPLICIT GO-AHEAD.
+```
+
+"Commit this", "push it", "open the PR", "create the PRs" authorize **that operation, once** — not the commits/pushes that follow later in the **same** task. "Create the PR" is spent on the initial branch + commit + push + PR; the next change (a follow-up fix, a review response, a quality pass, a "while I'm here" cleanup) waits for a new instruction. A task instruction that only asks for **code** ("fix X", "use file Y for tests", "there's a linter error") authorizes the code change **only** — never a commit or push. Re-using an earlier authorization for a later operation is exactly the inference (exception 2 misread as "standing") this rule forbids.
+
 ## NEVER ask about committing
 
 "Should I commit this?" / "do we want to commit?" — **forbidden**. The user invokes a command or says so. No commit option in numbered-options blocks unless the message is incomplete without it.

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -265,7 +265,7 @@
   "rules/cli-output-handling.md": "ae095d2d6de55191007ea21819dc657d8fe413eac09a0846ba3dbd021fbb272d",
   "rules/command-suggestion-policy.md": "b34523af7f5a054e68bc18a432eceb7f3cabbfeee63c6d6279ec730724a81a79",
   "rules/commit-conventions.md": "57c2a2d16c6ce00db5831fd4b7df99e29433680d742f4713f4738a8823e2f29f",
-  "rules/commit-policy.md": "900bd2004abf1fd9707600d45e9b12c361179d4de0c29b79f93270ec50b35191",
+  "rules/commit-policy.md": "eeb803c90535e541e3606d92420841b96373310c57367f6c1e85210611ef3736",
   "rules/content-quoting-floor.md": "91dc3fe9e3ce38802d6a2a816cd4473c65d9a766f6da28ca76562b4cd22e62a2",
   "rules/context-hygiene.md": "c86a2e090d01087e1ff0b97163883f1378fc28b239a0ba9d83bac8f70f5375b6",
   "rules/copilot-routing.md": "1aaa77973564e987bc02a9157493c3d7d30f5e382a293e60847b44be1d0663cd",

--- a/src/rules/commit-policy.md
+++ b/src/rules/commit-policy.md
@@ -31,6 +31,16 @@ Exactly four:
 
 Anything else → no commit. Hard Floor (bulk deletions, infra changes) still fires on top of any exception — see [`commit-mechanics`](../contexts/authority/commit-mechanics.md) for diff triggers and roadmap-authorized commit flow.
 
+## One-shot authorization is not a standing license
+
+```
+A ONE-OFF AUTHORIZATION IS SPENT ON EXACTLY THAT OPERATION, ONCE.
+IT NEVER BECOMES A STANDING LICENSE FOR LATER COMMITS OR PUSHES.
+EACH FURTHER COMMIT / PUSH NEEDS ITS OWN FRESH, EXPLICIT GO-AHEAD.
+```
+
+"Commit this", "push it", "open the PR", "create the PRs" authorize **that operation, once** — not the commits/pushes that follow later in the **same** task. "Create the PR" is spent on the initial branch + commit + push + PR; the next change (a follow-up fix, a review response, a quality pass, a "while I'm here" cleanup) waits for a new instruction. A task instruction that only asks for **code** ("fix X", "use file Y for tests", "there's a linter error") authorizes the code change **only** — never a commit or push. Re-using an earlier authorization for a later operation is exactly the inference (exception 2 misread as "standing") this rule forbids.
+
 ## NEVER ask about committing
 
 "Should I commit this?" / "do we want to commit?" — **forbidden**. The user invokes a command or says so. No commit option in numbered-options blocks unless the message is incomplete without it.


### PR DESCRIPTION
## Why

Closes a real gap in the commit-policy exceptions. The four exceptions cover *"user says so this turn"* (one-off) and *"standing instruction not yet revoked"*, but nothing explicitly said that a task-scoped one-off authorization — *"create the PRs"*, *"push it"* — is **not** a standing license. That let follow-up commits/pushes in the same task happen without fresh consent (exception 2 misread as "standing").

Real incident: after an authorized "create the PRs", every subsequent code fix was committed + pushed autonomously. The user was — rightly — angry.

## Change

New section in `src/rules/commit-policy.md`, right after the four exceptions:

~~~
## One-shot authorization is not a standing license

```
A ONE-OFF AUTHORIZATION IS SPENT ON EXACTLY THAT OPERATION, ONCE.
IT NEVER BECOMES A STANDING LICENSE FOR LATER COMMITS OR PUSHES.
EACH FURTHER COMMIT / PUSH NEEDS ITS OWN FRESH, EXPLICIT GO-AHEAD.
```
~~~

Prose clarifies: "commit this / push it / open the PR / create the PRs" authorize *that operation, once*; a code-only instruction ("fix X", "there's a linter error") authorizes the code change **only** — never a commit or push.

The Iron Law and the existing sections are unchanged.

## Files (3)

- `src/rules/commit-policy.md` — source (the new section)
- `dist/agent-src/rules/commit-policy.md` — condensed projection (1:1 for this rule)
- `internal/.condensation-hashes.json` — hash bump

## Verification

- `condense --check` → hashes in sync
- `check_condensation` → 0 errors

> Draft: `commit-policy` is a `safety-floor` rule (own PR per the kernel-rule slow-rollout guarantee); left as draft for review before merge.