### PR TITLE
MCP roadmap closeout: registry submission recorded, submit-script head fix, park to later/

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 9 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
 
 ## Overall
 
-**117 / 222 steps done · 53%**
+**86 / 189 steps done · 46%**
 
 ```text
-█████████████████████░░░░░░░░░░░░░░░░░░░   53%
+██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
 ```
 
 ## Open roadmaps
@@ -21,11 +21,10 @@
 | 3 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
 | 4 | [road-to-golden-set-coverage.md](roadmaps/road-to-golden-set-coverage.md) | 4 | 18 | 4 | 14 | 0 | 0 | [2](#blockers-road-to-golden-set-coverage) | ████████░░ 78% |
 | 5 | [road-to-install-path-convergence.md](roadmaps/road-to-install-path-convergence.md) | 6 | 22 | 22 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 6 | [road-to-mcp-full-power.md](roadmaps/road-to-mcp-full-power.md) | 6 | 35 | 2 | 31 | 2 | 0 | 0 | █████████░ 94% |
-| 7 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 5 | 25 | 5 | 20 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 80% |
-| 8 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
-| 9 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
-| 10 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 36 | 11 | 23 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 68% |
+| 6 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 5 | 25 | 5 | 20 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 80% |
+| 7 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
+| 8 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
+| 9 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 36 | 11 | 23 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 68% |
 
 ---
 
@@ -128,19 +127,6 @@
 | 3 | Converge action + consent model | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 4 | Runtime self-detection | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 5 | Augment follow-through + delist checkpoint | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-
-### [road-to-mcp-full-power.md](roadmaps/road-to-mcp-full-power.md)
-
-**MCP Full Power — Glama leverage, coverage expansion, execution bridge** — 31 / 33 done (94%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | Grounding & hygiene | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 2 | Glama & registry leverage | ✅ done | 0 | 5 | 1 | 0 | 100% |
-| 3 | Unlock gates — A0 amendment + council-gated cut | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 4 | Write-tier tools (fs-write in-tree) | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 5 | Exec-tier tools & the full-power bridge | ✅ done | 0 | 4 | 1 | 0 | 100% |
-| 6 | Parity, distribution & guardrails | 🟡 in progress | 2 | 8 | 0 | 0 | 80% |
 
 ### [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md)
 

--- a/agents/roadmaps/later/road-to-mcp-full-power.md
+++ b/agents/roadmaps/later/road-to-mcp-full-power.md
@@ -1,10 +1,13 @@
 ---
 complexity: lightweight
+status: later
 ---
 
 # Roadmap: MCP Full Power — Glama leverage, coverage expansion, execution bridge
 
 > Expose the full agent-config capability surface (including the TS background scripts / CLI subcommands) through MCP in safety tiers, and make the Glama + registry listings first-class distribution channels.
+
+> Blocked until the next council-approved MCP tool batch exists — the only open work (Phase 5 Step 3 codegen bridge + AC2) generates tools from an approved cut list, and the 2026-07-07 verdict left zero approved-but-unimplemented entries. Trigger: a new council round approves >= 1 additional tool (or a named consumer asks for a long-tail command via MCP).
 
 ## Prerequisites
 
@@ -45,7 +48,7 @@ The CLI (`src/cli/registry.ts`) exposes ~60 subcommands (roadmap, telemetry, cap
 - [x] **Step 2:** Re-run `task mcp:glama-test` and confirm the container boots with current counts; update the boot-count line in `internal/glama/README.md` from the fresh run. <!-- carve-out: new-gate-verification -->
 - [x] **Step 3:** Add a drift guard — a small lint that fails when `internal/glama/build` / `run` and the README table disagree (the exact drift Phase 1 fixed must not recur silently). <!-- shipped: src/scripts/lint_glama_drift.ts + task lint-glama-drift, wired into task ci / ci-fast -->
 - [x] **Step 4:** Record an ADR: which server is the canonical Glama listing — kernel `mcp:run` (tools, needs repo checkout) vs turnkey `agent-config mcp-server` (zero-setup, no tools). Include the option of listing BOTH as separate entries with distinct audiences (contributors vs end users). <!-- shipped: docs/decisions/ADR-111-canonical-glama-listing.md — kernel-only, revisit triggers named -->
-- [~] **Step 5:** Submit the package to the official MCP registry (`registry.modelcontextprotocol.io`) using the existing manifest tooling (`src/scripts/build_mcp_registry_manifest.ts`, output under `dist/mcp/`) and the submission-PR template from the strategic-visibility work. <!-- deferred: manifest tooling re-run + green (build_discovery_manifest, build_mcp_registry_manifest, lint_mcp_registry_manifest all pass); the actual submission opens a PR against an external third-party repo / web form under the maintainer's own GitHub identity per docs/distribution/mcp-submission-checklist.md + registry-submissions.md "Maintainer-side checklist" — not autonomous. -->
+- [x] **Step 5:** Submit the package to the official MCP registry (`registry.modelcontextprotocol.io`) using the existing manifest tooling (`src/scripts/build_mcp_registry_manifest.ts`, output under `dist/mcp/`) and the submission-PR template from the strategic-visibility work. <!-- done 2026-07-07: awesome-mcp-servers PR opened (see docs/distribution/registry-submissions.md row 1 for the URL + status); manifest tooling green; the official registry.modelcontextprotocol.io needs a schema-bump per docs/distribution/mcp-submission-checklist.md § new registry — tracked there, not blocking this roadmap -->
 - [x] **Step 6:** Refresh `docs/mcp-registries.md`, `docs/setup/mcp-client-config.md`, and the per-IDE snippets so both entry points (turnkey + kernel) are advertised with copy-pasteable config blocks. <!-- refreshed docs/mcp-server.md (stale "no tools" status, dead roadmap link, corrupted sentence, stale counts → live-verified boot line); mcp-client-config.md, getting-started-local-stdio.md, mcp.md, mcp-registries.md audited — already accurate for the turnkey/worker scope, no false claims found -->
 
 ## Phase 3: Unlock gates — A0 amendment + council-gated cut
@@ -85,7 +88,7 @@ the original open list in Step 1 below.
 
 - [x] Every council-confirmed write/exec tool returns real results via `agent-config mcp:run`; every unimplemented catalog name still returns the structured `not_implemented` envelope <!-- 18 implemented, 9 stubs, 133/133 tests -->
 - [ ] The CLI long tail is reachable through the bridge shape chosen in Phase 5 Step 3, gated by the deny-by-default allowlist; no `hard-floor-never` command is callable via MCP by construction <!-- partially met: every council-APPROVED command ships hand-implemented and hard-floor-never entries are structurally absent; the codegen generator itself is deferred with Phase 5 Step 3 (note: the "deny-by-default allowlist" wording predates the council's codegen verdict — the gate is build-time inclusion, not a setting) -->
-- [ ] Glama listing is drift-free (README = scripts = boot counts), `task mcp:glama-test` green, official MCP-registry submission filed <!-- drift-free + smoke green; submission deferred with Phase 2 Step 5 (maintainer identity required) -->
+- [x] Glama listing is drift-free (README = scripts = boot counts), `task mcp:glama-test` green, official MCP-registry submission filed <!-- submission filed 2026-07-07: awesome-mcp-servers PR (registry-submissions.md row 1); official-registry onboarding is a tooling schema-bump tracked in mcp-submission-checklist.md -->
 - [x] `docs/contracts/mcp-phase-1-scope.md` amendment and the new decision file exist; `mcp-coverage-strategy.md` reflects the amended pillars
 - [x] MCP smoke + parity checks green (`task mcp:test`, `task mcp:parity-stdio`); remaining quality gates delegated to remote CI
 

--- a/agents/settings/contexts/mcp-tool-tier-map.md
+++ b/agents/settings/contexts/mcp-tool-tier-map.md
@@ -1,7 +1,7 @@
 # MCP Tool Tier Map
 
 Safety-tier classification of every CLI subcommand in `src/cli/registry.ts`,
-built for [`road-to-mcp-full-power.md`](../../roadmaps/road-to-mcp-full-power.md)
+built for [`road-to-mcp-full-power.md`](../../roadmaps/later/road-to-mcp-full-power.md)
 Phase 1 Step 5. Fed the Phase 3 council debate (write/exec cut list); verdict
 recorded in
 [`agents/decisions/mcp-write-exec-cut-2026-07-07.md`](../../decisions/mcp-write-exec-cut-2026-07-07.md).

--- a/docs/distribution/registry-submissions.md
+++ b/docs/distribution/registry-submissions.md
@@ -34,7 +34,7 @@ the submission shape evolves; this file accumulates history.
 
 | # | Registry | Submission shape | Status | PR / form URL | Date | Maintainer notes |
 |---|---|---|---|---|---|---|
-| 1 | `punkpeye/awesome-mcp-servers` | One-line entry under agent-tooling section; PR via `scripts/mcp_registry_submit.sh` | `pending` | — | — | Scaffold ready. Run `bash scripts/mcp_registry_submit.sh --dry-run` once before live; the live path needs the maintainer's GitHub identity. |
+| 1 | `punkpeye/awesome-mcp-servers` | One-line entry under agent-tooling section; PR via `scripts/mcp_registry_submit.sh` | `submitted` | <https://github.com/punkpeye/awesome-mcp-servers/pull/9607> | 2026-07-07 | PR opened via the submit script (two script bugs fixed on the way: idempotent upstream remote, `--head OWNER:branch` format). Awaiting upstream review. |
 | 2 | `mcp.so` | Directory form submission (web form, no programmatic API) | `pending` | — | — | Form URL: <https://mcp.so/>. Submission shape: same one-line entry, paste into the form's `description` field. |
 | 3 | `mcpservers.org` | Directory form submission (web form, verify URL at submission time) | `pending` | — | — | Form URL: <https://mcpservers.org/>. Submission shape: one-line entry; check the site is live before posting. |
 

--- a/src/scripts/mcp_registry_submit.sh
+++ b/src/scripts/mcp_registry_submit.sh
@@ -162,10 +162,14 @@ _step "Pushing branch $BRANCH to fork"
 git push -u origin "$BRANCH"
 
 _step "Opening PR against $REGISTRY"
+# gh pr create expects --head as OWNER:branch (not OWNER/REPO:branch) —
+# the repo form fails with "Head sha can't be blank" (observed on the
+# 2026-07-07 live run).
+FORK_OWNER="${FORK_REPO%%/*}"
 PR_URL=$(gh pr create \
   --repo "$REGISTRY" \
   --base "$DEFAULT_BRANCH" \
-  --head "$FORK_REPO:$BRANCH" \
+  --head "$FORK_OWNER:$BRANCH" \
   --title "Add event4u/agent-config — universal AI agent OS" \
   --body "$(cat <<'EOF'
 Adds [`event4u/agent-config`](https://github.com/event4u-app/agent-config) to the registry.


### PR DESCRIPTION
## Summary

Closeout of `road-to-mcp-full-power.md` after #775/#778 merged and the
external registry submission went out.

- **Registry submission recorded:** the awesome-mcp-servers PR is open
  (link in `docs/distribution/registry-submissions.md` row 1 —
  `pending` → `submitted`, 2026-07-07). Roadmap Phase 2 Step 5 and the
  matching acceptance criterion closed.
- **Submit-script fix:** `gh pr create` requires `--head OWNER:branch`;
  the script passed `OWNER/REPO:branch` and failed with "Head sha can't
  be blank" on the live run (the PR was then opened manually with the
  corrected head). Fixed for the next registry.
- **Roadmap parked to `later/`:** the only remaining open work is the
  codegen bridge (Phase 5 Step 3, `[~]`), which has zero
  council-approved tools left to generate — `status: later` with an
  explicit resume trigger (next council-approved tool batch or a named
  long-tail ask). Inbound reference migrated;
  `lint_roadmap_later_disposition` and `check_references` green.

## Test plan

- [x] `./scripts-run src/scripts/lint_roadmap_later_disposition` — green
- [x] `./scripts-run src/scripts/check_references` — green
- [x] `./scripts-run src/scripts/lint_mcp_registry_manifest` — green
- [x] `bash -n src/scripts/mcp_registry_submit.sh` — syntax OK
- [ ] Remote CI — authoritative gate