### PR TITLE
docs(roadmap): draft retrieval-substrate hardening (source-anonymous borrow)

### DIFF
--- a/agents/roadmaps/road-to-retrieval-substrate-hardening.md
+++ b/agents/roadmaps/road-to-retrieval-substrate-hardening.md
@@ -1,0 +1,251 @@
+---
+complexity: structural
+status: draft
+execution:
+  mode: phase-checkpoints
+---
+
+# Road to retrieval-substrate hardening
+
+> Harden the memory/retrieval substrate with mechanisms adapted from an external
+> deterministic graph-retrieval reference (Source G): a token-budgeted compact
+> read surface, a real dependency-free lexical index, a learning sidecar that
+> verdicts signals, a sanitize floor, and an artefact relation-graph — every
+> item file-backed + projection/hook-time (ADR-040), no runtime daemon.
+
+## Goal
+
+Cut per-query retrieval tokens and close three verified substrate gaps
+(no token budget on `retrieve()`, no real index, no signal-verdicting) with
+deterministic TS that passes the existing checksum/determinism gates — while
+adding zero heavy dependency and copying none of the source's identity.
+
+## Provenance
+
+Source-anonymous adoption per [`source-confidentiality`](../../.agent-src.uncondensed/rules/source-confidentiality.md).
+**Source G** — an external, deterministic, LLM-free code-intelligence /
+graph-retrieval tool (Python). Analysed at the code level (full clone,
+2026-07-09), not the README. Raw analysis + the source name stay local-only
+(`agents/tmp/`, gitignored); the retained link is encrypted:
+
+- `ENC1:rOBZC4TOdi2ebuS4ADDlqt6QoX0kQGqDlmw2iKwYwbm/KvKW7pH00/fpflCr8MQGQMRcm/Lx/syJIMiVFRk8HrJFSv8E4XVF8YwvctjkEqou/R+IirUUQaAc69Pbt21qpEtr9ZgPMHXR`
+
+The borrowed *items* below are agent-config's own features; Source G is the
+mechanism reference, never a dependency.
+
+> **Honest framing (do not repeat the ruflo lesson).** Source G's own numbers
+> show the *graph* is a small lever (+2–2.6 pts on a public recall bench vs
+> seed-only retrieval); the real token win is the index/detail split + a hard
+> budget cut + a tiny always-on nudge. This roadmap adopts the *mechanisms that
+> pay* (B1–B3), not the graph as a headline. Source G's own `benchmark` measures
+> against a synthetic full-corpus strawman — explicitly NOT copied (see B7).
+
+## Context (verified in the code, 2026-07-09)
+
+Spot-checked against the current `main` (v8.8.0):
+
+- `memory_lookup.ts::_score` is naive substring/glob (0.8 glob / 0.6 substring /
+  0.1 fallback) — no IDF, no index, every lookup scans the tree.
+- `retrieve()` takes a `limit` (hit count) but **no token budget** and emits
+  full YAML entries — the index/detail split from `road-to-memory-retrieval-economy`
+  (archived) is a read-path *principle*, not enforced in code.
+- `memory_signal.ts` appends rate-limited signals but has **no decay, no
+  corroboration threshold, no dead-end verdicting** — `fold_intake.ts` collects,
+  nothing verdicts. This is the measured-missing half of the second-brain
+  substrate (`road-to-second-brain-delta-proof`, archived PASS).
+- Retrieval read-surfaces have **no sanitize floor**: user-ingested knowledge
+  chunks flow unfiltered into agent context — a real injection surface
+  (`hot_context_hook` sanitizes; `memory_lookup`/knowledge-chunk output does not).
+- `lint_knowledge_scale.ts` pre-decides an FTS5 activation at a tripwire
+  (>200/type, >500 total) but the engine choice vs [`ADR-061`](../../docs/decisions/ADR-061-corpus-grounding-layer.md)
+  (no engine-forks / minisearch-class dep) is unresolved — and the
+  `road-to-second-brain-retrieval-precision` (merged) finding **"recalls but does
+  not rank" (mean tie-set 3.3)** is the concrete evidence that `_score` needs a
+  real ranker. B2 is the answer to that finding.
+
+## Gap-table — KEEP / FOLD / CUT (integration, not dump)
+
+Audited each proposed borrow against the existing surface. Only `KEEP` items
+become scope.
+
+| Item | Disposition | Rationale |
+|---|---|---|
+| B1 token-budget + compact `retrieve()` | **KEEP** | verified gap; enforces the index/detail split in code |
+| B2 IDF + trigram prefilter (hand-rolled, stdlib) | **KEEP** | resolves the ADR-061 ↔ FTS5 conflict AND the "doesn't rank" finding |
+| B3 learning sidecar (decay + corroboration + dead-end) | **KEEP** | verified gap; the missing verdict half of `memory_signal`/`fold_intake` |
+| B4 artefact relation-graph (manifest extension) | **KEEP (scoped)** | NOT a code-graph; `affected` verb **FOLDs** alongside `check_structural_breaking` |
+| B5a stat-index for hook scans | **KEEP** | hook latency is UX; `stop`/`session_start` re-scan today |
+| B5b versioned-cache lint rule | **KEEP** | one lint; every future derived cache (B2!) needs a version namespace |
+| B6 sanitize floor on retrieval surfaces | **KEEP** | verified injection gap; ~40 lines + a security lint |
+| B7 Kappa second-judge validation | **KEEP** | directly closes the 33%-judge-inconsistency gap seen in the token-saving live run |
+| B7 self-measuring `benchmark` command | **KEEP (honest baseline)** | value for proof/GTM; measure vs real projection, not a strawman |
+| B8 file-slicing for knowledge ingest | **KEEP** | `fold_intake` has no tests; slicing invariants are the first test block |
+| B9 detect-and-point interop for code-graph | **KEEP** | orchestrator-not-competitor; ~10 projected lines |
+| tree-sitter / native AST extraction | **CUT** | heavy dep, identity fork (B9 is the interop answer) |
+| MCP runtime server as required path | **CUT** | ADR-040 violation; all items work as CLI/hook/projection |
+| naive `nodes × 50` benchmark baseline | **CUT** | anti-pattern for the claims ledger |
+| graph-expansion as a headline feature | **CUT** | small lever; value is B1–B3 |
+| watch-daemon | **CUT** | hook events already cover invalidation points |
+
+## Phase 0 — Sanitize floor + versioned-cache lint (no dependency)
+
+- [ ] B6: add a `sanitize_field()` (strip control chars, cap length, escape
+      markup) applied to every corpus-derived field concatenated into agent
+      context — `memory_lookup` output and knowledge-chunk read surfaces first;
+      a security-lint check asserts no retrieval surface emits unsanitized
+      corpus text.
+- [ ] B5b: add a lint rule — no derived cache without a version namespace OR an
+      explicit invalidation comment (the rule every later cache layer inherits).
+
+**Exit:** knowledge-chunk retrieval is sanitized; the lint fails a
+version-namespace-less derived cache. **Rollback:** revert the sanitizer call
+(pointer output unaffected).
+
+## Phase 1 — Token-budget + compact serialization in `retrieve()`
+
+- [ ] B1: `retrieve(types, keys, limit, token_budget?)` — render hits as
+      one-line compact form (`HIT <type>/<id> [src=<path> score=<x>] <~120-char
+      body head>`), exact/seed matches first, hard char-cut at `token_budget × 4`
+      with a truncation notice that names a concrete next step ("N more hits —
+      narrow with --key or read <path>"). Default (no budget) stays
+      byte-identical to today.
+- [ ] Wire the compact/budgeted mode into the MCP `memory_lookup` detail path +
+      the CLI, defaulting off (additive, per the v1 envelope contract).
+
+**Exit:** a budgeted `retrieve()` emits compact hits within the char cut + a
+navigation hint; the index/detail split is enforced in the read path.
+**Rollback:** one-line default revert.
+
+## Phase 2 — IDF + trigram index (resolves the ADR-061 ↔ FTS5 conflict)
+
+- [ ] B2: a hand-rolled, dependency-free lexical index (IDF weighting + trigram
+      candidate prefilter with a guard fraction) in TS (~150 lines, pure stdlib)
+      — mechanically the BM25 core ADR-061 already sanctions, NO engine fork, NO
+      minisearch-class dep. `_score()` stays as the mini-corpus fallback.
+- [ ] Activate at the existing `lint_knowledge_scale` tripwire (>200/type,
+      >500 total); measure the grep/substring baseline vs the index on the
+      then-current corpus BEFORE shipping (reuse the retrieval-precision replay
+      rig); ship only on measured ranking lift, else honest-null.
+- [ ] Record the ADR-061 ↔ FTS5 resolution (hand-rolled IDF+trigram = the
+      pre-decided path, no engine fork) in the ADR / `lint_knowledge_scale` doc.
+
+**Exit:** the index ranks (mean tie-set → 1 on the retrieval-precision corpus);
+the ADR-061 conflict is closed in writing. **Rollback:** fall back to `_score()`
+(tripwire-gated, so inert below scale). **Dependency:** B1.
+
+## Phase 3 — Learning sidecar: decay + corroboration + dead-end ledger
+
+- [ ] B3: a deterministic aggregator over the intake JSONL — signed score with a
+      30-day half-life, promotion only at ≥2 independent corroborations,
+      contested-resolution by recency, output as a sidecar (`.agent-learning.json`)
+      + a `LESSONS.md` "known dead ends — don't re-derive" section. Byte-stable
+      at a fixed `now` (fits the determinism gates).
+- [ ] Display-time merge into `retrieve()` output as a
+      `learning=preferred|contested|dead_end` suffix — the sidecar NEVER mutates
+      the curated YAML truths; a single session cannot mint a lesson.
+
+**Exit:** the aggregator verdicts intake into preferred/contested/dead-end,
+byte-stable; `retrieve()` surfaces the suffix. **Rollback:** drop the sidecar
+merge (curated memory unaffected). **Blocker:** council Q2 (gitignored vs
+committed) resolves the storage decision first.
+
+## Phase 4 — Artefact relation-graph + `affected` / `explain`
+
+- [ ] B4: extend the discovery scanner with deterministic edge-extraction from
+      existing fields + markdown links (`supersedes`/`superseded_by`, ADR refs,
+      workspace/pack membership, rule→skill mentions, memory-entry→path overlap)
+      → `discovery-graph.json`, same determinism gates. Edges carry confidence
+      labels on the shared trust scale (council Q1).
+- [ ] `agent-config affected <artefact>` (relation-filtered BFS — query-side
+      companion to CI's `check_structural_breaking`) and `agent-config explain
+      <concept>` (seed + 2-hop + budget-cut over the artefact graph).
+
+**Exit:** the graph builds deterministically; `affected`/`explain` answer from
+it within a budget. **Rollback:** none (additive artefact + verbs).
+**Blocker:** council Q1 (trust-scale unification) + Q3 (eager vs lazy build).
+
+## Phase 5 — Stat-index for hook/scan latency
+
+- [ ] B5a: a stat-index (size + mtime_ns → hash-skip, atexit flush,
+      `--force` bypass) for the memory/knowledge/discovery scans that run on
+      every `stop`/`session_start` hook. Version-namespaced per B5b.
+
+**Exit:** hook re-scans skip unchanged trees; latency measured before/after.
+**Rollback:** delete the stat-index (scans fall back to full read).
+
+## Phase 6 — Benchmark command + Kappa judge validation
+
+- [ ] B7a: `agent-config benchmark` — measure projected context vs the REAL
+      alternative (today's full projection / a grep session) on the user's own
+      repo, print the reduction ratio per query, bind the number to the claims
+      ledger with a method line. NEVER the synthetic-full-corpus strawman.
+- [ ] B7b: add second-independent-judge blind validation with Cohen's Kappa to
+      the paired-judge harness — the existing McNemar/Wilcoxon gates test effect
+      significance; Kappa tests grader trustworthiness. Directly closes the
+      33%-judge-inconsistency gap the token-saving live run surfaced.
+
+**Exit:** `benchmark` prints an honest, ledger-bound ratio; the judge harness
+reports Kappa. **Rollback:** none (measurement + reporting). **Blocker:**
+council Q4 (benchmark baseline choice).
+
+## Phase 7 — File-slicing + interop rule
+
+- [ ] B8: a file-slicer for oversized knowledge documents (heading→paragraph→line
+      boundaries, gap-free, non-overlapping, concat == original, each slice
+      reports its parent path) wired into knowledge ingest; the slicing
+      invariants are `fold_intake.ts`'s first test block.
+- [ ] B9: detect an external code-graph index committed to the repo (a
+      `graph.json`-shaped artifact, or a SCIP index) at install/projection time
+      and project a ~10-line interop rule ("for codebase questions query the
+      external index first, not grep") — orchestrator, not competitor. The
+      concrete tool name lives in the eventual interop rule (integration
+      carve-out), not in this harvest roadmap.
+
+**Exit:** knowledge ingest slices losslessly (tested); the interop rule projects
+when an external index is present. **Rollback:** none (additive).
+
+## Acceptance criteria
+
+- Each shipped phase carries a measured before/after (tokens or ranking) on the
+  existing replay rig; no lever ships on a proxy estimate.
+- No new heavy/native dependency; B2's index is pure stdlib (ADR-061 honoured).
+- The sanitize floor covers every retrieval read-surface (security lint green).
+- No public number from B7 enters prose without a `docs/CLAIMS.md` binding + a
+  method line; the source's strawman baseline is not reproduced.
+- **Anti-dump:** every new visible command (`affected`, `explain`, `benchmark`)
+  reuses existing skills/scanners; no new artefact duplicates an existing one;
+  no source filename or name appears in any tracked file (`check_no_external_sources`
+  green). Governance preflight recorded: `domain-adoption-policy` (no new domain),
+  `framework-neutrality` (generic), `size-enforcement` (per-artefact budgets).
+
+## Blockers
+
+### blocker: contested-design-council-pass
+- **Status:** open
+- **Owner:** user
+- **Blocks:** Phase 3 (Q2), Phase 4 (Q1, Q3), Phase 6 (Q4)
+- **What to do:** run an AI-council pass (spend-bearing) on the four contested
+  design questions; author the verdicts into the phases before their flip.
+  Recommended defaults carried below so the phases are shippable if council
+  simply ratifies them:
+  1. **Trust-scale unification** — one contract mapping edge-confidence
+     (EXTRACTED/INFERRED/AMBIGUOUS) ↔ evidence tiers (Verified/Assumed/Gap).
+     *Default: one shared contract, two vocabularies mapped.*
+  2. **Learning sidecar storage** — gitignored (like hot-context) vs committed
+     (like curated memory). *Default: gitignored intake + `merge=union`, matching
+     the existing intake model; team-share is a later decision.*
+  3. **B2 index build** — eager at discovery-build vs lazy at first lookup with
+     stat-index invalidation. *Default: lazy + stat-index (B5a), tripwire-gated.*
+  4. **B7 benchmark baseline** — full projection before thin-flip vs grep-session
+     replay. *Default: full projection (deterministic, already pinned).*
+- **Resolved when:** the four verdicts are recorded under `## Council notes`
+  (members + date, no session path) and the contested phases encode them.
+
+### blocker: draft-promotion
+- **Status:** open
+- **Owner:** user
+- **Blocks:** dashboard visibility + execution
+- **What to do:** this roadmap is `status: draft` (source-derived, council-pending)
+  — promote to `ready` after the council pass + a maintainer review of the
+  gap-table dispositions.
+- **Resolved when:** `status: ready` and the contested-design blocker is cleared.

--- a/src/scripts/external_sources_denylist.json
+++ b/src/scripts/external_sources_denylist.json
@@ -54,7 +54,10 @@
     "gztchan",
     "amaancoderx",
     "npxskillui",
-    "\\bskillui\\b"
+    "\\bskillui\\b",
+    "\\bgraphify\\b",
+    "graphify-labs",
+    "penpax"
   ],
   "skip_paths": [
     "src/scripts/check_no_external_sources.py",


### PR DESCRIPTION
## Was

Aus dem `agents/tmp`-Inbox-Item (`graphify.txt`, Code-Level-Analyse einer
externen deterministischen Graph-Retrieval-Referenz) die Roadmap
`road-to-retrieval-substrate-hardening` autoriert — das Turn-1-Muster
(Inbox → Roadmap), diesmal für einen Borrow.

## Source-anonym (source-confidentiality)

Kein Quellname in der getrackten Roadmap („Source G"); Rohmaterial + Name
bleiben local-only (`agents/tmp/`, gitignored); der Link ist **ENC1-verschlüsselt**;
die Harvest-Quelle steht jetzt im `external_sources_denylist.json`, sodass
`check_no_external_sources` künftige Leaks fängt. (B9-Interop nennt den Tool-Namen
bewusst nicht — das gehört in die spätere Interop-Rule via Integration-Carve-out.)

## Integration statt Dump

9 Borrow-Items KEEP/FOLD/CUT gegen die bestehende Fläche auditiert. Die
hochwertigen binden direkt an gelandete Session-Arbeit:
- **B1** (token-budget compact `retrieve()`) erweitert memory-retrieval-economy.
- **B2** (hand-rolled IDF+Trigramm-Index, pure stdlib) **löst den ADR-061 ↔
  FTS5-Konflikt UND ist die konkrete Antwort auf den gemergten Retrieval-
  Precision-Befund „recalls but does not rank" (mean tie-set 3.3)**.
- **B3** (Learning-Sidecar: Decay + Korroboration + Dead-End) = die fehlende
  Verdict-Hälfte von memory_signal/fold_intake.
- **B6** (Sanitize-Floor) schließt eine echte Knowledge-Chunk-Injection-Fläche.
- **B7** Kappa-Zweitjudge schließt die 33%-Judge-Inkonsistenz aus dem
  token-saving-Live-Run.

**CUT:** tree-sitter nativ, MCP-Runtime-als-Pflicht, die Strawman-Benchmark-
Baseline, Graph-als-Headline, Watch-Daemon.

## Ehrlichkeit + offene Entscheidungen

Provenance benennt explizit: der Graph selbst ist ein kleiner Hebel (+2–2.6 Pkt);
der Wert liegt in B1–B3. **`status: draft`** (source-derived, council-pending).
Zwei Blocker: (1) ein **Council-Pass** (spend-bearing, Dein Call) auf die 4
strittigen Design-Fragen — mit Default-Empfehlungen inline, sodass die Phasen bei
Ratifikation sofort shippen; (2) draft→ready nach Maintainer-Review der Gap-Table.
Kein Spend in diesem PR.

## Verifikation

`check_no_external_sources`, `check_references`, `check_no_roadmap_refs` grün.
Draft → dashboard-unsichtbar bis zur Promotion.
