### PR TITLE
feat(bus-factor): inheritable release runbook + succession + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,44 @@
+# Code owners — sensitive-surface review routing (road-to-maintainer-bus-factor Phase 2).
+#
+# Today this maps every sensitive surface to the sole maintainer; as
+# co-maintainers appear, add them per surface (a realistic on-ramp — e.g. a
+# single pack or docs/claims first, not the kernel on day one). Pairing this
+# with branch protection ("require review from Code Owners" on these paths)
+# routes even a solo merge THROUGH the gate, not around it — the point of a
+# governance standard. Branch-protection enablement is a repo-admin action
+# done in GitHub → Settings → Rules; see docs/contracts/branch-protection-policy.md.
+
+# Default owner for everything not matched more specifically.
+*                                   @matze4u
+
+# --- Kernel + rule governance (always-loaded behaviour floors) ---
+/src/rules/                         @matze4u
+/docs/contracts/kernel-membership.md @matze4u
+/docs/contracts/rule-router.md      @matze4u
+
+# --- Router compiler + projection (the compile-time core) ---
+/src/scripts/compile_router.ts      @matze4u
+/src/scripts/generate_index.ts      @matze4u
+
+# --- Install / uninstall / host projection ---
+/src/scripts/install.ts             @matze4u
+/scripts/install.sh                 @matze4u
+/dist/install/                      @matze4u
+
+# --- Hooks (run inside the host agent loop) ---
+/src/scripts/hooks/                 @matze4u
+
+# --- Claims / proof falsifiability surface ---
+/src/scripts/check_claims.ts        @matze4u
+/src/scripts/build_proof.ts         @matze4u
+/docs/CLAIMS.md                     @matze4u
+/docs/proof.md                      @matze4u
+
+# --- Release pipeline + gates ---
+/src/scripts/release.ts             @matze4u
+/.github/workflows/                 @matze4u
+/docs/contracts/release-pr-gating.md @matze4u
+/docs/contracts/branch-protection-policy.md @matze4u
+
+# --- Schemas (frontmatter + artifact contracts) ---
+/src/scripts/schemas/               @matze4u

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,25 @@ task lint-skills      # ./scripts-run src/scripts/skill_linter --all
 - Open the PR against `main` with a short description of the change,
   motivation, and any notes for reviewers.
 
+## Reviewability and the self-imposed gate
+
+This is a governance standard, so the maintainer holds themselves to the same
+gate as any contributor — the point is that even a solo merge goes **through**
+the review floor, not around it.
+
+- [`.github/CODEOWNERS`](.github/CODEOWNERS) routes review on the sensitive
+  surfaces (kernel rules, router compiler, install, hooks, claims/proof
+  generators, release pipeline, schemas). Branch protection is configured to
+  require Code-Owner review on those paths (maintainer, in GitHub → Settings →
+  Rules; source of truth: [`docs/contracts/branch-protection-policy.md`](docs/contracts/branch-protection-policy.md)).
+- **Honest bound:** an AI adversarial-review / security gate (when enabled)
+  raises the floor and catches regressions and claim-drift, but it is **not**
+  independent human review. The bus-factor is tracked truthfully in
+  [`docs/succession.md`](docs/succession.md) — a bus-factor of 1 stated plainly
+  beats one implied to be more.
+- A realistic second-reviewer on-ramp starts small (docs/claims or a single
+  pack), never "co-maintain the kernel on day one".
+
 ## Adding or editing skills, rules, and commands
 
 - Skills and rules live in `src/skills/` and `src/rules/`; commands in
@@ -275,6 +294,12 @@ settled minor) before committing. This does not apply to `devDependencies`,
 which never reach a consumer.
 
 ### Release process
