### PR TITLE
ci(security): fail-closed agent-security on publish + claims-ledger binding

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -122,6 +122,16 @@ jobs:
           npm pack --dry-run --json --ignore-scripts --silent \
             | jq -e '.[0].files | map(.path) | any(. == "dist/discovery/discovery-manifest.json")'
 
+      - name: Agent-security gate (hidden-unicode / confusable / instruction-smuggling)
+        if: steps.check.outputs.already_published != 'true'
+        # Fail-closed on the RELEASE path, not just the PR path: scan the exact
+        # bytes about to be published (src/ + dist/agent-src/) for hidden-Unicode,
+        # mixed-script-confusable, instruction-smuggling, mcp-config, and
+        # dangerous-frontmatter payloads. A blocking finding aborts the job before
+        # `npm publish`, so "what ships to npm is machine-checked" is a structural
+        # property of this workflow, not a branch-protection configuration.
+        run: ./scripts-run src/scripts/lint_agent_security
+
       - name: Publish via OIDC Trusted Publishing
         if: steps.check.outputs.already_published != 'true'
         run: npm publish

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -49,6 +49,13 @@
 - status: backed
 - last_verified: 2026-07-04
 
+### claim: shipped-artifacts-hidden-instruction-scanned
+- claim: Every artifact the package ships — source AND the condensed projection that reaches consumers — is machine-scanned in CI for hidden-Unicode, mixed-script-confusable, and instruction-smuggling payloads (the rules-file-backdoor class) before it can merge or publish.
+- kind: qual
+- evidence: .github/workflows/skill-lint.yml#task lint-agent-security
+- status: backed
+- last_verified: 2026-07-09
+
 ### claim: surgical-uninstall
 - claim: Removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries.
 - kind: qual

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -36,10 +36,11 @@ evidence pointer, or `task check-claims` fails the build.
 | The whole layer is compiled into host agents with zero runtime daemon. | qual | `docs/contracts/no-runtime-boundary.md#file-first, no-runtime suite` | ✅ |
 | 100 governed rules. | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
 | On a deterministic multi-session recall corpus, the memory substrate produces a measured, placebo-controlled recall lift — memory-on 27/27 vs no-memory 10/27 and vs equal-byte placebo 9/27 (claude-haiku-4-5, n=9 tasks x 3 seeds, sign test p=0.031 for BOTH pairings). Scoped honestly: this is the context-value upper bound (perfect retrieval on a one-fact-per-task corpus), not retrieval precision under a large store. | quant | `internal/bench/reports/second-brain-delta.json` | ✅ |
+| Every artifact the package ships — source AND the condensed projection that reaches consumers — is machine-scanned in CI for hidden-Unicode, mixed-script-confusable, and instruction-smuggling payloads (the rules-file-backdoor class) before it can merge or publish. | qual | `.github/workflows/skill-lint.yml#task lint-agent-security` | ✅ |
 | 267 skills (README hero + feature list). | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
 | Removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries. | qual | `docs/contracts/install-layout.md#JSON-pointer` | ✅ |
 
-**12 backed claim(s)** — all evidence pointers resolve in CI.
+**13 backed claim(s)** — all evidence pointers resolve in CI.
 
 Artefact counts in public prose (skills, commands, governed rules,
 guidelines, personas) are **generated from source and CI-drift-checked**:


### PR DESCRIPTION
Closes two of the three items flagged on `main` after #815/#817. The third (ASI coverage doc) is a scope decision — see below.

## What changed

1. **Release-path fail-closed** — `lint-agent-security` blocked *merge* (skill-lint PR workflow) but the *publish* job (`publish-npm.yml`) ran only `lint_discovery_manifest`. So "what npm receives is scanned" rested on branch-protection config, not the job. Added the umbrella scan as a step **before `npm publish`**: a hidden-Unicode / confusable / instruction-smuggling finding in the exact shipping bytes now aborts the release structurally, config-independent.
2. **Claims-ledger binding** — added a `backed` entry to `docs/CLAIMS.md`: *"every shipped artifact (source + condensed projection) is machine-scanned in CI for hidden-Unicode / confusable / instruction-smuggling payloads (the rules-file-backdoor class) before it can merge or publish"*, evidenced by the CI workflow step. `check_claims` green (13 backed / 1 inventory). The expensive part (linters + wiring + empirically-clean baseline, incl. the Tag-block U+E0000–E007F vector) already exists — this makes the claim falsifiable and CI-rot-guarded.

## Verification

- `check_claims` — 14 entries, evidence pointer resolves.
- `publish-npm.yml` — valid YAML; scan step gated on `already_published != 'true'`, before publish.
- `lint_agent_security` — baseline clean (0 blocking).

## Still open (not in this PR)

- **ASI coverage doc** — the `covered / partially / not-covered` mapping. Confirmed it is **not** already owned by the parallel frontier-quality track. It is a real doc (and the reviewer warned against thin mappings), so its home is a scope call — see the chat.
