### PR TITLE
chore(roadmap): token-saving closeout — park in later/, truth-sync the closed judge gate across the funnel

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -265,10 +265,9 @@ _1 blocker resolved._
 <a id="blockers-road-to-request-scoped-rule-load"></a>
 **Blockers**
 
-- **phase-0-golden-set (inherited)** (owner: maintainer) — blocks the held-quality verification arm of Phase 1's default flip. Does **not** block Phases 0, 2, 3 or the opt-in build of Phase 1 (mechanical, CI-verified).
+- **phase-0-golden-set (inherited)** (owner: maintainer) — blocks the held-quality verification arm of Phase 1's default flip — the flip therefore needs a DETERMINISTIC verification arm (anchor-scoring) instead of the retired LLM-judge batch; it stays evidence-blocked until one is built and run. Does **not** block Phases 0, 2, 3 or the opt-in build of Phase 1 (mechanical, CI-verified).
   - **What to do:**
-    § Program tracking step 2 — label the golden stubs, run the live judge
-    at `--scope consumer`, tick the live canary on 3 hosts.
+    labelled golden set; the live 3-host canary tick stays as the second half.
   - **Resolved when:** `check_quality_regression --as-flip-gate` exits 0 on a real (non-dry-run) report — hardened criterion per `road-to-token-proof-and-story` Phase 0. - **Evidence update 2026-07-11 (real run landed — gate is RED, not just pending):** the consumer golden set is complete (PR #885) and a full sonnet n=90 `check_quality_regression --as-flip-gate` ran (PR #887). It **FAILS** (thin win-rate 36.2% < 48% floor; length-confound 60%, judge inconsistency 31%). CAVEAT: that run measured the **thin** projection (kernel bodies + non-kernel pointers), NOT this roadmap's **workspace-scoping** reduction — a milder, different cut with **no dedicated arm** in `bench_quality_run` yet. So the held-quality arm is **not** directly resolved, but the strongest same-class reduction failed the gate decisively → treat context-reduction-for-tokens as **quality-risky by prior** on this eval. **Disposition (maintainer, 2026-07-11): do NOT spend another ~$33 on a workspace-scoped arm** that shares the same verbosity confound and would most likely reconfirm the negative; the Phase-1 DEFAULT flip stays **evidence-blocked**. The opt-in build path is unaffected (per Blocks above). Revisit only with a length-normalised arm that kills the confound.
 
 ### [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md)

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,18 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 24 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **8** open blockers
+> 22 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **7** open blockers
 
 ## Overall
 
-**102 / 338 steps done · 30%**
+**68 / 286 steps done · 24%**
 
 ```text
-████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   30%
-**94 / 328 steps done · 29%**
-
-```text
-████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░   29%
+██████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   24%
 ```
 
 ## Open roadmaps
@@ -37,13 +33,11 @@
 | 15 | [road-to-ecosystem-harvest-tool-pitfalls.md](roadmaps/road-to-ecosystem-harvest-tool-pitfalls.md) | 1 | 6 | 6 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 16 | [road-to-ecosystem-harvest-workflow-contracts.md](roadmaps/road-to-ecosystem-harvest-workflow-contracts.md) | 3 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 17 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 18 | [road-to-opt-measurement-unblock.md](roadmaps/road-to-opt-measurement-unblock.md) | 3 | 10 | 3 | 6 | 1 | 0 | 0 | ███████░░░ 67% |
-| 19 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 20 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 8 | 29 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 78% |
-| 21 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 22 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 23 | 15 | 1 | 0 | [2](#blockers-road-to-team-mode) | ████░░░░░░ 39% |
-| 23 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
-| 24 | [road-to-token-saving.md](roadmaps/road-to-token-saving.md) | 7 | 37 | 5 | 28 | 0 | 4 | [1](#blockers-road-to-token-saving) | ████████░░ 85% |
+| 18 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 19 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 8 | 29 | 0 | 0 | [1](#blockers-road-to-request-scoped-rule-load) | ████████░░ 78% |
+| 20 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 21 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 15 | 23 | 1 | 0 | [2](#blockers-road-to-team-mode) | ██████░░░░ 61% |
+| 22 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
 
@@ -343,31 +337,6 @@ _1 blocker resolved._
 | 2 | Internal dependency audit (just-in-time) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 3 | External soak confirmation | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 4 | Removal execution (blocked on Phases 1–3) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
-
-### [road-to-token-saving.md](roadmaps/road-to-token-saving.md)
-
-**Road to token saving — measure, then cut, at constant quality** — 28 / 33 done (85%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Measurement substrate (the prerequisite to every cut) | 🟡 in progress | 1 | 5 | 0 | 0 | 83% |
-| 1 | RTK everywhere (un-gate the scope) | 🟡 in progress | 1 | 2 | 0 | 1 | 67% |
-| 2 | Close the RTK trigger gap | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 3 | Deterministic RTK wrap hook + install verification | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 5 | Cache-aware ordering as a CI invariant (D5) | ✅ done | 0 | 2 | 0 | 1 | 100% |
-| 8 | Always-loaded budget linter (D6) | ✅ done | 0 | 2 | 0 | 1 | 100% |
-| 10 | Token-saving backlog (extensible umbrella) | 🟡 in progress | 2 | 11 | 0 | 1 | 85% |
-
-<a id="blockers-road-to-token-saving"></a>
-**Blockers**
-
-- **phase-0-golden-set** (owner: maintainer) — blocks Phase 0 Steps 1 + 2 (golden set + host-compliance probe), Phase 1 Step 1 (RTK golden-set run), Phase 8 Step 2 (quality-elbow threshold), and Phase 10 Step 1 (tier-conditional loading)
-  - **What to do:**
-    1. Build the held-out golden set of ~30 tasks spanning all 88 rules (see Phase 0 Step 1 comment — run the LIVE paired judge with `ANTHROPIC_API_KEY` set, estimated cost US$3–5).
-    2. Run: `task bench:ab:value:quick` (or the full bench target) to produce `internal/bench/reports/quality-run.json`.
-    3. Verify the paired judge output has the expected shape (model A vs model B, per-task scores, aggregate win rate).
-    4. The hardened gate is the unlock — once it exits 0 on the real report, Phase 1 Step 1 + Phase 8 Step 2 can proceed.
-  - **Resolved when:** `./scripts-run src/scripts/check_quality_regression --as-flip-gate` exits 0 AND `npx tsx tests/scripts/bench_ab_integrity.test.ts` exits 0. (Hardened 2026-07-07 per `road-to-token-proof-and-story` Phase 0 — a dry-run mock or an inconclusive report is NOT an unlock; the old "file exists" criterion was fakeable.)
 
 ---
 

--- a/agents/roadmaps/later/road-to-token-saving.md
+++ b/agents/roadmaps/later/road-to-token-saving.md
@@ -1,9 +1,21 @@
 ---
 complexity: structural
-status: ready
+status: later
 ---
 
 # Road to token saving — measure, then cut, at constant quality
+
+> **Parked (2026-07-12, later/ disposition).** Every remaining open step is
+> operator-gated; nothing is agent-workable now. **Resume when the operator
+> runs either gate:** (1) the RTK golden-set completeness validation (RTK
+> binary + live outputs) that gates the tier_2→kernel promotion — the
+> promotion itself then ships as its OWN PR under the kernel-edit slow-rollout
+> (≥24h soak, never autonomous); (2) the live trigger-eval spot-check
+> (`./scripts-run src/scripts/skill_trigger_eval` from a real terminal —
+> /dev/tty confirm, billable). The measurement blocker below is RESOLVED
+> NEGATIVE: the 2026-07-12 length-neutral judge RERUN was a second
+> inconclusive → LLM-paired judging is CLOSED-BY-DIAGNOSIS for thin-vs-eager
+> (docs/benchmark.md); deterministic anchor-scoring is the only re-open path.
 
 > Cut the package's per-request token load at **held-constant output quality** —
 > measurement substrate first, then the thin-projection lever, cache-aware
@@ -206,13 +218,18 @@ Build the evidence rig first.
       length-confound tracking, reuses bench_ab_v2_stats.wilcoxon; pluggable
       JudgeFn (mock in 10 tests). The LIVE judge-model verdict run is the
       operator/cost gate (produces internal/bench/reports/quality-run.json). -->
-- [ ] Add a **host-compliance probe**: ship a thin-projected canary rule, invoke
+- [-] Add a **host-compliance probe**: ship a thin-projected canary rule, invoke
       its keyword on each supported host (Claude Code, Cursor, Augment), assert
       the rule fires AND the host shows the pointer, not the body.
       <!-- scaffold built: canary fixture tests/fixtures/host-compliance/ +
       probe src/scripts/probe_host_compliance.ts (mechanical demotion via the real
       thin_entry projector VERIFIED: body→pointer, still selectable) + 5 tests +
       printed operator checklist. LIVE per-host invocation is the operator gate. -->
+      <!-- cancelled 2026-07-12: the probe verifies THIN-projection host behaviour;
+      the thin mechanism is dead (#887 win-rate 36.2% < 48%; council re-scope
+      2026-07-11) and the judge path is CLOSED-BY-DIAGNOSIS (2026-07-12 rerun,
+      second inconclusive). Scaffold + tests stay in-tree for a deterministic
+      anchor-scoring re-open. -->
 - [x] Instrument latency p95/p99 for on-demand rule loads (not just mean).
       <!-- done: src/scripts/bench_rule_load_latency.ts (non-kernel resolve+read,
       warm-up + nearest-rank p50/p95/p99) + 6 tests, task bench-rule-load-latency.
@@ -568,7 +585,7 @@ stale candidates.
 ## Blockers
 
 ### blocker: phase-0-golden-set
-- **Status:** open — live judge run executed 2026-07-09 (haiku) but INCONCLUSIVE (p=0.196, 33% inconsistency, 69% length-confound); a trustworthy verdict needs a stronger length-neutral judge. Coverage 14/89 also remains. Tooling update 2026-07-10: the judge-trustworthiness half is now instrumentable — `check_quality_regression.ts` gained `cohensKappa`/`judgeKappa` (second-independent-judge agreement, shipped with retrieval-substrate-hardening B7b), so the next paid run can VALIDATE the grader instead of discovering inconsistency after the fact. The blocker itself stays: the rerun is billable spend (human gate).
+- **Status:** RESOLVED NEGATIVE (2026-07-12) — the length-neutral judge RERUN (pre-registered: ±15% token-band pairing, double blind judges claude-opus-4-8 + gpt-4o both orders, κ floor 0.60) produced a SECOND inconclusive; the gate is **CLOSED-BY-DIAGNOSIS**: thin-vs-eager is not resolvable by LLM-paired judging on this corpus (see docs/benchmark.md § Length-neutral judge RERUN). Only re-open path: deterministic anchor-scoring against `must_include`/`must_not`. Consequence for this roadmap: the thin lever stays dead; the remaining open steps are operator-gated only (RTK validation + live trigger-eval), not judge-gated.
 - **Owner:** maintainer
 - **Blocks:** Phase 0 Steps 1 + 2 (golden set + host-compliance probe), Phase 1 Step 1 (RTK golden-set run), Phase 8 Step 2 (quality-elbow threshold), and Phase 10 Step 1 (tier-conditional loading)
 - **What to do:**

--- a/agents/roadmaps/road-to-request-scoped-rule-load.md
+++ b/agents/roadmaps/road-to-request-scoped-rule-load.md
@@ -465,14 +465,20 @@ target files' added sections are additive.
 ## Blockers
 
 ### blocker: phase-0-golden-set (inherited)
-- **Status:** open — owned by `road-to-token-saving` / HUMAN-MEASUREMENT
+- **Status:** RESOLVED NEGATIVE upstream (2026-07-12) — the owning gate in
+  `road-to-token-saving` (now parked in `later/`) is CLOSED-BY-DIAGNOSIS:
+  two pre-registered length-neutral judge runs were inconclusive; LLM-paired
+  judging cannot render a trustworthy held-quality verdict on this corpus
+  (docs/benchmark.md § Length-neutral judge RERUN). The only re-open path is
+  deterministic anchor-scoring against `must_include`/`must_not`.
 - **Owner:** maintainer
-- **Blocks:** the held-quality verification arm of Phase 1's default flip.
-  Does **not** block Phases 0, 2, 3 or the opt-in build of Phase 1
-  (mechanical, CI-verified).
-- **What to do:** operator batch per `road-to-token-proof-and-story`
-  § Program tracking step 2 — label the golden stubs, run the live judge
-  at `--scope consumer`, tick the live canary on 3 hosts.
+- **Blocks:** the held-quality verification arm of Phase 1's default flip —
+  the flip therefore needs a DETERMINISTIC verification arm (anchor-scoring)
+  instead of the retired LLM-judge batch; it stays evidence-blocked until one
+  is built and run. Does **not** block Phases 0, 2, 3 or the opt-in build of
+  Phase 1 (mechanical, CI-verified).
+- **What to do:** build/run the deterministic anchor-scoring arm over the
+  labelled golden set; the live 3-host canary tick stays as the second half.
 - **Resolved when:** `check_quality_regression --as-flip-gate` exits 0 on a
   real (non-dry-run) report — hardened criterion per
   `road-to-token-proof-and-story` Phase 0.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -453,7 +453,7 @@ covers only 14/89 rules (operator hand-labelling), a separate gap.
 - Runner: `src/scripts/bench_quality_run.ts` (`--dry-run` free / live is
   API-gated); gate: `src/scripts/check_quality_regression.ts` (inert until a
   `quality-run.json` — gitignored — exists locally).
-- Roadmap: `agents/roadmaps/road-to-token-saving.md` Phase 0.
+- Roadmap: `agents/roadmaps/later/road-to-token-saving.md` Phase 0.
 
 ## Length-neutral judge RERUN (2026-07-12) — SECOND INCONCLUSIVE, gate CLOSED-BY-DIAGNOSIS
 


### PR DESCRIPTION
## Summary

Downstream closeout after the `road-to-opt-*` cluster completed (#928 merged): the measurement gates that `road-to-token-saving` and its funnel siblings were blocked on are now **resolved by diagnosis** — this PR syncs the roadmap layer to that truth.

### road-to-token-saving → `later/` (blocked-for-later, resume conditions named)

- **Blocker `phase-0-golden-set` truth-synced to RESOLVED NEGATIVE:** two pre-registered length-neutral judge runs were inconclusive → LLM-paired judging is CLOSED-BY-DIAGNOSIS for thin-vs-eager (`docs/benchmark.md`); the only re-open path is deterministic anchor-scoring.
- **Thin host-compliance probe step cancelled** (`[-]`): it verifies thin-projection host behaviour, and the thin mechanism is dead (#887 win-rate 36.2% < 48%; council re-scope 2026-07-11). Scaffold + tests stay in-tree.
- **Every remaining open step is operator-gated, none agent-workable** → parked per the later/ contract with `status: later` + resume conditions in the header:
  1. RTK golden-set completeness validation (RTK binary + live outputs) gating the `cli-output-handling` tier_2→kernel promotion — the promotion then ships as its own PR under the kernel-edit slow-rollout (≥24h soak).
  2. Live trigger-eval spot-check (`./scripts-run src/scripts/skill_trigger_eval` from a real terminal — /dev/tty confirm, billable).

### road-to-request-scoped-rule-load — inherited blocker synced

The inherited `phase-0-golden-set` blocker now records the upstream closure: the Phase-1 default flip's held-quality arm requires a **deterministic anchor-scoring** verification instead of the retired LLM-judge batch. Phases 0/2/3 and the opt-in build stay unblocked, roadmap stays active.

### Bookkeeping

- Dashboard regenerated (22 active roadmaps); stale benchmark.md path reference migrated to the later/ path; branch fresh on `origin/main` at creation (freshness gate, behind=0).

## Operator actions to un-park (when wanted)

- Run the RTK golden-set validation, then request the kernel-promotion PR.
- Run the live trigger-eval spot-check from a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)