### PR TITLE
bench: resolve adversarial-council-finding-coverage — HONEST NULL (spend-authorized)

### DIFF
--- a/agents/roadmaps/archive/road-to-adversarial-council-benchmark.md
+++ b/agents/roadmaps/archive/road-to-adversarial-council-benchmark.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 ---
 
 # Road to resolving the adversarial-council finding-coverage claim (benchmark arm)
@@ -65,18 +65,18 @@ refined *before* the registered run; the pass/fail numbers may not move after it
 
 ## Phase 1 — Curate a judge-survivable residual-defect corpus
 
-- [ ] Build a corpus of planted defects designed to **survive a single strong
+- [x] Build a corpus of planted defects designed to **survive a single strong
       cross-model judge** (residual-defect subtlety), per the bar in
       `docs/design/adversarial-council-eval.md`. Each item: a real, non-obvious
       defect (subtle broken edge case / missing control / plausible-but-wrong
       logic), not a deliberately hollow impl.
-- [ ] Include a **controversial-but-correct clean control** carrying real
+- [x] Include a **controversial-but-correct clean control** carrying real
       perf/security tradeoffs + uncommon-but-correct patterns, so panel
       false-positive rate is measured against single-judge FP on the same control.
-- [ ] **Publish the subtlety distribution** (how many items at each subtlety
+- [x] **Publish the subtlety distribution** (how many items at each subtlety
       tier, defect classes covered) alongside the corpus, so the corpus is
       auditable and the residual claim is falsifiable.
-- [ ] Corpus-validity gate passes: an independent read confirms the corpus meets
+- [x] Corpus-validity gate passes: an independent read confirms the corpus meets
       the judge-survivable bar and is not the parity corpus in disguise.
 
 ## Phase 2 — Registered run + claim resolution (maintainer spend-gated)
@@ -86,15 +86,15 @@ refined *before* the registered run; the pass/fail numbers may not move after it
 > this-turn maintainer spend approval, and only after Phase 1's corpus-validity
 > gate passes.
 
-- [ ] Run Stage 1: a strong single cross-model judge over the corpus; record the
+- [x] Run Stage 1: a strong single cross-model judge over the corpus; record the
       residual subset (defects that survive it).
-- [ ] Run Stage 2: the cross-vendor adversarial panel (>=2 distinct providers via
+- [x] Run Stage 2: the cross-vendor adversarial panel (>=2 distinct providers via
       `council_cli.ts`) over the judge-passed residual subset; measure residual
       recall + false-positive rate on the controversial-clean control.
-- [ ] Evaluate against the locked dual threshold via `evaluateCouncilBench`;
+- [x] Evaluate against the locked dual threshold via `evaluateCouncilBench`;
       record the reproducible verdict (inputs, seeds, provider set, per-stage
       counts).
-- [ ] Resolve the `adversarial-council-finding-coverage` claim: `backed` with the
+- [x] Resolve the `adversarial-council-finding-coverage` claim: `backed` with the
       recorded evidence, **or** a documented honest-null. On honest-null, confirm
       the Mode 9 surface stays default-off permanently (no settings change needed —
       it already ships off).

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -257,4 +257,5 @@ visible, not hidden.
 - kind: quant
 - evidence: docs/benchmark.md#adversarial-verification-council
 - status: unbacked
-- last_verified:
+- last_verified: 2026-07-21
+- resolution: HONEST-NULL (resolved, not pending). Registered cross-vendor run 2026-07-21 on the curated judge-survivable corpus (internal/bench/adversarial-council/): on the judge-passed residual, the 2-vendor skeptic panel (anthropic+openai) matched the single skeptic exactly (residual recall 0.6 = 0.6, zero lift — the second vendor's residual catches were a strict subset of the first), at a 100% false-positive rate on the controversial-but-correct controls under the adversarial-skeptic posture. Both recall thresholds missed → honest-null → Mode 9 surface stays default-off permanently (like recursive-verification). Reproducible artifact: internal/bench/adversarial-council/runs/. Note: an initial run via `council_cli run` was REJECTED as a measurement artifact (that transport imposes multi-round peer-review + prose output, defeating the independent-skeptic + JSON-scoring protocol) — the valid run uses direct independent per-vendor client calls.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -559,7 +559,7 @@ replication on a per-token-billed key.
 - Runner: `src/scripts/bench_ab_v2_run.ts --host codex` (checkpoint-resumable).
 - Roadmap: `agents/roadmaps/archive/road-to-opt-measurement-unblock.md` Phase 2.
 
-## adversarial-verification-council finding coverage — UNBACKED (pending corpus + run)
+## adversarial-verification-council finding coverage — HONEST NULL (resolved 2026-07-21)
 
 Pre-registered claim `adversarial-council-finding-coverage` (docs/CLAIMS.md,
 ADR-122): on the RESIDUAL defect pool — defects that survive a single strong
@@ -574,14 +574,38 @@ controversial-but-correct control.
   **AND** absolute >= +8 pp, **AND** panel FP not worse than baseline within
   noise — encoded + tested in
   [`src/scripts/_lib/adversarial_council_gate.ts`](../src/scripts/_lib/adversarial_council_gate.ts).
-- **Status: UNBACKED.** The corpus-validity gate BLOCKS the registered run: the
-  existing `internal/bench/orchestration/corpus/` was built for cross-vendor
-  *parity* (obvious, model-differentiating defects), not judge-survivable
-  residual subtleties, so a run on it would be a measurement artifact (the
-  council's Round-1 critique). Resolving the claim needs (1) a curated
-  judge-survivable-subtlety corpus with a published distribution, then (2) a
-  maintainer-gated paid cross-vendor run. Honest-null on that run keeps the
-  surface default-off permanently, like recursive-verification.
+- **Status: HONEST NULL (resolved 2026-07-21).** A curated judge-survivable
+  corpus was built (`internal/bench/adversarial-council/`: 12 planted-defect
+  fixtures across 4 subtlety classes + 3 controversial-but-correct clean
+  controls; subtlety distribution published; passed an independent validity
+  audit after one fixture was repaired). The registered cross-vendor run
+  (anthropic `claude-sonnet-4-5` + openai `gpt-4o`, spend-authorized) resolved
+  the claim NEGATIVE:
+
+  | quantity | value |
+  |---|--:|
+  | judge-passed residual pool | 5–7 defects (missed by both neutral passes) |
+  | single-skeptic residual recall | 0.60 |
+  | 2-vendor panel residual recall | 0.60 (**zero lift**) |
+  | single-skeptic FP on clean controls | 1.00 |
+  | panel FP on clean controls | 1.00 |
+
+  The second vendor's residual catches were a **strict subset** of the first's,
+  so the panel added no marginal coverage; both recall thresholds (+25% rel,
+  +8 pp abs) missed → **honest-null**. Under the adversarial-skeptic posture
+  both the single skeptic and the panel false-flagged **all three**
+  controversial-but-correct controls (100% FP) — the posture over-flags correct
+  code. Stable across two runs. Per the locked gate, the Mode 9 surface stays
+  **default-off permanently** (like recursive-verification). Reproducible
+  artifact: `internal/bench/adversarial-council/runs/`.
+- **Transport lesson.** The first run attempted via `council_cli run` was
+  REJECTED as a measurement artifact: that transport runs multi-round
+  peer-review with cross-member visibility and returns prose ("Round 2 …
+  Reviewer A"), which both violates the independent-skeptic requirement and
+  defeats JSON scoring. The valid run uses direct, independent per-vendor
+  client calls (`bench_adversarial_council.ts`) with a strict-JSON system
+  prompt and a deterministic, pre-validated scorer
+  (`adversarial_bench_score.ts` + its synthetic red/green test).
 
 
 ## Defect-finding: team vs self-review vs council (2026-07-20) — HONEST NULL (ceiling-limited) {#honest-null-defect}

--- a/docs/decisions/ADR-122-adversarial-verification-council.md
+++ b/docs/decisions/ADR-122-adversarial-verification-council.md
@@ -134,3 +134,33 @@ Each settled decision this roadmap does NOT touch:
   ADR-120 (council chairman mode), ADR-109 (subagent-v1 contract).
 - `docs/CLAIMS.md#adversarial-council-finding-coverage` — the pre-registered claim.
 - `cross-vendor-parity` (backed) — the evidence the finding-coverage scope rests on.
+
+## Addendum (2026-07-21) — finding-coverage claim resolved HONEST-NULL
+
+The pre-registered `adversarial-council-finding-coverage` claim was executed and
+resolved **negative**. A curated judge-survivable corpus
+(`internal/bench/adversarial-council/`: 12 planted-defect fixtures across
+multi-file-interaction / logic-inversion / security-masked / complex-state + 3
+controversial-but-correct clean controls; subtlety distribution published;
+passed an independent validity audit after one fixture was repaired) was run
+cross-vendor (anthropic `claude-sonnet-4-5` + openai `gpt-4o`) under the
+maintainer spend authorization.
+
+**Result:** on the judge-passed residual, the 2-vendor skeptic panel matched the
+single skeptic exactly (residual recall 0.60 = 0.60, **zero lift** — the second
+vendor's catches were a strict subset of the first's), at a **100%** false-
+positive rate on the controversial-but-correct controls under the adversarial-
+skeptic posture. Both locked recall thresholds missed -> honest-null. **The
+Mode 9 `adversarial-verification-council` surface stays default-off permanently**
+(no settings change — it already ships off), recorded like recursive-verification
+(ADR-106). Detail + reproducible artifact:
+`docs/benchmark.md#adversarial-verification-council`,
+`internal/bench/adversarial-council/runs/`.
+
+**Transport lesson (durable):** `council_cli run`/`debate` is a *deliberation*
+transport — multi-round peer-review with cross-member visibility, prose output.
+It is the WRONG tool for an independent-skeptic, structured-output benchmark (it
+violated the independence requirement and defeated JSON scoring; the first run
+through it was rejected as an artifact). The valid measurement uses direct,
+independent per-vendor client calls with a strict-JSON contract and a
+deterministic, pre-validated scorer.

--- a/internal/bench/adversarial-council/corpus.json
+++ b/internal/bench/adversarial-council/corpus.json
@@ -1,0 +1,252 @@
+{
+  "_meta": {
+    "purpose": "Judge-survivable residual-defect corpus for the adversarial-council finding-coverage benchmark (ADR-122, road-to-adversarial-council-benchmark). Each defect fixture carries exactly one real, non-obvious defect designed to survive a single competent review pass. Clean controls are genuinely correct but carry controversial-looking patterns to measure false-positive cost. `ground_truth` is NEVER shown to reviewer models.",
+    "built": "2026-07-21",
+    "line_note": "defect_location lines are advisory; the scorer matches on file basename + category family, never exact line."
+  },
+  "items": [
+    {
+      "id": "mfi-01",
+      "class": "multi-file-interaction",
+      "subtlety_tier": "high",
+      "defect_category": "data-integrity",
+      "is_clean": false,
+      "files": [
+        { "path": "src/cursor.ts", "content": "export interface Cursor {\n  createdAt: number;\n}\n\nexport function encodeCursor(cursor: Cursor): string {\n  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');\n}\n\nexport function decodeCursor(token: string): Cursor {\n  const json = Buffer.from(token, 'base64url').toString('utf8');\n  const parsed = JSON.parse(json) as Partial<Cursor>;\n  if (typeof parsed.createdAt !== 'number') {\n    throw new Error('Invalid cursor');\n  }\n  return { createdAt: parsed.createdAt };\n}\n" },
+        { "path": "src/feed.ts", "content": "import { Cursor, decodeCursor, encodeCursor } from './cursor';\n\nexport interface Post {\n  id: number;\n  authorId: number;\n  createdAt: number;\n}\n\nexport interface Page {\n  items: Post[];\n  nextCursor: string | null;\n}\n\nexport class FeedRepository {\n  constructor(private readonly posts: Post[]) {}\n\n  page(limit: number, token?: string): Page {\n    const cursor: Cursor | null = token ? decodeCursor(token) : null;\n\n    const ordered = [...this.posts].sort(\n      (a, b) => b.createdAt - a.createdAt || a.id - b.id,\n    );\n\n    const window = ordered.filter(\n      (p) => cursor === null || p.createdAt < cursor.createdAt,\n    );\n\n    const items = window.slice(0, limit);\n    const last = items[items.length - 1];\n    const nextCursor =\n      items.length === limit && last\n        ? encodeCursor({ createdAt: last.createdAt })\n        : null;\n\n    return { items, nextCursor };\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["feed.ts", "cursor.ts"],
+        "defect_summary": "Keyset pagination orders by (createdAt DESC, id ASC) but the cursor stores/filters on createdAt alone with strict <, so rows sharing the boundary createdAt with the last returned item are silently skipped on the next page.",
+        "failing_scenario": "posts (100,1),(90,2),(90,3),(80,4); page(2)->[1,2] cursor.createdAt=90; page(2,cursor) filters createdAt<90 -> [4]; id 3 never returned.",
+        "one_line_fix": "Add id to Cursor; predicate p.createdAt < c.createdAt || (p.createdAt===c.createdAt && p.id>c.id)."
+      }
+    },
+    {
+      "id": "mfi-02",
+      "class": "multi-file-interaction",
+      "subtlety_tier": "high",
+      "defect_category": "concurrency",
+      "is_clean": false,
+      "files": [
+        { "path": "src/idempotency.ts", "content": "export interface KvStore {\n  get(key: string): Promise<string | null>;\n  set(key: string, value: string): Promise<void>;\n}\n\nexport class IdempotencyGuard {\n  constructor(private readonly store: KvStore) {}\n\n  async begin(key: string): Promise<boolean> {\n    const existing = await this.store.get(key);\n    if (existing !== null) {\n      return false;\n    }\n    await this.store.set(key, new Date().toISOString());\n    return true;\n  }\n}\n" },
+        { "path": "src/webhook.ts", "content": "import { IdempotencyGuard } from './idempotency';\n\nexport interface PaymentEvent {\n  idempotencyKey: string;\n  customerId: string;\n  amountCents: number;\n}\n\nexport interface Ledger {\n  charge(customerId: string, amountCents: number): Promise<void>;\n}\n\nexport class PaymentWebhook {\n  constructor(\n    private readonly guard: IdempotencyGuard,\n    private readonly ledger: Ledger,\n  ) {}\n\n  async handle(event: PaymentEvent): Promise<void> {\n    const fresh = await this.guard.begin(event.idempotencyKey);\n    if (!fresh) {\n      return;\n    }\n    await this.ledger.charge(event.customerId, event.amountCents);\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["idempotency.ts", "webhook.ts"],
+        "defect_summary": "begin() is a non-atomic check-then-set across an await; two concurrent same-key deliveries both observe null and both return true, so the webhook charges twice.",
+        "failing_scenario": "Two concurrent handle() with same idempotencyKey; both begin() resolve get as null before either set completes -> both true -> ledger.charge runs twice.",
+        "one_line_fix": "Use an atomic set-if-absent (SET key val NX) and gate on its boolean result."
+      }
+    },
+    {
+      "id": "mfi-03",
+      "class": "multi-file-interaction",
+      "subtlety_tier": "high",
+      "defect_category": "resource-leak",
+      "is_clean": false,
+      "files": [
+        { "path": "src/pubsub.ts", "content": "type Handler = (payload: unknown) => void;\n\nexport class EventBus {\n  private readonly handlers = new Map<string, Set<Handler>>();\n\n  subscribe(topic: string, handler: Handler): () => void {\n    let set = this.handlers.get(topic);\n    if (!set) {\n      set = new Set();\n      this.handlers.set(topic, set);\n    }\n    set.add(handler);\n    return () => {\n      set!.delete(handler);\n    };\n  }\n\n  publish(topic: string, payload: unknown): void {\n    const set = this.handlers.get(topic);\n    if (!set) return;\n    for (const handler of set) {\n      handler(payload);\n    }\n  }\n\n  listenerCount(topic: string): number {\n    return this.handlers.get(topic)?.size ?? 0;\n  }\n}\n" },
+        { "path": "src/subscriptions.ts", "content": "import { EventBus } from './pubsub';\n\nexport class ConnectionSubscriptions {\n  private readonly teardowns = new Map<string, () => void>();\n\n  constructor(private readonly bus: EventBus) {}\n\n  add(topic: string, handler: (payload: unknown) => void): void {\n    const unsubscribe = this.bus.subscribe(topic, handler);\n    this.teardowns.set(topic, unsubscribe);\n  }\n\n  dispose(): void {\n    for (const unsubscribe of this.teardowns.values()) {\n      unsubscribe();\n    }\n    this.teardowns.clear();\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["subscriptions.ts", "pubsub.ts"],
+        "defect_summary": "EventBus allows many listeners per topic but ConnectionSubscriptions stores one teardown per topic key; a second add on the same topic overwrites the first unsubscribe, so dispose can never remove the first handler (leak).",
+        "failing_scenario": "add('orders',h1); add('orders',h2); dispose() -> listenerCount('orders') is 1 (h1 still registered) instead of 0.",
+        "one_line_fix": "Track teardowns in a per-instance array and push each unsubscribe, instead of a Map keyed by topic."
+      }
+    },
+    {
+      "id": "inv-01",
+      "class": "logic-inversion",
+      "subtlety_tier": "high",
+      "defect_category": "access-control",
+      "is_clean": false,
+      "files": [
+        { "path": "src/member-access.ts", "content": "import type { Member, MemberRepo } from './types';\nimport { ForbiddenError, NotFoundError } from './errors';\n\nconst RANK: Record<string, number> = {\n  viewer: 0,\n  contributor: 1,\n  admin: 2,\n  owner: 3,\n};\n\nexport function canRemoveMember(actor: Member, target: Member): boolean {\n  if (actor.orgId !== target.orgId) return false;\n  if (actor.id === target.id) return false;\n  return RANK[actor.role] >= RANK[target.role];\n}\n\nexport async function removeMember(\n  actorId: string,\n  targetId: string,\n  repo: MemberRepo,\n): Promise<void> {\n  const actor = await repo.find(actorId);\n  const target = await repo.find(targetId);\n  if (!actor || !target) {\n    throw new NotFoundError('member not found');\n  }\n  if (!canRemoveMember(actor, target)) {\n    throw new ForbiddenError('insufficient privileges to remove this member');\n  }\n  await repo.delete(targetId);\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["member-access.ts"],
+        "defect_summary": "Privilege comparison uses >= instead of >, so an actor can remove a peer at the same rank (admin removes admin, owner removes owner).",
+        "failing_scenario": "Admin A (rank 2) removeMember(A,B) where B is admin (rank 2) same org -> 2>=2 true -> B deleted; a peer should not be removable.",
+        "one_line_fix": "Change >= to >."
+      }
+    },
+    {
+      "id": "inv-02",
+      "class": "logic-inversion",
+      "subtlety_tier": "high",
+      "defect_category": "correctness",
+      "is_clean": false,
+      "files": [
+        { "path": "src/paginate.ts", "content": "export interface Page<T> {\n  items: T[];\n  page: number;\n  pageSize: number;\n  totalItems: number;\n  totalPages: number;\n}\n\nexport function paginate<T>(all: T[], page: number, pageSize: number): Page<T> {\n  if (pageSize <= 0) {\n    throw new RangeError('pageSize must be positive');\n  }\n\n  const totalItems = all.length;\n  const totalPages = Math.floor(totalItems / pageSize);\n  const current = Math.max(1, Math.min(page, totalPages || 1));\n  const start = (current - 1) * pageSize;\n\n  return {\n    items: all.slice(start, start + pageSize),\n    page: current,\n    pageSize,\n    totalItems,\n    totalPages,\n  };\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["paginate.ts"],
+        "defect_summary": "totalPages uses Math.floor instead of Math.ceil, so a trailing partial page is never counted and its items are unreachable via the clamped page.",
+        "failing_scenario": "paginate(items25,3,10) with length 25 -> totalPages=2, page clamps to 2, returns items 11-20; items 21-25 unreachable.",
+        "one_line_fix": "Change Math.floor to Math.ceil."
+      }
+    },
+    {
+      "id": "inv-03",
+      "class": "logic-inversion",
+      "subtlety_tier": "high",
+      "defect_category": "data-integrity",
+      "is_clean": false,
+      "files": [
+        { "path": "src/contact-sync.ts", "content": "import type { ContactRecord, SyncTarget } from './types';\n\nexport function partitionForSync(records: ContactRecord[]): {\n  syncable: ContactRecord[];\n  quarantined: ContactRecord[];\n} {\n  const syncable: ContactRecord[] = [];\n  const quarantined: ContactRecord[] = [];\n\n  for (const r of records) {\n    if (!(r.externalId == null && r.email == null)) {\n      syncable.push(r);\n    } else {\n      quarantined.push(r);\n    }\n  }\n\n  return { syncable, quarantined };\n}\n\nexport async function pushContacts(\n  records: ContactRecord[],\n  target: SyncTarget,\n): Promise<void> {\n  const { syncable } = partitionForSync(records);\n  for (const r of syncable) {\n    await target.upsert({ externalId: r.externalId, email: r.email });\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["contact-sync.ts"],
+        "defect_summary": "A record should sync only with BOTH externalId and email, but the De Morgan-inverted guard keeps any record with at least one, so half-populated records are pushed downstream.",
+        "failing_scenario": "{externalId:'ext_9', email:null} placed in syncable; target.upsert writes a contact with null email, corrupting a downstream record that requires a valid email.",
+        "one_line_fix": "Use if (r.externalId != null && r.email != null)."
+      }
+    },
+    {
+      "id": "sec-01",
+      "class": "security-masked",
+      "subtlety_tier": "high",
+      "defect_category": "access-control",
+      "is_clean": false,
+      "files": [
+        { "path": "src/routes/documentShare.ts", "content": "import { Router, Request, Response } from 'express';\nimport { requireAuth } from '../middleware/auth';\nimport { documentRepo } from '../repositories/documentRepo';\n\nconst router = Router();\n\ninterface ShareRequest {\n  userId: string;\n  documentId: string;\n}\n\n// requireAuth populates req.user from the session cookie.\nrouter.post('/documents/share', requireAuth, async (req: Request, res: Response) => {\n  const { userId, documentId } = req.body as ShareRequest;\n\n  if (!userId || !documentId) {\n    return res.status(400).json({ error: 'userId and documentId are required' });\n  }\n\n  const document = await documentRepo.findById(documentId);\n  if (!document) {\n    return res.status(404).json({ error: 'document not found' });\n  }\n\n  // Only the owner of a document may create a public share link for it.\n  if (document.ownerId !== userId) {\n    return res.status(403).json({ error: 'forbidden' });\n  }\n\n  const link = await documentRepo.createShareLink(document.id);\n  return res.json({ shareUrl: `https://app.example.com/s/${link.token}` });\n});\n\nexport default router;\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["documentShare.ts"],
+        "defect_summary": "The ownership check compares document.ownerId against userId read from the request body (attacker-controlled) instead of the authenticated req.user.id; both sides are client-supplied.",
+        "failing_scenario": "Authenticated attacker B learns victim A's id, POSTs {documentId:<A's private doc>, userId:<A's id>}; ownerId===userId holds, check passes, B gets a share link to A's document.",
+        "one_line_fix": "Compare against the session identity: if (document.ownerId !== req.user.id); drop userId from the body."
+      }
+    },
+    {
+      "id": "sec-02",
+      "class": "security-masked",
+      "subtlety_tier": "high",
+      "defect_category": "ssrf",
+      "is_clean": false,
+      "files": [
+        { "path": "src/routes/fetchImage.ts", "content": "import { Router, Request, Response } from 'express';\nimport fetch from 'node-fetch';\n\nconst router = Router();\n\nconst ALLOWED_HOSTS = ['images.example.com', 'cdn.example.com'];\n\nfunction isAllowedTarget(target: string): boolean {\n  return ALLOWED_HOSTS.some((host) => target.includes(host));\n}\n\nrouter.post('/fetch-image', async (req: Request, res: Response) => {\n  const { url } = req.body as { url?: string };\n\n  if (!url || typeof url !== 'string') {\n    return res.status(400).json({ error: 'url is required' });\n  }\n\n  if (!url.startsWith('https://')) {\n    return res.status(400).json({ error: 'only https urls are allowed' });\n  }\n\n  if (!isAllowedTarget(url)) {\n    return res.status(403).json({ error: 'host not allowed' });\n  }\n\n  const response = await fetch(url, { redirect: 'error', timeout: 5000 });\n  if (!response.ok) {\n    return res.status(502).json({ error: 'upstream fetch failed' });\n  }\n\n  const buffer = await response.buffer();\n  res.set('content-type', response.headers.get('content-type') ?? 'application/octet-stream');\n  return res.send(buffer);\n});\n\nexport default router;\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["fetchImage.ts"],
+        "defect_summary": "The allowlist is checked with a substring match (target.includes(host)) against the raw URL string instead of the parsed hostname, so any URL merely containing an allowed host passes.",
+        "failing_scenario": "POST {url:'https://cdn.example.com.attacker.com/a'} or 'https://attacker.com/x?ref=images.example.com'; startsWith and includes pass -> server fetches attacker host (SSRF).",
+        "one_line_fix": "Parse first: const {hostname}=new URL(url); if(!ALLOWED_HOSTS.includes(hostname)) return 403."
+      }
+    },
+    {
+      "id": "sec-03",
+      "class": "security-masked",
+      "subtlety_tier": "high",
+      "defect_category": "path-traversal",
+      "is_clean": false,
+      "files": [
+        { "path": "src/routes/reportDownload.ts", "content": "import { Router, Request, Response } from 'express';\nimport * as path from 'path';\nimport * as fs from 'fs/promises';\n\nconst router = Router();\n\nconst REPORTS_DIR = path.resolve(__dirname, '../../storage/reports');\n\nrouter.post('/reports/download', async (req: Request, res: Response) => {\n  const { file } = req.body as { file?: string };\n\n  if (!file || typeof file !== 'string') {\n    return res.status(400).json({ error: 'file is required' });\n  }\n\n  // Reject traversal sequences and absolute paths.\n  if (file.includes('..') || file.startsWith('/') || file.includes('\\\\')) {\n    return res.status(400).json({ error: 'invalid file name' });\n  }\n\n  const name = decodeURIComponent(file);\n  const target = path.join(REPORTS_DIR, name);\n\n  try {\n    const data = await fs.readFile(target);\n    res.set('content-type', 'application/pdf');\n    return res.send(data);\n  } catch {\n    return res.status(404).json({ error: 'report not found' });\n  }\n});\n\nexport default router;\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["reportDownload.ts"],
+        "defect_summary": "The ..-and-absolute-path guard runs on the raw request value, but the value is then percent-decoded before being joined, so URL-encoded traversal sequences bypass the check (validate-before-decode ordering bug).",
+        "failing_scenario": "POST {file:'%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd'}; raw has no ../, guard passes; decodeURIComponent yields ../../../etc/passwd; path.join escapes REPORTS_DIR, discloses arbitrary files.",
+        "one_line_fix": "Decode first, then resolve and verify containment: target=path.resolve(REPORTS_DIR, decodeURIComponent(file)); if(!target.startsWith(REPORTS_DIR+path.sep)) 400."
+      }
+    },
+    {
+      "id": "state-01",
+      "class": "complex-state",
+      "subtlety_tier": "high",
+      "defect_category": "correctness",
+      "is_clean": false,
+      "files": [
+        { "path": "src/feed-paginator.ts", "content": "export interface Row {\n  id: string;\n  score: number;\n}\n\nexport interface Page {\n  rows: Row[];\n  nextCursor: string | null;\n}\n\ntype Fetcher = (afterId: string | null, take: number) => Promise<Row[]>;\n\nexport class Feed {\n  constructor(\n    private readonly fetch: Fetcher,\n    private readonly pageSize: number,\n  ) {}\n\n  async page(cursor: string | null): Promise<Page> {\n    const take = this.pageSize + 1;\n    const fetched = await this.fetch(cursor, take);\n\n    const hasMore = fetched.length >= this.pageSize;\n    const rows =\n      fetched.length > this.pageSize\n        ? fetched.slice(0, this.pageSize)\n        : fetched;\n\n    const nextCursor =\n      hasMore && rows.length > 0 ? rows[rows.length - 1].id : null;\n\n    return { rows, nextCursor };\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["feed-paginator.ts"],
+        "defect_summary": "Over-fetches pageSize+1 to detect a further page, so more-exists should be length>pageSize; using >= treats a full-but-final page as if more data follows, emitting a spurious empty next page.",
+        "failing_scenario": "Last page has exactly pageSize rows; fetch returns pageSize; hasMore=true, nextCursor set; client fetches again, gets zero rows -> spurious empty page / dead 'Load more'.",
+        "one_line_fix": "const hasMore = fetched.length > this.pageSize;"
+      }
+    },
+    {
+      "id": "state-02",
+      "class": "complex-state",
+      "subtlety_tier": "high",
+      "defect_category": "concurrency",
+      "is_clean": false,
+      "files": [
+        { "path": "src/batch-writer.ts", "content": "export type Sink<T> = (rows: readonly T[]) => Promise<void>;\n\nexport class BatchWriter<T> {\n  private batch: T[] = [];\n\n  constructor(\n    private readonly sink: Sink<T>,\n    private readonly flushAt: number = 100,\n  ) {}\n\n  async add(row: T): Promise<void> {\n    this.batch.push(row);\n    if (this.batch.length >= this.flushAt) {\n      await this.sink(this.batch);\n      this.batch = [];\n    }\n  }\n\n  async flush(): Promise<void> {\n    if (this.batch.length === 0) return;\n    await this.sink(this.batch);\n    this.batch = [];\n  }\n\n  get pending(): number {\n    return this.batch.length;\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["batch-writer.ts"],
+        "defect_summary": "The batch array is reset only after the await sink(); any add() during the in-flight sink pushes into the array being flushed, then this.batch=[] discards those rows (lost writes).",
+        "failing_scenario": "await Promise.all(rows.map(r=>writer.add(r))); the add hitting flushAt awaits sink; concurrent adds push into the flushing array; this.batch=[] drops them silently.",
+        "one_line_fix": "Swap before awaiting: const rows=this.batch; this.batch=[]; await this.sink(rows); (in add and flush)."
+      }
+    },
+    {
+      "id": "state-03",
+      "class": "complex-state",
+      "subtlety_tier": "high",
+      "defect_category": "resource-leak",
+      "is_clean": false,
+      "files": [
+        { "path": "src/account-store.ts", "content": "export interface Conn {\n  query<T>(sql: string, params: unknown[]): Promise<T[]>;\n  release(): void;\n}\n\nexport interface Pool {\n  acquire(): Promise<Conn>;\n}\n\nexport interface Account {\n  id: string;\n  balance: number;\n}\n\nexport class AccountStore {\n  constructor(private readonly pool: Pool) {}\n\n  async transfer(from: string, to: string, amount: number): Promise<void> {\n    const conn = await this.pool.acquire();\n    await conn.query('BEGIN', []);\n    await conn.query(\n      'UPDATE accounts SET balance = balance - $1 WHERE id = $2',\n      [amount, from],\n    );\n    await conn.query(\n      'UPDATE accounts SET balance = balance + $1 WHERE id = $2',\n      [amount, to],\n    );\n    await conn.query('COMMIT', []);\n    conn.release();\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": ["account-store.ts"],
+        "defect_summary": "conn.release() runs only if every query resolves; any rejecting query leaks the connection (never returned to the pool) and leaves the open BEGIN transaction un-rolled-back (no try/finally). Exactly one defect: the transfer arithmetic itself is unconditional and correct.",
+        "failing_scenario": "The credit UPDATE rejects (e.g. `to` violates a CHECK/FK constraint, or the pooled connection resets mid-transaction). The rejection propagates out of transfer(); execution unwinds past conn.release(); the connection is never returned. Repeated failures exhaust the pool, each leaked connection pinning an uncommitted BEGIN.",
+        "one_line_fix": "Wrap in try { ... } catch(e){ await conn.query('ROLLBACK',[]); throw e; } finally { conn.release(); }."
+      }
+    },
+    {
+      "id": "clean-01",
+      "class": "clean-control",
+      "subtlety_tier": "high",
+      "defect_category": "none",
+      "is_clean": true,
+      "files": [
+        { "path": "src/resolve-config.ts", "content": "export interface Config {\n  timeoutMs?: number | null;\n  retries?: number | null;\n  baseUrl?: string | null;\n}\n\nexport interface ResolvedConfig {\n  timeoutMs: number;\n  retries: number;\n  baseUrl: string;\n}\n\nconst DEFAULTS: ResolvedConfig = {\n  timeoutMs: 5000,\n  retries: 3,\n  baseUrl: 'https://api.example.com',\n};\n\nfunction pick<T>(value: T | null | undefined, fallback: T): T {\n  return value == null ? fallback : value;\n}\n\nexport function resolveConfig(input: Config): ResolvedConfig {\n  return {\n    timeoutMs: pick(input.timeoutMs, DEFAULTS.timeoutMs),\n    retries: pick(input.retries, DEFAULTS.retries),\n    baseUrl: pick(input.baseUrl, DEFAULTS.baseUrl),\n  };\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": [],
+        "defect_summary": "CORRECT. Controversial pattern: value == null in pick(). It is the canonical safe loose-equality (true for null and undefined only, not 0/''/false), which is exactly the intent: fall back for omitted or explicit-null, preserve legitimate falsy values like retries:0.",
+        "failing_scenario": "none",
+        "one_line_fix": "none"
+      }
+    },
+    {
+      "id": "clean-02",
+      "class": "clean-control",
+      "subtlety_tier": "high",
+      "defect_category": "none",
+      "is_clean": true,
+      "files": [
+        { "path": "src/ring-buffer.ts", "content": "export class RingBuffer<T> {\n  private readonly buf: (T | undefined)[];\n  private readonly mask: number;\n  private head = 0;\n  private count = 0;\n\n  constructor(capacity: number) {\n    if (capacity <= 0 || (capacity & (capacity - 1)) !== 0) {\n      throw new Error('capacity must be a positive power of two');\n    }\n    this.buf = new Array<T | undefined>(capacity);\n    this.mask = capacity - 1;\n  }\n\n  push(item: T): void {\n    const idx = (this.head + this.count) & this.mask;\n    if (this.count === this.buf.length) {\n      this.head = (this.head + 1) & this.mask;\n    } else {\n      this.count += 1;\n    }\n    this.buf[idx] = item;\n  }\n\n  toArray(): T[] {\n    const out: T[] = [];\n    for (let i = 0; i < this.count; i += 1) {\n      out.push(this.buf[(this.head + i) & this.mask] as T);\n    }\n    return out;\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": [],
+        "defect_summary": "CORRECT. Controversial pattern: bitwise index math (& mask) instead of % capacity, power-of-two check, and 'as T' cast. All sound: constructor rejects non-power-of-two so mask=capacity-1 makes n&mask===n%capacity for non-negative n; the cast is safe because toArray reads only the count written slots.",
+        "failing_scenario": "none",
+        "one_line_fix": "none"
+      }
+    },
+    {
+      "id": "clean-03",
+      "class": "clean-control",
+      "subtlety_tier": "high",
+      "defect_category": "none",
+      "is_clean": true,
+      "files": [
+        { "path": "src/workspace.ts", "content": "export interface Fs {\n  mkdir(path: string): Promise<void>;\n  stat(path: string): Promise<{ isDirectory: boolean }>;\n}\n\nexport class Workspace {\n  constructor(\n    private readonly fs: Fs,\n    private readonly root: string,\n  ) {}\n\n  async ensure(relative: string): Promise<string> {\n    const full = `${this.root}/${relative}`;\n\n    try {\n      await this.fs.mkdir(full);\n    } catch {}\n\n    const info = await this.fs.stat(full);\n    if (!info.isDirectory) {\n      throw new Error(`${full} exists but is not a directory`);\n    }\n\n    return full;\n  }\n}\n" }
+      ],
+      "ground_truth": {
+        "defect_files": [],
+        "defect_summary": "CORRECT. Controversial pattern: bare catch {} swallowing mkdir errors. Sound because the post-condition (path exists AND is a directory) is verified independently by the following stat: a genuine mkdir failure surfaces as a stat rejection or a non-directory throw. The swallow only drops the benign EEXIST signal.",
+        "failing_scenario": "none",
+        "one_line_fix": "none"
+      }
+    }
+  ]
+}

--- a/internal/bench/adversarial-council/runs/run-report.json
+++ b/internal/bench/adversarial-council/runs/run-report.json
@@ -1,0 +1,56 @@
+{
+  "mode": "run",
+  "corpus": "internal/bench/adversarial-council/corpus.json",
+  "protocol": "stage1 2-vendor neutral → residual (missed by both); stage2 single skeptic (anthropic) vs cross-vendor panel union on residual; FP on clean controls",
+  "inputs": {
+    "single_judge_residual_recall": 0.6,
+    "panel_residual_recall": 0.6,
+    "single_judge_fp_rate": 1,
+    "panel_fp_rate": 1,
+    "fp_noise_margin": 0.3333333333333333
+  },
+  "detail": {
+    "total_defects": 12,
+    "residual_ids": [
+      "mfi-01",
+      "mfi-03",
+      "inv-01",
+      "inv-03",
+      "state-02"
+    ],
+    "residual_size": 5,
+    "single_skeptic": "anthropic",
+    "single_residual_caught": [
+      "mfi-03",
+      "inv-01",
+      "state-02"
+    ],
+    "panel_residual_caught": [
+      "mfi-03",
+      "inv-01",
+      "state-02"
+    ],
+    "single_fp": [
+      "clean-01",
+      "clean-02",
+      "clean-03"
+    ],
+    "panel_fp": [
+      "clean-01",
+      "clean-02",
+      "clean-03"
+    ]
+  },
+  "verdict": {
+    "relative_lift": 0,
+    "absolute_lift_pp": 0,
+    "relative_pass": false,
+    "absolute_pass": false,
+    "fp_pass": true,
+    "verdict": "honest-null",
+    "reasons": [
+      "relative lift 0.0% < 25%",
+      "absolute lift 0.0pp < 8pp"
+    ]
+  }
+}

--- a/internal/bench/adversarial-council/runs/run-trace.txt
+++ b/internal/bench/adversarial-council/runs/run-trace.txt
@@ -1,0 +1,23 @@
+stage 1 (neutral, independent per vendor) over 12 defects…
+  neutral mfi-01: anthropic=1 openai=0
+  neutral mfi-02: anthropic=1 openai=0
+  neutral mfi-03: anthropic=1 openai=0
+  neutral inv-01: anthropic=1 openai=0
+  neutral inv-02: anthropic=1 openai=0
+  neutral inv-03: anthropic=1 openai=0
+  neutral sec-01: anthropic=1 openai=1
+  neutral sec-02: anthropic=1 openai=0
+  neutral sec-03: anthropic=1 openai=0
+  neutral state-01: anthropic=1 openai=0
+  neutral state-02: anthropic=0 openai=0
+  neutral state-03: anthropic=1 openai=1
+residual (missed by BOTH neutral passes): mfi-01, mfi-03, inv-01, inv-03, state-02
+stage 2 (adversarial skeptic, independent per vendor) over residual + controls…
+  skeptic mfi-01: anthropic=1 openai=1
+  skeptic mfi-03: anthropic=1 openai=1
+  skeptic inv-01: anthropic=1 openai=1
+  skeptic inv-03: anthropic=1 openai=0
+  skeptic state-02: anthropic=1 openai=1
+  skeptic clean-01: anthropic=1 openai=0
+  skeptic clean-02: anthropic=1 openai=0
+  skeptic clean-03: anthropic=1 openai=1

--- a/internal/bench/adversarial-council/subtlety-distribution.md
+++ b/internal/bench/adversarial-council/subtlety-distribution.md
@@ -1,0 +1,53 @@
+# Adversarial-council corpus — subtlety distribution
+
+> Published alongside `corpus.json` per the corpus-validity gate
+> (`docs/design/adversarial-council-eval.md`): the corpus must be auditable and
+> the residual claim falsifiable. Built 2026-07-21.
+
+## Composition
+
+- **15 fixtures** — 12 planted-defect fixtures + 3 controversial-but-correct clean controls.
+- All defect fixtures are authored at **subtlety_tier: high** (designed to survive a single competent review pass), not trivially-detectable hollow impls.
+
+## Defect fixtures by class (12)
+
+| Class | Count | Multi-file? | Fixtures |
+|---|---|---|---|
+| multi-file-interaction | 3 | yes (2 files each) | mfi-01 keyset-cursor tiebreak omission · mfi-02 non-atomic idempotency check-then-set · mfi-03 one-teardown-per-topic Map overwrite leak |
+| logic-inversion | 3 | no | inv-01 RBAC `>=` vs `>` peer-removal · inv-02 pagination `floor` vs `ceil` · inv-03 De Morgan conjunctive-sync inversion |
+| security-masked | 3 | no | sec-01 IDOR (ownership check reads body `userId` not session) · sec-02 SSRF (substring allowlist vs parsed host) · sec-03 path-traversal (validate-before-decode) |
+| complex-state | 3 | no | state-01 over-fetch `>=` boundary spurious page · state-02 batch reset-after-await lost writes · state-03 missing try/finally connection leak |
+
+## Defect fixtures by category (12)
+
+| Category | Count |
+|---|---|
+| access-control | 2 (inv-01, sec-01) |
+| data-integrity | 2 (mfi-01, inv-03) |
+| concurrency | 2 (mfi-02, state-02) |
+| resource-leak | 2 (mfi-03, state-03) |
+| correctness | 2 (inv-02, state-01) |
+| ssrf | 1 (sec-02) |
+| path-traversal | 1 (sec-03) |
+
+## Subtlety profile
+
+- **Multi-file interaction:** 3 / 12 (the hardest tier — the defect only manifests from a cross-file contract mismatch; each file reads correctly in isolation).
+- **Single-file, plausible-surrounding-code:** 9 / 12 (logic inversions, masked security controls, and rare-state edges where the common path is correct so a shallow read passes).
+- **No fixture carries a comment hint or a deliberately hollow / obviously-empty implementation** (that would be the parity-corpus anti-pattern the design doc rejects).
+
+## Clean controls (3) — controversial-but-correct
+
+| id | Controversial pattern | Why it is actually correct |
+|---|---|---|
+| clean-01 | `value == null` loose equality | canonical safe form: true for null+undefined only, preserves falsy `0`/`''` |
+| clean-02 | bitwise `& mask` indexing + power-of-two check + `as T` cast | constructor rejects non-power-of-two so `& mask === % capacity`; cast reads only written slots |
+| clean-03 | bare `catch {}` swallowing `mkdir` | post-condition verified independently by the following `stat`; only the benign EEXIST signal is dropped |
+
+## Falsifiability
+
+The residual pool is defined at run time as the defects that survive a strong
+2-vendor neutral first pass; the published per-fixture ground truth (defect
+location + failing scenario) lets any reader reproduce the scoring and contest
+whether a given fixture is genuinely judge-survivable. An independent validity
+audit gates the corpus before any paid run.

--- a/src/scripts/_lib/adversarial_bench_score.ts
+++ b/src/scripts/_lib/adversarial_bench_score.ts
@@ -1,0 +1,106 @@
+/**
+ * Deterministic scorer for the adversarial-council residual-detection benchmark
+ * (road-to-adversarial-council-benchmark Phase 1).
+ *
+ * Pure + countable — never LLM-computed (the anti-lesson from ADR-122). Given a
+ * corpus item's ground truth and a reviewer's structured findings, decide
+ * whether the reviewer CAUGHT the planted defect (for a defect fixture) or
+ * raised a FALSE POSITIVE (for a clean control). The two-stage recalls and FP
+ * rates this produces feed `evaluateCouncilBench` (adversarial_council_gate.ts).
+ *
+ * Matching rule (deliberately NOT exact file:line — the scorer bug from the
+ * earlier defect-finding benchmark required an exact line token and mis-scored
+ * genuine catches that cited a nearby line): a finding CATCHES a planted defect
+ * iff it names one of the defect's file(s) by basename AND its category falls in
+ * the same normalized family as the planted defect. Line numbers are advisory,
+ * never required. This credits a real catch that localizes the right file +
+ * defect class, and denies credit for a scattershot "something's wrong here"
+ * with the wrong class.
+ */
+
+/** Normalize a free-form category string to a coarse family. */
+export function categoryFamily(raw: string): string {
+    const c = raw.toLowerCase().replace(/[^a-z]/g, '');
+    if (/(accesscontrol|authz|authorization|idor|bola|ownership|privilege|rbac)/.test(c)) return 'access-control';
+    if (/(auth|authentication|session|credential|login)/.test(c)) return 'auth';
+    if (/(ssrf|serverside)/.test(c)) return 'ssrf';
+    if (/(pathtraversal|traversal|directorytraversal|lfi)/.test(c)) return 'path-traversal';
+    // NB: no bare "rce" token — it substring-matches inside "resou[rce]leak".
+    if (/(injection|sqli|xss|commandinjection|deserial|remotecodeexec)/.test(c)) return 'injection';
+    if (/(crypto|cryptographic|timing|constanttime|hash|signature)/.test(c)) return 'crypto';
+    if (/(concurrency|race|atomic|deadlock|idempoten)/.test(c)) return 'concurrency';
+    if (/(resourceleak|leak|memory|handle|unsubscrib|cleanup)/.test(c)) return 'resource-leak';
+    if (/(dataintegrity|integrity|corrupt|consistency|stale)/.test(c)) return 'data-integrity';
+    if (/(correctness|logic|offbyone|boundary|edgecase|bug)/.test(c)) return 'correctness';
+    return 'other';
+}
+
+export interface Finding {
+    /** File the finding points at (any path form; matched by basename). */
+    file: string;
+    /** Reviewer-supplied category (free text; normalized via categoryFamily). */
+    category: string;
+    /** Reviewer confidence, if given. Low-confidence findings can be excluded from FP counting. */
+    confidence?: 'high' | 'medium' | 'low';
+}
+
+export interface GroundTruth {
+    id: string;
+    /** true = clean control (no defect); a finding here is a false positive. */
+    is_clean: boolean;
+    /** Basenames of the file(s) the planted defect lives in (empty for clean). */
+    defect_files: string[];
+    /** Planted defect category family (via categoryFamily); empty for clean. */
+    defect_category: string;
+}
+
+function basename(p: string): string {
+    return p.split(/[\\/]/).pop() ?? p;
+}
+
+/**
+ * Did the reviewer CATCH the planted defect? file-basename match on any defect
+ * file AND category-family match. Clean controls always return false (they have
+ * no defect to catch — use `isFalsePositive` for them).
+ */
+export function caughtDefect(truth: GroundTruth, findings: Finding[]): boolean {
+    if (truth.is_clean) return false;
+    const wantFiles = new Set(truth.defect_files.map(basename));
+    const wantFamily = truth.defect_category;
+    return findings.some(
+        (f) => wantFiles.has(basename(f.file)) && categoryFamily(f.category) === wantFamily,
+    );
+}
+
+/**
+ * Did the reviewer raise a FALSE POSITIVE on a clean control? Any finding that
+ * points at the control file counts (a claimed defect where none exists).
+ * Low-confidence findings are excluded — a hedged "might check X" is not a FP
+ * claim. Non-clean fixtures always return false.
+ */
+export function isFalsePositive(truth: GroundTruth, findings: Finding[]): boolean {
+    if (!truth.is_clean) return false;
+    return findings.some((f) => (f.confidence ?? 'high') !== 'low');
+}
+
+export interface StageResult {
+    /** Per-defect-fixture: id → caught?. Excludes clean controls. */
+    caught: Record<string, boolean>;
+    /** Per-clean-control: id → false-positive?. */
+    fp: Record<string, boolean>;
+}
+
+/** Recall over a set of defect ids, given per-id caught flags. */
+export function recall(caught: Record<string, boolean>): number {
+    const ids = Object.keys(caught);
+    if (ids.length === 0) return 0;
+    const hits = ids.filter((id) => caught[id]).length;
+    return hits / ids.length;
+}
+
+/** FP rate over clean controls. */
+export function fpRate(fp: Record<string, boolean>): number {
+    const ids = Object.keys(fp);
+    if (ids.length === 0) return 0;
+    return ids.filter((id) => fp[id]).length / ids.length;
+}

--- a/src/scripts/bench_adversarial_council.ts
+++ b/src/scripts/bench_adversarial_council.ts
@@ -1,0 +1,292 @@
+/**
+ * Two-stage residual-detection benchmark runner for the adversarial-council
+ * finding-coverage claim (ADR-122, road-to-adversarial-council-benchmark,
+ * design: docs/design/adversarial-council-eval.md).
+ *
+ * Protocol (documented here so the verdict is reproducible; 2 working providers
+ * — anthropic + openai — so the design is adapted to isolate panel VALUE without
+ * a structural-zero artifact):
+ *
+ *   Stage 1 — define the residual. BOTH providers review the 12 defect fixtures
+ *   under a NEUTRAL review prompt. Residual R = defects that NEITHER neutral pass
+ *   caught (the judge-survivable pool: it survived a strong 2-vendor first read).
+ *
+ *   Stage 2 — single skeptic vs cross-vendor panel, on R + the clean controls,
+ *   under an ADVERSARIAL SKEPTIC prompt (the shipped Mode-9 posture):
+ *     - single_judge  = anthropic-skeptic alone.
+ *     - panel         = reconciled union of {anthropic, openai} skeptics.
+ *   Because panel ⊇ single, lift ≥ 0 and measures the MARGINAL value the
+ *   second vendor adds at a fixed skeptic posture — exactly "does a cross-vendor
+ *   panel out-find a single skeptic on the residual, at no-worse FP".
+ *
+ *   evaluateCouncilBench applies the LOCKED dual threshold → backed | honest-null.
+ *
+ * Limitation (recorded honestly): with 2 vendors this isolates the 2nd-vendor
+ * marginal contribution, not an N-vendor scaling curve. gemini/xai are stubbed
+ * or disabled in this CLI build.
+ *
+ * `--mock` runs the whole pipeline on canned responses (no spend) to pre-validate
+ * parsing + residual + scoring + gate in BOTH directions. `--run` fires the real
+ * paid cross-vendor calls (maintainer spend-gated).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+    AnthropicClient,
+    OpenAIClient,
+    load_anthropic_key,
+    load_openai_key,
+    type ExternalAIClient,
+} from './ai_council/clients.js';
+import { evaluateCouncilBench, type CouncilBenchInputs } from './_lib/adversarial_council_gate.js';
+import {
+    caughtDefect,
+    isFalsePositive,
+    recall,
+    fpRate,
+    categoryFamily,
+    type Finding,
+    type GroundTruth,
+} from './_lib/adversarial_bench_score.js';
+import { hardenedSpawnEnv } from './_lib/spawn_env.js';
+
+const REPO_ROOT = process.cwd();
+const CORPUS_PATH = path.join(REPO_ROOT, 'internal/bench/adversarial-council/corpus.json');
+const SINGLE_SKEPTIC = 'anthropic'; // the single-judge baseline in stage 2
+
+interface CorpusItem {
+    id: string;
+    class: string;
+    defect_category: string;
+    is_clean: boolean;
+    files: { path: string; content: string }[];
+    ground_truth: { defect_files: string[]; defect_summary: string };
+}
+
+function loadCorpus(): CorpusItem[] {
+    return JSON.parse(fs.readFileSync(CORPUS_PATH, 'utf8')).items as CorpusItem[];
+}
+function groundTruth(item: CorpusItem): GroundTruth {
+    return {
+        id: item.id,
+        is_clean: item.is_clean,
+        defect_files: item.ground_truth.defect_files,
+        defect_category: item.is_clean ? 'none' : categoryFamily(item.defect_category),
+    };
+}
+function codeBlock(item: CorpusItem): string {
+    return item.files.map((f) => `FILE: ${f.path}\n\`\`\`ts\n${f.content}\`\`\``).join('\n\n');
+}
+const JSON_SHAPE =
+    '{"findings":[{"file":"<file path>","category":"<defect category>","confidence":"high|medium|low","summary":"<one line>"}]}';
+function neutralPrompt(item: CorpusItem): string {
+    return [
+        'You are a senior code reviewer. Review the TypeScript below for REAL defects and report only genuine bugs you are confident about. If it is correct, report an empty findings array — do not invent problems.',
+        `Respond with STRICT JSON only, exactly: ${JSON_SHAPE}`,
+        '',
+        codeBlock(item),
+    ].join('\n');
+}
+function skepticPrompt(item: CorpusItem): string {
+    return [
+        'You are an adversarial security/correctness skeptic. Assume this code may hide a subtle, non-obvious defect that a normal review missed — a masked access-control/SSRF/traversal flaw, a boundary/logic inversion, a concurrency or resource-leak edge, a cross-file contract mismatch. Hunt for it. Report only defects you can concretely justify; if after hard scrutiny it is genuinely correct, report an empty array (do not fabricate).',
+        `Respond with STRICT JSON only, exactly: ${JSON_SHAPE}`,
+        '',
+        codeBlock(item),
+    ].join('\n');
+}
+
+function parseFindings(text: string): Finding[] {
+    if (!text) return [];
+    const start = text.indexOf('{');
+    if (start < 0) return [];
+    let depth = 0;
+    let end = -1;
+    for (let i = start; i < text.length; i++) {
+        if (text[i] === '{') depth++;
+        else if (text[i] === '}' && --depth === 0) {
+            end = i;
+            break;
+        }
+    }
+    if (end < 0) return [];
+    try {
+        const obj = JSON.parse(text.slice(start, end + 1)) as { findings?: unknown };
+        const arr = Array.isArray(obj.findings) ? obj.findings : [];
+        return arr
+            .filter((f): f is Record<string, unknown> => typeof f === 'object' && f !== null)
+            .map((f) => ({
+                file: String(f.file ?? ''),
+                category: String(f.category ?? ''),
+                confidence: (['high', 'medium', 'low'].includes(String(f.confidence)) ? String(f.confidence) : 'high') as
+                    | 'high'
+                    | 'medium'
+                    | 'low',
+            }))
+            .filter((f) => f.file.length > 0);
+    } catch {
+        return [];
+    }
+}
+
+type Reviews = Record<string, Record<string, Finding[]>>; // fixtureId → member → findings
+
+// Direct, INDEPENDENT client calls — NOT council_cli. The council `run`/`debate`
+// transport imposes multi-round peer-review with cross-member visibility and
+// returns prose ("## Round 2 … Reviewer A"), which (a) violates the claim's
+// independent-skeptic requirement and (b) defeats JSON parsing. We call each
+// provider's client once, in isolation, with a strict-JSON system prompt.
+const SYSTEM_JSON =
+    'You are a code reviewer. Output ONLY one JSON object — no prose, no markdown, no code fences. ' +
+    'Shape exactly: {"findings":[{"file":"<path>","category":"<category>","confidence":"high|medium|low","summary":"<one line>"}]}. ' +
+    'If the code is correct, output {"findings":[]}. Do not include any text before or after the JSON object.';
+
+let _clients: Record<string, ExternalAIClient> | null = null;
+function getClients(): Record<string, ExternalAIClient> {
+    if (!_clients) {
+        _clients = {
+            anthropic: new AnthropicClient({ model: 'claude-sonnet-4-5', api_key: load_anthropic_key() }),
+            openai: new OpenAIClient({ model: 'gpt-4o', api_key: load_openai_key() }),
+        };
+    }
+    return _clients;
+}
+
+async function directReview(item: CorpusItem, userPrompt: string): Promise<Record<string, Finding[]>> {
+    const cs = getClients();
+    const out: Record<string, Finding[]> = {};
+    for (const [name, client] of Object.entries(cs)) {
+        let text = '';
+        try {
+            const resp = await client.ask(SYSTEM_JSON, userPrompt, 1200);
+            text = resp.text ?? '';
+        } catch (e) {
+            process.stderr.write(`  ${name} error on ${item.id}: ${(e as Error).message}\n`);
+        }
+        out[name] = parseFindings(text);
+    }
+    return out;
+}
+
+interface Passes {
+    neutral: Reviews; // defect fixtures only
+    skeptic: Reviews; // residual + controls
+    residualIds: string[];
+}
+
+async function realPasses(items: CorpusItem[]): Promise<Passes> {
+    const defects = items.filter((i) => !i.is_clean);
+    const controls = items.filter((i) => i.is_clean);
+    const neutral: Reviews = {};
+    process.stderr.write('stage 1 (neutral, independent per vendor) over 12 defects…\n');
+    for (const d of defects) {
+        neutral[d.id] = await directReview(d, neutralPrompt(d));
+        process.stderr.write(`  neutral ${d.id}: ${Object.entries(neutral[d.id]).map(([m, f]) => `${m}=${f.length}`).join(' ')}\n`);
+    }
+    const residual = defects.filter((d) => !Object.values(neutral[d.id]).flat().some((f) => caughtDefect(groundTruth(d), [f])));
+    process.stderr.write(`residual (missed by BOTH neutral passes): ${residual.map((r) => r.id).join(', ') || '(none)'}\n`);
+    const skeptic: Reviews = {};
+    process.stderr.write('stage 2 (adversarial skeptic, independent per vendor) over residual + controls…\n');
+    for (const item of [...residual, ...controls]) {
+        skeptic[item.id] = await directReview(item, skepticPrompt(item));
+        process.stderr.write(`  skeptic ${item.id}: ${Object.entries(skeptic[item.id]).map(([m, f]) => `${m}=${f.length}`).join(' ')}\n`);
+    }
+    return { neutral, skeptic, residualIds: residual.map((r) => r.id) };
+}
+
+function mockPasses(items: CorpusItem[]): Passes {
+    // Deterministic proof that the pipeline discriminates: neutral 2-vendor pass
+    // catches the "easier" defects; a hard residual survives; the skeptic panel
+    // then recovers more of the residual than a single skeptic, at controlled FP.
+    const defects = items.filter((i) => !i.is_clean);
+    const controls = items.filter((i) => i.is_clean);
+    const neutralCatch = new Set(['sec-01', 'sec-02', 'inv-01', 'inv-02', 'state-03', 'mfi-01']); // 6 caught neutrally
+    // residual = the other 6: sec-03, inv-03, state-01, state-02, mfi-02, mfi-03
+    const anthropicSkepticCatch = new Set(['sec-03', 'state-01']); // single skeptic recovers 2/6
+    const openaiSkepticExtra = new Set(['inv-03', 'mfi-02', 'mfi-03']); // openai adds 3 more → panel 5/6
+    const hit = (i: CorpusItem, m: string): Finding[] => [
+        { file: i.ground_truth.defect_files[0] ?? i.files[0].path, category: i.defect_category, confidence: 'high' as const },
+    ].filter(() => true).map((f) => ({ ...f, _m: m })).map(({ _m, ...f }) => f);
+    const neutral: Reviews = {};
+    for (const d of defects) neutral[d.id] = { anthropic: neutralCatch.has(d.id) ? hit(d, 'a') : [], openai: [] };
+    const skeptic: Reviews = {};
+    const residual = defects.filter((d) => !neutralCatch.has(d.id));
+    for (const d of residual) {
+        skeptic[d.id] = {
+            anthropic: anthropicSkepticCatch.has(d.id) ? hit(d, 'a') : [],
+            openai: openaiSkepticExtra.has(d.id) ? hit(d, 'o') : [],
+        };
+    }
+    for (const c of controls) skeptic[c.id] = { anthropic: [], openai: c.id === 'clean-02' ? [{ file: c.files[0].path, category: 'correctness', confidence: 'high' }] : [] };
+    return { neutral, skeptic, residualIds: residual.map((r) => r.id) };
+}
+
+function scorePasses(items: CorpusItem[], p: Passes): { inputs: CouncilBenchInputs; detail: Record<string, unknown> } {
+    const byId = new Map(items.map((i) => [i.id, i]));
+    const residual = p.residualIds.map((id) => byId.get(id)!);
+    const controls = items.filter((i) => i.is_clean);
+
+    const singleCaught: Record<string, boolean> = {};
+    const panelCaught: Record<string, boolean> = {};
+    for (const d of residual) {
+        const gt = groundTruth(d);
+        singleCaught[d.id] = caughtDefect(gt, p.skeptic[d.id]?.[SINGLE_SKEPTIC] ?? []);
+        panelCaught[d.id] = caughtDefect(gt, Object.values(p.skeptic[d.id] ?? {}).flat());
+    }
+    const singleFp: Record<string, boolean> = {};
+    const panelFp: Record<string, boolean> = {};
+    for (const c of controls) {
+        const gt = groundTruth(c);
+        singleFp[c.id] = isFalsePositive(gt, p.skeptic[c.id]?.[SINGLE_SKEPTIC] ?? []);
+        panelFp[c.id] = isFalsePositive(gt, Object.values(p.skeptic[c.id] ?? {}).flat());
+    }
+    const inputs: CouncilBenchInputs = {
+        single_judge_residual_recall: recall(singleCaught),
+        panel_residual_recall: recall(panelCaught),
+        single_judge_fp_rate: fpRate(singleFp),
+        panel_fp_rate: fpRate(panelFp),
+        fp_noise_margin: 1 / 3,
+    };
+    const detail = {
+        total_defects: items.filter((i) => !i.is_clean).length,
+        residual_ids: p.residualIds,
+        residual_size: residual.length,
+        single_skeptic: SINGLE_SKEPTIC,
+        single_residual_caught: Object.entries(singleCaught).filter(([, v]) => v).map(([k]) => k),
+        panel_residual_caught: Object.entries(panelCaught).filter(([, v]) => v).map(([k]) => k),
+        single_fp: Object.entries(singleFp).filter(([, v]) => v).map(([k]) => k),
+        panel_fp: Object.entries(panelFp).filter(([, v]) => v).map(([k]) => k),
+    };
+    return { inputs, detail };
+}
+
+async function main(argv: string[]): Promise<number> {
+    const mock = argv.includes('--mock');
+    const run = argv.includes('--run');
+    if (!mock && !run) {
+        process.stderr.write('usage: bench_adversarial_council (--mock | --run)\n');
+        return 2;
+    }
+    const items = loadCorpus();
+    const passes = mock ? mockPasses(items) : await realPasses(items);
+    const { inputs, detail } = scorePasses(items, passes);
+    const verdict = evaluateCouncilBench(inputs);
+    const report = {
+        mode: mock ? 'mock' : 'run',
+        corpus: 'internal/bench/adversarial-council/corpus.json',
+        protocol:
+            'stage1 2-vendor neutral → residual (missed by both); stage2 single skeptic (anthropic) vs cross-vendor panel union on residual; FP on clean controls',
+        inputs,
+        detail,
+        verdict,
+    };
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    void main(process.argv.slice(2)).then((code) => process.exit(code));
+}
+
+export { parseFindings, scorePasses, main };

--- a/src/scripts/bench_adversarial_council.ts
+++ b/src/scripts/bench_adversarial_council.ts
@@ -49,7 +49,6 @@ import {
     type Finding,
     type GroundTruth,
 } from './_lib/adversarial_bench_score.js';
-import { hardenedSpawnEnv } from './_lib/spawn_env.js';
 
 const REPO_ROOT = process.cwd();
 const CORPUS_PATH = path.join(REPO_ROOT, 'internal/bench/adversarial-council/corpus.json');
@@ -182,15 +181,15 @@ async function realPasses(items: CorpusItem[]): Promise<Passes> {
     process.stderr.write('stage 1 (neutral, independent per vendor) over 12 defects…\n');
     for (const d of defects) {
         neutral[d.id] = await directReview(d, neutralPrompt(d));
-        process.stderr.write(`  neutral ${d.id}: ${Object.entries(neutral[d.id]).map(([m, f]) => `${m}=${f.length}`).join(' ')}\n`);
+        process.stderr.write(`  neutral ${d.id}: ${Object.entries(neutral[d.id] ?? {}).map(([m, f]) => `${m}=${f.length}`).join(' ')}\n`);
     }
-    const residual = defects.filter((d) => !Object.values(neutral[d.id]).flat().some((f) => caughtDefect(groundTruth(d), [f])));
+    const residual = defects.filter((d) => !Object.values(neutral[d.id] ?? {}).flat().some((f) => caughtDefect(groundTruth(d), [f])));
     process.stderr.write(`residual (missed by BOTH neutral passes): ${residual.map((r) => r.id).join(', ') || '(none)'}\n`);
     const skeptic: Reviews = {};
     process.stderr.write('stage 2 (adversarial skeptic, independent per vendor) over residual + controls…\n');
     for (const item of [...residual, ...controls]) {
         skeptic[item.id] = await directReview(item, skepticPrompt(item));
-        process.stderr.write(`  skeptic ${item.id}: ${Object.entries(skeptic[item.id]).map(([m, f]) => `${m}=${f.length}`).join(' ')}\n`);
+        process.stderr.write(`  skeptic ${item.id}: ${Object.entries(skeptic[item.id] ?? {}).map(([m, f]) => `${m}=${f.length}`).join(' ')}\n`);
     }
     return { neutral, skeptic, residualIds: residual.map((r) => r.id) };
 }
@@ -205,20 +204,21 @@ function mockPasses(items: CorpusItem[]): Passes {
     // residual = the other 6: sec-03, inv-03, state-01, state-02, mfi-02, mfi-03
     const anthropicSkepticCatch = new Set(['sec-03', 'state-01']); // single skeptic recovers 2/6
     const openaiSkepticExtra = new Set(['inv-03', 'mfi-02', 'mfi-03']); // openai adds 3 more → panel 5/6
-    const hit = (i: CorpusItem, m: string): Finding[] => [
-        { file: i.ground_truth.defect_files[0] ?? i.files[0].path, category: i.defect_category, confidence: 'high' as const },
-    ].filter(() => true).map((f) => ({ ...f, _m: m })).map(({ _m, ...f }) => f);
+    const hit = (i: CorpusItem): Finding[] => [
+        { file: i.ground_truth.defect_files[0] ?? i.files[0]?.path ?? '', category: i.defect_category, confidence: 'high' as const },
+    ];
     const neutral: Reviews = {};
-    for (const d of defects) neutral[d.id] = { anthropic: neutralCatch.has(d.id) ? hit(d, 'a') : [], openai: [] };
+    for (const d of defects) neutral[d.id] = { anthropic: neutralCatch.has(d.id) ? hit(d) : [], openai: [] };
     const skeptic: Reviews = {};
     const residual = defects.filter((d) => !neutralCatch.has(d.id));
     for (const d of residual) {
         skeptic[d.id] = {
-            anthropic: anthropicSkepticCatch.has(d.id) ? hit(d, 'a') : [],
-            openai: openaiSkepticExtra.has(d.id) ? hit(d, 'o') : [],
+            anthropic: anthropicSkepticCatch.has(d.id) ? hit(d) : [],
+            openai: openaiSkepticExtra.has(d.id) ? hit(d) : [],
         };
     }
-    for (const c of controls) skeptic[c.id] = { anthropic: [], openai: c.id === 'clean-02' ? [{ file: c.files[0].path, category: 'correctness', confidence: 'high' }] : [] };
+    for (const c of controls)
+        skeptic[c.id] = { anthropic: [], openai: c.id === 'clean-02' ? [{ file: c.files[0]?.path ?? '', category: 'correctness', confidence: 'high' }] : [] };
     return { neutral, skeptic, residualIds: residual.map((r) => r.id) };
 }
 

--- a/tests/lib/adversarial_bench_score.test.ts
+++ b/tests/lib/adversarial_bench_score.test.ts
@@ -1,0 +1,103 @@
+// Synthetic pre-validation of the residual-detection scorer, BEFORE any paid
+// model call (road-to-adversarial-council-benchmark Phase 1; the review-#7 /
+// defect-finding-benchmark lesson: prove the scorer red/green on known
+// hit/miss/wrong-file/wrong-category/clean outputs first, or the paid run is a
+// measurement artifact). No model calls here — pure fixtures.
+import { describe, expect, it } from 'vitest';
+
+import {
+    categoryFamily,
+    caughtDefect,
+    isFalsePositive,
+    recall,
+    fpRate,
+    type GroundTruth,
+    type Finding,
+} from '../../src/scripts/_lib/adversarial_bench_score.js';
+
+const defect: GroundTruth = {
+    id: 'sec-01',
+    is_clean: false,
+    defect_files: ['documentShare.ts'],
+    defect_category: 'access-control',
+};
+const multiFile: GroundTruth = {
+    id: 'mfi-02',
+    is_clean: false,
+    defect_files: ['idempotency.ts', 'webhook.ts'],
+    defect_category: 'concurrency',
+};
+const clean: GroundTruth = { id: 'clean-01', is_clean: true, defect_files: [], defect_category: 'none' };
+
+describe('categoryFamily normalization', () => {
+    it('maps synonyms to families', () => {
+        expect(categoryFamily('IDOR')).toBe('access-control');
+        expect(categoryFamily('Broken Access Control')).toBe('access-control');
+        expect(categoryFamily('BOLA / ownership')).toBe('access-control');
+        expect(categoryFamily('race condition')).toBe('concurrency');
+        expect(categoryFamily('non-atomic idempotency')).toBe('concurrency');
+        expect(categoryFamily('SSRF')).toBe('ssrf');
+        expect(categoryFamily('path traversal')).toBe('path-traversal');
+        expect(categoryFamily('resource leak')).toBe('resource-leak');
+        expect(categoryFamily('off-by-one')).toBe('correctness');
+        expect(categoryFamily('something vague')).toBe('other');
+    });
+});
+
+describe('caughtDefect — the matching rule (file + category family, NOT exact line)', () => {
+    it('CATCHES: right file basename + right category family, any path form, any/no line', () => {
+        const f: Finding[] = [{ file: 'src/routes/documentShare.ts', category: 'Broken Access Control' }];
+        expect(caughtDefect(defect, f)).toBe(true);
+    });
+    it('CATCHES even when the model cites a different line / path prefix (the last-bench bug fix)', () => {
+        // last time an exact file:line token was required and mis-scored real catches.
+        const f: Finding[] = [{ file: 'documentShare.ts', category: 'authorization bug' }];
+        expect(caughtDefect(defect, f)).toBe(true);
+    });
+    it('MISS: no finding at all', () => {
+        expect(caughtDefect(defect, [])).toBe(false);
+    });
+    it('NO CREDIT: right file, WRONG category family', () => {
+        const f: Finding[] = [{ file: 'src/routes/documentShare.ts', category: 'performance' }];
+        expect(caughtDefect(defect, f)).toBe(false);
+    });
+    it('NO CREDIT: right category, WRONG file (scattershot)', () => {
+        const f: Finding[] = [{ file: 'src/other.ts', category: 'access control' }];
+        expect(caughtDefect(defect, f)).toBe(false);
+    });
+    it('multi-file: matching EITHER involved file counts', () => {
+        expect(caughtDefect(multiFile, [{ file: 'src/webhook.ts', category: 'race' }])).toBe(true);
+        expect(caughtDefect(multiFile, [{ file: 'src/idempotency.ts', category: 'non-atomic' }])).toBe(true);
+    });
+    it('clean control never "catches" (use isFalsePositive instead)', () => {
+        expect(caughtDefect(clean, [{ file: 'src/resolve-config.ts', category: 'correctness' }])).toBe(false);
+    });
+});
+
+describe('isFalsePositive — clean controls only', () => {
+    it('FP when any high/medium-confidence finding is raised on the clean file', () => {
+        expect(isFalsePositive(clean, [{ file: 'src/resolve-config.ts', category: 'correctness' }])).toBe(true);
+    });
+    it('NO FP when the reviewer raises nothing on the clean control', () => {
+        expect(isFalsePositive(clean, [])).toBe(false);
+    });
+    it('low-confidence hedges are NOT counted as a false positive', () => {
+        expect(
+            isFalsePositive(clean, [{ file: 'src/resolve-config.ts', category: 'style', confidence: 'low' }]),
+        ).toBe(false);
+    });
+    it('defect fixtures never register a false positive', () => {
+        expect(isFalsePositive(defect, [{ file: 'src/routes/documentShare.ts', category: 'access-control' }])).toBe(false);
+    });
+});
+
+describe('recall + fpRate aggregation', () => {
+    it('recall = caught / total defects', () => {
+        expect(recall({ a: true, b: false, c: true, d: false })).toBe(0.5);
+        expect(recall({})).toBe(0);
+    });
+    it('fpRate = fp controls / total controls', () => {
+        expect(fpRate({ c1: false, c2: false, c3: true })).toBeCloseTo(1 / 3, 6);
+        expect(fpRate({})).toBe(0);
+    });
+});


### PR DESCRIPTION
## What

Resolves the pre-registered `adversarial-council-finding-coverage` claim (ADR-122) that was blocked on a corpus + a spend-gated run. Both gates cleared this turn (maintainer authorized the paid cross-vendor run).

**Phase 1 — corpus + harness (reusable):**
- `internal/bench/adversarial-council/corpus.json`: 12 judge-survivable planted-defect fixtures (multi-file-interaction / logic-inversion / security-masked / complex-state, 3 each) + 3 controversial-but-correct clean controls; ground truth separated from shown code; **subtlety distribution published**; **passed an independent validity audit** (one fixture, state-03, repaired to a single correctly-triggered defect before the run).
- `adversarial_bench_score.ts` — pure file+category-family scorer (NOT exact file:line — the defect-finding-benchmark scorer bug), with a synthetic red/green test **proven before any paid call** (it caught + fixed a category-family substring bug pre-spend).
- `bench_adversarial_council.ts` — two-stage runner via **direct independent per-vendor client calls** + a `--mock` pipeline pre-validation path.

**Phase 2 — registered cross-vendor run (anthropic `claude-sonnet-4-5` + openai `gpt-4o`):**

| quantity | value |
|---|--:|
| judge-passed residual pool | 5–7 (missed by both neutral passes) |
| single-skeptic residual recall | 0.60 |
| 2-vendor panel residual recall | **0.60 (zero lift)** |
| single-skeptic / panel FP on clean controls | **1.00 / 1.00** |

## Verdict: HONEST NULL

The 2-vendor panel matched the single skeptic exactly (the second vendor's residual catches were a strict subset of the first's), and both false-flagged **all three** controversial-but-correct controls under the adversarial-skeptic posture. Both locked recall thresholds (+25% rel, +8 pp abs) missed → **honest-null → Mode 9 `adversarial-verification-council` stays default-off permanently** (like recursive-verification). Stable across two runs. Recorded in `docs/CLAIMS.md`, `docs/benchmark.md`, and an ADR-122 addendum; reproducible artifact under `internal/bench/adversarial-council/runs/`.

## Transport lesson (durable)

An initial run via `council_cli run` was **rejected as a measurement artifact**: that transport runs multi-round peer-review with cross-member visibility and returns prose ("Round 2 … Reviewer A"), which violates the independent-skeptic requirement and defeats JSON scoring. The valid run uses direct, isolated per-vendor client calls with a strict-JSON contract. No false `backed` was recorded — the artifact run was discarded, honoring the claim's Iron Law.

## Not in this PR

Option 1 (a real npm release) is a distinct, irreversible Hard-Floor operation — see the chat summary; it is not folded into this benchmark PR.
