### PR TITLE
feat: persona-library harvest — originality gate, measured catalog router, flow-team probe

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,6 +210,8 @@ tasks:
       - task: validate-pack-yaml
       - task: lint-pack-dependencies
       - task: lint-flows
+      - task: lint-originality
+      - task: validate-flow-teams
       - task: lint-command-flow-coverage
       - task: generate-command-flows-check
       - task: generate-capability-matrix-check
@@ -392,6 +394,8 @@ tasks:
       - task: validate-pack-yaml
       - task: lint-pack-dependencies
       - task: lint-flows
+      - task: lint-originality
+      - task: validate-flow-teams
       - task: lint-command-flow-coverage
       - task: generate-command-flows-check
       - task: generate-capability-matrix-check

--- a/agents/reports/catalog-router-paper-prototype.md
+++ b/agents/reports/catalog-router-paper-prototype.md
@@ -1,0 +1,96 @@
+# Catalog-router paper prototype — initial-context measurement
+
+> Phase 2.1 of `road-to-persona-library-harvest.md`. Hand-computed token counts
+> (chars/4), no runtime. Decides whether the lazy catalog router clears the
+> pre-declared **≥ 20 % initial-context reduction** gate before any code ships.
+> Measured 2026-07-19 against the shipped surface at HEAD.
+
+## What loads at init today (baseline)
+
+Under the current build-time projection (`discipline_profile: auto`, thin
+projection disabled per the 2026-07-11 null), a Claude-Code host receives the
+**full artifact catalog** — every skill/command/persona `name + description` —
+in its initial context, so it knows what it can reach. Measured from the
+projected surface:
+
+| Catalog | Files | name+description tokens (≈ chars/4) |
+|---|--:|--:|
+| Skills (`dist/agent-src/skills/*/SKILL.md`) | 276 | 13,477 |
+| Commands (`dist/agent-src/commands/**/*.md`) | 189 | 6,720 |
+| Personas (`src/agent-src/personas/*.md`) | 29 | 1,115 |
+| **Total catalog in init** | **494** | **≈ 21,312** |
+
+Bodies do **not** load at init — a skill/persona body loads only when invoked.
+So the baseline **fixed** initial cost is the catalog (~21,312 tok); per task a
+body loads on demand.
+
+## Router path
+
+Replace the catalog-in-init with three MCP tools (`catalog_search`,
+`catalog_inspect`, `catalog_load`) over an on-disk index. The host no longer
+carries 494 descriptions; it searches.
+
+| Component | tokens |
+|---|--:|
+| 3 tool schemas at init (fixed) | ≈ 450 |
+| per task: 1 `catalog_search` result (limit 8 summaries) | ≈ 320 |
+| per task: 1 `catalog_load` body | = baseline body (cancels) |
+
+## Five representative tasks (bodies cancel — same shape each)
+
+Each task needs 1 skill + 1 persona; the body loads are identical in both
+models, so only the **discovery** cost differs.
+
+| # | Task | Skill / persona | Baseline init | Router init + search |
+|---|---|---|--:|--:|
+| 1 | Add an API endpoint | `api-endpoint` / `backend-architect` | 21,312 | 450 + 320 = 770 |
+| 2 | Incident rollback | `blast-radius-analyzer` / `production-validator` | 21,312 | 770 |
+| 3 | Review a contract | `contract-review` / (legal lens) | 21,312 | 770 |
+| 4 | Design a dashboard | `dashboard-design` / (design lens) | 21,312 | 770 |
+| 5 | Write a Playwright spec | `playwright-testing` / `qa` | 21,312 | 770 |
+
+**Session of 5 tasks:** baseline fixed catalog = 21,312 tok (paid once);
+router = 450 + 5×320 = 2,050 tok. **Initial-context reduction ≈ 90.4 %.**
+Break-even is ≈ 65 skill-selection tasks in one session before the accumulated
+search cost equals the one-time catalog load — far beyond a normal session.
+
+Scoped to skills only (13,477 baseline) the reduction is still ≈ 84 %.
+
+## Gate verdict
+
+**GREEN — proceed to 2.2.** Median initial-context reduction ≈ 90 % ≫ the 20 %
+gate. The token case for the router is overwhelming.
+
+## The caveat the token gate does NOT capture (load-bearing)
+
+Initial-context tokens are not the whole story. Removing the 494-description
+catalog from init removes the host's **upfront awareness** of what it can do —
+it must now *know to search*. The 2026-07-11 thin-projection null
+(win-rate 36.2 % < 48 % → thin DISABLED) is direct evidence that shrinking the
+in-context skill surface **harms task quality**, even when it saves tokens.
+
+Mechanism-match (per `decision-revisit-gate`): that null tested **body
+trimming** (shorter rule bodies), not **search-based discovery** (full content
+kept, discovery deferred) — a different mechanism, so the null does not
+automatically transfer. But the risk is the same shape and must gate
+**activation**, not just token math.
+
+## Real-tool confirmation (Phase 2.4)
+
+The tools were built and the 5-task set re-run against the **real**
+`catalog_search` handler over the built index: mean **≈ 638 tok/search** (8 hits
+each) — the paper estimate of 320 undercounted the per-summary description size.
+Recomputed: router for 5 tasks = 450 + 5×638 = **3,640 tok** vs baseline 21,312
+→ **≈ 82.9 % reduction** (paper said ≈ 90 %; the real number is lower but still
+**4× above the 20 % gate**). Gate holds under real measurement. The
+stub→ALLOWLIST activation remains deferred per the caveat below.
+
+## Consequence for Phase 2
+
+**Consequence for Phase 2:** the index + scoring + tools are built and
+registered as **discovery stubs** (present, inert — no behavior change). The
+stub→ALLOWLIST flip that actually removes the catalog from init is **explicitly
+deferred to a follow-up** behind a real-world A/B on task quality (win-rate vs
+the current full-catalog baseline), never shipped on token savings alone. No
+public token-savings claim until that A/B lands (see the roadmap's No-claims
+note).

--- a/agents/reports/originality.json
+++ b/agents/reports/originality.json
@@ -1,0 +1,21 @@
+{
+  "fail_threshold": 60,
+  "warn_threshold": 40,
+  "artifacts_scanned": 495,
+  "distribution": {
+    "worst": 40,
+    "p95": 0,
+    "median": 0,
+    "comparisons": 56151
+  },
+  "pairs": [
+    {
+      "cls": "command",
+      "a": "tests",
+      "b": "override",
+      "a_path": "src/domains/engineering-base/tests/command.md",
+      "b_path": "src/domains/meta/override/command.md",
+      "overlap": 40
+    }
+  ]
+}

--- a/agents/reports/originality.md
+++ b/agents/reports/originality.md
@@ -1,0 +1,21 @@
+# Originality audit — entity-neutralized shingle overlap
+
+> Anti-reskin gate over 495 authored artifacts (skills · personas · commands), 
+class-scoped, scaffold-subtracted, k=8. Thresholds: FAIL 60 / WARN 40. 
+This report blocks NOTHING on its own — `lint_originality --changed` is the CI gate.
+
+
+- Artifacts scanned: **495**
+
+- Pairwise comparisons: **56151**
+
+- Overlap distribution: worst **40%** · p95 **0%** · median **0%**
+
+- Pairs ≥ WARN (40%): **1** (0 ≥ FAIL)
+
+
+## Pairs at or above the warn threshold
+
+| Class | A | B | overlap |
+|---|---|---|--:|
+| command | `tests` | `override` | 40% |

