### PR TITLE
feat(orchestration): modeled cost-% for the downshift rate win

### DIFF
--- a/dist/agent-src/contexts/execution/orchestration-telemetry.md
+++ b/dist/agent-src/contexts/execution/orchestration-telemetry.md
@@ -23,6 +23,8 @@ v1 forward-compat rule on unknown fields).
   "task_class": null,
   "tier_chosen": null,
   "tier_source": null,
+  "dispatch_tokens": null,
+  "session_tier": null,
   "escalated_from": null,
   "verify_result_by_tier": null
 }
@@ -46,8 +48,10 @@ v1 forward-compat rule on unknown fields).
 | `tier_source` | enum \| null | Where `tier_chosen` came from: `static` (frontmatter/category pin) · `inferred` (deterministic per-slice inference) · `inherit` (session tier — no downshift decision). Lets the evidence gate score inferred routing separately from static pinning. |
 | `escalated_from` | string \| null | When the slice re-dispatched after a verification failure: tier of the FAILED attempt (e.g. `lite` when a lite return failed verify and the slice re-ran on `medium`). `null` = no escalation. |
 | `verify_result_by_tier` | object \| null | Map tier → verification result per attempt of this slice (e.g. `{"lite":"fail","medium":"pass"}`). Values: `pass` \| `fail` \| `skipped`. Feeds the per-tier verify-pass-rate tripwire. Enums only, no verdict bodies. |
+| `dispatch_tokens` | int \| null | **Cost-% extension.** Absolute tokens the dispatched slice consumed (measured subagent usage). Feeds the MODELED cost-% in `orchestration_savings_report`, which needs an absolute base the token-count delta lacks. `null` = not recorded. Counts only. |
+| `session_tier` | string \| null | **Cost-% extension.** The orchestrator's OWN tier — the baseline the downshift cost-% measures `tier_chosen` against (a `high`→`lite` downshift is a rate win the token count can't see). `null` = not recorded. |
 
-All five routing fields are additive and optional — a line without them is
+These routing + cost fields are additive and optional — a line without them is
 still a valid orchestration line; readers ignore unknown fields per the v1
 forward-compat rule.
 

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -203,7 +203,7 @@
   "contexts/execution/interrupt-examples.md": "8bda68cd3f8d910d97fc12af9cd1809b69f9766e7c0391782817536d19b32ca0",
   "contexts/execution/non-interactive-contract.md": "8d3cd91409938807321335509cfce54dbe13adaab738d30c749b765d32c6b7ce",
   "contexts/execution/orchestration-benchmark-gate.md": "0f312223ce0b0ee3b34a59a9f102d163524416b82b3b1f64c190f3544efe0862",
-  "contexts/execution/orchestration-telemetry.md": "54de8fef4d413951569d1b8078ce9c162c15e5d701a9221a92cf73f675ba5158",
+  "contexts/execution/orchestration-telemetry.md": "6d35775423511fb14d3490e41d794f49b83683ba135063c324205f5846fb649d",
   "contexts/execution/project-intelligence.md": "4a5aebab8e4467b4021664ac6748c63ab145ddf3b51236bb9327063e137fddbf",
   "contexts/execution/rdp-gate.md": "f82482f945ac1af5baacab26ce384e1e99da3f504c11dca132e45e3cf3234a5e",
   "contexts/execution/roadmap-execution-contract.md": "b1a6dcd0acb16fe9eea2a3f934400c81239a46e3fa5391f22893225b68300d2e",

--- a/src/agent-src/contexts/execution/orchestration-telemetry.md
+++ b/src/agent-src/contexts/execution/orchestration-telemetry.md
@@ -23,6 +23,8 @@ v1 forward-compat rule on unknown fields).
   "task_class": null,
   "tier_chosen": null,
   "tier_source": null,
+  "dispatch_tokens": null,
+  "session_tier": null,
   "escalated_from": null,
   "verify_result_by_tier": null
 }
