### PR TITLE
feat(orchestration): token-savings report over orchestration telemetry

### DIFF
--- a/dist/agent-src/contexts/execution/orchestration-telemetry.md
+++ b/dist/agent-src/contexts/execution/orchestration-telemetry.md
@@ -87,6 +87,21 @@ capture path (decided 2026-06-30, maintainer decision; see
    response length (chars / 4 ≈ tokens). Set `token_delta_provenance:
    "estimated"`. Lossy; measured always preferred.
 
+## Savings report
+
+Aggregate accumulated telemetry into a token-savings report:
+
+```bash
+./scripts-run src/scripts/orchestration_savings_report [--dir <path>] [--format text|json]
+```
+
+Sums `token_delta` across dispatches (negative = net saved); splits by
+provenance (measured vs estimated), `tier_chosen`, `task_class`. Reports
+**ABSOLUTE net tokens saved, never a percentage**: telemetry records net delta,
+not the absolute in-session baseline → "% of session saved" not derivable. A
+percentage needs an additive absolute-baseline field (deferred follow-up).
+Reader: [`src/scripts/_lib/orchestration_savings.ts`](../../../../src/scripts/_lib/orchestration_savings.ts).
+
 ## Related
 
 - [`audit-log-v1`](../../../../docs/contracts/audit-log-v1.md) — the frozen

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -203,7 +203,7 @@
   "contexts/execution/interrupt-examples.md": "8bda68cd3f8d910d97fc12af9cd1809b69f9766e7c0391782817536d19b32ca0",
   "contexts/execution/non-interactive-contract.md": "8d3cd91409938807321335509cfce54dbe13adaab738d30c749b765d32c6b7ce",
   "contexts/execution/orchestration-benchmark-gate.md": "0f312223ce0b0ee3b34a59a9f102d163524416b82b3b1f64c190f3544efe0862",
-  "contexts/execution/orchestration-telemetry.md": "98f3c06edcba9166df45c95c4ae8df69186c930ad0692f5a45df59935d4de9ef",
+  "contexts/execution/orchestration-telemetry.md": "26f057da552aed1f39568017631455f87e207f2823db89e6a26801f2c3b15a5d",
   "contexts/execution/project-intelligence.md": "4a5aebab8e4467b4021664ac6748c63ab145ddf3b51236bb9327063e137fddbf",
   "contexts/execution/rdp-gate.md": "f82482f945ac1af5baacab26ce384e1e99da3f504c11dca132e45e3cf3234a5e",
   "contexts/execution/roadmap-execution-contract.md": "b1a6dcd0acb16fe9eea2a3f934400c81239a46e3fa5391f22893225b68300d2e",

--- a/src/agent-src/contexts/execution/orchestration-telemetry.md
+++ b/src/agent-src/contexts/execution/orchestration-telemetry.md
@@ -88,6 +88,22 @@ see `road-to-subagent-value-realization.md § Council notes`).
    response length (chars / 4 ≈ tokens). Set `token_delta_provenance:
    "estimated"`. This estimate is lossy; measured is always preferred.
 
+## Savings report
+
+Aggregate the accumulated telemetry into a token-savings report:
+
+```bash
+./scripts-run src/scripts/orchestration_savings_report [--dir <path>] [--format text|json]
+```
+
+It sums `token_delta` across dispatches (negative = net saved) and splits by
+provenance (measured vs estimated), `tier_chosen`, and `task_class`. It reports
+**ABSOLUTE net tokens saved, never a percentage**: the telemetry records net
+delta, not the absolute in-session baseline, so a "% of session saved" is not
+derivable from this data. A percentage would require an additive
+absolute-baseline field on this object (deferred follow-up). Reader:
+[`src/scripts/_lib/orchestration_savings.ts`](../../../../src/scripts/_lib/orchestration_savings.ts).
+
 ## Related
 
 - [`audit-log-v1`](../../../../docs/contracts/audit-log-v1.md) — the frozen

