### PR TITLE
docs(memory): name the separator-recall limit in retrieval scope + ADR-116

### DIFF
--- a/docs/decisions/ADR-116-memory-tripwire-activation-path.md
+++ b/docs/decisions/ADR-116-memory-tripwire-activation-path.md
@@ -38,6 +38,15 @@ apart:
 The whole point of a pre-decided path is that the tripwire firing needs no
 new debate; in this state, firing would have required one.
 
+Additional evidence for the engine swap (2026-07-10, labelled replay of real
+maintainer queries): `_score()`'s raw-substring match has a
+**separator-recall gap** — hyphen/underscore query keys (`ai_council`,
+`roadmap-progress`, `force-push`) score 0 against space-normalized stored
+keys that spaced variants hit at 0.8. A tokenizing engine (FTS5 unicode61 /
+BM25 tokenizer) splits on separators and closes this class structurally;
+see `docs/second-brain-scope.md` § second named limit for the scoped-out
+claim boundary.
+
 ## Decision
 
 1. **One engine: SQLite FTS5 via Node's built-in `node:sqlite`.**

--- a/docs/second-brain-scope.md
+++ b/docs/second-brain-scope.md
@@ -53,6 +53,19 @@ this scale*; once more than k entries share a keyword it would degrade — which
 is exactly the discrimination gap the SQLite-FTS5 activation path (ADR-116)
 exists to close. The public claims are scoped to exactly this.
 
+**Second named limit (separator recall, found 2026-07-10 in a labelled replay
+of real maintainer queries):** `_score()` matches raw substrings, so a query
+key whose token separator differs from the stored field misses entirely —
+`ai_council`, `roadmap-progress`, `force-push` score 0 against space-normalized
+`key` fields that spaced variants (`ai council`) hit at 0.8. The precision
+measurement above did not probe this class (its confusers share exact
+keywords), so it is scoped OUT of the precision claim. Deliberately not
+hot-fixed: naive scoring is locked until the scale tripwire (the archived
+retrieval-economy roadmap's D5), and the FTS5 unicode61 tokenizer splits on
+separators, closing this structurally at activation time. Reproduce:
+`memory_lookup --types product-rules --key "ai_council"` vs `--key "ai council"`
+against any populated store.
+
 ## What it IS (measured lift, bounded as above)
 
 | Capability | What it does | Evidence status |


### PR DESCRIPTION
## What

Makes the separator-recall gap found in the 2026-07-10 labelled replay repo-visible, without touching scoring:

- `docs/second-brain-scope.md`: adds a **second named limit** next to the existing tie-ranking limit — `_score()` raw-substring matching misses hyphen/underscore query keys (`ai_council`, `roadmap-progress`, `force-push`) against space-normalized stored keys; spaced variants hit at 0.8. Explicitly scoped OUT of the `second-brain-retrieval-precision` claim (its confusers share exact keywords, so the measurement never probed this class). Includes a one-line repro.
- `docs/decisions/ADR-116`: the same finding recorded as additional evidence for the tokenizing-engine swap at tripwire time (FTS5 unicode61 / BM25 tokenizers split on separators and close the class structurally).

Deliberately NOT a scoring fix — naive scoring is locked until the scale tripwire (retrieval-economy D5), and a scoring change would invalidate the freshly pinned precision measurement.

## Tests

Docs-only; no behavior change. Repro command documented in the scope doc.