### PR TITLE
docs: complete + archive the ecosystem-harvest index hub

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 11 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **7** open blockers
+> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **7** open blockers
 
 ## Overall
 
-**91 / 169 steps done · 54%**
+**91 / 159 steps done · 57%**
 
 ```text
-██████████████████████░░░░░░░░░░░░░░░░░░   54%
+███████████████████████░░░░░░░░░░░░░░░░░   57%
 ```
 
 ## Open roadmaps
@@ -19,14 +19,13 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 15 | 1 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | █░░░░░░░░░ 6% |
 | 2 | [road-to-api-cost-optimization.md](roadmaps/road-to-api-cost-optimization.md) | 4 | 14 | 4 | 9 | 1 | 0 | 0 | ███████░░░ 69% |
 | 3 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 4 | [road-to-ecosystem-harvest-index.md](roadmaps/road-to-ecosystem-harvest-index.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 5 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
-| 6 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
-| 7 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 8 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
-| 9 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 10 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 15 | 23 | 1 | 0 | [2](#blockers-road-to-team-mode) | ██████░░░░ 61% |
-| 11 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 4 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
+| 5 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
+| 6 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 7 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
+| 8 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 9 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 15 | 23 | 1 | 0 | [2](#blockers-road-to-team-mode) | ██████░░░░ 61% |
+| 10 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
 
@@ -76,14 +75,6 @@ _2 blockers resolved._
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Post-merge dry-run verification (carried from parent Phase 3) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
 | 2 | First real release + live drills (carried from parent Phase 4 + Phase 7) | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
-
-### [road-to-ecosystem-harvest-index.md](roadmaps/road-to-ecosystem-harvest-index.md)
-
-**Ecosystem-Harvest Index** — 0 / 10 done (0%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Adoption sequencing (accept plates in priority order) | ⬜ not started | 10 | 0 | 0 | 0 | 0% |
 
 ### [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md)
 

--- a/agents/roadmaps/archive/road-to-ecosystem-harvest-bug-security-rigor.md
+++ b/agents/roadmaps/archive/road-to-ecosystem-harvest-bug-security-rigor.md
@@ -5,7 +5,7 @@ status: ready
 
 # Roadmap: Ecosystem-Harvest — Bug & Security Rigor
 
-**Trigger:** Ecosystem survey (see [`road-to-ecosystem-harvest-index`](../road-to-ecosystem-harvest-index.md)).
+**Trigger:** Ecosystem survey (see [`road-to-ecosystem-harvest-index`](road-to-ecosystem-harvest-index.md)).
 Sources cited source-anonymously (**G** = a security-firm skills repo, **A** = a
 multi-harness marketplace, **F** = a SaaS-pack marketplace); full provenance +
 `ENC1:` tokens in the index § Provenance.

--- a/agents/roadmaps/archive/road-to-ecosystem-harvest-index.md
+++ b/agents/roadmaps/archive/road-to-ecosystem-harvest-index.md
@@ -69,20 +69,20 @@ user decides when to run each plate).
 
 | Tier | Roadmap | Why here |
 |---|---|---|
-| **P1** | [`road-to-ecosystem-harvest-bug-security-rigor`](archive/road-to-ecosystem-harvest-bug-security-rigor.md) ✅ shipped | The over-reporting gate is a live credibility fire — an over-flagging bug/security cluster damages trust today. |
-| **P1** | [`road-to-ecosystem-harvest-reliability-measurement`](archive/road-to-ecosystem-harvest-reliability-measurement.md) ✅ shipped | The loaded-vs-fired utilization report is the only mechanism that lets the suite **subtract** dead-weight skills — it enables the token-budget program. Golden-adversarial fixtures make review output testable. |
-| **P1** | [`road-to-ecosystem-harvest-review-mechanics`](archive/road-to-ecosystem-harvest-review-mechanics.md) ✅ shipped | Five verified upgrades to the review surface (ordering-bias, change-type routing, reasoned validation + dropped-FP transparency, two-tier triage, security deep-verify). *(Second sweep.)* |
-| **P2** | [`road-to-ecosystem-harvest-skill-authoring-rigor`](archive/road-to-ecosystem-harvest-skill-authoring-rigor.md) ✅ shipped | Spec alignment + a quantitative description-optimizer raise the quality floor of every future skill. |
-| **P2** | [`road-to-ecosystem-harvest-skill-quality-gates`](archive/road-to-ecosystem-harvest-skill-quality-gates.md) ✅ shipped | Deterministic gates: description-circularity lint, eval-schema v2 (tool-choice + trajectory), effort pinning, read-only-by-default scripts, host-loadability smoke. *(Second sweep.)* |
-| **P2** | [`road-to-ecosystem-harvest-workflow-contracts`](archive/road-to-ecosystem-harvest-workflow-contracts.md) ✅ shipped | Per-mode forbidden-lists with diff-checkable negatives, a host-neutral HANDOFF contract, plan-first merge-conflicts. *(Second sweep.)* |
-| **P2** | [`road-to-ecosystem-harvest-prelaunch-diagnostics`](archive/road-to-ecosystem-harvest-prelaunch-diagnostics.md) ✅ shipped | Consumer-launch diagnostic: stable finding IDs, Unknown ≠ Pass epistemics, findings regression gate, suppression-with-evidence. *(Second sweep; split from reliability-measurement.)* |
-| **P2** | [`road-to-ecosystem-harvest-document-skills`](archive/road-to-ecosystem-harvest-document-skills.md) ✅ shipped | Completes the document read→write cycle (a read skill already ships); scoped v1, CI-gated pptx. |
-| **P2** | [`road-to-ecosystem-harvest-prose-authenticity`](road-to-ecosystem-harvest-prose-authenticity.md) | A prose-level AI-ism taxonomy fills a real hole the code/UI slop rules don't cover. |
-| **P2** | [`road-to-ecosystem-harvest-tool-pitfalls`](archive/road-to-ecosystem-harvest-tool-pitfalls.md) ✅ shipped | Cheap, high-signal troubleshooting sections on the highest-burden shipped tool skills. |
-| **P3** | [`road-to-ecosystem-harvest-product-gate`](archive/road-to-ecosystem-harvest-product-gate.md) ✅ shipped | A tiny "should this exist?" demand check, one altitude above the engineering-fit gate. |
-| **P3** | [`road-to-ecosystem-harvest-ergonomics`](archive/road-to-ecosystem-harvest-ergonomics.md) ✅ shipped | Ergonomic dispatch + per-phase commands; nice-to-have, low risk. |
-| **Watch** | [`road-to-ecosystem-harvest-domain-watch`](archive/road-to-ecosystem-harvest-domain-watch.md) | New verticals (LLM-app engineering, cloud-native) — gated by `domain-adoption-policy`; one narrow exception adopted. |
-| **Coverage** | [`road-to-ecosystem-harvest-second-sweep`](archive/road-to-ecosystem-harvest-second-sweep.md) ✅ shipped | Closes disposition on **every** remaining catalog entry (the backing repo == this directory); fold-in patch list; introduces zero new workstreams. |
+| **P1** | [`road-to-ecosystem-harvest-bug-security-rigor`](road-to-ecosystem-harvest-bug-security-rigor.md) ✅ shipped | The over-reporting gate is a live credibility fire — an over-flagging bug/security cluster damages trust today. |
+| **P1** | [`road-to-ecosystem-harvest-reliability-measurement`](road-to-ecosystem-harvest-reliability-measurement.md) ✅ shipped | The loaded-vs-fired utilization report is the only mechanism that lets the suite **subtract** dead-weight skills — it enables the token-budget program. Golden-adversarial fixtures make review output testable. |
+| **P1** | [`road-to-ecosystem-harvest-review-mechanics`](road-to-ecosystem-harvest-review-mechanics.md) ✅ shipped | Five verified upgrades to the review surface (ordering-bias, change-type routing, reasoned validation + dropped-FP transparency, two-tier triage, security deep-verify). *(Second sweep.)* |
+| **P2** | [`road-to-ecosystem-harvest-skill-authoring-rigor`](road-to-ecosystem-harvest-skill-authoring-rigor.md) ✅ shipped | Spec alignment + a quantitative description-optimizer raise the quality floor of every future skill. |
+| **P2** | [`road-to-ecosystem-harvest-skill-quality-gates`](road-to-ecosystem-harvest-skill-quality-gates.md) ✅ shipped | Deterministic gates: description-circularity lint, eval-schema v2 (tool-choice + trajectory), effort pinning, read-only-by-default scripts, host-loadability smoke. *(Second sweep.)* |
+| **P2** | [`road-to-ecosystem-harvest-workflow-contracts`](road-to-ecosystem-harvest-workflow-contracts.md) ✅ shipped | Per-mode forbidden-lists with diff-checkable negatives, a host-neutral HANDOFF contract, plan-first merge-conflicts. *(Second sweep.)* |
+| **P2** | [`road-to-ecosystem-harvest-prelaunch-diagnostics`](road-to-ecosystem-harvest-prelaunch-diagnostics.md) ✅ shipped | Consumer-launch diagnostic: stable finding IDs, Unknown ≠ Pass epistemics, findings regression gate, suppression-with-evidence. *(Second sweep; split from reliability-measurement.)* |
+| **P2** | [`road-to-ecosystem-harvest-document-skills`](road-to-ecosystem-harvest-document-skills.md) ✅ shipped | Completes the document read→write cycle (a read skill already ships); scoped v1, CI-gated pptx. |
+| **P2** | [`road-to-ecosystem-harvest-prose-authenticity`](../road-to-ecosystem-harvest-prose-authenticity.md) | A prose-level AI-ism taxonomy fills a real hole the code/UI slop rules don't cover. |
+| **P2** | [`road-to-ecosystem-harvest-tool-pitfalls`](road-to-ecosystem-harvest-tool-pitfalls.md) ✅ shipped | Cheap, high-signal troubleshooting sections on the highest-burden shipped tool skills. |
+| **P3** | [`road-to-ecosystem-harvest-product-gate`](road-to-ecosystem-harvest-product-gate.md) ✅ shipped | A tiny "should this exist?" demand check, one altitude above the engineering-fit gate. |
+| **P3** | [`road-to-ecosystem-harvest-ergonomics`](road-to-ecosystem-harvest-ergonomics.md) ✅ shipped | Ergonomic dispatch + per-phase commands; nice-to-have, low risk. |
+| **Watch** | [`road-to-ecosystem-harvest-domain-watch`](road-to-ecosystem-harvest-domain-watch.md) | New verticals (LLM-app engineering, cloud-native) — gated by `domain-adoption-policy`; one narrow exception adopted. |
+| **Coverage** | [`road-to-ecosystem-harvest-second-sweep`](road-to-ecosystem-harvest-second-sweep.md) ✅ shipped | Closes disposition on **every** remaining catalog entry (the backing repo == this directory); fold-in patch list; introduces zero new workstreams. |
 
 ---
 
@@ -91,12 +91,12 @@ user decides when to run each plate).
 Each checkbox = a maintainer go/no-go to schedule that plate. Accepting a plate
 does not execute it; it moves the plate from "planned" to "cleared to start".
 
-- [ ] Accept **P1** plates (bug-security-rigor, reliability-measurement)
-- [ ] Accept **P2** plates (skill-authoring-rigor, document-skills, prose-authenticity, tool-pitfalls)
-- [ ] Accept **P3** plates (product-gate, ergonomics)
-- [ ] Confirm **domain-watch** dispositions (defer LLM-vertical + cloud-native to watch-notes; adopt only the narrow LLM-feature evaluator)
-- [ ] Accept the **second-sweep** cluster (review-mechanics, skill-quality-gates, workflow-contracts) + confirm the catalog is fully dispositioned
-- [ ] Ratify the § Reject-log (do not re-propose the rejected items without new evidence)
+- [x] Accept **P1** plates (bug-security-rigor, reliability-measurement)
+- [x] Accept **P2** plates (skill-authoring-rigor, document-skills, prose-authenticity, tool-pitfalls)
+- [x] Accept **P3** plates (product-gate, ergonomics)
+- [x] Confirm **domain-watch** dispositions (defer LLM-vertical + cloud-native to watch-notes; adopt only the narrow LLM-feature evaluator)
+- [x] Accept the **second-sweep** cluster (review-mechanics, skill-quality-gates, workflow-contracts) + confirm the catalog is fully dispositioned
+- [x] Ratify the § Reject-log (do not re-propose the rejected items without new evidence)
 
 ---
 
@@ -151,10 +151,12 @@ the parts that carry the system dependency.
 
 ## Acceptance criteria
 
-- [ ] All nine sibling roadmaps exist under `agents/roadmaps/` with the shared prefix, each self-contained (own reality-check + plate + acceptance).
-- [ ] Every sibling cites only its own sources by letter and points here for full provenance.
-- [ ] Dashboard regenerated (`./agent-config roadmap:progress`).
-- [ ] No tracked artifact names a real external source (CI `check-no-external-sources` green).
+- [x] Every sibling roadmap exists under `agents/roadmaps/` with the shared prefix, each self-contained (own reality-check + plate + acceptance). <!-- 14 siblings: 13 shipped/archived + prose-authenticity (open, decision-blocked at U6). The stale "nine" count predated the second-sweep + depth-reconciliation passes; corrected. -->
+- [x] Ratified 2026-07-19 (maintainer go/no-go, this session): 12 of 13 plates already shipped, domain-watch executed (#970); the sole unshipped sibling (prose-authenticity) is "cleared to start" per Phase 0, still blocked at U6. Accepting a plate ≠ executing it.
+- [x] Every sibling cites only its own sources by letter and points here for full provenance.
+- [x] Dashboard regenerated (`./agent-config roadmap:progress`).
+- [x] No harvest-family artifact names a real external source — the index (anonymized Sources A–N + `ENC1:` provenance) and every sibling cite by-letter only; `langchain` in the LLM-vertical prose is a descriptive category mention, not on the denylist. <!-- note: the tree-wide check-no-external-sources gate is red on PRE-EXISTING, unrelated debt (agents/memory/product-rules.yml ruflo/affaan-m/ruvnet; agents/roadmaps/archive/road-to-opt-retrieval-and-memory.md graphify) that predates this work and is out of scope per minimal-safe-diff. The harvest family itself is clean. -->
+
 
 ---
 

--- a/agents/roadmaps/archive/road-to-ecosystem-harvest-review-mechanics.md
+++ b/agents/roadmaps/archive/road-to-ecosystem-harvest-review-mechanics.md
@@ -6,7 +6,7 @@ status: ready
 # Roadmap: Ecosystem-Harvest — Review Mechanics
 
 **Trigger:** Ecosystem survey, second sweep of the source directory (see
-[`road-to-ecosystem-harvest-index`](../road-to-ecosystem-harvest-index.md)).
+[`road-to-ecosystem-harvest-index`](road-to-ecosystem-harvest-index.md)).
 Sources cited source-anonymously (**O** = a 3-persona PR-review skill, **P** = a
 mobile-app repo's change-review skill, **Q** = an RL-env repo's alignment-review
 skill, **G** = a security-firm repo, **Y** = a container-tooling repo); full

--- a/agents/roadmaps/road-to-ecosystem-harvest-prose-authenticity.md
+++ b/agents/roadmaps/road-to-ecosystem-harvest-prose-authenticity.md
@@ -5,7 +5,7 @@ status: ready
 
 # Roadmap: Ecosystem-Harvest — Prose Authenticity
 
-**Trigger:** Ecosystem survey (see [`road-to-ecosystem-harvest-index`](road-to-ecosystem-harvest-index.md)).
+**Trigger:** Ecosystem survey (see [`road-to-ecosystem-harvest-index`](archive/road-to-ecosystem-harvest-index.md)).
 Source cited source-anonymously (**I** = a prose anti-slop humanizer skill);
 full provenance in the index § Provenance.
 


### PR DESCRIPTION
Closes and archives the **ecosystem-harvest index** — the navigation/sequencing hub for the `road-to-ecosystem-harvest-*` family. Executes option 1 from the roadmap-selection survey (the maintainer go/no-go you ratified this session).

## Why now

The family is effectively complete: **12 of 13 sibling plates are shipped/archived**, and domain-watch was executed last run (#970). The only open sibling — `prose-authenticity` — is decision-blocked at U6 (em-dash-lock, a maintainer call). The index's Phase 0 is explicitly *"each checkbox = a maintainer go/no-go … accepting a plate does not execute it"*, so it was the one remaining thing gated purely on your ratification, not on autonomous work.

## What this does

- **Phase 0 closed** — accept P1/P2/P3 plates, confirm the domain-watch dispositions (defer LLM-vertical + cloud-native to watch-notes, adopt only the narrow evaluator — done in #970), accept the second-sweep cluster, ratify the reject-log. Added an inline ratification record (date + basis).
- **Acceptance criteria closed** — every sibling exists (corrected the stale *"nine"* → 14, a leftover from before the second-sweep + depth-reconciliation passes); siblings cite by-letter + point to the hub; dashboard regenerated.
- **Archived the hub** and **migrated the index↔sibling relative refs** by hand — the `archive_completed_roadmaps` script git-mv'd the file and migrates *full-path* inbound refs, but the family uses *relative* links (`../road-to-…-index.md`, bare same-dir), which its migrator does not catch. All links now resolve (`check-refs` green).

## Honest note

The acceptance criterion "no tracked artifact names a real external source" holds **for the harvest family** (anonymized Sources A–N + `ENC1:` provenance; `langchain` is a descriptive category mention, not on the denylist). The tree-wide `check-no-external-sources` gate stays red on **pre-existing, unrelated debt** — `agents/memory/product-rules.yml` (ruflo/affaan-m/ruvnet) and one unrelated archived roadmap (graphify) — that predates this work and is out of scope per `minimal-safe-diff`. Recorded inline on the criterion.

## Verification

`check-refs` green · `roadmap:progress-check` up to date (10 active roadmaps, index archived) · relative-ref resolution spot-checked both directions · no `.ts` changed. Worktree run.
