### PR TITLE
fix(ci): install repo-root deps in the MCP deploy workflow

### DIFF
--- a/.github/workflows/deploy-mcp-worker.yml
+++ b/.github/workflows/deploy-mcp-worker.yml
@@ -67,6 +67,13 @@ jobs:
         run: npm ci
         working-directory: internal/workers/mcp
 
+      # scripts-run resolves the REPO-ROOT node_modules/.bin/tsx — the
+      # worker-scoped install above does not provide it. Missing root deps
+      # broke every release-triggered deploy since the scripts moved to tsx
+      # (8.2.0 … 8.6.0 all failed at "Pack content blob" with exit 127).
+      - name: Install repo deps (scripts-run needs root tsx)
+        run: npm ci
+
       - name: Pack content blob
         id: pack
         run: |


### PR DESCRIPTION
## Summary

`deploy-mcp-worker.yml` (release-triggered Cloudflare deploy) fails at **Pack content blob** with

```
./scripts-run: line 9: .../node_modules/.bin/tsx: No such file or directory
```

`scripts-run` resolves the repo-root `node_modules/.bin/tsx`, but the workflow only installs deps inside `internal/workers/mcp`. This has silently failed **every release-triggered deploy since the scripts moved from Python to tsx** — run history: 8.2.0, 8.3.0, 8.4.0, 8.4.1, 8.5.0, 8.6.0 all red at this step.

## Fix

One step: root `npm ci` before Pack content blob. The worker-scoped install stays (the Worker has its own package/lockfile).

## Verification

- YAML parses (`js-yaml` load).
- Root cause matches the log exactly (exit 127 on root tsx path); `pack_mcp_content` and the subsequent `node -e` manifest reads all run from the repo root.

## After merge (maintainer action)

Re-run the deploy for the current release: Actions → deploy-mcp-worker → Run workflow with `tag: 8.6.0` — the release itself (tag + GitHub Release + npm) is already complete; only the Cloudflare MCP deploy is outstanding.