### PR TITLE
feat: team-mode Phase 5 — defect-finding benchmark run + honest-null verdict

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**95 / 146 steps done · 65%**
+**99 / 145 steps done · 68%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   65%
+███████████████████████████░░░░░░░░░░░░░   68%
 ```
 
 ## Open roadmaps
@@ -23,7 +23,7 @@
 | 5 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
 | 6 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
 | 7 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 8 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 11 | 27 | 1 | 0 | [2](#blockers-road-to-team-mode) | ███████░░░ 71% |
+| 8 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
 | 9 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
@@ -164,7 +164,7 @@ _1 blocker resolved._
 
 ### [road-to-team-mode.md](roadmaps/road-to-team-mode.md)
 
-**Road to team mode — govern the official cross-model pair, don't rebuild it** — 27 / 38 done (71%)
+**Road to team mode — govern the official cross-model pair, don't rebuild it** — 31 / 37 done (84%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -173,8 +173,8 @@ _1 blocker resolved._
 | 2 | `/team` command family (Claude-Code path) | ✅ done | 0 | 6 | 0 | 0 | 100% |
 | 3 | Multi-host fallback (the gap only we can fill) | ✅ done | 0 | 4 | 1 | 0 | 100% |
 | 4 | Review-Gate governance | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 5 | Defect-finding benchmark (measure the marketing) | 🟡 in progress | 4 | 1 | 0 | 0 | 20% |
-| 6 | Close-out | 🟡 in progress | 7 | 4 | 0 | 0 | 36% |
+| 5 | Defect-finding benchmark (measure the marketing) | ✅ done | 0 | 4 | 1 | 0 | 100% |
+| 6 | Close-out | 🟡 in progress | 6 | 5 | 0 | 0 | 45% |
 
 <a id="blockers-road-to-team-mode"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-team-mode.md
+++ b/agents/roadmaps/road-to-team-mode.md
@@ -373,21 +373,39 @@ existing bench-rig discipline before any public copy exists.
       metrics, H1/H2/H3 + numeric thresholds, arms, and model pins BEFORE any
       spend (prereg discipline). Zero-spend authoring; Steps 2-5 (running the
       arms) stay gated on benchmark-spend-authorization. -->
-- [ ] **Step 2:** Three arms: (a) single-model adversarial self-review (host
+- [x] **Step 2:** Three arms: (a) single-model adversarial self-review (host
       model, existing skill), (b) cross-model team review (Phase 2/3 path),
       (c) `council:pr` at default depth. Record found/missed per defect class,
       wall time, call count per arm.
-- [ ] **Step 3:** Blind judging via the existing verification-judge pattern;
+      <!-- done 2026-07-20: src/scripts/bench_defect_finding.ts ran all three
+      arms over the 12 fixtures ($0.083 billable; arm b codex gpt-5.5 =
+      subscription). Report: internal/bench/reports/defect-finding.{json,md}. -->
+- [~] **Step 3:** Blind judging via the existing verification-judge pattern;
       judge never sees arm labels.
-- [ ] **Step 4:** Verdict in `docs/proof.md` + CLAIMS.md shape: per-arm
+      <!-- deferred 2026-07-20: the PRIMARY metric (defect recall) is scored
+      DETERMINISTICALLY against ground truth — no judge needed for the verdict.
+      A blind rubric (preference) judge is moot given the recall ceiling (all
+      arms 1.00); it re-opens with a judge-survivable-subtlety corpus that
+      breaks the ceiling. Secondary metric, no spend incurred. -->
+- [x] **Step 4:** Verdict in `docs/proof.md` + CLAIMS.md shape: per-arm
       detection rates; pre-registered hypothesis (b > a on correctness-class
       defects; c competitive on design-class); honest-null reporting if arms
       are indistinguishable.
-- [ ] **Step 5:** Disposition: on measured lift, bind the README/team-docs
+      <!-- done 2026-07-20: HONEST NULL — H1 not met (Δ=0, all arms recall 1.00),
+      H2 met, H3 met. docs/benchmark.md § Defect-finding (#honest-null-defect)
+      + CLAIMS `team-defect-finding-null` (backed); proof.md regenerated.
+      Ceiling-limited: the corpus is too obvious to discriminate on recall
+      (same corpus-validity bound as the adversarial-council section). -->
+- [x] **Step 5:** Disposition: on measured lift, bind the README/team-docs
       claim with a `<!-- claim:team-cross-model-lift -->` marker and re-open
       Phase 3 Step 4; on null, record evidence-closed with re-open conditions
       (new model generation) and keep the feature documented as *workflow*
       value only, never *quality* claims.
+      <!-- done 2026-07-20: NULL path taken — no lift claim bound; team mode
+      stays workflow-value-only (the CHANGELOG entry already says so). Recorded
+      evidence-closed (CLAIMS team-defect-finding-null). Re-open conditions:
+      judge-survivable-subtlety corpus OR new model generation. Phase 3 Step 4
+      stays deferred (re-opened only on lift, which did not occur). -->
 
 **Exit criteria:** benchmark artefacts for all arms exist; claims lint green;
 the disposition step executed either way.
@@ -436,9 +454,12 @@ the disposition step executed either way.
 - [ ] All new config keys live in `docs/contracts/ai-team-config.md` with
       schema validation rejecting unknown values; the shared quota bucket is
       documented.
-- [ ] No public claim about cross-model quality exists without the Phase 5
+- [x] No public claim about cross-model quality exists without the Phase 5
       verdict bound in CLAIMS.md — workflow-value prose allowed, lift claims
       not.
+      <!-- satisfied 2026-07-20: the Phase-5 verdict is a backed NULL
+      (CLAIMS team-defect-finding-null); no lift claim exists anywhere,
+      workflow-value prose only. -->
 - [ ] `/team:delegate` is unreachable until both `ai_team.enabled` and
       `ai_team.allow_delegate` are true.
 - [ ] All quality gates pass (delegated to remote CI per

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -245,6 +245,13 @@ visible, not hidden.
 - status: backed
 - last_verified: 2026-07-12
 
+### claim: team-defect-finding-null
+- claim: On the pre-registered 12-fixture defect-finding corpus (three arms, deterministic file-level recall, codex reviewer gpt-5.5), the cross-model team-review arm produced NO recall lift over single-model self-review — all three arms recalled every planted defect (Δ = 0, H1 not met). Honest null, ceiling-limited (recall 1.00 everywhere: the seeded defects are too obvious to discriminate the arms on recall); the only non-null signal is a single self-review false positive on the controversial-but-correct control vs 0 for team/council. No cross-model quality/lift claim binds; team mode stays workflow-value-only. Re-open: a judge-survivable-subtlety corpus or a new model generation.
+- kind: quant
+- evidence: internal/bench/reports/defect-finding.json#honest_null
+- status: backed
+- last_verified: 2026-07-20
+
 ### claim: adversarial-council-finding-coverage
 - claim: On the residual defect pool (planted defects that survive a single strong cross-model judge), an adversarial panel of >=2 distinct-vendor skeptics finds materially more residual defects than that single judge — relative residual-recall lift >= +25% AND absolute >= +8 percentage points — at a false-positive rate on a controversial-but-correct control no worse than the single-judge baseline (within noise). Scope: finding coverage, NOT decision quality (the separate, unbacked council-vs-solo-baseline question). Pre-registered; honest-null (either threshold missed or FP worse) keeps the surface off by default permanently.
 - kind: quant

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -582,3 +582,43 @@ controversial-but-correct control.
   judge-survivable-subtlety corpus with a published distribution, then (2) a
   maintainer-gated paid cross-vendor run. Honest-null on that run keeps the
   surface default-off permanently, like recursive-verification.
+
+
+## Defect-finding: team vs self-review vs council (2026-07-20) — HONEST NULL (ceiling-limited) {#honest-null-defect}
+
+Pre-registered 12-fixture corpus (`internal/bench/corpora/defect-finding.yaml`:
+10 seeded-defect diffs across logic / off-by-one / race / missing-empty-state /
+security-smell, + 2 controls), three arms, deterministic file-level recall
+against ground truth (blind rubric judge deferred — the primary metric is
+deterministic). Codex reviewer pinned `gpt-5.5`. Total billable $0.083 (arm b
+codex = ChatGPT subscription, $0).
+
+| arm | recall | correctness | design | false-positives |
+|---|--:|--:|--:|--:|
+| self-review (single model) | 1.00 | 1.00 | 1.00 | 1 |
+| team (cross-model, codex) | 1.00 | 1.00 | 1.00 | 0 |
+| council (neutral breadth)  | 1.00 | 1.00 | 1.00 | 0 |
+
+**Verdict: HONEST NULL.** H1 (cross-model team > single-model self-review on
+correctness recall, Δ ≥ +0.20) is **not met** — Δ = 0: all three arms recalled
+every planted defect. H2 (council ≈ team on design, within 0.10) is met (Δ = 0).
+H3 (≤ 1 false positive/arm) is met.
+
+**Corpus-validity caveat (the honest bound):** recall 1.00 across every arm is a
+**ceiling effect** — these seeded defects are catchable by any strong model, so
+the corpus cannot discriminate the arms on recall. This is the same limitation
+the adversarial-verification-council section names: a corpus of obvious,
+model-differentiating defects measures parity, not the judge-survivable
+subtleties where a cross-model lens might actually differ. The one non-null
+signal is precision, not recall: single-model self-review produced 1 false
+positive on the controversial-but-correct control (`df-ctl-01`, a
+behaviour-preserving `clamp` refactor) where team and council produced 0 — a
+hint of a multi-arm precision edge, within the pre-registered H3 bound, too
+small to claim.
+
+**Disposition (Phase 5 Step 5): evidence-closed as NULL.** No cross-model
+defect-finding *quality/lift* claim binds; team mode stays documented as
+**workflow value only**. Re-open conditions: (a) a curated
+judge-survivable-subtlety corpus that breaks the recall ceiling, or (b) a new
+model generation. The worker-via-bundle delegate (roadmap Phase 3 Step 4) stays
+deferred — it re-opened only on a measured review lift, which did not occur.

--- a/docs/proof.md
+++ b/docs/proof.md
@@ -48,9 +48,10 @@ evidence pointer, or `task check-claims` fails the build.
 | Every artifact the package ships — source AND the condensed projection that reaches consumers — is machine-scanned in CI for hidden-Unicode, mixed-script-confusable, and instruction-smuggling payloads (the rules-file-backdoor class); a finding blocks the release before `npm publish`, not just the merge. | qual | `.github/workflows/publish-npm.yml#lint_agent_security` | ✅ |
 | 278 skills. | quant | `src/scripts/check_artefact_count_messaging.ts#Artefact-count messaging gate` | ✅ |
 | Removes only its own keys from a shared host config (matched by JSON-pointer + SHA-256), never a neighbour tool's entries. | qual | `docs/contracts/install-layout.md#JSON-pointer` | ✅ |
