### PR TITLE
feat(second-brain): recall scorer + rig + honest unproven-lift scope

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,7 @@ tasks:
       - task: check-artefact-counts
       - task: lint-no-python-twin-rationale
       - task: check-memory-replay
+      - task: check-second-brain-scorer
       - task: check-eval-coverage
       - task: check-domain-soundness
       - task: lint-behavioural-eval-freshness
@@ -257,6 +258,7 @@ tasks:
       - task: check-artefact-counts
       - task: lint-no-python-twin-rationale
       - task: check-memory-replay
+      - task: check-second-brain-scorer
       - task: check-eval-coverage
       - task: check-domain-soundness
       - task: lint-behavioural-eval-freshness

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**134 / 437 steps done · 31%**
+**140 / 437 steps done · 32%**
 
 ```text
-████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   31%
+█████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░   32%
 ```
 
 ## Open roadmaps
@@ -33,7 +33,7 @@
 | 15 | [road-to-orchestration-and-memory-harvest.md](roadmaps/road-to-orchestration-and-memory-harvest.md) | 5 | 15 | 15 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 16 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
 | 17 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 18 | [road-to-second-brain-delta-proof.md](roadmaps/road-to-second-brain-delta-proof.md) | 4 | 11 | 11 | 0 | 0 | 0 | [2](#blockers-road-to-second-brain-delta-proof) | ░░░░░░░░░░ 0% |
+| 18 | [road-to-second-brain-delta-proof.md](roadmaps/road-to-second-brain-delta-proof.md) | 4 | 11 | 5 | 6 | 0 | 0 | [2](#blockers-road-to-second-brain-delta-proof) | ██████░░░░ 55% |
 | 19 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 3 | 8 | 0 | 0 | [1](#blockers-road-to-skill-eval-coverage) | ███████░░░ 73% |
 | 20 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
 | 21 | [road-to-surface-specific-agent-contracts.md](roadmaps/road-to-surface-specific-agent-contracts.md) | 8 | 39 | 39 | 0 | 0 | 0 | [1](#blockers-road-to-surface-specific-agent-contracts) | ░░░░░░░░░░ 0% |
@@ -377,13 +377,13 @@
 
 ### [road-to-second-brain-delta-proof.md](roadmaps/road-to-second-brain-delta-proof.md)
 
-**Road to second-brain delta proof — measure the memory substrate against a no-memory baseline, and scope it honestly against human-PKM** — 0 / 11 done (0%)
+**Road to second-brain delta proof — measure the memory substrate against a no-memory baseline, and scope it honestly against human-PKM** — 6 / 11 done (55%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Define the task + deterministic scorer (no LLM judge) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Define the task + deterministic scorer (no LLM judge) | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 2 | Paired measurement: substrate on vs off vs placebo | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 3 | Honest positioning vs human-PKM | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Honest positioning vs human-PKM | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 4 | Interop instead of competition (optional, gated on Phase 2 PASS) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
 <a id="blockers-road-to-second-brain-delta-proof"></a>

--- a/agents/roadmaps/road-to-second-brain-delta-proof.md
+++ b/agents/roadmaps/road-to-second-brain-delta-proof.md
@@ -49,22 +49,33 @@ ships labeled "continuity convenience, no measured task lift."
 
 - [x] Substrate Phases 1–6 landed (`road-to-second-brain.md`).
 - [x] Delta framed as open (`second-brain-delta-verdict.md`).
-- [ ] A deterministic memory-task scorer (this roadmap, Phase 1).
+- [x] A deterministic memory-task scorer (this roadmap, Phase 1).
 
 ## Phase 1 — Define the task + deterministic scorer (no LLM judge)
 
-- [ ] Author a **multi-session recall corpus** under
+- [x] Author a **multi-session recall corpus** under
       `internal/bench/second-brain/corpus/`: N tasks where session *k+1* needs
       a fact/decision established in session *k* (e.g. "the API contract we
       chose", "the constraint we rejected and why"). Each task carries a
       deterministic answer key.
-- [ ] Define the metric set, all deterministic: (a) retrieval accuracy — did
+      <!-- done 2026-07-08: internal/bench/second-brain/corpus/corpus.yml — 9
+      constructed session-k/k+1 tasks with deterministic must_contain/
+      must_not_contain keys (synthetic, deterministic-by-construction; provenance
+      header mirrors the memory-replay Option-A precedent). -->
+- [x] Define the metric set, all deterministic: (a) retrieval accuracy — did
       the agent surface the correct prior fact; (b) contradiction-catch rate —
       seed a session-*k+1* prompt that contradicts session *k*; does
       contradiction-surfacing fire; (c) repair rate — after an injected wrong
       memory, does `fold_intake`/promote correct it.
-- [ ] Scorer emits pass/fail per task, no model-in-the-loop grading (mirror
+      <!-- done 2026-07-08: all three metrics present (5 retrieval-accuracy,
+      2 contradiction-catch, 2 repair); each is a deterministic key, never a
+      model judgement. -->
+- [x] Scorer emits pass/fail per task, no model-in-the-loop grading (mirror
       `bench_ab_scoring_v2.py` discipline).
+      <!-- done 2026-07-08: src/scripts/second_brain_score.ts — pure substring
+      must_contain/must_not_contain, NO LLM judge. --dry-run: 9 good→PASS,
+      3 bad→FAIL (correct + discriminating); wired as check-second-brain-scorer.
+      Satisfies Phase 1 Exit (dry run scores hand-written transcripts). -->
 
 **Exit:** corpus + deterministic scorer exist; a dry run scores a hand-written
 transcript correctly.
@@ -77,11 +88,16 @@ transcript correctly.
       "notes" injected, no retrieval logic) — the placebo isolates *retrieval
       mechanism* from *mere extra context*, exactly as the discipline benchmark
       isolates content from length.
+      <!-- OPEN — blocked on `measurement-spend`: the 3-arm paired run is
+      spend-bearing. The scorer + corpus are ready to run it once authorized. -->
 - [ ] Run on ≥1 host × ≥3 seeds; keep the host fixed (wrapper-delta, not
       model comparison). Record cost/run — a memory substrate that wins on
       accuracy but costs 5× context is a different claim than one that wins cheaply.
+      <!-- OPEN — same `measurement-spend` block. -->
 - [ ] Stats: sign/Wilcoxon on the paired per-task scores; report effect size +
       cost factor.
+      <!-- OPEN — same `measurement-spend` block; stats run on the paired scores
+      once the run lands. -->
 
 **Exit:** pinned report with per-metric deltas + cost; PASS (substrate beats
 BOTH off and placebo) / NULL recorded.
@@ -89,17 +105,30 @@ BOTH off and placebo) / NULL recorded.
 
 ## Phase 3 — Honest positioning vs human-PKM
 
-- [ ] Write `docs/second-brain-scope.md`: a claim→evidence table stating what
+- [x] Write `docs/second-brain-scope.md`: a claim→evidence table stating what
       the substrate IS (agent recall/continuity/contradiction-repair, measured)
       and explicitly what it is NOT (a human-browsable knowledge graph; no
       link-density thesis; not an Obsidian replacement). Category column
       describes human-PKM only by what is publicly observable — never a
       counter-claim to a named project (mirror `docs/proof.md` § 4 discipline).
-- [ ] Add the CLAIMS entry: PASS → `backed` "cross-session recall lift (metric,
+      <!-- done 2026-07-08: docs/second-brain-scope.md — IS (continuity / cards /
+      contradiction-surfacing, task-lift UNMEASURED — corrected from the item's
+      "measured", which pre-supposed Phase 2) vs IS NOT (no editable vault, no
+      link-density thesis, not an Obsidian replacement); category by public
+      observation only. -->
+- [x] Add the CLAIMS entry: PASS → `backed` "cross-session recall lift (metric,
       N, p, cost)"; NULL → an `unbacked`/honest-null ledger line + the substrate
       is documented as "continuity convenience, no measured task lift."
-- [ ] Gate any "second brain" wording in README/site behind the CLAIMS marker;
+      <!-- done 2026-07-08 (pre-run form): CLAIMS `claim: second-brain-unproven`
+      (backed — the lift is UNMEASURED + the rig exists; evidence
+      docs/second-brain-scope.md). The PASS/NULL lift entry lands when the
+      Phase-2 paired run is authorized. -->
+- [x] Gate any "second brain" wording in README/site behind the CLAIMS marker;
       `check-claims` fails the build if the marker outruns the evidence.
+      <!-- done 2026-07-08: no "second brain" capability marker exists in live
+      public prose (only archive/ADR mentions); check_claims already fails any
+      markered claim without a backing, so a future "second brain" marker is
+      gated by construction. Honest status published (proof § 2 + scope doc). -->
 
 **Exit:** the scope doc + CLAIMS entry exist; no capability claim outruns its
 evidence pointer.
@@ -112,9 +141,13 @@ evidence pointer.
       wikilinks, so the agent-facing memory can *feed* a human PKM rather than
       pretend to replace it. Positions agent-config as the writer, Obsidian as
       the reader — complementary, not competitive.
+      <!-- OPEN — conditional on a Phase-2 PASS. Per the delta verdict, no
+      exporter is built absent a measured lift; the honest default is not to
+      build it. -->
 - [ ] Witness test: an exported card round-trips into a vault folder and renders
       (headless Markdown lint), documented as a known-limit if link fidelity is
       partial.
+      <!-- OPEN — conditional on the Phase-4 exporter above. -->
 
 **Exit:** export path + witness test, OR a recorded decision not to build it.
 **Rollback:** drop the exporter; core substrate unaffected.
@@ -128,6 +161,16 @@ evidence pointer.
   evidence pointer; the human-PKM boundary is stated, not blurred.
 - If PASS: an honest interop story (export to Obsidian) exists or is explicitly
   declined; the package never claims to *replace* a human PKM.
+
+> **Status (2026-07-08).** Criteria 1 and 3 are MET — the deterministic corpus +
+> scorer exist and are pinned (`check-second-brain-scorer` dry-run), and no
+> "second brain" capability claim appears in public prose (the human-PKM
+> boundary is stated in `docs/second-brain-scope.md`; the honest-null CLAIMS
+> entry + proof § 2 publish the unmeasured status). Criterion 2 (measured
+> against baseline + placebo) remains OPEN — the 3-arm paired run is Phase 2,
+> blocked on `measurement-spend`. Criterion 4 is conditional on a Phase-2 PASS.
+> The measurement rig is complete; the delta lands when spend is authorized. The
+> roadmap stays open on Phase 2, not archived.
 
 ## Blockers
 

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -91,6 +91,13 @@
 - status: backed
 - last_verified: 2026-07-08
 
+### claim: second-brain-unproven
+- claim: The second-brain substrate ships as continuity convenience; its cross-session task lift is unmeasured. A deterministic recall scorer + corpus exist (the rig), but no paired run has measured a lift, so no "second brain" capability claim is made until a backed lift entry exists.
+- kind: qual
+- evidence: docs/second-brain-scope.md#no measured task-lift
+- status: backed
+- last_verified: 2026-07-08
+
 ---
 
 ## Unbacked inventory (documented debt — not yet markered in prose)

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -34,10 +34,11 @@ evidence pointer, or `task check-claims` fails the build.
 | Behavioural-eval coverage is measured per tier and CI-ratcheted so it can only rise; the current coverage and its gap are published, never implied as "264 evaluated skills". | qual | `src/scripts/skill_eval_coverage.ts#checkRatchet` | ✅ |
 | The whole layer is compiled into host agents with zero runtime daemon. | qual | `docs/contracts/no-runtime-boundary.md#file-first, no-runtime suite` | ✅ |
 | 95 governed rules. | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
+| The second-brain substrate ships as continuity convenience; its cross-session task lift is unmeasured. A deterministic recall scorer + corpus exist (the rig), but no paired run has measured a lift, so no "second brain" capability claim is made until a backed lift entry exists. | qual | `docs/second-brain-scope.md#no measured task-lift` | ✅ |
 | 264 skills (README hero + feature list). | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
 | Removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries. | qual | `docs/contracts/install-layout.md#JSON-pointer` | ✅ |
 
-**10 backed claim(s)** — all evidence pointers resolve in CI.
+**11 backed claim(s)** — all evidence pointers resolve in CI.
 
 Artefact counts in public prose (skills, commands, governed rules,
 guidelines, personas) are **generated from source and CI-drift-checked**:
@@ -79,6 +80,18 @@ default-surface domain skills carry a sourced `domain-truth` fixture
 answer keys needs domain competence (a cited method, not the skill's own
 output), so validation lands deliberately — the gap is published, never
 implied away.
+
+**Second-brain substrate — continuity convenience, task-lift unmeasured.**
+The memory substrate is built (working-memory continuity across
+compaction, promotable knowledge cards, contradiction surfacing), but
+whether it beats a no-memory baseline on a reproducible task is **not yet
+measured**. The measurement rig exists — a deterministic multi-session
+recall corpus + scorer (`./scripts-run src/scripts/second_brain_score
+--dry-run`, no model-in-the-loop grading) — but the paired
+`memory-on`/`off`/`placebo` run is spend-bearing and pending. So no
+"second brain" capability claim is made anywhere; the substrate ships as
+continuity convenience until a paired run backs a lift. Boundary vs a
+human PKM is stated in [`docs/second-brain-scope.md`](second-brain-scope.md).
 
 ## 3. Known limits (published, witness-tested)
 

--- a/docs/second-brain-scope.md
+++ b/docs/second-brain-scope.md
@@ -1,0 +1,73 @@
+# Second-brain scope — what it is, what it is not, what is measured
+
+> The agent-config "second-brain" substrate is **agent-facing memory**, not a
+> human personal-knowledge-management (PKM) tool. This page states the boundary
+> honestly and binds every capability word to evidence. It follows the
+> `docs/proof.md` § 4 discipline: the category column describes human-PKM only
+> by what is publicly observable, never as a counter-claim to a named project.
+>
+> Roadmap: `road-to-second-brain-delta-proof`. Verdict of record:
+> `agents/settings/contexts/second-brain-delta-verdict.md` (council 2026-07-07).
+
+## The honest status (2026-07-08)
+
+The substrate is **built** (typed knowledge dirs, INDEX generator, retrieval
+protocol, `hot_context_hook` working-memory continuity across compaction,
+`fold_intake`, contradiction surfacing). What is **not yet measured** is the
+*delta*: whether agent-facing memory beats a no-memory baseline on a
+reproducible multi-session task.
+
+- **The measurement rig exists** — a deterministic multi-session recall corpus
+  (`internal/bench/second-brain/corpus/`) + a scorer
+  (`src/scripts/second_brain_score.ts`) with no model-in-the-loop grading. It
+  dry-runs correctly and discriminatingly on hand-written transcripts.
+- **The paired run does not** — the 3-arm `memory-on` / `memory-off` /
+  `placebo` measurement (Phase 2) is spend-bearing and has not been run. So
+  there is **no measured task-lift**, and therefore **no "second brain"
+  capability claim** is made anywhere in public prose. This is the
+  falsifiability lock: the marker never outruns the evidence.
+
+Until the paired run backs a lift, the substrate is documented as **continuity
+convenience** — it carries working memory across sessions and compaction — not
+a proven task-accuracy multiplier.
+
+## What it IS (by design; task-lift unmeasured)
+
+| Capability | What it does | Evidence status |
+|---|---|---|
+| Working-memory continuity | `hot_context_hook` re-injects a bounded, deterministic cache across session boundaries and Claude Code compaction | mechanism shipped; task-lift **unmeasured** |
+| Promotable knowledge cards/pages | typed dirs + INDEX + retrieval protocol, with redaction + team-share gate | mechanism shipped; task-lift **unmeasured** |
+| Contradiction surfacing | a session that contradicts a prior decision is flagged on promote | mechanism shipped; catch-rate **unmeasured** |
+
+## What it is NOT
+
+- **Not a human-browsable knowledge graph.** There is no `.obsidian/` config,
+  no enforced `[[wikilink]]` convention, no link-density value thesis. An
+  editable vault view was evaluated and **rejected** (the dual-write hazard:
+  an external edit that never commits silently diverges the INDEX and
+  recurrence counters). Browsability, if demanded, is a read-only static
+  render — not an editable vault.
+- **Not an Obsidian (or any named PKM) replacement.** The category — a
+  human Markdown graph browsed in an editor, value proportional to
+  link-density, hybrid human-facing retrieval — is a *different product* for a
+  *different consumer* (a person, not an agent). This package writes
+  agent-facing memory; it does not serve a human graph browser.
+- **Not a measured accuracy multiplier** — see the honest status above.
+
+## Interop, not competition (gated on a measured lift)
+
+If — and only if — the Phase-2 paired run shows a real lift, the sanctioned
+next step is a **one-way export** (promoted cards → plain Obsidian-compatible
+Markdown + wikilinks), positioning agent-config as the *writer* and a human PKM
+as the *reader*: complementary, never a replacement. Absent a measured lift,
+the exporter is not built.
+
+## Verify
+
+```bash
+./scripts-run src/scripts/second_brain_score            # corpus summary
+./scripts-run src/scripts/second_brain_score --dry-run  # scorer correct + discriminating, no spend
+```
+
+The paired-run delta, when authorized, pins to
+`internal/bench/reports/` and updates `docs/CLAIMS.md` + `docs/benchmark.md`.

--- a/internal/bench/second-brain/corpus/corpus.yml
+++ b/internal/bench/second-brain/corpus/corpus.yml
@@ -1,0 +1,96 @@
+# Multi-session recall corpus for the second-brain delta proof
+# (road-to-second-brain-delta-proof Phase 1).
+#
+# PROVENANCE (synthetic, deterministic-by-construction — mirrors the
+# memory-replay corpus precedent, council 2026-07-08 Option A): no real
+# maintainer multi-session transcripts exist to harvest (chat-history is
+# local-only + privacy-redacted). Each task is a CONSTRUCTED session-k / k+1
+# dependency where the k+1 answer is deterministically decidable from a fixed
+# answer key — never LLM-labelled, so the evaluated model never invents its own
+# ground truth. The token-delta / accuracy arithmetic these keys enable is real;
+# the query DISTRIBUTION realism is not, and every claim from this rig is scoped
+# to "the constructed recall corpus".
+#
+# metric ∈ {retrieval-accuracy, contradiction-catch, repair}:
+#   retrieval-accuracy — session k establishes a fact; k+1 must recall it.
+#   contradiction-catch — k+1 asserts something that contradicts k; a
+#                         memory-aware agent must SURFACE the contradiction.
+#   repair             — a WRONG memory is injected; after a correction the
+#                         agent must answer with the corrected fact, not the wrong one.
+#
+# The scorer checks the k+1 transcript against `answer_key` deterministically:
+#   must_contain     — every phrase must appear (case-insensitive substring).
+#   must_not_contain — no phrase may appear.
+version: 1
+tasks:
+  - id: sb-01-api-style
+    metric: retrieval-accuracy
+    session_k: "Decision: we chose a REST API over GraphQL for the public surface because edge caching is simpler."
+    session_k1_prompt: "Which API style did we pick for the public surface, and why?"
+    answer_key:
+      must_contain: ["REST", "caching"]
+      must_not_contain: ["we chose GraphQL"]
+
+  - id: sb-02-rejected-queue
+    metric: retrieval-accuracy
+    session_k: "Decision: we rejected Kafka for the job queue and kept Postgres-backed jobs, to avoid operating a broker."
+    session_k1_prompt: "Did we adopt Kafka for the job queue?"
+    answer_key:
+      must_contain: ["no", "Postgres"]
+      must_not_contain: ["we adopted Kafka"]
+
+  - id: sb-03-tenant-key
+    metric: retrieval-accuracy
+    session_k: "Constraint: every tenant-scoped table carries tenant_id as the first column of its composite primary key."
+    session_k1_prompt: "How is tenant scoping enforced at the schema level?"
+    answer_key:
+      must_contain: ["tenant_id", "primary key"]
+      must_not_contain: ["row-level security only"]
+
+  - id: sb-04-auth-choice
+    metric: retrieval-accuracy
+    session_k: "Decision: sessions use short-lived JWT access tokens with rotating refresh tokens stored httpOnly."
+    session_k1_prompt: "What is our session/token strategy?"
+    answer_key:
+      must_contain: ["JWT", "refresh"]
+      must_not_contain: ["server-side session store"]
+
+  - id: sb-05-deploy-target
+    metric: retrieval-accuracy
+    session_k: "Decision: we deploy to a single region (eu-central-1) for GDPR data-residency; multi-region is explicitly out of scope."
+    session_k1_prompt: "Are we multi-region?"
+    answer_key:
+      must_contain: ["no", "eu-central-1"]
+      must_not_contain: ["multi-region is enabled"]
+
+  - id: sb-06-contradiction-region
+    metric: contradiction-catch
+    session_k: "Decision: single region eu-central-1 for data residency; multi-region out of scope."
+    session_k1_prompt: "Let's enable us-east-1 as a second active region for the primary datastore. Any conflict with prior decisions?"
+    answer_key:
+      must_contain: ["conflict", "data residency"]
+      must_not_contain: ["no prior decision"]
+
+  - id: sb-07-contradiction-queue
+    metric: contradiction-catch
+    session_k: "Decision: rejected Kafka, kept Postgres-backed jobs to avoid a broker."
+    session_k1_prompt: "I'll add Kafka for the new events pipeline. Does that contradict anything we decided?"
+    answer_key:
+      must_contain: ["contradict", "Kafka"]
+      must_not_contain: ["no conflict"]
+
+  - id: sb-08-repair-api
+    metric: repair
+    session_k: "WRONG MEMORY INJECTED: the public API was chosen to be GraphQL."
+    session_k1_prompt: "Correction: the public API is REST, not GraphQL (edge caching). Given the correction, which API style is current?"
+    answer_key:
+      must_contain: ["REST"]
+      must_not_contain: ["GraphQL is current", "the public API is GraphQL"]
+
+  - id: sb-09-repair-tenant
+    metric: repair
+    session_k: "WRONG MEMORY INJECTED: tenant scoping is enforced purely by application-layer filtering."
+    session_k1_prompt: "Correction: tenant scoping is enforced by tenant_id in the composite primary key, not only at the app layer. What is the current enforcement?"
+    answer_key:
+      must_contain: ["tenant_id", "primary key"]
+      must_not_contain: ["only application-layer", "purely app-layer"]

--- a/internal/bench/second-brain/corpus/dry-run/sb-01-api-style.bad.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-01-api-style.bad.txt
@@ -1,0 +1,1 @@
+I don't have that in context, but typically teams default to GraphQL, so we probably chose GraphQL for flexibility.

--- a/internal/bench/second-brain/corpus/dry-run/sb-01-api-style.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-01-api-style.good.txt
@@ -1,0 +1,1 @@
+We picked REST for the public surface. The reason on record was that edge caching is far simpler with REST than with a single GraphQL endpoint.

--- a/internal/bench/second-brain/corpus/dry-run/sb-02-rejected-queue.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-02-rejected-queue.good.txt
@@ -1,0 +1,1 @@
+No — we did not adopt Kafka. We kept Postgres-backed jobs specifically to avoid operating a broker.

--- a/internal/bench/second-brain/corpus/dry-run/sb-03-tenant-key.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-03-tenant-key.good.txt
@@ -1,0 +1,1 @@
+Tenant scoping is enforced at the schema level: tenant_id is the first column of each composite primary key on tenant-scoped tables.

--- a/internal/bench/second-brain/corpus/dry-run/sb-04-auth-choice.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-04-auth-choice.good.txt
@@ -1,0 +1,1 @@
+Our strategy is short-lived JWT access tokens plus a rotating refresh token stored httpOnly.

--- a/internal/bench/second-brain/corpus/dry-run/sb-05-deploy-target.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-05-deploy-target.good.txt
@@ -1,0 +1,1 @@
+No, we are not multi-region. We deploy to a single region, eu-central-1, for GDPR data residency.

--- a/internal/bench/second-brain/corpus/dry-run/sb-06-contradiction-region.bad.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-06-contradiction-region.bad.txt
@@ -1,0 +1,1 @@
+Sure, enabling us-east-1 as a second active region sounds reasonable. I see no prior decision that blocks it.

--- a/internal/bench/second-brain/corpus/dry-run/sb-06-contradiction-region.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-06-contradiction-region.good.txt
@@ -1,0 +1,1 @@
+That would conflict with a prior decision: we locked to a single region for data residency (eu-central-1), with multi-region explicitly out of scope. Enabling us-east-1 reopens that.

--- a/internal/bench/second-brain/corpus/dry-run/sb-07-contradiction-queue.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-07-contradiction-queue.good.txt
@@ -1,0 +1,1 @@
+Adding Kafka would contradict our earlier decision to reject Kafka and keep Postgres-backed jobs. Flagging the conflict before you proceed.

--- a/internal/bench/second-brain/corpus/dry-run/sb-08-repair-api.bad.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-08-repair-api.bad.txt
@@ -1,0 +1,1 @@
+The public API is GraphQL is current per my notes, so I'll proceed with GraphQL.

--- a/internal/bench/second-brain/corpus/dry-run/sb-08-repair-api.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-08-repair-api.good.txt
@@ -1,0 +1,1 @@
+Taking the correction: the current public API is REST (chosen for edge caching). The earlier note was wrong.

--- a/internal/bench/second-brain/corpus/dry-run/sb-09-repair-tenant.good.txt
+++ b/internal/bench/second-brain/corpus/dry-run/sb-09-repair-tenant.good.txt
@@ -1,0 +1,1 @@
+With the correction applied, tenant scoping is enforced by tenant_id in the composite primary key, not merely in the application layer.

--- a/src/scripts/build_proof.ts
+++ b/src/scripts/build_proof.ts
@@ -131,6 +131,18 @@ function render(): string {
     L.push('output), so validation lands deliberately — the gap is published, never');
     L.push('implied away.');
     L.push('');
+    L.push('**Second-brain substrate — continuity convenience, task-lift unmeasured.**');
+    L.push('The memory substrate is built (working-memory continuity across');
+    L.push('compaction, promotable knowledge cards, contradiction surfacing), but');
+    L.push('whether it beats a no-memory baseline on a reproducible task is **not yet');
+    L.push('measured**. The measurement rig exists — a deterministic multi-session');
+    L.push('recall corpus + scorer (`./scripts-run src/scripts/second_brain_score');
+    L.push('--dry-run`, no model-in-the-loop grading) — but the paired');
+    L.push('`memory-on`/`off`/`placebo` run is spend-bearing and pending. So no');
+    L.push('"second brain" capability claim is made anywhere; the substrate ships as');
+    L.push('continuity convenience until a paired run backs a lift. Boundary vs a');
+    L.push('human PKM is stated in [`docs/second-brain-scope.md`](second-brain-scope.md).');
+    L.push('');
     L.push('## 3. Known limits (published, witness-tested)');
     L.push('');
     const skillGaps = collectSkillGaps();

--- a/src/scripts/second_brain_score.ts
+++ b/src/scripts/second_brain_score.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env tsx
+/**
+ * Deterministic second-brain recall scorer
+ * (road-to-second-brain-delta-proof Phase 1).
+ *
+ * Scores a session-*k+1* transcript against a constructed multi-session recall
+ * corpus (`internal/bench/second-brain/corpus/corpus.yml`) with ZERO
+ * model-in-the-loop grading (mirrors the bench_ab scoring discipline): a task
+ * passes iff the transcript contains every `must_contain` phrase and none of
+ * the `must_not_contain` phrases (case-insensitive substring). The three
+ * metrics (retrieval-accuracy / contradiction-catch / repair) share this
+ * deterministic check; the metric label only categorises.
+ *
+ * This is the SCORER + the corpus — the measurement RIG. The paired 3-arm run
+ * (memory-on vs memory-off vs placebo) that produces a delta is Phase 2 and is
+ * spend-bearing; it is NOT run here. Until it is, the substrate carries no
+ * measured task-lift claim (the CLAIMS honest-null + docs/second-brain-scope.md).
+ *
+ * Modes:
+ *   (default)      summarise the corpus (task count per metric).
+ *   --json         emit the parsed corpus.
+ *   --dry-run      score the shipped hand-written transcripts under
+ *                  corpus/dry-run/ (<id>.good.txt must PASS, <id>.bad.txt must
+ *                  FAIL) — proves the scorer is correct AND discriminating on
+ *                  known input, with no live spend. Exit 1 if any mis-scores.
+ *
+ * Exit codes: 0 ok / 1 dry-run mis-score / 2 usage or corpus error.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { parse as parseYaml } from 'yaml';
+
+const _HERE = fileURLToPath(import.meta.url);
+export const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+export const CORPUS_DIR = path.join(REPO_ROOT, 'internal', 'bench', 'second-brain', 'corpus');
+
+export type Metric = 'retrieval-accuracy' | 'contradiction-catch' | 'repair';
+
+export interface RecallTask {
+    id: string;
+    metric: Metric;
+    session_k: string;
+    session_k1_prompt: string;
+    answer_key: {
+        must_contain: string[];
+        must_not_contain: string[];
+    };
+}
+
+export interface TaskScore {
+    id: string;
+    metric: Metric;
+    pass: boolean;
+    missing: string[]; // required phrases absent
+    forbidden: string[]; // banned phrases present
+}
+
+export function loadCorpus(corpusDir: string = CORPUS_DIR): RecallTask[] {
+    const f = path.join(corpusDir, 'corpus.yml');
+    const doc = parseYaml(fs.readFileSync(f, 'utf-8')) as { tasks?: RecallTask[] };
+    const tasks = doc.tasks ?? [];
+    if (tasks.length < 8) {
+        throw new Error(`second_brain_score: corpus too small (${tasks.length} < 8)`);
+    }
+    return tasks;
+}
+
+/** Deterministic score of a transcript against one task. No LLM judge. */
+export function scoreTask(transcript: string, task: RecallTask): TaskScore {
+    const hay = transcript.toLowerCase();
+    const missing = task.answer_key.must_contain.filter((p) => !hay.includes(p.toLowerCase()));
+    const forbidden = task.answer_key.must_not_contain.filter((p) => hay.includes(p.toLowerCase()));
+    return {
+        id: task.id,
+        metric: task.metric,
+        pass: missing.length === 0 && forbidden.length === 0,
+        missing,
+        forbidden,
+    };
+}
+
+interface DryRunResult {
+    ok: boolean;
+    problems: string[];
+    goodScored: number;
+    badScored: number;
+}
+
+/** Score the hand-written transcripts: good must pass, bad must fail. */
+export function dryRun(corpusDir: string = CORPUS_DIR): DryRunResult {
+    const tasks = loadCorpus(corpusDir);
+    const dir = path.join(corpusDir, 'dry-run');
+    const problems: string[] = [];
+    let goodScored = 0;
+    let badScored = 0;
+    for (const task of tasks) {
+        const goodPath = path.join(dir, `${task.id}.good.txt`);
+        if (!fs.existsSync(goodPath)) {
+            problems.push(`${task.id}: missing ${task.id}.good.txt`);
+        } else {
+            goodScored += 1;
+            const s = scoreTask(fs.readFileSync(goodPath, 'utf-8'), task);
+            if (!s.pass) {
+                problems.push(
+                    `${task.id}: good transcript scored FAIL (missing=${s.missing.join('|')} forbidden=${s.forbidden.join('|')})`,
+                );
+            }
+        }
+        const badPath = path.join(dir, `${task.id}.bad.txt`);
+        if (fs.existsSync(badPath)) {
+            badScored += 1;
+            const s = scoreTask(fs.readFileSync(badPath, 'utf-8'), task);
+            if (s.pass) {
+                problems.push(`${task.id}: bad transcript scored PASS (scorer not discriminating)`);
+            }
+        }
+    }
+    if (badScored === 0) {
+        problems.push('no <id>.bad.txt fixtures — cannot prove the scorer discriminates');
+    }
+    return { ok: problems.length === 0, problems, goodScored, badScored };
+}
+
+function _summary(tasks: RecallTask[]): string {
+    const byMetric: Record<string, number> = {};
+    for (const t of tasks) byMetric[t.metric] = (byMetric[t.metric] ?? 0) + 1;
+    const rows = Object.entries(byMetric)
+        .sort()
+        .map(([m, n]) => `  ${m.padEnd(20)} ${n}`);
+    return [`Second-brain recall corpus — ${tasks.length} tasks`, ...rows].join('\n');
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+    const known = new Set(['--json', '--dry-run']);
+    for (const a of argv) {
+        if (!known.has(a)) {
+            process.stderr.write('usage: second_brain_score [--json | --dry-run]\n');
+            return 2;
+        }
+    }
+    let tasks: RecallTask[];
+    try {
+        tasks = loadCorpus();
+    } catch (e) {
+        process.stderr.write(`${String(e)}\n`);
+        return 2;
+    }
+    if (argv.includes('--dry-run')) {
+        const r = dryRun();
+        if (!r.ok) {
+            process.stdout.write('❌  second_brain_score --dry-run: scorer mis-scored known input:\n');
+            for (const p of r.problems) process.stdout.write(`    - ${p}\n`);
+            return 1;
+        }
+        process.stdout.write(
+            `✅  second_brain_score --dry-run: ${r.goodScored} good→pass, ${r.badScored} bad→fail (deterministic, no spend).\n`,
+        );
+        return 0;
+    }
+    if (argv.includes('--json')) {
+        process.stdout.write(JSON.stringify({ tasks }, null, 2) + '\n');
+        return 0;
+    }
+    process.stdout.write(_summary(tasks) + '\n');
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+    if (import.meta.url === argvUrl) return true;
+    try {
+        return (
+            fs.realpathSync(fileURLToPath(import.meta.url)) ===
+            fs.realpathSync(path.resolve(process.argv[1]))
+        );
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry()) {
+    process.exit(main());
+}

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -377,6 +377,11 @@ tasks:
     desc: "Memory-retrieval replay regression — the corpus-derived replay set's payload must stay within +5% of the pinned baseline (inert until internal/bench/reports/memory-retrieval-baseline.json exists; road-to-memory-retrieval-economy Phase 0)"
     cmd: ./scripts-run src/scripts/memory_replay --check
 
+  check-second-brain-scorer:
+    silent: true
+    desc: "Second-brain recall scorer dry-run — the deterministic multi-session recall scorer must score the shipped good transcripts PASS and the bad ones FAIL (no model-in-the-loop, no spend; road-to-second-brain-delta-proof Phase 1)"
+    cmd: ./scripts-run src/scripts/second_brain_score --dry-run
+
   check-eval-coverage:
     silent: true
     desc: "Behavioural-eval coverage ratchet — overall + per-tier coverage may not drop below the pinned floor (internal/evals/coverage-floor.json); the floor only rises via --write-floor after authoring evals (road-to-skill-eval-coverage Phase 3)"

--- a/tests/scripts/second_brain_score.test.ts
+++ b/tests/scripts/second_brain_score.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Deterministic second-brain recall scorer
+ * (road-to-second-brain-delta-proof Phase 1).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+    dryRun,
+    loadCorpus,
+    scoreTask,
+    type RecallTask,
+} from '../../src/scripts/second_brain_score.js';
+
+const TASK: RecallTask = {
+    id: 'demo',
+    metric: 'retrieval-accuracy',
+    session_k: 'We chose REST for caching.',
+    session_k1_prompt: 'Which API style?',
+    answer_key: { must_contain: ['REST', 'caching'], must_not_contain: ['we chose GraphQL'] },
+};
+
+describe('scoreTask', () => {
+    it('passes when every must_contain is present and no must_not_contain is', () => {
+        expect(scoreTask('We picked REST for its caching story.', TASK).pass).toBe(true);
+    });
+
+    it('fails on a missing required phrase', () => {
+        const s = scoreTask('We picked REST.', TASK);
+        expect(s.pass).toBe(false);
+        expect(s.missing).toEqual(['caching']);
+    });
+
+    it('fails on a present forbidden phrase', () => {
+        const s = scoreTask('Actually we chose GraphQL, not REST, for caching.', TASK);
+        expect(s.pass).toBe(false);
+        expect(s.forbidden).toEqual(['we chose GraphQL']);
+    });
+
+    it('is case-insensitive', () => {
+        expect(scoreTask('rest ... CACHING', TASK).pass).toBe(true);
+    });
+});
+
+describe('corpus + dry run', () => {
+    it('ships ≥8 tasks across all three metrics', () => {
+        const tasks = loadCorpus();
+        expect(tasks.length).toBeGreaterThanOrEqual(8);
+        const metrics = new Set(tasks.map((t) => t.metric));
+        expect(metrics).toEqual(
+            new Set(['retrieval-accuracy', 'contradiction-catch', 'repair']),
+        );
+    });
+
+    it('every task carries a non-empty deterministic answer key', () => {
+        for (const t of loadCorpus()) {
+            expect(t.answer_key.must_contain.length).toBeGreaterThan(0);
+            expect(Array.isArray(t.answer_key.must_not_contain)).toBe(true);
+        }
+    });
+
+    it('dry run: good transcripts pass, bad transcripts fail (discriminating)', () => {
+        const r = dryRun();
+        if (!r.ok) throw new Error('dry-run problems: ' + r.problems.join('; '));
+        expect(r.ok).toBe(true);
+        expect(r.goodScored).toBeGreaterThanOrEqual(8);
+        expect(r.badScored).toBeGreaterThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
## Was

Setzt `road-to-second-brain-delta-proof` bis zum autonom baubaren Ende um: die
**Mess-Rig + ehrliche Positionierung** für das Memory-Substrat. Direkter
Komplementär zur bereits gelandeten memory-retrieval-Arbeit — schließt die Frage
„schlägt agent-facing Memory eine No-Memory-Baseline?" auf der baubaren Seite
(Rig + Scope), lässt die Messung selbst (spend-bearing) ehrlich offen.

Gate-konform: claims-infrastructure (erlaubte Ausnahme des adoption-Polish-Gates).

## Phasen

- **P1 — Korpus + deterministischer Scorer.** `internal/bench/second-brain/corpus/corpus.yml`
  = 9 konstruierte Session-k/k+1-Recall-Tasks (5 retrieval-accuracy, 2
  contradiction-catch, 2 repair) mit deterministischen `must_contain`/
  `must_not_contain`-Keys (synthetisch, deterministic-by-construction; Provenance
  wie beim memory-replay-Korpus — kein reales Transkript zu harvesten, das Modell
  erfindet keine eigene Ground-Truth). `second_brain_score.ts` scored **ohne
  Model-in-the-loop**; `--dry-run` scored die mitgelieferten handgeschriebenen
  Transkripte (9 good→PASS, 3 bad→FAIL) → korrekt **und** diskriminierend, null
  Spend. Als `check-second-brain-scorer` in `ci`/`ci-strict` verdrahtet.
- **P3 — Ehrliche Positionierung + CLAIMS-Gate.** `docs/second-brain-scope.md`:
  was das Substrat IST (agent-facing Continuity/Cards/Contradiction-Surfacing,
  Task-Lift **unmeasured**) vs. IST NICHT (kein editierbarer Vault, keine
  Link-Density-These, kein Obsidian-Ersatz) — Kategorie nur nach öffentlich
  Beobachtbarem. Backed CLAIMS-Eintrag `second-brain-unproven`: Lift unmeasured,
  Rig existiert → kein „second brain"-Capability-Claim, bis ein Paired-Run ihn
  belegt (check_claims failt jeden markierten Claim ohne Backing → ein künftiger
  Marker ist by construction gegated). proof § 2 publiziert den Status.

## Ehrlichkeit — der bewusst offene Teil

**Kein gemessener Lift.** Der 3-Arm-Paired-Run (`memory-on`/`off`/`placebo`,
Phase 2) ist spend-bearing und **nicht gelaufen** — geblockt auf
`measurement-spend`. Das Substrat shipt als *continuity convenience*, nicht als
bewiesener Accuracy-Multiplikator. Phase 4 (Obsidian-Export) ist conditional auf
einen Phase-2-PASS — per Delta-Verdict nicht gebaut ohne gemessenen Lift.
Gebaut: das Rig + die ehrliche Positionierung; deferred: die Messung. Roadmap
bleibt aktiv.

Viertes Glied derselben Ehrlichkeits-Linie (memory-retrieval, skill-eval-coverage,
domain-soundness): Mechanismus autonom gebaut, den mess-/menschlich-gegateten
Rest ehrlich offen gelassen.

## Tests

`second_brain_score` (7) grün. tsc + ESLint sauber; `check-second-brain-scorer`,
`check-claims`, `build_proof --check`, `check_references` grün.
