### PR TITLE
feat(design): design-artifact-fidelity Phase 4 — variation & canvas planning

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**165 / 362 steps done · 46%**
+**170 / 362 steps done · 47%**
 
 ```text
-██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
+███████████████████░░░░░░░░░░░░░░░░░░░░░   47%
 ```
 
 ## Open roadmaps
@@ -19,7 +19,7 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 15 | 14 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 7% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-command-structure-optimization.md](roadmaps/road-to-command-structure-optimization.md) | 6 | 28 | 1 | 23 | 2 | 2 | 0 | ██████████ 96% |
-| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 21 | 18 | 0 | 0 | 0 | █████░░░░░ 46% |
+| 4 | [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md) | 8 | 39 | 16 | 23 | 0 | 0 | 0 | ██████░░░░ 59% |
 | 5 | [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md) | 1 | 3 | 3 | 0 | 0 | 0 | [1](#blockers-road-to-discipline-profile-tiering-followup) | ░░░░░░░░░░ 0% |
 | 6 | [road-to-domain-soundness.md](roadmaps/road-to-domain-soundness.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 7 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
@@ -88,7 +88,7 @@ _2 blockers resolved._
 
 ### [road-to-design-artifact-fidelity.md](roadmaps/road-to-design-artifact-fidelity.md)
 
-**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 18 / 39 done (46%)
+**Road to design artifact fidelity — make visual work production-grade before it reaches the user** — 23 / 39 done (59%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -96,7 +96,7 @@ _2 blockers resolved._
 | 1 | Design artifact lifecycle contract | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 2 | Resource-first design context gate | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 3 | Surgical edit preservation rule | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 4 | Variation and canvas planning | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 4 | Variation and canvas planning | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 5 | Asset and iconography discipline | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 6 | Render verification hard gate with honest degradation | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 7 | Design-system extraction floor | ⬜ not started | 8 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-design-artifact-fidelity.md
+++ b/agents/roadmaps/road-to-design-artifact-fidelity.md
@@ -216,21 +216,36 @@ as backend edits.
 
 ## Phase 4 — Variation and canvas planning
 
-- [ ] Add a `design-variation-planning` skill or extend `fe-design`: for
+- [x] Add a design-variation-planning skill or extend `fe-design`: for
       ambiguous creative work, decide whether to ask about variation count and
       axes (visual direction, UX flow, interaction, copy, density, brand
       strictness). For clear implementation tasks, proceed.
-- [ ] Define variation floors: two to three meaningfully different options
+      <!-- done 2026-07-10: EXTENDED fe-design "## Presenting variants" (no new
+      skill — the roadmap goal keeps surface minimal; design-variations already
+      owns the mechanics). New "Decide whether to vary (ask only if ambiguous)"
+      bullet with the 6 axes; clear implementation → proceed with one answer. -->
+- [x] Define variation floors: two to three meaningfully different options
       when the user asks for exploration; no decorative option spam when the
       user asks for one production answer.
-- [ ] Add a canvas/exploration contract for side-by-side concepts: stable
+      <!-- done: "Variation floors" bullet — 2–3 meaningfully different
+      decisions on explore; exactly one on a production answer; no option spam. -->
+- [x] Add a canvas/exploration contract for side-by-side concepts: stable
       frame labels, no nested cards, generous spacing, and export-safe
       coordinates for tools that support canvases. Keep it host-neutral.
-- [ ] Add cost/UX tie-breakers: ask only when the variation axis changes the
+      <!-- done: "Canvas / exploration contract (host-neutral)" bullet — stable
+      frame labels, flat frames, generous spacing, export-safe coords on canvas
+      tools; same labelled-frames shape with or without a real canvas. -->
+- [x] Add cost/UX tie-breakers: ask only when the variation axis changes the
       work materially; otherwise choose a strong default and document the axis
       used in the handoff.
-- [ ] Add trigger evals distinguishing "give me three directions" from
+      <!-- done: "Cost / UX tie-breaker" bullet — ask only when the axis changes
+      the work materially; else strong default + document the axis in handoff. -->
+- [x] Add trigger evals distinguishing "give me three directions" from
       "implement the selected direction".
+      <!-- done: src/skills/fe-design/evals/triggers.json — 5 should-trigger
+      (explore/variation-planning + pattern/flow-planning) + 5 should-not
+      (implement-the-selected-design, existing-ui-audit, surgical edit,
+      backend, non-UI). -->
 
 **Exit:** agents stop producing one generic design when exploration was asked,
 and stop producing unnecessary options when execution was asked.

--- a/dist/agent-src/skills/fe-design/SKILL.md
+++ b/dist/agent-src/skills/fe-design/SKILL.md
@@ -256,11 +256,33 @@ Animate `transform` and `opacity` only. Why: these run on the GPU compositor thr
 
 ## Presenting variants
 
-This skill produces ONE refined solution. When the user wants multiple options
-to compare (or a live tweak panel over one design), hand off to
-[`design-variations`](../design-variations/SKILL.md) — it owns the
-basic→bold variation method and the single-file tweak-panel mechanics
-(CSS custom properties + floating "Tweaks" panel + `localStorage`).
+This skill produces ONE refined solution by default. **Plan the variation
+decision before generating** — do not reflexively emit one generic design when
+exploration was asked, nor spam options when one production answer was asked.
+
+- **Decide whether to vary (ask only if ambiguous).** For ambiguous creative
+  work, decide the variation count and the axis that varies — visual direction,
+  UX flow, interaction model, copy, density, or brand strictness. Ask about
+  count + axis only when the choice changes the work materially; for a clear
+  implementation task, proceed with one answer. (fixture: `daf-requested-variations`.)
+- **Variation floors.** When the user asks to explore, produce **two to three
+  meaningfully different** options along the stated axis — different *decisions*,
+  not the same layout recoloured. When the user asks for one production answer,
+  produce one; no decorative option spam. (fixtures: `daf-requested-variations`,
+  `daf-unwanted-variations`.)
+- **Canvas / exploration contract (host-neutral).** Presenting side-by-side
+  concepts: give each a **stable frame label**, keep frames flat (no nested
+  cards), use generous spacing, and — on tools with a canvas — export-safe
+  coordinates so the layout survives export. Same labelled-frames shape whether
+  the host has a real canvas or just stacked sections.
+- **Cost / UX tie-breaker.** Ask about the axis only when it changes the work
+  materially; otherwise choose a strong default and **document the axis used in
+  the handoff** ("explored along visual-direction; density held constant").
+
+Hand off the actual variation **mechanics** — the basic→bold method and the
+single-file tweak-panel (CSS custom properties + floating "Tweaks" panel +
+`localStorage`) — to [`design-variations`](../design-variations/SKILL.md): this
+section owns the *planning decision*, that skill owns the *execution*.
 
 ## Cross-task design memory — read DESIGN.md / PRODUCT.md first
 

--- a/dist/agent-src/skills/fe-design/evals/triggers.json
+++ b/dist/agent-src/skills/fe-design/evals/triggers.json
@@ -1,0 +1,47 @@
+{
+    "skill": "fe-design",
+    "last_eval": "2026-07-10",
+    "description": "5 should-trigger + 5 should-not-trigger queries for the variation & canvas planning layer (road-to-design-artifact-fidelity Phase 4). Should-trigger covers exploration / variation planning and UI-design decisions where fe-design plans BEFORE generating (give me directions, explore, plan the flow, pattern choice). Should-not-trigger covers near-misses that must NOT invoke design planning: pure implementation of an already-selected design (apply-step), inventorying existing UI (existing-ui-audit), a surgical one-line edit, and non-UI/backend work.",
+    "queries": [
+        {
+            "q": "give me three directions for the pricing page",
+            "trigger": true
+        },
+        {
+            "q": "explore a few visual directions for the dashboard before we commit",
+            "trigger": true
+        },
+        {
+            "q": "design the multi-step onboarding flow",
+            "trigger": true
+        },
+        {
+            "q": "should this filter be a modal or an inline panel?",
+            "trigger": true
+        },
+        {
+            "q": "plan the responsive layout for the settings screen",
+            "trigger": true
+        },
+        {
+            "q": "implement the selected checkout design in React exactly as approved",
+            "trigger": false
+        },
+        {
+            "q": "what form components do we already have in the codebase?",
+            "trigger": false
+        },
+        {
+            "q": "change the primary button colour to green",
+            "trigger": false
+        },
+        {
+            "q": "add a database index on orders.status",
+            "trigger": false
+        },
+        {
+            "q": "fix the failing unit test in the auth module",
+            "trigger": false
+        }
+    ]
+}

--- a/internal/.condensation-hashes.json
+++ b/internal/.condensation-hashes.json
@@ -450,7 +450,7 @@
   "skills/estimate-ticket/SKILL.md": "cc343070af9d8d72615a40c0ce0e72d3e4953c81a7f415c5445bd2406569b179",
   "skills/existing-ui-audit/SKILL.md": "4720ee4afb9e145638398ae954efc97ce1d7d966b82ecfd243c4bab4d819b04b",
   "skills/expansion-playbook/SKILL.md": "3cdb8489d7dd85ed91257025999138aaaa6855c5632f90c53868703d2bc0ac02",
-  "skills/fe-design/SKILL.md": "d45a8e4a8e6c1de0acb4c390d47be82159c2ba3605fa4a71c41e4753694586d1",
+  "skills/fe-design/SKILL.md": "b269be342501720418b43e74cad1c13c9438e24a91432d4e28f795d02391a651",
   "skills/feature-planning/SKILL.md": "b293383bbd0dc698cd2b193c58180ed98a12f4da5e320c94aae95582a1d74a5e",
   "skills/file-editor/SKILL.md": "3ee56b6e676af61ce442ba4972babe1108d7f1b35eae8c5cc586bb9741fd60e9",
   "skills/finishing-a-development-branch/SKILL.md": "2511faedc7c434faccc0f69574d161874e873f72ccb35a78abaa796b4fdbd728",

--- a/src/skills/fe-design/SKILL.md
+++ b/src/skills/fe-design/SKILL.md
@@ -256,11 +256,33 @@ Animate `transform` and `opacity` only. Why: these run on the GPU compositor thr
 
 ## Presenting variants
 
-This skill produces ONE refined solution. When the user wants multiple options
-to compare (or a live tweak panel over one design), hand off to
-[`design-variations`](../design-variations/SKILL.md) — it owns the
-basic→bold variation method and the single-file tweak-panel mechanics
-(CSS custom properties + floating "Tweaks" panel + `localStorage`).
+This skill produces ONE refined solution by default. **Plan the variation
+decision before generating** — do not reflexively emit one generic design when
+exploration was asked, nor spam options when one production answer was asked.
+
+- **Decide whether to vary (ask only if ambiguous).** For ambiguous creative
+  work, decide the variation count and the axis that varies — visual direction,
+  UX flow, interaction model, copy, density, or brand strictness. Ask about
+  count + axis only when the choice changes the work materially; for a clear
+  implementation task, proceed with one answer. (fixture: `daf-requested-variations`.)
+- **Variation floors.** When the user asks to explore, produce **two to three
+  meaningfully different** options along the stated axis — different *decisions*,
+  not the same layout recoloured. When the user asks for one production answer,
+  produce one; no decorative option spam. (fixtures: `daf-requested-variations`,
+  `daf-unwanted-variations`.)
+- **Canvas / exploration contract (host-neutral).** Presenting side-by-side
+  concepts: give each a **stable frame label**, keep frames flat (no nested
+  cards), use generous spacing, and — on tools with a canvas — export-safe
+  coordinates so the layout survives export. Same labelled-frames shape whether
+  the host has a real canvas or just stacked sections.
+- **Cost / UX tie-breaker.** Ask about the axis only when it changes the work
+  materially; otherwise choose a strong default and **document the axis used in
+  the handoff** ("explored along visual-direction; density held constant").
+
+Hand off the actual variation **mechanics** — the basic→bold method and the
+single-file tweak-panel (CSS custom properties + floating "Tweaks" panel +
+`localStorage`) — to [`design-variations`](../design-variations/SKILL.md): this
+section owns the *planning decision*, that skill owns the *execution*.
 
 ## Cross-task design memory — read DESIGN.md / PRODUCT.md first
 

--- a/src/skills/fe-design/evals/triggers.json
+++ b/src/skills/fe-design/evals/triggers.json
@@ -1,0 +1,47 @@
+{
+    "skill": "fe-design",
+    "last_eval": "2026-07-10",
+    "description": "5 should-trigger + 5 should-not-trigger queries for the variation & canvas planning layer (road-to-design-artifact-fidelity Phase 4). Should-trigger covers exploration / variation planning and UI-design decisions where fe-design plans BEFORE generating (give me directions, explore, plan the flow, pattern choice). Should-not-trigger covers near-misses that must NOT invoke design planning: pure implementation of an already-selected design (apply-step), inventorying existing UI (existing-ui-audit), a surgical one-line edit, and non-UI/backend work.",
+    "queries": [
+        {
+            "q": "give me three directions for the pricing page",
+            "trigger": true
+        },
+        {
+            "q": "explore a few visual directions for the dashboard before we commit",
+            "trigger": true
+        },
+        {
+            "q": "design the multi-step onboarding flow",
+            "trigger": true
+        },
+        {
+            "q": "should this filter be a modal or an inline panel?",
+            "trigger": true
+        },
+        {
+            "q": "plan the responsive layout for the settings screen",
+            "trigger": true
+        },
+        {
+            "q": "implement the selected checkout design in React exactly as approved",
+            "trigger": false
+        },
+        {
+            "q": "what form components do we already have in the codebase?",
+            "trigger": false
+        },
+        {
+            "q": "change the primary button colour to green",
+            "trigger": false
+        },
+        {
+            "q": "add a database index on orders.status",
+            "trigger": false
+        },
+        {
+            "q": "fix the failing unit test in the auth module",
+            "trigger": false
+        }
+    ]
+}


### PR DESCRIPTION
Fifth phase of `road-to-design-artifact-fidelity` (phase-by-phase). Adds the variation **planning** layer — the decision *before* generating — to `fe-design`'s Presenting-variants section, so agents stop shipping one generic design when exploration was asked and stop spamming options when execution was asked. The variation **mechanics** stay in `design-variations` (no new skill — the roadmap goal keeps surface minimal).

## What landed

- **`fe-design` "## Presenting variants"** extended:
  - **Decide whether to vary** + the axis (visual direction / UX flow / interaction / copy / density / brand strictness); ask only when ambiguous, else proceed with one answer.
  - **Variation floors** — 2–3 *meaningfully different* options on explore; exactly one on a production answer; no decorative option spam.
  - **Canvas / exploration contract (host-neutral)** — stable frame labels, flat frames, generous spacing, export-safe coordinates on canvas tools; same labelled-frames shape with or without a real canvas.
  - **Cost / UX tie-breaker** — ask about the axis only when it changes the work materially; else strong default + document the axis in handoff.
- **`fe-design/evals/triggers.json`** — 5 should-trigger (explore / plan-the-flow / pattern choice) + 5 should-not (implement-the-selected-design, existing-ui-audit, surgical edit, backend, non-UI).

## Scope

`design-variations` owns the mechanics; this is the planning decision. Advisory — no default gate. Roadmap stays open (Phases 5–7 remain).

## Verification

`skill_linter --changed` (1 pass) · `check_condensation` · `check_references` · `check-trigger-evals` (48 sets fresh + valid) · `roadmap:progress-check` — green.