### PR TITLE
feat(flow-learnings): real org fleet run green → close the roadmap

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **9** open blockers
+> 9 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **8** open blockers
 
 ## Overall
 
-**102 / 175 steps done · 58%**
+**84 / 156 steps done · 54%**
 
 ```text
-███████████████████████░░░░░░░░░░░░░░░░░   58%
+██████████████████████░░░░░░░░░░░░░░░░░░   54%
 ```
 
 ## Open roadmaps
@@ -18,14 +18,13 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 15 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 6% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 3 | [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md) | 4 | 19 | 1 | 18 | 0 | 0 | [1](#blockers-road-to-flow-learnings) | ██████████ 95% |
-| 4 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 5 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 6 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 7 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 8 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
-| 9 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
-| 10 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 7 | 28 | 0 | 2 | [1](#blockers-road-to-token-saving) | ████████░░ 80% |
+| 3 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
+| 4 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 5 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
+| 6 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 7 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 8 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
+| 9 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 7 | 28 | 0 | 2 | [1](#blockers-road-to-token-saving) | ████████░░ 80% |
 
 ---
 
@@ -64,30 +63,6 @@ _2 blockers resolved._
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Post-merge dry-run verification (carried from parent Phase 3) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 2 | First real release + live drills (carried from parent Phase 4 + Phase 7) | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
-
-### [road-to-flow-learnings.md](roadmaps/road-to-flow-learnings.md)
-
-**Road to flow learnings — adopt the real fifth of an external orchestration suite, reject the theater** — 18 / 19 done (95%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Install & conformance contract | ✅ done | 0 | 7 | 0 | 0 | 100% |
-| 1 | Fleet rollout (`init --fleet fleet.yaml`) | 🟡 in progress | 1 | 4 | 0 | 0 | 80% |
-| 2 | Dispatch failure-policy clarification | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 3 | Bench matrix expansion + per-section render | ✅ done | 0 | 4 | 0 | 0 | 100% |
-
-<a id="blockers-road-to-flow-learnings"></a>
-**Blockers**
-
-- **org-fleet-run** (owner: maintainer) — blocks Phase 1 — Fleet rollout
-  - **What to do:**
-    1. After the fixture test is green, run the fleet init across ≥3 real
-    org repos (`fleet.yaml` listing the app/package repos) with one
-    intentionally mis-permissioned repo as the seeded failure.
-    2. Capture the aggregate JSON report.
-  - **Resolved when:** aggregate JSON is schema-valid; the seeded repo is red with its pre-flight finding; all siblings are green and conformance-passing.
-
-_1 blocker resolved._
 
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 

--- a/agents/roadmaps/archive/road-to-flow-learnings.md
+++ b/agents/roadmaps/archive/road-to-flow-learnings.md
@@ -181,8 +181,15 @@ it never bridges to or drives another tool's runtime.
 - [x] Fixture test: ≥3 fixture repos with one seeded failure — failing
       repo red with its finding, siblings green, aggregate JSON
       schema-validated.
-- [ ] Real org fleet run (internal-adoption lever + dogfood corpus).
-      <!-- blocked-by: org-fleet-run -->
+- [x] Real org fleet run (internal-adoption lever + dogfood corpus).
+      <!-- done 2026-07-11: maintainer ran `agent-config init --fleet fleet.yaml`
+      (global) across 3 real galawork org repos — galawork-api, galawork-web,
+      capisco — ALL green (installed + conformance exit 0). A `--json` re-run
+      (idempotent) with one intentionally-nonexistent seeded repo produced a
+      SCHEMA-VALID aggregate (validateFleetReport → no problems): 3 siblings ok +
+      the seeded repo `preflight-failed` red, and the failure did NOT abort the
+      siblings (per-repo isolation confirmed on real repos). Report operator-local
+      (not committed). Seeded-red isolation also covered by the [x] fixture test. -->
 
 **Exit gate:** fixture test green (deterministic); org fleet run
 recorded via the blocker below.
@@ -274,7 +281,13 @@ blocker below.
 ## Blockers
 
 ### blocker: org-fleet-run
-- **Status:** open
+- **Status:** resolved
+- **Resolved 2026-07-11:** all resolve conditions met on a real run —
+  `agent-config init --fleet` across 3 real galawork repos (galawork-api,
+  galawork-web, capisco) all **green + conformance-passing**; a `--json` capture
+  with one nonexistent seeded repo yielded a **schema-valid** aggregate
+  (`validateFleetReport` clean) where the **seeded repo is red** with its
+  pre-flight finding and **all 3 siblings stayed green** (isolation confirmed).
 - **Owner:** maintainer
 - **Blocks:** Phase 1 — Fleet rollout
 - **What to do:**


### PR DESCRIPTION
## What

You ran `agent-config init --fleet fleet.yaml` (the global command) across **3 real galawork org repos** — `galawork-api`, `galawork-web`, `capisco` — **all green** (installed + conformance exit 0). This closes `road-to-flow-learnings` (was 95%, one step from done).

A `--json` capture (idempotent re-run) with one intentionally-nonexistent seeded repo produced a **schema-valid** aggregate (`validateFleetReport` → no problems):

| repo | status | conformance |
|---|---|---|
| galawork-api | ok | exit 0 (green) |
| galawork-web | ok | exit 0 (green) |
| capisco | ok | exit 0 (green) |
| `__seeded-failure-does-not-exist__` | **preflight-failed (red)** | — |

The seeded failure did **not** abort the 3 siblings → per-repo isolation confirmed on real repos.

## Resolution

Resolves the `org-fleet-run` blocker (all resolve conditions met: schema-valid aggregate · seeded repo red with its pre-flight finding · siblings green + conformance-passing). Last open step flipped `[x]`; roadmap **complete → archived**. The seeded-red isolation is also covered by the `[x]` fixture test.

## Notes

- The aggregate report is operator-local (cmd_fleet emits `--json` on demand; not committed) — numbers cited above.
- The fleet install wrote reversible, uncommitted agent-config files into the 3 real repos (your chosen adoption targets). Undo per repo if unwanted: `git -C <repo> clean -fd` (untracked) or `agent-config uninstall`.

## Verification

`validateFleetReport` clean ✅ · `check_references` ✅ · `check_no_roadmap_refs` ✅ · `roadmap:progress-check` ✅ · dashboard regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)