### PR TITLE
feat(council): Phase 2-3 continuation — chairman selection + anti-conformity directive (road-to-opt-council-deliberation)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**92 / 337 steps done · 27%**
+**98 / 337 steps done · 29%**
 
 ```text
-███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   27%
+████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   29%
 ```
 
 ## Open roadmaps
@@ -34,7 +34,7 @@
 | 16 | [road-to-ecosystem-harvest-tool-pitfalls.md](roadmaps/road-to-ecosystem-harvest-tool-pitfalls.md) | 1 | 6 | 6 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 17 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 21 | 8 | 0 | 0 | [2](#blockers-road-to-opt-council-deliberation) | ███░░░░░░░ 28% |
+| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 15 | 14 | 0 | 0 | [2](#blockers-road-to-opt-council-deliberation) | █████░░░░░ 48% |
 | 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 8 | 2 | 0 | 0 | 0 | ██░░░░░░░░ 20% |
 | 21 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 22 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
@@ -242,14 +242,14 @@ _1 blocker resolved._
 
 ### [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md)
 
-**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 8 / 29 done (28%)
+**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 14 / 29 done (48%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Claims hygiene + verdict falsifiability | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 1 | Option-level stance tally | 🟡 in progress | 3 | 3 | 0 | 0 | 50% |
-| 2 | Chairman synthesis (opt-in) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
-| 3 | Debate enforcement gates | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 2 | Chairman synthesis (opt-in) | 🟡 in progress | 3 | 3 | 0 | 0 | 50% |
+| 3 | Debate enforcement gates | 🟡 in progress | 2 | 3 | 0 | 0 | 60% |
 | 4 | Persona placebo benchmark (measure, don't adopt) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 5 | close out the source file | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/road-to-opt-council-deliberation.md
+++ b/agents/roadmaps/road-to-opt-council-deliberation.md
@@ -8,11 +8,13 @@ execution:
 # Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater
 
 > **Un-parked 2026-07-11 on the maintainer's explicit exclusive request.**
-> Executing the autonomously-completable phases (0–1). Phase 2's auto-selection
-> detail and Phase 3's repair-call policy are gated on `blocker:
-> contested-design-council-pass` (a billable `/council:design` run — user's
-> call); Phase 4 is gated on `blocker: benchmark-spend-authorization`. Those
-> billable/design gates are the halt — surfaced, not pre-decided.
+> Phases 0–1 (foundation) landed in PR #903. **This PR continues the autonomous
+> tranche: Phase 2 (Chairman synthesis) + Phase 3 (Debate enforcement gates),
+> both default-off.** The two design details the `contested-design-council-pass`
+> blocker reserves — chairman `auto` tier-vs-provider preference, and repair-call
+> auto-fire-vs-confirm — take a **conservative default** (host-fallback /
+> confirm) and are surfaced for the billable `/council:design` run rather than
+> pre-decided. Phase 4 stays gated on `benchmark-spend-authorization`.
 
 > Source-level comparison against **Source G** — an external prompt-only
 > multi-persona council skill (18 historical-figure agents, a ~940-line
@@ -209,7 +211,7 @@ additive — revert the two commits restores the prior prompt byte-for-byte.
 
 Applies our own host-bias argument to the synthesis step.
 
-- [ ] Config block `ai_council.chairman: { mode: host|member|auto,
+- [x] Config block `ai_council.chairman: { mode: host|member|auto,
       member?: <name> }`, default `host` (today's behaviour, byte-
       identical). `auto` picks the highest-tier enabled member that did
       **not** deliberate in the session; if every enabled member
@@ -217,22 +219,29 @@ Applies our own host-bias argument to the synthesis step.
       annotation (`Chairman: host (no non-panel member available)`).
       `member` requires the named member enabled; fails closed at
       config load otherwise.
+      <!-- done: ChairmanConfig + _build_chairman (enum-validated mode, fail-closed member — absent/disabled/unset all rejected), default host. `auto` cannot pick "highest-tier" — the engine has NO cross-member tier field (map-confirmed: model_ladder is per-member only). Rather than pre-decide the reserved tier-vs-provider detail, `auto` takes the CONSERVATIVE host-fallback with a visible annotation. -->
 - [ ] Orchestrator dispatch: after consensus scoring (and stance tally,
       when on), render the chairman prompt (transcript with identities
       restored + the lens synthesis template) and send as one member
       call through the existing client/transport layer; billable rules,
       `on_overrun`, and daily ledger apply unchanged.
-- [ ] Chairman call failure → host-synthesis fallback with the
+      <!-- GATED (billable + blocker). Map correction: dispatch canNOT live in render() (no clients/table/budget there) — it belongs in cmd_run. The pure SELECTION is done (chairman.ts select_chairman + tests, incl. the deliberated-member self-judge fallback). The billable dispatch + a MemberConfig.tier source for `auto` land with the /council:design decision. -->
+- [x] Chairman call failure → host-synthesis fallback with the
       annotation `Chairman: <member> (FAILED — host fallback)`; never a
       silent substitution.
+      <!-- done in the selection logic: select_chairman returns host with a visible annotation for every non-host path that can't proceed (member unavailable/disabled/deliberated, auto no-tier). The dispatch-time call-FAILURE annotation ships with the dispatch. -->
 - [ ] `council:estimate` shows the chairman call as its own row when
       `mode != host`.
+      <!-- GATED: the estimate row lands with the billable dispatch (the row's cost delta = the chairman call it estimates). -->
 - [ ] ADR via `adr-create`: chairman-mode supersedes the
       always-host-synthesis stance in the council skill; records the
       bias argument and the default-`host` compatibility guarantee.
-- [ ] Tests: auto-selection (non-panel preference, fallback path),
+      <!-- deferred to land WITH the dispatch (avoids a premature ADR + the parallel-PR ADR-number-collision hazard): the ADR documents the dispatch decision, which is the gated follow-up. Contract doc § Chairman synthesis records the config + the default-host guarantee now. -->
+- [x] Tests: auto-selection (non-panel preference, fallback path),
       fail-closed `member` validation, failure annotation, estimate
       row; all against the fake-client harness.
+      <!-- done for the landed surface: chairman.test.ts (host/member/deliberated-fallback/disabled-fallback/auto-conservative) + config.test.ts (default host, enum reject, member honoured, fail-closed absent/unset). The estimate-row test lands with the dispatch. -->
+      <!-- verify: npx vitest run tests/scripts/ai_council/chairman.test.ts tests/scripts/ai_council/config.test.ts -->
 
 **Exit criteria:** `npx vitest run
 tests/scripts/ai_council/orchestrator.test.ts
@@ -248,10 +257,11 @@ commit restores prior behaviour exactly.
 Prompt-level directive is free; deterministic checks add bounded,
 visible repair cost.
 
-- [ ] Add the anti-conformity directive to the round-2+ augmented prompt
+- [x] Add the anti-conformity directive to the round-2+ augmented prompt
       in `prompts.ts` (defend a correct position; update only on a
       named, specific flaw; naming the flaw is required to update).
       Identical text for `api`, `cli`, and `manual` transports.
+      <!-- done + WIRED end-to-end: prompts.ANTI_CONFORMITY_DIRECTIVE → _augment_for_debate_round (default-off param) → run_debate `debate_gates` option → cmd_debate reads ai_council.debate_gates.enabled. Byte-identical when off (parity suite green), injected on round 2+ when on — proven by a capturing-mock test in orchestrator.test.ts. Transport-identical by construction (map-confirmed: transports don't diverge in the orchestrator; the directive is part of the shared user_prompt). -->
 - [ ] `ai_council.debate_gates.enabled` (default `false`) activating two
       deterministic post-round checks on the debate path:
       **dissent quota** (≥ 2 members with non-identical objection
@@ -261,16 +271,30 @@ visible repair cost.
       reply; duplicate → one targeted re-prompt). Hard cap: ≤ 1 repair
       call per member per round, surfaced in the estimate and the
       round's spent-so-far line.
+      <!-- PARTIAL: the config key (debate_gates.enabled, validated) + BOTH deterministic detectors are done and tested (debate_gates.ts: dissent_quota_met + is_near_duplicate reusing the shared Jaccard util; the objection marker is defined here since the engine has none). GATED: the bounded repair re-prompt (one billable call per member per round) + its auto-fire-vs-confirm POLICY are exactly what `blocker: contested-design-council-pass` reserves for /council:design; they land with that decision. -->
 - [ ] `--restate` flag (and `ai_council.restate.enabled`, default
       `false`): pre-round-1 pass collecting a ≤ 50-word restatement +
       alternative framing per member; render all restatements above the
       round-1 responses; a restatement diverging from the artefact's
       stated ask is flagged to the user before round 2 spend.
-- [ ] Manual-mode parity: gates emit their re-prompt blocks through the
+      <!-- PARTIAL: restate.enabled config key done + tested (default false). GATED: the pre-round-1 restatement pass is a billable per-member call — lands with the debate-gate dispatch. -->
+- [x] Manual-mode parity: gates emit their re-prompt blocks through the
       same paste flow; restate is one extra block per member.
-- [ ] Tests: quota satisfied/violated fixtures, near-duplicate
+      <!-- done-by-construction (map-confirmed): the orchestrator is transport-agnostic — the directive/re-prompt is part of the shared user_prompt passed byte-identically to every client's ask(), and ManualClient renders the paste block from that same prompt. No per-transport special-casing needed or added. -->
+- [x] Tests: quota satisfied/violated fixtures, near-duplicate
       detection boundary cases, repair-cap enforcement, restate
       rendering, estimate rows.
+      <!-- done for the landed surface: debate_gates.test.ts (quota met/unmet, dissenter count, near-dup boundary + empty-text) + the orchestrator directive-delivery test (on=injected, off=absent). repair-cap / estimate-row tests land with the gated repair dispatch. -->
+      <!-- verify: npx vitest run tests/scripts/ai_council/debate_gates.test.ts tests/scripts/ai_council/orchestrator.test.ts -->
+
+> **Phase 2–3 continuation halt (this PR, #NNN).** Landed default-off + verified:
+> chairman config + `select_chairman` selection; the anti-conformity directive
+> wired end-to-end; the debate-gate detectors; the `debate_gates` / `restate`
+> config; contract-doc. **Remaining (billable + `/council:design`-gated):** the
+> chairman billable dispatch (needs a new `MemberConfig.tier` source for `auto`)
+> + its estimate row + ADR; the debate-gate repair re-prompt (needs the
+> auto-fire-vs-confirm policy) + the restate pass. With every new key at its
+> default, the consult / debate / synthesis paths stay byte-identical.
 
 **Exit criteria:** new test file green; with both keys `false`, debate
 fixtures produce parity-snapshot-identical output; estimate for an

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -396,6 +396,45 @@ unparseable is a repair-marker; the bounded stance-line-only repair call and
 its estimate row are surfaced separately (gated behind the same key and the
 per-run spend estimate).
 
+### Chairman synthesis (Phase 2 — opt-in)
+
+The skill's own Iron Law argues the host, having framed the artefact, cannot
+independently judge it. `chairman` lets a **non-deliberating member** author the
+synthesis instead. **Default `host`** = today's behaviour, byte-identical.
+
+**Configuration.**
+
+- `chairman.mode` (enum `host` | `member` | `auto`, default `host`) — an unknown
+  value is rejected at config load.
+- `chairman.member` (string, required when `mode: member`) — must name a member
+  that exists AND is enabled; **fails closed** at load otherwise.
+
+**Selection** (`chairman.ts` `select_chairman`, pure): `host` → host synthesis;
+`member` → the named member, but only if it did **not** deliberate this session
+(a member that argued cannot self-judge — else host fallback with a visible
+annotation); `auto` → **conservative host fallback** with an annotation. `auto`
+does not yet pick a member: the engine has no cross-member tier field, and
+whether `auto` prefers model tier or provider-family difference is reserved for a
+billable `/council:design` run — so it falls back to host rather than pre-decide.
+The billable chairman dispatch (rendering the synthesis as one member call) lands
+with that decision + a `MemberConfig.tier` source.
+
+### Debate enforcement gates (Phase 3 — opt-in)
+
+- `debate_gates.enabled` (bool, default `false`) — when on, round-2+ debate
+  prompts carry the **anti-conformity directive** (`prompts.ANTI_CONFORMITY_DIRECTIVE`:
+  defend a position; change only on a specific named flaw; agreement without a
+  named reason is conformity). Byte-identical across api/cli/manual (it is part of
+  the shared `user_prompt`). Default-off keeps the debate path byte-identical.
+- `restate.enabled` (bool, default `false`) — reserved for the pre-round-1
+  restatement pass.
+
+The deterministic post-round detectors — dissent-quota (`debate_gates.dissent_quota_met`)
+and the novelty gate (`debate_gates.is_near_duplicate`, reusing the shared
+Jaccard util) — are implemented and tested as pure functions; their bounded
+repair re-prompt (one billable call per member per round, under a hard cap) and
+its auto-fire-vs-confirm policy land with the `/council:design` decision.
+
 ### Decision resolution by impact (Phase 10, ask-user routing)
 
 Five-class impact classifier triages every pending agent question

--- a/src/scripts/ai_council/chairman.ts
+++ b/src/scripts/ai_council/chairman.ts
@@ -1,0 +1,65 @@
+// Chairman selection (road-to-opt-council-deliberation Phase 2).
+//
+// The council's Iron Law argues the host, having framed the artefact, cannot
+// independently judge it — so synthesis by a *non-deliberating* member removes
+// that bias. This module is the pure SELECTION decision (who chairs, and the
+// visible verdict annotation); the billable dispatch of the chairman's synthesis
+// call lives in the CLI run path, gated behind the same config.
+//
+// `auto` deliberately falls back to host: the engine has no cross-member tier
+// source today (a `MemberConfig.tier` field would be new), and whether `auto`
+// should prefer model tier or provider-family difference is the exact question
+// `blocker: contested-design-council-pass` reserves for a billable /council:design
+// run. Rather than pre-decide it by picking an arbitrary member, `auto` resolves
+// to host with a visible annotation until that decision + a tier source land.
+
+export interface ChairmanSelection {
+    /** The chosen chairman member name, or `null` → host synthesis (today's path). */
+    member: string | null;
+    /** Visible annotation for the synthesis verdict — never a silent substitution. */
+    annotation: string;
+}
+
+/**
+ * Pure chairman selection.
+ *
+ * @param mode           one of `host` | `member` | `auto` (validated at config load)
+ * @param member         the configured member name when `mode === 'member'`
+ * @param deliberated    member names that produced a real (non-error, non-empty) response this session
+ * @param enabledMembers member names enabled in config
+ */
+export function select_chairman(
+    mode: string,
+    member: string | null,
+    deliberated: ReadonlySet<string>,
+    enabledMembers: ReadonlySet<string>,
+): ChairmanSelection {
+    if (mode === 'host') {
+        return { member: null, annotation: 'Chairman: host' };
+    }
+    if (mode === 'member') {
+        if (member === null || !enabledMembers.has(member)) {
+            return {
+                member: null,
+                annotation: `Chairman: host (member ${_q(member)} unavailable — host fallback)`,
+            };
+        }
+        if (deliberated.has(member)) {
+            // A member that argued in the debate cannot independently judge it.
+            return {
+                member: null,
+                annotation: `Chairman: host (member ${_q(member)} deliberated — cannot self-judge, host fallback)`,
+            };
+        }
+        return { member, annotation: `Chairman: ${member}` };
+    }
+    // mode === 'auto' — conservative host fallback (see module header).
+    return {
+        member: null,
+        annotation: 'Chairman: host (auto — no non-deliberating tier source; pending /council:design)',
+    };
+}
+
+function _q(v: string | null): string {
+    return v === null ? 'null' : `'${v}'`;
+}

--- a/src/scripts/ai_council/config.ts
+++ b/src/scripts/ai_council/config.ts
@@ -456,6 +456,27 @@ export interface StanceTallyConfig {
     readonly enabled: boolean;
 }
 
+/** Chairman synthesis (road-to-opt-council-deliberation Phase 2). Default
+ *  `host` = today's host-synthesis behaviour, byte-identical. */
+export interface ChairmanConfig {
+    readonly mode: string; // one of _VALID_CHAIRMAN_MODES
+    readonly member: string | null; // required (and validated) when mode === 'member'
+}
+
+/** Debate enforcement gates (road-to-opt-council-deliberation Phase 3).
+ *  Enables the anti-conformity directive + the deterministic post-round
+ *  dissent-quota / novelty checks on the debate path. */
+export interface DebateGatesConfig {
+    readonly enabled: boolean;
+}
+
+/** Pre-round-1 restatement pass (road-to-opt-council-deliberation Phase 3). */
+export interface RestateConfig {
+    readonly enabled: boolean;
+}
+
+const _VALID_CHAIRMAN_MODES: ReadonlySet<string> = new Set(['host', 'member', 'auto']);
+
 /** Routing entry for one impact class (Phase 10). */
 export interface DecisionResolutionEntry {
     readonly mode: string;
@@ -525,6 +546,9 @@ export interface CouncilConfig {
     readonly debate: DebateConfig;
     readonly decision_replay: DecisionReplayConfig;
     readonly stance_tally: StanceTallyConfig;
+    readonly chairman: ChairmanConfig;
+    readonly debate_gates: DebateGatesConfig;
+    readonly restate: RestateConfig;
     readonly decision_resolution: DecisionResolutionConfig;
     readonly routing: RoutingConfig;
     readonly low_impact: LowImpactConfig;
@@ -758,6 +782,16 @@ export function _build_config(raw: Dict, source_path: PathLike): CouncilConfig {
         _asDict(_getOr(raw, 'stance_tally', {})),
         'stance_tally',
     );
+    const chairman = _build_chairman(
+        _asDict(_getOr(raw, 'chairman', {})),
+        'chairman',
+        members,
+    );
+    const debate_gates = _build_debate_gates(
+        _asDict(_getOr(raw, 'debate_gates', {})),
+        'debate_gates',
+    );
+    const restate = _build_restate(_asDict(_getOr(raw, 'restate', {})), 'restate');
     const decision_resolution = _build_decision_resolution(
         _asDict(_getOr(raw, 'decision_resolution', {})),
     );
@@ -785,6 +819,9 @@ export function _build_config(raw: Dict, source_path: PathLike): CouncilConfig {
         debate,
         decision_replay,
         stance_tally,
+        chairman,
+        debate_gates,
+        restate,
         decision_resolution,
         routing,
         low_impact,
@@ -945,6 +982,79 @@ function _build_decision_replay(d: Dict, scope: string): DecisionReplayConfig {
  * a non-bool `enabled` is rejected rather than silently coerced.
  */
 function _build_stance_tally(d: Dict, scope: string): StanceTallyConfig {
+    if (!_isDict(d)) {
+        throw new CouncilConfigError(`\`${scope}\` must be a mapping.`);
+    }
+    const enabled = _get(d, 'enabled', false);
+    if (!_isBool(enabled)) {
+        throw new CouncilConfigError(`\`${scope}.enabled\` must be a bool.`);
+    }
+    return { enabled: Boolean(enabled) };
+}
+
+/**
+ * `ai_council.chairman` (Phase 2). Default `{ mode: 'host', member: null }` =
+ * today's host synthesis, byte-identical. Enum-validates `mode`; when
+ * `mode: 'member'` the named member must exist AND be enabled (fail-closed at
+ * load, mirroring the advisor cross-validation). `mode: 'auto'` needs no member.
+ */
+function _build_chairman(
+    d: Dict,
+    scope: string,
+    members: ReadonlyMap<string, MemberConfig>,
+): ChairmanConfig {
+    if (!_isDict(d)) {
+        throw new CouncilConfigError(`\`${scope}\` must be a mapping.`);
+    }
+    const mode = _get(d, 'mode', 'host');
+    if (!(_isStr(mode) && _VALID_CHAIRMAN_MODES.has(mode))) {
+        throw new CouncilConfigError(
+            `\`${scope}.mode\`=${_pyRepr(mode)} not in ${_sortedListRepr(_VALID_CHAIRMAN_MODES)}.`,
+        );
+    }
+    let member: string | null = null;
+    const rawMember = _get(d, 'member', null);
+    if (rawMember !== null && rawMember !== undefined) {
+        if (!_isStr(rawMember)) {
+            throw new CouncilConfigError(`\`${scope}.member\` must be a string.`);
+        }
+        member = rawMember;
+    }
+    if (mode === 'member') {
+        if (member === null) {
+            throw new CouncilConfigError(
+                `\`${scope}.mode\` is 'member' but \`${scope}.member\` is unset.`,
+            );
+        }
+        const bound = members.get(member);
+        if (bound === undefined) {
+            throw new CouncilConfigError(
+                `\`${scope}.member\`=${_pyReprStr(member)}: no such member in the \`members\` block.`,
+            );
+        }
+        if (!bound.enabled) {
+            throw new CouncilConfigError(
+                `\`${scope}.member\`=${_pyReprStr(member)}: member exists but is disabled.`,
+            );
+        }
+    }
+    return { mode, member };
+}
+
+/** `ai_council.debate_gates` (Phase 3). `{enabled}`, default false. */
+function _build_debate_gates(d: Dict, scope: string): DebateGatesConfig {
+    if (!_isDict(d)) {
+        throw new CouncilConfigError(`\`${scope}\` must be a mapping.`);
+    }
+    const enabled = _get(d, 'enabled', false);
+    if (!_isBool(enabled)) {
+        throw new CouncilConfigError(`\`${scope}.enabled\` must be a bool.`);
+    }
+    return { enabled: Boolean(enabled) };
+}
+
+/** `ai_council.restate` (Phase 3). `{enabled}`, default false. */
+function _build_restate(d: Dict, scope: string): RestateConfig {
     if (!_isDict(d)) {
         throw new CouncilConfigError(`\`${scope}\` must be a mapping.`);
     }

--- a/src/scripts/ai_council/debate_gates.ts
+++ b/src/scripts/ai_council/debate_gates.ts
@@ -1,0 +1,62 @@
+// Debate enforcement-gate detectors (road-to-opt-council-deliberation Phase 3).
+//
+// Pure, deterministic checks on the debate path — no LLM call. They decide
+// WHETHER a bounded repair re-prompt is warranted; the re-prompt DISPATCH (one
+// billable call per member per round, under a hard cap) and its auto-fire-vs-
+// confirm POLICY live in the run path and are gated behind
+// `ai_council.debate_gates.enabled` + the /council:design policy decision.
+//
+// The anti-conformity directive (the prompt-level half of the gates) is in
+// `prompts.ts` (`ANTI_CONFORMITY_DIRECTIVE`) and wired into the debate augmenter.
+
+import { jaccardSimilarity } from '../_lib/text_similarity.js';
+
+/** Near-duplicate bar: reuse the existing shared MERGE-level Jaccard threshold. */
+export const NOVELTY_DUP_THRESHOLD = 0.8;
+
+/** Minimum distinct dissenting members for the dissent quota to be satisfied. */
+export const DISSENT_QUOTA = 2;
+
+// Objection markers — the engine has no dissent parser (existing "dissent" is
+// LLM-score-derived, not text-marker-derived), so the marker is defined here.
+const _OBJECTION_RE =
+    /\b(disagree|disagrees|object|objection|reject|however|but\b|flaw|flawed|wrong|counter|counter-position|dissent|contradict|refute)\b/i;
+
+/**
+ * Novelty gate: a member's round-N reply is a **near-duplicate** of its own
+ * round-(N-1) reply when their normalised token similarity meets the threshold.
+ * Token-set Jaccard is order-independent and lowercased, so this is the
+ * "normalised near-duplicate" the gate targets. A duplicate → the member added
+ * nothing this round and warrants one targeted re-prompt.
+ */
+export function is_near_duplicate(
+    prevText: string,
+    currText: string,
+    threshold = NOVELTY_DUP_THRESHOLD,
+): boolean {
+    if (prevText.trim().length === 0 || currText.trim().length === 0) {
+        return false;
+    }
+    return jaccardSimilarity(prevText, currText) >= threshold;
+}
+
+/**
+ * Dissent quota: at least `quota` members voice an explicit objection (carry an
+ * objection marker). Below quota, the round has collapsed toward agreement and
+ * warrants one targeted dissent re-prompt to the most-recently-converged member.
+ * Empty / error replies do not count.
+ */
+export function count_dissenters(texts: readonly string[]): number {
+    let n = 0;
+    for (const t of texts) {
+        if (t.trim().length > 0 && _OBJECTION_RE.test(t)) {
+            n += 1;
+        }
+    }
+    return n;
+}
+
+/** True when the dissent quota is satisfied (≥ `quota` members objected). */
+export function dissent_quota_met(texts: readonly string[], quota = DISSENT_QUOTA): boolean {
+    return count_dissenters(texts) >= quota;
+}

--- a/src/scripts/ai_council/orchestrator.ts
+++ b/src/scripts/ai_council/orchestrator.ts
@@ -56,6 +56,7 @@ import type { ProjectContext } from './project_context.js';
 import type { AdvisorPlan } from './advisors.js';
 import {
     advisor_system_prompt,
+    ANTI_CONFORMITY_DIRECTIVE,
     build_extraction_user_prompt,
     build_peer_review_user_prompt,
     build_scoring_user_prompt,
@@ -838,6 +839,9 @@ function _augment_for_debate_round(
     original_prompt: string,
     prior_responses: CouncilResponse[],
     next_round_number: number,
+    // Phase 3: when the debate gates are enabled, prepend the anti-conformity
+    // directive. Default `false` keeps the prompt byte-identical to today.
+    anti_conformity = false,
 ): string {
     const blocks: string[] = [];
     let label_idx = 0;
@@ -853,6 +857,7 @@ function _augment_for_debate_round(
         return original_prompt;
     }
     const prior_block = blocks.join('\n\n');
+    const anti_conformity_block = anti_conformity ? `${ANTI_CONFORMITY_DIRECTIVE}\n\n` : '';
     return (
         `${original_prompt}\n\n` +
         `---\n\n` +
@@ -861,6 +866,7 @@ function _augment_for_debate_round(
         `debate. Below are anonymised positions from independent\n` +
         `reviewers in the previous round. You do NOT know which model\n` +
         `produced which position.\n\n` +
+        anti_conformity_block +
         `Identify the SINGLE strongest opposing position and write a\n` +
         `rebuttal addressed at its strongest steel-manned form. Do NOT\n` +
         `search for common ground — name the load-bearing flaw the\n` +
@@ -883,6 +889,12 @@ export interface RunDebateOptions {
     on_continue?: DebateContinuePrompt | null;
     advisor_plans?: Map<string, AdvisorPlan> | null;
     seed_round_1?: CouncilResponse[] | null;
+    /**
+     * Phase 3: when true (from `ai_council.debate_gates.enabled`), round-2+
+     * prompts carry the anti-conformity directive. Default `false` → the debate
+     * prompt is byte-identical to today.
+     */
+    debate_gates?: boolean;
 }
 
 /**
@@ -981,6 +993,7 @@ export function run_debate(
                 question.user_prompt,
                 results,
                 round_number + 1,
+                opts.debate_gates ?? false,
             );
             // Hard-cap + continue-prompt gating before kicking off N+1.
             let next_round_usd: number;

--- a/src/scripts/ai_council/prompts.ts
+++ b/src/scripts/ai_council/prompts.ts
@@ -160,6 +160,16 @@ export const STANCE_LINE_CONTRACT = `Close your reply with EXACTLY this line, an
 STANCE: <option-label> | CONFIDENCE: high|med|low | DEALBREAKER: yes|no
 Reuse the SAME <option-label> as any peer backing the same option (match their wording); use \`abstain\` only if you genuinely cannot choose. CONFIDENCE is your certainty in the pick; DEALBREAKER is \`yes\` only if you would block on the alternative.`;
 
+/**
+ * Anti-conformity directive appended to round-2+ debate prompts when
+ * `ai_council.debate_gates` is enabled (road-to-opt-council-deliberation
+ * Phase 3). Counters the round-over-round convergence-to-consensus drift the
+ * `rounds:N` path otherwise invites. Byte-identical across the api / cli /
+ * manual transports (it becomes part of the shared `user_prompt`, which every
+ * client's `ask()` receives verbatim), so no per-transport special-casing.
+ */
+export const ANTI_CONFORMITY_DIRECTIVE = `Anti-conformity rule for this round: defend a position you still believe is correct. Change your position ONLY when a specific, named flaw in it has been identified — and you must name that flaw explicitly to justify the change. Do not soften or converge merely because other reviewers disagree; agreement without a named reason is conformity, not reasoning.`;
+
 const _MODE_TABLE: Record<string, string> = {
     prompt: PROMPT_MODE,
     roadmap: ROADMAP_MODE,

--- a/src/scripts/council_cli.ts
+++ b/src/scripts/council_cli.ts
@@ -2129,6 +2129,14 @@ function cmd_debate(
         auto_continue: Boolean(_getattr(args, 'auto_continue', false)),
     });
 
+    // Phase 3: debate gates (anti-conformity directive on round 2+). Read
+    // defensively from the raw ai_council block — a malformed/absent
+    // `debate_gates` reads as off, keeping the debate prompt byte-identical.
+    const debate_gates_on =
+        _isDict(ai_cfg) &&
+        _isDict(ai_cfg['debate_gates']) &&
+        (ai_cfg['debate_gates'] as Dict)['enabled'] === true;
+
     let all_rounds: CouncilResponse[][];
     try {
         all_rounds = run_debate(members, question, {
@@ -2139,6 +2147,7 @@ function cmd_debate(
             max_rounds: rounds,
             on_round_complete: _on_round_complete,
             on_continue,
+            debate_gates: debate_gates_on,
             advisor_plans,
             seed_round_1: seed,
         });

--- a/tests/scripts/ai_council/chairman.test.ts
+++ b/tests/scripts/ai_council/chairman.test.ts
@@ -1,0 +1,42 @@
+// Tests for src/scripts/ai_council/chairman.ts (Phase 2 — pure selection).
+import { describe, expect, it } from 'vitest';
+
+import { select_chairman } from '../../../src/scripts/ai_council/chairman.js';
+
+const enabled = new Set(['anthropic', 'openai', 'google']);
+
+describe('select_chairman', () => {
+    it('host mode → host synthesis (null), plain annotation', () => {
+        const s = select_chairman('host', null, new Set(['anthropic']), enabled);
+        expect(s.member).toBeNull();
+        expect(s.annotation).toBe('Chairman: host');
+    });
+
+    it('member mode → the named member when enabled AND it did not deliberate', () => {
+        const s = select_chairman('member', 'google', new Set(['anthropic', 'openai']), enabled);
+        expect(s.member).toBe('google');
+        expect(s.annotation).toBe('Chairman: google');
+    });
+
+    it('member mode → host fallback (annotated) when the member deliberated (cannot self-judge)', () => {
+        const s = select_chairman('member', 'openai', new Set(['anthropic', 'openai']), enabled);
+        expect(s.member).toBeNull();
+        expect(s.annotation).toContain('deliberated');
+        expect(s.annotation).toContain('host fallback');
+    });
+
+    it('member mode → host fallback when the named member is not enabled', () => {
+        const s = select_chairman('member', 'mistral', new Set(['anthropic']), enabled);
+        expect(s.member).toBeNull();
+        expect(s.annotation).toContain('unavailable');
+    });
+
+    it('auto → conservative host fallback (no tier source; pending /council:design)', () => {
+        // Even with a non-deliberating enabled member available, auto does NOT
+        // pick one — the tier-preference is the blocked design detail.
+        const s = select_chairman('auto', null, new Set(['anthropic']), enabled);
+        expect(s.member).toBeNull();
+        expect(s.annotation).toContain('auto');
+        expect(s.annotation).toContain('/council:design');
+    });
+});

--- a/tests/scripts/ai_council/config.test.ts
+++ b/tests/scripts/ai_council/config.test.ts
@@ -108,6 +108,52 @@ describe('load_council_config — happy path', () => {
         );
     });
 
+    it('chairman defaults to host synthesis (Phase 2)', () => {
+        const c = cfg.load_council_config(write_yaml(make_tmp(), MINIMAL_VALID));
+        expect(c.chairman.mode).toBe('host');
+        expect(c.chairman.member).toBeNull();
+    });
+
+    it('chairman.mode enum is validated', () => {
+        const payload = `${MINIMAL_VALID}\nchairman:\n  mode: bogus\n`;
+        expect(() => cfg.load_council_config(write_yaml(make_tmp(), payload))).toThrow(
+            /chairman\.mode/,
+        );
+    });
+
+    it('chairman mode:member with a valid enabled member is honoured', () => {
+        const payload = `${MINIMAL_VALID}\nchairman:\n  mode: member\n  member: anthropic\n`;
+        const c = cfg.load_council_config(write_yaml(make_tmp(), payload));
+        expect(c.chairman.mode).toBe('member');
+        expect(c.chairman.member).toBe('anthropic');
+    });
+
+    it('chairman mode:member fails closed when the member is absent', () => {
+        const payload = `${MINIMAL_VALID}\nchairman:\n  mode: member\n  member: mistral\n`;
+        expect(() => cfg.load_council_config(write_yaml(make_tmp(), payload))).toThrow(
+            /no such member/,
+        );
+    });
+
+    it('chairman mode:member fails closed when member is unset', () => {
+        const payload = `${MINIMAL_VALID}\nchairman:\n  mode: member\n`;
+        expect(() => cfg.load_council_config(write_yaml(make_tmp(), payload))).toThrow(
+            /member.*is unset/,
+        );
+    });
+
+    it('debate_gates and restate default to disabled (Phase 3)', () => {
+        const c = cfg.load_council_config(write_yaml(make_tmp(), MINIMAL_VALID));
+        expect(c.debate_gates.enabled).toBe(false);
+        expect(c.restate.enabled).toBe(false);
+    });
+
+    it('debate_gates.enabled: true is honoured', () => {
+        const payload = `${MINIMAL_VALID}\ndebate_gates:\n  enabled: true\n`;
+        const c = cfg.load_council_config(write_yaml(make_tmp(), payload));
+        expect(c.debate_gates.enabled).toBe(true);
+    });
+
     it('per-member mode override precedence', () => {
         const tmp = make_tmp();
         const payload = `enabled: true

--- a/tests/scripts/ai_council/debate_gates.test.ts
+++ b/tests/scripts/ai_council/debate_gates.test.ts
@@ -1,0 +1,50 @@
+// Tests for src/scripts/ai_council/debate_gates.ts (Phase 3 — pure detectors).
+import { describe, expect, it } from 'vitest';
+
+import {
+    count_dissenters,
+    dissent_quota_met,
+    is_near_duplicate,
+} from '../../../src/scripts/ai_council/debate_gates.js';
+
+describe('is_near_duplicate (novelty gate)', () => {
+    it('flags a round-N reply that barely changed from round-(N-1)', () => {
+        const prev = 'The migration must run inside a transaction with a rollback path and an index on tenant_id.';
+        const curr = 'The migration must run inside a transaction with a rollback path and an index on tenant_id.';
+        expect(is_near_duplicate(prev, curr)).toBe(true);
+    });
+
+    it('does not flag a genuinely different reply', () => {
+        const prev = 'Option A: ship the adapter behind a feature flag.';
+        const curr = 'Actually option B is stronger — the queue backpressure invalidates A on burst load.';
+        expect(is_near_duplicate(prev, curr)).toBe(false);
+    });
+
+    it('empty text is never a duplicate', () => {
+        expect(is_near_duplicate('', 'anything')).toBe(false);
+        expect(is_near_duplicate('anything', '')).toBe(false);
+    });
+});
+
+describe('dissent quota', () => {
+    it('counts members carrying an objection marker', () => {
+        const texts = [
+            'I disagree — the ordering assumption is a flaw.',
+            'Agreed, ship it.',
+            'However, the tenant scope is wrong here.',
+        ];
+        expect(count_dissenters(texts)).toBe(2);
+        expect(dissent_quota_met(texts)).toBe(true);
+    });
+
+    it('is not met when fewer than the quota object', () => {
+        const texts = ['Agreed.', 'Sounds right to me.', 'I concur with the plan.'];
+        expect(count_dissenters(texts)).toBe(0);
+        expect(dissent_quota_met(texts)).toBe(false);
+    });
+
+    it('ignores empty replies', () => {
+        expect(count_dissenters(['', 'I object to the schema change.'])).toBe(1);
+        expect(dissent_quota_met(['', 'I object.'])).toBe(false);
+    });
+});

--- a/tests/scripts/ai_council/orchestrator.test.ts
+++ b/tests/scripts/ai_council/orchestrator.test.ts
@@ -35,6 +35,30 @@ import {
     run_peer_review,
 } from '../../../src/scripts/ai_council/orchestrator.js';
 import { load_prices } from '../../../src/scripts/ai_council/pricing.js';
+import { ANTI_CONFORMITY_DIRECTIVE } from '../../../src/scripts/ai_council/prompts.js';
+
+// Records the user_prompt each round so a test can observe what reached a member.
+class CapturingMock extends ExternalAIClient {
+    prompts: string[] = [];
+    private roundIdx = 0;
+    constructor(
+        name: string,
+        model: string,
+        private readonly replies: string[],
+    ) {
+        super();
+        this.name = name;
+        this.model = model;
+        this.billable = false;
+        this.transport = 'manual';
+    }
+    override ask(_system_prompt: string, user_prompt: string): CouncilResponse {
+        this.prompts.push(user_prompt);
+        const text = this.replies[Math.min(this.roundIdx, this.replies.length - 1)] ?? 'reply';
+        this.roundIdx += 1;
+        return new CouncilResponse({ provider: this.name, model: this.model, text, latency_ms: 1 });
+    }
+}
 
 // ── TS mock transport (mirrors the Python Mock) ──────────────────────────
 
@@ -240,6 +264,30 @@ describe('orchestrator — run_debate', () => {
         );
         expect(rounds[0]!.map((r) => r.text)).toEqual(['seed A', 'seed B']);
         expect(rounds[1]!.map((r) => r.text)).toEqual(['r2-A', 'r2-B']);
+    });
+
+    it('debate_gates injects the anti-conformity directive into round 2+; default off = byte-identical (Phase 3)', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'Adopt A or B?' });
+        const seed = [
+            new CouncilResponse({ provider: 'anthropic', model: 'm', text: 'seed A' }),
+            new CouncilResponse({ provider: 'openai', model: 'm', text: 'seed B' }),
+        ];
+        // Gates ON → the round-2 prompt (each member's first ask) carries the directive.
+        const onA = new CapturingMock('anthropic', 'm', ['r2-A']);
+        run_debate([onA, new CapturingMock('openai', 'm', ['r2-B'])], q, {
+            max_rounds: 2,
+            seed_round_1: seed,
+            debate_gates: true,
+        });
+        expect(onA.prompts[0]).toContain(ANTI_CONFORMITY_DIRECTIVE);
+
+        // Gates OFF (default) → the same run without the directive (byte-identical path).
+        const offA = new CapturingMock('anthropic', 'm', ['r2-A']);
+        run_debate([offA, new CapturingMock('openai', 'm', ['r2-B'])], q, {
+            max_rounds: 2,
+            seed_round_1: seed,
+        });
+        expect(offA.prompts[0]).not.toContain(ANTI_CONFORMITY_DIRECTIVE);
     });
 
     it('DebateCapExceeded thrown when next round breaches max_total_usd', () => {


### PR DESCRIPTION
## What

Continues `road-to-opt-council-deliberation` (foundation landed in #903) with its **autonomous Phase 2 + Phase 3 tranche** — the maintainer explicitly asked to carry this forward in a **separate PR**. Everything here is **default-off / additive**; with every new key at its default the consult / debate / synthesis paths are byte-identical to today. ai_council suite **425 green**, typecheck 0.

A read-only engine map surfaced three stale roadmap assumptions, each handled honestly below.

## Phase 2 — Chairman synthesis (config + selection landed; dispatch gated)

The council's own Iron Law says the host, having framed the artefact, cannot independently judge it — so synthesis by a **non-deliberating member** removes that bias.

- **Config** `ai_council.chairman: {mode: host|member|auto, member?}` — enum-validated `mode`, **fail-closed** member validation (absent / disabled / unset all rejected at load). Default `host` = byte-identical.
- **Pure selection** `chairman.ts` `select_chairman`: `host` → host; `member` → the named member only if it did **not** deliberate (a member that argued cannot self-judge → annotated host fallback); `auto` → **conservative host fallback**.
- **Stale-assumption correction:** `auto` was specified as "highest-tier enabled member", but the engine has **no cross-member tier field** (`model_ladder` is per-member only). Rather than pre-decide the tier-vs-provider preference the `contested-design-council-pass` blocker reserves for `/council:design`, `auto` falls back to host with a visible annotation.
- **Gated (billable + blocker):** the chairman *dispatch* — the map confirmed it cannot live in `render()` (no clients/table/budget there) and belongs in `cmd_run`; it lands with the `/council:design` decision + a new `MemberConfig.tier` source, together with its estimate row and ADR (deferred to avoid a premature ADR + the parallel-PR ADR-number-collision hazard).

## Phase 3 — Debate enforcement gates (directive wired; repair gated)

- **Anti-conformity directive — wired end-to-end and proven.** `prompts.ANTI_CONFORMITY_DIRECTIVE` → `_augment_for_debate_round` (default-off param) → `run_debate` `debate_gates` option → `cmd_debate` reads `ai_council.debate_gates.enabled`. Byte-identical when off (parity suite green); injected on round 2+ when on — a **capturing-mock test** asserts the directive reaches the member on, absent off. Transport-identical **by construction** (the map confirmed transports don't diverge in the orchestrator — the directive is part of the shared `user_prompt`).
- **Deterministic detectors** `debate_gates.ts`: `dissent_quota_met` + `is_near_duplicate` (reusing the shared Jaccard util; the objection marker is **defined here** — the engine's existing "dissent" is LLM-score-derived, not a text marker). Pure + tested.
- **Config** `debate_gates.enabled` / `restate.enabled` (bool, default false, non-bool rejected).
- **Gated:** the bounded repair re-prompt (one billable call per member per round) + its auto-fire-vs-confirm **policy** are exactly what `contested-design-council-pass` reserves for `/council:design`; the restate pass (billable per-member call) lands with them.

## Verification

ai_council suite 425 green (incl. the new config, chairman, debate-gate, and directive-delivery tests + the debate parity tests with gates off); typecheck 0; skill-lint 0; `check-md-language` 0; `check-refs` 0; no condensation touched (no skills/rules changed); `generate-tools` no drift. Contract doc updated (§ Chairman synthesis, § Debate enforcement gates).