### PR TITLE
chore(roadmaps): AI-council re-scope of the token/measurement cluster after the thin-null

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 9 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **8** open blockers
+> 8 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **6** open blockers
 
 ## Overall
 
-**84 / 156 steps done · 54%**
+**72 / 128 steps done · 56%**
 
 ```text
-██████████████████████░░░░░░░░░░░░░░░░░░   54%
+██████████████████████░░░░░░░░░░░░░░░░░░   56%
 ```
 
 ## Open roadmaps
@@ -23,8 +23,7 @@
 | 5 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
 | 6 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 7 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
-| 8 | [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md) | 5 | 26 | 14 | 12 | 0 | 0 | [2](#blockers-road-to-token-proof-and-story) | █████░░░░░ 46% |
-| 9 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 7 | 28 | 0 | 2 | [1](#blockers-road-to-token-saving) | ████████░░ 80% |
+| 8 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 5 | 28 | 0 | 4 | [1](#blockers-road-to-token-saving) | ████████░░ 85% |
 
 ---
 
@@ -165,40 +164,9 @@ _1 blocker resolved._
 | 3 | External soak confirmation | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 4 | Removal execution (blocked on Phases 1–3) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
-### [road-to-token-proof-and-story.md](roadmaps/road-to-token-proof-and-story.md)
-
-**Road to token proof and story — orchestrate, prove, activate, adopt** — 12 / 26 done (46%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Harden the flip gate (small, verified, do first) | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 1 | One critical path for six tracks (the program table) | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 2 | Field evidence: replay + session telemetry | 🟡 in progress | 3 | 2 | 0 | 0 | 40% |
-| 3 | Public proof refresh (benchmark, claims, release story) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 4 | Spend the story: one named external pilot (N=1) | 🟡 in progress | 7 | 2 | 0 | 0 | 22% |
-
-<a id="blockers-road-to-token-proof-and-story"></a>
-**Blockers**
-
-- **flip-gates-upstream (inherited)** (owner: maintainer) — blocks Phase 2 post-flip arms and Phase 3 (need the flips landed); Phases 0, 1 and the Phase 2 corpus/tooling build are unblocked now.
-  - **What to do:**
-    (consumer-scoping default → discipline_profile default → thin
-    un-deferral decision), each behind its own hardened gate.
-  - **Resolved when:** the consumer-scoping default flip and the discipline_profile default flip have landed (thin optional — arms can run with the "modelled, not shipped" label for the thin arm).
-- **field-corpus-privacy** (owner: maintainer) — blocks Phase 2 replay arms (need the exported, privacy-reviewed corpus from Galawork/event4u sessions).
-  - **What to do:**
-    --history <repo>/agents/runtime/.agent-chat-history --limit 200` per
-    repo, then review the `.local.yaml` output under the low-impact-corpus
-    privacy floor (drop/redact anything client- or person-identifying).
-    Progress 2026-07-07: agent-config's own history exported (30 prompts →
-    `internal/bench/corpora/field-prompts.local.yaml`, gitignored, awaiting
-    review). Still needed: exports from the Galawork consumer repos (their
-    history files are outside this checkout — operator run) to reach N≥100.
-  - **Resolved when:** a reviewed corpus file exists and the low-impact-corpus privacy floor checklist for it is signed off.
-
 ### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
 
-**Road to token saving — measure, then cut, at constant quality** — 28 / 35 done (80%)
+**Road to token saving — measure, then cut, at constant quality** — 28 / 33 done (85%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -207,8 +175,8 @@ _1 blocker resolved._
 | 2 | Close the RTK trigger gap | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 3 | Deterministic RTK wrap hook + install verification | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 5 | Cache-aware ordering as a CI invariant (D5) | ✅ done | 0 | 2 | 0 | 1 | 100% |
-| 8 | Always-loaded budget linter (D6) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 3 | 11 | 0 | 0 | 79% |
+| 8 | Always-loaded budget linter (D6) | ✅ done | 0 | 2 | 0 | 1 | 100% |
+| 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 2 | 11 | 0 | 1 | 85% |
 
 <a id="blockers-road-to-token-saving"></a>
 **Blockers**

--- a/agents/roadmaps/later/road-to-token-proof-and-story.md
+++ b/agents/roadmaps/later/road-to-token-proof-and-story.md
@@ -1,10 +1,26 @@
 ---
 complexity: structural
-status: ready
+status: later
 parent_roadmap: road-to-token-saving
 ---
 
 # Road to token proof and story — orchestrate, prove, activate, adopt
+
+> **Parked in `later/` (2026-07-11, AI-council re-scoping).** Phase 2 measures
+> FIELD token savings "before vs after each flip" + correlates with real
+> `sessions.jsonl` — but the thin/scoped default-flips it would measure FAILED
+> the quality gate (#887, thin 36.2% < 48%) and are evidence-blocked (#888), and
+> no field cost data is captured. So the field-evidence report cannot exist yet.
+> Council (claude-sonnet-4-5 + gpt-4o, 2-round debate, 2026-07-11) converged:
+> **park, do not close** — the token-savings THESIS is intact; only the *thin*
+> mechanism died. If scoped-context-reduction under orchestration (the live path,
+> `road-to-orchestration-scope-decision` + `road-to-subagent-value-realization-followup`)
+> shows quality-neutral savings, Phase 2's measurement chain applies to that
+> mechanism instead.
+>
+> **Resume when:** a context-reduction mechanism (orchestration-scoped loading,
+> or a new single-request one) passes the quality gate AND real field
+> `sessions.jsonl` spend data exists for a before/after window.
 
 > The token program now spans six tracks (`road-to-token-saving` +
 > HUMAN-MEASUREMENT, `road-to-request-scoped-rule-load`,

--- a/agents/roadmaps/road-to-token-saving.md
+++ b/agents/roadmaps/road-to-token-saving.md
@@ -10,6 +10,26 @@ status: ready
 > ordering, RTK everywhere, and the dead-weight removals — each gated on real
 > evidence, never on a chars/4 estimate.
 
+> **Council re-scope (2026-07-11, claude-sonnet-4-5 + gpt-4o, 2-round debate,
+> cluster head for the token/measurement roadmaps).** After the thin-null (#887,
+> thin 36.2% < 48%) + the evidence-blocked flips (#888), the council converged:
+> **the token-savings THESIS is intact; only the *thin* mechanism died.**
+> Per-item disposition:
+> - **token-saving (this roadmap): RE-SCOPE.** DEAD (quality-blocked): the
+>   thin-flip, the scoped-flip, and the quality-elbow-gated budget linter
+>   (`[-]` below). KEEP: RTK tier_2→kernel promotion (an orthogonal refactor,
+>   not a token bet). CONDITIONAL: "every shipped lever measured" stays as a
+>   gate for any *future* lever.
+> - **token-proof-and-story: PARKED in `later/`** — measures savings from flips
+>   that did not ship; resume when a context-reduction mechanism passes the
+>   quality gate + real field spend data exists.
+> - **request-scoped-rule-load + orchestration-scope-decision +
+>   subagent-value-realization: KEEP ACTIVE** — orchestration telemetry is
+>   *scoped-context-reduction tested in a decomposed setting*, i.e. the LIVE
+>   continuation of the thesis (a different mechanism than thin, still untested).
+>   The opt-in workspace-scoping path is shippable today + is the measurement
+>   target; parking it would orphan the target.
+
 
 > **Program sequencing:** the token program's single critical path + tracking
 > table live in `road-to-token-proof-and-story.md` § Program tracking — this
@@ -403,12 +423,15 @@ Make the always-loaded token surface a first-class, gated metric.
       extracted to a pure `evaluate_budgets()` + 12 tests (synthetic over-budget
       fails, current passes). NOTE: a kernel/tier-1 *aggregate* sum was not added
       — the per-surface caps + check_always_budget already cover the floor. -->
-- [ ] Set the threshold at the **quality elbow** found in Phase 0 (context-rot:
+- [-] Set the threshold at the **quality elbow** found in Phase 0 (context-rot:
       quality degrades well before the window fills), not at a % of max window.
-      <!-- PROVISIONAL caps in place (current + ~15% headroom = regression caps,
-      explicitly NOT the elbow). The context-rot quality elbow needs the Phase 0
-      live validation run (operator/cost-gated) — same key that unblocks the
-      thin-flip + RTK kernel-promotion. Re-anchor the caps with that evidence then. -->
+      <!-- cancelled 2026-07-11 (AI-council re-scope): the quality-elbow was
+      never established — the Phase-0 live run that ran was the thin-vs-eager
+      win-rate judge (#887), not a context-rot degradation curve, and its main
+      consumer (the thin-flip) is measured-dead. The budget linter stays at the
+      PROVISIONAL regression caps (already in place); the "elbow threshold"
+      refinement is moot. Re-open only if a context-reduction mechanism ships and
+      a real elbow curve is measured. -->
 - [x] Trim the 15 skill descriptions at the 202-char cap toward ~150; descriptions
       are always-scanned across ~250 skills.
       <!-- done 2026-06-27: trimmed the 15 at the 199–200 cap (systematic-debugging,
@@ -527,8 +550,14 @@ stale candidates.
       kernel-rule prefix drifts from internal/bench/reports/kernel-prefix.json — a
       change there invalidates every consumer's KV-cache. Shipped earlier
       (token-saving Phase 5); the acceptance box was stale-open. -->
-- [ ] An always-loaded budget linter gates CI at the quality-elbow threshold
+- [-] An always-loaded budget linter gates CI at the quality-elbow threshold
       (Phase 8).
+      <!-- cancelled 2026-07-11 (AI-council re-scope): the budget linter
+      (check_always_budget) IS wired + gates CI, but at the PROVISIONAL
+      concentration/regression caps — NOT a quality-elbow, which was never
+      established (thin failed; no context-rot curve run). The "at the
+      quality-elbow threshold" acceptance-as-worded is moot; the linter itself
+      stands. -->
 - [x] The Phase 10 backlog is triaged (no stale candidates).
       <!-- met (reality-sync 2026-07-11): all 8 Phase-10 backlog items are [x]
       (each promoted to a phase, folded, or triaged with a recorded reason —


### PR DESCRIPTION
## What

Under your standing council authorization, ran an AI-council debate (claude-sonnet-4-5 + gpt-4o, 2 rounds, 2026-07-11, **~$0.07**) on the honest disposition of the token/measurement roadmap cluster, given **thin failed the quality gate** (#887, thin 36.2% < 48%) and the **flips are evidence-blocked** (#888).

**Convergence: the token-savings THESIS is intact — only the *thin* mechanism died.** Orchestration telemetry is scoped-context-reduction in a decomposed setting = the live continuation of the same thesis (a different, untested mechanism).

## Per-item disposition (implemented)

| Roadmap | Disposition |
|---|---|
| **token-proof-and-story** | **PARKED → `later/`** — measures savings from flips that didn't ship; resume when a context-reduction mechanism passes the quality gate + real field spend data exists. |
| **token-saving** | **RE-SCOPE** — quality-elbow threshold step + quality-elbow-gated budget-linter acceptance → `[-]` (elbow never established; thin-flip consumer dead). RTK tier_2→kernel promotion **kept**; "every shipped lever measured" stays a conditional gate. 7→5 open. Cluster-head council note added. |
| **request-scoped-rule-load** · **orchestration-scope-decision** · **subagent-value-realization** | **KEEP ACTIVE** — the live scoped-context-reduction path; the opt-in workspace-scoping is the measurement target (parking it would orphan the target). |

## Scope

No capability change — honest disposition of now-moot/blocked work so the backlog stops carrying dead fantasy. The council session JSON is gitignored (convergence inlined per `no-roadmap-references`).

## Verification

`lint_roadmap_later_disposition` ✅ · `check_references` ✅ · `check_no_roadmap_refs` ✅ · dashboard regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)