### PR TITLE
fix(self-review-gate): never fail CI on missing key / no credit

### DIFF
--- a/src/scripts/self_review_gate.ts
+++ b/src/scripts/self_review_gate.ts
@@ -259,21 +259,38 @@ export function main(argv: string[]): 0 | 2 {
         return 0;
     }
 
-    const client = new AnthropicClient({ api_key: key });
-    const resp = client.ask(buildSystemPrompt(), diffText(baseRef, plan.files), 4096);
-    if (resp.error) {
-        process.stdout.write(`::warning::self-review-gate — model call failed: ${resp.error}\n`);
-        return 0; // advisory: a transport failure never blocks the merge
-    }
-    const findings = parseFindings(resp.text);
-    const body = renderReview(findings, enforce);
-    postReview(body);
+    // Belt-and-suspenders: the WHOLE live path is wrapped so that ANYTHING going
+    // wrong — no API credit / balance (HTTP 402), rate-limit (429), network error,
+    // a client-ctor throw, a parse failure — resolves to a NEUTRAL exit 0, never a
+    // red CI. A missing key or no-credit must never become a merge blocker; the
+    // gate is advisory by design. (Only an --enforce run with real blocking
+    // findings returns 2 — an error is not a finding.)
+    try {
+        const client = new AnthropicClient({ api_key: key });
+        const resp = client.ask(buildSystemPrompt(), diffText(baseRef, plan.files), 4096);
+        if (resp.error) {
+            process.stdout.write(
+                `::warning::self-review-gate NEUTRAL — model call did not complete (${resp.error}); ` +
+                    'nothing was reviewed, not a blocker.\n',
+            );
+            return 0; // no credit / transport / API error → never blocks the merge
+        }
+        const findings = parseFindings(resp.text);
+        const body = renderReview(findings, enforce);
+        postReview(body);
 
-    const code = gateVerdict(findings, { enforce });
-    if (code === 2) {
-        process.stdout.write('::error::self-review-gate — merge-blocking findings under enforce mode.\n');
+        const code = gateVerdict(findings, { enforce });
+        if (code === 2) {
+            process.stdout.write('::error::self-review-gate — merge-blocking findings under enforce mode.\n');
+        }
+        return code;
+    } catch (e) {
+        process.stdout.write(
+            `::warning::self-review-gate NEUTRAL — unexpected error (${e instanceof Error ? e.message : String(e)}); ` +
+                'nothing was reviewed, not a blocker.\n',
+        );
+        return 0;
     }
-    return code;
 }
 
 if (existsSync(process.argv[1] ?? '') && import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
## What

You added `ANTHROPIC_API_KEY` to CI and asked: a missing key **or no API credit/balance must never fail the check** — it should just pass through (no blocker). Hardened accordingly.

- The **whole live path** (client ctor → `ask` → parse → post → verdict) is now wrapped in `try/catch`. **Any** failure — no credit (HTTP 402), rate-limit (429), network error, a client-ctor throw, a parse failure — logs a `::warning::` **NEUTRAL** and returns **exit 0**. Only an `--enforce` run with real blocking findings returns 2; an error is never a finding.
- Combined with the job's existing `continue-on-error: true` and the no-key NEUTRAL exit-0 path, the check is **non-blocking by construction**: a missing key or empty balance surfaces as an honest **NEUTRAL** (not a green "reviewed", not a red failure), never a merge blocker.

## Verification

`task typecheck-ts` ✅ · `vitest self_review_gate.test.ts` 7/7 ✅ · no-key live path → exit 0 (NEUTRAL) ✅.

Advisory-only behaviour unchanged; the gate stays a floor, never a gate that blocks on infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)