### PR TITLE
feat(council): stance-tally end-to-end wiring — final-round contract + Vote Tally (road-to-opt-council-deliberation)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 27 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 27 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **9** open blockers
 
 ## Overall
 
-**102 / 375 steps done · 27%**
+**104 / 375 steps done · 28%**
 
 ```text
-███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   27%
+███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   28%
 ```
 
 ## Open roadmaps
@@ -34,7 +34,7 @@
 | 16 | [road-to-ecosystem-harvest-tool-pitfalls.md](roadmaps/road-to-ecosystem-harvest-tool-pitfalls.md) | 1 | 6 | 6 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 17 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 15 | 14 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | █████░░░░░ 48% |
+| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 13 | 16 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | ██████░░░░ 55% |
 | 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 8 | 2 | 0 | 0 | 0 | ██░░░░░░░░ 20% |
 | 21 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 22 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
@@ -243,12 +243,12 @@ _1 blocker resolved._
 
 ### [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md)
 
-**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 14 / 29 done (48%)
+**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 16 / 29 done (55%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Claims hygiene + verdict falsifiability | ✅ done | 0 | 5 | 0 | 0 | 100% |
-| 1 | Option-level stance tally | 🟡 in progress | 3 | 3 | 0 | 0 | 50% |
+| 1 | Option-level stance tally | 🟡 in progress | 1 | 5 | 0 | 0 | 83% |
 | 2 | Chairman synthesis (opt-in) | 🟡 in progress | 3 | 3 | 0 | 0 | 50% |
 | 3 | Debate enforcement gates | 🟡 in progress | 2 | 3 | 0 | 0 | 60% |
 | 4 | Persona placebo benchmark (measure, don't adopt) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-opt-council-deliberation.md
+++ b/agents/roadmaps/road-to-opt-council-deliberation.md
@@ -155,12 +155,12 @@ schema or engine behaviour changed in this phase.
 
 Deterministic port of Source G's tally, engineered instead of prompted.
 
-- [ ] Final-round prompt (in `prompts.ts`) appends the mandatory closing
+- [x] Final-round prompt (in `prompts.ts`) appends the mandatory closing
       line contract:
       `STANCE: <label> | CONFIDENCE: high|med|low | DEALBREAKER: yes|no`,
       with the label-matching instruction (peers backing the same option
       use the same label; `abstain` allowed).
-      <!-- partial: STANCE_LINE_CONTRACT constant authored in prompts.ts (with the label-matching + abstain instruction). The orchestrator wiring that APPENDS it to the final round (_augment_for_next_round, gated on next_round === rounds) is the remaining integration — see the halt note at the phase foot. -->
+      <!-- done (wiring PR, 2026-07-12): consult() appends STANCE_LINE_CONTRACT to the FINAL round when stance_tally is on (rounds:1 → round 1; rounds:N → round N); default-off byte-identical (original question object flows untouched). Proven by capturing-mock tests. -->
 - [x] New module `src/scripts/ai_council/stance_tally.ts`: parse stance
       lines (tolerant of whitespace/case, re-prompt-marker on
       unparseable — never infer from prose); canonicalise labels
@@ -176,10 +176,10 @@ Deterministic port of Source G's tally, engineered instead of prompted.
       any member call; surfaced in the estimate as a `may add up to N
       repair calls` row.
       <!-- BLOCKED on `blocker: contested-design-council-pass` — the repair-call auto-fire-vs-confirm policy is the design question that blocker reserves for a billable /council:design run. The tally already RETURNS needs_repair (parsed, tested); only the billable dispatch policy waits. -->
-- [ ] Verdict section **Vote Tally** in the synthesis template: one line
+- [x] Verdict section **Vote Tally** in the synthesis template: one line
       per option (`<option> — <weight> (<backers with confidence>)`),
       threshold stated, cleared-or-escalated stated.
-      <!-- partial: render_vote_tally() authored + tested in stance_tally.ts (exactly this shape). Injecting it into the live synthesis output is part of the same orchestrator integration as the final-round wiring — remaining. -->
+      <!-- done (wiring PR, 2026-07-12): render() emits the Vote Tally block (deterministic projection from final-round texts) when stance_tally is on; threaded cmd_run → payload.stance_tally → cmd_render. Split escalates honestly; off = byte-identical. -->
 - [x] Tests in `tests/scripts/ai_council/stance_tally.test.ts` including
       Source G's own worked example as a fixture (3-seat panel, one
       abstain; assert the abstain raises the bar and the split

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -400,10 +400,12 @@ included, so they raise the bar). Consensus requires an option to clear
 `⅔ × W_total`; below threshold a structured **split** is returned to the
 user — never a forced winner, never an auto-added round. The synthesis gains
 a **Vote Tally** section (one line per option, the threshold, and a
-cleared-or-escalated line). A member whose stance line is missing or
-unparseable is a repair-marker; the bounded stance-line-only repair call and
-its estimate row are surfaced separately (gated behind the same key and the
-per-run spend estimate).
+cleared-or-escalated line). The final-round wiring is LIVE (2026-07-12): `consult` appends the contract to
+the final round and `render` emits the Vote Tally block, threaded via
+`payload.stance_tally`. A member whose stance line is missing or unparseable is
+a repair-marker; the bounded stance-line-only repair CALL (policy: `repair_action`
+— confirm-interactive / auto-fire under `--auto-continue`) and its estimate row
+are the remaining dispatch wiring.
 
 ### Chairman synthesis (Phase 2 — opt-in)
 