+| On the pre-registered 12-fixture defect-finding corpus (three arms, deterministic file-level recall, codex reviewer gpt-5.5), the cross-model team-review arm produced NO recall lift over single-model self-review — all three arms recalled every planted defect (Δ = 0, H1 not met). Honest null, ceiling-limited (recall 1.00 everywhere: the seeded defects are too obvious to discriminate the arms on recall); the only non-null signal is a single self-review false positive on the controversial-but-correct control vs 0 for team/council. No cross-model quality/lift claim binds; team mode stays workflow-value-only. Re-open: a judge-survivable-subtlety corpus or a new model generation. | quant | `internal/bench/reports/defect-finding.json#honest_null` | ✅ |
 | On the A3 orchestration eval (deterministic verify, measured token deltas), the production-validator subagent returned the correct verdict on both fixtures — NOT READY with the exact `file:line` citation on a planted hollow implementation, READY with zero spurious findings on the clean control — while consuming ~45k fewer tokens than the inline-host baseline on each task. Scope: two planted fixtures on a Claude Code host, not a broad hit-rate. | quant | `internal/bench/orchestration/pv-a3-results.md#token_delta_provenance: measured` | ✅ |
 
-**23 backed claim(s)** — all evidence pointers resolve in CI.
+**24 backed claim(s)** — all evidence pointers resolve in CI.
 
 Artefact counts in public prose (skills, commands, governed rules,
 guidelines, personas) are **generated from source and CI-drift-checked**:

