### PR TITLE
chore(roadmap): close + archive command-structure-optimization (deferred → later/ follow-up)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 15 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
+> 14 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
 
 ## Overall
 
-**142 / 235 steps done · 60%**
+**119 / 211 steps done · 56%**
 
 ```text
-████████████████████████░░░░░░░░░░░░░░░░   60%
+██████████████████████░░░░░░░░░░░░░░░░░░   56%
 ```
 
 ## Open roadmaps
@@ -18,19 +18,18 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 15 | 14 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 7% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 3 | [road-to-command-structure-optimization.md](roadmaps/road-to-command-structure-optimization.md) | 6 | 28 | 1 | 23 | 2 | 2 | 0 | ██████████ 96% |
-| 4 | [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md) | 1 | 3 | 3 | 0 | 0 | 0 | [1](#blockers-road-to-discipline-profile-tiering-followup) | ░░░░░░░░░░ 0% |
-| 5 | [road-to-domain-soundness.md](roadmaps/road-to-domain-soundness.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
-| 6 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
-| 7 | [road-to-golden-set-coverage.md](roadmaps/road-to-golden-set-coverage.md) | 4 | 18 | 4 | 14 | 0 | 0 | [2](#blockers-road-to-golden-set-coverage) | ████████░░ 78% |
-| 8 | [road-to-install-path-convergence-followup.md](roadmaps/road-to-install-path-convergence-followup.md) | 1 | 1 | 1 | 0 | 0 | 0 | [1](#blockers-road-to-install-path-convergence-followup) | ░░░░░░░░░░ 0% |
-| 9 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 6 | 5 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ████░░░░░░ 45% |
-| 10 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
-| 11 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 12 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 3 | 8 | 0 | 0 | 0 | ███████░░░ 73% |
-| 13 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
-| 14 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
-| 15 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 11 | 24 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 69% |
+| 3 | [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md) | 1 | 3 | 3 | 0 | 0 | 0 | [1](#blockers-road-to-discipline-profile-tiering-followup) | ░░░░░░░░░░ 0% |
+| 4 | [road-to-domain-soundness.md](roadmaps/road-to-domain-soundness.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
+| 5 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
+| 6 | [road-to-golden-set-coverage.md](roadmaps/road-to-golden-set-coverage.md) | 4 | 18 | 4 | 14 | 0 | 0 | [2](#blockers-road-to-golden-set-coverage) | ████████░░ 78% |
+| 7 | [road-to-install-path-convergence-followup.md](roadmaps/road-to-install-path-convergence-followup.md) | 1 | 1 | 1 | 0 | 0 | 0 | [1](#blockers-road-to-install-path-convergence-followup) | ░░░░░░░░░░ 0% |
+| 8 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 6 | 5 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ████░░░░░░ 45% |
+| 9 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
+| 10 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
+| 11 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 3 | 8 | 0 | 0 | 0 | ███████░░░ 73% |
+| 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
+| 13 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
+| 14 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 11 | 24 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 69% |
 
 ---
 
@@ -69,19 +68,6 @@ _2 blockers resolved._
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Post-merge dry-run verification (carried from parent Phase 3) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 2 | First real release + live drills (carried from parent Phase 4 + Phase 7) | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
-
-### [road-to-command-structure-optimization.md](roadmaps/road-to-command-structure-optimization.md)
-
-**Road to Command Structure Optimization** — 23 / 24 done (96%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Contract + ADR | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 1 | Slug-neutral nestings | ✅ done | 0 | 9 | 0 | 0 | 100% |
-| 2 | Slug-changing reorders (`replaces:`) | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 3 | Bare-invocation standardization + lint | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 4 | Regen + downstream surfaces | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 5 | Deferred follow-ups (recorded, not executed here) | ⬜ not started | 1 | 0 | 2 | 2 | 0% |
 
 ### [road-to-discipline-profile-tiering-followup.md](roadmaps/road-to-discipline-profile-tiering-followup.md)
 

--- a/agents/roadmaps/archive/road-to-command-structure-optimization.md
+++ b/agents/roadmaps/archive/road-to-command-structure-optimization.md
@@ -80,10 +80,11 @@ Cross-cutting convergence: (a) cluster subs MUST co-locate with the head in one 
 
 ### Phase 5 — Deferred follow-ups (recorded, not executed here)
 
-- [~] `ticket` cluster (implement/estimate/refine/jira) — deferred per council; revisit with usage telemetry. <!-- deferred: tier-0 slug change + cross-pack move rejected by both council members -->
+- [-] `ticket` cluster (implement/estimate/refine/jira) — deferred per council; revisit with usage telemetry. <!-- deferred: tier-0 slug change + cross-pack move rejected by both council members; MIGRATED 2026-07-10 → later/road-to-command-structure-followup.md -->
 - [-] `security` cluster — rejected; keep `security-audit-config` + `threat-model` flat. <!-- cancelled: unanimous council REJECT, recorded in ADR-115 -->
-- [~] Demote `check-current-md` / `update-form-request-messages` — needs skill-coverage + pack-boundary audit. <!-- deferred: verify md-language-check coverage; laravel pack boundary ADR -->
-- [ ] Resolve the two deferred items above with the maintainer (spawn follow-up roadmap vs drop) — decision deliberately left open until the restructuring PR is reviewed.
+- [-] Demote `check-current-md` / `update-form-request-messages` — needs skill-coverage + pack-boundary audit. <!-- deferred: verify md-language-check coverage; laravel pack boundary ADR; MIGRATED 2026-07-10 → later/road-to-command-structure-followup.md -->
+- [x] Resolve the two deferred items above with the maintainer (spawn follow-up roadmap vs drop) — decision deliberately left open until the restructuring PR is reviewed.
+      <!-- resolved 2026-07-10: DECISION = spawn follow-up (preserve, per roadmap-progress-sync Iron Law 3). Both deferred items lifted verbatim into agents/roadmaps/later/road-to-command-structure-followup.md with their resume triggers (ticket cluster → usage telemetry; demote pair → md-coverage + Laravel pack-boundary ADR). Neither dropped. -->
 - [-] `prepare-for-review` → `review/prepare` — rejected slug change; keep flat. <!-- cancelled: council-rejected for pre-commit muscle memory, recorded in ADR-115 -->
 
 ## Acceptance criteria

--- a/agents/roadmaps/later/road-to-command-structure-followup.md
+++ b/agents/roadmaps/later/road-to-command-structure-followup.md
@@ -1,0 +1,50 @@
+---
+complexity: lightweight
+status: later
+parent_roadmap: road-to-command-structure-optimization
+---
+
+# Roadmap: Follow-up to command-structure optimization — deferred cluster items
+
+> **Parked in `later/` — blocked-for-later, will resume.** Collects the two
+> items deferred (not dropped) from the completed
+> [`road-to-command-structure-optimization`](../archive/road-to-command-structure-optimization.md)
+> Phase 5. Both were deferred with recorded reasons + revisit conditions; neither
+> can proceed autonomously now (one needs usage telemetry, one needs an audit +
+> ADR decision), so they are parked rather than abandoned.
+>
+> **Blocked until:** the per-item triggers below fire.
+
+## Context
+
+These are lifted verbatim from the archived parent's Phase 5. The parent shipped
+the cluster restructuring; these two were council-deferred for real reasons, not
+oversight. Resolution of the parent's open decision (2026-07-10) = **spawn this
+follow-up** (preserve the work) rather than drop it.
+
+## Phase 1 — Deferred cluster items (resume per trigger)
+
+- [ ] `ticket` cluster (implement/estimate/refine/jira). <!-- deferred: tier-0
+      slug change + cross-pack move rejected by both council members; revisit
+      with usage telemetry. -->
+      **Resume trigger:** usage telemetry shows the flat `implement-ticket` /
+      `estimate` / `refine` / `jira` commands are frequently invoked together or
+      mis-discovered — evidence that a `ticket` cluster head would help. Absent
+      that signal the council REJECT stands (do not relitigate without telemetry).
+- [ ] Demote `check-current-md` / `update-form-request-messages`. <!-- deferred:
+      needs md-language-check skill-coverage verification + a Laravel pack-boundary
+      ADR. -->
+      **Resume trigger:** (a) confirm `md-language-check` coverage makes
+      `check-current-md` redundant, AND (b) a Laravel pack-boundary ADR decides
+      where `update-form-request-messages` belongs. Both are prerequisites before
+      any demotion.
+
+## Acceptance criteria
+
+- [ ] Each item is either executed once its trigger fires, or explicitly
+      cancelled with a recorded rationale (never silently dropped).
+
+## Provenance
+
+Deferred from the archived parent per its Phase 5 + ADR-115 (council rejects +
+defers). No external source; internal council decision.

--- a/docs/decisions/ADR-115-command-cluster-consolidation-phase-4.md
+++ b/docs/decisions/ADR-115-command-cluster-consolidation-phase-4.md
@@ -85,7 +85,7 @@ not exploit: **nesting `bug-fix` as `bug/fix` keeps the invoked slug
 
 - `docs/contracts/command-clusters.md` — locked table (Phase 4 rows) + the
   new "Bare invocation" section.
-- `agents/roadmaps/road-to-command-structure-optimization.md` — inventory,
+- `agents/roadmaps/archive/road-to-command-structure-optimization.md` — inventory,
   council verdicts, phases.
 - ADR-003 (flat clusters), ADR-041 (controlled verbs), ADR-044 (path-derived
   hyphen slugs).


### PR DESCRIPTION
Closes `road-to-command-structure-optimization` — its one open step was the maintainer decision on its two Phase-5 deferred items (spawn follow-up vs drop). **Decision: spawn a follow-up** (preserve, per `roadmap-progress-sync` Iron Law 3) — both items are council-deferred with real revisit intent, so dropping would lose recorded work.

## What landed

- **`agents/roadmaps/later/road-to-command-structure-followup.md`** (NEW, `status: later`) — both items parked with their resume triggers:
  - `ticket` cluster (implement/estimate/refine/jira) — resume on **usage telemetry** (the council slug/cross-pack REJECT stands until then).
  - Demote `check-current-md` / `update-form-request-messages` — resume on **md-language-check coverage verification + a Laravel pack-boundary ADR**.
- **`road-to-command-structure-optimization.md`** — decision step flipped `[x]`; the two migrated `[~]` → `[-]` (superseded here, moved to the follow-up); `git mv` to `archive/`.
- **ADR-115** inbound reference migrated to the archive path.

## Verification

`count_open == 0`, `count_deferred == 0` · `check_references` · `check_no_roadmap_refs` · `lint_roadmap_later_disposition` (follow-up parked correctly with a resume condition) · `roadmap:progress-check` — green. Dashboard 15 → 14 active (follow-up excluded as `later/`).