--- a/src/scripts/_lib/orchestration_savings.ts
+++ b/src/scripts/_lib/orchestration_savings.ts
@@ -1,0 +1,127 @@
+/**
+ * Orchestration savings aggregator (pure, no-I/O).
+ *
+ * Aggregates realized orchestration telemetry into a token-savings report.
+ * Consumes the `orchestration` sub-object of audit-log-v1 JSONL lines
+ * (contract: `src/agent-src/contexts/execution/orchestration-telemetry.md`).
+ *
+ * HONEST LIMIT — the telemetry records `token_delta` (net dispatch cost vs the
+ * in-session baseline; negative = saved) but NOT the absolute baseline. A clean
+ * "% of session saved" is therefore NOT derivable from this data alone — only
+ * ABSOLUTE net tokens saved, plus the measured-vs-estimated provenance split.
+ * A percentage would need an absolute-baseline field on the telemetry (see the
+ * report `notes` and the PR's follow-up section).
+ */
+
+export type TokenDeltaProvenance = 'measured' | 'estimated';
+
+/** The `orchestration` sub-object shape we read (subset — additive fields only). */
+export interface OrchestrationRecord {
+    spawn_count?: number;
+    token_delta?: number;
+    token_delta_provenance?: TokenDeltaProvenance;
+    tier_chosen?: string | null;
+    task_class?: string | null;
+    outcome?: string;
+}
+
+/** A parsed audit-log-v1 line (only the fields this aggregator touches). */
+export interface AuditLine {
+    input_kind?: string;
+    orchestration?: OrchestrationRecord;
+}
+
+export interface ProvenanceStat {
+    dispatches: number;
+    /** Σ token_delta for this provenance (negative = net saved). */
+    net_token_delta: number;
+}
+
+export interface SavingsReport {
+    /** Lines carrying an orchestration object with spawn_count > 0. */
+    dispatches: number;
+    total_spawns: number;
+    /** Σ token_delta across all dispatches (negative = net saved). */
+    net_token_delta: number;
+    /** Magnitude of tokens saved (sum of negative deltas, as a positive number). */
+    tokens_saved: number;
+    /** Sum of positive deltas (orchestration that cost MORE than baseline). */
+    tokens_added: number;
+    by_provenance: { measured: ProvenanceStat; estimated: ProvenanceStat };
+    /** tier_chosen → Σ token_delta (negative = net saved on that tier). */
+    by_tier: Record<string, number>;
+    /** task_class → Σ token_delta. */
+    by_task_class: Record<string, number>;
+    /** measured dispatches / dispatches, 0..1 (0 when no dispatches). */
+    measured_share: number;
+    /** Honest caveats about what the number does and does not mean. */
+    notes: string[];
+}
+
+function emptyProvenance(): ProvenanceStat {
+    return { dispatches: 0, net_token_delta: 0 };
+}
+
+/**
+ * Aggregate orchestration telemetry lines into a savings report.
+ *
+ * A line counts as a dispatch only when it carries an `orchestration` object
+ * with `spawn_count > 0` (spawn_count 0 / absent = handled in-session, not a
+ * dispatch). Unknown/absent fields default safely (token_delta → 0, provenance
+ * → estimated) so a pre-extension line never throws.
+ */
+export function aggregateOrchestrationSavings(lines: AuditLine[]): SavingsReport {
+    const report: SavingsReport = {
+        dispatches: 0,
+        total_spawns: 0,
+        net_token_delta: 0,
+        tokens_saved: 0,
+        tokens_added: 0,
+        by_provenance: { measured: emptyProvenance(), estimated: emptyProvenance() },
+        by_tier: {},
+        by_task_class: {},
+        measured_share: 0,
+        notes: [],
+    };
+
+    for (const line of lines) {
+        const o = line.orchestration;
+        if (!o) continue;
+        const spawns = o.spawn_count ?? 0;
+        if (!(spawns > 0)) continue; // in-session, not a dispatch
+
+        report.dispatches += 1;
+        report.total_spawns += spawns;
+
+        const delta = o.token_delta ?? 0;
+        report.net_token_delta += delta;
+        if (delta < 0) report.tokens_saved += -delta;
+        else report.tokens_added += delta;
+
+        // Provenance defaults to `estimated` when unstated (matches the
+        // telemetry contract: estimated is the lossy fallback).
+        const prov: TokenDeltaProvenance = o.token_delta_provenance === 'measured' ? 'measured' : 'estimated';
+        report.by_provenance[prov].dispatches += 1;
+        report.by_provenance[prov].net_token_delta += delta;
+
+        const tier = o.tier_chosen ?? 'unknown';
+        report.by_tier[tier] = (report.by_tier[tier] ?? 0) + delta;
+
+        const cls = o.task_class ?? 'unclassified';
+        report.by_task_class[cls] = (report.by_task_class[cls] ?? 0) + delta;
+    }
+
+    report.measured_share = report.dispatches === 0 ? 0 : report.by_provenance.measured.dispatches / report.dispatches;
+
+    // Honest caveats — always attached so a consumer never over-reads the number.
+    if (report.dispatches === 0) {
+        report.notes.push('No orchestration telemetry yet (0 dispatches). The number accrues as `subagents.auto: on` runs delegate real slices.');
+    } else {
+        report.notes.push('Reports ABSOLUTE net token_delta (negative = saved). A "% of session saved" is NOT derivable — the telemetry records net delta, not the absolute baseline. A percentage needs an absolute-baseline field on the telemetry.');
+        if (report.by_provenance.estimated.dispatches > 0) {
+            report.notes.push(`${report.by_provenance.estimated.dispatches}/${report.dispatches} dispatch(es) use ESTIMATED token_delta (chars/4, lossy). Prefer measured (host usage metadata).`);
+        }
+    }
+
+    return report;
+}

