### PR TITLE
feat: upgrade-time settings-change review (surface snapshot + dynamic review form)

### DIFF
--- a/dist/install/install.mjs
+++ b/dist/install/install.mjs
@@ -15,6 +15,10 @@ var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require
 var __commonJS = (cb, mod) => function __require2() {
   return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
 };
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
 var __copyProps = (to, from, except, desc) => {
   if (from && typeof from === "object" || typeof from === "function") {
     for (let key of __getOwnPropNames(from))
@@ -329,8 +333,8 @@ var require_directives = __commonJS({
               this.yaml.version = version;
               return true;
             } else {
-              const isValid = /^\d+\.\d+$/.test(version);
-              onError(6, `Unsupported YAML version ${version}`, isValid);
+              const isValid2 = /^\d+\.\d+$/.test(version);
+              onError(6, `Unsupported YAML version ${version}`, isValid2);
               return false;
             }
           }
@@ -9727,6 +9731,5811 @@ function _is_plain_dict(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+// src/shared/settingsSurface.ts
+function unwrapRef(root) {
+  if (root.$ref !== void 0 && root.definitions !== void 0) {
+    const name = root.$ref.replace("#/definitions/", "");
+    const def = root.definitions[name];
+    if (def !== void 0) return def;
+  }
+  return root;
+}
+function flattenSurface(schema, version) {
+  const entries = {};
+  const walk = (node, prefix) => {
+    if (node.type === "object" && node.properties !== void 0) {
+      for (const key of Object.keys(node.properties).sort()) {
+        const child = node.properties[key];
+        walk(child, prefix === "" ? key : `${prefix}.${key}`);
+      }
+      return;
+    }
+    if (prefix === "") return;
+    const entry = { type: node.type ?? (node.enum !== void 0 ? "enum" : "unknown") };
+    if (node.default !== void 0) entry.default = node.default;
+    if (node.enum !== void 0) entry.enum = [...node.enum];
+    if (node.description !== void 0) entry.description = node.description;
+    entries[prefix] = entry;
+  };
+  walk(unwrapRef(schema), "");
+  return { version, entries };
+}
+function sameJson(a, b) {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+function computeSurfaceDelta(oldS, newS) {
+  const changes = [];
+  const oldKeys = new Set(Object.keys(oldS.entries));
+  const newKeys = new Set(Object.keys(newS.entries));
+  for (const key of [...newKeys].sort()) {
+    const n = newS.entries[key];
+    if (!oldKeys.has(key)) {
+      changes.push({ key, kind: "added", new: n });
+      continue;
+    }
+    const o = oldS.entries[key];
+    if (o.type !== n.type) {
+      changes.push({ key, kind: "type_changed", old: o, new: n });
+    }
+    if (!sameJson(o.default, n.default)) {
+      changes.push({ key, kind: "default_changed", old: o, new: n });
+    }
+    const oldEnum = new Set(o.enum ?? []);
+    const newEnum = new Set(n.enum ?? []);
+    if (o.enum !== void 0 || n.enum !== void 0) {
+      const addedVals = [...newEnum].filter((v) => !oldEnum.has(v));
+      const removedVals = [...oldEnum].filter((v) => !newEnum.has(v));
+      if (addedVals.length > 0) {
+        changes.push({ key, kind: "enum_added", old: o, new: n, values: addedVals });
+      }
+      if (removedVals.length > 0) {
+        changes.push({ key, kind: "enum_removed", old: o, new: n, values: removedVals });
+      }
+    }
+  }
+  for (const key of [...oldKeys].sort()) {
+    if (!newKeys.has(key)) {
+      changes.push({ key, kind: "removed", old: oldS.entries[key] });
+    }
+  }
+  return { oldVersion: oldS.version, newVersion: newS.version, changes };
+}
+
+// node_modules/zod/v3/external.js
+var external_exports = {};
+__export(external_exports, {
+  BRAND: () => BRAND,
+  DIRTY: () => DIRTY,
+  EMPTY_PATH: () => EMPTY_PATH,
+  INVALID: () => INVALID,
+  NEVER: () => NEVER,
+  OK: () => OK,
+  ParseStatus: () => ParseStatus,
+  Schema: () => ZodType,
+  ZodAny: () => ZodAny,
+  ZodArray: () => ZodArray,
+  ZodBigInt: () => ZodBigInt,
+  ZodBoolean: () => ZodBoolean,
+  ZodBranded: () => ZodBranded,
+  ZodCatch: () => ZodCatch,
+  ZodDate: () => ZodDate,
+  ZodDefault: () => ZodDefault,
+  ZodDiscriminatedUnion: () => ZodDiscriminatedUnion,
+  ZodEffects: () => ZodEffects,
+  ZodEnum: () => ZodEnum,
+  ZodError: () => ZodError,
+  ZodFirstPartyTypeKind: () => ZodFirstPartyTypeKind,
+  ZodFunction: () => ZodFunction,
+  ZodIntersection: () => ZodIntersection,
+  ZodIssueCode: () => ZodIssueCode,
+  ZodLazy: () => ZodLazy,
+  ZodLiteral: () => ZodLiteral,
+  ZodMap: () => ZodMap,
+  ZodNaN: () => ZodNaN,
+  ZodNativeEnum: () => ZodNativeEnum,
+  ZodNever: () => ZodNever,
+  ZodNull: () => ZodNull,
+  ZodNullable: () => ZodNullable,
+  ZodNumber: () => ZodNumber,
+  ZodObject: () => ZodObject,
+  ZodOptional: () => ZodOptional,
+  ZodParsedType: () => ZodParsedType,
+  ZodPipeline: () => ZodPipeline,
+  ZodPromise: () => ZodPromise,
+  ZodReadonly: () => ZodReadonly,
+  ZodRecord: () => ZodRecord,
+  ZodSchema: () => ZodType,
+  ZodSet: () => ZodSet,
+  ZodString: () => ZodString,
+  ZodSymbol: () => ZodSymbol,
+  ZodTransformer: () => ZodEffects,
+  ZodTuple: () => ZodTuple,
+  ZodType: () => ZodType,
+  ZodUndefined: () => ZodUndefined,
+  ZodUnion: () => ZodUnion,
+  ZodUnknown: () => ZodUnknown,
+  ZodVoid: () => ZodVoid,
+  addIssueToContext: () => addIssueToContext,
+  any: () => anyType,
+  array: () => arrayType,
+  bigint: () => bigIntType,
+  boolean: () => booleanType,
+  coerce: () => coerce,
+  custom: () => custom,
+  date: () => dateType,
+  datetimeRegex: () => datetimeRegex,
+  defaultErrorMap: () => en_default,
+  discriminatedUnion: () => discriminatedUnionType,
+  effect: () => effectsType,
+  enum: () => enumType,
+  function: () => functionType,
+  getErrorMap: () => getErrorMap,
+  getParsedType: () => getParsedType,
+  instanceof: () => instanceOfType,
+  intersection: () => intersectionType,
+  isAborted: () => isAborted,
+  isAsync: () => isAsync,
+  isDirty: () => isDirty,
+  isValid: () => isValid,
+  late: () => late,
+  lazy: () => lazyType,
+  literal: () => literalType,
+  makeIssue: () => makeIssue,
+  map: () => mapType,
+  nan: () => nanType,
+  nativeEnum: () => nativeEnumType,
+  never: () => neverType,
+  null: () => nullType,
+  nullable: () => nullableType,
+  number: () => numberType,
+  object: () => objectType,
+  objectUtil: () => objectUtil,
+  oboolean: () => oboolean,
+  onumber: () => onumber,
+  optional: () => optionalType,
+  ostring: () => ostring,
+  pipeline: () => pipelineType,
+  preprocess: () => preprocessType,
+  promise: () => promiseType,
+  quotelessJson: () => quotelessJson,
+  record: () => recordType,
+  set: () => setType,
+  setErrorMap: () => setErrorMap,
+  strictObject: () => strictObjectType,
+  string: () => stringType,
+  symbol: () => symbolType,
+  transformer: () => effectsType,
+  tuple: () => tupleType,
+  undefined: () => undefinedType,
+  union: () => unionType,
+  unknown: () => unknownType,
+  util: () => util,
+  void: () => voidType
+});
+
+// node_modules/zod/v3/helpers/util.js
+var util;
+(function(util2) {
+  util2.assertEqual = (_) => {
+  };
+  function assertIs(_arg) {
+  }
+  util2.assertIs = assertIs;
+  function assertNever(_x) {
+    throw new Error();
+  }
+  util2.assertNever = assertNever;
+  util2.arrayToEnum = (items) => {
+    const obj = {};
+    for (const item of items) {
+      obj[item] = item;
+    }
+    return obj;
+  };
+  util2.getValidEnumValues = (obj) => {
+    const validKeys = util2.objectKeys(obj).filter((k) => typeof obj[obj[k]] !== "number");
+    const filtered = {};
+    for (const k of validKeys) {
+      filtered[k] = obj[k];
+    }
+    return util2.objectValues(filtered);
+  };
+  util2.objectValues = (obj) => {
+    return util2.objectKeys(obj).map(function(e) {
+      return obj[e];
+    });
+  };
+  util2.objectKeys = typeof Object.keys === "function" ? (obj) => Object.keys(obj) : (object) => {
+    const keys = [];
+    for (const key in object) {
+      if (Object.prototype.hasOwnProperty.call(object, key)) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  };
+  util2.find = (arr, checker) => {
+    for (const item of arr) {
+      if (checker(item))
+        return item;
+    }
+    return void 0;
+  };
+  util2.isInteger = typeof Number.isInteger === "function" ? (val) => Number.isInteger(val) : (val) => typeof val === "number" && Number.isFinite(val) && Math.floor(val) === val;
+  function joinValues(array, separator = " | ") {
+    return array.map((val) => typeof val === "string" ? `'${val}'` : val).join(separator);
+  }
+  util2.joinValues = joinValues;
+  util2.jsonStringifyReplacer = (_, value) => {
+    if (typeof value === "bigint") {
+      return value.toString();
+    }
+    return value;
+  };
+})(util || (util = {}));
+var objectUtil;
+(function(objectUtil2) {
+  objectUtil2.mergeShapes = (first, second) => {
+    return {
+      ...first,
+      ...second
+      // second overwrites first
+    };
+  };
+})(objectUtil || (objectUtil = {}));
+var ZodParsedType = util.arrayToEnum([
+  "string",
+  "nan",
+  "number",
+  "integer",
+  "float",
+  "boolean",
+  "date",
+  "bigint",
+  "symbol",
+  "function",
+  "undefined",
+  "null",
+  "array",
+  "object",
+  "unknown",
+  "promise",
+  "void",
+  "never",
+  "map",
+  "set"
+]);
+var getParsedType = (data) => {
+  const t = typeof data;
+  switch (t) {
+    case "undefined":
+      return ZodParsedType.undefined;
+    case "string":
+      return ZodParsedType.string;
+    case "number":
+      return Number.isNaN(data) ? ZodParsedType.nan : ZodParsedType.number;
+    case "boolean":
+      return ZodParsedType.boolean;
+    case "function":
+      return ZodParsedType.function;
+    case "bigint":
+      return ZodParsedType.bigint;
+    case "symbol":
+      return ZodParsedType.symbol;
+    case "object":
+      if (Array.isArray(data)) {
+        return ZodParsedType.array;
+      }
+      if (data === null) {
+        return ZodParsedType.null;
+      }
+      if (data.then && typeof data.then === "function" && data.catch && typeof data.catch === "function") {
+        return ZodParsedType.promise;
+      }
+      if (typeof Map !== "undefined" && data instanceof Map) {
+        return ZodParsedType.map;
+      }
+      if (typeof Set !== "undefined" && data instanceof Set) {
+        return ZodParsedType.set;
+      }
+      if (typeof Date !== "undefined" && data instanceof Date) {
+        return ZodParsedType.date;
+      }
+      return ZodParsedType.object;
+    default:
+      return ZodParsedType.unknown;
+  }
+};
+
+// node_modules/zod/v3/ZodError.js
+var ZodIssueCode = util.arrayToEnum([
+  "invalid_type",
+  "invalid_literal",
+  "custom",
+  "invalid_union",
+  "invalid_union_discriminator",
+  "invalid_enum_value",
+  "unrecognized_keys",
+  "invalid_arguments",
+  "invalid_return_type",
+  "invalid_date",
+  "invalid_string",
+  "too_small",
+  "too_big",
+  "invalid_intersection_types",
+  "not_multiple_of",
+  "not_finite"
+]);
+var quotelessJson = (obj) => {
+  const json = JSON.stringify(obj, null, 2);
+  return json.replace(/"([^"]+)":/g, "$1:");
+};
+var ZodError = class _ZodError extends Error {
+  get errors() {
+    return this.issues;
+  }
+  constructor(issues) {
+    super();
+    this.issues = [];
+    this.addIssue = (sub) => {
+      this.issues = [...this.issues, sub];
+    };
+    this.addIssues = (subs = []) => {
+      this.issues = [...this.issues, ...subs];
+    };
+    const actualProto = new.target.prototype;
+    if (Object.setPrototypeOf) {
+      Object.setPrototypeOf(this, actualProto);
+    } else {
+      this.__proto__ = actualProto;
+    }
+    this.name = "ZodError";
+    this.issues = issues;
+  }
+  format(_mapper) {
+    const mapper = _mapper || function(issue) {
+      return issue.message;
+    };
+    const fieldErrors = { _errors: [] };
+    const processError = (error) => {
+      for (const issue of error.issues) {
+        if (issue.code === "invalid_union") {
+          issue.unionErrors.map(processError);
+        } else if (issue.code === "invalid_return_type") {
+          processError(issue.returnTypeError);
+        } else if (issue.code === "invalid_arguments") {
+          processError(issue.argumentsError);
+        } else if (issue.path.length === 0) {
+          fieldErrors._errors.push(mapper(issue));
+        } else {
+          let curr = fieldErrors;
+          let i = 0;
+          while (i < issue.path.length) {
+            const el = issue.path[i];
+            const terminal = i === issue.path.length - 1;
+            if (!terminal) {
+              curr[el] = curr[el] || { _errors: [] };
+            } else {
+              curr[el] = curr[el] || { _errors: [] };
+              curr[el]._errors.push(mapper(issue));
+            }
+            curr = curr[el];
+            i++;
+          }
+        }
+      }
+    };
+    processError(this);
+    return fieldErrors;
+  }
+  static assert(value) {
+    if (!(value instanceof _ZodError)) {
+      throw new Error(`Not a ZodError: ${value}`);
+    }
+  }
+  toString() {
+    return this.message;
+  }
+  get message() {
+    return JSON.stringify(this.issues, util.jsonStringifyReplacer, 2);
+  }
+  get isEmpty() {
+    return this.issues.length === 0;
+  }
+  flatten(mapper = (issue) => issue.message) {
+    const fieldErrors = {};
+    const formErrors = [];
+    for (const sub of this.issues) {
+      if (sub.path.length > 0) {
+        const firstEl = sub.path[0];
+        fieldErrors[firstEl] = fieldErrors[firstEl] || [];
+        fieldErrors[firstEl].push(mapper(sub));
+      } else {
+        formErrors.push(mapper(sub));
+      }
+    }
+    return { formErrors, fieldErrors };
+  }
+  get formErrors() {
+    return this.flatten();
+  }
+};
+ZodError.create = (issues) => {
+  const error = new ZodError(issues);
+  return error;
+};
+
+// node_modules/zod/v3/locales/en.js
+var errorMap = (issue, _ctx) => {
+  let message;
+  switch (issue.code) {
+    case ZodIssueCode.invalid_type:
+      if (issue.received === ZodParsedType.undefined) {
+        message = "Required";
+      } else {
+        message = `Expected ${issue.expected}, received ${issue.received}`;
+      }
+      break;
+    case ZodIssueCode.invalid_literal:
+      message = `Invalid literal value, expected ${JSON.stringify(issue.expected, util.jsonStringifyReplacer)}`;
+      break;
+    case ZodIssueCode.unrecognized_keys:
+      message = `Unrecognized key(s) in object: ${util.joinValues(issue.keys, ", ")}`;
+      break;
+    case ZodIssueCode.invalid_union:
+      message = `Invalid input`;
+      break;
+    case ZodIssueCode.invalid_union_discriminator:
+      message = `Invalid discriminator value. Expected ${util.joinValues(issue.options)}`;
+      break;
+    case ZodIssueCode.invalid_enum_value:
+      message = `Invalid enum value. Expected ${util.joinValues(issue.options)}, received '${issue.received}'`;
+      break;
+    case ZodIssueCode.invalid_arguments:
+      message = `Invalid function arguments`;
+      break;
+    case ZodIssueCode.invalid_return_type:
+      message = `Invalid function return type`;
+      break;
+    case ZodIssueCode.invalid_date:
+      message = `Invalid date`;
+      break;
+    case ZodIssueCode.invalid_string:
+      if (typeof issue.validation === "object") {
+        if ("includes" in issue.validation) {
+          message = `Invalid input: must include "${issue.validation.includes}"`;
+          if (typeof issue.validation.position === "number") {
+            message = `${message} at one or more positions greater than or equal to ${issue.validation.position}`;
+          }
+        } else if ("startsWith" in issue.validation) {
+          message = `Invalid input: must start with "${issue.validation.startsWith}"`;
+        } else if ("endsWith" in issue.validation) {
+          message = `Invalid input: must end with "${issue.validation.endsWith}"`;
+        } else {
+          util.assertNever(issue.validation);
+        }
+      } else if (issue.validation !== "regex") {
+        message = `Invalid ${issue.validation}`;
+      } else {
+        message = "Invalid";
+      }
+      break;
+    case ZodIssueCode.too_small:
+      if (issue.type === "array")
+        message = `Array must contain ${issue.exact ? "exactly" : issue.inclusive ? `at least` : `more than`} ${issue.minimum} element(s)`;
+      else if (issue.type === "string")
+        message = `String must contain ${issue.exact ? "exactly" : issue.inclusive ? `at least` : `over`} ${issue.minimum} character(s)`;
+      else if (issue.type === "number")
+        message = `Number must be ${issue.exact ? `exactly equal to ` : issue.inclusive ? `greater than or equal to ` : `greater than `}${issue.minimum}`;
+      else if (issue.type === "bigint")
+        message = `Number must be ${issue.exact ? `exactly equal to ` : issue.inclusive ? `greater than or equal to ` : `greater than `}${issue.minimum}`;
+      else if (issue.type === "date")
+        message = `Date must be ${issue.exact ? `exactly equal to ` : issue.inclusive ? `greater than or equal to ` : `greater than `}${new Date(Number(issue.minimum))}`;
+      else
+        message = "Invalid input";
+      break;
+    case ZodIssueCode.too_big:
+      if (issue.type === "array")
+        message = `Array must contain ${issue.exact ? `exactly` : issue.inclusive ? `at most` : `less than`} ${issue.maximum} element(s)`;
+      else if (issue.type === "string")
+        message = `String must contain ${issue.exact ? `exactly` : issue.inclusive ? `at most` : `under`} ${issue.maximum} character(s)`;
+      else if (issue.type === "number")
+        message = `Number must be ${issue.exact ? `exactly` : issue.inclusive ? `less than or equal to` : `less than`} ${issue.maximum}`;
+      else if (issue.type === "bigint")
+        message = `BigInt must be ${issue.exact ? `exactly` : issue.inclusive ? `less than or equal to` : `less than`} ${issue.maximum}`;
+      else if (issue.type === "date")
+        message = `Date must be ${issue.exact ? `exactly` : issue.inclusive ? `smaller than or equal to` : `smaller than`} ${new Date(Number(issue.maximum))}`;
+      else
+        message = "Invalid input";
+      break;
+    case ZodIssueCode.custom:
+      message = `Invalid input`;
+      break;
+    case ZodIssueCode.invalid_intersection_types:
+      message = `Intersection results could not be merged`;
+      break;
+    case ZodIssueCode.not_multiple_of:
+      message = `Number must be a multiple of ${issue.multipleOf}`;
+      break;
+    case ZodIssueCode.not_finite:
+      message = "Number must be finite";
+      break;
+    default:
+      message = _ctx.defaultError;
+      util.assertNever(issue);
+  }
+  return { message };
+};
+var en_default = errorMap;
+
+// node_modules/zod/v3/errors.js
+var overrideErrorMap = en_default;
+function setErrorMap(map) {
+  overrideErrorMap = map;
+}
+function getErrorMap() {
+  return overrideErrorMap;
+}
+
+// node_modules/zod/v3/helpers/parseUtil.js
+var makeIssue = (params) => {
+  const { data, path: path12, errorMaps, issueData } = params;
+  const fullPath = [...path12, ...issueData.path || []];
+  const fullIssue = {
+    ...issueData,
+    path: fullPath
+  };
+  if (issueData.message !== void 0) {
+    return {
+      ...issueData,
+      path: fullPath,
+      message: issueData.message
+    };
+  }
+  let errorMessage = "";
+  const maps = errorMaps.filter((m) => !!m).slice().reverse();
+  for (const map of maps) {
+    errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
+  }
+  return {
+    ...issueData,
+    path: fullPath,
+    message: errorMessage
+  };
+};
+var EMPTY_PATH = [];
+function addIssueToContext(ctx, issueData) {
+  const overrideMap = getErrorMap();
+  const issue = makeIssue({
+    issueData,
+    data: ctx.data,
+    path: ctx.path,
+    errorMaps: [
+      ctx.common.contextualErrorMap,
+      // contextual error map is first priority
+      ctx.schemaErrorMap,
+      // then schema-bound map if available
+      overrideMap,
+      // then global override map
+      overrideMap === en_default ? void 0 : en_default
+      // then global default map
+    ].filter((x) => !!x)
+  });
+  ctx.common.issues.push(issue);
+}
+var ParseStatus = class _ParseStatus {
+  constructor() {
+    this.value = "valid";
+  }
+  dirty() {
+    if (this.value === "valid")
+      this.value = "dirty";
+  }
+  abort() {
+    if (this.value !== "aborted")
+      this.value = "aborted";
+  }
+  static mergeArray(status, results) {
+    const arrayValue = [];
+    for (const s of results) {
+      if (s.status === "aborted")
+        return INVALID;
+      if (s.status === "dirty")
+        status.dirty();
+      arrayValue.push(s.value);
+    }
+    return { status: status.value, value: arrayValue };
+  }
+  static async mergeObjectAsync(status, pairs) {
+    const syncPairs = [];
+    for (const pair of pairs) {
+      const key = await pair.key;
+      const value = await pair.value;
+      syncPairs.push({
+        key,
+        value
+      });
+    }
+    return _ParseStatus.mergeObjectSync(status, syncPairs);
+  }
+  static mergeObjectSync(status, pairs) {
+    const finalObject = {};
+    for (const pair of pairs) {
+      const { key, value } = pair;
+      if (key.status === "aborted")
+        return INVALID;
+      if (value.status === "aborted")
+        return INVALID;
+      if (key.status === "dirty")
+        status.dirty();
+      if (value.status === "dirty")
+        status.dirty();
+      if (key.value !== "__proto__" && (typeof value.value !== "undefined" || pair.alwaysSet)) {
+        finalObject[key.value] = value.value;
+      }
+    }
+    return { status: status.value, value: finalObject };
+  }
+};
+var INVALID = Object.freeze({
+  status: "aborted"
+});
+var DIRTY = (value) => ({ status: "dirty", value });
+var OK = (value) => ({ status: "valid", value });
+var isAborted = (x) => x.status === "aborted";
+var isDirty = (x) => x.status === "dirty";
+var isValid = (x) => x.status === "valid";
+var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
+
+// node_modules/zod/v3/helpers/errorUtil.js
+var errorUtil;
+(function(errorUtil2) {
+  errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
+  errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
+})(errorUtil || (errorUtil = {}));
+
+// node_modules/zod/v3/types.js
+var ParseInputLazyPath = class {
+  constructor(parent, value, path12, key) {
+    this._cachedPath = [];
+    this.parent = parent;
+    this.data = value;
+    this._path = path12;
+    this._key = key;
+  }
+  get path() {
+    if (!this._cachedPath.length) {
+      if (Array.isArray(this._key)) {
+        this._cachedPath.push(...this._path, ...this._key);
+      } else {
+        this._cachedPath.push(...this._path, this._key);
+      }
+    }
+    return this._cachedPath;
+  }
+};
+var handleResult = (ctx, result) => {
+  if (isValid(result)) {
+    return { success: true, data: result.value };
+  } else {
+    if (!ctx.common.issues.length) {
+      throw new Error("Validation failed but no issues detected.");
+    }
+    return {
+      success: false,
+      get error() {
+        if (this._error)
+          return this._error;
+        const error = new ZodError(ctx.common.issues);
+        this._error = error;
+        return this._error;
+      }
+    };
+  }
+};
+function processCreateParams(params) {
+  if (!params)
+    return {};
+  const { errorMap: errorMap2, invalid_type_error, required_error, description } = params;
+  if (errorMap2 && (invalid_type_error || required_error)) {
+    throw new Error(`Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`);
+  }
+  if (errorMap2)
+    return { errorMap: errorMap2, description };
+  const customMap = (iss, ctx) => {
+    const { message } = params;
+    if (iss.code === "invalid_enum_value") {
+      return { message: message ?? ctx.defaultError };
+    }
+    if (typeof ctx.data === "undefined") {
+      return { message: message ?? required_error ?? ctx.defaultError };
+    }
+    if (iss.code !== "invalid_type")
+      return { message: ctx.defaultError };
+    return { message: message ?? invalid_type_error ?? ctx.defaultError };
+  };
+  return { errorMap: customMap, description };
+}
+var ZodType = class {
+  get description() {
+    return this._def.description;
+  }
+  _getType(input) {
+    return getParsedType(input.data);
+  }
+  _getOrReturnCtx(input, ctx) {
+    return ctx || {
+      common: input.parent.common,
+      data: input.data,
+      parsedType: getParsedType(input.data),
+      schemaErrorMap: this._def.errorMap,
+      path: input.path,
+      parent: input.parent
+    };
+  }
+  _processInputParams(input) {
+    return {
+      status: new ParseStatus(),
+      ctx: {
+        common: input.parent.common,
+        data: input.data,
+        parsedType: getParsedType(input.data),
+        schemaErrorMap: this._def.errorMap,
+        path: input.path,
+        parent: input.parent
+      }
+    };
+  }
+  _parseSync(input) {
+    const result = this._parse(input);
+    if (isAsync(result)) {
+      throw new Error("Synchronous parse encountered promise.");
+    }
+    return result;
+  }
+  _parseAsync(input) {
+    const result = this._parse(input);
+    return Promise.resolve(result);
+  }
+  parse(data, params) {
+    const result = this.safeParse(data, params);
+    if (result.success)
+      return result.data;
+    throw result.error;
+  }
+  safeParse(data, params) {
+    const ctx = {
+      common: {
+        issues: [],
+        async: params?.async ?? false,
+        contextualErrorMap: params?.errorMap
+      },
+      path: params?.path || [],
+      schemaErrorMap: this._def.errorMap,
+      parent: null,
+      data,
+      parsedType: getParsedType(data)
+    };
+    const result = this._parseSync({ data, path: ctx.path, parent: ctx });
+    return handleResult(ctx, result);
+  }
+  "~validate"(data) {
+    const ctx = {
+      common: {
+        issues: [],
+        async: !!this["~standard"].async
+      },
+      path: [],
+      schemaErrorMap: this._def.errorMap,
+      parent: null,
+      data,
+      parsedType: getParsedType(data)
+    };
+    if (!this["~standard"].async) {
+      try {
+        const result = this._parseSync({ data, path: [], parent: ctx });
+        return isValid(result) ? {
+          value: result.value
+        } : {
+          issues: ctx.common.issues
+        };
+      } catch (err) {
+        if (err?.message?.toLowerCase()?.includes("encountered")) {
+          this["~standard"].async = true;
+        }
+        ctx.common = {
+          issues: [],
+          async: true
+        };
+      }
+    }
+    return this._parseAsync({ data, path: [], parent: ctx }).then((result) => isValid(result) ? {
+      value: result.value
+    } : {
+      issues: ctx.common.issues
+    });
+  }
+  async parseAsync(data, params) {
+    const result = await this.safeParseAsync(data, params);
+    if (result.success)
+      return result.data;
+    throw result.error;
+  }
+  async safeParseAsync(data, params) {
+    const ctx = {
+      common: {
+        issues: [],
+        contextualErrorMap: params?.errorMap,
+        async: true
+      },
+      path: params?.path || [],
+      schemaErrorMap: this._def.errorMap,
+      parent: null,
+      data,
+      parsedType: getParsedType(data)
+    };
+    const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
+    const result = await (isAsync(maybeAsyncResult) ? maybeAsyncResult : Promise.resolve(maybeAsyncResult));
+    return handleResult(ctx, result);
+  }
+  refine(check, message) {
+    const getIssueProperties = (val) => {
+      if (typeof message === "string" || typeof message === "undefined") {
+        return { message };
+      } else if (typeof message === "function") {
+        return message(val);
+      } else {
+        return message;
+      }
+    };
+    return this._refinement((val, ctx) => {
+      const result = check(val);
+      const setError = () => ctx.addIssue({
+        code: ZodIssueCode.custom,
+        ...getIssueProperties(val)
+      });
+      if (typeof Promise !== "undefined" && result instanceof Promise) {
+        return result.then((data) => {
+          if (!data) {
+            setError();
+            return false;
+          } else {
+            return true;
+          }
+        });
+      }
+      if (!result) {
+        setError();
+        return false;
+      } else {
+        return true;
+      }
+    });
+  }
+  refinement(check, refinementData) {
+    return this._refinement((val, ctx) => {
+      if (!check(val)) {
+        ctx.addIssue(typeof refinementData === "function" ? refinementData(val, ctx) : refinementData);
+        return false;
+      } else {
+        return true;
+      }
+    });
+  }
+  _refinement(refinement) {
+    return new ZodEffects({
+      schema: this,
+      typeName: ZodFirstPartyTypeKind.ZodEffects,
+      effect: { type: "refinement", refinement }
+    });
+  }
+  superRefine(refinement) {
+    return this._refinement(refinement);
+  }
+  constructor(def) {
+    this.spa = this.safeParseAsync;
+    this._def = def;
+    this.parse = this.parse.bind(this);
+    this.safeParse = this.safeParse.bind(this);
+    this.parseAsync = this.parseAsync.bind(this);
+    this.safeParseAsync = this.safeParseAsync.bind(this);
+    this.spa = this.spa.bind(this);
+    this.refine = this.refine.bind(this);
+    this.refinement = this.refinement.bind(this);
+    this.superRefine = this.superRefine.bind(this);
+    this.optional = this.optional.bind(this);
+    this.nullable = this.nullable.bind(this);
+    this.nullish = this.nullish.bind(this);
+    this.array = this.array.bind(this);
+    this.promise = this.promise.bind(this);
+    this.or = this.or.bind(this);
+    this.and = this.and.bind(this);
+    this.transform = this.transform.bind(this);
+    this.brand = this.brand.bind(this);
+    this.default = this.default.bind(this);
+    this.catch = this.catch.bind(this);
+    this.describe = this.describe.bind(this);
+    this.pipe = this.pipe.bind(this);
+    this.readonly = this.readonly.bind(this);
+    this.isNullable = this.isNullable.bind(this);
+    this.isOptional = this.isOptional.bind(this);
+    this["~standard"] = {
+      version: 1,
+      vendor: "zod",
+      validate: (data) => this["~validate"](data)
+    };
+  }
+  optional() {
+    return ZodOptional.create(this, this._def);
+  }
+  nullable() {
+    return ZodNullable.create(this, this._def);
+  }
+  nullish() {
+    return this.nullable().optional();
+  }
+  array() {
+    return ZodArray.create(this);
+  }
+  promise() {
+    return ZodPromise.create(this, this._def);
+  }
+  or(option) {
+    return ZodUnion.create([this, option], this._def);
+  }
+  and(incoming) {
+    return ZodIntersection.create(this, incoming, this._def);
+  }
+  transform(transform) {
+    return new ZodEffects({
+      ...processCreateParams(this._def),
+      schema: this,
+      typeName: ZodFirstPartyTypeKind.ZodEffects,
+      effect: { type: "transform", transform }
+    });
+  }
+  default(def) {
+    const defaultValueFunc = typeof def === "function" ? def : () => def;
+    return new ZodDefault({
+      ...processCreateParams(this._def),
+      innerType: this,
+      defaultValue: defaultValueFunc,
+      typeName: ZodFirstPartyTypeKind.ZodDefault
+    });
+  }
+  brand() {
+    return new ZodBranded({
+      typeName: ZodFirstPartyTypeKind.ZodBranded,
+      type: this,
+      ...processCreateParams(this._def)
+    });
+  }
+  catch(def) {
+    const catchValueFunc = typeof def === "function" ? def : () => def;
+    return new ZodCatch({
+      ...processCreateParams(this._def),
+      innerType: this,
+      catchValue: catchValueFunc,
+      typeName: ZodFirstPartyTypeKind.ZodCatch
+    });
+  }
+  describe(description) {
+    const This = this.constructor;
+    return new This({
+      ...this._def,
+      description
+    });
+  }
+  pipe(target) {
+    return ZodPipeline.create(this, target);
+  }
+  readonly() {
+    return ZodReadonly.create(this);
+  }
+  isOptional() {
+    return this.safeParse(void 0).success;
+  }
+  isNullable() {
+    return this.safeParse(null).success;
+  }
+};
+var cuidRegex = /^c[^\s-]{8,}$/i;
+var cuid2Regex = /^[0-9a-z]+$/;
+var ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
+var uuidRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+var nanoidRegex = /^[a-z0-9_-]{21}$/i;
+var jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
+var durationRegex = /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
+var emailRegex = /^(?!\.)(?!.*\.\.)([A-Z0-9_'+\-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i;
+var _emojiRegex = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
+var emojiRegex;
+var ipv4Regex = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
+var ipv4CidrRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/(3[0-2]|[12]?[0-9])$/;
+var ipv6Regex = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/;
+var ipv6CidrRegex = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
+var base64Regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+var base64urlRegex = /^([0-9a-zA-Z-_]{4})*(([0-9a-zA-Z-_]{2}(==)?)|([0-9a-zA-Z-_]{3}(=)?))?$/;
+var dateRegexSource = `((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))`;
+var dateRegex = new RegExp(`^${dateRegexSource}$`);
+function timeRegexSource(args) {
+  let secondsRegexSource = `[0-5]\\d`;
+  if (args.precision) {
+    secondsRegexSource = `${secondsRegexSource}\\.\\d{${args.precision}}`;
+  } else if (args.precision == null) {
+    secondsRegexSource = `${secondsRegexSource}(\\.\\d+)?`;
+  }
+  const secondsQuantifier = args.precision ? "+" : "?";
+  return `([01]\\d|2[0-3]):[0-5]\\d(:${secondsRegexSource})${secondsQuantifier}`;
+}
+function timeRegex(args) {
+  return new RegExp(`^${timeRegexSource(args)}$`);
+}
+function datetimeRegex(args) {
+  let regex = `${dateRegexSource}T${timeRegexSource(args)}`;
+  const opts = [];
+  opts.push(args.local ? `Z?` : `Z`);
+  if (args.offset)
+    opts.push(`([+-]\\d{2}:?\\d{2})`);
+  regex = `${regex}(${opts.join("|")})`;
+  return new RegExp(`^${regex}$`);
+}
+function isValidIP(ip, version) {
+  if ((version === "v4" || !version) && ipv4Regex.test(ip)) {
+    return true;
+  }
+  if ((version === "v6" || !version) && ipv6Regex.test(ip)) {
+    return true;
+  }
+  return false;
+}
+function isValidJWT(jwt, alg) {
+  if (!jwtRegex.test(jwt))
+    return false;
+  try {
+    const [header] = jwt.split(".");
+    if (!header)
+      return false;
+    const base64 = header.replace(/-/g, "+").replace(/_/g, "/").padEnd(header.length + (4 - header.length % 4) % 4, "=");
+    const decoded = JSON.parse(atob(base64));
+    if (typeof decoded !== "object" || decoded === null)
+      return false;
+    if ("typ" in decoded && decoded?.typ !== "JWT")
+      return false;
+    if (!decoded.alg)
+      return false;
+    if (alg && decoded.alg !== alg)
+      return false;
+    return true;
+  } catch {
+    return false;
+  }
+}
+function isValidCidr(ip, version) {
+  if ((version === "v4" || !version) && ipv4CidrRegex.test(ip)) {
+    return true;
+  }
+  if ((version === "v6" || !version) && ipv6CidrRegex.test(ip)) {
+    return true;
+  }
+  return false;
+}
+var ZodString = class _ZodString extends ZodType {
+  _parse(input) {
+    if (this._def.coerce) {
+      input.data = String(input.data);
+    }
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.string) {
+      const ctx2 = this._getOrReturnCtx(input);
+      addIssueToContext(ctx2, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.string,
+        received: ctx2.parsedType
+      });
+      return INVALID;
+    }
+    const status = new ParseStatus();
+    let ctx = void 0;
+    for (const check of this._def.checks) {
+      if (check.kind === "min") {
+        if (input.data.length < check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_small,
+            minimum: check.value,
+            type: "string",
+            inclusive: true,
+            exact: false,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "max") {
+        if (input.data.length > check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_big,
+            maximum: check.value,
+            type: "string",
+            inclusive: true,
+            exact: false,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "length") {
+        const tooBig = input.data.length > check.value;
+        const tooSmall = input.data.length < check.value;
+        if (tooBig || tooSmall) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          if (tooBig) {
+            addIssueToContext(ctx, {
+              code: ZodIssueCode.too_big,
+              maximum: check.value,
+              type: "string",
+              inclusive: true,
+              exact: true,
+              message: check.message
+            });
+          } else if (tooSmall) {
+            addIssueToContext(ctx, {
+              code: ZodIssueCode.too_small,
+              minimum: check.value,
+              type: "string",
+              inclusive: true,
+              exact: true,
+              message: check.message
+            });
+          }
+          status.dirty();
+        }
+      } else if (check.kind === "email") {
+        if (!emailRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "email",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "emoji") {
+        if (!emojiRegex) {
+          emojiRegex = new RegExp(_emojiRegex, "u");
+        }
+        if (!emojiRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "emoji",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "uuid") {
+        if (!uuidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "uuid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "nanoid") {
+        if (!nanoidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "nanoid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "cuid") {
+        if (!cuidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "cuid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "cuid2") {
+        if (!cuid2Regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "cuid2",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "ulid") {
+        if (!ulidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "ulid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "url") {
+        try {
+          new URL(input.data);
+        } catch {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "url",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "regex") {
+        check.regex.lastIndex = 0;
+        const testResult = check.regex.test(input.data);
+        if (!testResult) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "regex",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "trim") {
+        input.data = input.data.trim();
+      } else if (check.kind === "includes") {
+        if (!input.data.includes(check.value, check.position)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: { includes: check.value, position: check.position },
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "toLowerCase") {
+        input.data = input.data.toLowerCase();
+      } else if (check.kind === "toUpperCase") {
+        input.data = input.data.toUpperCase();
+      } else if (check.kind === "startsWith") {
+        if (!input.data.startsWith(check.value)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: { startsWith: check.value },
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "endsWith") {
+        if (!input.data.endsWith(check.value)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: { endsWith: check.value },
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "datetime") {
+        const regex = datetimeRegex(check);
+        if (!regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: "datetime",
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "date") {
+        const regex = dateRegex;
+        if (!regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: "date",
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "time") {
+        const regex = timeRegex(check);
+        if (!regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: "time",
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "duration") {
+        if (!durationRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "duration",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "ip") {
+        if (!isValidIP(input.data, check.version)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "ip",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "jwt") {
+        if (!isValidJWT(input.data, check.alg)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "jwt",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "cidr") {
+        if (!isValidCidr(input.data, check.version)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "cidr",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "base64") {
+        if (!base64Regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "base64",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "base64url") {
+        if (!base64urlRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "base64url",
+            code: ZodIssueCode.invalid_string,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else {
+        util.assertNever(check);
+      }
+    }
+    return { status: status.value, value: input.data };
+  }
+  _regex(regex, validation, message) {
+    return this.refinement((data) => regex.test(data), {
+      validation,
+      code: ZodIssueCode.invalid_string,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  _addCheck(check) {
+    return new _ZodString({
+      ...this._def,
+      checks: [...this._def.checks, check]
+    });
+  }
+  email(message) {
+    return this._addCheck({ kind: "email", ...errorUtil.errToObj(message) });
+  }
+  url(message) {
+    return this._addCheck({ kind: "url", ...errorUtil.errToObj(message) });
+  }
+  emoji(message) {
+    return this._addCheck({ kind: "emoji", ...errorUtil.errToObj(message) });
+  }
+  uuid(message) {
+    return this._addCheck({ kind: "uuid", ...errorUtil.errToObj(message) });
+  }
+  nanoid(message) {
+    return this._addCheck({ kind: "nanoid", ...errorUtil.errToObj(message) });
+  }
+  cuid(message) {
+    return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
+  }
+  cuid2(message) {
+    return this._addCheck({ kind: "cuid2", ...errorUtil.errToObj(message) });
+  }
+  ulid(message) {
+    return this._addCheck({ kind: "ulid", ...errorUtil.errToObj(message) });
+  }
+  base64(message) {
+    return this._addCheck({ kind: "base64", ...errorUtil.errToObj(message) });
+  }
+  base64url(message) {
+    return this._addCheck({
+      kind: "base64url",
+      ...errorUtil.errToObj(message)
+    });
+  }
+  jwt(options) {
+    return this._addCheck({ kind: "jwt", ...errorUtil.errToObj(options) });
+  }
+  ip(options) {
+    return this._addCheck({ kind: "ip", ...errorUtil.errToObj(options) });
+  }
+  cidr(options) {
+    return this._addCheck({ kind: "cidr", ...errorUtil.errToObj(options) });
+  }
+  datetime(options) {
+    if (typeof options === "string") {
+      return this._addCheck({
+        kind: "datetime",
+        precision: null,
+        offset: false,
+        local: false,
+        message: options
+      });
+    }
+    return this._addCheck({
+      kind: "datetime",
+      precision: typeof options?.precision === "undefined" ? null : options?.precision,
+      offset: options?.offset ?? false,
+      local: options?.local ?? false,
+      ...errorUtil.errToObj(options?.message)
+    });
+  }
+  date(message) {
+    return this._addCheck({ kind: "date", message });
+  }
+  time(options) {
+    if (typeof options === "string") {
+      return this._addCheck({
+        kind: "time",
+        precision: null,
+        message: options
+      });
+    }
+    return this._addCheck({
+      kind: "time",
+      precision: typeof options?.precision === "undefined" ? null : options?.precision,
+      ...errorUtil.errToObj(options?.message)
+    });
+  }
+  duration(message) {
+    return this._addCheck({ kind: "duration", ...errorUtil.errToObj(message) });
+  }
+  regex(regex, message) {
+    return this._addCheck({
+      kind: "regex",
+      regex,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  includes(value, options) {
+    return this._addCheck({
+      kind: "includes",
+      value,
+      position: options?.position,
+      ...errorUtil.errToObj(options?.message)
+    });
+  }
+  startsWith(value, message) {
+    return this._addCheck({
+      kind: "startsWith",
+      value,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  endsWith(value, message) {
+    return this._addCheck({
+      kind: "endsWith",
+      value,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  min(minLength, message) {
+    return this._addCheck({
+      kind: "min",
+      value: minLength,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  max(maxLength, message) {
+    return this._addCheck({
+      kind: "max",
+      value: maxLength,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  length(len, message) {
+    return this._addCheck({
+      kind: "length",
+      value: len,
+      ...errorUtil.errToObj(message)
+    });
+  }
+  /**
+   * Equivalent to `.min(1)`
+   */
+  nonempty(message) {
+    return this.min(1, errorUtil.errToObj(message));
+  }
+  trim() {
+    return new _ZodString({
+      ...this._def,
+      checks: [...this._def.checks, { kind: "trim" }]
+    });
+  }
+  toLowerCase() {
+    return new _ZodString({
+      ...this._def,
+      checks: [...this._def.checks, { kind: "toLowerCase" }]
+    });
+  }
+  toUpperCase() {
+    return new _ZodString({
+      ...this._def,
+      checks: [...this._def.checks, { kind: "toUpperCase" }]
+    });
+  }
+  get isDatetime() {
+    return !!this._def.checks.find((ch) => ch.kind === "datetime");
+  }
+  get isDate() {
+    return !!this._def.checks.find((ch) => ch.kind === "date");
+  }
+  get isTime() {
+    return !!this._def.checks.find((ch) => ch.kind === "time");
+  }
+  get isDuration() {
+    return !!this._def.checks.find((ch) => ch.kind === "duration");
+  }
+  get isEmail() {
+    return !!this._def.checks.find((ch) => ch.kind === "email");
+  }
+  get isURL() {
+    return !!this._def.checks.find((ch) => ch.kind === "url");
+  }
+  get isEmoji() {
+    return !!this._def.checks.find((ch) => ch.kind === "emoji");
+  }
+  get isUUID() {
+    return !!this._def.checks.find((ch) => ch.kind === "uuid");
+  }
+  get isNANOID() {
+    return !!this._def.checks.find((ch) => ch.kind === "nanoid");
+  }
+  get isCUID() {
+    return !!this._def.checks.find((ch) => ch.kind === "cuid");
+  }
+  get isCUID2() {
+    return !!this._def.checks.find((ch) => ch.kind === "cuid2");
+  }
+  get isULID() {
+    return !!this._def.checks.find((ch) => ch.kind === "ulid");
+  }
+  get isIP() {
+    return !!this._def.checks.find((ch) => ch.kind === "ip");
+  }
+  get isCIDR() {
+    return !!this._def.checks.find((ch) => ch.kind === "cidr");
+  }
+  get isBase64() {
+    return !!this._def.checks.find((ch) => ch.kind === "base64");
+  }
+  get isBase64url() {
+    return !!this._def.checks.find((ch) => ch.kind === "base64url");
+  }
+  get minLength() {
+    let min = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min)
+          min = ch.value;
+      }
+    }
+    return min;
+  }
+  get maxLength() {
+    let max = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max)
+          max = ch.value;
+      }
+    }
+    return max;
+  }
+};
+ZodString.create = (params) => {
+  return new ZodString({
+    checks: [],
+    typeName: ZodFirstPartyTypeKind.ZodString,
+    coerce: params?.coerce ?? false,
+    ...processCreateParams(params)
+  });
+};
+function floatSafeRemainder(val, step) {
+  const valDecCount = (val.toString().split(".")[1] || "").length;
+  const stepDecCount = (step.toString().split(".")[1] || "").length;
+  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
+  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
+  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
+  return valInt % stepInt / 10 ** decCount;
+}
+var ZodNumber = class _ZodNumber extends ZodType {
+  constructor() {
+    super(...arguments);
+    this.min = this.gte;
+    this.max = this.lte;
+    this.step = this.multipleOf;
+  }
+  _parse(input) {
+    if (this._def.coerce) {
+      input.data = Number(input.data);
+    }
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.number) {
+      const ctx2 = this._getOrReturnCtx(input);
+      addIssueToContext(ctx2, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.number,
+        received: ctx2.parsedType
+      });
+      return INVALID;
+    }
+    let ctx = void 0;
+    const status = new ParseStatus();
+    for (const check of this._def.checks) {
+      if (check.kind === "int") {
+        if (!util.isInteger(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_type,
+            expected: "integer",
+            received: "float",
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "min") {
+        const tooSmall = check.inclusive ? input.data < check.value : input.data <= check.value;
+        if (tooSmall) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_small,
+            minimum: check.value,
+            type: "number",
+            inclusive: check.inclusive,
+            exact: false,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "max") {
+        const tooBig = check.inclusive ? input.data > check.value : input.data >= check.value;
+        if (tooBig) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_big,
+            maximum: check.value,
+            type: "number",
+            inclusive: check.inclusive,
+            exact: false,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "multipleOf") {
+        if (floatSafeRemainder(input.data, check.value) !== 0) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.not_multiple_of,
+            multipleOf: check.value,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "finite") {
+        if (!Number.isFinite(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.not_finite,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else {
+        util.assertNever(check);
+      }
+    }
+    return { status: status.value, value: input.data };
+  }
+  gte(value, message) {
+    return this.setLimit("min", value, true, errorUtil.toString(message));
+  }
+  gt(value, message) {
+    return this.setLimit("min", value, false, errorUtil.toString(message));
+  }
+  lte(value, message) {
+    return this.setLimit("max", value, true, errorUtil.toString(message));
+  }
+  lt(value, message) {
+    return this.setLimit("max", value, false, errorUtil.toString(message));
+  }
+  setLimit(kind, value, inclusive, message) {
+    return new _ZodNumber({
+      ...this._def,
+      checks: [
+        ...this._def.checks,
+        {
+          kind,
+          value,
+          inclusive,
+          message: errorUtil.toString(message)
+        }
+      ]
+    });
+  }
+  _addCheck(check) {
+    return new _ZodNumber({
+      ...this._def,
+      checks: [...this._def.checks, check]
+    });
+  }
+  int(message) {
+    return this._addCheck({
+      kind: "int",
+      message: errorUtil.toString(message)
+    });
+  }
+  positive(message) {
+    return this._addCheck({
+      kind: "min",
+      value: 0,
+      inclusive: false,
+      message: errorUtil.toString(message)
+    });
+  }
+  negative(message) {
+    return this._addCheck({
+      kind: "max",
+      value: 0,
+      inclusive: false,
+      message: errorUtil.toString(message)
+    });
+  }
+  nonpositive(message) {
+    return this._addCheck({
+      kind: "max",
+      value: 0,
+      inclusive: true,
+      message: errorUtil.toString(message)
+    });
+  }
+  nonnegative(message) {
+    return this._addCheck({
+      kind: "min",
+      value: 0,
+      inclusive: true,
+      message: errorUtil.toString(message)
+    });
+  }
+  multipleOf(value, message) {
+    return this._addCheck({
+      kind: "multipleOf",
+      value,
+      message: errorUtil.toString(message)
+    });
+  }
+  finite(message) {
+    return this._addCheck({
+      kind: "finite",
+      message: errorUtil.toString(message)
+    });
+  }
+  safe(message) {
+    return this._addCheck({
+      kind: "min",
+      inclusive: true,
+      value: Number.MIN_SAFE_INTEGER,
+      message: errorUtil.toString(message)
+    })._addCheck({
+      kind: "max",
+      inclusive: true,
+      value: Number.MAX_SAFE_INTEGER,
+      message: errorUtil.toString(message)
+    });
+  }
+  get minValue() {
+    let min = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min)
+          min = ch.value;
+      }
+    }
+    return min;
+  }
+  get maxValue() {
+    let max = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max)
+          max = ch.value;
+      }
+    }
+    return max;
+  }
+  get isInt() {
+    return !!this._def.checks.find((ch) => ch.kind === "int" || ch.kind === "multipleOf" && util.isInteger(ch.value));
+  }
+  get isFinite() {
+    let max = null;
+    let min = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "finite" || ch.kind === "int" || ch.kind === "multipleOf") {
+        return true;
+      } else if (ch.kind === "min") {
+        if (min === null || ch.value > min)
+          min = ch.value;
+      } else if (ch.kind === "max") {
+        if (max === null || ch.value < max)
+          max = ch.value;
+      }
+    }
+    return Number.isFinite(min) && Number.isFinite(max);
+  }
+};
+ZodNumber.create = (params) => {
+  return new ZodNumber({
+    checks: [],
+    typeName: ZodFirstPartyTypeKind.ZodNumber,
+    coerce: params?.coerce || false,
+    ...processCreateParams(params)
+  });
+};
+var ZodBigInt = class _ZodBigInt extends ZodType {
+  constructor() {
+    super(...arguments);
+    this.min = this.gte;
+    this.max = this.lte;
+  }
+  _parse(input) {
+    if (this._def.coerce) {
+      try {
+        input.data = BigInt(input.data);
+      } catch {
+        return this._getInvalidInput(input);
+      }
+    }
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.bigint) {
+      return this._getInvalidInput(input);
+    }
+    let ctx = void 0;
+    const status = new ParseStatus();
+    for (const check of this._def.checks) {
+      if (check.kind === "min") {
+        const tooSmall = check.inclusive ? input.data < check.value : input.data <= check.value;
+        if (tooSmall) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_small,
+            type: "bigint",
+            minimum: check.value,
+            inclusive: check.inclusive,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "max") {
+        const tooBig = check.inclusive ? input.data > check.value : input.data >= check.value;
+        if (tooBig) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_big,
+            type: "bigint",
+            maximum: check.value,
+            inclusive: check.inclusive,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "multipleOf") {
+        if (input.data % check.value !== BigInt(0)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.not_multiple_of,
+            multipleOf: check.value,
+            message: check.message
+          });
+          status.dirty();
+        }
+      } else {
+        util.assertNever(check);
+      }
+    }
+    return { status: status.value, value: input.data };
+  }
+  _getInvalidInput(input) {
+    const ctx = this._getOrReturnCtx(input);
+    addIssueToContext(ctx, {
+      code: ZodIssueCode.invalid_type,
+      expected: ZodParsedType.bigint,
+      received: ctx.parsedType
+    });
+    return INVALID;
+  }
+  gte(value, message) {
+    return this.setLimit("min", value, true, errorUtil.toString(message));
+  }
+  gt(value, message) {
+    return this.setLimit("min", value, false, errorUtil.toString(message));
+  }
+  lte(value, message) {
+    return this.setLimit("max", value, true, errorUtil.toString(message));
+  }
+  lt(value, message) {
+    return this.setLimit("max", value, false, errorUtil.toString(message));
+  }
+  setLimit(kind, value, inclusive, message) {
+    return new _ZodBigInt({
+      ...this._def,
+      checks: [
+        ...this._def.checks,
+        {
+          kind,
+          value,
+          inclusive,
+          message: errorUtil.toString(message)
+        }
+      ]
+    });
+  }
+  _addCheck(check) {
+    return new _ZodBigInt({
+      ...this._def,
+      checks: [...this._def.checks, check]
+    });
+  }
+  positive(message) {
+    return this._addCheck({
+      kind: "min",
+      value: BigInt(0),
+      inclusive: false,
+      message: errorUtil.toString(message)
+    });
+  }
+  negative(message) {
+    return this._addCheck({
+      kind: "max",
+      value: BigInt(0),
+      inclusive: false,
+      message: errorUtil.toString(message)
+    });
+  }
+  nonpositive(message) {
+    return this._addCheck({
+      kind: "max",
+      value: BigInt(0),
+      inclusive: true,
+      message: errorUtil.toString(message)
+    });
+  }
+  nonnegative(message) {
+    return this._addCheck({
+      kind: "min",
+      value: BigInt(0),
+      inclusive: true,
+      message: errorUtil.toString(message)
+    });
+  }
+  multipleOf(value, message) {
+    return this._addCheck({
+      kind: "multipleOf",
+      value,
+      message: errorUtil.toString(message)
+    });
+  }
+  get minValue() {
+    let min = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min)
+          min = ch.value;
+      }
+    }
+    return min;
+  }
+  get maxValue() {
+    let max = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max)
+          max = ch.value;
+      }
+    }
+    return max;
+  }
+};
+ZodBigInt.create = (params) => {
+  return new ZodBigInt({
+    checks: [],
+    typeName: ZodFirstPartyTypeKind.ZodBigInt,
+    coerce: params?.coerce ?? false,
+    ...processCreateParams(params)
+  });
+};
+var ZodBoolean = class extends ZodType {
+  _parse(input) {
+    if (this._def.coerce) {
+      input.data = Boolean(input.data);
+    }
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.boolean) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.boolean,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+};
+ZodBoolean.create = (params) => {
+  return new ZodBoolean({
+    typeName: ZodFirstPartyTypeKind.ZodBoolean,
+    coerce: params?.coerce || false,
+    ...processCreateParams(params)
+  });
+};
+var ZodDate = class _ZodDate extends ZodType {
+  _parse(input) {
+    if (this._def.coerce) {
+      input.data = new Date(input.data);
+    }
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.date) {
+      const ctx2 = this._getOrReturnCtx(input);
+      addIssueToContext(ctx2, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.date,
+        received: ctx2.parsedType
+      });
+      return INVALID;
+    }
+    if (Number.isNaN(input.data.getTime())) {
+      const ctx2 = this._getOrReturnCtx(input);
+      addIssueToContext(ctx2, {
+        code: ZodIssueCode.invalid_date
+      });
+      return INVALID;
+    }
+    const status = new ParseStatus();
+    let ctx = void 0;
+    for (const check of this._def.checks) {
+      if (check.kind === "min") {
+        if (input.data.getTime() < check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_small,
+            message: check.message,
+            inclusive: true,
+            exact: false,
+            minimum: check.value,
+            type: "date"
+          });
+          status.dirty();
+        }
+      } else if (check.kind === "max") {
+        if (input.data.getTime() > check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.too_big,
+            message: check.message,
+            inclusive: true,
+            exact: false,
+            maximum: check.value,
+            type: "date"
+          });
+          status.dirty();
+        }
+      } else {
+        util.assertNever(check);
+      }
+    }
+    return {
+      status: status.value,
+      value: new Date(input.data.getTime())
+    };
+  }
+  _addCheck(check) {
+    return new _ZodDate({
+      ...this._def,
+      checks: [...this._def.checks, check]
+    });
+  }
+  min(minDate, message) {
+    return this._addCheck({
+      kind: "min",
+      value: minDate.getTime(),
+      message: errorUtil.toString(message)
+    });
+  }
+  max(maxDate, message) {
+    return this._addCheck({
+      kind: "max",
+      value: maxDate.getTime(),
+      message: errorUtil.toString(message)
+    });
+  }
+  get minDate() {
+    let min = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min)
+          min = ch.value;
+      }
+    }
+    return min != null ? new Date(min) : null;
+  }
+  get maxDate() {
+    let max = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max)
+          max = ch.value;
+      }
+    }
+    return max != null ? new Date(max) : null;
+  }
+};
+ZodDate.create = (params) => {
+  return new ZodDate({
+    checks: [],
+    coerce: params?.coerce || false,
+    typeName: ZodFirstPartyTypeKind.ZodDate,
+    ...processCreateParams(params)
+  });
+};
+var ZodSymbol = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.symbol) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.symbol,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+};
+ZodSymbol.create = (params) => {
+  return new ZodSymbol({
+    typeName: ZodFirstPartyTypeKind.ZodSymbol,
+    ...processCreateParams(params)
+  });
+};
+var ZodUndefined = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.undefined) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.undefined,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+};
+ZodUndefined.create = (params) => {
+  return new ZodUndefined({
+    typeName: ZodFirstPartyTypeKind.ZodUndefined,
+    ...processCreateParams(params)
+  });
+};
+var ZodNull = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.null) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.null,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+};
+ZodNull.create = (params) => {
+  return new ZodNull({
+    typeName: ZodFirstPartyTypeKind.ZodNull,
+    ...processCreateParams(params)
+  });
+};
+var ZodAny = class extends ZodType {
+  constructor() {
+    super(...arguments);
+    this._any = true;
+  }
+  _parse(input) {
+    return OK(input.data);
+  }
+};
+ZodAny.create = (params) => {
+  return new ZodAny({
+    typeName: ZodFirstPartyTypeKind.ZodAny,
+    ...processCreateParams(params)
+  });
+};
+var ZodUnknown = class extends ZodType {
+  constructor() {
+    super(...arguments);
+    this._unknown = true;
+  }
+  _parse(input) {
+    return OK(input.data);
+  }
+};
+ZodUnknown.create = (params) => {
+  return new ZodUnknown({
+    typeName: ZodFirstPartyTypeKind.ZodUnknown,
+    ...processCreateParams(params)
+  });
+};
+var ZodNever = class extends ZodType {
+  _parse(input) {
+    const ctx = this._getOrReturnCtx(input);
+    addIssueToContext(ctx, {
+      code: ZodIssueCode.invalid_type,
+      expected: ZodParsedType.never,
+      received: ctx.parsedType
+    });
+    return INVALID;
+  }
+};
+ZodNever.create = (params) => {
+  return new ZodNever({
+    typeName: ZodFirstPartyTypeKind.ZodNever,
+    ...processCreateParams(params)
+  });
+};
+var ZodVoid = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.undefined) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.void,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+};
+ZodVoid.create = (params) => {
+  return new ZodVoid({
+    typeName: ZodFirstPartyTypeKind.ZodVoid,
+    ...processCreateParams(params)
+  });
+};
+var ZodArray = class _ZodArray extends ZodType {
+  _parse(input) {
+    const { ctx, status } = this._processInputParams(input);
+    const def = this._def;
+    if (ctx.parsedType !== ZodParsedType.array) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.array,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    if (def.exactLength !== null) {
+      const tooBig = ctx.data.length > def.exactLength.value;
+      const tooSmall = ctx.data.length < def.exactLength.value;
+      if (tooBig || tooSmall) {
+        addIssueToContext(ctx, {
+          code: tooBig ? ZodIssueCode.too_big : ZodIssueCode.too_small,
+          minimum: tooSmall ? def.exactLength.value : void 0,
+          maximum: tooBig ? def.exactLength.value : void 0,
+          type: "array",
+          inclusive: true,
+          exact: true,
+          message: def.exactLength.message
+        });
+        status.dirty();
+      }
+    }
+    if (def.minLength !== null) {
+      if (ctx.data.length < def.minLength.value) {
+        addIssueToContext(ctx, {
+          code: ZodIssueCode.too_small,
+          minimum: def.minLength.value,
+          type: "array",
+          inclusive: true,
+          exact: false,
+          message: def.minLength.message
+        });
+        status.dirty();
+      }
+    }
+    if (def.maxLength !== null) {
+      if (ctx.data.length > def.maxLength.value) {
+        addIssueToContext(ctx, {
+          code: ZodIssueCode.too_big,
+          maximum: def.maxLength.value,
+          type: "array",
+          inclusive: true,
+          exact: false,
+          message: def.maxLength.message
+        });
+        status.dirty();
+      }
+    }
+    if (ctx.common.async) {
+      return Promise.all([...ctx.data].map((item, i) => {
+        return def.type._parseAsync(new ParseInputLazyPath(ctx, item, ctx.path, i));
+      })).then((result2) => {
+        return ParseStatus.mergeArray(status, result2);
+      });
+    }
+    const result = [...ctx.data].map((item, i) => {
+      return def.type._parseSync(new ParseInputLazyPath(ctx, item, ctx.path, i));
+    });
+    return ParseStatus.mergeArray(status, result);
+  }
+  get element() {
+    return this._def.type;
+  }
+  min(minLength, message) {
+    return new _ZodArray({
+      ...this._def,
+      minLength: { value: minLength, message: errorUtil.toString(message) }
+    });
+  }
+  max(maxLength, message) {
+    return new _ZodArray({
+      ...this._def,
+      maxLength: { value: maxLength, message: errorUtil.toString(message) }
+    });
+  }
+  length(len, message) {
+    return new _ZodArray({
+      ...this._def,
+      exactLength: { value: len, message: errorUtil.toString(message) }
+    });
+  }
+  nonempty(message) {
+    return this.min(1, message);
+  }
+};
+ZodArray.create = (schema, params) => {
+  return new ZodArray({
+    type: schema,
+    minLength: null,
+    maxLength: null,
+    exactLength: null,
+    typeName: ZodFirstPartyTypeKind.ZodArray,
+    ...processCreateParams(params)
+  });
+};
+function deepPartialify(schema) {
+  if (schema instanceof ZodObject) {
+    const newShape = {};
+    for (const key in schema.shape) {
+      const fieldSchema = schema.shape[key];
+      newShape[key] = ZodOptional.create(deepPartialify(fieldSchema));
+    }
+    return new ZodObject({
+      ...schema._def,
+      shape: () => newShape
+    });
+  } else if (schema instanceof ZodArray) {
+    return new ZodArray({
+      ...schema._def,
+      type: deepPartialify(schema.element)
+    });
+  } else if (schema instanceof ZodOptional) {
+    return ZodOptional.create(deepPartialify(schema.unwrap()));
+  } else if (schema instanceof ZodNullable) {
+    return ZodNullable.create(deepPartialify(schema.unwrap()));
+  } else if (schema instanceof ZodTuple) {
+    return ZodTuple.create(schema.items.map((item) => deepPartialify(item)));
+  } else {
+    return schema;
+  }
+}
+var ZodObject = class _ZodObject extends ZodType {
+  constructor() {
+    super(...arguments);
+    this._cached = null;
+    this.nonstrict = this.passthrough;
+    this.augment = this.extend;
+  }
+  _getCached() {
+    if (this._cached !== null)
+      return this._cached;
+    const shape = this._def.shape();
+    const keys = util.objectKeys(shape);
+    this._cached = { shape, keys };
+    return this._cached;
+  }
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.object) {
+      const ctx2 = this._getOrReturnCtx(input);
+      addIssueToContext(ctx2, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.object,
+        received: ctx2.parsedType
+      });
+      return INVALID;
+    }
+    const { status, ctx } = this._processInputParams(input);
+    const { shape, keys: shapeKeys } = this._getCached();
+    const extraKeys = [];
+    if (!(this._def.catchall instanceof ZodNever && this._def.unknownKeys === "strip")) {
+      for (const key in ctx.data) {
+        if (!shapeKeys.includes(key)) {
+          extraKeys.push(key);
+        }
+      }
+    }
+    const pairs = [];
+    for (const key of shapeKeys) {
+      const keyValidator = shape[key];
+      const value = ctx.data[key];
+      pairs.push({
+        key: { status: "valid", value: key },
+        value: keyValidator._parse(new ParseInputLazyPath(ctx, value, ctx.path, key)),
+        alwaysSet: key in ctx.data
+      });
+    }
+    if (this._def.catchall instanceof ZodNever) {
+      const unknownKeys = this._def.unknownKeys;
+      if (unknownKeys === "passthrough") {
+        for (const key of extraKeys) {
+          pairs.push({
+            key: { status: "valid", value: key },
+            value: { status: "valid", value: ctx.data[key] }
+          });
+        }
+      } else if (unknownKeys === "strict") {
+        if (extraKeys.length > 0) {
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.unrecognized_keys,
+            keys: extraKeys
+          });
+          status.dirty();
+        }
+      } else if (unknownKeys === "strip") {
+      } else {
+        throw new Error(`Internal ZodObject error: invalid unknownKeys value.`);
+      }
+    } else {
+      const catchall = this._def.catchall;
+      for (const key of extraKeys) {
+        const value = ctx.data[key];
+        pairs.push({
+          key: { status: "valid", value: key },
+          value: catchall._parse(
+            new ParseInputLazyPath(ctx, value, ctx.path, key)
+            //, ctx.child(key), value, getParsedType(value)
+          ),
+          alwaysSet: key in ctx.data
+        });
+      }
+    }
+    if (ctx.common.async) {
+      return Promise.resolve().then(async () => {
+        const syncPairs = [];
+        for (const pair of pairs) {
+          const key = await pair.key;
+          const value = await pair.value;
+          syncPairs.push({
+            key,
+            value,
+            alwaysSet: pair.alwaysSet
+          });
+        }
+        return syncPairs;
+      }).then((syncPairs) => {
+        return ParseStatus.mergeObjectSync(status, syncPairs);
+      });
+    } else {
+      return ParseStatus.mergeObjectSync(status, pairs);
+    }
+  }
+  get shape() {
+    return this._def.shape();
+  }
+  strict(message) {
+    errorUtil.errToObj;
+    return new _ZodObject({
+      ...this._def,
+      unknownKeys: "strict",
+      ...message !== void 0 ? {
+        errorMap: (issue, ctx) => {
+          const defaultError = this._def.errorMap?.(issue, ctx).message ?? ctx.defaultError;
+          if (issue.code === "unrecognized_keys")
+            return {
+              message: errorUtil.errToObj(message).message ?? defaultError
+            };
+          return {
+            message: defaultError
+          };
+        }
+      } : {}
+    });
+  }
+  strip() {
+    return new _ZodObject({
+      ...this._def,
+      unknownKeys: "strip"
+    });
+  }
+  passthrough() {
+    return new _ZodObject({
+      ...this._def,
+      unknownKeys: "passthrough"
+    });
+  }
+  // const AugmentFactory =
+  //   <Def extends ZodObjectDef>(def: Def) =>
+  //   <Augmentation extends ZodRawShape>(
+  //     augmentation: Augmentation
+  //   ): ZodObject<
+  //     extendShape<ReturnType<Def["shape"]>, Augmentation>,
+  //     Def["unknownKeys"],
+  //     Def["catchall"]
+  //   > => {
+  //     return new ZodObject({
+  //       ...def,
+  //       shape: () => ({
+  //         ...def.shape(),
+  //         ...augmentation,
+  //       }),
+  //     }) as any;
+  //   };
+  extend(augmentation) {
+    return new _ZodObject({
+      ...this._def,
+      shape: () => ({
+        ...this._def.shape(),
+        ...augmentation
+      })
+    });
+  }
+  /**
+   * Prior to zod@1.0.12 there was a bug in the
+   * inferred type of merged objects. Please
+   * upgrade if you are experiencing issues.
+   */
+  merge(merging) {
+    const merged = new _ZodObject({
+      unknownKeys: merging._def.unknownKeys,
+      catchall: merging._def.catchall,
+      shape: () => ({
+        ...this._def.shape(),
+        ...merging._def.shape()
+      }),
+      typeName: ZodFirstPartyTypeKind.ZodObject
+    });
+    return merged;
+  }
+  // merge<
+  //   Incoming extends AnyZodObject,
+  //   Augmentation extends Incoming["shape"],
+  //   NewOutput extends {
+  //     [k in keyof Augmentation | keyof Output]: k extends keyof Augmentation
+  //       ? Augmentation[k]["_output"]
+  //       : k extends keyof Output
+  //       ? Output[k]
+  //       : never;
+  //   },
+  //   NewInput extends {
+  //     [k in keyof Augmentation | keyof Input]: k extends keyof Augmentation
+  //       ? Augmentation[k]["_input"]
+  //       : k extends keyof Input
+  //       ? Input[k]
+  //       : never;
+  //   }
+  // >(
+  //   merging: Incoming
+  // ): ZodObject<
+  //   extendShape<T, ReturnType<Incoming["_def"]["shape"]>>,
+  //   Incoming["_def"]["unknownKeys"],
+  //   Incoming["_def"]["catchall"],
+  //   NewOutput,
+  //   NewInput
+  // > {
+  //   const merged: any = new ZodObject({
+  //     unknownKeys: merging._def.unknownKeys,
+  //     catchall: merging._def.catchall,
+  //     shape: () =>
+  //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
+  //     typeName: ZodFirstPartyTypeKind.ZodObject,
+  //   }) as any;
+  //   return merged;
+  // }
+  setKey(key, schema) {
+    return this.augment({ [key]: schema });
+  }
+  // merge<Incoming extends AnyZodObject>(
+  //   merging: Incoming
+  // ): //ZodObject<T & Incoming["_shape"], UnknownKeys, Catchall> = (merging) => {
+  // ZodObject<
+  //   extendShape<T, ReturnType<Incoming["_def"]["shape"]>>,
+  //   Incoming["_def"]["unknownKeys"],
+  //   Incoming["_def"]["catchall"]
+  // > {
+  //   // const mergedShape = objectUtil.mergeShapes(
+  //   //   this._def.shape(),
+  //   //   merging._def.shape()
+  //   // );
+  //   const merged: any = new ZodObject({
+  //     unknownKeys: merging._def.unknownKeys,
+  //     catchall: merging._def.catchall,
+  //     shape: () =>
+  //       objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
+  //     typeName: ZodFirstPartyTypeKind.ZodObject,
+  //   }) as any;
+  //   return merged;
+  // }
+  catchall(index) {
+    return new _ZodObject({
+      ...this._def,
+      catchall: index
+    });
+  }
+  pick(mask) {
+    const shape = {};
+    for (const key of util.objectKeys(mask)) {
+      if (mask[key] && this.shape[key]) {
+        shape[key] = this.shape[key];
+      }
+    }
+    return new _ZodObject({
+      ...this._def,
+      shape: () => shape
+    });
+  }
+  omit(mask) {
+    const shape = {};
+    for (const key of util.objectKeys(this.shape)) {
+      if (!mask[key]) {
+        shape[key] = this.shape[key];
+      }
+    }
+    return new _ZodObject({
+      ...this._def,
+      shape: () => shape
+    });
+  }
+  /**
+   * @deprecated
+   */
+  deepPartial() {
+    return deepPartialify(this);
+  }
+  partial(mask) {
+    const newShape = {};
+    for (const key of util.objectKeys(this.shape)) {
+      const fieldSchema = this.shape[key];
+      if (mask && !mask[key]) {
+        newShape[key] = fieldSchema;
+      } else {
+        newShape[key] = fieldSchema.optional();
+      }
+    }
+    return new _ZodObject({
+      ...this._def,
+      shape: () => newShape
+    });
+  }
+  required(mask) {
+    const newShape = {};
+    for (const key of util.objectKeys(this.shape)) {
+      if (mask && !mask[key]) {
+        newShape[key] = this.shape[key];
+      } else {
+        const fieldSchema = this.shape[key];
+        let newField = fieldSchema;
+        while (newField instanceof ZodOptional) {
+          newField = newField._def.innerType;
+        }
+        newShape[key] = newField;
+      }
+    }
+    return new _ZodObject({
+      ...this._def,
+      shape: () => newShape
+    });
+  }
+  keyof() {
+    return createZodEnum(util.objectKeys(this.shape));
+  }
+};
+ZodObject.create = (shape, params) => {
+  return new ZodObject({
+    shape: () => shape,
+    unknownKeys: "strip",
+    catchall: ZodNever.create(),
+    typeName: ZodFirstPartyTypeKind.ZodObject,
+    ...processCreateParams(params)
+  });
+};
+ZodObject.strictCreate = (shape, params) => {
+  return new ZodObject({
+    shape: () => shape,
+    unknownKeys: "strict",
+    catchall: ZodNever.create(),
+    typeName: ZodFirstPartyTypeKind.ZodObject,
+    ...processCreateParams(params)
+  });
+};
+ZodObject.lazycreate = (shape, params) => {
+  return new ZodObject({
+    shape,
+    unknownKeys: "strip",
+    catchall: ZodNever.create(),
+    typeName: ZodFirstPartyTypeKind.ZodObject,
+    ...processCreateParams(params)
+  });
+};
+var ZodUnion = class extends ZodType {
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    const options = this._def.options;
+    function handleResults(results) {
+      for (const result of results) {
+        if (result.result.status === "valid") {
+          return result.result;
+        }
+      }
+      for (const result of results) {
+        if (result.result.status === "dirty") {
+          ctx.common.issues.push(...result.ctx.common.issues);
+          return result.result;
+        }
+      }
+      const unionErrors = results.map((result) => new ZodError(result.ctx.common.issues));
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_union,
+        unionErrors
+      });
+      return INVALID;
+    }
+    if (ctx.common.async) {
+      return Promise.all(options.map(async (option) => {
+        const childCtx = {
+          ...ctx,
+          common: {
+            ...ctx.common,
+            issues: []
+          },
+          parent: null
+        };
+        return {
+          result: await option._parseAsync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: childCtx
+          }),
+          ctx: childCtx
+        };
+      })).then(handleResults);
+    } else {
+      let dirty = void 0;
+      const issues = [];
+      for (const option of options) {
+        const childCtx = {
+          ...ctx,
+          common: {
+            ...ctx.common,
+            issues: []
+          },
+          parent: null
+        };
+        const result = option._parseSync({
+          data: ctx.data,
+          path: ctx.path,
+          parent: childCtx
+        });
+        if (result.status === "valid") {
+          return result;
+        } else if (result.status === "dirty" && !dirty) {
+          dirty = { result, ctx: childCtx };
+        }
+        if (childCtx.common.issues.length) {
+          issues.push(childCtx.common.issues);
+        }
+      }
+      if (dirty) {
+        ctx.common.issues.push(...dirty.ctx.common.issues);
+        return dirty.result;
+      }
+      const unionErrors = issues.map((issues2) => new ZodError(issues2));
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_union,
+        unionErrors
+      });
+      return INVALID;
+    }
+  }
+  get options() {
+    return this._def.options;
+  }
+};
+ZodUnion.create = (types, params) => {
+  return new ZodUnion({
+    options: types,
+    typeName: ZodFirstPartyTypeKind.ZodUnion,
+    ...processCreateParams(params)
+  });
+};
+var getDiscriminator = (type) => {
+  if (type instanceof ZodLazy) {
+    return getDiscriminator(type.schema);
+  } else if (type instanceof ZodEffects) {
+    return getDiscriminator(type.innerType());
+  } else if (type instanceof ZodLiteral) {
+    return [type.value];
+  } else if (type instanceof ZodEnum) {
+    return type.options;
+  } else if (type instanceof ZodNativeEnum) {
+    return util.objectValues(type.enum);
+  } else if (type instanceof ZodDefault) {
+    return getDiscriminator(type._def.innerType);
+  } else if (type instanceof ZodUndefined) {
+    return [void 0];
+  } else if (type instanceof ZodNull) {
+    return [null];
+  } else if (type instanceof ZodOptional) {
+    return [void 0, ...getDiscriminator(type.unwrap())];
+  } else if (type instanceof ZodNullable) {
+    return [null, ...getDiscriminator(type.unwrap())];
+  } else if (type instanceof ZodBranded) {
+    return getDiscriminator(type.unwrap());
+  } else if (type instanceof ZodReadonly) {
+    return getDiscriminator(type.unwrap());
+  } else if (type instanceof ZodCatch) {
+    return getDiscriminator(type._def.innerType);
+  } else {
+    return [];
+  }
+};
+var ZodDiscriminatedUnion = class _ZodDiscriminatedUnion extends ZodType {
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.object) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.object,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    const discriminator = this.discriminator;
+    const discriminatorValue = ctx.data[discriminator];
+    const option = this.optionsMap.get(discriminatorValue);
+    if (!option) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_union_discriminator,
+        options: Array.from(this.optionsMap.keys()),
+        path: [discriminator]
+      });
+      return INVALID;
+    }
+    if (ctx.common.async) {
+      return option._parseAsync({
+        data: ctx.data,
+        path: ctx.path,
+        parent: ctx
+      });
+    } else {
+      return option._parseSync({
+        data: ctx.data,
+        path: ctx.path,
+        parent: ctx
+      });
+    }
+  }
+  get discriminator() {
+    return this._def.discriminator;
+  }
+  get options() {
+    return this._def.options;
+  }
+  get optionsMap() {
+    return this._def.optionsMap;
+  }
+  /**
+   * The constructor of the discriminated union schema. Its behaviour is very similar to that of the normal z.union() constructor.
+   * However, it only allows a union of objects, all of which need to share a discriminator property. This property must
+   * have a different value for each object in the union.
+   * @param discriminator the name of the discriminator property
+   * @param types an array of object schemas
+   * @param params
+   */
+  static create(discriminator, options, params) {
+    const optionsMap = /* @__PURE__ */ new Map();
+    for (const type of options) {
+      const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+      if (!discriminatorValues.length) {
+        throw new Error(`A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`);
+      }
+      for (const value of discriminatorValues) {
+        if (optionsMap.has(value)) {
+          throw new Error(`Discriminator property ${String(discriminator)} has duplicate value ${String(value)}`);
+        }
+        optionsMap.set(value, type);
+      }
+    }
+    return new _ZodDiscriminatedUnion({
+      typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
+      discriminator,
+      options,
+      optionsMap,
+      ...processCreateParams(params)
+    });
+  }
+};
+function mergeValues(a, b) {
+  const aType = getParsedType(a);
+  const bType = getParsedType(b);
+  if (a === b) {
+    return { valid: true, data: a };
+  } else if (aType === ZodParsedType.object && bType === ZodParsedType.object) {
+    const bKeys = util.objectKeys(b);
+    const sharedKeys = util.objectKeys(a).filter((key) => bKeys.indexOf(key) !== -1);
+    const newObj = { ...a, ...b };
+    for (const key of sharedKeys) {
+      const sharedValue = mergeValues(a[key], b[key]);
+      if (!sharedValue.valid) {
+        return { valid: false };
+      }
+      newObj[key] = sharedValue.data;
+    }
+    return { valid: true, data: newObj };
+  } else if (aType === ZodParsedType.array && bType === ZodParsedType.array) {
+    if (a.length !== b.length) {
+      return { valid: false };
+    }
+    const newArray = [];
+    for (let index = 0; index < a.length; index++) {
+      const itemA = a[index];
+      const itemB = b[index];
+      const sharedValue = mergeValues(itemA, itemB);
+      if (!sharedValue.valid) {
+        return { valid: false };
+      }
+      newArray.push(sharedValue.data);
+    }
+    return { valid: true, data: newArray };
+  } else if (aType === ZodParsedType.date && bType === ZodParsedType.date && +a === +b) {
+    return { valid: true, data: a };
+  } else {
+    return { valid: false };
+  }
+}
+var ZodIntersection = class extends ZodType {
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    const handleParsed = (parsedLeft, parsedRight) => {
+      if (isAborted(parsedLeft) || isAborted(parsedRight)) {
+        return INVALID;
+      }
+      const merged = mergeValues(parsedLeft.value, parsedRight.value);
+      if (!merged.valid) {
+        addIssueToContext(ctx, {
+          code: ZodIssueCode.invalid_intersection_types
+        });
+        return INVALID;
+      }
+      if (isDirty(parsedLeft) || isDirty(parsedRight)) {
+        status.dirty();
+      }
+      return { status: status.value, value: merged.data };
+    };
+    if (ctx.common.async) {
+      return Promise.all([
+        this._def.left._parseAsync({
+          data: ctx.data,
+          path: ctx.path,
+          parent: ctx
+        }),
+        this._def.right._parseAsync({
+          data: ctx.data,
+          path: ctx.path,
+          parent: ctx
+        })
+      ]).then(([left, right]) => handleParsed(left, right));
+    } else {
+      return handleParsed(this._def.left._parseSync({
+        data: ctx.data,
+        path: ctx.path,
+        parent: ctx
+      }), this._def.right._parseSync({
+        data: ctx.data,
+        path: ctx.path,
+        parent: ctx
+      }));
+    }
+  }
+};
+ZodIntersection.create = (left, right, params) => {
+  return new ZodIntersection({
+    left,
+    right,
+    typeName: ZodFirstPartyTypeKind.ZodIntersection,
+    ...processCreateParams(params)
+  });
+};
+var ZodTuple = class _ZodTuple extends ZodType {
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.array) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.array,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    if (ctx.data.length < this._def.items.length) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.too_small,
+        minimum: this._def.items.length,
+        inclusive: true,
+        exact: false,
+        type: "array"
+      });
+      return INVALID;
+    }
+    const rest = this._def.rest;
+    if (!rest && ctx.data.length > this._def.items.length) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.too_big,
+        maximum: this._def.items.length,
+        inclusive: true,
+        exact: false,
+        type: "array"
+      });
+      status.dirty();
+    }
+    const items = [...ctx.data].map((item, itemIndex) => {
+      const schema = this._def.items[itemIndex] || this._def.rest;
+      if (!schema)
+        return null;
+      return schema._parse(new ParseInputLazyPath(ctx, item, ctx.path, itemIndex));
+    }).filter((x) => !!x);
+    if (ctx.common.async) {
+      return Promise.all(items).then((results) => {
+        return ParseStatus.mergeArray(status, results);
+      });
+    } else {
+      return ParseStatus.mergeArray(status, items);
+    }
+  }
+  get items() {
+    return this._def.items;
+  }
+  rest(rest) {
+    return new _ZodTuple({
+      ...this._def,
+      rest
+    });
+  }
+};
+ZodTuple.create = (schemas, params) => {
+  if (!Array.isArray(schemas)) {
+    throw new Error("You must pass an array of schemas to z.tuple([ ... ])");
+  }
+  return new ZodTuple({
+    items: schemas,
+    typeName: ZodFirstPartyTypeKind.ZodTuple,
+    rest: null,
+    ...processCreateParams(params)
+  });
+};
+var ZodRecord = class _ZodRecord extends ZodType {
+  get keySchema() {
+    return this._def.keyType;
+  }
+  get valueSchema() {
+    return this._def.valueType;
+  }
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.object) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.object,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    const pairs = [];
+    const keyType = this._def.keyType;
+    const valueType = this._def.valueType;
+    for (const key in ctx.data) {
+      pairs.push({
+        key: keyType._parse(new ParseInputLazyPath(ctx, key, ctx.path, key)),
+        value: valueType._parse(new ParseInputLazyPath(ctx, ctx.data[key], ctx.path, key)),
+        alwaysSet: key in ctx.data
+      });
+    }
+    if (ctx.common.async) {
+      return ParseStatus.mergeObjectAsync(status, pairs);
+    } else {
+      return ParseStatus.mergeObjectSync(status, pairs);
+    }
+  }
+  get element() {
+    return this._def.valueType;
+  }
+  static create(first, second, third) {
+    if (second instanceof ZodType) {
+      return new _ZodRecord({
+        keyType: first,
+        valueType: second,
+        typeName: ZodFirstPartyTypeKind.ZodRecord,
+        ...processCreateParams(third)
+      });
+    }
+    return new _ZodRecord({
+      keyType: ZodString.create(),
+      valueType: first,
+      typeName: ZodFirstPartyTypeKind.ZodRecord,
+      ...processCreateParams(second)
+    });
+  }
+};
+var ZodMap = class extends ZodType {
+  get keySchema() {
+    return this._def.keyType;
+  }
+  get valueSchema() {
+    return this._def.valueType;
+  }
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.map) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.map,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    const keyType = this._def.keyType;
+    const valueType = this._def.valueType;
+    const pairs = [...ctx.data.entries()].map(([key, value], index) => {
+      return {
+        key: keyType._parse(new ParseInputLazyPath(ctx, key, ctx.path, [index, "key"])),
+        value: valueType._parse(new ParseInputLazyPath(ctx, value, ctx.path, [index, "value"]))
+      };
+    });
+    if (ctx.common.async) {
+      const finalMap = /* @__PURE__ */ new Map();
+      return Promise.resolve().then(async () => {
+        for (const pair of pairs) {
+          const key = await pair.key;
+          const value = await pair.value;
+          if (key.status === "aborted" || value.status === "aborted") {
+            return INVALID;
+          }
+          if (key.status === "dirty" || value.status === "dirty") {
+            status.dirty();
+          }
+          finalMap.set(key.value, value.value);
+        }
+        return { status: status.value, value: finalMap };
+      });
+    } else {
+      const finalMap = /* @__PURE__ */ new Map();
+      for (const pair of pairs) {
+        const key = pair.key;
+        const value = pair.value;
+        if (key.status === "aborted" || value.status === "aborted") {
+          return INVALID;
+        }
+        if (key.status === "dirty" || value.status === "dirty") {
+          status.dirty();
+        }
+        finalMap.set(key.value, value.value);
+      }
+      return { status: status.value, value: finalMap };
+    }
+  }
+};
+ZodMap.create = (keyType, valueType, params) => {
+  return new ZodMap({
+    valueType,
+    keyType,
+    typeName: ZodFirstPartyTypeKind.ZodMap,
+    ...processCreateParams(params)
+  });
+};
+var ZodSet = class _ZodSet extends ZodType {
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.set) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.set,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    const def = this._def;
+    if (def.minSize !== null) {
+      if (ctx.data.size < def.minSize.value) {
+        addIssueToContext(ctx, {
+          code: ZodIssueCode.too_small,
+          minimum: def.minSize.value,
+          type: "set",
+          inclusive: true,
+          exact: false,
+          message: def.minSize.message
+        });
+        status.dirty();
+      }
+    }
+    if (def.maxSize !== null) {
+      if (ctx.data.size > def.maxSize.value) {
+        addIssueToContext(ctx, {
+          code: ZodIssueCode.too_big,
+          maximum: def.maxSize.value,
+          type: "set",
+          inclusive: true,
+          exact: false,
+          message: def.maxSize.message
+        });
+        status.dirty();
+      }
+    }
+    const valueType = this._def.valueType;
+    function finalizeSet(elements2) {
+      const parsedSet = /* @__PURE__ */ new Set();
+      for (const element of elements2) {
+        if (element.status === "aborted")
+          return INVALID;
+        if (element.status === "dirty")
+          status.dirty();
+        parsedSet.add(element.value);
+      }
+      return { status: status.value, value: parsedSet };
+    }
+    const elements = [...ctx.data.values()].map((item, i) => valueType._parse(new ParseInputLazyPath(ctx, item, ctx.path, i)));
+    if (ctx.common.async) {
+      return Promise.all(elements).then((elements2) => finalizeSet(elements2));
+    } else {
+      return finalizeSet(elements);
+    }
+  }
+  min(minSize, message) {
+    return new _ZodSet({
+      ...this._def,
+      minSize: { value: minSize, message: errorUtil.toString(message) }
+    });
+  }
+  max(maxSize, message) {
+    return new _ZodSet({
+      ...this._def,
+      maxSize: { value: maxSize, message: errorUtil.toString(message) }
+    });
+  }
+  size(size, message) {
+    return this.min(size, message).max(size, message);
+  }
+  nonempty(message) {
+    return this.min(1, message);
+  }
+};
+ZodSet.create = (valueType, params) => {
+  return new ZodSet({
+    valueType,
+    minSize: null,
+    maxSize: null,
+    typeName: ZodFirstPartyTypeKind.ZodSet,
+    ...processCreateParams(params)
+  });
+};
+var ZodFunction = class _ZodFunction extends ZodType {
+  constructor() {
+    super(...arguments);
+    this.validate = this.implement;
+  }
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.function) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.function,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    function makeArgsIssue(args, error) {
+      return makeIssue({
+        data: args,
+        path: ctx.path,
+        errorMaps: [ctx.common.contextualErrorMap, ctx.schemaErrorMap, getErrorMap(), en_default].filter((x) => !!x),
+        issueData: {
+          code: ZodIssueCode.invalid_arguments,
+          argumentsError: error
+        }
+      });
+    }
+    function makeReturnsIssue(returns, error) {
+      return makeIssue({
+        data: returns,
+        path: ctx.path,
+        errorMaps: [ctx.common.contextualErrorMap, ctx.schemaErrorMap, getErrorMap(), en_default].filter((x) => !!x),
+        issueData: {
+          code: ZodIssueCode.invalid_return_type,
+          returnTypeError: error
+        }
+      });
+    }
+    const params = { errorMap: ctx.common.contextualErrorMap };
+    const fn = ctx.data;
+    if (this._def.returns instanceof ZodPromise) {
+      const me = this;
+      return OK(async function(...args) {
+        const error = new ZodError([]);
+        const parsedArgs = await me._def.args.parseAsync(args, params).catch((e) => {
+          error.addIssue(makeArgsIssue(args, e));
+          throw error;
+        });
+        const result = await Reflect.apply(fn, this, parsedArgs);
+        const parsedReturns = await me._def.returns._def.type.parseAsync(result, params).catch((e) => {
+          error.addIssue(makeReturnsIssue(result, e));
+          throw error;
+        });
+        return parsedReturns;
+      });
+    } else {
+      const me = this;
+      return OK(function(...args) {
+        const parsedArgs = me._def.args.safeParse(args, params);
+        if (!parsedArgs.success) {
+          throw new ZodError([makeArgsIssue(args, parsedArgs.error)]);
+        }
+        const result = Reflect.apply(fn, this, parsedArgs.data);
+        const parsedReturns = me._def.returns.safeParse(result, params);
+        if (!parsedReturns.success) {
+          throw new ZodError([makeReturnsIssue(result, parsedReturns.error)]);
+        }
+        return parsedReturns.data;
+      });
+    }
+  }
+  parameters() {
+    return this._def.args;
+  }
+  returnType() {
+    return this._def.returns;
+  }
+  args(...items) {
+    return new _ZodFunction({
+      ...this._def,
+      args: ZodTuple.create(items).rest(ZodUnknown.create())
+    });
+  }
+  returns(returnType) {
+    return new _ZodFunction({
+      ...this._def,
+      returns: returnType
+    });
+  }
+  implement(func) {
+    const validatedFunc = this.parse(func);
+    return validatedFunc;
+  }
+  strictImplement(func) {
+    const validatedFunc = this.parse(func);
+    return validatedFunc;
+  }
+  static create(args, returns, params) {
+    return new _ZodFunction({
+      args: args ? args : ZodTuple.create([]).rest(ZodUnknown.create()),
+      returns: returns || ZodUnknown.create(),
+      typeName: ZodFirstPartyTypeKind.ZodFunction,
+      ...processCreateParams(params)
+    });
+  }
+};
+var ZodLazy = class extends ZodType {
+  get schema() {
+    return this._def.getter();
+  }
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    const lazySchema = this._def.getter();
+    return lazySchema._parse({ data: ctx.data, path: ctx.path, parent: ctx });
+  }
+};
+ZodLazy.create = (getter, params) => {
+  return new ZodLazy({
+    getter,
+    typeName: ZodFirstPartyTypeKind.ZodLazy,
+    ...processCreateParams(params)
+  });
+};
+var ZodLiteral = class extends ZodType {
+  _parse(input) {
+    if (input.data !== this._def.value) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        received: ctx.data,
+        code: ZodIssueCode.invalid_literal,
+        expected: this._def.value
+      });
+      return INVALID;
+    }
+    return { status: "valid", value: input.data };
+  }
+  get value() {
+    return this._def.value;
+  }
+};
+ZodLiteral.create = (value, params) => {
+  return new ZodLiteral({
+    value,
+    typeName: ZodFirstPartyTypeKind.ZodLiteral,
+    ...processCreateParams(params)
+  });
+};
+function createZodEnum(values, params) {
+  return new ZodEnum({
+    values,
+    typeName: ZodFirstPartyTypeKind.ZodEnum,
+    ...processCreateParams(params)
+  });
+}
+var ZodEnum = class _ZodEnum extends ZodType {
+  _parse(input) {
+    if (typeof input.data !== "string") {
+      const ctx = this._getOrReturnCtx(input);
+      const expectedValues = this._def.values;
+      addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues),
+        received: ctx.parsedType,
+        code: ZodIssueCode.invalid_type
+      });
+      return INVALID;
+    }
+    if (!this._cache) {
+      this._cache = new Set(this._def.values);
+    }
+    if (!this._cache.has(input.data)) {
+      const ctx = this._getOrReturnCtx(input);
+      const expectedValues = this._def.values;
+      addIssueToContext(ctx, {
+        received: ctx.data,
+        code: ZodIssueCode.invalid_enum_value,
+        options: expectedValues
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+  get options() {
+    return this._def.values;
+  }
+  get enum() {
+    const enumValues = {};
+    for (const val of this._def.values) {
+      enumValues[val] = val;
+    }
+    return enumValues;
+  }
+  get Values() {
+    const enumValues = {};
+    for (const val of this._def.values) {
+      enumValues[val] = val;
+    }
+    return enumValues;
+  }
+  get Enum() {
+    const enumValues = {};
+    for (const val of this._def.values) {
+      enumValues[val] = val;
+    }
+    return enumValues;
+  }
+  extract(values, newDef = this._def) {
+    return _ZodEnum.create(values, {
+      ...this._def,
+      ...newDef
+    });
+  }
+  exclude(values, newDef = this._def) {
+    return _ZodEnum.create(this.options.filter((opt) => !values.includes(opt)), {
+      ...this._def,
+      ...newDef
+    });
+  }
+};
+ZodEnum.create = createZodEnum;
+var ZodNativeEnum = class extends ZodType {
+  _parse(input) {
+    const nativeEnumValues = util.getValidEnumValues(this._def.values);
+    const ctx = this._getOrReturnCtx(input);
+    if (ctx.parsedType !== ZodParsedType.string && ctx.parsedType !== ZodParsedType.number) {
+      const expectedValues = util.objectValues(nativeEnumValues);
+      addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues),
+        received: ctx.parsedType,
+        code: ZodIssueCode.invalid_type
+      });
+      return INVALID;
+    }
+    if (!this._cache) {
+      this._cache = new Set(util.getValidEnumValues(this._def.values));
+    }
+    if (!this._cache.has(input.data)) {
+      const expectedValues = util.objectValues(nativeEnumValues);
+      addIssueToContext(ctx, {
+        received: ctx.data,
+        code: ZodIssueCode.invalid_enum_value,
+        options: expectedValues
+      });
+      return INVALID;
+    }
+    return OK(input.data);
+  }
+  get enum() {
+    return this._def.values;
+  }
+};
+ZodNativeEnum.create = (values, params) => {
+  return new ZodNativeEnum({
+    values,
+    typeName: ZodFirstPartyTypeKind.ZodNativeEnum,
+    ...processCreateParams(params)
+  });
+};
+var ZodPromise = class extends ZodType {
+  unwrap() {
+    return this._def.type;
+  }
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    if (ctx.parsedType !== ZodParsedType.promise && ctx.common.async === false) {
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.promise,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    const promisified = ctx.parsedType === ZodParsedType.promise ? ctx.data : Promise.resolve(ctx.data);
+    return OK(promisified.then((data) => {
+      return this._def.type.parseAsync(data, {
+        path: ctx.path,
+        errorMap: ctx.common.contextualErrorMap
+      });
+    }));
+  }
+};
+ZodPromise.create = (schema, params) => {
+  return new ZodPromise({
+    type: schema,
+    typeName: ZodFirstPartyTypeKind.ZodPromise,
+    ...processCreateParams(params)
+  });
+};
+var ZodEffects = class extends ZodType {
+  innerType() {
+    return this._def.schema;
+  }
+  sourceType() {
+    return this._def.schema._def.typeName === ZodFirstPartyTypeKind.ZodEffects ? this._def.schema.sourceType() : this._def.schema;
+  }
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    const effect = this._def.effect || null;
+    const checkCtx = {
+      addIssue: (arg) => {
+        addIssueToContext(ctx, arg);
+        if (arg.fatal) {
+          status.abort();
+        } else {
+          status.dirty();
+        }
+      },
+      get path() {
+        return ctx.path;
+      }
+    };
+    checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
+    if (effect.type === "preprocess") {
+      const processed = effect.transform(ctx.data, checkCtx);
+      if (ctx.common.async) {
+        return Promise.resolve(processed).then(async (processed2) => {
+          if (status.value === "aborted")
+            return INVALID;
+          const result = await this._def.schema._parseAsync({
+            data: processed2,
+            path: ctx.path,
+            parent: ctx
+          });
+          if (result.status === "aborted")
+            return INVALID;
+          if (result.status === "dirty")
+            return DIRTY(result.value);
+          if (status.value === "dirty")
+            return DIRTY(result.value);
+          return result;
+        });
+      } else {
+        if (status.value === "aborted")
+          return INVALID;
+        const result = this._def.schema._parseSync({
+          data: processed,
+          path: ctx.path,
+          parent: ctx
+        });
+        if (result.status === "aborted")
+          return INVALID;
+        if (result.status === "dirty")
+          return DIRTY(result.value);
+        if (status.value === "dirty")
+          return DIRTY(result.value);
+        return result;
+      }
+    }
+    if (effect.type === "refinement") {
+      const executeRefinement = (acc) => {
+        const result = effect.refinement(acc, checkCtx);
+        if (ctx.common.async) {
+          return Promise.resolve(result);
+        }
+        if (result instanceof Promise) {
+          throw new Error("Async refinement encountered during synchronous parse operation. Use .parseAsync instead.");
+        }
+        return acc;
+      };
+      if (ctx.common.async === false) {
+        const inner = this._def.schema._parseSync({
+          data: ctx.data,
+          path: ctx.path,
+          parent: ctx
+        });
+        if (inner.status === "aborted")
+          return INVALID;
+        if (inner.status === "dirty")
+          status.dirty();
+        executeRefinement(inner.value);
+        return { status: status.value, value: inner.value };
+      } else {
+        return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((inner) => {
+          if (inner.status === "aborted")
+            return INVALID;
+          if (inner.status === "dirty")
+            status.dirty();
+          return executeRefinement(inner.value).then(() => {
+            return { status: status.value, value: inner.value };
+          });
+        });
+      }
+    }
+    if (effect.type === "transform") {
+      if (ctx.common.async === false) {
+        const base = this._def.schema._parseSync({
+          data: ctx.data,
+          path: ctx.path,
+          parent: ctx
+        });
+        if (!isValid(base))
+          return INVALID;
+        const result = effect.transform(base.value, checkCtx);
+        if (result instanceof Promise) {
+          throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
+        }
+        return { status: status.value, value: result };
+      } else {
+        return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
+          if (!isValid(base))
+            return INVALID;
+          return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
+            status: status.value,
+            value: result
+          }));
+        });
+      }
+    }
+    util.assertNever(effect);
+  }
+};
+ZodEffects.create = (schema, effect, params) => {
+  return new ZodEffects({
+    schema,
+    typeName: ZodFirstPartyTypeKind.ZodEffects,
+    effect,
+    ...processCreateParams(params)
+  });
+};
+ZodEffects.createWithPreprocess = (preprocess, schema, params) => {
+  return new ZodEffects({
+    schema,
+    effect: { type: "preprocess", transform: preprocess },
+    typeName: ZodFirstPartyTypeKind.ZodEffects,
+    ...processCreateParams(params)
+  });
+};
+var ZodOptional = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType === ZodParsedType.undefined) {
+      return OK(void 0);
+    }
+    return this._def.innerType._parse(input);
+  }
+  unwrap() {
+    return this._def.innerType;
+  }
+};
+ZodOptional.create = (type, params) => {
+  return new ZodOptional({
+    innerType: type,
+    typeName: ZodFirstPartyTypeKind.ZodOptional,
+    ...processCreateParams(params)
+  });
+};
+var ZodNullable = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType === ZodParsedType.null) {
+      return OK(null);
+    }
+    return this._def.innerType._parse(input);
+  }
+  unwrap() {
+    return this._def.innerType;
+  }
+};
+ZodNullable.create = (type, params) => {
+  return new ZodNullable({
+    innerType: type,
+    typeName: ZodFirstPartyTypeKind.ZodNullable,
+    ...processCreateParams(params)
+  });
+};
+var ZodDefault = class extends ZodType {
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    let data = ctx.data;
+    if (ctx.parsedType === ZodParsedType.undefined) {
+      data = this._def.defaultValue();
+    }
+    return this._def.innerType._parse({
+      data,
+      path: ctx.path,
+      parent: ctx
+    });
+  }
+  removeDefault() {
+    return this._def.innerType;
+  }
+};
+ZodDefault.create = (type, params) => {
+  return new ZodDefault({
+    innerType: type,
+    typeName: ZodFirstPartyTypeKind.ZodDefault,
+    defaultValue: typeof params.default === "function" ? params.default : () => params.default,
+    ...processCreateParams(params)
+  });
+};
+var ZodCatch = class extends ZodType {
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    const newCtx = {
+      ...ctx,
+      common: {
+        ...ctx.common,
+        issues: []
+      }
+    };
+    const result = this._def.innerType._parse({
+      data: newCtx.data,
+      path: newCtx.path,
+      parent: {
+        ...newCtx
+      }
+    });
+    if (isAsync(result)) {
+      return result.then((result2) => {
+        return {
+          status: "valid",
+          value: result2.status === "valid" ? result2.value : this._def.catchValue({
+            get error() {
+              return new ZodError(newCtx.common.issues);
+            },
+            input: newCtx.data
+          })
+        };
+      });
+    } else {
+      return {
+        status: "valid",
+        value: result.status === "valid" ? result.value : this._def.catchValue({
+          get error() {
+            return new ZodError(newCtx.common.issues);
+          },
+          input: newCtx.data
+        })
+      };
+    }
+  }
+  removeCatch() {
+    return this._def.innerType;
+  }
+};
+ZodCatch.create = (type, params) => {
+  return new ZodCatch({
+    innerType: type,
+    typeName: ZodFirstPartyTypeKind.ZodCatch,
+    catchValue: typeof params.catch === "function" ? params.catch : () => params.catch,
+    ...processCreateParams(params)
+  });
+};
+var ZodNaN = class extends ZodType {
+  _parse(input) {
+    const parsedType = this._getType(input);
+    if (parsedType !== ZodParsedType.nan) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.nan,
+        received: ctx.parsedType
+      });
+      return INVALID;
+    }
+    return { status: "valid", value: input.data };
+  }
+};
+ZodNaN.create = (params) => {
+  return new ZodNaN({
+    typeName: ZodFirstPartyTypeKind.ZodNaN,
+    ...processCreateParams(params)
+  });
+};
+var BRAND = /* @__PURE__ */ Symbol("zod_brand");
+var ZodBranded = class extends ZodType {
+  _parse(input) {
+    const { ctx } = this._processInputParams(input);
+    const data = ctx.data;
+    return this._def.type._parse({
+      data,
+      path: ctx.path,
+      parent: ctx
+    });
+  }
+  unwrap() {
+    return this._def.type;
+  }
+};
+var ZodPipeline = class _ZodPipeline extends ZodType {
+  _parse(input) {
+    const { status, ctx } = this._processInputParams(input);
+    if (ctx.common.async) {
+      const handleAsync = async () => {
+        const inResult = await this._def.in._parseAsync({
+          data: ctx.data,
+          path: ctx.path,
+          parent: ctx
+        });
+        if (inResult.status === "aborted")
+          return INVALID;
+        if (inResult.status === "dirty") {
+          status.dirty();
+          return DIRTY(inResult.value);
+        } else {
+          return this._def.out._parseAsync({
+            data: inResult.value,
+            path: ctx.path,
+            parent: ctx
+          });
+        }
+      };
+      return handleAsync();
+    } else {
+      const inResult = this._def.in._parseSync({
+        data: ctx.data,
+        path: ctx.path,
+        parent: ctx
+      });
+      if (inResult.status === "aborted")
+        return INVALID;
+      if (inResult.status === "dirty") {
+        status.dirty();
+        return {
+          status: "dirty",
+          value: inResult.value
+        };
+      } else {
+        return this._def.out._parseSync({
+          data: inResult.value,
+          path: ctx.path,
+          parent: ctx
+        });
+      }
+    }
+  }
+  static create(a, b) {
+    return new _ZodPipeline({
+      in: a,
+      out: b,
+      typeName: ZodFirstPartyTypeKind.ZodPipeline
+    });
+  }
+};
+var ZodReadonly = class extends ZodType {
+  _parse(input) {
+    const result = this._def.innerType._parse(input);
+    const freeze = (data) => {
+      if (isValid(data)) {
+        data.value = Object.freeze(data.value);
+      }
+      return data;
+    };
+    return isAsync(result) ? result.then((data) => freeze(data)) : freeze(result);
+  }
+  unwrap() {
+    return this._def.innerType;
+  }
+};
+ZodReadonly.create = (type, params) => {
+  return new ZodReadonly({
+    innerType: type,
+    typeName: ZodFirstPartyTypeKind.ZodReadonly,
+    ...processCreateParams(params)
+  });
+};
+function cleanParams(params, data) {
+  const p = typeof params === "function" ? params(data) : typeof params === "string" ? { message: params } : params;
+  const p2 = typeof p === "string" ? { message: p } : p;
+  return p2;
+}
+function custom(check, _params = {}, fatal) {
+  if (check)
+    return ZodAny.create().superRefine((data, ctx) => {
+      const r = check(data);
+      if (r instanceof Promise) {
+        return r.then((r2) => {
+          if (!r2) {
+            const params = cleanParams(_params, data);
+            const _fatal = params.fatal ?? fatal ?? true;
+            ctx.addIssue({ code: "custom", ...params, fatal: _fatal });
+          }
+        });
+      }
+      if (!r) {
+        const params = cleanParams(_params, data);
+        const _fatal = params.fatal ?? fatal ?? true;
+        ctx.addIssue({ code: "custom", ...params, fatal: _fatal });
+      }
+      return;
+    });
+  return ZodAny.create();
+}
+var late = {
+  object: ZodObject.lazycreate
+};
+var ZodFirstPartyTypeKind;
+(function(ZodFirstPartyTypeKind2) {
+  ZodFirstPartyTypeKind2["ZodString"] = "ZodString";
+  ZodFirstPartyTypeKind2["ZodNumber"] = "ZodNumber";
+  ZodFirstPartyTypeKind2["ZodNaN"] = "ZodNaN";
+  ZodFirstPartyTypeKind2["ZodBigInt"] = "ZodBigInt";
+  ZodFirstPartyTypeKind2["ZodBoolean"] = "ZodBoolean";
+  ZodFirstPartyTypeKind2["ZodDate"] = "ZodDate";
+  ZodFirstPartyTypeKind2["ZodSymbol"] = "ZodSymbol";
+  ZodFirstPartyTypeKind2["ZodUndefined"] = "ZodUndefined";
+  ZodFirstPartyTypeKind2["ZodNull"] = "ZodNull";
+  ZodFirstPartyTypeKind2["ZodAny"] = "ZodAny";
+  ZodFirstPartyTypeKind2["ZodUnknown"] = "ZodUnknown";
+  ZodFirstPartyTypeKind2["ZodNever"] = "ZodNever";
+  ZodFirstPartyTypeKind2["ZodVoid"] = "ZodVoid";
+  ZodFirstPartyTypeKind2["ZodArray"] = "ZodArray";
+  ZodFirstPartyTypeKind2["ZodObject"] = "ZodObject";
+  ZodFirstPartyTypeKind2["ZodUnion"] = "ZodUnion";
+  ZodFirstPartyTypeKind2["ZodDiscriminatedUnion"] = "ZodDiscriminatedUnion";
+  ZodFirstPartyTypeKind2["ZodIntersection"] = "ZodIntersection";
+  ZodFirstPartyTypeKind2["ZodTuple"] = "ZodTuple";
+  ZodFirstPartyTypeKind2["ZodRecord"] = "ZodRecord";
+  ZodFirstPartyTypeKind2["ZodMap"] = "ZodMap";
+  ZodFirstPartyTypeKind2["ZodSet"] = "ZodSet";
+  ZodFirstPartyTypeKind2["ZodFunction"] = "ZodFunction";
+  ZodFirstPartyTypeKind2["ZodLazy"] = "ZodLazy";
+  ZodFirstPartyTypeKind2["ZodLiteral"] = "ZodLiteral";
+  ZodFirstPartyTypeKind2["ZodEnum"] = "ZodEnum";
+  ZodFirstPartyTypeKind2["ZodEffects"] = "ZodEffects";
+  ZodFirstPartyTypeKind2["ZodNativeEnum"] = "ZodNativeEnum";
+  ZodFirstPartyTypeKind2["ZodOptional"] = "ZodOptional";
+  ZodFirstPartyTypeKind2["ZodNullable"] = "ZodNullable";
+  ZodFirstPartyTypeKind2["ZodDefault"] = "ZodDefault";
+  ZodFirstPartyTypeKind2["ZodCatch"] = "ZodCatch";
+  ZodFirstPartyTypeKind2["ZodPromise"] = "ZodPromise";
+  ZodFirstPartyTypeKind2["ZodBranded"] = "ZodBranded";
+  ZodFirstPartyTypeKind2["ZodPipeline"] = "ZodPipeline";
+  ZodFirstPartyTypeKind2["ZodReadonly"] = "ZodReadonly";
+})(ZodFirstPartyTypeKind || (ZodFirstPartyTypeKind = {}));
+var instanceOfType = (cls, params = {
+  message: `Input not instance of ${cls.name}`
+}) => custom((data) => data instanceof cls, params);
+var stringType = ZodString.create;
+var numberType = ZodNumber.create;
+var nanType = ZodNaN.create;
+var bigIntType = ZodBigInt.create;
+var booleanType = ZodBoolean.create;
+var dateType = ZodDate.create;
+var symbolType = ZodSymbol.create;
+var undefinedType = ZodUndefined.create;
+var nullType = ZodNull.create;
+var anyType = ZodAny.create;
+var unknownType = ZodUnknown.create;
+var neverType = ZodNever.create;
+var voidType = ZodVoid.create;
+var arrayType = ZodArray.create;
+var objectType = ZodObject.create;
+var strictObjectType = ZodObject.strictCreate;
+var unionType = ZodUnion.create;
+var discriminatedUnionType = ZodDiscriminatedUnion.create;
+var intersectionType = ZodIntersection.create;
+var tupleType = ZodTuple.create;
+var recordType = ZodRecord.create;
+var mapType = ZodMap.create;
+var setType = ZodSet.create;
+var functionType = ZodFunction.create;
+var lazyType = ZodLazy.create;
+var literalType = ZodLiteral.create;
+var enumType = ZodEnum.create;
+var nativeEnumType = ZodNativeEnum.create;
+var promiseType = ZodPromise.create;
+var effectsType = ZodEffects.create;
+var optionalType = ZodOptional.create;
+var nullableType = ZodNullable.create;
+var preprocessType = ZodEffects.createWithPreprocess;
+var pipelineType = ZodPipeline.create;
+var ostring = () => stringType().optional();
+var onumber = () => numberType().optional();
+var oboolean = () => booleanType().optional();
+var coerce = {
+  string: ((arg) => ZodString.create({ ...arg, coerce: true })),
+  number: ((arg) => ZodNumber.create({ ...arg, coerce: true })),
+  boolean: ((arg) => ZodBoolean.create({
+    ...arg,
+    coerce: true
+  })),
+  bigint: ((arg) => ZodBigInt.create({ ...arg, coerce: true })),
+  date: ((arg) => ZodDate.create({ ...arg, coerce: true }))
+};
+var NEVER = INVALID;
+
+// src/server/schemas/settings.ts
+var ruleLoadingTier = external_exports.enum(["minimal", "balanced", "full", "custom"]);
+var disciplineProfile = external_exports.enum(["auto", "off", "essential", "full"]);
+var enforcementMode = external_exports.enum(["advisory", "hard-stop"]);
+var autonomyMode = external_exports.enum(["on", "off", "auto"]);
+var userType = external_exports.enum(["", "consultant", "creator", "developer", "finance", "founder", "gtm", "ops"]);
+var profileId = external_exports.enum(["developer", "content_creator", "founder", "agency", "finance", "ops"]);
+var accessStyle = external_exports.enum(["getters_setters", "get_attribute", "magic_properties"]);
+var chatFreq = external_exports.enum(["per_turn", "per_phase", "per_tool"]);
+var chatOverflow = external_exports.enum(["rotate", "condense"]);
+var qualityCadence = external_exports.enum(["end_of_roadmap", "per_phase", "per_step"]);
+var regenCadence = external_exports.enum(["per_step", "every_5_steps", "phase_boundary"]);
+var worktreeMode = external_exports.enum(["off", "on", "ask"]);
+var fidelityMode = external_exports.enum(["strict", "structural", "hard-floor"]);
+var richSkillsMode = external_exports.enum(["on", "ask", "off"]);
+var replyMethod = external_exports.enum(["replies_endpoint", "create_review_comment", "auto"]);
+var confidenceBand = external_exports.enum(["off", "low", "medium", "high"]);
+var onBlock = external_exports.enum(["stop", "ask", "warn"]);
+var onBlockFallback = external_exports.enum(["stop", "warn"]);
+var modelAutoSwitch = external_exports.enum(["auto", "suggest", "off"]);
+var leanProjectionMode = external_exports.enum(["eager-all", "thin"]);
+var projectionMode = external_exports.enum(["legacy-all", "scoped"]);
+var memoryCadence = external_exports.enum(["auto", "always", "never"]);
+var settingsSchema = external_exports.object({
+  agent_config_version: external_exports.string().default("").describe(
+    'Pin the package to an exact semver (e.g. "1.4.2") so all teammates load the same skill / rule set. Leave empty to track whatever is installed locally \u2014 useful for the maintainers of this package, risky for production projects.'
+  ),
+  profile: external_exports.object({
+    id: profileId.default("developer").describe(
+      "Which experience you run \u2014 the audience identity that selects your default skill / command surface, README entry-path, and persona pre-selection (ADR-010, docs/contracts/profile-system.md). Six seed profiles: developer \xB7 content_creator \xB7 founder \xB7 agency \xB7 finance \xB7 ops. This is the first wizard question. In 6.0.0-A it records the choice only; pack-scoped surfacing (projection-time filtering, ADR-040) activates in 6.0.0-B behind a staged, opt-in rollout. Switch later with `agent-config use --profile=<id>`."
+    )
+  }).default({ id: "developer" }),
+  projection: external_exports.object({
+    mode: projectionMode.default("legacy-all").describe(
+      "Whether the per-tool projector writes EVERY artefact into the host-tool trees (.claude/ .cursor/ .windsurf/) or only the active profile + packs' artefacts (ADR-040, docs/contracts/capability-packs.md). legacy-all = (default, non-breaking) project the full surface exactly as 5.x did. scoped = project only the active profile's packs unioned with the runtime.active_packs overlay, expanded over the requires graph \u2014 opt in with `agent-config use --profile=<id>`. A failed scoped projection restores the full tree."
+    )
+  }).default({ mode: "legacy-all" }),
+  rule_loading_tier: ruleLoadingTier.default("balanced").describe(
+    "Master switch for which rule tiers load and how cautiously the agent spends tokens. minimal = only the 9 kernel rules (cheapest, fewest guardrails). balanced = kernel + tier-1 (recommended default). full = kernel + tier-1 + tier-2 (most guardrails, highest token cost). custom = roll your own in agents/overrides/. LEGACY: superseded by discipline_profile \u2014 when that key is set it wins (mapping: minimal\u2192off, balanced\u2192essential, full\u2192full)."
+  ),
+  discipline_profile: disciplineProfile.optional().describe(
+    "The ONE runtime knob for the discipline-rule tier (successor of rule_loading_tier; council 2026-07-07). off = kernel only (~1x tokens). essential = kernel + the measured lift-carrying rules (~3.3x, keeps the weak-host discipline lift). full = everything (~11.7x, EXPERIMENTAL \u2014 residual lift over essential not established). auto = resolve per session against the evidence-gated NULL-lift disable-list in src/config/host-capabilities.yml (measured-null host \u2192 off, otherwise \u2192 essential). Optional and opt-in until the P1/P2 evidence gates pass (agents/roadmaps/road-to-discipline-profile-tiering.md); absent = legacy rule_loading_tier applies."
+  ),
+  lean_projection: external_exports.object({
+    mode: leanProjectionMode.default("eager-all").describe(
+      "How the per-tool projector emits the rule layer. eager-all = every rule body inlined into every projection (default, safe). thin = kernel rules full-bodied + non-kernel rules as router-resolved pointers (~45k GPT-tok lighter per session). EXPERIMENTAL: validate with the live A/B before flipping; one-flip revert to eager-all."
+    )
+  }).default({ mode: "eager-all" }),
+  cost: external_exports.object({
+    budgets: external_exports.object({
+      daily: external_exports.number().min(0).default(0).describe(
+        "Daily USD ceiling across all model calls. The agent warns at 50% / 75% / 90% and either stops or warns at 100% depending on cost.enforcement. Set 0 to disable the daily budget entirely."
+      ),
+      weekly: external_exports.number().min(0).default(0).describe(
+        "Rolling 7-day USD ceiling. Same alert ladder as cost.budgets.daily but useful when work bursts unevenly across the week. Set 0 to disable."
+      ),
+      monthly: external_exports.number().min(0).default(0).describe(
+        "Calendar-month USD ceiling. Pairs with cost.enforcement = hard-stop for a hard cap on agent spend before the next billing cycle. Set 0 to disable."
+      )
+    }),
+    enforcement: enforcementMode.default("advisory").describe(
+      "What happens when a budget hits 100%. advisory = show a banner, keep working (default \u2014 never blocks an active task). hard-stop = refuse further model calls until the budget resets or you raise the ceiling."
+    )
+  }),
+  model: external_exports.object({
+    auto_switch: modelAutoSwitch.default("suggest").describe(
+      "Per-skill model auto-switch (ADR-035). Skills declare a vendor-neutral model_tier (lite/medium/high); the generator maps it to a native Claude model (high\u2192opus, medium\u2192sonnet, lite\u2192haiku). suggest (default) = never emit a native Claude model: key; the model-recommendation rule names the tier as a one-question suggestion on every surface \u2014 your explicit /model choice is never silently overridden. auto = render a native Claude model: into lite/medium/high-tier skills so Claude Code switches automatically for that turn (reverts next prompt), and suggest on surfaces without a native override. off = inert, no native key and no suggestion."
+    )
+  }).default({ auto_switch: "suggest" }),
+  personal: external_exports.object({
+    ide: external_exports.string().default("").describe(
+      "CLI binary your IDE registers (code, code-insiders, phpstorm, cursor, windsurf, idea, subl, \u2026). Used by the file-editor skill to open edited files. Leave empty to disable IDE integration."
+    ),
+    open_edited_files: external_exports.boolean().default(false).describe(
+      "After the agent edits a file, run `<ide> <path>` to surface it in your editor immediately. Off by default to avoid window-stealing during long agent runs."
+    ),
+    rtk_installed: external_exports.boolean().default(false).describe(
+      "Does this machine have rtk (Rust Token Killer, https://github.com/event4u-app/rtk) on PATH? When true the agent wraps verbose CLI output (git, tests, linters, docker, npm, composer) with rtk for ~60-90% token savings. Leave false if rtk is missing \u2014 the agent falls back to tail / grep."
+    ),
+    minimal_output: external_exports.boolean().default(true).describe(
+      "Prefer short bullets and tables (true, default) vs verbose prose with rationale (false). Affects every chat reply; flip to false during debugging when you want the agent to think out loud."
+    ),
+    play_by_play: external_exports.boolean().default(false).describe(
+      `Narrate intermediate findings between tool calls ("Found it.", "Let me check Y."). Off by default \u2014 most users find it noisy. Turn on when you want to follow the agent's reasoning step by step.`
+    ),
+    pr_comment_bot_icon: external_exports.boolean().default(false).describe(
+      "Prefix every PR review-comment reply with \u{1F916} so humans can tell agent-authored comments apart from teammate comments at a glance. Cosmetic only; the comment body itself never changes."
+    ),
+    pr_progress_comments: external_exports.boolean().default(false).describe(
+      'Permit the agent to post unsolicited progress / status comments on an open PR (e.g. "CI fix iteration #2", "still blocked on workflow scope"). Default off \u2014 most teammates find them noisy. User-invoked flows (/fix:pr-comments, /create-pr, /code-review, explicit "post a comment that \u2026") are NOT gated by this setting. See rules/no-pr-progress-comments.md.'
+    ),
+    autonomy: autonomyMode.default("auto").describe(
+      'How aggressively the agent suppresses trivial workflow questions ("commit now?", "open PR?"). on = silently pick the sensible default. off = always ask. auto (default) = decide per project, on for solo / off when collaborators are involved. The Hard Floor (prod, deploys, bulk deletes) ignores this setting and always asks.'
+    ),
+    user_type: userType.default("").describe(
+      "Optional persona axis used by the skill-suggester to surface the relevant subset (consultant / creator / developer / finance / founder / gtm / ops). Empty = no filter, all skills available. You can change this any time without re-running setup."
+    )
+  }),
+  project: external_exports.object({
+    pr_template: external_exports.string().default(".github/pull_request_template.md").describe(
+      "Path (relative to project root) to the PR-description template the agent fills in before opening a pull request. Override only if your repo keeps the template somewhere non-standard."
+    ),
+    upstream_repo: external_exports.string().default("").describe(
+      "GitHub slug (owner/repo) the upstream-contribute skill targets when you ask the agent to push a learning back to the shared agent-config package. Empty = improvement PRs are disabled."
+    ),
+    improvement_pr_branch_prefix: external_exports.string().default("improve/agent-").describe(
+      'Branch-name prefix for improvement PRs the agent opens against project.upstream_repo (e.g. "improve/agent-add-react-skill"). Pick a prefix your repo conventions allow.'
+    )
+  }),
+  github: external_exports.object({
+    pr_reply_method: replyMethod.default("create_review_comment").describe(
+      "How the agent replies to PR review comments. create_review_comment = post a new review comment (works on every GitHub plan). replies_endpoint = thread the reply under the original comment (needs the newer REST endpoint). auto = detect at runtime, prefer threaded replies when available."
+    )
+  }),
+  augment: external_exports.object({
+    rules_use_symlinks: external_exports.boolean().default(false).describe(
+      "When true, .augment/rules/*.md are symlinks into dist/agent-src/rules/ \u2014 edits flow back to source on save. When false (default), they are copies \u2014 safer on Windows and shared volumes, but rule edits in .augment/ are lost on the next `task sync`."
+    )
+  }),
+  eloquent: external_exports.object({
+    access_style: accessStyle.default("getters_setters").describe(
+      'How the agent writes Laravel Eloquent property access. getters_setters = explicit getName() / setName() methods (most refactor-safe). get_attribute = $model->getAttribute("name") (verbose but explicit). magic_properties = $model->name (idiomatic but harder to grep).'
+    )
+  }),
+  chat_history: external_exports.object({
+    enabled: external_exports.boolean().default(true).describe(
+      "Persist a structured log of every chat turn to .agent-config/chat-history/ so /chat-history:show, :import, and :learn can replay sessions. Turn off if you never want chat transcripts on disk."
+    ),
+    frequency: chatFreq.default("per_turn").describe(
+      "How often the chat-history writer flushes to disk. per_turn = after every user / agent exchange (default, lowest data loss on crash). per_phase = at phase boundaries (cheaper I/O). per_tool = after every tool call (highest fidelity, noisiest log)."
+    ),
+    max_size_kb: external_exports.number().int().min(0).default(2048).describe(
+      "Maximum size (KB) of the active chat-history file before chat_history.on_overflow kicks in. Set 0 to disable rotation / condensation entirely (file grows forever)."
+    ),
+    on_overflow: chatOverflow.default("rotate").describe(
+      "What happens when chat_history.max_size_kb is hit. rotate = move the current log aside and start fresh (default). condense = telegraph-condense the oldest entries in place to keep recent context."
+    ),
+    text_limits: external_exports.object({
+      user: external_exports.number().int().min(0).default(0).describe(
+        "Per-message character cap for user inputs in the chat-history log. 0 = log verbatim (default). Raise above 0 only if your prompts contain large pasted artefacts you do not want stored."
+      ),
+      agent: external_exports.number().int().min(0).default(5e3).describe(
+        "Per-message character cap for agent replies in the chat-history log. Truncates with an ellipsis past the cap. Lower to shrink history files, raise for long-reasoning replies."
+      ),
+      tool: external_exports.number().int().min(0).default(200).describe(
+        "Per-call character cap for tool input / output blobs in the chat-history log. The default 200 keeps history files compact while preserving enough signal to replay a session."
+      ),
+      phase: external_exports.number().int().min(0).default(200).describe(
+        "Per-marker character cap for phase markers (Phase=Refine, Phase=Plan, \u2026) in the chat-history log. Rarely needs tuning."
+      )
+    })
+  }),
+  pipelines: external_exports.object({
+    skill_improvement: external_exports.boolean().default(true).describe(
+      "After a meaningful task the agent proposes a learning-capture turn (new skill, rule tweak, guideline). Turn off if you find the prompts noisy \u2014 you can still run /memory:promote manually."
+    )
+  }),
+  roadmap: external_exports.object({
+    skip_pre_run_gate: external_exports.boolean().default(true).describe(
+      'Skip the /roadmap:process-* pre-run confirmation gate. true (default) starts processing immediately and surfaces the resolved config inline; false shows the numbered-options gate and waits. A genuine "which roadmap?" ambiguity always prompts regardless.'
+    ),
+    quality_cadence: qualityCadence.default("end_of_roadmap").describe(
+      "When the agent runs the full quality / test suite during /roadmap:process-* runs. end_of_roadmap = once, after the last step (fastest, default). per_phase = after each phase boundary. per_step = after every single step (slowest, highest confidence)."
+    ),
+    dashboard_regen_cadence: regenCadence.default("per_step").describe(
+      "How often the agent regenerates agents/roadmaps/dashboard.md during a roadmap run. per_step = after every step (default, freshest dashboard). every_5_steps = batch the regen. phase_boundary = only at phase edges."
+    ),
+    horizon_weeks: external_exports.number().int().min(0).default(0).describe(
+      'Optional planning horizon (weeks) the agent shows in roadmap framing ("next 4 weeks"). Set 0 to omit the horizon \u2014 most teams prefer to ship without a hardcoded window.'
+    )
+  }),
+  quality: external_exports.object({
+    local_auto_run: external_exports.boolean().default(false).describe(
+      "Run quality tools (linters, type-checks, formatters) and the local test suite autonomously after edits. Off by default \u2014 the agent never runs quality tools proactively and does not ask; the user runs them manually (e.g. /quality-fix) and remote CI is the authoritative gate. The agent only runs a quality tool on an explicit ask, a concrete CI failure, or the new-gate carve-out. Turn on to restore autonomous pipeline runs."
+    ),
+    wait_for_remote_ci: external_exports.boolean().default(false).describe(
+      "After pushing a branch, poll the remote CI provider (GitHub Actions, GitLab CI) and surface failures inline. Off by default \u2014 useful when local CI does not cover everything the remote pipeline runs."
+    )
+  }),
+  design: external_exports.object({
+    fidelity_mode: fidelityMode.default("strict").describe(
+      "How strictly the agent must follow a user-provided prototype / mockup / design system (consumed by the design-fidelity rule). strict = build 1:1, every visible deviation needs confirmation; structural = structure locked, silent gaps fillable with a stated assumption; hard-floor = any deviation is never autonomous."
+    )
+  }).default({ fidelity_mode: "strict" }),
+  tokens: external_exports.object({
+    rich_skills: richSkillsMode.default("on").describe(
+      "Whether skills marked token_budget_class: rich may load in full (exempt from telegraph-speak + thin-projector trimming), consumed by the token-budget-discipline rule. on = allowed (default); off = fall back to standard condensed behavior; ask = surface an estimated token delta (tokens, not dollars) and ask once per session before loading."
+    )
+  }).default({ rich_skills: "on" }),
+  reasoning: external_exports.object({
+    enabled: external_exports.boolean().default(true).describe(
+      "Master switch for the Reasoning Discipline Protocol (RDP). false = the whole layer is inert (zero overhead)."
+    ),
+    auto_gate: external_exports.boolean().default(true).describe(
+      "Engage the discipline only where it pays, using table-free signals (task triviality + agent-self-assessed host reasoning strength; no runtime model->band lookup, per ADR-035). false = gate on task-signal + the component toggles only."
+    ),
+    components: external_exports.object({
+      orchestrator: external_exports.boolean().default(true).describe(
+        "Sequence the reasoning chain (ground->intent->notes->gather->audit->verify) as one system; the single coordination point."
+      ),
+      notes_first: external_exports.boolean().default(true).describe(
+        "Keep hypotheses/predictions/decisions in session notes; the response carries conclusions + evidence only."
+      ),
+      grounding: external_exports.boolean().default(true).describe(
+        "Explore the environment / close info-gaps before designing."
+      ),
+      intent: external_exports.boolean().default(true).describe(
+        "Infer the underlying goal before solving the literal ask (standard host only)."
+      ),
+      complexity_first: external_exports.boolean().default(true).describe(
+        "Risk-first: resolve the load-bearing unknown before the easy parts (RDP derivation, not a Fable-documented behavior)."
+      ),
+      verifier_default: external_exports.boolean().default(true).describe(
+        "Run a fresh-context verifier on the structural-complexity gate (branching/constraints/stateful/irreversible + token floor)."
+      ),
+      prediction_tracking: external_exports.boolean().default(true).describe(
+        "Log prediction + confidence + outcome + lesson (calibration loop)."
+      ),
+      decision_ledger: external_exports.boolean().default(true).describe(
+        "Log decision + alternatives + reason + revisit-if; escalates to decision-record/ADR when durable."
+      ),
+      uncertainty_budget: external_exports.boolean().default(true).describe(
+        "Per-dimension uncertainty score that feeds adaptive effort."
+      )
+    }).default({})
+  }).default({}),
+  subagents: external_exports.object({
+    enabled: external_exports.boolean().default(true).describe(
+      "Global master switch for the subagent layer. true (default) = available; false = fully disabled (the canonical kill-switch \u2014 no auto-dispatch, no routing, everything runs in-session)."
+    ),
+    auto: external_exports.enum(["off", "ask", "on"]).default("ask").describe(
+      "Automatic-dispatch mode. off = subagents only via explicit command. ask = classify the task and ask once before dispatching. on = auto-dispatch delegable tasks (surface the choice in one line). Shipped default is ask on subagent-capable hosts, off elsewhere; no-op where the host has no subagent primitive."
+    ),
+    downshift: external_exports.boolean().default(true).describe(
+      "Route delegable sub-tasks to the lowest-capable model tier (cost + speed via model downshift). false = every subagent runs on the session tier."
+    ),
+    quota_arbitrage: external_exports.boolean().default(true).describe(
+      "Prefer a separate quota-pool model for delegable sub-tasks where the host manifest reports one. Optional bonus only \u2014 identical behaviour (minus the quota win) where unsupported. Never load-bearing."
+    ),
+    model_map: external_exports.object({
+      lite: external_exports.string().default("").describe("Model alias for lite-tier sub-tasks. Empty = the tier runtime default."),
+      medium: external_exports.string().default("").describe("Model alias for medium-tier sub-tasks. Empty = the tier runtime default."),
+      high: external_exports.string().default("").describe("Model alias for high-tier sub-tasks. Empty = the tier runtime default.")
+    }).default({}).describe(
+      "Per-tier model map for downshift routing. Each empty value uses the tier runtime default (no vendor model baked in)."
+    ),
+    host_capabilities: external_exports.object({}).passthrough().default({}).describe(
+      "Optional override of the host-capability manifest (subagent_spawn / parallel_spawn / status_polling / separate_quota_pool). Any field set wins; omitted fields fall back to the all-false safe default. Empty = the agent resolves the manifest from host knowledge."
+    ),
+    implementer_model: external_exports.string().default("").describe(
+      "Override the model the orchestrator dispatches to subagents that write code (e.g. claude-sonnet-4, gpt-5). Empty (default) = inherit the session's primary model \u2014 cheapest and usually right."
+    ),
+    judge_model: external_exports.string().default("").describe(
+      "Override the model used for review / judge subagents that critique implementer output. Empty (default) = one tier above the implementer model \u2014 picks up nuance the implementer missed."
+    ),
+    max_parallel: external_exports.number().int().min(1).default(3).describe(
+      "Hard cap on subagents running in parallel during /do-in-parallel, /do-competitively, and /judge runs. Raise for faster fan-out, lower if you hit rate limits or want lower token spend."
+    )
+  }),
+  worktrees: external_exports.object({
+    mode: worktreeMode.default("ask").describe(
+      "When the agent considers a parallel `git worktree` for risky / large work. ask (default) = surface a numbered option and wait. on = spawn worktrees autonomously. off = never use worktrees, edit in place."
+    )
+  }),
+  onboarding: external_exports.object({
+    onboarded: external_exports.boolean().default(false).describe(
+      "Set to true once the developer has completed `agent-config setup`. The onboarding-gate rule blocks the first turn of every chat until this is true. Toggle back to false to re-trigger the wizard."
+    )
+  }),
+  commands: external_exports.object({
+    auto_detect: external_exports.enum(["enabled", "warn", "disabled"]).default("enabled").describe(
+      "Global kill-switch for orchestrator auto-detection (6.1.0 non-interactive-contract). enabled (default) = /judge, /fix, /analytics, /tests, /override auto-detect their sub-command per a confidence-tiered table; warn = detect but always confirm before routing; disabled = never auto-detect (always show the menu interactively, require an explicit sub-command in CI). Per-orchestrator override: auto_detect:false in front-matter. Per-invocation: --no-auto-detect."
+    ),
+    suggestion: external_exports.object({
+      enabled: external_exports.boolean().default(true).describe(
+        'Master switch for the slash-command suggestion layer. When on, the agent offers numbered options ("did you mean /commit?") instead of guessing. Turn off if you prefer to type every command yourself.'
+      ),
+      confidence_floor: external_exports.number().min(0).max(1).default(0.6).describe(
+        "Minimum semantic-match score (0.0\u20131.0) before a command is offered as a suggestion. 0.6 (default) balances precision and recall. Raise toward 0.8 for fewer false positives, lower for broader hints."
+      ),
+      cooldown_seconds: external_exports.number().int().min(0).default(600).describe(
+        "How long (seconds) the suggester waits before offering the same command again after you ignored it. Default 600s (10 min) keeps the agent from nagging. Set 0 to disable the cooldown."
+      ),
+      max_options: external_exports.number().int().min(0).default(4).describe(
+        'Maximum number of command suggestions shown in a single numbered-options block, before the "Proceed as-is" escape. Lower for terser prompts, raise if you regularly want broader fan-out.'
+      ),
+      blocklist: external_exports.array(external_exports.string()).default([]).describe(
+        'Slash-command names that should never be suggested, one per line (e.g. "commit", "create-pr"). Useful if a command misfires on your common phrasing.'
+      )
+    }),
+    create_pr: external_exports.object({
+      preview_description: external_exports.boolean().default(false).describe(
+        "When /create-pr runs, show the generated title and body and wait for confirmation before opening the PR. Off by default (zero-friction PR creation); turn on if you want a last-look gate."
+      )
+    })
+  }),
+  memory: external_exports.object({
+    cadence: memoryCadence.default("always").describe(
+      "Cadence of the \u{1F9E0} memory-visibility line after a memory-consulting step. always (default) = show whenever a memory type was asked; auto = show only when 3+ types were consulted (less noise); never = suppress. Distinct from rule_loading_tier \u2014 owns its own key since the 2026-06-01 untangle."
+    ),
+    review_threshold: external_exports.number().int().min(0).default(10).describe(
+      "Maximum number of memory entries /memory:load surfaces inline before falling back to a summary view. Default 10 keeps the chat readable. Raise to see more candidates, lower to keep the context tight."
+    ),
+    redact_patterns: external_exports.array(external_exports.string()).default([]).describe(
+      "Regex patterns (one per line) that scrub matches from chat-history transcripts and memory before they hit disk. Use for secrets, customer names, internal URLs. Patterns are anchored and case-insensitive."
+    )
+  }),
+  knowledge: external_exports.object({
+    global_sharing: external_exports.object({
+      enabled: external_exports.boolean().default(false).describe(
+        "Master switch for the file-first global knowledge-card store (ADR-100, default-off per ADR-101 / Evidence v2 Phase 0 until cross-project reuse is measured). User-global setting \u2014 keep in ~/.event4u/agent-config/agent-settings.yml. false fully no-ops the layer; project-local cards (v1) are unaffected."
+      ),
+      allowed_tiers: external_exports.array(external_exports.string()).default(["public", "vendor"]).describe(
+        "Origin tiers auto-eligible to cross a project boundary. proprietary is manual-only regardless (the gate hard-codes it), so an in-house schema never auto-shares."
+      ),
+      redaction: external_exports.object({
+        enabled: external_exports.boolean().default(true).describe(
+          "Run the privacy-floor + source-confidentiality scan before any card goes global."
+        ),
+        halt_on_trigger: external_exports.boolean().default(true).describe(
+          "Halt-and-surface on a confidential-pattern hit; never silent-share, never auto-rewrite."
+        )
+      }).default({}),
+      auto_promote_threshold: external_exports.number().int().min(1).default(2).describe(
+        "Distinct-repo count at which a public/vendor card triggers a promotion suggestion (never a silent write)."
+      ),
+      freshness: external_exports.object({
+        hypothesis_after_days: external_exports.number().int().min(0).default(90).describe(
+          "A global card older than this is lead-only (positive structure must be re-confirmed before use)."
+        ),
+        stale_after_days: external_exports.number().int().min(0).default(180).describe(
+          "A global card older than this is skipped until re-verified."
+        )
+      }).default({})
+    }).default({})
+  }).default({}),
+  hooks: external_exports.object({
+    concern_budget: external_exports.object({
+      max_per_event: external_exports.number().int().min(1).default(8).describe(
+        "Maximum number of concerns (issues / warnings) a single hook may raise per (platform, event) pair before the hook is rate-limited. Default 8 prevents noisy hooks from drowning out high-signal ones."
+      ),
+      tier1_concerns: external_exports.array(external_exports.string()).default([]).describe(
+        "Concern IDs (one per line) that are allowed to block the run on failure rather than warn. Reserved for high-confidence guards \u2014 leave empty unless you maintain custom hooks."
+      ),
+      hard_fail: external_exports.boolean().default(false).describe(
+        "When a hook exceeds hooks.concern_budget.max_per_event, fail the run (true) instead of warning and continuing (false, default). Turn on in CI when you want hook quality to gate merges."
+      )
+    }),
+    injection_scan: external_exports.object({
+      enabled: external_exports.boolean().default(false).describe(
+        "PostToolUse prompt-injection scanner (road-to-security-pillar.md P3.2). Default off. When on, scans tool output (file reads, web fetches, MCP responses) for injection signatures and WARNS in context (never blocks). Runtime backstop on top of the always-on untrusted-input-defense rule; detection is probabilistic."
+      )
+    }).default({}),
+    rtk_wrap: external_exports.object({
+      enabled: external_exports.boolean().default(false).describe(
+        'PreToolUse RTK-wrap nudge (token-saving Phase 3). Default off. When on AND rtk is on PATH (a live probe \u2014 not a self-reported flag), warns (never blocks) "re-run wrapped with rtk" before a single verbose CLI command (git/npm/cargo/docker/\u2026) for 60\u201390% token saving. Skips completeness-critical / piped / compound commands and git diff. No-op when rtk is absent.'
+      )
+    }).default({}),
+    design_slop: external_exports.object({
+      enabled: external_exports.boolean().default(false).describe(
+        "PreToolUse anti-slop nudge (road-to-anti-slop-detector Phase 3). Default off. When on, runs the lint_design_slop registry against about-to-be-written UI content and WARNS (never blocks) on P0/P1 aesthetic tells (side-stripe, gradient-text, magic z-index, \u2026). Flags are rebuttable via DESIGN.md / design-slop-disable. Anti-loop: a file::rule signature surfaced 3x goes silent. Host-limited convenience layer; the universal gate is the lint_design_slop linter/CI."
+      )
+    }).default({})
+  }),
+  decision_engine: external_exports.object({
+    surface_traces: external_exports.boolean().default(false).describe(
+      "Emit DecisionTraceHook events that surface why the agent picked one option over another. Useful when debugging unexpected choices; off by default to keep chat noise low."
+    ),
+    min_confidence: confidenceBand.default("off").describe(
+      "During Phase=Plan, refuse to advance to Phase=Implement if confidence is below this band. off (default) = no gate. low / medium / high = raise the floor; on miss, decision_engine.on_block decides what happens."
+    ),
+    block_on_risk: confidenceBand.default("off").describe(
+      "During Phase=Implement, refuse to act when the risk class meets or exceeds this band. off (default) = no gate. low / medium / high = stricter ceilings; pairs with decision_engine.on_block."
+    ),
+    require_memory_hits: external_exports.boolean().default(false).describe(
+      "During Phase=Refine, require at least one relevant memory hit (skill, ADR, past decision) before the agent proceeds. Off by default; turn on for highly conventional codebases where memory should always inform decisions."
+    ),
+    on_block: onBlock.default("stop").describe(
+      "What the decision engine does when a gate (min_confidence / block_on_risk / require_memory_hits) fires. stop (default) = halt and surface the reason. ask = present numbered options. warn = log and continue."
+    ),
+    ask_timeout_seconds: external_exports.number().int().min(0).default(30).describe(
+      "Non-TTY timeout (seconds) for decision_engine.on_block = ask. After this elapses without input, decision_engine.on_block_fallback takes over. Default 30s; raise for slow human review, 0 = wait forever."
+    ),
+    on_block_fallback: onBlockFallback.default("stop").describe(
+      "Resolution when decision_engine.on_block = ask times out (see decision_engine.ask_timeout_seconds). stop (default) = halt the run. warn = log and continue with the agent's best guess."
+    )
+  }),
+  update_check: external_exports.object({
+    enabled: external_exports.boolean().default(true).describe(
+      "Once per day the agent checks the npm registry for a newer agent-config release and surfaces a one-line banner if one exists. Turn off in air-gapped environments or to silence the banner."
+    )
+  }),
+  explain: external_exports.object({
+    enable_last: external_exports.boolean().default(true).describe(
+      "Enable the `agent-config explain last` command, which prints the reasoning behind the agent's most recent decision (last tool call, last suggestion). Disable if you never use it and want a smaller CLI surface."
+    )
+  }),
+  legal_review_prep: external_exports.object({
+    acknowledged: external_exports.boolean().default(false).describe(
+      "I understand the legal-review-prep pack provides templates and general information ONLY \u2014 it is NOT legal advice, creates no attorney-client relationship, and never replaces a licensed lawyer. Individual cases require an attorney. The pack stays inactive until this is checked."
+    ),
+    consented_at: external_exports.string().default("").describe(
+      "ISO timestamp recorded when the legal-review-prep acknowledgment was given. Set automatically by the setup wizard; leave empty otherwise."
+    ),
+    require_council: external_exports.boolean().default(true).describe(
+      "Gate legal work-product behind a multi-model AI-council / deep-research pass (defense-in-depth: documented multi-stage review + audit trail; fail-closed when no council is configured). Leave on for the safest posture. Turning it off lets single-model legal output through \u2014 not recommended for a high-risk pack."
+    )
+  }).default({ acknowledged: false, consented_at: "", require_council: true })
+});
+
+// node_modules/zod-to-json-schema/dist/esm/Options.js
+var ignoreOverride = /* @__PURE__ */ Symbol("Let zodToJsonSchema decide on which parser to use");
+var defaultOptions = {
+  name: void 0,
+  $refStrategy: "root",
+  basePath: ["#"],
+  effectStrategy: "input",
+  pipeStrategy: "all",
+  dateStrategy: "format:date-time",
+  mapStrategy: "entries",
+  removeAdditionalStrategy: "passthrough",
+  allowedAdditionalProperties: true,
+  rejectedAdditionalProperties: false,
+  definitionPath: "definitions",
+  target: "jsonSchema7",
+  strictUnions: false,
+  definitions: {},
+  errorMessages: false,
+  markdownDescription: false,
+  patternStrategy: "escape",
+  applyRegexFlags: false,
+  emailStrategy: "format:email",
+  base64Strategy: "contentEncoding:base64",
+  nameStrategy: "ref",
+  openAiAnyTypeName: "OpenAiAnyType"
+};
+var getDefaultOptions = (options) => typeof options === "string" ? {
+  ...defaultOptions,
+  name: options
+} : {
+  ...defaultOptions,
+  ...options
+};
+
+// node_modules/zod-to-json-schema/dist/esm/Refs.js
+var getRefs = (options) => {
+  const _options = getDefaultOptions(options);
+  const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
+  return {
+    ..._options,
+    flags: { hasReferencedOpenAiAnyType: false },
+    currentPath,
+    propertyPath: void 0,
+    seen: new Map(Object.entries(_options.definitions).map(([name, def]) => [
+      def._def,
+      {
+        def: def._def,
+        path: [..._options.basePath, _options.definitionPath, name],
+        // Resolution of references will be forced even though seen, so it's ok that the schema is undefined here for now.
+        jsonSchema: void 0
+      }
+    ]))
+  };
+};
+
+// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+function addErrorMessage(res, key, errorMessage, refs) {
+  if (!refs?.errorMessages)
+    return;
+  if (errorMessage) {
+    res.errorMessage = {
+      ...res.errorMessage,
+      [key]: errorMessage
+    };
+  }
+}
+function setResponseValueAndErrors(res, key, value, errorMessage, refs) {
+  res[key] = value;
+  addErrorMessage(res, key, errorMessage, refs);
+}
+
+// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+var getRelativePath = (pathA, pathB) => {
+  let i = 0;
+  for (; i < pathA.length && i < pathB.length; i++) {
+    if (pathA[i] !== pathB[i])
+      break;
+  }
+  return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+function parseAnyDef(refs) {
+  if (refs.target !== "openAi") {
+    return {};
+  }
+  const anyDefinitionPath = [
+    ...refs.basePath,
+    refs.definitionPath,
+    refs.openAiAnyTypeName
+  ];
+  refs.flags.hasReferencedOpenAiAnyType = true;
+  return {
+    $ref: refs.$refStrategy === "relative" ? getRelativePath(anyDefinitionPath, refs.currentPath) : anyDefinitionPath.join("/")
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+function parseArrayDef(def, refs) {
+  const res = {
+    type: "array"
+  };
+  if (def.type?._def && def.type?._def?.typeName !== ZodFirstPartyTypeKind.ZodAny) {
+    res.items = parseDef(def.type._def, {
+      ...refs,
+      currentPath: [...refs.currentPath, "items"]
+    });
+  }
+  if (def.minLength) {
+    setResponseValueAndErrors(res, "minItems", def.minLength.value, def.minLength.message, refs);
+  }
+  if (def.maxLength) {
+    setResponseValueAndErrors(res, "maxItems", def.maxLength.value, def.maxLength.message, refs);
+  }
+  if (def.exactLength) {
+    setResponseValueAndErrors(res, "minItems", def.exactLength.value, def.exactLength.message, refs);
+    setResponseValueAndErrors(res, "maxItems", def.exactLength.value, def.exactLength.message, refs);
+  }
+  return res;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+function parseBigintDef(def, refs) {
+  const res = {
+    type: "integer",
+    format: "int64"
+  };
+  if (!def.checks)
+    return res;
+  for (const check of def.checks) {
+    switch (check.kind) {
+      case "min":
+        if (refs.target === "jsonSchema7") {
+          if (check.inclusive) {
+            setResponseValueAndErrors(res, "minimum", check.value, check.message, refs);
+          } else {
+            setResponseValueAndErrors(res, "exclusiveMinimum", check.value, check.message, refs);
+          }
+        } else {
+          if (!check.inclusive) {
+            res.exclusiveMinimum = true;
+          }
+          setResponseValueAndErrors(res, "minimum", check.value, check.message, refs);
+        }
+        break;
+      case "max":
+        if (refs.target === "jsonSchema7") {
+          if (check.inclusive) {
+            setResponseValueAndErrors(res, "maximum", check.value, check.message, refs);
+          } else {
+            setResponseValueAndErrors(res, "exclusiveMaximum", check.value, check.message, refs);
+          }
+        } else {
+          if (!check.inclusive) {
+            res.exclusiveMaximum = true;
+          }
+          setResponseValueAndErrors(res, "maximum", check.value, check.message, refs);
+        }
+        break;
+      case "multipleOf":
+        setResponseValueAndErrors(res, "multipleOf", check.value, check.message, refs);
+        break;
+    }
+  }
+  return res;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+function parseBooleanDef() {
+  return {
+    type: "boolean"
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+function parseBrandedDef(_def, refs) {
+  return parseDef(_def.type._def, refs);
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+var parseCatchDef = (def, refs) => {
+  return parseDef(def.innerType._def, refs);
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+function parseDateDef(def, refs, overrideDateStrategy) {
+  const strategy = overrideDateStrategy ?? refs.dateStrategy;
+  if (Array.isArray(strategy)) {
+    return {
+      anyOf: strategy.map((item, i) => parseDateDef(def, refs, item))
+    };
+  }
+  switch (strategy) {
+    case "string":
+    case "format:date-time":
+      return {
+        type: "string",
+        format: "date-time"
+      };
+    case "format:date":
+      return {
+        type: "string",
+        format: "date"
+      };
+    case "integer":
+      return integerDateParser(def, refs);
+  }
+}
+var integerDateParser = (def, refs) => {
+  const res = {
+    type: "integer",
+    format: "unix-time"
+  };
+  if (refs.target === "openApi3") {
+    return res;
+  }
+  for (const check of def.checks) {
+    switch (check.kind) {
+      case "min":
+        setResponseValueAndErrors(
+          res,
+          "minimum",
+          check.value,
+          // This is in milliseconds
+          check.message,
+          refs
+        );
+        break;
+      case "max":
+        setResponseValueAndErrors(
+          res,
+          "maximum",
+          check.value,
+          // This is in milliseconds
+          check.message,
+          refs
+        );
+        break;
+    }
+  }
+  return res;
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+function parseDefaultDef(_def, refs) {
+  return {
+    ...parseDef(_def.innerType._def, refs),
+    default: _def.defaultValue()
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+function parseEffectsDef(_def, refs) {
+  return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+function parseEnumDef(def) {
+  return {
+    type: "string",
+    enum: Array.from(def.values)
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+var isJsonSchema7AllOfType = (type) => {
+  if ("type" in type && type.type === "string")
+    return false;
+  return "allOf" in type;
+};
+function parseIntersectionDef(def, refs) {
+  const allOf = [
+    parseDef(def.left._def, {
+      ...refs,
+      currentPath: [...refs.currentPath, "allOf", "0"]
+    }),
+    parseDef(def.right._def, {
+      ...refs,
+      currentPath: [...refs.currentPath, "allOf", "1"]
+    })
+  ].filter((x) => !!x);
+  let unevaluatedProperties = refs.target === "jsonSchema2019-09" ? { unevaluatedProperties: false } : void 0;
+  const mergedAllOf = [];
+  allOf.forEach((schema) => {
+    if (isJsonSchema7AllOfType(schema)) {
+      mergedAllOf.push(...schema.allOf);
+      if (schema.unevaluatedProperties === void 0) {
+        unevaluatedProperties = void 0;
+      }
+    } else {
+      let nestedSchema = schema;
+      if ("additionalProperties" in schema && schema.additionalProperties === false) {
+        const { additionalProperties, ...rest } = schema;
+        nestedSchema = rest;
+      } else {
+        unevaluatedProperties = void 0;
+      }
+      mergedAllOf.push(nestedSchema);
+    }
+  });
+  return mergedAllOf.length ? {
+    allOf: mergedAllOf,
+    ...unevaluatedProperties
+  } : void 0;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+function parseLiteralDef(def, refs) {
+  const parsedType = typeof def.value;
+  if (parsedType !== "bigint" && parsedType !== "number" && parsedType !== "boolean" && parsedType !== "string") {
+    return {
+      type: Array.isArray(def.value) ? "array" : "object"
+    };
+  }
+  if (refs.target === "openApi3") {
+    return {
+      type: parsedType === "bigint" ? "integer" : parsedType,
+      enum: [def.value]
+    };
+  }
+  return {
+    type: parsedType === "bigint" ? "integer" : parsedType,
+    const: def.value
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+var emojiRegex2 = void 0;
+var zodPatterns = {
+  /**
+   * `c` was changed to `[cC]` to replicate /i flag
+   */
+  cuid: /^[cC][^\s-]{8,}$/,
+  cuid2: /^[0-9a-z]+$/,
+  ulid: /^[0-9A-HJKMNP-TV-Z]{26}$/,
+  /**
+   * `a-z` was added to replicate /i flag
+   */
+  email: /^(?!\.)(?!.*\.\.)([a-zA-Z0-9_'+\-\.]*)[a-zA-Z0-9_+-]@([a-zA-Z0-9][a-zA-Z0-9\-]*\.)+[a-zA-Z]{2,}$/,
+  /**
+   * Constructed a valid Unicode RegExp
+   *
+   * Lazily instantiate since this type of regex isn't supported
+   * in all envs (e.g. React Native).
+   *
+   * See:
+   * https://github.com/colinhacks/zod/issues/2433
+   * Fix in Zod:
+   * https://github.com/colinhacks/zod/commit/9340fd51e48576a75adc919bff65dbc4a5d4c99b
+   */
+  emoji: () => {
+    if (emojiRegex2 === void 0) {
+      emojiRegex2 = RegExp("^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$", "u");
+    }
+    return emojiRegex2;
+  },
+  /**
+   * Unused
+   */
+  uuid: /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/,
+  /**
+   * Unused
+   */
+  ipv4: /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/,
+  ipv4Cidr: /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\/(3[0-2]|[12]?[0-9])$/,
+  /**
+   * Unused
+   */
+  ipv6: /^(([a-f0-9]{1,4}:){7}|::([a-f0-9]{1,4}:){0,6}|([a-f0-9]{1,4}:){1}:([a-f0-9]{1,4}:){0,5}|([a-f0-9]{1,4}:){2}:([a-f0-9]{1,4}:){0,4}|([a-f0-9]{1,4}:){3}:([a-f0-9]{1,4}:){0,3}|([a-f0-9]{1,4}:){4}:([a-f0-9]{1,4}:){0,2}|([a-f0-9]{1,4}:){5}:([a-f0-9]{1,4}:){0,1})([a-f0-9]{1,4}|(((25[0-5])|(2[0-4][0-9])|(1[0-9]{2})|([0-9]{1,2}))\.){3}((25[0-5])|(2[0-4][0-9])|(1[0-9]{2})|([0-9]{1,2})))$/,
+  ipv6Cidr: /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/,
+  base64: /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/,
+  base64url: /^([0-9a-zA-Z-_]{4})*(([0-9a-zA-Z-_]{2}(==)?)|([0-9a-zA-Z-_]{3}(=)?))?$/,
+  nanoid: /^[a-zA-Z0-9_-]{21}$/,
+  jwt: /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/
+};
+function parseStringDef(def, refs) {
+  const res = {
+    type: "string"
+  };
+  if (def.checks) {
+    for (const check of def.checks) {
+      switch (check.kind) {
+        case "min":
+          setResponseValueAndErrors(res, "minLength", typeof res.minLength === "number" ? Math.max(res.minLength, check.value) : check.value, check.message, refs);
+          break;
+        case "max":
+          setResponseValueAndErrors(res, "maxLength", typeof res.maxLength === "number" ? Math.min(res.maxLength, check.value) : check.value, check.message, refs);
+          break;
+        case "email":
+          switch (refs.emailStrategy) {
+            case "format:email":
+              addFormat(res, "email", check.message, refs);
+              break;
+            case "format:idn-email":
+              addFormat(res, "idn-email", check.message, refs);
+              break;
+            case "pattern:zod":
+              addPattern(res, zodPatterns.email, check.message, refs);
+              break;
+          }
+          break;
+        case "url":
+          addFormat(res, "uri", check.message, refs);
+          break;
+        case "uuid":
+          addFormat(res, "uuid", check.message, refs);
+          break;
+        case "regex":
+          addPattern(res, check.regex, check.message, refs);
+          break;
+        case "cuid":
+          addPattern(res, zodPatterns.cuid, check.message, refs);
+          break;
+        case "cuid2":
+          addPattern(res, zodPatterns.cuid2, check.message, refs);
+          break;
+        case "startsWith":
+          addPattern(res, RegExp(`^${escapeLiteralCheckValue(check.value, refs)}`), check.message, refs);
+          break;
+        case "endsWith":
+          addPattern(res, RegExp(`${escapeLiteralCheckValue(check.value, refs)}$`), check.message, refs);
+          break;
+        case "datetime":
+          addFormat(res, "date-time", check.message, refs);
+          break;
+        case "date":
+          addFormat(res, "date", check.message, refs);
+          break;
+        case "time":
+          addFormat(res, "time", check.message, refs);
+          break;
+        case "duration":
+          addFormat(res, "duration", check.message, refs);
+          break;
+        case "length":
+          setResponseValueAndErrors(res, "minLength", typeof res.minLength === "number" ? Math.max(res.minLength, check.value) : check.value, check.message, refs);
+          setResponseValueAndErrors(res, "maxLength", typeof res.maxLength === "number" ? Math.min(res.maxLength, check.value) : check.value, check.message, refs);
+          break;
+        case "includes": {
+          addPattern(res, RegExp(escapeLiteralCheckValue(check.value, refs)), check.message, refs);
+          break;
+        }
+        case "ip": {
+          if (check.version !== "v6") {
+            addFormat(res, "ipv4", check.message, refs);
+          }
+          if (check.version !== "v4") {
+            addFormat(res, "ipv6", check.message, refs);
+          }
+          break;
+        }
+        case "base64url":
+          addPattern(res, zodPatterns.base64url, check.message, refs);
+          break;
+        case "jwt":
+          addPattern(res, zodPatterns.jwt, check.message, refs);
+          break;
+        case "cidr": {
+          if (check.version !== "v6") {
+            addPattern(res, zodPatterns.ipv4Cidr, check.message, refs);
+          }
+          if (check.version !== "v4") {
+            addPattern(res, zodPatterns.ipv6Cidr, check.message, refs);
+          }
+          break;
+        }
+        case "emoji":
+          addPattern(res, zodPatterns.emoji(), check.message, refs);
+          break;
+        case "ulid": {
+          addPattern(res, zodPatterns.ulid, check.message, refs);
+          break;
+        }
+        case "base64": {
+          switch (refs.base64Strategy) {
+            case "format:binary": {
+              addFormat(res, "binary", check.message, refs);
+              break;
+            }
+            case "contentEncoding:base64": {
+              setResponseValueAndErrors(res, "contentEncoding", "base64", check.message, refs);
+              break;
+            }
+            case "pattern:zod": {
+              addPattern(res, zodPatterns.base64, check.message, refs);
+              break;
+            }
+          }
+          break;
+        }
+        case "nanoid": {
+          addPattern(res, zodPatterns.nanoid, check.message, refs);
+        }
+        case "toLowerCase":
+        case "toUpperCase":
+        case "trim":
+          break;
+        default:
+          /* @__PURE__ */ ((_) => {
+          })(check);
+      }
+    }
+  }
+  return res;
+}
+function escapeLiteralCheckValue(literal, refs) {
+  return refs.patternStrategy === "escape" ? escapeNonAlphaNumeric(literal) : literal;
+}
+var ALPHA_NUMERIC = new Set("ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvxyz0123456789");
+function escapeNonAlphaNumeric(source) {
+  let result = "";
+  for (let i = 0; i < source.length; i++) {
+    if (!ALPHA_NUMERIC.has(source[i])) {
+      result += "\\";
+    }
+    result += source[i];
+  }
+  return result;
+}
+function addFormat(schema, value, message, refs) {
+  if (schema.format || schema.anyOf?.some((x) => x.format)) {
+    if (!schema.anyOf) {
+      schema.anyOf = [];
+    }
+    if (schema.format) {
+      schema.anyOf.push({
+        format: schema.format,
+        ...schema.errorMessage && refs.errorMessages && {
+          errorMessage: { format: schema.errorMessage.format }
+        }
+      });
+      delete schema.format;
+      if (schema.errorMessage) {
+        delete schema.errorMessage.format;
+        if (Object.keys(schema.errorMessage).length === 0) {
+          delete schema.errorMessage;
+        }
+      }
+    }
+    schema.anyOf.push({
+      format: value,
+      ...message && refs.errorMessages && { errorMessage: { format: message } }
+    });
+  } else {
+    setResponseValueAndErrors(schema, "format", value, message, refs);
+  }
+}
+function addPattern(schema, regex, message, refs) {
+  if (schema.pattern || schema.allOf?.some((x) => x.pattern)) {
+    if (!schema.allOf) {
+      schema.allOf = [];
+    }
+    if (schema.pattern) {
+      schema.allOf.push({
+        pattern: schema.pattern,
+        ...schema.errorMessage && refs.errorMessages && {
+          errorMessage: { pattern: schema.errorMessage.pattern }
+        }
+      });
+      delete schema.pattern;
+      if (schema.errorMessage) {
+        delete schema.errorMessage.pattern;
+        if (Object.keys(schema.errorMessage).length === 0) {
+          delete schema.errorMessage;
+        }
+      }
+    }
+    schema.allOf.push({
+      pattern: stringifyRegExpWithFlags(regex, refs),
+      ...message && refs.errorMessages && { errorMessage: { pattern: message } }
+    });
+  } else {
+    setResponseValueAndErrors(schema, "pattern", stringifyRegExpWithFlags(regex, refs), message, refs);
+  }
+}
+function stringifyRegExpWithFlags(regex, refs) {
+  if (!refs.applyRegexFlags || !regex.flags) {
+    return regex.source;
+  }
+  const flags = {
+    i: regex.flags.includes("i"),
+    m: regex.flags.includes("m"),
+    s: regex.flags.includes("s")
+    // `.` matches newlines
+  };
+  const source = flags.i ? regex.source.toLowerCase() : regex.source;
+  let pattern = "";
+  let isEscaped = false;
+  let inCharGroup = false;
+  let inCharRange = false;
+  for (let i = 0; i < source.length; i++) {
+    if (isEscaped) {
+      pattern += source[i];
+      isEscaped = false;
+      continue;
+    }
+    if (flags.i) {
+      if (inCharGroup) {
+        if (source[i].match(/[a-z]/)) {
+          if (inCharRange) {
+            pattern += source[i];
+            pattern += `${source[i - 2]}-${source[i]}`.toUpperCase();
+            inCharRange = false;
+          } else if (source[i + 1] === "-" && source[i + 2]?.match(/[a-z]/)) {
+            pattern += source[i];
+            inCharRange = true;
+          } else {
+            pattern += `${source[i]}${source[i].toUpperCase()}`;
+          }
+          continue;
+        }
+      } else if (source[i].match(/[a-z]/)) {
+        pattern += `[${source[i]}${source[i].toUpperCase()}]`;
+        continue;
+      }
+    }
+    if (flags.m) {
+      if (source[i] === "^") {
+        pattern += `(^|(?<=[\r
+]))`;
+        continue;
+      } else if (source[i] === "$") {
+        pattern += `($|(?=[\r
+]))`;
+        continue;
+      }
+    }
+    if (flags.s && source[i] === ".") {
+      pattern += inCharGroup ? `${source[i]}\r
+` : `[${source[i]}\r
+]`;
+      continue;
+    }
+    pattern += source[i];
+    if (source[i] === "\\") {
+      isEscaped = true;
+    } else if (inCharGroup && source[i] === "]") {
+      inCharGroup = false;
+    } else if (!inCharGroup && source[i] === "[") {
+      inCharGroup = true;
+    }
+  }
+  try {
+    new RegExp(pattern);
+  } catch {
+    console.warn(`Could not convert regex pattern at ${refs.currentPath.join("/")} to a flag-independent form! Falling back to the flag-ignorant source`);
+    return regex.source;
+  }
+  return pattern;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+function parseRecordDef(def, refs) {
+  if (refs.target === "openAi") {
+    console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
+  }
+  if (refs.target === "openApi3" && def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodEnum) {
+    return {
+      type: "object",
+      required: def.keyType._def.values,
+      properties: def.keyType._def.values.reduce((acc, key) => ({
+        ...acc,
+        [key]: parseDef(def.valueType._def, {
+          ...refs,
+          currentPath: [...refs.currentPath, "properties", key]
+        }) ?? parseAnyDef(refs)
+      }), {}),
+      additionalProperties: refs.rejectedAdditionalProperties
+    };
+  }
+  const schema = {
+    type: "object",
+    additionalProperties: parseDef(def.valueType._def, {
+      ...refs,
+      currentPath: [...refs.currentPath, "additionalProperties"]
+    }) ?? refs.allowedAdditionalProperties
+  };
+  if (refs.target === "openApi3") {
+    return schema;
+  }
+  if (def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodString && def.keyType._def.checks?.length) {
+    const { type, ...keyType } = parseStringDef(def.keyType._def, refs);
+    return {
+      ...schema,
+      propertyNames: keyType
+    };
+  } else if (def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodEnum) {
+    return {
+      ...schema,
+      propertyNames: {
+        enum: def.keyType._def.values
+      }
+    };
+  } else if (def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodBranded && def.keyType._def.type._def.typeName === ZodFirstPartyTypeKind.ZodString && def.keyType._def.type._def.checks?.length) {
+    const { type, ...keyType } = parseBrandedDef(def.keyType._def, refs);
+    return {
+      ...schema,
+      propertyNames: keyType
+    };
+  }
+  return schema;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+function parseMapDef(def, refs) {
+  if (refs.mapStrategy === "record") {
+    return parseRecordDef(def, refs);
+  }
+  const keys = parseDef(def.keyType._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "items", "items", "0"]
+  }) || parseAnyDef(refs);
+  const values = parseDef(def.valueType._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "items", "items", "1"]
+  }) || parseAnyDef(refs);
+  return {
+    type: "array",
+    maxItems: 125,
+    items: {
+      type: "array",
+      items: [keys, values],
+      minItems: 2,
+      maxItems: 2
+    }
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+function parseNativeEnumDef(def) {
+  const object = def.values;
+  const actualKeys = Object.keys(def.values).filter((key) => {
+    return typeof object[object[key]] !== "number";
+  });
+  const actualValues = actualKeys.map((key) => object[key]);
+  const parsedTypes = Array.from(new Set(actualValues.map((values) => typeof values)));
+  return {
+    type: parsedTypes.length === 1 ? parsedTypes[0] === "string" ? "string" : "number" : ["string", "number"],
+    enum: actualValues
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+function parseNeverDef(refs) {
+  return refs.target === "openAi" ? void 0 : {
+    not: parseAnyDef({
+      ...refs,
+      currentPath: [...refs.currentPath, "not"]
+    })
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+function parseNullDef(refs) {
+  return refs.target === "openApi3" ? {
+    enum: ["null"],
+    nullable: true
+  } : {
+    type: "null"
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+var primitiveMappings = {
+  ZodString: "string",
+  ZodNumber: "number",
+  ZodBigInt: "integer",
+  ZodBoolean: "boolean",
+  ZodNull: "null"
+};
+function parseUnionDef(def, refs) {
+  if (refs.target === "openApi3")
+    return asAnyOf(def, refs);
+  const options = def.options instanceof Map ? Array.from(def.options.values()) : def.options;
+  if (options.every((x) => x._def.typeName in primitiveMappings && (!x._def.checks || !x._def.checks.length))) {
+    const types = options.reduce((types2, x) => {
+      const type = primitiveMappings[x._def.typeName];
+      return type && !types2.includes(type) ? [...types2, type] : types2;
+    }, []);
+    return {
+      type: types.length > 1 ? types : types[0]
+    };
+  } else if (options.every((x) => x._def.typeName === "ZodLiteral" && !x.description)) {
+    const types = options.reduce((acc, x) => {
+      const type = typeof x._def.value;
+      switch (type) {
+        case "string":
+        case "number":
+        case "boolean":
+          return [...acc, type];
+        case "bigint":
+          return [...acc, "integer"];
+        case "object":
+          if (x._def.value === null)
+            return [...acc, "null"];
+        case "symbol":
+        case "undefined":
+        case "function":
+        default:
+          return acc;
+      }
+    }, []);
+    if (types.length === options.length) {
+      const uniqueTypes = types.filter((x, i, a) => a.indexOf(x) === i);
+      return {
+        type: uniqueTypes.length > 1 ? uniqueTypes : uniqueTypes[0],
+        enum: options.reduce((acc, x) => {
+          return acc.includes(x._def.value) ? acc : [...acc, x._def.value];
+        }, [])
+      };
+    }
+  } else if (options.every((x) => x._def.typeName === "ZodEnum")) {
+    return {
+      type: "string",
+      enum: options.reduce((acc, x) => [
+        ...acc,
+        ...x._def.values.filter((x2) => !acc.includes(x2))
+      ], [])
+    };
+  }
+  return asAnyOf(def, refs);
+}
+var asAnyOf = (def, refs) => {
+  const anyOf = (def.options instanceof Map ? Array.from(def.options.values()) : def.options).map((x, i) => parseDef(x._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "anyOf", `${i}`]
+  })).filter((x) => !!x && (!refs.strictUnions || typeof x === "object" && Object.keys(x).length > 0));
+  return anyOf.length ? { anyOf } : void 0;
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+function parseNullableDef(def, refs) {
+  if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
+    if (refs.target === "openApi3") {
+      return {
+        type: primitiveMappings[def.innerType._def.typeName],
+        nullable: true
+      };
+    }
+    return {
+      type: [
+        primitiveMappings[def.innerType._def.typeName],
+        "null"
+      ]
+    };
+  }
+  if (refs.target === "openApi3") {
+    const base2 = parseDef(def.innerType._def, {
+      ...refs,
+      currentPath: [...refs.currentPath]
+    });
+    if (base2 && "$ref" in base2)
+      return { allOf: [base2], nullable: true };
+    return base2 && { ...base2, nullable: true };
+  }
+  const base = parseDef(def.innerType._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "anyOf", "0"]
+  });
+  return base && { anyOf: [base, { type: "null" }] };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+function parseNumberDef(def, refs) {
+  const res = {
+    type: "number"
+  };
+  if (!def.checks)
+    return res;
+  for (const check of def.checks) {
+    switch (check.kind) {
+      case "int":
+        res.type = "integer";
+        addErrorMessage(res, "type", check.message, refs);
+        break;
+      case "min":
+        if (refs.target === "jsonSchema7") {
+          if (check.inclusive) {
+            setResponseValueAndErrors(res, "minimum", check.value, check.message, refs);
+          } else {
+            setResponseValueAndErrors(res, "exclusiveMinimum", check.value, check.message, refs);
+          }
+        } else {
+          if (!check.inclusive) {
+            res.exclusiveMinimum = true;
+          }
+          setResponseValueAndErrors(res, "minimum", check.value, check.message, refs);
+        }
+        break;
+      case "max":
+        if (refs.target === "jsonSchema7") {
+          if (check.inclusive) {
+            setResponseValueAndErrors(res, "maximum", check.value, check.message, refs);
+          } else {
+            setResponseValueAndErrors(res, "exclusiveMaximum", check.value, check.message, refs);
+          }
+        } else {
+          if (!check.inclusive) {
+            res.exclusiveMaximum = true;
+          }
+          setResponseValueAndErrors(res, "maximum", check.value, check.message, refs);
+        }
+        break;
+      case "multipleOf":
+        setResponseValueAndErrors(res, "multipleOf", check.value, check.message, refs);
+        break;
+    }
+  }
+  return res;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+function parseObjectDef(def, refs) {
+  const forceOptionalIntoNullable = refs.target === "openAi";
+  const result = {
+    type: "object",
+    properties: {}
+  };
+  const required = [];
+  const shape = def.shape();
+  for (const propName in shape) {
+    let propDef = shape[propName];
+    if (propDef === void 0 || propDef._def === void 0) {
+      continue;
+    }
+    let propOptional = safeIsOptional(propDef);
+    if (propOptional && forceOptionalIntoNullable) {
+      if (propDef._def.typeName === "ZodOptional") {
+        propDef = propDef._def.innerType;
+      }
+      if (!propDef.isNullable()) {
+        propDef = propDef.nullable();
+      }
+      propOptional = false;
+    }
+    const parsedDef = parseDef(propDef._def, {
+      ...refs,
+      currentPath: [...refs.currentPath, "properties", propName],
+      propertyPath: [...refs.currentPath, "properties", propName]
+    });
+    if (parsedDef === void 0) {
+      continue;
+    }
+    result.properties[propName] = parsedDef;
+    if (!propOptional) {
+      required.push(propName);
+    }
+  }
+  if (required.length) {
+    result.required = required;
+  }
+  const additionalProperties = decideAdditionalProperties(def, refs);
+  if (additionalProperties !== void 0) {
+    result.additionalProperties = additionalProperties;
+  }
+  return result;
+}
+function decideAdditionalProperties(def, refs) {
+  if (def.catchall._def.typeName !== "ZodNever") {
+    return parseDef(def.catchall._def, {
+      ...refs,
+      currentPath: [...refs.currentPath, "additionalProperties"]
+    });
+  }
+  switch (def.unknownKeys) {
+    case "passthrough":
+      return refs.allowedAdditionalProperties;
+    case "strict":
+      return refs.rejectedAdditionalProperties;
+    case "strip":
+      return refs.removeAdditionalStrategy === "strict" ? refs.allowedAdditionalProperties : refs.rejectedAdditionalProperties;
+  }
+}
+function safeIsOptional(schema) {
+  try {
+    return schema.isOptional();
+  } catch {
+    return true;
+  }
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+var parseOptionalDef = (def, refs) => {
+  if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
+    return parseDef(def.innerType._def, refs);
+  }
+  const innerSchema = parseDef(def.innerType._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "anyOf", "1"]
+  });
+  return innerSchema ? {
+    anyOf: [
+      {
+        not: parseAnyDef(refs)
+      },
+      innerSchema
+    ]
+  } : parseAnyDef(refs);
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+var parsePipelineDef = (def, refs) => {
+  if (refs.pipeStrategy === "input") {
+    return parseDef(def.in._def, refs);
+  } else if (refs.pipeStrategy === "output") {
+    return parseDef(def.out._def, refs);
+  }
+  const a = parseDef(def.in._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "allOf", "0"]
+  });
+  const b = parseDef(def.out._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "allOf", a ? "1" : "0"]
+  });
+  return {
+    allOf: [a, b].filter((x) => x !== void 0)
+  };
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+function parsePromiseDef(def, refs) {
+  return parseDef(def.type._def, refs);
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+function parseSetDef(def, refs) {
+  const items = parseDef(def.valueType._def, {
+    ...refs,
+    currentPath: [...refs.currentPath, "items"]
+  });
+  const schema = {
+    type: "array",
+    uniqueItems: true,
+    items
+  };
+  if (def.minSize) {
+    setResponseValueAndErrors(schema, "minItems", def.minSize.value, def.minSize.message, refs);
+  }
+  if (def.maxSize) {
+    setResponseValueAndErrors(schema, "maxItems", def.maxSize.value, def.maxSize.message, refs);
+  }
+  return schema;
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+function parseTupleDef(def, refs) {
+  if (def.rest) {
+    return {
+      type: "array",
+      minItems: def.items.length,
+      items: def.items.map((x, i) => parseDef(x._def, {
+        ...refs,
+        currentPath: [...refs.currentPath, "items", `${i}`]
+      })).reduce((acc, x) => x === void 0 ? acc : [...acc, x], []),
+      additionalItems: parseDef(def.rest._def, {
+        ...refs,
+        currentPath: [...refs.currentPath, "additionalItems"]
+      })
+    };
+  } else {
+    return {
+      type: "array",
+      minItems: def.items.length,
+      maxItems: def.items.length,
+      items: def.items.map((x, i) => parseDef(x._def, {
+        ...refs,
+        currentPath: [...refs.currentPath, "items", `${i}`]
+      })).reduce((acc, x) => x === void 0 ? acc : [...acc, x], [])
+    };
+  }
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+function parseUndefinedDef(refs) {
+  return {
+    not: parseAnyDef(refs)
+  };
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+function parseUnknownDef(refs) {
+  return parseAnyDef(refs);
+}
+
+// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+var parseReadonlyDef = (def, refs) => {
+  return parseDef(def.innerType._def, refs);
+};
+
+// node_modules/zod-to-json-schema/dist/esm/selectParser.js
+var selectParser = (def, typeName, refs) => {
+  switch (typeName) {
+    case ZodFirstPartyTypeKind.ZodString:
+      return parseStringDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodNumber:
+      return parseNumberDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodObject:
+      return parseObjectDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodBigInt:
+      return parseBigintDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodBoolean:
+      return parseBooleanDef();
+    case ZodFirstPartyTypeKind.ZodDate:
+      return parseDateDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodUndefined:
+      return parseUndefinedDef(refs);
+    case ZodFirstPartyTypeKind.ZodNull:
+      return parseNullDef(refs);
+    case ZodFirstPartyTypeKind.ZodArray:
+      return parseArrayDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodUnion:
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+      return parseUnionDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodIntersection:
+      return parseIntersectionDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodTuple:
+      return parseTupleDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodRecord:
+      return parseRecordDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodLiteral:
+      return parseLiteralDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodEnum:
+      return parseEnumDef(def);
+    case ZodFirstPartyTypeKind.ZodNativeEnum:
+      return parseNativeEnumDef(def);
+    case ZodFirstPartyTypeKind.ZodNullable:
+      return parseNullableDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodOptional:
+      return parseOptionalDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodMap:
+      return parseMapDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodSet:
+      return parseSetDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodLazy:
+      return () => def.getter()._def;
+    case ZodFirstPartyTypeKind.ZodPromise:
+      return parsePromiseDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodNaN:
+    case ZodFirstPartyTypeKind.ZodNever:
+      return parseNeverDef(refs);
+    case ZodFirstPartyTypeKind.ZodEffects:
+      return parseEffectsDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodAny:
+      return parseAnyDef(refs);
+    case ZodFirstPartyTypeKind.ZodUnknown:
+      return parseUnknownDef(refs);
+    case ZodFirstPartyTypeKind.ZodDefault:
+      return parseDefaultDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodBranded:
+      return parseBrandedDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodReadonly:
+      return parseReadonlyDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodCatch:
+      return parseCatchDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodPipeline:
+      return parsePipelineDef(def, refs);
+    case ZodFirstPartyTypeKind.ZodFunction:
+    case ZodFirstPartyTypeKind.ZodVoid:
+    case ZodFirstPartyTypeKind.ZodSymbol:
+      return void 0;
+    default:
+      return /* @__PURE__ */ ((_) => void 0)(typeName);
+  }
+};
+
+// node_modules/zod-to-json-schema/dist/esm/parseDef.js
+function parseDef(def, refs, forceResolution = false) {
+  const seenItem = refs.seen.get(def);
+  if (refs.override) {
+    const overrideResult = refs.override?.(def, refs, seenItem, forceResolution);
+    if (overrideResult !== ignoreOverride) {
+      return overrideResult;
+    }
+  }
+  if (seenItem && !forceResolution) {
+    const seenSchema = get$ref(seenItem, refs);
+    if (seenSchema !== void 0) {
+      return seenSchema;
+    }
+  }
+  const newItem = { def, path: refs.currentPath, jsonSchema: void 0 };
+  refs.seen.set(def, newItem);
+  const jsonSchemaOrGetter = selectParser(def, def.typeName, refs);
+  const jsonSchema = typeof jsonSchemaOrGetter === "function" ? parseDef(jsonSchemaOrGetter(), refs) : jsonSchemaOrGetter;
+  if (jsonSchema) {
+    addMeta(def, refs, jsonSchema);
+  }
+  if (refs.postProcess) {
+    const postProcessResult = refs.postProcess(jsonSchema, def, refs);
+    newItem.jsonSchema = jsonSchema;
+    return postProcessResult;
+  }
+  newItem.jsonSchema = jsonSchema;
+  return jsonSchema;
+}
+var get$ref = (item, refs) => {
+  switch (refs.$refStrategy) {
+    case "root":
+      return { $ref: item.path.join("/") };
+    case "relative":
+      return { $ref: getRelativePath(refs.currentPath, item.path) };
+    case "none":
+    case "seen": {
+      if (item.path.length < refs.currentPath.length && item.path.every((value, index) => refs.currentPath[index] === value)) {
+        console.warn(`Recursive reference detected at ${refs.currentPath.join("/")}! Defaulting to any`);
+        return parseAnyDef(refs);
+      }
+      return refs.$refStrategy === "seen" ? parseAnyDef(refs) : void 0;
+    }
+  }
+};
+var addMeta = (def, refs, jsonSchema) => {
+  if (def.description) {
+    jsonSchema.description = def.description;
+    if (refs.markdownDescription) {
+      jsonSchema.markdownDescription = def.description;
+    }
+  }
+  return jsonSchema;
+};
+
+// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+var zodToJsonSchema = (schema, options) => {
+  const refs = getRefs(options);
+  let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
+    ...acc,
+    [name2]: parseDef(schema2._def, {
+      ...refs,
+      currentPath: [...refs.basePath, refs.definitionPath, name2]
+    }, true) ?? parseAnyDef(refs)
+  }), {}) : void 0;
+  const name = typeof options === "string" ? options : options?.nameStrategy === "title" ? void 0 : options?.name;
+  const main3 = parseDef(schema._def, name === void 0 ? refs : {
+    ...refs,
+    currentPath: [...refs.basePath, refs.definitionPath, name]
+  }, false) ?? parseAnyDef(refs);
+  const title = typeof options === "object" && options.name !== void 0 && options.nameStrategy === "title" ? options.name : void 0;
+  if (title !== void 0) {
+    main3.title = title;
+  }
+  if (refs.flags.hasReferencedOpenAiAnyType) {
+    if (!definitions) {
+      definitions = {};
+    }
+    if (!definitions[refs.openAiAnyTypeName]) {
+      definitions[refs.openAiAnyTypeName] = {
+        // Skipping "object" as no properties can be defined and additionalProperties must be "false"
+        type: ["string", "number", "integer", "boolean", "array", "null"],
+        items: {
+          $ref: refs.$refStrategy === "relative" ? "1" : [
+            ...refs.basePath,
+            refs.definitionPath,
+            refs.openAiAnyTypeName
+          ].join("/")
+        }
+      };
+    }
+  }
+  const combined = name === void 0 ? definitions ? {
+    ...main3,
+    [refs.definitionPath]: definitions
+  } : main3 : {
+    $ref: [
+      ...refs.$refStrategy === "relative" ? [] : refs.basePath,
+      refs.definitionPath,
+      name
+    ].join("/"),
+    [refs.definitionPath]: {
+      ...definitions,
+      [name]: main3
+    }
+  };
+  if (refs.target === "jsonSchema7") {
+    combined.$schema = "http://json-schema.org/draft-07/schema#";
+  } else if (refs.target === "jsonSchema2019-09" || refs.target === "openAi") {
+    combined.$schema = "https://json-schema.org/draft/2019-09/schema#";
+  }
+  if (refs.target === "openAi" && ("anyOf" in combined || "oneOf" in combined || "allOf" in combined || "type" in combined && Array.isArray(combined.type))) {
+    console.warn("Warning: OpenAI may not support schemas with unions as roots! Try wrapping it in an object property.");
+  }
+  return combined;
+};
+
 // src/scripts/_lib/module_detection.ts
 import * as fs10 from "node:fs";
 import * as path9 from "node:path";
@@ -13097,12 +18906,58 @@ function install_global(tools, force, project_root = null, core_only = false) {
       }
     }
   }
+  try {
+    _write_settings_surface_snapshot(installed_version);
+  } catch (e) {
+    if (!state.QUIET) warn(`settings-surface snapshot failed \u2014 ${String(e)}`);
+  }
   if (!state.QUIET) {
     process3.stdout.write("\n");
     success(`Global install completed (v${installed_version}).`);
     process3.stdout.write("\n");
   }
   return 0;
+}
+var SETTINGS_SURFACE_REL = path11.join("state", "settings-surface.json");
+var SETTINGS_DELTA_REL = path11.join("state", "settings-delta.json");
+function _current_settings_surface(version) {
+  const jsonSchema = zodToJsonSchema(settingsSchema, {
+    name: "AgentSettings",
+    $refStrategy: "none",
+    target: "jsonSchema7"
+  });
+  return flattenSurface(jsonSchema, version);
+}
+function _write_settings_surface_snapshot(installed_version) {
+  const root = event4u_root();
+  const surface_path = path11.join(root, SETTINGS_SURFACE_REL);
+  const delta_path = path11.join(root, SETTINGS_DELTA_REL);
+  const next = _current_settings_surface(installed_version);
+  let previous = null;
+  try {
+    const parsed = JSON.parse(fs13.readFileSync(surface_path, "utf8"));
+    if (parsed !== null && typeof parsed === "object" && parsed.entries !== void 0) previous = parsed;
+  } catch {
+  }
+  if (previous !== null && previous.version !== next.version) {
+    const delta = computeSurfaceDelta(previous, next);
+    if (delta.changes.length > 0) {
+      fs13.mkdirSync(path11.dirname(delta_path), { recursive: true, mode: 448 });
+      fs13.writeFileSync(delta_path, `${JSON.stringify(delta, null, 2)}
+`, { mode: 384 });
+      if (!state.QUIET) {
+        const counts = {};
+        for (const c of delta.changes) counts[c.kind] = (counts[c.kind] ?? 0) + 1;
+        const parts = Object.entries(counts).map(([k, v]) => `${v} ${k.replace("_", " ")}`);
+        info(
+          `Settings surface changed ${delta.oldVersion} \u2192 ${delta.newVersion}: ${parts.join(", ")}. Review with \`agent-config config\` (Settings \u2192 banner) \u2014 nothing was changed automatically.`
+        );
+      }
+    }
+  }
+  fs13.mkdirSync(path11.dirname(surface_path), { recursive: true, mode: 448 });
+  fs13.writeFileSync(surface_path, `${JSON.stringify(next, null, 2)}
+`, { mode: 384 });
 }
 function arrayStrEqual(a, b) {
   return a.length === b.length && a.every((v, i) => v === b[i]);
@@ -14198,6 +20053,7 @@ export {
   _apply_payload_preview,
   _bridge_marker,
   _canonical_settings_target,
+  _current_settings_surface,
   _detect_legacy_for_migration,
   _dry_run_summary,
   _files_by_tool_from_bridges,
@@ -14219,6 +20075,7 @@ export {
   _validate_scope,
   _verify_deploy_targets,
   _wizard_should_launch,
+  _write_settings_surface_snapshot,
   _yaml_scalar,
   deep_merge,
   detect_package_type,

--- a/docs/contracts/settings-api.md
+++ b/docs/contracts/settings-api.md
@@ -131,6 +131,56 @@ Errors: **412 Precondition Required** when the header is absent;
 **422 Unprocessable Entity** with per-field errors on validation
 failure; **500** with `code=ATOMIC_WRITE` if the temp-rename loop fails.
 
+### `GET /api/v1/settings/changes`
+
+Pending upgrade-time settings-surface delta
+(road-to-settings-change-review). The installer persists the flattened
+settings surface (`state/settings-surface.json`: per dotted leaf its
+type / default / enum / description + package version) on every global
+install; when a previous snapshot from a different version exists it
+computes the semantic delta and writes `state/settings-delta.json` —
+that file is what this route serves. Classification against the user's
+current values happens client-side via the shared
+`src/shared/settingsSurface.ts` module (`must_fix` / `adopt` /
+`review` / `info`).
+
+Response (200):
+
+```json
+{
+    "delta": {
+        "oldVersion": "8.3.0",
+        "newVersion": "8.4.0",
+        "changes": [
+            { "key": "personal.autonomy", "kind": "default_changed", "old": { "...": "..." }, "new": { "...": "..." } },
+            { "key": "discipline_profile", "kind": "added", "new": { "...": "..." } }
+        ]
+    },
+    "source": "writeRoot"
+}
+```
+
+`kind` &isin; `added | removed | default_changed | enum_added |
+enum_removed | type_changed`. `source` is `userGlobal` when the delta
+was found via the package-sandbox read fallback.
+
+Errors: **404** with `code=NO_PENDING_CHANGES` when no (parseable)
+delta file exists.
+
+### `POST /api/v1/settings/changes/ack`
+
+Clears the pending delta after the review form is resolved (or
+dismissed). Deletes only `<writeRoot>/state/settings-delta.json` —
+never the real machine's file when running in a sandbox. Idempotent.
+
+Response (200): `{ "ok": true, "cleared": true }` (`cleared: false`
+when nothing was pending; `dryRun: true` and no deletion in dry-run
+mode).
+
+A matching `settings-review-pending` doctor check warns while the
+delta file exists; the settings hub renders a review banner linking to
+`#/settings/changes`.
+
 ### `GET /api/v1/user-md`
 
 Reads `<projectRoot>/.agent-user.md`. Returns `{ body: '', exists: false, lastModified: null }`

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
         "dist/",
         "docs/",
         "src/scripts/",
+        "src/server/schemas/",
+        "src/shared/",
         "src/install/",
         "src/agent-src/scripts/",
         "src/agent-src/templates/scripts/",

--- a/src/scripts/_cli/cmd_doctor.ts
+++ b/src/scripts/_cli/cmd_doctor.ts
@@ -746,6 +746,7 @@ const CHECK_IDS = [
     'council-cli',
     'unsupported-combos',
     'wizard-state',
+    'settings-review-pending',
 ] as const;
 
 /** Checks that need only the project root and run regardless of a lockfile. */
@@ -764,6 +765,7 @@ const GLOBAL_CHECK_IDS: ReadonlySet<string> = new Set([
     'tier-usage-readiness',
     'council-cli',
     'wizard-state',
+    'settings-review-pending',
 ]);
 
 /** Checks that genuinely cannot run without the project manifest. */
@@ -1966,6 +1968,43 @@ function _check_wizard_state(): Dict {
     };
 }
 
+/**
+ * Pending settings-surface review (road-to-settings-change-review): the
+ * installer writes `state/settings-delta.json` when an upgrade changed
+ * defaults / enum vocabularies / added settings. The flag persists until
+ * the user resolves the review form (`agent-config config` → Settings →
+ * banner) — this check keeps it visible in every doctor run.
+ */
+function _check_settings_review_pending(): Dict {
+    const delta_pth = path.join(user_global_paths.event4u_root(), 'state', 'settings-delta.json');
+    if (!pathExists(delta_pth)) {
+        return {
+            id: 'settings-review-pending',
+            status: 'ok',
+            message: 'no pending settings-surface changes',
+            remedy: '',
+        };
+    }
+    let summary = '';
+    try {
+        const data = JSON.parse(readText0(delta_pth)) as {
+            oldVersion?: string;
+            newVersion?: string;
+            changes?: unknown[];
+        };
+        const n = Array.isArray(data.changes) ? data.changes.length : 0;
+        summary = `${n} change${n === 1 ? '' : 's'} (${data.oldVersion ?? '?'} → ${data.newVersion ?? '?'})`;
+    } catch {
+        summary = 'unreadable delta file';
+    }
+    return {
+        id: 'settings-review-pending',
+        status: 'warn',
+        message: `settings surface changed on upgrade — ${summary} awaiting review`,
+        remedy: 'agent-config config (Settings → “Review changes” banner)',
+    };
+}
+
 interface JsonDecodeError {
     msg: string;
     lineno: number;
@@ -2095,6 +2134,7 @@ function _run_checks(
         'council-cli': () => _check_council_cli(project_root),
         'unsupported-combos': () => _check_unsupported_combos(manifest),
         'wizard-state': _check_wizard_state,
+        'settings-review-pending': _check_settings_review_pending,
     };
     const out: Dict[] = [];
     for (const cid of CHECK_IDS) {
@@ -2164,6 +2204,7 @@ function _run_checks_no_manifest(
         'council-cli': () => _check_council_cli(project_root),
         'unsupported-combos': () => _skipped_manifest_check('unsupported-combos'),
         'wizard-state': _check_wizard_state,
+        'settings-review-pending': _check_settings_review_pending,
     };
     const out: Dict[] = [];
     for (const cid of CHECK_IDS) {
@@ -2651,6 +2692,7 @@ export {
     _check_council_cli,
     _check_unsupported_combos,
     _check_wizard_state,
+    _check_settings_review_pending,
     _run_checks,
     _skipped_manifest_check,
     _check_bridge_drift_no_manifest,

--- a/src/scripts/install.ts
+++ b/src/scripts/install.ts
@@ -80,6 +80,9 @@ import * as user_global_paths from './_lib/user_global_paths.js';
 import * as claude_desktop_bundler from './_lib/claude_desktop_bundler.js';
 import * as claude_settings_hooks from './_lib/claude_settings_hooks.js';
 import { find_project_root_with_anchor, load_agent_settings } from './_lib/agent_settings.js';
+import { flattenSurface, computeSurfaceDelta, type SettingsSurface } from '../shared/settingsSurface.js';
+import { settingsSchema } from '../server/schemas/settings.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { detect_module_roots } from './_lib/module_detection.js';
 import {
     TIER_TO_CLAUDE_MODEL,
@@ -3349,12 +3352,75 @@ function install_global(
         }
     }
 
+    // Settings-surface snapshot + upgrade delta (road-to-settings-change-
+    // review; council 2026-07-08, 2/2 converged on snapshot-at-install).
+    // Every global install persists the flattened settings surface; when a
+    // PREVIOUS snapshot from a different version exists, the semantic delta
+    // (added / default_changed / enum_added / enum_removed / type_changed)
+    // is written to state/settings-delta.json — the pending-review flag the
+    // GUI banner, the review page, and doctor consume. Never fatal: a
+    // snapshot failure must not sink the install.
+    try {
+        _write_settings_surface_snapshot(installed_version);
+    } catch (e) {
+        if (!state.QUIET) warn(`settings-surface snapshot failed — ${String(e)}`);
+    }
+
     if (!state.QUIET) {
         process.stdout.write('\n');
         success(`Global install completed (v${installed_version}).`);
         process.stdout.write('\n');
     }
     return 0;
+}
+
+const SETTINGS_SURFACE_REL = path.join('state', 'settings-surface.json');
+const SETTINGS_DELTA_REL = path.join('state', 'settings-delta.json');
+
+function _current_settings_surface(version: string): SettingsSurface {
+    const jsonSchema = zodToJsonSchema(settingsSchema, {
+        name: 'AgentSettings',
+        $refStrategy: 'none',
+        target: 'jsonSchema7',
+    }) as Parameters<typeof flattenSurface>[0];
+    return flattenSurface(jsonSchema, version);
+}
+
+function _write_settings_surface_snapshot(installed_version: string): void {
+    const root = user_global_paths.event4u_root();
+    const surface_path = path.join(root, SETTINGS_SURFACE_REL);
+    const delta_path = path.join(root, SETTINGS_DELTA_REL);
+    const next = _current_settings_surface(installed_version);
+
+    let previous: SettingsSurface | null = null;
+    try {
+        const parsed = JSON.parse(fs.readFileSync(surface_path, 'utf8')) as SettingsSurface;
+        if (parsed !== null && typeof parsed === 'object' && parsed.entries !== undefined) previous = parsed;
+    } catch {
+        // First run after this feature ships — seed-only (council Q1:
+        // no template fallback; the transition cost is paid once).
+    }
+
+    if (previous !== null && previous.version !== next.version) {
+        const delta = computeSurfaceDelta(previous, next);
+        if (delta.changes.length > 0) {
+            fs.mkdirSync(path.dirname(delta_path), { recursive: true, mode: 0o700 });
+            fs.writeFileSync(delta_path, `${JSON.stringify(delta, null, 2)}\n`, { mode: 0o600 });
+            if (!state.QUIET) {
+                const counts: Record<string, number> = {};
+                for (const c of delta.changes) counts[c.kind] = (counts[c.kind] ?? 0) + 1;
+                const parts = Object.entries(counts).map(([k, v]) => `${v} ${k.replace('_', ' ')}`);
+                info(
+                    `Settings surface changed ${delta.oldVersion} → ${delta.newVersion}: ` +
+                        `${parts.join(', ')}. Review with \`agent-config config\` ` +
+                        '(Settings → banner) — nothing was changed automatically.',
+                );
+            }
+        }
+    }
+
+    fs.mkdirSync(path.dirname(surface_path), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(surface_path, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 });
 }
 
 function arrayStrEqual(a: string[], b: string[]): boolean {
@@ -4605,6 +4671,8 @@ export {
     _wizard_should_launch,
     _dry_run_summary,
     _apply_payload_preview,
+    _write_settings_surface_snapshot,
+    _current_settings_surface,
     jsonDumpsIndent,
     jsonDumpsCompact,
     _canonical_settings_target,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -27,6 +27,7 @@ import { discoveryRoute } from './routes/discovery.js';
 import { installRoute, type InstallRouteOptions } from './routes/install.js';
 import { schemaRoute } from './routes/schema.js';
 import { settingsRoute } from './routes/settings.js';
+import { settingsChangesRoute } from './routes/settingsChanges.js';
 import { userMdRoute } from './routes/userMd.js';
 import { wizardRoute } from './routes/wizard.js';
 import { workspaceRoute } from './routes/workspace.js';
@@ -279,6 +280,7 @@ export async function createApp(opts: CreateAppOptions): Promise<FastifyInstance
     );
     await app.register(schemaRoute());
     await app.register(settingsRoute({ writeRoot, legacyReadRoot, packageRoot, dryRun, userGlobalReadRoot: userGlobalRead }));
+    await app.register(settingsChangesRoute({ writeRoot, userGlobalReadRoot: userGlobalRead, dryRun }));
     await app.register(userMdRoute({ writeRoot, legacyReadRoot, dryRun, userGlobalReadRoot: userGlobalRead }));
     await app.register(installRoute(opts.installRouteOptions ?? {}));
     await app.register(wizardRoute({

--- a/src/server/routes/settingsChanges.ts
+++ b/src/server/routes/settingsChanges.ts
@@ -1,0 +1,80 @@
+/**
+ * Pending settings-surface delta routes
+ * (road-to-settings-change-review; council 2026-07-08).
+ *
+ *   GET  /api/v1/settings/changes      → pending SurfaceDelta or 404
+ *   POST /api/v1/settings/changes/ack  → clear the pending delta
+ *
+ * The delta file is written by the installer when an upgrade changes the
+ * settings surface (`state/settings-delta.json` under the global root).
+ * The review page classifies each change against the user's current
+ * values client-side via the shared `settingsSurface` module; the server
+ * only serves and clears the flag. In package-sandbox mode the read
+ * falls back to the real user-global root (consistent with the settings
+ * prefill fallback) — ack never deletes outside the writeRoot.
+ */
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import type { SurfaceDelta } from '../../shared/settingsSurface.js';
+
+const DELTA_REL = join('state', 'settings-delta.json');
+
+export interface SettingsChangesRouteOptions {
+    writeRoot: string;
+    /** Read-only user-global fallback (package-sandbox mode). */
+    userGlobalReadRoot?: string | null;
+    /** Dry-run — ack returns a preview and deletes nothing. */
+    dryRun?: boolean;
+}
+
+async function readDelta(path: string): Promise<SurfaceDelta | null> {
+    try {
+        const raw = await fs.readFile(path, 'utf8');
+        const parsed = JSON.parse(raw) as SurfaceDelta;
+        if (Array.isArray(parsed.changes)) return parsed;
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+export function settingsChangesRoute(opts: SettingsChangesRouteOptions): FastifyPluginAsync {
+    const plugin: FastifyPluginAsync = async (app: FastifyInstance) => {
+        app.get('/api/v1/settings/changes', async (_request, reply) => {
+            const primary = join(opts.writeRoot, DELTA_REL);
+            let delta = await readDelta(primary);
+            let source: 'writeRoot' | 'userGlobal' = 'writeRoot';
+            if (delta === null && opts.userGlobalReadRoot && opts.userGlobalReadRoot !== opts.writeRoot) {
+                delta = await readDelta(join(opts.userGlobalReadRoot, DELTA_REL));
+                source = 'userGlobal';
+            }
+            if (delta === null) {
+                await reply.code(404).send({ error: { code: 'NO_PENDING_CHANGES', message: 'no pending settings-surface delta' } });
+                return reply;
+            }
+            return { delta, source };
+        });
+
+        app.post('/api/v1/settings/changes/ack', async (_request, reply) => {
+            const primary = join(opts.writeRoot, DELTA_REL);
+            if (opts.dryRun === true) {
+                return { ok: true, dryRun: true, cleared: false };
+            }
+            try {
+                await fs.unlink(primary);
+                return { ok: true, cleared: true };
+            } catch (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                    // Sandbox fallback reads never delete the real machine's
+                    // delta — reviewing in a sandbox resolves the sandbox only.
+                    return { ok: true, cleared: false };
+                }
+                const message = err instanceof Error ? err.message : 'ack failed';
+                await reply.code(500).send({ error: { code: 'ACK_FAILED', message } });
+                return reply;
+            }
+        });
+    };
+    return plugin;
+}

--- a/src/shared/settingsSurface.ts
+++ b/src/shared/settingsSurface.ts
@@ -1,0 +1,184 @@
+/**
+ * Settings-surface snapshot + semantic delta
+ * (road-to-settings-change-review).
+ *
+ * A *surface* is the flattened, machine-comparable shape of the settings
+ * schema at one package version: per dotted leaf key its type, default,
+ * enum vocabulary, and description. Every global install persists the
+ * surface to `state/settings-surface.json`; the next upgrade reads the
+ * persisted file as the OLD surface before overwriting it and computes a
+ * semantic delta (added / removed / default_changed / enum_added /
+ * enum_removed / type_changed) that drives the upgrade review form.
+ *
+ * Pure module — no I/O; consumed by the installer (bundled), the Fastify
+ * server, and the Preact UI.
+ */
+
+export type JsonLike =
+    | string
+    | number
+    | boolean
+    | null
+    | JsonLike[]
+    | { [key: string]: JsonLike };
+
+export interface SurfaceEntry {
+    type: string;
+    default?: JsonLike;
+    enum?: Array<string | number>;
+    description?: string;
+}
+
+export interface SettingsSurface {
+    /** Package version that produced the snapshot. */
+    version: string;
+    /** Dotted leaf key → shape. */
+    entries: Record<string, SurfaceEntry>;
+}
+
+/** One reviewable change between two surfaces. */
+export interface SurfaceChange {
+    key: string;
+    kind: 'added' | 'removed' | 'default_changed' | 'enum_added' | 'enum_removed' | 'type_changed';
+    /** Old surface entry (absent for `added`). */
+    old?: SurfaceEntry;
+    /** New surface entry (absent for `removed`). */
+    new?: SurfaceEntry;
+    /** For enum_added/enum_removed: the specific values. */
+    values?: Array<string | number>;
+}
+
+export interface SurfaceDelta {
+    oldVersion: string;
+    newVersion: string;
+    changes: SurfaceChange[];
+}
+
+interface JsonSchemaNode {
+    type?: string;
+    default?: JsonLike;
+    enum?: Array<string | number>;
+    description?: string;
+    properties?: Record<string, JsonSchemaNode>;
+    items?: JsonSchemaNode;
+    additionalProperties?: boolean | JsonSchemaNode;
+    definitions?: Record<string, JsonSchemaNode>;
+    $ref?: string;
+}
+
+function unwrapRef(root: JsonSchemaNode): JsonSchemaNode {
+    if (root.$ref !== undefined && root.definitions !== undefined) {
+        const name = root.$ref.replace('#/definitions/', '');
+        const def = root.definitions[name];
+        if (def !== undefined) return def;
+    }
+    return root;
+}
+
+/**
+ * Flatten a `zodToJsonSchema` output into dotted leaf entries. Objects with
+ * `properties` recurse; everything else (scalars, enums, arrays, free-form
+ * maps) is a leaf. Deterministic key order (sorted) so snapshots diff
+ * cleanly in git and across runs.
+ */
+export function flattenSurface(schema: JsonSchemaNode, version: string): SettingsSurface {
+    const entries: Record<string, SurfaceEntry> = {};
+    const walk = (node: JsonSchemaNode, prefix: string): void => {
+        if (node.type === 'object' && node.properties !== undefined) {
+            for (const key of Object.keys(node.properties).sort()) {
+                const child = node.properties[key] as JsonSchemaNode;
+                walk(child, prefix === '' ? key : `${prefix}.${key}`);
+            }
+            return;
+        }
+        if (prefix === '') return;
+        const entry: SurfaceEntry = { type: node.type ?? (node.enum !== undefined ? 'enum' : 'unknown') };
+        if (node.default !== undefined) entry.default = node.default;
+        if (node.enum !== undefined) entry.enum = [...node.enum];
+        if (node.description !== undefined) entry.description = node.description;
+        entries[prefix] = entry;
+    };
+    walk(unwrapRef(schema), '');
+    return { version, entries };
+}
+
+function sameJson(a: JsonLike | undefined, b: JsonLike | undefined): boolean {
+    return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+/**
+ * Semantic delta between two surfaces. One key can contribute multiple
+ * changes (e.g. a default change AND new enum values). Order: stable by
+ * key, then by kind — the UI groups by kind anyway.
+ */
+export function computeSurfaceDelta(oldS: SettingsSurface, newS: SettingsSurface): SurfaceDelta {
+    const changes: SurfaceChange[] = [];
+    const oldKeys = new Set(Object.keys(oldS.entries));
+    const newKeys = new Set(Object.keys(newS.entries));
+
+    for (const key of [...newKeys].sort()) {
+        const n = newS.entries[key] as SurfaceEntry;
+        if (!oldKeys.has(key)) {
+            changes.push({ key, kind: 'added', new: n });
+            continue;
+        }
+        const o = oldS.entries[key] as SurfaceEntry;
+        if (o.type !== n.type) {
+            changes.push({ key, kind: 'type_changed', old: o, new: n });
+        }
+        if (!sameJson(o.default, n.default)) {
+            changes.push({ key, kind: 'default_changed', old: o, new: n });
+        }
+        const oldEnum = new Set(o.enum ?? []);
+        const newEnum = new Set(n.enum ?? []);
+        if (o.enum !== undefined || n.enum !== undefined) {
+            const addedVals = [...newEnum].filter((v) => !oldEnum.has(v));
+            const removedVals = [...oldEnum].filter((v) => !newEnum.has(v));
+            if (addedVals.length > 0) {
+                changes.push({ key, kind: 'enum_added', old: o, new: n, values: addedVals });
+            }
+            if (removedVals.length > 0) {
+                changes.push({ key, kind: 'enum_removed', old: o, new: n, values: removedVals });
+            }
+        }
+    }
+    for (const key of [...oldKeys].sort()) {
+        if (!newKeys.has(key)) {
+            changes.push({ key, kind: 'removed', old: oldS.entries[key] as SurfaceEntry });
+        }
+    }
+    return { oldVersion: oldS.version, newVersion: newS.version, changes };
+}
+
+/**
+ * Classify a change against the user's CURRENT value — drives the review
+ * form's per-item control and the blocking semantics:
+ *
+ *   - `must_fix`  — the stored value is invalid under the new surface
+ *                   (enum_removed hit / type_changed mismatch). Blocks save.
+ *   - `adopt`     — user never customized (value equals the OLD default) and
+ *                   the default changed → preselect adopting the new default.
+ *   - `review`    — user customized; informational old→new context.
+ *   - `info`      — nothing actionable (enum_added, removed, added-with-default).
+ */
+export type ChangeSeverity = 'must_fix' | 'adopt' | 'review' | 'info';
+
+export function classifyChange(change: SurfaceChange, currentValue: JsonLike | undefined): ChangeSeverity {
+    if (change.kind === 'enum_removed') {
+        const removed = new Set(change.values ?? []);
+        if (currentValue !== undefined && removed.has(currentValue as string | number)) return 'must_fix';
+        return 'info';
+    }
+    if (change.kind === 'type_changed') {
+        return 'must_fix';
+    }
+    if (change.kind === 'default_changed') {
+        const neverCustomized = currentValue === undefined
+            || sameJson(currentValue, change.old?.default);
+        return neverCustomized ? 'adopt' : 'review';
+    }
+    if (change.kind === 'added') {
+        return change.new?.default === undefined ? 'must_fix' : 'info';
+    }
+    return 'info';
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -25,6 +25,7 @@ import { useEffect } from 'preact/hooks';
 import { route, initRouter, navigate } from './router.js';
 import { WizardPage } from './pages/WizardPage.js';
 import { SettingsHubPage } from './pages/SettingsHubPage.js';
+import { SettingsChangesPage } from './pages/SettingsChangesPage.js';
 import { ProjectSettingsPage } from './pages/ProjectSettingsPage.js';
 import { WorkspacePage } from './pages/WorkspacePage.js';
 import { serverStatus, fetchServerStatus } from './serverStatus.js';
@@ -138,6 +139,9 @@ function dispatch(path: string): preact.JSX.Element {
     // again (simple/advanced tiers, search, modified indicators). The
     // wizard stays the guided first-run flow; `agent-config config` and
     // the Settings tab land here.
+    // Upgrade-time review form (road-to-settings-change-review) — must
+    // dispatch BEFORE the /settings prefix match.
+    if (path === '/settings/changes') return <SettingsChangesPage />;
     if (path === '/settings' || path.startsWith('/settings/')) return <SettingsHubPage />;
     if (path === '/project' || path.startsWith('/project/')) return <ProjectSettingsPage />;
     // Placeholder surfaces (Tasks / Council / Memory / Explain) were removed

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -806,3 +806,102 @@ code {
     color: var(--color-text-muted);
     font-size: var(--font-size-xs);
 }
+
+/* --- Settings-changes review (road-to-settings-change-review) --------- */
+
+.ac-banner--pending {
+    border-left-color: var(--color-warning);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.ac-button--small {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--font-size-sm);
+}
+
+.ac-page__lede {
+    color: var(--color-text-muted);
+    margin: var(--space-1) 0 0 0;
+}
+
+.ac-settings-changes__group h2 {
+    font-size: var(--font-size-lg);
+    margin: 0 0 var(--space-1);
+}
+.ac-settings-changes__count { color: var(--color-text-muted); font-weight: var(--font-weight-regular, 400); }
+.ac-settings-changes__hint {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    margin: 0 0 var(--space-3);
+}
+.ac-settings-changes__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.ac-change-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-border-strong);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    min-width: 0;
+}
+.ac-change-card--must_fix { border-left-color: var(--color-danger); }
+.ac-change-card--adopt    { border-left-color: var(--color-accent); }
+.ac-change-card--review   { border-left-color: var(--color-warning); }
+
+.ac-change-card__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}
+.ac-change-card__key { font-size: var(--font-size-sm); overflow-wrap: anywhere; }
+.ac-change-card__badge {
+    font-size: var(--font-size-xs);
+    border-radius: var(--radius-sm);
+    padding: 0 var(--space-2);
+    border: 1px solid var(--color-border);
+    white-space: nowrap;
+    color: var(--color-text-muted);
+}
+.ac-change-card__badge--must_fix { color: var(--color-danger); border-color: var(--color-danger); }
+.ac-change-card__badge--adopt    { color: var(--color-accent); border-color: var(--color-accent); }
+.ac-change-card__badge--review   { color: var(--color-warning); border-color: var(--color-warning); }
+
+.ac-change-card__desc {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    margin: 0;
+}
+.ac-change-card__detail {
+    font-size: var(--font-size-sm);
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+.ac-change-card__choices {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+.ac-change-card__choice {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+}
+.ac-change-card .ac-input { max-width: 24rem; }

--- a/src/ui/pages/SettingsChangesPage.tsx
+++ b/src/ui/pages/SettingsChangesPage.tsx
@@ -1,0 +1,476 @@
+/**
+ * SettingsChangesPage — upgrade-time settings review
+ * (road-to-settings-change-review; council 2026-07-08).
+ *
+ * Renders the pending settings-surface delta (written by the installer on
+ * upgrade) against the user's CURRENT values, grouped by severity:
+ *
+ *   - Must fix          — stored value invalid under the new surface
+ *                         (removed enum value / type change); blocks save.
+ *   - Changed defaults  — `adopt` (never customized → preselected to take
+ *                         the new default) and `review` (customized →
+ *                         keep by default, old→new shown as context).
+ *   - New settings      — prefilled with the shipped default; editable.
+ *   - New options       — enum vocabulary grew; informational.
+ *   - Removed           — key no longer exists; informational (sync parks
+ *                         user-only keys, nothing is deleted).
+ *
+ * One save action: resolutions are applied onto the merged values and
+ * written through the existing comment-preserving settings PUT
+ * (optimistic locking via If-Unmodified-Since), then the pending delta
+ * is acknowledged. Classification is client-side via the shared
+ * `settingsSurface` module — the server only serves and clears the flag.
+ */
+
+import { useEffect } from 'preact/hooks';
+import { signal } from '@preact/signals';
+import { apiFetch, ApiCallError } from '../api.js';
+import { navigate } from '../router.js';
+import {
+    classifyChange,
+    type ChangeSeverity,
+    type SurfaceChange,
+    type SurfaceDelta,
+    type JsonLike,
+} from '../../shared/settingsSurface.js';
+import { getValueAt, setValueAt, type JsonValue } from '../forms/schemaTypes.js';
+import { topLevelCopy } from '../copyErrors.js';
+
+interface ChangesGetResponse {
+    delta: SurfaceDelta;
+    source: 'writeRoot' | 'userGlobal';
+}
+
+interface SettingsGetResponse {
+    values: Record<string, JsonValue>;
+    lastModified: number;
+}
+
+/** How the user resolved one actionable change. */
+interface Resolution {
+    /** 'keep' | 'adopt' | 'custom' — must_fix items start unresolved (null). */
+    mode: 'keep' | 'adopt' | 'custom' | null;
+    /** Custom value (mode === 'custom' or must-fix pick). */
+    value?: JsonValue;
+}
+
+const loading = signal(true);
+const loadError = signal<string | null>(null);
+const noPending = signal(false);
+const delta = signal<SurfaceDelta | null>(null);
+const values = signal<Record<string, JsonValue>>({});
+const lastModified = signal<number>(0);
+const resolutions = signal<Record<string, Resolution>>({});
+const banner = signal<string | null>(null);
+const saving = signal(false);
+const done = signal(false);
+
+function changeId(c: SurfaceChange): string {
+    return `${c.key}:${c.kind}`;
+}
+
+async function load(): Promise<void> {
+    loading.value = true;
+    loadError.value = null;
+    noPending.value = false;
+    done.value = false;
+    try {
+        const changes = await apiFetch<ChangesGetResponse>('/api/v1/settings/changes');
+        const settings = await apiFetch<SettingsGetResponse>('/api/v1/settings');
+        delta.value = changes.delta;
+        values.value = settings.values;
+        lastModified.value = settings.lastModified;
+        seedResolutions(changes.delta, settings.values);
+    } catch (err) {
+        if (err instanceof ApiCallError && err.status === 404) {
+            noPending.value = true;
+        } else {
+            loadError.value = err instanceof Error ? err.message : String(err);
+        }
+    } finally {
+        loading.value = false;
+    }
+}
+
+/** Preselect per council Q3: adopt-class items start checked; review keeps. */
+function seedResolutions(d: SurfaceDelta, vals: Record<string, JsonValue>): void {
+    const seeded: Record<string, Resolution> = {};
+    for (const c of d.changes) {
+        const severity = classifyChange(c, getValueAt(vals, c.key.split('.')) as JsonLike | undefined);
+        if (severity === 'adopt') seeded[changeId(c)] = { mode: 'adopt' };
+        else if (severity === 'review') seeded[changeId(c)] = { mode: 'keep' };
+        else if (severity === 'must_fix') seeded[changeId(c)] = { mode: null };
+    }
+    resolutions.value = seeded;
+}
+
+function severityOf(c: SurfaceChange): ChangeSeverity {
+    return classifyChange(c, getValueAt(values.value, c.key.split('.')) as JsonLike | undefined);
+}
+
+function setResolution(id: string, res: Resolution): void {
+    resolutions.value = { ...resolutions.value, [id]: res };
+}
+
+function unresolvedMustFix(): SurfaceChange[] {
+    const d = delta.value;
+    if (d === null) return [];
+    return d.changes.filter((c) => {
+        if (severityOf(c) !== 'must_fix') return false;
+        const res = resolutions.value[changeId(c)];
+        return res === undefined || res.mode === null
+            || (res.mode === 'custom' && (res.value === undefined || res.value === ''));
+    });
+}
+
+/** Apply all resolutions onto the merged values object. */
+function applyResolutions(): Record<string, JsonValue> {
+    const d = delta.value;
+    let next = values.value;
+    if (d === null) return next;
+    for (const c of d.changes) {
+        const res = resolutions.value[changeId(c)];
+        if (res === undefined || res.mode === null || res.mode === 'keep') continue;
+        const path = c.key.split('.');
+        if (res.mode === 'adopt' && c.new?.default !== undefined) {
+            next = setValueAt(next, path, c.new.default as JsonValue);
+        } else if (res.mode === 'custom' && res.value !== undefined) {
+            next = setValueAt(next, path, res.value);
+        }
+    }
+    return next;
+}
+
+async function save(): Promise<void> {
+    if (saving.value) return;
+    const blocking = unresolvedMustFix();
+    if (blocking.length > 0) {
+        banner.value = `Resolve the ${blocking.length} “Must fix” item${blocking.length === 1 ? '' : 's'} first.`;
+        return;
+    }
+    saving.value = true;
+    banner.value = null;
+    try {
+        const nextValues = applyResolutions();
+        if (JSON.stringify(nextValues) !== JSON.stringify(values.value)) {
+            const res = await apiFetch<{ lastModified: number }>('/api/v1/settings', {
+                method: 'PUT',
+                headers: { 'If-Unmodified-Since': String(lastModified.value) },
+                body: { values: nextValues },
+            });
+            values.value = nextValues;
+            lastModified.value = res.lastModified;
+        }
+        await apiFetch('/api/v1/settings/changes/ack', { method: 'POST' });
+        done.value = true;
+    } catch (err) {
+        if (err instanceof ApiCallError) {
+            banner.value = topLevelCopy(err.body.error ?? { code: 'UNKNOWN', message: err.message });
+        } else {
+            banner.value = err instanceof Error ? err.message : String(err);
+        }
+    } finally {
+        saving.value = false;
+    }
+}
+
+async function dismissAll(): Promise<void> {
+    if (saving.value) return;
+    const blocking = unresolvedMustFix();
+    if (blocking.length > 0) {
+        banner.value = 'Cannot dismiss — “Must fix” items would leave invalid values in place.';
+        return;
+    }
+    saving.value = true;
+    try {
+        await apiFetch('/api/v1/settings/changes/ack', { method: 'POST' });
+        done.value = true;
+    } catch (err) {
+        banner.value = err instanceof Error ? err.message : String(err);
+    } finally {
+        saving.value = false;
+    }
+}
+
+function fmt(v: JsonLike | JsonValue | undefined): string {
+    if (v === undefined) return '—';
+    return typeof v === 'string' ? v : JSON.stringify(v);
+}
+
+/** Value editor for must-fix / custom entries — enum select or typed input. */
+function ValueEditor({ change, id }: { change: SurfaceChange; id: string }): preact.JSX.Element {
+    const entry = change.new;
+    const res = resolutions.value[id];
+    const current = res?.value;
+    if (entry?.enum !== undefined) {
+        return (
+            <select
+                class="ac-input"
+                aria-label={`New value for ${change.key}`}
+                value={current === undefined ? '' : String(current)}
+                onChange={(e): void => {
+                    const raw = (e.currentTarget as HTMLSelectElement).value;
+                    setResolution(id, { mode: 'custom', value: raw });
+                }}
+            >
+                <option value="" disabled>Choose a value…</option>
+                {entry.enum.map((opt) => (
+                    <option key={String(opt)} value={String(opt)}>{String(opt)}</option>
+                ))}
+            </select>
+        );
+    }
+    if (entry?.type === 'boolean') {
+        return (
+            <select
+                class="ac-input"
+                aria-label={`New value for ${change.key}`}
+                value={current === undefined ? '' : String(current)}
+                onChange={(e): void => {
+                    setResolution(id, { mode: 'custom', value: (e.currentTarget as HTMLSelectElement).value === 'true' });
+                }}
+            >
+                <option value="" disabled>Choose…</option>
+                <option value="true">true</option>
+                <option value="false">false</option>
+            </select>
+        );
+    }
+    return (
+        <input
+            class="ac-input"
+            type={entry?.type === 'number' || entry?.type === 'integer' ? 'number' : 'text'}
+            aria-label={`New value for ${change.key}`}
+            value={current === undefined ? '' : String(current)}
+            onInput={(e): void => {
+                const raw = (e.currentTarget as HTMLInputElement).value;
+                const val: JsonValue = entry?.type === 'number' || entry?.type === 'integer' ? Number(raw) : raw;
+                setResolution(id, { mode: 'custom', value: val });
+            }}
+        />
+    );
+}
+
+function ChangeCard({ change }: { change: SurfaceChange }): preact.JSX.Element {
+    const severity = severityOf(change);
+    const id = changeId(change);
+    const res = resolutions.value[id];
+    const currentValue = getValueAt(values.value, change.key.split('.'));
+    return (
+        <li class={`ac-change-card ac-change-card--${severity}`} data-key={change.key} data-kind={change.kind}>
+            <div class="ac-change-card__head">
+                <code class="ac-change-card__key">{change.key}</code>
+                <span class={`ac-change-card__badge ac-change-card__badge--${severity}`}>
+                    {severity === 'must_fix' ? 'Must fix' : severity === 'adopt' ? 'New default' : severity === 'review' ? 'Review' : 'Info'}
+                </span>
+            </div>
+            {change.new?.description !== undefined
+                ? <p class="ac-change-card__desc">{change.new.description}</p>
+                : null}
+            {change.kind === 'default_changed' ? (
+                <>
+                    <p class="ac-change-card__detail">
+                        Default changed: <code>{fmt(change.old?.default)}</code> → <code>{fmt(change.new?.default)}</code>
+                        {severity === 'review' ? <> · your value: <code>{fmt(currentValue)}</code></> : null}
+                    </p>
+                    <div class="ac-change-card__choices" role="radiogroup" aria-label={`Resolution for ${change.key}`}>
+                        <label class="ac-change-card__choice">
+                            <input
+                                type="radio"
+                                name={id}
+                                checked={res?.mode === 'adopt'}
+                                onChange={(): void => { setResolution(id, { mode: 'adopt' }); }}
+                            />
+                            <span>Adopt new default (<code>{fmt(change.new?.default)}</code>)</span>
+                        </label>
+                        <label class="ac-change-card__choice">
+                            <input
+                                type="radio"
+                                name={id}
+                                checked={res?.mode === 'keep'}
+                                onChange={(): void => { setResolution(id, { mode: 'keep' }); }}
+                            />
+                            <span>Keep current (<code>{fmt(currentValue ?? change.old?.default)}</code>)</span>
+                        </label>
+                    </div>
+                </>
+            ) : null}
+            {change.kind === 'enum_removed' ? (
+                severity === 'must_fix' ? (
+                    <>
+                        <p class="ac-change-card__detail">
+                            Your value <code>{fmt(currentValue)}</code> is no longer valid — removed option{(change.values?.length ?? 0) === 1 ? '' : 's'}: <code>{(change.values ?? []).join(', ')}</code>. Pick a replacement:
+                        </p>
+                        <ValueEditor change={change} id={id} />
+                    </>
+                ) : (
+                    <p class="ac-change-card__detail">
+                        Removed option{(change.values?.length ?? 0) === 1 ? '' : 's'}: <code>{(change.values ?? []).join(', ')}</code> — your value <code>{fmt(currentValue ?? change.new?.default)}</code> is unaffected.
+                    </p>
+                )
+            ) : null}
+            {change.kind === 'enum_added' ? (
+                <p class="ac-change-card__detail">
+                    New option{(change.values?.length ?? 0) === 1 ? '' : 's'} available: <code>{(change.values ?? []).join(', ')}</code>
+                </p>
+            ) : null}
+            {change.kind === 'added' ? (
+                severity === 'must_fix' ? (
+                    <>
+                        <p class="ac-change-card__detail">New setting without a shipped default — define a value:</p>
+                        <ValueEditor change={change} id={id} />
+                    </>
+                ) : (
+                    <p class="ac-change-card__detail">
+                        New setting · default: <code>{fmt(change.new?.default)}</code>
+                        {change.new?.enum !== undefined ? <> · options: <code>{change.new.enum.join(', ')}</code></> : null}
+                    </p>
+                )
+            ) : null}
+            {change.kind === 'removed' ? (
+                <p class="ac-change-card__detail">
+                    This setting no longer exists. Your stored value is kept in place and ignored (nothing is deleted).
+                </p>
+            ) : null}
+            {change.kind === 'type_changed' ? (
+                <>
+                    <p class="ac-change-card__detail">
+                        Type changed: <code>{change.old?.type}</code> → <code>{change.new?.type}</code>. Define a new value:
+                    </p>
+                    <ValueEditor change={change} id={id} />
+                </>
+            ) : null}
+        </li>
+    );
+}
+
+interface Group {
+    title: string;
+    hint?: string;
+    changes: SurfaceChange[];
+}
+
+function buildGroups(d: SurfaceDelta): Group[] {
+    const bySeverity = new Map<ChangeSeverity, SurfaceChange[]>();
+    for (const c of d.changes) {
+        const s = severityOf(c);
+        bySeverity.set(s, [...(bySeverity.get(s) ?? []), c]);
+    }
+    const groups: Group[] = [];
+    const mustFix = bySeverity.get('must_fix') ?? [];
+    if (mustFix.length > 0) {
+        groups.push({ title: 'Must fix', hint: 'These stored values are invalid after the upgrade — saving is blocked until each has a valid value.', changes: mustFix });
+    }
+    const defaults = [...(bySeverity.get('adopt') ?? []), ...(bySeverity.get('review') ?? [])];
+    if (defaults.length > 0) {
+        groups.push({ title: 'Changed defaults', hint: 'Values you never customized are preselected to adopt the new default; customized values are kept unless you choose otherwise.', changes: defaults });
+    }
+    const info = bySeverity.get('info') ?? [];
+    const added = info.filter((c) => c.kind === 'added');
+    const enumAdded = info.filter((c) => c.kind === 'enum_added');
+    const rest = info.filter((c) => c.kind !== 'added' && c.kind !== 'enum_added');
+    if (added.length > 0) groups.push({ title: 'New settings', changes: added });
+    if (enumAdded.length > 0) groups.push({ title: 'New options', changes: enumAdded });
+    if (rest.length > 0) groups.push({ title: 'Removed / other', changes: rest });
+    return groups;
+}
+
+export function SettingsChangesPage(): preact.JSX.Element {
+    useEffect(() => { void load(); }, []);
+
+    if (loading.value) {
+        return <div class="ac-page"><h1>Settings changes</h1><p>Loading…</p></div>;
+    }
+    if (loadError.value !== null) {
+        return (
+            <div class="ac-page">
+                <h1>Settings changes</h1>
+                <p class="ac-banner ac-banner--error">{loadError.value}</p>
+            </div>
+        );
+    }
+    if (done.value || noPending.value) {
+        return (
+            <div class="ac-page ac-settings-changes">
+                <h1>Settings changes</h1>
+                <p class="ac-banner">
+                    {done.value ? 'Review complete — all changes resolved.' : 'Nothing to review — your settings are up to date.'}
+                </p>
+                <button type="button" class="ac-button" onClick={(): void => navigate('/settings')}>
+                    Back to Settings
+                </button>
+            </div>
+        );
+    }
+
+    const d = delta.value;
+    if (d === null) return <div class="ac-page"><h1>Settings changes</h1></div>;
+    const groups = buildGroups(d);
+    const blocking = unresolvedMustFix().length;
+
+    return (
+        <div class="ac-page ac-settings-changes">
+            <header class="ac-page__header">
+                <h1>Settings changes</h1>
+                <p class="ac-page__lede">
+                    The upgrade <code>{d.oldVersion}</code> → <code>{d.newVersion}</code> changed the available
+                    settings. Review below — nothing was changed automatically.
+                </p>
+            </header>
+            {banner.value !== null ? <p class="ac-banner ac-banner--error" role="alert">{banner.value}</p> : null}
+            {groups.map((g) => (
+                <section key={g.title} class="ac-settings-changes__group">
+                    <h2>{g.title} <span class="ac-settings-changes__count">({g.changes.length})</span></h2>
+                    {g.hint !== undefined ? <p class="ac-settings-changes__hint">{g.hint}</p> : null}
+                    <ul class="ac-settings-changes__list">
+                        {g.changes.map((c) => <ChangeCard key={changeId(c)} change={c} />)}
+                    </ul>
+                </section>
+            ))}
+            <div class="ac-form__actions">
+                <button type="button" class="ac-button" disabled={saving.value} onClick={(): void => { void dismissAll(); }}>
+                    Dismiss (keep everything)
+                </button>
+                <button
+                    type="button"
+                    class="ac-button ac-button--primary"
+                    disabled={saving.value || blocking > 0}
+                    title={blocking > 0 ? `${blocking} “Must fix” item${blocking === 1 ? '' : 's'} unresolved` : undefined}
+                    onClick={(): void => { void save(); }}
+                >
+                    {saving.value ? 'Saving…' : 'Apply & finish review'}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Pending-review banner — rendered by the Settings hub (and reusable
+ * elsewhere). Cheap probe: one GET; 404 → renders nothing.
+ */
+const pendingCount = signal<number | null>(null);
+
+export function SettingsChangesBanner(): preact.JSX.Element | null {
+    useEffect(() => {
+        void (async (): Promise<void> => {
+            try {
+                const res = await apiFetch<ChangesGetResponse>('/api/v1/settings/changes');
+                pendingCount.value = res.delta.changes.length;
+            } catch {
+                pendingCount.value = null;
+            }
+        })();
+    }, []);
+    if (pendingCount.value === null || pendingCount.value === 0) return null;
+    return (
+        <div class="ac-banner ac-banner--pending" role="status">
+            <span>
+                An upgrade changed {pendingCount.value} setting{pendingCount.value === 1 ? '' : 's'} — review recommended.
+            </span>
+            <button type="button" class="ac-button ac-button--small" onClick={(): void => navigate('/settings/changes')}>
+                Review changes
+            </button>
+        </div>
+    );
+}

--- a/src/ui/pages/SettingsHubPage.tsx
+++ b/src/ui/pages/SettingsHubPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '../forms/schemaTypes.js';
 import { isBasicPath } from '../settings/basicPaths.js';
 import { topLevelCopy, fieldErrorMap } from '../copyErrors.js';
+import { SettingsChangesBanner } from './SettingsChangesPage.js';
 
 interface SettingsGetResponse {
     values: Record<string, JsonValue>;
@@ -297,6 +298,7 @@ export function SettingsHubPage(): preact.JSX.Element {
                     <a href="#/settings/user">Edit .agent-user.yml →</a>
                 </nav>
             </header>
+            <SettingsChangesBanner />
             <div class="ac-settings-hub__toolbar" role="search">
                 <input
                     class="ac-input ac-settings-hub__search"

--- a/tests/e2e/settings-changes-browser.spec.ts
+++ b/tests/e2e/settings-changes-browser.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Browser E2E for the upgrade-time settings review
+ * (road-to-settings-change-review).
+ *
+ * Seeds a pending `state/settings-delta.json` (as the installer writes it
+ * on upgrade) plus a settings file whose stored value is invalid under
+ * the new surface, then drives real Chromium through the full flow:
+ * pending banner on the hub → review page groups → must-fix blocks save
+ * → resolve → apply writes the settings + clears the flag → banner gone.
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:net';
+
+import { createApp } from '../../src/server/app.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(__filename), '..', '..');
+
+async function findFreePort(): Promise<number> {
+    return await new Promise<number>((res, rej) => {
+        const srv = createServer();
+        srv.unref();
+        srv.on('error', rej);
+        srv.listen(0, '127.0.0.1', () => {
+            const addr = srv.address();
+            if (addr === null || typeof addr === 'string') {
+                rej(new Error('no address'));
+                return;
+            }
+            const port = addr.port;
+            srv.close(() => res(port));
+        });
+    });
+}
+
+/**
+ * The delta an upgrade would have produced:
+ *   - personal.autonomy lost the 'on' option → the stored value ('on')
+ *     is invalid → Must fix.
+ *   - rule_loading_tier default changed balanced → full and the user
+ *     never customized → adopt preselected.
+ *   - discipline_profile is new with a default → info.
+ * Replacement values are drawn from the REAL schema enums so the final
+ * PUT validates.
+ */
+function fixtureDelta(): object {
+    return {
+        oldVersion: '8.3.0',
+        newVersion: '8.4.0',
+        changes: [
+            {
+                key: 'personal.autonomy',
+                kind: 'enum_removed',
+                old: { type: 'string', default: 'auto', enum: ['on', 'off', 'auto'] },
+                new: { type: 'string', default: 'auto', enum: ['off', 'auto'], description: 'Autonomy mode.' },
+                values: ['on'],
+            },
+            {
+                key: 'rule_loading_tier',
+                kind: 'default_changed',
+                old: { type: 'string', default: 'balanced', enum: ['minimal', 'balanced', 'full', 'custom'] },
+                new: { type: 'string', default: 'full', enum: ['minimal', 'balanced', 'full', 'custom'] },
+            },
+            {
+                key: 'discipline_profile',
+                kind: 'added',
+                new: { type: 'string', default: 'auto', enum: ['auto', 'off', 'essential', 'full'], description: 'The ONE runtime discipline knob.' },
+            },
+        ],
+    };
+}
+
+let tmpRoot: string;
+let baseURL: string;
+let shutdown: () => Promise<void>;
+
+test.beforeAll(async () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'settings-changes-browser-'));
+    mkdirSync(join(tmpRoot, 'settings'), { recursive: true });
+    mkdirSync(join(tmpRoot, 'state'), { recursive: true });
+    // autonomy=on: invalid under the delta's new surface (must-fix);
+    // rule_loading_tier=balanced == old default (adopt preselected).
+    writeFileSync(
+        join(tmpRoot, 'settings', '.agent-settings.yml'),
+        'rule_loading_tier: balanced\npersonal:\n  autonomy: "on"\n',
+        { mode: 0o600 },
+    );
+    writeFileSync(join(tmpRoot, 'state', 'settings-delta.json'), JSON.stringify(fixtureDelta(), null, 2));
+
+    const port = await findFreePort();
+    // Real writes (dryRun: false) — everything stays inside the temp root.
+    const app = await createApp({
+        writeRoot: tmpRoot,
+        packageRoot: REPO_ROOT,
+        projectRoot: tmpRoot,
+        dryRun: false,
+        skipReplay: true,
+        token: 'test-token',
+        expectedPort: port,
+        uiDistDir: join(REPO_ROOT, 'dist', 'ui'),
+    });
+    await app.listen({ host: '127.0.0.1', port });
+    baseURL = `http://127.0.0.1:${port}`;
+    shutdown = async () => { await app.close(); };
+});
+
+test.afterAll(async () => {
+    if (shutdown) await shutdown();
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+async function expectNoPageOverflow(page: Page): Promise<void> {
+    const delta = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(delta, `page overflows horizontally by ${delta}px`).toBeLessThanOrEqual(1);
+}
+
+test.describe('settings changes review — browser', () => {
+    test.use({ viewport: { width: 1280, height: 900 } });
+
+    test('banner → review → must-fix gate → apply → resolved', async ({ page }, testInfo) => {
+        // 1. Hub shows the pending banner.
+        await page.goto(`${baseURL}/?token=test-token#/settings`);
+        await expect(page.getByRole('heading', { name: 'Settings', exact: true })).toBeVisible();
+        const bannerButton = page.getByRole('button', { name: 'Review changes' });
+        await expect(bannerButton).toBeVisible();
+        await expect(page.getByText(/An upgrade changed 3 settings/)).toBeVisible();
+        await page.screenshot({ path: testInfo.outputPath('01-hub-pending-banner.png'), fullPage: true });
+
+        // 2. Banner navigates to the review page — groups render.
+        await bannerButton.click();
+        await expect(page.getByRole('heading', { name: 'Settings changes' })).toBeVisible();
+        await expect(page.getByText(/8\.3\.0/).first()).toBeVisible();
+        await expect(page.getByRole('heading', { name: /Must fix/ })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /Changed defaults/ })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /New settings/ })).toBeVisible();
+        await expectNoPageOverflow(page);
+        await page.screenshot({ path: testInfo.outputPath('02-review-page.png'), fullPage: true });
+
+        // Must-fix card explains the invalid value.
+        const mustFixCard = page.locator('.ac-change-card--must_fix');
+        await expect(mustFixCard).toHaveCount(1);
+        await expect(mustFixCard.getByText(/no longer valid/)).toBeVisible();
+
+        // Adopt card is preselected to the new default.
+        const adoptCard = page.locator('.ac-change-card[data-key="rule_loading_tier"]');
+        await expect(adoptCard.getByRole('radio').first()).toBeChecked();
+
+        // 3. Save is blocked while the must-fix item is unresolved.
+        const applyButton = page.getByRole('button', { name: 'Apply & finish review' });
+        await expect(applyButton).toBeDisabled();
+
+        // Resolve: pick a replacement from the NEW enum.
+        await mustFixCard.getByRole('combobox').selectOption('off');
+        await expect(applyButton).toBeEnabled();
+
+        // 4. Apply — settings written, delta acknowledged.
+        await applyButton.click();
+        await expect(page.getByText('Review complete — all changes resolved.')).toBeVisible();
+        await page.screenshot({ path: testInfo.outputPath('03-review-done.png'), fullPage: true });
+
+        const settingsBody = readFileSync(join(tmpRoot, 'settings', '.agent-settings.yml'), 'utf8');
+        expect(settingsBody).toMatch(/autonomy:\s*['"]?off['"]?/);
+        expect(settingsBody).toMatch(/rule_loading_tier:\s*['"]?full['"]?/);
+        expect(existsSync(join(tmpRoot, 'state', 'settings-delta.json'))).toBe(false);
+
+        // 5. Banner is gone; direct visit reports nothing pending.
+        await page.goto(`${baseURL}/?token=test-token#/settings`);
+        await expect(page.getByRole('heading', { name: 'Settings', exact: true })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Review changes' })).toHaveCount(0);
+        await page.goto(`${baseURL}/?token=test-token#/settings/changes`);
+        await expect(page.getByText('Nothing to review — your settings are up to date.')).toBeVisible();
+    });
+});

--- a/tests/install/settings_surface_snapshot.test.ts
+++ b/tests/install/settings_surface_snapshot.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Installer settings-surface snapshot + upgrade delta
+ * (road-to-settings-change-review).
+ *
+ * Every global install writes `state/settings-surface.json` (the
+ * flattened live Zod schema + package version). When a PREVIOUS snapshot
+ * from a DIFFERENT version exists, the semantic delta lands in
+ * `state/settings-delta.json` — the pending-review flag the GUI banner,
+ * the review page, and doctor consume. Root override via
+ * `EVENT4U_CONFIG_HOME` keeps the test hermetic.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    _write_settings_surface_snapshot,
+    _current_settings_surface,
+    state,
+} from '../../src/scripts/install.js';
+import type { SettingsSurface, SurfaceDelta } from '../../src/shared/settingsSurface.js';
+
+let root: string;
+let prevEnv: string | undefined;
+let prevQuiet: boolean;
+
+beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'e4u-surface-'));
+    prevEnv = process.env['EVENT4U_CONFIG_HOME'];
+    process.env['EVENT4U_CONFIG_HOME'] = root;
+    prevQuiet = state.QUIET;
+    state.QUIET = true;
+});
+afterEach(() => {
+    if (prevEnv === undefined) delete process.env['EVENT4U_CONFIG_HOME'];
+    else process.env['EVENT4U_CONFIG_HOME'] = prevEnv;
+    state.QUIET = prevQuiet;
+    rmSync(root, { recursive: true, force: true });
+});
+
+function surfacePath(): string {
+    return join(root, 'state', 'settings-surface.json');
+}
+function deltaPath(): string {
+    return join(root, 'state', 'settings-delta.json');
+}
+function readSurface(): SettingsSurface {
+    return JSON.parse(readFileSync(surfacePath(), 'utf8')) as SettingsSurface;
+}
+
+describe('_current_settings_surface', () => {
+    it('flattens the live Zod schema to dotted leaves with defaults', () => {
+        const s = _current_settings_surface('9.9.9');
+        expect(s.version).toBe('9.9.9');
+        expect(s.entries['personal.autonomy']).toBeDefined();
+        expect(s.entries['personal.autonomy']?.enum).toContain('auto');
+        expect(Object.keys(s.entries).length).toBeGreaterThan(20);
+    });
+});
+
+describe('_write_settings_surface_snapshot', () => {
+    it('first run seeds the snapshot only — no delta (council Q1)', () => {
+        _write_settings_surface_snapshot('9.9.9');
+        expect(existsSync(surfacePath())).toBe(true);
+        expect(existsSync(deltaPath())).toBe(false);
+        expect(readSurface().version).toBe('9.9.9');
+    });
+
+    it('same-version re-install refreshes the snapshot, no delta', () => {
+        _write_settings_surface_snapshot('9.9.9');
+        _write_settings_surface_snapshot('9.9.9');
+        expect(existsSync(deltaPath())).toBe(false);
+    });
+
+    it('upgrade with a changed surface writes the delta and refreshes the snapshot', () => {
+        // Seed an OLD snapshot: same live schema, but doctor one entry so a
+        // default_changed + removed key show up against the live surface.
+        const old = _current_settings_surface('9.0.0');
+        const doctored: SettingsSurface = {
+            version: '9.0.0',
+            entries: {
+                ...old.entries,
+                'personal.autonomy': { ...(old.entries['personal.autonomy'] ?? { type: 'string' }), default: 'LEGACY' },
+                'legacy.only_key': { type: 'string', default: 'x' },
+            },
+        };
+        mkdirSync(join(root, 'state'), { recursive: true });
+        writeFileSync(surfacePath(), JSON.stringify(doctored));
+
+        _write_settings_surface_snapshot('9.9.9');
+
+        expect(existsSync(deltaPath())).toBe(true);
+        const delta = JSON.parse(readFileSync(deltaPath(), 'utf8')) as SurfaceDelta;
+        expect(delta.oldVersion).toBe('9.0.0');
+        expect(delta.newVersion).toBe('9.9.9');
+        const kinds = delta.changes.map((c) => `${c.key}:${c.kind}`);
+        expect(kinds).toContain('personal.autonomy:default_changed');
+        expect(kinds).toContain('legacy.only_key:removed');
+        // Snapshot advanced to the new surface.
+        expect(readSurface().version).toBe('9.9.9');
+        expect(readSurface().entries['personal.autonomy']?.default).not.toBe('LEGACY');
+    });
+
+    it('version bump with an IDENTICAL surface writes no delta', () => {
+        const old = _current_settings_surface('9.0.0');
+        mkdirSync(join(root, 'state'), { recursive: true });
+        writeFileSync(surfacePath(), JSON.stringify(old));
+        _write_settings_surface_snapshot('9.9.9');
+        expect(existsSync(deltaPath())).toBe(false);
+        expect(readSurface().version).toBe('9.9.9');
+    });
+
+    it('a corrupt existing snapshot degrades to seed-only, never throws', () => {
+        mkdirSync(join(root, 'state'), { recursive: true });
+        writeFileSync(surfacePath(), '{corrupt');
+        expect(() => { _write_settings_surface_snapshot('9.9.9'); }).not.toThrow();
+        expect(readSurface().version).toBe('9.9.9');
+        expect(existsSync(deltaPath())).toBe(false);
+    });
+});

--- a/tests/scripts/_cli/cmd_doctor.test.ts
+++ b/tests/scripts/_cli/cmd_doctor.test.ts
@@ -44,7 +44,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { _parse, main } from '../../../src/scripts/_cli/cmd_doctor.js';
+import { _parse, main, _check_settings_review_pending } from '../../../src/scripts/_cli/cmd_doctor.js';
 import { runInProc } from '../../_lib/run_in_process.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
@@ -510,6 +510,70 @@ describe('doctor — wizard-state check', () => {
     });
     it('totalSteps is zero → fail', () => {
         parityWithState('{"step":1,"partial":{},"totalSteps":0}');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// settings-review-pending check (road-to-settings-change-review) — direct
+// unit calls in a hermetic EVENT4U_CONFIG_HOME.
+// ---------------------------------------------------------------------------
+
+describe('doctor — settings-review-pending check', () => {
+    function withDelta(content: string | null, fn: () => void): void {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-srp-'));
+        const prev = process.env['EVENT4U_CONFIG_HOME'];
+        process.env['EVENT4U_CONFIG_HOME'] = home;
+        try {
+            if (content !== null) {
+                const stateDir = path.join(home, 'state');
+                fs.mkdirSync(stateDir, { recursive: true });
+                fs.writeFileSync(path.join(stateDir, 'settings-delta.json'), content);
+            }
+            fn();
+        } finally {
+            if (prev === undefined) delete process.env['EVENT4U_CONFIG_HOME'];
+            else process.env['EVENT4U_CONFIG_HOME'] = prev;
+            fs.rmSync(home, { recursive: true, force: true });
+        }
+    }
+
+    it('absent delta → ok', () => {
+        withDelta(null, () => {
+            const res = _check_settings_review_pending();
+            expect(res['status']).toBe('ok');
+        });
+    });
+
+    it('pending delta → warn with change count + version span + remedy', () => {
+        withDelta(
+            JSON.stringify({ oldVersion: '8.3.0', newVersion: '8.4.0', changes: [{}, {}, {}] }),
+            () => {
+                const res = _check_settings_review_pending();
+                expect(res['status']).toBe('warn');
+                expect(res['message']).toContain('3 changes');
+                expect(res['message']).toContain('8.3.0 → 8.4.0');
+                expect(res['remedy']).toContain('agent-config config');
+            },
+        );
+    });
+
+    it('unreadable delta → warn (never throws)', () => {
+        withDelta('{corrupt', () => {
+            const res = _check_settings_review_pending();
+            expect(res['status']).toBe('warn');
+            expect(res['message']).toContain('unreadable delta file');
+        });
+    });
+
+    it('runs stable via --check settings-review-pending', () => {
+        const home = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-srp-cli-'));
+        try {
+            expectStable(['--check', 'settings-review-pending'], tmp, [home, tmp], {
+                EVENT4U_CONFIG_HOME: home,
+            });
+        } finally {
+            fs.rmSync(home, { recursive: true, force: true });
+        }
     });
 });
 

--- a/tests/server/settingsChanges.test.ts
+++ b/tests/server/settingsChanges.test.ts
@@ -1,0 +1,143 @@
+/**
+ * /api/v1/settings/changes — pending settings-surface delta routes
+ * (road-to-settings-change-review).
+ *
+ * The delta file is written by the installer (`state/settings-delta.json`
+ * under the global root = the server writeRoot in tests); the server only
+ * serves and clears it. Classification lives client-side in the shared
+ * module (covered by tests/shared/settingsSurface.test.ts).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { bootTestApp, authHeaders, type TestApp } from './helpers.js';
+import type { SurfaceDelta } from '../../src/shared/settingsSurface.js';
+
+const PORT = 41955;
+
+function fixtureDelta(): SurfaceDelta {
+    return {
+        oldVersion: '8.3.0',
+        newVersion: '8.4.0',
+        changes: [
+            {
+                key: 'personal.autonomy',
+                kind: 'default_changed',
+                old: { type: 'string', default: 'auto', enum: ['auto', 'on', 'off'] },
+                new: { type: 'string', default: 'on', enum: ['auto', 'on', 'off'] },
+            },
+            {
+                key: 'discipline_profile',
+                kind: 'added',
+                new: { type: 'string', default: 'auto', enum: ['auto', 'off', 'essential', 'full'] },
+            },
+        ],
+    };
+}
+
+function writeDelta(root: string, delta: SurfaceDelta = fixtureDelta()): string {
+    const dir = join(root, 'state');
+    mkdirSync(dir, { recursive: true });
+    const pth = join(dir, 'settings-delta.json');
+    writeFileSync(pth, JSON.stringify(delta, null, 2));
+    return pth;
+}
+
+describe('GET /api/v1/settings/changes', () => {
+    let t: TestApp;
+    beforeEach(async () => { t = await bootTestApp({ port: PORT }); });
+    afterEach(async () => { await t.cleanup(); });
+
+    it('404s with NO_PENDING_CHANGES when no delta file exists', async () => {
+        const res = await t.app.inject({
+            method: 'GET',
+            url: '/api/v1/settings/changes',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(res.statusCode).toBe(404);
+        expect(res.json().error.code).toBe('NO_PENDING_CHANGES');
+    });
+
+    it('serves the pending delta from the writeRoot', async () => {
+        writeDelta(t.projectRoot);
+        const res = await t.app.inject({
+            method: 'GET',
+            url: '/api/v1/settings/changes',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(res.statusCode).toBe(200);
+        const body = res.json() as { delta: SurfaceDelta; source: string };
+        expect(body.source).toBe('writeRoot');
+        expect(body.delta.oldVersion).toBe('8.3.0');
+        expect(body.delta.changes).toHaveLength(2);
+        expect(body.delta.changes.map((c) => `${c.key}:${c.kind}`)).toEqual([
+            'personal.autonomy:default_changed',
+            'discipline_profile:added',
+        ]);
+    });
+
+    it('treats a malformed delta file as no pending changes', async () => {
+        const dir = join(t.projectRoot, 'state');
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, 'settings-delta.json'), '{not json');
+        const res = await t.app.inject({
+            method: 'GET',
+            url: '/api/v1/settings/changes',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(res.statusCode).toBe(404);
+    });
+});
+
+describe('POST /api/v1/settings/changes/ack', () => {
+    let t: TestApp;
+    beforeEach(async () => { t = await bootTestApp({ port: PORT }); });
+    afterEach(async () => { await t.cleanup(); });
+
+    it('deletes the pending delta and subsequent GET 404s', async () => {
+        const pth = writeDelta(t.projectRoot);
+        const ack = await t.app.inject({
+            method: 'POST',
+            url: '/api/v1/settings/changes/ack',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(ack.statusCode).toBe(200);
+        expect(ack.json()).toMatchObject({ ok: true, cleared: true });
+        expect(existsSync(pth)).toBe(false);
+
+        const after = await t.app.inject({
+            method: 'GET',
+            url: '/api/v1/settings/changes',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(after.statusCode).toBe(404);
+    });
+
+    it('is idempotent — ack with nothing pending still succeeds', async () => {
+        const res = await t.app.inject({
+            method: 'POST',
+            url: '/api/v1/settings/changes/ack',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toMatchObject({ ok: true, cleared: false });
+    });
+});
+
+describe('dry-run mode', () => {
+    let t: TestApp;
+    beforeEach(async () => { t = await bootTestApp({ port: PORT, dryRun: true }); });
+    afterEach(async () => { await t.cleanup(); });
+
+    it('ack never deletes the delta file in dry-run', async () => {
+        const pth = writeDelta(t.projectRoot);
+        const ack = await t.app.inject({
+            method: 'POST',
+            url: '/api/v1/settings/changes/ack',
+            headers: authHeaders(t.token, t.host),
+        });
+        expect(ack.statusCode).toBe(200);
+        expect(ack.json()).toMatchObject({ ok: true, dryRun: true, cleared: false });
+        expect(existsSync(pth)).toBe(true);
+    });
+});

--- a/tests/shared/settingsSurface.test.ts
+++ b/tests/shared/settingsSurface.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Settings-surface flatten / delta / classification
+ * (road-to-settings-change-review) — the pure engine behind the
+ * upgrade-time settings review form.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+    flattenSurface,
+    computeSurfaceDelta,
+    classifyChange,
+    type SettingsSurface,
+} from '../../src/shared/settingsSurface.js';
+
+const SCHEMA_V1 = {
+    type: 'object',
+    properties: {
+        personal: {
+            type: 'object',
+            properties: {
+                autonomy: { type: 'string', enum: ['auto', 'on', 'off'], default: 'auto', description: 'Autonomy mode' },
+                minimal_output: { type: 'boolean', default: true },
+            },
+        },
+        rule_loading_tier: { type: 'string', enum: ['minimal', 'balanced', 'full'], default: 'balanced' },
+    },
+};
+
+const SCHEMA_V2 = {
+    type: 'object',
+    properties: {
+        personal: {
+            type: 'object',
+            properties: {
+                // default flipped + a NEW enum value
+                autonomy: { type: 'string', enum: ['auto', 'on', 'off', 'strict'], default: 'on', description: 'Autonomy mode' },
+                minimal_output: { type: 'boolean', default: true },
+            },
+        },
+        // enum value REMOVED ('minimal' gone)
+        rule_loading_tier: { type: 'string', enum: ['balanced', 'full'], default: 'balanced' },
+        // brand-new setting
+        discipline_profile: { type: 'string', enum: ['auto', 'off'], default: 'auto' },
+    },
+};
+
+function surfaces(): { v1: SettingsSurface; v2: SettingsSurface } {
+    return {
+        v1: flattenSurface(SCHEMA_V1, '8.0.0'),
+        v2: flattenSurface(SCHEMA_V2, '9.0.0'),
+    };
+}
+
+describe('flattenSurface', () => {
+    it('flattens nested objects to dotted leaves with default/enum/description', () => {
+        const { v1 } = surfaces();
+        expect(Object.keys(v1.entries).sort()).toEqual([
+            'personal.autonomy', 'personal.minimal_output', 'rule_loading_tier',
+        ]);
+        expect(v1.entries['personal.autonomy']).toMatchObject({
+            type: 'string', default: 'auto', enum: ['auto', 'on', 'off'], description: 'Autonomy mode',
+        });
+    });
+
+    it('unwraps a $ref/definitions root (zod-to-json-schema named output)', () => {
+        const wrapped = { $ref: '#/definitions/S', definitions: { S: SCHEMA_V1 } };
+        const s = flattenSurface(wrapped, '8.0.0');
+        expect(Object.keys(s.entries)).toHaveLength(3);
+    });
+});
+
+describe('computeSurfaceDelta', () => {
+    it('detects added keys, default changes, enum additions and removals', () => {
+        const { v1, v2 } = surfaces();
+        const delta = computeSurfaceDelta(v1, v2);
+        const kinds = delta.changes.map((c) => `${c.key}:${c.kind}`);
+        expect(kinds).toContain('discipline_profile:added');
+        expect(kinds).toContain('personal.autonomy:default_changed');
+        expect(kinds).toContain('personal.autonomy:enum_added');
+        expect(kinds).toContain('rule_loading_tier:enum_removed');
+        // unchanged key contributes nothing
+        expect(kinds.some((k) => k.startsWith('personal.minimal_output'))).toBe(false);
+        expect(delta.oldVersion).toBe('8.0.0');
+        expect(delta.newVersion).toBe('9.0.0');
+    });
+
+    it('is empty for identical surfaces', () => {
+        const { v1 } = surfaces();
+        expect(computeSurfaceDelta(v1, { ...v1, version: '8.0.1' }).changes).toEqual([]);
+    });
+
+    it('reports removed keys', () => {
+        const { v1, v2 } = surfaces();
+        const delta = computeSurfaceDelta(v2, v1);
+        expect(delta.changes.map((c) => `${c.key}:${c.kind}`)).toContain('discipline_profile:removed');
+    });
+});
+
+describe('classifyChange', () => {
+    it('enum_removed hitting the stored value is must_fix, otherwise info', () => {
+        const { v1, v2 } = surfaces();
+        const change = computeSurfaceDelta(v1, v2).changes
+            .find((c) => c.key === 'rule_loading_tier' && c.kind === 'enum_removed')!;
+        expect(classifyChange(change, 'minimal')).toBe('must_fix');
+        expect(classifyChange(change, 'balanced')).toBe('info');
+    });
+
+    it('default_changed preselects adopt for never-customized values', () => {
+        const { v1, v2 } = surfaces();
+        const change = computeSurfaceDelta(v1, v2).changes
+            .find((c) => c.key === 'personal.autonomy' && c.kind === 'default_changed')!;
+        expect(classifyChange(change, 'auto')).toBe('adopt');      // == old default
+        expect(classifyChange(change, undefined)).toBe('adopt');   // never present
+        expect(classifyChange(change, 'off')).toBe('review');      // customized
+    });
+
+    it('added settings with a default are info; without a default must_fix', () => {
+        const { v1, v2 } = surfaces();
+        const added = computeSurfaceDelta(v1, v2).changes
+            .find((c) => c.key === 'discipline_profile' && c.kind === 'added')!;
+        expect(classifyChange(added, undefined)).toBe('info');
+        expect(classifyChange({ ...added, new: { type: 'string' } }, undefined)).toBe('must_fix');
+    });
+});


### PR DESCRIPTION
Follow-up to #783 (merged). Branch is based on the #783 tip, so the diff against `main` is exactly the five feature commits.

## What

On every global install/upgrade the installer now detects changes to the *available settings surface* — changed defaults, grown/shrunk enum vocabularies, newly added or removed settings — and the GUI presents a dynamic review form where the user adopts new defaults, keeps their values, or MUST fix values that became invalid.

## How (council 2026-07-08, 2/2 converged)

- **Snapshot-at-install** — `state/settings-surface.json` (flattened live Zod schema + version) is written on every global install. The next upgrade reads it as the OLD surface before overwriting and computes a semantic delta (`added / removed / default_changed / enum_added / enum_removed / type_changed`) into `state/settings-delta.json`. First run after this ships is seed-only (transition cost paid once, no template fallback).
- **Never auto-open a browser** — the installer prints a one-line summary; the flag persists; the settings hub shows a banner; `doctor` warns (`settings-review-pending`) until resolved.
- **Severity semantics** — `must_fix` (stored value invalid: removed enum value / type change — blocks save), `adopt` (never customized + default changed — preselected to take the new default), `review` (customized — keep by default, old→new shown), `info` (new settings with defaults, new options, removed keys).
- **Dedicated page** `#/settings/changes` — grouped cards (Must fix / Changed defaults / New settings / New options / Removed), one save action. Resolutions are applied through the existing comment-preserving settings PUT (optimistic locking), then the delta is acknowledged. Ack deletes only under the writeRoot — a sandbox review never clears the real machine's flag; dry-run never deletes.

## Pieces

- `src/shared/settingsSurface.ts` — pure flatten/delta/classify engine (installer-bundled, server, UI)
- `src/scripts/install.ts` — snapshot + delta write in `install_global` (never fatal); install bundle rebuilt
- `src/server/routes/settingsChanges.ts` — `GET /api/v1/settings/changes` + `POST …/ack`; contract documented in `docs/contracts/settings-api.md`
- `src/ui/pages/SettingsChangesPage.tsx` — review form + pending banner (hub)
- `cmd_doctor.ts` — `settings-review-pending` check

## Verification

- 8 shared-engine tests, 6 installer snapshot/delta tests, 6 server route tests, 4 doctor-check tests — all green (445 total across touched suites)
- Browser e2e (`tests/e2e/settings-changes-browser.spec.ts`): banner → review → must-fix gate blocks save → resolve → apply writes `autonomy: off` + adopted `rule_loading_tier: full` → delta cleared → banner gone (10/10 e2e green)
- `tsc --noEmit` clean; rebuilt `dist/install/install.mjs` smoke-tested (`--help` exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)