### PR TITLE
feat(bench): length-neutral judge rerun executed — second inconclusive, gate CLOSED-BY-DIAGNOSIS (road-to-opt-measurement-unblock)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**110 / 375 steps done · 29%**
+**113 / 375 steps done · 30%**
 
 ```text
-████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   29%
+████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   30%
 ```
 
 ## Open roadmaps
@@ -35,7 +35,7 @@
 | 17 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
 | 19 | [road-to-opt-council-deliberation.md](roadmaps/road-to-opt-council-deliberation.md) | 6 | 29 | 7 | 22 | 0 | 0 | [1](#blockers-road-to-opt-council-deliberation) | ████████░░ 76% |
-| 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 8 | 2 | 0 | 0 | 0 | ██░░░░░░░░ 20% |
+| 20 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 5 | 5 | 0 | 0 | 0 | █████░░░░░ 50% |
 | 21 | [road-to-opt-retrieval-and-memory.md](roadmaps/road-to-opt-retrieval-and-memory.md) | 4 | 12 | 2 | 10 | 0 | 0 | 0 | ████████░░ 83% |
 | 22 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
 | 23 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 6 | 33 | 5 | 28 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 85% |
@@ -268,11 +268,11 @@ _1 blocker resolved._
 
 ### [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md)
 
-**Road to opt measurement unblock — one judge run cascade-unblocks the token program** — 2 / 10 done (20%)
+**Road to opt measurement unblock — one judge run cascade-unblocks the token program** — 5 / 10 done (50%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | length-neutral judge rerun (the cascade key) | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
+| 1 | length-neutral judge rerun (the cascade key) | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 2 | non-Claude lift replication (discipline_profile auto flip gate) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 3 | cross-model e2e parity eval: re-scope the keystone | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 

--- a/agents/roadmaps/later/road-to-token-proof-and-story.md
+++ b/agents/roadmaps/later/road-to-token-proof-and-story.md
@@ -48,6 +48,16 @@ evidence-backed value prop tested at N=1, not the assumed adoption blocker.
 
 ## Context — verified on the live checkout, 2026-07-07
 
+> **Gate update (2026-07-12):** the thin-vs-eager quality question is
+> **CLOSED-BY-DIAGNOSIS** — the length-neutral rerun (double-blind
+> cross-family judges, ±15% pairing, pre-registered n=90) returned the SECOND
+> inconclusive (κ=0.46 < 0.60; 65/90 pairs length-dropped; ρ=0.45 within-band;
+> 7 agreed decisive pairs). Per the pre-registered design, no third
+> paired-judge run: any future attempt must use a categorically different
+> method (deterministic anchor-scoring). Thin stays disabled. Evidence:
+> `internal/bench/reports/quality-rerun-length-neutral.json` +
+> `docs/benchmark.md` § Length-neutral judge RERUN.
+
 - **Gate hole (live-verified):** `bench_quality_run --dry-run` writes
   `internal/bench/reports/quality-run.json` (`dry_run: true`, 30 mock ties);
   `check_quality_regression` consumes it and **exits 0** ("inconclusive —

--- a/agents/roadmaps/road-to-opt-measurement-unblock.md
+++ b/agents/roadmaps/road-to-opt-measurement-unblock.md
@@ -54,18 +54,18 @@ longer holds — turning the portfolio's measurement debt into verdicts.
       fix the sample size from the golden corpus before the first
       billable call.
       <!-- done: docs/design/length-neutral-judge-rerun.md — (a) ±15% length-matched pairs AND a length-partialed rubric with a Spearman-ρ confound flag; (b) strongest judge tier + blind second judge reported via the EXISTING cohensKappa/judgeKappa in check_quality_regression.ts (reuse, not rebuild), κ ≥ 0.60 floor; (c) pre-registered n for 80% power at ≥10pp, fixed before the first call, sign-test/McNemar. Report schema + disposition specified. -->
-- [ ] Render the cost estimate (`council:estimate`-class disclosure) and
+- [x] Render the cost estimate (`council:estimate`-class disclosure) and
       confirm the run budget in-session before executing.
-      <!-- GATED: billable run — needs an in-session estimate + the maintainer's budget confirmation (Hard-Floor money-moving). Not auto-fired. -->
-- [ ] Execute the paired judge run; write the verdict artifact under
+      <!-- done (2026-07-12): estimate disclosed in-session (~$40-45 expected, judges probed for $0.02, 1-task smoke $0.36) against the maintainer's confirmed EUR 250 cap; hard --max-usd 250 guard enforced in the runner. -->
+- [x] Execute the paired judge run; write the verdict artifact under
       `internal/bench/reports/` with κ and confound diagnostics inline.
-      <!-- GATED: the judged run is money-moving AND an interactive /dev/tty gate that hard-aborts under automation. Maintainer executes per the design doc above. -->
-- [ ] Disposition step: on a trustworthy verdict (either direction),
+      <!-- done (2026-07-12): bench_quality_rerun.ts executed live — n=90 pre-registered, ±15% token-band pairing (25 surviving / 65 dropped), double blind judges claude-opus-4-8 + gpt-4o both orders, kappa + Spearman diagnostics inline; artifact internal/bench/reports/quality-rerun-length-neutral.json; actual $34.80 (cap $250). -->
+- [x] Disposition step: on a trustworthy verdict (either direction),
       update the token-program tracking table in
       `road-to-token-proof-and-story.md` and unblock/close the dependent
       gates; on a second inconclusive, record WHY with the diagnostics
       and stop — no third run without a design change.
-      <!-- GATED: fires only once the run above produces a verdict. -->
+      <!-- done (2026-07-12): SECOND INCONCLUSIVE (kappa=0.46 < 0.60 floor; rho=0.45 flagged; 7 agreed decisive) -> per the pre-registered design: WHY recorded (docs/benchmark.md § Length-neutral judge RERUN — the signal is structurally length-dominated and judge-noise-dominated in BOTH designs) and STOP, no third run without a categorically different method. Token-program table updated: gate CLOSED-BY-DIAGNOSIS in road-to-token-proof-and-story.md. -->
       <!-- verify: test -f docs/design/length-neutral-judge-rerun.md -->
 
 **Exit criteria:** verdict artifact exists with κ ≥ agreed floor and no

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -454,3 +454,42 @@ covers only 14/89 rules (operator hand-labelling), a separate gap.
   API-gated); gate: `src/scripts/check_quality_regression.ts` (inert until a
   `quality-run.json` — gitignored — exists locally).
 - Roadmap: `agents/roadmaps/road-to-token-saving.md` Phase 0.
+
+## Length-neutral judge RERUN (2026-07-12) — SECOND INCONCLUSIVE, gate CLOSED-BY-DIAGNOSIS
+
+**Verdict: `inconclusive-low-kappa` — and per the pre-registered design
+(`docs/design/length-neutral-judge-rerun.md`) a second inconclusive means
+RECORD WHY AND STOP: no third run without a design change. The thin lever
+stays NOT adopted; further paired-judge spend on this question is closed.**
+
+The rerun fixed all three recorded failure modes *by construction* — ±15%
+output-token pair matching with a reported dropped-bucket, two arm-blind
+judges from different provider families (claude-opus-4-8 + gpt-4o, both
+orders, reject-on-flip) with a κ ≥ 0.60 admissibility floor, a Spearman-ρ
+length diagnostic (|ρ| ≥ 0.3 withholds), and a pre-registered n = 90 (the
+full council-labelled corpus). Runner: `src/scripts/bench_quality_rerun.ts`;
+artifact: `internal/bench/reports/quality-rerun-length-neutral.json`;
+actual cost $34.80 (cap $250).
+
+**Why the gate is now closed rather than pending — the diagnostics carry the
+answer:**
+
+| Diagnostic | Value | Reading |
+|---|---|---|
+| Pair survival | **25/90** (65 dropped by the ±15% band) | Eager answers are *systematically* longer — the length difference is structural to the arms, not noise a judge can be told to ignore |
+| Cross-family judge agreement | **κ = 0.46** (< 0.60 floor) | Even top-tier judges from different vendors disagree on which answer is better — the rubric-visible quality difference is smaller than judge noise |
+| Length leakage within the band | **ρ = 0.45** (flagged ≥ 0.3) | Even among length-matched pairs, wins still track length |
+| Agreed decisive pairs | **7** (thin 3 / eager 4, p = 1.0) | Nothing separable remains once length and judge noise are controlled |
+
+**The honest conclusion:** the thin-vs-eager output-quality question is not
+resolvable by LLM-paired judging on this corpus — the measurable signal is
+dominated by structural length effects and judge disagreement, in BOTH the
+naive (2026-07-09/11) and the length-neutral (2026-07-12) designs. This is a
+*diagnosis*, not a "pending": the thin projection stays DISABLED on the
+existing precedent, the quality-regression gate stays inert, and any future
+attempt must use a categorically different method (e.g. deterministic
+anchor-scoring against `must_include`/`must_not`, not pairwise LLM judging).
+
+- Runner: `src/scripts/bench_quality_rerun.ts` (design-pinned constants:
+  band ±15%, κ floor 0.60, ρ flag 0.3, effect floor 10pp; `--max-usd` guard).
+- Roadmap: `agents/roadmaps/road-to-opt-measurement-unblock.md` Phase 1.

--- a/internal/bench/reports/quality-rerun-length-neutral.json
+++ b/internal/bench/reports/quality-rerun-length-neutral.json
@@ -1,0 +1,411 @@
+{
+  "generated_by": "bench_quality_rerun",
+  "design": "docs/design/length-neutral-judge-rerun.md",
+  "dry_run": false,
+  "gen_model": "claude-sonnet-4-5",
+  "judges": [
+    "claude-opus-4-8",
+    "gpt-4o"
+  ],
+  "preregistered": {
+    "n": 90,
+    "pair_band": 0.15,
+    "kappa_floor": 0.6,
+    "spearman_flag": 0.3,
+    "effect_floor_pp": 10,
+    "power_note": "n is corpus-limited (all labelled golden tasks); 80% power at ≥10pp needs ~190 decisive pairs — achievable power at this n is lower and stated rather than grown post-hoc."
+  },
+  "pairing": {
+    "surviving": 25,
+    "dropped": 65,
+    "dropped_ids": [
+      "tq-scope-01",
+      "tq-scope-02",
+      "tq-evidence-01",
+      "tq-testing-02",
+      "tq-security-01",
+      "tq-performance-01",
+      "tq-performance-02",
+      "tq-review-01",
+      "tq-review-02",
+      "tq-docs-01",
+      "tq-docs-02",
+      "tq-architecture-01",
+      "tq-refactor-01",
+      "tq-refactor-02",
+      "tq-roadmap-01",
+      "tq-roadmap-02",
+      "tq-subagent-02",
+      "tq-summary-01",
+      "tq-language-01",
+      "tq-language-02",
+      "tq-hallucination-01",
+      "tq-user-intent-01",
+      "tq-user-intent-02",
+      "tq-floor-eng-01",
+      "tq-floor-fin-01",
+      "tq-floor-legal-01",
+      "tq-floor-trifecta-01",
+      "tq-git-flow-01",
+      "tq-stack-symfony-01",
+      "tq-design-fid-01",
+      "tq-brand-01",
+      "tq-ui-audit-01",
+      "tq-interact-01",
+      "tq-interrupt-01",
+      "tq-hygiene-01",
+      "tq-tokeneff-01",
+      "tq-autonomy-01",
+      "tq-cmd-route-01",
+      "tq-authority-01",
+      "tq-output-01",
+      "tq-quote-01",
+      "tq-external-01",
+      "tq-invite-01",
+      "tq-decision-01",
+      "tq-missing-tool-01",
+      "tq-model-rec-01",
+      "tq-attrib-01",
+      "tq-onboard-01",
+      "tq-role-01",
+      "tq-cli-01",
+      "tq-copilot-01",
+      "tq-source-disc-01",
+      "tq-media-gov-01",
+      "tq-media-sync-01",
+      "tq-domain-disc-01",
+      "tq-domain-pii-01",
+      "tq-domain-ret-01",
+      "tq-upstream-01",
+      "tq-exec-safety-01",
+      "tq-rem-01",
+      "tq-cmt-01",
+      "tq-grf-01",
+      "tq-enm-01",
+      "tq-qst-01",
+      "tq-sen-01"
+    ]
+  },
+  "judge_agreement": {
+    "kappa": 0.4612,
+    "kappa_floor": 0.6
+  },
+  "length_diagnostic": {
+    "spearman_rho": 0.4493585171364585,
+    "flag_at": 0.3,
+    "flagged": true
+  },
+  "result": {
+    "agreed_decisive": 7,
+    "agreed_thin": 3,
+    "agreed_eager": 4,
+    "sign_test_p": 1,
+    "thin_win_rate": 0.42857142857142855
+  },
+  "judge1_results": [
+    {
+      "id": "tq-direct-01",
+      "winner": "tie",
+      "length_delta": 120,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-direct-02",
+      "winner": "tie",
+      "length_delta": 0,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-evidence-02",
+      "winner": "thin",
+      "length_delta": -212,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-rootcause-01",
+      "winner": "thin",
+      "length_delta": -423,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-testing-01",
+      "winner": "thin",
+      "length_delta": -7,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-security-02",
+      "winner": "tie",
+      "length_delta": -171,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-subagent-01",
+      "winner": "tie",
+      "length_delta": 25,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-floor-strat-01",
+      "winner": "inconsistent",
+      "length_delta": 50,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-floor-nondestruct-01",
+      "winner": "inconsistent",
+      "length_delta": -149,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-floor-untrusted-01",
+      "winner": "tie",
+      "length_delta": 107,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-git-hist-01",
+      "winner": "thin",
+      "length_delta": -59,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-stack-laravel-01",
+      "winner": "inconsistent",
+      "length_delta": -64,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-notes-01",
+      "winner": "thin",
+      "length_delta": -154,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-markdown-01",
+      "winner": "eager",
+      "length_delta": 15,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-devcontainer-01",
+      "winner": "inconsistent",
+      "length_delta": -1,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-linked-01",
+      "winner": "inconsistent",
+      "length_delta": -151,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-artifact-01",
+      "winner": "eager",
+      "length_delta": -74,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-telemetry-01",
+      "winner": "eager",
+      "length_delta": 215,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-skill-imp-01",
+      "winner": "inconsistent",
+      "length_delta": 66,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-fastpath-01",
+      "winner": "inconsistent",
+      "length_delta": 11,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-roadmap-sync-01",
+      "winner": "thin",
+      "length_delta": 171,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-roadmap-ci-01",
+      "winner": "eager",
+      "length_delta": -508,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-bac-01",
+      "winner": "thin",
+      "length_delta": 1456,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-ctl-01",
+      "winner": "eager",
+      "length_delta": 192,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-spr-01",
+      "winner": "eager",
+      "length_delta": 44,
+      "winner_is_longer": false
+    }
+  ],
+  "judge2_results": [
+    {
+      "id": "tq-direct-01",
+      "winner": "tie",
+      "length_delta": 120,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-direct-02",
+      "winner": "tie",
+      "length_delta": 0,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-evidence-02",
+      "winner": "inconsistent",
+      "length_delta": -212,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-rootcause-01",
+      "winner": "inconsistent",
+      "length_delta": -423,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-testing-01",
+      "winner": "thin",
+      "length_delta": -7,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-security-02",
+      "winner": "tie",
+      "length_delta": -171,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-subagent-01",
+      "winner": "tie",
+      "length_delta": 25,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-floor-strat-01",
+      "winner": "thin",
+      "length_delta": 50,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-floor-nondestruct-01",
+      "winner": "thin",
+      "length_delta": -149,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-floor-untrusted-01",
+      "winner": "inconsistent",
+      "length_delta": 107,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-git-hist-01",
+      "winner": "inconsistent",
+      "length_delta": -59,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-stack-laravel-01",
+      "winner": "inconsistent",
+      "length_delta": -64,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-notes-01",
+      "winner": "eager",
+      "length_delta": -154,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-markdown-01",
+      "winner": "eager",
+      "length_delta": 15,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-devcontainer-01",
+      "winner": "inconsistent",
+      "length_delta": -1,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-linked-01",
+      "winner": "inconsistent",
+      "length_delta": -151,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-artifact-01",
+      "winner": "eager",
+      "length_delta": -74,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-telemetry-01",
+      "winner": "inconsistent",
+      "length_delta": 215,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-skill-imp-01",
+      "winner": "eager",
+      "length_delta": 66,
+      "winner_is_longer": false
+    },
+    {
+      "id": "tq-fastpath-01",
+      "winner": "inconsistent",
+      "length_delta": 11,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-roadmap-sync-01",
+      "winner": "thin",
+      "length_delta": 171,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-roadmap-ci-01",
+      "winner": "eager",
+      "length_delta": -508,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-bac-01",
+      "winner": "thin",
+      "length_delta": 1456,
+      "winner_is_longer": true
+    },
+    {
+      "id": "tq-ctl-01",
+      "winner": "inconsistent",
+      "length_delta": 192,
+      "winner_is_longer": null
+    },
+    {
+      "id": "tq-spr-01",
+      "winner": "eager",
+      "length_delta": 44,
+      "winner_is_longer": false
+    }
+  ],
+  "cost_usd_actual": 34.7951,
+  "verdict": "inconclusive-low-kappa (κ=0.46 < 0.6)"
+}

--- a/src/scripts/bench_quality_rerun.ts
+++ b/src/scripts/bench_quality_rerun.ts
@@ -1,0 +1,357 @@
+#!/usr/bin/env tsx
+/**
+ * Length-neutral thin-vs-eager judge RERUN (road-to-opt-measurement-unblock
+ * Phase 1; design: docs/design/length-neutral-judge-rerun.md).
+ *
+ * The 2026-07-09/11 runs were untrustworthy on three recorded failure modes;
+ * this rerun fixes each BY CONSTRUCTION:
+ *   (a) length confound — pairs outside a ±15% output-token band are DROPPED
+ *       (reported, never silently discarded) AND a Spearman-ρ win-vs-length
+ *       diagnostic flags residual leakage (|ρ| ≥ 0.3 → verdict withheld);
+ *   (b) judge inconsistency — TWO arm-blind judges from different provider
+ *       families (strongest Anthropic tier + OpenAI), each judging both orders
+ *       (reject-on-flip), reported as Cohen's κ with a ≥ 0.60 admissibility
+ *       floor (`judgeKappa` — its first production caller);
+ *   (c) underpowered — n is PRE-REGISTERED as the full labelled corpus before
+ *       the first billable call; the achievable power at the corpus size is
+ *       stated honestly in the report (corpus-limited, not grown post-hoc).
+ *
+ * Budget: --max-usd guard — cumulative actual spend (usage × PRICES) aborts
+ * the run before the call that would breach the cap.
+ *
+ * CLI:
+ *   ./scripts-run src/scripts/bench_quality_rerun --dry-run
+ *   ./scripts-run src/scripts/bench_quality_rerun --max-usd 250 [--limit N]
+ *     [--gen-model claude-sonnet-4-5] [--judge1 claude-opus-4-8] [--judge2 gpt-4o]
+ *
+ * Exit codes: 0 wrote report · 1 error · 2 budget abort.
+ */
+import { createRequire } from 'node:module';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+  assemble_contexts,
+  judge_prompt,
+  load_golden,
+  parse_verdict,
+  type GoldenTask,
+} from './bench_quality_run.js';
+import {
+  evaluatePair,
+  judgeKappa,
+  type JudgeFn,
+  type PairResult,
+} from './check_quality_regression.js';
+import { signTestP } from './second_brain_retrieval.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const OUT = path.join(REPO_ROOT, 'internal/bench/reports/quality-rerun-length-neutral.json');
+
+/** Pre-registered analysis constants — fixed BEFORE the first billable call. */
+export const PAIR_BAND = 0.15; // ±15% output-token band
+export const KAPPA_FLOOR = 0.6;
+export const SPEARMAN_FLAG = 0.3; // |ρ| at or above → length-confounded
+export const EFFECT_FLOOR_PP = 10; // smallest effect worth shipping (pp from 50%)
+
+/** USD per 1M tokens (mirrors internal/bench/pricing.yaml + public OpenAI). */
+const PRICES: Array<{ needle: string; in_usd: number; out_usd: number }> = [
+  { needle: 'opus', in_usd: 15.0, out_usd: 75.0 },
+  { needle: 'sonnet', in_usd: 3.0, out_usd: 15.0 },
+  { needle: 'haiku', in_usd: 0.25, out_usd: 1.25 },
+  { needle: 'gpt-4o', in_usd: 2.5, out_usd: 10.0 },
+];
+
+export function price_usd(model: string, in_tok: number, out_tok: number): number {
+  const p = PRICES.find((x) => model.includes(x.needle));
+  if (p === undefined) return 0;
+  return (in_tok / 1e6) * p.in_usd + (out_tok / 1e6) * p.out_usd;
+}
+
+/** ±band pairing filter on output tokens. */
+export function within_band(thinTok: number, eagerTok: number, band = PAIR_BAND): boolean {
+  const mx = Math.max(thinTok, eagerTok);
+  if (mx === 0) return true;
+  return Math.abs(thinTok - eagerTok) / mx <= band;
+}
+
+/** Spearman rank correlation (average-rank ties). */
+export function spearman(xs: readonly number[], ys: readonly number[]): number {
+  const n = Math.min(xs.length, ys.length);
+  if (n < 3) return 0;
+  const rank = (v: readonly number[]): number[] => {
+    const idx = v.map((x, i) => [x, i] as const).sort((a, b) => a[0] - b[0]);
+    const r = new Array<number>(n);
+    let i = 0;
+    while (i < n) {
+      let j = i;
+      while (j + 1 < n && (idx[j + 1] as [number, number])[0] === (idx[i] as [number, number])[0]) j++;
+      const avg = (i + j) / 2 + 1;
+      for (let k = i; k <= j; k++) r[(idx[k] as [number, number])[1]] = avg;
+      i = j + 1;
+    }
+    return r;
+  };
+  const rx = rank(xs.slice(0, n));
+  const ry = rank(ys.slice(0, n));
+  const mean = (n + 1) / 2;
+  let num = 0;
+  let dx = 0;
+  let dy = 0;
+  for (let i = 0; i < n; i++) {
+    const a = (rx[i] as number) - mean;
+    const b = (ry[i] as number) - mean;
+    num += a * b;
+    dx += a * a;
+    dy += b * b;
+  }
+  const den = Math.sqrt(dx * dy);
+  return den === 0 ? 0 : num / den;
+}
+
+export interface RerunVerdictInput {
+  kappa: number;
+  rho: number;
+  agreed_thin: number;
+  agreed_eager: number;
+}
+
+/** Pre-registered verdict logic (pure). */
+export function decide_verdict(v: RerunVerdictInput): string {
+  if (!Number.isFinite(v.kappa) || v.kappa < KAPPA_FLOOR) {
+    return `inconclusive-low-kappa (κ=${v.kappa.toFixed(2)} < ${KAPPA_FLOOR})`;
+  }
+  if (Math.abs(v.rho) >= SPEARMAN_FLAG) {
+    return `inconclusive-length-confounded (|ρ|=${Math.abs(v.rho).toFixed(2)} ≥ ${SPEARMAN_FLAG})`;
+  }
+  const n = v.agreed_thin + v.agreed_eager;
+  if (n === 0) return 'inconclusive-no-decisive-pairs';
+  const p = signTestP(v.agreed_thin, v.agreed_eager);
+  const rate = v.agreed_thin / n;
+  const pp = Math.abs(rate - 0.5) * 100;
+  if (p < 0.05 && pp >= EFFECT_FLOOR_PP) {
+    return rate > 0.5
+      ? `ships-lift (thin wins ${(rate * 100).toFixed(1)}%, p=${p.toFixed(4)})`
+      : `honest-null-thin-loses (thin ${(rate * 100).toFixed(1)}%, p=${p.toFixed(4)})`;
+  }
+  return `inconclusive-underpowered (p=${p.toFixed(4)}, effect ${pp.toFixed(1)}pp, n=${n})`;
+}
+
+interface Args {
+  dryRun: boolean;
+  genModel: string;
+  judge1: string;
+  judge2: string;
+  limit: number | null;
+  maxUsd: number;
+  output: string;
+}
+
+function parse_args(argv: string[]): Args | number {
+  const a: Args = {
+    dryRun: false,
+    genModel: 'claude-sonnet-4-5',
+    judge1: 'claude-opus-4-8',
+    judge2: 'gpt-4o',
+    limit: null,
+    maxUsd: 250,
+    output: OUT,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') a.dryRun = true;
+    else if (arg === '--gen-model') a.genModel = String(argv[(i += 1)] ?? a.genModel);
+    else if (arg === '--judge1') a.judge1 = String(argv[(i += 1)] ?? a.judge1);
+    else if (arg === '--judge2') a.judge2 = String(argv[(i += 1)] ?? a.judge2);
+    else if (arg === '--output') a.output = String(argv[(i += 1)] ?? a.output);
+    else if (arg === '--limit') a.limit = Number(argv[(i += 1)]);
+    else if (arg === '--max-usd') a.maxUsd = Number(argv[(i += 1)]);
+    else if (arg === '-h' || arg === '--help') {
+      process.stdout.write(
+        'usage: bench_quality_rerun [--dry-run] [--gen-model M] [--judge1 M] [--judge2 M] [--limit N] [--max-usd X] [--output PATH]\n',
+      );
+      return 0;
+    } else {
+      process.stderr.write(`error: unknown argument: ${arg}\n`);
+      return 1;
+    }
+  }
+  return a;
+}
+
+interface AskClient {
+  ask(system: string, user: string): { text: string; input_tokens: number; output_tokens: number };
+}
+
+function main(argv: string[]): number {
+  const parsed = parse_args(argv);
+  if (typeof parsed === 'number') return parsed;
+  const args = parsed;
+
+  let tasks = load_golden();
+  if (args.limit !== null && Number.isInteger(args.limit) && args.limit > 0) {
+    tasks = tasks.slice(0, args.limit);
+  }
+  const preregistered_n = tasks.length;
+  const contexts = assemble_contexts();
+
+  let spent = 0;
+  const guard = (model: string, in_tok: number, out_tok: number): void => {
+    spent += price_usd(model, in_tok, out_tok);
+    if (spent > args.maxUsd) {
+      process.stderr.write(`\n❌  budget abort: cumulative $${spent.toFixed(2)} > cap $${args.maxUsd}\n`);
+      process.exit(2);
+    }
+  };
+
+  let gen: AskClient;
+  let j1: AskClient;
+  let j2: AskClient;
+  if (args.dryRun) {
+    let flip = 0;
+    const mk = (): AskClient => ({
+      ask: (_s: string, u: string) => ({
+        text: /VERDICT/.test(u) || /ANSWER A/.test(u) ? 'VERDICT: TIE' : `mock answer ${(flip += 1)}`,
+        input_tokens: 100,
+        output_tokens: 50,
+      }),
+    });
+    gen = mk();
+    j1 = mk();
+    j2 = mk();
+    process.stdout.write('⚠️  --dry-run: deterministic mock, no API.\n');
+  } else {
+    const require = createRequire(import.meta.url);
+    const c = require('./ai_council/clients.js') as {
+      AnthropicClient: new (o: { model: string; api_key: string }) => AskClient;
+      OpenAIClient: new (o: { model: string; api_key: string }) => AskClient;
+      load_anthropic_key: () => string;
+      load_openai_key: () => string;
+    };
+    const akey = c.load_anthropic_key();
+    gen = new c.AnthropicClient({ model: args.genModel, api_key: akey });
+    j1 = new c.AnthropicClient({ model: args.judge1, api_key: akey });
+    j2 = new c.OpenAIClient({ model: args.judge2, api_key: c.load_openai_key() });
+    process.stdout.write(
+      `Live rerun: n=${preregistered_n} (pre-registered) × 2 arms; judges ${args.judge1} + ${args.judge2}; cap $${args.maxUsd}.\n`,
+    );
+  }
+
+  // ── Generation (thin + eager per task, output tokens recorded) ────────────
+  const SYS =
+    'You are an AI coding agent governed by the following always-loaded package rules. ' +
+    'Answer the user request as that agent would, honouring these rules:\n\n';
+  interface Gen {
+    task: GoldenTask;
+    thin: string;
+    eager: string;
+    thin_tok: number;
+    eager_tok: number;
+  }
+  const gens: Gen[] = [];
+  for (const task of tasks) {
+    const rt = gen.ask(SYS + contexts.thin, task.prompt);
+    guard(args.genModel, rt.input_tokens, rt.output_tokens);
+    const re = gen.ask(SYS + contexts.eager, task.prompt);
+    guard(args.genModel, re.input_tokens, re.output_tokens);
+    gens.push({ task, thin: rt.text, eager: re.text, thin_tok: rt.output_tokens, eager_tok: re.output_tokens });
+    process.stdout.write(`  gen ${task.id} (thin ${rt.output_tokens}t / eager ${re.output_tokens}t) $${spent.toFixed(2)}\n`);
+  }
+
+  // ── Pairing filter (±band on output tokens) ───────────────────────────────
+  const surviving = gens.filter((g) => within_band(g.thin_tok, g.eager_tok));
+  const dropped = gens.filter((g) => !within_band(g.thin_tok, g.eager_tok));
+  process.stdout.write(`pairing: ${surviving.length} surviving / ${dropped.length} dropped (±${PAIR_BAND * 100}% band)\n`);
+
+  // ── Two blind judges, both orders each ────────────────────────────────────
+  const judgeWith = (client: AskClient, model: string): PairResult[] =>
+    surviving.map((g) => {
+      const fn: JudgeFn = (_ctx, first, second) => {
+        const r = client.ask('You are a strict, length-neutral answer judge.', judge_prompt(g.task, first, second));
+        guard(model, r.input_tokens, r.output_tokens);
+        return parse_verdict(r.text);
+      };
+      return evaluatePair(g.task, g.thin, g.eager, fn);
+    });
+  const r1 = judgeWith(j1, args.judge1);
+  const r2 = judgeWith(j2, args.judge2);
+
+  // ── Stats (pre-registered) ─────────────────────────────────────────────────
+  const kappa = judgeKappa(r1, r2);
+  const byId2 = new Map(r2.map((r) => [r.id, r.winner]));
+  const agreed = r1.filter(
+    (r) => (r.winner === 'thin' || r.winner === 'eager') && byId2.get(r.id) === r.winner,
+  );
+  const agreed_thin = agreed.filter((r) => r.winner === 'thin').length;
+  const agreed_eager = agreed.filter((r) => r.winner === 'eager').length;
+  const tokDelta = new Map(surviving.map((g) => [g.task.id, g.thin_tok - g.eager_tok]));
+  const rho = spearman(
+    agreed.map((r) => tokDelta.get(r.id) ?? 0),
+    agreed.map((r) => (r.winner === 'thin' ? 1 : -1)),
+  );
+  const p = signTestP(agreed_thin, agreed_eager);
+  const verdict = decide_verdict({ kappa, rho, agreed_thin, agreed_eager });
+
+  const payload = {
+    generated_by: 'bench_quality_rerun',
+    design: 'docs/design/length-neutral-judge-rerun.md',
+    dry_run: args.dryRun,
+    gen_model: args.genModel,
+    judges: [args.judge1, args.judge2],
+    preregistered: {
+      n: preregistered_n,
+      pair_band: PAIR_BAND,
+      kappa_floor: KAPPA_FLOOR,
+      spearman_flag: SPEARMAN_FLAG,
+      effect_floor_pp: EFFECT_FLOOR_PP,
+      power_note:
+        'n is corpus-limited (all labelled golden tasks); 80% power at ≥10pp needs ~190 decisive pairs — achievable power at this n is lower and stated rather than grown post-hoc.',
+    },
+    pairing: {
+      surviving: surviving.length,
+      dropped: dropped.length,
+      dropped_ids: dropped.map((g) => g.task.id),
+    },
+    judge_agreement: { kappa, kappa_floor: KAPPA_FLOOR },
+    length_diagnostic: { spearman_rho: rho, flag_at: SPEARMAN_FLAG, flagged: Math.abs(rho) >= SPEARMAN_FLAG },
+    result: {
+      agreed_decisive: agreed.length,
+      agreed_thin,
+      agreed_eager,
+      sign_test_p: p,
+      thin_win_rate: agreed.length > 0 ? agreed_thin / agreed.length : null,
+    },
+    judge1_results: r1,
+    judge2_results: r2,
+    cost_usd_actual: Number(spent.toFixed(4)),
+    verdict,
+  };
+  fs.mkdirSync(path.dirname(args.output), { recursive: true });
+  fs.writeFileSync(args.output, JSON.stringify(payload, null, 2) + '\n');
+  process.stdout.write(
+    `\n→ wrote ${path.relative(REPO_ROOT, args.output)}\n` +
+      `   κ=${Number.isFinite(kappa) ? kappa.toFixed(3) : 'NaN'} · ρ=${rho.toFixed(3)} · agreed thin ${agreed_thin} / eager ${agreed_eager} · p=${p.toFixed(4)} · $${spent.toFixed(2)}\n` +
+      `   VERDICT: ${verdict}\n`,
+  );
+  return 0;
+}
+
+function _isCliEntry(): boolean {
+  if (process.argv[1] === undefined) return false;
+  if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) return true;
+  try {
+    return (
+      fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]))
+    );
+  } catch {
+    return false;
+  }
+}
+if (_isCliEntry()) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/tests/scripts/bench_quality_rerun.test.ts
+++ b/tests/scripts/bench_quality_rerun.test.ts
@@ -1,0 +1,50 @@
+// Pure-function tests for the length-neutral judge rerun (design invariants).
+import { describe, expect, it } from 'vitest';
+
+import {
+    decide_verdict,
+    price_usd,
+    spearman,
+    within_band,
+} from '../../src/scripts/bench_quality_rerun.js';
+
+describe('within_band (±15% output-token pairing)', () => {
+    it('keeps matched pairs, drops divergent ones', () => {
+        expect(within_band(100, 110)).toBe(true);
+        expect(within_band(100, 115)).toBe(true); // exactly 15/115 ≈ 13%
+        expect(within_band(100, 200)).toBe(false);
+        expect(within_band(0, 0)).toBe(true);
+    });
+});
+
+describe('spearman', () => {
+    it('perfect monotone → 1; anti-monotone → -1; noise → near 0', () => {
+        expect(spearman([1, 2, 3, 4], [10, 20, 30, 40])).toBeCloseTo(1, 9);
+        expect(spearman([1, 2, 3, 4], [40, 30, 20, 10])).toBeCloseTo(-1, 9);
+        expect(Math.abs(spearman([1, 2, 3, 4, 5, 6], [1, -1, 1, -1, 1, -1]))).toBeLessThan(0.5);
+    });
+});
+
+describe('decide_verdict (pre-registered logic)', () => {
+    it('low κ withholds', () => {
+        expect(decide_verdict({ kappa: 0.4, rho: 0, agreed_thin: 30, agreed_eager: 5 })).toContain('low-kappa');
+    });
+    it('length flag withholds even with a strong split', () => {
+        expect(decide_verdict({ kappa: 0.9, rho: 0.5, agreed_thin: 30, agreed_eager: 5 })).toContain('length-confounded');
+    });
+    it('significant ≥10pp effect ships or records the honest null', () => {
+        expect(decide_verdict({ kappa: 0.9, rho: 0.1, agreed_thin: 28, agreed_eager: 8 })).toContain('ships-lift');
+        expect(decide_verdict({ kappa: 0.9, rho: 0.1, agreed_thin: 8, agreed_eager: 28 })).toContain('honest-null');
+    });
+    it('non-significant → underpowered', () => {
+        expect(decide_verdict({ kappa: 0.9, rho: 0.1, agreed_thin: 10, agreed_eager: 8 })).toContain('underpowered');
+    });
+});
+
+describe('price_usd', () => {
+    it('matches pricing.yaml tiers by substring', () => {
+        expect(price_usd('claude-opus-4-8', 1e6, 0)).toBeCloseTo(15, 6);
+        expect(price_usd('claude-sonnet-4-5', 0, 1e6)).toBeCloseTo(15, 6);
+        expect(price_usd('gpt-4o', 1e6, 1e6)).toBeCloseTo(12.5, 6);
+    });
+});