--- a/src/scripts/orchestration_savings_report.ts
+++ b/src/scripts/orchestration_savings_report.ts
@@ -1,0 +1,99 @@
+/**
+ * Orchestration savings report — CLI.
+ *
+ * Reads accumulated orchestration telemetry from the audit-log-v1 JSONL files
+ * and prints an aggregate token-savings report. Read-only; no network, no
+ * mutation. Handles a missing/empty audit dir gracefully.
+ *
+ * Usage:
+ *   ./scripts-run src/scripts/orchestration_savings_report [--dir <path>] [--format text|json]
+ *
+ * Default dir: agents/runtime/state/audit (the audit-log-v1 path where the
+ * orchestration layer writes telemetry lines). See
+ * `src/agent-src/contexts/execution/orchestration-telemetry.md`.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { aggregateOrchestrationSavings, type AuditLine, type SavingsReport } from './_lib/orchestration_savings.js';
+
+const DEFAULT_DIR = 'agents/runtime/state/audit';
+
+interface Options {
+    dir: string;
+    format: 'text' | 'json';
+}
+
+function parseArgs(argv: string[]): Options {
+    const opts: Options = { dir: DEFAULT_DIR, format: 'text' };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--dir') opts.dir = argv[++i] ?? opts.dir;
+        else if (a.startsWith('--dir=')) opts.dir = a.slice('--dir='.length);
+        else if (a === '--format') opts.format = (argv[++i] as Options['format']) ?? opts.format;
+        else if (a.startsWith('--format=')) opts.format = a.slice('--format='.length) as Options['format'];
+    }
+    if (opts.format !== 'text' && opts.format !== 'json') opts.format = 'text';
+    return opts;
+}
+
+/** Read + parse every `.jsonl` line in `dir`. Malformed lines are skipped. */
+export function readAuditLines(dir: string): AuditLine[] {
+    if (!fs.existsSync(dir)) return [];
+    const lines: AuditLine[] = [];
+    for (const entry of fs.readdirSync(dir).sort()) {
+        if (!entry.endsWith('.jsonl')) continue;
+        const raw = fs.readFileSync(path.join(dir, entry), 'utf8');
+        for (const ln of raw.split('\n')) {
+            const trimmed = ln.trim();
+            if (!trimmed) continue;
+            try {
+                lines.push(JSON.parse(trimmed) as AuditLine);
+            } catch {
+                // Skip malformed line — a partial write must not crash the report.
+            }
+        }
+    }
+    return lines;
+}
+
+function renderText(r: SavingsReport, dir: string): string {
+    const out: string[] = [];
+    out.push('Orchestration savings report');
+    out.push(`  source: ${dir}`);
+    out.push(`  dispatches: ${r.dispatches}  (total spawns: ${r.total_spawns})`);
+    out.push(`  net token_delta: ${r.net_token_delta}  (negative = net saved)`);
+    out.push(`  tokens saved: ${r.tokens_saved}   tokens added: ${r.tokens_added}`);
+    out.push(`  provenance: measured ${r.by_provenance.measured.dispatches} (Δ ${r.by_provenance.measured.net_token_delta}) · estimated ${r.by_provenance.estimated.dispatches} (Δ ${r.by_provenance.estimated.net_token_delta})`);
+    out.push(`  measured share: ${(r.measured_share * 100).toFixed(0)}%`);
+    if (Object.keys(r.by_tier).length) {
+        out.push('  by tier (Δ tokens):');
+        for (const [tier, d] of Object.entries(r.by_tier).sort()) out.push(`    ${tier}: ${d}`);
+    }
+    if (Object.keys(r.by_task_class).length) {
+        out.push('  by task_class (Δ tokens):');
+        for (const [cls, d] of Object.entries(r.by_task_class).sort()) out.push(`    ${cls}: ${d}`);
+    }
+    out.push('  notes:');
+    for (const n of r.notes) out.push(`    - ${n}`);
+    return out.join('\n');
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    const opts = parseArgs(argv);
+    const lines = readAuditLines(opts.dir);
+    const report = aggregateOrchestrationSavings(lines);
+    if (opts.format === 'json') {
+        process.stdout.write(JSON.stringify({ ...report, source: opts.dir }, null, 2) + '\n');
+    } else {
+        process.stdout.write(renderText(report, opts.dir) + '\n');
+    }
+    return 0;
+}
+
+if (process.argv[1] !== undefined) {
+    const invokedUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+    if (import.meta.url === invokedUrl) process.exit(main());
+}

