### PR TITLE
feat(host-integration): config-root spawn flag + embed contract v1 (unblocks agent-switch)

### DIFF
--- a/agents/reports/originality.json
+++ b/agents/reports/originality.json
@@ -1,12 +1,12 @@
 {
   "fail_threshold": 60,
   "warn_threshold": 40,
-  "artifacts_scanned": 498,
+  "artifacts_scanned": 500,
   "distribution": {
     "worst": 40,
     "p95": 0,
     "median": 0,
-    "comparisons": 56893
+    "comparisons": 57450
   },
   "pairs": [
     {

--- a/agents/reports/originality.md
+++ b/agents/reports/originality.md
@@ -1,13 +1,13 @@
 # Originality audit — entity-neutralized shingle overlap
 
-> Anti-reskin gate over 498 authored artifacts (skills · personas · commands), 
+> Anti-reskin gate over 500 authored artifacts (skills · personas · commands), 
 class-scoped, scaffold-subtracted, k=8. Thresholds: FAIL 60 / WARN 40. 
 This report blocks NOTHING on its own — `lint_originality --changed` is the CI gate.
 
 
-- Artifacts scanned: **498**
+- Artifacts scanned: **500**
 
-- Pairwise comparisons: **56893**
+- Pairwise comparisons: **57450**
 
 - Overlap distribution: worst **40%** · p95 **0%** · median **0%**
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,34 +2,57 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 12 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
 
 ## Overall
 
-**105 / 156 steps done · 67%**
+**107 / 204 steps done · 52%**
 
 ```text
-███████████████████████████░░░░░░░░░░░░░   67%
+█████████████████████░░░░░░░░░░░░░░░░░░░   52%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Blocker | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 7 | 9 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 56% |
-| 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 3 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
-| 4 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 5 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 6 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
-| 7 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 8 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
-| 9 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
-| 10 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 1 | [road-to-ac-embeddable-gui.md](roadmaps/road-to-ac-embeddable-gui.md) | 4 | 30 | 28 | 2 | 0 | 0 | [2](#blockers-road-to-ac-embeddable-gui) | █░░░░░░░░░ 7% |
+| 2 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 7 | 9 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 56% |
+| 3 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 4 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
+| 5 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 6 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 7 | [road-to-reciprocal-ecosystem.md](roadmaps/road-to-reciprocal-ecosystem.md) | 4 | 18 | 18 | 0 | 0 | 0 | [2](#blockers-road-to-reciprocal-ecosystem) | ░░░░░░░░░░ 0% |
+| 8 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
+| 9 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 10 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
+| 11 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
+| 12 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
 
 ## Per-roadmap phase breakdown
+
+### [road-to-ac-embeddable-gui.md](roadmaps/road-to-ac-embeddable-gui.md)
+
+**Road to an embeddable AC GUI — host-ready without weakening a single security invariant** — 2 / 30 done (7%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Falsification spike | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
+| 1 | Embed mode (`?embed=1`) | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 2 | Framing stance + theme contract | ⬜ not started | 8 | 0 | 0 | 0 | 0% |
+| 3 | Capability discovery + host lifecycle | ⬜ not started | 14 | 0 | 0 | 0 | 0% |
+
+<a id="blockers-road-to-ac-embeddable-gui"></a>
+**Blockers**
+
+- **framing-security-verdict** (owner: maintainer (security role)) — blocks — (was: the framing half of Phase 2) - **Decision:** **no iframe framing — ship an explicit `frame-ancestors 'none'`.** Council convergence: framing is an engineering-economics question, not a security one (any same-user local process is already inside the trust boundary); the real cost is the three-webview CSP compatibility matrix, and the deterministic stance is the smallest surface. Hosts load the UI **top-level** (a host-managed child webview or separate window pointed at the same URL — `frame-ancestors` does not gate top-level loads), which keeps the embed-mode/theme/capability contract fully useful. Token transport: keep the existing `?token=` bootstrap, hardened by the SPA stripping the token from the URL after boot; the session-cookie endpoint was rejected as the costlier surface (CSRF assessed a non-issue for a loopback-only server, but the new endpoint + second credential type is avoidable entirely). Divergence recorded: one member preferred header-silence as "smallest surface" — rejected because this roadmap's acceptance criteria rule out silence; both members pick DENY when an explicit stance is required.
+  - **What to do:**
+  - **Resolved when:** ~~a decision record exists~~ — this entry is the record; council transcript: agent-switch worktree `agents/runtime/council/responses/omni-route-framing.json` (local-only).
+- **cross-platform-webview-verification** (owner: maintainer) — blocks — (was: scoping the top-level-load guidance per platform) - **Decision:** hosts use the stable separate `WebviewWindow` transport on all platforms (unstable child-webview API rejected — open upstream bugs on every engine); top-level plain-HTTP loopback is a secure context per spec and Tauri's own dev-flow precedent. The thin residual (live per-platform QA) lives in S0.1 as an ordinary verification item, not a blocker. Council transcript: agent-switch worktree `agents/runtime/council/responses/omni-route-spikes.json` (local-only).
+  - **What to do:**
+  - **Resolved when:** ~~per-OS top-level-load behaviour is recorded~~ — decided; S0.1 records the QA pass.
 
 ### [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md)
 
@@ -116,6 +139,27 @@ _1 blocker resolved._
     the post-ADR-117 default (`subagents.auto: on`), then check
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
+
+### [road-to-reciprocal-ecosystem.md](roadmaps/road-to-reciprocal-ecosystem.md)
+
+**Road to a reciprocal ecosystem — AC recommends AS the way AS already recommends AC** — 0 / 18 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Falsification spike | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 1 | Detection + the single card | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 2 | Behave correctly under AS (the part that is not promotion) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 3 | Symmetry in the docs | ⬜ not started | 9 | 0 | 0 | 0 | 0% |
+
+<a id="blockers-road-to-reciprocal-ecosystem"></a>
+**Blockers**
+
+- **restraint-review** (owner: maintainer) — blocks — (was: Phase 1 shipping at all) - **Decision:** affirmed — the distribution value outweighs the surface cost. Phase 1 ships, under the unchanged hard bound: **one card, one surface, self-retiring, permanently dismissible, no second placement ever.**
+  - **What to do:**
+  - **Resolved when:** ~~the decision is recorded either way~~ — recorded here.
+- **adoption-measurement** (owner: user) — blocks knowing whether reciprocal promotion moves anything
+  - **What to do:**
+  - **Resolved when:** ≥1 external user reports (issue/discussion/direct message) arriving at either package through the other.
 
 ### [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md)
 

--- a/agents/roadmaps/road-to-ac-embeddable-gui.md
+++ b/agents/roadmaps/road-to-ac-embeddable-gui.md
@@ -1,0 +1,258 @@
+---
+status: ready
+complexity: structural
+execution:
+  mode: phase-checkpoints
+---
+
+# Road to an embeddable AC GUI — host-ready without weakening a single security invariant
+
+> agent-switch wants to render AC's settings inside its own window so an AS
+> user never hunts for a second GUI (AS-side counterpart:
+> `road-to-ac-embedded-settings` in the agent-switch repo). Everything
+> needed is *almost* already there: a discovery file, a per-process token,
+> a hash router, a pre-paint theme stamp. What is missing is a **contract**
+> — today the embed would work by accident (nothing forbids framing) and
+> break silently the first time someone adds a hardening header. This turns
+> the accident into a promise.
+
+## Goal
+
+Ship a small, versioned **embed contract** — `?embed=1`, a theme query, a
+discoverable capability flag, and a documented framing stance — so a host
+application can render AC's settings surface reliably, while the standalone
+GUI (the surface for everyone who does *not* use AS) is unchanged and the
+three security hooks are untouched.
+
+## Context (verified 2026-07-23 at agent-config@9.7.0, do not relitigate)
+
+What already exists and is load-bearing:
+
+- **`src/server/app.ts:186-218` — three onRequest hooks:** Host allow-list
+  (421), Origin allow-list **only when the header is present** (403, with
+  the comment "browser-issued requests only — server-to-server skips this
+  header"), Bearer gate on `/api/*` (401). Static files under `/` are
+  ungated by design. **None of these change** for embedding: a host's
+  server-side HTTP client sends no Origin, and the hosted page loads
+  static assets ungated and authenticates with the token from its own URL
+  (`src/ui/main.tsx` `readToken()` reads `?token=`).
+- **`src/server/serverInfo.ts`** already writes
+  `~/.event4u/agent-config/local-server.json` (`pid`, `port`, `url`,
+  `startedAt`) on real-serve boot, removes it on graceful shutdown, and
+  tolerates staleness because readers check liveness. **This is the
+  discovery contract** — built for `install.py`, reusable by a host as-is.
+- **`src/server/token.ts`** — 32 bytes hex, per-process, `0600`, replaced
+  on every boot. A host must re-read it after every respawn. (Doc nit,
+  fixed here: the header comment claims the token is handed back "as a
+  cookie" — no cookie mechanism exists; the UI re-reads `?token=`.)
+- **`src/server/port.ts`** — 41000–41999 per ADR-012, with an explicit
+  anti-regression guard (`validateRange`, :43-56). (Doc nit, fixed here:
+  `port.ts:14` references `docs/contracts/local-server-ports.md`, which
+  **does not exist on disk** — a dangling pointer this roadmap resolves
+  when it writes the embed contract into `docs/contracts/`.)
+- **`src/ui/App.tsx`** — Preact, flat hash-route switch (ADR-014, no
+  router lib), `SURFACES` already conditionally rendered
+  (`projectSurface`, `AGENT_CONFIG_DEV_MODE=1` dev surfaces). **The
+  mechanism for hiding nav chrome exists**; embed mode is one more
+  condition, not a new system.
+- **`src/ui/index.html:8-20`** stamps `data-theme` **before first paint**
+  via an inline boot snippet. A theme passed at boot costs no flash; a
+  theme applied after mount would flash.
+- **`src/cli/commands/uiServe.ts`** already supports `--no-open`,
+  `--port`, `--allow-headless`, and an `initialRoute` deep-link — a host
+  needs no new CLI flags to boot a server on a specific page. Headless
+  refusal fires on `SSH_CONNECTION` or (Linux **and** no `DISPLAY`).
+- **`app.ts:220-251` — idle-shutdown watchdog:** disarmed until the first
+  client, then self-terminates after 30 min without an authed `/api/*`
+  request; `POST /api/v1/shutdown` is the immediate beacon.
+
+What is missing, precisely:
+
+1. **No framing stance.** No `X-Frame-Options`, no CSP `frame-ancestors`
+   (grep-verified absent). Framing works because nothing forbids it — an
+   accident, not a contract.
+2. **No embed mode.** A hosted AC shows its own top nav, competing with
+   the host's navigation.
+3. **No theme input.** AC picks light/dark from its own persisted setting
+   and OS preference; a host cannot hand it one.
+4. **No capability discovery.** A host cannot tell from outside whether an
+   installed AC supports embedding — only by version-guessing.
+
+## Landed 2026-07-25 — embed contract v1 (the host-blocking core)
+
+This PR ships embed contract v1 (the `ac-embed-contract` blocker agent-switch
+waits on): `?embed=1` (hides the standalone chrome + theme toggle, settings deep
+links intact), CSP `frame-ancestors 'none'` (AC is never iframe-able; the host
+renders it in a separate window), `?theme=light|dark`, `?token=` boot-strip, and
+`capabilities.embed = {supported:true, version:1, features:['theme','deepLink']}`
+in the ping + `--version --json` readout. The three `src/server/app.ts` security
+hooks are unchanged. Deferred to v2 (not in this PR): accent override, live theme,
+idle-shutdown watchdog docs.
+
+## Phase 0 — Falsification spike
+
+- [ ] S0.1 — **Top-level loopback load works in the host webviews.**
+      Documentation-level answer already researched (2026-07-23):
+      `http://127.0.0.1` is a spec-level secure context in all three
+      engines, and Tauri's own dev flow loads plain-http localhost
+      top-level routinely; the host transport is the stable separate
+      `WebviewWindow` (council-decided — the unstable child-webview API
+      is out). Residual: a live per-platform QA pass (render +
+      window lifecycle) on WKWebView / WebView2 / WebKitGTK — shared with
+      the AS-side roadmap's S0.1; run once, record for both repos.
+- [x] S0.2 — **Is a framing *permission* safe here?** Resolved via AI
+      council 2026-07-23 (see blocker `framing-security-verdict`):
+      framing is **denied** — ship `frame-ancestors 'none'`; hosts load
+      top-level. Deterministic across webviews, zero CSP compatibility
+      matrix to maintain, and the three gates stay untouched.
+      <!-- done 2026-07-23: council verdict recorded in the blocker entry; transcript local-only in the AS worktree -->
+- [x] S0.3 — **Token-transport decision for embedded hosts.** Resolved
+      with S0.2: keep the existing `?token=` bootstrap (it is the shipped
+      standalone mechanism), hardened in Phase 2 by the SPA stripping the
+      token from the URL after boot. The session-cookie endpoint is
+      rejected — a new endpoint plus a second credential type on `/api/*`
+      for a leak class already inside the same-user trust boundary.
+      <!-- done 2026-07-23: council verdict; hardening item lands in Phase 2 -->
+
+Exit: S0.1's per-platform matrix recorded. S0.2/S0.3 are decided; Phase 2
+implements `frame-ancestors 'none'` + the token-strip hardening.
+
+## Phase 1 — Embed mode (`?embed=1`)
+
+- [ ] Add `embed` to the boot-time UI state (read from the query alongside
+      the existing `token` param). When set:
+      hide the top-level `SURFACES` nav (the host owns navigation) ·
+      hide the theme toggle (the host owns the theme) ·
+      keep every settings surface, form and save path **byte-identical**.
+- [ ] Reuse the existing conditional-surface machinery in `App.tsx`; do
+      not introduce a parallel layout component. Embed mode is a *chrome*
+      switch, not a second UI.
+- [ ] Deep links keep working for the **settings surfaces**:
+      `#/settings`, `#/settings/<section>` render under `embed=1`, so a
+      host can route directly to a section. The **wizard is out of scope
+      for embed v1** — it is the one multi-step flow that ends in a
+      redirect and would need a completion contract with the host;
+      document the exclusion, revisit as a v2 feature if a host asks.
+- [ ] *(Sequencing aid, optional but cheap)* Ship the **capability flag
+      early**: extend the authed ping/status readout with
+      `embed: { supported: false, plannedVersion: 1 }` before the full
+      `?embed=1` implementation lands — it unblocks the host's discovery
+      and "AC too old" messaging while Phase 1 finishes.
+- [ ] **The standalone surface is unaffected.** Without `embed=1`, nothing
+      changes for a user who runs `agent-config config` in a browser.
+      <!-- was-verify: UI snapshot without embed=1 unchanged -->
+
+## Phase 2 — Framing stance + theme contract
+
+- [ ] Ship the decided framing stance: **CSP `frame-ancestors 'none'`** on
+      UI responses, plus the contract statement "framing not supported —
+      hosts load the URL top-level (child webview or window)". Written
+      into `docs/contracts/` with the council reasoning, so a future
+      hardening pass doesn't break AS by accident. While writing that
+      contract file, also create the missing
+      `docs/contracts/local-server-ports.md` that `port.ts:14` already
+      points at (or repoint the reference) — no dangling contract
+      pointers.
+- [ ] **Token-strip hardening:** after the SPA reads `?token=` at boot,
+      it removes the token from the URL (`history.replaceState`) so the
+      credential does not linger in the address bar, webview navigation
+      history, or copy-pasted URLs. Applies to standalone and embedded
+      alike; no behaviour change beyond the URL cosmetic.
+- [ ] Document in the contract that the discovery file's `url` field
+      embeds `?token=` (live-verified 2026-07-23: both `local-server.json`
+      and `local-server.token` are mode 0600, so no leak today) — hosts
+      SHOULD ignore the `url` field and rebuild from `port` + a fresh
+      token read, which also keeps a tampered url from redirecting the
+      token off loopback; and the 0600 mode on `local-server.json` is a
+      contract invariant, not an accident.
+- [ ] **Theme query:** `?theme=light|dark` feeds the existing pre-paint
+      `data-theme` stamp in `index.html`. Applied at boot → no flash.
+- [ ] **Accent override is capability v2, not v1.** Embed v1 accepts
+      `?theme=` only; once the shared-token brand decision resolves
+      (`road-to-shared-design-tokens.md` blocker), a **bounded allow-list**
+      accent name (e.g. `accent=event4u`) may follow — never an arbitrary
+      hex from the URL, which is a contrast-failure vector and an
+      open-ended support surface. If both GUIs simply share the same
+      accent via the token source, the parameter may never be needed —
+      the cheapest correct outcome.
+- [ ] The contract file states the token transport explicitly: `?token=`
+      bootstrap + post-boot URL strip, with the accepted-risk reasoning
+      (same-user loopback scope, per-process TTL) — per the S0.3 verdict.
+- [ ] **Live theme changes:** the host may flip theme while the frame is
+      open (OS switches to dark). Prefer the documented reload-with-new-
+      query over a `postMessage` surface: one line for the host, no new
+      message-handling surface in AC.
+- [ ] Fix the `token.ts` header-comment inaccuracy (cookie claim) in
+      passing — the comment must describe the real `?token=` bootstrap.
+
+## Phase 3 — Capability discovery + host lifecycle
+
+- [ ] Extend the ping/status readout with a **capability block**:
+      `{ embed: { supported: true, version: 1, features: ['theme','accent','deepLink'] } }`.
+      A host checks a capability, not a version number — so AS's "update
+      agent-config" prompt is accurate instead of guessed.
+- [ ] Mirror the same block in `agent-config --version --json` so a host
+      can decide *before* booting a server.
+- [ ] **Idle-shutdown under a host:** document the watchdog as part of the
+      embed contract (armed on first client, 30 min, beacon at
+      `POST /api/v1/shutdown`). A host holding an idle frame open will
+      lose its server; that must be a documented expectation with a
+      documented keepalive, not a surprise.
+- [ ] **Headless:** `ui:serve`'s headless refusal is correct and stays.
+      The contract documents it so hosts render a clear message instead of
+      hanging on a spawn that will never come.
+
+## Acceptance criteria (pre-registered)
+
+- [ ] **`src/server/app.ts`'s three security hooks are unchanged** by this
+      roadmap. No new allowed Origin, no widened Host list, no ungated
+      `/api/*` route.
+- [ ] **The standalone GUI is visually and functionally unchanged**
+      without `embed=1`.
+- [ ] **No theme flash** on an embedded boot with `?theme=`.
+- [ ] **The framing stance is explicit and documented** —
+      `frame-ancestors 'none'` ships and the contract names the top-level
+      load path; silence is not an acceptable outcome.
+- [ ] **The token never lingers in the URL after boot** (strip verified
+      in standalone and embedded mode).
+- [ ] **Accent input is allow-listed**, never free-form — and absent
+      from embed v1 entirely.
+- [ ] **The token transport for embedded hosts is an explicit contract
+      statement** (session cookie or documented accepted-risk), not
+      silence.
+- [ ] **A host can determine embed support without version-guessing.**
+- [ ] **No dangling contract pointers** — `port.ts:14`'s referenced
+      contract file exists (or the reference is fixed).
+- [ ] **Honest-null path:** if S0.2 rules against framing, Phases 1 and 3
+      still ship (embed mode + capability + theme are useful for a
+      separate-window host) and the framing item is recorded as a rejected
+      approach with its reasoning.
+
+## Blockers
+
+### blocker: framing-security-verdict
+- **Status:** resolved (2026-07-23, AI council: claude-sonnet-4-5 + gpt-4o, 2 rounds)
+- **Owner:** maintainer (security role)
+- **Blocks:** — (was: the framing half of Phase 2)
+- **Decision:** **no iframe framing — ship an explicit `frame-ancestors 'none'`.** Council convergence: framing is an engineering-economics question, not a security one (any same-user local process is already inside the trust boundary); the real cost is the three-webview CSP compatibility matrix, and the deterministic stance is the smallest surface. Hosts load the UI **top-level** (a host-managed child webview or separate window pointed at the same URL — `frame-ancestors` does not gate top-level loads), which keeps the embed-mode/theme/capability contract fully useful. Token transport: keep the existing `?token=` bootstrap, hardened by the SPA stripping the token from the URL after boot; the session-cookie endpoint was rejected as the costlier surface (CSRF assessed a non-issue for a loopback-only server, but the new endpoint + second credential type is avoidable entirely). Divergence recorded: one member preferred header-silence as "smallest surface" — rejected because this roadmap's acceptance criteria rule out silence; both members pick DENY when an explicit stance is required.
+- **Resolved when:** ~~a decision record exists~~ — this entry is the record; council transcript: agent-switch worktree `agents/runtime/council/responses/omni-route-framing.json` (local-only).
+
+### blocker: cross-platform-webview-verification
+- **Status:** resolved (2026-07-23, web research + AI council)
+- **Owner:** maintainer
+- **Blocks:** — (was: scoping the top-level-load guidance per platform)
+- **Decision:** hosts use the stable separate `WebviewWindow` transport on all platforms (unstable child-webview API rejected — open upstream bugs on every engine); top-level plain-HTTP loopback is a secure context per spec and Tauri's own dev-flow precedent. The thin residual (live per-platform QA) lives in S0.1 as an ordinary verification item, not a blocker. Council transcript: agent-switch worktree `agents/runtime/council/responses/omni-route-spikes.json` (local-only).
+- **Resolved when:** ~~per-OS top-level-load behaviour is recorded~~ — decided; S0.1 records the QA pass.
+
+## Provenance
+
+Source read 2026-07-23 of `agent-config@9.7.0`, re-verified by an
+independent second pass this session: `src/server/app.ts` (hooks 186-218,
+idle watchdog 220-251), `src/server/{port,token,serverInfo}.ts`
+(incl. the dangling `local-server-ports.md` reference and the inaccurate
+cookie comment), `src/cli/commands/uiServe.ts`, `src/ui/App.tsx`
+(ADR-014 flat switch, conditional `SURFACES`), `src/ui/main.tsx`
+(`readToken()`), `src/ui/index.html` (pre-paint `data-theme` stamp).
+Grep-verified: no `X-Frame-Options` / `frame-ancestors` /
+`contentSecurityPolicy` / `helmet` anywhere in `src/server/`. No
+third-party code is adopted by this roadmap.

--- a/agents/roadmaps/road-to-reciprocal-ecosystem.md
+++ b/agents/roadmaps/road-to-reciprocal-ecosystem.md
@@ -1,0 +1,203 @@
+---
+status: ready
+complexity: moderate
+execution:
+  mode: phase-checkpoints
+---
+
+# Road to a reciprocal ecosystem — AC recommends AS the way AS already recommends AC
+
+> The promotion is currently one-way. agent-switch ships a designed, tested,
+> three-state agent-config banner. AC mentions agent-switch **nowhere** in
+> `src/`, `README.md`, or any wizard/settings surface (grep-verified; the
+> only repo-wide hit is a GitHub PR URL inside a test fixture,
+> `tests/scripts/pr_url_reminder_hook.test.ts:19`). An AC user running two
+> Claude accounts by logging in and out has a problem AS solves, and AC
+> never tells them. Making it mutual costs one detection and one card — and
+> it is the second half of the distribution loop the adoption gap needs.
+> Pairs with agent-switch's `road-to-agent-setup-hub` Phase 2 (the
+> Ecosystem section).
+
+## Goal
+
+Give AC a **single, self-retiring** agent-switch recommendation on the
+surface where it is actually relevant (the wizard's tooling step), plus the
+profile-awareness that makes AC behave correctly when it *is* running under
+AS — without turning AC's GUI into a promotion surface.
+
+## Context (verified 2026-07-23 at agent-config@9.7.0 / agent-switch@1.6.1, do not relitigate)
+
+- **AS's side is already built and is the reference implementation.**
+  `agent-switch/gui/src/agent-config.ts` — `deriveAgentConfigView(status,
+  devMode)` returns `install` (not present) · `update` (newer release
+  available) · `installed` (dev-mode info only, otherwise **hidden**). The
+  banner *disappears* once the user is installed and current. That
+  self-retiring property is the part worth copying; the permanent-strip
+  placement is not (AS is itself moving it into an Ecosystem section).
+- **AC already has the detection plumbing**:
+  `src/install/toolDetection.ts` (`isBinaryOnPath`, tool signals with
+  `homePaths`/`absPaths`) and the wizard endpoint pattern. Note the
+  shapes differ: `/api/v1/wizard/detect-rtk` returns
+  `{ installed, platform, repo, installCommand }` (`wizard.ts:727-732`) —
+  **that** is the shape to mirror; `/detect-tools` returns
+  `{ tools, configured }` and is a different contract.
+- **AC already chose the right install stance**: surface the command for
+  the user to copy rather than shelling out an unverified install
+  (`wizard.ts:708-711`). The AS recommendation inherits it —
+  `npm install -g @event4u/agent-switch` is shown, not silently run.
+- **AS's install path is npm-global** (`@event4u/agent-switch`, Node ≥ 20
+  per its root `package.json`), same command on every OS — no per-OS map
+  needed, unlike rtk.
+- **The relevance signal exists in AC's own domain**: AC writes to
+  `~/.event4u/agent-config/` globally, but a user with multiple agent
+  accounts wants per-account config. That is precisely AS's
+  `CLAUDE_CONFIG_DIR` isolation — an env var AC already knows from its
+  Claude-Code plugin-registry handling (`doctor`/`upgrade` paths). The
+  recommendation is substantive, not cross-selling.
+
+### The restraint rule for this roadmap
+
+`road-to-surface-consolidation` established that the package is
+**complexity-limited, not capability-limited**, and that no new mechanism
+ships without naming what it replaces. A promotion card adds surface for
+zero user capability. Therefore this roadmap is bounded hard:
+
+> **One card. One surface. Self-retiring. Dismissible permanently. No
+> second placement, ever.** If it cannot earn its place under those
+> constraints, it does not ship.
+
+## Landed 2026-07-25 — the host-blocking config-root only
+
+This PR ships ONLY the Phase-2 host-supplied config-root (the
+`ac-profile-config-root` blocker agent-switch's `road-to-ac-embedded-settings`
+Phase 3 waits on): `--config-root <path>` (flag) / `EVENT4U_CONFIG_HOME` (env),
+advertised as `capabilities.configRoot` in `agent-config --version --json` +
+`GET /api/v1/ping`. The rest of this roadmap (Phase-0 verdict, the recommendation
+card, docs symmetry) is NOT in this PR — it remains for the AC maintainer.
+
+## Phase 0 — Falsification spike
+
+- [ ] S0.1 — **Is the recommendation even relevant to AC's users?**
+      Determine whether AC can cheaply detect *multi-account intent* —
+      concretely: a handful of `existsSync` checks against the known host
+      credential locations `toolDetection.ts` already models
+      (`homePaths`/`absPaths` signals), plus `~/.agent-switch/` presence.
+      **No filesystem scanning** — if the answer needs more than a fixed
+      list of stat calls, it is too expensive and the answer is "cannot
+      target". If AC cannot tell a multi-account user from a
+      single-account one, the card would show to everyone —
+      indiscriminate promotion, failing the restraint rule. In that case
+      ship it **only** as a passive row in the tooling step (listed among
+      companion tools, never as a proactive card).
+
+Exit: a verdict on targeted-vs-passive. This determines the entire shape.
+
+## Phase 1 — Detection + the single card
+
+- [ ] Add an AS probe alongside the rtk one:
+      `GET /api/v1/wizard/detect-agent-switch` →
+      `{ installed, version|null, installCommand }` (mirroring
+      `/detect-rtk`'s shape). Detect by binary on PATH **and** the
+      presence of `~/.agent-switch/`, so a user who installed it another
+      way is not told to install it again.
+- [ ] Two states only: not installed → recommend · installed → **hidden**
+      (self-retiring, the property worth copying from
+      `deriveAgentConfigView`). There is deliberately **no** "outdated"
+      state — classifying it would require exactly the version-currency
+      check the acceptance criteria forbid; AS's own updater owns updates.
+- [ ] Place it on the wizard's tooling step (per S0.1: card or passive
+      row) and nowhere else. Copy stays substantive: what AS does
+      (per-account isolation, no re-login), that it is free and MIT, one
+      command.
+- [ ] **Permanently dismissible**, persisted. A dismissed recommendation
+      never returns.
+
+## Phase 2 — Behave correctly under AS (the part that is not promotion)
+
+This is where AC earns the integration rather than advertising it.
+**Ships even if Phase 1 is cut** — it is correctness work.
+
+- [ ] **Detect that AC is running under an AS profile** —
+      `CLAUDE_CONFIG_DIR` (or the sibling provider env var) pointing
+      inside `~/.agent-switch/`.
+- [ ] When detected, **say so in the settings hub**: which profile is
+      active, and that writes are profile-scoped. An AC user who switches
+      profiles and sees different settings must not think AC lost their
+      config.
+- [ ] **Warn on the share collision.** AS's `share on` symlinks
+      `settings.json`, `keybindings.json`, `CLAUDE.md`, `skills/`,
+      `commands/`, `agents/` across profiles (`agent-switch/src/
+      share.ts:37-43`). A write AC believes is profile-local can land
+      through a symlink and change every profile. Detection is
+      **AC-local and topology-free**: `lstat` the write target (or its
+      nearest ancestor inside the profile dir) for a symlink — AC never
+      needs to understand AS's share model. The warning is a **blocking
+      confirm, not a toast** (a missable toast = silent cross-profile
+      corruption), with exactly two choices: "Write (affects all profiles
+      via the shared tree)" / "Cancel" — plus a pointer to
+      `agent-switch share off` for users who want profile-local writes.
+      AC never breaks AS's symlinks itself.
+- [ ] Accept the host-supplied config root from AS's spawn (pairs with
+      agent-switch's `road-to-ac-embedded-settings` Phase 3), so
+      profile-scoped AC settings work rather than silently colliding.
+      The flag/env is **discoverable** — advertised in the version/ping
+      capability readout — so an older AS against a newer AC (or vice
+      versa) degrades to a clear "not supported" instead of silent
+      breakage.
+
+## Phase 3 — Symmetry in the docs
+
+- [ ] One "Works with agent-switch" section in AC's README, mirroring AS's
+      existing agent-config mention. Not a badge wall — a short section
+      explaining the composition (AS isolates accounts, AC governs what
+      the agents do inside them).
+- [ ] The long-form explainer of how the two compose is **owned by AC's
+      docs** (this repo publishes a docs site; one owner, no third
+      artefact). AS's README section is a two-sentence summary **plus the
+      link** — so even a broken link degrades to still-correct text, and
+      the two descriptions cannot drift into contradiction.
+
+## Acceptance criteria (pre-registered)
+
+- [ ] **Exactly one AS recommendation surface in AC.** A second placement
+      requires naming what it retires.
+- [ ] **Self-retiring:** invisible to users who already have AS.
+- [ ] **Permanently dismissible**, and the dismissal survives updates.
+- [ ] **AC never auto-installs AS**, and never runs a package install the
+      user did not initiate — same stance as rtk.
+- [ ] **AC does not report on AS's version currency.** AS owns its
+      updates.
+- [ ] **Phase 2 ships even if Phase 1 is cut.** Profile-awareness and the
+      share-collision warning are correctness work, valuable with or
+      without any promotion.
+- [ ] **Honest-null path:** if S0.1 shows AC cannot target the
+      recommendation, the proactive card is dropped and only the passive
+      tooling row ships. Record the negative result rather than showing an
+      untargeted ad to every user.
+
+## Blockers
+
+### blocker: restraint-review
+- **Status:** resolved (2026-07-23)
+- **Owner:** maintainer
+- **Blocks:** — (was: Phase 1 shipping at all)
+- **Decision:** affirmed — the distribution value outweighs the surface cost. Phase 1 ships, under the unchanged hard bound: **one card, one surface, self-retiring, permanently dismissible, no second placement ever.**
+- **Resolved when:** ~~the decision is recorded either way~~ — recorded here.
+
+### blocker: adoption-measurement
+- **Status:** open
+- **Owner:** user
+- **Blocks:** knowing whether reciprocal promotion moves anything
+- **What to do:** both directions are now mechanisms without a measurement. AC has no telemetry and should not grow any for this; the accepted evidence is an explicit user report (GitHub issue/discussion/direct message) of having found one package through the other.
+- **Resolved when:** ≥1 external user reports (issue/discussion/direct message) arriving at either package through the other.
+
+## Provenance
+
+Read 2026-07-23, re-verified by an independent second pass:
+`agent-switch@358059d` v1.6.1 (`gui/src/agent-config.ts`,
+`gui/src/AgentConfigBanner.tsx`, `src/share.ts`, root `package.json` for
+the npm name + Node floor) and `agent-config@9.7.0`
+(`src/install/toolDetection.ts`, `src/server/routes/wizard.ts`,
+`agents/roadmaps/road-to-surface-consolidation.md` for the restraint
+rule). The absence of any agent-switch mention in AC's `src/` + root docs
+was verified by grep; the single repo-wide hit is a test-fixture PR URL.

--- a/docs/contracts/local-server-ports.md
+++ b/docs/contracts/local-server-ports.md
@@ -1,0 +1,53 @@
+# Contract: local server ports + host integration
+
+> The loopback/port contract `src/server/port.ts` enforces, plus the
+> host-integration surface (config root + embed) a host like agent-switch binds
+> to. This file resolves the long-standing pointer in `src/server/port.ts`.
+
+## Port range
+
+- The GUI/API server binds on **loopback `127.0.0.1` only**, on a free port in
+  **41000–41999** (per ADR-012). `src/server/port.ts` picks a free port by
+  actually binding (no is-free → bind race) and refuses any range that overlaps
+  the privileged ports `[0, 1024]` or strays outside this documented range —
+  both are anti-regression guards (`validateRange`).
+- The chosen port is ephemeral per process; a host discovers the live port from
+  the server-info readout, never by assuming a fixed value.
+
+## Auth token
+
+- `src/server/token.ts`: a 32-byte hex token, per-process, mode `0600`, replaced
+  on every boot. The SPA reads it once from `?token=` at boot, then strips it
+  from the URL; subsequent calls use the `Authorization: Bearer` header. There is
+  no cookie. A host must re-read the token after every respawn.
+
+## Host integration — config root
+
+- `agent-config --config-root <path>` (flag) or `EVENT4U_CONFIG_HOME` (env) sets
+  AC's config home. Precedence: **flag > env > default**; absent → default
+  behavior is unchanged. This lets a host give AC a per-profile config root so
+  profile-scoped settings do not silently collide.
+
+## Host integration — embed
+
+- `?embed=1` renders AC chrome-stripped (no standalone nav/brand, no theme
+  toggle — the host owns the theme); settings deep-links `#/settings` and
+  `#/settings/<section>` keep working.
+- **Framing:** AC sends CSP `frame-ancestors 'none'` and is **never** iframe-able
+  — a host renders AC's URL in a **separate top-level window**, not a frame.
+- `?theme=light|dark` feeds the pre-paint `data-theme` stamp (no flash).
+
+## Capability discovery
+
+- `GET /api/v1/ping` and `agent-config --version --json` carry a `capabilities`
+  block: `{ configRoot: true, embed: { supported: true, version: 1, features:
+  ['theme', 'deepLink'] } }`. A host checks a capability, not a version number —
+  an older AC omits the block and the host degrades to a clear "not supported".
+
+## References
+
+- Port range: ADR-012. Enforcement: `src/server/port.ts`.
+- Token transport: `src/server/token.ts`.
+- Capabilities source: `src/shared/capabilities.ts`.
+- Host-side plans: `agents/roadmaps/road-to-ac-embeddable-gui.md`,
+  `agents/roadmaps/road-to-reciprocal-ecosystem.md`.

--- a/src/cli/configRoot.test.ts
+++ b/src/cli/configRoot.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the host-supplied config-root seam.
+ *
+ *   - `resolveConfigRoot` applies `flag > env > default` precedence.
+ *   - `ensureConfigRoot` validates + creates the dir (0700), rejects empty.
+ *   - `applyConfigRootFromArgv` extracts the flag, exports the env, cleans
+ *     argv, and is a pure passthrough (no side effects) when absent.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, statSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import {
+    CONFIG_ROOT_ENV,
+    applyConfigRootFromArgv,
+    ensureConfigRoot,
+    resolveConfigRoot,
+} from './configRoot.js';
+
+describe('config root', () => {
+    let scratch: string;
+    let savedEnv: string | undefined;
+
+    beforeEach(() => {
+        scratch = mkdtempSync(join(tmpdir(), 'configroot-'));
+        savedEnv = process.env[CONFIG_ROOT_ENV];
+        delete process.env[CONFIG_ROOT_ENV];
+    });
+    afterEach(() => {
+        rmSync(scratch, { recursive: true, force: true });
+        if (savedEnv === undefined) {
+            delete process.env[CONFIG_ROOT_ENV];
+        } else {
+            process.env[CONFIG_ROOT_ENV] = savedEnv;
+        }
+    });
+
+    describe('resolveConfigRoot (precedence flag > env > default)', () => {
+        it('returns the flag value (absolute-resolved) when set — even if env is also set', () => {
+            const flag = join(scratch, 'from-flag');
+            const res = resolveConfigRoot({
+                flag,
+                env: { [CONFIG_ROOT_ENV]: join(scratch, 'from-env') },
+            });
+            expect(res).toBe(resolve(flag));
+        });
+
+        it('returns the env value when no flag is set', () => {
+            const envRoot = join(scratch, 'from-env');
+            const res = resolveConfigRoot({ env: { [CONFIG_ROOT_ENV]: envRoot } });
+            expect(res).toBe(envRoot);
+        });
+
+        it('returns the vendor-namespaced default when neither flag nor env is set', () => {
+            const res = resolveConfigRoot({ env: {} });
+            expect(res).toBe(join(homedir(), '.event4u', 'agent-config'));
+        });
+    });
+
+    describe('ensureConfigRoot', () => {
+        it('creates the directory (mode 0700, no group/other access)', () => {
+            const target = join(scratch, 'nested', 'root');
+            expect(existsSync(target)).toBe(false);
+
+            const abs = ensureConfigRoot(target);
+
+            expect(abs).toBe(resolve(target));
+            expect(statSync(abs).isDirectory()).toBe(true);
+            const mode = statSync(abs).mode & 0o777;
+            // Owner rwx present; group/other stripped (umask only restricts).
+            expect(mode & 0o700).toBe(0o700);
+            expect(mode & 0o077).toBe(0);
+        });
+
+        it('rejects an empty path', () => {
+            expect(() => ensureConfigRoot('   ')).toThrow(/non-empty/);
+        });
+    });
+
+    describe('applyConfigRootFromArgv', () => {
+        it('extracts `--config-root <path>`, exports the env, and cleans argv', () => {
+            const root = join(scratch, 'profile-a');
+            const env: NodeJS.ProcessEnv = {};
+            const res = applyConfigRootFromArgv(['config', '--config-root', root, '--port', '8080'], env);
+
+            expect(res.configRoot).toBe(resolve(root));
+            expect(env[CONFIG_ROOT_ENV]).toBe(resolve(root));
+            expect(res.argv).toEqual(['config', '--port', '8080']);
+            expect(existsSync(resolve(root))).toBe(true);
+        });
+
+        it('supports the `--config-root=<path>` form', () => {
+            const root = join(scratch, 'profile-b');
+            const env: NodeJS.ProcessEnv = {};
+            const res = applyConfigRootFromArgv([`--config-root=${root}`, 'setup'], env);
+
+            expect(res.configRoot).toBe(resolve(root));
+            expect(env[CONFIG_ROOT_ENV]).toBe(resolve(root));
+            expect(res.argv).toEqual(['setup']);
+        });
+
+        it('is a pure passthrough with no side effects when the flag is absent', () => {
+            const env: NodeJS.ProcessEnv = {};
+            const res = applyConfigRootFromArgv(['config', '--port', '8080'], env);
+
+            expect(res.configRoot).toBeNull();
+            expect(env[CONFIG_ROOT_ENV]).toBeUndefined();
+            expect(res.argv).toEqual(['config', '--port', '8080']);
+        });
+
+        it('throws when the flag is present without a value', () => {
+            expect(() => applyConfigRootFromArgv(['config', '--config-root'], {})).toThrow(
+                /requires a path/,
+            );
+            expect(() => applyConfigRootFromArgv(['--config-root', '--port'], {})).toThrow(
+                /requires a path/,
+            );
+        });
+    });
+});

--- a/src/cli/configRoot.ts
+++ b/src/cli/configRoot.ts
@@ -1,0 +1,136 @@
+/**
+ * Host-supplied config-root resolution (reciprocal-ecosystem Phase 2).
+ *
+ * A host that spawns `agent-config` per profile needs AC to read/write
+ * its own config/settings/state under a host-chosen directory instead of
+ * the shared `~/.event4u/agent-config/` default — otherwise two profiles
+ * silently collide on the same files.
+ *
+ * The seam is the existing single source of truth `event4u_root()`
+ * (`scripts/_lib/user_global_paths.ts`), which already honours the
+ * `EVENT4U_CONFIG_HOME` environment variable. This module layers a
+ * documented CLI flag on top and wires both into one precedence:
+ *
+ *   flag (`--config-root <path>`)  >  env (`EVENT4U_CONFIG_HOME`)  >  default
+ *
+ * The flag is applied by exporting its value into `EVENT4U_CONFIG_HOME`
+ * once at CLI entry (`applyConfigRootFromArgv`), so every downstream
+ * resolver — the scripts family via `event4u_root()`, the server family
+ * via the same seam, and every Bash-delegated subprocess (which inherits
+ * `process.env`) — observes the override through the same variable.
+ *
+ * With no flag and no env, this module has zero side effects and AC's
+ * behaviour is byte-identical to before.
+ */
+
+import { mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { event4u_root, EVENT4U_HOME_ENV } from '../scripts/_lib/user_global_paths.js';
+
+/** The documented CLI flag a host passes on spawn. */
+export const CONFIG_ROOT_FLAG = '--config-root';
+
+/**
+ * The environment variable the flag maps onto — the established
+ * config-home override honoured by `event4u_root()`. Reused (rather than
+ * introducing a second name) so there is exactly one override variable.
+ */
+export const CONFIG_ROOT_ENV = EVENT4U_HOME_ENV;
+
+/** Expand a leading `~` / `~/` like a shell would. */
+function expandHome(p: string): string {
+    if (p === '~') return homedir();
+    if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+    return p;
+}
+
+export interface ResolveConfigRootOptions {
+    /** Explicit `--config-root` value (highest precedence). */
+    flag?: string | null;
+    /** Environment map to read `EVENT4U_CONFIG_HOME` from. Defaults to `process.env`. */
+    env?: Record<string, string | undefined> | null;
+}
+
+/**
+ * Resolve the effective config root for the given inputs, applying the
+ * `flag > env > default` precedence. Pure — no filesystem writes.
+ *
+ * The flag is expanded (`~`) and resolved to an absolute path; the env /
+ * default path is delegated to `event4u_root()` so there is a single
+ * source of truth for the non-flag branches.
+ */
+export function resolveConfigRoot(opts: ResolveConfigRootOptions = {}): string {
+    const flag = opts.flag?.trim();
+    if (flag !== undefined && flag.length > 0) {
+        return resolve(expandHome(flag));
+    }
+    return event4u_root(opts.env ?? null);
+}
+
+/**
+ * Validate and materialise a host-supplied config root: expand `~`,
+ * resolve to an absolute path, and create the directory (mode 0700) if
+ * missing. Throws on an empty value. Returns the absolute path.
+ */
+export function ensureConfigRoot(rawPath: string): string {
+    const trimmed = rawPath.trim();
+    if (trimmed.length === 0) {
+        throw new Error(`${CONFIG_ROOT_FLAG} requires a non-empty path`);
+    }
+    const abs = resolve(expandHome(trimmed));
+    mkdirSync(abs, { recursive: true, mode: 0o700 });
+    return abs;
+}
+
+export interface ApplyConfigRootResult {
+    /** `argv` with the `--config-root` flag (and its value) removed. */
+    argv: string[];
+    /** The absolute config root that was applied, or `null` when no flag was present. */
+    configRoot: string | null;
+}
+
+/**
+ * Extract the first `--config-root <path>` / `--config-root=<path>` from
+ * `argv`, apply it (validate → mkdir 0700 → set `EVENT4U_CONFIG_HOME`),
+ * and return the cleaned `argv`.
+ *
+ * When the flag is absent this is a pure passthrough: a copy of `argv`,
+ * `configRoot: null`, and no environment or filesystem mutation — so the
+ * default behaviour is byte-identical.
+ *
+ * Throws (a clear message) when the flag is present without a value.
+ */
+export function applyConfigRootFromArgv(
+    argv: readonly string[],
+    env: NodeJS.ProcessEnv = process.env,
+): ApplyConfigRootResult {
+    const out: string[] = [];
+    let value: string | null = null;
+
+    for (let i = 0; i < argv.length; i++) {
+        const token = argv[i] as string;
+        if (value === null && token === CONFIG_ROOT_FLAG) {
+            const next = argv[i + 1];
+            if (next === undefined || next.startsWith('-')) {
+                throw new Error(`${CONFIG_ROOT_FLAG} requires a path argument`);
+            }
+            value = next;
+            i += 1; // consume the value token
+            continue;
+        }
+        if (value === null && token.startsWith(`${CONFIG_ROOT_FLAG}=`)) {
+            value = token.slice(CONFIG_ROOT_FLAG.length + 1);
+            continue;
+        }
+        out.push(token);
+    }
+
+    if (value === null) {
+        return { argv: out, configRoot: null };
+    }
+
+    const configRoot = ensureConfigRoot(value);
+    env[CONFIG_ROOT_ENV] = configRoot;
+    return { argv: out, configRoot };
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -18,7 +18,10 @@ export function buildHelp(): string {
         'Usage:',
         '  agent-config <command> [options]',
         '  agent-config --help',
-        '  agent-config --version',
+        '  agent-config --version [--json]',
+        '',
+        'Global options:',
+        '  --config-root <path>       Config/settings/state home (else $EVENT4U_CONFIG_HOME, else ~/.event4u/agent-config)',
         '',
         'Native commands (TS shell):',
     ];

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -29,13 +29,21 @@ import { runPacksLs } from './commands/packs.js';
 import { runCommandsLs, runCommandsExplain, looksLikeCommandTarget } from './commands/commands.js';
 import { logger } from './log/logger.js';
 import { buildHelp } from './help.js';
+import { applyConfigRootFromArgv } from './configRoot.js';
+import { buildVersionReadout } from '../shared/capabilities.js';
 
 function readVersion(): string {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, 'utf8')) as { version?: unknown };
     return typeof pkg.version === 'string' ? pkg.version : '0.0.0';
 }
 
-async function main(argv: readonly string[]): Promise<number> {
+async function main(rawArgv: readonly string[]): Promise<number> {
+    // Accept a host-supplied config root (`--config-root <path>`) before
+    // anything resolves the config home. Applied by exporting into
+    // `EVENT4U_CONFIG_HOME`, so the scripts family, the server family, and
+    // every Bash-delegated subprocess (inherits `process.env`) observe the
+    // override. Absent flag → pure passthrough, byte-identical behaviour.
+    const { argv } = applyConfigRootFromArgv(rawArgv);
     const program = new Command();
     program
         .name('agent-config')
@@ -334,7 +342,15 @@ async function main(argv: readonly string[]): Promise<number> {
         return 0;
     }
     if (head === '--version' || head === '-V') {
-        process.stdout.write(`${readVersion()}\n`);
+        // `--version --json` is the host-facing capability readout: emits
+        // `{ version, capabilities: { configRoot: true } }` so a spawner
+        // can detect support before relying on `--config-root`. Plain
+        // `--version` keeps printing just the version string.
+        if (argv.includes('--json')) {
+            process.stdout.write(`${JSON.stringify(buildVersionReadout(readVersion()))}\n`);
+        } else {
+            process.stdout.write(`${readVersion()}\n`);
+        }
         return 0;
     }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -254,6 +254,16 @@ export async function createApp(opts: CreateAppOptions): Promise<FastifyInstance
         root: opts.uiDistDir,
         prefix: '/',
         decorateReply: false,
+        // Framing stance (reciprocal-ecosystem embed contract, Phase 2):
+        // AC refuses to be iframed — a host renders the UI top-level in its
+        // own window (`?embed=1`), never inside an iframe. `frame-ancestors`
+        // is a header-only directive (ignored in a <meta> CSP), so it ships
+        // here on the static UI responses. Additive hardening only: the
+        // three onRequest security hooks above (Host / Origin / Bearer) are
+        // unchanged, and no `/api/*` route is affected.
+        setHeaders: (res): void => {
+            res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+        },
     });
 
     const packageRoot = opts.packageRoot ?? PACKAGE_ROOT;

--- a/src/server/routes/ping.ts
+++ b/src/server/routes/ping.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import { readFileSync } from 'node:fs';
 import { userInfo } from 'node:os';
 import { PACKAGE_JSON } from '../../cli/paths.js';
+import { CAPABILITIES } from '../../shared/capabilities.js';
 
 function systemUserName(): string {
     try {
@@ -60,6 +61,22 @@ export const PingResponseSchema = z.object({
      * `#/workspace` deep link keeps working regardless).
      */
     devSurfaces: z.boolean(),
+    /**
+     * Host-facing capability advertisement (reciprocal-ecosystem Phase 2)
+     * — a spawner reads `capabilities.configRoot` to detect support for a
+     * host-supplied config root, and `capabilities.embed` to detect the
+     * `?embed=1` embed contract, before relying on either. An older server
+     * omits this block, so a newer host degrades to "not supported". The
+     * shape mirrors `Capabilities` in `src/shared/capabilities.ts`.
+     */
+    capabilities: z.object({
+        configRoot: z.boolean(),
+        embed: z.object({
+            supported: z.boolean(),
+            version: z.number(),
+            features: z.array(z.enum(['theme', 'deepLink'])),
+        }),
+    }),
 });
 
 export type PingResponse = z.infer<typeof PingResponseSchema>;
@@ -101,6 +118,7 @@ export function pingRoute(opts: PingRouteOptions): FastifyPluginAsync {
                 systemUser: systemUserName(),
                 projectSurface: opts.projectSurface === true,
                 devSurfaces: (process.env['AGENT_CONFIG_DEV_MODE'] ?? '') === '1',
+                capabilities: { ...CAPABILITIES },
             };
             return response;
         });

--- a/src/server/serverInfo.ts
+++ b/src/server/serverInfo.ts
@@ -11,8 +11,8 @@
  */
 
 import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { resolve } from 'node:path';
+import { event4u_root } from '../scripts/_lib/user_global_paths.js';
 
 export interface ServerInfo {
     pid: number;
@@ -22,7 +22,11 @@ export interface ServerInfo {
 }
 
 function infoDir(): string {
-    return resolve(homedir(), '.event4u', 'agent-config');
+    // Follows a host-supplied config root (EVENT4U_CONFIG_HOME / --config-root)
+    // so a profile-scoped server records its liveness under its own root
+    // instead of clobbering the shared default. Byte-identical to
+    // `~/.event4u/agent-config` when no override is set.
+    return event4u_root();
 }
 
 export function serverInfoPath(): string {

--- a/src/server/token.ts
+++ b/src/server/token.ts
@@ -8,8 +8,9 @@
  * token is fresh per process, written to
  * `~/.event4u/agent-config/local-server.token` with mode 0600, and
  * the UI bundle reads it via a `?token=…` query param on the initial
- * page load (handed back as a cookie by the server's static-file
- * handler — see `src/server/app.ts`).
+ * page load. There is no cookie mechanism: the SPA strips the token
+ * from the URL after boot (see `src/ui/urlToken.ts`) and sends it as
+ * an `Authorization: Bearer <token>` header on every API request.
  *
  * The file is replaced (not appended) on every process boot. A stale
  * token from a previous process is invalid.
@@ -17,8 +18,8 @@
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
-import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
+import { event4u_root } from '../scripts/_lib/user_global_paths.js';
 
 export interface TokenFile {
     /** Token bytes, hex-encoded (64 chars / 32 bytes of entropy). */
@@ -44,7 +45,13 @@ export interface MintTokenOptions {
 }
 
 function tokenDir(): string {
-    return resolve(homedir(), '.event4u', 'agent-config');
+    // Follows a host-supplied config root (EVENT4U_CONFIG_HOME / --config-root)
+    // so a profile-scoped server mints its bearer token under its own root.
+    // The token's security properties (fresh per process, mode 0600,
+    // 127.0.0.1-only) are unchanged — only the parent directory follows the
+    // operator-chosen root. Byte-identical to `~/.event4u/agent-config` with
+    // no override.
+    return event4u_root();
 }
 
 function tokenPath(): string {

--- a/src/server/writeRoot.ts
+++ b/src/server/writeRoot.ts
@@ -26,6 +26,7 @@
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { event4u_root, EVENT4U_HOME_ENV } from '../scripts/_lib/user_global_paths.js';
 
 export type WriteRootMode = 'package-sandbox' | 'global';
 
@@ -72,8 +73,21 @@ export function isInsidePackage(cwd: string): boolean {
     }
 }
 
-/** Absolute path to the user-scope global config directory. */
+/**
+ * Absolute path to the user-scope global config directory.
+ *
+ * Honours a host-supplied config root (`EVENT4U_CONFIG_HOME`, set by the
+ * `--config-root` flag) first, so the GUI wizard writes profile-scoped
+ * settings under the same override as the scripts family — routed through
+ * the single source of truth `event4u_root()`. With no override, falls
+ * back to `<home>/.event4u/agent-config` (byte-identical to before; the
+ * `home` param is still honoured for tests and callers that pass it).
+ */
 export function globalWriteRoot(home: string = homedir()): string {
+    const override = process.env[EVENT4U_HOME_ENV];
+    if (override !== undefined && override.length > 0) {
+        return event4u_root();
+    }
     return join(home, GLOBAL_REL);
 }
 

--- a/src/shared/capabilities.test.ts
+++ b/src/shared/capabilities.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the host-facing capability advertisement.
+ *
+ * The `configRoot` and `embed` capabilities must appear in the
+ * `--version --json` readout (and, via the same module, `GET /api/v1/ping`)
+ * so a spawner can feature-detect support before relying on either.
+ */
+import { describe, expect, it } from 'vitest';
+import { CAPABILITIES, buildVersionReadout } from './capabilities.js';
+
+describe('capabilities', () => {
+    it('advertises configRoot support', () => {
+        expect(CAPABILITIES.configRoot).toBe(true);
+    });
+
+    it('advertises the embed contract (reciprocal-ecosystem Phase 3)', () => {
+        expect(CAPABILITIES.embed).toEqual({
+            supported: true,
+            version: 1,
+            features: ['theme', 'deepLink'],
+        });
+    });
+
+    it('does NOT advertise the accent feature (v2, not v1)', () => {
+        expect(CAPABILITIES.embed.features).not.toContain('accent');
+    });
+
+    it('buildVersionReadout carries the version and the full capability block', () => {
+        const readout = buildVersionReadout('9.7.0');
+        expect(readout).toEqual({
+            version: '9.7.0',
+            capabilities: {
+                configRoot: true,
+                embed: { supported: true, version: 1, features: ['theme', 'deepLink'] },
+            },
+        });
+    });
+
+    it('buildVersionReadout copies capabilities (no shared mutable reference)', () => {
+        const readout = buildVersionReadout('1.2.3');
+        expect(readout.capabilities).not.toBe(CAPABILITIES);
+    });
+});

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -1,0 +1,75 @@
+/**
+ * Host-facing capability advertisement.
+ *
+ * A host that spawns `agent-config` (e.g. an orchestrator managing
+ * profile-scoped configuration) needs to detect, before it relies on a
+ * behaviour, whether the AC binary on `PATH` actually supports it. This
+ * module is the single source of truth for that advertisement; it is
+ * surfaced in two readouts a host can probe:
+ *
+ *   - `agent-config --version --json` — the CLI capability readout.
+ *   - `GET /api/v1/ping` — the local-server status readout.
+ *
+ * An older AC (predating a capability) omits the flag / the whole
+ * `capabilities` block, so a newer host reading `capabilities.<x> === true`
+ * degrades to a clear "not supported" instead of silently breaking.
+ *
+ * `src/shared/**` is consumed by both the Node server and the browser UI
+ * bundle, so this module stays pure — no Node built-ins, no I/O.
+ */
+
+/**
+ * Named embed features this build actually ships (reciprocal-ecosystem
+ * embed contract). A host reads the list to feature-detect instead of
+ * version-guessing. Only shipped features appear — v1 ships `theme`
+ * (the `?theme=light|dark` boot query) and `deepLink` (`#/settings` /
+ * `#/settings/<section>` deep links under `?embed=1`). `accent` is a
+ * v2 feature and is deliberately absent.
+ */
+export type EmbedFeature = 'theme' | 'deepLink';
+
+export interface EmbedCapability {
+    /** `true` when this build honours the `?embed=1` embed contract. */
+    supported: boolean;
+    /** Embed-contract version this build implements. */
+    version: number;
+    /** The embed features actually shipped by this build. */
+    features: EmbedFeature[];
+}
+
+export interface Capabilities {
+    /**
+     * `true` when the binary accepts a host-supplied config root on spawn
+     * via the `--config-root <path>` flag or the `EVENT4U_CONFIG_HOME`
+     * environment variable — letting a host scope AC's config/settings/
+     * state to a per-profile directory instead of the shared default.
+     */
+    configRoot: boolean;
+    /**
+     * Host-embed contract advertisement — a host reads `embed.supported`
+     * + `embed.version` + `embed.features` to decide whether it can render
+     * AC's settings surface inside its own window (via `?embed=1`, a
+     * `?theme=` boot query, and settings deep links) before relying on it.
+     */
+    embed: EmbedCapability;
+}
+
+/** The capabilities this build advertises. */
+export const CAPABILITIES: Capabilities = {
+    configRoot: true,
+    embed: { supported: true, version: 1, features: ['theme', 'deepLink'] },
+};
+
+export interface VersionReadout {
+    version: string;
+    capabilities: Capabilities;
+}
+
+/**
+ * Build the machine-readable `--version --json` payload. Pure — the
+ * caller supplies the version string it already resolved from
+ * `package.json`.
+ */
+export function buildVersionReadout(version: string): VersionReadout {
+    return { version, capabilities: { ...CAPABILITIES } };
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -30,6 +30,7 @@ import { ProjectSettingsPage } from './pages/ProjectSettingsPage.js';
 import { WorkspacePage } from './pages/WorkspacePage.js';
 import { serverStatus, fetchServerStatus } from './serverStatus.js';
 import { theme, toggleTheme } from './theme.js';
+import { embed } from './embed.js';
 
 interface Surface {
     readonly id: 'setup' | 'settings' | 'project' | 'workspace';
@@ -156,10 +157,17 @@ export function App(): preact.JSX.Element {
         if (route.value === '/') navigate('/setup');
         void fetchServerStatus();
     }, []);
+    // Embed mode (reciprocal-ecosystem embed contract, Phase 1) is a chrome
+    // switch, not a second UI: under `?embed=1` the host owns navigation and
+    // theme, so the standalone chrome (TopNav — brand, surface tabs, theme
+    // toggle) is hidden. One more render condition alongside the existing
+    // per-surface visibility gating — every settings surface, form, and save
+    // path (dispatch) is byte-identical, so `#/settings` / `#/settings/<x>`
+    // deep links keep working.
     return (
         <>
             <DryRunBanner />
-            <TopNav />
+            {embed ? null : <TopNav />}
             {dispatch(route.value)}
         </>
     );

--- a/src/ui/embed.ts
+++ b/src/ui/embed.ts
@@ -1,0 +1,23 @@
+/**
+ * Embed-mode boot flag (reciprocal-ecosystem embed contract, Phase 1).
+ *
+ * A host that renders AC's settings surface inside its own window opens
+ * the page with `?embed=1`. Under embed, AC hides its standalone chrome
+ * (the top nav + brand + theme toggle) because the host owns navigation
+ * and theme; every settings surface, form, and save path stays
+ * byte-identical. Without the flag the standalone GUI is unchanged.
+ *
+ * Read once at boot from the page URL — alongside the token read in
+ * `main.tsx` and the `?theme=` read in the `index.html` pre-paint stamp.
+ * `src/ui/**` is a browser bundle, so this module stays free of Node
+ * built-ins and I/O.
+ */
+
+/** Read the `?embed=1` flag from the current page URL. */
+export function readEmbed(): boolean {
+    if (typeof window === 'undefined') return false;
+    return new URLSearchParams(window.location.search).get('embed') === '1';
+}
+
+/** `true` when the page was opened with `?embed=1`. */
+export const embed = readEmbed();

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -8,13 +8,22 @@
         <script>
             // Theme boot — set data-theme BEFORE first paint so there is no
             // flash of the wrong theme (road-to-setup-experience § Phase 4.2).
-            // Persisted override in localStorage wins; otherwise follow the OS.
+            // Precedence: a host-supplied `?theme=light|dark` boot query wins
+            // (reciprocal-ecosystem embed contract — the host owns the theme),
+            // then a persisted localStorage override, then the OS preference.
             (function () {
+                var query = null;
+                try {
+                    var q = new URLSearchParams(window.location.search).get('theme');
+                    if (q === 'light' || q === 'dark') query = q;
+                } catch (e) { /* older engine */ }
                 var stored = null;
                 try { stored = localStorage.getItem('agent-config-theme'); } catch (e) { /* private mode */ }
-                var theme = stored === 'light' || stored === 'dark'
-                    ? stored
-                    : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+                var theme = query
+                    ? query
+                    : stored === 'light' || stored === 'dark'
+                        ? stored
+                        : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
                 document.documentElement.setAttribute('data-theme', theme);
             })();
         </script>

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -14,6 +14,7 @@ import { App } from './App.js';
 import { setAuthToken } from './api.js';
 import { startServerLifecycle } from './serverLifecycle.js';
 import { watchSystemTheme } from './theme.js';
+import { stripTokenFromUrl } from './urlToken.js';
 import './tokens.css';
 import './app.css';
 
@@ -31,6 +32,10 @@ function bootstrap(): void {
         return;
     }
     setAuthToken(token);
+    // Token-strip hardening (embed contract Phase 2): the token is now on
+    // the API client, so drop it from the URL before anything else can read
+    // or copy the address bar.
+    stripTokenFromUrl();
     // Keep the server alive while open; ask it to exit when the window closes.
     startServerLifecycle(token);
     // Follow OS light/dark changes while no explicit override is stored.

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -31,6 +31,32 @@ function storedOverride(): Theme | null {
     }
 }
 
+/**
+ * Host-supplied `?theme=light|dark` boot override (reciprocal-ecosystem
+ * embed contract, Phase 2). When a host opens the page with `?theme=`, the
+ * host owns the theme — the same query the pre-paint stamp in `index.html`
+ * reads at boot.
+ */
+function urlThemeOverride(): Theme | null {
+    if (typeof window === 'undefined') return null;
+    try {
+        const q = new URLSearchParams(window.location.search).get('theme');
+        return q === 'light' || q === 'dark' ? q : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * OS light/dark changes are followed only when the user has NOT pinned an
+ * explicit theme — either a persisted standalone override or a host-supplied
+ * `?theme=` boot query. An explicit theme (stored or host-owned) wins over
+ * the OS preference. Exported for direct unit coverage.
+ */
+export function shouldFollowSystemTheme(): boolean {
+    return storedOverride() === null && urlThemeOverride() === null;
+}
+
 function apply(next: Theme): void {
     theme.value = next;
     document.documentElement.setAttribute('data-theme', next);
@@ -51,7 +77,7 @@ export function watchSystemTheme(): void {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = (): void => {
-        if (storedOverride() !== null) return;
+        if (!shouldFollowSystemTheme()) return;
         apply(mq.matches ? 'dark' : 'light');
     };
     if (typeof mq.addEventListener === 'function') mq.addEventListener('change', onChange);

--- a/src/ui/urlToken.ts
+++ b/src/ui/urlToken.ts
@@ -1,0 +1,26 @@
+/**
+ * Post-boot token-strip hardening (reciprocal-ecosystem embed contract,
+ * Phase 2).
+ *
+ * The SPA bootstraps by reading `?token=` from the page URL (`main.tsx`).
+ * Once the token is set on the API client it no longer needs to linger in
+ * the address bar, the webview navigation history, or a copy-pasted URL,
+ * so this removes the `token` param via `history.replaceState`. Only the
+ * `token` param is dropped — the path, every other query param (`embed`,
+ * `theme`), and the hash route (`#/settings/<section>`) are preserved.
+ *
+ * Applies to standalone and embedded boots alike; no behaviour change
+ * beyond the URL cosmetic. `src/ui/**` is a browser bundle — no Node
+ * built-ins, no I/O.
+ */
+
+/** Strip the `?token=` credential from the current URL after boot. */
+export function stripTokenFromUrl(): void {
+    if (typeof window === 'undefined' || typeof window.history?.replaceState !== 'function') return;
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('token')) return;
+    params.delete('token');
+    const query = params.toString();
+    const next = window.location.pathname + (query ? `?${query}` : '') + window.location.hash;
+    window.history.replaceState(window.history.state, '', next);
+}

--- a/tests/server/app.framing.test.ts
+++ b/tests/server/app.framing.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Framing stance (reciprocal-ecosystem embed contract, Phase 2).
+ *
+ * AC refuses to be iframed — a host renders the UI top-level in its own
+ * window. The decided stance is CSP `frame-ancestors 'none'`, served on the
+ * static UI responses (header-only; a <meta> CSP would ignore it). This test
+ * pins that the header ships and that the three security hooks still hold.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { createApp } from '../../src/server/app.js';
+
+const TOKEN = 'b'.repeat(64);
+const PORT = 41556;
+const HOST = `127.0.0.1:${PORT}`;
+
+describe('createApp — framing stance', () => {
+    let app: FastifyInstance;
+    let uiDir: string;
+
+    beforeEach(async () => {
+        uiDir = mkdtempSync(join(tmpdir(), 'agent-config-framing-test-'));
+        writeFileSync(join(uiDir, 'index.html'), '<!doctype html><html><body>ok</body></html>');
+        app = await createApp({
+            projectRoot: '/tmp/fake-project',
+            uiDistDir: uiDir,
+            token: TOKEN,
+            expectedPort: PORT,
+            logLevel: 'fatal',
+        });
+        await app.ready();
+    });
+
+    afterEach(async () => {
+        await app.close();
+        rmSync(uiDir, { recursive: true, force: true });
+    });
+
+    it("serves CSP frame-ancestors 'none' on the static UI response", async () => {
+        const res = await app.inject({ method: 'GET', url: '/', headers: { host: HOST } });
+        expect(res.statusCode).toBe(200);
+        expect(res.headers['content-security-policy']).toBe("frame-ancestors 'none'");
+    });
+
+    it('still gates /api/* behind the Bearer token (hook unchanged)', async () => {
+        const res = await app.inject({ method: 'GET', url: '/api/v1/ping', headers: { host: HOST } });
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('still rejects a bad Host header with 421 (hook unchanged)', async () => {
+        const res = await app.inject({ method: 'GET', url: '/', headers: { host: 'evil.example:80' } });
+        expect(res.statusCode).toBe(421);
+    });
+});

--- a/tests/server/app.test.ts
+++ b/tests/server/app.test.ts
@@ -54,6 +54,16 @@ describe('createApp', () => {
         expect(body).toMatchObject({ ok: true, projectRoot: '/tmp/fake-project' });
     });
 
+    it('advertises the configRoot capability in the ping readout', async () => {
+        const res = await app.inject({
+            method: 'GET',
+            url: '/api/v1/ping',
+            headers: { host: HOST, authorization: `Bearer ${TOKEN}` },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toMatchObject({ capabilities: { configRoot: true } });
+    });
+
     it('accepts the token via ?token= query param', async () => {
         const res = await app.inject({
             method: 'GET',

--- a/tests/ui/App.embed.test.tsx
+++ b/tests/ui/App.embed.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * App embed chrome switch (reciprocal-ecosystem embed contract, Phase 1).
+ *
+ * Under `?embed=1` the host owns navigation and theme, so the standalone
+ * chrome (TopNav — brand, surface tabs, theme toggle) is hidden while every
+ * settings surface stays reachable: the `#/settings` / `#/settings/<section>`
+ * deep links still render. Without the flag the standalone surface — chrome
+ * included — is unchanged.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/preact';
+
+function installFetch(): { restore: () => void } {
+    const original = global.fetch;
+    global.fetch = vi.fn(async (url: string | URL | Request) => {
+        const path = typeof url === 'string' ? url : url.toString();
+        if (path.startsWith('/api/v1/ping')) {
+            return new Response(JSON.stringify({
+                ok: true,
+                version: '9.7.0',
+                projectRoot: '/x',
+                writeRoot: '/x',
+                mode: 'global',
+                dryRun: false,
+                projectScopeAvailable: false,
+                systemUser: 'test',
+                projectSurface: false,
+                devSurfaces: false,
+                capabilities: { configRoot: true, embed: { supported: true, version: 1, features: ['theme', 'deepLink'] } },
+            }), { status: 200 });
+        }
+        if (path.startsWith('/api/v1/settings')) {
+            return new Response(JSON.stringify({
+                values: {},
+                lastModified: 1700000000000,
+                path: '.agent-settings.yml',
+                schema: { type: 'object', properties: {} },
+            }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: path } }), { status: 404 });
+    }) as unknown as typeof fetch;
+    return { restore: (): void => { global.fetch = original; } };
+}
+
+async function renderAppAt(url: string): Promise<ReturnType<typeof render>> {
+    vi.resetModules();
+    window.location.href = url;
+    const { App } = await import('../../src/ui/App.js');
+    return render(<App />);
+}
+
+beforeEach(() => { vi.resetModules(); });
+afterEach(() => { cleanup(); vi.resetModules(); });
+
+describe('App — embed chrome switch', () => {
+    it('standalone (#/settings): renders the top nav + theme toggle and the settings surface', async () => {
+        const mock = installFetch();
+        try {
+            const { container } = await renderAppAt('http://localhost/#/settings');
+            await waitFor(() => expect(container.querySelector('.ac-page')).not.toBeNull());
+            expect(container.querySelector('.ac-topnav')).not.toBeNull();
+            expect(container.querySelector('.ac-topnav__theme')).not.toBeNull();
+        } finally {
+            mock.restore();
+        }
+    });
+
+    it('embed (?embed=1#/settings): hides the top nav + theme toggle, settings deep link still renders', async () => {
+        const mock = installFetch();
+        try {
+            const { container } = await renderAppAt('http://localhost/?embed=1#/settings');
+            await waitFor(() => expect(container.querySelector('.ac-page')).not.toBeNull());
+            expect(container.querySelector('.ac-topnav')).toBeNull();
+            expect(container.querySelector('.ac-topnav__theme')).toBeNull();
+            expect(container.querySelector('.ac-page')?.textContent).toContain('Settings');
+        } finally {
+            mock.restore();
+        }
+    });
+
+    it('embed deep link to a settings section (#/settings/personal) renders the surface, no chrome', async () => {
+        const mock = installFetch();
+        try {
+            const { container } = await renderAppAt('http://localhost/?embed=1#/settings/personal');
+            await waitFor(() => expect(container.querySelector('.ac-page')).not.toBeNull());
+            expect(container.querySelector('.ac-topnav')).toBeNull();
+        } finally {
+            mock.restore();
+        }
+    });
+});

--- a/tests/ui/bootTheme.test.tsx
+++ b/tests/ui/bootTheme.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Pre-paint theme stamp (reciprocal-ecosystem embed contract, Phase 2).
+ *
+ * Executes the REAL inline boot snippet from `src/ui/index.html` — the one
+ * that runs before first paint — so this locks the shipped precedence with
+ * zero drift: a host-supplied `?theme=light|dark` wins, then a persisted
+ * localStorage override, then the OS preference. Applied at boot → no flash.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** The inline pre-paint boot snippet, extracted from the shipped index.html. */
+const BOOT_SNIPPET = (() => {
+    const html = readFileSync(resolve(process.cwd(), 'src/ui/index.html'), 'utf8');
+    const m = /<script>([\s\S]*?)<\/script>/.exec(html);
+    if (m === null) throw new Error('index.html: pre-paint boot <script> not found');
+    return m[1] as string;
+})();
+
+/**
+ * Deterministic in-memory localStorage stub. The env's happy-dom storage is
+ * flaky across `window.location.href` navigation, so we control it directly.
+ */
+function stubStorage(stored?: 'light' | 'dark'): void {
+    const store = new Map<string, string>();
+    if (stored !== undefined) store.set('agent-config-theme', stored);
+    vi.stubGlobal('localStorage', {
+        getItem: (k: string): string | null => store.get(k) ?? null,
+        setItem: (k: string, v: string): void => { store.set(k, String(v)); },
+        removeItem: (k: string): void => { store.delete(k); },
+        clear: (): void => { store.clear(); },
+        key: (): string | null => null,
+        length: 0,
+    });
+}
+
+/** Run the boot snippet against a given URL and return the stamped theme. */
+function runBoot(url: string, stored?: 'light' | 'dark'): string | null {
+    window.location.href = url;
+    stubStorage(stored);
+    document.documentElement.removeAttribute('data-theme');
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    new Function(BOOT_SNIPPET)();
+    return document.documentElement.getAttribute('data-theme');
+}
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe('index.html pre-paint theme stamp', () => {
+    it('?theme=dark stamps data-theme="dark"', () => {
+        expect(runBoot('http://localhost/?theme=dark')).toBe('dark');
+    });
+
+    it('?theme=light stamps data-theme="light"', () => {
+        expect(runBoot('http://localhost/?theme=light')).toBe('light');
+    });
+
+    it('?theme= wins over a persisted localStorage override (host owns the theme)', () => {
+        expect(runBoot('http://localhost/?embed=1&theme=dark', 'light')).toBe('dark');
+    });
+
+    it('an invalid ?theme= value falls through to the persisted override', () => {
+        expect(runBoot('http://localhost/?theme=purple', 'dark')).toBe('dark');
+    });
+
+    it('without ?theme= the persisted override still wins (standalone unchanged)', () => {
+        expect(runBoot('http://localhost/#/settings', 'dark')).toBe('dark');
+    });
+});

--- a/tests/ui/embed.test.ts
+++ b/tests/ui/embed.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Embed boot-flag reader (reciprocal-ecosystem embed contract, Phase 1).
+ *
+ * `?embed=1` opts the page into embed mode; anything else (absent, other
+ * values) is standalone. `vi.resetModules()` + dynamic import re-reads the
+ * flag off the URL set for each case, matching how `main.tsx` reads it once
+ * at boot.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => { vi.resetModules(); });
+
+async function readEmbedFor(url: string): Promise<boolean> {
+    vi.resetModules();
+    window.location.href = url;
+    const { readEmbed } = await import('../../src/ui/embed.js');
+    return readEmbed();
+}
+
+describe('readEmbed', () => {
+    it('is true with ?embed=1', async () => {
+        expect(await readEmbedFor('http://localhost/?embed=1')).toBe(true);
+    });
+
+    it('is true when ?embed=1 sits alongside token/theme/hash', async () => {
+        expect(await readEmbedFor('http://localhost/?token=abc&embed=1&theme=dark#/settings')).toBe(true);
+    });
+
+    it('is false without the query', async () => {
+        expect(await readEmbedFor('http://localhost/#/settings')).toBe(false);
+    });
+
+    it('is false for other embed values (only "1" opts in)', async () => {
+        expect(await readEmbedFor('http://localhost/?embed=0')).toBe(false);
+        expect(await readEmbedFor('http://localhost/?embed=true')).toBe(false);
+    });
+
+    it('the module-level `embed` const reflects the boot URL', async () => {
+        vi.resetModules();
+        window.location.href = 'http://localhost/?embed=1';
+        const mod = await import('../../src/ui/embed.js');
+        expect(mod.embed).toBe(true);
+    });
+});

--- a/tests/ui/theme.systemFollow.test.ts
+++ b/tests/ui/theme.systemFollow.test.ts
@@ -1,0 +1,54 @@
+/**
+ * OS-follow guard (reciprocal-ecosystem embed contract, Phase 2).
+ *
+ * `watchSystemTheme()` follows OS light/dark changes only when the user has
+ * NOT pinned an explicit theme — a persisted standalone override OR a
+ * host-supplied `?theme=` boot query. Under embed the host owns the theme,
+ * so an OS flip must not override it.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => { vi.resetModules(); vi.unstubAllGlobals(); });
+
+/**
+ * Deterministic in-memory localStorage stub — the env's happy-dom storage is
+ * flaky across `window.location.href` navigation.
+ */
+function stubStorage(stored?: 'light' | 'dark'): void {
+    const store = new Map<string, string>();
+    if (stored !== undefined) store.set('agent-config-theme', stored);
+    vi.stubGlobal('localStorage', {
+        getItem: (k: string): string | null => store.get(k) ?? null,
+        setItem: (k: string, v: string): void => { store.set(k, String(v)); },
+        removeItem: (k: string): void => { store.delete(k); },
+        clear: (): void => { store.clear(); },
+        key: (): string | null => null,
+        length: 0,
+    });
+}
+
+async function shouldFollow(url: string, stored?: 'light' | 'dark'): Promise<boolean> {
+    vi.resetModules();
+    window.location.href = url;
+    stubStorage(stored);
+    const { shouldFollowSystemTheme } = await import('../../src/ui/theme.js');
+    return shouldFollowSystemTheme();
+}
+
+describe('shouldFollowSystemTheme', () => {
+    it('follows the OS when no explicit theme is pinned (standalone default)', async () => {
+        expect(await shouldFollow('http://localhost/')).toBe(true);
+    });
+
+    it('does NOT follow the OS when the host supplied ?theme= (host owns theme)', async () => {
+        expect(await shouldFollow('http://localhost/?embed=1&theme=dark')).toBe(false);
+    });
+
+    it('does NOT follow the OS when a standalone override is persisted', async () => {
+        expect(await shouldFollow('http://localhost/', 'light')).toBe(false);
+    });
+
+    it('ignores an invalid ?theme= value (falls back to OS-follow)', async () => {
+        expect(await shouldFollow('http://localhost/?theme=purple')).toBe(true);
+    });
+});

--- a/tests/ui/urlToken.test.ts
+++ b/tests/ui/urlToken.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Post-boot token-strip hardening (reciprocal-ecosystem embed contract,
+ * Phase 2). After the SPA reads `?token=` at boot it removes only that
+ * param from the URL, preserving the path, every other query param, and the
+ * hash route — in both standalone and embedded boots.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { stripTokenFromUrl } from '../../src/ui/urlToken.js';
+
+beforeEach(() => { window.location.href = 'http://localhost/'; });
+
+describe('stripTokenFromUrl', () => {
+    it('removes the token param after boot', () => {
+        window.location.href = 'http://localhost/?token=deadbeef';
+        stripTokenFromUrl();
+        expect(window.location.search).toBe('');
+        expect(new URLSearchParams(window.location.search).has('token')).toBe(false);
+    });
+
+    it('preserves embed, theme, and the hash route (embedded boot)', () => {
+        window.location.href = 'http://localhost/?token=deadbeef&embed=1&theme=dark#/settings/personal';
+        stripTokenFromUrl();
+        const params = new URLSearchParams(window.location.search);
+        expect(params.has('token')).toBe(false);
+        expect(params.get('embed')).toBe('1');
+        expect(params.get('theme')).toBe('dark');
+        expect(window.location.hash).toBe('#/settings/personal');
+    });
+
+    it('is a no-op when no token is present (standalone, already stripped)', () => {
+        window.location.href = 'http://localhost/?embed=1#/settings';
+        stripTokenFromUrl();
+        expect(window.location.search).toBe('?embed=1');
+        expect(window.location.hash).toBe('#/settings');
+    });
+
+    it('strips only the token when it is the last of several params', () => {
+        window.location.href = 'http://localhost/?theme=light&token=cafe#/setup';
+        stripTokenFromUrl();
+        expect(window.location.search).toBe('?theme=light');
+        expect(window.location.hash).toBe('#/setup');
+    });
+});


### PR DESCRIPTION
## Summary

Two **host-integration** blockers that agent-switch's `road-to-ac-embedded-settings` waits on, so AS can render AC's settings per-profile inside its own window. Both are additive and discoverable; the standalone GUI and the CLI's default behavior are byte-identical without the new flags.

## 1. Host-supplied config root (`ac-profile-config-root`)

- `agent-config --config-root <path>` (flag) and the existing `EVENT4U_CONFIG_HOME` (env) route AC's config home through the single `event4u_root()` seam. Precedence: **flag > env > default**. No flag/env → unchanged. The path is validated + created `0700`.
- Routed the server family (`writeRoot`/`serverInfo`/`token` dir) through the same seam so the override is genuinely single-source.
- **AS integration note:** target `--config-root` / `EVENT4U_CONFIG_HOME` — there is intentionally no new `AGENT_CONFIG_ROOT` (that name is a different concept, the consumer project root).

## 2. Embed contract v1 (`ac-embed-contract`)

- `?embed=1` hides the standalone chrome + theme toggle (settings deep-links `#/settings[/<section>]` intact), reusing `App.tsx`'s existing conditional-surface machinery.
- **Framing stance:** CSP `frame-ancestors 'none'` (additive response header) — AC is **never iframe-able**; a host renders AC's URL in a separate top-level window.
- `?theme=light|dark` feeds the pre-paint `data-theme` stamp (no flash); `?token=` is stripped from the URL after boot.
- Fixed the stale cookie claim in `token.ts`'s header comment.

## Discoverability

A single `src/shared/capabilities.ts` surfaces `{ configRoot: true, embed: { supported: true, version: 1, features: ['theme','deepLink'] } }` in **`GET /api/v1/ping`** and **`agent-config --version --json`**, so an older host degrades to "not supported" instead of breaking. (accent override / live theme are v2 — not here.)

## Security / guardrails

- The three `src/server/app.ts` security hooks (Host 421 / Origin 403 / Bearer 401) are **byte-identical**; the only app.ts change is the additive `frame-ancestors` header on static responses (hardening, header-only by necessity).
- `token.ts` change is directory-routing only — freshness / 0600 / 127.0.0.1 properties unchanged (flagged for review).

## Verification

- `npm run typecheck` clean; `tsc -p tsconfig.ui.json` adds **0** new errors (8 pre-existing in untouched files stay 8).
- `npm run build:ui` OK; **full `vitest run`: 8204 passed, 14 skipped, 0 failed** (781 files).

## Notes

- Includes the two AC-side roadmaps (`reciprocal-ecosystem`, `ac-embeddable-gui`) — previously untracked drafts — each with a "Landed" note stating exactly what shipped here (the host-blocking core) vs what remains (recommendation card, docs symmetry, accent v2).
- One `chore:` commit regenerates `agents/reports/originality.*` — a pre-existing derived-output drift the pre-push consistency hook required, unrelated to the code change.
