### PR TITLE
chore(flow-learnings): commit bench matrix run-config + concretize the live-run blocker

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -102,9 +102,15 @@ _2 blockers resolved._
 - **live-matrix-run** (owner: maintainer) — blocks Phase 3 — live matrix run (live API spend)
   - **What to do:**
     1. Invoke the matrix runner for ≥2 task families × 2 hosts from the
-    matrix YAML (paired arms per the existing ab-v2 discipline).
-    2. Pin the resulting report alongside the existing pinned reports.
-  - **Resolved when:** one schema-valid matrix report exists and the per-section render consumes it without manual edits.
+    matrix YAML (paired arms per the existing ab-v2 discipline). The config
+    is committed at `internal/bench/matrix.yaml` (2 families × 2 hosts × arms
+    `vanilla`,`rules-kernel-dc`; host-compatible — codex rejects the plugin
+    `package` arm) and dry-verified: `npx tsx src/scripts/bench_matrix.ts
+    --config internal/bench/matrix.yaml --expand` → 4 cells. Run it with
+    `--run` (per-cell `--budget` caps spend; 4 cells).
+    2. Pin the resulting report alongside the existing pinned reports; regen
+    `docs/benchmark.md` via the per-section renderer (zero manual edits).
+  - **Resolved when:** one schema-valid matrix report exists and the per-section render consumes it without manual edits. - **Why not autonomous (beyond spend):** `--run` spawns the real `claude` + `codex` host CLIs as unattended coding agents (sandbox/approvals off) — an auto-mode agent-spawn gate blocks it independently of the paid-run authorization. Run it in a non-auto session (or approve the permission prompt); the numbers become published benchmark evidence, so the PR review that pins them is the integrity sign-off.
 
 ### [road-to-golden-set-coverage.md](roadmaps/road-to-golden-set-coverage.md)
 

--- a/agents/roadmaps/road-to-flow-learnings.md
+++ b/agents/roadmaps/road-to-flow-learnings.md
@@ -278,10 +278,22 @@ blocker below.
 - **Blocks:** Phase 3 — live matrix run (live API spend)
 - **What to do:**
   1. Invoke the matrix runner for ≥2 task families × 2 hosts from the
-     matrix YAML (paired arms per the existing ab-v2 discipline).
-  2. Pin the resulting report alongside the existing pinned reports.
+     matrix YAML (paired arms per the existing ab-v2 discipline). The config
+     is committed at `internal/bench/matrix.yaml` (2 families × 2 hosts × arms
+     `vanilla`,`rules-kernel-dc`; host-compatible — codex rejects the plugin
+     `package` arm) and dry-verified: `npx tsx src/scripts/bench_matrix.ts
+     --config internal/bench/matrix.yaml --expand` → 4 cells. Run it with
+     `--run` (per-cell `--budget` caps spend; 4 cells).
+  2. Pin the resulting report alongside the existing pinned reports; regen
+     `docs/benchmark.md` via the per-section renderer (zero manual edits).
 - **Resolved when:** one schema-valid matrix report exists and the
   per-section render consumes it without manual edits.
+- **Why not autonomous (beyond spend):** `--run` spawns the real `claude` +
+  `codex` host CLIs as unattended coding agents (sandbox/approvals off) — an
+  auto-mode agent-spawn gate blocks it independently of the paid-run
+  authorization. Run it in a non-auto session (or approve the permission
+  prompt); the numbers become published benchmark evidence, so the PR review
+  that pins them is the integrity sign-off.
 
 ## Acceptance criteria (anti-dump)
 

--- a/internal/bench/matrix.yaml
+++ b/internal/bench/matrix.yaml
@@ -1,0 +1,10 @@
+# Bench matrix (road-to-flow-learnings Phase 3) — task-family × host × arm.
+# Expanded by src/scripts/bench_matrix.ts into paired bench_ab_v2_run cells.
+# Bounded live run: 2 families × 2 hosts = 4 cells; budget is PER CELL.
+families: [over-engineering-bait, regression-landmine]
+hosts: [claude, codex]
+arms: [vanilla, rules-kernel-dc]
+seeds: 2
+model: claude-haiku-4-5
+budget: 2.0
+timeout: 180


### PR DESCRIPTION
## What

`road-to-flow-learnings` Phase 3 prep. The matrix runner `bench_matrix.ts` needs a `--config` YAML and none was committed. Adds **`internal/bench/matrix.yaml`**:

- 2 task families (`over-engineering-bait`, `regression-landmine`) × 2 hosts (`claude`, `codex`) × arms `vanilla,rules-kernel-dc` — **host-compatible** (codex rejects the plugin `package` arm), haiku, per-cell `--budget` cap.
- **Dry-verified:** `npx tsx src/scripts/bench_matrix.ts --config internal/bench/matrix.yaml --expand` → **4 cells, no spend.**

## Why the live run is NOT in this PR (honest)

You authorized paid runs, and I set out to run the live matrix — but the auto-mode classifier **correctly blocked** `bench_matrix --run`: it spawns the real `claude` + `codex` host CLIs as **unattended coding agents** (sandbox/approvals off). That is more than spend — it is running third-party agent loops unattended — so "paid runs OK" does not authorize it. **No spend occurred** (blocked before execution).

The `live-matrix-run` blocker's *What-to-do* now cites the exact one-command invocation and records that the run must happen in a **non-auto session** (or with an approved permission prompt), and that the pinned numbers become **published benchmark evidence** gated by PR review.

## Scope

This ships the run-config + a validated dry-plan so the paid run is **one command away** — it does **not** run it and does **not** close `road-to-flow-learnings` (the live-matrix-run step + the org-fleet-run step, which needs real org repos, both stay open). No checkbox flipped.

## Verification

`check_references` ✅ · `check_no_roadmap_refs` ✅ · `bench_matrix --expand` → 4 cells ✅ · dashboard regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)