--- a/src/scripts/orchestration_savings_report.ts
+++ b/src/scripts/orchestration_savings_report.ts
@@ -30,6 +30,7 @@ function parseArgs(argv: string[]): Options {
     const opts: Options = { dir: DEFAULT_DIR, format: 'text' };
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
+        if (a === undefined) continue;
         if (a === '--dir') opts.dir = argv[++i] ?? opts.dir;
         else if (a.startsWith('--dir=')) opts.dir = a.slice('--dir='.length);
         else if (a === '--format') opts.format = (argv[++i] as Options['format']) ?? opts.format;

--- a/tests/scripts/_lib_orchestration_savings.test.ts
+++ b/tests/scripts/_lib_orchestration_savings.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregateOrchestrationSavings, type AuditLine } from '../../src/scripts/_lib/orchestration_savings.js';
+
+describe('aggregateOrchestrationSavings', () => {
+    it('empty input → 0 dispatches with a "no telemetry yet" note', () => {
+        const r = aggregateOrchestrationSavings([]);
+        expect(r.dispatches).toBe(0);
+        expect(r.net_token_delta).toBe(0);
+        expect(r.measured_share).toBe(0);
+        expect(r.notes.join(' ')).toMatch(/No orchestration telemetry yet/i);
+    });
+
+    it('ignores non-orchestration lines and in-session (spawn_count 0) lines', () => {
+        const lines: AuditLine[] = [
+            { input_kind: 'phase' }, // no orchestration object
+            { orchestration: { spawn_count: 0, token_delta: -999 } }, // in-session → not a dispatch
+        ];
+        const r = aggregateOrchestrationSavings(lines);
+        expect(r.dispatches).toBe(0);
+        expect(r.net_token_delta).toBe(0);
+    });
+
+    it('aggregates net delta, saved/added split, provenance, tier and class buckets', () => {
+        const lines: AuditLine[] = [
+            {
+                orchestration: {
+                    spawn_count: 1,
+                    token_delta: -8000, // saved
+                    token_delta_provenance: 'measured',
+                    tier_chosen: 'lite',
+                    task_class: 'read-only-fanout',
+                },
+            },
+            {
+                orchestration: {
+                    spawn_count: 2,
+                    token_delta: -2000, // saved
+                    token_delta_provenance: 'estimated',
+                    tier_chosen: 'lite',
+                    task_class: 'mechanical-edit',
+                },
+            },
+            {
+                orchestration: {
+                    spawn_count: 1,
+                    token_delta: 500, // cost MORE than baseline
+                    token_delta_provenance: 'measured',
+                    tier_chosen: 'medium',
+                    task_class: 'review-synthesis',
+                },
+            },
+        ];
+        const r = aggregateOrchestrationSavings(lines);
+
+        expect(r.dispatches).toBe(3);
+        expect(r.total_spawns).toBe(4);
+        expect(r.net_token_delta).toBe(-9500);
+        expect(r.tokens_saved).toBe(10000);
+        expect(r.tokens_added).toBe(500);
+
+        expect(r.by_provenance.measured.dispatches).toBe(2);
+        expect(r.by_provenance.measured.net_token_delta).toBe(-7500);
+        expect(r.by_provenance.estimated.dispatches).toBe(1);
+        expect(r.by_provenance.estimated.net_token_delta).toBe(-2000);
+        expect(r.measured_share).toBeCloseTo(2 / 3);
+
+        expect(r.by_tier.lite).toBe(-10000);
+        expect(r.by_tier.medium).toBe(500);
+        expect(r.by_task_class['read-only-fanout']).toBe(-8000);
+
+        // Honest caveats present: no-percentage limit + estimated-lossy warning.
+        expect(r.notes.join(' ')).toMatch(/not derivable/i);
+        expect(r.notes.join(' ')).toMatch(/ESTIMATED/i);
+    });
+
+    it('defaults absent fields safely (pre-extension line never throws)', () => {
+        const r = aggregateOrchestrationSavings([{ orchestration: { spawn_count: 1 } }]);
+        expect(r.dispatches).toBe(1);
+        expect(r.net_token_delta).toBe(0);
+        expect(r.by_tier.unknown).toBe(0);
+        expect(r.by_task_class.unclassified).toBe(0);
+        // Absent provenance defaults to estimated per the telemetry contract.
+        expect(r.by_provenance.estimated.dispatches).toBe(1);
+    });
+});


