### PR TITLE
fix(ai-council): enforce config is user-global only, never project-local

### DIFF
--- a/agents/templates/.ai-council.yml.example
+++ b/agents/templates/.ai-council.yml.example
@@ -1,5 +1,14 @@
 # --- AI Council (external second-opinion network) ---
 #
+# WHERE THIS FILE GOES: copy it to the USER-GLOBAL path
+#   ~/.event4u/agent-config/settings/.ai-council.yml
+# and edit it there. This is the ONLY location the council reads (ADR-104,
+# superseding ADR-093) — one global file serves every project, worktree,
+# and CWD. Do NOT place it in a project's `agents/` tree: the project tree
+# is never searched and a `.ai-council.yml` found there is ignored. The
+# only other accepted source is an explicit absolute path in the
+# `$AI_COUNCIL_CONFIG` env var (tests / power users).
+#
 # When enabled, the /council command lets the agent poll independent
 # external models (Anthropic, OpenAI, Gemini, xAI, Perplexity) for a
 # neutral critique of a roadmap, diff, prompt, or file set. Council

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -787,11 +787,18 @@ error) when any of these hold:
 
 ## Migration footprint (Phase 0)
 
+> Historical record of the Step-2 consolidation. **The project-local file
+> described below is no longer read** — ADR-104 (superseding ADR-093) moved
+> the council config to the user-global location documented at the top of
+> this contract. A `.ai-council.yml` under any project `agents/` tree is
+> ignored. Read this section for provenance only, not for placement.
+
 - `.agent-settings.yml` → 14-key inventory under `ai_council:` removed
   after a one-line breadcrumb comment is in place pointing at this
   contract.
 - `.agent-settings.template.yml` → same removal.
-- New file `agents/settings/.ai-council.yml` checked in with two enabled
+- New file `agents/settings/.ai-council.yml` checked in with two enabled <!-- council-config-allowed -->
   providers (anthropic + openai) and three disabled
   (gemini + xai + perplexity). Models pre-filled from the Phase 0
-  default set; comments mirror this contract.
+  default set; comments mirror this contract. *(This project-tracked file
+  was later removed; per ADR-104 the config is user-global only.)*

--- a/docs/decisions/ADR-049-configuration-trust-boundary.md
+++ b/docs/decisions/ADR-049-configuration-trust-boundary.md
@@ -44,7 +44,9 @@ filtered** to a small curated set (`MERGEABLE_KEYS` = `name`, `ide`,
 ignored. `ai_council` is not on the whitelist, and council configuration lives
 project-local in `agents/settings/.ai-council.yml` (per
 [`ai-council-config`](../contracts/ai-council-config.md), the Phase-0 single
-source of truth).
+source of truth). <!-- Council placement superseded by ADR-104: the config is
+now user-global only (`~/.event4u/agent-config/settings/.ai-council.yml`),
+never project-local. The trust-boundary reasoning below is unaffected. -->
 
 The maintainer questioned whether that project-local placement is a bug. The AI
 council was asked to decide and **converged** that it is **not** a bug — the
@@ -72,6 +74,12 @@ personas, rule tier) **belongs in version control**, and onboarding stays clean
    for council config is `agents/settings/.ai-council.yml`
    ([`ai-council-config`](../contracts/ai-council-config.md)); personas live in
    the project surface. Neither is a user-global concern.
+   <!-- Superseded for the COUNCIL part by ADR-104: council config is now
+   user-global only, never project-local (personas are unaffected). -->
+   **Update (ADR-104):** the council half of this decision was reversed — the
+   council config now lives user-global only
+   (`~/.event4u/agent-config/settings/.ai-council.yml`) and the project tree is
+   never read. Personas stay project-local as stated.
 
 3. **Only secrets and the curated identity whitelist are global.** Provider API
    keys already live global in `~/.event4u/agent-config/<provider>.key` (0600);

--- a/src/config/agent-settings.template.yml
+++ b/src/config/agent-settings.template.yml
@@ -627,10 +627,14 @@ worktrees:
 
 # --- AI Council (external second-opinion network) ---
 #
