### PR TITLE
feat(hooks): PR-URL reminder — deterministic backstop for direct-answers reply-close

### DIFF
--- a/src/scripts/hook_manifest.yaml
+++ b/src/scripts/hook_manifest.yaml
@@ -145,6 +145,17 @@ concerns:
     script: src/scripts/team_review_gate_hook.ts
     args: []
     fail_closed: false
+  # Reply-shape backstop for the direct-answers rule (reply-close): a PR
+  # created THIS turn must end the reply as the literal last raw URL. This
+  # PostToolUse hook fires right after a PR *create* (gh pr create, or a
+  # github create-pull-request tool) that produced a `…/pull/<n>` URL, and
+  # WARNS in context (exit 2) so the reminder lands before the reply closes.
+  # Never blocks; unconditional (reinforces an always-on rule, fires only on
+  # the rare create event, so no settings gate). fail_closed: false.
+  pr-url-reminder:
+    script: src/scripts/pr_url_reminder_hook.ts
+    args: []
+    fail_closed: false
 
 platforms:
   augment:
@@ -152,7 +163,7 @@ platforms:
     session_end:      [chat-history]
     stop:             [chat-history, hot-context, verify-before-complete]
     pre_tool_use:     [block-no-verify, rtk-wrap, design-slop]
-    post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
+    post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan, pr-url-reminder]
 
   claude:
     session_start:    [chat-history, hot-context, first-run-gate, onboarding-gate, verify-before-complete, minimal-safe-diff, profile-staleness, wrapper-freshness, surface-probe]
@@ -160,7 +171,7 @@ platforms:
     stop:             [chat-history, hot-context, verify-before-complete, team-review-gate]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
     pre_tool_use:     [block-no-verify, rtk-wrap, design-slop]
-    post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
+    post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan, pr-url-reminder]
 
   # Cowork — the Claude desktop app's local-agent-mode runtime, built
   # on top of the Claude Code CLI. Same lifecycle vocabulary, same