### PR DESCRIPTION
## What

A read-only measurement instrument that aggregates realized orchestration telemetry into a token-savings report — so the "how much do we save?" question gets answered by **data**, not a guessed percentage.

- `src/scripts/_lib/orchestration_savings.ts` — pure aggregator over the `orchestration` sub-object of audit-log-v1 JSONL lines.
- `src/scripts/orchestration_savings_report.ts` — CLI (`--dir`, `--format text|json`), handles a missing/empty audit dir gracefully.
- `tests/scripts/_lib_orchestration_savings.test.ts` — 4 cases (green).

```bash
./scripts-run src/scripts/orchestration_savings_report [--dir <path>] [--format text|json]
```

Sums `token_delta` across dispatches (negative = net saved), splits by provenance (measured vs estimated), `tier_chosen`, and `task_class`.

## The honest limitation (load-bearing)

This reports **ABSOLUTE net tokens saved, NOT a percentage.** The telemetry records `token_delta` (net dispatch cost vs the in-session baseline) but **not the absolute baseline**, so a "% of session saved" is not derivable from this data. Every report carries this caveat in its `notes`. This is why I would not put a "20-40%" figure anywhere — the data doesn't support one yet.

**Follow-up (deferred):** to get a defensible percentage, add an additive absolute-baseline (or absolute-dispatch-cost) field to the orchestration telemetry object, then extend this aggregator. Noted in the telemetry contract doc.

## Why now

The `subagents.auto` default was flipped to `on` (#808), so real orchestration telemetry now accrues. This instrument turns that stream into an auditable savings number over 1-2 weeks of real use — replacing the arithmetic/N=2 directional estimate with realized data.

## Verification

- New test green (4/4, run locally — narrow, single file).
- CLI exercised end-to-end: empty dir → graceful "no telemetry yet"; fixture (two ~72k/84k measured-saved dispatches) → net −156000 saved, correct tier/class buckets, JSON output.
- `condense --check` green; `check_condensation` no errors.
- Built in an isolated git worktree off `origin/main`; independent of #808.
