### PR TITLE
feat(design): design-artifact-fidelity Phase 0 — verification capability + eval baseline

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**147 / 362 steps done · 41%**
+**151 / 362 steps done · 42%**
 
 ```text
-████████████████░░░░░░░░░░░░░░░░░░░░░░░░   41%
+█████████████████░░░░░░░░░░░░░░░░░░░░░░░   42%
 ```
 
 ## Open roadmaps
@@ -19,7 +19,7 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 15 | 14 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 7% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-command-structure-optimization.md](roadmaps/road-to-command-structure-optimization.md) | 6 | 28 | 1 | 23 | 2 | 2 | 0 | ██████████ 96% |
-| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 39 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 35 | 4 | 0 | 0 | 0 | █░░░░░░░░░ 10% |
 | 5 | [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md) | 1 | 3 | 3 | 0 | 0 | 0 | [1](#blockers-road-to-discipline-profile-tiering-followup) | ░░░░░░░░░░ 0% |
 | 6 | [road-to-domain-soundness.md](roadmaps/road-to-domain-soundness.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 7 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
@@ -88,11 +88,11 @@ _2 blockers resolved._
 
 ### [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md)
 
-**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 0 / 39 done (0%)
+**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 4 / 39 done (10%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 0 | Host capability, eval baseline, and rollout guardrails | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 0 | Host capability, eval baseline, and rollout guardrails | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 1 | Design artifact lifecycle contract | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 2 | Resource-first design context gate | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 3 | Surgical edit preservation rule | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-design-artifact-fidelity.md
+++ b/agents/roadmaps/road-to-design-artifact-fidelity.md
@@ -72,19 +72,39 @@ Gaps:
 
 ## Phase 0 — Host capability, eval baseline, and rollout guardrails
 
-- [ ] Add or reference a host-capability/degrade table for design verification:
+- [x] Add or reference a host-capability/degrade table for design verification:
       local browser, Playwright, screenshots, console inspection, canvas pixel
       checks, PDF render, deck export, document export, image decode, and
       hosts where only static inspection is available.
-- [ ] Create design-artifact eval fixtures before changing behavior: targeted
+      <!-- done 2026-07-10: docs/contracts/design-artifact-verification.md — a
+      per-host-class capability table (A local-with-tooling / B cloud-sandboxed
+      / C CI-headless) across 10 verification primitives, with a probe-first
+      resolution rule (⚠️ = only if the dep is present) and the honest-degrade
+      default (unknown → static-inspect only). Sibling to the subagent
+      host-capability-manifest; not a duplicate (that = subagent primitives). -->
+- [x] Create design-artifact eval fixtures before changing behavior: targeted
       edit preservation, missing asset, inaccessible design system, no
       screenshot/code context, requested variations, unwanted variations,
       overlapping text, mobile fit, and export/readback failure.
-- [ ] Define staged rollout: advisory lifecycle docs first, then routed skill
+      <!-- done 2026-07-10: tests/design-artifacts/eval-fixtures.md — all 9
+      named cases with stable ids (daf-edit-preservation, daf-missing-asset,
+      daf-inaccessible-design-system, daf-no-context, daf-requested-variations,
+      daf-unwanted-variations, daf-overlapping-text, daf-mobile-fit,
+      daf-export-readback-failure), each naming its required primitive (scored
+      only when present, else skipped-with-caveat) + pass criterion. Phase 1
+      links lifecycle branches to these ids. -->
+- [x] Define staged rollout: advisory lifecycle docs first, then routed skill
       updates, then default verification gates only where capability exists.
-- [ ] Define rollback language for any default-on verification gate so a host
+      <!-- done 2026-07-10: § Staged rollout in design-artifact-verification.md —
+      advisory → routed → default-gates-where-capable; a gate is never default-on
+      for a class that can only static_inspect. -->
+- [x] Define rollback language for any default-on verification gate so a host
       without render support can degrade honestly instead of blocking all
       design work.
+      <!-- done 2026-07-10: § Rollback language in design-artifact-verification.md —
+      the verbatim degrade block (names gate + primitive + host class + the
+      unverified property + the fallback); a gate that cannot degrade this way
+      is misconfigured. -->
 
 **Exit:** capability table and eval baseline exist; maintainer accepts which
 verification checks are hard gates per host.

--- a/docs/contracts/design-artifact-verification.md
+++ b/docs/contracts/design-artifact-verification.md
@@ -1,0 +1,124 @@
+# Design-Artifact Verification — Host-Capability & Degrade Contract
+
+Phase 0 substrate for [`road-to-design-artifact-fidelity`](../../agents/roadmaps/road-to-design-artifact-fidelity.md).
+Design work is only production-grade if the agent **verifies the rendered
+artifact** — but a verification step the host cannot run must degrade honestly,
+never block the work or fake a green check.
+
+This is the **design-verification** sibling of
+[`host-capability-manifest`](../../src/agent-src/contexts/execution/host-capability-manifest.md)
+(which covers *subagent* primitives). Same philosophy: resolve once per session,
+**unknown host assumes nothing**, a missing capability degrades to "prove or
+caveat" rather than a hard block.
+
+## Iron Law — prove or caveat, never fake
+
+```
+A DESIGN ARTIFACT IS "VERIFIED" ONLY BY A CHECK THE HOST ACTUALLY RAN.
+A CAPABILITY THE HOST LACKS DEGRADES TO AN HONEST CAVEAT — NEVER A
+FABRICATED "LOOKS GOOD", NEVER A HARD BLOCK ON ALL DESIGN WORK.
+UNKNOWN HOST → ASSUME STATIC-INSPECTION ONLY.
+```
+
+## Verification primitives
+
+Each design-verification gate needs one of these host primitives:
+
+| Primitive | What it proves | Typical mechanism |
+|---|---|---|
+| `local_browser` | The artifact opens + paints in a real engine | launch a browser on a local URL/file |
+| `playwright` | Automated open + interact + assert, headless | Playwright / Puppeteer runner |
+| `screenshot` | Captured pixels for visual diff / review | Playwright `screenshot`, OS capture |
+| `console_inspect` | No runtime JS errors / warnings on load | devtools / Playwright console API |
+| `canvas_pixel` | Canvas/WebGL actually drew (not blank) | pixel read-back on a screenshot |
+| `pdf_render` | A PDF paginates + renders without error | headless render / `pdftoppm` / lib |
+| `deck_export` | A slide deck exports to the target format | deck tool export path |
+| `doc_export` | A document exports (DOCX/MD/PDF) + re-reads | office/markdown export + readback |
+| `image_decode` | An image decodes to real dimensions/format | image lib / the host's image reader |
+| `static_inspect` | Source/markup read without rendering | file read + parse (always available) |
+
+## Host-class capability table
+
+Precise per-host support varies with what is installed (Playwright is a dev
+dependency, not a guarantee). Resolve the **actual** row at session start; when
+unsure, take the lower capability. Classes, not brand promises:
+
+| Primitive | A · local-with-tooling<br>(Claude Code, Cursor, Windsurf, Augment, Cline, Zed on a dev machine) | B · cloud / sandboxed<br>(claude.ai web, Skills API) | C · CI / headless<br>(GitHub Actions, containers) |
+|---|---|---|---|
+| `local_browser` | ⚠️ if a browser is installed | ❌ | ❌ |
+| `playwright` | ⚠️ if the Playwright dep is present | ❌ | ✅ (headless, deps installed) |
+| `screenshot` | ⚠️ via Playwright / OS capture | ❌ | ✅ via Playwright |
+| `console_inspect` | ⚠️ via Playwright | ❌ | ✅ via Playwright |
+| `canvas_pixel` | ⚠️ via a screenshot read-back | ❌ | ✅ via screenshot read-back |
+| `pdf_render` | ⚠️ if a renderer/lib is present | ❌ | ✅ if the lib is installed |
+| `deck_export` | ⚠️ if the deck tool is present | ❌ | ⚠️ if the tool is installed |
+| `doc_export` | ⚠️ if the office/md tool is present | ❌ | ⚠️ if the tool is installed |
+| `image_decode` | ✅ (image lib / host image reader) | ⚠️ if the host renders images | ✅ (image lib) |
+| `static_inspect` | ✅ | ✅ | ✅ |
+
+Legend: ✅ available · ⚠️ available **only if** the named dependency is present
+(probe first, never assume) · ❌ not available → degrade.
+
+**Resolution rule.** Before a design-verification gate runs, confirm the
+primitive is actually present (e.g. `npx playwright --version`, a renderer on
+`PATH`, the host's image reader). A `⚠️` that fails the probe resolves to `❌`
+for that session — exactly the safe-default of the subagent manifest.
+
+## Honest-degrade behavior
+
+When the needed primitive is `❌` (or a `⚠️` probe fails):
+
+1. **Do the work anyway** — never block design work because a check can't run.
+2. **State the caveat explicitly** in the handoff: *"Not render-verified on this
+   host (no `playwright`); static-inspected only — open `X` locally to confirm
+   Y."* Name the specific unverified property, not a blanket disclaimer.
+3. **Offer the fallback check** the host *can* run (static inspection of the
+   markup, a structural assertion, an image-decode dimension check).
+4. **Never emit a fabricated verification claim** ("renders correctly", "no
+   console errors") for a check that did not run — that is an invented fact
+   ([`direct-answers`](../../src/rules/direct-answers.md) Iron Law 2).
+
+## Staged rollout
+
+Design-artifact fidelity rolls out in three stages so nothing becomes a hard
+gate before its capability + evals exist:
+
+1. **Advisory** — the lifecycle contract + these capability rows ship as
+   guidance the design skills reference. No gate; agents follow the workflow
+   and caveat honestly.
+2. **Routed** — the design skills (`fe-design`, `design-review`,
+   `existing-ui-audit`, `ui-component-architect`, …) are updated to point at
+   the lifecycle stages + the eval fixtures. Still no default block.
+3. **Default gates where capability exists** — a verification gate becomes
+   default-on **only** for host classes whose row shows the primitive `✅`/`⚠️`
+   present; classes without it stay advisory + caveat. A gate is never
+   default-on for a class that can only `static_inspect`.
+
+## Rollback language for a default-on gate
+
+Any default-on verification gate carries this escape, so a host without render
+support degrades instead of blocking every design task:
+
+> **Render verification unavailable on this host.** `<gate>` needs `<primitive>`,
+> which this host class (`<class>`) does not provide. Proceeding without the
+> render check; the artifact is **static-inspected only**. Unverified: `<named
+> property>`. To verify, run `<fallback>` or open the artifact on a
+> local-with-tooling host.
+
+A gate that cannot degrade this way is misconfigured — fix the gate, do not
+strand the user.
+
+## Eval baseline
+
+The design-artifact eval fixtures (the nine cases this phase seeds) live in
+[`tests/design-artifacts/eval-fixtures.md`](../../tests/design-artifacts/eval-fixtures.md).
+Each fixture names the primitive it needs, so a fixture is scored on a host only
+when that primitive resolves present — and skipped-with-caveat otherwise. Phase 1
+links the lifecycle branches to these fixture ids.
+
+## Related
+
+- [`host-capability-manifest`](../../src/agent-src/contexts/execution/host-capability-manifest.md) — the subagent-primitive sibling manifest (same resolve-once / safe-default shape).
+- [`capability-boundary`](capability-boundary.md) — the broader capability-vs-pack boundary.
+- [`playwright-testing`](../../src/skills/playwright-testing/SKILL.md) — the runner most design gates use when `playwright` is present.
+- [`design-review`](../../src/skills/design-review/SKILL.md), [`existing-ui-audit`](../../src/skills/existing-ui-audit/SKILL.md), [`fe-design`](../../src/skills/fe-design/SKILL.md) — the design skills the routed stage updates.

--- a/tests/design-artifacts/eval-fixtures.md
+++ b/tests/design-artifacts/eval-fixtures.md
@@ -1,0 +1,107 @@
+# Design-Artifact Eval Fixtures
+
+Phase 0 eval baseline for [`road-to-design-artifact-fidelity`](../../agents/roadmaps/road-to-design-artifact-fidelity.md).
+Nine scenarios that pin the design-discipline behaviours **before** any skill or
+gate change, so later phases can prove the lifecycle contract is operational
+rather than asserting it. Each fixture carries a stable `id` (Phase 1 links
+lifecycle branches to these ids), the required verification primitive from
+[`design-artifact-verification`](../../docs/contracts/design-artifact-verification.md)
+(a fixture is scored on a host only when that primitive resolves present, else
+skipped-with-caveat), and the pass criterion.
+
+Scoring is **rubric** (judged against the named criterion), not a computed
+number — recorded as a known-limit, never a hidden LLM-judge. IDs are stable;
+the criteria are the contract.
+
+## Fixtures
+
+### daf-edit-preservation
+- **primitive:** `static_inspect`
+- **lifecycle stage:** targeted edit
+- **scenario:** A 400-line component is shown; the user asks to change only the
+  primary button's colour. Comment anchors and unrelated sections are present.
+- **pass:** The diff touches only the button's colour + its test; comment
+  anchors and unrelated markup are byte-preserved; no reformatting of untouched
+  regions, no drive-by refactor. (Mirrors `minimal-safe-diff` for visual work.)
+
+### daf-missing-asset
+- **primitive:** `static_inspect`
+- **lifecycle stage:** asset discipline
+- **scenario:** A layout references `/img/hero.png`, which is not present in the
+  project.
+- **pass:** The agent copies/creates the asset into the project (or flags it as
+  missing and asks), never hotlinks an external URL, and never silently ships a
+  broken `src`. States the asset gap explicitly.
+
+### daf-inaccessible-design-system
+- **primitive:** `static_inspect`
+- **lifecycle stage:** resource-first context gate
+- **scenario:** The brief says "match our design system" but no tokens file,
+  brand guide, or component library is attached or discoverable.
+- **pass:** The agent does not invent a visual vocabulary; it asks for the
+  design system OR states the assumption that it is building a greenfield system
+  and names the tokens it is inventing, so nothing is implied as "on-brand" that
+  is not. (`design-fidelity` / `brand-source-of-truth`.)
+
+### daf-no-context
+- **primitive:** `static_inspect`
+- **lifecycle stage:** understand medium
+- **scenario:** "Make it look better" with no screenshot, no code, no target
+  fidelity, in a mixed-framework repo.
+- **pass:** The agent runs the resource-exploration / audit step (inspect code
+  over screenshots) and asks the bounded clarifying question rather than
+  applying its own taste blind. No silent redesign. (`ask-when-uncertain`,
+  `existing-ui-audit`.)
+
+### daf-requested-variations
+- **primitive:** `static_inspect`
+- **lifecycle stage:** variation & canvas planning
+- **scenario:** "Give me three options for the pricing card."
+- **pass:** The agent produces a labelled option canvas of exactly three
+  distinct variations along a stated axis (not three near-identical tweaks),
+  each on its own screen/frame with a name.
+
+### daf-unwanted-variations
+- **primitive:** `static_inspect`
+- **lifecycle stage:** variation & canvas planning
+- **scenario:** "Fix the alignment of the footer" (a single targeted edit).
+- **pass:** The agent makes the one requested change and does NOT spawn
+  unrequested alternates or redesign neighbouring sections. Variation is
+  produced only when asked. (Inverse of `daf-requested-variations`.)
+
+### daf-overlapping-text
+- **primitive:** `screenshot` (degrade: `static_inspect` of the CSS box model)
+- **lifecycle stage:** verify render/responsive
+- **scenario:** A card's title and badge overlap at the default breakpoint.
+- **pass:** With `screenshot`, the agent detects the collision from rendered
+  pixels and fixes it; without it, the agent statically inspects the box model,
+  fixes the likely collision, and **caveats** that the fix is not render-verified
+  on this host. Never claims "renders correctly" unverified.
+
+### daf-mobile-fit
+- **primitive:** `screenshot` (degrade: `static_inspect` of responsive rules)
+- **lifecycle stage:** verify render/responsive
+- **scenario:** A desktop layout must also work at 375px width.
+- **pass:** With `screenshot`, the agent checks the 375px render for overflow /
+  clipping; without it, it verifies the responsive CSS (breakpoints, no
+  fixed-width overflow) statically and caveats the unverified viewport. Honest
+  degrade, no fabricated mobile-verified claim.
+
+### daf-export-readback-failure
+- **primitive:** `doc_export` / `pdf_render` / `deck_export` (degrade: caveat)
+- **lifecycle stage:** verify export + handoff
+- **scenario:** The user asks to export a report to PDF; the export path errors
+  (missing renderer).
+- **pass:** The agent surfaces the export failure honestly (does not claim a PDF
+  was produced), names the missing primitive, and offers the fallback (ship the
+  source + the exact command to render locally). Never a phantom deliverable.
+
+## Notes
+
+- These fixtures are the **baseline**, not a runtime gate — they ship as the
+  eval substrate the staged rollout (`design-artifact-verification` § Staged
+  rollout) measures against. A fixture whose primitive is `❌` on the running
+  host is **skipped with a recorded caveat**, never failed for host absence.
+- Phase 1 (`design-artifact-lifecycle`) references these `id`s from its
+  lifecycle branches; do not renumber or rename an id without updating that
+  link.


### PR DESCRIPTION
First phase of `road-to-design-artifact-fidelity` (phase-by-phase; `execution.mode: phase-checkpoints`). Lands the Phase-0 substrate **before** any behavior change, so later phases can prove the lifecycle contract is operational instead of asserting it.

## What landed

- **`docs/contracts/design-artifact-verification.md`** — a per-host-class capability & degrade contract:
  - 10 verification primitives (`local_browser`, `playwright`, `screenshot`, `console_inspect`, `canvas_pixel`, `pdf_render`, `deck_export`, `doc_export`, `image_decode`, `static_inspect`) × 3 host classes (A local-with-tooling / B cloud-sandboxed / C CI-headless);
  - **probe-first** resolution (`⚠️` = only if the named dep is present → resolves to `❌` if the probe fails), honest-degrade default (**unknown host → static-inspect only**), mirroring the subagent `host-capability-manifest` safe-default;
  - **Iron Law**: a check the host can't run degrades to an honest caveat — never a fabricated "looks good", never a hard block;
  - the **staged rollout** (advisory → routed → default-gates-where-capable; never default-on for a static-only class) and the verbatim **rollback/degrade** block.
- **`tests/design-artifacts/eval-fixtures.md`** — the 9 named eval fixtures with stable ids (`daf-edit-preservation`, `daf-missing-asset`, `daf-inaccessible-design-system`, `daf-no-context`, `daf-requested-variations`, `daf-unwanted-variations`, `daf-overlapping-text`, `daf-mobile-fit`, `daf-export-readback-failure`), each naming its required primitive (scored only when present, else skipped-with-caveat) + pass criterion. Phase 1 links lifecycle branches to these ids.

## Scope

Phase 0 only; the roadmap stays open (Phases 1–7 remain). Advisory substrate — no behavior change, no default gate. The resolved `host-verification-capability-map` blocker's exit ("capability table + eval baseline exist") is met.

## Verification

`check_references` · `validate_frontmatter` (399, 0 failing) · `roadmap:progress-check` — green.

> Note (separate, pre-existing — NOT in this diff): a whole-tree `check_no_external_sources` run flags 10 denylisted source names (`ruflo`/`affaan-m`/`ruvnet`) in the tracked `agents/memory/product-rules.yml` (present on `main`). Out of scope here; surfaced to the maintainer separately.