### PR TITLE
fix(install): accept --no-ui in the bash orchestrator (unblocks npx upgrade)

### DIFF
--- a/src/scripts/install
+++ b/src/scripts/install
@@ -27,6 +27,9 @@
 #                     the comma-separated values are unioned.
 #   --list-tools      Print supported tool IDs with descriptions, then exit
 #   --yes, -y         Non-interactive mode: do not prompt (default for non-TTY)
+#   --no-ui           Unattended install: never launch the browser setup
+#                     wizard and skip the terminal tool picker (tools default
+#                     to all). Used by `agent-config upgrade`.
 #   --force           Overwrite existing bridge files
 #   --dry-run         Show what payload sync would do (does not run bridges)
 #   --verbose         Detailed payload sync output
@@ -95,12 +98,13 @@ MINIMAL=false
 VALIDATE_ONLY=false
 FLEET_CONFIG=""
 USER_TYPE=""
+NO_UI=false
 
 # Single source of truth for valid tool IDs (also referenced by install.sh / install.py).
 VALID_TOOLS="claude-code claude-desktop cursor windsurf cline gemini-cli copilot augment aider codex roocode continue kilocode zed jetbrains kiro all"
 
 show_help() {
-    sed -n '3,58p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '3,61p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 list_tools() {
@@ -167,6 +171,7 @@ while [[ $# -gt 0 ]]; do
         --ai=*)          TOOLS="${TOOLS:+$TOOLS,}${1#*=}"; TOOLS_EXPLICIT=true; shift ;;
         --list-tools)    LIST_TOOLS=true; shift ;;
         --yes|-y)        YES=true; shift ;;
+        --no-ui)         NO_UI=true; shift ;;
         --force)         FORCE=true; shift ;;
         --dry-run)       DRY_RUN=true; shift ;;
         --verbose)       VERBOSE=true; shift ;;
@@ -192,6 +197,15 @@ done
 if $LIST_TOOLS; then
     list_tools
     exit 0
+fi
+
+# --no-ui = unattended install (the `agent-config upgrade` path). Export the
+# suppression env so every downstream stage (install.ts honors both the flag
+# and AGENT_CONFIG_NO_UI) skips the browser setup wizard — the wizard is an
+# onboarding surface whose foreground server used to block `upgrade` until
+# Ctrl-C.
+if $NO_UI; then
+    export AGENT_CONFIG_NO_UI=1
 fi
 
 # road-to-global-only-install § Phase 3.3 — consumer-floor gate.