### PR DESCRIPTION
## What

Executes **Phase 1 of `road-to-opt-measurement-unblock`** — the paid, length-neutral judge rerun of the thin-vs-eager quality question, the cascade gate blocking ~40% of the token-program portfolio. Run under the maintainer's in-session **€250 budget authorization**; estimate disclosed before the first billable call; **actual cost $34.80** (hard `--max-usd 250` guard).

## The rerun (design-pinned, all three failure modes fixed by construction)

`bench_quality_rerun.ts` implements `docs/design/length-neutral-judge-rerun.md` exactly:
- **±15% output-token pair matching** — non-matching pairs dropped into a *reported* bucket, never silently;
- **two arm-blind judges from different provider families** (claude-opus-4-8 + gpt-4o), each judging both orders (reject-on-flip), reported as **Cohen's κ with a ≥ 0.60 floor** (`judgeKappa`'s first production caller);
- **Spearman-ρ win-vs-length diagnostic** (|ρ| ≥ 0.3 withholds the verdict);
- **pre-registered n = 90** (the full council-labelled golden corpus; corpus-limited power stated, not grown post-hoc);
- verified before the paid run: dry-run pipeline, 1-task live smoke ($0.36), judge probes ($0.02); 7 unit tests on the pure invariants.

## The verdict — and why it CLOSES the gate instead of leaving it pending

