### PR TITLE
feat(council): restate pass — the last autonomous wiring item (road-to-opt-council-deliberation)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**109 / 375 steps done · 29%**
+**110 / 375 steps done · 29%**
 
 ```text
 ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   29%
@@ -34,7 +34,7 @@
 | 16 | [road-to-ecosystem-harvest-tool-pitfalls.md](roadmaps/road-to-ecosystem-harvest-tool-pitfalls.md) | 1 | 6 | 6 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 17 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 8 | 21 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | ███████░░░ 72% |
+| 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 7 | 22 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | ████████░░ 76% |
 | 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 8 | 2 | 0 | 0 | 0 | ██░░░░░░░░ 20% |
 | 21 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 22 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
@@ -243,14 +243,14 @@ _1 blocker resolved._
 
 ### [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md)
 
-**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 21 / 29 done (72%)
+**Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater** — 22 / 29 done (76%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Claims hygiene + verdict falsifiability | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 1 | Option-level stance tally | ✅ done | 0 | 6 | 0 | 0 | 100% |
 | 2 | Chairman synthesis (opt-in) | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 3 | Debate enforcement gates | 🟡 in progress | 1 | 4 | 0 | 0 | 80% |
+| 3 | Debate enforcement gates | ✅ done | 0 | 5 | 0 | 0 | 100% |
 | 4 | Persona placebo benchmark (measure, don't adopt) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 5 | close out the source file | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 

--- a/agents/roadmaps/road-to-opt-council-deliberation.md
+++ b/agents/roadmaps/road-to-opt-council-deliberation.md
@@ -45,8 +45,9 @@ before any panel-mode work is considered.
 ## Prerequisites
 
 - [x] Provenance ENC1 token minted with the maintainer key (2026-07-11).
-- [ ] Confirm `tests/scripts/ai_council/_harness.ts` covers a fake-client
+- [x] Confirm `tests/scripts/ai_council/_harness.ts` covers a fake-client
       seam usable for tally/chairman tests (no billable calls in CI).
+      <!-- confirmed (2026-07-11 map correction): _harness.ts is the py2ts parity oracle; the actual no-billable seam is subclassing ExternalAIClient with an overridden ask() (orchestrator.test.ts Mock/CapturingMock) — used by every tally/chairman/gate test since. -->
 
 ## Context
 
@@ -273,12 +274,12 @@ visible repair cost.
       call per member per round, surfaced in the estimate and the
       round's spent-so-far line.
       <!-- PARTIAL: the config key (debate_gates.enabled, validated) + BOTH deterministic detectors are done and tested (debate_gates.ts: dissent_quota_met + is_near_duplicate reusing the shared Jaccard util; the objection marker is defined here since the engine has none). GATED: the bounded repair re-prompt (one billable call per member per round) + its auto-fire-vs-confirm POLICY are exactly what `blocker: contested-design-council-pass` reserves for /council:design; the policy is now DECIDED (council 2026-07-12, see ## Council notes; encoded in repair_action) — only the dispatch wiring remains. -->
-- [ ] `--restate` flag (and `ai_council.restate.enabled`, default
+- [x] `--restate` flag (and `ai_council.restate.enabled`, default
       `false`): pre-round-1 pass collecting a ≤ 50-word restatement +
       alternative framing per member; render all restatements above the
       round-1 responses; a restatement diverging from the artefact's
       stated ask is flagged to the user before round 2 spend.
-      <!-- PARTIAL: restate.enabled config key done + tested (default false). GATED: the pre-round-1 restatement pass is a billable per-member call — lands with the debate-gate dispatch. -->
+      <!-- done (restate PR, 2026-07-12): --restate CLI flag + config key; pre-round-1 pass via _run_round (spend gate/ledger/stamping unchanged) BEFORE any debate spend; restatements rendered above round 1 by cmd_debate; a low-overlap restatement vs the stated ask is flagged to stderr before further spend; restate responses included in the actual-cost total. Tested (extra call + on_restate + round prompt untouched; default-off parity). -->
 - [x] Manual-mode parity: gates emit their re-prompt blocks through the
       same paste flow; restate is one extra block per member.
       <!-- done-by-construction (map-confirmed): the orchestrator is transport-agnostic — the directive/re-prompt is part of the shared user_prompt passed byte-identically to every client's ask(), and ManualClient renders the paste block from that same prompt. No per-transport special-casing needed or added. -->

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -443,8 +443,11 @@ remaining wiring step.
   defend a position; change only on a specific named flaw; agreement without a
   named reason is conformity). Byte-identical across api/cli/manual (it is part of
   the shared `user_prompt`). Default-off keeps the debate path byte-identical.
-- `restate.enabled` (bool, default `false`) — reserved for the pre-round-1
-  restatement pass.
+- `restate.enabled` (bool, default `false`) — or the `--restate` debate flag:
+  a pre-round-1 pass collecting a ≤ 50-word restatement + one alternative
+  framing per member (billable, through the same spend gate), rendered above
+  the round-1 responses; a restatement with little token overlap vs the stated
+  ask is flagged before further spend.
 
 The deterministic post-round detectors — dissent-quota (`debate_gates.dissent_quota_met`)
 and the novelty gate (`debate_gates.is_near_duplicate`, reusing the shared

--- a/src/scripts/ai_council/orchestrator.ts
+++ b/src/scripts/ai_council/orchestrator.ts
@@ -1055,6 +1055,14 @@ export interface RunDebateOptions {
      * (no unplanned spend without an explicit transport).
      */
     on_repair?: ((member: string, reason: string) => boolean) | null;
+    /**
+     * Phase 3 restate pass (`ai_council.restate.enabled` / `--restate`): a
+     * pre-round-1 billable call per member collecting a <=50-word restatement
+     * + one alternative framing. Default off -> no extra calls, byte-identical.
+     */
+    restate?: boolean;
+    /** Receives the restate responses (rendering, divergence flags, cost). */
+    on_restate?: ((responses: CouncilResponse[]) => void) | null;
 }
 
 /**
@@ -1115,6 +1123,27 @@ export function run_debate(
     const spent: Spent = { input: 0, output: 0, usd: 0.0 };
     const all_rounds: CouncilResponse[][] = [];
     let current_user_prompt = question.user_prompt;
+
+    // Phase 3 restate: one pre-round-1 call per member. Runs BEFORE any debate
+    // spend so a diverging restatement can be flagged before round-2 cost.
+    if (opts.restate === true) {
+        const restateQ = new CouncilQuestion({
+            mode: question.mode,
+            user_prompt:
+                `Before the debate begins: RESTATE the question below in at most 50 words, ` +
+                `then offer ONE alternative framing of it. Do not argue a position yet.\n\n---\n\n` +
+                `${question.user_prompt}`,
+            max_tokens: question.max_tokens,
+        });
+        const restated = _run_round(members, restateQ, budget, spent, {
+            table,
+            on_overrun,
+            project,
+            original_ask,
+            advisor_plans,
+        });
+        opts.on_restate?.(restated);
+    }
 
     for (let round_idx = 0; round_idx < max_rounds; round_idx++) {
         const round_number = round_idx + 1;

--- a/src/scripts/council_cli.ts
+++ b/src/scripts/council_cli.ts
@@ -25,6 +25,7 @@ import {
     bundle_roadmap,
 } from './ai_council/bundler.js';
 import { select_chairman } from './ai_council/chairman.js';
+import { jaccardSimilarity } from './_lib/text_similarity.js';
 import type { ChairmanCandidate } from './ai_council/chairman.js';
 import { synthesis_template } from './ai_council/prompts.js';
 import type {
@@ -2287,6 +2288,31 @@ function cmd_debate(
         auto_continue: Boolean(_getattr(args, 'auto_continue', false)),
     });
 
+    // Phase 3: restate pass — CLI flag OR config key; default off.
+    const restate_on =
+        Boolean(_getattr(args, 'restate', false)) ||
+        (_isDict(ai_cfg) && _isDict(ai_cfg['restate']) && (ai_cfg['restate'] as Dict)['enabled'] === true);
+    const restate_responses: CouncilResponse[] = [];
+    const ask_for_divergence = (args.original_ask as string) || '';
+    const on_restate = (rs: CouncilResponse[]): void => {
+        restate_responses.push(...rs);
+        const blocks = rs
+            .filter((r) => !r.error && r.text.trim() !== '')
+            .map((r) => `### ${r.provider} - ${r.model}\n\n${r.text.trim()}`);
+        if (blocks.length > 0) {
+            _stdout(`\n## Restatements (pre-round-1)\n\n${blocks.join('\n\n')}\n`);
+        }
+        // Divergence flag BEFORE further spend: a restatement far from the
+        // stated ask is surfaced to the user (Jaccard over token sets).
+        if (ask_for_divergence.trim() !== '') {
+            for (const r of rs) {
+                if (!r.error && r.text.trim() !== '' && jaccardSimilarity(ask_for_divergence, r.text) < 0.1) {
+                    _stderr(`⚠️  restate divergence: ${r.provider} restated the ask with little overlap — verify framing before continuing.\n`);
+                }
+            }
+        }
+    };
+
     // Phase 3: debate gates (anti-conformity directive on round 2+). Read
     // defensively from the raw ai_council block — a malformed/absent
     // `debate_gates` reads as off, keeping the debate prompt byte-identical.