-# Configuration moved to `agents/.ai-council.yml` as of the Step-2
-# consolidation roadmap. Consumer projects opt in by copying the
-# reference file from the package (`agents/.ai-council.yml`) into their
-# own `agents/` tree and flipping `enabled: true` per provider.
+# The council config is NOT here and is NOT project-local. It lives ONLY
+# user-global at `~/.event4u/agent-config/settings/.ai-council.yml` — one
+# file, configured once, serving every project / worktree / CWD (ADR-104,
+# superseding ADR-093). The project tree is NEVER searched; a
+# `.ai-council.yml` under any `agents/` tree is ignored. To opt in, copy
+# the shape from `agents/templates/.ai-council.yml.example` to that
+# user-global path and flip `enabled: true` per provider — do NOT drop it
+# into a project's `agents/` tree.
 #
 # See `docs/contracts/ai-council-config.md` for the schema.
 

--- a/src/scripts/check_council_config_location.ts
+++ b/src/scripts/check_council_config_location.ts
@@ -3,11 +3,17 @@
  * CI guard: council config lives in `.ai-council.yml`, never `.agent-settings.yml`.
  *
  * Ported from the retired Python `src/scripts/check_council_config_location.py` (ADR-200).
- * The CLI contract is pinned — `--quiet` flag, exit codes (0 clean,
- * 1 at least one violation), byte-identical finding messages, same scan globs
- * (sorted), same fence tracking, same negation / `ai_council:` block detection,
- * and the same `<!-- council-config-allowed -->` escape pragma. No behaviour
- * changes — historical quirks preserved (consumers pin the exact behaviour).
+ * The original two checks keep their pinned CLI contract — `--quiet` flag,
+ * exit codes (0 clean, 1 at least one violation), byte-identical finding
+ * messages, same `SCAN_GLOBS` (sorted), same fence tracking, same negation /
+ * `ai_council:` block detection, and the same `<!-- council-config-allowed -->`
+ * escape pragma.
+ *
+ * Additive since ADR-104: a third check (§3 below) flags project-tree
+ * *placement* of the council file. The original two checks are unchanged; the
+ * path check runs over its own `PATH_CHECK_GLOBS` (the council surfaces + the
+ * settings template + the `.ai-council.yml.example`) so the settings template's
+ * many legitimate `.agent-settings.yml` self-references never trip check §1.
  *
  * Per ADR-104 (superseding ADR-093) the council reads a dedicated
  * `.ai-council.yml` resolved ALWAYS from the user-global location
@@ -16,19 +22,26 @@
  * path). Keys are top-level in that file; the legacy `ai_council.*` block
  * under `.agent-settings.yml` was removed in Phase 0.
  *
- * What it flags, in the council command/skill surfaces + the config contract:
+ * What it flags:
  *
  *   1. A `.agent-settings.yml` reference that is NOT negated — i.e. an
  *      instruction to read/use it for council config. Corrective mentions
  *      ("NOT in `.agent-settings.yml`", "was removed", "never read") carry a
- *      negation marker on the same line and are allowed.
+ *      negation marker on the same line and are allowed. (SCAN_GLOBS)
  *   2. A bare `ai_council:` YAML parent-block declaration — post-ADR-093 the
  *      keys are top-level in `.ai-council.yml`; there is no `ai_council:`
- *      namespace to nest under.
+ *      namespace to nest under. (SCAN_GLOBS)
+ *   3. A project-tree PLACEMENT of the council file — `agents/.ai-council.yml`,
+ *      `agents/settings/.ai-council.yml`, or a `<project_root>/…/.ai-council.yml`
+ *      path — that is NOT negated. The council file is user-global ONLY
+ *      (ADR-104); any project-tree path is drift. Corrective mentions ("is
+ *      ignored", "never read", "no project-local", "superseded") pass on the
+ *      same line. (PATH_CHECK_GLOBS)
  *
  * Escape hatch: a line carrying `<!-- council-config-allowed -->` is exempt
  * (for a legitimate non-council `.agent-settings.yml` reference, e.g.
- * `personal.autonomy`).
+ * `personal.autonomy`, or a historical placement mention in a section
+ * explicitly marked superseded).
  *
  * Exit codes:
  *   0 — clean.
