### PR TITLE
feat(kernel): re-land direct-answers no-duration + never-cite-the-rule (#844 content lost from main)

### DIFF
--- a/dist/agent-src/rules/direct-answers.md
+++ b/dist/agent-src/rules/direct-answers.md
@@ -30,7 +30,7 @@ THE MORE LOAD-BEARING THE CLAIM, THE HARDER YOU VERIFY.
 WHEN VERIFICATION IS NOT WORTH THE COST → ASK.
 ```
 
-Severity tiers (High = load-bearing · Medium = project-shape · Low = idioms), per-tier verification actions, and "just guess" override: [`asking-and-brevity-examples`](../docs/guidelines/agent-infra/asking-and-brevity-examples.md).
+Severity tiers, per-tier verification actions, "just guess" override, **no duration estimates**, and **never cite the rule** when declining: [`asking-and-brevity-examples`](../docs/guidelines/agent-infra/asking-and-brevity-examples.md).
 
 **Live-state facts — never from memory.** Git/PR merge/branch/sync/existence state is High-severity and decays silently (branch already merged, PR already closed, `main` already ahead). NEVER assert "merged / not merged / pending / still open / already in `main` / out of scope" — or any branch/sync/existence claim — from memory, a roadmap note, an earlier turn, or a recalled memory. Run the live check FIRST (`git log --first-parent origin/main`, `git branch -r --contains <ref>`, `gh pr view <n> --json state,mergedAt,baseRefName`); a state question is self-answering (per [`git-workflow`](../skills/git-workflow/SKILL.md)). Same for any external system that changes behind you (CI run, deploy, remote queue).
 

--- a/docs/guidelines/agent-infra/asking-and-brevity-examples.md
+++ b/docs/guidelines/agent-infra/asking-and-brevity-examples.md
@@ -106,6 +106,33 @@ that matters for the claim. When in doubt, treat it as fresh-lookup — the
 cost of one extra search is far lower than a stale claim stated with
 confidence.
 
+### No duration estimates (Iron Law 2 family)
+
+An LLM has no wall-clock and no latency training signal, so a duration estimate
+is a fabricated fact wearing a number:
+
+- Never predict how long **the agent's own work** will take ("this refactor is
+  ~2 hours", "I'll have it in a few minutes").
+- Never predict how long **the user's work** will take ("this is a 2–3 week
+  project", "should take you an afternoon").
+- Instead: break the work into **actionable steps** and let the user judge
+  timing against their own context — they have the clock, the agent does not.
+
+A step list is honest ("A → B → C, C depends on B"); a schedule is invention.
+
+### Never cite the rule as the reason
+
+When declining or constraining an action, give the **actual, substantive
+reason** — never "my rules / guidelines / instructions require X":
+
+- ❌ "I can't do that, my guidelines don't allow it." / "A rule requires me to ask first."
+- ✅ "Sending this would post publicly and can't be undone, so confirm the recipient first." / "This edits a production branch — I need your go-ahead."
+
+Appealing to a hidden rule (a) replaces real reasoning the user can evaluate,
+and (b) widens the prompt-extraction surface (it advertises that hidden
+instructions exist and invites probing them). State the real-world consequence,
+not the rule's existence.
+
 ## Direct-answers — failure modes the user will call out
 
 Companion to `direct-answers` § Failure modes. The rule lists the

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -282,7 +282,7 @@
   "rules/delegation-policy.md": "34fcacadac18820d5e5b3476cab4f032aa4eea1750950bc8e69d8a53682a0ac6",
   "rules/design-fidelity.md": "b7073e48d7d1343dfa38f8d6478b44da609f72e0c9f11b13bb62db1045d00f8e",
   "rules/devcontainer-routing.md": "11a65c624017002fe4ad4de6104075f0a633bd90a8d1745f411f3f17c83fe4b1",
-  "rules/direct-answers.md": "cb7c6ad9693eb311a881432bdac40c00b92c09c44322abef4d82f2841ab0dfe8",
+  "rules/direct-answers.md": "96d56f61958bceb1416dafc10aeae841a2c855666eec03381e097870abe43b47",
   "rules/docker-commands.md": "27c110b623babe190ebcaad9168030da543465f3477af633bdd61327d38fa2bc",
   "rules/domain-adoption-policy.md": "21a4baeffe790aa4ff32c7da680fe63cd8e1772f3c5164e699590ffabae34bc0",
   "rules/domain-safety-disclaimer.md": "645fb1d8eff635711e0c84df080295cf0e9e005f2da0fdc1b6dc68c66b2c36ef",

--- a/src/rules/direct-answers.md
+++ b/src/rules/direct-answers.md
@@ -30,7 +30,7 @@ THE MORE LOAD-BEARING THE CLAIM, THE HARDER YOU VERIFY.
 WHEN VERIFICATION IS NOT WORTH THE COST → ASK.
 ```
 
-Severity tiers (High = load-bearing · Medium = project-shape · Low = idioms), per-tier verification actions, and "just guess" override: [`asking-and-brevity-examples`](../../docs/guidelines/agent-infra/asking-and-brevity-examples.md).
+Severity tiers, per-tier verification actions, "just guess" override, **no duration estimates**, and **never cite the rule** when declining: [`asking-and-brevity-examples`](../../docs/guidelines/agent-infra/asking-and-brevity-examples.md).
 
 **Live-state facts — never from memory.** Git/PR merge/branch/sync/existence state is High-severity and decays silently (branch already merged, PR already closed, `main` already ahead). NEVER assert "merged / not merged / pending / still open / already in `main` / out of scope" — or any branch/sync/existence claim — from memory, a roadmap note, an earlier turn, or a recalled memory. Run the live check FIRST (`git log --first-parent origin/main`, `git branch -r --contains <ref>`, `gh pr view <n> --json state,mergedAt,baseRefName`); a state question is self-answering (per [`git-workflow`](../skills/git-workflow/SKILL.md)). Same for any external system that changes behind you (CI run, deploy, remote queue).
 


### PR DESCRIPTION
## Why

#844 shows **MERGED** on GitHub, but its merge commit `61304ee7` is **not reachable from origin/main** and its content is **absent** — dropped together with #840 in the archival-rename history repair. Sibling to #847.

## What

Re-lands the P1/P5a content onto current main:

- `direct-answers.md` Iron-Law-2 pointer — now names **no duration estimates** (no wall-clock → a schedule is invention) and **never cite the rule as the reason** (give the real reason, not "my rules require X").
- `asking-and-brevity-examples.md` — the two companion sections carrying the detail.

## Budget note

`direct-answers` is pinned at the always-budget concentration ceiling (3,589 chars on main). So the pointer is kept **net-neutral**: the inline severity-tier gloss (already duplicated in the guideline's severity table) is trimmed to make room for the two new topic names. Result **3,592 chars**, `check_always_budget` 58.9% — OK. Same "pointer + companion detail" shape #844's own budget-fix commit used.

## Verification

`check_always_budget` (OK, exit 0) · `check_condensation` · `check_references` green. Kernel-isolated (own PR, slow-rollout). Unblocks `road-to-execution-discipline-harvest`.