@@ -2307,6 +2333,8 @@ function cmd_debate(
             on_continue,
             debate_gates: debate_gates_on,
             on_repair: debate_gates_on ? _make_repair_confirm(Boolean(_getattr(args, 'auto_continue', false))) : null,
+            restate: restate_on,
+            on_restate: restate_on ? on_restate : null,
             advisor_plans,
             seed_round_1: seed,
         });
@@ -2324,7 +2352,7 @@ function cmd_debate(
     }
 
     let actual_total = 0.0;
-    for (const rnd of all_rounds) {
+    for (const rnd of [...all_rounds, restate_responses]) {
         for (const r of rnd) {
             if (r.error) {
                 continue;
@@ -2571,6 +2599,7 @@ interface Args {
     single: boolean;
     prose_synthesis: boolean | null;
     auto_continue: boolean;
+    restate?: boolean;
     continue_as_debate: string | null;
     // render / replay
     responses?: string | null;
@@ -2700,6 +2729,7 @@ function _specsFor(cmd: string): { positionals: string[]; opts: OptSpec[]; requi
                     { flag: '--confirm', takesValue: false, apply: (o) => (o.confirm = true) },
                     { flag: '--rounds', takesValue: true, isInt: true, apply: (o, v) => (o.rounds = v === null ? null : parseInt(v, 10)) },
                     { flag: '--auto-continue', takesValue: false, apply: (o) => (o.auto_continue = true) },
+                    { flag: '--restate', takesValue: false, apply: (o) => (o.restate = true) },
                     { flag: '--continue-as-debate', takesValue: true, apply: (o, v) => (o.continue_as_debate = v) },
                     { flag: '--invocation', takesValue: true, choices: ['agent', 'user_explicit'], apply: (o, v) => (o.invocation = v as string) },
                     { flag: '--proceed-anyway', takesValue: false, apply: (o) => (o.proceed_anyway = true) },

--- a/tests/scripts/ai_council/orchestrator.test.ts
+++ b/tests/scripts/ai_council/orchestrator.test.ts
@@ -509,3 +509,31 @@ describe('stance repair call (Phase 1 wiring)', () => {
         expect(hasStance.prompts.length).toBe(1);
     });
 });
+
+describe('restate pass (Phase 3 wiring)', () => {
+    const q = new CouncilQuestion({ mode: 'prompt', user_prompt: 'A or B?' });
+
+    it('restate on → one pre-round-1 call per member, surfaced via on_restate', () => {
+        const a = new CapturingMock('anthropic', 'm', ['Restated: choose A or B.', 'pos A']);
+        const b = new CapturingMock('openai', 'm', ['Restated: pick between A and B.', 'pos B']);
+        const seen: CouncilResponse[][] = [];
+        const rounds = run_debate([a, b], q, {
+            max_rounds: 1,
+            restate: true,
+            on_restate: (rs) => seen.push(rs),
+        });
+        expect(a.prompts.length).toBe(2); // restate + round 1
+        expect(a.prompts[0]).toContain('RESTATE');
+        expect(a.prompts[1]).not.toContain('RESTATE');
+        expect(seen).toHaveLength(1);
+        expect(seen[0]!.map((r) => r.text)).toEqual(['Restated: choose A or B.', 'Restated: pick between A and B.']);
+        expect(rounds[0]!.map((r) => r.text)).toEqual(['pos A', 'pos B']);
+    });
+
+    it('default off → no extra call, round-1 prompt untouched', () => {
+        const a = new CapturingMock('anthropic', 'm', ['pos A']);
+        run_debate([a], q, { max_rounds: 1 });
+        expect(a.prompts.length).toBe(1);
+        expect(a.prompts[0]).toBe(q.user_prompt);
+    });
+});


### PR DESCRIPTION
## What

The **final autonomous wiring slice** of `road-to-opt-council-deliberation`: the Phase-3 **restate pass**, end-to-end and default-off. With this, **every non-spend-gated step of the roadmap is done**.

## Wired (default-off = byte-identical)

- **`run_debate` pre-round-1 pass** — when restate is on (`--restate` flag OR `ai_council.restate.enabled`): one call per member collecting a ≤ 50-word restatement + one alternative framing, via `_run_round` (spend gate, daily ledger, metadata stamping unchanged), **before any debate spend**.
- **`cmd_debate`** renders the restatements above round 1; a restatement with little token overlap vs the stated ask is **flagged to stderr before further spend** (the divergence check the roadmap asked for); restate responses are included in the actual-cost total (cost honesty).
- **Manual-mode parity by construction** — one more paste block through the shared transport-agnostic `ask()`.
- Also flips the long-confirmed harness-seam prerequisite checkbox (the fake-client seam is `ExternalAIClient` subclassing, map-corrected 2026-07-11).

## Verification

Suite **445 green** (2 new tests: restate call + `on_restate` + round-1 prompt untouched; default-off parity), typecheck 0, md-language/refs/condensation clean. Contract doc updated.

## Roadmap state after this PR

Phases 0–3 **fully complete** (stance tally + repair, chairman + ADR-120, debate gates + repairs, restate). Remaining: **Phase 4** (persona placebo benchmark) + **Phase 5** (close-out) — both behind `blocker: benchmark-spend-authorization`, i.e. the maintainer's billable benchmark run.