@@ -282,8 +296,8 @@ prompt_tools() {
 # When an interactive global install will hand off to the browser wizard,
 # the wizard is the single tool-selection surface — skip the terminal
 # picker so it does not pre-empt (and, via TOOLS_EXPLICIT, suppress) the
-# GUI. Mirrors install.py::_wizard_should_launch minus the --no-ui flag,
-# which the bash orchestrator never receives (it errors on unknown args).
+# GUI. Mirrors install.py::_wizard_should_launch (the --no-ui flag is
+# handled here too — it suppresses both the wizard and the picker).
 # Headless paths (no TTY / CI / AGENT_CONFIG_NO_UI) still get the picker.
 wizard_will_handle_tools=false
 if $GLOBAL && [[ -t 0 && -t 1 && -z "${CI:-}" ]] \
@@ -291,8 +305,12 @@ if $GLOBAL && [[ -t 0 && -t 1 && -z "${CI:-}" ]] \
     wizard_will_handle_tools=true
 fi
 
+# --no-ui also skips the terminal picker: the flag means "fully unattended"
+# (its only caller today is `agent-config upgrade`, where a mid-upgrade
+# prompt reads as a hang). Tools fall through to the "all" default below —
+# the same effective selection the wizard-handoff path used.
 if ! $MINIMAL && ! $TOOLS_EXPLICIT && ! $YES && ! $QUIET && ! $LIST_TOOLS \
-   && [[ -t 0 && -t 1 ]] && ! $wizard_will_handle_tools; then
+   && [[ -t 0 && -t 1 ]] && ! $wizard_will_handle_tools && ! $NO_UI; then
     prompt_tools
     TOOLS_EXPLICIT=true
 fi
@@ -416,6 +434,7 @@ run_bridges() {
     [[ -n "$CUSTOM_PATH" ]] && args+=(--custom-path="$CUSTOM_PATH")
     $OFFLINE && args+=(--offline)
     $MINIMAL && args+=(--minimal)
+    $NO_UI && args+=(--no-ui)
     args+=(--tools="$TOOLS")
     "${runner[@]}" "${args[@]}"
 }

--- a/tests/test_install_orchestrator.sh
+++ b/tests/test_install_orchestrator.sh
@@ -276,6 +276,36 @@ test_source_repo_guard_override_env_bypasses() {
     teardown
 }
 
+# --- `agent-config upgrade` contract (--no-ui) ---
+
+# `agent-config upgrade` runs `agent-config global --no-ui` as its refresh
+# step (the browser setup wizard is an onboarding surface, not an upgrade
+# step — its foreground server made `npx @event4u/agent-config upgrade` hang
+# until Ctrl-C). The orchestrator MUST accept the flag: an unknown-arg error
+# here fails every published upgrade at step 2.
+test_global_no_ui_flag_accepted() {
+    setup
+    local out exit_code
+    out="$(AGENT_CONFIG_INSTALLED_LOCK="$TEST_TARGET/installed.lock" \
+        bash "$INSTALL" --target "$TEST_TARGET" --global --no-ui --tools=claude-code --quiet 2>&1)"; exit_code=$?
+    assert_true "--no-ui: exit 0 on global install (rc=$exit_code)" test "$exit_code" -eq 0
+    assert_false "--no-ui: no 'Unknown argument' error" grep -q "Unknown argument: --no-ui" <<<"$out"
+    assert_true "--no-ui: lockfile written (install actually ran)" test -f "$TEST_TARGET/installed.lock"
+    teardown
+}
+
+# --no-ui documents itself: the help text must name the flag so the contract
+# between cmd_upgrade.ts and this orchestrator stays discoverable.
+test_global_no_ui_flag_documented_in_help() {
+    local out
+    out="$(bash "$INSTALL" --help 2>&1)"
+    if echo "$out" | grep -q -- "--no-ui"; then
+        pass "--help documents --no-ui"
+    else
+        fail "--help output missing --no-ui"
+    fi
+}
+
 test_source_repo_guard_package_json_marker() {
     setup
     # No .agent-src.uncondensed/, but package.json declares the source name.
@@ -312,6 +342,8 @@ TESTS=(
     test_source_repo_guard_allows_global_install
     test_source_repo_guard_override_env_bypasses
     test_source_repo_guard_package_json_marker
+    test_global_no_ui_flag_accepted
+    test_global_no_ui_flag_documented_in_help
 )
 
 # SHARD=N/M env var: keep only Nth slice of M (1-indexed) before dispatch.


### PR DESCRIPTION
## Problem

`npx -y @event4u/agent-config upgrade` was unusable:

- **Before 8.2.0** — the global-refresh step (`agent-config global`) auto-launched the setup wizard's foreground server on a TTY, so the upgrade hung endlessly until Ctrl-C (which then reported the run as failed).
- **Since 8.2.0** — f2c6cc5a9 made `cmd_upgrade` pass `agent-config global --no-ui` to skip the wizard, but the bash orchestrator (`src/scripts/install`, which `global` execs into) never learned the flag: `❌ Unknown argument: --no-ui` → every published upgrade now fails at step 2 instead of hanging.

## Fix

`src/scripts/install` now understands `--no-ui`:

- parses the flag and exports `AGENT_CONFIG_NO_UI=1` so every downstream stage (`install.ts` honors both the flag and the env) suppresses the browser setup wizard,
- forwards `--no-ui` to the bridge stage explicitly,
- skips the interactive terminal tool picker under `--no-ui` (fully unattended — tools fall through to the same `all` default the wizard-handoff path used), so an upgrade on a TTY never blocks on a prompt,
- documents the flag in the header help (`show_help` sed range extended accordingly).

## Tests (CI)

Two regression tests in `tests/test_install_orchestrator.sh` (runs in `.github/workflows/tests.yml`):

- `test_global_no_ui_flag_accepted` — a sandboxed `--global --no-ui --tools=claude-code` install exits 0, emits no `Unknown argument` error, and writes the lockfile (proof the install actually ran). Red before this fix, green after.
- `test_global_no_ui_flag_documented_in_help` — `--help` names the flag, keeping the cmd_upgrade ↔ orchestrator contract discoverable.

## Verification

- Reproduced the failure against the published 8.2.0 (`npx -y @event4u/agent-config upgrade` → `Unknown argument: --no-ui`, step 2 exit 1).
- Pre-fix baseline in this branch reproduces the same error; both new tests pass post-fix (`bash tests/test_install_orchestrator.sh --single …`).
- `bash -n` clean on both edited scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)