### PR TITLE
feat(install): restart/launch the GUI on a global (re)install

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
         "test:ts": "vitest run",
         "prepack": "npm run build && npm run build:discovery && npm run build:mcp-manifest && node src/scripts/prepack-check.mjs",
         "prepublishOnly": "./scripts-run src/scripts/check_release_includes_discovery",
-        "prepare": "[ -d .git ] && bash src/scripts/install-hooks.sh || true"
+        "prepare": "[ -d .git ] && bash src/scripts/install-hooks.sh || true",
+        "postinstall": "node dist/scripts/postinstall_gui.js 2>/dev/null || true"
     },
     "publishConfig": {
         "access": "public",

--- a/src/scripts/postinstall_gui.ts
+++ b/src/scripts/postinstall_gui.ts
@@ -21,12 +21,45 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-import { isHeadless } from '../cli/commands/uiServe.js';
-import { readServerInfo, clearServerInfo } from '../server/serverInfo.js';
+// NB: this file ships as SOURCE under `src/scripts/` (package.json `files`), so
+// it must import ONLY node builtins — a cross-dir import into src/cli or
+// src/server (not in the `files` whitelist) would fail the prepack-check and
+// crash a source run with ERR_MODULE_NOT_FOUND. The two helpers below are
+// therefore inlined from their canonical homes (kept trivially in sync):
+//   isHeadless()  — mirror of src/cli/commands/uiServe.ts
+//   serverInfo    — mirror of src/server/serverInfo.ts (path + pid read + clear)
+
+/** Mirror of `src/cli/commands/uiServe.ts` isHeadless(). */
+function isHeadless(): boolean {
+    if (process.env['SSH_CONNECTION']) return true;
+    if (process.platform === 'linux' && !process.env['DISPLAY']) return true;
+    return false;
+}
+
+/** Mirror of `src/server/serverInfo.ts` — the on-disk running-server record. */
+function serverInfoPath(): string {
+    return resolve(homedir(), '.event4u', 'agent-config', 'local-server.json');
+}
+function readServerPid(): number | null {
+    try {
+        const parsed = JSON.parse(readFileSync(serverInfoPath(), 'utf8')) as { pid?: unknown };
+        return typeof parsed.pid === 'number' ? parsed.pid : null;
+    } catch {
+        return null;
+    }
+}
+function clearServerInfo(): void {
+    try {
+        rmSync(serverInfoPath(), { force: true });
+    } catch {
+        /* best-effort */
+    }
+}
 
 export interface LaunchEnv {
     npm_config_global?: string | undefined;
@@ -50,16 +83,16 @@ export function shouldPostinstallLaunchGui(env: LaunchEnv, headless: boolean): b
 
 /** Terminate a previously-recorded live server instance, if any. Best-effort. */
 function terminatePreviousInstance(): void {
-    const info = readServerInfo();
-    if (!info) return;
+    const pid = readServerPid();
+    if (pid === null) return;
     try {
-        process.kill(info.pid, 0); // liveness probe — throws if the process is gone
+        process.kill(pid, 0); // liveness probe — throws if the process is gone
     } catch {
         clearServerInfo(); // stale record — nothing to kill
         return;
     }
     try {
-        process.kill(info.pid, 'SIGTERM');
+        process.kill(pid, 'SIGTERM');
     } catch {
         // already exiting / not ours — leave the record for the new instance to overwrite
         return;

--- a/src/scripts/postinstall_gui.ts
+++ b/src/scripts/postinstall_gui.ts
@@ -1,0 +1,96 @@
+/**
+ * npm `postinstall` entry — on a GLOBAL (re)install of this package, terminate a
+ * running local GUI server (if one is live) and start a fresh one, so the GUI a
+ * user has open picks up the just-installed version.
+ *
+ * Requested behaviour (2026-07-22): on `npm i -g @event4u/agent-config@latest`
+ * in an interactive desktop context, restart the GUI — killing any running
+ * instance first; and if none was running, still start it. In CI / headless /
+ * non-global / opted-out contexts, do nothing.
+ *
+ * Safety contract (a postinstall must never break `npm install`):
+ *   - Every path exits 0. Any error is swallowed. The package.json hook also
+ *     appends `|| true` and silences stderr, so a not-yet-built dist during the
+ *     repo's own `npm ci` (dist/scripts/postinstall_gui.js absent) is a no-op.
+ *   - The GUI is spawned DETACHED + unref'd so npm does not hang on it.
+ *   - Gated to GLOBAL installs only (`npm_config_global`), so installing this
+ *     package as a transitive dependency never launches a browser.
+ *   - TTY is deliberately NOT required: npm does not give lifecycle scripts a
+ *     TTY, so requiring one would suppress the GUI on every real terminal
+ *     install. The reliable non-interactive signals are CI / headless / opt-out.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { isHeadless } from '../cli/commands/uiServe.js';
+import { readServerInfo, clearServerInfo } from '../server/serverInfo.js';
+
+export interface LaunchEnv {
+    npm_config_global?: string | undefined;
+    CI?: string | undefined;
+    AGENT_CONFIG_NO_UI?: string | undefined;
+}
+
+/**
+ * Pure gate: should the postinstall (re)start the GUI? True only for a global
+ * install on a non-CI, non-opted-out, non-headless host. `headless` is passed in
+ * (from `isHeadless()`) to keep this unit-testable without env/platform mocking.
+ */
+export function shouldPostinstallLaunchGui(env: LaunchEnv, headless: boolean): boolean {
+    const truthy = (v: string | undefined): boolean => v !== undefined && v.trim() !== '' && v.trim() !== '0';
+    if (!truthy(env.npm_config_global)) return false; // only global installs
+    if (truthy(env.CI)) return false; // never in CI
+    if (truthy(env.AGENT_CONFIG_NO_UI)) return false; // explicit opt-out
+    if (headless) return false; // SSH / no-DISPLAY
+    return true;
+}
+
+/** Terminate a previously-recorded live server instance, if any. Best-effort. */
+function terminatePreviousInstance(): void {
+    const info = readServerInfo();
+    if (!info) return;
+    try {
+        process.kill(info.pid, 0); // liveness probe — throws if the process is gone
+    } catch {
+        clearServerInfo(); // stale record — nothing to kill
+        return;
+    }
+    try {
+        process.kill(info.pid, 'SIGTERM');
+    } catch {
+        // already exiting / not ours — leave the record for the new instance to overwrite
+        return;
+    }
+    clearServerInfo();
+}
+
+/** Spawn the config GUI detached so npm returns immediately. */
+function launchGuiDetached(): void {
+    const here = dirname(fileURLToPath(import.meta.url)); // dist/scripts
+    const bin = resolve(here, '..', 'cli', 'agent-config.js'); // dist/cli/agent-config.js
+    if (!existsSync(bin)) return; // built artefact missing (dev npm ci before build) — no-op
+    const child = spawn(process.execPath, [bin, 'config'], {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+    });
+    child.unref();
+}
+
+export function main(env: LaunchEnv = process.env): number {
+    try {
+        if (!shouldPostinstallLaunchGui(env, isHeadless())) return 0;
+        terminatePreviousInstance();
+        launchGuiDetached();
+    } catch {
+        // A postinstall must never fail the install.
+    }
+    return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    process.exit(main());
+}

--- a/tests/scripts/postinstall_gui.test.ts
+++ b/tests/scripts/postinstall_gui.test.ts
@@ -1,0 +1,38 @@
+// Gate for the postinstall GUI (re)start. The gate is the risk surface — a
+// wrong "true" launches a browser in CI / as a transitive dependency. Cover the
+// launch decision exhaustively; the kill + detached-spawn are side-effectful and
+// out of scope for a unit test.
+import { describe, expect, it } from 'vitest';
+
+import { shouldPostinstallLaunchGui } from '../../src/scripts/postinstall_gui.js';
+
+describe('shouldPostinstallLaunchGui', () => {
+    it('launches on a global, interactive-context, non-CI, non-headless install', () => {
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true' }, false)).toBe(true);
+    });
+
+    it('does NOT launch when not a global install (transitive dependency)', () => {
+        expect(shouldPostinstallLaunchGui({ npm_config_global: '' }, false)).toBe(false);
+        expect(shouldPostinstallLaunchGui({ npm_config_global: undefined }, false)).toBe(false);
+        expect(shouldPostinstallLaunchGui({ npm_config_global: '0' }, false)).toBe(false);
+        expect(shouldPostinstallLaunchGui({}, false)).toBe(false);
+    });
+
+    it('does NOT launch in CI', () => {
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true', CI: 'true' }, false)).toBe(false);
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true', CI: '1' }, false)).toBe(false);
+    });
+
+    it('treats CI=0 / CI="" as not-CI (still launches)', () => {
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true', CI: '0' }, false)).toBe(true);
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true', CI: '' }, false)).toBe(true);
+    });
+
+    it('does NOT launch when opted out via AGENT_CONFIG_NO_UI', () => {
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true', AGENT_CONFIG_NO_UI: '1' }, false)).toBe(false);
+    });
+
+    it('does NOT launch on a headless host (SSH / no DISPLAY)', () => {
+        expect(shouldPostinstallLaunchGui({ npm_config_global: 'true' }, true)).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

On `npm i -g @event4u/agent-config@latest` (the package name — note it's `agent-config`, not `agent-switch`), (re)start the local GUI so a running instance picks up the new version:

- **A GUI is running** → terminate it (SIGTERM) → start a fresh one on the new version.
- **None running** → still start it.
- **CI / headless / non-global / opted-out** → do nothing.

## How

New `src/scripts/postinstall_gui.ts` wired as the `postinstall` hook:

- **Gate** `shouldPostinstallLaunchGui(env, headless)` (pure, unit-tested):
  - global-only via `npm_config_global` — never launches when installed as a **transitive dependency**;
  - not CI (`CI`), not headless (`isHeadless()` — SSH / no-DISPLAY), opt-out via `AGENT_CONFIG_NO_UI`;
  - **TTY deliberately not required** — npm gives lifecycle scripts no TTY, so requiring one would suppress the GUI on every real terminal install. The reliable non-interactive signals are CI / headless / opt-out.
- **Terminate previous:** `readServerInfo()` (the existing `~/.event4u/agent-config/local-server.json` record) → liveness probe `kill(pid,0)` → `SIGTERM` → `clearServerInfo()`.
- **Launch detached:** spawns `agent-config config` with `detached + stdio:'ignore' + unref()` so **npm never hangs** on it.
- **Never fails the install:** every path returns 0, and the hook is `node dist/scripts/postinstall_gui.js 2>/dev/null || true` so a not-yet-built dist during the repo's own `npm ci` is a silent no-op.

## Reuses existing building blocks

`serverInfo.ts` already records the running server's pid/port expressly so "a fresh launch can find and terminate a previous instance"; `isHeadless()` already encapsulates the headless gate. This wires them to the global-install lifecycle.

## Verification + caveats

- Gate unit test: 6/6 (global / non-global / CI / CI=0-is-not-CI / opt-out / headless). `tsc` clean; import has no side effects (entry guard).
- **Full end-to-end (an actual `npm i -g`) can't be exercised in CI** — the gate (the real risk surface: a wrong launch in CI or as a transitive dep) is what's unit-verified. Recommend one manual `npm i -g …@latest` on a dev machine to confirm the detached launch + browser-open.
- GUI target is the **config GUI** (`config`) — trivially changeable to `setup`/wizard if you'd rather it re-land on onboarding.
- Opt-out: `AGENT_CONFIG_NO_UI=1 npm i -g …` suppresses the launch.