@@ -182,7 +193,7 @@ platforms:
     stop:             [chat-history, hot-context, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
     pre_tool_use:     [block-no-verify, rtk-wrap, design-slop]
-    post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
+    post_tool_use:    [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan, pr-url-reminder]
 
   # Phase 7.5 — Cursor. `.cursor/hooks.json` (project) is read by the
   # IDE and CLI; `~/.cursor/hooks.json` (user) is opt-in via
@@ -196,7 +207,7 @@ platforms:
     session_end:        [chat-history]
     stop:               [chat-history, hot-context, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    post_tool_use:      [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
+    post_tool_use:      [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan, pr-url-reminder]
 
   # Phase 7.6 — Cline. Hooks live under `.clinerules/hooks/<HookName>`
   # (project, no file extension, must be executable per Cline docs) or
@@ -211,7 +222,7 @@ platforms:
     session_end:        [chat-history]
     stop:               [chat-history, hot-context, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    post_tool_use:      [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
+    post_tool_use:      [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan, pr-url-reminder]
 
   # Phase 7.7 — Windsurf (Cascade). Hooks live at `.windsurf/hooks.json`
   # (project) or `~/.codeium/windsurf/hooks.json` (user). Cascade has
@@ -245,7 +256,7 @@ platforms:
     session_end:        [chat-history]
     stop:               [chat-history, hot-context, verify-before-complete]
     user_prompt_submit: [chat-history, verify-before-complete, minimal-safe-diff]
-    post_tool_use:      [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan]
+    post_tool_use:      [chat-history, roadmap-progress, context-hygiene, verify-before-complete, minimal-safe-diff, injection-scan, pr-url-reminder]
 
   # Phase 7.9 — Copilot has no hook surface. Concerns route through
   # rule-only fallback; the dispatcher silently no-ops on --platform copilot.

--- a/src/scripts/pr_url_reminder_hook.ts
+++ b/src/scripts/pr_url_reminder_hook.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse PR-URL reminder — reply-shape backstop for `direct-answers`.
+ *
+ * The `direct-answers` rule (reply-close) requires: a PR created THIS turn puts
+ * its raw URL as the **literal last line** of the reply. That is a behavioural
+ * rule with no deterministic backstop, so it can be silently missed — the URL
+ * ends up inline mid-reply instead of last. This hook fires right after a
+ * PR-creating tool call, extracts the created PR URL from the tool output, and
+ * WARNS in context (exit 2) so the reminder lands exactly when the PR is born,
+ * before the reply closes.
+ *
+ * Fires ONLY on an actual PR *create*:
+ *   - a shell command matching `gh pr create`, OR
+ *   - a GitHub tool whose name means "create a pull request"
+ *     (e.g. create_pull_request / createPullRequest / pulls.create),
+ * AND only when the tool output actually contains a `…/pull/<n>` URL — so a
+ * failed / dry-run create (no URL) does not nag, and `gh pr view/checks/list/
+ * comment` (which also print PR URLs) never fire it.
+ *
+ * Warn only — never blocks (fail_closed: false). Unconditional: it reinforces
+ * an always-on rule and only fires on the rare PR-create event, so it carries
+ * no settings gate (mirrors verify-before-complete / roadmap-progress).
+ *
+ * Exit codes (dispatcher contract): 0 allow · 2 warn (+ `{decision,reason}`
+ * JSON on stdout).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const EXIT_ALLOW = 0;
+const EXIT_WARN = 2;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
+type JsonObject = { [k: string]: JsonValue };
+
+// Tool names across platforms whose command field carries a shell command
+// (kept in lock-step with verify_before_complete_hook.COMMAND_TOOLS).
+const COMMAND_TOOLS: ReadonlySet<string> = new Set([
+  "launch-process",
+  "launch_process",
+  "Bash",
+  "BashTool",
+  "run-process",
+  "runProcess",
+  "shell",
+  "execute_shell",
+  "RunShellCommand",
+]);
+
+// A shell command that CREATES a pull request. Anchored on a shell separator so
+// it matches inside a chained command (`git push && gh pr create …`) but not a
+// substring of another word. `gh pr view/checks/list/comment` do not match.
+const _GH_PR_CREATE = /(?:^|[\s;&|`(])gh\s+pr\s+create\b/i;
+
+// A non-shell tool whose NAME means "create a pull request" (github-api / MCP).
+const _CREATE_PR_TOOL = /(?:create[_-]?pull_?request|createpullrequest|pulls[._-]create|create_pr\b)/i;
+
+// A GitHub pull-request URL as printed by `gh pr create` / returned as html_url.
+const _PR_URL = /https?:\/\/github\.com\/[^\s"'`<>]+\/pull\/\d+/i;
+
+function _isObject(v: unknown): v is JsonObject {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Return [tool_name, command_text] from a tool-event payload. */
+function _extractCommand(payload: JsonObject): [string | null, string | null] {
+  const toolRaw = payload["tool_name"] ?? payload["toolName"] ?? payload["tool"];
+  const tool = typeof toolRaw === "string" ? toolRaw : null;
+  if (!(tool !== null && COMMAND_TOOLS.has(tool))) {
+    return [tool, null];
+  }
+  const ti = payload["tool_input"];
+  if (_isObject(ti)) {
+    for (const key of ["command", "cmd", "shell_command"]) {
+      const v = ti[key];
+      if (typeof v === "string" && v) {
+        return [tool, v];
+      }
+    }
+  }
+  for (const key of ["command", "cmd"]) {
+    const v = payload[key];
+    if (typeof v === "string" && v) {
+      return [tool, v];
+    }
+  }
+  return [tool, null];
+}
+
+/** Best-effort extraction of the tool-output text from the envelope. */
+function _toolOutput(envelope: JsonObject): string {
+  for (const key of ["tool_response", "tool_result", "toolResponse", "output", "result", "stdout"]) {
+    const v = envelope[key];
+    if (typeof v === "string") {
+      return v;
+    }
+    if (_isObject(v) || Array.isArray(v)) {
+      return JSON.stringify(v);
+    }
+  }
+  return JSON.stringify(envelope);
+}
+
+/** True when this tool event created a pull request. */
+function _isPrCreate(tool: string | null, command: string | null): boolean {
+  if (command !== null && _GH_PR_CREATE.test(command)) {
+    return true;
+  }
+  return tool !== null && _CREATE_PR_TOOL.test(tool);
+}
+
+export function main(): number {
+  let envelope: JsonValue;
+  try {
+    const raw = _readStdin();
+    envelope = raw.trim() ? (JSON.parse(raw) as JsonValue) : {};
+  } catch {
+    return EXIT_ALLOW; // never block on a malformed envelope
+  }
+  if (!_isObject(envelope)) {
+    return EXIT_ALLOW;
+  }
+
+  const [tool, command] = _extractCommand(envelope);
+  if (!_isPrCreate(tool, command)) {
+    return EXIT_ALLOW;
+  }
+
+  const match = _PR_URL.exec(_toolOutput(envelope));
+  if (match === null) {
+    return EXIT_ALLOW; // create attempted but no URL produced (failed / dry-run) — do not nag
+  }
+  const url = match[0];
+
+  // `reason` (≤ 200 chars) goes to stderr; `additional_context` is what
+  // surfaces back to the model on platforms that support it — so the
+  // actionable instruction lives there (a stderr-only reason would not
+  // change the reply that this hook exists to shape).
+  const reason = `PR created this turn (${url}) — end your reply with this raw URL as the literal last line (direct-answers/reply-close).`;
+  const additional_context =
+    `You created a pull request this turn: ${url}\n\n` +
+    `Per the direct-answers rule (reply-close): a PR created this turn must appear ` +
+    `as the raw URL on the LITERAL LAST LINE of your reply — not inline mid-message. ` +
+    `Before ending the turn, make your final line exactly:\n${url}\n` +
+    `If it already is, no action needed.`;
+  process.stdout.write(`${JSON.stringify({ decision: "warn", reason, additional_context })}\n`);
+  return EXIT_WARN;
+}
+
+function _readStdin(): string {
+  return fs.readFileSync(0, "utf-8");
+}
+
+function _isCliEntry(): boolean {
+  if (process.argv[1] === undefined) {
+    return false;
+  }
+  const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+  if (import.meta.url === argvUrl) {
+    return true;
+  }
+  // Symlinked invocation (installed projection, or macOS /var → /private/var
+  // temp dirs) makes the raw URLs differ; compare realpaths so the guard fires.
+  try {
+    const here = fs.realpathSync(fileURLToPath(import.meta.url));
+    const argv = fs.realpathSync(path.resolve(process.argv[1]));
+    return here === argv;
+  } catch {
+    return false;
+  }
+}
+
+if (_isCliEntry()) {
+  process.exit(main());
+}

--- a/tests/scripts/pr_url_reminder_hook.test.ts
+++ b/tests/scripts/pr_url_reminder_hook.test.ts
@@ -1,0 +1,91 @@
+// Tests for src/scripts/pr_url_reminder_hook.ts — the reply-shape backstop for
+// the direct-answers rule (a PR created this turn must end the reply as the
+// literal last raw URL). Feeds PostToolUse stdin envelopes to the tsx hook and
+// asserts exit code + the warn JSON on stdout. The hook writes no state files.
+import { spawnSync } from "node:child_process";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), "..", "..", "..");
+const TS_SCRIPT = path.join(REPO_ROOT, "src", "scripts", "pr_url_reminder_hook.ts");
+const TSX_BIN = path.join(
+  REPO_ROOT,
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx",
+);
+
+const PR_URL = "https://github.com/event4u-app/agent-switch/pull/20";
+
+function run(envelope: unknown): { stdout: string; status: number | null } {
+  const r = spawnSync(TSX_BIN, [TS_SCRIPT], {
+    encoding: "utf8",
+    cwd: REPO_ROOT,
+    input: typeof envelope === "string" ? envelope : JSON.stringify(envelope),
+  });
+  expect(r.status).not.toBeNull();
+  return { stdout: r.stdout as string, status: r.status };
+}
+
+describe("pr_url_reminder_hook", () => {
+  it("warns (exit 2) on `gh pr create` that produced a PR URL, echoing the exact URL", () => {
+    const { stdout, status } = run({
+      tool_name: "Bash",
+      tool_input: { command: `git push && gh pr create --base main --title x` },
+      tool_response: `Creating pull request...\n${PR_URL}\n`,
+    });
+    expect(status).toBe(2);
+    const out = JSON.parse(stdout);
+    expect(out.decision).toBe("warn");
+    expect(out.reason).toContain(PR_URL);
+    expect(out.reason.length).toBeLessThanOrEqual(200);
+    // the actionable instruction must ride additional_context — that is what
+    // surfaces back to the model (reason alone only reaches stderr).
+    expect(out.additional_context).toContain(PR_URL);
+    expect(out.additional_context).toContain("LITERAL LAST LINE");
+  });
+
+  it("fires on a github create-pull-request tool (name-based), URL from the response", () => {
+    const { status, stdout } = run({
+      tool_name: "create_pull_request",
+      tool_response: { html_url: PR_URL, number: 20 },
+    });
+    expect(status).toBe(2);
+    expect(JSON.parse(stdout).reason).toContain(PR_URL);
+  });
+
+  it("does NOT fire on `gh pr view` even though the output carries a PR URL", () => {
+    const { status, stdout } = run({
+      tool_name: "Bash",
+      tool_input: { command: "gh pr view 20 --json url" },
+      tool_response: `{"url":"${PR_URL}"}`,
+    });
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("does NOT fire on `gh pr create` that produced no URL (failed / dry-run)", () => {
+    const { status } = run({
+      tool_name: "Bash",
+      tool_input: { command: "gh pr create --fill" },
+      tool_response: "error: a pull request for branch already exists\n",
+    });
+    expect(status).toBe(0);
+  });
+
+  it("does NOT fire on an unrelated tool call", () => {
+    const { status } = run({
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+      tool_response: "On branch main\n",
+    });
+    expect(status).toBe(0);
+  });
+
+  it("never blocks on a malformed or empty envelope", () => {
+    expect(run("not json {").status).toBe(0);
+    expect(run("").status).toBe(0);
+    expect(run([1, 2, 3]).status).toBe(0);
+  });
+});


### PR DESCRIPTION
Hardens the `direct-answers` reply-close rule with a deterministic backstop.

## Problem

`direct-answers` (reply-close) requires: **a PR created this turn puts its raw URL as the literal last line** of the reply. It was behaviour-only — no hook, no lint — so the URL could be (and was) silently placed **inline mid-reply** instead of last. `check_reply_consistency` only covers numbered-options, not this.

## Fix — `pr-url-reminder` PostToolUse hook

`src/scripts/pr_url_reminder_hook.ts`, wired via `hook_manifest.yaml` to `post_tool_use` on every platform that exposes it (all but windsurf).

- Fires **only on a real PR create**: a `gh pr create` shell command, or a GitHub tool whose name means "create a pull request" (`create_pull_request` / `createPullRequest` / `pulls.create`), **and** only when the tool output actually contains a `…/pull/<n>` URL.
- So it never fires on `gh pr view/checks/list/comment` (which also print PR URLs) and never nags on a failed / dry-run create (no URL).
- **Warn only** (exit 2), never blocks (`fail_closed: false`). The actionable instruction rides `additional_context` (what surfaces back to the model) — a stderr-only `reason` would not change the reply the hook exists to shape. `reason` kept ≤ 200 chars per the stdout contract.
- **Unconditional** (no settings gate): it reinforces an always-on rule and only triggers on the rare create event, mirroring `verify-before-complete` / `roadmap-progress`. That's what makes it *harden by default*.

## Verification

- New unit test `tests/scripts/pr_url_reminder_hook.test.ts` — 6 cases: create-with-URL fires (URL echoed on `additional_context`, `reason` ≤ 200), name-based github-tool create fires, `gh pr view` does NOT fire, create-without-URL does NOT fire, unrelated tool does NOT fire, malformed/empty envelope never blocks. All green.
- `lint_hook_manifest` exit 0; `lint_hook_concern_budget` + manifest-lint tests green; `consumer_matrix_hook_lifecycle` + `hooks_status` (23 tests) green.
- eslint clean, `tsc --noEmit` clean on the changed files.
- Not projected to `dist/` (hooks are not mirrored there) — no condensation/sync-check impact.

## Not in scope

Did **not** touch `direct-answers.md` (a core rule — a "Enforced by" citation would drag in the kernel-rule slow-rollout). The hook stands alone; the rule reference lives in the hook docstring. A rule-citation is a possible follow-up.
