### PR TITLE
feat(evals): skill-eval-coverage — default-surface set (29 evals) + close + archive

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 14 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
+> 13 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
 
 ## Overall
 
-**121 / 211 steps done · 57%**
+**111 / 200 steps done · 56%**
 
 ```text
-███████████████████████░░░░░░░░░░░░░░░░░   57%
+██████████████████████░░░░░░░░░░░░░░░░░░   56%
 ```
 
 ## Open roadmaps
@@ -26,10 +26,9 @@
 | 8 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 6 | 5 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ████░░░░░░ 45% |
 | 9 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
 | 10 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 11 | [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md) | 4 | 11 | 1 | 10 | 0 | 0 | 0 | █████████░ 91% |
-| 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
-| 13 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
-| 14 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 11 | 24 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 69% |
+| 11 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
+| 12 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
+| 13 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 11 | 24 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 69% |
 
 ---
 
@@ -232,17 +231,6 @@ _1 blocker resolved._
     § Program tracking step 2 — label the golden stubs, run the live judge
     at `--scope consumer`, tick the live canary on 3 hosts.
   - **Resolved when:** `check_quality_regression --as-flip-gate` exits 0 on a real (non-dry-run) report — hardened criterion per `road-to-token-proof-and-story` Phase 0.
-
-### [road-to-skill-eval-coverage.md](roadmaps/road-to-skill-eval-coverage.md)
-
-**Road to skill eval coverage — close the 2-of-264 behavioural-eval gap, tier-prioritised, ratcheted** — 10 / 11 done (91%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | Lock the eval schema + a coverage metric | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 2 | Cover the highest-traffic / highest-cost skills first | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 3 | Ratchet: a floor that only rises | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 4 | Honest disposition of the long tail | ✅ done | 0 | 2 | 0 | 0 | 100% |
 
 ### [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md)
 

--- a/agents/roadmaps/archive/road-to-skill-eval-coverage.md
+++ b/agents/roadmaps/archive/road-to-skill-eval-coverage.md
@@ -80,7 +80,7 @@ uncovered remainder is honestly labeled, not implied-tested.
 
 ## Phase 2 — Cover the highest-traffic / highest-cost skills first
 
-- [ ] Author behavioural `evals.json` for every skill in each profile's curated
+- [x] Author behavioural `evals.json` for every skill in each profile's curated
       default surface (`src/agent-src/profiles/` "focused five" per profile) —
       these are what a fresh installer hits first.
       <!-- OPEN — blocked on `eval-authoring-throughput` (below). The

--- a/dist/agent-src/skills/character-consistency/evals/evals.json
+++ b/dist/agent-src/skills/character-consistency/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "character-consistency",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "keep-character-consistent",
+      "prompt": "Keep this recurring character consistent across a multi-scene story.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Pins a character bible (traits, voice, visual anchors) and checks each scene against it, flagging drift — not re-inventing per scene."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/dashboard-design/evals/evals.json
+++ b/dist/agent-src/skills/dashboard-design/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "dashboard-design",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "design-metrics-dashboard",
+      "prompt": "Design a metrics dashboard for our SaaS ops team.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Leads with the decisions the viewer must make, groups metrics by that, uses the right chart per data shape, and avoids vanity metrics."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/dcf-modeling/evals/evals.json
+++ b/dist/agent-src/skills/dcf-modeling/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "dcf-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "dcf-terminal-value-and-sensitivity",
+      "prompt": "DCF this target: year-6 FCFF $108M, WACC 10%, terminal growth 2%, net debt $200M. Give enterprise + equity value and the discount-rate sensitivity.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "WACC"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes Gordon terminal value = FCFF_{n+1}/(WACC−g) = 108/0.08 = 1350, bridges EV→equity via net debt, and includes a WACC/terminal-growth sensitivity grid — never a single point estimate."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/decision-record/evals/evals.json
+++ b/dist/agent-src/skills/decision-record/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "decision-record",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "record-adr",
+      "prompt": "Record our decision to adopt Postgres over MySQL as an ADR.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "Consequences"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Uses the ADR shape — Status / Context / Decision / Consequences / Alternatives — and states the trade-off given up, not only the choice."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/developer-like-execution/evals/evals.json
+++ b/dist/agent-src/skills/developer-like-execution/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "developer-like-execution",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "execute-like-dev",
+      "prompt": "Implement this small change end-to-end the way a senior would.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Reads before editing, keeps the diff minimal + scoped, updates downstream callers/tests, and verifies with a real run before claiming done."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/doc-coauthoring/evals/evals.json
+++ b/dist/agent-src/skills/doc-coauthoring/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "doc-coauthoring",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "coauthor-prd",
+      "prompt": "Help me write the PRD for our new onboarding flow.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Runs the 3-stage flow — context → section-by-section → reader-test — rather than dumping a full doc; asks for the missing context first."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/editorial-calendar/evals/evals.json
+++ b/dist/agent-src/skills/editorial-calendar/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "editorial-calendar",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "plan-content-calendar",
+      "prompt": "Plan a content calendar for next quarter for our dev-tools blog.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Grounds cadence + themes in a named audience + goal, sequences pieces with dependencies, not a random topic list."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/estimate-ticket/evals/evals.json
+++ b/dist/agent-src/skills/estimate-ticket/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "estimate-ticket",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "estimate-ticket",
+      "prompt": "Estimate this ticket: add CSV export to the reports page.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Estimates from decomposed work + named unknowns/risks; gives a range or points, and does NOT invent a wall-clock duration."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/forecasting/evals/evals.json
+++ b/dist/agent-src/skills/forecasting/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "forecasting",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "reconcile-topdown-bottomup",
+      "prompt": "Top-down says $30M ARR, bottom-up commit sums to $8.1M for Q1. Build the forecast call.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "confidence"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "States the construction shape (top-down/bottom-up/hybrid) and attaches a confidence band; when they diverge, the divergence IS the forecast — not either single number."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/fundraising-narrative/evals/evals.json
+++ b/dist/agent-src/skills/fundraising-narrative/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "fundraising-narrative",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "raise-narrative",
+      "prompt": "Draft the fundraising narrative for our seed round.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Builds a narrative around traction + why-now + why-us with a stated ask; surfaces the risk, does not issue a raise/don't-raise verdict (finance safety floor)."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/incident-commander/evals/evals.json
+++ b/dist/agent-src/skills/incident-commander/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "incident-commander",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "coordinate-incident",
+      "prompt": "Production is down — checkout is failing for all users. Coordinate the incident.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "sever"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Declares a severity, assigns IC/comms/ops roles, sets a comms cadence, and drives to mitigation-before-root-cause — matches a named IC practice."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/launch-readiness/evals/evals.json
+++ b/dist/agent-src/skills/launch-readiness/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill": "launch-readiness",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "launch-go-no-go",
+      "prompt": "Are we ready to launch this feature to production?",
+      "assertions": [
+        {
+          "kind": "finding_floor",
+          "n": 3,
+          "pattern": "(?m)^\\s*[-*+]\\s+"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Surfaces blast radius, rollback path, and observability/monitoring as explicit gates; a missing gate blocks go."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/logging-monitoring/evals/evals.json
+++ b/dist/agent-src/skills/logging-monitoring/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "logging-monitoring",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "add-logging-endpoint",
+      "prompt": "Add logging to this login endpoint so we can debug failures.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Logs allowlisted structured fields (user_id, request_id, outcome) — never the raw request/credential/PII; the credential never reaches the log stream."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/messaging-architecture/evals/evals.json
+++ b/dist/agent-src/skills/messaging-architecture/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "messaging-architecture",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "design-messaging",
+      "prompt": "Design the messaging architecture for our product.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Produces a layered message hierarchy (core → pillars → proof) grounded in a named audience, not generic slogans."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/perf-feedback-craft/evals/evals.json
+++ b/dist/agent-src/skills/perf-feedback-craft/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "perf-feedback-craft",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "perf-review-feedback",
+      "prompt": "Give this engineer performance feedback: they ship fast but skip tests.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Names the specific behaviour + its impact with an example, is balanced (strength + growth), and gives an actionable next step — not vague praise/blame."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/prompt-engineering-patterns/evals/evals.json
+++ b/dist/agent-src/skills/prompt-engineering-patterns/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "prompt-engineering-patterns",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "apply-prompt-pattern",
+      "prompt": "Which prompting pattern should I use to get structured extraction from messy text, and why?",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Names a concrete pattern (e.g. schema-constrained/structured-output, few-shot) matched to the extraction task, with the trade-off — not a generic tips list."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/refine-prompt/evals/evals.json
+++ b/dist/agent-src/skills/refine-prompt/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "refine-prompt",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "refine-a-prompt",
+      "prompt": "Improve this prompt: 'write good marketing copy'.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Adds role, concrete task, constraints, and success criteria; removes vague adjectives — a measurably tighter prompt, not a paraphrase."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/refine-ticket/evals/evals.json
+++ b/dist/agent-src/skills/refine-ticket/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "refine-ticket",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "refine-ticket-dor",
+      "prompt": "Refine this ticket: 'make search better'.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Tightens to a bounded scope with acceptance criteria + a definition-of-ready; asks the one blocking question rather than guessing scope."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/release-comms/evals/evals.json
+++ b/dist/agent-src/skills/release-comms/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "release-comms",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "write-release-note",
+      "prompt": "Write the release announcement for our v-next dashboard redesign.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Leads with user value + what changed, notes any migration/breaking step, and matches the product voice — not a raw changelog dump."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/rice-prioritization/evals/evals.json
+++ b/dist/agent-src/skills/rice-prioritization/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "rice-prioritization",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "rice-rank-three",
+      "prompt": "Prioritize these three features with RICE: A (reach 5000, impact 2, conf 80%, effort 3), B (reach 1000, impact 3, conf 100%, effort 1), C (reach 8000, impact 1, conf 50%, effort 5).",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "RICE"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes RICE = Reach×Impact×Confidence/Effort per item (A≈2667, B=3000, C=800) and ranks by the score, not by gut feel."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/runway-cognition/evals/evals.json
+++ b/dist/agent-src/skills/runway-cognition/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "runway-cognition",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "runway-shape-and-decision",
+      "prompt": "We have $4.2M cash and burn $560k/month. How long do we have and what should we do?",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "runway"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes months-of-runway = cash/burn (≈7.5) AND frames raise/hold/cut-vs-grow as a shape against the org-stage band, not a single number."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/scenario-modeling/evals/evals.json
+++ b/dist/agent-src/skills/scenario-modeling/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "scenario-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "base-upside-downside",
+      "prompt": "Model base / upside / downside for our annual plan off a $6.3M commit.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "downside"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Downside names a concrete HEADWIND (not base×0.8), upside names a tailwind, and reads optionality — not just ±20% on base."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/systematic-debugging/evals/evals.json
+++ b/dist/agent-src/skills/systematic-debugging/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "systematic-debugging",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "debug-flaky-test",
+      "prompt": "A test passes locally but fails in CI intermittently. Walk me through debugging it.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "hypothesis"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Forms a hypothesis, isolates one variable, and runs one-test-one-fix-one-rerun rather than shotgun edits."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/test-driven-development/evals/evals.json
+++ b/dist/agent-src/skills/test-driven-development/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "test-driven-development",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "tdd-new-validator",
+      "prompt": "TDD a password-strength validator (min length, mixed case, a digit).",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Writes a failing test FIRST (red), then the minimal code (green), then refactors — and covers boundary + negative cases, not only the happy path."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/threat-modeling/evals/evals.json
+++ b/dist/agent-src/skills/threat-modeling/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill": "threat-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "threat-model-upload",
+      "prompt": "Threat-model a new file-upload endpoint that accepts user files.",
+      "assertions": [
+        {
+          "kind": "finding_floor",
+          "n": 3,
+          "pattern": "(?m)^\\s*[-*+]\\s+"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Enumerates concrete abuse cases (path traversal, SSRF via URL fetch, malicious file, authz bypass) and the missing control per case — not generic 'validate input'."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/unit-economics-modeling/evals/evals.json
+++ b/dist/agent-src/skills/unit-economics-modeling/evals/evals.json
@@ -1,0 +1,24 @@
+{
+  "skill": "unit-economics-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "saas-unit-economics",
+      "prompt": "SaaS: ARPA $500/mo, gross margin 80%, monthly churn 2%, fully-loaded CAC $2000. Are we unit-economic?",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "LTV"
+        },
+        {
+          "kind": "contains",
+          "value": "CAC"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes LTV=ARPA·GM/churn (=20000), CAC payback=CAC/(ARPA·GM) (=5mo), and LTV:CAC (=10) with the SaaS formulas; states the payback + ratio, not one number."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/verify-completion-evidence/evals/evals.json
+++ b/dist/agent-src/skills/verify-completion-evidence/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "verify-completion-evidence",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "is-this-done",
+      "prompt": "I think the feature is done — the code looks right. Can we close it?",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Refuses to claim done without fresh verification evidence (a run/test), not an eyeball of the code — names the exact command that would prove it."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/vision-articulation/evals/evals.json
+++ b/dist/agent-src/skills/vision-articulation/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "vision-articulation",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "articulate-vision",
+      "prompt": "Articulate our product vision.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "States the bet in one sentence, why-now/why-us with evidence, and a counter-case — not an unopposed aspiration."
+        }
+      ]
+    }
+  ]
+}

--- a/dist/agent-src/skills/voice-and-tone-design/evals/evals.json
+++ b/dist/agent-src/skills/voice-and-tone-design/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "voice-and-tone-design",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "define-voice",
+      "prompt": "Define the brand voice and tone for our fintech product.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Produces named voice attributes with do/don't examples and a tone-by-context matrix, grounded in the audience — not adjectives alone."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/character-consistency/evals/evals.json
+++ b/src/skills/character-consistency/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "character-consistency",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "keep-character-consistent",
+      "prompt": "Keep this recurring character consistent across a multi-scene story.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Pins a character bible (traits, voice, visual anchors) and checks each scene against it, flagging drift — not re-inventing per scene."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/dashboard-design/evals/evals.json
+++ b/src/skills/dashboard-design/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "dashboard-design",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "design-metrics-dashboard",
+      "prompt": "Design a metrics dashboard for our SaaS ops team.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Leads with the decisions the viewer must make, groups metrics by that, uses the right chart per data shape, and avoids vanity metrics."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/dcf-modeling/evals/evals.json
+++ b/src/skills/dcf-modeling/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "dcf-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "dcf-terminal-value-and-sensitivity",
+      "prompt": "DCF this target: year-6 FCFF $108M, WACC 10%, terminal growth 2%, net debt $200M. Give enterprise + equity value and the discount-rate sensitivity.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "WACC"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes Gordon terminal value = FCFF_{n+1}/(WACC−g) = 108/0.08 = 1350, bridges EV→equity via net debt, and includes a WACC/terminal-growth sensitivity grid — never a single point estimate."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/decision-record/evals/evals.json
+++ b/src/skills/decision-record/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "decision-record",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "record-adr",
+      "prompt": "Record our decision to adopt Postgres over MySQL as an ADR.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "Consequences"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Uses the ADR shape — Status / Context / Decision / Consequences / Alternatives — and states the trade-off given up, not only the choice."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/developer-like-execution/evals/evals.json
+++ b/src/skills/developer-like-execution/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "developer-like-execution",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "execute-like-dev",
+      "prompt": "Implement this small change end-to-end the way a senior would.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Reads before editing, keeps the diff minimal + scoped, updates downstream callers/tests, and verifies with a real run before claiming done."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/doc-coauthoring/evals/evals.json
+++ b/src/skills/doc-coauthoring/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "doc-coauthoring",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "coauthor-prd",
+      "prompt": "Help me write the PRD for our new onboarding flow.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Runs the 3-stage flow — context → section-by-section → reader-test — rather than dumping a full doc; asks for the missing context first."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/editorial-calendar/evals/evals.json
+++ b/src/skills/editorial-calendar/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "editorial-calendar",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "plan-content-calendar",
+      "prompt": "Plan a content calendar for next quarter for our dev-tools blog.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Grounds cadence + themes in a named audience + goal, sequences pieces with dependencies, not a random topic list."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/estimate-ticket/evals/evals.json
+++ b/src/skills/estimate-ticket/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "estimate-ticket",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "estimate-ticket",
+      "prompt": "Estimate this ticket: add CSV export to the reports page.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Estimates from decomposed work + named unknowns/risks; gives a range or points, and does NOT invent a wall-clock duration."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/forecasting/evals/evals.json
+++ b/src/skills/forecasting/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "forecasting",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "reconcile-topdown-bottomup",
+      "prompt": "Top-down says $30M ARR, bottom-up commit sums to $8.1M for Q1. Build the forecast call.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "confidence"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "States the construction shape (top-down/bottom-up/hybrid) and attaches a confidence band; when they diverge, the divergence IS the forecast — not either single number."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/fundraising-narrative/evals/evals.json
+++ b/src/skills/fundraising-narrative/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "fundraising-narrative",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "raise-narrative",
+      "prompt": "Draft the fundraising narrative for our seed round.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Builds a narrative around traction + why-now + why-us with a stated ask; surfaces the risk, does not issue a raise/don't-raise verdict (finance safety floor)."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/incident-commander/evals/evals.json
+++ b/src/skills/incident-commander/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "incident-commander",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "coordinate-incident",
+      "prompt": "Production is down — checkout is failing for all users. Coordinate the incident.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "sever"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Declares a severity, assigns IC/comms/ops roles, sets a comms cadence, and drives to mitigation-before-root-cause — matches a named IC practice."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/launch-readiness/evals/evals.json
+++ b/src/skills/launch-readiness/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill": "launch-readiness",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "launch-go-no-go",
+      "prompt": "Are we ready to launch this feature to production?",
+      "assertions": [
+        {
+          "kind": "finding_floor",
+          "n": 3,
+          "pattern": "(?m)^\\s*[-*+]\\s+"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Surfaces blast radius, rollback path, and observability/monitoring as explicit gates; a missing gate blocks go."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/logging-monitoring/evals/evals.json
+++ b/src/skills/logging-monitoring/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "logging-monitoring",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "add-logging-endpoint",
+      "prompt": "Add logging to this login endpoint so we can debug failures.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Logs allowlisted structured fields (user_id, request_id, outcome) — never the raw request/credential/PII; the credential never reaches the log stream."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/messaging-architecture/evals/evals.json
+++ b/src/skills/messaging-architecture/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "messaging-architecture",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "design-messaging",
+      "prompt": "Design the messaging architecture for our product.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Produces a layered message hierarchy (core → pillars → proof) grounded in a named audience, not generic slogans."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/perf-feedback-craft/evals/evals.json
+++ b/src/skills/perf-feedback-craft/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "perf-feedback-craft",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "perf-review-feedback",
+      "prompt": "Give this engineer performance feedback: they ship fast but skip tests.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Names the specific behaviour + its impact with an example, is balanced (strength + growth), and gives an actionable next step — not vague praise/blame."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/prompt-engineering-patterns/evals/evals.json
+++ b/src/skills/prompt-engineering-patterns/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "prompt-engineering-patterns",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "apply-prompt-pattern",
+      "prompt": "Which prompting pattern should I use to get structured extraction from messy text, and why?",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Names a concrete pattern (e.g. schema-constrained/structured-output, few-shot) matched to the extraction task, with the trade-off — not a generic tips list."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/refine-prompt/evals/evals.json
+++ b/src/skills/refine-prompt/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "refine-prompt",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "refine-a-prompt",
+      "prompt": "Improve this prompt: 'write good marketing copy'.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Adds role, concrete task, constraints, and success criteria; removes vague adjectives — a measurably tighter prompt, not a paraphrase."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/refine-ticket/evals/evals.json
+++ b/src/skills/refine-ticket/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "refine-ticket",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "refine-ticket-dor",
+      "prompt": "Refine this ticket: 'make search better'.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Tightens to a bounded scope with acceptance criteria + a definition-of-ready; asks the one blocking question rather than guessing scope."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/release-comms/evals/evals.json
+++ b/src/skills/release-comms/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "release-comms",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "write-release-note",
+      "prompt": "Write the release announcement for our v-next dashboard redesign.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Leads with user value + what changed, notes any migration/breaking step, and matches the product voice — not a raw changelog dump."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/rice-prioritization/evals/evals.json
+++ b/src/skills/rice-prioritization/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "rice-prioritization",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "rice-rank-three",
+      "prompt": "Prioritize these three features with RICE: A (reach 5000, impact 2, conf 80%, effort 3), B (reach 1000, impact 3, conf 100%, effort 1), C (reach 8000, impact 1, conf 50%, effort 5).",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "RICE"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes RICE = Reach×Impact×Confidence/Effort per item (A≈2667, B=3000, C=800) and ranks by the score, not by gut feel."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/runway-cognition/evals/evals.json
+++ b/src/skills/runway-cognition/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "runway-cognition",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "runway-shape-and-decision",
+      "prompt": "We have $4.2M cash and burn $560k/month. How long do we have and what should we do?",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "runway"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes months-of-runway = cash/burn (≈7.5) AND frames raise/hold/cut-vs-grow as a shape against the org-stage band, not a single number."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/scenario-modeling/evals/evals.json
+++ b/src/skills/scenario-modeling/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "scenario-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "base-upside-downside",
+      "prompt": "Model base / upside / downside for our annual plan off a $6.3M commit.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "downside"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Downside names a concrete HEADWIND (not base×0.8), upside names a tailwind, and reads optionality — not just ±20% on base."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/systematic-debugging/evals/evals.json
+++ b/src/skills/systematic-debugging/evals/evals.json
@@ -1,0 +1,20 @@
+{
+  "skill": "systematic-debugging",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "debug-flaky-test",
+      "prompt": "A test passes locally but fails in CI intermittently. Walk me through debugging it.",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "hypothesis"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Forms a hypothesis, isolates one variable, and runs one-test-one-fix-one-rerun rather than shotgun edits."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/test-driven-development/evals/evals.json
+++ b/src/skills/test-driven-development/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "test-driven-development",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "tdd-new-validator",
+      "prompt": "TDD a password-strength validator (min length, mixed case, a digit).",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Writes a failing test FIRST (red), then the minimal code (green), then refactors — and covers boundary + negative cases, not only the happy path."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/threat-modeling/evals/evals.json
+++ b/src/skills/threat-modeling/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill": "threat-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "threat-model-upload",
+      "prompt": "Threat-model a new file-upload endpoint that accepts user files.",
+      "assertions": [
+        {
+          "kind": "finding_floor",
+          "n": 3,
+          "pattern": "(?m)^\\s*[-*+]\\s+"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Enumerates concrete abuse cases (path traversal, SSRF via URL fetch, malicious file, authz bypass) and the missing control per case — not generic 'validate input'."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/unit-economics-modeling/evals/evals.json
+++ b/src/skills/unit-economics-modeling/evals/evals.json
@@ -1,0 +1,24 @@
+{
+  "skill": "unit-economics-modeling",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "saas-unit-economics",
+      "prompt": "SaaS: ARPA $500/mo, gross margin 80%, monthly churn 2%, fully-loaded CAC $2000. Are we unit-economic?",
+      "assertions": [
+        {
+          "kind": "contains",
+          "value": "LTV"
+        },
+        {
+          "kind": "contains",
+          "value": "CAC"
+        },
+        {
+          "kind": "rubric",
+          "criterion": "Computes LTV=ARPA·GM/churn (=20000), CAC payback=CAC/(ARPA·GM) (=5mo), and LTV:CAC (=10) with the SaaS formulas; states the payback + ratio, not one number."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/verify-completion-evidence/evals/evals.json
+++ b/src/skills/verify-completion-evidence/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "verify-completion-evidence",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "is-this-done",
+      "prompt": "I think the feature is done — the code looks right. Can we close it?",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Refuses to claim done without fresh verification evidence (a run/test), not an eyeball of the code — names the exact command that would prove it."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/vision-articulation/evals/evals.json
+++ b/src/skills/vision-articulation/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "vision-articulation",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "articulate-vision",
+      "prompt": "Articulate our product vision.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "States the bet in one sentence, why-now/why-us with evidence, and a counter-case — not an unopposed aspiration."
+        }
+      ]
+    }
+  ]
+}

--- a/src/skills/voice-and-tone-design/evals/evals.json
+++ b/src/skills/voice-and-tone-design/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill": "voice-and-tone-design",
+  "_calibration": "Behavioural fixture (road-to-skill-eval-coverage Phase 2, default-surface). Deterministic assertions on a real output property where reliable; rubric pins the qualitative core as a known-limit (pass ratified in PR review, not a hidden judge). finding_floor n is a conservative floor, not a calibrated per-host number.",
+  "scenarios": [
+    {
+      "id": "define-voice",
+      "prompt": "Define the brand voice and tone for our fintech product.",
+      "assertions": [
+        {
+          "kind": "rubric",
+          "criterion": "Produces named voice attributes with do/don't examples and a tone-by-context matrix, grounded in the audience — not adjectives alone."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Completes `road-to-skill-eval-coverage` — the **whole** roadmap (rich + router in #869; this lands the default-surface set and closes it). `count_open == 0`, archived.

## What landed

Behavioural `evals.json` for all **29 default-surface skills** (the union of every profile's `skills_hint` — what a fresh installer hits first): dcf-modeling, runway-cognition, unit-economics-modeling, forecasting, scenario-modeling, rice-prioritization, fundraising-narrative, vision-articulation, messaging-architecture, incident-commander, launch-readiness, logging-monitoring, threat-modeling, systematic-debugging, test-driven-development, verify-completion-evidence, developer-like-execution, perf-feedback-craft, decision-record, refine-ticket, estimate-ticket, refine-prompt, prompt-engineering-patterns, doc-coauthoring, editorial-calendar, release-comms, voice-and-tone-design, character-consistency, dashboard-design.

## Quality

Each: a realistic scenario + a **deterministic assertion on a real output property** where reliable (`contains` WACC/LTV/CAC/RICE/Consequences/severity/hypothesis; `finding_floor` for list-producing skills like threat-modeling / launch-readiness) + a **rubric** pinning the qualitative core as a known-limit (ratified in PR review per the resolved `eval-authoring-throughput` blocker — never a hidden judge). The finance five assert the computed-value discipline from the domain-soundness work (e.g. Gordon TV = 1350, LTV = 20000, payback = 5mo).

## Coverage

default-surface **0/29 → 29/29**; overall **8 → 37/270**. rich 4/4 + router 2/2 (from #869).

## Verification

All 37 evals **ajv-valid** vs `evals.schema.json` · `skill_eval_coverage --check` (ratchet: no regression) · `lint_behavioural_eval_freshness` · `build_proof` (in sync) · `check_references` · `check_no_roadmap_refs` · `check_condensation` · `roadmap:progress-check` — green. Dashboard 14 → 13.