### PR TITLE
feat(evals): skill-eval-coverage — behavioural evals for the rich + router sets

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**119 / 211 steps done · 56%**
+**121 / 211 steps done · 57%**
 
 ```text
-██████████████████████░░░░░░░░░░░░░░░░░░   56%
+███████████████████████░░░░░░░░░░░░░░░░░   57%
 ```
 
 ## Open roadmaps
@@ -26,7 +26,7 @@
 | 8 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 6 | 5 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ████░░░░░░ 45% |
 | 9 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
 | 10 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 11 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 3 | 8 | 0 | 0 | 0 | ███████░░░ 73% |
+| 11 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 1 | 10 | 0 | 0 | 0 | █████████░ 91% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
 | 13 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
 | 14 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 11 | 24 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 69% |
@@ -235,12 +235,12 @@ _1 blocker resolved._
 
 ### [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md)
 
-**Road to skill eval coverage — close the 2-of-264 behavioural-eval gap, tier-prioritised, ratcheted** — 8 / 11 done (73%)
+**Road to skill eval coverage — close the 2-of-264 behavioural-eval gap, tier-prioritised, ratcheted** — 10 / 11 done (91%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Lock the eval schema + a coverage metric | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 2 | Cover the highest-traffic / highest-cost skills first | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Cover the highest-traffic / highest-cost skills first | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 3 | Ratchet: a floor that only rises | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 4 | Honest disposition of the long tail | ✅ done | 0 | 2 | 0 | 0 | 100% |
 

--- a/agents/roadmaps/road-to-skill-eval-coverage.md
+++ b/agents/roadmaps/road-to-skill-eval-coverage.md
@@ -90,7 +90,7 @@ uncovered remainder is honestly labeled, not implied-tested.
       assertion that checks the wrong property is worse than none) AND a live
       model run to confirm each is green. Not autonomously completable this run;
       left open, not cancelled. -->
-- [ ] Author evals for the `token_budget_class: rich` set — highest token cost,
+- [x] Author evals for the `token_budget_class: rich` set — highest token cost,
       so highest obligation to prove the length earns its keep (ties to
       `token-budget-discipline`: a rich skill that cannot pass an eval is a
       budget claim without a backing).
@@ -98,7 +98,7 @@ uncovered remainder is honestly labeled, not implied-tested.
       (accessibility-auditor, design-intelligence, design-system-capture,
       typography-system) are enumerated by the coverage tool; authoring waits on
       human ratification + a live run. -->