@@ -61,6 +74,35 @@ const NEGATION_RE = /\b(not|never|removed|no\s+longer|neither|instead)\b/i;
 const AI_COUNCIL_BLOCK_RE = /^\s*ai_council:\s*(#.*)?$/;
 const ALLOW_PRAGMA = '<!-- council-config-allowed -->';
 
+// ── §3 project-tree placement check (ADR-104) ──────────────────────
+// The council file is user-global ONLY. These are the surfaces where a
+// stray project-tree placement instruction does real damage — the council
+// command/skill surfaces + contract (SCAN_GLOBS) PLUS the settings template
+// and the copy-from example. The template carries countless legitimate
+// `.agent-settings.yml` self-references, so it is scanned ONLY by §3, never
+// by §1.
+const PATH_CHECK_GLOBS = [
+    ...SCAN_GLOBS,
+    'src/config/agent-settings.template.yml',
+    'agents/templates/.ai-council.yml.example',
+] as const;
+
+// A project-tree PLACEMENT of the council file: `agents/.ai-council.yml`,
+// `agents/settings/.ai-council.yml`, or any `<project_root>/…/.ai-council.yml`.
+// Deliberately does NOT match the user-global `…/agent-config/settings/
+// .ai-council.yml` (no literal `agents/` segment) nor the copy-from
+// `agents/templates/.ai-council.yml.example` (segment is `templates/`, and
+// `.example` is not the config file).
+const PROJECT_PATH_COUNCIL_RE =
+    /(?:agents\/(?:settings\/)?\.ai-council\.yml(?!\.example)|<project[_-]?root>[^\n`]*\.ai-council\.yml)/;
+
+// Broader negation set for §3 — corrective placement mentions use vocabulary
+// the §1 NEGATION_RE does not cover ("is ignored", "no project-local
+// lookup", "superseded"). A match on the same line marks the reference
+// corrective and is allowed.
+const PATH_NEGATION_RE =
+    /\b(not|never|removed|no\s+longer|neither|instead|ignored|superseded|no\s+project-local|not\s+read|does\s+not\s+read)\b/i;
+
 /**
  * Mirror Python `str.lstrip()` — strips all leading Unicode whitespace.
  * Python's `str.lstrip()` (no args) strips the Unicode whitespace class;
@@ -79,9 +121,12 @@ function _lstrip(s: string): string {
  * the same sort (component-wise via Path comparison). We approximate with a
  * recursive walk per glob pattern, sorting POSIX paths.
  */
-function* iter_files(root: string): Generator<string> {
+function* iter_files(
+    root: string,
+    globs: readonly string[] = SCAN_GLOBS,
+): Generator<string> {
     const seen = new Set<string>();
-    for (const pattern of SCAN_GLOBS) {
+    for (const pattern of globs) {
         for (const p of _glob(root, pattern)) {
             if (_isFile(p) && !seen.has(p)) {
                 seen.add(p);
@@ -220,18 +265,69 @@ function find_violations(root: string): string[] {
     return findings;
 }
 
+/**
+ * §3 — flag project-tree PLACEMENT of the council config file (ADR-104).
+ *
+ * The council file is user-global only; any `agents/(settings/)?.ai-council.yml`
+ * or `<project_root>/…/.ai-council.yml` path is drift. Corrective mentions
+ * (same-line `PATH_NEGATION_RE`) and the `<!-- council-config-allowed -->`
+ * pragma pass. Fenced code is skipped, mirroring §1/§2.
+ */
+function find_path_violations(root: string): string[] {
+    const findings: string[] = [];
+    for (const p of iter_files(root, PATH_CHECK_GLOBS)) {
+        const rel = _relPosix(root, p);
+        let in_fence = false;
+        const lines = fs.readFileSync(p, 'utf-8').split('\n');
+        if (lines.length > 0 && lines[lines.length - 1] === '') {
+            lines.pop();
+        }
+        for (let i = 0; i < lines.length; i++) {
+            const lineno = i + 1;
+            const raw = lines[i]!;
+            const stripped = _lstrip(raw);
+            if (stripped.startsWith('```') || stripped.startsWith('~~~')) {
+                in_fence = !in_fence;
+                continue;
+            }
+            if (in_fence || raw.includes(ALLOW_PRAGMA)) {
+                continue;
+            }
+            // Corrective sentences often wrap, leaving the negation
+            // ("never reads", "no project-local lookup") on the previous
+            // line and the path on this one. Check both lines for negation
+            // so a correctly-negated wrapped mention is not flagged. A real
+            // "place it here" instruction never carries a negation one line up.
+            const prev = i > 0 ? lines[i - 1]! : '';
+            const negated =
+                PATH_NEGATION_RE.test(raw) || PATH_NEGATION_RE.test(prev);
+            if (PROJECT_PATH_COUNCIL_RE.test(raw) && !negated) {
+                findings.push(
+                    `${rel}:${lineno}: council config placed in the project tree ` +
+                        '— the `.ai-council.yml` file is user-global ONLY ' +
+                        '(`~/.event4u/agent-config/settings/.ai-council.yml`, ADR-104). ' +
+                        'The project tree is never searched. Point at the user-global ' +
+                        'path, add a negation marker, or add ' +
+                        `\`${ALLOW_PRAGMA}\` for a historical/superseded reference.`,
+                );
+            }
+        }
+    }
+    return findings;
+}
+
 function main(): number {
     const root = process.cwd();
-    const findings = find_violations(root);
+    const findings = [...find_violations(root), ...find_path_violations(root)];
     if (findings.length) {
         process.stdout.write('❌  Council config-location violations:\n\n');
         for (const f of findings) {
             process.stdout.write(`  - ${f}\n`);
         }
         process.stdout.write(
-            '\nRule: council config lives in `.ai-council.yml` ' +
-                '(docs/contracts/ai-council-config.md + ADR-093), never in ' +
-                '`.agent-settings.yml`.\n',
+            '\nRule: council config lives in the user-global `.ai-council.yml` ' +
+                '(`~/.event4u/agent-config/settings/.ai-council.yml`, ADR-104) — ' +
+                'never in `.agent-settings.yml`, never in a project `agents/` tree.\n',
         );
         return 1;
     }
@@ -270,11 +366,15 @@ if (_isCliEntry() || process.argv[1] === _HERE) {
 
 export {
     SCAN_GLOBS,
+    PATH_CHECK_GLOBS,
     AGENT_SETTINGS_RE,
     NEGATION_RE,
     AI_COUNCIL_BLOCK_RE,
+    PROJECT_PATH_COUNCIL_RE,
+    PATH_NEGATION_RE,
     ALLOW_PRAGMA,
     iter_files,
     find_violations,
+    find_path_violations,
     main,
 };

--- a/tests/scripts/check_council_config_location.test.ts
+++ b/tests/scripts/check_council_config_location.test.ts
@@ -116,6 +116,81 @@ describe('check_council_config_location — golden parity (tmp fixtures)', () =>
     });
 });
 