--- a/src/scripts/ai_council/orchestrator.ts
+++ b/src/scripts/ai_council/orchestrator.ts
@@ -57,6 +57,7 @@ import type { AdvisorPlan } from './advisors.js';
 import {
     advisor_system_prompt,
     ANTI_CONFORMITY_DIRECTIVE,
+    STANCE_LINE_CONTRACT,
     build_extraction_user_prompt,
     build_peer_review_user_prompt,
     build_scoring_user_prompt,
@@ -64,6 +65,7 @@ import {
     synthesis_template,
     system_prompt_for,
 } from './prompts.js';
+import { render_vote_tally, tally_stances } from './stance_tally.js';
 
 // ── Python-format / stdlib parity helpers ────────────────────────────────
 //
@@ -410,6 +412,13 @@ export interface ConsultOptions {
         | ((round_idx: number, responses: CouncilResponse[]) => void)
         | null;
     advisor_plans?: Map<string, AdvisorPlan> | null;
+    /**
+     * Phase 1 (stance tally): when true, the FINAL round's user prompt appends
+     * the mandatory `STANCE:` closing-line contract so `stance_tally.ts` can
+     * tally option-level verdicts deterministically. Default `false` → every
+     * round's prompt is byte-identical to today.
+     */
+    stance_tally?: boolean;
 }
 
 /**
@@ -468,13 +477,23 @@ export function consult(
     let last_results: CouncilResponse[] = [];
     let current_user_prompt = question.user_prompt;
 
+    const stance_tally = opts.stance_tally ?? false;
     for (let round_idx = 0; round_idx < rounds; round_idx++) {
+        // Phase 1: the FINAL round carries the mandatory STANCE closing-line
+        // contract when the tally is enabled. Off (default) → the original
+        // question object flows through untouched, byte-identical to today.
+        const is_final = round_idx === rounds - 1;
+        const base_prompt = round_idx === 0 ? question.user_prompt : current_user_prompt;
+        const prompt_for_round =
+            is_final && stance_tally
+                ? `${base_prompt}\n\n---\n\n${STANCE_LINE_CONTRACT}`
+                : base_prompt;
         const round_question =
-            round_idx === 0
+            round_idx === 0 && prompt_for_round === question.user_prompt
                 ? question
                 : new CouncilQuestion({
                       mode: question.mode,
-                      user_prompt: current_user_prompt,
+                      user_prompt: prompt_for_round,
                       max_tokens: question.max_tokens,
                   });
         last_results = _run_round(members, round_question, resolvedBudget, spent, {
@@ -1446,6 +1465,12 @@ export interface RenderOptions {
     consensus?: ConsensusResult | null;
     peer_review?: PeerReviewResult | null;
     explain_confidence?: boolean | null;
+    /**
+     * Phase 1 (stance tally): when true, a `### Vote Tally` block — computed
+     * deterministically from the final-round response texts — is rendered
+     * before the Convergence / Divergence slot. Default `false` → byte-identical.
+     */
+    stance_tally?: boolean;
 }
 
 /**
@@ -1517,6 +1542,17 @@ export function render(responses: CouncilResponse[], opts: RenderOptions = {}): 
         body = template;
     } else {
         body = '*to be summarised by the host agent*';
+    }
+    if (opts.stance_tally === true) {
+        // Phase 1: deterministic option-level tally from the final-round
+        // response texts (the STANCE closing lines live IN the texts, so the
+        // render is a pure projection — no config or transport needed here).
+        const tally = tally_stances(
+            responses
+                .filter((r) => !r.error)
+                .map((r) => ({ member: `${r.provider}:${r.model}`, text: r.text })),
+        );
+        blocks.push(render_vote_tally(tally));
     }
     blocks.push(`## Convergence / Divergence\n\n${body}`);
     return blocks.join('\n\n---\n\n');

--- a/src/scripts/council_cli.ts
+++ b/src/scripts/council_cli.ts
@@ -1781,12 +1781,18 @@ function cmd_run(
         max_total_usd: _pyFloat(cost_cfg['max_total_usd'] ?? 0.0, 0.0) || 0.0,
     });
     const rounds = _resolve_rounds(args, ai_cfg);
+    // Phase 1: stance tally — defensive read; malformed/absent block reads as off.
+    const stance_tally_on =
+        _isDict(ai_cfg) &&
+        _isDict(ai_cfg['stance_tally']) &&
+        (ai_cfg['stance_tally'] as Dict)['enabled'] === true;
     const responses = consult(members, question, budget, {
         table,
         project,
         original_ask: args.original_ask,
         rounds,
         advisor_plans,
+        stance_tally: stance_tally_on,
     });
     const persona_labels = build_persona_labels(advisor_plans, billable);
     const peer_review = _maybe_run_peer_review(
@@ -1830,6 +1836,7 @@ function cmd_run(
         rounds,
         cost_usd_estimated: _pyRound(estimated_total, 6),
         cost_usd_actual: _pyRound(actual_total, 6),
+        stance_tally: stance_tally_on,
         responses: _serialise_responses(responses),
     };
     if (peer_review !== null) {
@@ -2199,6 +2206,7 @@ function cmd_render(args: Args): number {
         prose_synthesis: prose,
         consensus,
         peer_review,
+        stance_tally: payload['stance_tally'] === true,
     });
     if (_getattr<string | null>(args, 'output', null)) {
         const out_path = _validate_council_output_path(args.output as string, {

--- a/tests/scripts/ai_council/orchestrator.test.ts
+++ b/tests/scripts/ai_council/orchestrator.test.ts
@@ -351,3 +351,48 @@ describe('orchestrator — run_consensus_scoring', () => {
         expect(r.findings.map((f) => f.id).sort()).toEqual(['a', 'b']);
     });
 });
+
+describe('stance-tally integration (Phase 1)', () => {
+    const stanceText = (label: string): string =>
+        `Reasoning.\n\nSTANCE: ${label} | CONFIDENCE: high | DEALBREAKER: no`;
+
+    it('consult appends the STANCE contract to the FINAL round only; default off = untouched', () => {
+        const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'A or B?' });
+        // rounds:2, on → round-1 prompt clean, round-2 (final) carries the contract.
+        const on = new CapturingMock('anthropic', 'm', ['pos', stanceText('A')]);
+        consult([on, new CapturingMock('openai', 'm', ['pos', stanceText('A')])], q, null, {
+            rounds: 2,
+            stance_tally: true,
+        });
+        expect(on.prompts[0]).not.toContain('STANCE:');
+        expect(on.prompts[1]).toContain('STANCE: <option-label>');
+        // rounds:1, on → the single (final) round carries it.
+        const single = new CapturingMock('anthropic', 'm', [stanceText('A')]);
+        consult([single], q, null, { rounds: 1, stance_tally: true });
+        expect(single.prompts[0]).toContain('STANCE: <option-label>');
+        // default off → byte-identical prompt.
+        const off = new CapturingMock('anthropic', 'm', ['pos']);
+        consult([off], q);
+        expect(off.prompts[0]).toBe(q.user_prompt);
+    });
+
+    it('render emits the Vote Tally block when stance_tally is on, none when off', () => {
+        const responses = [
+            new CouncilResponse({ provider: 'anthropic', model: 'm', text: stanceText('Adopt'), latency_ms: 1 }),
+            new CouncilResponse({ provider: 'openai', model: 'm', text: stanceText('Adopt'), latency_ms: 1 }),
+        ];
+        const withTally = render(responses, { stance_tally: true });
+        expect(withTally).toContain('### Vote Tally');
+        expect(withTally).toContain('Cleared: Adopt');
+        expect(render(responses, {})).not.toContain('### Vote Tally');
+    });
+
+    it('render Vote Tally escalates a split honestly (never a forced winner)', () => {
+        const responses = [
+            new CouncilResponse({ provider: 'anthropic', model: 'm', text: stanceText('A'), latency_ms: 1 }),
+            new CouncilResponse({ provider: 'openai', model: 'm', text: stanceText('B'), latency_ms: 1 }),
+        ];
+        const out = render(responses, { stance_tally: true });
+        expect(out).toContain('Escalated: no option cleared');
+    });
+});


### PR DESCRIPTION
## What

Continues `road-to-opt-council-deliberation` with the first slice of the **now-unblocked wiring tranche** (#910 resolved the design blocker): the **stance-tally Phase-1 orchestrator integration**, end-to-end and default-off.

## Wired (all default-off; byte-identical at defaults)

- **`consult()` appends `STANCE_LINE_CONTRACT` to the FINAL round's prompt** when `ai_council.stance_tally.enabled` — rounds:1 → round 1, rounds:N → round N. Off (default): the original question object flows through untouched.
- **`render()` emits the Vote Tally block** — a deterministic projection of the final-round response texts via the existing `tally_stances`/`render_vote_tally` (#903) — before the Convergence/Divergence slot. A split **escalates honestly**, never a forced winner.
- **Threading:** `cmd_run` reads the config defensively → persists `payload.stance_tally` → `cmd_render` reads the payload, so the render step needs no config access.

## Tests

3 new integration tests: capturing-mock proof that the contract lands on the final round only (rounds:1 and rounds:2) and that default-off is byte-identical; Vote Tally present/absent; honest split escalation. **Suite 436 green, typecheck 0**, md-language/refs/condensation clean.

## Remaining wiring (next tranche — designs all decided)

The bounded **repair call** for unparseable stances (policy decided: `repair_action` — confirm-interactive / auto-fire under `--auto-continue`) + its estimate row; the **chairman dispatch** in `cmd_run` + estimate row + ADR; the debate-gate **repair/restate** wiring in `run_debate`. Phase 4 stays benchmark-spend-gated.