### PR TITLE
feat(hooks): pre-push changed-TypeScript static pass (typecheck + lint)

### DIFF
--- a/src/scripts/install-hooks.sh
+++ b/src/scripts/install-hooks.sh
@@ -42,6 +42,31 @@ if ! ./scripts-run src/scripts/check_no_conflict_markers --quiet; then
     fail=1
 fi
 
+# Changed-files static pass (typecheck + lint) — the deterministic backstop to
+# the behavioural verify-before-complete rule (#818). Catches the compile/lint
+# errors that reach remote CI "Static Checks" (e.g. TS18048). Runs only when
+# the push touches .ts, so docs-only pushes stay fast. Skip a genuine WIP push
+# with AGENT_CONFIG_SKIP_PREPUSH_STATIC=1 (the agent cannot use --no-verify).
+echo "🔍 Static check on changed TypeScript (typecheck + lint)..."
+if [ "${AGENT_CONFIG_SKIP_PREPUSH_STATIC:-}" = "1" ]; then
+    echo "⏭️  skipped via AGENT_CONFIG_SKIP_PREPUSH_STATIC=1"
+else
+    base="$(git merge-base HEAD origin/main 2>/dev/null || echo HEAD~1)"
+    changed_ts="$(git diff --name-only --diff-filter=d "$base"...HEAD -- '*.ts' 2>/dev/null || true)"
+    if [ -n "$changed_ts" ]; then
+        if ! npx eslint $changed_ts; then
+            echo "❌  ESLint failed on changed TypeScript. Fix before pushing (or AGENT_CONFIG_SKIP_PREPUSH_STATIC=1 for a WIP push)."
+            fail=1
+        fi
+        if ! npm run --silent typecheck; then
+            echo "❌  Typecheck (tsc) failed — this is the class of error remote CI 'Static Checks' catches (#818). Fix before pushing."
+            fail=1
+        fi
+    else
+        echo "⏭️  no changed .ts vs origin/main — skipping."
+    fi
+fi
+
 if [ $fail -ne 0 ]; then
     echo ""
     echo "   Push blocked — fix the failures above and re-push."


### PR DESCRIPTION
## What

A deterministic **backstop** to the behavioural `verify-before-complete` rule shipped in #818. The maintainer pre-push git hook (`install-hooks.sh`) now runs, before a push:

1. ESLint on the **changed** `.ts` files (`git diff … origin/main…HEAD -- '*.ts'`), and
2. the project typecheck (`npm run typecheck`)

— so the compile/lint errors that otherwise reach remote CI "Static Checks" (e.g. the `TS18048` that hit #810 this session) are caught locally first.

## Why this scope (not consumer-imposing)

This is the **maintainer-only** hook, installed explicitly by `bash src/scripts/install-hooks.sh` in *this* repo. It is **not** shipped to consumer projects (the package can't know a consumer's typecheck/lint command), so it imposes on nobody but agent-config maintainers — which is exactly where the #810 error happened. That's why #818 was behavioural-primary and deferred this; here it's added narrowly where it's safe.

- **Runs only when the push touches `.ts`** — docs-only pushes stay fast.
- **Env escape** `AGENT_CONFIG_SKIP_PREPUSH_STATIC=1` for a genuine WIP push. Needed because the agent cannot use `--no-verify` (blocked by the `block_no_verify` PreToolUse guard) — so the hook provides its own opt-out.
- Runtime ~1 min when `.ts` changed (same typecheck CI runs); zero when it didn't.

Belt to the behavioural suspenders: #818 makes the static pass an *obligation*; this makes skipping it *structurally visible* at push time.

## Verification

- `bash -n` clean on both the installer and the extracted generated hook body.
- Skip-logic dry-run in an isolated worktree: this branch changes only `.sh`, so the static check correctly self-skips (no `.ts` in the diff).
- `npx eslint <files>` + `npm run typecheck` are the same invocations already used across the suite.
