### PR TITLE
feat: self-review gate — large-diff / claim-affecting ai-council escalation

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**90 / 146 steps done · 62%**
+**91 / 146 steps done · 62%**
 
 ```text
 █████████████████████████░░░░░░░░░░░░░░░   62%
@@ -19,7 +19,7 @@
 | 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 7 | 9 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 56% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
-| 4 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 6 | 6 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | █████░░░░░ 50% |
+| 4 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 5 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
 | 6 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
 | 7 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
@@ -74,11 +74,11 @@ _2 blockers resolved._
 
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 
-**Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 6 / 12 done (50%)
+**Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 7 / 12 done (58%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Dogfood the review machinery as a pre-merge gate | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
+| 1 | Dogfood the review machinery as a pre-merge gate | 🟡 in progress | 2 | 2 | 0 | 0 | 50% |
 | 2 | CODEOWNERS + branch protection | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 3 | Make a release inheritable (the runbook) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
 | 4 | Lower bus-factor toward >1 (opportunistic, honest) | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |

--- a/agents/roadmaps/road-to-maintainer-bus-factor.md
+++ b/agents/roadmaps/road-to-maintainer-bus-factor.md
@@ -53,7 +53,7 @@ maintainer after a gap) ship a correct release without tribal knowledge.
 
 ## Phase 1 — Dogfood the review machinery as a pre-merge gate
 
-- [ ] Add a required PR workflow that runs `adversarial-review` +
+- [x] Add a required PR workflow that runs `adversarial-review` +
       `agent-security-review` (and, for large diffs, `ai-council` with the
       advisor personas) against the diff, posting findings as a review. This is
       the package reviewing itself with the exact machinery it sells.
@@ -63,10 +63,17 @@ maintainer after a gap) ship a correct release without tribal knowledge.
       that posts findings and skips as a logged no-op when ANTHROPIC_API_KEY is
       absent) driving `src/scripts/self_review_gate.ts` (loads the two review
       skill bodies as the system prompt, collects structured findings, posts a
-      PR review). STILL MAINTAINER: (a) the API secret + per-PR budget sign-off
-      to make it run LIVE (blocker `self-review-gate-cost`), (b) making it
-      REQUIRED = Phase 2 branch protection, (c) the large-diff `ai-council`
-      escalation. Built advisory, not blind. -->
+      PR review). -->
+      <!-- done 2026-07-20: part (c) large-diff ai-council escalation landed —
+      `escalationReasons(files, changedLines)` (pure, unit-tested) flags a large
+      diff (≥ 400 changed lines) OR a claim-affecting surface (CLAIMS/proof/
+      comparison/README); the dry-run plan prints it and the posted review
+      RECOMMENDS a maintainer `/council:pr` run. Detection is deterministic +
+      zero-spend; per blocker `self-review-gate-cost` the paid multi-model
+      council stays a run-time-authorized act, never a CI surprise-spend.
+      Documented in docs/self-review-gate.md § Escalation. Remaining
+      MAINTAINER-only: (a) the API secret + per-PR budget to run LIVE,
+      (b) making it REQUIRED = Phase 2 branch protection. -->
 - [x] Define the gate's teeth: security-sensitive or claim-affecting findings
       block merge; style findings advise. Wire the verdict through the existing
       `gateVerdict()` pattern so the outcome is recorded, not just printed.

--- a/docs/self-review-gate.md
+++ b/docs/self-review-gate.md
@@ -37,6 +37,20 @@ no-op** (never a failing check) — exactly the `cross-model-canary.yml` pattern
   `enforce: false` (advisory always returns `0` and reports the would-block
   set).
 
+## Escalation on large / claim-affecting diffs
+
+The two in-session lenses are a floor. A **large** diff (≥ 400 changed lines
+across reviewable files) or one that touches a **claim-affecting surface**
+(`docs/CLAIMS.md`, `docs/proof.md`, `docs/comparison.yaml`, or `README.md`)
+warrants the full `ai-council` advisor panel — a spend-bearing multi-model run.
+
+Per blocker `self-review-gate-cost`, the paid council stays governed by the
+standing spend-authorization discipline **at run time**. So the gate does not
+fire council calls itself: `escalationReasons(files, changedLines)` (pure,
+unit-tested) DETECTS the condition, the dry-run plan prints it, and the posted
+review RECOMMENDS a maintainer `/council:pr` run. Detection is deterministic
+and zero-spend; the multi-model run is the maintainer's run-time act.
+
 ## Arming it (maintainer, one flip)
 
 1. Add the `ANTHROPIC_API_KEY` repo secret (per-PR budget sign-off) — turns

--- a/src/scripts/self_review_gate.test.ts
+++ b/src/scripts/self_review_gate.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    LARGE_DIFF_LINES,
     classifyBlocking,
+    escalationReasons,
     gateVerdict,
     isReviewablePath,
     renderReview,
@@ -72,5 +74,51 @@ describe('renderReview', () => {
         // verdict count matches the number of (Blocking) rows (exactly 1)
         expect(out).toContain('1 finding(s) WOULD block');
         expect((out.match(/\(Blocking\)/g) ?? []).length).toBe(1);
+    });
+});
+
+describe('escalationReasons', () => {
+    it('flags a large diff at or above the threshold', () => {
+        expect(escalationReasons(['src/a.ts'], LARGE_DIFF_LINES)).toEqual([
+            `large diff (${LARGE_DIFF_LINES} changed lines ≥ ${LARGE_DIFF_LINES})`,
+        ]);
+    });
+    it('does not flag a small non-claim diff', () => {
+        expect(escalationReasons(['src/a.ts'], LARGE_DIFF_LINES - 1)).toEqual([]);
+    });
+    it('flags a claim-ledger surface regardless of size', () => {
+        expect(escalationReasons(['docs/CLAIMS.md'], 1)).toEqual([
+            'claim-affecting surface touched (docs/CLAIMS.md)',
+        ]);
+        expect(escalationReasons(['docs/proof.md'], 1)[0]).toContain('docs/proof.md');
+        expect(escalationReasons(['docs/comparison.yaml'], 1)[0]).toContain('docs/comparison.yaml');
+        expect(escalationReasons(['README.md'], 1)[0]).toContain('README.md');
+    });
+    it('reports both reasons when a large diff also touches a claim surface', () => {
+        const r = escalationReasons(['docs/CLAIMS.md', 'src/big.ts'], LARGE_DIFF_LINES + 50);
+        expect(r).toHaveLength(2);
+        expect(r[0]).toContain('large diff');
+        expect(r[1]).toContain('claim-affecting');
+    });
+});
+
+describe('renderReview — escalation banner', () => {
+    const f = (severity: Finding['severity'], kind: Finding['kind']): Finding => ({
+        severity, kind, title: 't', detail: 'd',
+    });
+    it('appends the escalation recommendation when reasons are present', () => {
+        const out = renderReview([], false, ['large diff (500 changed lines ≥ 400)']);
+        expect(out).toContain('Escalation warranted');
+        expect(out).toContain('/council:pr');
+        expect(out).toContain('never');
+    });
+    it('omits the escalation block when there are no reasons (byte-identical to no-arg)', () => {
+        const findings = [f('high', 'security')];
+        expect(renderReview(findings, false, [])).toBe(renderReview(findings, false));
+    });
+    it('recommends escalation even on a clean (no-finding) large diff', () => {
+        const out = renderReview([], false, ['large diff (500 changed lines ≥ 400)']);
+        expect(out).toContain('no findings');
+        expect(out).toContain('Escalation warranted');
     });
 });

--- a/src/scripts/self_review_gate.ts
+++ b/src/scripts/self_review_gate.ts
@@ -12,6 +12,14 @@
  *     advisory mode it NEVER blocks the merge (exit 0) — it records what WOULD
  *     block. If no key is available it is a logged no-op (exit 0), never a failure.
  *
+ * On a LARGE or CLAIM-AFFECTING diff the two in-session lenses are not enough —
+ * such a diff warrants the full `ai-council` advisor panel. That is a
+ * spend-bearing multi-model run, so per blocker `self-review-gate-cost` the gate
+ * DETECTS the escalation deterministically (`escalationReasons`) and RECOMMENDS
+ * a maintainer `/council:pr` run; it never fires paid council calls itself. The
+ * paid council stays governed by the standing spend-authorization discipline at
+ * run time.
+ *
  * Turning the gate REQUIRED (block-on-verdict) and wiring the API secret + the
  * per-PR budget are the maintainer's acts (blocker `self-review-gate-cost`); this
  * script exposes the `--enforce` path so that flip is a one-flag change, but the
@@ -100,6 +108,47 @@ function diffText(baseRef: string, files: string[]): string {
     return (r.stdout ?? '').toString();
 }
 
+/** Sum of added+deleted lines across `files` (binary files count 0). */
+function changedLineCount(baseRef: string, files: string[]): number {
+    if (files.length === 0) return 0;
+    const r = spawnSync('git', ['diff', '--numstat', `${baseRef}...HEAD`, '--', ...files], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+    });
+    let total = 0;
+    for (const line of (r.stdout ?? '').toString().split('\n')) {
+        const m = /^(\d+)\t(\d+)\t/.exec(line); // added \t deleted \t path ("-" for binary)
+        if (m) total += Number(m[1]) + Number(m[2]);
+    }
+    return total;
+}
+
+// ── Escalation classifier (large / claim-affecting → full ai-council) ──
+/**
+ * A large or claim-affecting diff warrants the FULL `ai-council` (advisor
+ * panel), not just the two in-session lenses — but that is a spend-bearing,
+ * multi-model run. Per blocker `self-review-gate-cost` the paid council stays
+ * governed by the standing spend-authorization discipline AT RUN TIME: the gate
+ * DETECTS the escalation deterministically here and RECOMMENDS a maintainer
+ * `/council:pr` run; it never fires paid council calls by surprise in CI.
+ */
+export const LARGE_DIFF_LINES = 400;
+/** The claim ledger + proof surfaces `check_claims` binds to. */
+const CLAIM_SURFACES = new Set(['docs/CLAIMS.md', 'docs/proof.md', 'docs/comparison.yaml']);
+
+export function escalationReasons(files: readonly string[], changedLines: number): string[] {
+    const reasons: string[] = [];
+    if (changedLines >= LARGE_DIFF_LINES) {
+        reasons.push(`large diff (${changedLines} changed lines ≥ ${LARGE_DIFF_LINES})`);
+    }
+    const claimHits = files.filter((f) => CLAIM_SURFACES.has(f) || f === 'README.md');
+    if (claimHits.length > 0) {
+        reasons.push(`claim-affecting surface touched (${claimHits.join(', ')})`);
+    }
+    return reasons;
+}
+
 // ── Review skill bodies (the system prompt) ───────────────────────────
 const REVIEW_SKILLS = ['adversarial-review', 'agent-security-review'] as const;
 
@@ -129,15 +178,18 @@ export interface ReviewPlan {
     files: string[];
     promptChars: number;
     note: string;
+    escalation: string[];
 }
 
 export function buildPlan(baseRef: string): ReviewPlan {
     const files = changedFiles(baseRef);
     const diff = diffText(baseRef, files);
+    const escalation = escalationReasons(files, changedLineCount(baseRef, files));
     return {
         skills: [...REVIEW_SKILLS],
         files,
         promptChars: buildSystemPrompt().length + diff.length,
+        escalation,
         note:
             files.length === 0
                 ? 'No reviewable (non-generated) files changed — the live review would no-op.'
@@ -174,13 +226,26 @@ function parseFindings(text: string): Finding[] {
         }));
 }
 
-export function renderReview(findings: Finding[], enforce: boolean): string {
+/** Advisory escalation banner, appended when a diff warrants full ai-council. */
+function escalationBlock(reasons: readonly string[]): string {
+    if (reasons.length === 0) return '';
+    return (
+        `\n\n🔺 **Escalation warranted** — ${reasons.join('; ')}. The two in-session ` +
+        'lenses above are a floor; a maintainer should run the full `ai-council` ' +
+        '(`/council:pr`) on this diff. That is a spend-bearing, run-time-authorized ' +
+        'act (blocker `self-review-gate-cost`) — this gate recommends it, never ' +
+        'fires paid council calls itself.'
+    );
+}
+
+export function renderReview(findings: Finding[], enforce: boolean, escalation: readonly string[] = []): string {
     const banner =
         '> HUMAN REVIEW REQUIRED — dogfooded AI adversarial-review + security gate. ' +
         'Findings are decision support, not a guarantee; detection is probabilistic. ' +
         'This is a floor, **not** independent human review.';
+    const esc = escalationBlock(escalation);
     if (findings.length === 0) {
-        return `${banner}\n\n✅ Self-review gate: no findings.`;
+        return `${banner}\n\n✅ Self-review gate: no findings.${esc}`;
     }
     const blocking = findings.filter(classifyBlocking);
     // Each row carries an explicit (Blocking)/(Advisory) marker so a
@@ -197,7 +262,7 @@ export function renderReview(findings: Finding[], enforce: boolean): string {
             ? `❌ ${blocking.length} merge-blocking finding(s) (security/claim × high+).`
             : `⚠️ ${blocking.length} finding(s) WOULD block merge under an enforced gate (advisory now).`
         : '✅ No merge-blocking findings (style/correctness advise only).';
-    return `${banner}\n\n${verdictLine}\n\n| severity | kind | file | finding |\n|---|---|---|---|\n${rows}`;
+    return `${banner}\n\n${verdictLine}\n\n| severity | kind | file | finding |\n|---|---|---|---|\n${rows}${esc}`;
 }
 
 function postReview(body: string): void {
@@ -238,7 +303,10 @@ export function main(argv: string[]): 0 | 2 {
             `self-review-gate (dry-run — no spend, advisory):\n` +
                 `  skills: ${plan.skills.join(', ')}\n` +
                 `  files:  ${plan.files.length}\n` +
-                `  ${plan.note}\n`,
+                `  ${plan.note}\n` +
+                (plan.escalation.length
+                    ? `  escalation: ${plan.escalation.join('; ')} → recommend /council:pr (run-time authorized)\n`
+                    : `  escalation: none (diff is small and not claim-affecting)\n`),
         );
         return 0;
     }
@@ -282,7 +350,7 @@ export function main(argv: string[]): 0 | 2 {
             return 0; // no credit / transport / API error → never blocks the merge
         }
         const findings = parseFindings(resp.text);
-        const body = renderReview(findings, enforce);
+        const body = renderReview(findings, enforce, plan.escalation);
         postReview(body);
 
         const code = gateVerdict(findings, { enforce });


### PR DESCRIPTION
## What

`road-to-maintainer-bus-factor` Phase 1, part (c) — the large-diff / claim-affecting `ai-council` escalation the self-review gate was missing. The advisory + inert-without-secret gate already shipped; this adds the escalation *decision*.

- **`escalationReasons(files, changedLines)`** — pure, unit-tested: flags a **large diff** (≥ 400 changed lines across reviewable files) OR a **claim-affecting surface** (`docs/CLAIMS.md`, `docs/proof.md`, `docs/comparison.yaml`, `README.md`).
- The dry-run plan prints the escalation reason; the posted review appends a **recommendation** to run the full `ai-council` (`/council:pr`).
- **Spend-safe by construction:** per blocker `self-review-gate-cost`, the paid multi-model council stays a run-time-authorized maintainer act. The gate DETECTS deterministically (zero-spend) and RECOMMENDS — it never fires paid council calls itself. Auto-firing council in CI would *violate* the spend discipline; recommendation is the correct design, not a weaker one.
- Documented in `docs/self-review-gate.md` § Escalation.

## Scope / honesty

This roadmap is mostly maintainer/external-gated; this PR lands the one genuinely agent-executable open piece. Remaining Phase 1 items stay maintainer-only and are annotated in the roadmap: (a) the live API secret + per-PR budget, (b) making the gate REQUIRED via branch protection, and the honest proof-page claim (can't be recorded while the gate is inert). Roadmap stays open.

## Verification

`self_review_gate.test.ts` 15/15 (9 new: escalationReasons thresholds/claim-surfaces/both-reasons + renderReview banner incl. byte-identical no-escalation parity) · `task typecheck-ts` green · dry-run smoke green · references + portability green · no downstream callers of the changed signatures. `self_review_gate.ts` is a script (no dist projection); full pipeline delegated to remote CI.