### PR TITLE
fix(ci): pin publish-npm to npm 11 for Node 20 compat

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -25,7 +25,9 @@ on:
       - "tests/**"
       - "Taskfile.yml"
       - "taskfiles/**"
-      - ".github/workflows/consistency.yml"
+      # Any workflow-file change must trigger the REQUIRED Consistency check
+      # too, or a workflow-only PR deadlocks on "Expected — Waiting for status".
+      - ".github/workflows/**"
       # docs-only PR shape (per docs/contracts/branch-protection-policy.md):
       # Consistency is a REQUIRED check for docs-only PRs, so it must trigger
       # on the docs-only paths or such PRs deadlock (required check never runs).
@@ -62,7 +64,9 @@ on:
       - "tests/**"
       - "Taskfile.yml"
       - "taskfiles/**"
-      - ".github/workflows/consistency.yml"
+      # Any workflow-file change must trigger the REQUIRED Consistency check
+      # too, or a workflow-only PR deadlocks on "Expected — Waiting for status".
+      - ".github/workflows/**"
       # docs-only PR shape (per docs/contracts/branch-protection-policy.md):
       # Consistency is a REQUIRED check for docs-only PRs, so it must trigger
       # on the docs-only paths or such PRs deadlock (required check never runs).

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -56,7 +56,10 @@ jobs:
           cache: 'npm'
 
       - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
-        run: npm install -g npm@latest
+        # Pin to the npm 11 line: npm@latest is now 12.x, which requires
+        # Node >=22 and fails EBADENGINE on this job's Node 20. npm 11 is
+        # Node-20-compatible and already satisfies the >= 11.5.1 floor.
+        run: npm install -g npm@11
 
       - name: Resolve effective tag
         id: tag


### PR DESCRIPTION
The 8.8.0 npm publish run failed at the `Upgrade npm` step: `npm install -g npm@latest` now resolves to npm 12.x, whose engines require Node `>=22`, but the `publish-npm` job runs on Node 20 → `EBADENGINE`.

Pin to the npm 11 line, which is Node-20-compatible and still satisfies the Trusted Publishing `>= 11.5.1` floor.

After merge, dispatch `publish-npm.yml` with `tag=8.8.0` to publish the pending 8.8.0 release to npm.

Failed run: https://github.com/event4u-app/agent-config/actions/runs/29016875510