### PR TITLE
fix: originality DF batch-masking hole + harvest-roadmap review corrections

### DIFF
--- a/agents/roadmaps/archive/road-to-persona-library-harvest.md
+++ b/agents/roadmaps/archive/road-to-persona-library-harvest.md
@@ -48,8 +48,8 @@ default-off or advisory-first per house culture.
   (post-9.2.0, `package.json` 9.3.0). All Source-A file claims are against
   that commit.
 - Three analysis passes: (1) GitHub-API deep-dive (subagent), (2) full-clone
-  SHA-pinned source pass (parallel session, archived at
-  `agents/tmp/agency-agents.txt`, gitignored), (3) local verification of every
+  SHA-pinned source pass (parallel session, archived in a gitignored local
+  scratch file under `agents/tmp/`), (3) local verification of every
   load-bearing claim about THIS package (results inline below).
 
 ## § Council convergence (2026-07-19)
@@ -180,9 +180,13 @@ content linters, e.g. `lint_agent_skill_names.ts`):
   Source A's calibration: worst legitimate pair in low single digits. If ours
   lands above ~20 → investigate (likely template-strip gap in 1.2) before any
   flip.
-- [x] **Flip gate:** thresholds move to FAIL 40 / WARN 20 only after the audit
-  shows worst-legitimate-pair ≤ WARN/2. Record numbers in the report, not as a
-  README claim.
+- [-] **Flip gate — NOT satisfied as written; rule replaced (see 1.4).** The
+  gate said thresholds move to FAIL 40 / WARN 20 once worst-legitimate-pair
+  ≤ WARN/2 (= 10). Measured worst = **40**, so the precondition never held. It
+  was NOT met and then flipped anyway — instead the calibration (1.4) *replaced*
+  the rule with "block threshold above the measured floor" → FAIL 60 / WARN 40.
+  Struck (not checked) so a later reader does not mistake an unmet precondition
+  for a satisfied one. Numbers recorded in the report, not as a README claim.
 - [x] Wire into CI (lint taskfile target + the changed-files path the other
   content linters use). Blocking from this point on.
 
@@ -309,10 +313,14 @@ matters, without a new artifact class:
   id resolves to `src/agent-src/personas/<id>.md`, every skill slug to
   `src/skills/<slug>/SKILL.md`. Wire as advisory into the flow lint path.
 - [x] Annotate ONE existing flow (e.g. `delivery.yaml`) as the worked example.
-- [x] **Promotion criterion (recorded, not built):** ≥ 5 flows carrying
-  `team:` with repeated conditional shape, OR ≥ 2 external-user requests for
-  scenario-team selection → THEN design a roster schema as its own roadmap.
-  Until then, no schema, no linter class, no `/roster` commands.
+- [x] **Promotion criterion (recorded, not built) — self-measurement branch
+  removed.** Original "≥ 5 flows carrying `team:`" was self-satisfiable: there
+  are only ~6 flows total (one is the surface-map), so the maintainer could
+  clear it in one afternoon and the probe would report annotation mood, not
+  demand. Tightened to **≥ 2 external-user requests for scenario-team selection,
+  OR ≥ 5 flows carrying `team:` of which ≥ 2 were annotated by someone other
+  than the maintainer** → THEN design a roster schema as its own roadmap. Until
+  then, no schema, no linter class, no `/roster` commands.
 
 ---
 

--- a/src/scripts/lint_originality.ts
+++ b/src/scripts/lint_originality.ts
@@ -26,11 +26,29 @@
  * Thresholds (env-overridable): ORIGINALITY_FAIL (60), ORIGINALITY_WARN (40).
  * Calibrated 2026-07-19 over 495 artifacts / 56 151 comparisons: after the
  * template + document-frequency boilerplate subtraction the worst legitimate
