### PR TITLE
feat(council): debate-gate repair dispatch — bounded, policy-gated (road-to-opt-council-deliberation)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**106 / 375 steps done · 28%**
+**107 / 375 steps done · 29%**
 
 ```text
-███████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   28%
+████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   29%
 ```
 
 ## Open roadmaps
@@ -34,7 +34,7 @@
 | 16 | [road-to-ecosystem-harvest-tool-pitfalls.md](roadmaps/road-to-ecosystem-harvest-tool-pitfalls.md) | 1 | 6 | 6 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 17 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 11 | 18 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | ██████░░░░ 62% |
+| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 10 | 19 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | ███████░░░ 66% |
 | 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 8 | 2 | 0 | 0 | 0 | ██░░░░░░░░ 20% |
 | 21 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 22 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
@@ -243,14 +243,14 @@ _1 blocker resolved._
 
 ### [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md)
 
-**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 18 / 29 done (62%)
+**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 19 / 29 done (66%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Claims hygiene + verdict falsifiability | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 1 | Option-level stance tally | 🟡 in progress | 1 | 5 | 0 | 0 | 83% |
 | 2 | Chairman synthesis (opt-in) | 🟡 in progress | 1 | 5 | 0 | 0 | 83% |
-| 3 | Debate enforcement gates | 🟡 in progress | 2 | 3 | 0 | 0 | 60% |
+| 3 | Debate enforcement gates | 🟡 in progress | 1 | 4 | 0 | 0 | 80% |
 | 4 | Persona placebo benchmark (measure, don't adopt) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 5 | close out the source file | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/road-to-opt-council-deliberation.md
+++ b/agents/roadmaps/road-to-opt-council-deliberation.md
@@ -263,7 +263,7 @@ visible repair cost.
       named, specific flaw; naming the flaw is required to update).
       Identical text for `api`, `cli`, and `manual` transports.
       <!-- done + WIRED end-to-end: prompts.ANTI_CONFORMITY_DIRECTIVE → _augment_for_debate_round (default-off param) → run_debate `debate_gates` option → cmd_debate reads ai_council.debate_gates.enabled. Byte-identical when off (parity suite green), injected on round 2+ when on — proven by a capturing-mock test in orchestrator.test.ts. Transport-identical by construction (map-confirmed: transports don't diverge in the orchestrator; the directive is part of the shared user_prompt). -->
-- [ ] `ai_council.debate_gates.enabled` (default `false`) activating two
+- [x] `ai_council.debate_gates.enabled` (default `false`) activating two
       deterministic post-round checks on the debate path:
       **dissent quota** (≥ 2 members with non-identical objection
       markers; below quota → one targeted dissent re-prompt to the most

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -456,8 +456,10 @@ estimate is an upper bound, not a spend commitment, and repairs are failure-mode
 responses — so **interactive runs get a one-line confirm** before each repair
 call; **unattended runs (`--auto-continue`) auto-fire** under the hard cap
 (≤ 1 repair per member per round, absolute — an already-repaired member is
-skipped in every mode); manual-transport members follow the same policy. The
-repair-dispatch wiring in `run_debate` is the remaining step.
+skipped in every mode); manual-transport members follow the same policy. The repair dispatch is LIVE in `run_debate` (2026-07-12): post-round checks on
+round 2+, ≤ 1 repair per member per round, dispatched via the CLI's
+`_make_repair_confirm` transport (auto-fire under `--auto-continue`, one-line
+confirm interactive); a successful repair replaces the member's round entry.
 
 ### Decision resolution by impact (Phase 10, ask-user routing)
 

--- a/src/scripts/ai_council/orchestrator.ts
+++ b/src/scripts/ai_council/orchestrator.ts
@@ -65,6 +65,7 @@ import {
     synthesis_template,
     system_prompt_for,
 } from './prompts.js';
+import { count_dissenters, dissent_quota_met, is_near_duplicate } from './debate_gates.js';
 import { render_vote_tally, tally_stances } from './stance_tally.js';
 
 // ── Python-format / stdlib parity helpers ────────────────────────────────
@@ -895,6 +896,90 @@ function _augment_for_debate_round(
     );
 }
 
+/**
+ * Phase 3 post-round enforcement (2026-07-12 council policy): deterministic
+ * detectors flag members whose round added nothing (novelty near-duplicate of
+ * their own prior round) or when the round collapsed toward agreement (dissent
+ * quota unmet → the most-recently-converged member). At most ONE bounded repair
+ * re-prompt per member per round, dispatched only through the `on_repair`
+ * transport (confirm-interactive / auto-fire under --auto-continue); the repair
+ * call reuses `_run_round`, so the projected-spend gate, ledger, and metadata
+ * stamping apply unchanged. A successful repair REPLACES the member's entry so
+ * downstream rounds/persistence see the repaired reply.
+ */
+function _run_debate_gate_repairs(
+    members: ExternalAIClient[],
+    results: CouncilResponse[],
+    prior: CouncilResponse[],
+    round_question: CouncilQuestion,
+    budget: CostBudget,
+    spent: Spent,
+    round_opts: {
+        table: PriceTable | null;
+        on_overrun: OnOverrunCallback | null;
+        project: ProjectContext | null;
+        original_ask: string;
+        advisor_plans: Map<string, AdvisorPlan> | null;
+    },
+    on_repair: ((member: string, reason: string) => boolean) | null,
+): CouncilResponse[] {
+    const flagged: Array<{ idx: number; reason: string }> = [];
+    const okText = (r: CouncilResponse | undefined): string =>
+        r !== undefined && r.error === null ? r.text : '';
+    for (let i = 0; i < results.length; i++) {
+        const curr = okText(results[i]);
+        const prev = okText(prior[i]);
+        if (curr !== '' && prev !== '' && is_near_duplicate(prev, curr)) {
+            flagged.push({ idx: i, reason: 'novelty: near-duplicate of your own prior round' });
+        }
+    }
+    const texts = results.map((r) => okText(r));
+    if (!dissent_quota_met(texts.filter((t) => t !== ''))) {
+        // Most-recently-converged heuristic: the LAST member with a real reply
+        // that carries no objection marker.
+        for (let i = results.length - 1; i >= 0; i--) {
+            const t = okText(results[i]);
+            if (t !== '' && count_dissenters([t]) === 0 && !flagged.some((f) => f.idx === i)) {
+                flagged.push({ idx: i, reason: 'dissent quota unmet: state a genuine objection or confirm with a named reason' });
+                break;
+            }
+        }
+    }
+    if (flagged.length === 0 || on_repair === null) {
+        return results;
+    }
+    const repaired = new Set<number>();
+    const out = [...results];
+    for (const f of flagged) {
+        if (repaired.has(f.idx)) {
+            continue; // hard cap: <= 1 repair per member per round
+        }
+        const member = members[f.idx];
+        if (member === undefined) {
+            continue;
+        }
+        if (!on_repair(member.name, f.reason)) {
+            continue;
+        }
+        repaired.add(f.idx);
+        const repairQ = new CouncilQuestion({
+            mode: round_question.mode,
+            user_prompt:
+                `${round_question.user_prompt}\n\n---\n\n` +
+                `REPAIR RE-PROMPT (${f.reason}). Your previous reply this round did not ` +
+                `advance the debate. Respond again: either a genuinely updated position ` +
+                `naming the specific flaw that moved you, or an explicit defense with NEW evidence.`,
+            max_tokens: round_question.max_tokens,
+        });
+        const rr = _run_round([member], repairQ, budget, spent, round_opts);
+        const r0 = rr[0];
+        if (r0 !== undefined && r0.error === null && r0.text.trim() !== '') {
+            out[f.idx] = r0;
+        }
+    }
+    return out;
+}
+
 export interface RunDebateOptions {
     budget?: CostBudget | null;
     table?: PriceTable | null;
@@ -914,6 +999,14 @@ export interface RunDebateOptions {
      * prompt is byte-identical to today.
      */
     debate_gates?: boolean;
+    /**
+     * Phase 3 repair transport, per the 2026-07-12 council policy
+     * (`debate_gates.repair_action`): the CLI passes `() => true` under
+     * `--auto-continue` (auto-fire under the cap) or an interactive one-line
+     * confirm otherwise. `null`/absent → gates detect but never dispatch
+     * (no unplanned spend without an explicit transport).
+     */
+    on_repair?: ((member: string, reason: string) => boolean) | null;
 }
 
 /**
@@ -1000,6 +1093,23 @@ export function run_debate(
             });
         }
 
+        if (opts.debate_gates === true && round_idx > 0 && all_rounds.length > 0) {
+            results = _run_debate_gate_repairs(
+                members,
+                results,
+                all_rounds[all_rounds.length - 1] as CouncilResponse[],
+                // round_idx > 0 here, so current_user_prompt IS this round's prompt.
+                new CouncilQuestion({
+                    mode: question.mode,
+                    user_prompt: current_user_prompt,
+                    max_tokens: question.max_tokens,
+                }),
+                budget,
+                spent,
+                { table, on_overrun, project, original_ask, advisor_plans },
+                opts.on_repair ?? null,
+            );
+        }
         all_rounds.push(results);
         if (on_round_complete !== null) {
             on_round_complete(round_number, results);

--- a/src/scripts/council_cli.ts
+++ b/src/scripts/council_cli.ts
@@ -2068,6 +2068,20 @@ function _listEq(a: string[], b: string[]): boolean {
     return a.every((v, i) => v === b[i]);
 }
 
+
+/** Phase 3 repair transport (council 2026-07-12): auto-fire under
+ *  --auto-continue; one-line confirm otherwise (blank/EOF stdin = N). */
+function _make_repair_confirm(auto_continue: boolean): (member: string, reason: string) => boolean {
+    if (auto_continue) {
+        return () => true;
+    }
+    return (member: string, reason: string): boolean => {
+        _stdout(`\ndebate:repair ${member} — ${reason} — send one bounded repair re-prompt? [y/N]: `);
+        const answer = _readStdinLine();
+        return answer === 'y' || answer === 'yes';
+    };
+}
+
 function _make_debate_continue_prompt(opts: {
     auto_continue: boolean;
     stream?: ((s: string) => void) | null;
@@ -2282,6 +2296,7 @@ function cmd_debate(
             on_round_complete: _on_round_complete,
             on_continue,
             debate_gates: debate_gates_on,
+            on_repair: debate_gates_on ? _make_repair_confirm(Boolean(_getattr(args, 'auto_continue', false))) : null,
             advisor_plans,
             seed_round_1: seed,
         });

--- a/tests/scripts/ai_council/orchestrator.test.ts
+++ b/tests/scripts/ai_council/orchestrator.test.ts
@@ -421,3 +421,59 @@ describe('chairman synthesis injection (Phase 2 wiring)', () => {
         expect(plain).not.toContain('Chairman:');
     });
 });
+
+describe('debate-gate repair dispatch (Phase 3 wiring)', () => {
+    const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'A or B?' });
+    const seed = [
+        new CouncilResponse({ provider: 'anthropic', model: 'm', text: 'I object: A has a flaw in ordering.', latency_ms: 1 }),
+        new CouncilResponse({ provider: 'openai', model: 'm', text: 'However, B mishandles retries — I disagree.', latency_ms: 1 }),
+    ];
+
+    it('a near-duplicate round-2 reply triggers ONE repair and the repaired reply replaces it', () => {
+        // anthropic repeats its round-1 text verbatim in round 2 (novelty dup),
+        // then returns a fresh reply on the repair call.
+        const a = new CapturingMock('anthropic', 'm', [
+            'I object: A has a flaw in ordering.', // round 2 = dup of seed
+            'Updated: the ordering flaw is resolved by the queue barrier — I now back B.',
+        ]);
+        const b = new CapturingMock('openai', 'm', ['However, B mishandles retries — I disagree; the flaw is unaddressed.']);
+        const rounds = run_debate([a, b], q, {
+            max_rounds: 2,
+            seed_round_1: seed,
+            debate_gates: true,
+            on_repair: () => true,
+        });
+        expect(a.prompts.length).toBe(2); // round-2 ask + exactly one repair
+        expect(a.prompts[1]).toContain('REPAIR RE-PROMPT');
+        expect(rounds[1]![0]!.text).toContain('queue barrier'); // repaired reply replaced
+    });
+
+    it('on_repair=null (no transport) detects but never dispatches; gates off = no checks', () => {
+        const a = new CapturingMock('anthropic', 'm', ['I object: A has a flaw in ordering.']);
+        run_debate([a, new CapturingMock('openai', 'm', ['However — I disagree.'])], q, {
+            max_rounds: 2,
+            seed_round_1: seed,
+            debate_gates: true,
+            on_repair: null,
+        });
+        expect(a.prompts.length).toBe(1); // no repair call
+        const c = new CapturingMock('anthropic', 'm', ['I object: A has a flaw in ordering.']);
+        run_debate([c, new CapturingMock('openai', 'm', ['However — I disagree.'])], q, {
+            max_rounds: 2,
+            seed_round_1: seed,
+        });
+        expect(c.prompts.length).toBe(1);
+    });
+
+    it('a declined confirm skips the repair', () => {
+        const a = new CapturingMock('anthropic', 'm', ['I object: A has a flaw in ordering.']);
+        const rounds = run_debate([a, new CapturingMock('openai', 'm', ['However — I disagree.'])], q, {
+            max_rounds: 2,
+            seed_round_1: seed,
+            debate_gates: true,
+            on_repair: () => false,
+        });
+        expect(a.prompts.length).toBe(1);
+        expect(rounds[1]![0]!.text).toContain('flaw in ordering'); // original kept
+    });
+});


