### PR TITLE
docs(design): measurement-unblock design prep — length-neutral rerun + parity-eval re-scope (road-to-opt-measurement-unblock)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 25 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **8** open blockers
+> 26 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **8** open blockers
 
 ## Overall
 
-**90 / 327 steps done · 28%**
+**92 / 337 steps done · 27%**
 
 ```text
-███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   28%
+███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   27%
 ```
 
 ## Open roadmaps
@@ -35,12 +35,13 @@
 | 17 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
 | 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 21 | 8 | 0 | 0 | [2](#blockers-road-to-opt-council-deliberation) | ███░░░░░░░ 28% |
-| 20 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
-| 21 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 22 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
-| 23 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 24 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
-| 25 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 5 | 28 | 0 | 4 | [1](#blockers-road-to-token-saving) | ████████░░ 85% |
+| 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 8 | 2 | 0 | 0 | 0 | ██░░░░░░░░ 20% |
+| 21 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
+| 22 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 23 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
+| 24 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 25 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 26 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 5 | 28 | 0 | 4 | [1](#blockers-road-to-token-saving) | ████████░░ 85% |
 
 ---
 
@@ -268,6 +269,16 @@ _1 blocker resolved._
     the fixture count is fixed (estimate rendered by `council:estimate`
     across arms before the first billable call).
   - **Resolved when:** the user has confirmed the run budget in-session.
+
+### [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md)
+
+**Road to opt measurement unblock — one judge run cascade-unblocks the token program** — 2 / 10 done (20%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | length-neutral judge rerun (the cascade key) | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
+| 2 | non-Claude lift replication (discipline_profile auto flip gate) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | cross-model e2e parity eval: re-scope the keystone | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 
 ### [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md)
 

--- a/agents/roadmaps/road-to-opt-measurement-unblock.md
+++ b/agents/roadmaps/road-to-opt-measurement-unblock.md
@@ -1,16 +1,19 @@
 ---
-status: later
+status: ready
 complexity: lightweight
 ---
 
 # Road to opt measurement unblock — one judge run cascade-unblocks the token program
 
-> **Parked in `later/` by maintainer decision (2026-07-12).**
-> Blocked until: the pre-existing active roadmap portfolio (the
-> roadmaps that were active before the 2026-07-11 `road-to-opt-*`
-> cluster landed) is worked down, OR the maintainer explicitly and
-> exclusively requests execution of this roadmap. Do NOT pick this
-> file up as part of another task or an autonomous sweep.
+> **Un-parked 2026-07-11 on the maintainer's explicit exclusive request.**
+> This roadmap's value is billable **verdicts** — judge / benchmark runs that,
+> under automation, are interactive `/dev/tty` gates and money-moving Hard-Floor
+> actions. The autonomously-completable work is the **design prep** those runs
+> need: the length-neutral rerun design (Phase 1 step 1) and the re-scoped
+> cross-model parity-eval design doc (Phase 3 step 1). Every paid execution, host
+> auth, and build-vs-defer decision is surfaced, not auto-fired. Prereqs
+> re-verified live: PR #885 MERGED; the delegable corpus
+> `internal/bench/orchestration/corpus/` EXISTS.
 
 > Part of the `road-to-opt-*` cluster (2026-07-11 sweep). The single
 > highest-leverage finding: five roadmaps (~40 % of the active portfolio —
@@ -42,7 +45,7 @@ longer holds — turning the portfolio's measurement debt into verdicts.
 
 ## Phase 1 — length-neutral judge rerun (the cascade key)
 
-- [ ] Design the rerun against the three recorded failure modes of the
+- [x] Design the rerun against the three recorded failure modes of the
       2026-07-09 attempt: (a) length confound — enforce length-matched
       pairs or a length-partialed scoring rubric; (b) judge
       inconsistency — stronger judge tier + the blind second-judge /
@@ -50,15 +53,20 @@ longer holds — turning the portfolio's measurement debt into verdicts.
       Phase 3; reuse, don't duplicate); (c) underpowered comparison —
       fix the sample size from the golden corpus before the first
       billable call.
+      <!-- done: docs/design/length-neutral-judge-rerun.md — (a) ±15% length-matched pairs AND a length-partialed rubric with a Spearman-ρ confound flag; (b) strongest judge tier + blind second judge reported via the EXISTING cohensKappa/judgeKappa in check_quality_regression.ts (reuse, not rebuild), κ ≥ 0.60 floor; (c) pre-registered n for 80% power at ≥10pp, fixed before the first call, sign-test/McNemar. Report schema + disposition specified. -->
 - [ ] Render the cost estimate (`council:estimate`-class disclosure) and
       confirm the run budget in-session before executing.
+      <!-- GATED: billable run — needs an in-session estimate + the maintainer's budget confirmation (Hard-Floor money-moving). Not auto-fired. -->
 - [ ] Execute the paired judge run; write the verdict artifact under
       `internal/bench/reports/` with κ and confound diagnostics inline.
+      <!-- GATED: the judged run is money-moving AND an interactive /dev/tty gate that hard-aborts under automation. Maintainer executes per the design doc above. -->
 - [ ] Disposition step: on a trustworthy verdict (either direction),
       update the token-program tracking table in
       `road-to-token-proof-and-story.md` and unblock/close the dependent
       gates; on a second inconclusive, record WHY with the diagnostics
       and stop — no third run without a design change.
+      <!-- GATED: fires only once the run above produces a verdict. -->
+      <!-- verify: test -f docs/design/length-neutral-judge-rerun.md -->
 
 **Exit criteria:** verdict artifact exists with κ ≥ agreed floor and no
 length confound flag; the token-program table cites it.
@@ -72,14 +80,17 @@ unit-tested; the run is blocked on auth + spend.
 - [ ] Restore non-Claude host auth (codex or the cheapest available
       non-Anthropic host with a built adapter); verify with a 1-task
       smoke before the paired run.
+      <!-- GATED: host auth is a human/repo-admin credential step — cannot be done autonomously. -->
 - [ ] Run the paired vanilla-vs-`essential` discipline benchmark on the
       non-Claude host per the parked design in
       `agents/tmp.old/road-to-alternatives/road-to-non-claude-lift-replication.md`.
+      <!-- GATED: billable paired benchmark on the non-Claude host — money-moving + depends on the auth step. Not auto-fired. -->
 - [ ] Disposition: replicated lift → ship the `auto` default flip
       (settings template + install bundle regen + docs); null/negative →
       record the honest null and keep the current default, citing the
       2026-07-10 flow-learnings two-host precedent (claude ceilings +
       codex capability=0 for those families).
+      <!-- GATED: fires only once the run above produces a verdict. The flip itself (settings template + install-bundle regen) is a shippable step once the evidence exists. -->
 
 **Exit criteria:** a recorded verdict either ships the flip or closes it
 with evidence; no placeholder default remains unexplained.
@@ -91,18 +102,22 @@ delegable-task corpus (NOW EXISTS — `internal/bench/orchestration/corpus/`)
 and a harness that cannot execute model-emitted subagent calls (still
 true — re-scope, don't assume).
 
-- [ ] Write the re-scoped design doc: smallest harness capability that
+- [x] Write the re-scoped design doc: smallest harness capability that
       lets ≥ 2 vendors execute the SAME delegable corpus end-to-end
       (candidate: council-transport-backed execution of the existing
       corpus tasks rather than a full in-host harness).
+      <!-- done: docs/design/cross-model-parity-eval.md — re-scopes to council-transport dispatch (consult over ≥2 ExternalAIClient vendors) of a task-adapter over internal/bench/orchestration/corpus/, measuring per-host finding output (NOT running model-emitted subagent calls — the still-open blocker is designed around, not assumed away). Feeds finding_floor calibration (cross-host lower-envelope) to promote it from inert to an enforcing gate. Build-vs-defer cost inputs specified. -->
 - [ ] Decide build-vs-defer on that design with the maintainer (cost
       estimate attached). If deferred again, park with the concrete
       missing capability named — not the generic "harness doesn't exist".
+      <!-- GATED: build-vs-defer is a maintainer cost decision (the design + cost inputs are in the doc above). -->
 - [ ] If built: run the parity eval; feed the per-host finding-count
       distributions into `finding_floor` calibration and promote
       `finding_floor` from inert mechanism to enforcing CI gate (its
       recorded deferral reason was exactly this missing calibration
       input).
+      <!-- GATED: billable multi-vendor run, depends on the build decision. -->
+      <!-- verify: test -f docs/design/cross-model-parity-eval.md -->
 
 **Exit criteria:** design doc + explicit build/defer decision recorded;
 if built, `finding_floor` calibration data exists and the gate is armed.

--- a/docs/design/cross-model-parity-eval.md
+++ b/docs/design/cross-model-parity-eval.md
@@ -1,0 +1,82 @@
+# Cross-model parity eval — re-scoped design
+
+> Design artifact for `road-to-opt-measurement-unblock` Phase 3 step 1. It
+> re-scopes the archive's most-deferred item (deferred across 4+ roadmaps) to the
+> **smallest capability** that produces a real cross-vendor parity signal, so the
+> build-vs-defer decision (step 2) rests on a concrete design, not the generic
+> "the harness doesn't exist". Writing this design is autonomous; **building and
+> running it is a maintainer cost decision** (step 2/3), disclosed and gated.
+
+## What changed since the last deferral
+
+| Original blocker | Status now |
+|---|---|
+| No delegable-task corpus | **RESOLVED** — `internal/bench/orchestration/corpus/` exists (`orch-*` orchestration tasks + `pv-*` production-validator tasks) |
+| Harness cannot execute model-emitted subagent calls | **STILL TRUE** — do not assume it away; re-scope around it |
+
+The corpus blocker no longer holds, so the item is re-openable — but only if we
+stop trying to build the thing that is still blocked (a full in-host harness that
+runs arbitrary model-emitted subagent calls).
+
+## The re-scope: council-transport execution, not an in-host harness
+
+**Don't** build a harness that executes model-emitted subagent calls end-to-end
+(the still-open blocker). **Do** reuse the capability that already exists: the AI
+council transport dispatches the *same* prompt to *multiple vendors* through
+`consult(members: ExternalAIClient[], …)` in
+[`src/scripts/ai_council/orchestrator.ts`](../../src/scripts/ai_council/orchestrator.ts).
+
+The smallest capability that yields a cross-model parity signal:
+
+1. **Task adapter.** Render each corpus task (`internal/bench/orchestration/corpus/*.md`)
+   into a single self-contained council prompt: the task + its rubric, asking the
+   model to *produce the findings it would surface* (not to actually spawn
+   subagents). This sidesteps the subagent-execution blocker — we measure the
+   model's **finding output on the delegable task**, not its ability to drive a
+   live subagent runtime.
+2. **≥ 2 vendors, same corpus.** Dispatch the identical prompt set to two distinct
+   vendors via the existing `ExternalAIClient` array — no new transport, no new
+   auth surface beyond what the council already has.
+3. **Per-host finding-count distribution.** For each (host × task), record the
+   count and the findings; aggregate to a per-host distribution over the corpus.
+4. **Blind judged quality (optional, gated).** If a quality signal beyond raw
+   counts is wanted, reuse the blind second-judge + Cohen's κ from
+   [`check_quality_regression.ts`](../../src/scripts/check_quality_regression.ts)
+   — the same discipline the Phase-1 rerun uses. This is the billable half; the
+   count distributions (step 3) are cheap and already informative.
+
+**Explicitly out of scope:** running the models' emitted subagent calls, a
+persistent multi-host runtime, any new vendor integration. If the signal needs
+more than council-transport can give, that is a *separate, later* build — named,
+not assumed.
+
+## What the signal feeds — `finding_floor` calibration
+
+`finding_floor` is an **inert mechanism today** (referenced in
+`run_skill_evals.ts` / `skill_linter.ts` / `evals.schema.json`); its recorded
+deferral reason was exactly the missing calibration input this eval produces. The
+per-host finding-count distributions calibrate the floor:
+
+- Derive the floor from the **cross-host lower envelope** (e.g. a low percentile of
+  the per-task finding counts across vendors) so the gate fires on a host/task that
+  under-produces relative to the cross-vendor norm, not relative to one vendor.
+- Once calibrated, promote `finding_floor` from inert to an **enforcing CI gate**
+  (its intended end state).
+
+## Build-vs-defer decision inputs (for step 2, maintainer)
+
+- **Cost:** the count-distribution pass (steps 1–3) is `N_tasks × N_vendors`
+  council calls — small and cheap; render the `council:estimate`-class disclosure
+  before the first call. The judged-quality half (step 4) roughly doubles it.
+- **Value:** unblocks `finding_floor` (arms a real CI gate) **and** produces the
+  first honest cross-vendor parity number the portfolio has ever had.
+- **Defer condition:** if built later, park with the concrete missing capability
+  named — here it would be "council-transport task-adapter for the orchestration
+  corpus", never the generic "harness doesn't exist".
+
+## Exit criteria mapping
+
+- This design doc **exists** (step 1 — done by writing this). ✓
+- Explicit **build/defer decision recorded** (step 2 — maintainer, cost attached). ⏳
+- If built: `finding_floor` calibration data exists and the gate is armed
+  (step 3 — gated on the decision + spend). ⏳

--- a/docs/design/length-neutral-judge-rerun.md
+++ b/docs/design/length-neutral-judge-rerun.md
@@ -1,0 +1,92 @@
+# Length-neutral judge rerun — design
+
+> Design artifact for `road-to-opt-measurement-unblock` Phase 1. It fixes the
+> methodology **before** the first billable call; the run itself is a maintainer
+> `/dev/tty`-gated, money-moving execution (disclose the estimate, confirm the
+> budget in-session, then run). This document is the "design the rerun" step —
+> not the run.
+
+## Why a rerun
+
+The 2026-07-09 discipline-lift judge run was **inconclusive** and now gates ~40%
+of the active token-program portfolio. Three recorded failure modes made it
+un-trustworthy; each has a concrete fix below. Nothing ships from the prior run —
+its verdict is void, not "weakly positive".
+
+| # | Failure mode (2026-07-09) | Magnitude | Fix in this design |
+|---|---|---|---|
+| a | **Length confound** — the preferred arm was systematically longer, so the judge rewarded length, not discipline | 69% of variance | Length-matched pairs **and** a length-partialed rubric (both, belt-and-braces) |
+| b | **Judge inconsistency** — a single judge disagreed with itself / a second grader | 33% inconsistency | Stronger judge tier + a blind second judge, reported as Cohen's κ |
+| c | **Underpowered comparison** | p = 0.196 (n too small) | Pre-registered sample size from the golden corpus, fixed before the first call |
+
+## (a) Length confound — neutralise it two ways
+
+1. **Length-matched pairing.** For each decision task, constrain the two arms
+   (vanilla vs `essential` discipline) to within a **±15% token band** of each
+   other before judging. Pairs that cannot be matched within the band are
+   dropped from the primary analysis and reported separately (never silently
+   discarded). This removes length as a *between-arm* signal.
+2. **Length-partialed rubric.** The judge prompt scores **task quality only** and
+   is explicitly instructed that response length is **not** a quality signal;
+   the harness additionally records each response's token count and runs the
+   verdict through a length-partialed check — if the win-rate correlates with the
+   length delta (Spearman ρ over the surviving pairs), the run is flagged
+   `length-confounded` and the verdict is withheld, exactly as the exit criterion
+   demands ("no length confound flag").
+
+Both, not either: matching removes the gross effect, partialing catches residual
+leakage the band still admits.
+
+## (b) Judge inconsistency — stronger tier + a second judge, reported as κ
+
+- **Judge tier.** Use the strongest available judge model for the primary grade
+  (not the cheapest); the grading cost is a fraction of the generation cost and
+  judge quality is the binding constraint here.
+- **Blind second judge + Cohen's κ — reuse, do not rebuild.** The second-judge
+  agreement machinery already exists: `cohensKappa()` + `judgeKappa()` in
+  [`src/scripts/check_quality_regression.ts`](../../src/scripts/check_quality_regression.ts)
+  align two judges' per-pair winner labels by task id and return chance-corrected
+  κ. Run both judges **blind to arm labels** and to each other; report κ
+  **alongside every verdict**.
+- **κ floor.** The verdict is admissible only when **κ ≥ 0.60** (substantial
+  agreement). Below the floor, the win-rate rests on an unreliable grader — record
+  the κ, do **not** report the win-rate as a finding, and stop (see disposition).
+
+## (c) Underpowered — pre-register the sample size
+
+- **Corpus.** Draw decision tasks from the council-labelled golden set landed by
+  PR #885 (labels are final per the 2026-07-11 amendment — **no re-labelling**).
+- **Power target.** Pre-register n for **80% power** at the smallest
+  effect worth shipping (target: detect a **≥ 10pp** win-rate difference from 50%
+  at α = 0.05). Fix n **before** the first billable call; do not grow n after
+  seeing results (that is the p-hacking the prior run's `p = 0.196` invites).
+- **Statistic.** Paired win/loss over matched pairs → the exact binomial
+  sign-test (`signTestP` already in `second_brain_retrieval.ts`) or McNemar
+  (`bench_ab_v2_stats.ts`); report the two-sided p and the effect size, never a
+  bare "significant".
+
+## Report schema (verdict artifact)
+
+Written under `internal/bench/reports/` with, inline and non-optional:
+
+- per-arm win/loss/tie counts over the **surviving matched pairs** (+ the dropped-pair count);
+- **κ** (both judges) and the κ floor used;
+- the length-confound diagnostic (Spearman ρ of win-rate vs length delta) and the
+  pass/`length-confounded` flag;
+- pre-registered n, achieved power, and the sign-test / McNemar p + effect size;
+- a one-line **verdict**: `ships-lift` / `honest-null` / `inconclusive-<reason>`.
+
+## Disposition (Phase 1 step 4)
+
+- **Trustworthy verdict, either direction** (κ ≥ floor, no length flag, powered):
+  update the token-program tracking table in `road-to-token-proof-and-story.md`
+  and unblock/close the dependent gates.
+- **Second inconclusive:** record *why* with the diagnostics above and **stop** —
+  no third run without a further design change. The anti-pattern this roadmap
+  kills is "gate pending" with no diagnosis.
+
+## What this design does NOT decide
+
+The **execution** — the cost estimate, the in-session budget confirmation, and the
+paid paired run — is the maintainer's, disclosed and confirmed per the acceptance
+criteria. This document only makes the run, when authorized, trustworthy.


### PR DESCRIPTION
## What

`/roadmap:process-full` run of `road-to-opt-measurement-unblock` — the **6th and final** `road-to-opt-*` cluster roadmap, un-parked on the maintainer's explicit exclusive request.

This roadmap is fundamentally a **paid-execution** roadmap: its value is billable **verdicts** (judge / benchmark runs), which under automation are interactive `/dev/tty` gates **and** money-moving Hard-Floor actions — they cannot be auto-fired. The autonomously-completable work is the **design prep** those runs need, and that is what this PR lands. Prereqs re-verified live: PR #885 **MERGED**; the delegable corpus `internal/bench/orchestration/corpus/` **EXISTS**.

## Delivered (the two autonomous steps)

- **`docs/design/length-neutral-judge-rerun.md`** (Phase 1 step 1) — fixes the three recorded failure modes of the 2026-07-09 inconclusive run that gates ~40% of the token-program portfolio:
  - *length confound (69%)* → ±15% length-matched pairs **and** a length-partialed rubric with a Spearman-ρ confound flag (both, belt-and-braces);
  - *judge inconsistency (33%)* → strongest judge tier + a blind second judge reported as Cohen's κ, **reusing the existing `cohensKappa`/`judgeKappa` in `check_quality_regression.ts`** (not rebuilt), with a κ ≥ 0.60 admissibility floor;
  - *underpowered (p = 0.196)* → pre-registered n for 80% power at a ≥ 10pp effect, fixed before the first billable call.
  - Report schema + disposition (ship / honest-null / inconclusive-with-diagnosis) specified.
- **`docs/design/cross-model-parity-eval.md`** (Phase 3 step 1) — re-scopes the archive's most-deferred item (4+ roadmaps). The corpus blocker is resolved; the subagent-execution blocker is **not**, so the design **works around it**: council-transport dispatch (`consult` over ≥ 2 `ExternalAIClient` vendors) of a task-adapter over the existing orchestration corpus, measuring per-host **finding output** rather than running model-emitted subagent calls. Feeds `finding_floor` calibration (cross-host lower-envelope) to promote it from inert to an enforcing CI gate.

## Gated — surfaced, not auto-fired

Everything else in the roadmap stays open behind a real gate:
- **Phase 1** steps 2–4: the cost estimate + in-session budget confirmation, the **paid judged run**, and its disposition.
- **Phase 2** (non-Claude lift replication): **host auth** (human/repo-admin) + a **paid** paired benchmark → the `discipline_profile: auto` flip.
- **Phase 3** steps 2–3: the **build-vs-defer** maintainer decision (cost inputs are in the design doc) + the paid multi-vendor run.

## Verification

Pure design authoring (no code changed): check-refs 0 (both design docs' `src/scripts` links resolve); md-language English; no condensation touched (docs/ is not condensed).

## Cluster complete

All 6 `road-to-opt-*` roadmaps are now processed: #897 subagent-harvest, #898 design-polish, #900 harness-discipline, #903 council-deliberation, #904 retrieval-and-memory (merged), and this. The cluster's remaining value across #903/#904/this is the **billable verdict runs**, which need your interactive spend authorization.