--- a/internal/bench/reports/defect-finding.json
+++ b/internal/bench/reports/defect-finding.json
@@ -1,0 +1,450 @@
+{
+  "preregistered": {
+    "roadmap": "road-to-team-mode Phase 5",
+    "authored": "2026-07-20",
+    "primary": [
+      "recall",
+      "false_positives",
+      "cost/time/calls"
+    ],
+    "secondary": "blind rubric judge — DEFERRED this pass (primary recall is deterministic)",
+    "hypotheses": {
+      "H1": "team>self on correctness, Δrecall>=+0.20",
+      "H2": "council≈team on design, within 0.10",
+      "H3": "FP<=1/arm on controls"
+    },
+    "codex_model": "gpt-5.5",
+    "models_cache_fetched": "2026-07-20T12:21Z"
+  },
+  "arms": {
+    "self-review": {
+      "recall_rate": 1,
+      "recall": 10,
+      "planted": 10,
+      "false_positives": 1,
+      "usd": 0.0438,
+      "ms": 70975,
+      "calls": 12,
+      "correctness_recall": 1,
+      "design_recall": 1
+    },
+    "team": {
+      "recall_rate": 1,
+      "recall": 10,
+      "planted": 10,
+      "false_positives": 0,
+      "usd": 0,
+      "ms": 165280,
+      "calls": 12,
+      "correctness_recall": 1,
+      "design_recall": 1
+    },
+    "council": {
+      "recall_rate": 1,
+      "recall": 10,
+      "planted": 10,
+      "false_positives": 0,
+      "usd": 0.0394,
+      "ms": 61256,
+      "calls": 24,
+      "correctness_recall": 1,
+      "design_recall": 1
+    }
+  },
+  "verdict": {
+    "H1_team_minus_self_correctness": 0,
+    "H1_met": false,
+    "H2_council_vs_team_design_absdelta": 0,
+    "H2_met": true,
+    "H3_fp_within_bound": true,
+    "honest_null": true,
+    "disposition": "HONEST NULL — arms indistinguishable within pre-registered thresholds; no lift claim binds."
+  },
+  "total_billable_usd": 0.0832,
+  "detail": [
+    {
+      "id": "df-logic-01",
+      "defect_class": "logic-bug",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0014,
+        "ms": 3188,
+        "error": null,
+        "review": "DEFECT: src/access/canView.ts:6 — Changed AND to OR allows viewing documents from any tenant if tenantId matches, bypassing ownership check\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 12836,
+        "error": null,
+        "review": "DEFECT: src/access/canView.ts:5 — Replacing `&&` with `||` allows users to view any document in their tenant or any owned document across tenants, breaking owner-and-tenant authorization.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0022,
+        "ms": 3342,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/access/canView.ts:6 — Changed logical AND to OR, allowing access if either ownerId matches OR tenantId matches instead of requiring both conditions\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/access/canView.ts:6 — Potential unauthorized access due to logical OR\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-logic-02",
+      "defect_class": "logic-bug",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0046,
+        "ms": 6730,
+        "error": null,
+        "review": "Looking at this diff, I need to analyze the logic change:\n\n**Before:** `if (order.status !== 'paid') return 0;`\n- This returns 0 for orders that are NOT paid\n- For paid orders, it calculates: `order.amountCents - order.feeCents`\n\n**After:** `if (order.status === 'paid') return 0;`\n- This returns 0 for orders that ARE paid\n- For non-paid orders, it calculates: `order.amountCents - order.feeCents`\n\nThe logic is now inverted. The function appears to calculate refund amounts. The original logic makes sense: only paid orders should be refunded (return the calculation), while unpaid orders get 0 refund. The new logic is backwards: it returns 0 for paid orders and calculates refunds for non-paid orders, which is illogical - you cannot refund something that wasn't paid.\n\nDEFECT: src/billing/refund.ts:8 — Logic inverted: now returns 0 for paid orders instead of unpaid orders, breaking refund calculation\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 11196,
+        "error": null,
+        "review": "DEFECT: src/billing/refund.ts:5 — Inverts the paid-status guard, returning 0 for paid orders and refunding unpaid/non-paid orders.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0022,
+        "ms": 4010,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/billing/refund.ts:8 — Logic inverted: now returns 0 for paid orders instead of unpaid orders, preventing refunds for paid orders\n\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/billing/refund.ts:6 — Logic is inverted: refunds should apply to paid orders, but currently return 0.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-offbyone-01",
+      "defect_class": "off-by-one",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0066,
+        "ms": 7218,
+        "error": null,
+        "review": "Looking at this diff, I need to analyze the change to the `lastN` function.\n\n**Original behavior:**\n```typescript\nxs.slice(Math.max(0, xs.length - n));\n```\n- For an array of length 5, `lastN(xs, 3)` would do `xs.slice(2)`, returning the last 3 elements (indices 2, 3, 4).\n- For an array of length 5, `lastN(xs, 5)` would do `xs.slice(0)`, returning all 5 elements.\n\n**New behavior:**\n```typescript\nxs.slice(Math.max(0, xs.length - n - 1));\n```\n- For an array of length 5, `lastN(xs, 3)` would do `xs.slice(1)`, returning the last 4 elements (indices 1, 2, 3, 4).\n- For an array of length 5, `lastN(xs, 5)` would do `xs.slice(0)`, returning all 5 elements (still correct for this case).\n- For an array of length 5, `lastN(xs, 2)` would do `xs.slice(2)`, returning the last 3 elements instead of 2.\n\nThe change breaks the function's intended behavior. The function is supposed to return the last N elements, but with the `-1` added, it now returns N+1 elements (except in edge cases where `Math.max(0, ...)` caps it at 0).\n\nDEFECT: src/util/lastN.ts:5 — Off-by-one error: returns N+1 elements instead of N elements\n\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 13836,
+        "error": null,
+        "review": "DEFECT: src/util/lastN.ts:3 — Off-by-one subtraction returns n+1 trailing elements instead of exactly n.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0058,
+        "ms": 7614,
+        "error": null,
+        "review": "# reviewer A\nAnalyzing the diff:\n\nThe change modifies `lastN` function from:\n```typescript\nreturn xs.slice(Math.max(0, xs.length - n));\n```\nto:\n```typescript\nreturn xs.slice(Math.max(0, xs.length - n - 1));\n```\n\nThe function is intended to return the last N elements of an array.\n\nWith the original code:\n- For `lastN([1,2,3,4,5], 2)`: `slice(Math.max(0, 5-2))` = `slice(3)` = `[4,5]` ✓ (correct: last 2 elements)\n\nWith the modified code:\n- For `lastN([1,2,3,4,5], 2)`: `slice(Math.max(0, 5-2-1))` = `slice(2)` = `[3,4,5]` ✗ (wrong: returns 3 elements instead of 2)\n\nThe modified code returns `n+1` elements instead of `n` elements, which is a defect.\n\nDEFECT: src/util/lastN.ts:5 — Returns n+1 elements instead of n elements due to incorrect offset calculation\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/util/lastN.ts:3 — Off-by-one error in slice calculation\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-offbyone-02",
+      "defect_class": "off-by-one",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0016,
+        "ms": 5496,
+        "error": null,
+        "review": "DEFECT: src/pager/pageRange.ts:7 — Changed Math.ceil to Math.floor incorrectly calculates page count (e.g., 10 items with size 3 needs 4 pages but returns 3)\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 12259,
+        "error": null,
+        "review": "DEFECT: src/pager/pageRange.ts:5 — `Math.floor` undercounts pages when `total` is not evenly divisible by `size`.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0024,
+        "ms": 4150,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/pager/pageRange.ts:7 — Changed Math.ceil to Math.floor will incorrectly calculate page count when total is not evenly divisible by size (e.g., 11 items with size 10 should be 2 pages, not 1)\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/pager/pageRange.ts:5 — Incorrect function; Math.floor changes intended behavior from ceiling to floor.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-race-01",
+      "defect_class": "race",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 2,
+        "usd": 0.002,
+        "ms": 3610,
+        "error": null,
+        "review": "DEFECT: src/counter/increment.ts:9 — Race condition: non-atomic read-modify-write allows lost updates when concurrent increments occur\nDEFECT: src/counter/increment.ts:9 — Missing null check: row.n will throw if key doesn't exist in counters table\nVERDICT: 2"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 14452,
+        "error": null,
+        "review": "DEFECT: src/counter/increment.ts:6 — Read-then-write increment is no longer atomic, so concurrent calls can lose updates\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 2,
+        "usd": 0.0029,
+        "ms": 5021,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/counter/increment.ts:7 — Race condition: non-atomic read-modify-write allows lost updates under concurrent access\nDEFECT: src/counter/increment.ts:7 — No null check: row.n will throw if key doesn't exist (row is undefined/null)\nVERDICT: 2\n\n# reviewer B\nDEFECT: src/counter/increment.ts:7 — row.n may be undefined, leading to a potential NaN result when adding 1 if the key does not exist.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-race-02",
+      "defect_class": "race",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 2,
+        "usd": 0.0083,
+        "ms": 12806,
+        "error": null,
+        "review": "I need to analyze this diff carefully to find real defects.\n\nThe original code:\n```typescript\nreturn this.inflight[key] ??= this.load(key);\n```\n\nThe new code:\n```typescript\nif (this.cache[key]) return this.cache[key];\nconst v = await this.load(key);\nthis.cache[key] = v;\nreturn v;\n```\n\nLet me identify the issues:\n\n1. **Race condition**: The original code used `this.inflight[key]` to track in-flight requests, preventing duplicate loads for the same key. The new code uses `this.cache[key]` but doesn't prevent multiple simultaneous calls to `this.load(key)` for the same key. If `getOrLoad(key)` is called twice before the first load completes, both will call `this.load(key)`.\n\n2. **Wrong cache check**: The condition `if (this.cache[key])` is falsy for valid cached values like `0`, `false`, `\"\"`, `null`. This will cause unnecessary reloads for falsy but valid values.\n\n3. **Missing await in original**: Looking at the original code more carefully - `this.inflight[key] ??= this.load(key)` assigns the Promise directly (no await), but the function signature is `Promise<Val>`. The new code adds `await`, which changes the behavior - it now waits for the load to complete before returning, wherea"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 2,
+        "usd": 0,
+        "ms": 13546,
+        "error": null,
+        "review": "DEFECT: src/cache/getOrLoad.ts:4 — Truthy cache check treats cached falsy values as misses, causing unnecessary reloads or changed behavior.\nDEFECT: src/cache/getOrLoad.ts:5 — Removed inflight promise reuse, so concurrent calls for the same key now trigger duplicate loads and possible races.\nVERDICT: 2"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0021,
+        "ms": 3434,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/cache/getOrLoad.ts:6 — Multiple concurrent calls with same key will trigger multiple load() calls (removed inflight tracking)\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/cache/getOrLoad.ts:3 — Awaiting the promise before assigning to cache causes concurrent load calls.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-empty-01",
+      "defect_class": "missing-empty-state",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0013,
+        "ms": 1966,
+        "error": null,
+        "review": "DEFECT: src/ui/Avg.tsx:2 — Division by zero when scores array is empty (removed length check)\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 12919,
+        "error": null,
+        "review": "DEFECT: src/ui/Avg.tsx:2 — Empty scores now calls reduce without an initial value, throwing instead of rendering the fallback.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0021,
+        "ms": 4062,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/ui/Avg.tsx:3 — Division by zero when scores array is empty (removed guard check)\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/ui/Avg.tsx:3 — Potential division by zero when scores array is empty.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-empty-02",
+      "defect_class": "missing-empty-state",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0016,
+        "ms": 5707,
+        "error": null,
+        "review": "DEFECT: src/report/summary.ts:6 — Accessing sorted[0] and sorted[sorted.length - 1] on empty array causes undefined behavior; removed empty check makes this unsafe\n\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 13356,
+        "error": null,
+        "review": "DEFECT: src/report/summary.ts:6 — Empty input now returns `undefined` for `first`/`last` instead of the expected `null` values.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0025,
+        "ms": 3741,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/report/summary.ts:6 — Accessing sorted[0] and sorted[sorted.length - 1] will be undefined when rows is empty, causing runtime errors despite non-null assertions\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/report/summary.ts:6 — Using non-null assertion operators can lead to runtime errors if \"rows\" is empty.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-secsmell-01",
+      "defect_class": "security-smell",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0012,
+        "ms": 2256,
+        "error": null,
+        "review": "DEFECT: src/search/find.ts:6 — SQL injection vulnerability: user input concatenated directly into query without parameterization\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 10710,
+        "error": null,
+        "review": "DEFECT: src/search/find.ts:4 — Interpolating `term` into SQL makes the query vulnerable to SQL injection.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0019,
+        "ms": 3461,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/search/find.ts:6 — SQL injection vulnerability: user input `term` is directly interpolated into query string without sanitization\n\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/search/find.ts:4 — Potential SQL injection due to using string interpolation instead of a parameterized query.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-secsmell-02",
+      "defect_class": "security-smell",
+      "control": false,
+      "self-review": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0012,
+        "ms": 2245,
+        "error": null,
+        "review": "DEFECT: src/auth/login.ts:8 — Logging plaintext password violates security best practices and exposes credentials\n\nVERDICT: 1"
+      },
+      "team": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0,
+        "ms": 23326,
+        "error": null,
+        "review": "DEFECT: src/auth/login.ts:10 — Logs the plaintext password, exposing credentials in application logs.\nVERDICT: 1"
+      },
+      "council": {
+        "recall_hit": true,
+        "false_positive": false,
+        "claimed": 1,
+        "usd": 0.0018,
+        "ms": 3785,
+        "error": null,
+        "review": "# reviewer A\nDEFECT: src/auth/login.ts:10 — Logging plaintext password exposes sensitive credential in logs\n\nVERDICT: 1\n\n# reviewer B\nDEFECT: src/auth/login.ts:8 — Logging sensitive information (password) may lead to security issues.\nVERDICT: 1"
+      }
+    },
+    {
+      "id": "df-ctl-01",
+      "defect_class": "control-clean-refactor",
+      "control": true,
+      "self-review": {
+        "recall_hit": false,
+        "false_positive": true,
+        "claimed": 1,
+        "usd": 0.0112,
+        "ms": 13875,
+        "error": null,
+        "review": "I need to analyze this diff carefully to find any real defects introduced by the change.\n\nThe original code:\n```typescript\nif (x < lo) return lo;\nif (x > hi) return hi;\nreturn x;\n```\n\nThe new code:\n```typescript\nreturn Math.min(hi, Math.max(lo, x));\n```\n\nLet me verify the logic is equivalent by testing different cases:\n\n1. When `x < lo`: \n   - Original: returns `lo`\n   - New: `Math.max(lo, x)` = `lo`, then `Math.min(hi, lo)` = `lo` (assuming `lo <= hi`)\n   - ✓ Equivalent\n\n2. When `x > hi`:\n   - Original: returns `hi`\n   - New: `Math.max(lo, x)` = `x`, then `Math.min(hi, x)` = `hi`\n   - ✓ Equivalent\n\n3. When `lo <= x <= hi`:\n   - Original: returns `x`\n   - New: `Math.max(lo, x)` = `x`, then `Math.min(hi, x)` = `x`\n   - ✓ Equivalent\n\n4. Edge case: What if `lo > hi` (invalid range)?\n   - Original: If `x < lo`, returns `lo`. If `x > hi`, returns `hi`. If `hi < x < lo`, returns `x`.\n   - New: `Math.max(lo, x)` takes the larger of `lo` and `x`, then `Math.min(hi, that)` could return `hi` even when `hi < lo`.\n   \n   Example: `clamp(5, 10, 2)` where `lo=10, hi=2, x=5`\n   - Original: `5 < 10` → returns `10`\n   - New: `Math.max(10, 5)` = `10`, then `Math.min(2, 10)` = `2`\n   - ✗ Different be"
+      },
+      "team": {
+        "recall_hit": false,
+        "false_positive": false,
+        "claimed": 0,
+        "usd": 0,
+        "ms": 15307,
+        "error": null,
+        "review": "VERDICT: 0"
+      },
+      "council": {
+        "recall_hit": false,
+        "false_positive": false,
+        "claimed": 0,
+        "usd": 0.011,
+        "ms": 13953,
+        "error": null,
+        "review": "# reviewer A\nI need to analyze this diff for the `clamp` function to check if the new implementation is equivalent to the old one.\n\n**Original implementation:**\n```typescript\nif (x < lo) return lo;\nif (x > hi) return hi;\nreturn x;\n```\n\n**New implementation:**\n```typescript\nreturn Math.min(hi, Math.max(lo, x));\n```\n\nLet me trace through the logic:\n\n**Original logic:**\n- If `x < lo`, return `lo`\n- Else if `x > hi`, return `hi`\n- Else return `x`\n\n**New logic:**\n- `Math.max(lo, x)` returns the larger of `lo` and `x`\n  - If `x < lo`, this returns `lo`\n  - If `x >= lo`, this returns `x`\n- `Math.min(hi, ...)` takes the result above and returns the smaller of `hi` and that result\n  - If the result from max is greater than `hi`, return `hi`\n  - Otherwise return the result from max\n\n**Test cases:**\n1. `x < lo`: `Math.max(lo, x)` = `lo`, then `Math.min(hi, lo)` = `lo` (assuming `lo <= hi`) ✓\n2. `lo <= x <= hi`: `Math.max(lo, x)` = `x`, then `Math.min(hi, x)` = `x` ✓\n3. `x > hi`: `Math.max(lo, x)` = `x`, then `Math.min(hi, x)` = `hi` ✓\n\n**Edge case to consider:**\nWhat if `lo > hi` (invalid range)?\n\nOriginal: If `x < lo` and `lo > hi`, returns `lo`. The second check `x > hi` might also be true,"
+      }
+    },
+    {
+      "id": "df-ctl-02",
+      "defect_class": "control-controversial-but-correct",
+      "control": true,
+      "self-review": {
+        "recall_hit": false,
+        "false_positive": false,
+        "claimed": 0,
+        "usd": 0.0027,
+        "ms": 5878,
+        "error": null,
+        "review": "This diff shows a bug fix rather than introducing a defect. The change adds an explicit radix parameter of 10 to `parseInt()`, which is actually a correction of a previous defect.\n\nThe original code `parseInt(s)` without a radix is problematic because:\n- Strings starting with \"0x\" would parse as hexadecimal\n- In older JavaScript environments, strings starting with \"0\" could parse as octal\n\nThe new code `parseInt(s, 10)` correctly enforces base-10 parsing, which aligns with the comment's intent.\n\nVERDICT: 0"
+      },
+      "team": {
+        "recall_hit": false,
+        "false_positive": false,
+        "claimed": 0,
+        "usd": 0,
+        "ms": 11537,
+        "error": null,
+        "review": "VERDICT: 0"
+      },
+      "council": {
+        "recall_hit": false,
+        "false_positive": false,
+        "claimed": 0,
+        "usd": 0.0024,
+        "ms": 4683,
+        "error": null,
+        "review": "# reviewer A\nThis diff shows a fix being applied, not a defect being introduced. The change adds an explicit radix parameter of 10 to `parseInt()`, which is actually a best practice that prevents the function from interpreting strings with leading zeros as octal numbers (a legacy JavaScript behavior).\n\nThe new code is an improvement over the old code. There are no defects in the supplied diff.\n\nVERDICT: 0\n\n# reviewer B\nVERDICT: 0"
+      }
+    }
+  ]
+}

