### PR TITLE
docs: correct outdated Antigravity host claims

### DIFF
--- a/docs/contracts/tier-3-contrib-plugin.md
+++ b/docs/contracts/tier-3-contrib-plugin.md
@@ -16,7 +16,7 @@ promotion path from Tier-3 → Tier-2, and the non-implementation
 guarantee. Does **not** ship code: `agents/manifests/contrib/` is
 unmanifested until a user asks for an entry by name.
 
-Last refreshed: 2026-05-12.
+Last refreshed: 2026-07-16.
 
 ## Tier definitions
 
@@ -35,8 +35,16 @@ Tier-3 is the explicit overflow bucket.
 The following surfaces are Tier-3 candidates as of 2026-05-12. They
 were surfaced during the
 [`2026-05-12-installer-expansion`](../../agents/runtime/council/sessions/2026-05-12-installer-expansion/synthesis.md)
-council round and have **no entries** in `_VALID_TOOLS`,
-`USER_SCOPE_PATHS`, `SCOPE_SUPPORT`, or the bash `VALID_TOOLS` set.
+council round and had **no entries** in `_VALID_TOOLS`,
+`USER_SCOPE_PATHS`, `SCOPE_SUPPORT` or the bash `VALID_TOOLS` set at
+proposal time.
+
+**Status update (2026-07-16):** the candidates below have since been
+promoted to shipped hosts — each now has entries in `_VALID_TOOLS`,
+`USER_SCOPE_PATHS` and `SCOPE_SUPPORT`, deployed as the universal
+global skill bundle. The bullets are kept as the frozen proposal-time
+record; their rationales describe the pre-promotion state and no
+longer reflect current shipping status.
 
 - `qoder` — community fork, no public adoption signal
 - `trae` — ByteDance IDE, behind login wall
@@ -44,7 +52,7 @@ council round and have **no entries** in `_VALID_TOOLS`,
 - `codebuddy` — Tencent-internal, no public install path
 - `droid` — proposed CLI agent, alpha
 - `warp` — terminal-with-AI; integration shape unclear (PTY vs file marker)
-- `antigravity` — Google research project, no shipping surface
+- `antigravity` — Google's agentic IDE (public since 2026); shipped as a global bundle host (see status update above)
 
 Inclusion in this list is **not** a commitment to ship. Promotion
 requires a real user asking by name (issue, PR, council session, or

--- a/docs/setup/per-ide/antigravity.md
+++ b/docs/setup/per-ide/antigravity.md
@@ -2,8 +2,9 @@
 
 Antigravity (Google's agentic IDE) reads the Anthropic-shaped
 markdown skill bundle from its user-scope anchor `~/.agents/`. The
-package deploys via the universal skill convention; project-scope
-bridge is not yet wired (Phase 2.4 anchor).
+package deploys the universal skill bundle at global scope, the same
+projection its other bundle hosts get (codex, continue, roocode and
+the rest) — global-only by design, not a pending gap.
 
 ## Prerequisites
 
@@ -25,7 +26,11 @@ Populates:
 - `~/.agents/personas/` — review-lens personas
 
 (Project-scope `--tools=antigravity` is rejected with exit code 1
-— Antigravity has no documented project-discovery convention yet.)
+— every bundle host is global-only; the package writes the shared
+bundle to a user-scope anchor, not into the project. Antigravity does
+have a native project `.agents/` convention (`skills/`, `agents.md`,
+`workflows/`), but a project-scope projection is not part of the
+shipped surface.)
 
 ## How to use
 


### PR DESCRIPTION
## What

Doc-only freshness fix for two outdated Google Antigravity claims. No install-behaviour change.

- **`docs/setup/per-ide/antigravity.md`** — dropped "Antigravity has no documented project-discovery convention yet" (false: Antigravity natively recognises a project `.agents/` directory — `skills/`, `agents.md`, `workflows/`) and the "project-scope bridge not yet wired (Phase 2.4 anchor)" framing. Replaced with the real reason project scope is rejected: every bundle host is global-only by design.
- **`docs/contracts/tier-3-contrib-plugin.md`** — the frozen candidate list claimed the entries have "no entries in `_VALID_TOOLS`". That premise is overtaken: all seven listed candidates (incl. `antigravity`) have since shipped as global bundle hosts. Added a dated status update, corrected the `antigravity` bullet ("Google research project, no shipping surface" → shipped agentic IDE), bumped "Last refreshed".

## Why

Antigravity is already integrated at full parity with the other bundle-projection hosts (codex, continue, roocode et al.) — confirmed by codebase grep + AI council. The docs lagged reality. This corrects the record without changing any wiring.

## Scope

Two files, prose only. Pre-existing serial-comma style hits on untouched lines were left as-is (minimal-safe-diff; out of scope for this fix). New prose follows the no-serial-comma house style.

## Not in this PR (informational)

The global `~/.agents/` anchor for Antigravity is an unverified convention (its real global home is `~/.gemini/`); that is a Population-A-wide question, not an Antigravity doc-freshness item, and is left untouched.
