### PR TITLE
fix(roadmap): live-verify PR merge state before any in-flight/merged claim

### DIFF
--- a/dist/agent-src/contexts/execution/roadmap-process-loop.md
+++ b/dist/agent-src/contexts/execution/roadmap-process-loop.md
@@ -28,6 +28,25 @@ roadmaps with open work that is blocked-for-later — parked, not active).
   surface alternatives in the pre-run summary.
 - None active → tell the user; suggest [`/roadmap:create`](../../commands/roadmap/create.md).
 
+### Live merge-state before any "in-flight / merged / handled" claim
+
+Selection reasoning that **excludes** a roadmap — or a pre-run summary,
+decision, or user-facing message that **describes** one — as *in-flight*,
+*handled by an open PR*, *already merged*, or *not yet merged* → verify **live
+at claim time** (`gh pr view <n> --json state,mergedAt` / `gh pr list --search
+"<slug>"`). Never infer merge state from:
+
+- **dashboard open-count** — lags: a completed roadmap archives in the
+  **merging** PR, so it can read "open" on `main` while its PR is already
+  merged, or read "open" seconds before a merge you never re-checked;
+- **session memory** ("opened a PR for this earlier") or an **earlier fetch** —
+  a merge can land between fetch and message.
+
+Stale merge-state claim ships an unnecessary message about work already done —
+the failure this prevents. The [`direct-answers`](../../rules/direct-answers.md)
+Iron-Law-2 live-state rule (git/PR state never from memory), applied to
+roadmap selection.
+
 ## 2. Pre-run summary — gate or inline note
 
 Read `roadmap.skip_pre_run_gate` from `.agent-settings.yml` (default

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -207,7 +207,7 @@
   "contexts/execution/project-intelligence.md": "4a5aebab8e4467b4021664ac6748c63ab145ddf3b51236bb9327063e137fddbf",
   "contexts/execution/rdp-gate.md": "f82482f945ac1af5baacab26ce384e1e99da3f504c11dca132e45e3cf3234a5e",
   "contexts/execution/roadmap-execution-contract.md": "b1a6dcd0acb16fe9eea2a3f934400c81239a46e3fa5391f22893225b68300d2e",
-  "contexts/execution/roadmap-process-loop.md": "77950f9caafe1b522874e4233999c333693a07b6c197c5036535ecc9ad63407d",
+  "contexts/execution/roadmap-process-loop.md": "359d2c33dd01c51f5c354737ccfa0d822b49dcd066bfd6a3d8854c5ebe35a93d",
   "contexts/execution/subagent-response-contract.md": "340a2f564f7d885ee56c7458db851c3fb43c8b75af0d0a0a84ee683d38414d26",
   "contexts/execution/subagent-routing.md": "ab37120f33fb199d7893dceb25e582d47b02cb4b2c384c36e92d33129723b06c",
   "contexts/execution/subagent-spawn-contract.md": "825dea509536f2a81a9588e36c102c9076246d01336c39e26b4085291e2aed6f",

--- a/src/agent-src/contexts/execution/roadmap-process-loop.md
+++ b/src/agent-src/contexts/execution/roadmap-process-loop.md
@@ -28,6 +28,26 @@ roadmaps with open work that is blocked-for-later — parked, not active).
   surface alternatives in the pre-run summary.
 - None active → tell the user; suggest [`/roadmap:create`](../../commands/roadmap/create.md).
 
+### Live merge-state before any "in-flight / merged / handled" claim
+
+When selection reasoning would **exclude** a roadmap — or a pre-run summary,
+decision, or any user-facing message would **describe** one — as *in-flight*,
+*handled by an open PR*, *already merged*, or *not yet merged*, verify that
+claim **live at the moment of the claim** (`gh pr view <n> --json state,mergedAt`
+or `gh pr list --search "<slug>"`). Never infer merge state from:
+
+- the **dashboard's open-count** — it lags: a completed roadmap is archived in
+  the **merging** PR, so a roadmap can still read "open" on `main` while its PR
+  is already merged (archive not yet on your checkout), or read "open" seconds
+  before a merge you never re-checked;
+- **session memory** ("I opened a PR for this earlier") or an **earlier fetch** —
+  a merge can land between your fetch and your message.
+
+A stale merge-state claim ships an unnecessary user-facing message about work
+that is already done — the exact failure this clause prevents. This is the
+[`direct-answers`](../../rules/direct-answers.md) Iron-Law-2 live-state rule
+(git/PR state never from memory), applied to roadmap selection.
+
 ## 2. Pre-run summary — gate or inline note
 
 Read `roadmap.skip_pre_run_gate` from `.agent-settings.yml` (default


### PR DESCRIPTION
## Why

Roadmap selection (`roadmap-process-loop § 1`) could classify or describe a roadmap as *in-flight / handled by an open PR / already merged / not yet merged* from the **dashboard open-count** or **session memory** — both lag the true merge state:

- a completed roadmap is archived in the **merging** PR, so it reads "open" on `main` until that archive lands on your checkout;
- a merge can land between an earlier `git fetch` and the message.

Result: an unnecessary user-facing message about work that was already done.

## What

Add a mandatory **live merge-state check** to § 1: any exclusion or user-facing description of a roadmap as in-flight/merged/handled must verify live (`gh pr view <n> --json state,mergedAt` / `gh pr list --search`) **at the moment of the claim** — never from the dashboard count, session memory, or an earlier fetch.

This is the [`direct-answers`](../blob/main/src/rules/direct-answers.md) Iron-Law-2 live-state rule (git/PR state never from memory) applied to the roadmap-selection surface.

## Scope

- `src/agent-src/contexts/execution/roadmap-process-loop.md` (+ condensed `dist/` projection + condensation hashes). Non-kernel; no rule-body change.