### PR TITLE
feat(subagent-value): verify orchestration telemetry pipeline end-to-end (Phase 1 Step 1)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**117 / 198 steps done · 59%**
+**118 / 198 steps done · 60%**
 
 ```text
-████████████████████████░░░░░░░░░░░░░░░░   59%
+████████████████████████░░░░░░░░░░░░░░░░   60%
 ```
 
 ## Open roadmaps
@@ -25,7 +25,7 @@
 | 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
 | 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 7 | 3 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ███░░░░░░░ 30% |
 | 9 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 10 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 9 | 0 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ░░░░░░░░░░ 0% |
+| 10 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 8 | 1 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | █░░░░░░░░░ 11% |
 | 11 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
 | 12 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 11 | 24 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 69% |
 
@@ -213,11 +213,11 @@ _1 blocker resolved._
 
 ### [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md)
 
-**Follow-up to Subagent value realization** — 0 / 9 done (0%)
+**Follow-up to Subagent value realization** — 1 / 9 done (11%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Seed real telemetry | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Seed real telemetry | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 | 2 | Re-gate the `auto: on` flip | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 
 <a id="blockers-road-to-subagent-value-realization-followup"></a>

--- a/agents/roadmaps/road-to-subagent-value-realization-followup.md
+++ b/agents/roadmaps/road-to-subagent-value-realization-followup.md
@@ -23,7 +23,21 @@ and `agents/settings/contexts/orchestration-default-flip-verdict.md`).
 
 ## Phase 1: Seed real telemetry
 
-- [ ] **Step 1:** Verify end-to-end on one real `do-in-parallel` dispatch: a telemetry line is emitted, appended, and reportable. Cite the JSONL line. (Run corpus `orch-01` from `internal/bench/orchestration/corpus/` with `subagents.auto: on`.)
+- [x] **Step 1:** Verify end-to-end on one real `do-in-parallel` dispatch: a telemetry line is emitted, appended, and reportable. Cite the JSONL line. (Run corpus `orch-01` from `internal/bench/orchestration/corpus/` with `subagents.auto: on`.)
+      <!-- done 2026-07-11: ran orch-01 (multi-file analysis) as a real
+      do-in-parallel dispatch via the native Agent tool — 3 parallel read-only
+      subagents (parser.ts / formatter.ts / cli.ts; the 4th fixture reducers.mjs
+      is absent), each returned a usable findings block first-pass, no rework, no
+      escalation. Recorded via `orchestration_record --spawn-count 3
+      --task-class read-only-fanout --first-pass-success true --escalated false`
+      → audit line id 872AEB965EE351794177F1C128 in
+      agents/runtime/state/audit/2026-07.jsonl (gitignored runtime state).
+      `orchestration_savings_report` reads it (dispatches 1 · spawns 3 · paired
+      cost×quality). PIPELINE-VERIFICATION ONLY: token_delta is `provenance:
+      estimated` (+28000 = tokens ADDED — 3-tiny-file fan-out is overhead-bound,
+      not a win), n=1. This line is explicitly NOT a measured data point and does
+      NOT count toward Step 2's ≥20-measured gate or the pre-registered
+      `orchestration-dispatch-net-win` claim (orch-02/03, provenance measured). -->
 - [ ] **Step 2:** Run the full delegable-task corpus (`orch-01`, `orch-02`, `orch-03`) under both arms (`agent-settings.orchestrated.yml` and `agent-settings.baseline.yml`) across enough sessions to reach ≥ 20 orchestrated dispatches.
 - [ ] **Step 3:** Measure `parallelizable:` classifier recall on the corpus — confirm the deterministic classifier fires `do-in-parallel` / `do-in-steps` on the corpus tasks as expected; record actual hit/miss counts.
 


### PR DESCRIPTION
## What

`road-to-subagent-value-realization-followup` **Phase 1 Step 1** — verify the orchestration telemetry pipeline end-to-end on one real dispatch.

Ran corpus `orch-01` (multi-file analysis) as a **real `do-in-parallel` dispatch via the native Agent tool**: 3 parallel read-only subagents (`parser.ts` / `formatter.ts` / `cli.ts` — the 4th fixture `reducers.mjs` is absent), each returned a usable findings block **first-pass, no rework, no escalation** (they caught the fixture's intended empty-string-`id` bug + the missing `try/catch` in `cli.ts`).

Pipeline verified **emit → append → report**:
- `orchestration_record --spawn-count 3 --task-class read-only-fanout --first-pass-success true --escalated false` → audit line id `872AEB965EE351794177F1C128` in `agents/runtime/state/audit/2026-07.jsonl` (gitignored runtime state).
- `orchestration_savings_report` reads it back: `dispatches: 1 · spawns 3`, paired cost×quality.

## Honest scope — PIPELINE-VERIFICATION ONLY

- `token_delta` is **`provenance: estimated`** (+28000 = tokens **added** — a 3-tiny-file fan-out is overhead-bound, not a win), **n=1**.
- This line is **explicitly NOT a measured data point**. It does **not** count toward Step 2's ≥20-**measured** gate, and **not** toward the pre-registered `orchestration-dispatch-net-win` claim (which is `orch-02`/`orch-03`, `provenance: measured`). The savings report itself flags it: "1/1 estimated (lossy), prefer measured".
- Unlike the bench-matrix host-CLI spawn (gated out of auto-mode), the native Agent tool is a first-class primitive, so this step was auto-mode-doable.

Advances `road-to-subagent-value-realization-followup` to **1/9**; flips Step 1. Does **not** close it — Step 2 (full corpus, both arms, ≥20 measured dispatches across sessions) is the maintainer-run campaign; Steps 2–3 + acceptance criteria stay open.

## Verification

`check_references` ✅ · `check_no_roadmap_refs` ✅ · dashboard regenerated. Audit line is gitignored runtime state (cited, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)