### PR TITLE
fix(glama): source node 24 from official image, drop nodesource

### DIFF
--- a/.github/workflows/glama-mcp-smoke.yml
+++ b/.github/workflows/glama-mcp-smoke.yml
@@ -10,7 +10,9 @@ name: glama MCP smoke
 # openai/gpt-4o, converged):
 #   - path-filtered to the MCP-build surface + weekly cron on main (bitrot)
 #   - NON-BLOCKING / informational: the failure domain includes third-party
-#     registries (Docker Hub, nodesource, astral.sh, PyPI) we do not control.
+#     registries (Docker Hub, npm) we do not control. (nodesource dropped
+#     2026-07-28: its setup script 403'd with a swallowed error — node now
+#     comes from the official node:24 image via a multi-stage copy.)
 #     Do NOT add this check to the required-checks set in
 #     docs/contracts/branch-protection-policy.md. Failures stay visible (red)
 #     so the forcing function works: a glama sync failure audits ignored runs.

--- a/internal/glama/Dockerfile
+++ b/internal/glama/Dockerfile
@@ -12,11 +12,19 @@
 # toolchain below is a DATED SNAPSHOT of glama's generated Dockerfile, not a
 # live mirror. See internal/glama/README.md before trusting it for glama
 # sync debugging.
+# Node 24 comes from the official node image, NOT the nodesource apt repo:
+# deb.nodesource.com's setup script fails with a swallowed curl 403 and exits
+# 0 (first seen 2026-07-27), leaving apt to resolve Debian's distro nodejs
+# 20.x — which ships WITHOUT npm, so the image broke with `npm: not found`.
+# The multi-stage copy is hermetic (Docker Hub only, no third-party apt repo)
+# and keeps glibc parity: both stages are trixie. The `command -v npm` probe
+# fails the build loudly if the toolchain ever silently regresses again.
+FROM node:24-trixie-slim AS node24
 FROM debian:trixie-slim
 ENV DEBIAN_FRONTEND=noninteractive
+COPY --from=node24 /usr/local /usr/local
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git \
-    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
+    && command -v npm \
     && npm install -g mcp-proxy@6.4.3 pnpm@10.14.0 \
     && node --version \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Problem

The glama parity image (`internal/glama/Dockerfile`) stopped building on 2026-07-27 with `npm: not found` (exit 127).

Root cause: `deb.nodesource.com`'s `setup_24.x` script fails with a curl 403 **and swallows the error (exits 0)**, so no nodesource repo is ever registered. apt then resolves Debian trixie's distro `nodejs` 20.x — which ships **without npm** — and the toolchain step dies. An apt pin cannot fix this: the repo the pin targets never exists in the image.

## Fix

- Drop the nodesource apt repo entirely; copy `/usr/local` from the official `node:24-trixie-slim` image via a multi-stage build. Hermetic (Docker Hub only), identical glibc (both stages trixie), same node 24 major as glama's generated Dockerfile.
- Keep a `command -v npm` probe so any future toolchain regression fails the build loudly instead of surfacing later at `npm install -g`.
- Update the stale registry list in the workflow comment (nodesource no longer in the failure domain).

## Verification

`task mcp:glama-test` green locally: image builds, `npm ci` completes, MCP smoke passes —

~~~
mcp-server: loaded 473 prompts (0 warnings)
mcp-server: registered 19 tools (19 implemented, 0 stubs)
OK: MCP initialize + prompts/list succeeded
~~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)