### PR TITLE
fix(release): non-fatal tag-workflow dispatch + document actions:write scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,17 @@ name: Release
 #
 # Token: uses secrets.RELEASE_PR_TOKEN when configured (a fine-grained PAT
 # or GitHub App installation token with contents:write + pull-requests:write
-# on this repo), falling back to the default GITHUB_TOKEN.
+# + actions:write on this repo), falling back to the default GITHUB_TOKEN.
+# actions:write ("Actions: read and write" on a fine-grained PAT, or the
+# "workflow" scope on a classic PAT) is required for step 9's explicit
+# dispatch of the tag-triggered workflows (release-guard / publish-npm /
+# cloud-release); WITHOUT it that dispatch returns HTTP 403. It is non-fatal
+# (the release is already complete by then, and a PAT-pushed tag fires those
+# workflows on the push anyway — see release.ts step 9), but the run's log
+# will carry a warning until the scope is granted.
 #
-#   - With RELEASE_PR_TOKEN: fully unattended end-to-end.
+#   - With RELEASE_PR_TOKEN (contents + pull-requests + actions): fully
+#     unattended end-to-end.
 #   - Without it (default): GitHub's bot-created-PR safeguard (introduced
 #     2026-06-11) queues the release PR's checks — including the required
 #     "Sync + Generate Tools Consistency" check — in an approval-required

--- a/docs/decisions/ADR-113-ci-native-release-label-trigger.md
+++ b/docs/decisions/ADR-113-ci-native-release-label-trigger.md
@@ -112,9 +112,17 @@ maintainer approves the run once per release.
   on deploys, a single human checkpoint before a release's own CI even
   runs is arguably a feature, not friction.
 - `RELEASE_PR_TOKEN` (a fine-grained PAT or GitHub App installation
-  token with `contents: write` + `pull-requests: write` on this repo)
-  removes the approval requirement entirely — documented as the
-  zero-friction upgrade path in `release.yml`'s header comment. Adding
+  token with `contents: write` + `pull-requests: write` + `actions: write`
+  on this repo) removes the approval requirement entirely — documented as
+  the zero-friction upgrade path in `release.yml`'s header comment. The
+  `actions: write` scope ("Actions: read and write" on a fine-grained PAT,
+  or the classic `workflow` scope) is required by release.ts step 9's
+  explicit `gh workflow run` dispatch of the tag-triggered workflows
+  (release-guard / publish-npm / cloud-release); without it that dispatch
+  returns HTTP 403. As of 2026-07-21 that dispatch is **non-fatal** — the
+  release is already complete when it runs, and a PAT-pushed tag fires
+  those workflows on the push regardless — so a missing scope degrades to
+  a logged warning, never a failed-but-shipped release. Adding
   it is a maintainer action, not part of this ADR.
 
 ## Verified facts (not assumed)

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -1451,9 +1451,30 @@ function execute(
         // publish that already happened.
         if (ci) {
             _step(9, total, 'Dispatch release-guard.yml + publish-npm.yml + cloud-release.yml for the tag');
-            run(['gh', 'workflow', 'run', 'release-guard.yml', '--ref', MAIN_BRANCH, '-f', `tag=${plan.target}`]);
-            run(['gh', 'workflow', 'run', 'publish-npm.yml', '--ref', MAIN_BRANCH, '-f', `tag=${plan.target}`]);
-            run(['gh', 'workflow', 'run', 'cloud-release.yml', '--ref', MAIN_BRANCH, '-f', `tag=${plan.target}`]);
+            // NON-FATAL by design. By this point the release is already complete
+            // — the tag is pushed and the GitHub Release is created above, and
+            // npm publish runs asynchronously. These explicit dispatches are a
+            // FALLBACK for a tag pushed with the default GITHUB_TOKEN, which does
+            // NOT fire tag-triggered workflows (GitHub's recursion guard). When
+            // the tag was pushed with a PAT (RELEASE_PR_TOKEN), those three
+            // workflows already fired on the push and this dispatch is redundant.
+            // Dispatching via the API additionally needs the token's
+            // `actions:write` scope; a 403 here (scope missing) must NOT mark an
+            // already-shipped release as failed — warn and continue.
+            for (const wf of ['release-guard.yml', 'publish-npm.yml', 'cloud-release.yml']) {
+                const r = run(['gh', 'workflow', 'run', wf, '--ref', MAIN_BRANCH, '-f', `tag=${plan.target}`], {
+                    check: false,
+                });
+                if (r.returncode !== 0) {
+                    process.stderr.write(
+                        `⚠️  Could not dispatch ${wf} (exit ${r.returncode}) — the release ${plan.target} is ` +
+                            `already complete (tag + GitHub Release created; npm publishes async). If the tag was ` +
+                            `pushed with a PAT, ${wf} already fired on the tag push. If you rely on the explicit ` +
+                            `dispatch, grant RELEASE_PR_TOKEN the "Actions: read and write" scope (fine-grained PAT) ` +
+                            `or the "workflow" scope (classic PAT).\n`,
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What

Fixes the "successful release reports failure" bug seen on the 9.7.0 run. The release shipped correctly (npm `latest` = 9.7.0, tag + GitHub Release created), but `release.ts` step 9 threw on the **final** step — dispatching the tag-triggered workflows:

```
gh workflow run release-guard.yml --ref main -f tag=9.7.0
→ HTTP 403: Resource not accessible by personal access token
```

## Root cause

`RELEASE_PR_TOKEN` **was** active (PR #990 auto-merged with no approval click), but its scope was `contents:write` + `pull-requests:write` — enough to create/merge the PR, push the tag, and cut the GitHub Release, but **not** to dispatch another workflow. `gh workflow run` (the `actions/workflows/*/dispatches` API) needs `actions:write`. So the dispatch 403'd — **after** the release was already complete.

## Fix

- **Non-fatal dispatch (release.ts step 9):** the three `gh workflow run` calls (release-guard / publish-npm / cloud-release) switch from a throwing `run()` to `run(..., { check: false })` + a warning that names the missing scope. Rationale: by step 9 the release is done (tag pushed, Release created, npm publishes async), and a **PAT-pushed tag fires those workflows on the push regardless** — the explicit dispatch is only a fallback for a `GITHUB_TOKEN`-pushed tag. A 403 there must never mark an already-shipped release as failed.
- **Documentation:** `release.yml` header + ADR-113 now state the token needs `contents:write` + `pull-requests:write` + **`actions:write`** ("Actions: read and write" fine-grained / `workflow` classic).

## Note

The maintainer has already granted `RELEASE_PR_TOKEN` the `actions:write` scope, so future releases dispatch the guard cleanly **and** never false-fail if the scope is ever missing again. 9.7.0 itself is live and correct — this only fixes the run-status reporting + hardening.

## Verification

- `tsc` clean on `release.ts`; no test asserts the dispatch chain.
- Pre-push static + consistency gates green.