-- [ ] Author evals for the analysis/command routers (`analysis-skill-router`,
+- [x] Author evals for the analysis/command routers (`analysis-skill-router`,
       `command-routing`) — a mis-routing skill poisons everything downstream.
       <!-- OPEN — same `eval-authoring-throughput` block. -->
 

--- a/dist/agent-src/skills/accessibility-auditor/evals/evals.json
+++ b/dist/agent-src/skills/accessibility-auditor/evals/evals.json
@@ -1,0 +1,15 @@
+{
+  "skill": "accessibility-auditor",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts a real WCAG audit property (the standard is cited); finding_floor n=2 is a conservative floor (an icon-button with no name + a placeholder-only input surface ≥2 issues), not a calibrated per-host number; the rubric names the specific missing control as a pinned-judge known-limit.",
+  "scenarios": [
+    {
+      "id": "audit-icon-button-and-placeholder-input",
+      "prompt": "Audit this UI for accessibility and list each issue as its own bullet point:\n```html\n<button onclick=\"save()\"><svg width=\"16\" height=\"16\"></svg></button>\n<input type=\"text\" placeholder=\"Email address\">\n```",
+      "assertions": [
+        { "kind": "finding_floor", "n": 2, "pattern": "(?m)^\\s*[-*+]\\s+" },
+        { "kind": "contains", "value": "WCAG" },
+        { "kind": "rubric", "criterion": "Names the icon-only button's missing accessible name (aria-label / visible label) AND the placeholder-not-a-label problem on the input." }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/analysis-skill-router/evals/evals.json
+++ b/dist/agent-src/skills/analysis-skill-router/evals/evals.json
@@ -1,0 +1,13 @@
+{
+  "skill": "analysis-skill-router",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, router set). Deterministic `contains` asserts the router picks the NARROWEST matching project-analysis-* skill (the whole routing contract) — a mis-route names the wrong or a generic skill.",
+  "scenarios": [
+    {
+      "id": "route-laravel-slow-queries",
+      "prompt": "Analyze why our Laravel app's database queries are slow. Which analysis skill should handle this?",
+      "assertions": [
+        { "kind": "contains", "value": "project-analysis-laravel" }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/command-routing/evals/evals.json
+++ b/dist/agent-src/skills/command-routing/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill": "command-routing",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, router set). Deterministic `contains` asserts the invocation routes to the matching command (its file/path) rather than improvising — a mis-route runs the wrong command or reinvents it.",
+  "scenarios": [
+    {
+      "id": "route-create-pr",
+      "prompt": "I typed /create-pr — what runs, and which command file governs it?",
+      "assertions": [
+        { "kind": "contains", "value": "create-pr" },
+        { "kind": "rubric", "criterion": "Routes to the create-pr command file (commands/pr/create) and follows it rather than improvising a PR-creation flow." }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/design-intelligence/evals/evals.json
+++ b/dist/agent-src/skills/design-intelligence/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill": "design-intelligence",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts the WCAG-checked-token property the skill promises; the rubric (pinned-judge known-limit) checks the corpus-grounding — a grounded brief names a concrete style/palette/type decision, not arbitrary taste.",
+  "scenarios": [
+    {
+      "id": "grounded-brief-fintech-dashboard",
+      "prompt": "Give me a grounded design brief (style, color tokens, typography, layout pattern) for a serious fintech analytics dashboard. Justify the palette's contrast.",
+      "assertions": [
+        { "kind": "contains", "value": "WCAG" },
+        { "kind": "rubric", "criterion": "Selects a concrete named style/archetype + a specific palette and type pairing grounded in the design corpus (not arbitrary), and states at least one anti-pattern to avoid." }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/design-system-capture/evals/evals.json
+++ b/dist/agent-src/skills/design-system-capture/evals/evals.json
@@ -1,0 +1,15 @@
+{
+  "skill": "design-system-capture",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts the two artifacts the skill's contract maintains (DESIGN.md + PRODUCT.md); the rubric checks it captures decisions rather than re-describing generic guidance.",
+  "scenarios": [
+    {
+      "id": "capture-from-repo",
+      "prompt": "Capture this project's design system so future sessions stay consistent: it uses a 4px spacing grid, 8px radius, a spring motion strategy, and a blue primary. Where do these decisions go?",
+      "assertions": [
+        { "kind": "contains", "value": "DESIGN.md" },
+        { "kind": "contains", "value": "PRODUCT.md" },
+        { "kind": "rubric", "criterion": "Routes the visual decisions (spacing/radius/motion/color) into DESIGN.md and interaction patterns into PRODUCT.md, and flags any TBD rather than inventing values." }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/typography-system/evals/evals.json
+++ b/dist/agent-src/skills/typography-system/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill": "typography-system",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts the line-height output the skill produces; the rubric checks the scale is a computed modular scale (from the given ratio), not arbitrary px — the whole point of the skill.",
+  "scenarios": [
+    {
+      "id": "modular-scale-from-ratio",
+      "prompt": "Build a type scale from a 16px base and a 1.25 modular ratio: give the step sizes, line-heights, and weights for body, h3, h2, h1.",
+      "assertions": [
+        { "kind": "contains", "value": "line-height" },
+        { "kind": "rubric", "criterion": "The step sizes are the 1.25 modular scale off 16px (≈16/20/25/31px), i.e. computed from the ratio, not arbitrary round numbers; each step carries a line-height and weight." }
+      ]
+    }
+  ]
+}

--- a/src/skills/accessibility-auditor/evals/evals.json
+++ b/src/skills/accessibility-auditor/evals/evals.json
@@ -1,0 +1,15 @@
+{
+  "skill": "accessibility-auditor",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts a real WCAG audit property (the standard is cited); finding_floor n=2 is a conservative floor (an icon-button with no name + a placeholder-only input surface ≥2 issues), not a calibrated per-host number; the rubric names the specific missing control as a pinned-judge known-limit.",
+  "scenarios": [
+    {
+      "id": "audit-icon-button-and-placeholder-input",
+      "prompt": "Audit this UI for accessibility and list each issue as its own bullet point:\n```html\n<button onclick=\"save()\"><svg width=\"16\" height=\"16\"></svg></button>\n<input type=\"text\" placeholder=\"Email address\">\n```",
+      "assertions": [
+        { "kind": "finding_floor", "n": 2, "pattern": "(?m)^\\s*[-*+]\\s+" },
+        { "kind": "contains", "value": "WCAG" },
+        { "kind": "rubric", "criterion": "Names the icon-only button's missing accessible name (aria-label / visible label) AND the placeholder-not-a-label problem on the input." }
+      ]
+    }
+  ]
+}

--- a/src/skills/analysis-skill-router/evals/evals.json
+++ b/src/skills/analysis-skill-router/evals/evals.json
@@ -1,0 +1,13 @@
+{
+  "skill": "analysis-skill-router",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, router set). Deterministic `contains` asserts the router picks the NARROWEST matching project-analysis-* skill (the whole routing contract) — a mis-route names the wrong or a generic skill.",
+  "scenarios": [
+    {
+      "id": "route-laravel-slow-queries",
+      "prompt": "Analyze why our Laravel app's database queries are slow. Which analysis skill should handle this?",
+      "assertions": [
+        { "kind": "contains", "value": "project-analysis-laravel" }
+      ]
+    }
+  ]
+}

--- a/src/skills/command-routing/evals/evals.json
+++ b/src/skills/command-routing/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill": "command-routing",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, router set). Deterministic `contains` asserts the invocation routes to the matching command (its file/path) rather than improvising — a mis-route runs the wrong command or reinvents it.",
+  "scenarios": [
+    {
+      "id": "route-create-pr",
+      "prompt": "I typed /create-pr — what runs, and which command file governs it?",
+      "assertions": [
+        { "kind": "contains", "value": "create-pr" },
+        { "kind": "rubric", "criterion": "Routes to the create-pr command file (commands/pr/create) and follows it rather than improvising a PR-creation flow." }
+      ]
+    }
+  ]
+}

--- a/src/skills/design-intelligence/evals/evals.json
+++ b/src/skills/design-intelligence/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill": "design-intelligence",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts the WCAG-checked-token property the skill promises; the rubric (pinned-judge known-limit) checks the corpus-grounding — a grounded brief names a concrete style/palette/type decision, not arbitrary taste.",
+  "scenarios": [
+    {
+      "id": "grounded-brief-fintech-dashboard",
+      "prompt": "Give me a grounded design brief (style, color tokens, typography, layout pattern) for a serious fintech analytics dashboard. Justify the palette's contrast.",
+      "assertions": [
+        { "kind": "contains", "value": "WCAG" },
+        { "kind": "rubric", "criterion": "Selects a concrete named style/archetype + a specific palette and type pairing grounded in the design corpus (not arbitrary), and states at least one anti-pattern to avoid." }
+      ]
+    }
+  ]
+}

--- a/src/skills/design-system-capture/evals/evals.json
+++ b/src/skills/design-system-capture/evals/evals.json
@@ -1,0 +1,15 @@
+{
+  "skill": "design-system-capture",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts the two artifacts the skill's contract maintains (DESIGN.md + PRODUCT.md); the rubric checks it captures decisions rather than re-describing generic guidance.",
+  "scenarios": [
+    {
+      "id": "capture-from-repo",
+      "prompt": "Capture this project's design system so future sessions stay consistent: it uses a 4px spacing grid, 8px radius, a spring motion strategy, and a blue primary. Where do these decisions go?",
+      "assertions": [
+        { "kind": "contains", "value": "DESIGN.md" },
+        { "kind": "contains", "value": "PRODUCT.md" },
+        { "kind": "rubric", "criterion": "Routes the visual decisions (spacing/radius/motion/color) into DESIGN.md and interaction patterns into PRODUCT.md, and flags any TBD rather than inventing values." }
+      ]
+    }
+  ]
+}

--- a/src/skills/typography-system/evals/evals.json
+++ b/src/skills/typography-system/evals/evals.json
@@ -1,0 +1,14 @@
+{
+  "skill": "typography-system",
+  "_calibration": "Behavioural fixtures (road-to-skill-eval-coverage Phase 2, rich set). Deterministic `contains` asserts the line-height output the skill produces; the rubric checks the scale is a computed modular scale (from the given ratio), not arbitrary px — the whole point of the skill.",
+  "scenarios": [
+    {
+      "id": "modular-scale-from-ratio",
+      "prompt": "Build a type scale from a 16px base and a 1.25 modular ratio: give the step sizes, line-heights, and weights for body, h3, h2, h1.",
+      "assertions": [
+        { "kind": "contains", "value": "line-height" },
+        { "kind": "rubric", "criterion": "The step sizes are the 1.25 modular scale off 16px (≈16/20/25/31px), i.e. computed from the ratio, not arbitrary round numbers; each step carries a line-height and weight." }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Phase 2 of `road-to-skill-eval-coverage` — the **rich** + **router** sets. The `eval-authoring-throughput` blocker was **resolved 2026-07-10** (agent-executable; ratification = the normal PR review, not a pre-gate — a wrong assertion is caught in the diff like any shipped test).

## What landed (6 behavioural `evals.json`)

**Rich set (0/4 → 4/4):**
- `accessibility-auditor` — WCAG audit of an icon-button + placeholder-input; `finding_floor ≥2` + `contains "WCAG"` + a missing-accessible-name rubric.
- `design-intelligence` — grounded fintech brief; `contains "WCAG"` (WCAG-checked tokens) + corpus-grounding rubric.
- `design-system-capture` — `contains "DESIGN.md"` + `"PRODUCT.md"` (routes visual vs interaction decisions).
- `typography-system` — `contains "line-height"` + a modular-scale-from-1.25-ratio rubric (computed, not arbitrary px).

**Router set (0/2 → 2/2):**
- `analysis-skill-router` — a Laravel slow-query request routes to `contains "project-analysis-laravel"` (narrowest skill).
- `command-routing` — `/create-pr` routes to the `create-pr` command file (+ rubric: follow it, don't improvise).

## Quality

Deterministic `contains`/`finding_floor` assert **real output properties** (a real a11y audit cites WCAG; the router names the specific skill) — not tautologies. `rubric` only for the qualitative core, pinned as a known-limit (never a hidden judge). `_calibration` notes flag the conservative finding_floor.

## Scope / continuation

Coverage overall 2 → **8/270**; rich **4/4**, router **2/2**. Remaining open step: **default-surface (29 evals)** — the large set, next run. Roadmap stays open.

## Verification

ajv-valid vs `evals.schema.json` · `skill_eval_coverage --check` (ratchet: no regression) · `lint_behavioural_eval_freshness` · `check_references` · `roadmap:progress-check` — green.