### PR TITLE
Retire the consumer bridge marker (ADR-020 amendment) + hermetic wrapper test

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ npx -y @event4u/agent-config init
 
 **Verify hook coverage:** `npx @event4u/agent-config hooks:status` prints the per-platform matrix (`--strict` for CI, `--format json` for tooling).
 
-> **Scope (v2.5+):** `init` writes **global** only — `~/.event4u/agent-config/`, `~/.claude/`, `~/.cursor/`, …. The project tree gets `agents/overrides/` + `agents/.event4u-bridge.yml`. `--project` is maintainer-only behind `AGENT_CONFIG_DEV_MODE=1` ([ADR-020](docs/decisions/ADR-020-global-only-consumer-scope.md), [dev-mode](docs/maintainers/dev-mode.md)).
+> **Scope (v2.5+):** `init` writes **global** only — `~/.event4u/agent-config/`, `~/.claude/`, `~/.cursor/`, …. The project tree gets `agents/overrides/` only (the bridge marker was retired — ADR-020 amendment 2026-07-13; the global root resolves from `~/.event4u/agent-config`). `--project` is maintainer-only behind `AGENT_CONFIG_DEV_MODE=1` ([ADR-020](docs/decisions/ADR-020-global-only-consumer-scope.md), [dev-mode](docs/maintainers/dev-mode.md)).
 
 Migrating from a v1.x install? `npx @event4u/agent-config migrate` — full notes in [`docs/migration/v1-to-v2.md`](docs/migration/v1-to-v2.md).
 

--- a/agents/.maintainer-workspace.md
+++ b/agents/.maintainer-workspace.md
@@ -17,7 +17,7 @@ This `agents/` directory serves **two roles at once, by design**:
 
 The runtime settings loader (`src/scripts/_lib/agent_settings.ts`) anchors on a
 directory literally named `agents/` carrying convention markers (`roadmaps/`,
-`settings/.ai-council.yml`, `roadmaps-progress.md`, `.event4u-bridge.yml`) and
+`settings/.ai-council.yml`, `roadmaps-progress.md`) and
 reads `.agent-settings.yml` from `agents/settings/`. Those are **convention**
 identifiers — the same strings a consumer project carries. Renaming this workspace would
 either break the loader's convention coupling or force dual-path logic

--- a/dist/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
+++ b/dist/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
@@ -252,7 +252,10 @@ const _AGENTS_DIR_MARKERS: readonly string[] = [
     'roadmaps',
     'settings/.ai-council.yml',
     'roadmaps-progress.md',
-    '.event4u-bridge.yml',
+    // `overrides/` is the guaranteed minimal-consumer surface (ADR-020).
+    // Replaced the retired `.event4u-bridge.yml` marker (ADR-020 amendment
+    // 2026-07-13) so a bare consumer `agents/` dir stays anchorable.
+    'overrides',
 ];
 
 /**

--- a/dist/install/install.mjs
+++ b/dist/install/install.mjs
@@ -36,9 +36,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/yaml/dist/nodes/identity.js
+// ../agent-config/node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "node_modules/yaml/dist/nodes/identity.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/identity.js"(exports) {
     "use strict";
     var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias");
     var DOC = /* @__PURE__ */ Symbol.for("yaml.document");
@@ -93,9 +93,9 @@ var require_identity = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/visit.js
+// ../agent-config/node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "node_modules/yaml/dist/visit.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/visit.js"(exports) {
     "use strict";
     var identity = require_identity();
     var BREAK = /* @__PURE__ */ Symbol("break visit");
@@ -251,9 +251,9 @@ var require_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/directives.js
+// ../agent-config/node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "node_modules/yaml/dist/doc/directives.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/doc/directives.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -422,9 +422,9 @@ var require_directives = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/anchors.js
+// ../agent-config/node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "node_modules/yaml/dist/doc/anchors.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/doc/anchors.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -492,9 +492,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/applyReviver.js
+// ../agent-config/node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "node_modules/yaml/dist/doc/applyReviver.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/doc/applyReviver.js"(exports) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -542,9 +542,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/toJS.js
+// ../agent-config/node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "node_modules/yaml/dist/nodes/toJS.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/toJS.js"(exports) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -572,9 +572,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Node.js
+// ../agent-config/node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "node_modules/yaml/dist/nodes/Node.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/Node.js"(exports) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -613,9 +613,9 @@ var require_Node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Alias.js
+// ../agent-config/node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "node_modules/yaml/dist/nodes/Alias.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/Alias.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -729,9 +729,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Scalar.js
+// ../agent-config/node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "node_modules/yaml/dist/nodes/Scalar.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/Scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -759,9 +759,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/createNode.js
+// ../agent-config/node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "node_modules/yaml/dist/doc/createNode.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/doc/createNode.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -834,9 +834,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Collection.js
+// ../agent-config/node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "node_modules/yaml/dist/nodes/Collection.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/Collection.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -977,9 +977,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyComment.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent) {
@@ -994,9 +994,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/foldFlowLines.js
+// ../agent-config/node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -1130,9 +1130,9 @@ ${indent}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyString.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -1413,9 +1413,9 @@ ${indent}`);
   }
 });
 
-// node_modules/yaml/dist/stringify/stringify.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "node_modules/yaml/dist/stringify/stringify.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringify.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -1537,9 +1537,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyPair.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1670,9 +1670,9 @@ ${ctx.indent}`;
   }
 });
 
