### PR TITLE
feat(design): design-artifact-fidelity Phase 1 — lifecycle contract

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**151 / 362 steps done · 42%**
+**156 / 362 steps done · 43%**
 
 ```text
-█████████████████░░░░░░░░░░░░░░░░░░░░░░░   42%
+█████████████████░░░░░░░░░░░░░░░░░░░░░░░   43%
 ```
 
 ## Open roadmaps
@@ -19,7 +19,7 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 15 | 14 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 7% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-command-structure-optimization.md](roadmaps/road-to-command-structure-optimization.md) | 6 | 28 | 1 | 23 | 2 | 2 | 0 | ██████████ 96% |
-| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 35 | 4 | 0 | 0 | 0 | █░░░░░░░░░ 10% |
+| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 30 | 9 | 0 | 0 | 0 | ██░░░░░░░░ 23% |
 | 5 | [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md) | 1 | 3 | 3 | 0 | 0 | 0 | [1](#blockers-road-to-discipline-profile-tiering-followup) | ░░░░░░░░░░ 0% |
 | 6 | [road-to-domain-soundness.md](roadmaps/road-to-domain-soundness.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 7 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
@@ -88,12 +88,12 @@ _2 blockers resolved._
 
 ### [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md)
 
-**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 4 / 39 done (10%)
+**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 9 / 39 done (23%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Host capability, eval baseline, and rollout guardrails | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 1 | Design artifact lifecycle contract | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 1 | Design artifact lifecycle contract | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 2 | Resource-first design context gate | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 3 | Surgical edit preservation rule | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 4 | Variation and canvas planning | ⬜ not started | 5 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-design-artifact-fidelity.md
+++ b/agents/roadmaps/road-to-design-artifact-fidelity.md
@@ -111,21 +111,35 @@ verification checks are hard gates per host.
 
 ## Phase 1 — Design artifact lifecycle contract
 
-- [ ] Add `docs/contracts/design-artifact-lifecycle.md` describing the common
+- [x] Add `docs/contracts/design-artifact-lifecycle.md` describing the common
       lifecycle: understand medium/audience/fidelity → inspect source assets
       and design system → define visual system/variation plan → build artifact
       → verify render/load/responsive states → brief handoff.
-- [ ] Map existing skills to lifecycle stages: `existing-ui-audit`,
+      <!-- done 2026-07-10: docs/contracts/design-artifact-lifecycle.md — the
+      6-stage lifecycle table (Understand/Inspect/Plan/Build/Verify/Handoff),
+      each stage citing the fixtures that exercise it. -->
+- [x] Map existing skills to lifecycle stages: `existing-ui-audit`,
       `fe-design`, `design-review`, `ui-component-architect`,
       `playwright-testing`, `brand-audit`, `brand-to-tokens`,
       `presentations`, `PDF`, and document skills where applicable.
-- [ ] Add explicit branch rules: new design vs targeted edit vs iteration vs
+      <!-- done: § Skill → stage map. Conceptual "presentations"/"PDF"/document
+      map to the real skills html-deck / markitdown / doc-coauthoring
+      (design-system-capture added for Handoff). -->
+- [x] Add explicit branch rules: new design vs targeted edit vs iteration vs
       design-system extraction vs handoff to production code.
-- [ ] Add "do not invent filler" and "ask before adding material" as design
+      <!-- done: § Branch rules — 5 branches, each selecting the stages it runs
+      + ≥1 gating fixture; targeted-edit stays surgical, iteration preserves the
+      prior version on a major revision. -->
+- [x] Add "do not invent filler" and "ask before adding material" as design
       constraints. Empty space is a composition problem, not permission to add
       fake sections, fake metrics, or stock-like decoration.
-- [ ] Link lifecycle states to eval ids from Phase 0 so later skill edits can
+      <!-- done: § Design constraints (Iron-Law fence) — no invented filler,
+      ask before adding material; cross-linked direct-answers IL2 +
+      output-discipline. -->
+- [x] Link lifecycle states to eval ids from Phase 0 so later skill edits can
       prove the contract is operational.
+      <!-- done: each lifecycle stage + each branch names its gating fixture id
+      from tests/design-artifacts/eval-fixtures.md; every branch has ≥1. -->
 
 **Exit:** all design-related skills can point to one lifecycle without
 duplicating it, and each lifecycle branch has at least one eval fixture.

--- a/docs/contracts/design-artifact-lifecycle.md
+++ b/docs/contracts/design-artifact-lifecycle.md
@@ -1,0 +1,93 @@
+# Design-Artifact Lifecycle Contract
+
+Phase 1 of [`road-to-design-artifact-fidelity`](../../agents/roadmaps/road-to-design-artifact-fidelity.md).
+One lifecycle every design/artifact skill points at, so "context before taste"
+and "rendered artifact before claim" are a shared workflow, not per-skill folklore.
+Design work is a **pipeline** — understand, inspect, plan, build, verify, hand
+off — not a bag of styling tips.
+
+This contract is advisory (staged-rollout stage 1 per
+[`design-artifact-verification` § Staged rollout](design-artifact-verification.md#staged-rollout)):
+skills reference these stages; nothing here is a default gate yet.
+
+## The lifecycle
+
+Six stages. Every design task runs the stages its branch (below) selects — never
+skips straight to "build".
+
+| # | Stage | What it does | Exercised by fixtures |
+|---|---|---|---|
+| 1 | **Understand** | Medium, audience, fidelity, target host. What *kind* of artifact (screen, deck, doc, component, prototype), for whom, at what polish, verifiable how (per the capability table). | `daf-no-context` |
+| 2 | **Inspect** | Read the existing design system + code **before** styling — code over screenshots when available; copy the visual vocabulary; confirm assets exist. Ask when no context is attached. | `daf-inaccessible-design-system`, `daf-missing-asset` |
+| 3 | **Plan** | Define the visual system + the variation plan: which axis varies, how many options, labelled. No unrequested variations. | `daf-requested-variations`, `daf-unwanted-variations` |
+| 4 | **Build** | Produce the artifact against the system. Surgical on edits; no invented filler (§ Design constraints). | `daf-edit-preservation` |
+| 5 | **Verify** | Prove the rendered artifact — render / load / responsive / export — via a primitive the host has, else caveat honestly (never fake). | `daf-overlapping-text`, `daf-mobile-fit`, `daf-export-readback-failure` |
+| 6 | **Handoff** | Brief, honest handoff: what was built, what is verified vs caveated, implementation intent, preserved comment anchors. | `daf-export-readback-failure` |
+
+Fixtures are defined in [`tests/design-artifacts/eval-fixtures.md`](../../tests/design-artifacts/eval-fixtures.md);
+the ids are stable so skill edits in later phases can prove the stage is operational.
+
+## Skill → stage map
+
+Skills own the *depth* at each stage; the lifecycle owns the *order*. A skill
+cites the stage(s) it serves instead of re-describing the workflow.
+
+| Stage | Primary skills |
+|---|---|
+| Understand | [`fe-design`](../../src/skills/fe-design/SKILL.md), [`design-review`](../../src/skills/design-review/SKILL.md) |
+| Inspect | [`existing-ui-audit`](../../src/skills/existing-ui-audit/SKILL.md), [`brand-audit`](../../src/skills/brand-audit/SKILL.md), [`brand-to-tokens`](../../src/skills/brand-to-tokens/SKILL.md) |
+| Plan | [`fe-design`](../../src/skills/fe-design/SKILL.md), [`ui-component-architect`](../../src/skills/ui-component-architect/SKILL.md) |
+| Build | [`ui-component-architect`](../../src/skills/ui-component-architect/SKILL.md), [`html-deck`](../../src/skills/html-deck/SKILL.md) (decks), [`doc-coauthoring`](../../src/skills/doc-coauthoring/SKILL.md) (documents) |
+| Verify | [`playwright-testing`](../../src/skills/playwright-testing/SKILL.md), [`design-review`](../../src/skills/design-review/SKILL.md), [`markitdown`](../../src/skills/markitdown/SKILL.md) (export readback) |
+| Handoff | [`design-review`](../../src/skills/design-review/SKILL.md), [`design-system-capture`](../../src/skills/design-system-capture/SKILL.md) |
+
+(The roadmap's conceptual "presentations" / "PDF / document" skills map to the
+real `html-deck`, `markitdown`, and `doc-coauthoring` skills above.)
+
+## Branch rules
+
+The lifecycle is not linear for every task. Pick the branch first; it selects
+which stages run and which fixtures gate it (each branch has ≥1 fixture).
+
+| Branch | Trigger | Stages run | Gating fixtures |
+|---|---|---|---|
+| **New design** | Greenfield artifact, no prior version | 1→2→3→4→5→6 (full) | `daf-no-context`, `daf-inaccessible-design-system`, `daf-requested-variations` |
+| **Targeted edit** | Change one named thing in an existing artifact | 2 (light) → 4 → 5 | `daf-edit-preservation`, `daf-unwanted-variations` |
+| **Iteration** | Refine an existing artifact across a version bump | 1 (delta) → 3 → 4 → 5; **preserve the prior version** on a major revision | `daf-requested-variations` |
+| **Design-system extraction** | Derive tokens/components from existing artifacts | 2 (deep) → 6 | `daf-inaccessible-design-system` |
+| **Handoff to production code** | Turn a design into implementation intent | 5 → 6 | `daf-overlapping-text`, `daf-mobile-fit`, `daf-export-readback-failure` |
+
+**Targeted edit stays surgical** — no redesign of neighbours, no reformatting of
+untouched regions, comment anchors preserved (the `daf-edit-preservation`
+contract; mirrors [`minimal-safe-diff`](../../src/rules/minimal-safe-diff.md) for
+visual work). **Iteration preserves the prior version** on a major revision so a
+regression is recoverable.
+
+## Design constraints — do not invent filler
+
+```
+EMPTY SPACE IS A COMPOSITION PROBLEM, NOT PERMISSION TO ADD MATERIAL.
+NEVER INVENT FAKE SECTIONS, FAKE METRICS, LOREM-STYLE COPY, OR STOCK
+DECORATION TO FILL A LAYOUT. ASK BEFORE ADDING MATERIAL THAT ISN'T IN THE BRIEF.
+```
+
+- **Do not invent filler.** A sparse layout is solved with composition
+  (spacing, scale, hierarchy), not with fabricated content. Fake KPIs, invented
+  testimonials, placeholder charts with made-up numbers, and decorative
+  stock-like imagery are content the user did not ask for and cannot trust.
+- **Ask before adding material.** If the artifact genuinely needs content that
+  isn't supplied (a section the brief implies but doesn't provide), surface the
+  gap and ask — do not silently manufacture it. Realistic placeholder clearly
+  labelled as placeholder is acceptable when the user asked for a mock; passing
+  invented data off as real is not.
+
+This is the design-surface instance of the no-invented-facts discipline
+([`direct-answers`](../../src/rules/direct-answers.md) Iron Law 2) and the
+no-placeholder-slop rule ([`output-discipline`](../../src/rules/output-discipline.md)).
+
+## Related
+
+- [`design-artifact-verification`](design-artifact-verification.md) — the Phase-0 host-capability & degrade contract this lifecycle's Verify stage runs against.
+- [`tests/design-artifacts/eval-fixtures.md`](../../tests/design-artifacts/eval-fixtures.md) — the nine fixtures the stages + branches gate on.
+- [`design-fidelity`](../../src/rules/design-fidelity.md) — the provided-design-is-the-spec rule the Inspect stage enforces.
+- [`fe-design`](../../src/skills/fe-design/SKILL.md), [`existing-ui-audit`](../../src/skills/existing-ui-audit/SKILL.md), [`design-review`](../../src/skills/design-review/SKILL.md), [`ui-component-architect`](../../src/skills/ui-component-architect/SKILL.md) — the design skills that cite these stages.


### PR DESCRIPTION
Second phase of `road-to-design-artifact-fidelity` (phase-by-phase). Adds the single lifecycle every design/artifact skill points at, so "context before taste" and "rendered artifact before claim" are a shared workflow rather than per-skill folklore.

## What landed

**`docs/contracts/design-artifact-lifecycle.md`**:
- **6-stage lifecycle** — Understand → Inspect → Plan → Build → Verify → Handoff — each stage citing the Phase-0 fixture(s) that exercise it.
- **Skill → stage map** — `existing-ui-audit`, `fe-design`, `design-review`, `ui-component-architect`, `playwright-testing`, `brand-audit`, `brand-to-tokens`, `design-system-capture`, plus the real deck/doc skills (`html-deck`, `markitdown`, `doc-coauthoring`) standing in for the roadmap's conceptual "presentations"/"PDF"/document.
- **5 branch rules** — new design / targeted edit / iteration / design-system extraction / handoff to production — each selecting the stages it runs and ≥1 gating fixture (exit criterion: every branch has a fixture). Targeted-edit stays surgical; iteration preserves the prior version on a major revision.
- **"Do not invent filler / ask before adding material"** Iron-Law constraint — the design-surface instance of no-invented-facts (`direct-answers` IL2) + no-placeholder-slop (`output-discipline`).

## Scope

Advisory (staged-rollout stage 1) — no behavior change, no default gate. Roadmap stays open (Phases 2–7 remain).

## Verification

`check_references` (all skill/rule/fixture links resolve) · `roadmap:progress-check` — green.