**`inconclusive-low-kappa` — the second inconclusive.** Per the pre-registered design: **record why and STOP** (no third run without a categorically different method). The diagnostics carry the answer:

| Diagnostic | Value | Reading |
|---|---|---|
| Pair survival | **25/90** (65 dropped) | Eager is *structurally* longer — length is intrinsic to the arms, not judge-ignorable noise |
| Cross-family κ | **0.46** (< 0.60) | Even top-tier judges from different vendors disagree beyond the floor |
| In-band length leakage | **ρ = 0.45** (flagged) | Even length-matched wins still track length |
| Agreed decisive pairs | **7** (thin 3 / eager 4, p = 1.0) | Nothing separable remains once length + judge noise are controlled |

**Honest conclusion:** the thin-vs-eager quality question is **not resolvable by LLM-paired judging on this corpus** — in both the naive (2026-07-09/11) and the length-neutral design. Thin stays disabled; the cascade gate flips from "pending" to **closed-by-diagnosis** (the exact anti-pattern this roadmap exists to kill). A future attempt must use deterministic anchor-scoring, not pairwise LLM judging.

## Disposition (all recorded in this PR)

- `docs/benchmark.md` § *Length-neutral judge RERUN* — verdict + diagnostics table + conclusion.
- `road-to-token-proof-and-story.md` — gate annotated **CLOSED-BY-DIAGNOSIS** with evidence pointers.
- `road-to-opt-measurement-unblock.md` Phase 1 — all four steps flipped with the run record.
- Proof artifact committed: `internal/bench/reports/quality-rerun-length-neutral.json` (per-pair results of both judges, κ, ρ, cost).

## Verification

Suite: 13 tests green (7 new invariant tests + judge-kappa); typecheck 0; md-language/refs/condensation clean. Remaining in the roadmap: Phase 2 (needs **your codex/non-Claude host auth**) and Phase 3 (build-vs-defer decision).