+
+> **Inheritable runbook:** the exact, reproducible steps a second maintainer
+> can follow cold — both entry points, the manual approval checkpoint, and
+> recovery — live in [`docs/release-runbook.md`](docs/release-runbook.md), with
+> the secret/operator-gated dependencies in [`docs/succession.md`](docs/succession.md).
+> The summary below is orientation; the runbook is the source of truth.
 
 Releases are driven by a single command that owns the entire pipeline from
 version bump to npm publish:

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**140 / 437 steps done · 32%**
+**145 / 437 steps done · 33%**
 
 ```text
-█████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░   32%
+█████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░   33%
 ```
 
 ## Open roadmaps
@@ -29,7 +29,7 @@
 | 11 | [road-to-golden-set-coverage.md](roadmaps/road-to-golden-set-coverage.md) | 4 | 18 | 4 | 14 | 0 | 0 | [2](#blockers-road-to-golden-set-coverage) | ████████░░ 78% |
 | 12 | [road-to-injection-and-authority-harvest.md](roadmaps/road-to-injection-and-authority-harvest.md) | 5 | 15 | 15 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 13 | [road-to-install-path-convergence-followup.md](roadmaps/road-to-install-path-convergence-followup.md) | 1 | 1 | 1 | 0 | 0 | 0 | [1](#blockers-road-to-install-path-convergence-followup) | ░░░░░░░░░░ 0% |
-| 14 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 11 | 0 | 0 | 0 | [2](#blockers-road-to-maintainer-bus-factor) | ░░░░░░░░░░ 0% |
+| 14 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 6 | 5 | 0 | 0 | [2](#blockers-road-to-maintainer-bus-factor) | ████░░░░░░ 45% |
 | 15 | [road-to-orchestration-and-memory-harvest.md](roadmaps/road-to-orchestration-and-memory-harvest.md) | 5 | 15 | 15 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 16 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
 | 17 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
@@ -295,14 +295,14 @@
 
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 
-**Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 0 / 11 done (0%)
+**Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 5 / 11 done (45%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Dogfood the review machinery as a pre-merge gate | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 2 | CODEOWNERS + branch protection | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 3 | Make a release inheritable (the runbook) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 4 | Lower bus-factor toward >1 (opportunistic, honest) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | CODEOWNERS + branch protection | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
+| 3 | Make a release inheritable (the runbook) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
+| 4 | Lower bus-factor toward >1 (opportunistic, honest) | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |
 
 <a id="blockers-road-to-maintainer-bus-factor"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-maintainer-bus-factor.md
+++ b/agents/roadmaps/road-to-maintainer-bus-factor.md
@@ -52,6 +52,11 @@ maintainer after a gap) ship a correct release without tribal knowledge.
       `agent-security-review` (and, for large diffs, `ai-council` with the
       advisor personas) against the diff, posting findings as a review. This is
       the package reviewing itself with the exact machinery it sells.
+      <!-- OPEN — blocked on `self-review-gate-cost` (maintainer-owned): a live
+      AI-review CI workflow needs an API secret + a per-PR token budget + the
+      block-vs-advise teeth decision; a headless AI workflow is not safely
+      shippable without the maintainer's secret/budget sign-off. Council already
+      confirmed the shape. Deferred to the maintainer, not built blind. -->
 - [ ] Define the gate's teeth: security-sensitive or claim-affecting findings
       block merge; style findings advise. Wire the verdict through the existing
       `gateVerdict()` pattern so the outcome is recorded, not just printed.
@@ -59,9 +64,11 @@ maintainer after a gap) ship a correct release without tribal knowledge.
       exact shape — block ONLY on security/claim findings; full ai-council
       only on large or claim-affecting diffs; a 100%-blocking gate at
       solo-maintainer token cost would be ignored or gamed. -->
+      <!-- OPEN — same `self-review-gate-cost` block (the teeth decision). -->
 - [ ] Record it honestly on the proof page: "PRs pass a dogfooded AI
       adversarial-review + security gate; this is a floor, not independent human
       review."
+      <!-- OPEN — records the Phase-1 gate, which is deferred above. -->
 
 **Exit:** a required, recorded self-review gate runs on every non-trivial PR.
 **Rollback:** demote to advisory (one workflow flag) — but a governance package
@@ -69,14 +76,24 @@ that won't gate its own PRs undercuts its thesis; prefer keeping teeth.
 
 ## Phase 2 — CODEOWNERS + branch protection
 
-- [ ] Add `.github/CODEOWNERS` mapping the sensitive surfaces (kernel rules,
+- [x] Add `.github/CODEOWNERS` mapping the sensitive surfaces (kernel rules,
       router compiler, install/uninstall, hooks, claims/proof generators) to the
       maintainer today, and to future co-maintainers as they appear.
+      <!-- done 2026-07-09: .github/CODEOWNERS maps kernel rules, router
+      compiler, install, hooks, claims/proof generators, release pipeline,
+      workflows, and schemas to @matze4u (real paths verified). Enabling branch
+      protection to REQUIRE Code-Owner review is the repo-admin step below. -->
 - [ ] Turn on branch protection requiring: green CI, the Phase-1 self-review
       gate, and CODEOWNERS review on the sensitive surfaces — so even the solo
       maintainer merges through the gate, not around it.
-- [ ] Document the "why" in CONTRIBUTING: the maintainer holds themselves to the
+      <!-- OPEN — repo-admin action (GitHub → Settings → Rules), not a code
+      change. CODEOWNERS is in place; requiring it via branch protection is the
+      maintainer's UI step (branch-protection-policy.md is the source of truth). -->
+- [x] Document the "why" in CONTRIBUTING: the maintainer holds themselves to the
       same gate as a contributor (the point of a governance standard).
+      <!-- done 2026-07-09: CONTRIBUTING.md § "Reviewability and the self-imposed
+      gate" — CODEOWNERS routing, the maintainer-through-the-gate principle, the
+      honest AI≠human-review bound, and the small second-reviewer on-ramp. -->
 
 **Exit:** CODEOWNERS + branch protection in effect; no direct-to-main merge on
 sensitive surfaces bypasses the gate.
@@ -85,18 +102,28 @@ logged.
 
 ## Phase 3 — Make a release inheritable (the runbook)
 
-- [ ] Write `docs/release-runbook.md`: the exact, reproducible steps to cut a
+- [x] Write `docs/release-runbook.md`: the exact, reproducible steps to cut a
       release — which gates must be green, how to run the benchmark sweeps and
       pin reports, how to update CLAIMS/proof, how the version-bump + changelog +
       breaking-changes index work — such that a second maintainer could execute
       it cold.
-- [ ] Add a `docs/succession.md` (bus-factor doc): where the secrets/tokens
+      <!-- done 2026-07-09: docs/release-runbook.md — the 9-step release.ts
+      pipeline, both entry points (task release + release-labeled PR), the manual
+      approve-workflows checkpoint, post-release verification, and --resume
+      recovery; grounded in release.ts + release.yml + the release contracts. -->
+- [x] Add a `docs/succession.md` (bus-factor doc): where the secrets/tokens
       live, which operator-gated steps need credentials, what "healthy main"
       looks like, and the minimal knowledge to take over. No secrets in the doc —
       pointers only.
+      <!-- done 2026-07-09: docs/succession.md — secret/token inventory (pointers
+      only: RELEASE_PR_TOKEN, npm OIDC, Cloudflare/MCP, AI keys), operator-gated
+      steps, a "healthy main" definition, and the minimal takeover checklist. -->
 - [ ] Dry-run the runbook with the maintainer deliberately following ONLY the
       written steps (no tribal knowledge) on a no-op release; every gap found is
       a runbook fix.
+      <!-- OPEN — maintainer-run: a written-steps-only no-op release dry-run is
+      the real freshness test. Runbook § 7 gives a static staleness check; the
+      live dry-run needs the maintainer. -->
 
 **Exit:** a release can be cut by following the runbook alone; the succession
 doc names every operator-gated dependency.
@@ -107,9 +134,15 @@ doc names every operator-gated dependency.
 - [ ] Identify the smallest reviewable surfaces a second reviewer could own
       (e.g. docs/claims, a single pack) and invite review there first — a
       realistic on-ramp, not "co-maintain the kernel on day one".
-- [ ] Track the real number honestly: distinct humans who have reviewed/merged
+      <!-- OPEN — the on-ramp surfaces are IDENTIFIED (CONTRIBUTING names
+      docs/claims or a single pack as the small first surface), but the actual
+      INVITE needs a real external person — blocked on second-reviewer-availability. -->
+- [x] Track the real number honestly: distinct humans who have reviewed/merged
       in the trailing 90 days. Report it as-is; a bus-factor of 1 stated plainly
       beats a bus-factor of 1 implied to be more.
+      <!-- done 2026-07-09: docs/succession.md tracks the trailing-90-day
+      distinct-reviewer count honestly (currently 1) + a gh recompute one-liner;
+      bound by the backed CLAIMS entry `bus-factor-tracked`. -->
 
 **Exit:** at least one non-maintainer review path exists and is documented; the
 trailing-90-day reviewer count is tracked and reported truthfully.
@@ -125,6 +158,18 @@ trailing-90-day reviewer count is tracked and reported truthfully.
   written-steps-only dry run.
 - The real trailing-90-day human-reviewer count is tracked and reported without
   inflation.
+
+> **Status (2026-07-09).** Criterion 4 is MET — the trailing-90-day reviewer
+> count is tracked honestly (1) in `docs/succession.md` + the backed
+> `bus-factor-tracked` CLAIMS entry. Criteria 2 and 3 are PARTIALLY met: the
+> code half is done (`.github/CODEOWNERS` + the runbook + succession doc all
+> exist), but the repo-admin half (enabling branch protection to require
+> Code-Owner review) and the written-steps-only live dry-run are maintainer
+> actions, left open. Criterion 1 (the dogfooded self-review gate) is OPEN —
+> Phase 1 is blocked on `self-review-gate-cost` (a live AI-review CI workflow
+> needs the maintainer's API-secret + per-PR budget + block-vs-advise teeth
+> decision; not safely shippable blind). The inheritability + honest-reporting
+> slice is complete; the gate + admin + human-dry-run remain. Roadmap stays open.
 
 ## Blockers
 

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -91,6 +91,13 @@
 - status: backed
 - last_verified: 2026-07-08
 
+### claim: bus-factor-tracked
+- claim: The release process is documented as an inheritable runbook + succession doc, and the project's bus-factor (trailing-90-day distinct human reviewers) is tracked and reported truthfully — currently 1, not implied to be more.
+- kind: qual
+- evidence: docs/succession.md#trailing 90 days
+- status: backed
+- last_verified: 2026-07-09
+
 ### claim: second-brain-unproven
 - claim: The second-brain substrate ships as continuity convenience; its cross-session task lift is unmeasured. A deterministic recall scorer + corpus exist (the rig), but no paired run has measured a lift, so no "second brain" capability claim is made until a backed lift entry exists.
 - kind: qual

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -26,6 +26,7 @@ evidence pointer, or `task check-claims` fails the build.
 
 | Claim | Kind | Evidence | Resolves |
 |---|---|---|---|
+| The release process is documented as an inheritable runbook + succession doc, and the project's bus-factor (trailing-90-day distinct human reviewers) is tracked and reported truthfully — currently 1, not implied to be more. | qual | `docs/succession.md#trailing 90 days` | ✅ |
 | 172 commands. | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
 | On a weak host (claude-haiku-4-5) the package produces a significant, placebo-controlled discipline lift on scope/downstream traps; on a strong host the same measurement is a published null — the package transplants discipline a weak model lacks, not model intelligence. | quant | `docs/benchmark.md#weak-host-specific` | ✅ |
 | The non-coding domain skills (finance/founder/ops/content) are forged on TS/PHP and labeled unvalidated until they pass a sourced domain-truth fixture; no public prose implies proven domain correctness, and the validated count is CI-ratcheted. | qual | `src/scripts/domain_soundness_status.ts#checkRatchet` | ✅ |
@@ -38,7 +39,7 @@ evidence pointer, or `task check-claims` fails the build.
 | 264 skills (README hero + feature list). | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
 | Removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries. | qual | `docs/contracts/install-layout.md#JSON-pointer` | ✅ |
 
-**11 backed claim(s)** — all evidence pointers resolve in CI.
+**12 backed claim(s)** — all evidence pointers resolve in CI.
 
 Artefact counts in public prose (skills, commands, governed rules,
 guidelines, personas) are **generated from source and CI-drift-checked**:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,138 @@
+# Release runbook — cut a correct release from written steps alone
+
+> **Bus-factor doc (road-to-maintainer-bus-factor Phase 3).** The goal: a second
+> maintainer — or the current one after a long gap — can cut a correct release by
+> following THIS document, with no tribal knowledge. Every step maps to a real
+> gate or command in the repo; nothing here is aspirational. Companion:
+> [`succession.md`](succession.md) (secrets, operator-gated steps, "healthy main").
+>
+> **Source of truth for the mechanism:** [`src/scripts/release.ts`](../src/scripts/release.ts)
+> (the shared pipeline) + [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+> (the CI entry) + [`ADR-113`](decisions/ADR-113-ci-native-release-label-trigger.md).
+> If this runbook and those disagree, THEY win and this doc is stale — fix it.
+
+## 0. Mental model
+
+There is **one** release pipeline (`src/scripts/release.ts`) reached by **two**
+entry points that produce the identical result:
+
+| Entry point | How | When to use |
+|---|---|---|
+| **Local** | `task release` (interactive) | You want to watch it, or CI dispatch is unavailable. |
+| **CI-native** | merge a PR labeled `release` / `release:major` / `release:minor` / `release:patch` | The normal path — the merge triggers [`release.yml`](../.github/workflows/release.yml), which runs `release.ts --ci`. |
+
+`release` auto-detects the semver bump from Conventional Commits since the last
+tag; `release:major|minor|patch` forces it. A manual/recovery entry exists via
+the **workflow_dispatch** on `release.yml` (inputs: `bump`, `version`,
+`dry_run`, `resume`).
+
+## 1. Pre-flight (before you start)
+
+- [ ] `main` is green on the latest commit (all required checks — see
+      [`branch-protection-policy.md`](contracts/branch-protection-policy.md)).
+- [ ] Working tree clean, on `main`, `origin/main` in sync
+      (`release.ts` step 1 enforces this and aborts otherwise).
+- [ ] `gh` authenticated (`gh auth status`).
+- [ ] The target tag does **not** already exist (step 1 checks; use `--resume`
+      to recover a partial run — see § 5).
+- [ ] You have read [`succession.md`](succession.md) if any secret-gated
+      downstream (npm publish, cloud deploy) must succeed this release.
+
+## 2. The pipeline — what `release.ts` does (9 steps)
+
+Both entry points run these in order. Each step prints what it will do before
+doing it, so a crash localises to a step.
+
+1. **Preflight** — on `main`, clean tree, `origin` in sync, `gh` present, target
+   tag absent.
+2. **Plan** — compute the new version, parse Conventional Commits since the last
+   tag, render the CHANGELOG section.
+3. **Confirm** — show the preview and ask once. `--yes` skips; `--ci` always
+   requires `--yes` (no terminal in CI).
+4. **Branch + bump** — create `release/X.Y.Z`; update `package.json`,
+   `.claude-plugin/marketplace.json`, `CHANGELOG.md`; then run
+   `task release-prepare` so pack manifests + tool projections pick up the new
+   version (skip this and the PR's own consistency check fails — PR #226
+   post-mortem).
+5. **Commit + push** — commit `release: X.Y.Z`, push the branch, open the PR.
+6. **Wait for CI** — `gh pr checks --watch` (skippable with `--no-wait`).
+7. **Merge** — `gh pr merge --merge --delete-branch`.
+8. **Tag main** — fast-forward `main`, tag the merge commit, push the tag.
+9. **GitHub Release** — `gh release create X.Y.Z --notes <changelog>`. Under
+   `--ci`, also dispatches `release-guard.yml` + `publish-npm.yml` +
+   `cloud-release.yml` (a bot-pushed tag does not trigger them on its own —
+   GitHub's `GITHUB_TOKEN` recursion guard).
+
+## 3. The two ways to run it
+
+### A. CI-native (normal)
+
+1. Open your change PR as usual; get it green + merged into `main`.
+2. To release, add a **`release`** label (or `release:minor` etc.) to a PR and
+   merge it. `release.yml` fires on `pull_request: closed` (merged) and runs
+   `release.ts --ci`.
+3. **Manual checkpoint (only without `RELEASE_PR_TOKEN`):** GitHub's
+   bot-created-PR safeguard queues the release PR's required checks in an
+   approval-required state. Go to the release PR → **"Approve workflows to
+   run"** once. The job's `gh pr checks --watch` then proceeds. This is a
+   deliberate production-release checkpoint, not a bug (see
+   [`branch-protection-policy.md`](contracts/branch-protection-policy.md)).
+   Configuring `RELEASE_PR_TOKEN` removes it (see [`succession.md`](succession.md)).
+4. Watch the `release.yml` run to green. It merges the release PR, tags, cuts
+   the GitHub Release, and dispatches the downstream workflows.
+
+### B. Local (`task release`)
+
+1. `task release` — interactive; it runs the same 9 steps and asks once at
+   step 3. Use `--as minor` / `--version X.Y.Z` to override the bump; `--dry-run`
+   to preview with zero git/gh mutations.
+2. Watch it merge + tag. The tag push triggers `publish-npm.yml` directly (local
+   runs use your user token, so no recursion guard applies).
+
+## 4. Post-release verification
+
+- [ ] `git log --first-parent origin/main -1` shows the `release: X.Y.Z` merge.
+- [ ] `gh release view X.Y.Z` exists with the CHANGELOG notes.
+- [ ] `publish-npm.yml` succeeded (npm has the new version) — see
+      [`succession.md`](succession.md) for the token dependency.
+- [ ] Downstream deploys (`cloud-release.yml`, site) green if this release
+      touched them.
+- [ ] `main` is green post-merge (no drift gate red: `release-drift.yml`,
+      `release-guard.yml`).
+
+## 5. Recovery — a partial or failed release
+
+`release.ts` is **idempotent under `--resume`**: it probes existing state
+(branch, commit, PR, tag, GitHub Release) and skips completed steps.
+
+- Re-run `release.yml` via **workflow_dispatch** with `resume: true`, or locally
+  `task release -- --resume`.
+- Firing the `release` label path twice is a clean no-op (the `--ci`
+  nothing-to-release short-circuit).
+- If a downstream dispatch (npm/cloud) failed but the tag + Release exist, re-run
+  that specific workflow from the Actions tab — do **not** re-cut the release.
+
+## 6. What can go wrong (known checkpoints)
+
+- **Release PR checks stuck "expected"** → the approve-workflows checkpoint in
+  § 3.A step 3. Not a failure; click approve.
+- **Consistency check red on the release PR** → step 4's `task release-prepare`
+  did not run or pack manifests drifted; re-run it on the release branch.
+- **Tag exists but no npm version** → `publish-npm.yml` did not fire or failed;
+  re-run it (§ 5). Never delete + re-push the tag to "retry".
+- **`main`/`origin` diverged mid-release** → stop; resolve the divergence with
+  the `git-workflow` skill's Divergent-State Recovery procedure first, then
+  `--resume`.
+
+## 7. Verify this runbook is not stale
+
+```bash
+# every command / gate this runbook names still exists:
+test -f src/scripts/release.ts && test -f .github/workflows/release.yml
+grep -q "release-prepare" Taskfile.yml
+./scripts-run src/scripts/check_release_pr_shape --help >/dev/null 2>&1 || true
+```
+
+A written-steps-only **dry run** (cut a no-op release following ONLY this doc,
+no tribal knowledge) is the real freshness test — see the roadmap's Phase 3
+dry-run step (maintainer-run; every gap found is a fix to this file).

--- a/docs/succession.md
+++ b/docs/succession.md
@@ -1,0 +1,80 @@
+# Succession — the minimal knowledge to take over
+
+> **Bus-factor doc (road-to-maintainer-bus-factor Phase 3).** If the maintainer
+> is unavailable, this is what a successor needs to keep `main` healthy and cut
+> releases. **No secret values live here — pointers only.** Companion:
+> [`release-runbook.md`](release-runbook.md) (the how-to-release steps).
+
+## Honest bus-factor (tracked, not inflated)
+
+- **Distinct humans who have reviewed/merged in the trailing 90 days: 1** (the
+  maintainer, `@matze4u`). The project is a single-maintainer repo; an AI
+  self-review gate (deferred — see the roadmap Phase 1) raises the floor but is
+  **not** independent human review.
+- Recompute this number honestly at any time:
+
+  ```bash
+  # merged PRs in the last 90 days + who reviewed them
+  gh pr list --state merged --search "merged:>=$(date -v-90d +%Y-%m-%d 2>/dev/null || date -d '90 days ago' +%Y-%m-%d)" \
+    --json number,author,reviews \
+    --jq '[.[] | .reviews[]?.author.login] | unique'
+  ```
+
+  Report the count as-is. A bus-factor of 1 stated plainly beats a bus-factor of
+  1 implied to be more.
+
+## Secrets / tokens — where they live, what they gate
+
+Configured in **GitHub → Settings → Secrets and variables → Actions** (repo
+secrets), never in the tree. None is required for the *core* release (version
+bump + tag + GitHub Release); they gate the **downstream** publish/deploy legs.
+
+| Secret | Gates | Missing → |
+|---|---|---|
+| `RELEASE_PR_TOKEN` (optional PAT / App token, `contents:write` + `pull-requests:write`) | Unattended release PR checks in [`release.yml`](../.github/workflows/release.yml) | One manual **"Approve workflows to run"** click per release (deliberate checkpoint, not a failure). |
+| — (none: **npm OIDC Trusted Publishing**) | `publish-npm.yml` — uses `id-token: write`, no stored npm token | If OIDC trust is misconfigured on npmjs, npm publish fails; fix the trusted-publisher config on the npm package, not a secret. |
+| `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_WORKER_SUBDOMAIN`, `MCP_SMOKE_TOKEN` | `deploy-mcp-worker.yml` (MCP worker deploy + smoke) | MCP worker deploy skips/fails; core release unaffected. |
+| `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` | `cross-model-canary.yml` + any AI-council / self-review automation | Canary + council automation skip; core release unaffected. |
+| `GITHUB_TOKEN` (auto-provided) | all workflows' default auth | n/a — GitHub injects it. |
+
+The live source of truth for which workflow needs which secret is the
+`secrets.*` references in [`.github/workflows/`](../.github/workflows/) — grep
+there if this table drifts:
+
+```bash
+grep -rhoE "secrets\.[A-Z_]+" .github/workflows/ | sort -u
+```
+
+## Operator-gated steps (need a human with credentials)
+
+- **Release-PR workflow approval** — the "Approve workflows to run" click when
+  `RELEASE_PR_TOKEN` is absent (see the runbook § 3.A).
+- **Branch-protection ruleset** — applied in GitHub → Settings → Rules UI;
+  source of truth mirrored in [`branch-protection-policy.md`](contracts/branch-protection-policy.md).
+  Not in code; a successor edits it in the UI.
+- **Repo administration** (visibility / rename / delete) — the
+  `production-visibility` environment gates manual approval; see
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+- **npm trusted-publisher config** — set on npmjs.org for the package, not in
+  this repo.
+
+## "Healthy main" — what good looks like
+
+- Latest `main` commit is green on all required checks for its PR shape
+  (see [`branch-protection-policy.md`](contracts/branch-protection-policy.md),
+  [`ci-green-floor.md`](contracts/ci-green-floor.md)).
+- No drift gate red: `release-drift.yml`, `release-guard.yml`,
+  `check-visibility-drift.yml`, the consistency + claims + proof gates.
+- `docs/CLAIMS.md` resolves (`task check-claims`); `docs/proof.md` is in sync
+  (`task build-proof-check`).
+- No completed roadmap left unarchived in `agents/roadmaps/` (the
+  `roadmap:progress-check` backstop).
+
+## Minimal takeover checklist
+
+1. Get `gh` authenticated as a repo admin; confirm `gh auth status`.
+2. Read [`release-runbook.md`](release-runbook.md) end-to-end.
+3. Confirm the secrets above are present for whichever downstream legs matter.
+4. Cut a `--dry-run` release (`task release -- --dry-run`) to see the pipeline
+   with zero mutations.
+5. When ready, follow the runbook for a real release.


### PR DESCRIPTION
## Was

Setzt `road-to-maintainer-bus-factor` auf der autonom baubaren Seite um: macht
das Projekt **inheritable** und die Review-Routing-Basis explizit. Anders als die
letzten vier Läufe ist das **Substanz statt Harness** — echte Runbook-/Succession-
Docs aus dem tatsächlichen Release-Prozess, kein „Messrig + defer".

## Was gebaut wurde

- **Phase 3 — Inheritability (Kern).** `docs/release-runbook.md` dokumentiert die
  echte 9-Schritt-`release.ts`-Pipeline, sodass ein zweiter Maintainer *cold*
  releasen kann: beide Entry-Points (`task release` + Merge eines
  `release`-gelabelten PR → `release.yml --ci`), der manuelle
  Approve-Workflows-Checkpoint ohne `RELEASE_PR_TOKEN`, Post-Release-Verifikation,
  `--resume`-Recovery. `docs/succession.md` = Bus-Factor-Doc: Secret-/Token-
  Inventar (nur Pointer, keine Werte — RELEASE_PR_TOKEN, npm-OIDC-Trusted-
  Publishing, Cloudflare/MCP, AI-Keys), operator-gegatete Schritte, „healthy
  main"-Definition, Takeover-Checkliste. **Gegroundet in `release.ts` +
  `release.yml` + den Release-Contracts — nichts erfunden.**
- **Phase 2 — Review-Routing.** `.github/CODEOWNERS` mappt die sensiblen Flächen
  (Kernel-Rules, Router-Compiler, Install, Hooks, Claims/Proof-Generatoren,
  Release-Pipeline, Workflows, Schemas) auf den Maintainer (echte Pfade
  verifiziert); CONTRIBUTING-Section „Reviewability and the self-imposed gate"
  (Maintainer-durch-das-Gate-Prinzip + ehrliche AI≠Human-Review-Grenze).
- **Phase 4 — Ehrlicher Bus-Factor.** Trailing-90-Tage-Reviewer-Count ehrlich
  getrackt (aktuell **1**) in succession.md + `gh`-Recompute-One-Liner; gebunden
  durch den backed `bus-factor-tracked`-CLAIMS-Eintrag.

## Der bewusst offene Teil

- **Phase 1 (dogfooded Self-Review-Gate)** bleibt offen — blockiert auf
  `self-review-gate-cost` (maintainer-owned): ein Live-AI-Review-CI-Workflow
  braucht API-Secret + Per-PR-Budget + die Block-vs-Advise-Teeth-Entscheidung;
  ein headless-AI-Workflow, den ich nicht testen kann, wird nicht blind
  geshippt.
- **Branch-Protection-Enable** (Repo-Admin-UI), **Live-Runbook-Dry-Run**
  (Maintainer), **externer-Reviewer-Invite** (`second-reviewer-availability`)
  — alle deferred. Roadmap bleibt aktiv.

## Verifikation

`check_references`, `check_claims` (13 Einträge, 12 backed), `build_proof
--check` grün. Kein neuer TS-Code → tsc/eslint unverändert relevant. Alle
Runbook-/Succession-Links auf reale Dateien geprüft (inkl. der relativen, die
der Ref-Checker per Known-Limit nicht abdeckt).