-// node_modules/yaml/dist/log.js
+// ../agent-config/node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "node_modules/yaml/dist/log.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/log.js"(exports) {
     "use strict";
     var node_process = __require("process");
     function debug(logLevel, ...messages) {
@@ -1692,9 +1692,9 @@ var require_log = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1752,9 +1752,9 @@ var require_merge = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/addPairToJSMap.js
+// ../agent-config/node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
     "use strict";
     var log = require_log();
     var merge = require_merge();
@@ -1816,9 +1816,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/Pair.js
+// ../agent-config/node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "node_modules/yaml/dist/nodes/Pair.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/Pair.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -1856,9 +1856,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyCollection.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -2007,9 +2007,9 @@ ${indent}${end}`;
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLMap.js
+// ../agent-config/node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -2151,9 +2151,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/map.js
+// ../agent-config/node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "node_modules/yaml/dist/schema/common/map.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/common/map.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -2173,9 +2173,9 @@ var require_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/nodes/YAMLSeq.js
+// ../agent-config/node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -2289,9 +2289,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/seq.js
+// ../agent-config/node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "node_modules/yaml/dist/schema/common/seq.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/common/seq.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -2311,9 +2311,9 @@ var require_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/string.js
+// ../agent-config/node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "node_modules/yaml/dist/schema/common/string.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/common/string.js"(exports) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string = {
@@ -2330,9 +2330,9 @@ var require_string = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/common/null.js
+// ../agent-config/node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "node_modules/yaml/dist/schema/common/null.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/common/null.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -2348,9 +2348,9 @@ var require_null = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/bool.js
+// ../agent-config/node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "node_modules/yaml/dist/schema/core/bool.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/core/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -2372,9 +2372,9 @@ var require_bool = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyNumber.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -2399,9 +2399,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/float.js
+// ../agent-config/node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "node_modules/yaml/dist/schema/core/float.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/core/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2445,9 +2445,9 @@ var require_float = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/int.js
+// ../agent-config/node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "node_modules/yaml/dist/schema/core/int.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/core/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2490,9 +2490,9 @@ var require_int = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/core/schema.js
+// ../agent-config/node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "node_modules/yaml/dist/schema/core/schema.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -2518,9 +2518,9 @@ var require_schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/json/schema.js
+// ../agent-config/node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "node_modules/yaml/dist/schema/json/schema.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var map = require_map();
@@ -2585,9 +2585,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
     "use strict";
     var node_buffer = __require("buffer");
     var Scalar = require_Scalar();
@@ -2651,9 +2651,9 @@ var require_binary = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -2729,9 +2729,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -2807,9 +2807,9 @@ var require_omap = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -2839,9 +2839,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/float.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2888,9 +2888,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/int.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2967,9 +2967,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/set.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -3056,9 +3056,9 @@ var require_set = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -3144,9 +3144,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3188,9 +3188,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/tags.js
+// ../agent-config/node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "node_modules/yaml/dist/schema/tags.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/tags.js"(exports) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3282,9 +3282,9 @@ var require_tags = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/schema/Schema.js
+// ../agent-config/node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "node_modules/yaml/dist/schema/Schema.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/schema/Schema.js"(exports) {
     "use strict";
     var identity = require_identity();
     var map = require_map();
@@ -3314,9 +3314,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/stringify/stringifyDocument.js
+// ../agent-config/node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -3394,9 +3394,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/doc/Document.js
+// ../agent-config/node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "node_modules/yaml/dist/doc/Document.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/doc/Document.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -3703,9 +3703,9 @@ var require_Document = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/errors.js
+// ../agent-config/node_modules/yaml/dist/errors.js
 var require_errors = __commonJS({
-  "node_modules/yaml/dist/errors.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -3768,9 +3768,9 @@ ${pointer}
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-props.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-props.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-props.js"(exports) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -3902,9 +3902,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-contains-newline.js
+// ../agent-config/node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -3944,9 +3944,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-flow-indent-check.js
+// ../agent-config/node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent, fc, onError) {
@@ -3962,9 +3962,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-map-includes.js
+// ../agent-config/node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -3978,9 +3978,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-map.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -4086,9 +4086,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-seq.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -4137,9 +4137,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-end.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-end.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-end.js"(exports) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -4180,9 +4180,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-collection.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -4374,9 +4374,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-collection.js
+// ../agent-config/node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "node_modules/yaml/dist/compose/compose-collection.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/compose-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4439,9 +4439,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-block-scalar.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -4622,9 +4622,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// ../agent-config/node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -4842,9 +4842,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-scalar.js
+// ../agent-config/node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4923,9 +4923,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// ../agent-config/node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -4953,9 +4953,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-node.js
+// ../agent-config/node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "node_modules/yaml/dist/compose/compose-node.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/compose-node.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -5059,9 +5059,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/compose-doc.js
+// ../agent-config/node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "node_modules/yaml/dist/compose/compose-doc.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/compose-doc.js"(exports) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -5102,9 +5102,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/compose/composer.js
+// ../agent-config/node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "node_modules/yaml/dist/compose/composer.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/compose/composer.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var directives = require_directives();
@@ -5310,9 +5310,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// node_modules/yaml/dist/parse/cst-scalar.js
+// ../agent-config/node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -5495,9 +5495,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-stringify.js
+// ../agent-config/node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -5556,9 +5556,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst-visit.js
+// ../agent-config/node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "node_modules/yaml/dist/parse/cst-visit.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/cst-visit.js"(exports) {
     "use strict";
     var BREAK = /* @__PURE__ */ Symbol("break visit");
     var SKIP = /* @__PURE__ */ Symbol("skip children");
@@ -5618,9 +5618,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/cst.js
+// ../agent-config/node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "node_modules/yaml/dist/parse/cst.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/cst.js"(exports) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -5720,9 +5720,9 @@ var require_cst = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/lexer.js
+// ../agent-config/node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "node_modules/yaml/dist/parse/lexer.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/lexer.js"(exports) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -6309,9 +6309,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/line-counter.js
+// ../agent-config/node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "node_modules/yaml/dist/parse/line-counter.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/line-counter.js"(exports) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -6340,9 +6340,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/parse/parser.js
+// ../agent-config/node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "node_modules/yaml/dist/parse/parser.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/parse/parser.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var cst = require_cst();
@@ -7214,9 +7214,9 @@ var require_parser = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/public-api.js
+// ../agent-config/node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "node_modules/yaml/dist/public-api.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/public-api.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -7311,9 +7311,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// node_modules/yaml/dist/index.js
+// ../agent-config/node_modules/yaml/dist/index.js
 var require_dist = __commonJS({
-  "node_modules/yaml/dist/index.js"(exports) {
+  "../agent-config/node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -9536,7 +9536,10 @@ var _AGENTS_DIR_MARKERS = [
   "roadmaps",
   "settings/.ai-council.yml",
   "roadmaps-progress.md",
-  ".event4u-bridge.yml"
+  // `overrides/` is the guaranteed minimal-consumer surface (ADR-020).
+  // Replaced the retired `.event4u-bridge.yml` marker (ADR-020 amendment
+  // 2026-07-13) so a bare consumer `agents/` dir stays anchorable.
+  "overrides"
 ];
 var _LEGACY_ANCHOR_ENV = "AGENT_CONFIG_LEGACY_ANCHOR";
 function _exists(p) {
@@ -9917,7 +9920,7 @@ function computeSurfaceDelta(oldS, newS) {
   return { oldVersion: oldS.version, newVersion: newS.version, changes };
 }
 
-// node_modules/zod/v3/external.js
+// ../agent-config/node_modules/zod/v3/external.js
 var external_exports = {};
 __export(external_exports, {
   BRAND: () => BRAND,
@@ -10029,7 +10032,7 @@ __export(external_exports, {
   void: () => voidType
 });
 
-// node_modules/zod/v3/helpers/util.js
+// ../agent-config/node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -10163,7 +10166,7 @@ var getParsedType = (data) => {
   }
 };
 
-// node_modules/zod/v3/ZodError.js
+// ../agent-config/node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -10281,7 +10284,7 @@ ZodError.create = (issues) => {
   return error;
 };
 
-// node_modules/zod/v3/locales/en.js
+// ../agent-config/node_modules/zod/v3/locales/en.js
 var errorMap = (issue, _ctx) => {
   let message;
   switch (issue.code) {
@@ -10384,7 +10387,7 @@ var errorMap = (issue, _ctx) => {
 };
 var en_default = errorMap;
 
-// node_modules/zod/v3/errors.js
+// ../agent-config/node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function setErrorMap(map) {
   overrideErrorMap = map;
@@ -10393,7 +10396,7 @@ function getErrorMap() {
   return overrideErrorMap;
 }
 
-// node_modules/zod/v3/helpers/parseUtil.js
+// ../agent-config/node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path12, errorMaps, issueData } = params;
   const fullPath = [...path12, ...issueData.path || []];
@@ -10503,14 +10506,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// node_modules/zod/v3/helpers/errorUtil.js
+// ../agent-config/node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// node_modules/zod/v3/types.js
+// ../agent-config/node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path12, key) {
     this._cachedPath = [];
@@ -14407,7 +14410,7 @@ var settingsSchema = external_exports.object({
   }).default({ acknowledged: false, consented_at: "", require_council: true })
 });
 
-// node_modules/zod-to-json-schema/dist/esm/Options.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = /* @__PURE__ */ Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -14441,7 +14444,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// node_modules/zod-to-json-schema/dist/esm/Refs.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -14462,7 +14465,7 @@ var getRefs = (options) => {
   };
 };
 
-// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage, refs) {
   if (!refs?.errorMessages)
     return;
@@ -14478,7 +14481,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage, refs) {
   addErrorMessage(res, key, errorMessage, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -14488,7 +14491,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -14504,7 +14507,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -14528,7 +14531,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -14574,24 +14577,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -14650,7 +14653,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -14658,12 +14661,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -14671,7 +14674,7 @@ function parseEnumDef(def) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -14713,7 +14716,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType = typeof def.value;
   if (parsedType !== "bigint" && parsedType !== "number" && parsedType !== "boolean" && parsedType !== "string") {
@@ -14733,7 +14736,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -15058,7 +15061,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -15110,7 +15113,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -15135,7 +15138,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -15149,7 +15152,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -15159,7 +15162,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -15169,7 +15172,7 @@ function parseNullDef(refs) {
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -15237,7 +15240,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -15269,7 +15272,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -15318,7 +15321,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -15388,7 +15391,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -15407,7 +15410,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -15427,12 +15430,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -15452,7 +15455,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -15480,24 +15483,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -15573,7 +15576,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -15629,7 +15632,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// ../agent-config/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({
@@ -18387,7 +18390,7 @@ function _detect_legacy_for_migration(project_root) {
     }
     return [];
   }
-  if (isFile(path11.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH))) return [];
+  if (isFile(path11.join(project_root, INSTALL_MODE_MARKER_REL))) return [];
   const found = [];
   for (const name of MIGRATE_LEGACY_YAML_FILES) {
     if (isFile(path11.join(project_root, name))) {
@@ -18446,26 +18449,17 @@ function _format_global_root_for_marker(global_root) {
   }
   return `~/${rel.split(path11.sep).join("/")}`;
 }
-function _write_consumer_bridge_marker(project_root, installer_version, env = null, now = null) {
+function _remove_legacy_consumer_bridge_marker(project_root, env = null) {
   const env_map = env ?? process3.env;
   if (env_map["AGENT_CONFIG_DEV_MODE"] === "1") return null;
   if (isDir(path11.join(project_root, ".agent-src.uncondensed"))) return null;
-  const global_root_str = _format_global_root_for_marker(
-    event4u_root(env_map)
-  );
-  const stamp = utcStamp(now ?? void 0);
-  const body = `# event4u/agent-config \u2014 consumer bridge marker (auto-written).
-# Spec: docs/contracts/consumer-bridge.md (event4u-bridge/v1).
-# Reader contract: expand ~ against the current $HOME; fail closed
-# when global_root is missing on disk; never write back through it.
-schema: event4u-bridge/v1
-global_root: ${global_root_str}
-installed_at: ${stamp}
-installer_version: ${installer_version}
-`;
   const target = path11.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
-  mkdirp(path11.dirname(target));
-  atomicWrite0644(target, body, ".event4u-bridge.");
+  if (!isFile(target)) return null;
+  try {
+    fs13.rmSync(target);
+  } catch {
+    return null;
+  }
   return target;
 }
 var PROJECT_ANCHOR_TOOLS = {
@@ -18487,14 +18481,13 @@ function _write_per_tool_project_anchors(project_root, tools, env = null, now = 
     if (!tools.has(tool_id)) continue;
     const target = path11.join(project_root, rel_path);
     mkdirp(path11.dirname(target));
-    const bridge_abs = path11.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
-    const bridge_rel = path11.relative(path11.dirname(target), bridge_abs);
     const body = `# event4u/agent-config \u2014 per-tool project anchor (auto-written).
 # Spec: docs/contracts/consumer-bridge.md \xA7 Per-tool anchor strategy.
-# Tool: ${tool_id}. Bridge marker: agents/.event4u-bridge.yml.
+# Tool: ${tool_id}. Resolves the global install directly \u2014 no
+# project-local bridge marker (retired, ADR-020 amendment 2026-07-13).
+# This anchor is gitignored: each developer regenerates it on install.
 schema: event4u-bridge/v1
 tool: ${tool_id}
-bridge: ${bridge_rel}
 global_root: ${global_root_str}
 installed_at: ${stamp}
 `;
@@ -19067,10 +19060,10 @@ function install_global(tools, force, project_root = null, core_only = false) {
     const files_by_tool = _files_by_tool_from_deploy(deploy_results);
     const rc = _update_installed_tools_manifest(project_root, tools, "global", force, files_by_tool);
     if (rc !== 0) return rc;
-    const marker_path = _write_consumer_bridge_marker(project_root, installed_version);
-    if (marker_path !== null && !state.QUIET) {
-      const rel = isRelativeTo(marker_path, project_root) ? path11.relative(project_root, marker_path) : marker_path;
-      info(`Bridge marker written: ${rel}`);
+    const removed_marker = _remove_legacy_consumer_bridge_marker(project_root);
+    if (removed_marker !== null && !state.QUIET) {
+      const rel = isRelativeTo(removed_marker, project_root) ? path11.relative(project_root, removed_marker) : removed_marker;
+      info(`Removed legacy bridge marker: ${rel}`);
     }
     const anchor_paths = _write_per_tool_project_anchors(project_root, tools);
     if (anchor_paths.length > 0 && !state.QUIET) {
@@ -19423,11 +19416,10 @@ personal:
       success(`Wrote ${SETTINGS_FILE} (user_type=${user_type})`);
     }
   }
-  const installed_version = current_package_version();
-  const marker_path = _write_consumer_bridge_marker(target_root, installed_version);
-  if (marker_path !== null) {
-    const rel = isRelativeTo(marker_path, target_root) ? path11.relative(target_root, marker_path) : marker_path;
-    success(`Wrote ${rel}`);
+  const removed_marker = _remove_legacy_consumer_bridge_marker(target_root);
+  if (removed_marker !== null) {
+    const rel = isRelativeTo(removed_marker, target_root) ? path11.relative(target_root, removed_marker) : removed_marker;
+    success(`Removed legacy bridge marker: ${rel}`);
   }
   _write_install_mode_marker(target_root, "minimal");
   if (!state.QUIET) {

--- a/dist/install/install.mjs
+++ b/dist/install/install.mjs
@@ -36,9 +36,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// ../agent-config/node_modules/yaml/dist/nodes/identity.js
+// node_modules/yaml/dist/nodes/identity.js
 var require_identity = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/identity.js"(exports) {
+  "node_modules/yaml/dist/nodes/identity.js"(exports) {
     "use strict";
     var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias");
     var DOC = /* @__PURE__ */ Symbol.for("yaml.document");
@@ -93,9 +93,9 @@ var require_identity = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/visit.js
+// node_modules/yaml/dist/visit.js
 var require_visit = __commonJS({
-  "../agent-config/node_modules/yaml/dist/visit.js"(exports) {
+  "node_modules/yaml/dist/visit.js"(exports) {
     "use strict";
     var identity = require_identity();
     var BREAK = /* @__PURE__ */ Symbol("break visit");
@@ -251,9 +251,9 @@ var require_visit = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/doc/directives.js
+// node_modules/yaml/dist/doc/directives.js
 var require_directives = __commonJS({
-  "../agent-config/node_modules/yaml/dist/doc/directives.js"(exports) {
+  "node_modules/yaml/dist/doc/directives.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -422,9 +422,9 @@ var require_directives = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/doc/anchors.js
+// node_modules/yaml/dist/doc/anchors.js
 var require_anchors = __commonJS({
-  "../agent-config/node_modules/yaml/dist/doc/anchors.js"(exports) {
+  "node_modules/yaml/dist/doc/anchors.js"(exports) {
     "use strict";
     var identity = require_identity();
     var visit = require_visit();
@@ -492,9 +492,9 @@ var require_anchors = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/doc/applyReviver.js
+// node_modules/yaml/dist/doc/applyReviver.js
 var require_applyReviver = __commonJS({
-  "../agent-config/node_modules/yaml/dist/doc/applyReviver.js"(exports) {
+  "node_modules/yaml/dist/doc/applyReviver.js"(exports) {
     "use strict";
     function applyReviver(reviver, obj, key, val) {
       if (val && typeof val === "object") {
@@ -542,9 +542,9 @@ var require_applyReviver = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/toJS.js
+// node_modules/yaml/dist/nodes/toJS.js
 var require_toJS = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/toJS.js"(exports) {
+  "node_modules/yaml/dist/nodes/toJS.js"(exports) {
     "use strict";
     var identity = require_identity();
     function toJS(value, arg, ctx) {
@@ -572,9 +572,9 @@ var require_toJS = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/Node.js
+// node_modules/yaml/dist/nodes/Node.js
 var require_Node = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/Node.js"(exports) {
+  "node_modules/yaml/dist/nodes/Node.js"(exports) {
     "use strict";
     var applyReviver = require_applyReviver();
     var identity = require_identity();
@@ -613,9 +613,9 @@ var require_Node = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/Alias.js
+// node_modules/yaml/dist/nodes/Alias.js
 var require_Alias = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/Alias.js"(exports) {
+  "node_modules/yaml/dist/nodes/Alias.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var visit = require_visit();
@@ -729,9 +729,9 @@ var require_Alias = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/Scalar.js
+// node_modules/yaml/dist/nodes/Scalar.js
 var require_Scalar = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/Scalar.js"(exports) {
+  "node_modules/yaml/dist/nodes/Scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Node = require_Node();
@@ -759,9 +759,9 @@ var require_Scalar = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/doc/createNode.js
+// node_modules/yaml/dist/doc/createNode.js
 var require_createNode = __commonJS({
-  "../agent-config/node_modules/yaml/dist/doc/createNode.js"(exports) {
+  "node_modules/yaml/dist/doc/createNode.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -834,9 +834,9 @@ var require_createNode = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/Collection.js
+// node_modules/yaml/dist/nodes/Collection.js
 var require_Collection = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/Collection.js"(exports) {
+  "node_modules/yaml/dist/nodes/Collection.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var identity = require_identity();
@@ -977,9 +977,9 @@ var require_Collection = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringifyComment.js
+// node_modules/yaml/dist/stringify/stringifyComment.js
 var require_stringifyComment = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyComment.js"(exports) {
     "use strict";
     var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
     function indentComment(comment, indent) {
@@ -994,9 +994,9 @@ var require_stringifyComment = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/foldFlowLines.js
+// node_modules/yaml/dist/stringify/foldFlowLines.js
 var require_foldFlowLines = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
+  "node_modules/yaml/dist/stringify/foldFlowLines.js"(exports) {
     "use strict";
     var FOLD_FLOW = "flow";
     var FOLD_BLOCK = "block";
@@ -1130,9 +1130,9 @@ ${indent}${text.slice(fold + 1, end2)}`;
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringifyString.js
+// node_modules/yaml/dist/stringify/stringifyString.js
 var require_stringifyString = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyString.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var foldFlowLines = require_foldFlowLines();
@@ -1413,9 +1413,9 @@ ${indent}`);
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringify.js
+// node_modules/yaml/dist/stringify/stringify.js
 var require_stringify = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringify.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringify.js"(exports) {
     "use strict";
     var anchors = require_anchors();
     var identity = require_identity();
@@ -1537,9 +1537,9 @@ ${ctx.indent}${str}`;
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringifyPair.js
+// node_modules/yaml/dist/stringify/stringifyPair.js
 var require_stringifyPair = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyPair.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1670,9 +1670,9 @@ ${ctx.indent}`;
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/log.js
+// node_modules/yaml/dist/log.js
 var require_log = __commonJS({
-  "../agent-config/node_modules/yaml/dist/log.js"(exports) {
+  "node_modules/yaml/dist/log.js"(exports) {
     "use strict";
     var node_process = __require("process");
     function debug(logLevel, ...messages) {
@@ -1692,9 +1692,9 @@ var require_log = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/merge.js
+// node_modules/yaml/dist/schema/yaml-1.1/merge.js
 var require_merge = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/merge.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -1752,9 +1752,9 @@ var require_merge = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/addPairToJSMap.js
+// node_modules/yaml/dist/nodes/addPairToJSMap.js
 var require_addPairToJSMap = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
+  "node_modules/yaml/dist/nodes/addPairToJSMap.js"(exports) {
     "use strict";
     var log = require_log();
     var merge = require_merge();
@@ -1816,9 +1816,9 @@ var require_addPairToJSMap = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/Pair.js
+// node_modules/yaml/dist/nodes/Pair.js
 var require_Pair = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/Pair.js"(exports) {
+  "node_modules/yaml/dist/nodes/Pair.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyPair = require_stringifyPair();
@@ -1856,9 +1856,9 @@ var require_Pair = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringifyCollection.js
+// node_modules/yaml/dist/stringify/stringifyCollection.js
 var require_stringifyCollection = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyCollection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -2007,9 +2007,9 @@ ${indent}${end}`;
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/YAMLMap.js
+// node_modules/yaml/dist/nodes/YAMLMap.js
 var require_YAMLMap = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
+  "node_modules/yaml/dist/nodes/YAMLMap.js"(exports) {
     "use strict";
     var stringifyCollection = require_stringifyCollection();
     var addPairToJSMap = require_addPairToJSMap();
@@ -2151,9 +2151,9 @@ var require_YAMLMap = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/common/map.js
+// node_modules/yaml/dist/schema/common/map.js
 var require_map = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/common/map.js"(exports) {
+  "node_modules/yaml/dist/schema/common/map.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLMap = require_YAMLMap();
@@ -2173,9 +2173,9 @@ var require_map = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/nodes/YAMLSeq.js
+// node_modules/yaml/dist/nodes/YAMLSeq.js
 var require_YAMLSeq = __commonJS({
-  "../agent-config/node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
+  "node_modules/yaml/dist/nodes/YAMLSeq.js"(exports) {
     "use strict";
     var createNode = require_createNode();
     var stringifyCollection = require_stringifyCollection();
@@ -2289,9 +2289,9 @@ var require_YAMLSeq = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/common/seq.js
+// node_modules/yaml/dist/schema/common/seq.js
 var require_seq = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/common/seq.js"(exports) {
+  "node_modules/yaml/dist/schema/common/seq.js"(exports) {
     "use strict";
     var identity = require_identity();
     var YAMLSeq = require_YAMLSeq();
@@ -2311,9 +2311,9 @@ var require_seq = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/common/string.js
+// node_modules/yaml/dist/schema/common/string.js
 var require_string = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/common/string.js"(exports) {
+  "node_modules/yaml/dist/schema/common/string.js"(exports) {
     "use strict";
     var stringifyString = require_stringifyString();
     var string = {
@@ -2330,9 +2330,9 @@ var require_string = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/common/null.js
+// node_modules/yaml/dist/schema/common/null.js
 var require_null = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/common/null.js"(exports) {
+  "node_modules/yaml/dist/schema/common/null.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var nullTag = {
@@ -2348,9 +2348,9 @@ var require_null = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/core/bool.js
+// node_modules/yaml/dist/schema/core/bool.js
 var require_bool = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/core/bool.js"(exports) {
+  "node_modules/yaml/dist/schema/core/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var boolTag = {
@@ -2372,9 +2372,9 @@ var require_bool = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringifyNumber.js
+// node_modules/yaml/dist/stringify/stringifyNumber.js
 var require_stringifyNumber = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyNumber.js"(exports) {
     "use strict";
     function stringifyNumber({ format, minFractionDigits, tag, value }) {
       if (typeof value === "bigint")
@@ -2399,9 +2399,9 @@ var require_stringifyNumber = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/core/float.js
+// node_modules/yaml/dist/schema/core/float.js
 var require_float = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/core/float.js"(exports) {
+  "node_modules/yaml/dist/schema/core/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2445,9 +2445,9 @@ var require_float = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/core/int.js
+// node_modules/yaml/dist/schema/core/int.js
 var require_int = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/core/int.js"(exports) {
+  "node_modules/yaml/dist/schema/core/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2490,9 +2490,9 @@ var require_int = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/core/schema.js
+// node_modules/yaml/dist/schema/core/schema.js
 var require_schema = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/core/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/core/schema.js"(exports) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -2518,9 +2518,9 @@ var require_schema = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/json/schema.js
+// node_modules/yaml/dist/schema/json/schema.js
 var require_schema2 = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/json/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/json/schema.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var map = require_map();
@@ -2585,9 +2585,9 @@ var require_schema2 = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/binary.js
+// node_modules/yaml/dist/schema/yaml-1.1/binary.js
 var require_binary = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/binary.js"(exports) {
     "use strict";
     var node_buffer = __require("buffer");
     var Scalar = require_Scalar();
@@ -2651,9 +2651,9 @@ var require_binary = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/pairs.js
+// node_modules/yaml/dist/schema/yaml-1.1/pairs.js
 var require_pairs = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/pairs.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -2729,9 +2729,9 @@ ${cn.comment}` : item.comment;
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/omap.js
+// node_modules/yaml/dist/schema/yaml-1.1/omap.js
 var require_omap = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/omap.js"(exports) {
     "use strict";
     var identity = require_identity();
     var toJS = require_toJS();
@@ -2807,9 +2807,9 @@ var require_omap = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/bool.js
+// node_modules/yaml/dist/schema/yaml-1.1/bool.js
 var require_bool2 = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/bool.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function boolStringify({ value, source }, ctx) {
@@ -2839,9 +2839,9 @@ var require_bool2 = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/float.js
+// node_modules/yaml/dist/schema/yaml-1.1/float.js
 var require_float2 = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/float.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var stringifyNumber = require_stringifyNumber();
@@ -2888,9 +2888,9 @@ var require_float2 = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/int.js
+// node_modules/yaml/dist/schema/yaml-1.1/int.js
 var require_int2 = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/int.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     var intIdentify = (value) => typeof value === "bigint" || Number.isInteger(value);
@@ -2967,9 +2967,9 @@ var require_int2 = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/set.js
+// node_modules/yaml/dist/schema/yaml-1.1/set.js
 var require_set = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/set.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -3056,9 +3056,9 @@ var require_set = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
+// node_modules/yaml/dist/schema/yaml-1.1/timestamp.js
 var require_timestamp = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/timestamp.js"(exports) {
     "use strict";
     var stringifyNumber = require_stringifyNumber();
     function parseSexagesimal(str, asBigInt) {
@@ -3144,9 +3144,9 @@ var require_timestamp = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/yaml-1.1/schema.js
+// node_modules/yaml/dist/schema/yaml-1.1/schema.js
 var require_schema3 = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
+  "node_modules/yaml/dist/schema/yaml-1.1/schema.js"(exports) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3188,9 +3188,9 @@ var require_schema3 = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/tags.js
+// node_modules/yaml/dist/schema/tags.js
 var require_tags = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/tags.js"(exports) {
+  "node_modules/yaml/dist/schema/tags.js"(exports) {
     "use strict";
     var map = require_map();
     var _null = require_null();
@@ -3282,9 +3282,9 @@ var require_tags = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/schema/Schema.js
+// node_modules/yaml/dist/schema/Schema.js
 var require_Schema = __commonJS({
-  "../agent-config/node_modules/yaml/dist/schema/Schema.js"(exports) {
+  "node_modules/yaml/dist/schema/Schema.js"(exports) {
     "use strict";
     var identity = require_identity();
     var map = require_map();
@@ -3314,9 +3314,9 @@ var require_Schema = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/stringify/stringifyDocument.js
+// node_modules/yaml/dist/stringify/stringifyDocument.js
 var require_stringifyDocument = __commonJS({
-  "../agent-config/node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
+  "node_modules/yaml/dist/stringify/stringifyDocument.js"(exports) {
     "use strict";
     var identity = require_identity();
     var stringify = require_stringify();
@@ -3394,9 +3394,9 @@ var require_stringifyDocument = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/doc/Document.js
+// node_modules/yaml/dist/doc/Document.js
 var require_Document = __commonJS({
-  "../agent-config/node_modules/yaml/dist/doc/Document.js"(exports) {
+  "node_modules/yaml/dist/doc/Document.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var Collection = require_Collection();
@@ -3703,9 +3703,9 @@ var require_Document = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/errors.js
+// node_modules/yaml/dist/errors.js
 var require_errors = __commonJS({
-  "../agent-config/node_modules/yaml/dist/errors.js"(exports) {
+  "node_modules/yaml/dist/errors.js"(exports) {
     "use strict";
     var YAMLError = class extends Error {
       constructor(name, pos, code, message) {
@@ -3768,9 +3768,9 @@ ${pointer}
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-props.js
+// node_modules/yaml/dist/compose/resolve-props.js
 var require_resolve_props = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-props.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-props.js"(exports) {
     "use strict";
     function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
       let spaceBefore = false;
@@ -3902,9 +3902,9 @@ var require_resolve_props = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/util-contains-newline.js
+// node_modules/yaml/dist/compose/util-contains-newline.js
 var require_util_contains_newline = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
+  "node_modules/yaml/dist/compose/util-contains-newline.js"(exports) {
     "use strict";
     function containsNewline(key) {
       if (!key)
@@ -3944,9 +3944,9 @@ var require_util_contains_newline = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/util-flow-indent-check.js
+// node_modules/yaml/dist/compose/util-flow-indent-check.js
 var require_util_flow_indent_check = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
+  "node_modules/yaml/dist/compose/util-flow-indent-check.js"(exports) {
     "use strict";
     var utilContainsNewline = require_util_contains_newline();
     function flowIndentCheck(indent, fc, onError) {
@@ -3962,9 +3962,9 @@ var require_util_flow_indent_check = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/util-map-includes.js
+// node_modules/yaml/dist/compose/util-map-includes.js
 var require_util_map_includes = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
+  "node_modules/yaml/dist/compose/util-map-includes.js"(exports) {
     "use strict";
     var identity = require_identity();
     function mapIncludes(ctx, items, search) {
@@ -3978,9 +3978,9 @@ var require_util_map_includes = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-block-map.js
+// node_modules/yaml/dist/compose/resolve-block-map.js
 var require_resolve_block_map = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-map.js"(exports) {
     "use strict";
     var Pair = require_Pair();
     var YAMLMap = require_YAMLMap();
@@ -4086,9 +4086,9 @@ var require_resolve_block_map = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-block-seq.js
+// node_modules/yaml/dist/compose/resolve-block-seq.js
 var require_resolve_block_seq = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-seq.js"(exports) {
     "use strict";
     var YAMLSeq = require_YAMLSeq();
     var resolveProps = require_resolve_props();
@@ -4137,9 +4137,9 @@ var require_resolve_block_seq = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-end.js
+// node_modules/yaml/dist/compose/resolve-end.js
 var require_resolve_end = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-end.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-end.js"(exports) {
     "use strict";
     function resolveEnd(end, offset, reqSpace, onError) {
       let comment = "";
@@ -4180,9 +4180,9 @@ var require_resolve_end = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-flow-collection.js
+// node_modules/yaml/dist/compose/resolve-flow-collection.js
 var require_resolve_flow_collection = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-flow-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Pair = require_Pair();
@@ -4374,9 +4374,9 @@ var require_resolve_flow_collection = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/compose-collection.js
+// node_modules/yaml/dist/compose/compose-collection.js
 var require_compose_collection = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/compose-collection.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-collection.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4439,9 +4439,9 @@ var require_compose_collection = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-block-scalar.js
+// node_modules/yaml/dist/compose/resolve-block-scalar.js
 var require_resolve_block_scalar = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-block-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     function resolveBlockScalar(ctx, scalar, onError) {
@@ -4622,9 +4622,9 @@ var require_resolve_block_scalar = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/resolve-flow-scalar.js
+// node_modules/yaml/dist/compose/resolve-flow-scalar.js
 var require_resolve_flow_scalar = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/resolve-flow-scalar.js"(exports) {
     "use strict";
     var Scalar = require_Scalar();
     var resolveEnd = require_resolve_end();
@@ -4842,9 +4842,9 @@ var require_resolve_flow_scalar = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/compose-scalar.js
+// node_modules/yaml/dist/compose/compose-scalar.js
 var require_compose_scalar = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-scalar.js"(exports) {
     "use strict";
     var identity = require_identity();
     var Scalar = require_Scalar();
@@ -4923,9 +4923,9 @@ var require_compose_scalar = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/util-empty-scalar-position.js
+// node_modules/yaml/dist/compose/util-empty-scalar-position.js
 var require_util_empty_scalar_position = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
+  "node_modules/yaml/dist/compose/util-empty-scalar-position.js"(exports) {
     "use strict";
     function emptyScalarPosition(offset, before, pos) {
       if (before) {
@@ -4953,9 +4953,9 @@ var require_util_empty_scalar_position = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/compose-node.js
+// node_modules/yaml/dist/compose/compose-node.js
 var require_compose_node = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/compose-node.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-node.js"(exports) {
     "use strict";
     var Alias = require_Alias();
     var identity = require_identity();
@@ -5059,9 +5059,9 @@ var require_compose_node = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/compose-doc.js
+// node_modules/yaml/dist/compose/compose-doc.js
 var require_compose_doc = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/compose-doc.js"(exports) {
+  "node_modules/yaml/dist/compose/compose-doc.js"(exports) {
     "use strict";
     var Document = require_Document();
     var composeNode = require_compose_node();
@@ -5102,9 +5102,9 @@ var require_compose_doc = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/compose/composer.js
+// node_modules/yaml/dist/compose/composer.js
 var require_composer = __commonJS({
-  "../agent-config/node_modules/yaml/dist/compose/composer.js"(exports) {
+  "node_modules/yaml/dist/compose/composer.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var directives = require_directives();
@@ -5310,9 +5310,9 @@ ${end.comment}` : end.comment;
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/cst-scalar.js
+// node_modules/yaml/dist/parse/cst-scalar.js
 var require_cst_scalar = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-scalar.js"(exports) {
     "use strict";
     var resolveBlockScalar = require_resolve_block_scalar();
     var resolveFlowScalar = require_resolve_flow_scalar();
@@ -5495,9 +5495,9 @@ var require_cst_scalar = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/cst-stringify.js
+// node_modules/yaml/dist/parse/cst-stringify.js
 var require_cst_stringify = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-stringify.js"(exports) {
     "use strict";
     var stringify = (cst) => "type" in cst ? stringifyToken(cst) : stringifyItem(cst);
     function stringifyToken(token) {
@@ -5556,9 +5556,9 @@ var require_cst_stringify = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/cst-visit.js
+// node_modules/yaml/dist/parse/cst-visit.js
 var require_cst_visit = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/cst-visit.js"(exports) {
+  "node_modules/yaml/dist/parse/cst-visit.js"(exports) {
     "use strict";
     var BREAK = /* @__PURE__ */ Symbol("break visit");
     var SKIP = /* @__PURE__ */ Symbol("skip children");
@@ -5618,9 +5618,9 @@ var require_cst_visit = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/cst.js
+// node_modules/yaml/dist/parse/cst.js
 var require_cst = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/cst.js"(exports) {
+  "node_modules/yaml/dist/parse/cst.js"(exports) {
     "use strict";
     var cstScalar = require_cst_scalar();
     var cstStringify = require_cst_stringify();
@@ -5720,9 +5720,9 @@ var require_cst = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/lexer.js
+// node_modules/yaml/dist/parse/lexer.js
 var require_lexer = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/lexer.js"(exports) {
+  "node_modules/yaml/dist/parse/lexer.js"(exports) {
     "use strict";
     var cst = require_cst();
     function isEmpty(ch) {
@@ -6309,9 +6309,9 @@ var require_lexer = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/line-counter.js
+// node_modules/yaml/dist/parse/line-counter.js
 var require_line_counter = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/line-counter.js"(exports) {
+  "node_modules/yaml/dist/parse/line-counter.js"(exports) {
     "use strict";
     var LineCounter = class {
       constructor() {
@@ -6340,9 +6340,9 @@ var require_line_counter = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/parse/parser.js
+// node_modules/yaml/dist/parse/parser.js
 var require_parser = __commonJS({
-  "../agent-config/node_modules/yaml/dist/parse/parser.js"(exports) {
+  "node_modules/yaml/dist/parse/parser.js"(exports) {
     "use strict";
     var node_process = __require("process");
     var cst = require_cst();
@@ -7214,9 +7214,9 @@ var require_parser = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/public-api.js
+// node_modules/yaml/dist/public-api.js
 var require_public_api = __commonJS({
-  "../agent-config/node_modules/yaml/dist/public-api.js"(exports) {
+  "node_modules/yaml/dist/public-api.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -7311,9 +7311,9 @@ var require_public_api = __commonJS({
   }
 });
 
-// ../agent-config/node_modules/yaml/dist/index.js
+// node_modules/yaml/dist/index.js
 var require_dist = __commonJS({
-  "../agent-config/node_modules/yaml/dist/index.js"(exports) {
+  "node_modules/yaml/dist/index.js"(exports) {
     "use strict";
     var composer = require_composer();
     var Document = require_Document();
@@ -9920,7 +9920,7 @@ function computeSurfaceDelta(oldS, newS) {
   return { oldVersion: oldS.version, newVersion: newS.version, changes };
 }
 
-// ../agent-config/node_modules/zod/v3/external.js
+// node_modules/zod/v3/external.js
 var external_exports = {};
 __export(external_exports, {
   BRAND: () => BRAND,
@@ -10032,7 +10032,7 @@ __export(external_exports, {
   void: () => voidType
 });
 
-// ../agent-config/node_modules/zod/v3/helpers/util.js
+// node_modules/zod/v3/helpers/util.js
 var util;
 (function(util2) {
   util2.assertEqual = (_) => {
@@ -10166,7 +10166,7 @@ var getParsedType = (data) => {
   }
 };
 
-// ../agent-config/node_modules/zod/v3/ZodError.js
+// node_modules/zod/v3/ZodError.js
 var ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
@@ -10284,7 +10284,7 @@ ZodError.create = (issues) => {
   return error;
 };
 
-// ../agent-config/node_modules/zod/v3/locales/en.js
+// node_modules/zod/v3/locales/en.js
 var errorMap = (issue, _ctx) => {
   let message;
   switch (issue.code) {
@@ -10387,7 +10387,7 @@ var errorMap = (issue, _ctx) => {
 };
 var en_default = errorMap;
 
-// ../agent-config/node_modules/zod/v3/errors.js
+// node_modules/zod/v3/errors.js
 var overrideErrorMap = en_default;
 function setErrorMap(map) {
   overrideErrorMap = map;
@@ -10396,7 +10396,7 @@ function getErrorMap() {
   return overrideErrorMap;
 }
 
-// ../agent-config/node_modules/zod/v3/helpers/parseUtil.js
+// node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
   const { data, path: path12, errorMaps, issueData } = params;
   const fullPath = [...path12, ...issueData.path || []];
@@ -10506,14 +10506,14 @@ var isDirty = (x) => x.status === "dirty";
 var isValid = (x) => x.status === "valid";
 var isAsync = (x) => typeof Promise !== "undefined" && x instanceof Promise;
 
-// ../agent-config/node_modules/zod/v3/helpers/errorUtil.js
+// node_modules/zod/v3/helpers/errorUtil.js
 var errorUtil;
 (function(errorUtil2) {
   errorUtil2.errToObj = (message) => typeof message === "string" ? { message } : message || {};
   errorUtil2.toString = (message) => typeof message === "string" ? message : message?.message;
 })(errorUtil || (errorUtil = {}));
 
-// ../agent-config/node_modules/zod/v3/types.js
+// node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
   constructor(parent, value, path12, key) {
     this._cachedPath = [];
@@ -14410,7 +14410,7 @@ var settingsSchema = external_exports.object({
   }).default({ acknowledged: false, consented_at: "", require_council: true })
 });
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/Options.js
+// node_modules/zod-to-json-schema/dist/esm/Options.js
 var ignoreOverride = /* @__PURE__ */ Symbol("Let zodToJsonSchema decide on which parser to use");
 var defaultOptions = {
   name: void 0,
@@ -14444,7 +14444,7 @@ var getDefaultOptions = (options) => typeof options === "string" ? {
   ...options
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/Refs.js
+// node_modules/zod-to-json-schema/dist/esm/Refs.js
 var getRefs = (options) => {
   const _options = getDefaultOptions(options);
   const currentPath = _options.name !== void 0 ? [..._options.basePath, _options.definitionPath, _options.name] : _options.basePath;
@@ -14465,7 +14465,7 @@ var getRefs = (options) => {
   };
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/errorMessages.js
+// node_modules/zod-to-json-schema/dist/esm/errorMessages.js
 function addErrorMessage(res, key, errorMessage, refs) {
   if (!refs?.errorMessages)
     return;
@@ -14481,7 +14481,7 @@ function setResponseValueAndErrors(res, key, value, errorMessage, refs) {
   addErrorMessage(res, key, errorMessage, refs);
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
+// node_modules/zod-to-json-schema/dist/esm/getRelativePath.js
 var getRelativePath = (pathA, pathB) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
@@ -14491,7 +14491,7 @@ var getRelativePath = (pathA, pathB) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join("/");
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/any.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/any.js
 function parseAnyDef(refs) {
   if (refs.target !== "openAi") {
     return {};
@@ -14507,7 +14507,7 @@ function parseAnyDef(refs) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/array.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/array.js
 function parseArrayDef(def, refs) {
   const res = {
     type: "array"
@@ -14531,7 +14531,7 @@ function parseArrayDef(def, refs) {
   return res;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/bigint.js
 function parseBigintDef(def, refs) {
   const res = {
     type: "integer",
@@ -14577,24 +14577,24 @@ function parseBigintDef(def, refs) {
   return res;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/boolean.js
 function parseBooleanDef() {
   return {
     type: "boolean"
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/branded.js
 function parseBrandedDef(_def, refs) {
   return parseDef(_def.type._def, refs);
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/catch.js
 var parseCatchDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/date.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/date.js
 function parseDateDef(def, refs, overrideDateStrategy) {
   const strategy = overrideDateStrategy ?? refs.dateStrategy;
   if (Array.isArray(strategy)) {
@@ -14653,7 +14653,7 @@ var integerDateParser = (def, refs) => {
   return res;
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/default.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/default.js
 function parseDefaultDef(_def, refs) {
   return {
     ...parseDef(_def.innerType._def, refs),
@@ -14661,12 +14661,12 @@ function parseDefaultDef(_def, refs) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/effects.js
 function parseEffectsDef(_def, refs) {
   return refs.effectStrategy === "input" ? parseDef(_def.schema._def, refs) : parseAnyDef(refs);
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/enum.js
 function parseEnumDef(def) {
   return {
     type: "string",
@@ -14674,7 +14674,7 @@ function parseEnumDef(def) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/intersection.js
 var isJsonSchema7AllOfType = (type) => {
   if ("type" in type && type.type === "string")
     return false;
@@ -14716,7 +14716,7 @@ function parseIntersectionDef(def, refs) {
   } : void 0;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/literal.js
 function parseLiteralDef(def, refs) {
   const parsedType = typeof def.value;
   if (parsedType !== "bigint" && parsedType !== "number" && parsedType !== "boolean" && parsedType !== "string") {
@@ -14736,7 +14736,7 @@ function parseLiteralDef(def, refs) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/string.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/string.js
 var emojiRegex2 = void 0;
 var zodPatterns = {
   /**
@@ -15061,7 +15061,7 @@ function stringifyRegExpWithFlags(regex, refs) {
   return pattern;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/record.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/record.js
 function parseRecordDef(def, refs) {
   if (refs.target === "openAi") {
     console.warn("Warning: OpenAI may not support records in schemas! Try an array of key-value pairs instead.");
@@ -15113,7 +15113,7 @@ function parseRecordDef(def, refs) {
   return schema;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/map.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/map.js
 function parseMapDef(def, refs) {
   if (refs.mapStrategy === "record") {
     return parseRecordDef(def, refs);
@@ -15138,7 +15138,7 @@ function parseMapDef(def, refs) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nativeEnum.js
 function parseNativeEnumDef(def) {
   const object = def.values;
   const actualKeys = Object.keys(def.values).filter((key) => {
@@ -15152,7 +15152,7 @@ function parseNativeEnumDef(def) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/never.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/never.js
 function parseNeverDef(refs) {
   return refs.target === "openAi" ? void 0 : {
     not: parseAnyDef({
@@ -15162,7 +15162,7 @@ function parseNeverDef(refs) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/null.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/null.js
 function parseNullDef(refs) {
   return refs.target === "openApi3" ? {
     enum: ["null"],
@@ -15172,7 +15172,7 @@ function parseNullDef(refs) {
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/union.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/union.js
 var primitiveMappings = {
   ZodString: "string",
   ZodNumber: "number",
@@ -15240,7 +15240,7 @@ var asAnyOf = (def, refs) => {
   return anyOf.length ? { anyOf } : void 0;
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/nullable.js
 function parseNullableDef(def, refs) {
   if (["ZodString", "ZodNumber", "ZodBigInt", "ZodBoolean", "ZodNull"].includes(def.innerType._def.typeName) && (!def.innerType._def.checks || !def.innerType._def.checks.length)) {
     if (refs.target === "openApi3") {
@@ -15272,7 +15272,7 @@ function parseNullableDef(def, refs) {
   return base && { anyOf: [base, { type: "null" }] };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/number.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/number.js
 function parseNumberDef(def, refs) {
   const res = {
     type: "number"
@@ -15321,7 +15321,7 @@ function parseNumberDef(def, refs) {
   return res;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/object.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/object.js
 function parseObjectDef(def, refs) {
   const forceOptionalIntoNullable = refs.target === "openAi";
   const result = {
@@ -15391,7 +15391,7 @@ function safeIsOptional(schema) {
   }
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/optional.js
 var parseOptionalDef = (def, refs) => {
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
@@ -15410,7 +15410,7 @@ var parseOptionalDef = (def, refs) => {
   } : parseAnyDef(refs);
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/pipeline.js
 var parsePipelineDef = (def, refs) => {
   if (refs.pipeStrategy === "input") {
     return parseDef(def.in._def, refs);
@@ -15430,12 +15430,12 @@ var parsePipelineDef = (def, refs) => {
   };
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/promise.js
 function parsePromiseDef(def, refs) {
   return parseDef(def.type._def, refs);
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/set.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/set.js
 function parseSetDef(def, refs) {
   const items = parseDef(def.valueType._def, {
     ...refs,
@@ -15455,7 +15455,7 @@ function parseSetDef(def, refs) {
   return schema;
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/tuple.js
 function parseTupleDef(def, refs) {
   if (def.rest) {
     return {
@@ -15483,24 +15483,24 @@ function parseTupleDef(def, refs) {
   }
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/undefined.js
 function parseUndefinedDef(refs) {
   return {
     not: parseAnyDef(refs)
   };
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/unknown.js
 function parseUnknownDef(refs) {
   return parseAnyDef(refs);
 }
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
+// node_modules/zod-to-json-schema/dist/esm/parsers/readonly.js
 var parseReadonlyDef = (def, refs) => {
   return parseDef(def.innerType._def, refs);
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/selectParser.js
+// node_modules/zod-to-json-schema/dist/esm/selectParser.js
 var selectParser = (def, typeName, refs) => {
   switch (typeName) {
     case ZodFirstPartyTypeKind.ZodString:
@@ -15576,7 +15576,7 @@ var selectParser = (def, typeName, refs) => {
   }
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/parseDef.js
+// node_modules/zod-to-json-schema/dist/esm/parseDef.js
 function parseDef(def, refs, forceResolution = false) {
   const seenItem = refs.seen.get(def);
   if (refs.override) {
@@ -15632,7 +15632,7 @@ var addMeta = (def, refs, jsonSchema) => {
   return jsonSchema;
 };
 
-// ../agent-config/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
+// node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js
 var zodToJsonSchema = (schema, options) => {
   const refs = getRefs(options);
   let definitions = typeof options === "object" && options.definitions ? Object.entries(options.definitions).reduce((acc, [name2, schema2]) => ({

--- a/docs/contracts/agents-layout.md
+++ b/docs/contracts/agents-layout.md
@@ -100,7 +100,7 @@ After `agent-config migrate`, a consumer project's `agents/` contains only:
 | Entry | Rationale |
 |---|---|
 | `overrides/` | Per-project skill/rule customisation |
-| `.event4u-bridge.yml` | ADR-020 bridge marker (global-only install) |
+| `.event4u-bridge.yml` | Retired (ADR-020 amendment 2026-07-13); global root resolves from `~/.event4u/agent-config`. Legacy leftover only — deleted by installer / `refresh --project`. |
 | `.gitkeep` | Keeps `agents/` in the tree |
 | `knowledge/` | Optional: curated project-specific knowledge pages |
 | `memory/` | Optional: promotion pipeline (intake gitignored, curated YAML committed) |

--- a/docs/contracts/consumer-bridge.md
+++ b/docs/contracts/consumer-bridge.md
@@ -1,81 +1,73 @@
 ---
-stability: beta
-keep-beta-until: 2026-08-21
+stability: stable
 ---
 
-# Consumer Bridge Marker
+# Consumer Bridge Marker (retired)
 
-**Status:** Proposed — road-to-global-only-install Phase 4.1.
+**Status:** Retired — [`ADR-020 § Amendment 2026-07-13`](../decisions/ADR-020-global-only-consumer-scope.md#amendment--2026-07-13--bridge-marker-retired).
 **Pairs with:** [`ADR-020 — global-only consumer scope`](../decisions/ADR-020-global-only-consumer-scope.md), [`ADR-007 § Amendment 2026-05-13`](../decisions/ADR-007-agent-discovery-scopes.md#amendment-2026-05-13--augment-global-only).
 
-## Purpose
+## Why it was retired
 
-After Phase 3 of `road-to-global-only-install` lands, a consumer
-project carries **only** `agents/overrides/` plus this bridge marker.
-Every other agent artefact (rules, skills, commands, personas,
-settings, user identity) is read from `~/.event4u/agent-config/`. The
-bridge marker is the single, declarative pointer that lets per-tool
-adapters (Windsurf, Cline, Gemini-CLI, the Augment workspace
-projector) locate the global root from inside the repo.
+The bridge marker `agents/.event4u-bridge.yml` was a per-project file that
+pointed at the global install. It carried **no project-specific data**:
+`global_root` is always the well-known `~/.event4u/agent-config` (one global
+install per machine), and nothing in the codebase ever read the field — the
+loader, doctor, and conformance checks all derive the global root independently
+via `user_global_paths.event4u_root()`. Yet the marker was **committed** to the
+shared project tree and rewrote its volatile `installed_at` / `installer_version`
+fields on every install, so each developer's install produced a diff and
+overwrote every other developer's committed copy. A file whose scope (global)
+did not match its location (per-project, committed) — pure churn.
 
-## File
+It is retired: the global root is resolved directly from the well-known path.
 
-`agents/.event4u-bridge.yml` at the consumer project root. <!-- ref-ignore -->
-Written by `scripts/install.py` on every successful consumer install
-(global scope). Idempotent — same file, refreshed `installed_at`.
+## What replaced it
 
-## Schema
+- **Global-root resolution** — `user_global_paths.event4u_root()` returns
+  `~/.event4u/agent-config` (overridable via `EVENT4U_CONFIG_HOME`). Readers fail
+  closed when that path is missing on disk. No per-project pointer is consulted.
+- **Migration-idempotency sentinel** — moved to
+  `agents/.agent-state/install-mode.txt` (written on every full / minimal
+  install), which the installer's legacy-detection and the doctor's
+  "global-only consumer" branch key on. `agents/overrides/` is an equivalent
+  signal.
+- **Project anchor** — a bare consumer `agents/` directory is anchored on
+  `agents/overrides/` (the guaranteed minimal-consumer surface), not the marker.
+- **Cleanup** — the installer and `agent-config refresh --project` delete any
+  legacy `agents/.event4u-bridge.yml` a prior install committed; the managed
+  `.gitignore` block also ignores it so a stale copy is never re-committed.
+
+## Per-tool anchor strategy (still active)
+
+Some AI tools only load rules when an anchor file is **inside** the workspace
+(Windsurf, Cline, Gemini-CLI). For those IDs the installer plants a thin pointer
+file under the tool's per-project directory:
 
 ```yaml
 schema: event4u-bridge/v1
+tool: windsurf
 global_root: ~/.event4u/agent-config
-installed_at: 2026-05-23T14:00:00Z
-installer_version: 2.4.0
+installed_at: 2026-07-13T00:00:00Z
 ```
 
-### Fields
+- Files: `.windsurf/agent-config.bridge.yml`, `.clinerules/agent-config.bridge.yml`,
+  `.gemini/agent-config.bridge.yml`.
+- `global_root` is the well-known path (readers expand `~` against the current
+  `$HOME`, never the writer's). There is no `bridge:` back-pointer — the retired
+  marker no longer exists to point at.
+- These anchors are **gitignored**: each developer regenerates them on install,
+  so they never churn in version control. Tools that load purely from user scope
+  (Claude Code, Cursor, Augment) need no per-tool file.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `schema` | string | yes | Must equal `event4u-bridge/v1`. Bumped on breaking field changes. |
-| `global_root` | string | yes | Absolute path or `~`-prefixed path to the global install. Readers MUST expand `~` against the current user's `$HOME`. |
-| `installed_at` | string (ISO-8601 UTC) | yes | Timestamp of the last successful install or refresh. |
-| `installer_version` | string (semver) | yes | Version of `@event4u/agent-config` that produced the marker. |
+## Legacy reader note
 
-Unknown fields are ignored by `v1` readers (forward-compat).
-
-## Reader contract
-
-Per-tool adapters MUST:
-
-1. Read `agents/.event4u-bridge.yml` from the project root. <!-- ref-ignore -->
-2. Reject `schema != event4u-bridge/v1` with a clear error pointing at this contract.
-3. Expand `~` in `global_root` against the **current process's** `$HOME` (not the writer's).
-4. Fail closed if `global_root` is missing on disk — never silently fall back to project-local lookup.
-5. Treat the marker as **read-only data**. Adapters MUST NOT write back through it.
-
-## Writer contract
-
-`scripts/install.py` MUST:
-
-1. Write the marker atomically (temp file + rename) so a crash never leaves a half-formed pointer.
-2. Refresh `installed_at` + `installer_version` on every consumer-scope install.
-3. Use `0644` permissions (world-readable, owner-writable). The marker contains no secrets.
-4. Skip the write under `AGENT_CONFIG_DEV_MODE=1` — maintainer dev installs never lay the bridge into the source repo (this repo's `agents/` directory is the project surface, not a consumer surface).
-
-The marker is (re-)written by the consumer install, by the wizard's apply step, and by `agent-config refresh --project` — which also scaffolds `agents/overrides/` and syncs the managed `agents/` block in `.gitignore` (the full minimal project surface, no wizard). `refresh --project` no-ops inside an agent-config checkout (same source-repo guard as rule 4).
-
-## Per-tool anchor strategy
-
-Some AI tools only load rules when an anchor file is **inside** the workspace (Windsurf, Cline, Gemini-CLI). For those IDs, Phase 4.3 plants a thin pointer file under the tool's per-project directory whose body resolves to the bridge marker. Tools that load purely from user-scope (Claude Code, Cursor, Augment) read the marker once and need no per-tool file.
-
-## Out of scope
-
-- Cross-machine sync of `~/.event4u/agent-config/` (the marker is local-only).
-- Editing the marker by hand to swap installs (use `agent-config init --global-root=…` instead, once that flag ships in Phase 5).
-- Multi-tenant `global_root` (one marker = one global install per project).
+A `v1` marker left in an un-migrated consumer repo still parses as before
+(`schema: event4u-bridge/v1`, `~`-expanded `global_root`). Do not add new readers
+of it — resolve the global root from the well-known path instead. The next
+install removes it.
 
 ## References
 
-- [`ADR-020`](../decisions/ADR-020-global-only-consumer-scope.md) — global-only consumer scope; cites the in-flight roadmap for Phase 4 surface design + Phase 5 migration order.
+- [`ADR-020`](../decisions/ADR-020-global-only-consumer-scope.md) — global-only consumer scope + the 2026-07-13 retirement amendment.
 - [`ADR-007`](../decisions/ADR-007-agent-discovery-scopes.md) — scope precedence and the global-default amendment.

--- a/docs/contracts/install-layout.md
+++ b/docs/contracts/install-layout.md
@@ -72,7 +72,7 @@ run writes only the subset for the selected scope + tools.
 |---|---|---|
 | `<root>/agents/settings/.agent-settings.yml` | deployed | canonical YAML settings (ADR-038) |
 | `<root>/.agent-settings.yml` | deployed | legacy fallback; migrated then removed on first run |
-| `<root>/agents/.event4u-bridge.yml` | bridge | project → `~/.event4u/agent-config/` pointer; schema `event4u-bridge/v1` |
+| `<root>/agents/.event4u-bridge.yml` | retired | Retired (ADR-020 amendment 2026-07-13); no longer written. Global root resolves from `~/.event4u/agent-config`; installer / `refresh --project` delete any legacy leftover. |
 | `<root>/agents/.agent-state/install-mode.txt` | marker | `minimal\n` or `full\n` |
 
 Minimal-install scaffold (override layer): `agents/overrides/{rules,skills,commands}/.gitkeep`,

--- a/docs/contracts/migrate-command.md
+++ b/docs/contracts/migrate-command.md
@@ -178,7 +178,7 @@ intentionally **outside** the unified `migrate` command:
 | Write a fresh `.agent-settings.yml` | wizard (`agent-config setup`) | Same as above — the wizard is the source of truth for new project config. |
 | Run the perms gate (`lint_global_paths.py`) | `agent-config doctor` | Migration deletes project-local state; the perms audit is a separate diagnostic on the global tree. |
 | `.legacy-pre-global-only/<stamp>/` snapshot | (removed) | Snapshot-and-rollback was a `migrate-to-global` semantic. The deletion path needs no snapshot — git history is the rollback surface. |
-| `agents/.event4u-bridge.yml` bridge marker write | `install.py` | Bridge marker is an install-time artefact, not a migration concern. |
+| `agents/.event4u-bridge.yml` legacy marker removal | `install.py` | Marker is retired (ADR-020 amendment 2026-07-13); install now deletes any legacy leftover instead of writing it. Global root resolves from `~/.event4u/agent-config`. |
 | `settings:migrate` (read-only copy of project YAML into global) | (removed; superseded by wizard) | The read-only copy was a stepping stone for the destructive move. With the deletion policy, neither step survives. |
 
 ## Exit codes

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -395,7 +395,6 @@ Consumer projects can maintain their own agent documentation:
 ```
 agents/
 ├── overrides/               ← Skill/rule/command overrides (required after migrate)
-├── .event4u-bridge.yml      ← Global-only bridge marker (ADR-020)
 ├── knowledge/               ← Optional: curated project-specific knowledge pages
 ├── memory/                  ← Optional: memory promotion pipeline
 ├── roadmaps/                ← Optional: project-local roadmaps

--- a/docs/decisions/ADR-020-global-only-consumer-scope.md
+++ b/docs/decisions/ADR-020-global-only-consumer-scope.md
@@ -126,6 +126,40 @@ This amendment narrows ADR-020's wording; the global-only **consumer install**
 decision (distributed content writes only to `~/.event4u/agent-config/`) is
 unchanged.
 
+## Amendment — 2026-07-13 · bridge marker retired
+
+The 2026-05-30 amendment restated `agents/.event4u-bridge.yml` as a mandated
+consumer metadata artefact. Field use showed the marker was a design mistake:
+it was **committed** to the shared project tree yet carried **no
+project-specific data**. `global_root` is always the well-known
+`~/.event4u/agent-config` (one global install per machine), and no code ever
+read the field — the loader, doctor, and conformance checks resolve the global
+root independently via `user_global_paths.event4u_root()`. Its only volatile
+content (`installed_at`, `installer_version`) meant every developer's install
+produced a diff and overwrote every other developer's committed copy. Scope
+(global) did not match location (per-project, committed).
+
+AI-council-converged (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2026-07-13,
+2-round debate): **Option B — eliminate the project marker; resolve the global
+root from the well-known path.** Changes:
+
+- The installer and `agent-config refresh --project` no longer write
+  `agents/.event4u-bridge.yml`; they **delete** any legacy committed copy. The
+  managed `.gitignore` block ignores it so a stale copy is never re-committed.
+- The global root is resolved from `~/.event4u/agent-config`
+  (`EVENT4U_CONFIG_HOME`-overridable), failing closed when absent.
+- Migration idempotency moved from the marker's presence to
+  `agents/.agent-state/install-mode.txt` (written on every install);
+  project-anchor detection keys on `agents/overrides/`.
+- The Windsurf / Cline / Gemini-CLI per-tool anchors stay (those tools cannot
+  read user scope) but now resolve the well-known path directly (no `bridge:`
+  back-pointer) and are **gitignored** — regenerated per-install, never shared.
+
+The single project-local agent surface is now **`agents/overrides/`** alone.
+This narrows the 2026-05-30 amendment; the global-only **consumer install**
+decision is unchanged. See [`consumer-bridge`](../contracts/consumer-bridge.md)
+(retired) for the reader/writer detail.
+
 ## Alternatives considered
 
 - **Status quo (project default + global opt-in).** Keeps the drift

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,8 @@
 **Principle:** Global is the only consumer scope. `init` writes to
 user-scope paths (`~/.event4u/agent-config/`, `~/.claude/`,
 `~/.cursor/`, …); the project tree only gets `agents/overrides/`
-and `agents/.event4u-bridge.yml`. Opt-in `export` if a team wants
+(the bridge marker was retired — ADR-020 amendment 2026-07-13; the
+global root resolves from `~/.event4u/agent-config`). Opt-in `export` if a team wants
 a tool's config committed to a repo. No Task, no Make, no build
 tools required.
 

--- a/docs/maintainers/dev-mode.md
+++ b/docs/maintainers/dev-mode.md
@@ -23,8 +23,9 @@ With the flag set, the installer:
 1. Allows project-scope writes back into the repo tree (so a
    maintainer can run `task dev:install-global` and iterate on the
    working copy).
-2. **Skips** writing `agents/.event4u-bridge.yml` into the package
-   repo (per `consumer-bridge § Writer contract`). The repo is the
+2. **Skips** consumer-surface writes into the package repo. (The
+   `agents/.event4u-bridge.yml` marker is retired — ADR-020 amendment
+   2026-07-13 — and no longer written at all.) The repo is the
    source, not a consumer of itself.
 3. Treats `~/.event4u/agent-config/` as a peer install — touches are
    limited to the working-copy projection.

--- a/src/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
+++ b/src/agent-src/templates/scripts/work_engine/_lib/agent_settings.ts
@@ -252,7 +252,10 @@ const _AGENTS_DIR_MARKERS: readonly string[] = [
     'roadmaps',
     'settings/.ai-council.yml',
     'roadmaps-progress.md',
-    '.event4u-bridge.yml',
+    // `overrides/` is the guaranteed minimal-consumer surface (ADR-020).
+    // Replaced the retired `.event4u-bridge.yml` marker (ADR-020 amendment
+    // 2026-07-13) so a bare consumer `agents/` dir stays anchorable.
+    'overrides',
 ];
 
 /**

--- a/src/config/gitignore-block.txt
+++ b/src/config/gitignore-block.txt
@@ -1,12 +1,9 @@
 # Agent config — tool-scope leftovers (ADR-020 § global-only consumer
 # install). After the Phase-5 migration the entire `.augment/`, `.claude/`,
 # `.cursor/` trees live under `~/.event4u/agent-config/`; consumers carry
-# only `agents/overrides/` + `agents/.event4u-bridge.yml`. The per-tool
-# bridge pointer files for Windsurf / Cline / Gemini-CLI live under
-# `.windsurf/`, `.clinerules/`, `.gemini/` and ARE committed — those
-# directories stay tracked (not listed here). Pre-Phase-5 entries kept
-# as a defence-in-depth ignore list for legacy installs that have not
-# migrated yet — Phase 5 unstages them on first migrate run.
+# only `agents/overrides/`. Pre-Phase-5 entries kept as a defence-in-depth
+# ignore list for legacy installs that have not migrated yet — Phase 5
+# unstages them on first migrate run.
 .augment/skills/
 .augment/commands/
 .augment/guidelines/
@@ -20,6 +17,19 @@
 .claude/agents/
 .claude/CLAUDE.md
 .cursor/rules/
+
+# Agent config — consumer bridge marker + per-tool project anchors.
+# The bridge marker was retired (ADR-020 amendment 2026-07-13): it carried
+# no project-specific data (global_root resolves from `~/.event4u/agent-config`)
+# yet was committed and rewritten by every developer's install. The global
+# root is now the well-known path. The Windsurf / Cline / Gemini-CLI anchors
+# remain (those tools cannot read user scope) but are gitignored — each
+# developer regenerates them on install; they are never shared. The install
+# deletes any legacy committed marker; this entry keeps a stale one ignored.
+/agents/.event4u-bridge.yml
+.windsurf/agent-config.bridge.yml
+.clinerules/agent-config.bridge.yml
+.gemini/agent-config.bridge.yml
 
 # Agent config — Phase 5 migration snapshot (ADR-020). Written by
 # `agent-config migrate-to-global` as a copy-then-move safety net so a

--- a/src/scripts/_cli/cmd_conformance.ts
+++ b/src/scripts/_cli/cmd_conformance.ts
@@ -47,7 +47,7 @@ import {
     _run_checks_no_manifest,
     _scan_foreign,
     ArgparseExit,
-    BRIDGE_MARKER_RELATIVE,
+    _is_global_only_consumer,
     STATUS_SYMBOLS,
 } from './cmd_doctor.js';
 
@@ -630,7 +630,7 @@ function main(argv: string[] | null = null): number {
     let doctorChecks: Dict[];
     let drift: Record<string, Dict[]> = { missing: [], modified: [], foreign: [], tag_drift: [] };
     if (manifest === null) {
-        const bridge_present = fs.existsSync(path.join(project_root, BRIDGE_MARKER_RELATIVE));
+        const bridge_present = _is_global_only_consumer(project_root);
         doctorChecks = _run_checks_no_manifest(project_root, bridge_present, null);
     } else {
         const [records, known] = _collect_manifest_entries(project_root, manifest);

--- a/src/scripts/_cli/cmd_doctor.ts
+++ b/src/scripts/_cli/cmd_doctor.ts
@@ -783,8 +783,20 @@ const MANIFEST_REQUIRED_CHECK_IDS: ReadonlySet<string> = new Set([
     'unsupported-combos',
 ]);
 
-/** Project-root-relative path of the ADR-020 global-only consumer marker. */
-const BRIDGE_MARKER_RELATIVE = 'agents/.event4u-bridge.yml';
+/**
+ * Signals a set-up global-only consumer. The `.event4u-bridge.yml` marker was
+ * retired (ADR-020 amendment 2026-07-13); the durable project-side signal is
+ * the install-mode marker (written on every install) or the `agents/overrides/`
+ * scaffold. Either is sufficient.
+ */
+const INSTALL_MODE_MARKER_RELATIVE = 'agents/.agent-state/install-mode.txt';
+
+function _is_global_only_consumer(project_root: string): boolean {
+    return (
+        isFile(path.join(project_root, INSTALL_MODE_MARKER_RELATIVE)) ||
+        isDir(path.join(project_root, 'agents', 'overrides'))
+    );
+}
 
 /** Repair targets that `--repair <id>` accepts. */
 const REPAIR_IDS = ['wizard-state'] as const;
@@ -1091,15 +1103,16 @@ function _check_global_binary(project_root: string): Dict {
             remedy: 'agent-config upgrade (refresh the global install + plugin)',
         };
     }
-    const bridge = path.join(project_root, 'agents', '.event4u-bridge.yml');
-    const bridge_note = isFile(bridge) ? '' : ' · no project bridge marker';
+    const consumer_note = _is_global_only_consumer(project_root)
+        ? ''
+        : ' · no project install marker';
     return {
         id: 'global-binary',
         status: 'ok',
-        message: `on PATH (${binary}); version ${binary_v || 'unknown'}${bridge_note}`,
-        remedy: !bridge_note
+        message: `on PATH (${binary}); version ${binary_v || 'unknown'}${consumer_note}`,
+        remedy: !consumer_note
             ? ''
-            : 'agent-config refresh --project (scaffold the bridge marker)',
+            : 'agent-config refresh --project (scaffold agents/overrides/)',
     };
 }
 
@@ -2582,8 +2595,8 @@ function _check_bridge_drift_no_manifest(bridge_present: boolean): Dict {
         id: 'bridge-drift',
         status: 'skipped',
         message:
-            'no project lockfile and no bridge marker → drift check ' +
-            'not applicable',
+            'no project lockfile and no consumer install marker → drift ' +
+            'check not applicable',
         remedy:
             'run `agent-config init` (project install) or ' +
             '`agent-config refresh --project` (global-only consumer)',
@@ -2647,7 +2660,7 @@ function _run_no_manifest(
         print(`  📍  project_root: ${project_root} (origin: ${origin})`);
         if (bridge_present) {
             print(
-                '  ℹ️   global-only consumer: bridge marker present, no ' +
+                '  ℹ️   global-only consumer: install marker present, no ' +
                     'project lockfile (expected under ADR-020)',
             );
             print(
@@ -2655,7 +2668,7 @@ function _run_no_manifest(
                     'to project-local distributed tools',
             );
         } else {
-            eprint(`  ⚠️   no project lockfile and no bridge marker at ${project_root}`);
+            eprint(`  ⚠️   no project lockfile and no consumer install marker at ${project_root}`);
             eprint(
                 '      run `agent-config init` (project install) or ' +
                     '`agent-config refresh --project` (global-only consumer)',
@@ -2998,7 +3011,7 @@ function main(argv: string[] | null = null): number {
     const manifest_pth = installed_tools.manifest_path(project_root);
     const manifest = installed_tools.read_manifest(manifest_pth);
     if (manifest === null) {
-        const bridge_present = isFile(path.join(project_root, BRIDGE_MARKER_RELATIVE));
+        const bridge_present = _is_global_only_consumer(project_root);
         return _run_no_manifest(opts, project_root, origin, bridge_present);
     }
 
@@ -3122,7 +3135,8 @@ export {
     CHECK_IDS,
     GLOBAL_CHECK_IDS,
     MANIFEST_REQUIRED_CHECK_IDS,
-    BRIDGE_MARKER_RELATIVE,
+    INSTALL_MODE_MARKER_RELATIVE,
+    _is_global_only_consumer,
     REPAIR_IDS,
     MCP_BETA_GATES,
     STATUS_SYMBOLS,

--- a/src/scripts/_cli/cmd_refresh.ts
+++ b/src/scripts/_cli/cmd_refresh.ts
@@ -16,9 +16,11 @@
  *   global root + Claude plugin hooks are rewritten from the
  *   currently-installed package. Idempotent: a second run is a no-op diff.
  * - `--project` — refresh the **minimal** project surface ADR-020 permits for
- *   a consumer: the `agents/.event4u-bridge.yml` marker, an `agents/overrides/`
- *   scaffold, and the managed `agents/` block in `.gitignore`. Writes **no**
- *   distributed content. No wizard.
+ *   a consumer: an `agents/overrides/` scaffold and the managed `agents/`
+ *   block in `.gitignore`, plus cleanup of any legacy
+ *   `agents/.event4u-bridge.yml` (the marker was retired — ADR-020 amendment
+ *   2026-07-13; the global root is resolved from `~/.event4u/agent-config`).
+ *   Writes **no** distributed content. No wizard.
  *
  * Bare `agent-config refresh` (no scope flag) errors — never a silent global
  * default (council 2026-05-30).
@@ -39,17 +41,15 @@
  *   `cannot run <cmd[0]>: <err>` line to stderr and returns 1, mirroring the
  *   Python `except OSError`. The runner is injectable for tests.
  * - `_lib.*` / `scripts.install` / `scripts.sync_gitignore` imports resolve to
- *   the `.ts` twins. `scripts.install._write_consumer_bridge_marker` is
- *   module-private in the install twin (not exported); it is replicated here
- *   byte-for-byte from the install-twin source — its helper chain
- *   (`_format_global_root_for_marker`, the atomic 0644 write, the UTC stamp,
- *   `user_global_paths.event4u_root`) is replicated alongside, keeping the
- *   shared import surface unchanged (same approach as `cmd_update.ts`).
+ *   the `.ts` twins. `scripts.install._remove_legacy_consumer_bridge_marker`
+ *   is module-private in the install twin (not exported); it is replicated
+ *   here — a small `isFile` + `fs.rmSync` guard gated on dev-mode / source
+ *   repo, matching the install-twin source.
  * - `Path(__file__).resolve().parents[3]` → `path.resolve(_HERE_DIR, '..',
  *   '..', '..')`. `.is_file()` / `.is_dir()` / `.exists()` →
  *   `_isFile` / `_isDir` / `_exists`. The `packages/` source-marker glob probe
  *   becomes a `readdirSync` scan of `packages/` (the source-marker dir name is
- *   the `SRC_MARKER_DIR` constant, shared with the bridge-marker guard).
+ *   the `SRC_MARKER_DIR` constant, shared with the marker-cleanup guard).
  * - `print(..., file=out/err)` → an injectable `OutSink` defaulting to
  *   `process.stdout` / `process.stderr`. The Python `out`/`err` kwargs default
  *   to `sys.stdout` / `sys.stderr`.
@@ -60,17 +60,13 @@
  *   `except ImportError` branch wording.
  */
 
-import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import * as installed_lock from '../_lib/installed_lock.js';
 import * as cli_wrapper from '../_lib/cli_wrapper.js';
-import * as user_global_paths from '../_lib/user_global_paths.js';
 import * as sync_gitignore from '../sync_gitignore.js';
 
 const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
@@ -149,103 +145,30 @@ const CONSUMER_BRIDGE_MARKER_RELPATH = path.join('agents', '.event4u-bridge.yml'
  */
 const SRC_MARKER_DIR = '.agent-src.uncondensed';
 
-/** `Path.resolve()` — absolute, symlink-resolved where possible. */
-function resolvePath(p: string): string {
-    try {
-        return fs.realpathSync(path.resolve(p));
-    } catch {
-        return path.resolve(p);
-    }
-}
-
-function _format_global_root_for_marker(global_root: string): string {
-    const home = resolvePath(os.homedir());
-    const resolved = resolvePath(global_root);
-    const rel = path.relative(home, resolved);
-    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
-        return global_root;
-    }
-    return `~/${rel.split(path.sep).join('/')}`;
-}
-
-/** `datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")`. */
-function utcStamp(now?: Date): string {
-    const d = now ?? new Date();
-    const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
-    return (
-        `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}` +
-        `T${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}Z`
-    );
-}
-
-function mkdirp(p: string): void {
-    fs.mkdirSync(p, { recursive: true });
-}
-
-/** `tempfile.mkstemp` + write + `os.chmod(0o644)` + `os.replace` (atomic). */
-function atomicWrite0644(target: string, body: string, prefix: string): void {
-    const dir = path.dirname(target);
-    const tmpName = path.join(
-        dir,
-        `${prefix}${process.pid}.${crypto.randomBytes(6).toString('hex')}.yml.tmp`,
-    );
-    let fd: number | null = null;
-    try {
-        fd = fs.openSync(tmpName, 'wx', 0o644);
-        fs.writeFileSync(fd, body, 'utf-8');
-        fs.closeSync(fd);
-        fd = null;
-        fs.chmodSync(tmpName, 0o644);
-        fs.renameSync(tmpName, target);
-    } catch (err) {
-        if (fd !== null) {
-            try {
-                fs.closeSync(fd);
-            } catch {
-                /* fd may already be closed */
-            }
-        }
-        try {
-            fs.unlinkSync(tmpName);
-        } catch {
-            /* best-effort cleanup */
-        }
-        throw err;
-    }
-}
 
 /**
- * Mirrors `install._write_consumer_bridge_marker` (module-private). Returns the
- * written path, or `null` when skipped (dev mode / source repo).
+ * Mirrors `install._remove_legacy_consumer_bridge_marker` (module-private).
+ * The consumer bridge marker was retired (ADR-020 amendment 2026-07-13); the
+ * global root is resolved from the well-known `~/.event4u/agent-config` path.
+ * `refresh --project` deletes any legacy `agents/.event4u-bridge.yml` a prior
+ * install committed. Returns the removed path, or `null` when nothing to do
+ * (no marker / dev mode / source repo).
  */
-function _write_consumer_bridge_marker(
+function _remove_legacy_consumer_bridge_marker(
     project_root: string,
-    installer_version: string,
     env: NodeJS.ProcessEnv | null = null,
-    now: Date | null = null,
 ): string | null {
     const env_map = env ?? process.env;
     if (env_map['AGENT_CONFIG_DEV_MODE'] === '1') return null;
     if (_isDir(path.join(project_root, SRC_MARKER_DIR))) return null;
 
-    const global_root_str = _format_global_root_for_marker(
-        user_global_paths.event4u_root(env_map),
-    );
-    const stamp = utcStamp(now ?? undefined);
-
-    const body =
-        '# event4u/agent-config — consumer bridge marker (auto-written).\n' +
-        '# Spec: docs/contracts/consumer-bridge.md (event4u-bridge/v1).\n' +
-        '# Reader contract: expand ~ against the current $HOME; fail closed\n' +
-        '# when global_root is missing on disk; never write back through it.\n' +
-        'schema: event4u-bridge/v1\n' +
-        `global_root: ${global_root_str}\n` +
-        `installed_at: ${stamp}\n` +
-        `installer_version: ${installer_version}\n`;
-
     const target = path.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
-    mkdirp(path.dirname(target));
-    atomicWrite0644(target, body, '.event4u-bridge.');
+    if (!_isFile(target)) return null;
+    try {
+        fs.rmSync(target);
+    } catch {
+        return null;
+    }
     return target;
 }
 
@@ -292,10 +215,10 @@ function _refresh_global(runner: Runner, out: OutSink, err: OutSink): number {
 /**
  * True when `project_root` is the agent-config package itself.
  *
- * `_write_consumer_bridge_marker` only guards on a root-level
+ * `_remove_legacy_consumer_bridge_marker` only guards on a root-level
  * `.agent-src.uncondensed/`, which the monorepo keeps under `packages/<pkg>/`
- * instead — so the narrow guard misses here and would write a consumer marker
- * into the maintainer tree. This broader check (condensed output, packaged
+ * instead — so the narrow guard misses here and would touch the maintainer
+ * tree. This broader check (condensed output, packaged
  * source, or the package's own `package.json` name) makes `refresh --project`
  * a no-op in any agent-config checkout. Consumers use dev-mode, not refresh.
  */
@@ -350,19 +273,13 @@ function _refresh_project(project_root: string, out: OutSink, err: OutSink): num
         return 0;
     }
 
-    const version = installed_lock.current_package_version() || '0.0.0';
-    const marker = _write_consumer_bridge_marker(project_root, version);
-    if (marker === null) {
-        _print(
-            out,
-            'ℹ️  refresh --project skipped the bridge marker: this is the ' +
-                'agent-config source repo (or AGENT_CONFIG_DEV_MODE=1). Nothing ' +
-                'to scaffold in a maintainer checkout.',
-        );
-        return 0;
+    // Bridge marker retired (ADR-020 amendment 2026-07-13). The global root is
+    // resolved from the well-known `~/.event4u/agent-config` path, so there is
+    // no per-project marker to scaffold — clean up any legacy one instead.
+    const removed = _remove_legacy_consumer_bridge_marker(project_root);
+    if (removed !== null) {
+        _print(out, `✅  removed legacy bridge marker: ${removed}`);
     }
-
-    _print(out, `✅  bridge marker: ${marker}`);
 
     const overrides = path.join(project_root, 'agents', 'overrides');
     fs.mkdirSync(overrides, { recursive: true });
@@ -372,8 +289,8 @@ function _refresh_project(project_root: string, out: OutSink, err: OutSink): num
             keep,
             '# Project overrides\n\n' +
                 'Project-local overrides/extensions of shared skills, rules, and ' +
-                'commands. The only project-side agent surface ADR-020 permits ' +
-                'besides the bridge marker. See the `override-management` skill.\n',
+                'commands. The only project-side agent surface ADR-020 permits. ' +
+                'See the `override-management` skill.\n',
         );
     }
     _print(out, `✅  overrides scaffold: ${overrides}`);
@@ -543,7 +460,7 @@ export {
     _is_source_repo,
     _refresh_project,
     _sync_gitignore,
-    _write_consumer_bridge_marker,
+    _remove_legacy_consumer_bridge_marker,
     ArgparseExit,
 };
 export type { Args, Runner };

--- a/src/scripts/_lib/agent_settings.ts
+++ b/src/scripts/_lib/agent_settings.ts
@@ -254,7 +254,10 @@ const _AGENTS_DIR_MARKERS: readonly string[] = [
     'roadmaps',
     'settings/.ai-council.yml',
     'roadmaps-progress.md',
-    '.event4u-bridge.yml',
+    // `overrides/` is the guaranteed minimal-consumer surface (ADR-020).
+    // Replaced the retired `.event4u-bridge.yml` marker (ADR-020 amendment
+    // 2026-07-13) so a bare consumer `agents/` dir stays anchorable.
+    'overrides',
 ];
 
 /**

--- a/src/scripts/install.ts
+++ b/src/scripts/install.ts
@@ -2494,7 +2494,11 @@ function _detect_legacy_for_migration(project_root: string): string[] {
         return [];
     }
 
-    if (isFile(path.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH))) return [];
+    // Migration-idempotency sentinel. Previously the consumer bridge marker;
+    // that file was retired (ADR-020 amendment 2026-07-13), so the durable
+    // "this project has already been installed / migrated" signal is now the
+    // install-mode marker, written on every full or minimal install.
+    if (isFile(path.join(project_root, INSTALL_MODE_MARKER_REL))) return [];
 
     const found: string[] = [];
     for (const name of MIGRATE_LEGACY_YAML_FILES) {
@@ -2573,38 +2577,34 @@ function _format_global_root_for_marker(global_root: string): string {
 }
 
 /**
- * Write `agents/.event4u-bridge.yml`. Skipped under `AGENT_CONFIG_DEV_MODE=1`
- * and when the project root is the agent-config source repo
- * (`.agent-src.uncondensed/` present) — same rationale. Atomic write.
+ * Remove a legacy `agents/.event4u-bridge.yml` if a previous install wrote
+ * one. The bridge marker was retired (ADR-020 dated amendment 2026-07-13):
+ * it carried no project-specific data — `global_root` is derived directly
+ * from the well-known `~/.event4u/agent-config` path — yet was committed to
+ * the shared project tree, so every developer's install rewrote its volatile
+ * `installed_at` / `installer_version` fields and overwrote each other's.
+ * The global root is now resolved from the well-known path; the migration
+ * idempotency sentinel moved to `agents/.agent-state/install-mode.txt`.
+ *
+ * Skipped under `AGENT_CONFIG_DEV_MODE=1` and inside the agent-config source
+ * repo (`.agent-src.uncondensed/` present) — the same gate the writer used.
+ * Returns the removed path (so the caller can report it) or null.
  */
-function _write_consumer_bridge_marker(
+function _remove_legacy_consumer_bridge_marker(
     project_root: string,
-    installer_version: string,
     env: NodeJS.ProcessEnv | null = null,
-    now: Date | null = null,
 ): string | null {
     const env_map = env ?? process.env;
     if (env_map['AGENT_CONFIG_DEV_MODE'] === '1') return null;
     if (isDir(path.join(project_root, '.agent-src.uncondensed'))) return null;
 
-    const global_root_str = _format_global_root_for_marker(
-        user_global_paths.event4u_root(env_map),
-    );
-    const stamp = utcStamp(now ?? undefined);
-
-    const body =
-        '# event4u/agent-config — consumer bridge marker (auto-written).\n' +
-        '# Spec: docs/contracts/consumer-bridge.md (event4u-bridge/v1).\n' +
-        '# Reader contract: expand ~ against the current $HOME; fail closed\n' +
-        '# when global_root is missing on disk; never write back through it.\n' +
-        'schema: event4u-bridge/v1\n' +
-        `global_root: ${global_root_str}\n` +
-        `installed_at: ${stamp}\n` +
-        `installer_version: ${installer_version}\n`;
-
     const target = path.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
-    mkdirp(path.dirname(target));
-    atomicWrite0644(target, body, '.event4u-bridge.');
+    if (!isFile(target)) return null;
+    try {
+        fs.rmSync(target);
+    } catch {
+        return null;
+    }
     return target;
 }
 
@@ -2641,16 +2641,14 @@ function _write_per_tool_project_anchors(
         const target = path.join(project_root, rel_path);
         mkdirp(path.dirname(target));
 
-        const bridge_abs = path.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
-        const bridge_rel = path.relative(path.dirname(target), bridge_abs);
-
         const body =
             '# event4u/agent-config — per-tool project anchor (auto-written).\n' +
             '# Spec: docs/contracts/consumer-bridge.md § Per-tool anchor strategy.\n' +
-            `# Tool: ${tool_id}. Bridge marker: agents/.event4u-bridge.yml.\n` +
+            `# Tool: ${tool_id}. Resolves the global install directly — no\n` +
+            '# project-local bridge marker (retired, ADR-020 amendment 2026-07-13).\n' +
+            '# This anchor is gitignored: each developer regenerates it on install.\n' +
             'schema: event4u-bridge/v1\n' +
             `tool: ${tool_id}\n` +
-            `bridge: ${bridge_rel}\n` +
             `global_root: ${global_root_str}\n` +
             `installed_at: ${stamp}\n`;
 
@@ -3377,15 +3375,15 @@ function install_global(
         const rc = _update_installed_tools_manifest(project_root, tools, 'global', force, files_by_tool);
         if (rc !== 0) return rc;
 
-        // Consumer bridge marker (Phase 4.2). The surrounding
-        // `.agent-src.uncondensed` guard already covers the source-repo case;
-        // the dev-mode skip is enforced inside the writer.
-        const marker_path = _write_consumer_bridge_marker(project_root, installed_version);
-        if (marker_path !== null && !state.QUIET) {
-            const rel = isRelativeTo(marker_path, project_root)
-                ? path.relative(project_root, marker_path)
-                : marker_path;
-            info(`Bridge marker written: ${rel}`);
+        // Consumer bridge marker retired (ADR-020 amendment 2026-07-13):
+        // clean up any legacy `agents/.event4u-bridge.yml` a prior install
+        // committed. The global root is resolved from the well-known path.
+        const removed_marker = _remove_legacy_consumer_bridge_marker(project_root);
+        if (removed_marker !== null && !state.QUIET) {
+            const rel = isRelativeTo(removed_marker, project_root)
+                ? path.relative(project_root, removed_marker)
+                : removed_marker;
+            info(`Removed legacy bridge marker: ${rel}`);
         }
 
         const anchor_paths = _write_per_tool_project_anchors(project_root, tools);
@@ -3800,13 +3798,14 @@ function install_minimal(target_root_in: string, force: boolean, user_type: stri
         }
     }
 
-    const installed_version = installed_lock.current_package_version();
-    const marker_path = _write_consumer_bridge_marker(target_root, installed_version);
-    if (marker_path !== null) {
-        const rel = isRelativeTo(marker_path, target_root)
-            ? path.relative(target_root, marker_path)
-            : marker_path;
-        success(`Wrote ${rel}`);
+    // Bridge marker retired (ADR-020 amendment 2026-07-13) — clean up any
+    // legacy `agents/.event4u-bridge.yml` a prior install left behind.
+    const removed_marker = _remove_legacy_consumer_bridge_marker(target_root);
+    if (removed_marker !== null) {
+        const rel = isRelativeTo(removed_marker, target_root)
+            ? path.relative(target_root, removed_marker)
+            : removed_marker;
+        success(`Removed legacy bridge marker: ${rel}`);
     }
 
     _write_install_mode_marker(target_root, 'minimal');

--- a/src/scripts/install.ts
+++ b/src/scripts/install.ts
@@ -2587,8 +2587,8 @@ function _format_global_root_for_marker(global_root: string): string {
  * idempotency sentinel moved to `agents/.agent-state/install-mode.txt`.
  *
  * Skipped under `AGENT_CONFIG_DEV_MODE=1` and inside the agent-config source
- * repo (`.agent-src.uncondensed/` present) — the same gate the writer used.
- * Returns the removed path (so the caller can report it) or null.
+ * repo (detected by the uncondensed-source marker dir) — the same gate the
+ * writer used. Returns the removed path (so the caller can report it) or null.
  */
 function _remove_legacy_consumer_bridge_marker(
     project_root: string,

--- a/src/scripts/lint_agents_layout.ts
+++ b/src/scripts/lint_agents_layout.ts
@@ -42,7 +42,11 @@ const ALLOWED_FLAT_FILES: ReadonlySet<string> = new Set([
     // separate violation caught by check_tracked_but_ignored.ts.
     '.ai-video.xml',       // operator AI-video config; gitignored per .gitignore § AI Video
     'installed-tools.lock', // installer per-user inventory; gitignored per ADR-020
-    '.event4u-bridge.yml',  // consumer bridge marker; ADR-020 (should only be in consumers)
+    // Retired marker (ADR-020 amendment 2026-07-13). No longer written; the
+    // global root resolves from `~/.event4u/agent-config`. Kept tolerated so a
+    // legacy leftover in a not-yet-reinstalled consumer is not flagged as a
+    // violation — the next install deletes it.
+    '.event4u-bridge.yml',
 ]);
 
 // All directories allowed at the agents/ root in the SOURCE REPO.
@@ -75,6 +79,8 @@ const ALLOWED_SOURCE_DIRS: ReadonlySet<string> = new Set([
 const CONSUMER_EXPECTED_ENTRIES: ReadonlySet<string> = new Set([
     // Required consumer entries
     'overrides',
+    // Retired marker (ADR-020 amendment 2026-07-13) — no longer written, but
+    // kept in the tolerated set so a legacy leftover does not warn.
     '.event4u-bridge.yml',
     '.gitkeep',
     // Optional but legitimate consumer entries (will not trigger warnings)
@@ -93,9 +99,9 @@ const CONSUMER_EXPECTED_ENTRIES: ReadonlySet<string> = new Set([
 const MIGRATE_HINT =
     'Run `npx @event4u/agent-config migrate` to sweep legacy project-scope ' +
     'artefacts in one pass. The unified `migrate` command (see ' +
-    '`docs/contracts/migrate-command.md`) leaves `agents/overrides/` + ' +
-    '`agents/.event4u-bridge.yml` as the only consumer-side files; the ' +
-    'wizard recreates fresh config on `agent-config setup`.';
+    '`docs/contracts/migrate-command.md`) leaves `agents/overrides/` as the ' +
+    'only consumer-side agent surface; the wizard recreates fresh config on ' +
+    '`agent-config setup`.';
 
 function _isDir(p: string): boolean {
     try {

--- a/src/scripts/mcp_server/tools.ts
+++ b/src/scripts/mcp_server/tools.ts
@@ -775,9 +775,7 @@ async function _runDoctorLeg(consumerRoot: string): Promise<{
         let tagDrift: Record<string, unknown>[] = [];
         let checks: Record<string, unknown>[];
         if (manifest === null) {
-            const bridgePresent = fs.existsSync(
-                path.join(projectRoot, doctor.BRIDGE_MARKER_RELATIVE),
-            );
+            const bridgePresent = doctor._is_global_only_consumer(projectRoot);
             checks = doctor._run_checks_no_manifest(projectRoot, bridgePresent, null);
         } else {
             const [records, known] = doctor._collect_manifest_entries(projectRoot, manifest);

--- a/tests/scripts/_cli/cmd_doctor.test.ts
+++ b/tests/scripts/_cli/cmd_doctor.test.ts
@@ -119,10 +119,12 @@ afterEach(() => {
     fs.rmSync(tmp, { recursive: true, force: true });
 });
 
+// A global-only consumer fixture. The `.event4u-bridge.yml` marker was retired
+// (ADR-020 amendment 2026-07-13); the doctor now recognises a global-only
+// consumer by the `agents/overrides/` scaffold (or the install-mode marker).
 function bridgeRepo(): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-bridge-'));
-    fs.mkdirSync(path.join(dir, 'agents'), { recursive: true });
-    fs.writeFileSync(path.join(dir, 'agents', '.event4u-bridge.yml'), 'x: 1\n');
+    fs.mkdirSync(path.join(dir, 'agents', 'overrides'), { recursive: true });
     return dir;
 }
 

--- a/tests/scripts/_cli/cmd_refresh.test.ts
+++ b/tests/scripts/_cli/cmd_refresh.test.ts
@@ -112,7 +112,7 @@ describe('refresh — argument errors', () => {
 // ---------------------------------------------------------------------------
 
 describe('refresh --project — fresh consumer', () => {
-    it('scaffolds bridge marker + overrides + gitignore; output parity, exit 0', () => {
+    it('scaffolds overrides + gitignore (no bridge marker); output parity, exit 0', () => {
         // Independent fixtures so neither side observes the other's writes.
         const pcwd = fs.mkdtempSync(path.join(os.tmpdir(), 'refresh-py-'));
         const tcwd = fs.mkdtempSync(path.join(os.tmpdir(), 'refresh-ts-'));
@@ -126,7 +126,10 @@ describe('refresh --project — fresh consumer', () => {
                     .map((e) => path.relative(d, path.join((e as fs.Dirent).parentPath ?? d, e.name)))
                     .sort();
             const scaffolded = tree(tcwd);
-            expect(scaffolded).toContain('agents/.event4u-bridge.yml');
+            // Bridge marker retired (ADR-020 amendment 2026-07-13) — refresh
+            // no longer scaffolds it; the global root resolves from the
+            // well-known path. Only the overrides scaffold lands.
+            expect(scaffolded).not.toContain('agents/.event4u-bridge.yml');
             expect(scaffolded).toContain('agents/overrides/README.md');
         } finally {
             fs.rmSync(pcwd, { recursive: true, force: true });

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -353,9 +353,17 @@ test_cli_wrapper_overwrites_on_reinstall() {
 
 test_cli_wrapper_delegates_to_master() {
     setup; run_install
-    # Simulate node_modules layout so the wrapper can find the master CLI.
-    mkdir -p "$TMPDIR/node_modules/@event4u"
-    ln -sf "$SCRIPT_DIR" "$TMPDIR/node_modules/@event4u/agent-config"
+    # Simulate the npm-install layout at the EXACT path the wrapper probes
+    # (node_modules/@event4u/agent-config/scripts/agent-config → master
+    # shim). Symlinking the whole package dir to $SCRIPT_DIR does not expose
+    # that path (the repo ships src/scripts/, not top-level scripts/), so
+    # the wrapper silently fell through to the npx network fallback — which
+    # flakes during a release when the @latest dist-tag briefly outruns
+    # tarball propagation. Point at the real shim so this exercises LOCAL
+    # delegation deterministically, offline.
+    mkdir -p "$TMPDIR/node_modules/@event4u/agent-config/scripts"
+    ln -sf "$SCRIPT_DIR/src/scripts/agent-config" \
+        "$TMPDIR/node_modules/@event4u/agent-config/scripts/agent-config"
     local out
     out="$(cd "$TMPDIR" && ./agent-config help 2>&1)"
     if printf '%s' "$out" | grep -q "agent-config — event4u/agent-config CLI"; then


### PR DESCRIPTION
## Why

Two independent fixes, one PR.

### 1. Retire the consumer bridge marker (main change)

`agents/.event4u-bridge.yml` was **committed** to the shared project tree but carried **no project-specific data**: `global_root` is always the well-known `~/.event4u/agent-config` (one global install per machine), and no code ever read the field — the loader, doctor, and conformance checks all derive the global root independently via `user_global_paths.event4u_root()`. Its only volatile content (`installed_at` / `installer_version`) meant every developer's install produced a diff and overwrote every other developer's committed copy. The file's scope (global) did not match its location (per-project, committed).

**Decision:** AI-council-converged (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2026-07-13, 2-round debate) on **Option B — eliminate the project marker; resolve the global root from the well-known path.**

Changes:
- installer + `refresh --project` stop writing the marker and **delete** any legacy committed copy; the managed `.gitignore` block ignores it so a stale copy is never re-committed
- migration-idempotency sentinel moved to `agents/.agent-state/install-mode.txt` (written on every install); bare-`agents/`-dir project anchor moved to `agents/overrides/`
- the Windsurf/Cline/Gemini per-tool anchors stay (those tools cannot read user scope) but now resolve the well-known path directly (no `bridge:` back-pointer) and are **gitignored** — regenerated per install, never shared
- `doctor` / `conformance` / `mcp` detect a global-only consumer via the install-mode marker or the `overrides/` scaffold
- ADR-020 dated amendment (2026-07-13), `consumer-bridge` contract marked retired, docs swept

The only project-local consumer agent surface is now `agents/overrides/`.

### 2. Hermetic wrapper-delegation test (flaky CI fix)

`test_cli_wrapper_delegates_to_master` symlinked the whole package dir to the repo root, but the wrapper's local-master path probes `node_modules/@event4u/agent-config/scripts/agent-config` — a path the repo layout (`src/scripts/`, not top-level `scripts/`) never exposes — so the test silently fell through to the **npx network fallback**. During the 9.0.0 release the `@latest` dist-tag briefly outran tarball propagation → `ETARGET for @9.0.0` → flaky failure. The test now symlinks the exact probed path to the real master shim, exercising local delegation deterministically and offline.

## Verification

- `task typecheck-ts` — clean
- `vitest run` on install / cmd_refresh / cmd_doctor / cmd_conformance / lint_agents_layout — **170 passed**
- `bash tests/test_install.sh` — **100 passed, 0 failed** (wrapper delegation now reaches master locally)
- `check_references` — no broken references
- `task sync` — regenerated the one dist template twin