### PR TITLE
feat(bus-factor): dogfooded self-review gate (advisory, inert without secret)

### DIFF
--- a/.github/workflows/self-review-gate.yml
+++ b/.github/workflows/self-review-gate.yml
@@ -1,0 +1,58 @@
+name: Self-review gate
+
+# road-to-maintainer-bus-factor Phase 1 — the package reviews its own PRs with
+# the exact machinery it sells (`adversarial-review` + `agent-security-review`).
+#
+# ADVISORY + INERT-WITHOUT-SECRET (mirrors cross-model-canary.yml):
+#   - gate (every PR): DRY-RUN only — no API, no spend, no secret. Validates the
+#     harness + prints the review plan. Never blocks.
+#   - live-advisory (PR, when ANTHROPIC_API_KEY is set): runs the real dogfooded
+#     review and posts findings as a PR comment. ADVISORY — records what WOULD
+#     block; never fails the check. No key → logged no-op, never a failure.
+#
+# To make it REQUIRED (block on security/claim × high+ findings): add the
+# ANTHROPIC_API_KEY repo secret, pass `--enforce` in the live job, and require
+# this check in branch protection. That flip is the maintainer's act (blocker
+# `self-review-gate-cost`); shipped advisory until then.
+
+on:
+  pull_request:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate-dry-run:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Self-review plan (dry-run — no spend, advisory)
+        run: ./node_modules/.bin/tsx src/scripts/self_review_gate.ts --dry-run --base "origin/${{ github.base_ref }}"
+
+  live-advisory:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Dogfooded self-review (advisory; skips if ANTHROPIC_API_KEY absent)
+        run: ./node_modules/.bin/tsx src/scripts/self_review_gate.ts --base "origin/${{ github.base_ref }}"

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**112 / 200 steps done · 56%**
+**113 / 201 steps done · 56%**
 
 ```text
 ██████████████████████░░░░░░░░░░░░░░░░░░   56%
@@ -23,7 +23,7 @@
 | 5 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 2 | 17 | 0 | 0 | [2](#blockers-road-to-flow-learnings) | █████████░ 89% |
 | 6 | [road-to-golden-set-coverage.md](roadmaps/road-to-golden-set-coverage.md) | 4 | 18 | 4 | 14 | 0 | 0 | [2](#blockers-road-to-golden-set-coverage) | ████████░░ 78% |
 | 7 | [road-to-install-path-convergence-followup.md](roadmaps/road-to-install-path-convergence-followup.md) | 1 | 1 | 1 | 0 | 0 | 0 | [1](#blockers-road-to-install-path-convergence-followup) | ░░░░░░░░░░ 0% |
-| 8 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 6 | 5 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ████░░░░░░ 45% |
+| 8 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
 | 9 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 10 | 0 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ░░░░░░░░░░ 0% |
 | 10 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
 | 11 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
@@ -168,11 +168,11 @@ _2 blockers resolved._
 
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 
-**Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 5 / 11 done (45%)
+**Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 6 / 12 done (50%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Dogfood the review machinery as a pre-merge gate | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Dogfood the review machinery as a pre-merge gate | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
 | 2 | CODEOWNERS + branch protection | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 3 | Make a release inheritable (the runbook) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 4 | Lower bus-factor toward >1 (opportunistic, honest) | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |

--- a/agents/roadmaps/road-to-maintainer-bus-factor.md
+++ b/agents/roadmaps/road-to-maintainer-bus-factor.md
@@ -52,18 +52,40 @@ maintainer after a gap) ship a correct release without tribal knowledge.
       `agent-security-review` (and, for large diffs, `ai-council` with the
       advisor personas) against the diff, posting findings as a review. This is
       the package reviewing itself with the exact machinery it sells.
-      <!-- OPEN — blocked on `self-review-gate-cost` (maintainer-owned): a live
-      AI-review CI workflow needs an API secret + a per-PR token budget + the
-      block-vs-advise teeth decision; a headless AI workflow is not safely
-      shippable without the maintainer's secret/budget sign-off. Council already
-      confirmed the shape. Deferred to the maintainer, not built blind. -->
-- [ ] Define the gate's teeth: security-sensitive or claim-affecting findings
+      <!-- PARTIAL 2026-07-10: the ADVISORY + INERT-WITHOUT-SECRET half shipped —
+      `.github/workflows/self-review-gate.yml` (mirrors cross-model-canary: a
+      no-spend dry-run plan job on every PR + a secret-gated live-advisory job
+      that posts findings and skips as a logged no-op when ANTHROPIC_API_KEY is
+      absent) driving `src/scripts/self_review_gate.ts` (loads the two review
+      skill bodies as the system prompt, collects structured findings, posts a
+      PR review). STILL MAINTAINER: (a) the API secret + per-PR budget sign-off
+      to make it run LIVE (blocker `self-review-gate-cost`), (b) making it
+      REQUIRED = Phase 2 branch protection, (c) the large-diff `ai-council`
+      escalation. Built advisory, not blind. -->
+- [x] Define the gate's teeth: security-sensitive or claim-affecting findings
       block merge; style findings advise. Wire the verdict through the existing
       `gateVerdict()` pattern so the outcome is recorded, not just printed.
       <!-- council 2026-07-08 (claude-sonnet-4-5 + gpt-4o): confirmed this
       exact shape — block ONLY on security/claim findings; full ai-council
       only on large or claim-affecting diffs; a 100%-blocking gate at
       solo-maintainer token cost would be ignored or gamed. -->
+      <!-- done 2026-07-10: `self_review_gate.ts` exposes pure, unit-tested
+      `classifyBlocking()` (blocks iff kind∈{security,claim} × severity∈
+      {critical,high}) + `gateVerdict(findings,{enforce})` mirroring
+      `check_quality_regression.gateVerdict` (0 pass / 2 block). The verdict is
+      RECORDED via `renderReview()` (advisory phrasing = "WOULD block"), not just
+      printed. Shipped `enforce:false` (advisory); the `--enforce` flip that
+      arms the teeth is the maintainer's act, one flag. -->
+- [ ] Record it honestly on the proof page: "PRs pass a dogfooded AI
+      adversarial-review + security gate; this is a floor, not independent human
+      review."
+      <!-- OPEN 2026-07-10: the literal "PRs pass a dogfooded AI gate" proof-page
+      CLAIM is FALSE while the gate is inert-without-secret (no live run), so
+      recording it now would breach check_claims / no-invented-facts. The honest
+      advisory status IS documented in `docs/self-review-gate.md` (gate exists,
+      advisory, inert without the secret; how to arm it). The proof-page floor
+      CLAIM is the maintainer's to create the moment the gate goes live with the
+      secret — not before. -->
       <!-- OPEN — same `self-review-gate-cost` block (the teeth decision). -->
 - [ ] Record it honestly on the proof page: "PRs pass a dogfooded AI
       adversarial-review + security gate; this is a floor, not independent human

--- a/docs/self-review-gate.md
+++ b/docs/self-review-gate.md
@@ -1,0 +1,51 @@
+# Self-review gate (dogfooded PR review)
+
+The package reviews its own PRs with the exact machinery it ships —
+[`adversarial-review`](../src/skills/adversarial-review/SKILL.md) +
+[`agent-security-review`](../src/skills/agent-security-review/SKILL.md) — via
+[`.github/workflows/self-review-gate.yml`](../.github/workflows/self-review-gate.yml)
+and [`src/scripts/self_review_gate.ts`](../src/scripts/self_review_gate.ts).
+
+`road-to-maintainer-bus-factor` Phase 1.
+
+## Current status — ADVISORY, inert without a secret
+
+This is an **honest floor, not independent human review**, and today it is
+**advisory + inert-without-secret**. Do not read it as "every PR is
+AI-reviewed" — that is only true once the maintainer arms it (below).
+
+| Job | Runs | Spend | Blocks merge |
+|---|---|---|---|
+| `gate-dry-run` | every PR | none (no API) | never — prints the review plan only |
+| `live-advisory` | every PR **iff** `ANTHROPIC_API_KEY` is set | one review call | never — posts findings, records what *would* block |
+
+Without the `ANTHROPIC_API_KEY` repo secret, `live-advisory` is a **logged
+no-op** (never a failing check) — exactly the `cross-model-canary.yml` pattern.
+
+## The teeth (defined + wired, not yet armed)
+
+`self_review_gate.ts` exposes pure, unit-tested:
+
+- `classifyBlocking(finding)` — a finding is merge-blocking **iff**
+  `kind ∈ {security, claim}` **and** `severity ∈ {critical, high}`. Style and
+  correctness findings, and low/medium security findings, advise only. (Council
+  2026-07-08, claude-sonnet-4-5 + gpt-4o: a 100 %-blocking gate at
+  solo-maintainer token cost gets ignored or gamed — block only on the narrow
+  security/claim × high+ intersection.)
+- `gateVerdict(findings, {enforce})` — mirrors
+  `check_quality_regression.gateVerdict`: `0` pass / `2` block. Shipped
+  `enforce: false` (advisory always returns `0` and reports the would-block
+  set).
+
+## Arming it (maintainer, one flip)
+
+1. Add the `ANTHROPIC_API_KEY` repo secret (per-PR budget sign-off) — turns
+   `live-advisory` from no-op into a real dogfooded review.
+2. Pass `--enforce` in the live job to arm the teeth (block on
+   security/claim × high+).
+3. Require the `Self-review gate` check in branch protection
+   (`road-to-maintainer-bus-factor` Phase 2) so even solo merges pass the gate.
+4. Record the floor CLAIM on the proof page **once it is live** — not before
+   (an inert gate is not a passed gate).
+
+Blocker `self-review-gate-cost` (maintainer-owned) gates steps 1–2.

--- a/src/scripts/self_review_gate.test.ts
+++ b/src/scripts/self_review_gate.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    classifyBlocking,
+    gateVerdict,
+    isReviewablePath,
+    renderReview,
+    type Finding,
+} from './self_review_gate.js';
+
+const f = (severity: Finding['severity'], kind: Finding['kind']): Finding => ({
+    severity,
+    kind,
+    title: `${severity} ${kind}`,
+    detail: 'x',
+});
+
+describe('classifyBlocking', () => {
+    it('blocks security + high and claim + critical', () => {
+        expect(classifyBlocking(f('high', 'security'))).toBe(true);
+        expect(classifyBlocking(f('critical', 'claim'))).toBe(true);
+    });
+    it('does not block low/medium security, or any style/correctness', () => {
+        expect(classifyBlocking(f('medium', 'security'))).toBe(false);
+        expect(classifyBlocking(f('low', 'claim'))).toBe(false);
+        expect(classifyBlocking(f('critical', 'style'))).toBe(false);
+        expect(classifyBlocking(f('high', 'correctness'))).toBe(false);
+    });
+});
+
+describe('gateVerdict', () => {
+    const blocking = [f('high', 'security')];
+    it('advisory (default shipped mode) never blocks, even with a blocking finding', () => {
+        expect(gateVerdict(blocking, { enforce: false })).toBe(0);
+    });
+    it('enforce blocks only on a merge-blocking finding', () => {
+        expect(gateVerdict(blocking, { enforce: true })).toBe(2);
+        expect(gateVerdict([f('critical', 'style')], { enforce: true })).toBe(0);
+        expect(gateVerdict([], { enforce: true })).toBe(0);
+    });
+});
+
+describe('isReviewablePath', () => {
+    it('skips generated projections + lockfiles, keeps source', () => {
+        expect(isReviewablePath('dist/agent-src/skills/x/SKILL.md')).toBe(false);
+        expect(isReviewablePath('.augment/rules/x.md')).toBe(false);
+        expect(isReviewablePath('.windsurfrules')).toBe(false);
+        expect(isReviewablePath('package-lock.json')).toBe(false);
+        expect(isReviewablePath('src/rules/x.md')).toBe(true);
+        expect(isReviewablePath('src/scripts/y.ts')).toBe(true);
+    });
+});
+
+describe('renderReview', () => {
+    it('carries the HUMAN REVIEW REQUIRED banner + the floor-not-human-review caveat', () => {
+        const out = renderReview([], false);
+        expect(out).toContain('HUMAN REVIEW REQUIRED');
+        expect(out).toContain('not** independent human review');
+    });
+    it('advisory phrasing says WOULD block, enforce phrasing says blocking', () => {
+        const blocking = [f('high', 'security')];
+        expect(renderReview(blocking, false)).toContain('WOULD block');
+        expect(renderReview(blocking, true)).toContain('merge-blocking');
+    });
+});

--- a/src/scripts/self_review_gate.ts
+++ b/src/scripts/self_review_gate.ts
@@ -1,0 +1,272 @@
+/**
+ * Self-review gate — the package reviewing its own PRs with the exact machinery
+ * it sells (`adversarial-review` + `agent-security-review`).
+ *
+ * road-to-maintainer-bus-factor Phase 1. Ships ADVISORY + INERT-WITHOUT-SECRET:
+ *   - `--dry-run` (the PR gate job): no API, no spend, no secret. Assembles and
+ *     prints the review plan (which skills, which files, budget estimate) and
+ *     validates the harness. Always exit 0.
+ *   - live `--advisory` (the secret-gated job): loads the two review skill bodies
+ *     as the system prompt, sends the diff to the model, collects structured
+ *     findings, classifies them, records a verdict, and posts a PR review. In
+ *     advisory mode it NEVER blocks the merge (exit 0) — it records what WOULD
+ *     block. If no key is available it is a logged no-op (exit 0), never a failure.
+ *
+ * Turning the gate REQUIRED (block-on-verdict) and wiring the API secret + the
+ * per-PR budget are the maintainer's acts (blocker `self-review-gate-cost`); this
+ * script exposes the `--enforce` path so that flip is a one-flag change, but the
+ * shipped workflow runs advisory only.
+ *
+ * `classifyBlocking` + `gateVerdict` are pure and unit-tested (no API) — mirrors
+ * the `check_quality_regression.gateVerdict` pattern.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { AnthropicClient, load_anthropic_key } from './ai_council/clients.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// ── Finding model ─────────────────────────────────────────────────────
+export type Severity = 'critical' | 'high' | 'medium' | 'low';
+export type FindingKind = 'security' | 'claim' | 'correctness' | 'style';
+
+export interface Finding {
+    severity: Severity;
+    kind: FindingKind;
+    title: string;
+    detail: string;
+    file?: string;
+}
+
+/**
+ * A finding is merge-blocking iff it is security- or claim-affecting AND at
+ * least `high` severity. Style and correctness findings advise; low/medium
+ * security findings advise. Council 2026-07-08 (claude-sonnet-4-5 + gpt-4o):
+ * a 100 %-blocking gate at solo-maintainer token cost gets ignored or gamed —
+ * block ONLY on the narrow security/claim × {critical,high} intersection.
+ */
+export function classifyBlocking(f: Finding): boolean {
+    return (f.kind === 'security' || f.kind === 'claim') && (f.severity === 'critical' || f.severity === 'high');
+}
+
+/**
+ * Deterministic gate verdict. Mirrors `check_quality_regression.gateVerdict`:
+ * exit 2 blocks the merge, exit 0 passes.
+ *   - advisory (default shipped mode): always 0; the caller reports the
+ *     would-block set without failing the check.
+ *   - enforce (maintainer flip): 2 iff any finding is merge-blocking.
+ */
+export function gateVerdict(findings: readonly Finding[], opts: { enforce: boolean }): 0 | 2 {
+    if (!opts.enforce) return 0;
+    return findings.some(classifyBlocking) ? 2 : 0;
+}
+
+// ── Diff collection ───────────────────────────────────────────────────
+/** Generated projections + lockfiles a self-review should not re-read. */
+const SKIP_PREFIXES = ['dist/agent-src/', '.augment/', '.claude/', '.cursor/', '.clinerules/'];
+const SKIP_EXACT = new Set(['.windsurfrules', 'GEMINI.md', 'package-lock.json']);
+
+export function isReviewablePath(p: string): boolean {
+    if (SKIP_EXACT.has(p)) return false;
+    return !SKIP_PREFIXES.some((pre) => p.startsWith(pre));
+}
+
+function changedFiles(baseRef: string): string[] {
+    const r = spawnSync('git', ['diff', '--name-only', `${baseRef}...HEAD`], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+    });
+    if (r.status !== 0) {
+        throw new Error(`git diff failed: ${(r.stderr ?? '').toString().slice(0, 300)}`);
+    }
+    return (r.stdout ?? '')
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .filter(isReviewablePath);
+}
+
+function diffText(baseRef: string, files: string[]): string {
+    if (files.length === 0) return '';
+    const r = spawnSync('git', ['diff', `${baseRef}...HEAD`, '--', ...files], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+    });
+    return (r.stdout ?? '').toString();
+}
+
+// ── Review skill bodies (the system prompt) ───────────────────────────
+const REVIEW_SKILLS = ['adversarial-review', 'agent-security-review'] as const;
+
+function loadSkillBody(name: string): string {
+    const p = path.join(REPO_ROOT, 'src', 'skills', name, 'SKILL.md');
+    return readFileSync(p, 'utf8');
+}
+
+function buildSystemPrompt(): string {
+    const bodies = REVIEW_SKILLS.map((s) => `# Skill: ${s}\n\n${loadSkillBody(s)}`).join('\n\n---\n\n');
+    return [
+        'You are the self-review gate for an AI-agent governance package. Apply the',
+        'two skills below to the supplied PR diff. Return ONLY a JSON object of the',
+        'shape {"findings":[{"severity":"critical|high|medium|low",',
+        '"kind":"security|claim|correctness|style","title":"...","detail":"...",',
+        '"file":"optional/path"}]}. Use kind="claim" for an unbacked headline number',
+        'or a proof/CLAIMS-affecting statement, kind="security" for an auth/tenant/',
+        'secret/egress/injection gap. No prose outside the JSON.',
+        '',
+        bodies,
+    ].join('\n');
+}
+
+// ── Plan (dry-run) ────────────────────────────────────────────────────
+export interface ReviewPlan {
+    skills: string[];
+    files: string[];
+    promptChars: number;
+    note: string;
+}
+
+export function buildPlan(baseRef: string): ReviewPlan {
+    const files = changedFiles(baseRef);
+    const diff = diffText(baseRef, files);
+    return {
+        skills: [...REVIEW_SKILLS],
+        files,
+        promptChars: buildSystemPrompt().length + diff.length,
+        note:
+            files.length === 0
+                ? 'No reviewable (non-generated) files changed — the live review would no-op.'
+                : `${files.length} reviewable file(s); live review would send ~${Math.ceil(
+                      (buildSystemPrompt().length + diff.length) / 4,
+                  )} input tokens.`,
+    };
+}
+
+// ── Live review ───────────────────────────────────────────────────────
+function parseFindings(text: string): Finding[] {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start < 0 || end <= start) return [];
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(text.slice(start, end + 1));
+    } catch {
+        return [];
+    }
+    const arr = (parsed as { findings?: unknown })?.findings;
+    if (!Array.isArray(arr)) return [];
+    const sev = new Set<Severity>(['critical', 'high', 'medium', 'low']);
+    const kind = new Set<FindingKind>(['security', 'claim', 'correctness', 'style']);
+    return arr
+        .filter((f): f is Record<string, unknown> => typeof f === 'object' && f !== null)
+        .filter((f) => sev.has(f.severity as Severity) && kind.has(f.kind as FindingKind))
+        .map((f) => ({
+            severity: f.severity as Severity,
+            kind: f.kind as FindingKind,
+            title: String(f.title ?? '').slice(0, 300),
+            detail: String(f.detail ?? '').slice(0, 2000),
+            ...(typeof f.file === 'string' ? { file: f.file } : {}),
+        }));
+}
+
+export function renderReview(findings: Finding[], enforce: boolean): string {
+    const banner =
+        '> HUMAN REVIEW REQUIRED — dogfooded AI adversarial-review + security gate. ' +
+        'Findings are decision support, not a guarantee; detection is probabilistic. ' +
+        'This is a floor, **not** independent human review.';
+    if (findings.length === 0) {
+        return `${banner}\n\n✅ Self-review gate: no findings.`;
+    }
+    const blocking = findings.filter(classifyBlocking);
+    const rows = findings
+        .map((f) => `| ${f.severity} | ${f.kind} | ${f.file ?? '—'} | ${f.title} |`)
+        .join('\n');
+    const verdictLine = blocking.length
+        ? enforce
+            ? `❌ ${blocking.length} merge-blocking finding(s) (security/claim × high+).`
+            : `⚠️ ${blocking.length} finding(s) WOULD block merge under an enforced gate (advisory now).`
+        : '✅ No merge-blocking findings (style/correctness advise only).';
+    return `${banner}\n\n${verdictLine}\n\n| severity | kind | file | finding |\n|---|---|---|---|\n${rows}`;
+}
+
+function postReview(body: string): void {
+    const pr = process.env.PR_NUMBER;
+    if (!pr) {
+        process.stdout.write('::notice::self-review-gate — no PR_NUMBER; printing review instead of posting.\n');
+        process.stdout.write(body + '\n');
+        return;
+    }
+    const r = spawnSync('gh', ['pr', 'comment', pr, '--body', body], { cwd: REPO_ROOT, encoding: 'utf8' });
+    if (r.status !== 0) {
+        process.stdout.write(`::warning::self-review-gate — gh pr comment failed: ${(r.stderr ?? '').toString().slice(0, 300)}\n`);
+        process.stdout.write(body + '\n');
+    }
+}
+
+function resolveKey(): string | null {
+    const env = process.env.ANTHROPIC_API_KEY;
+    if (env && env.trim()) return env.trim();
+    try {
+        return load_anthropic_key();
+    } catch {
+        return null;
+    }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────
+export function main(argv: string[]): 0 | 2 {
+    const dryRun = argv.includes('--dry-run');
+    const enforce = argv.includes('--enforce');
+    const baseIdx = argv.indexOf('--base');
+    const baseRef = (baseIdx >= 0 ? argv[baseIdx + 1] : undefined) ?? 'origin/main';
+
+    const plan = buildPlan(baseRef);
+
+    if (dryRun) {
+        process.stdout.write(
+            `self-review-gate (dry-run — no spend, advisory):\n` +
+                `  skills: ${plan.skills.join(', ')}\n` +
+                `  files:  ${plan.files.length}\n` +
+                `  ${plan.note}\n`,
+        );
+        return 0;
+    }
+
+    if (plan.files.length === 0) {
+        process.stdout.write('::notice::self-review-gate — no reviewable files changed; skipping.\n');
+        return 0;
+    }
+
+    const key = resolveKey();
+    if (!key) {
+        process.stdout.write(
+            '::notice::self-review-gate skipped — set the ANTHROPIC_API_KEY repo secret to enable the live dogfooded review.\n',
+        );
+        return 0;
+    }
+
+    const client = new AnthropicClient({ api_key: key });
+    const resp = client.ask(buildSystemPrompt(), diffText(baseRef, plan.files), 4096);
+    if (resp.error) {
+        process.stdout.write(`::warning::self-review-gate — model call failed: ${resp.error}\n`);
+        return 0; // advisory: a transport failure never blocks the merge
+    }
+    const findings = parseFindings(resp.text);
+    const body = renderReview(findings, enforce);
+    postReview(body);
+
+    const code = gateVerdict(findings, { enforce });
+    if (code === 2) {
+        process.stdout.write('::error::self-review-gate — merge-blocking findings under enforce mode.\n');
+    }
+    return code;
+}
+
+if (existsSync(process.argv[1] ?? '') && import.meta.url === `file://${process.argv[1]}`) {
+    process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## What

`road-to-maintainer-bus-factor` Phase 1 — the package reviews its own PRs with the exact machinery it sells (`adversarial-review` + `agent-security-review`), in the **advisory + inert-without-secret** shape approved for autonomous build.

- **`src/scripts/self_review_gate.ts`** — pure, unit-tested `classifyBlocking()` (blocks iff `kind∈{security,claim} × severity∈{critical,high}`) + `gateVerdict(findings,{enforce})` mirroring `check_quality_regression.gateVerdict` (`0` pass / `2` block). `--dry-run` assembles the review plan with **no API / no spend**; the live path loads the two review skill bodies as the system prompt, collects structured findings, and posts a PR review. Advisory: never blocks; a missing key or transport failure is a **logged no-op** (exit 0).
- **`.github/workflows/self-review-gate.yml`** — mirrors `cross-model-canary.yml`: a no-spend dry-run plan job on every PR + a secret-gated `live-advisory` job that skips as a logged no-op when `ANTHROPIC_API_KEY` is absent.
- **`src/scripts/self_review_gate.test.ts`** — 7 vitest cases.
- **`docs/self-review-gate.md`** — honest status + how the maintainer arms it.

## Honest scope — Phase 1 stays OPEN

This ships the advisory half only. The roadmap step boxes reflect it: **step 2 (teeth) `[x]`**; **step 1 (workflow) PARTIAL**; **step 3 (proof CLAIM) open**. Remaining acts are the **maintainer's**:

1. Add `ANTHROPIC_API_KEY` + per-PR budget sign-off → runs LIVE (blocker `self-review-gate-cost`).
2. `--enforce` to arm the teeth (block on security/claim × high+).
3. Branch protection to make the check required (Phase 2).
4. The proof-page floor CLAIM **once live** — recording "PRs pass a dogfooded gate" while the gate is inert would be false (`check_claims` / no-invented-facts), so it is deliberately **not** recorded now.

## Verification

- `vitest self_review_gate.test.ts` → 7/7 ✅ · `task typecheck-ts` ✅
- `--dry-run` + no-key live path → inert no-op, exit 0 ✅
- `check_references` ✅ · `check_no_roadmap_refs` ✅ · `check_claims` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)