### PR DESCRIPTION
## What

The next slice of the wiring tranche of `road-to-opt-council-deliberation`: the **Phase-3 debate-gate repair re-prompts**, end-to-end and default-off (policy decided by the 2026-07-12 council pass; detectors landed in #906/#910).

## Wired (default-off = byte-identical)

- **Post-round gate checks in `run_debate`** (round 2+, `debate_gates` on): **novelty** — a member's reply is a near-duplicate of its own prior round; **dissent quota** — the round collapsed toward agreement → the most-recently-converged member is flagged. **Hard cap ≤ 1 repair per member per round.**
- **Dispatch only through the `on_repair` transport**, per the council policy: **auto-fire under `--auto-continue`**, **one-line confirm** in interactive runs (`_make_repair_confirm`, blank/EOF = N), `null` transport = **detect-only** — no unplanned spend without an explicit transport.
- **The repair call reuses `_run_round`** — projected-spend gate, daily ledger, and metadata stamping unchanged; a successful repair **replaces** the member's round entry so later rounds and persistence see the repaired reply.

## Verification

Suite **441 green** (3 new dispatch tests: fire+replace via capturing mock, null-transport detect-only, declined-confirm keeps the original; plus gates-off parity), typecheck 0, md-language/refs/condensation clean.

## Remaining

The **restate pass** (`restate.enabled`, pre-round-1 billable per-member call), the **stance repair call** (consult path), and the **chairman ADR** — plus the benchmark-spend-gated Phase 4.