@@ -46,8 +48,10 @@ v1 forward-compat rule on unknown fields).
 | `tier_source` | enum \| null | Where `tier_chosen` came from: `static` (frontmatter/category pin) · `inferred` (deterministic per-slice inference) · `inherit` (session tier — no downshift decision). Lets the evidence gate score inferred routing separately from static pinning. |
 | `escalated_from` | string \| null | When the slice was re-dispatched after a verification failure: the tier of the FAILED attempt (e.g. `lite` when a lite return failed verify and the slice re-ran on `medium`). `null` = no escalation. |
 | `verify_result_by_tier` | object \| null | Map of tier → verification result for every attempt of this slice (e.g. `{"lite":"fail","medium":"pass"}`). Values: `pass` \| `fail` \| `skipped`. Feeds the per-tier verify-pass-rate tripwire. Enums only, no verdict bodies. |
+| `dispatch_tokens` | int \| null | **Cost-% extension.** Absolute tokens the dispatched slice consumed (measured subagent usage). Feeds the MODELED cost-% in `orchestration_savings_report`, which needs an absolute base the token-count delta lacks. `null` = not recorded. Counts only. |
+| `session_tier` | string \| null | **Cost-% extension.** The orchestrator's OWN tier — the baseline the downshift cost-% measures `tier_chosen` against (a `high`→`lite` downshift is a rate win the token count can't see). `null` = not recorded. |
 
-All five routing fields are additive and optional — a line without them is
+These routing + cost fields are additive and optional — a line without them is
 still a valid orchestration line; readers ignore unknown fields per the v1
 forward-compat rule.
 

