### PR TITLE
test(humanizer): lock scan-what-you-ingest invariant + spend-gate no-network

### DIFF
--- a/tests/scripts/bench_humanizer_spend_gate.test.ts
+++ b/tests/scripts/bench_humanizer_spend_gate.test.ts
@@ -25,7 +25,13 @@ describe("bench_humanizer_eval spend gate", () => {
     expect(r.status).toBe(2);
     expect(r.stderr).toMatch(/billable API call/i);
     expect(r.stderr).toMatch(/--confirm-spend/);
-    // Halted before the judge loop → no per-pair "judged …" line on stdout.
+    // Structural "no network" proof: the gate returns via process.exit(2)
+    // BEFORE the judge loop and BEFORE any report is emitted. The API client
+    // is only constructed inside judgePair(), which the loop never reaches —
+    // so absence of both the per-pair "judged …" line AND the report header
+    // means no billable call could have fired.
     expect(r.stdout).not.toMatch(/judged /);
+    expect(r.stdout).not.toMatch(/Humanizer paired eval/);
+    expect((r.stdout ?? "").trim()).toBe("");
   });
 });

--- a/tests/scripts/detect_ai_tells.test.ts
+++ b/tests/scripts/detect_ai_tells.test.ts
@@ -212,3 +212,31 @@ describe("untrusted-input handling (Phase 1 hardening)", () => {
     expect(Date.now() - start).toBeLessThan(5000);
   });
 });
+
+describe("scan-what-you-ingest invariant (Phase 1 regression lock)", () => {
+  // The hidden-unicode guard MUST scan the raw, full input — before exemption
+  // stripping and before the ReDoS truncation — because an attacker plants
+  // bidi/zero-width/tag chars exactly in the spans a naive scanner skips (code
+  // fences, blockquotes, past a length cap) while the LLM still ingests them.
+  // These lock the invariant so a future refactor cannot move the scan after
+  // stripExempt()/slice() without turning a test red.
+  it("catches a hidden-unicode payload INSIDE a code fence (pre-strip scan)", () => {
+    const fenced = "Clean prose.\n\n```\ncode ‮​ here\n```\n";
+    const r = analyzeText(fenced, "en");
+    const total = r.hidden_unicode.reduce((s, f) => s + f.count, 0);
+    expect(total).toBeGreaterThanOrEqual(2);
+  });
+
+  it("catches a hidden-unicode payload INSIDE a blockquote (pre-strip scan)", () => {
+    const quoted = "Normal line.\n\n> quoted ‍⁦ text\n";
+    const r = analyzeText(quoted, "en");
+    expect(r.hidden_unicode.length).toBeGreaterThan(0);
+  });
+
+  it("catches a hidden-unicode payload BEYOND the ReDoS truncation bound", () => {
+    const far = "x".repeat(MAX_SCAN_CHARS + 50) + " ​‮";
+    const r = analyzeText(far, "en");
+    expect(r.truncated).toBe(true); // tell scan is bounded...
+    expect(r.hidden_unicode.length).toBeGreaterThan(0); // ...but the guard still saw it
+  });
+});


### PR DESCRIPTION
## Summary

Small follow-up to the merged humanizer-hardening PR (#899). Two review points from the final adversarial run, **both test-only** — the production code already behaves correctly, verified empirically before writing anything.

1. **scan-what-you-ingest invariant.** The reviewer flagged that the hidden-unicode scan might run on stripped/truncated text, missing payloads in code fences / blockquotes / beyond the length cap. Verified against merged code: `scanHiddenUnicode(text)` already runs on the **raw, full** input, before `stripExempt()` and before the `MAX_SCAN_CHARS` truncation — all three spans ARE caught (empirically: code-fence payload → 2 findings; beyond-truncation → `truncated: true` yet still 2 findings). The specific 'scans stripped text' finding was a **false positive**; the underlying invariant had no regression test, so this adds three lock tests so a future refactor can't silently move the scan after stripping/truncation.

2. **spend-gate no-network.** Strengthened the assertion: previously checked exit 2 + no per-pair line; now also asserts stdout is empty (no report header), proving `main()` returns before the judge loop constructs the API client — a structural no-network proof, not just an exit code.

No production code changed — both are test hardening on the already-correct behavior.

## Verification

- `detect_ai_tells` 61/61 (3 new invariant tests), spend-gate 1/1, both green locally.
- ESLint clean on both touched test files.

Follow-up to #899; the `real-draft-lift-unmeasured` gate from that PR stays open by design.