### PR TITLE
chore(gitignore): re-ignore dist/install/*_cli.js tsc byproducts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,11 @@ dist/agent-src/skills/*/evals/runs/
 # bridges via plain `node` without a tsx/node_modules toolchain (fallback D
 # of the py2ts consumer-runtime decision). Freshness enforced in CI.
 !/dist/install/
+# …but NOT the *_cli.js entry points: tsc emits them here, yet they run from
+# src/install/*_cli.ts (via install.sh), never from dist. Re-ignore the
+# byproducts so they don't show as untracked or get committed by accident.
+/dist/install/*_cli.js
+/dist/install/*_cli.js.map
 
 # AI Council per-run cache (raw provider responses keyed by run id).
 # Regenerated on demand from the council session JSON; never commit.


### PR DESCRIPTION
## What

Follow-up to #882. `.gitignore` re-includes `!/dist/install/` (the tracked installer bridge), which also surfaced tsc's `*_cli.js` **entry-point** emits (`rule_scope_cli.js`, `emit_host_rules_cli.js` + maps) as untracked noise.

Those CLIs run from `src/install/*_cli.ts` (via `src/scripts/install.sh`), **never** from `dist` — nothing loads their dist path. So this re-ignores them right after the carve-out:

```gitignore
!/dist/install/
/dist/install/*_cli.js
/dist/install/*_cli.js.map
```

## Verification

- `git check-ignore` → `*_cli.js` + `.map` ignored ✓; `rule_scope.js` (a real imported module, tracked via #882) **not** ignored ✓.
- A fresh `npm run build:cli` leaves the tree clean (only intended files show).

Keeps `dist/install/rule_scope.js` tracked (the stop-hook fix, #882); the throwaway `_cli` byproducts no longer appear as untracked or risk accidental commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)