### PR TITLE
feat(memory): lexical index + measured ranking lift (B2) [stacked on #828]

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**149 / 443 steps done · 34%**
+**151 / 443 steps done · 34%**
 
 ```text
 ██████████████░░░░░░░░░░░░░░░░░░░░░░░░░░   34%
@@ -33,7 +33,7 @@
 | 15 | [road-to-orchestration-and-memory-harvest.md](roadmaps/road-to-orchestration-and-memory-harvest.md) | 5 | 15 | 15 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 16 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
 | 17 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 18 | [road-to-retrieval-substrate-hardening.md](roadmaps/road-to-retrieval-substrate-hardening.md) | 8 | 17 | 13 | 4 | 0 | 0 | 0 | ██░░░░░░░░ 24% |
+| 18 | [road-to-retrieval-substrate-hardening.md](roadmaps/road-to-retrieval-substrate-hardening.md) | 8 | 17 | 11 | 6 | 0 | 0 | 0 | ████░░░░░░ 35% |
 | 19 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 3 | 8 | 0 | 0 | [1](#blockers-road-to-skill-eval-coverage) | ███████░░░ 73% |
 | 20 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
 | 21 | [road-to-surface-specific-agent-contracts.md](roadmaps/road-to-surface-specific-agent-contracts.md) | 8 | 39 | 39 | 0 | 0 | 0 | [1](#blockers-road-to-surface-specific-agent-contracts) | ░░░░░░░░░░ 0% |
@@ -377,13 +377,13 @@
 
 ### [road-to-retrieval-substrate-hardening.md](roadmaps/road-to-retrieval-substrate-hardening.md)
 
-**Road to retrieval-substrate hardening** — 4 / 17 done (24%)
+**Road to retrieval-substrate hardening** — 6 / 17 done (35%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Sanitize floor + versioned-cache lint (no dependency) | ✅ done | 0 | 2 | 0 | 0 | 100% |
 | 1 | Token-budget + compact serialization in `retrieve()` | ✅ done | 0 | 2 | 0 | 0 | 100% |
-| 2 | IDF + trigram index (resolves the ADR-061 ↔ FTS5 conflict) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | IDF + trigram index (resolves the ADR-061 ↔ FTS5 conflict) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 3 | Learning sidecar: decay + corroboration + dead-end ledger | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 4 | Artefact relation-graph + `affected` / `explain` | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 5 | Stat-index for hook/scan latency | ⬜ not started | 1 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-retrieval-substrate-hardening.md
+++ b/agents/roadmaps/road-to-retrieval-substrate-hardening.md
@@ -146,18 +146,34 @@ navigation hint; the index/detail split is enforced in the read path.
 
 ## Phase 2 — IDF + trigram index (resolves the ADR-061 ↔ FTS5 conflict)
 
-- [ ] B2: a hand-rolled, dependency-free lexical index (IDF weighting + trigram
+- [x] B2: a hand-rolled, dependency-free lexical index (IDF weighting + trigram
       candidate prefilter with a guard fraction) in TS (~150 lines, pure stdlib)
       — mechanically the BM25 core ADR-061 already sanctions, NO engine fork, NO
       minisearch-class dep. `_score()` stays as the mini-corpus fallback.
+      <!-- done 2026-07-09: src/scripts/_lib/lexical_index.ts (LexicalIndex:
+      BM25 k1=1.5/b=0.75 over an IDF term index + character-trigram candidate
+      prefilter with a token-match guard; deterministic, id-stable tie-break).
+      8 unit tests. -->
 - [ ] Activate at the existing `lint_knowledge_scale` tripwire (>200/type,
       >500 total); build **lazily at first lookup** + a stat-index (size+mtime_ns),
       atomic temp-write + `rename()`, version-namespaced per B5b (council Q3 —
       NOT eager); measure the grep/substring baseline vs the index on the
       then-current corpus BEFORE shipping (reuse the retrieval-precision replay
       rig); ship only on measured ranking lift, else honest-null.
-- [ ] Record the ADR-061 ↔ FTS5 resolution (hand-rolled IDF+trigram = the
+      <!-- measurement done 2026-07-09 (the ship-gate): measure_lexical_ranking.ts
+      runs both scorers over the retrieval-precision corpus/store — baseline mean
+      top tie-set 3.333 → index 1.0, precision@1 and @5 unchanged at 1.0
+      (internal/bench/reports/lexical-ranking.json, pinned + CLAIMS-bound +
+      regression-locked test). Lift PROVEN → activation authorised. The hot-path
+      wiring (tripwire re-rank in _retrieve_internal + lazy stat-index cache +
+      [0,1] confidence normalisation) is the next increment — it touches the v1
+      confidence contract + the shared retrieval loop and warrants isolated
+      review; step stays open until that lands. -->
+- [x] Record the ADR-061 ↔ FTS5 resolution (hand-rolled IDF+trigram = the
       pre-decided path, no engine fork) in the ADR / `lint_knowledge_scale` doc.
+      <!-- done 2026-07-09: ADR-061 "Resolution note — retrieval ranking at
+      scale" + lint_knowledge_scale tripwire messages now name lexical_index.ts
+      as the resolved (no-FTS5) path with the measured lift. -->
 
 **Exit:** the index ranks (mean tie-set → 1 on the retrieval-precision corpus);
 the ADR-061 conflict is closed in writing. **Rollback:** fall back to `_score()`

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -119,6 +119,13 @@
 - status: backed
 - last_verified: 2026-07-09
 
+### claim: lexical-ranking-lift
+- claim: A hand-rolled, dependency-free BM25 + trigram lexical index resolves the "recalls but does not rank" gap: on the retrieval-precision corpus (9 keyword-overlapping-confuser tasks) it drives the mean top tie-set from 3.333 (the `_score` bucket scorer) to 1.0 — every needed decision uniquely top-ranked — with precision@1 and precision@5 unchanged at 1.0. Method: deterministic, model-free re-ranking of the SAME retrieved entry set; both scorers measured over the identical store via `measure_lexical_ranking.ts`.
+- kind: quant
+- evidence: internal/bench/reports/lexical-ranking.json
+- status: backed
+- last_verified: 2026-07-09
+
 ---
 
 ## Unbacked inventory (documented debt — not yet markered in prose)

--- a/docs/decisions/ADR-061-corpus-grounding-layer.md
+++ b/docs/decisions/ADR-061-corpus-grounding-layer.md
@@ -215,3 +215,16 @@ marking. The shared grounding engine is still attributed via
 Implementing roadmap: `road-to-image-brand-typography` (Phase A–D),
 archived 2026-06-16; live-validation + command-surface follow-on tracked in
 its sibling follow-up roadmap.
+
+## Resolution note — retrieval ranking at scale (2026-07-09)
+
+The "no engine fork / no minisearch-class dependency" decision is honoured at
+memory/knowledge retrieval scale by a **hand-rolled BM25 + trigram index**
+(`src/scripts/_lib/lexical_index.ts`, pure Node stdlib) rather than SQLite-FTS5
+or any embedded search engine. It activates at the `lint_knowledge_scale`
+tripwire (>200/type or >500 total files) and replaces the coarse `_score`
+bucket scorer's ranking; measured lift on the retrieval-precision corpus is a
+mean top tie-set of 3.333 → 1.0 with precision@1/@5 unchanged
+(`internal/bench/reports/lexical-ranking.json`). This closes the ADR-061 ↔
+FTS5 open question flagged in `road-to-retrieval-substrate-hardening` (B2): the
+BM25 core ADR-061 sanctioned is realised without an engine dependency.

--- a/internal/bench/reports/lexical-ranking.json
+++ b/internal/bench/reports/lexical-ranking.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": 1,
+  "tasks": [
+    {
+      "id": "rp-01-api-style",
+      "needed": "dec-api-style",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 4
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-02-job-queue",
+      "needed": "dec-job-queue",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 3
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-03-tenant-scope",
+      "needed": "dec-tenant-scope",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 3
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-04-auth-tokens",
+      "needed": "dec-auth-tokens",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 2
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-05-region",
+      "needed": "dec-region",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 3
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-06-region-contradiction",
+      "needed": "dec-region",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 3
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-07-queue-contradiction",
+      "needed": "dec-job-queue",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 4
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-08-api-repair",
+      "needed": "dec-api-style",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 4
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    },
+    {
+      "id": "rp-09-tenant-repair",
+      "needed": "dec-tenant-scope",
+      "baseline": {
+        "rank": 0,
+        "tieSet": 4
+      },
+      "index": {
+        "rank": 0,
+        "tieSet": 1
+      }
+    }
+  ],
+  "summary": {
+    "tasks": 9,
+    "k": 5,
+    "baseline_mean_tie_set": 3.333,
+    "index_mean_tie_set": 1,
+    "baseline_precision_at_1": 1,
+    "index_precision_at_1": 1,
+    "baseline_precision_at_k": 1,
+    "index_precision_at_k": 1
+  }
+}

--- a/src/scripts/_lib/lexical_index.ts
+++ b/src/scripts/_lib/lexical_index.ts
@@ -1,0 +1,155 @@
+/**
+ * Hand-rolled, dependency-free lexical index for memory/knowledge retrieval
+ * (road-to-retrieval-substrate-hardening B2).
+ *
+ * The current `memory_lookup._score` gives every keyword match the SAME coarse
+ * bucket (0.8 glob / 0.6 substring), so several entries tie at the top and
+ * retrieval "recalls but does not rank" (the mean-tie-set 3.3 finding from
+ * road-to-second-brain-retrieval-precision). This module replaces that bucket
+ * with a continuous BM25 score over an IDF-weighted term index, plus a
+ * character-trigram candidate prefilter so it stays cheap at corpus scale.
+ *
+ * It is the BM25 core ADR-061 already sanctions — pure Node stdlib, NO engine
+ * fork, NO minisearch-class dependency. `_score` stays as the below-tripwire
+ * mini-corpus fallback; this index activates at the `lint_knowledge_scale`
+ * tripwire. Deterministic: identical docs + query → identical scores + order.
+ */
+
+/** BM25 term-frequency saturation. */
+export const BM25_K1 = 1.5;
+/** BM25 length-normalisation strength. */
+export const BM25_B = 0.75;
+/** Minimum token length kept (drops single chars / punctuation noise). */
+export const MIN_TOKEN_LEN = 2;
+
+export interface IndexDoc {
+    id: string;
+    /** All searchable text of the entry, already concatenated. */
+    text: string;
+}
+
+interface DocStats {
+    id: string;
+    len: number; // token count
+    tf: Map<string, number>; // term → frequency in this doc
+    trigrams: Set<string>;
+}
+
+/** Lowercase, split on non-alphanumeric, keep tokens ≥ MIN_TOKEN_LEN. */
+export function tokenize(s: string): string[] {
+    const out: string[] = [];
+    for (const raw of s.toLowerCase().split(/[^a-z0-9]+/)) {
+        if (raw.length >= MIN_TOKEN_LEN) out.push(raw);
+    }
+    return out;
+}
+
+/** Character trigrams of a normalised string (alphanumerics + single spaces). */
+export function trigrams(s: string): Set<string> {
+    const norm = s.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+    const out = new Set<string>();
+    if (norm.length < 3) {
+        if (norm.length > 0) out.add(norm);
+        return out;
+    }
+    for (let i = 0; i + 3 <= norm.length; i++) {
+        out.add(norm.slice(i, i + 3));
+    }
+    return out;
+}
+
+/**
+ * An in-memory BM25 index over a fixed document set. Built once, queried many
+ * times. Stateless after construction — `rank()` / `score()` never mutate it,
+ * so a cached instance is safe to reuse until the underlying corpus changes.
+ */
+export class LexicalIndex {
+    private readonly docs: Map<string, DocStats> = new Map();
+    private readonly df: Map<string, number> = new Map();
+    private readonly n: number;
+    private readonly avgdl: number;
+
+    constructor(documents: readonly IndexDoc[]) {
+        let totalLen = 0;
+        for (const d of documents) {
+            const tokens = tokenize(d.text);
+            const tf = new Map<string, number>();
+            for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
+            for (const t of tf.keys()) this.df.set(t, (this.df.get(t) ?? 0) + 1);
+            this.docs.set(d.id, { id: d.id, len: tokens.length, tf, trigrams: trigrams(d.text) });
+            totalLen += tokens.length;
+        }
+        this.n = documents.length;
+        this.avgdl = this.n > 0 ? totalLen / this.n : 0;
+    }
+
+    /** Robertson–Spärck-Jones IDF, floored at 0 so common terms never subtract. */
+    private idf(term: string): number {
+        const df = this.df.get(term) ?? 0;
+        if (df === 0) return 0;
+        return Math.max(0, Math.log(1 + (this.n - df + 0.5) / (df + 0.5)));
+    }
+
+    /** BM25 score of one document against the tokenised query terms. */
+    score(queryTerms: readonly string[], docId: string): number {
+        const doc = this.docs.get(docId);
+        if (doc === undefined || doc.len === 0) return 0;
+        let s = 0;
+        for (const term of queryTerms) {
+            const tf = doc.tf.get(term);
+            if (tf === undefined) continue;
+            const idf = this.idf(term);
+            if (idf === 0) continue;
+            const denom = tf + BM25_K1 * (1 - BM25_B + (BM25_B * doc.len) / (this.avgdl || 1));
+            s += (idf * (tf * (BM25_K1 + 1))) / denom;
+        }
+        return s;
+    }
+
+    /**
+     * Rank documents for a set of query keys (phrases are tokenised). A
+     * character-trigram prefilter selects candidates cheaply; the guard keeps
+     * any doc sharing a query TOKEN even when no trigram overlaps, so the
+     * prefilter never drops a genuine lexical match. Ties break by id for a
+     * stable, deterministic order.
+     */
+    rank(queryKeys: readonly string[]): Array<{ id: string; score: number }> {
+        const queryText = queryKeys.join(' ');
+        const qTerms = tokenize(queryText);
+        const qTermSet = new Set(qTerms);
+        const qTrigrams = trigrams(queryText);
+
+        const candidates: string[] = [];
+        for (const [id, doc] of this.docs) {
+            let hit = false;
+            for (const t of qTrigrams) {
+                if (doc.trigrams.has(t)) {
+                    hit = true;
+                    break;
+                }
+            }
+            if (!hit) {
+                // Guard: keep a doc that shares an exact query token even with
+                // no trigram overlap (short tokens / edge normalisation).
+                for (const t of qTermSet) {
+                    if (doc.tf.has(t)) {
+                        hit = true;
+                        break;
+                    }
+                }
+            }
+            if (hit) candidates.push(id);
+        }
+
+        const scored = candidates
+            .map((id) => ({ id, score: this.score(qTerms, id) }))
+            .filter((r) => r.score > 0);
+        scored.sort((a, b) => (b.score - a.score) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+        return scored;
+    }
+
+    /** Document count — for the caller's tripwire / diagnostics. */
+    get size(): number {
+        return this.n;
+    }
+}

--- a/src/scripts/lint_knowledge_scale.ts
+++ b/src/scripts/lint_knowledge_scale.ts
@@ -14,9 +14,10 @@
  *   - sessions scale   — `agents/knowledge/sessions/` > 50 pages
  *                        → design fold-through-consolidate-gate for tracked pages
  *   - type scale       — any single memory/knowledge type > 200 files
- *                        → build the pre-decided file-first in-memory BM25 CLI
+ *                        → rank via `_lib/lexical_index.ts` (hand-rolled BM25 +
+ *                          trigram, no engine fork / no FTS5; ADR-061 honoured)
  *   - corpus scale     — > 500 files across all types
- *                        → same BM25 activation path
+ *                        → same lexical-index activation path
  *   - hot-context size — `agents/runtime/state/hot-context.md` > 600 tokens
  *                        (estimated at 4 chars/token) → trim schema / fix the
  *                        deterministic writer
@@ -151,7 +152,7 @@ export function runChecks(root: string): Warning[] {
                 metric: `${n}/${TYPE_FILES_MAX}`,
                 message:
                     `type '${type}' holds ${n} files (> ${TYPE_FILES_MAX}). ` +
-                    'Activation path (pre-decided): build the file-first in-memory BM25 CLI (re-index at session start, no vectors, no service).',
+                    'Activation path (resolved, road-to-retrieval-substrate-hardening B2): rank via the hand-rolled BM25 + trigram index in `_lib/lexical_index.ts` (pure stdlib, NO engine fork / NO SQLite-FTS5, ADR-061 honoured). Measured lift: mean tie-set 3.333 → 1.0 (internal/bench/reports/lexical-ranking.json). Wire it lazily at first lookup + a stat-index, no vectors, no service.',
             });
         }
     }

--- a/src/scripts/measure_lexical_ranking.ts
+++ b/src/scripts/measure_lexical_ranking.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env tsx
+/**
+ * Ranking-lift measurement for the hand-rolled lexical index
+ * (road-to-retrieval-substrate-hardening B2, deterministic + free).
+ *
+ * The gate on shipping the index (roadmap Phase 2): it must measurably rank
+ * BETTER than the current `_score` bucket scorer, else honest-null. This
+ * script runs both scorers over the SAME retrieval-precision corpus + store
+ * (internal/bench/second-brain/retrieval-store/) and reports, per task and in
+ * aggregate:
+ *
+ *   - mean top tie-set size — how many entries share the TOP score. `_score`
+ *     gives 0.8 to any keyword match, so the needed entry ties with its
+ *     confusers (the "recalls but does not rank" finding, mean 3.3). A good
+ *     ranker drives this toward 1.
+ *   - precision@1 / @k — was the NEEDED entry actually first / in the top-k.
+ *
+ * No model, no spend: pure retrieval scoring. Exit 0 ok / 1 error / 2 usage.
+ *
+ * Usage: measure_lexical_ranking.ts [--write] [--format text|json]
+ *   --write  persist the report to internal/bench/reports/lexical-ranking.json
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import * as YAML from 'yaml';
+
+import { LexicalIndex } from './_lib/lexical_index.js';
+import { _score, _setIntakeRoot, _setKnowledgeRoot, _setMemoryRoot, retrieve } from './memory_lookup.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+export const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+export const STORE_DIR = path.join(REPO_ROOT, 'internal', 'bench', 'second-brain', 'retrieval-store');
+export const CORPUS = path.join(STORE_DIR, 'retrieval-corpus.yml');
+export const REPORT = path.join(REPO_ROOT, 'internal', 'bench', 'reports', 'lexical-ranking.json');
+
+interface Task {
+    id: string;
+    query: string[];
+    needed: string;
+}
+
+interface TaskResult {
+    id: string;
+    needed: string;
+    baseline: { rank: number; tieSet: number };
+    index: { rank: number; tieSet: number };
+}
+
+/** Text an entry contributes to the index — the fields `_score` also reads. */
+function entryText(entry: Record<string, unknown>): string {
+    const parts: string[] = [];
+    for (const f of ['path', 'key', 'symptom', 'feature', 'rule', 'body']) {
+        const v = entry[f];
+        if (typeof v === 'string') parts.push(v);
+        else if (Array.isArray(v)) for (const x of v) parts.push(String(x));
+    }
+    return parts.join(' | ');
+}
+
+/** Top tie-set size + rank of the needed id in a sorted (id, score) list. */
+function diagnose(ranked: Array<{ id: string; score: number }>, needed: string): { rank: number; tieSet: number } {
+    if (ranked.length === 0) return { rank: -1, tieSet: 0 };
+    const top = ranked[0]?.score ?? 0;
+    const tieSet = ranked.filter((r) => r.score === top).length;
+    const rank = ranked.findIndex((r) => r.id === needed);
+    return { rank, tieSet };
+}
+
+export function measure(): { tasks: TaskResult[]; summary: Record<string, number> } {
+    _setMemoryRoot(STORE_DIR);
+    _setKnowledgeRoot(path.join(STORE_DIR, 'knowledge-none'));
+    _setIntakeRoot(path.join(STORE_DIR, 'intake-none'));
+
+    const doc = YAML.parse(fs.readFileSync(CORPUS, 'utf-8')) as { type: string; k: number; tasks: Task[] };
+    const type = doc.type;
+    const k = doc.k;
+    const results: TaskResult[] = [];
+
+    for (const task of doc.tasks) {
+        // Shared universe: every store entry `_score` considers relevant.
+        const hits = retrieve([type], task.query, 100);
+
+        // Baseline — rank by the current bucket scorer, ties broken by the
+        // order `retrieve` already returns (store order), exactly as today.
+        const baselineRanked = hits.map((h) => ({ id: h.id, score: h.score }));
+        const baseline = diagnose(baselineRanked, task.needed);
+
+        // Index — BM25 over the same entries' text.
+        const index = new LexicalIndex(hits.map((h) => ({ id: h.id, text: entryText(h.entry) })));
+        const indexRanked = index.rank(task.query);
+        const idx = diagnose(indexRanked, task.needed);
+
+        results.push({ id: task.id, needed: task.needed, baseline, index: idx });
+        void _score; // referenced for provenance — retrieve() applies it internally
+    }
+
+    const n = results.length;
+    const mean = (sel: (r: TaskResult) => number): number =>
+        n === 0 ? 0 : Math.round((results.reduce((a, r) => a + sel(r), 0) / n) * 1000) / 1000;
+    const precAt = (sel: (r: TaskResult) => number, kk: number): number =>
+        n === 0 ? 0 : Math.round((results.filter((r) => sel(r) >= 0 && sel(r) < kk).length / n) * 1000) / 1000;
+
+    const summary = {
+        tasks: n,
+        k,
+        baseline_mean_tie_set: mean((r) => r.baseline.tieSet),
+        index_mean_tie_set: mean((r) => r.index.tieSet),
+        baseline_precision_at_1: precAt((r) => r.baseline.rank, 1),
+        index_precision_at_1: precAt((r) => r.index.rank, 1),
+        baseline_precision_at_k: precAt((r) => r.baseline.rank, k),
+        index_precision_at_k: precAt((r) => r.index.rank, k),
+    };
+    return { tasks: results, summary };
+}
+
+export function main(argv: string[]): number {
+    let write = false;
+    let format: 'text' | 'json' = 'text';
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i] as string;
+        if (a === '--write') write = true;
+        else if (a === '--format') format = (argv[++i] as 'text' | 'json') ?? 'text';
+        else if (a === '-h' || a === '--help') {
+            process.stdout.write('usage: measure_lexical_ranking.ts [--write] [--format text|json]\n');
+            return 0;
+        } else {
+            process.stderr.write(`measure_lexical_ranking: unknown argument ${a}\n`);
+            return 2;
+        }
+    }
+
+    let out: { tasks: TaskResult[]; summary: Record<string, number> };
+    try {
+        out = measure();
+    } catch (exc) {
+        process.stderr.write(`measure_lexical_ranking: error: ${String(exc)}\n`);
+        return 1;
+    }
+
+    if (write) {
+        fs.mkdirSync(path.dirname(REPORT), { recursive: true });
+        fs.writeFileSync(REPORT, JSON.stringify({ schema_version: 1, ...out }, null, 2) + '\n');
+    }
+    if (format === 'json') {
+        process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+        return 0;
+    }
+    const s = out.summary;
+    process.stdout.write(
+        `lexical-ranking (${s.tasks} tasks, k=${s.k}):\n` +
+            `  mean top tie-set   baseline=${s.baseline_mean_tie_set}  index=${s.index_mean_tie_set}\n` +
+            `  precision@1        baseline=${s.baseline_precision_at_1}  index=${s.index_precision_at_1}\n` +
+            `  precision@${s.k}        baseline=${s.baseline_precision_at_k}  index=${s.index_precision_at_k}\n`,
+    );
+    return 0;
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] ?? '')) {
+    process.exit(main(process.argv.slice(2)));
+}

--- a/tests/scripts/lexical_index.test.ts
+++ b/tests/scripts/lexical_index.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Hand-rolled lexical index (road-to-retrieval-substrate-hardening B2).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { LexicalIndex, tokenize, trigrams } from '../../src/scripts/_lib/lexical_index.js';
+
+describe('tokenize', () => {
+    it('lowercases, splits on non-alphanumerics, drops single chars', () => {
+        expect(tokenize('Public API: REST, not GraphQL (v2)!')).toEqual([
+            'public',
+            'api',
+            'rest',
+            'not',
+            'graphql',
+            'v2',
+        ]);
+    });
+});
+
+describe('trigrams', () => {
+    it('emits sliding character trigrams over the normalised string', () => {
+        expect([...trigrams('REST')]).toEqual(['res', 'est']);
+    });
+    it('handles short strings without throwing', () => {
+        expect([...trigrams('a')]).toEqual(['a']);
+        expect([...trigrams('')]).toEqual([]);
+    });
+});
+
+describe('LexicalIndex ranking', () => {
+    const docs = [
+        { id: 'api', text: 'We chose REST for the public API with edge caching, not GraphQL.' },
+        { id: 'queue', text: 'The job queue runs on Postgres, we did not adopt Kafka.' },
+        { id: 'api-distract', text: 'Internal API notes mention GraphQL experiments only.' },
+    ];
+    const idx = new LexicalIndex(docs);
+
+    it('ranks the on-topic doc first and breaks the keyword tie', () => {
+        const ranked = idx.rank(['public API', 'REST', 'GraphQL']);
+        expect(ranked[0]?.id).toBe('api');
+        // Continuous scores → the two API docs do NOT tie at the top.
+        const top = ranked[0]?.score ?? 0;
+        const sharedTop = ranked.filter((r) => r.score === top).length;
+        expect(sharedTop).toBe(1);
+    });
+
+    it('returns only positive-scoring candidates', () => {
+        const ranked = idx.rank(['Kafka', 'job queue']);
+        expect(ranked[0]?.id).toBe('queue');
+        expect(ranked.every((r) => r.score > 0)).toBe(true);
+    });
+
+    it('is deterministic — identical query yields identical order + scores', () => {
+        const a = idx.rank(['REST', 'API']);
+        const b = idx.rank(['REST', 'API']);
+        expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+
+    it('empty query and no-match query return no hits', () => {
+        expect(idx.rank([])).toEqual([]);
+        expect(idx.rank(['zzzznomatch'])).toEqual([]);
+    });
+
+    it('reports corpus size', () => {
+        expect(idx.size).toBe(3);
+    });
+});

--- a/tests/scripts/measure_lexical_ranking.test.ts
+++ b/tests/scripts/measure_lexical_ranking.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Ranking-lift measurement (road-to-retrieval-substrate-hardening B2).
+ *
+ * Locks the gate that authorises shipping the lexical index: on the
+ * retrieval-precision corpus the BM25 index must rank strictly better than the
+ * `_score` bucket scorer (smaller top tie-set) with no precision regression.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { measure } from '../../src/scripts/measure_lexical_ranking.js';
+
+describe('measure_lexical_ranking', () => {
+    it('the index breaks keyword ties the bucket scorer leaves (3.333 → 1.0)', () => {
+        const { summary } = measure();
+        // Baseline reproduces the documented "recalls but does not rank" gap.
+        expect(summary.baseline_mean_tie_set).toBeGreaterThan(1);
+        // The index uniquely top-ranks every needed entry.
+        expect(summary.index_mean_tie_set).toBe(1);
+        expect(summary.index_mean_tie_set).toBeLessThan(summary.baseline_mean_tie_set);
+    });
+
+    it('precision is not regressed by the re-ranking', () => {
+        const { summary } = measure();
+        expect(summary.index_precision_at_1).toBeGreaterThanOrEqual(summary.baseline_precision_at_1);
+        expect(summary.index_precision_at_k).toBeGreaterThanOrEqual(summary.baseline_precision_at_k);
+        expect(summary.index_precision_at_k).toBe(1);
+    });
+
+    it('is deterministic across runs', () => {
+        expect(JSON.stringify(measure().summary)).toBe(JSON.stringify(measure().summary));
+    });
+});


### PR DESCRIPTION
## What

Phase 2 (B2) of `road-to-retrieval-substrate-hardening` — the hand-rolled
lexical index + the measured ranking-lift evidence + the ADR-061 ↔ FTS5
resolution. **Stacked on #828** (`feat/retrieve-token-budget`); review/merge
that first.

### Lexical index (dependency-free)
`src/scripts/_lib/lexical_index.ts` — a `LexicalIndex` (BM25, k1=1.5/b=0.75,
over an IDF term index + a character-trigram candidate prefilter with a
token-match guard). The BM25 core ADR-061 already sanctions, pure Node stdlib,
**no engine fork / no SQLite-FTS5 / no minisearch-class dep**. Deterministic and
id-stable. `_score` stays the below-tripwire mini-corpus fallback.

### The ship-gate: measured ranking lift (proven)
The roadmap gates shipping on a measured lift, else honest-null.
`measure_lexical_ranking.ts` runs both scorers over the **same**
retrieval-precision corpus + store — deterministic, model-free, no spend:

| metric | baseline (`_score`) | index (BM25) |
|---|---|---|
| mean top tie-set | **3.333** | **1.0** |
| precision@1 | 1.0 | 1.0 |
| precision@5 | 1.0 | 1.0 |

Tie-set 3.333 → 1.0 is the direct answer to the "recalls but does not rank
(mean tie-set 3.3)" finding from the retrieval-precision follow-up: every needed
decision is now uniquely top-ranked, with **no precision regression**. Report
pinned (`internal/bench/reports/lexical-ranking.json`), bound in `docs/CLAIMS.md`
(`status: backed`), and regression-locked by a test.

### ADR-061 ↔ FTS5 resolution
ADR-061 gains a "Resolution note — retrieval ranking at scale"; the
`lint_knowledge_scale` tripwire messages now name `lexical_index.ts` as the
resolved (no-FTS5) activation path with the measured lift.

## Scope / what's deferred
This PR ships the index **module + measurement + evidence + doc**. The hot-path
**activation** (tripwire re-rank in `_retrieve_internal` + lazy stat-index cache
+ `[0,1]` confidence normalisation) is the next increment — it touches the v1
`confidence` contract and the shared retrieval loop, so it warrants isolated
review. Activation is inert below the `lint_knowledge_scale` tripwire
(>200/type, >500 total), so nothing changes for the current corpus. The
roadmap's activation step stays open with the measurement recorded.

## Verification
- `tsc --noEmit` clean.
- 11 new tests green (index unit tests + the lift/precision/determinism lock).
- `check_claims`, `check_references`, `check_no_external_sources`,
  `lint_versioned_cache` all green.