+describe('check_council_config_location — §3 project-tree placement (ADR-104)', () => {
+    let tmp: string;
+    beforeEach(() => {
+        tmp = mkTmp();
+    });
+    afterEach(() => {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('violation: un-negated agents/.ai-council.yml placement → exit 1', () => {
+        write(
+            tmp,
+            'src/skills/ai-council/SKILL.md',
+            'Copy the reference into your own `agents/.ai-council.yml`.\n',
+        );
+        const a = runTs(tmp);
+        expect(a.status).toBe(1);
+        expect(a.stdout).toContain('user-global ONLY');
+    });
+
+    it('violation: placement drift in the settings template is scanned (§3 only) → exit 1', () => {
+        write(
+            tmp,
+            'src/config/agent-settings.template.yml',
+            '# copy the file to `agents/settings/.ai-council.yml`\n',
+        );
+        expect(runTs(tmp).status).toBe(1);
+    });
+
+    it('clean: a negated placement mention on the same line → exit 0', () => {
+        write(
+            tmp,
+            'docs/contracts/ai-council-config.md',
+            'A `<project_root>/agents/settings/.ai-council.yml` is ignored (ADR-104).\n',
+        );
+        expect(runTs(tmp).status).toBe(0);
+    });
+
+    it('clean: negation wraps to the previous line → exit 0', () => {
+        write(
+            tmp,
+            'src/domains/meta/council/default/command.md',
+            'The council never reads\n`<project_root>/agents/settings/.ai-council.yml` or any project file.\n',
+        );
+        expect(runTs(tmp).status).toBe(0);
+    });
+
+    it('clean: the user-global path is not project-tree drift → exit 0', () => {
+        write(
+            tmp,
+            'src/skills/ai-council/SKILL.md',
+            'Config lives at `~/.event4u/agent-config/settings/.ai-council.yml`.\n',
+        );
+        expect(runTs(tmp).status).toBe(0);
+    });
+
+    it('clean: the copy-from .example path is not flagged → exit 0', () => {
+        write(
+            tmp,
+            'src/skills/ai-council/SKILL.md',
+            'Copy the shape from `agents/templates/.ai-council.yml.example`.\n',
+        );
+        expect(runTs(tmp).status).toBe(0);
+    });
+
+    it('clean: an allow-pragma exempts a historical placement line → exit 0', () => {
+        write(
+            tmp,
+            'docs/contracts/ai-council-config.md',
+            'New file `agents/settings/.ai-council.yml` checked in <!-- council-config-allowed -->\n',
+        );
+        expect(runTs(tmp).status).toBe(0);
+    });
+});
+
 describe('check_council_config_location — golden parity (real repo)', () => {
     it('runs deterministically on the live council surfaces', () => {
         const a = runTs(REPO_ROOT);


### PR DESCRIPTION
## Problem

Docs across several surfaces still implied the AI-council config lives **project-local** at `agents/.ai-council.yml` — the pre-ADR-104 model. The loader has resolved it **user-global only** for a while (`~/.event4u/agent-config/settings/.ai-council.yml`; ADR-104 supersedes ADR-093, project tree never searched). The stale phrasing has misled repeatedly — the existing CI guard (`check_council_config_location.ts`) only caught `.agent-settings.yml` references and `ai_council:` blocks, so **project-tree path drift sailed straight through**.

## What changed

- **Settings template** (`src/config/agent-settings.template.yml`): rewrite the AI-council breadcrumb from "copy into their own `agents/` tree" to "user-global only; the project tree is never searched".
- **`.ai-council.yml.example`**: add a top `WHERE THIS FILE GOES` header pointing at the user-global path — it's the file people copy.
- **Contract migration footnote** + **ADR-049** positive project-local claims: inline ADR-104 superseded markers. History preserved, not rewritten; the misread is killed at the exact line.
- **`check_council_config_location.ts`**: additive **§3 check** that flags project-tree *placement* of `.ai-council.yml` (`agents/.ai-council.yml`, `agents/settings/.ai-council.yml`, `<project_root>/…`) without a negation marker. Scans the council surfaces + settings template + example. The original §1/§2 checks and their pinned messages are **unchanged**; a one-line negation lookback avoids false positives on wrapped corrective sentences.

This is the durable half: it was documentation-only fixes that kept regressing, so the guard now blocks project-tree placement in CI.

## Verification

- `check_council_config_location.ts` → clean (exit 0) on the full repo.
- `tests/scripts/check_council_config_location.test.ts` → 17/17 pass (10 existing + 7 new §3 tests with strict exit-code assertions: drift → exit 1; global path, `.example`, negated + pragma → exit 0).
- Regex unit assertions confirm the global path and the copy-from `.example` are not flagged while every project-tree shape is.

Config resolution truth: `src/scripts/ai_council/config.ts:resolve_config_path` (ADR-104).