- * pair is 40 % (a single command pair sharing residual cluster-orchestrator
- * prose), p95 and median 0 %. A find-replace re-skin scores ~100 % (entities
- * neutralize away), so FAIL 60 blocks every real re-skin with a 20-point margin
- * above the legitimate floor and 40-point margin below a re-skin. Distribution
- * recorded in agents/reports/originality.md. Exit 0 clean/warn · 1 fail · 2 usage.
+ * pair is 40 % (`domains/engineering-base/tests` ~ `domains/meta/override` —
+ * two cluster-orchestrator commands sharing the family template's
+ * "Top-level orchestrator … / Non-interactive & auto-detection" scaffold;
+ * triaged as legitimate, not a merge candidate), p95 and median 0 %. A
+ * find-replace re-skin scores ~100 % (entities neutralize away), so FAIL 60
+ * blocks every real re-skin with a 20-point margin above the legitimate floor
+ * and 40-point margin below a re-skin. Distribution in agents/reports/originality.md.
+ *
+ * TWO PROPERTIES OF THE DF PASS A LATER READER MUST NOT MISTAKE FOR CONSTANTS:
+ *   1. Scores are CORPUS-RELATIVE. The DF floor subtracts what is common across
+ *      the class, so every overlap number is measured against the corpus as it
+ *      stands. The 40 % floor is a 2026-07-19 SNAPSHOT, not a fixed constant —
+ *      it drifts as commands/skills are added or removed. Re-run the full audit
+ *      after any large corpus change; do not treat 40 % as invariant.
+ *   2. Adversarial batch masking. In `--changed` mode the boilerplate set is
+ *      computed from the corpus MINUS the change set, so a batch of ≥ _dfFloor
+ *      near-identical re-skins submitted together cannot classify its own shared
+ *      shingles as boilerplate (see `_changed`). The full-audit sweep (no
+ *      "changed" notion) does NOT have this guard — a batch of ≥ floor identical
+ *      NEW files committed at once would mutually mask there; the `--changed` PR
+ *      gate, not the sweep, is the adversarial defense.
+ *
+ * Exit 0 clean/warn · 1 fail · 2 usage.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -311,6 +329,15 @@ function _writeReport(byClass: Map<ArtifactClass, Artifact[]>, pairs: Pair[], di
 // --- changed mode ------------------------------------------------------------
 
 function _changed(files: string[]): { pairs: Pair[]; fails: number } {
+    // The boilerplate DF set is derived from the ESTABLISHED corpus only — the
+    // change set under review is excluded. Without this, a batch of ≥ _dfFloor
+    // near-identical re-skins submitted together would lift its OWN shared
+    // shingles over the floor, be reclassified as boilerplate, subtracted from
+    // every copy, and score 0 against each other — the gate blinds itself on
+    // exactly the attack it exists to catch. "What is scaffold" must be defined
+    // by the corpus as it stands, never by the diff proposing to change it.
+    const changedRel = new Set(files.map((f) => _rel(path.resolve(ROOT, f))));
+
     // Build the corpus in RAW (template-subtracted, pre-DF) form per class so we
     // can derive the same boilerplate set the candidate is filtered against.
     const byClass = new Map<ArtifactClass, Artifact[]>();
@@ -320,7 +347,8 @@ function _changed(files: string[]): { pairs: Pair[]; fails: number } {
         const tmpl = _templateShingles(spec);
         templateCache.set(spec.name, tmpl);
         const arts = spec.files().map((f) => _load(f, spec.name, tmpl));
-        const boiler = _boilerplateSet(arts);
+        // Established corpus = on-disk arts minus the change set.
+        const boiler = _boilerplateSet(arts.filter((a) => !changedRel.has(a.relpath)));
         for (const a of arts) _subtract(a, boiler);
         byClass.set(spec.name, arts);
         boilerByClass.set(spec.name, boiler);

--- a/tests/scripts/lint_originality.test.ts
+++ b/tests/scripts/lint_originality.test.ts
@@ -90,3 +90,39 @@ describe('lint_originality — integration against the real corpus', () => {
         expect(main(['--changed', 'src/skills/__origtest_reskin_fixture/SKILL.md', '--quiet'])).toBe(1);
     });
 });
+
+describe('lint_originality — adversarial batch masking is closed', () => {
+    // A batch of >= _dfFloor near-identical NEW command files submitted together.
+    // With the pre-fix DF pass (boilerplate computed INCLUDING the change set)
+    // their shared shingles reach the floor, get classified as boilerplate,
+    // subtracted, and score 0 against each other — the gate blinds itself. The
+    // fix excludes the change set from the boilerplate baseline, so the batch is
+    // caught. Commands floor = max(4, 3% of ~189) = 6, so 7 copies exercises it.
+    const BATCH_DIR = path.join(ROOT, 'src', 'domains', '__origtest_batch');
+    // A novel body (not in the corpus), long enough to shingle at k=8.
+    const NOVEL = `---
+name: batchcmd
+pack: __origtest
+---
+
+# /batchcmd
+
+This orchestrator coordinates a bespoke reconciliation sweep across every
+ledger partition, folding divergent snapshots into a single authoritative
+manifest before the downstream settlement window opens for the trading desk.
+It never mutates a partition in place; it stages a shadow copy, diffs the
+delta, and promotes only once the invariant checker signs off on the merge.`;
+
+    afterEach(() => { fs.rmSync(BATCH_DIR, { recursive: true, force: true }); });
+
+    it('flags a batch of 7 near-identical new commands (exit 1)', () => {
+        const rel: string[] = [];
+        for (let i = 1; i <= 7; i++) {
+            const dir = path.join(BATCH_DIR, `c${i}`);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(path.join(dir, 'command.md'), NOVEL, 'utf-8');
+            rel.push(`src/domains/__origtest_batch/c${i}/command.md`);
+        }
+        expect(main(['--changed', ...rel, '--quiet'])).toBe(1);
+    });
+});


### PR DESCRIPTION
Follow-up to the merged #968, addressing three review findings (checked against `pull/968/head`, not the web view). No new feature surface — a correctness fix plus two record corrections.

## 1. Closed an adversarial hole in the DF boilerplate pass (`fix(originality)`)

The document-frequency subtraction had a self-masking hole: `_dfFloor = max(4, 3% of class)` ≈ 6 for commands, and `_changed()` computed the boilerplate set from `spec.files()` — which **includes the candidate files**. A batch of ≥ floor near-identical re-skins submitted together lifts its own shared shingles over the floor, gets reclassified as boilerplate, subtracted, and scores 0 against itself — the gate blinds itself on exactly the attack it exists to catch.

Fix: `--changed` now derives the boilerplate set from the corpus **minus the change set** ("what is scaffold" is defined by the corpus as it stands, never by the diff proposing to change it). Added a 7-copy batch integration test (now caught → exit 1; would have passed silently before). The full-audit calibration is unchanged (only `--changed` touched; worst pair still 40%).

Also documented two DF properties a later reader must not read as constants: scores are **corpus-relative** (the 40% floor is a 2026-07-19 snapshot that drifts as the corpus changes, not an invariant), and the full-audit sweep has **no batch guard** (the `--changed` PR gate is the adversarial defense, not the sweep).

## 2. Corrected the 1.3 flip-gate checkbox (`docs(roadmap)`)

The gate's precondition — thresholds move to FAIL 40 / WARN 20 once worst-legitimate-pair ≤ WARN/2 (= 10) — never held: measured worst = 40. The box was checked anyway. It's now struck (`[x]` → `[-]`) with a note that the rule was *replaced* in 1.4 (block threshold above the measured floor → FAIL 60/WARN 40), not satisfied — so a later reader doesn't mistake an unmet precondition for a met one.

## 3. Tightened the Phase 3 promotion criterion (`docs(roadmap)`)

"≥ 5 flows carrying `team:`" was self-satisfiable (only ~6 flows exist; the maintainer alone could clear it in an afternoon — measuring annotation mood, not demand). Removed that branch; now requires ≥ 2 external-user requests, OR ≥ 5 flows of which ≥ 2 were annotated by someone other than the maintainer.

## Triage of the single warn-pair (no code change)

`domains/engineering-base/tests` ~ `domains/meta/override` at 40% is the audit's one warn-pair. Read both: they share the cluster-orchestrator family template ("Top-level orchestrator for the `/X` family … Replaces N standalone commands" + the identical `## Non-interactive & auto-detection` block + "create-vs-X is the only disambiguation"). Legitimate shared scaffold, not a merge candidate — confirms the 40% floor is template prose and FAIL 60 correctly does not flag it. Recorded in the linter's module doc-comment.

Also scrubbed a source-name leak the earlier sweep missed: the archived roadmap referenced the gitignored scratch path by its real name (`agents/tmp/agency-agents.txt`) — now a neutral description, per source-confidentiality.

## Verification

`task typecheck-ts` green · ESLint clean on changed files · 44 new-suite tests pass (incl. the batch test) · full audit unchanged (worst 40%, exit 0) · `lint_versioned_cache` clean.
