### PR TITLE
chore(roadmaps): execute road-to-opt-portfolio-consolidation (process-full)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **9** open blockers
 
 ## Overall
 
-**98 / 168 steps done · 58%**
+**100 / 175 steps done · 57%**
 
 ```text
-███████████████████████░░░░░░░░░░░░░░░░░   58%
+███████████████████████░░░░░░░░░░░░░░░░░   57%
 ```
 
 ## Open roadmaps
@@ -19,11 +19,11 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 15 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 6% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 1 | 18 | 0 | 0 | [1](#blockers-road-to-flow-learnings) | ██████████ 95% |
-| 4 | [road-to-install-path-convergence-followup.md](roadmaps/road-to-install-path-convergence-followup.md) | 1 | 1 | 1 | 0 | 0 | 0 | [1](#blockers-road-to-install-path-convergence-followup) | ░░░░░░░░░░ 0% |
-| 5 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 6 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 7 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 8 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 4 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
+| 5 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 6 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
+| 7 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 8 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 | 9 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
 | 10 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 9 | 26 | 0 | 2 | [1](#blockers-road-to-token-saving) | ███████░░░ 74% |
 
@@ -89,22 +89,6 @@ _2 blockers resolved._
 
 _1 blocker resolved._
 
-### [road-to-install-path-convergence-followup.md](roadmaps/road-to-install-path-convergence-followup.md)
-
-**Follow-up to install-path convergence — delist decision checkpoint** — 0 / 1 done (0%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | Delist decision checkpoint | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
-
-<a id="blockers-road-to-install-path-convergence-followup"></a>
-**Blockers**
-
-- **legacy** (owner: user) — blocks entire roadmap
-  - **What to do:**
-    the bootstrap shim has shipped and a monitoring window
-  - **Resolved when:** condition described above clears
-
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 
 **Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 6 / 12 done (50%)
@@ -144,8 +128,8 @@ _1 blocker resolved._
 
 - **real-orchestration-usage** (owner: user) — blocks Phase 2 (and thereby Phase 3's decision)
   - **What to do:**
-    telemetry. Use the agent on genuinely parallel/ordered multi-file tasks with
-    `subagents.auto: ask`, then check
+    telemetry. Use the agent on genuinely parallel/ordered multi-file tasks under
+    the post-ADR-117 default (`subagents.auto: on`), then check
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
 
@@ -178,21 +162,33 @@ _1 blocker resolved._
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Seed real telemetry | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 2 | Re-gate the `auto: on` flip | 🟡 in progress | 5 | 1 | 0 | 0 | 17% |
+| 2 | Confirm or demote the ADR-117 `auto: on` default | 🟡 in progress | 5 | 1 | 0 | 0 | 17% |
 
 <a id="blockers-road-to-subagent-value-realization-followup"></a>
 **Blockers**
 
 - **telemetry-sample-size** (owner: user) — blocks Phase 1 — Seed real telemetry
   - **What to do:**
-    1. Use the agent with `subagents.enabled: true` and `subagents.auto: ask`
-    (or `on`) during real work, long enough to accumulate real orchestrated
-    dispatches — the build work is done; only real usage produces this.
+    1. Use the agent with `subagents.enabled: true` under the post-ADR-117
+    default (`subagents.auto: on`) during real work, long enough to
+    accumulate real orchestrated dispatches — the build work is done;
+    only real usage produces this.
     2. Check the current-month audit log line count:
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`.
     3. Once the count reaches ≥ 20, resume this roadmap
     (`/roadmap:process-full road-to-subagent-value-realization-followup.md`).
   - **Resolved when:** `agents/runtime/state/audit/YYYY-MM.jsonl` carries ≥ 20 orchestration lines for the current month.
+
+### [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md)
+
+**Command `tier:` Alias Removal** — 2 / 7 done (29%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Evidence mechanism build-out | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
+| 2 | Internal dependency audit (just-in-time) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 3 | External soak confirmation | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 4 | Removal execution (blocked on Phases 1–3) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
 ### [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md)
 

--- a/agents/roadmaps/archive/road-to-opt-portfolio-consolidation.md
+++ b/agents/roadmaps/archive/road-to-opt-portfolio-consolidation.md
@@ -1,16 +1,13 @@
 ---
-status: later
 complexity: lightweight
 ---
 
 # Road to opt portfolio consolidation — merge, revive, park, and dedupe the roadmap estate
 
-> **Parked in `later/` by maintainer decision (2026-07-12).**
-> Blocked until: the pre-existing active roadmap portfolio (the
-> roadmaps that were active before the 2026-07-11 `road-to-opt-*`
-> cluster landed) is worked down, OR the maintainer explicitly and
-> exclusively requests execution of this roadmap. Do NOT pick this
-> file up as part of another task or an autonomous sweep.
+> **Un-parked 2026-07-12:** the `later/` resume trigger fired — the
+> maintainer explicitly and exclusively requested this roadmap's
+> execution (`/roadmap:process-full`). The other eight `road-to-opt-*`
+> roadmaps remain parked.
 
 > Part of the `road-to-opt-*` cluster (2026-07-11 sweep). The portfolio is
 > disciplined, not sprawling — but ADR-117 orphaned two active roadmaps'
@@ -40,19 +37,35 @@ fired.
 parent/child telemetry-then-decide track, both still written against the
 pre-flip `ask` default.
 
-- [ ] Merge into a single `road-to-subagent-telemetry-decision.md`: absorb
+- [-] Merge into a single `road-to-subagent-telemetry-decision.md`: absorb
       ADR-117 into the Context (the flip already happened on
       bounded-downside grounds), carry over all open steps verbatim, and
       narrow the decision scope to prove-or-drop-the-public-claim once the
       ≥20-real-orchestration-lines telemetry gate fills (it now fills
       passively with subagents on).
-- [ ] Preserve both source files' done-history: archive the two originals
+      <!-- cancelled 2026-07-12: the merge contradicts a recorded council
+      lock — road-to-orchestration-scope-decision.md header, council
+      claude-sonnet-4-5 + gpt-4o 2026-07-08, "Standalone by council
+      decision … merging would bury the prove-or-drop decision". The
+      mechanism-match check (decision-revisit-gate §1) holds: the lock is
+      about the adoption-claim vs internal-telemetry SEPARATION, which
+      ADR-117 (a default change) does not touch — the lock applies, no new
+      evidence. The step's real substance — absorb ADR-117 into both
+      roadmaps' prose — WAS executed instead: both files reconciled
+      (default described as `on` since ADR-117, Phase-3/Phase-2 verdict
+      paths rewritten as confirm-or-demote via the retained demotion
+      gate). The 2026-07-11 sweep missed the lock because the two files
+      were judged on staleness signals without reading the header. -->
+- [-] Preserve both source files' done-history: archive the two originals
       (`git mv` → `archive/`) with a one-line successor pointer each, per
       the roadmap-lifecycle rules.
-- [ ] Regenerate the dashboard in the same change.
+      <!-- cancelled 2026-07-12: consequence of the cancelled merge above —
+      both roadmaps stay active and separate per the council lock. -->
+- [x] Regenerate the dashboard in the same change.
+      <!-- done 2026-07-12: regen after the reconciliation edits. -->
 
-**Exit criteria:** one merged roadmap active; both predecessors archived
-with successor pointers; dashboard reflects the merge.
+**Exit criteria (as executed):** merge cancelled per council lock; both
+roadmaps reconciled with ADR-117 and still standalone; dashboard current.
 
 ## Phase 2 — revive `later/road-to-tier-removal.md`
 
@@ -61,50 +74,79 @@ shipped (Phase 1 done), the soak clock started at publish, and reviving it
 breaks the circular dependency with `later/road-to-contract-integrity.md`
 (whose Phase 2 waits on tier-removal's pruning).
 
-- [ ] Verify the soak evidence (released manifest carries the deprecation
+- [x] Verify the soak evidence (released manifest carries the deprecation
       block; no breakage reports), then move the file back to
       `agents/roadmaps/` and drop its `status: later`.
-- [ ] Record inside `later/road-to-contract-integrity.md` that its blocking
+      <!-- done 2026-07-12: verified LIVE against the released artifact —
+      npm 8.10.0 (published 2026-07-10) ships
+      dist/discovery/discovery-manifest.json with deprecations[0] =
+      {key: tier, replacement: visibility, since: ADR-092, sunset: null};
+      gh issue list --search tier = zero breakage reports. Roadmap
+      un-parked with the evidence cited in its banner. -->
+- [x] Record inside `later/road-to-contract-integrity.md` that its blocking
       dependency is active again (resume-condition note update only; it
       stays parked until tier-removal's pruning actually lands).
+      <!-- done 2026-07-12: dependency-status paragraph appended to its
+      parked banner; resume condition itself unchanged. -->
 
 **Exit criteria:** tier-removal active with soak evidence cited;
 contract-integrity's resume note updated.
 
 ## Phase 3 — dispositions that no longer match reality
 
-- [ ] `road-to-install-path-convergence-followup.md` (1 open step, a
+- [x] `road-to-install-path-convergence-followup.md` (1 open step, a
       maintainer delist-checkpoint gated on a ~4-week monitoring window):
       move to `later/` with `status: later` + the monitoring-window resume
       trigger — it is parked-shaped, not workable-now.
-- [ ] `skipped/multi-package-architecture.md`: add an explicit supersede
+      <!-- done 2026-07-12: status: later + resume paragraph added, git mv
+      to later/; later-disposition lint green. -->
+- [x] `skipped/multi-package-architecture.md`: add an explicit supersede
       note — its value propositions (minimal install, per-user surface) are
       delivered by `discipline_profile`, workspace/pack scoping, and
       request-scoped rule projection; point to
       `domain-pack-extraction-when-triggered.md` as the live successor for
       the residual pack-extraction idea. The file stays in `skipped/`.
-- [ ] `road-to-flow-learnings.md` (18/19 done): confirm the single
+      <!-- done 2026-07-12: supersede blockquote added under the H1. -->
+- [x] `road-to-flow-learnings.md` (18/19 done): confirm the single
       remaining step (`org-fleet-run`, maintainer-owned) still stands;
       annotate it as the sole blocker so the near-archive state is visible.
-- [ ] `later/road-to-discipline-profile-tiering-followup.md`: the council
+      <!-- done 2026-07-12: confirmed 1 open step (grep: exactly one
+      `- [ ]`, line 179, blocked-by org-fleet-run); near-archive banner
+      added under the H1. -->
+- [x] `later/road-to-discipline-profile-tiering-followup.md`: the council
       branch resolved 2026-07-10 (keep `full` experimental, opt-in); only
       the OSS-host graduation sweep remains, blocked on an absent adapter.
       Tighten its resume condition to exactly that adapter existing.
+      <!-- done 2026-07-12, no change needed: verified the file already
+      carries exactly this resume condition ("Resume when: an
+      open-source-host adapter exists AND the maintainer wants the
+      graduation answer (or the recorded revisit-if drop-condition
+      fires)"), tightened on 2026-07-10 when the council branch fired. -->
 
 **Exit criteria:** every touched file's disposition folder, status
 frontmatter, and resume condition agree; dashboard regenerated.
 
 ## Phase 4 — dedupe double-tracked scopes
 
-- [ ] Connectors: `stubs/road-to-internal-connectors` vs
+- [x] Connectors: `stubs/road-to-internal-connectors` vs
       `road-to-product-bets.md` Phase 3 track the same Jira/Confluence/
       GitHub/Drive surface. Keep ONE owner (recommendation: product-bets
       Phase 3, since it carries the demand gate) and reduce the stub to a
       pointer or delete it.
-- [ ] Note the clean forward dependency for
+      <!-- done 2026-07-12: product-bets Phase 3 recorded as the single
+      tracking owner; stub reduced to a pointer that keeps only its
+      workspace-OAuth-specific promotion gates (org customer per
+      connector, SSO-first, funded audit) — those are additive criteria,
+      not duplicate tracking. -->
+- [x] Note the clean forward dependency for
       `stubs/road-to-council-visibility` on the merged Phase-1 roadmap
       (it is gated on the orchestration prove-or-drop decision) so the
       stub names its trigger file correctly after the merge.
+      <!-- done 2026-07-12, no change needed: the Phase-1 merge was
+      cancelled (council lock — the two roadmaps stay standalone), and the
+      stub already names the correct trigger file
+      (road-to-orchestration-scope-decision.md, intro + promotion gate 1).
+      Verified both references. -->
 
 **Exit criteria:** one owner per scope; no stub duplicates an active
 roadmap's phase.

--- a/agents/roadmaps/later/road-to-contract-integrity.md
+++ b/agents/roadmaps/later/road-to-contract-integrity.md
@@ -11,6 +11,13 @@ status: later
 > prunes against the Phase-0 census; documenting families before the cull would
 > enshrine a bloated surface. **Resume when** that pruning lands. Open `[ ]`
 > items are intentionally kept open — this roadmap is parked whole, not dropped.
+>
+> **Dependency status update (2026-07-12,
+> road-to-opt-portfolio-consolidation Phase 2):** `road-to-tier-removal`
+> was revived from `later/` to active — its soak evidence (deprecations
+> block shipped in released 8.10.0, zero breakage reports) verified. The
+> circular parking is broken; this roadmap STAYS parked until that
+> pruning actually lands (the resume condition above is unchanged).
 
 **Trigger:** Two independent external reviews of the unreleased `main` (103
 commits past `6.1.0` = 6.2.0-in-progress, captured in

--- a/agents/roadmaps/later/road-to-install-path-convergence-followup.md
+++ b/agents/roadmaps/later/road-to-install-path-convergence-followup.md
@@ -1,5 +1,6 @@
 ---
 complexity: lightweight
+status: later
 parent_roadmap: road-to-install-path-convergence
 ---
 
@@ -21,6 +22,11 @@ the recorded revisit-if conditions.
 > (suggested: ~4 weeks post-merge) has elapsed. Execution starts when the
 > maintainer opens the checkpoint — this is a maintainer call, explicitly
 > NOT autonomous.
+>
+> **Moved to `later/` 2026-07-12 (road-to-opt-portfolio-consolidation
+> Phase 3):** the single open item is monitoring-window-gated and
+> maintainer-only — parked-shaped, not workable-now. Resume when the
+> ~4-week window has elapsed and the maintainer opens the checkpoint.
 
 ## Phase 1: Delist decision checkpoint
 

--- a/agents/roadmaps/road-to-flow-learnings.md
+++ b/agents/roadmaps/road-to-flow-learnings.md
@@ -7,6 +7,11 @@ execution:
 
 # Road to flow learnings — adopt the real fifth of an external orchestration suite, reject the theater
 
+> **Near-archive (verified 2026-07-12, road-to-opt-portfolio-consolidation
+> Phase 3):** 18 of 19 steps done. The single open step is the real org
+> fleet run (`blocker: org-fleet-run`, maintainer-owned) — nothing else
+> blocks archival.
+
 > Source-level comparison against **Source F** — an external
 > agent-orchestration / scaffolding suite (a stale, zero-own-commit fork
 > of a high-star upstream) — re-verified on both sides this session.

--- a/agents/roadmaps/road-to-orchestration-scope-decision.md
+++ b/agents/roadmaps/road-to-orchestration-scope-decision.md
@@ -17,10 +17,15 @@ parent_roadmap: road-to-subagent-value-realization-followup
 > Decide, on evidence, whether agent-config competes on orchestration at all —
 > and if so, on exactly one narrow, measured claim rather than a swarm feature
 > race. The subagent-v1 contract (ADR-109) and telemetry path are built; the
-> A3 production-validator Gate-A eval is an honest null; `subagents.auto`
-> stays `ask`. This roadmap converts that standing null into a decision:
+> A3 production-validator Gate-A eval is an honest null. `subagents.auto`
+> defaults to `on` since ADR-117 (2026-07-09) — a bounded-downside flip,
+> explicitly NOT a passed benchmark; `resolveShippedDefault()`/`gateVerdict()`
+> is retained as the telemetry-driven demotion gate back to `ask`. This
+> roadmap converts the standing null into a decision on the PUBLIC claim:
 > prove a minimal orchestration win, or remove the surface from the public
 > value proposition and keep it as an internal contract only.
+> <!-- reconciled 2026-07-12 with ADR-117 via road-to-opt-portfolio-consolidation
+>      Phase 1 (default was described as `ask` — stale since 2026-07-09). -->
 
 ## Goal
 
@@ -39,7 +44,9 @@ not an unfinished swarm.
   `/cost:report` orchestration summary, `gateVerdict()` in
   `src/scripts/_lib/orchestration_gate.ts`.
 - Standing evidence: A3 production-validator Gate-A eval = honest null;
-  `subagents.auto` default = `ask`; the flip is gated on real telemetry
+  `subagents.auto` default = `on` since ADR-117 (2026-07-09,
+  bounded-downside basis — not evidence of value; demotion gate to `ask`
+  retained). The PUBLIC claim stays gated on real telemetry
   (`agents/settings/contexts/orchestration-default-flip-verdict.md`).
 - The blocker is structural, not code: real orchestrated dispatches cannot be
   produced by a headless harness — they need real usage (parent followup
@@ -84,9 +91,10 @@ CLAIMS, `unbacked`.
 
 ## Phase 2 — Accumulate real telemetry (inherits parent followup)
 
-- [ ] Run real delegable work with `subagents.enabled: true`,
-      `subagents.auto: ask` until `agents/runtime/state/audit/YYYY-MM.jsonl`
-      carries ≥20 orchestration lines (parent followup Phase 1, Steps 1–3).
+- [ ] Run real delegable work with `subagents.enabled: true` under the
+      post-ADR-117 default (`subagents.auto: on`) until
+      `agents/runtime/state/audit/YYYY-MM.jsonl` carries ≥20 orchestration
+      lines (parent followup Phase 1, Steps 1–3).
 - [x] Measure `parallelizable:` classifier recall AND false-positive rate on the
       corpus (`orch-01..03`, `pv-01`, `pv-02`) — both matter; a leaky classifier
       loses on cost even when it wins on the true positives.
@@ -104,13 +112,14 @@ CLAIMS, `unbacked`.
 
 ## Phase 3 — Gate the claim: prove or drop
 
-- [ ] Feed the accumulated `ask`-mode telemetry through `gateVerdict()` /
+- [ ] Feed the accumulated real telemetry through `gateVerdict()` /
       `resolveShippedDefault()`. PROVE = the pre-registered claim clears its
       threshold at held quality AND the negative control stayed quiet.
-- [ ] PROVE → mark the CLAIMS entry `backed` with a resolving pointer; propose
-      `subagents.auto: ask → on` for the proven family only (scoped, not global);
-      update the flip verdict.
-- [ ] DROP → record the renewed honest null; keep `ask`; **and** demote the
+- [ ] PROVE → mark the CLAIMS entry `backed` with a resolving pointer; the
+      ADR-117 `on` default is thereby CONFIRMED for the proven family (the
+      bounded-downside basis upgrades to evidence); update the flip verdict.
+- [ ] DROP → record the renewed honest null; demote the default back to
+      `ask` via ADR-117's retained demotion gate; **and** demote the
       orchestration surface from the public value proposition: README/site stop
       listing orchestration as a capability and instead state the honest stance —
       "contract exists, default off, value not established; we do not ship
@@ -139,8 +148,8 @@ proof surface.
 
 - Exactly one orchestration claim is pre-registered, deterministically scored,
   and resolved to `backed` or honest-null — never left ambiguous.
-- The `subagents.auto` default moves only on proven, family-scoped evidence;
-  `ask` remains the floor.
+- The ADR-117 `on` default is confirmed or demoted only on real,
+  family-scoped evidence; `ask` remains the demotion floor.
 - If dropped, the public value proposition no longer implies orchestration; the
   contract survives internally, unadvertised.
 - The negative control (`pv-02`) is part of the pass condition — a classifier
@@ -153,7 +162,7 @@ proof surface.
 - **Owner:** user
 - **Blocks:** Phase 2 (and thereby Phase 3's decision)
 - **What to do:** the build work is done; only real delegable work produces the
-  telemetry. Use the agent on genuinely parallel/ordered multi-file tasks with
-  `subagents.auto: ask`, then check
+  telemetry. Use the agent on genuinely parallel/ordered multi-file tasks under
+  the post-ADR-117 default (`subagents.auto: on`), then check
   `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
 - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.

--- a/agents/roadmaps/road-to-subagent-value-realization-followup.md
+++ b/agents/roadmaps/road-to-subagent-value-realization-followup.md
@@ -5,7 +5,10 @@ parent_roadmap: subagent-value-realization
 
 # Roadmap: Follow-up to Subagent value realization
 
-> Seed real orchestration telemetry from production use, then re-gate the `subagents.auto` default flip on that evidence via `gateVerdict()`.
+> Seed real orchestration telemetry from production use, then confirm-or-demote the ADR-117 `subagents.auto: on` default on that evidence via `gateVerdict()`.
+> <!-- reconciled 2026-07-12 with ADR-117 (default flipped ask → on on 2026-07-09,
+>      bounded-downside basis; this roadmap was written pre-flip) via
+>      road-to-opt-portfolio-consolidation Phase 1. -->
 
 ## Context
 
@@ -52,10 +55,10 @@ and `agents/settings/contexts/orchestration-default-flip-verdict.md`).
 **Exit criteria:** ≥ 20 orchestration lines in the audit log; `/cost:report` surfaces a non-empty orchestration summary; classifier recall recorded. The ≥ 20-dispatch measurement must include the `first_pass_success` / `escalated` quality columns (per road-to-proof-under-real-conditions Phase 4 — cost and quality reported as a pair, never savings alone).
 **Rollback:** none (measurement only; no code change).
 
-## Phase 2: Re-gate the `auto: on` flip
+## Phase 2: Confirm or demote the ADR-117 `auto: on` default
 
-- [ ] **Step 1:** Feed the accumulated real `ask`-mode orchestration telemetry through the existing `gateVerdict()` / `resolveShippedDefault()`.
-- [ ] **Step 2:** If (and only if) the data shows a net token-or-time win at held quality, propose flipping `subagents.auto` default `ask → on` as a maintainer decision; otherwise record the renewed honest-null and keep `ask`.
+- [ ] **Step 1:** Feed the accumulated real orchestration telemetry through the existing `gateVerdict()` / `resolveShippedDefault()`.
+- [ ] **Step 2:** If the data shows a net token-or-time win at held quality, record the ADR-117 `on` default as evidence-CONFIRMED (bounded-downside basis upgrades to measured); otherwise record the renewed honest-null and demote the default back to `ask` via ADR-117's retained demotion gate — a maintainer decision either way.
 - [ ] **Step 3:** Update `agents/settings/contexts/orchestration-default-flip-verdict.md` with the new evidence pass (date + outcome), per `no-roadmap-references` (inline, no session path).
 
 **Exit criteria:** `gateVerdict()` run on real telemetry; flip decision recorded with evidence either way.
@@ -80,7 +83,7 @@ and `agents/settings/contexts/orchestration-default-flip-verdict.md`).
 - [x] `parallelizable:` classifier recall measured on the corpus.
       <!-- met 2026-07-11: recall 2/2 (v1-covered modes) + FP 0, via
       src/scripts/_lib/auto_dispatch.corpus.test.ts. -->
-- [ ] The `auto: on` flip is re-evaluated through `gateVerdict()` on real telemetry, with the outcome recorded — flip only if evidenced.
+- [ ] The ADR-117 `auto: on` default is re-evaluated through `gateVerdict()` on real telemetry, with the outcome recorded — confirmed if evidenced, demoted to `ask` if not.
 
 ## Blockers
 
@@ -89,9 +92,10 @@ and `agents/settings/contexts/orchestration-default-flip-verdict.md`).
 - **Owner:** user
 - **Blocks:** Phase 1 — Seed real telemetry
 - **What to do:**
-  1. Use the agent with `subagents.enabled: true` and `subagents.auto: ask`
-     (or `on`) during real work, long enough to accumulate real orchestrated
-     dispatches — the build work is done; only real usage produces this.
+  1. Use the agent with `subagents.enabled: true` under the post-ADR-117
+     default (`subagents.auto: on`) during real work, long enough to
+     accumulate real orchestrated dispatches — the build work is done;
+     only real usage produces this.
   2. Check the current-month audit log line count:
      `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`.
   3. Once the count reaches ≥ 20, resume this roadmap

--- a/agents/roadmaps/road-to-tier-removal.md
+++ b/agents/roadmaps/road-to-tier-removal.md
@@ -1,13 +1,18 @@
 ---
 complexity: structural
-status: later
 parent_roadmap: metadata-and-command-surface-leanness
 ---
 
 # Roadmap: Command `tier:` Alias Removal
 
-> **Parked in `later/` — Phase 1 (evidence mechanism) shipped; remaining work
-> is soak-gated.** The re-open mechanism the roadmap was blocked on now exists:
+> **Un-parked 2026-07-12 (road-to-opt-portfolio-consolidation Phase 2):**
+> resume evidence verified live — the released npm 8.10.0 (2026-07-10)
+> ships `dist/discovery/discovery-manifest.json` with the `deprecations`
+> block on `tier` (since ADR-092, replacement `visibility`, `sunset:
+> null`), and zero tier-related breakage issues exist. The maintainer
+> review happened via the merged optimization-sweep PR that scheduled
+> this revival. Phase 1 (evidence mechanism) shipped; the soak clock has
+> been running since publish. The re-open mechanism the roadmap was blocked on now exists:
 > the discovery manifest is **v2** with a machine-readable `deprecations`
 > signal on the integer `tier` key (Option B — chosen by AI council, telemetry
 > ruled out as infeasible in a no-runtime package; see § Council notes). `tier`

--- a/agents/roadmaps/skipped/multi-package-architecture.md
+++ b/agents/roadmaps/skipped/multi-package-architecture.md
@@ -1,5 +1,16 @@
 # Multi-Package Architecture Roadmap
 
+> **Superseded, not blocked (recorded 2026-07-12,
+> road-to-opt-portfolio-consolidation Phase 3):** the value propositions
+> this roadmap chased are delivered by mechanisms that actually shipped —
+> minimal install / "users only see what they install" via
+> `discipline_profile` + workspace/pack scoping + consumer-scoped rule
+> projection (road-to-request-scoped-rule-load), and the
+> extract-packs idea lives on in the gated
+> `domain-pack-extraction-when-triggered.md` (the live successor). The
+> premise (split into separately distributed npm packages) is obsolete;
+> this file stays in `skipped/` as the historical record.
+
 Source: GPT strategic analysis (April 2026) on modular distribution for agent-config.
 
 ## Goal

--- a/agents/roadmaps/stubs/road-to-internal-connectors.md
+++ b/agents/roadmaps/stubs/road-to-internal-connectors.md
@@ -1,5 +1,15 @@
 # Road to Internal Connectors — STUB
 
+> **Ownership (deduped 2026-07-12, road-to-opt-portfolio-consolidation
+> Phase 4):** the connector bet has ONE tracking owner —
+> [`road-to-product-bets.md`](../road-to-product-bets.md) Phase 3
+> (knowledge connectors, `domain-adoption-policy` gates: named adopter +
+> owner + CI, MCP-first pilot). This stub is NOT a second tracking
+> surface; it records only the workspace-OAuth-specific promotion
+> criteria below (per-connector org customer, SSO-first, funded security
+> audit) that apply ON TOP of the product-bets gates if that phase ever
+> promotes and chooses the OAuth (non-MCP) route.
+
 > **Status** · stub. Not started. Created 2026-05-24 to satisfy
 > Phase 9 Step 4 of
 > [`road-to-employee-product-and-external-proof.md`](../archive/road-to-employee-product-and-external-proof.md).


### PR DESCRIPTION
## What

Full `/roadmap:process-full` run of `road-to-opt-portfolio-consolidation` — un-parked from `later/` on the maintainer's explicit exclusive request (the recorded resume trigger). All 11 steps closed: 9 done, 2 cancelled with recorded reasons. The completed roadmap is archived in this PR per the PR-gate.

## The one substantive deviation — a council lock the sweep had missed

Phase 1 planned to **merge** `road-to-orchestration-scope-decision` + `road-to-subagent-value-realization-followup`. SHA-fresh verification found a recorded council lock in the scope-decision header (claude-sonnet-4-5 + gpt-4o, 2026-07-08): *"Standalone by council decision … merging would bury the prove-or-drop decision."* Mechanism-match check (decision-revisit-gate § 1): the lock protects the adoption-claim vs internal-telemetry **separation**, which ADR-117 (a default change) does not touch — the lock applies, no new evidence. The merge steps are `[-]` cancelled with the reasoning inline; the step's real substance ran instead:

- **Both roadmaps reconciled with ADR-117**: default described as `on` since 2026-07-09 (bounded-downside basis, not evidence of value), Phase-2/Phase-3 verdict paths rewritten as **confirm-or-demote** via the retained `gateVerdict()` demotion gate, blockers updated to the post-flip default.

## The rest of the run

| Phase | Outcome |
|---|---|
| 2 — tier-removal revival | Soak evidence verified **live against the released artifact**: npm 8.10.0 ships `deprecations[0] = {key: tier, replacement: visibility, since: ADR-092}`; zero tier breakage issues. Roadmap moved `later/` → active with the evidence in its banner. Circular dependency with `contract-integrity` broken (dependency-status note added; it stays parked until the pruning lands). |
| 3 — dispositions | `install-path-convergence-followup` → `later/` (monitoring-window trigger, maintainer-only). `skipped/multi-package-architecture` gets an explicit supersede note (value props delivered by `discipline_profile` + packs + scoped projection; `domain-pack-extraction` is the live successor). `flow-learnings` gets a near-archive banner (18/19, sole blocker `org-fleet-run`). `discipline-profile-tiering-followup`'s resume condition verified already-tight (no change needed). |
| 4 — dedupe | Connector surface: `road-to-product-bets` Phase 3 is the single tracking owner; the `internal-connectors` stub is reduced to a pointer keeping only its additive workspace-OAuth gates (org customer per connector, SSO-first, funded audit). `council-visibility` stub references verified correct as-is. |

## Verification

- `lint_roadmap_later_disposition`: green (every parked roadmap carries a resume condition)
- `lint_roadmap_complexity`: 13 roadmaps clean
- md-language on all touched files: no German content
- Dashboard regenerated per step (`per_step` cadence); end state **10 active roadmaps**, portfolio consistent with ADR-117 (zero active roadmaps premised on `auto: ask`)
- Checkbox flips per step with inline evidence annotations — no batch flip

Roadmap/dashboard markdown only; no code, rules, or ADR files change.