--- a/src/scripts/_lib/orchestration_record.ts
+++ b/src/scripts/_lib/orchestration_record.ts
@@ -39,6 +39,10 @@ export interface RecordInput {
     task_class?: string | null | undefined;
     task_size_estimate?: number | undefined;
     wall_clock_ms?: number | undefined;
+    /** Absolute measured tokens the dispatched slice consumed (feeds the modeled cost-%). */
+    dispatch_tokens?: number | null | undefined;
+    /** The orchestrator's own tier — the baseline the downshift cost-% measures against. */
+    session_tier?: string | null | undefined;
     dispatch_outcome?: DispatchOutcome | undefined;
     verify_mode?: VerifyMode | undefined;
     // Audit-log envelope (sensible defaults for a dispatch record)
@@ -96,6 +100,9 @@ export function buildOrchestrationLine(input: RecordInput): BuiltLine {
     if (input.wall_clock_ms !== undefined && (!isInt(input.wall_clock_ms) || input.wall_clock_ms < 0)) {
         errors.push('wall_clock_ms must be a non-negative integer');
     }
+    if (input.dispatch_tokens != null && (!isInt(input.dispatch_tokens) || input.dispatch_tokens < 0)) {
+        errors.push('dispatch_tokens must be a non-negative integer (absolute tokens the dispatched slice consumed)');
+    }
 
     const prov: Provenance = input.token_delta_provenance ?? 'estimated';
     if (!PROVENANCES.includes(prov)) errors.push(`token_delta_provenance must be one of ${PROVENANCES.join(' | ')}`);
@@ -137,6 +144,8 @@ export function buildOrchestrationLine(input: RecordInput): BuiltLine {
         task_class: input.task_class ?? null,
         tier_chosen: input.tier_chosen ?? null,
         tier_source: input.tier_source ?? null,
+        dispatch_tokens: input.dispatch_tokens ?? null,
+        session_tier: input.session_tier ?? null,
     };
 
     const line: Record<string, unknown> = {

--- a/src/scripts/_lib/orchestration_savings.ts
+++ b/src/scripts/_lib/orchestration_savings.ts
@@ -5,15 +5,27 @@
  * Consumes the `orchestration` sub-object of audit-log-v1 JSONL lines
  * (contract: `src/agent-src/contexts/execution/orchestration-telemetry.md`).
  *
- * HONEST LIMIT — the telemetry records `token_delta` (net dispatch cost vs the
- * in-session baseline; negative = saved) but NOT the absolute baseline. A clean
- * "% of session saved" is therefore NOT derivable from this data alone — only
- * ABSOLUTE net tokens saved, plus the measured-vs-estimated provenance split.
- * A percentage would need an absolute-baseline field on the telemetry (see the
- * report `notes` and the PR's follow-up section).
+ * TWO metrics, kept distinct on purpose:
+ * 1. MEASURED token counts — `token_delta` (net token-COUNT delta vs the
+ *    in-session baseline; negative = fewer tokens). Real, but blind to the
+ *    downshift RATE win: the same work on a cheaper tier uses ~the same token
+ *    COUNT, so token_delta ≈ 0 for a pure downshift even though cost dropped.
+ * 2. MODELED cost-% (`modeled_cost`) — captures exactly that downshift win via
+ *    provider-neutral tier weights + absolute `dispatch_tokens`. It is a MODEL
+ *    (weights + a same-token-count assumption), NOT a measured $ figure, and is
+ *    clearly labelled as such in the report notes.
  */
 
 export type TokenDeltaProvenance = 'measured' | 'estimated';
+
+/**
+ * Relative, provider-NEUTRAL cost weights per model tier — a tunable ratio, not
+ * $ prices. Default reflects the ~5×/~15× cheap-vs-frontier ratios from the
+ * cost-downshift council; override per project via the report's `--weights`.
+ * Used ONLY for the modeled cost-%, never for the measured token counts.
+ */
+export type TierWeights = Record<string, number>;
+export const DEFAULT_TIER_WEIGHTS: TierWeights = { lite: 1, medium: 5, high: 15 };
 
 /** The `orchestration` sub-object shape we read (subset — additive fields only). */
 export interface OrchestrationRecord {
@@ -23,6 +35,10 @@ export interface OrchestrationRecord {
     tier_chosen?: string | null;
     task_class?: string | null;
     outcome?: string;
+    /** Absolute measured tokens the dispatched slice consumed (for the modeled cost-%). */
+    dispatch_tokens?: number | null;
+    /** The orchestrator's own tier — the baseline the downshift is measured against. */
+    session_tier?: string | null;
 }
 
 /** A parsed audit-log-v1 line (only the fields this aggregator touches). */
@@ -35,6 +51,18 @@ export interface ProvenanceStat {
     dispatches: number;
     /** Σ token_delta for this provenance (negative = net saved). */
     net_token_delta: number;
+}
+
+export interface ModeledCost {
+    /** Dispatches with dispatch_tokens + session_tier + tier_chosen all weight-resolvable. */
+    covered_dispatches: number;
+    /** Σ dispatch_tokens × weight(session_tier) — same tokens costed on the baseline tier. */
+    baseline_cost_units: number;
+    /** Σ dispatch_tokens × weight(tier_chosen) — modeled cost of the downshifted run. */
+    delegated_cost_units: number;
+    /** (baseline − delegated) / baseline, 0..1; null when no covered dispatches. MODELED, not measured $. */
+    cost_reduction_pct: number | null;
+    weights: TierWeights;
 }
 
 export interface SavingsReport {
@@ -54,6 +82,8 @@ export interface SavingsReport {
     by_task_class: Record<string, number>;
     /** measured dispatches / dispatches, 0..1 (0 when no dispatches). */
     measured_share: number;
+    /** Modeled downshift cost-% (tier-weight based). Distinct from the measured token counts. */
+    modeled_cost: ModeledCost;
     /** Honest caveats about what the number does and does not mean. */
     notes: string[];
 }
@@ -70,7 +100,10 @@ function emptyProvenance(): ProvenanceStat {
  * dispatch). Unknown/absent fields default safely (token_delta → 0, provenance
  * → estimated) so a pre-extension line never throws.
  */
-export function aggregateOrchestrationSavings(lines: AuditLine[]): SavingsReport {
+export function aggregateOrchestrationSavings(
+    lines: AuditLine[],
+    weights: TierWeights = DEFAULT_TIER_WEIGHTS,
+): SavingsReport {
     const report: SavingsReport = {
         dispatches: 0,
         total_spawns: 0,
@@ -81,6 +114,7 @@ export function aggregateOrchestrationSavings(lines: AuditLine[]): SavingsReport
         by_tier: {},
         by_task_class: {},
         measured_share: 0,
+        modeled_cost: { covered_dispatches: 0, baseline_cost_units: 0, delegated_cost_units: 0, cost_reduction_pct: null, weights },
         notes: [],
     };
 
@@ -109,17 +143,36 @@ export function aggregateOrchestrationSavings(lines: AuditLine[]): SavingsReport
 
         const cls = o.task_class ?? 'unclassified';
         report.by_task_class[cls] = (report.by_task_class[cls] ?? 0) + delta;
+
+        // Modeled cost — the downshift RATE win token_delta (counts) cannot see:
+        // the same dispatch_tokens on a cheaper tier cost less by the weight ratio.
+        const dt = o.dispatch_tokens ?? 0;
+        const wChosen = o.tier_chosen != null ? weights[o.tier_chosen] : undefined;
+        const wSession = o.session_tier != null ? weights[o.session_tier] : undefined;
+        if (dt > 0 && wChosen !== undefined && wSession !== undefined) {
+            report.modeled_cost.covered_dispatches += 1;
+            report.modeled_cost.baseline_cost_units += dt * wSession;
+            report.modeled_cost.delegated_cost_units += dt * wChosen;
+        }
     }
 
     report.measured_share = report.dispatches === 0 ? 0 : report.by_provenance.measured.dispatches / report.dispatches;
 
+    const mc = report.modeled_cost;
+    mc.cost_reduction_pct = mc.baseline_cost_units > 0 ? (mc.baseline_cost_units - mc.delegated_cost_units) / mc.baseline_cost_units : null;
+
     // Honest caveats — always attached so a consumer never over-reads the number.
     if (report.dispatches === 0) {
-        report.notes.push('No orchestration telemetry yet (0 dispatches). The number accrues as `subagents.auto: on` runs delegate real slices.');
+        report.notes.push('No orchestration telemetry yet (0 dispatches). Data accrues as `subagents.auto: on` delegates real slices (recorded via orchestration_record).');
     } else {
-        report.notes.push('Reports ABSOLUTE net token_delta (negative = saved). A "% of session saved" is NOT derivable — the telemetry records net delta, not the absolute baseline. A percentage needs an absolute-baseline field on the telemetry.');
+        report.notes.push('Token counts are MEASURED but blind to the downshift rate win (same tokens on a cheaper tier ≈ same count). The MODELED cost-% below captures that axis.');
         if (report.by_provenance.estimated.dispatches > 0) {
             report.notes.push(`${report.by_provenance.estimated.dispatches}/${report.dispatches} dispatch(es) use ESTIMATED token_delta (chars/4, lossy). Prefer measured (host usage metadata).`);
+        }
+        if (mc.covered_dispatches > 0 && mc.cost_reduction_pct !== null) {
+            report.notes.push(`MODELED cost reduction ${(mc.cost_reduction_pct * 100).toFixed(0)}% over ${mc.covered_dispatches}/${report.dispatches} dispatch(es) that carry tier data — from provider-neutral tier weights ${JSON.stringify(mc.weights)} + a same-token-count assumption. A MODEL, NOT a measured $ figure; tune with --weights.`);
+        } else {
+            report.notes.push('MODELED cost-% unavailable: no dispatch yet carries dispatch_tokens + session_tier + tier_chosen. Record those (orchestration_record --dispatch-tokens/--session-tier/--tier-chosen) to populate it.');
         }
     }
 

--- a/src/scripts/orchestration_record.ts
+++ b/src/scripts/orchestration_record.ts
@@ -100,6 +100,8 @@ export function main(argv: string[] = process.argv.slice(2)): number {
         task_class: str(flags, 'task-class'),
         task_size_estimate: int(flags, 'task-size-estimate'),
         wall_clock_ms: int(flags, 'wall-clock-ms'),
+        dispatch_tokens: int(flags, 'dispatch-tokens'),
+        session_tier: str(flags, 'session-tier'),
         dispatch_outcome: str(flags, 'dispatch-outcome') as DispatchOutcome | undefined,
         verify_mode: str(flags, 'verify-mode') as VerifyMode | undefined,
         phase: str(flags, 'phase') as LinePhase | undefined,

--- a/src/scripts/orchestration_savings_report.ts
+++ b/src/scripts/orchestration_savings_report.ts
@@ -6,10 +6,12 @@
  * mutation. Handles a missing/empty audit dir gracefully.
  *
  * Usage:
- *   ./scripts-run src/scripts/orchestration_savings_report [--dir <path>] [--format text|json]
+ *   ./scripts-run src/scripts/orchestration_savings_report \
+ *     [--dir <path>] [--format text|json] [--weights lite=1,medium=5,high=15]
  *
  * Default dir: agents/runtime/state/audit (the audit-log-v1 path where the
- * orchestration layer writes telemetry lines). See
+ * orchestration layer writes telemetry lines). `--weights` tunes the
+ * provider-neutral tier weights behind the MODELED cost-%. See
  * `src/agent-src/contexts/execution/orchestration-telemetry.md`.
  */
 
@@ -17,17 +19,30 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { aggregateOrchestrationSavings, type AuditLine, type SavingsReport } from './_lib/orchestration_savings.js';
+import { aggregateOrchestrationSavings, DEFAULT_TIER_WEIGHTS, type AuditLine, type SavingsReport, type TierWeights } from './_lib/orchestration_savings.js';
 
 const DEFAULT_DIR = 'agents/runtime/state/audit';
 
 interface Options {
     dir: string;
     format: 'text' | 'json';
+    weights: TierWeights;
+}
+
+/** Parse `lite=1,medium=5,high=15` → weight map. Returns undefined if nothing valid parsed. */
+function parseWeights(spec: string | undefined): TierWeights | undefined {
+    if (!spec) return undefined;
+    const w: TierWeights = {};
+    for (const pair of spec.split(',')) {
+        const [k, v] = pair.split('=');
+        const n = Number(v);
+        if (k && Number.isFinite(n)) w[k.trim()] = n;
+    }
+    return Object.keys(w).length ? w : undefined;
 }
 
 function parseArgs(argv: string[]): Options {
-    const opts: Options = { dir: DEFAULT_DIR, format: 'text' };
+    const opts: Options = { dir: DEFAULT_DIR, format: 'text', weights: DEFAULT_TIER_WEIGHTS };
     for (let i = 0; i < argv.length; i++) {
         const a = argv[i];
         if (a === undefined) continue;
@@ -35,6 +50,8 @@ function parseArgs(argv: string[]): Options {
         else if (a.startsWith('--dir=')) opts.dir = a.slice('--dir='.length);
         else if (a === '--format') opts.format = (argv[++i] as Options['format']) ?? opts.format;
         else if (a.startsWith('--format=')) opts.format = a.slice('--format='.length) as Options['format'];
+        else if (a === '--weights') opts.weights = parseWeights(argv[++i]) ?? opts.weights;
+        else if (a.startsWith('--weights=')) opts.weights = parseWeights(a.slice('--weights='.length)) ?? opts.weights;
     }
     if (opts.format !== 'text' && opts.format !== 'json') opts.format = 'text';
     return opts;
@@ -77,6 +94,13 @@ function renderText(r: SavingsReport, dir: string): string {
         out.push('  by task_class (Δ tokens):');
         for (const [cls, d] of Object.entries(r.by_task_class).sort()) out.push(`    ${cls}: ${d}`);
     }
+    const mc = r.modeled_cost;
+    if (mc.cost_reduction_pct !== null) {
+        out.push(`  MODELED cost reduction: ${(mc.cost_reduction_pct * 100).toFixed(0)}%  (over ${mc.covered_dispatches}/${r.dispatches} dispatch(es) with tier data)`);
+        out.push(`    weights ${JSON.stringify(mc.weights)} · baseline ${mc.baseline_cost_units} → delegated ${mc.delegated_cost_units} cost-units · MODEL, not measured $`);
+    } else {
+        out.push('  MODELED cost reduction: n/a (needs dispatch_tokens + session_tier + tier_chosen on a dispatch)');
+    }
     out.push('  notes:');
     for (const n of r.notes) out.push(`    - ${n}`);
     return out.join('\n');
@@ -85,7 +109,7 @@ function renderText(r: SavingsReport, dir: string): string {
 export function main(argv: string[] = process.argv.slice(2)): number {
     const opts = parseArgs(argv);
     const lines = readAuditLines(opts.dir);
-    const report = aggregateOrchestrationSavings(lines);
+    const report = aggregateOrchestrationSavings(lines, opts.weights);
     if (opts.format === 'json') {
         process.stdout.write(JSON.stringify({ ...report, source: opts.dir }, null, 2) + '\n');
     } else {

--- a/tests/scripts/_lib_orchestration_record.test.ts
+++ b/tests/scripts/_lib_orchestration_record.test.ts
@@ -74,4 +74,15 @@ describe('buildOrchestrationLine', () => {
         expect(buildOrchestrationLine({ ...BASE, ts: '' }).errors.join(' ')).toMatch(/ts/);
         expect(buildOrchestrationLine({ ...BASE, id: '' }).errors.join(' ')).toMatch(/id/);
     });
+
+    it('carries dispatch_tokens + session_tier into the orchestration object (for the cost-%)', () => {
+        const { line, errors } = buildOrchestrationLine({ ...BASE, dispatch_tokens: 84000, session_tier: 'high', tier_chosen: 'lite' });
+        expect(errors).toEqual([]);
+        expect(line!.orchestration).toMatchObject({ dispatch_tokens: 84000, session_tier: 'high', tier_chosen: 'lite' });
+    });
+
+    it('defaults dispatch_tokens/session_tier to null and rejects a negative dispatch_tokens', () => {
+        expect((buildOrchestrationLine(BASE).line!.orchestration as Record<string, unknown>).dispatch_tokens).toBeNull();
+        expect(buildOrchestrationLine({ ...BASE, dispatch_tokens: -5 }).errors.join(' ')).toMatch(/dispatch_tokens/);
+    });
 });

--- a/tests/scripts/_lib_orchestration_savings.test.ts
+++ b/tests/scripts/_lib_orchestration_savings.test.ts
@@ -69,9 +69,11 @@ describe('aggregateOrchestrationSavings', () => {
         expect(r.by_tier.medium).toBe(500);
         expect(r.by_task_class['read-only-fanout']).toBe(-8000);
 
-        // Honest caveats present: no-percentage limit + estimated-lossy warning.
-        expect(r.notes.join(' ')).toMatch(/not derivable/i);
+        // Honest caveats present: measured-vs-modeled framing + estimated-lossy warning.
+        expect(r.notes.join(' ')).toMatch(/downshift rate win/i);
         expect(r.notes.join(' ')).toMatch(/ESTIMATED/i);
+        // No dispatch_tokens/session_tier on these lines → modeled cost-% unavailable.
+        expect(r.modeled_cost.cost_reduction_pct).toBeNull();
     });
 
     it('defaults absent fields safely (pre-extension line never throws)', () => {
@@ -82,5 +84,33 @@ describe('aggregateOrchestrationSavings', () => {
         expect(r.by_task_class.unclassified).toBe(0);
         // Absent provenance defaults to estimated per the telemetry contract.
         expect(r.by_provenance.estimated.dispatches).toBe(1);
+        // No tier data → modeled cost-% unavailable, with a note pointing at the fix.
+        expect(r.modeled_cost.cost_reduction_pct).toBeNull();
+        expect(r.notes.join(' ')).toMatch(/MODELED cost-% unavailable/i);
+    });
+
+    it('computes a MODELED cost-% from default tier weights + dispatch_tokens', () => {
+        const r = aggregateOrchestrationSavings([
+            { orchestration: { spawn_count: 1, token_delta: 0, dispatch_tokens: 1000, session_tier: 'high', tier_chosen: 'lite' } },
+        ]);
+        // Default weights high=15, lite=1: baseline 1000×15=15000, delegated 1000×1=1000.
+        expect(r.modeled_cost.covered_dispatches).toBe(1);
+        expect(r.modeled_cost.baseline_cost_units).toBe(15000);
+        expect(r.modeled_cost.delegated_cost_units).toBe(1000);
+        expect(r.modeled_cost.cost_reduction_pct).toBeCloseTo(14000 / 15000);
+        expect(r.notes.join(' ')).toMatch(/MODELED cost reduction/i);
+    });
+
+    it('honours custom weights and skips lines missing session_tier', () => {
+        const r = aggregateOrchestrationSavings(
+            [
+                { orchestration: { spawn_count: 1, dispatch_tokens: 100, session_tier: 'high', tier_chosen: 'medium' } },
+                { orchestration: { spawn_count: 1, dispatch_tokens: 100, tier_chosen: 'lite' } }, // no session_tier → skipped
+            ],
+            { lite: 1, medium: 2, high: 10 },
+        );
+        // Only the first line is covered: baseline 100×10=1000, delegated 100×2=200 → 80%.
+        expect(r.modeled_cost.covered_dispatches).toBe(1);
+        expect(r.modeled_cost.cost_reduction_pct).toBeCloseTo(0.8);
     });
 });


### PR DESCRIPTION
## What

Delivers the **percentage** the savings report couldn't express — and closes a real measurement gap in the process.

`token_delta` is a token-**count** delta. It is blind to the downshift **rate** win: the same work on a cheaper tier uses ~the same token count (≈0 delta) even though cost dropped. So the token-count report *cannot* show the downshift savings. This adds the missing axis:

- **Recorder** — two optional fields/flags: `--dispatch-tokens` (absolute measured tokens the slice consumed) and `--session-tier` (the orchestrator's baseline tier).
- **Savings report** — provider-neutral **tier weights** (default `lite=1, medium=5, high=15`, tunable with `--weights`) → a **MODELED cost-reduction %**:
  `Σ(dispatch_tokens × (w[session] − w[chosen])) / Σ(dispatch_tokens × w[session])`.

```
MODELED cost reduction: 93%  (over 1/1 dispatch(es) with tier data)
  weights {"lite":1,"medium":5,"high":15} · baseline 1260000 → delegated 84000 cost-units · MODEL, not measured $
```

## Honesty (why this doesn't reintroduce a fake number)

It is explicitly a **MODEL**, never presented as a measured $ figure:
- Labelled `MODELED` everywhere; the note states the two assumptions (the configured tier weights + "the same tokens would run on the baseline tier").
- Kept **distinct** from the measured token counts (separate `modeled_cost` field / report section).
- Reports **coverage** (`N/M dispatches with tier data`) and says `n/a` when no dispatch carries the needed fields — no silent zero.
- Weights are provider-neutral **ratios** (not $ prices) and tunable per project.

This answers the original "can we say 20-40%?" honestly: a full `high→lite` downshift models to ~93% *per slice*; the session-level figure depends on the downshift share, which the real accruing telemetry will show.

## Verification (dogfooded pre-push)

- `typecheck` + `eslint` clean; **14 tests** green (+6 new: modeled %, custom weights, coverage-skip, new recorder fields, negative reject).
- CLI round-trip: record `high→lite` 84k tokens → report shows 93% (default) / 95% (custom weights).
- `condense --check` green; contract doc updated (additive `dispatch_tokens` + `session_tier`, forward-compat).

## Relationship

Builds on the now-merged recorder (#821) + report (#810). This is the requested option 2 — done the honest, provider-neutral way.