--- a/internal/bench/reports/defect-finding.md
+++ b/internal/bench/reports/defect-finding.md
@@ -1,0 +1,22 @@
+# Defect-finding benchmark — results (road-to-team-mode Phase 5)
+
+> Run 2026-07-20. Codex reviewer: `gpt-5.5`. Primary metric = deterministic
+> recall against corpus ground truth; blind rubric judge (secondary) deferred.
+
+## Per-arm
+
+| arm | recall | correctness | design | false-pos | calls | $ |
+|---|--:|--:|--:|--:|--:|--:|
+| self-review | 1 | 1 | 1 | 1 | 12 | 0.0438 |
+| team | 1 | 1 | 1 | 0 | 12 | 0 |
+| council | 1 | 1 | 1 | 0 | 24 | 0.0394 |
+
+## Verdict
+
+- H1 (team − self, correctness recall Δ): **0** — met: false
+- H2 (council vs team, design recall |Δ|): **0** — met: true
+- H3 (false positives ≤ 1/arm): true
+
+**Disposition:** HONEST NULL — arms indistinguishable within pre-registered thresholds; no lift claim binds.
+
+Total billable: $0.0832 (arm b codex = subscription, $0 billable).

--- a/src/scripts/bench_defect_finding.ts
+++ b/src/scripts/bench_defect_finding.ts
@@ -1,0 +1,348 @@
+#!/usr/bin/env tsx
+/**
+ * Defect-finding benchmark runner (road-to-team-mode Phase 5, Steps 2-4).
+ *
+ * Three arms over the pre-registered corpus (internal/bench/corpora/defect-finding.yaml):
+ *   (a) self-review  — single strong model (Anthropic) + the adversarial-review frame
+ *   (b) team         — codex exec (subscription; reviewer pinned via --codex-model)
+ *   (c) council      — the neutral breadth arm: Anthropic + OpenAI independent reviews, union
+ *
+ * Every arm gets the SAME strict output contract so scoring is fair + objective:
+ * a review must end with `VERDICT: <n>` and one `DEFECT: <file>:<line> — <why>`
+ * line per defect. Recall + false-positives are then scored DETERMINISTICALLY
+ * against the corpus ground truth (no LLM judge for the PRIMARY metric — the
+ * blind rubric judge is the SECONDARY metric and is deferred this pass).
+ *
+ * Spend: arm (a) + arm (c) are billable API calls; arm (b) is the ChatGPT
+ * subscription (non-billable through this process). `--max-usd` is a HARD cap:
+ * the run aborts before a call that would cross it. `--dry-run` makes zero calls.
+ *
+ * Exit 0 ok · 1 aborted-on-cap / error · 2 usage.
+ */
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { load as yamlLoad } from 'js-yaml';
+
+import {
+    AnthropicClient,
+    OpenAIClient,
+    load_anthropic_key,
+    load_openai_key,
+} from './ai_council/clients.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, '..', '..');
+const CORPUS = path.join(ROOT, 'internal', 'bench', 'corpora', 'defect-finding.yaml');
+const OUT_JSON = path.join(ROOT, 'internal', 'bench', 'reports', 'defect-finding.json');
+const OUT_MD = path.join(ROOT, 'internal', 'bench', 'reports', 'defect-finding.md');
+
+const OUTPUT_CONTRACT =
+    '\n\nReport STRICTLY in this format, nothing after it:\n' +
+    'DEFECT: <file>:<line> — <one-line why>   (one line per real defect; omit if none)\n' +
+    'VERDICT: <integer count of defects>';
+
+interface Fixture {
+    id: string;
+    defect_class: string;
+    prompt: string;
+    ground_truth: string;
+    rubric: string;
+    negative_control?: boolean;
+}
+
+type ArmId = 'self-review' | 'team' | 'council';
+
+interface ArmResult {
+    arm: ArmId;
+    text: string;
+    calls: number;
+    input_tokens: number;
+    output_tokens: number;
+    usd: number;
+    ms: number;
+    error: string | null;
+}
+
+/** Ground-truth FILENAME for a fixture, or null for a control. Each planted
+ * fixture touches exactly ONE unique file, so "a DEFECT line names this file"
+ * is the honest, line-number-robust recall signal (diff line numbering is
+ * ambiguous and models cite lines inconsistently — matching the exact
+ * file:line token systematically under-counts real finds). */
+function groundTruthFile(gt: string): string | null {
+    if (/^\s*NONE\b/i.test(gt)) return null;
+    const head = gt.split('—')[0] ?? gt;
+    const m = /([\w./-]+\.\w+):[\d,]+/.exec(head);
+    return m ? (m[1] as string) : null;
+}
+/** Basename of a path token (find.ts from src/search/find.ts). */
+function basename(p: string): string { return p.split('/').pop() ?? p; }
+
+/** Parse the DEFECT lines an arm emitted (file:line tokens it claims). */
+function parseClaimedDefects(text: string): { count: number; files: string[] } {
+    const files: string[] = [];
+    for (const line of text.split('\n')) {
+        // DEFECT: <file>[:line] — ... ; capture the file token (line optional).
+        const m = /^\s*DEFECT:\s*([\w./-]+\.\w+)/.exec(line);
+        if (m) files.push(m[1] as string);
+    }
+    const vm = /VERDICT:\s*(\d+)/i.exec(text);
+    const count = vm ? Number(vm[1]) : files.length;
+    return { count, files };
+}
+
+/** Deterministic recall/FP for one arm on one fixture. */
+function score(
+    fx: Fixture,
+    arm: ArmResult,
+): { recall_hit: boolean; false_positive: boolean; claimed: number } {
+    const gtFile = groundTruthFile(fx.ground_truth);
+    const claimed = parseClaimedDefects(arm.text);
+    if (gtFile === null || fx.negative_control === true) {
+        // Control: any claimed defect is a false positive.
+        return { recall_hit: false, false_positive: claimed.count > 0, claimed: claimed.count };
+    }
+    // Recall: a DEFECT line names the planted file (by basename — robust to the
+    // model prefixing or omitting the dir). Line-agnostic on purpose.
+    const target = basename(gtFile);
+    const hit = claimed.files.some((f) => basename(f) === target) || arm.text.includes(target);
+    return { recall_hit: hit, false_positive: false, claimed: claimed.count };
+}
+
+function usd(inTok: number, outTok: number, inRate: number, outRate: number): number {
+    return (inTok / 1_000_000) * inRate + (outTok / 1_000_000) * outRate;
+}
+
+// Conservative published-tier rates (per 1M tokens) for the estimate + tally.
+const RATES = {
+    anthropic: { in: 3, out: 15 }, // claude-sonnet class
+    openai: { in: 2.5, out: 10 }, // gpt-4o class
+};
+
+interface Budget {
+    cap: number;
+    spent: number;
+}
+
+function guard(b: Budget, next: number): void {
+    if (b.cap > 0 && b.spent + next > b.cap) {
+        throw new Error(`hard cap $${b.cap} would be crossed (spent $${b.spent.toFixed(4)}, next ~$${next.toFixed(4)})`);
+    }
+}
+
+function armSelfReview(fx: Fixture, key: string, b: Budget): ArmResult {
+    const t0 = Date.now();
+    guard(b, 0.05);
+    const client = new AnthropicClient({ api_key: key });
+    const sys =
+        'You are a single-model adversarial code reviewer (Attack-Defend-Revise). ' +
+        'Find real defects in the diff; do not invent problems in correct code.';
+    const r = client.ask(sys, fx.prompt + OUTPUT_CONTRACT, 1024);
+    const cost = usd(r.input_tokens, r.output_tokens, RATES.anthropic.in, RATES.anthropic.out);
+    b.spent += cost;
+    return {
+        arm: 'self-review', text: r.text, calls: 1,
+        input_tokens: r.input_tokens, output_tokens: r.output_tokens,
+        usd: cost, ms: Date.now() - t0, error: r.error,
+    };
+}
+
+function armTeam(fx: Fixture, model: string, _b: Budget): ArmResult {
+    const t0 = Date.now();
+    // codex = ChatGPT subscription: non-billable through this process. `--json`
+    // streams events; the review is the LAST agent_message item's text (the
+    // interactive mode without --json blocks/hangs — must use --json here).
+    let text = '';
+    let error: string | null = null;
+    try {
+        const raw = execFileSync('codex', ['exec', '--json', '-m', model, fx.prompt + OUTPUT_CONTRACT], {
+            encoding: 'utf8', maxBuffer: 16 * 1024 * 1024, timeout: 180_000,
+        });
+        for (const line of raw.split('\n')) {
+            const s = line.trim();
+            if (!s.startsWith('{')) continue;
+            try {
+                const ev = JSON.parse(s) as { item?: { type?: string; text?: string } };
+                if (ev.item?.type === 'agent_message' && typeof ev.item.text === 'string') {
+                    text = ev.item.text; // keep the last agent_message
+                }
+            } catch { /* skip non-JSON / partial lines */ }
+        }
+        if (!text) error = 'no agent_message in codex --json stream';
+    } catch (e) {
+        error = e instanceof Error ? e.message.slice(0, 300) : String(e);
+    }
+    return { arm: 'team', text, calls: 1, input_tokens: 0, output_tokens: 0, usd: 0, ms: Date.now() - t0, error };
+}
+
+function armCouncil(fx: Fixture, aKey: string, oKey: string, b: Budget): ArmResult {
+    const t0 = Date.now();
+    const sys =
+        'You are a neutral code reviewer. Review ONLY the supplied diff for real ' +
+        'defects; never invent problems in correct code.';
+    guard(b, 0.05);
+    const a = new AnthropicClient({ api_key: aKey }).ask(sys, fx.prompt + OUTPUT_CONTRACT, 1024);
+    let cost = usd(a.input_tokens, a.output_tokens, RATES.anthropic.in, RATES.anthropic.out);
+    b.spent += cost;
+    guard(b, 0.05);
+    const o = new OpenAIClient({ api_key: oKey }).ask(sys, fx.prompt + OUTPUT_CONTRACT, 1024);
+    const oc = usd(o.input_tokens, o.output_tokens, RATES.openai.in, RATES.openai.out);
+    b.spent += oc;
+    cost += oc;
+    // Council = breadth: union the two independent reviews.
+    const text = `# reviewer A\n${a.text}\n\n# reviewer B\n${o.text}`;
+    return {
+        arm: 'council', text, calls: 2,
+        input_tokens: a.input_tokens + o.input_tokens,
+        output_tokens: a.output_tokens + o.output_tokens,
+        usd: cost, ms: Date.now() - t0, error: a.error ?? o.error,
+    };
+}
+
+const CORRECTNESS = new Set(['logic-bug', 'off-by-one', 'race']);
+const DESIGN = new Set(['missing-empty-state', 'security-smell']);
+
+export function main(argv: string[]): 0 | 1 | 2 {
+    const dryRun = argv.includes('--dry-run');
+    const capIdx = argv.indexOf('--max-usd');
+    const cap = capIdx >= 0 ? Number(argv[capIdx + 1]) : 1.2;
+    const modelIdx = argv.indexOf('--codex-model');
+    const codexModel = (modelIdx >= 0 ? argv[modelIdx + 1] : undefined) ?? 'gpt-5.5';
+
+    const doc = yamlLoad(fs.readFileSync(CORPUS, 'utf8')) as { fixtures: Fixture[] };
+    const fixtures = doc.fixtures;
+
+    if (dryRun) {
+        const planted = fixtures.filter((f) => !f.negative_control).length;
+        process.stdout.write(
+            `defect-finding (dry-run — no calls):\n` +
+                `  fixtures: ${fixtures.length} (${planted} planted, ${fixtures.length - planted} control)\n` +
+                `  arms: self-review (anthropic, ${fixtures.length} calls) · team (codex ${codexModel}, ${fixtures.length} calls, subscription) · council (anthropic+openai, ${fixtures.length * 2} calls)\n` +
+                `  billable estimate: arm a ~$${(fixtures.length * 0.02).toFixed(2)} + arm c ~$${(fixtures.length * 0.04).toFixed(2)} ≈ $${(fixtures.length * 0.06).toFixed(2)} (hard cap $${cap})\n` +
+                `  arm b (codex): 0 billable (ChatGPT subscription quota)\n`,
+        );
+        return 0;
+    }
+
+    const aKey = load_anthropic_key();
+    const oKey = load_openai_key();
+    const budget: Budget = { cap, spent: 0 };
+    const rows: Array<{ fx: Fixture; arms: Record<ArmId, ArmResult> }> = [];
+
+    try {
+        for (const fx of fixtures) {
+            process.stdout.write(`· ${fx.id} (${fx.defect_class})\n`);
+            const arms = {
+                'self-review': armSelfReview(fx, aKey, budget),
+                team: armTeam(fx, codexModel, budget),
+                council: armCouncil(fx, aKey, oKey, budget),
+            } as Record<ArmId, ArmResult>;
+            rows.push({ fx, arms });
+        }
+    } catch (e) {
+        process.stderr.write(`ABORTED: ${e instanceof Error ? e.message : String(e)}\n`);
+        // fall through to write a partial report
+    }
+
+    // ── aggregate ──
+    const ARMS: ArmId[] = ['self-review', 'team', 'council'];
+    const agg: Record<string, unknown> = {};
+    const perArm: Record<ArmId, { recall: number; planted: number; fp: number; usd: number; ms: number; calls: number; byClass: Record<string, { hit: number; n: number }> }> =
+        Object.fromEntries(ARMS.map((a) => [a, { recall: 0, planted: 0, fp: 0, usd: 0, ms: 0, calls: 0, byClass: {} }])) as never;
+
+    const detail: unknown[] = [];
+    for (const { fx, arms } of rows) {
+        const d: Record<string, unknown> = { id: fx.id, defect_class: fx.defect_class, control: !!fx.negative_control };
+        for (const a of ARMS) {
+            const ar = arms[a];
+            const sc = score(fx, ar);
+            const pa = perArm[a];
+            pa.usd += ar.usd; pa.ms += ar.ms; pa.calls += ar.calls;
+            if (!fx.negative_control) {
+                pa.planted += 1;
+                if (sc.recall_hit) pa.recall += 1;
+                const c = (pa.byClass[fx.defect_class] ??= { hit: 0, n: 0 });
+                c.n += 1; if (sc.recall_hit) c.hit += 1;
+            } else if (sc.false_positive) {
+                pa.fp += 1;
+            }
+            d[a] = { recall_hit: sc.recall_hit, false_positive: sc.false_positive, claimed: sc.claimed, usd: Number(ar.usd.toFixed(4)), ms: ar.ms, error: ar.error, review: ar.text.slice(0, 1200) };
+        }
+        detail.push(d);
+    }
+
+    const recallRate = (a: ArmId): number => (perArm[a].planted ? perArm[a].recall / perArm[a].planted : 0);
+    const classRecall = (a: ArmId, classes: Set<string>): { hit: number; n: number } => {
+        let hit = 0, n = 0;
+        for (const [cls, c] of Object.entries(perArm[a].byClass)) if (classes.has(cls)) { hit += c.hit; n += c.n; }
+        return { hit, n };
+    };
+    const rr = (x: { hit: number; n: number }): number => (x.n ? x.hit / x.n : 0);
+
+    // Hypotheses (pre-registered thresholds).
+    const aCorr = classRecall('self-review', CORRECTNESS), bCorr = classRecall('team', CORRECTNESS);
+    const bDes = classRecall('team', DESIGN), cDes = classRecall('council', DESIGN);
+    const h1 = rr(bCorr) - rr(aCorr); // team - self on correctness; predict >= +0.20
+    const h2 = Math.abs(rr(cDes) - rr(bDes)); // council vs team on design; predict within 0.10
+    const h3ok = ARMS.every((a) => perArm[a].fp <= 1);
+
+    agg['preregistered'] = {
+        roadmap: 'road-to-team-mode Phase 5', authored: '2026-07-20',
+        primary: ['recall', 'false_positives', 'cost/time/calls'],
+        secondary: 'blind rubric judge — DEFERRED this pass (primary recall is deterministic)',
+        hypotheses: { H1: 'team>self on correctness, Δrecall>=+0.20', H2: 'council≈team on design, within 0.10', H3: 'FP<=1/arm on controls' },
+        codex_model: codexModel, models_cache_fetched: '2026-07-20T12:21Z',
+    };
+    agg['arms'] = Object.fromEntries(ARMS.map((a) => [a, {
+        recall_rate: Number(recallRate(a).toFixed(3)), recall: perArm[a].recall, planted: perArm[a].planted,
+        false_positives: perArm[a].fp, usd: Number(perArm[a].usd.toFixed(4)), ms: perArm[a].ms, calls: perArm[a].calls,
+        correctness_recall: Number(rr(classRecall(a, CORRECTNESS)).toFixed(3)),
+        design_recall: Number(rr(classRecall(a, DESIGN)).toFixed(3)),
+    }]));
+    const nullish = Math.abs(h1) <= 0.1 && h2 <= 0.1;
+    agg['verdict'] = {
+        H1_team_minus_self_correctness: Number(h1.toFixed(3)), H1_met: h1 >= 0.2,
+        H2_council_vs_team_design_absdelta: Number(h2.toFixed(3)), H2_met: h2 <= 0.1,
+        H3_fp_within_bound: h3ok,
+        honest_null: nullish,
+        disposition: nullish
+            ? 'HONEST NULL — arms indistinguishable within pre-registered thresholds; no lift claim binds.'
+            : h1 >= 0.2
+                ? 'LIFT on correctness-class — H1 met; a team-lift CLAIM may bind (maintainer decision).'
+                : 'MIXED — see per-class rates; no blanket lift claim.',
+    };
+    agg['total_billable_usd'] = Number((perArm['self-review'].usd + perArm.council.usd).toFixed(4));
+    agg['detail'] = detail;
+
+    fs.mkdirSync(path.dirname(OUT_JSON), { recursive: true });
+    fs.writeFileSync(OUT_JSON, JSON.stringify(agg, null, 2) + '\n');
+
+    const v = agg['verdict'] as Record<string, unknown>;
+    const md = [
+        '# Defect-finding benchmark — results (road-to-team-mode Phase 5)',
+        '', `> Run 2026-07-20. Codex reviewer: \`${codexModel}\`. Primary metric = deterministic`,
+        '> recall against corpus ground truth; blind rubric judge (secondary) deferred.',
+        '', '## Per-arm', '', '| arm | recall | correctness | design | false-pos | calls | $ |', '|---|--:|--:|--:|--:|--:|--:|',
+        ...ARMS.map((a) => {
+            const x = (agg['arms'] as Record<string, Record<string, number>>)[a] as Record<string, number>;
+            return `| ${a} | ${x.recall_rate} | ${x.correctness_recall} | ${x.design_recall} | ${x.false_positives} | ${x.calls} | ${x.usd} |`;
+        }),
+        '', '## Verdict', '',
+        `- H1 (team − self, correctness recall Δ): **${v.H1_team_minus_self_correctness}** — met: ${v.H1_met}`,
+        `- H2 (council vs team, design recall |Δ|): **${v.H2_council_vs_team_design_absdelta}** — met: ${v.H2_met}`,
+        `- H3 (false positives ≤ 1/arm): ${v.H3_fp_within_bound}`,
+        '', `**Disposition:** ${v.disposition}`,
+        '', `Total billable: $${agg['total_billable_usd']} (arm b codex = subscription, $0 billable).`,
+        '',
+    ].join('\n');
+    fs.writeFileSync(OUT_MD, md);
+    process.stdout.write(`\nwrote ${path.relative(ROOT, OUT_JSON)} + ${path.relative(ROOT, OUT_MD)}\n`);
+    process.stdout.write(`spent ~$${budget.spent.toFixed(4)} (cap $${cap})\n`);
+    return 0;
+}
+
+if (fs.existsSync(process.argv[1] ?? '') && import.meta.url === `file://${process.argv[1]}`) {
+    process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
## What

Completes `road-to-team-mode` Phase 5 (Steps 2-5) on the pre-registered defect-finding corpus merged in #980. The user authorized the benchmark spend (option 2); this ran the three arms and records the verdict. **Total billable: $0.083** (arm b codex = ChatGPT subscription, $0), well under the $1.2 cap.

- **`src/scripts/bench_defect_finding.ts`** — runs three arms (self-review / Anthropic, team / `codex exec --json` gpt-5.5, council / Anthropic+OpenAI union) over the 12 fixtures with a shared strict `DEFECT: file:line` output contract; scores recall + false-positives **deterministically** against ground truth (I am the harness author, not a benchmark subject; recall is objective, not my judgment). Hard `--max-usd` cap; `--dry-run` = zero calls.
- **Result — HONEST NULL:** all three arms recalled every planted defect (recall **1.00**, H1 not met, Δ=0); self-review produced **1 false positive** on the clean-refactor control vs **0** for team and council (within the pre-registered H3 bound). Report: `internal/bench/reports/defect-finding.{json,md}`.
- **Honest caveat (recorded):** recall 1.00 everywhere is a **ceiling effect** — the seeded defects are catchable by any strong model, so the corpus cannot discriminate the arms on recall. Same corpus-validity bound the adversarial-council section already names. The one non-null signal is precision (the FP delta), too small to claim.
- **Disposition (Step 5): evidence-closed as NULL.** No cross-model quality/lift claim binds; team mode stays **workflow-value-only** (the CHANGELOG already says so). `docs/benchmark.md` § `#honest-null-defect` + CLAIMS `team-defect-finding-null` (backed) + regenerated `proof.md`. Re-open on a judge-survivable-subtlety corpus or a new model generation.

## Scope notes

- **A scorer bug was caught and fixed before any verdict bound.** The first run scored recall by exact `file:line` token — but diff line numbering is ambiguous and all arms were mis-scored as misses despite finding the defects. Fixed to file-level recall (each fixture has one defect in one unique file) and re-ran; the null verdict is on the corrected, sanity-checked scorer, with raw arm outputs persisted for audit.
- Step 3 (blind rubric judge) is **deferred** — the primary metric is deterministic and a preference judge is moot at the recall ceiling; it re-opens with a discriminating corpus. Phase 3 Step 4 (worker-delegate) stays deferred (re-opened only on lift, which did not occur).

## Verification

`build-proof-check` in sync · `check_claims` 6 markered / 29 ledger (24 backed) · `check_references` green · `task typecheck-ts` green · portability green · rebased onto current main (post-#980), dashboard in sync. Full pipeline delegated to remote CI.