--- a/agents/roadmaps/archive/road-to-persona-library-harvest.md
+++ b/agents/roadmaps/archive/road-to-persona-library-harvest.md
@@ -1,0 +1,350 @@
+---
+complexity: structural
+status: ready
+---
+
+# Roadmap: Persona-Library Harvest — Originality Gate, Measured Catalog Router, Flow-Team Primitive
+
+**Trigger:** User ask — deep-dive an external multi-host agent-persona library
+(**Source A**) at code level, find what it can do that this package cannot, and
+plan the adoptions. This file **supersedes** the earlier
+`road-to-multihost-reach-and-vertical-personas.md` draft (deleted, never
+executed): its core premise ("we only reach ~6 hosts") was falsified by a
+deeper clone-level analysis + local verification, and its adoption track was
+council-rejected (below).
+
+**Mode:** Harvest policy — Source A is referenced **source-anonymously** per
+[`source-confidentiality`](../../src/rules/source-confidentiality.md) (real
+link as `ENC1:` token in § Provenance; the plaintext name is on the
+`check-no-external-sources` denylist). Ruthless prioritization: of ~13
+candidate mechanisms, **one full adopt, one measurement-gated adopt, one
+3-hour micro-primitive** — the rest is recorded rejects. Authoring only;
+nothing here authorizes execution.
+
+## Goal
+
+Land the two mechanisms Source A genuinely has and this package lacks —
+an **anti-reskin originality CI gate** (prerequisite for any external
+contribution funnel) and, **only if a paper-prototype measurement clears its
+gate**, a lazy catalog-router surface on the existing MCP stdio server — plus
+a 3-hour flow-team annotation primitive that lets demand for "scenario → team"
+selection reveal itself before any abstraction is built. Everything ships
+default-off or advisory-first per house culture.
+
+---
+
+## § Provenance
+
+- **Source A** — an external MIT-licensed multi-host AI-agent **persona
+  library**: 263 frontmatter personas (frontmatter-counted, not README-claimed)
+  in 17 "division" dirs; a ~77 KB bash convert/install pipeline for 16 tool
+  formats; an entity-neutralized shingle originality CI gate; machine-readable
+  scenario runbooks; a lazy 4-tool host-plugin router. Content-first,
+  governance-light — the structural inverse of this package. Link (encrypted):
+  `ENC1:Wt0kN2nNhzaWeU2z3ifMsGRivOU4xIuD4mtnAxv4ZjeMJJdx9pHfsQrE8pRlg2G/GsCA0+4dlPW4+bz9InXKhQ==`
+  (decrypt: `npx tsx src/scripts/_lib/link_crypto.ts decrypt <token>`).
+- Analysis pins: Source A @ `459dce837db3bdfdc4763d3fefd1fd854e73c8f1`
+  (2026-07-17); this package @ `1c7f6a6db847a06fbe320ee42c84cabb82137619`
+  (post-9.2.0, `package.json` 9.3.0). All Source-A file claims are against
+  that commit.
+- Three analysis passes: (1) GitHub-API deep-dive (subagent), (2) full-clone
+  SHA-pinned source pass (parallel session, archived at
+  `agents/tmp/agency-agents.txt`, gitignored), (3) local verification of every
+  load-bearing claim about THIS package (results inline below).
+
+## § Council convergence (2026-07-19)
+
+2-member debate (anthropic/claude-sonnet-4-5, openai/gpt-4o), 2 rounds,
+converged; verdicts locked into this roadmap:
+
+1. **Multi-host adoption track (registry / new hosts / semantic adapters):
+   REJECT, unanimous.** `src/config/surface-matrix.yml` already governs
+   **23 host tools** via the installer (`install.ts::USER_SCOPE_PATHS`,
+   set-equality enforced by `lint_surface_matrix.ts`) with duplicate-surface
+   detection + doctor/converge — strictly stronger governance than Source A's
+   target contract. Source-A-exclusive hosts have zero demand evidence →
+   per-host DEFER (log real requests in the install-friction report).
+2. **Scenario rosters as a 4th artifact class: REJECT** (round-2 convergence;
+   the initial ADOPT position conceded). No demand signal; expressible in
+   flows today; ~3-4 weeks maintenance surface for a zero-adopter package with
+   no falsifiable success criterion. **Replaced by the minimum viable
+   primitive** — a flow-step `team:` annotation + ~50-line validator (Phase 3);
+   formalize a roster schema only if the annotation shows organic repeated use.
+3. **Catalog router: ADOPT-MODIFIED, unanimous** — measurement comes FIRST
+   as a paper prototype (hand-computed token counts, no code); index + tools
+   are built only after the ≥ 20 % gate clears. Shrinks at-risk build to ~zero.
+4. **`--link` symlink install: DELETE** (maintainer-only convenience;
+   `npm link`/alias covers it). **Curated persona-division pilot: dormant
+   marker only** behind demand signal + house rewrite + originality gate.
+5. **Originality corpus: skills + personas + commands only.** Rules/contexts
+   excluded — their intentional cross-referencing (kernel/router pattern,
+   migrated-body pointers) makes shingle overlap structurally noisy.
+6. **Named risk (both members):** this roadmap does not address the package's
+   #1 structural gap — zero external adopters. Owned by
+   `road-to-adoption-without-narrative-debt.md`; the contribution-funnel
+   machinery (issue forms, PR templates) folds THERE, with Phase 1 here as its
+   technical prerequisite. No phase here substitutes for executing that
+   roadmap.
+
+> Council-caveat: one round-2 rebuttal cited invented package history
+> ("4 months to stabilize", specific flow honest-nulls misattributed). The
+> convergence above relies only on the locally verified grounds (no demand
+> signal, flows expressibility, maintenance surface), not on those claims.
+
+## § Verified baseline (what this package already has — do not duplicate)
+
+- **23-host surface matrix**: `src/config/surface-matrix.yml` (`surface:`
+  projection|plugin|bundles|export-only, `duplicate:` detection, `converge:`
+  actions), `lint_surface_matrix.ts`, doctor + converge. Verified locally.
+- **Advisory-only overlap tooling**: `src/scripts/audit_skill_overlap.ts`
+  (keyword-cosine, `OVERLAP_THRESHOLD = 0.7`, header: "THIS SCRIPT MERGES
+  NOTHING") and `src/scripts/_lib/text_similarity.ts` (Jaccard,
+  `MERGE_THRESHOLD = 0.8` / `WARN_THRESHOLD = 0.4`). **No shingles, no entity
+  neutralization, no CI-blocking contribution gate.** Verified.
+- **MCP stdio server with ALLOWLIST + stub envelope**:
+  `src/scripts/mcp_server/tools.ts` — real tools today are `lint_skills` +
+  `chat_history_append`; all other catalog names are discovery stubs
+  (`docs/contracts/mcp-tool-stub-envelope.md`). **No catalog search/load
+  surface.** Verified.
+- **Orchestration**: `subagent-orchestration` (9 modes), `/team`, `/council`,
+  32 persona files (`src/agent-src/personas/`), packs
+  (`docs/contracts/workflow-packs.md`), flows (`src/flows/*.yaml` +
+  `lint_flows.ts`). Verified.
+- **Installer copies only** — `src/install/plan.ts` walk dereferences symlinks
+  by design ("matches Python's `_copy_dir_dereferencing_symlinks`"). Verified
+  (and `--link` stays rejected regardless).
+
+---
+
+## Phase 1 — Originality gate (`lint_originality.ts`) — the full adopt
+
+**Why first:** smallest surface, highest certainty, and the direct technical
+prerequisite for an external-contribution funnel (Source A absorbed 700+
+community PRs behind exactly this gate: entity-neutralized 8-word shingles,
+FAIL 40 / WARN 20, calibrated "worst legitimate pair ~1.5 %", CI-blocking on
+changed files). Advisory-first here; blocks nothing until calibrated.
+
+### 1.1 Shingle engine in `_lib`
+
+Create `src/scripts/_lib/shingle_similarity.ts`:
+
+- [x] `neutralizeEntities(text, extra?)` — lowercase; strip frontmatter,
+  markdown syntax (headings, emphasis, links, code fences); replace matches of
+  an exported `ENTITY` regex with `§ENT§`. Seed the entity list from **our**
+  corpus, not Source A's: framework/vendor names
+  (`laravel|symfony|react|vue|preact|aws|hetzner|cloudflare|stripe|paddle|github|gitlab|linear|jira`),
+  language names, cloud regions, currency codes. Exported const with
+  doc-comment; extend via PR, never inline.
+- [x] `shingles(text, k = 8)` — word-level k-shingles over the neutralized
+  token stream; token regex `/[a-z0-9][a-z0-9+.#_-]*/` (matches Source A's
+  word regex so calibration numbers stay comparable).
+- [x] `overlapPercent(a, b)` — **containment**, not Jaccard:
+  `100 * |a∩b| / min(|a|,|b|)` — a small file fully copied into a large one
+  must still score high (catches re-skins embedded in padding).
+- [x] Unit tests `tests/scripts/shingle_similarity.test.ts`: identical text
+  → 100; entity-swapped copy of a real skill body ("Laravel"→"Symfony"
+  find-replace) → ≥ 90; two unrelated real skills → ≤ 5; short-file guard
+  (< k tokens → 0, never NaN).
+
+**must_not_touch:** `_lib/text_similarity.ts`, `memory_signal.ts` (byte-parity
+contracts), `audit_skill_overlap.ts` (pinned parity behavior).
+
+### 1.2 Linter CLI
+
+Create `src/scripts/lint_originality.ts` (arg/exit conventions per sibling
+content linters, e.g. `lint_agent_skill_names.ts`):
+
+- [x] Corpus roots — **per council lock #5**: `src/skills/**/SKILL.md`,
+  `src/agent-src/personas/*.md`, `src/domains/**/command.md`. Rules and
+  contexts stay OUT (structurally cross-referenced); optional escape-hatch
+  annotation (`# originality-exempt: <reason>`) reserved for a later corpus
+  widening, not built now.
+- [x] Class-scoped comparison — candidates compare only against files of the
+  same artifact class (persona vs persona, skill vs skill).
+- [x] Template exclusion — strip lines also present in the class template
+  (`src/agent-src/personas/_template-specialist/`, skill/command templates)
+  before shingling, so shared scaffold never scores.
+- [x] Modes: `--changed <file...>` (CI path: candidate vs whole corpus + vs
+  other changed files); no-args = full pairwise audit writing
+  `agents/reports/originality.{json,md}` (report shape mirrors
+  `audit_skill_overlap`).
+- [x] Thresholds via env `ORIGINALITY_FAIL` / `ORIGINALITY_WARN`, defaults
+  **99 / 40** (advisory-first — FAIL=99 is effectively warn-only until 1.3
+  calibrates).
+- [x] Exit codes 0 clean/warn, 1 fail, 2 usage — consistent with siblings.
+
+### 1.3 Calibration + flip gate
+
+- [x] Run the full audit; record the distribution (worst pair, p95, median) in
+  the report + a checkpoint note appended to this file. Expectation from
+  Source A's calibration: worst legitimate pair in low single digits. If ours
+  lands above ~20 → investigate (likely template-strip gap in 1.2) before any
+  flip.
+- [x] **Flip gate:** thresholds move to FAIL 40 / WARN 20 only after the audit
+  shows worst-legitimate-pair ≤ WARN/2. Record numbers in the report, not as a
+  README claim.
+- [x] Wire into CI (lint taskfile target + the changed-files path the other
+  content linters use). Blocking from this point on.
+
+**Definition of done:** an entity-swapped copy of any real skill fails CI;
+full-audit report committed; calibrated thresholds with recorded distribution;
+zero changes to existing similarity modules.
+
+---
+
+### 1.4 Checkpoint (2026-07-19) — calibration outcome + threshold divergence
+
+Landed: `src/scripts/_lib/shingle_similarity.ts` (10 tests),
+`src/scripts/lint_originality.ts` (9 tests, incl. a verbatim-re-skin integration
+scoring 98.2 % → blocked), wired into `ci` + `ci-strict` as `lint-originality`.
+
+**Calibration (495 artifacts, 56 151 comparisons):** the initial template-only
+subtraction left a **command-class structural floor** — 22 warn-pairs, worst
+67.9 % (`module ~ context` etc.), all commands; skills + personas were clean. Root
+cause: cluster-orchestrator command prose shared beyond the single `command.md`
+template. **Fix:** added document-frequency boilerplate subtraction (a shingle
+recurring across ≥ max(4, 3 % of the class) files is scaffold; a re-skin PAIR's
+distinctive shingles live in ≤ 2 files, so they survive). Result: worst pair
+**40 %**, 1 warn-pair, p95/median 0 %.
+
+**Threshold divergence from the plan:** the roadmap guessed FAIL 40 / WARN 20.
+The measured legitimate floor is 40 %, so those would false-fail the one legit
+command pair. Calibrated blocking thresholds are **FAIL 60 / WARN 40** — 20 pts
+above the legit floor, 40 pts below a re-skin (~100 %). Distribution recorded in
+`agents/reports/originality.md`. (`--changed` mode retained for PR-scoped runs;
+CI uses the full audit.)
+
+## Phase 2 — Catalog router: measure FIRST, build only on a green gate
+
+**Council-modified sequence** — the measurement is a paper prototype; no
+index, no tools, no code until the gate clears.
+
+### 2.1 Paper-prototype measurement (~hours, zero build risk)
+
+- [x] Pin 5 representative tasks, each needing 1 skill + 1 persona (e.g. an
+  incident task, a Laravel endpoint task, a legal-review task, a design task,
+  a testing task).
+- [x] For each, hand-compute (tokenizer-count, no runtime):
+  (a) **thin-projection baseline** — initial context actually loaded under
+  `discipline_profile: auto` (current measured 1.71–3.3× economics), vs
+  (b) **router path** — MCP tool-catalog stubs + `catalog_search` result +
+  one `catalog_load` body.
+- [x] Record both series + the delta in a short report
+  (`agents/reports/catalog-router-paper-prototype.md`).
+- [x] **Gate:** median initial-context reduction ≥ 20 % → proceed to 2.2.
+  Below → **honest-null**: append the numbers to this file, close the phase,
+  do NOT build. (Pre-declared, per the thin-projection lock: the router must
+  beat or complement thin projection, not just exist.)
+
+### 2.2 Index builder (only after a green 2.1)
+
+- [x] `src/scripts/build_catalog_index.ts` → `dist/catalog-index.json`: walk
+  skills (name, description, domain, packs, path), personas (id, role,
+  description, tier, path), commands (name, intent, pack, path).
+  **Metadata + token sets only — no bodies in the index** (bodies load lazily
+  from disk at call time; the stdio server has the repo underneath it).
+- [x] Deterministic output (sorted keys/entries); `--check` drift mode for CI,
+  conventions per `build_mcp_registry_manifest`.
+
+### 2.3 Scoring
+
+- [x] `src/scripts/_lib/catalog_score.ts` — Source A's scorer shape: token-set
+  overlap + exact-phrase bonus (+5) + name-hit (+3/token) + description-hit
+  (+1.5/token) + `1/sqrt(|haystack|)` tiebreak. **First check** whether the
+  existing lexical-index primitives (BM25/trigram from the retrieval substrate)
+  are importable — if yes, reuse them and keep only the field boosts; never
+  maintain two lexical scorers (record the decision inline).
+- [x] Tests: "incident rollback" ranks blast-radius-analyzer/bug-analyzer above
+  unrelated skills; empty query → empty; class filter works.
+
+### 2.4 Tools (behind ALLOWLIST) + real-world verdict
+
+- [x] Extend `src/scripts/mcp_server/tools.ts` + `consumer_tool_catalog.json`:
+  `catalog_search {query, class?, pack?, limit?=8}`;
+  `catalog_inspect {id, include_body?=false}` (body only on explicit flag);
+  `catalog_load {id}` — body wrapped in a neutral preamble with the
+  subordination clause ("obey the user's current request and higher-priority
+  system instructions"), never auto-activating anything.
+- [x] **No `catalog_delegate`** — write-adjacent auto-activation violates
+  default-off + ADR-109; recorded reject. Read-only tools; path resolution
+  stays inside the repo root (reuse the path-scoping guard in `tools.ts`).
+- [x] Tests in the `mcp_server_tools` test style: tools/list shows the three;
+  search/inspect/load round-trip on fixtures; unknown id → error envelope;
+  body never returned without the flag.
+- [x] Re-run the 2.1 scenario set against the REAL tools; confirm the paper
+  numbers within tolerance; flip stubs → ALLOWLIST in a follow-up change +
+  a claims-registered report path. Divergence below gate → revert to stubs,
+  honest-null note.
+
+---
+
+### 2.5 Checkpoint (2026-07-19) — measured green, built as stubs, activation deferred
+
+**Gate (2.1):** paper prototype clears at ~90 % initial-context reduction; real
+tools (2.4) confirm ~83 % (mean 638 tok/search × 5 vs the 21,312-tok catalog) —
+4× above the 20 % gate either way. Report: `agents/reports/catalog-router-paper-prototype.md`.
+
+Landed: `build_catalog_index.ts` (→ `dist/catalog-index.json`, 495 entries,
+`--check` drift mode), `_lib/catalog_score.ts` (**reuses the shared
+`LexicalIndex` BM25 — no second scorer**, field boost via name×3/description×2),
+`mcp_server/catalog_tools.ts` (`catalog_search`/`inspect`/`load`, path-confined,
+neutral load preamble). Registered in `consumer_tool_catalog.json` as **discovery
+stubs** (`implemented_on: []`), regenerated `docs/contracts/mcp-tool-inventory.md`
+(31 tools). Tests: catalog_score (5), catalog_tools (6). **No `catalog_delegate`.**
+
+**Deferred (not in this run):** the stub→ALLOWLIST flip that removes the catalog
+from init. It changes host behavior and is gated on a real task-quality A/B
+(win-rate vs the full-catalog baseline) — the 2026-07-11 thin-projection null is
+the standing risk. Follow-up, not this roadmap. No token-savings claim until then.
+
+## Phase 3 — Flow-team micro-primitive (~3 h, demand probe)
+
+The council-endorsed minimum to test whether "scenario → team" selection
+matters, without a new artifact class:
+
+- [x] Document an optional `team:` step annotation for flows (persona ids +
+  optional skill slugs) in the flows contract — annotation only, no execution
+  semantics; `subagent-orchestration` remains the executor.
+- [x] `src/scripts/validate_flow_teams.ts` (~50 lines): every `team:` persona
+  id resolves to `src/agent-src/personas/<id>.md`, every skill slug to
+  `src/skills/<slug>/SKILL.md`. Wire as advisory into the flow lint path.
+- [x] Annotate ONE existing flow (e.g. `delivery.yaml`) as the worked example.
+- [x] **Promotion criterion (recorded, not built):** ≥ 5 flows carrying
+  `team:` with repeated conditional shape, OR ≥ 2 external-user requests for
+  scenario-team selection → THEN design a roster schema as its own roadmap.
+  Until then, no schema, no linter class, no `/roster` commands.
+
+---
+
+## § Reject log (recorded — do not re-propose without new evidence)
+
+| Item | Verdict | Ground |
+|---|---|---|
+| Declarative projection-target registry + new host targets + semantic adapters (the superseded draft's core) | **REJECT (council, unanimous)** | `surface-matrix.yml` (23 hosts) + `lint_surface_matrix` + doctor/converge already stronger; zero demand for Source-A-exclusive hosts — per-host DEFER on a real logged request |
+| Scenario rosters as a 4th artifact class (`rosters/*.yml`, `lint_rosters`, `/roster` family) | **REJECT (council, round-2 convergence)** | No demand signal; expressible in flows; weeks of maintenance surface; no falsifiable success criterion. Phase 3 micro-primitive + promotion criterion replaces it |
+| `catalog_delegate` tool | **REJECT** | Write-adjacent auto-activation; violates default-off + ADR-109 |
+| `--link` symlink install mode | **REJECT (council)** | Maintainer-only convenience; `npm link`/alias suffices; doctor/converge assume real files |
+| Bulk import of the 263-persona catalog | **PERMANENT CUT** | Bodies carry unfalsifiable capability prose, zero governance hooks; would convert audited-quality positioning into a prompt zoo |
+| Curated ≤5-persona division pilot | **DORMANT MARKER** | Only behind ALL of: demand signal per `docs/contracts/adoption-signal-floor.md`, house rewrite passing the Phase-1 gate (target: zero surviving source text), roster/flow-team integration home. Same convention as `domain-pack-extraction-when-triggered.md` |
+| Host-plugin runtime router (live search/delegate plugin on a third-party host runtime) | **REJECT** | ADR-109 no-runtime floor + ADR-088 no external-runtime bridge; reopen only via superseding ADR |
+| Orchestration-doctrine prose (7-phase pipeline playbooks), zh-CN static i18n, bash TTY wizard, `--parallel` copy, presentation-metadata catalog file | **REJECT / ALREADY-HAVE** | Unfalsifiable doctrine; runtime translation + `.md`-English rule; browser wizard + 2PC installer; no measured bottleneck; discovery-manifest covers it |
+| BYO MCP-memory 4-tool contract | **REJECT** | File-first memory ships; heavyweight memory removed (ADR-094) |
+| Contribution-funnel machinery (issue forms, PR templates) | **FOLD OUT** → `road-to-adoption-without-narrative-debt.md` | Funnel belongs to the adoption roadmap; Phase 1 here is its technical prerequisite |
+
+## § Execution order & protocol
+
+**1 → 2 → 3.** Phases are independent-additive; each lands as its own change
+with verification evidence (per `verify-before-complete`) and a checkpoint
+note appended here (numbers, verdicts, deviations). Rollback = revert; no data
+migration anywhere. Phases 1 and 3 may run in parallel by two agents IF the
+Phase-3 agent does not touch `src/scripts/_lib/`.
+
+## § No-claims note
+
+Nothing here licenses a public claim. Forbidden until gates pass:
+"duplicate-proof contribution pipeline" (needs 1.3 calibration numbers),
+any token-savings claim for the router (needs the 2.1/2.4 measured reports,
+claims-registered), "team deploy" (Phase 3 is an annotation probe, not a
+feature). The zero-external-adopters gap is NOT addressed by this roadmap and
+remains the top structural issue — owned by
+`road-to-adoption-without-narrative-debt.md`.

--- a/docs/contracts/mcp-tool-inventory.md
+++ b/docs/contracts/mcp-tool-inventory.md
@@ -14,22 +14,22 @@ keep-beta-until: 2026-08-14
 
 ## Summary
 
-- **Total tools:** 28
+- **Total tools:** 31
 - **By transport:** stdio=19
-- **By side-effect:** fs-write=8, ro=17, shell=3
-- **Discovery-only stubs (no implementation):** 9
+- **By side-effect:** fs-write=8, ro=20, shell=3
+- **Discovery-only stubs (no implementation):** 12
 
 ## Tools
 
 | Tool | Side-effect | Transports | Catalog | Handler |
 |---|---|---|---|---|
-| `lint_skills` | `ro` | stdio | [`consumer_tool_catalog.json:7`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L7) | [`tools.ts:1200`](../../src/scripts/mcp_server/tools.ts#L1200) |
-| `chat_history_append` | `fs-write` | stdio | [`consumer_tool_catalog.json:24`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L24) | [`tools.ts:1228`](../../src/scripts/mcp_server/tools.ts#L1228) |
-| `chat_history_read` | `ro` | stdio | [`consumer_tool_catalog.json:43`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L43) | [`tools.ts:1289`](../../src/scripts/mcp_server/tools.ts#L1289) |
-| `memory_lookup` | `ro` | stdio | [`consumer_tool_catalog.json:63`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L63) | [`tools.ts:1365`](../../src/scripts/mcp_server/tools.ts#L1365) |
-| `memory_get` | `ro` | stdio | [`consumer_tool_catalog.json:81`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L81) | [`tools.ts:1432`](../../src/scripts/mcp_server/tools.ts#L1432) |
-| `memory_signal` | `fs-write` | stdio | [`consumer_tool_catalog.json:95`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L95) | [`tools.ts:1541`](../../src/scripts/mcp_server/tools.ts#L1541) |
-| `memory_status` | `ro` | stdio | [`consumer_tool_catalog.json:111`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L111) | [`tools.ts:1456`](../../src/scripts/mcp_server/tools.ts#L1456) |
+| `lint_skills` | `ro` | stdio | [`consumer_tool_catalog.json:7`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L7) | [`tools.ts:1198`](../../src/scripts/mcp_server/tools.ts#L1198) |
+| `chat_history_append` | `fs-write` | stdio | [`consumer_tool_catalog.json:24`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L24) | [`tools.ts:1226`](../../src/scripts/mcp_server/tools.ts#L1226) |
+| `chat_history_read` | `ro` | stdio | [`consumer_tool_catalog.json:43`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L43) | [`tools.ts:1287`](../../src/scripts/mcp_server/tools.ts#L1287) |
+| `memory_lookup` | `ro` | stdio | [`consumer_tool_catalog.json:63`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L63) | [`tools.ts:1363`](../../src/scripts/mcp_server/tools.ts#L1363) |
+| `memory_get` | `ro` | stdio | [`consumer_tool_catalog.json:81`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L81) | [`tools.ts:1430`](../../src/scripts/mcp_server/tools.ts#L1430) |
+| `memory_signal` | `fs-write` | stdio | [`consumer_tool_catalog.json:95`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L95) | [`tools.ts:1539`](../../src/scripts/mcp_server/tools.ts#L1539) |
+| `memory_status` | `ro` | stdio | [`consumer_tool_catalog.json:111`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L111) | [`tools.ts:1454`](../../src/scripts/mcp_server/tools.ts#L1454) |
 | `skill_trigger_eval` | `ro` | _(stub)_ | [`consumer_tool_catalog.json:118`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L118) | _stub-only_ |
 | `suggest_command` | `ro` | _(stub)_ | [`consumer_tool_catalog.json:134`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L134) | _stub-only_ |
 | `suggest_skill_for_task` | `ro` | _(stub)_ | [`consumer_tool_catalog.json:149`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L149) | _stub-only_ |
@@ -37,20 +37,23 @@ keep-beta-until: 2026-08-14
 | `update_form_request_messages` | `fs-write` | _(stub)_ | [`consumer_tool_catalog.json:178`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L178) | _stub-only_ |
 | `sync_gitignore` | `fs-write` | _(stub)_ | [`consumer_tool_catalog.json:193`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L193) | _stub-only_ |
 | `sync_agent_settings` | `fs-write` | _(stub)_ | [`consumer_tool_catalog.json:206`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L206) | _stub-only_ |
-| `run_tests` | `shell` | stdio | [`consumer_tool_catalog.json:220`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L220) | [`tools.ts:1716`](../../src/scripts/mcp_server/tools.ts#L1716) |
+| `run_tests` | `shell` | stdio | [`consumer_tool_catalog.json:220`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L220) | [`tools.ts:1714`](../../src/scripts/mcp_server/tools.ts#L1714) |
 | `run_quality_checks` | `shell` | _(stub)_ | [`consumer_tool_catalog.json:234`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L234) | _stub-only_ |
-| `list_skills` | `ro` | stdio | [`consumer_tool_catalog.json:247`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L247) | [`tools.ts:1470`](../../src/scripts/mcp_server/tools.ts#L1470) |
-| `list_commands` | `ro` | stdio | [`consumer_tool_catalog.json:254`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L254) | [`tools.ts:1485`](../../src/scripts/mcp_server/tools.ts#L1485) |
-| `list_rules` | `ro` | stdio | [`consumer_tool_catalog.json:261`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L261) | [`tools.ts:1500`](../../src/scripts/mcp_server/tools.ts#L1500) |
+| `list_skills` | `ro` | stdio | [`consumer_tool_catalog.json:247`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L247) | [`tools.ts:1468`](../../src/scripts/mcp_server/tools.ts#L1468) |
+| `list_commands` | `ro` | stdio | [`consumer_tool_catalog.json:254`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L254) | [`tools.ts:1483`](../../src/scripts/mcp_server/tools.ts#L1483) |
+| `list_rules` | `ro` | stdio | [`consumer_tool_catalog.json:261`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L261) | [`tools.ts:1498`](../../src/scripts/mcp_server/tools.ts#L1498) |
 | `compile_router` | `shell` | _(stub)_ | [`consumer_tool_catalog.json:268`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L268) | _stub-only_ |
-| `read_resource_body` | `ro` | stdio | [`consumer_tool_catalog.json:281`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L281) | [`tools.ts:1516`](../../src/scripts/mcp_server/tools.ts#L1516) |
-| `roadmap_progress` | `fs-write` | stdio | [`consumer_tool_catalog.json:295`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L295) | [`tools.ts:1575`](../../src/scripts/mcp_server/tools.ts#L1575) |
-| `roadmap_archive` | `fs-write` | stdio | [`consumer_tool_catalog.json:308`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L308) | [`tools.ts:1598`](../../src/scripts/mcp_server/tools.ts#L1598) |
-| `capabilities_index` | `fs-write` | stdio | [`consumer_tool_catalog.json:315`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L315) | [`tools.ts:1614`](../../src/scripts/mcp_server/tools.ts#L1614) |
-| `doctor_report` | `ro` | stdio | [`consumer_tool_catalog.json:328`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L328) | [`tools.ts:1637`](../../src/scripts/mcp_server/tools.ts#L1637) |
-| `conformance_check` | `ro` | stdio | [`consumer_tool_catalog.json:335`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L335) | [`tools.ts:1651`](../../src/scripts/mcp_server/tools.ts#L1651) |
-| `telemetry_report` | `ro` | stdio | [`consumer_tool_catalog.json:342`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L342) | [`tools.ts:1665`](../../src/scripts/mcp_server/tools.ts#L1665) |
-| `council_estimate` | `ro` | stdio | [`consumer_tool_catalog.json:355`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L355) | [`tools.ts:1687`](../../src/scripts/mcp_server/tools.ts#L1687) |
+| `read_resource_body` | `ro` | stdio | [`consumer_tool_catalog.json:281`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L281) | [`tools.ts:1514`](../../src/scripts/mcp_server/tools.ts#L1514) |
+| `roadmap_progress` | `fs-write` | stdio | [`consumer_tool_catalog.json:295`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L295) | [`tools.ts:1573`](../../src/scripts/mcp_server/tools.ts#L1573) |
+| `roadmap_archive` | `fs-write` | stdio | [`consumer_tool_catalog.json:308`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L308) | [`tools.ts:1596`](../../src/scripts/mcp_server/tools.ts#L1596) |
+| `capabilities_index` | `fs-write` | stdio | [`consumer_tool_catalog.json:315`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L315) | [`tools.ts:1612`](../../src/scripts/mcp_server/tools.ts#L1612) |
+| `doctor_report` | `ro` | stdio | [`consumer_tool_catalog.json:328`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L328) | [`tools.ts:1635`](../../src/scripts/mcp_server/tools.ts#L1635) |
+| `conformance_check` | `ro` | stdio | [`consumer_tool_catalog.json:335`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L335) | [`tools.ts:1649`](../../src/scripts/mcp_server/tools.ts#L1649) |
+| `telemetry_report` | `ro` | stdio | [`consumer_tool_catalog.json:342`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L342) | [`tools.ts:1663`](../../src/scripts/mcp_server/tools.ts#L1663) |
+| `catalog_search` | `ro` | _(stub)_ | [`consumer_tool_catalog.json:355`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L355) | _stub-only_ |
+| `catalog_inspect` | `ro` | _(stub)_ | [`consumer_tool_catalog.json:372`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L372) | _stub-only_ |
+| `catalog_load` | `ro` | _(stub)_ | [`consumer_tool_catalog.json:387`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L387) | _stub-only_ |
+| `council_estimate` | `ro` | stdio | [`consumer_tool_catalog.json:401`](../../src/scripts/mcp_server/consumer_tool_catalog.json#L401) | [`tools.ts:1685`](../../src/scripts/mcp_server/tools.ts#L1685) |
 
 ## Glossary
 

--- a/src/flows/delivery.yaml
+++ b/src/flows/delivery.yaml
@@ -28,3 +28,12 @@ commands:              # seed from worksheet ·_flow:delivery_ tags
   - pr/create
   - fix/pr-comments
   - prepare-for-review
+team:                  # OPTIONAL demand-probe annotation (Phase 3) — no execution semantics
+  personas:
+    - production-validator
+    - qa
+    - senior-engineer
+  skills:
+    - verify-completion-evidence
+    - code-review
+    - requesting-code-review

--- a/src/scripts/_lib/catalog_score.ts
+++ b/src/scripts/_lib/catalog_score.ts
@@ -1,0 +1,64 @@
+/**
+ * Catalog search scoring — a thin field-boosted wrapper over the shared
+ * `LexicalIndex` (BM25 + trigram prefilter).
+ *
+ * DECISION (road-to-persona-library-harvest.md Phase 2.3): the roadmap sketched
+ * porting the upstream Hermes `_score` (token overlap + name/description
+ * boosts). We do NOT — `_lib/lexical_index.ts` already ships a calibrated BM25
+ * core (ADR-061-sanctioned, dependency-free) with a coverage² multi-term
+ * weighting and a trigram candidate prefilter. Maintaining a second lexical
+ * scorer would be duplication. Instead we reuse `LexicalIndex` and get the
+ * field boost by REPEATING the name (×3) and description (×2) terms in each
+ * doc's indexed text, so a query term hitting the name outranks the same term
+ * buried in a tag. No new scorer.
+ */
+import type { CatalogIndexEntry } from '../build_catalog_index.js';
+import { LexicalIndex } from './lexical_index.js';
+
+export interface CatalogFilter {
+    cls?: CatalogIndexEntry['cls'];
+    /** Match against the entry's tags (packs/domain/tier). */
+    pack?: string;
+    limit?: number;
+}
+
+export interface CatalogHit {
+    entry: CatalogIndexEntry;
+    score: number;
+}
+
+/** Field-boosted searchable text: name ×3, description ×2, tags ×1. */
+function _docText(e: CatalogIndexEntry): string {
+    return [e.name, e.name, e.name, e.description, e.description, ...e.tags].join(' ');
+}
+
+function _filter(entries: readonly CatalogIndexEntry[], f: CatalogFilter): CatalogIndexEntry[] {
+    return entries.filter((e) => {
+        if (f.cls && e.cls !== f.cls) return false;
+        if (f.pack && !e.tags.includes(f.pack)) return false;
+        return true;
+    });
+}
+
+/**
+ * Rank catalog entries against a free-text query. The index is built over the
+ * (filtered) candidate set so IDF reflects the searched scope. Empty or
+ * whitespace query → no hits (a search tool must not dump the catalog).
+ */
+export function searchCatalog(
+    entries: readonly CatalogIndexEntry[],
+    query: string,
+    filter: CatalogFilter = {},
+): CatalogHit[] {
+    const q = query.trim();
+    if (q.length === 0) return [];
+    const candidates = _filter(entries, filter);
+    if (candidates.length === 0) return [];
+
+    const index = new LexicalIndex(candidates.map((e) => ({ id: e.id, text: _docText(e) })));
+    const byId = new Map(candidates.map((e) => [e.id, e]));
+    const limit = filter.limit && filter.limit > 0 ? filter.limit : 8;
+
+    const ranked = index.rank([q]).filter((r) => r.score > 0);
+    return ranked.slice(0, limit).map((r) => ({ entry: byId.get(r.id) as CatalogIndexEntry, score: r.score }));
+}

--- a/src/scripts/_lib/shingle_similarity.ts
+++ b/src/scripts/_lib/shingle_similarity.ts
@@ -1,0 +1,146 @@
+/**
+ * Entity-neutralized shingle-overlap primitive — the anti-reskin engine behind
+ * `lint_originality.ts`.
+ *
+ * Deterministic, no embeddings, no network. This is a DIFFERENT primitive from
+ * `text_similarity.ts` (token-set Jaccard, dedup) and `audit_skill_overlap.ts`
+ * (keyword-cosine, advisory) — both of which a find-replace re-skin
+ * ("Laravel" → "Symfony", "Vietnam" → "Korea") can defeat, because the swapped
+ * proper nouns shift the token/keyword vectors enough to drop the score.
+ *
+ * The defence is two-fold:
+ *   1. NEUTRALIZE entities — replace framework / vendor / language / region /
+ *      currency proper nouns with a single placeholder BEFORE comparison, so a
+ *      find-replace re-skin collapses to the original text.
+ *   2. SHINGLE — compare k-word shingles (default k = 8), not a bag of tokens,
+ *      so re-skins that only swap scattered nouns still share long verbatim
+ *      runs, and unrelated files that happen to share vocabulary do not.
+ *
+ * Overlap is CONTAINMENT (`|a∩b| / min(|a|,|b|)`), not Jaccard: a small file
+ * copied verbatim into a large padded one must still score high — the exact
+ * shape of an embedded re-skin.
+ *
+ * Deliberately does NOT touch `text_similarity.ts` or `memory_signal.ts`
+ * (byte-faithful parity contracts). This module is a new, additional layer.
+ */
+
+/**
+ * Proper-noun families that a find-replace re-skin swaps. Neutralized to a
+ * single placeholder so the swap does not move the score. Word-boundary
+ * matched, case-insensitive. **Extend via PR, never inline at a call site** —
+ * the list is the calibration surface, and a scattered entity list drifts.
+ *
+ * Seed the list from OUR corpus (the frameworks / vendors / regions the suite
+ * actually names), not from any external source.
+ */
+export const ENTITY_TERMS: readonly string[] = [
+    // Frameworks / libraries
+    'laravel', 'symfony', 'react', 'vue', 'preact', 'angular', 'svelte', 'nextjs',
+    'next', 'nuxt', 'livewire', 'flux', 'inertia', 'blade', 'tailwind', 'eloquent',
+    'doctrine', 'pest', 'phpunit', 'vitest', 'jest', 'playwright', 'express',
+    'fastify', 'django', 'flask', 'rails', 'spring',
+    // Languages
+    'php', 'typescript', 'javascript', 'python', 'ruby', 'golang', 'rust', 'java',
+    'kotlin', 'swift', 'csharp', 'elixir',
+    // Vendors / platforms / services
+    'aws', 'gcp', 'azure', 'hetzner', 'cloudflare', 'vercel', 'netlify', 'stripe',
+    'paddle', 'paypal', 'github', 'gitlab', 'bitbucket', 'linear', 'jira',
+    'confluence', 'slack', 'sentry', 'datadog', 'grafana', 'prometheus', 'redis',
+    'postgres', 'postgresql', 'mysql', 'mariadb', 'sqlite', 'mongodb', 'kafka',
+    'rabbitmq', 'terraform', 'terragrunt', 'kubernetes', 'docker', 'ansible',
+    'openai', 'anthropic', 'gemini', 'claude',
+    // Cloud regions / locales that re-skins swap
+    'us-east-1', 'us-west-2', 'eu-west-1', 'eu-central-1', 'ap-southeast-1',
+    // Currency codes / symbols
+    'usd', 'eur', 'gbp', 'chf', 'jpy',
+];
+
+const _ENTITY_RE = new RegExp(
+    `\\b(?:${ENTITY_TERMS.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\b`,
+    'gi',
+);
+
+/** Placeholder every entity family collapses to. Distinct token so it shingles. */
+export const ENTITY_PLACEHOLDER = 'entterm';
+
+/** Word token — mirrors the upstream re-skin gate's word regex so a calibrated
+ * threshold ports across corpora. Digits, `+ . # _ -` kept (e.g. `c#`, `9.3.0`). */
+const _WORD_RE = /[a-z0-9][a-z0-9+.#_-]*/g;
+
+/**
+ * Lowercase, strip frontmatter + markdown syntax, then replace entity proper
+ * nouns with `ENTITY_PLACEHOLDER`. `extra` is an optional caller-supplied regex
+ * (global) of additional terms to neutralize for one call (e.g. a corpus-
+ * specific product name); it never mutates the shared list.
+ */
+export function neutralizeEntities(text: string, extra?: RegExp): string {
+    let t = text;
+    // Leading YAML frontmatter.
+    t = t.replace(/^---\n[\s\S]*?\n---\n?/, '');
+    // Fenced code blocks (``` or ~~~).
+    t = t.replace(/^([`~]{3,}).*$[\s\S]*?^\1[ \t]*$/gm, ' ');
+    // HTML comments.
+    t = t.replace(/<!--[\s\S]*?-->/g, ' ');
+    // Inline code spans.
+    t = t.replace(/`[^`]*`/g, ' ');
+    // Links / images: keep the visible label, drop the target.
+    t = t.replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1');
+    t = t.toLowerCase();
+    // Heading / emphasis / list / blockquote / table punctuation → spaces, so
+    // the same prose scores identically regardless of markdown decoration.
+    t = t.replace(/[#*_>|~]+/g, ' ');
+    if (extra) {
+        t = t.replace(extra, ENTITY_PLACEHOLDER);
+    }
+    t = t.replace(_ENTITY_RE, ENTITY_PLACEHOLDER);
+    return t;
+}
+
+/** Ordered word tokens of the neutralized text (no set — shingles need order). */
+export function words(text: string): string[] {
+    return text.match(_WORD_RE) ?? [];
+}
+
+/**
+ * Word-level k-shingles over the neutralized token stream. A file with fewer
+ * than `k` tokens yields the empty set (guarded downstream → score 0, never
+ * NaN). Shingles join on a single space so they are comparable across files.
+ */
+export function shingles(text: string, k = 8): Set<string> {
+    const toks = words(neutralizeEntities(text));
+    const out = new Set<string>();
+    if (toks.length < k) {
+        return out;
+    }
+    for (let i = 0; i + k <= toks.length; i++) {
+        out.add(toks.slice(i, i + k).join(' '));
+    }
+    return out;
+}
+
+/**
+ * Containment overlap in percent: `100 * |a∩b| / min(|a|,|b|)`.
+ *
+ * Containment (not Jaccard) so a small file copied verbatim into a large padded
+ * one still scores high. Two empty shingle sets → 0 (a file too short to
+ * shingle carries no originality signal — never flag it). One empty → 0.
+ */
+export function overlapPercent(a: Set<string>, b: Set<string>): number {
+    const min = Math.min(a.size, b.size);
+    if (min === 0) {
+        return 0;
+    }
+    const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+    let shared = 0;
+    for (const s of small) {
+        if (large.has(s)) {
+            shared++;
+        }
+    }
+    return (100 * shared) / min;
+}
+
+/** Convenience: shingle both texts and score. */
+export function shingleOverlap(a: string, b: string, k = 8): number {
+    return overlapPercent(shingles(a, k), shingles(b, k));
+}

--- a/src/scripts/build_catalog_index.ts
+++ b/src/scripts/build_catalog_index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 /**
- * Build the lazy-catalog index — `dist/catalog-index.json`.
+ * Build the lazy-catalog index — `dist/catalog-index-v1.json`.
  *
  * A queryable metadata index over every skill, persona, and domain command:
  * `{ id, cls, name, description, tags, path }` — **metadata only, no bodies**.
@@ -22,7 +22,10 @@ import { parse as parseYaml } from 'yaml';
 
 const _HERE = fileURLToPath(import.meta.url);
 export const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
-export const OUT = path.join(ROOT, 'dist', 'catalog-index.json');
+// The `-v1` namespace tracks `schema_version` below (per lint_versioned_cache):
+// bump both together on a shape change so any stale cached copy self-invalidates
+// by name rather than being read as the new shape.
+export const OUT = path.join(ROOT, 'dist', 'catalog-index-v1.json');
 
 export type CatalogClass = 'skill' | 'persona' | 'command';
 

--- a/src/scripts/build_catalog_index.ts
+++ b/src/scripts/build_catalog_index.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env tsx
+/**
+ * Build the lazy-catalog index — `dist/catalog-index.json`.
+ *
+ * A queryable metadata index over every skill, persona, and domain command:
+ * `{ id, cls, name, description, tags, path }` — **metadata only, no bodies**.
+ * Bodies load lazily from disk at `catalog_load` time (the stdio server has the
+ * repo underneath it, unlike the upstream Hermes plugin which embeds bodies).
+ *
+ * Feeds the `catalog_search / _inspect / _load` MCP tools (built as discovery
+ * stubs; activation deferred behind a quality A/B — see
+ * road-to-persona-library-harvest.md Phase 2). Deterministic output (entries
+ * sorted by (cls, id), stable keys) so the artifact diffs cleanly. `--check`
+ * fails on drift instead of writing (CI mode), mirroring the
+ * build_mcp_registry_manifest convention.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { parse as parseYaml } from 'yaml';
+
+const _HERE = fileURLToPath(import.meta.url);
+export const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+export const OUT = path.join(ROOT, 'dist', 'catalog-index.json');
+
+export type CatalogClass = 'skill' | 'persona' | 'command';
+
+export interface CatalogIndexEntry {
+    /** Globally unique handle: `<cls>:<slug>`. */
+    id: string;
+    cls: CatalogClass;
+    name: string;
+    description: string;
+    /** Domain / packs / tier — for filtering and search-text weighting. */
+    tags: string[];
+    /** Repo-relative path to the body (resolved by catalog_load). */
+    path: string;
+}
+
+const SKILLS_DIR = path.join(ROOT, 'src', 'skills');
+const PERSONAS_DIR = path.join(ROOT, 'src', 'agent-src', 'personas');
+const DOMAINS_DIR = path.join(ROOT, 'src', 'domains');
+
+function _isDir(p: string): boolean {
+    try { return fs.statSync(p).isDirectory(); } catch { return false; }
+}
+function _isFile(p: string): boolean {
+    try { return fs.statSync(p).isFile(); } catch { return false; }
+}
+function _rel(abs: string): string {
+    return path.relative(ROOT, abs).split(path.sep).join('/');
+}
+
+function _frontmatter(abs: string): Record<string, unknown> {
+    const text = fs.readFileSync(abs, 'utf-8');
+    const m = /^---\n([\s\S]*?)\n---/.exec(text);
+    if (!m || m.index !== 0) return {};
+    try {
+        const fm = parseYaml(m[1] as string, { version: '1.1' });
+        return fm !== null && typeof fm === 'object' && !Array.isArray(fm) ? (fm as Record<string, unknown>) : {};
+    } catch {
+        return {};
+    }
+}
+
+function _str(v: unknown): string {
+    return typeof v === 'string' ? v.trim() : v == null ? '' : String(v);
+}
+function _list(v: unknown): string[] {
+    if (Array.isArray(v)) return v.map((x) => _str(x)).filter((s) => s.length > 0);
+    const s = _str(v);
+    return s ? [s] : [];
+}
+
+function _walkLeaf(dir: string, leaf: string, out: string[]): void {
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const ent of entries) {
+        const full = path.join(dir, ent.name);
+        if (ent.isDirectory() || (ent.isSymbolicLink() && _isDir(full))) _walkLeaf(full, leaf, out);
+        else if (ent.name === leaf) out.push(full);
+    }
+}
+
+export function buildEntries(): CatalogIndexEntry[] {
+    const out: CatalogIndexEntry[] = [];
+
+    // Skills
+    if (_isDir(SKILLS_DIR)) {
+        for (const slug of fs.readdirSync(SKILLS_DIR).sort()) {
+            const abs = path.join(SKILLS_DIR, slug, 'SKILL.md');
+            if (!_isFile(abs)) continue;
+            const fm = _frontmatter(abs);
+            out.push({
+                id: `skill:${slug}`,
+                cls: 'skill',
+                name: _str(fm['name']) || slug,
+                description: _str(fm['description']),
+                tags: [_str(fm['domain']), ..._list(fm['packs'])].filter((s) => s.length > 0),
+                path: _rel(abs),
+            });
+        }
+    }
+
+    // Personas (top-level *.md, skip _template/advisors and underscore-prefixed)
+    if (_isDir(PERSONAS_DIR)) {
+        for (const name of fs.readdirSync(PERSONAS_DIR).sort()) {
+            if (!name.endsWith('.md') || name.startsWith('_')) continue;
+            const abs = path.join(PERSONAS_DIR, name);
+            if (!_isFile(abs)) continue;
+            const fm = _frontmatter(abs);
+            const id = _str(fm['id']) || name.replace(/\.md$/, '');
+            out.push({
+                id: `persona:${id}`,
+                cls: 'persona',
+                name: _str(fm['role']) || id,
+                description: _str(fm['description']),
+                tags: [_str(fm['tier']), _str(fm['mode'])].filter((s) => s.length > 0),
+                path: _rel(abs),
+            });
+        }
+    }
+
+    // Domain commands
+    const cmds: string[] = [];
+    _walkLeaf(DOMAINS_DIR, 'command.md', cmds);
+    for (const abs of cmds.sort()) {
+        const fm = _frontmatter(abs);
+        // logical id = <pack>/<subpath> under src/domains, without /command.md
+        const relFromDomains = path.relative(DOMAINS_DIR, path.dirname(abs)).split(path.sep).join('/');
+        const name = _str(fm['name']) || relFromDomains.split('/').pop() || relFromDomains;
+        out.push({
+            id: `command:${relFromDomains}`,
+            cls: 'command',
+            name,
+            description: _str(fm['description']) || _str(fm['intent']),
+            tags: [_str(fm['pack']), _str(fm['tier']), _str(fm['visibility'])].filter((s) => s.length > 0),
+            path: _rel(abs),
+        });
+    }
+
+    // Deterministic order: (cls, id).
+    out.sort((a, b) => (a.cls < b.cls ? -1 : a.cls > b.cls ? 1 : a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    return out;
+}
+
+export function serialize(entries: CatalogIndexEntry[]): string {
+    return JSON.stringify({ schema_version: 1, count: entries.length, entries }, null, 2) + '\n';
+}
+
+export function main(argv?: string[]): number {
+    const args = argv ?? process.argv.slice(2);
+    const check = args.includes('--check');
+    const quiet = args.includes('--quiet');
+    const entries = buildEntries();
+    const rendered = serialize(entries);
+
+    if (check) {
+        const current = _isFile(OUT) ? fs.readFileSync(OUT, 'utf-8') : '';
+        if (current !== rendered) {
+            process.stderr.write(`build_catalog_index: DRIFT — ${_rel(OUT)} is stale; run build_catalog_index to regenerate.\n`);
+            return 1;
+        }
+        if (!quiet) process.stdout.write(`build_catalog_index: OK — ${entries.length} entries, index up to date.\n`);
+        return 0;
+    }
+
+    fs.mkdirSync(path.dirname(OUT), { recursive: true });
+    fs.writeFileSync(OUT, rendered, 'utf-8');
+    if (!quiet) process.stdout.write(`build_catalog_index: wrote ${entries.length} entries → ${_rel(OUT)}\n`);
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) return true;
+    try {
+        return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]));
+    } catch { return false; }
+}
+
+if (_isCliEntry()) {
+    process.exit(main());
+}

--- a/src/scripts/lint_originality.ts
+++ b/src/scripts/lint_originality.ts
@@ -1,0 +1,433 @@
+#!/usr/bin/env tsx
+/**
+ * Anti-reskin originality linter.
+ *
+ * Entity-neutralized shingle-overlap gate over the authored corpus — skills,
+ * personas, and domain commands. Catches the failure mode that keyword-cosine
+ * (`audit_skill_overlap.ts`) and token-Jaccard (`_lib/text_similarity.ts`)
+ * miss: a find-replace re-skin ("Laravel" → "Symfony", "Vietnam" → "Korea")
+ * submitted as a "new" artifact. The engine (`_lib/shingle_similarity.ts`)
+ * neutralizes framework/vendor/region proper nouns before comparing 8-word
+ * shingles, so the swap does not move the score.
+ *
+ * Corpus is class-scoped: a skill compares only against skills, a persona only
+ * against personas, a command only against commands — a persona legitimately
+ * shares scaffold phrasing with the persona template, never with a skill.
+ * Shared-scaffold shingles are subtracted per class (the class template's
+ * shingles are removed from every candidate) so boilerplate never scores.
+ * Rules and contexts are OUT of scope by design (their intentional
+ * cross-referencing makes shingle overlap structurally noisy).
+ *
+ * Modes:
+ *   (no args)          full pairwise audit → agents/reports/originality.{json,md}
+ *   --changed <f...>   CI path: each changed file vs the whole same-class corpus
+ *                      AND vs the other changed files of its class
+ *
+ * Thresholds (env-overridable): ORIGINALITY_FAIL (60), ORIGINALITY_WARN (40).
+ * Calibrated 2026-07-19 over 495 artifacts / 56 151 comparisons: after the
+ * template + document-frequency boilerplate subtraction the worst legitimate
+ * pair is 40 % (a single command pair sharing residual cluster-orchestrator
+ * prose), p95 and median 0 %. A find-replace re-skin scores ~100 % (entities
+ * neutralize away), so FAIL 60 blocks every real re-skin with a 20-point margin
+ * above the legitimate floor and 40-point margin below a re-skin. Distribution
+ * recorded in agents/reports/originality.md. Exit 0 clean/warn · 1 fail · 2 usage.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { shingles } from './_lib/shingle_similarity.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+export const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const REPORT_DIR = path.join(ROOT, 'agents', 'reports');
+const OUT_JSON = path.join(REPORT_DIR, 'originality.json');
+const OUT_MD = path.join(REPORT_DIR, 'originality.md');
+
+const K = 8;
+
+export type ArtifactClass = 'skill' | 'persona' | 'command';
+
+interface ClassSpec {
+    readonly name: ArtifactClass;
+    /** Absolute paths of every corpus file in this class (sorted). */
+    files(): string[];
+    /** Class template file whose shingles are subtracted as shared scaffold. */
+    readonly templatePath: string;
+    /** Classify an absolute path into this class, or null. */
+    matches(abs: string): boolean;
+}
+
+function _isDir(p: string): boolean {
+    try { return fs.statSync(p).isDirectory(); } catch { return false; }
+}
+function _isFile(p: string): boolean {
+    try { return fs.statSync(p).isFile(); } catch { return false; }
+}
+function _rel(abs: string): string {
+    return path.relative(ROOT, abs).split(path.sep).join('/');
+}
+
+/** Recursive walk collecting files whose basename === `leaf`. */
+function _walkLeaf(dir: string, leaf: string, out: string[]): void {
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const ent of entries) {
+        const full = path.join(dir, ent.name);
+        if (ent.isDirectory() || (ent.isSymbolicLink() && _isDir(full))) {
+            _walkLeaf(full, leaf, out);
+        } else if (ent.name === leaf) {
+            out.push(full);
+        }
+    }
+}
+
+const SKILLS_DIR = path.join(ROOT, 'src', 'skills');
+const PERSONAS_DIR = path.join(ROOT, 'src', 'agent-src', 'personas');
+const DOMAINS_DIR = path.join(ROOT, 'src', 'domains');
+
+const CLASSES: readonly ClassSpec[] = [
+    {
+        name: 'skill',
+        templatePath: path.join(ROOT, 'src', 'agent-src', 'templates', 'skill.md'),
+        files() {
+            if (!_isDir(SKILLS_DIR)) return [];
+            return fs.readdirSync(SKILLS_DIR)
+                .map((n) => path.join(SKILLS_DIR, n, 'SKILL.md'))
+                .filter(_isFile)
+                .sort();
+        },
+        matches: (abs) => abs.startsWith(SKILLS_DIR + path.sep) && path.basename(abs) === 'SKILL.md',
+    },
+    {
+        name: 'persona',
+        templatePath: path.join(PERSONAS_DIR, '_template-specialist', 'persona.md'),
+        files() {
+            if (!_isDir(PERSONAS_DIR)) return [];
+            // Top-level *.md only (subdirs like _template-specialist/, advisors/
+            // are not first-class personas — the corpus is the flat set).
+            return fs.readdirSync(PERSONAS_DIR)
+                .filter((n) => n.endsWith('.md') && !n.startsWith('_'))
+                .map((n) => path.join(PERSONAS_DIR, n))
+                .filter(_isFile)
+                .sort();
+        },
+        matches: (abs) =>
+            path.dirname(abs) === PERSONAS_DIR &&
+            abs.endsWith('.md') &&
+            !path.basename(abs).startsWith('_'),
+    },
+    {
+        name: 'command',
+        templatePath: path.join(ROOT, 'src', 'agent-src', 'templates', 'command.md'),
+        files() {
+            const out: string[] = [];
+            _walkLeaf(DOMAINS_DIR, 'command.md', out);
+            return out.sort();
+        },
+        matches: (abs) => abs.startsWith(DOMAINS_DIR + path.sep) && path.basename(abs) === 'command.md',
+    },
+];
+
+interface Artifact {
+    cls: ArtifactClass;
+    relpath: string;
+    /** Human name — frontmatter name/id, else parent dir. */
+    label: string;
+    /** Scaffold-stripped shingle set. */
+    shingles: Set<string>;
+}
+
+/** Cheap frontmatter name/id read for a readable label (no yaml dep needed). */
+function _label(text: string, abs: string): string {
+    const fm = /^---\n([\s\S]*?)\n---/.exec(text);
+    if (fm) {
+        const m = /^(?:name|id):\s*["']?([^"'\n]+)["']?\s*$/m.exec(fm[1] as string);
+        if (m) return (m[1] as string).trim();
+    }
+    return path.basename(path.dirname(abs)) || path.basename(abs);
+}
+
+function _templateShingles(spec: ClassSpec): Set<string> {
+    if (!_isFile(spec.templatePath)) return new Set();
+    return shingles(fs.readFileSync(spec.templatePath, 'utf-8'), K);
+}
+
+function _load(abs: string, cls: ArtifactClass, tmpl: Set<string>): Artifact {
+    const text = fs.readFileSync(abs, 'utf-8');
+    const raw = shingles(text, K);
+    // Subtract shared scaffold — a shingle also present in the class template
+    // is boilerplate, not authored content.
+    const kept = new Set<string>();
+    for (const s of raw) if (!tmpl.has(s)) kept.add(s);
+    return { cls, relpath: _rel(abs), label: _label(text, abs), shingles: kept };
+}
+
+export function overlap(a: Artifact, b: Artifact): number {
+    const min = Math.min(a.shingles.size, b.shingles.size);
+    if (min === 0) return 0;
+    const [small, large] = a.shingles.size <= b.shingles.size ? [a.shingles, b.shingles] : [b.shingles, a.shingles];
+    let shared = 0;
+    for (const s of small) if (large.has(s)) shared++;
+    return (100 * shared) / min;
+}
+
+interface Pair { cls: ArtifactClass; a: string; b: string; a_path: string; b_path: string; overlap: number; }
+
+function _round1(x: number): number { return Math.round(x * 10) / 10; }
+
+// --- thresholds --------------------------------------------------------------
+
+function _threshold(env: string, dflt: number): number {
+    const v = process.env[env];
+    if (v === undefined || v === '') return dflt;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : dflt;
+}
+export const FAIL = _threshold('ORIGINALITY_FAIL', 60);
+export const WARN = _threshold('ORIGINALITY_WARN', 40);
+
+// --- corpus ------------------------------------------------------------------
+
+/**
+ * Document-frequency boilerplate floor. A shingle that recurs across many
+ * artifacts of a class is shared scaffold the single template file does not
+ * capture (command orchestrators especially share structural prose). A
+ * find-replace re-skin, by contrast, is a PAIR: its distinctive shingles live
+ * in ≤ 2 files, so DF-filtering keeps exactly the content a re-skin copies while
+ * dropping the class boilerplate — a per-class IDF stopword pass at shingle
+ * granularity. Floor = max(4, 3% of the class size).
+ */
+export function _dfFloor(n: number): number {
+    return Math.max(4, Math.round(0.03 * n));
+}
+
+/** The high-DF shingle set — class boilerplate to subtract from every artifact. */
+export function _boilerplateSet(arts: Artifact[]): Set<string> {
+    const floor = _dfFloor(arts.length);
+    const df = new Map<string, number>();
+    for (const a of arts) for (const s of a.shingles) df.set(s, (df.get(s) ?? 0) + 1);
+    const boiler = new Set<string>();
+    for (const [s, c] of df) if (c >= floor) boiler.add(s);
+    return boiler;
+}
+
+function _subtract(a: Artifact, boiler: Set<string>): void {
+    if (boiler.size === 0) return;
+    const kept = new Set<string>();
+    for (const s of a.shingles) if (!boiler.has(s)) kept.add(s);
+    a.shingles = kept;
+}
+
+/** Per-class artifacts with the class template + DF-boilerplate subtracted. */
+function _corpus(): Map<ArtifactClass, Artifact[]> {
+    const byClass = new Map<ArtifactClass, Artifact[]>();
+    for (const spec of CLASSES) {
+        const tmpl = _templateShingles(spec);
+        const arts = spec.files().map((f) => _load(f, spec.name, tmpl));
+        const boiler = _boilerplateSet(arts);
+        for (const a of arts) _subtract(a, boiler);
+        byClass.set(spec.name, arts);
+    }
+    return byClass;
+}
+
+function _classify(abs: string): ClassSpec | null {
+    for (const spec of CLASSES) if (spec.matches(abs)) return spec;
+    return null;
+}
+
+// --- full audit --------------------------------------------------------------
+
+function _fullPairs(byClass: Map<ArtifactClass, Artifact[]>): Pair[] {
+    const pairs: Pair[] = [];
+    for (const arts of byClass.values()) {
+        for (let i = 0; i < arts.length; i++) {
+            for (let j = i + 1; j < arts.length; j++) {
+                const a = arts[i] as Artifact;
+                const b = arts[j] as Artifact;
+                const o = overlap(a, b);
+                if (o >= WARN) {
+                    pairs.push({ cls: a.cls, a: a.label, b: b.label, a_path: a.relpath, b_path: b.relpath, overlap: _round1(o) });
+                }
+            }
+        }
+    }
+    return pairs.sort((x, y) => y.overlap - x.overlap || (x.a_path < y.a_path ? -1 : 1));
+}
+
+/** worst / p95 / median over EVERY pair (not just the >= WARN ones). */
+function _distribution(byClass: Map<ArtifactClass, Artifact[]>): { worst: number; p95: number; median: number; comparisons: number } {
+    const scores: number[] = [];
+    for (const arts of byClass.values()) {
+        for (let i = 0; i < arts.length; i++) {
+            for (let j = i + 1; j < arts.length; j++) {
+                scores.push(overlap(arts[i] as Artifact, arts[j] as Artifact));
+            }
+        }
+    }
+    if (scores.length === 0) return { worst: 0, p95: 0, median: 0, comparisons: 0 };
+    scores.sort((a, b) => a - b);
+    const at = (q: number): number => _round1(scores[Math.min(scores.length - 1, Math.floor(q * scores.length))] as number);
+    return { worst: _round1(scores[scores.length - 1] as number), p95: at(0.95), median: at(0.5), comparisons: scores.length };
+}
+
+function _writeReport(byClass: Map<ArtifactClass, Artifact[]>, pairs: Pair[], dist: ReturnType<typeof _distribution>): void {
+    fs.mkdirSync(REPORT_DIR, { recursive: true });
+    const scanned = [...byClass.values()].reduce((n, a) => n + a.length, 0);
+    const json = {
+        fail_threshold: FAIL,
+        warn_threshold: WARN,
+        artifacts_scanned: scanned,
+        distribution: dist,
+        pairs,
+    };
+    fs.writeFileSync(OUT_JSON, JSON.stringify(json, null, 2) + '\n', 'utf-8');
+
+    const L: string[] = [
+        '# Originality audit — entity-neutralized shingle overlap\n',
+        `> Anti-reskin gate over ${scanned} authored artifacts (skills · personas · commands), `,
+        `class-scoped, scaffold-subtracted, k=${K}. Thresholds: FAIL ${FAIL} / WARN ${WARN}. `,
+        'This report blocks NOTHING on its own — `lint_originality --changed` is the CI gate.\n',
+        `\n- Artifacts scanned: **${scanned}**`,
+        `\n- Pairwise comparisons: **${dist.comparisons}**`,
+        `\n- Overlap distribution: worst **${dist.worst}%** · p95 **${dist.p95}%** · median **${dist.median}%**`,
+        `\n- Pairs ≥ WARN (${WARN}%): **${pairs.length}** (${pairs.filter((p) => p.overlap >= FAIL).length} ≥ FAIL)\n`,
+        '\n## Pairs at or above the warn threshold\n',
+    ];
+    if (pairs.length === 0) {
+        L.push('None — no same-class pair exceeds the warn threshold.\n');
+    } else {
+        L.push('| Class | A | B | overlap |');
+        L.push('|---|---|---|--:|');
+        for (const p of pairs) {
+            const flag = p.overlap >= FAIL ? ' ❌' : '';
+            L.push(`| ${p.cls} | \`${p.a}\` | \`${p.b}\` | ${p.overlap}%${flag} |`);
+        }
+    }
+    fs.writeFileSync(OUT_MD, L.join('\n') + '\n', 'utf-8');
+}
+
+// --- changed mode ------------------------------------------------------------
+
+function _changed(files: string[]): { pairs: Pair[]; fails: number } {
+    // Build the corpus in RAW (template-subtracted, pre-DF) form per class so we
+    // can derive the same boilerplate set the candidate is filtered against.
+    const byClass = new Map<ArtifactClass, Artifact[]>();
+    const boilerByClass = new Map<ArtifactClass, Set<string>>();
+    const templateCache = new Map<ArtifactClass, Set<string>>();
+    for (const spec of CLASSES) {
+        const tmpl = _templateShingles(spec);
+        templateCache.set(spec.name, tmpl);
+        const arts = spec.files().map((f) => _load(f, spec.name, tmpl));
+        const boiler = _boilerplateSet(arts);
+        for (const a of arts) _subtract(a, boiler);
+        byClass.set(spec.name, arts);
+        boilerByClass.set(spec.name, boiler);
+    }
+
+    // Load each changed file as an artifact (skip un-classifiable ones) and
+    // subtract the same class boilerplate so the comparison is apples-to-apples.
+    const changedArts: Artifact[] = [];
+    for (const f of files) {
+        const abs = path.resolve(ROOT, f);
+        const spec = _classify(abs);
+        if (!spec || !_isFile(abs)) continue;
+        const a = _load(abs, spec.name, templateCache.get(spec.name) as Set<string>);
+        _subtract(a, boilerByClass.get(spec.name) as Set<string>);
+        changedArts.push(a);
+    }
+
+    const pairs: Pair[] = [];
+    const seen = new Set<string>();
+    const record = (a: Artifact, b: Artifact): void => {
+        if (a.relpath === b.relpath) return;
+        const key = [a.relpath, b.relpath].sort().join(' ');
+        if (seen.has(key)) return;
+        const o = overlap(a, b);
+        if (o >= WARN) {
+            seen.add(key);
+            const [x, y] = a.relpath <= b.relpath ? [a, b] : [b, a];
+            pairs.push({ cls: a.cls, a: x.label, b: y.label, a_path: x.relpath, b_path: y.relpath, overlap: _round1(o) });
+        }
+    };
+
+    for (const cand of changedArts) {
+        // vs the whole same-class corpus
+        for (const other of byClass.get(cand.cls) ?? []) record(cand, other);
+        // vs the other changed files of the same class
+        for (const other of changedArts) if (other.cls === cand.cls) record(cand, other);
+    }
+    pairs.sort((x, y) => y.overlap - x.overlap || (x.a_path < y.a_path ? -1 : 1));
+    return { pairs, fails: pairs.filter((p) => p.overlap >= FAIL).length };
+}
+
+// --- main --------------------------------------------------------------------
+
+export function main(argv?: string[]): number {
+    const args = argv ?? process.argv.slice(2);
+    if (args.includes('-h') || args.includes('--help')) {
+        process.stdout.write(_usage());
+        return 0;
+    }
+    let quiet = false;
+    let changedFiles: string[] | null = null;
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i] as string;
+        if (a === '--quiet') { quiet = true; }
+        else if (a === '--changed') { changedFiles = args.slice(i + 1).filter((x) => !x.startsWith('-')); break; }
+        else if (a.startsWith('-')) { process.stderr.write(`unrecognized argument: ${a}\n${_usage()}`); return 2; }
+        else { process.stderr.write(`unexpected argument: ${a} (did you mean --changed ${a}?)\n${_usage()}`); return 2; }
+    }
+
+    if (changedFiles !== null) {
+        const { pairs, fails } = _changed(changedFiles);
+        if (pairs.length > 0) {
+            const stream = fails > 0 ? process.stderr : process.stdout;
+            stream.write(`lint_originality: ${pairs.length} overlap(s) ≥ WARN ${WARN}% (${fails} ≥ FAIL ${FAIL}%):\n`);
+            for (const p of pairs) {
+                stream.write(`  [${p.cls}] ${p.a_path}  ~  ${p.b_path}  ${p.overlap}%${p.overlap >= FAIL ? '  ❌' : ''}\n`);
+            }
+        } else if (!quiet) {
+            process.stdout.write(`lint_originality: OK — ${changedFiles.length} changed file(s), no overlap ≥ WARN ${WARN}%.\n`);
+        }
+        return fails > 0 ? 1 : 0;
+    }
+
+    // Full audit
+    const byClass = _corpus();
+    const scanned = [...byClass.values()].reduce((n, a) => n + a.length, 0);
+    if (scanned === 0) {
+        process.stderr.write('❌  No artifacts found under the corpus roots.\n');
+        return 3;
+    }
+    const dist = _distribution(byClass);
+    const pairs = _fullPairs(byClass);
+    _writeReport(byClass, pairs, dist);
+    const fails = pairs.filter((p) => p.overlap >= FAIL).length;
+    if (!quiet) {
+        process.stdout.write(
+            `lint_originality: ${scanned} artifacts, worst ${dist.worst}% · p95 ${dist.p95}% · median ${dist.median}%; ` +
+                `${pairs.length} pair(s) ≥ WARN ${WARN}% (${fails} ≥ FAIL ${FAIL}%).\n`,
+        );
+        process.stdout.write(`   JSON: ${_rel(OUT_JSON)}\n`);
+        process.stdout.write(`   MD:   ${_rel(OUT_MD)}\n`);
+    }
+    return fails > 0 ? 1 : 0;
+}
+
+function _usage(): string {
+    return 'usage: lint_originality [--quiet] [--changed <file...>]\n';
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) return true;
+    try {
+        return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]));
+    } catch { return false; }
+}
+
+if (_isCliEntry()) {
+    process.exit(main());
+}

--- a/src/scripts/mcp_server/catalog_tools.ts
+++ b/src/scripts/mcp_server/catalog_tools.ts
@@ -3,7 +3,7 @@
  * `catalog_load`.
  *
  * Read-only discovery over the package's own artifact catalog
- * (`dist/catalog-index.json`), so a host can find and load ONE skill / persona
+ * (`dist/catalog-index-v1.json`), so a host can find and load ONE skill / persona
  * / command body on demand instead of carrying all ~495 descriptions in its
  * initial context. Reuses `_lib/catalog_score` (BM25 via the shared
  * LexicalIndex).
@@ -29,7 +29,7 @@ import { searchCatalog, type CatalogFilter } from '../_lib/catalog_score.js';
 const _HERE = fileURLToPath(import.meta.url);
 // src/scripts/mcp_server → repo root is three dirs up.
 export const ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
-const INDEX_PATH = path.join(ROOT, 'dist', 'catalog-index.json');
+const INDEX_PATH = path.join(ROOT, 'dist', 'catalog-index-v1.json');
 
 /**
  * Neutral preamble wrapping a loaded body. Adapted from the upstream

--- a/src/scripts/mcp_server/catalog_tools.ts
+++ b/src/scripts/mcp_server/catalog_tools.ts
@@ -1,0 +1,114 @@
+/**
+ * Lazy-catalog MCP tool handlers — `catalog_search`, `catalog_inspect`,
+ * `catalog_load`.
+ *
+ * Read-only discovery over the package's own artifact catalog
+ * (`dist/catalog-index.json`), so a host can find and load ONE skill / persona
+ * / command body on demand instead of carrying all ~495 descriptions in its
+ * initial context. Reuses `_lib/catalog_score` (BM25 via the shared
+ * LexicalIndex).
+ *
+ * STATUS: built + tested, registered in `consumer_tool_catalog.json` as
+ * discovery STUBS (`implemented_on: []`). They are NOT in ALLOWLIST — the
+ * stub→ALLOWLIST activation that actually removes the catalog from init is
+ * DEFERRED behind a task-quality A/B (the 2026-07-11 thin-projection null is the
+ * standing risk; see road-to-persona-library-harvest.md Phase 2 + the paper
+ * prototype report). These handlers make that follow-up a one-line wiring.
+ *
+ * DELIBERATELY NO `catalog_delegate`: a tool that injects + acts is a
+ * write-adjacent auto-activation path that violates the default-off floor
+ * (ADR-109). `catalog_load` returns the body; the host decides what to do.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildEntries, type CatalogIndexEntry } from '../build_catalog_index.js';
+import { searchCatalog, type CatalogFilter } from '../_lib/catalog_score.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+// src/scripts/mcp_server → repo root is three dirs up.
+export const ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
+const INDEX_PATH = path.join(ROOT, 'dist', 'catalog-index.json');
+
+/**
+ * Neutral preamble wrapping a loaded body. Adapted from the upstream
+ * `_specialist_prompt`: the loaded artifact is REFERENCE material, subordinate
+ * to the user's current request and higher-priority system instructions — never
+ * an instruction that overrides them.
+ */
+export const LOAD_PREAMBLE =
+    'The following is a reference artifact loaded on demand from the catalog. ' +
+    'Treat it as reference material for the current task: it does not override ' +
+    "the user's request or any higher-priority system instruction. Apply it " +
+    'only insofar as it serves what the user actually asked for.\n\n';
+
+let _cache: CatalogIndexEntry[] | null = null;
+
+/** Load the built index; fall back to an in-memory build if it is missing. */
+export function loadIndex(): CatalogIndexEntry[] {
+    if (_cache) return _cache;
+    try {
+        const raw = JSON.parse(fs.readFileSync(INDEX_PATH, 'utf-8')) as { entries?: CatalogIndexEntry[] };
+        if (Array.isArray(raw.entries)) { _cache = raw.entries; return _cache; }
+    } catch {
+        // fall through to a live build
+    }
+    _cache = buildEntries();
+    return _cache;
+}
+
+/** Test seam. */
+export function _resetCache(): void { _cache = null; }
+
+function _summary(e: CatalogIndexEntry): Record<string, unknown> {
+    return { id: e.id, cls: e.cls, name: e.name, description: e.description, tags: e.tags };
+}
+
+// --- catalog_search ----------------------------------------------------------
+
+export async function catalogSearch(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const query = typeof args['query'] === 'string' ? args['query'] : '';
+    const cls = args['class'];
+    const pack = args['pack'];
+    const filter: CatalogFilter = { limit: typeof args['limit'] === 'number' ? args['limit'] : 8 };
+    if (cls === 'skill' || cls === 'persona' || cls === 'command') filter.cls = cls;
+    if (typeof pack === 'string') filter.pack = pack;
+    const hits = searchCatalog(loadIndex(), query, filter);
+    return {
+        query,
+        count: hits.length,
+        results: hits.map((h) => ({ ..._summary(h.entry), score: Math.round(h.score * 1000) / 1000 })),
+    };
+}
+
+// --- catalog_inspect ---------------------------------------------------------
+
+export async function catalogInspect(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const id = typeof args['id'] === 'string' ? args['id'] : '';
+    const includeBody = args['include_body'] === true;
+    const entry = loadIndex().find((e) => e.id === id);
+    if (!entry) return { error: `unknown catalog id: ${id}` };
+    const out: Record<string, unknown> = { ..._summary(entry), path: entry.path };
+    if (includeBody) out['body'] = _readBody(entry);
+    return out;
+}
+
+// --- catalog_load ------------------------------------------------------------
+
+export async function catalogLoad(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const id = typeof args['id'] === 'string' ? args['id'] : '';
+    const entry = loadIndex().find((e) => e.id === id);
+    if (!entry) return { error: `unknown catalog id: ${id}` };
+    return { id: entry.id, cls: entry.cls, name: entry.name, path: entry.path, body: LOAD_PREAMBLE + _readBody(entry) };
+}
+
+/** Read a body from disk, path-confined to the package root. */
+function _readBody(entry: CatalogIndexEntry): string {
+    const abs = path.resolve(ROOT, entry.path);
+    // Path-confinement: never read outside the package root, even if the index
+    // were tampered with.
+    const rootWithSep = ROOT.endsWith(path.sep) ? ROOT : ROOT + path.sep;
+    if (!abs.startsWith(rootWithSep)) return '';
+    try { return fs.readFileSync(abs, 'utf-8'); } catch { return ''; }
+}

--- a/src/scripts/mcp_server/consumer_tool_catalog.json
+++ b/src/scripts/mcp_server/consumer_tool_catalog.json
@@ -352,6 +352,52 @@
       }
     },
     {
+      "name": "catalog_search",
+      "description": "Search the package's own artifact catalog (skills, personas, commands) by free-text query and return ranked summaries — name, description, tags, score — WITHOUT loading any body. Use to discover which skill or persona fits a task when the full catalog is not in context. Read-only, deterministic (BM25 over an on-disk index). DISCOVERY STUB — the real handler ships behind a task-quality A/B before activation (see road-to-persona-library-harvest.md Phase 2); until then this returns the not_implemented envelope.",
+      "side_effect": "ro",
+      "implemented_on": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {"type": "string", "description": "Free-text search query."},
+          "class": {"type": "string", "enum": ["skill", "persona", "command"], "description": "Optional: restrict to one artifact class."},
+          "pack": {"type": "string", "description": "Optional: restrict to entries tagged with this pack/domain."},
+          "limit": {"type": "integer", "minimum": 1, "default": 8, "description": "Maximum results. Defaults to 8."}
+        },
+        "required": ["query"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "catalog_inspect",
+      "description": "Return the metadata for one catalog entry by id (id, class, name, description, tags, path). Body is returned ONLY when include_body is true. Use after catalog_search to look at a candidate before loading it. Read-only. DISCOVERY STUB — real handler activation deferred (see catalog_search).",
+      "side_effect": "ro",
+      "implemented_on": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string", "description": "Catalog id, e.g. `skill:api-design` or `persona:backend-architect`."},
+          "include_body": {"type": "boolean", "default": false, "description": "When true, include the full body. Defaults to false (metadata only)."}
+        },
+        "required": ["id"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "catalog_load",
+      "description": "Load the full body of one catalog entry by id, wrapped in a neutral reference preamble that subordinates it to the user's request and system instructions. Use to bring a skill/persona/command body into context on demand. Read-only, path-confined to the package root. Never injects or acts — the host decides what to do with the body. DISCOVERY STUB — real handler activation deferred (see catalog_search).",
+      "side_effect": "ro",
+      "implemented_on": [],
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string", "description": "Catalog id to load the body for."}
+        },
+        "required": ["id"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "council_estimate",
       "description": "Estimate the token cost of an AI-council debate over a given input (roadmap, diff, prompt, or file set) without spending — no network call, no billing. Use before deciding whether to authorize a real council run. Read-only.",
       "side_effect": "ro",

--- a/src/scripts/schemas/flow.schema.json
+++ b/src/scripts/schemas/flow.schema.json
@@ -47,6 +47,23 @@
       "type": "array",
       "items": { "$ref": "#/definitions/commandRef" },
       "description": "Optional descriptive seed list lifted from the command-classification worksheet `·_flow:` tags. Annotation only — entry_points / default_path are the validated reference fields. Each entry, if present, must still resolve to a real command."
+    },
+    "team": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OPTIONAL demand-probe annotation (road-to-persona-library-harvest.md Phase 3): the persona/skill team that this flow's work typically pulls in. Annotation ONLY — no execution semantics; subagent-orchestration remains the executor. Referential integrity (every persona id / skill slug resolves) is checked by scripts/validate_flow_teams.ts, not this schema. Exists so demand for scenario→team selection can reveal itself before a roster schema is designed.",
+      "properties": {
+        "personas": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+          "description": "Persona ids the flow typically pulls in. Each must resolve to a real src/agent-src/personas/<id>.md."
+        },
+        "skills": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+          "description": "Skill slugs the flow's team relies on. Each must resolve to a real skills/<slug>/SKILL.md."
+        }
+      }
     }
   },
   "definitions": {

--- a/src/scripts/validate_flow_teams.ts
+++ b/src/scripts/validate_flow_teams.ts
@@ -1,0 +1,127 @@
+#!/usr/bin/env tsx
+/**
+ * Validate the optional `team:` annotation on flows (`src/flows/*.yaml`).
+ *
+ * A demand-probe primitive (road-to-persona-library-harvest.md Phase 3): a flow
+ * MAY declare `team: { personas: [...], skills: [...] }` naming the persona/skill
+ * team its work typically pulls in. This validator checks referential
+ * integrity — every persona id resolves to `src/agent-src/personas/<id>.md`,
+ * every skill slug to a real `skills/<slug>/SKILL.md` — so a typo is caught, but
+ * it adds NO execution semantics (subagent-orchestration stays the executor) and
+ * no new artifact class. If organic use grows (≥ 5 flows carrying `team:` with a
+ * repeated conditional shape), THAT is the signal to design a roster schema —
+ * not before.
+ *
+ * Exit 0 clean (incl. no flow carrying `team:`) · 1 on an unresolved reference
+ * · 2 usage.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import YAML from 'yaml';
+
+import { resolve_logical } from './_lib/agent_src.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const FLOWS_DIR = path.join(ROOT, 'src', 'flows');
+const PERSONAS_DIR = path.join(ROOT, 'src', 'agent-src', 'personas');
+const NON_FLOW = new Set(['surface-map.yaml', 'cookbook.yaml']);
+
+function _isFile(p: string): boolean {
+    try { return fs.statSync(p).isFile(); } catch { return false; }
+}
+function _rel(p: string): string {
+    return path.relative(ROOT, p).split(path.sep).join('/');
+}
+function _personaExists(id: string): boolean {
+    return _isFile(path.join(PERSONAS_DIR, `${id}.md`));
+}
+function _skillExists(slug: string): boolean {
+    return resolve_logical(`skills/${slug}/SKILL.md`) !== null;
+}
+
+interface Violation { file: string; reason: string; }
+
+export function checkFile(abs: string): Violation[] {
+    const rel = _rel(abs);
+    let data: unknown;
+    try {
+        data = YAML.parse(fs.readFileSync(abs, 'utf-8'), { version: '1.1' });
+    } catch (e) {
+        return [{ file: rel, reason: `not valid YAML: ${e instanceof Error ? e.message : String(e)}` }];
+    }
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) return [];
+    const team = (data as Record<string, unknown>)['team'];
+    if (team === undefined || team === null) return [];
+    if (typeof team !== 'object' || Array.isArray(team)) {
+        return [{ file: rel, reason: '`team` must be a mapping with optional `personas` / `skills` arrays' }];
+    }
+    const vios: Violation[] = [];
+    const personas = (team as Record<string, unknown>)['personas'];
+    for (const id of Array.isArray(personas) ? personas : []) {
+        if (typeof id === 'string' && !_personaExists(id)) {
+            vios.push({ file: rel, reason: `team.personas: persona '${id}' does not resolve (no src/agent-src/personas/${id}.md)` });
+        }
+    }
+    const skills = (team as Record<string, unknown>)['skills'];
+    for (const slug of Array.isArray(skills) ? skills : []) {
+        if (typeof slug === 'string' && !_skillExists(slug)) {
+            vios.push({ file: rel, reason: `team.skills: skill '${slug}' does not resolve (no skills/${slug}/SKILL.md)` });
+        }
+    }
+    return vios;
+}
+
+export function main(argv?: string[]): number {
+    const args = argv ?? process.argv.slice(2);
+    if (args.includes('-h') || args.includes('--help')) {
+        process.stdout.write('usage: validate_flow_teams [--quiet]\n');
+        return 0;
+    }
+    const unknown = args.filter((a) => a !== '--quiet');
+    if (unknown.length > 0) {
+        process.stderr.write(`unrecognized argument: ${unknown[0]}\nusage: validate_flow_teams [--quiet]\n`);
+        return 2;
+    }
+    const quiet = args.includes('--quiet');
+
+    let files: string[];
+    try {
+        files = fs.readdirSync(FLOWS_DIR).filter((n) => n.endsWith('.yaml') && !NON_FLOW.has(n)).sort();
+    } catch {
+        process.stderr.write(`flows dir not found: ${FLOWS_DIR}\n`);
+        return 0; // nothing to validate
+    }
+
+    const vios: Violation[] = [];
+    let annotated = 0;
+    for (const name of files) {
+        const abs = path.join(FLOWS_DIR, name);
+        vios.push(...checkFile(abs));
+        if (/^team:/m.test(fs.readFileSync(abs, 'utf-8'))) annotated++;
+    }
+
+    if (vios.length > 0) {
+        process.stderr.write(`validate_flow_teams: ${vios.length} unresolved reference(s):\n`);
+        for (const v of vios) process.stderr.write(`  ${v.file}: ${v.reason}\n`);
+        return 1;
+    }
+    if (!quiet) {
+        process.stdout.write(`validate_flow_teams: OK — ${annotated} flow(s) carry a \`team:\` annotation, all references resolve.\n`);
+    }
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) return true;
+    try {
+        return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]));
+    } catch { return false; }
+}
+
+if (_isCliEntry()) {
+    process.exit(main());
+}

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -329,6 +329,16 @@ tasks:
     desc: "road-to-6.1.0 Step 8b (ADR-055) — validate src/flows/*.yaml against the flow schema + resolve every command/skill reference + closed-set/completeness"
     cmd: ./scripts-run src/scripts/lint_flows {{.QUIET_FLAG}}
 
+  lint-originality:
+    silent: true
+    desc: "Anti-reskin gate — entity-neutralized shingle overlap over skills/personas/commands; blocks find-replace re-skins (FAIL 60, calibrated). Full audit writes agents/reports/originality.md; --changed <file...> for a PR-scoped check."
+    cmd: ./scripts-run src/scripts/lint_originality {{.QUIET_FLAG}}
+
+  validate-flow-teams:
+    silent: true
+    desc: "Advisory — every flow `team:` annotation resolves to a real persona id and skill slug (demand-probe primitive; formalize a roster schema only on organic use)."
+    cmd: ./scripts-run src/scripts/validate_flow_teams {{.QUIET_FLAG}}
+
   lint-command-flow-coverage:
     silent: true
     desc: "road-to-6.1.0 Step 9 — every src/domains command is classified into exactly one flow/surface in src/flows/surface-map.yaml (the Flows primary view)"

--- a/tests/scripts/catalog_score.test.ts
+++ b/tests/scripts/catalog_score.test.ts
@@ -1,0 +1,43 @@
+// Tests for src/scripts/_lib/catalog_score.ts — catalog search over the real
+// index, reusing the shared LexicalIndex (no second scorer).
+import { describe, expect, it } from 'vitest';
+
+import { buildEntries } from '../../src/scripts/build_catalog_index.js';
+import { searchCatalog } from '../../src/scripts/_lib/catalog_score.js';
+
+const ENTRIES = buildEntries();
+
+describe('catalog_score — searchCatalog', () => {
+    it('ranks the relevant skills for a real query', () => {
+        const hits = searchCatalog(ENTRIES, 'incident rollback blast radius', { cls: 'skill', limit: 8 });
+        const ids = hits.map((h) => h.entry.id);
+        // The purpose-built incident/blast-radius skills must surface near the top.
+        expect(ids).toContain('skill:blast-radius-analyzer');
+        expect(hits.length).toBeGreaterThan(0);
+        // Scores are descending.
+        for (let i = 1; i < hits.length; i++) {
+            expect(hits[i - 1]!.score).toBeGreaterThanOrEqual(hits[i]!.score);
+        }
+    });
+
+    it('an empty / whitespace query returns no hits (never dumps the catalog)', () => {
+        expect(searchCatalog(ENTRIES, '')).toEqual([]);
+        expect(searchCatalog(ENTRIES, '   ')).toEqual([]);
+    });
+
+    it('respects the class filter', () => {
+        const hits = searchCatalog(ENTRIES, 'review architecture', { cls: 'persona', limit: 10 });
+        expect(hits.length).toBeGreaterThan(0);
+        expect(hits.every((h) => h.entry.cls === 'persona')).toBe(true);
+    });
+
+    it('respects the limit', () => {
+        const hits = searchCatalog(ENTRIES, 'test', { limit: 3 });
+        expect(hits.length).toBeLessThanOrEqual(3);
+    });
+
+    it('respects the pack filter (tag membership)', () => {
+        const hits = searchCatalog(ENTRIES, 'endpoint validation', { pack: 'engineering-base', limit: 10 });
+        expect(hits.every((h) => h.entry.tags.includes('engineering-base'))).toBe(true);
+    });
+});

--- a/tests/scripts/catalog_tools.test.ts
+++ b/tests/scripts/catalog_tools.test.ts
@@ -1,0 +1,83 @@
+// Tests for src/scripts/mcp_server/catalog_tools.ts — the lazy-catalog tool
+// handlers (built + tested; registered as discovery stubs, activation deferred).
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import {
+    LOAD_PREAMBLE,
+    ROOT,
+    _resetCache,
+    catalogInspect,
+    catalogLoad,
+    catalogSearch,
+} from '../../src/scripts/mcp_server/catalog_tools.js';
+import { main as buildIndex } from '../../src/scripts/build_catalog_index.js';
+
+beforeAll(() => {
+    // Ensure the on-disk index exists and is fresh for loadIndex().
+    buildIndex(['--quiet']);
+    _resetCache();
+});
+
+describe('catalog_tools — registration (tools/list surface)', () => {
+    it('registers the three catalog tools as discovery stubs (implemented_on: [])', () => {
+        const catalog = JSON.parse(
+            fs.readFileSync(path.join(ROOT, 'src/scripts/mcp_server/consumer_tool_catalog.json'), 'utf-8'),
+        ) as { tools: Array<{ name: string; implemented_on: string[]; side_effect: string }> };
+        const names = new Set(catalog.tools.map((t) => t.name));
+        for (const n of ['catalog_search', 'catalog_inspect', 'catalog_load']) {
+            expect(names.has(n)).toBe(true);
+            const t = catalog.tools.find((x) => x.name === n)!;
+            expect(t.implemented_on).toEqual([]); // stub — activation deferred
+            expect(t.side_effect).toBe('ro'); // read-only
+        }
+        // The write-adjacent delegate tool must NOT exist.
+        expect(names.has('catalog_delegate')).toBe(false);
+    });
+});
+
+describe('catalog_tools — catalog_search', () => {
+    it('returns ranked summaries with scores, no bodies', async () => {
+        const res = await catalogSearch({ query: 'incident rollback blast radius', class: 'skill', limit: 5 });
+        expect(res['count']).toBeGreaterThan(0);
+        const results = res['results'] as Array<Record<string, unknown>>;
+        expect(results.length).toBeLessThanOrEqual(5);
+        expect(results.some((r) => r['id'] === 'skill:blast-radius-analyzer')).toBe(true);
+        for (const r of results) {
+            expect(typeof r['score']).toBe('number');
+            expect(r).not.toHaveProperty('body'); // search never carries a body
+        }
+    });
+});
+
+describe('catalog_tools — catalog_inspect', () => {
+    it('returns metadata only by default; body only on the explicit flag', async () => {
+        const meta = await catalogInspect({ id: 'skill:api-design' });
+        expect(meta['id']).toBe('skill:api-design');
+        expect(meta).not.toHaveProperty('body');
+
+        const withBody = await catalogInspect({ id: 'skill:api-design', include_body: true });
+        expect(typeof withBody['body']).toBe('string');
+        expect((withBody['body'] as string).length).toBeGreaterThan(0);
+    });
+
+    it('unknown id → error, never a crash', async () => {
+        const res = await catalogInspect({ id: 'skill:__does_not_exist__' });
+        expect(res['error']).toMatch(/unknown catalog id/);
+    });
+});
+
+describe('catalog_tools — catalog_load', () => {
+    it('loads a body wrapped in the neutral subordination preamble', async () => {
+        const res = await catalogLoad({ id: 'skill:api-design' });
+        expect(res['id']).toBe('skill:api-design');
+        expect((res['body'] as string).startsWith(LOAD_PREAMBLE)).toBe(true);
+        expect((res['body'] as string).length).toBeGreaterThan(LOAD_PREAMBLE.length);
+    });
+
+    it('unknown id → error', async () => {
+        const res = await catalogLoad({ id: 'persona:__nope__' });
+        expect(res['error']).toMatch(/unknown catalog id/);
+    });
+});

--- a/tests/scripts/lint_originality.test.ts
+++ b/tests/scripts/lint_originality.test.ts
@@ -1,0 +1,92 @@
+// Tests for src/scripts/lint_originality.ts — the anti-reskin gate wiring.
+//
+// Unit layer over the pure helpers, plus two integration checks against the
+// REAL corpus: a clean full audit exits 0, and a verbatim re-skin of an
+// existing skill (written into a temp skill dir, removed in finally) is caught.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FAIL, ROOT, WARN, _boilerplateSet, _dfFloor, main, overlap } from '../../src/scripts/lint_originality.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const art = (shingles: string[]): any => ({ cls: 'skill', relpath: 'x', label: 'x', shingles: new Set(shingles) });
+
+describe('lint_originality — thresholds', () => {
+    it('calibrated defaults: FAIL 60 above the legit floor, WARN 40', () => {
+        expect(FAIL).toBe(60);
+        expect(WARN).toBe(40);
+        expect(FAIL).toBeGreaterThan(WARN);
+    });
+});
+
+describe('lint_originality — _dfFloor', () => {
+    it('is max(4, 3% of class size)', () => {
+        expect(_dfFloor(10)).toBe(4); // 0.3 → rounded 0, floored to 4
+        expect(_dfFloor(100)).toBe(4); // 3 → floored to 4
+        expect(_dfFloor(200)).toBe(6);
+        expect(_dfFloor(1000)).toBe(30);
+    });
+});
+
+describe('lint_originality — _boilerplateSet', () => {
+    it('flags shingles recurring in >= floor artifacts, keeps rare ones', () => {
+        // 5 artifacts (floor = 4): "shared" appears in 4, "rare" in 2.
+        const arts = [
+            art(['shared', 'a1']),
+            art(['shared', 'a2']),
+            art(['shared', 'rare']),
+            art(['shared', 'rare']),
+            art(['unique']),
+        ];
+        const boiler = _boilerplateSet(arts);
+        expect(boiler.has('shared')).toBe(true); // DF 4 >= floor 4
+        expect(boiler.has('rare')).toBe(false); // DF 2 < floor — a re-skin pair survives
+        expect(boiler.has('unique')).toBe(false);
+    });
+});
+
+describe('lint_originality — overlap (containment)', () => {
+    it('identical shingle sets score 100, disjoint score 0', () => {
+        expect(overlap(art(['a', 'b', 'c']), art(['a', 'b', 'c']))).toBe(100);
+        expect(overlap(art(['a', 'b']), art(['x', 'y']))).toBe(0);
+    });
+    it('containment uses the smaller set as denominator', () => {
+        // small={a,b} fully inside large={a,b,c,d} → 100%.
+        expect(overlap(art(['a', 'b']), art(['a', 'b', 'c', 'd']))).toBe(100);
+    });
+    it('empty set scores 0, never NaN', () => {
+        expect(overlap(art([]), art(['a']))).toBe(0);
+    });
+});
+
+describe('lint_originality — integration against the real corpus', () => {
+    const FIXTURE_DIR = path.join(ROOT, 'src', 'skills', '__origtest_reskin_fixture');
+    const FIXTURE = path.join(FIXTURE_DIR, 'SKILL.md');
+
+    afterEach(() => {
+        fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+    });
+
+    it('full audit of the shipped corpus exits 0 (no re-skin present)', () => {
+        expect(main(['--quiet'])).toBe(0);
+    });
+
+    it('a changed real skill does not flag itself (self-exclusion)', () => {
+        // api-design is a real, unique skill; comparing it vs the corpus that
+        // contains it must not fail on a self-match.
+        expect(main(['--changed', 'src/skills/api-design/SKILL.md', '--quiet'])).toBe(1 - 1);
+    });
+
+    it('catches a verbatim re-skin of an existing skill (exit 1)', () => {
+        const original = fs.readFileSync(path.join(ROOT, 'src', 'skills', 'api-design', 'SKILL.md'), 'utf-8');
+        // A re-skin: the same body with framework nouns swapped — the engine
+        // neutralizes those, so it still scores as a near-copy.
+        const reskin = original
+            .replace(/Laravel/g, 'Symfony')
+            .replace(/\bREST\b/g, 'gRPC');
+        fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+        fs.writeFileSync(FIXTURE, reskin, 'utf-8');
+        expect(main(['--changed', 'src/skills/__origtest_reskin_fixture/SKILL.md', '--quiet'])).toBe(1);
+    });
+});

--- a/tests/scripts/shingle_similarity.test.ts
+++ b/tests/scripts/shingle_similarity.test.ts
@@ -1,0 +1,101 @@
+// Tests for src/scripts/_lib/shingle_similarity.ts — the anti-reskin engine.
+//
+// Behavioural, not golden: every expectation is derived from the input
+// (entity-swap of a fixture, unrelated prose), never a hard-coded corpus score.
+import { describe, expect, it } from 'vitest';
+
+import {
+    ENTITY_PLACEHOLDER,
+    neutralizeEntities,
+    overlapPercent,
+    shingleOverlap,
+    shingles,
+    words,
+} from '../../src/scripts/_lib/shingle_similarity.js';
+
+// A realistic skill-body fixture, long enough to shingle at k=8.
+const LARAVEL_BODY = `
+When building an API endpoint in Laravel, keep the controller thin and push
+business logic into a dedicated service class. Validate the request payload at
+the boundary with a FormRequest, never inline inside the action. Persist through
+Eloquent models, wrap multi-step writes in a database transaction, and return a
+typed API resource so the response shape stays stable across releases. Every
+query that filters user-owned rows must be tenant-scoped before any data leaves
+the handler, and the endpoint ships with three negative authorization tests.
+`;
+
+// The SAME body a re-skinner would produce by find-replacing the framework
+// nouns. A naive token/keyword comparison drops on the swaps; the shingle gate,
+// which neutralizes entities first, must still see it as a near-copy.
+const SYMFONY_RESKIN = LARAVEL_BODY
+    .replace(/Laravel/g, 'Symfony')
+    .replace(/Eloquent/g, 'Doctrine')
+    .replace(/FormRequest/g, 'FormRequest'); // control: a non-entity term stays
+
+// Unrelated prose from a different domain — shares stopwords, not structure.
+const TYPOGRAPHY_BODY = `
+A modular type scale multiplies a base size by a fixed ratio to derive every
+step, so headings and body copy relate by a consistent rhythm rather than
+arbitrary pixel values. Choose the ratio from the content density: a marketing
+page tolerates a dramatic 1.333, a data-dense dashboard wants a calmer 1.2.
+Anchor line-height to the step, tighten it as the size grows, and keep the
+vertical rhythm on a single spacing unit so the whole page breathes evenly.
+`;
+
+describe('shingle_similarity — neutralizeEntities', () => {
+    it('collapses framework/vendor proper nouns to a single placeholder', () => {
+        const n = neutralizeEntities('Deploy the Laravel app to AWS via GitHub Actions.');
+        expect(n).toContain(ENTITY_PLACEHOLDER);
+        expect(n).not.toContain('laravel');
+        expect(n).not.toContain('aws');
+        expect(n).not.toContain('github');
+    });
+
+    it('makes an entity find-replace a no-op on the neutralized text', () => {
+        expect(neutralizeEntities(LARAVEL_BODY)).toBe(neutralizeEntities(SYMFONY_RESKIN));
+    });
+
+    it('strips frontmatter and markdown decoration so prose scores the same', () => {
+        const decorated = `---\nid: x\n---\n# Heading\n\n**Bold** _italic_ and \`code\` and a [link](http://x).`;
+        const plain = 'Heading Bold italic and and a link.';
+        expect(words(neutralizeEntities(decorated))).toEqual(words(neutralizeEntities(plain)));
+    });
+});
+
+describe('shingle_similarity — overlapPercent (containment)', () => {
+    it('identical text scores 100', () => {
+        expect(shingleOverlap(LARAVEL_BODY, LARAVEL_BODY)).toBe(100);
+    });
+
+    it('an entity-swapped re-skin still scores >= 90', () => {
+        expect(shingleOverlap(LARAVEL_BODY, SYMFONY_RESKIN)).toBeGreaterThanOrEqual(90);
+    });
+
+    it('two unrelated bodies score <= 5', () => {
+        expect(shingleOverlap(LARAVEL_BODY, TYPOGRAPHY_BODY)).toBeLessThanOrEqual(5);
+    });
+
+    it('a small file copied into a large padded one scores high (containment, not Jaccard)', () => {
+        const large = `${TYPOGRAPHY_BODY}\n${LARAVEL_BODY}\n${TYPOGRAPHY_BODY}`;
+        // The whole LARAVEL_BODY lives inside `large`, so containment ≈ 100.
+        expect(shingleOverlap(LARAVEL_BODY, large)).toBeGreaterThanOrEqual(90);
+    });
+});
+
+describe('shingle_similarity — guards', () => {
+    it('a file shorter than k tokens yields no shingles and never NaN', () => {
+        const short = 'too short to shingle';
+        expect(shingles(short, 8).size).toBe(0);
+        expect(shingleOverlap(short, LARAVEL_BODY)).toBe(0);
+        expect(Number.isNaN(shingleOverlap(short, short))).toBe(false);
+    });
+
+    it('two empty shingle sets score 0 (no originality signal to flag)', () => {
+        expect(overlapPercent(new Set(), new Set())).toBe(0);
+    });
+
+    it('respects a custom k', () => {
+        // At k=3 the re-skin is still a near-copy after neutralization.
+        expect(shingleOverlap(LARAVEL_BODY, SYMFONY_RESKIN, 3)).toBeGreaterThanOrEqual(90);
+    });
+});

--- a/tests/scripts/validate_flow_teams.test.ts
+++ b/tests/scripts/validate_flow_teams.test.ts
@@ -1,0 +1,46 @@
+// Tests for src/scripts/validate_flow_teams.ts — the flow `team:` demand-probe.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { checkFile, main } from '../../src/scripts/validate_flow_teams.js';
+
+const tmp: string[] = [];
+function write(yaml: string): string {
+    const p = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'flowteam-')), 'f.yaml');
+    fs.writeFileSync(p, yaml, 'utf-8');
+    tmp.push(path.dirname(p));
+    return p;
+}
+afterEach(() => { for (const d of tmp.splice(0)) fs.rmSync(d, { recursive: true, force: true }); });
+
+describe('validate_flow_teams — checkFile', () => {
+    it('clean when a real team resolves', () => {
+        const p = write('id: x\nteam:\n  personas: [production-validator, qa]\n  skills: [code-review]\n');
+        expect(checkFile(p)).toEqual([]);
+    });
+
+    it('flags an unresolved persona id', () => {
+        const p = write('id: x\nteam:\n  personas: [not-a-real-persona]\n');
+        const v = checkFile(p);
+        expect(v).toHaveLength(1);
+        expect(v[0]!.reason).toMatch(/persona 'not-a-real-persona' does not resolve/);
+    });
+
+    it('flags an unresolved skill slug', () => {
+        const p = write('id: x\nteam:\n  skills: [not-a-real-skill]\n');
+        expect(checkFile(p)[0]!.reason).toMatch(/skill 'not-a-real-skill' does not resolve/);
+    });
+
+    it('no `team:` block → nothing to check', () => {
+        const p = write('id: x\ntitle: y\n');
+        expect(checkFile(p)).toEqual([]);
+    });
+});
+
+describe('validate_flow_teams — real repo (delivery.yaml annotated)', () => {
+    it('the shipped flows pass (exit 0)', () => {
+        expect(main(['--quiet'])).toBe(0);
+    });
+});


### PR DESCRIPTION
## What & why

Executes `road-to-persona-library-harvest.md` — the council-converged harvest of an external MIT-licensed multi-host agent-persona library. A deeper clone-level analysis falsified the first draft's premise (this package's 23-host `surface-matrix.yml` already governs projection more strongly than the source), so the multi-host adoption track was **rejected** and the plan re-cut to the two mechanisms the source genuinely has and this package lacked, plus one demand-probe primitive.

A 2-member AI-council debate (2 rounds, converged) set the scope; verdicts and the honest calibration/measurement are recorded inline in the archived roadmap.

## Phase 1 — Anti-reskin originality gate (full adopt)

Entity-neutralized k-shingle **containment** over skills / personas / commands — catches find-replace re-skins ("Laravel"→"Symfony") that keyword-cosine (`audit_skill_overlap`) and token-Jaccard (`text_similarity`) miss.

- `_lib/shingle_similarity.ts` + `lint_originality.ts` (full audit + `--changed` CI mode), wired into `ci`/`ci-strict`.
- **Calibrated** over 495 artifacts: template-only subtraction left a command-class boilerplate floor (worst 67.9%); added document-frequency boilerplate subtraction → worst legit pair **40%**, p95/median 0%. Thresholds **FAIL 60 / WARN 40** (diverged from the plan's guessed 40/20 — recorded), 20 pts above the legit floor, 40 pts below a re-skin.
- 19 tests incl. a verbatim-re-skin integration scoring 98.2% → blocked.

## Phase 2 — Lazy catalog router (measured, built as stubs)

Measure-first per the council: a paper prototype (then real tools) showed **~83–90% initial-context reduction** vs the ~21k-token catalog that loads at init — 4× above the 20% gate.

- `build_catalog_index.ts` (→ `dist/catalog-index.json`, 495 entries, `--check` drift), `_lib/catalog_score.ts` (**reuses the shared `LexicalIndex` BM25 — no second scorer**), `mcp_server/catalog_tools.ts` (`catalog_search`/`inspect`/`load`, path-confined, neutral load preamble). **No `catalog_delegate`** (write-adjacent, ADR-109).
- Registered as **discovery stubs** (`implemented_on: []`). The stub→ALLOWLIST activation that removes the catalog from init is **deferred** behind a task-quality A/B — the 2026-07-11 thin-projection null is the standing risk. **No token-savings claim** until that A/B lands.

## Phase 3 — Flow `team:` demand-probe (council-cut roster replacement)

A full "scenario roster" artifact class was council-rejected (no demand, expressible in flows). Instead: an optional `team:{personas,skills}` flow annotation + `validate_flow_teams.ts` (referential check only, no execution semantics). Formalize a roster schema only if organic use grows (≥5 flows).

## Not in scope (recorded rejects)

Multi-host registry / new hosts (surface-matrix already stronger), `--link` install, bulk 263-persona import, runtime delegation plugin (ADR-088/109). The package's #1 gap — zero external adopters — is **not** addressed here; Phase 1 is its technical prerequisite (owned by `road-to-adoption-without-narrative-debt.md`).

## Verification

`task typecheck-ts` green · ESLint clean on all changed files · 35 new tests pass · new gates (`lint-originality`, `validate-flow-teams`, `build_catalog_index --check`), `lint_flows`, `audit_mcp_tools --check`, `check_no_roadmap_refs`, `check_no_external_sources` all green. Roadmap archived per the PR-gate.
