### PR TITLE
feat(design): design-artifact-fidelity Phase 3 — surgical edit preservation

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**161 / 362 steps done · 44%**
+**165 / 362 steps done · 46%**
 
 ```text
-██████████████████░░░░░░░░░░░░░░░░░░░░░░   44%
+██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
 ```
 
 ## Open roadmaps
@@ -19,7 +19,7 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 15 | 14 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 7% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-command-structure-optimization.md](roadmaps/road-to-command-structure-optimization.md) | 6 | 28 | 1 | 23 | 2 | 2 | 0 | ██████████ 96% |
-| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 25 | 14 | 0 | 0 | 0 | ████░░░░░░ 36% |
+| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 21 | 18 | 0 | 0 | 0 | █████░░░░░ 46% |
 | 5 | [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md) | 1 | 3 | 3 | 0 | 0 | 0 | [1](#blockers-road-to-discipline-profile-tiering-followup) | ░░░░░░░░░░ 0% |
 | 6 | [road-to-domain-soundness.md](roadmaps/road-to-domain-soundness.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 7 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
@@ -88,14 +88,14 @@ _2 blockers resolved._
 
 ### [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md)
 
-**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 14 / 39 done (36%)
+**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 18 / 39 done (46%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Host capability, eval baseline, and rollout guardrails | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 1 | Design artifact lifecycle contract | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 2 | Resource-first design context gate | ✅ done | 0 | 5 | 0 | 0 | 100% |
-| 3 | Surgical edit preservation rule | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 3 | Surgical edit preservation rule | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 4 | Variation and canvas planning | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 5 | Asset and iconography discipline | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 6 | Render verification hard gate with honest degradation | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-design-artifact-fidelity.md
+++ b/agents/roadmaps/road-to-design-artifact-fidelity.md
@@ -184,19 +184,32 @@ project-specific context exists or was promised.
 
 ## Phase 3 — Surgical edit preservation rule
 
-- [ ] Add or extend a rule for small visual edits: if the user asks for a
+- [x] Add or extend a rule for small visual edits: if the user asks for a
       color/text/one-element change, change only that semantic target and
       preserve surrounding layout, spacing, typography, dimensions, content,
       animation, and interaction states.
-- [ ] Add examples of legitimate broader redesign triggers: "new direction",
+      <!-- done 2026-07-10: extended src/rules/design-fidelity.md with a
+      "## Surgical visual edits" section — change only the semantic target,
+      preserve the surrounding layout/spacing/typography/dimensions/content/
+      animation/interaction; cross-links minimal-safe-diff. -->
+- [x] Add examples of legitimate broader redesign triggers: "new direction",
       "from scratch", "make it feel premium", "rework the flow", "give me
       variations".
-- [ ] Add comment-anchor/screen-label preservation guidance for hosts that can
+      <!-- done: the section's "A broader redesign needs an explicit trigger"
+      bullet lists exactly these phrases; absent one, a fix/change/update
+      request is surgical. -->
+- [x] Add comment-anchor/screen-label preservation guidance for hosts that can
       expose DOM/comment metadata. Where host support is absent, preserve
       stable semantic anchors in source code comments/data attributes only if
       already present.
-- [ ] Add regression tests or trigger evals where an agent must not rewrite an
+      <!-- done: the "Preserve stable anchors" bullet — keep DOM/comment anchors
+      + screen labels where the host exposes them; else preserve already-present
+      source comment / data-* anchors, never strip or invent. -->
+- [x] Add regression tests or trigger evals where an agent must not rewrite an
       entire component for a one-line copy or color edit.
+      <!-- done: tests/design-artifacts/eval-fixtures.md gains daf-redesign-trigger
+      (surgical one-line edit vs explicit-trigger redesign), the regression
+      witness alongside the existing daf-edit-preservation + daf-unwanted-variations. -->
 
 **Exit:** small-change design tasks get the same minimal-safe-diff discipline
 as backend edits.

--- a/dist/agent-src/rules/design-fidelity.md
+++ b/dist/agent-src/rules/design-fidelity.md
@@ -88,6 +88,28 @@ redesign.
 - Treating an internal "honesty gate" or "stub" concern as licence to redesign the UI.
 - Re-running a redesign after the user already said "match the prototype".
 
+## Surgical visual edits
+
+A request to change one visual thing — a colour, a label, a single element — is
+a **targeted edit**, not a redesign licence. Apply the same
+[`minimal-safe-diff`](minimal-safe-diff.md) discipline to design work that
+backend edits have always owed.
+
+- **Change only the semantic target.** Preserve the surrounding layout,
+  spacing, typography, dimensions, content, animation, and interaction states.
+  Do not rewrite the component, reflow the section, or "modernise" neighbours
+  while you are in there. (fixtures: `daf-edit-preservation`, `daf-unwanted-variations`.)
+- **A broader redesign needs an explicit trigger.** Only phrases like *"new
+  direction"*, *"from scratch"*, *"make it feel premium"*, *"rework the flow"*,
+  or *"give me variations / options"* license a from-scratch rework. Absent such
+  a phrase, a "fix / change / update the X" request is surgical — when unsure
+  which, ask ([`ask-when-uncertain`](ask-when-uncertain.md)). (fixture: `daf-redesign-trigger`.)
+- **Preserve stable anchors.** Where the host exposes DOM/comment metadata, keep
+  comment anchors and screen labels intact so the edit stays locatable. Where
+  the host has no such surface, preserve stable semantic anchors already present
+  in source comments / `data-*` attributes — never strip them, and do not invent
+  new ones.
+
 ## See also
 
 - [`brand-source-of-truth`](brand-source-of-truth.md) / [`brand-consistency`](brand-consistency.md) — same precedence shape, for registered brand tokens.

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -281,7 +281,7 @@
   "rules/copilot-routing.md": "1aaa77973564e987bc02a9157493c3d7d30f5e382a293e60847b44be1d0663cd",
   "rules/decision-revisit-gate.md": "9665e685a872815edae6dc93aa55841a71243abfe21e1fa3e8f95fdd1ff44023",
   "rules/delegation-policy.md": "34fcacadac18820d5e5b3476cab4f032aa4eea1750950bc8e69d8a53682a0ac6",
-  "rules/design-fidelity.md": "b7073e48d7d1343dfa38f8d6478b44da609f72e0c9f11b13bb62db1045d00f8e",
+  "rules/design-fidelity.md": "897577d12a3192b1e6fa72f48f5d44ccdd4b7c7055a213a85e17d86f30e02b75",
   "rules/devcontainer-routing.md": "11a65c624017002fe4ad4de6104075f0a633bd90a8d1745f411f3f17c83fe4b1",
   "rules/direct-answers.md": "96d56f61958bceb1416dafc10aeae841a2c855666eec03381e097870abe43b47",
   "rules/docker-commands.md": "27c110b623babe190ebcaad9168030da543465f3477af633bdd61327d38fa2bc",

--- a/src/rules/design-fidelity.md
+++ b/src/rules/design-fidelity.md
@@ -88,6 +88,28 @@ redesign.
 - Treating an internal "honesty gate" or "stub" concern as licence to redesign the UI.
 - Re-running a redesign after the user already said "match the prototype".
 
+## Surgical visual edits
+
+A request to change one visual thing — a colour, a label, a single element — is
+a **targeted edit**, not a redesign licence. Apply the same
+[`minimal-safe-diff`](minimal-safe-diff.md) discipline to design work that
+backend edits have always owed.
+
+- **Change only the semantic target.** Preserve the surrounding layout,
+  spacing, typography, dimensions, content, animation, and interaction states.
+  Do not rewrite the component, reflow the section, or "modernise" neighbours
+  while you are in there. (fixtures: `daf-edit-preservation`, `daf-unwanted-variations`.)
+- **A broader redesign needs an explicit trigger.** Only phrases like *"new
+  direction"*, *"from scratch"*, *"make it feel premium"*, *"rework the flow"*,
+  or *"give me variations / options"* license a from-scratch rework. Absent such
+  a phrase, a "fix / change / update the X" request is surgical — when unsure
+  which, ask ([`ask-when-uncertain`](ask-when-uncertain.md)). (fixture: `daf-redesign-trigger`.)
+- **Preserve stable anchors.** Where the host exposes DOM/comment metadata, keep
+  comment anchors and screen labels intact so the edit stays locatable. Where
+  the host has no such surface, preserve stable semantic anchors already present
+  in source comments / `data-*` attributes — never strip them, and do not invent
+  new ones.
+
 ## See also
 
 - [`brand-source-of-truth`](brand-source-of-truth.md) / [`brand-consistency`](brand-consistency.md) — same precedence shape, for registered brand tokens.

--- a/tests/design-artifacts/eval-fixtures.md
+++ b/tests/design-artifacts/eval-fixtures.md
@@ -69,6 +69,19 @@ the criteria are the contract.
   unrequested alternates or redesign neighbouring sections. Variation is
   produced only when asked. (Inverse of `daf-requested-variations`.)
 
+### daf-redesign-trigger
+- **primitive:** `static_inspect`
+- **lifecycle stage:** targeted edit vs new design (branch selection)
+- **scenario:** Two requests on the same existing component: (a) "change the CTA
+  colour to green"; (b) "give this component a new direction, make it feel
+  premium".
+- **pass:** (a) is a **surgical** edit — only the colour changes, everything
+  else preserved; the agent does not rewrite the whole component for a one-line
+  change. (b) is a **broader redesign** because it carries an explicit
+  redesign-trigger phrase. The agent distinguishes the two by the presence of a
+  redesign trigger, not by rewriting on every edit. Regression witness for the
+  surgical-edit rule (`design-fidelity` § Surgical visual edits).
+
 ### daf-overlapping-text
 - **primitive:** `screenshot` (degrade: `static_inspect` of the CSS box model)
 - **lifecycle stage:** verify render/responsive


### PR DESCRIPTION
Fourth phase of `road-to-design-artifact-fidelity` (phase-by-phase). Gives small visual edits the same `minimal-safe-diff` discipline backend edits have owed — the lifecycle's targeted-edit branch, made enforceable.

## What landed

- **`design-fidelity`** — new **Surgical visual edits** section:
  - **Change only the semantic target** — a colour/text/one-element change preserves the surrounding layout, spacing, typography, dimensions, content, animation, and interaction states; no whole-component rewrite, no reflow, no "modernise the neighbours" (fixtures `daf-edit-preservation`, `daf-unwanted-variations`).
  - **A broader redesign needs an explicit trigger** — only *"new direction" / "from scratch" / "make it feel premium" / "rework the flow" / "give me variations"* (or equivalent) license a from-scratch rework; absent one, a "fix/change/update X" request is surgical — ask when unsure.
  - **Preserve stable anchors** — keep DOM/comment/screen-label anchors where the host exposes them; else preserve already-present source comment / `data-*` anchors, never strip or invent.
- **`tests/design-artifacts/eval-fixtures.md`** — `daf-redesign-trigger`: a surgical one-line edit vs an explicit-trigger redesign, the regression witness for "must not rewrite the whole component for a one-line edit".

## Scope

Advisory — no default gate. Roadmap stays open (Phases 4–7 remain).

## Verification

`check_condensation` · `check_references` · `compile_router` (kernel=9, unchanged — body-only) · `roadmap:progress-check` — green.