### PR TITLE
feat: reciprocal ecosystem - agent-config recommends and behaves correctly under agent-switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,6 +289,7 @@ agents/runtime/council/sessions/
 /site/src/content/docs/benchmark.md
 /site/src/content/docs/claims.md
 /site/src/content/docs/catalog.md
+/site/src/content/docs/works-with-agent-switch.md
 # Media assets copied from docs/media/ by sync-docs.mjs (source lives in docs/media/).
 /site/public/media/
 # Field replay corpora await operator privacy review before any commit

--- a/README.md
+++ b/README.md
@@ -414,6 +414,21 @@ For platforms where the package's scripts cannot run, artefacts are built for pa
 
 ---
 
+## Works with agent-switch
+
+[`agent-switch`](https://github.com/event4u-app/agent-switch) is the companion
+CLI for running several agent accounts on one machine: it isolates each account
+in its own profile (`CLAUDE_CONFIG_DIR` per profile), so switching accounts
+never means logging out and back in. The two compose — **agent-switch isolates
+the accounts, agent-config governs what the agents do inside them**. When
+agent-config runs under an agent-switch profile it says so in the settings hub,
+warns before writes that would land in a shared (cross-profile) tree, and
+accepts a host-supplied config root so its own settings stay profile-scoped.
+
+→ [How the two compose →](docs/guides/works-with-agent-switch.md)
+
+---
+
 ## Who this is for
 
 Stack-agnostic governance core (orchestration · role modes · command clusters · quality gates · audit-discipline) plus parallel stack-specific skill sets:

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 17 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **16** open blockers
+> 16 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
 
 ## Overall
 
-**168 / 281 steps done · 60%**
+**168 / 263 steps done · 64%**
 
 ```text
-████████████████████████░░░░░░░░░░░░░░░░   60%
+██████████████████████████░░░░░░░░░░░░░░   64%
 ```
 
 ## Open roadmaps
@@ -26,13 +26,12 @@
 | 8 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
 | 9 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 10 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 11 | [road-to-reciprocal-ecosystem.md](roadmaps/road-to-reciprocal-ecosystem.md) | 4 | 18 | 18 | 0 | 0 | 0 | [2](#blockers-road-to-reciprocal-ecosystem) | ░░░░░░░░░░ 0% |
-| 12 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
-| 13 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 14 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 15 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
-| 16 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
-| 17 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 11 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
+| 12 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 13 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 14 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
+| 15 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
+| 16 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
 
@@ -197,27 +196,6 @@ _1 blocker resolved._
     the post-ADR-117 default (`subagents.auto: on`), then check
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
-
-### [road-to-reciprocal-ecosystem.md](roadmaps/road-to-reciprocal-ecosystem.md)
-
-**Road to a reciprocal ecosystem — AC recommends AS the way AS already recommends AC** — 0 / 18 done (0%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Falsification spike | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
-| 1 | Detection + the single card | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 2 | Behave correctly under AS (the part that is not promotion) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 3 | Symmetry in the docs | ⬜ not started | 9 | 0 | 0 | 0 | 0% |
-
-<a id="blockers-road-to-reciprocal-ecosystem"></a>
-**Blockers**
-
-- **restraint-review** (owner: maintainer) — blocks — (was: Phase 1 shipping at all) - **Decision:** affirmed — the distribution value outweighs the surface cost. Phase 1 ships, under the unchanged hard bound: **one card, one surface, self-retiring, permanently dismissible, no second placement ever.**
-  - **What to do:**
-  - **Resolved when:** ~~the decision is recorded either way~~ — recorded here.
-- **adoption-measurement** (owner: user) — blocks knowing whether reciprocal promotion moves anything
-  - **What to do:**
-  - **Resolved when:** ≥1 external user reports (issue/discussion/direct message) arriving at either package through the other.
 
 ### [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md)
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 16 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
+> 17 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
 
 ## Overall
 
-**168 / 263 steps done · 64%**
+**168 / 277 steps done · 61%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   64%
+████████████████████████░░░░░░░░░░░░░░░░   61%
 ```
 
 ## Open roadmaps
@@ -24,14 +24,15 @@
 | 6 | [road-to-feedback-9.2.0-followups.md](roadmaps/road-to-feedback-9.2.0-followups.md) | 4 | 11 | 1 | 10 | 0 | 0 | 0 | █████████░ 91% |
 | 7 | [road-to-feedback-9.8.0-followups.md](roadmaps/road-to-feedback-9.8.0-followups.md) | 5 | 22 | 1 | 21 | 0 | 0 | 0 | ██████████ 95% |
 | 8 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 9 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 10 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 11 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
-| 12 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 13 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 14 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
-| 15 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
-| 16 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 9 | [road-to-lean-agent-init.md](roadmaps/road-to-lean-agent-init.md) | 5 | 14 | 14 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 10 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 11 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 12 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
+| 13 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 14 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 15 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
+| 16 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
+| 17 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
 

--- a/agents/roadmaps/archive/road-to-reciprocal-ecosystem.md
+++ b/agents/roadmaps/archive/road-to-reciprocal-ecosystem.md
@@ -77,7 +77,7 @@ card, docs symmetry) is NOT in this PR — it remains for the AC maintainer.
 
 ## Phase 0 — Falsification spike
 
-- [ ] S0.1 — **Is the recommendation even relevant to AC's users?**
+- [x] S0.1 — **Is the recommendation even relevant to AC's users?**
       Determine whether AC can cheaply detect *multi-account intent* —
       concretely: a handful of `existsSync` checks against the known host
       credential locations `toolDetection.ts` already models
@@ -92,39 +92,64 @@ card, docs symmetry) is NOT in this PR — it remains for the AC maintainer.
 
 Exit: a verdict on targeted-vs-passive. This determines the entire shape.
 
+> **Verdict (2026-07-28): B — passive row (honest null, cannot target).**
+> AI-council debate, 2 rounds, unanimous round-1 convergence
+> (claude-sonnet-4-5 + gpt-4o; transcript not cited by path — council
+> output is gitignored and auto-pruned; date + members are the durable
+> trace). Grounds: `toolDetection.ts` models tool presence (one config-dir
+> slot per host, e.g. `~/.claude`); a second account via native
+> login/logout reuses the same credential slot and leaves no separate
+> fixed-path trace. `~/.agent-switch/` presence and `CLAUDE_CONFIG_DIR`
+> pointing into it are both self-retiring states (user already has AS).
+> Multiple host configs (`.claude` + `.codex`) signal multi-*tool*, not
+> multi-*account*. The round-2 counter-arguments (home-dir `readdir`
+> scanning, project-dir config paths, access-frequency heuristics,
+> telemetry) all violate the pre-registered fixed-stat-list constraint or
+> the package's no-telemetry stance. Consequence: Phase 1 ships the
+> recommendation as a **passive row** among companion tools in the
+> wizard's tooling step — never a proactive card; endpoint, two states,
+> placement, and permanent dismissal proceed unchanged.
+
 ## Phase 1 — Detection + the single card
 
-- [ ] Add an AS probe alongside the rtk one:
+- [x] Add an AS probe alongside the rtk one:
       `GET /api/v1/wizard/detect-agent-switch` →
       `{ installed, version|null, installCommand }` (mirroring
       `/detect-rtk`'s shape). Detect by binary on PATH **and** the
       presence of `~/.agent-switch/`, so a user who installed it another
       way is not told to install it again.
-- [ ] Two states only: not installed → recommend · installed → **hidden**
+      <!-- done 2026-07-28: src/install/agentSwitchDetection.ts + wizard.ts endpoint (ungated, next to detect-rtk); tests/install/agentSwitchDetection.test.ts + tests/server/wizard.detectAgentSwitch.test.ts -->
+- [x] Two states only: not installed → recommend · installed → **hidden**
       (self-retiring, the property worth copying from
       `deriveAgentConfigView`). There is deliberately **no** "outdated"
       state — classifying it would require exactly the version-currency
       check the acceptance criteria forbid; AS's own updater owns updates.
-- [ ] Place it on the wizard's tooling step (per S0.1: card or passive
+      <!-- done 2026-07-28: installCommand null when installed; AgentSwitchRow renders null unless installed === false; no latest-release fetch anywhere -->
+- [x] Place it on the wizard's tooling step (per S0.1: card or passive
       row) and nowhere else. Copy stays substantive: what AS does
       (per-account isolation, no re-login), that it is free and MIT, one
       command.
-- [ ] **Permanently dismissible**, persisted. A dismissed recommendation
+      <!-- done 2026-07-28: passive row (S0.1 verdict B) on the identity step next to RtkRow, WizardPage.tsx AgentSwitchRow; single placement, grep-verified -->
+- [x] **Permanently dismissible**, persisted. A dismissed recommendation
       never returns.
+      <!-- done 2026-07-28: src/install/wizardDismissals.ts (user-global wizard-dismissals.json, no un-dismiss API) + POST /api/v1/wizard/dismiss-recommendation -->
+
 
 ## Phase 2 — Behave correctly under AS (the part that is not promotion)
 
 This is where AC earns the integration rather than advertising it.
 **Ships even if Phase 1 is cut** — it is correctness work.
 
-- [ ] **Detect that AC is running under an AS profile** —
+- [x] **Detect that AC is running under an AS profile** —
       `CLAUDE_CONFIG_DIR` (or the sibling provider env var) pointing
       inside `~/.agent-switch/`.
-- [ ] When detected, **say so in the settings hub**: which profile is
+      <!-- done 2026-07-28: src/install/agentSwitchProfile.ts (pure env/path logic, CLAUDE_CONFIG_DIR + CODEX_HOME vs AGENT_SWITCH_HOME ?? ~/.agent-switch); tests/install/agentSwitchProfile.test.ts -->
+- [x] When detected, **say so in the settings hub**: which profile is
       active, and that writes are profile-scoped. An AC user who switches
       profiles and sees different settings must not think AC lost their
       config.
-- [ ] **Warn on the share collision.** AS's `share on` symlinks
+      <!-- done 2026-07-28: ping advertises agentSwitchProfile {active,provider,profile}; AgentSwitchProfileBanner in SettingsHubPage next to SettingsChangesBanner -->
+- [x] **Warn on the share collision.** AS's `share on` symlinks
       `settings.json`, `keybindings.json`, `CLAUDE.md`, `skills/`,
       `commands/`, `agents/` across profiles (`agent-switch/src/
       share.ts:37-43`). A write AC believes is profile-local can land
@@ -137,43 +162,57 @@ This is where AC earns the integration rather than advertising it.
       via the shared tree)" / "Cancel" — plus a pointer to
       `agent-switch share off` for users who want profile-local writes.
       AC never breaks AS's symlinks itself.
-- [ ] Accept the host-supplied config root from AS's spawn (pairs with
+      <!-- done 2026-07-28: src/server/io/sharedWriteCheck.ts (lstat walk bounded to the AS root) gating PUT /settings + PUT /user-md with 409 shared-write; SharedWriteModal blocking confirm (Write-all-profiles / Cancel + `agent-switch share off` pointer); confirmed writes resolve THROUGH the symlink so AS's links are never broken; tests/server/sharedWriteCheck.test.ts -->
+- [x] Accept the host-supplied config root from AS's spawn (pairs with
       agent-switch's `road-to-ac-embedded-settings` Phase 3), so
       profile-scoped AC settings work rather than silently colliding.
       The flag/env is **discoverable** — advertised in the version/ping
       capability readout — so an older AS against a newer AC (or vice
       versa) degrades to a clear "not supported" instead of silent
       breakage.
+      <!-- done (landed 2026-07-25, commit a9f003863, verified 2026-07-28): src/cli/configRoot.ts (--config-root flag + EVENT4U_CONFIG_HOME), capabilities.configRoot in --version --json (src/shared/capabilities.ts) + GET /api/v1/ping (ping.ts); tests: src/cli/configRoot.test.ts, src/shared/capabilities.test.ts, tests/server/app.test.ts -->
+
 
 ## Phase 3 — Symmetry in the docs
 
-- [ ] One "Works with agent-switch" section in AC's README, mirroring AS's
+- [x] One "Works with agent-switch" section in AC's README, mirroring AS's
       existing agent-config mention. Not a badge wall — a short section
       explaining the composition (AS isolates accounts, AC governs what
       the agents do inside them).
-- [ ] The long-form explainer of how the two compose is **owned by AC's
+      <!-- done 2026-07-28: README.md § "Works with agent-switch" (after § Supported tools) -->
+- [x] The long-form explainer of how the two compose is **owned by AC's
       docs** (this repo publishes a docs site; one owner, no third
       artefact). AS's README section is a two-sentence summary **plus the
       link** — so even a broken link degrades to still-correct text, and
       the two descriptions cannot drift into contradiction.
+      <!-- done 2026-07-28: docs/guides/works-with-agent-switch.md, published on the docs site (site/sync-docs.mjs PAGES + Guides sidebar section in site/astro.config.mjs) -->
+
 
 ## Acceptance criteria (pre-registered)
 
-- [ ] **Exactly one AS recommendation surface in AC.** A second placement
+- [x] **Exactly one AS recommendation surface in AC.** A second placement
       requires naming what it retires.
-- [ ] **Self-retiring:** invisible to users who already have AS.
-- [ ] **Permanently dismissible**, and the dismissal survives updates.
-- [ ] **AC never auto-installs AS**, and never runs a package install the
+      <!-- verified 2026-07-28: grep — exactly one render site, WizardPage.tsx identity step -->
+- [x] **Self-retiring:** invisible to users who already have AS.
+      <!-- verified 2026-07-28: AgentSwitchRow renders null unless installed === false; installCommand null when installed; test-covered -->
+- [x] **Permanently dismissible**, and the dismissal survives updates.
+      <!-- verified 2026-07-28: wizard-dismissals.json lives in the user-global config root (not the package install), no un-dismiss API exists -->
+- [x] **AC never auto-installs AS**, and never runs a package install the
       user did not initiate — same stance as rtk.
-- [ ] **AC does not report on AS's version currency.** AS owns its
+      <!-- verified 2026-07-28: AGENT_SWITCH_INSTALL_COMMAND is only ever returned/displayed for copy, never spawned (grep: 3 hits, all display-path) -->
+- [x] **AC does not report on AS's version currency.** AS owns its
       updates.
-- [ ] **Phase 2 ships even if Phase 1 is cut.** Profile-awareness and the
+      <!-- verified 2026-07-28: no latest-release fetch anywhere in agentSwitchDetection.ts; version is a local --version probe only, no comparison -->
+- [x] **Phase 2 ships even if Phase 1 is cut.** Profile-awareness and the
       share-collision warning are correctness work, valuable with or
       without any promotion.
-- [ ] **Honest-null path:** if S0.1 shows AC cannot target the
+      <!-- verified 2026-07-28: zero imports of agentSwitchDetection/wizardDismissals from any Phase-2 file (grep) -->
+- [x] **Honest-null path:** if S0.1 shows AC cannot target the
       recommendation, the proactive card is dropped and only the passive
       tooling row ships. Record the negative result rather than showing an
       untargeted ad to every user.
+      <!-- verified 2026-07-28: S0.1 verdict B recorded above (council convergence); shipped surface is a passive row, no proactive card exists -->
+
 
 ## Blockers
 

--- a/agents/roadmaps/road-to-lean-agent-init.md
+++ b/agents/roadmaps/road-to-lean-agent-init.md
@@ -68,8 +68,8 @@ run needs no significance test.
 - **No second ledger:** all telemetry is additive fields on the existing
   audit stream (`agents/runtime/state/audit/YYYY-MM.jsonl`);
   `readOrchestrationMetrics` (`src/scripts/orchestration_record.ts`) reads
-  new fields tolerantly. (Anti-fragmentation lesson from the ruflo audit —
-  one canonical location, never CWD-relative.)
+  new fields tolerantly. (Anti-fragmentation lesson from the external
+  orchestrator-reference audit — one canonical location, never CWD-relative.)
 - **ADR-124 / MCP-REJECT untouched:** no resident retrieval server, no second
   engine; `later/road-to-deferred-rule-retriever.md` stays parked — this
   roadmap only produces the demand-signal datum its parked condition asks for
@@ -78,7 +78,7 @@ run needs no significance test.
   deterministic v1 classifier (`src/scripts/_lib/auto_dispatch.ts`,
   `auto-dispatch-classification.md`); no LLM classifier fallback (cut C3).
 - **User-spec inviolability:** routing chooses HOW a task runs, never WHAT
-  was asked (ruflo queen-agent anti-pattern).
+  was asked (the external reference's queen-agent anti-pattern).
 - **Subordination:** while `road-to-orchestration-scope-decision.md` is open,
   no new PUBLIC orchestration claim is created here; the one claim below is
   an internal efficiency claim, family-scoped, modeled on

--- a/docs/guides/works-with-agent-switch.md
+++ b/docs/guides/works-with-agent-switch.md
@@ -1,0 +1,82 @@
+# Works with agent-switch
+
+`agent-config` (AC) and [`agent-switch`](https://github.com/event4u-app/agent-switch)
+(AS) are companion tools that compose without depending on each other:
+
+- **agent-switch isolates accounts.** One machine, several agent accounts
+  (work / personal / client) — AS keeps each in its own profile
+  (`CLAUDE_CONFIG_DIR` and sibling provider variables point into
+  `~/.agent-switch/<provider>/<name>/config`), so switching accounts never
+  means logging out and back in.
+- **agent-config governs what the agents do** inside whichever account is
+  active — skills, rules, commands, quality gates, review discipline.
+
+Neither tool requires the other. This page documents what AC does when the
+two meet.
+
+## The wizard recommendation (passive, self-retiring)
+
+The setup wizard's tooling step lists agent-switch as a companion tool —
+a passive row, not a promotion card. This shape is deliberate
+(pre-registered in the reciprocal-ecosystem roadmap and confirmed by an
+AI-council review, 2026-07-28): AC cannot distinguish a multi-account user
+from a single-account user with a fixed list of filesystem checks, so a
+proactive card would be indiscriminate. The row therefore:
+
+- shows only while agent-switch is **not** installed (detected by the
+  `agent-switch` binary on `PATH` or a `~/.agent-switch/` directory —
+  either counts, so an unusual install is not told to install again);
+- disappears permanently once installed (self-retiring — there is no
+  "outdated" state; AS's own updater owns updates, AC never reports on
+  AS's version currency);
+- is **permanently dismissible** — "Don't show again" persists to the
+  user-global config root and survives package updates;
+- only **shows** the install command (`npm install -g @event4u/agent-switch`)
+  for you to copy. AC never runs a package install you did not initiate —
+  the same stance it takes for every companion tool.
+
+Detection is served by `GET /api/v1/wizard/detect-agent-switch`
+(`{ installed, version, installCommand, repo, dismissed }`); dismissal by
+`POST /api/v1/wizard/dismiss-recommendation`.
+
+## Running agent-config under an agent-switch profile
+
+This is the substantive half of the integration — correctness, not
+promotion. When AC runs inside an AS profile (a provider config variable
+such as `CLAUDE_CONFIG_DIR` points into the AS profile tree), AC:
+
+1. **Says so.** `GET /api/v1/ping` advertises the active profile
+   (`agentSwitchProfile: { active, provider, profile }`), and the settings
+   hub shows a banner naming it. Settings shown and saved there are
+   profile-scoped — switching profiles shows that profile's own settings;
+   nothing is lost.
+2. **Warns before writing through a shared symlink.** AS's `share on`
+   links files across profiles; a write AC believes is profile-local can
+   land through such a symlink and change **every** profile. Before a
+   settings-hub write, AC `lstat`s the target (and its ancestors inside
+   the profile tree). If the write would go through a symlink, the save
+   is blocked by an explicit confirm — "Write (affects all profiles)" or
+   "Cancel" — with a pointer to `agent-switch share off` for
+   profile-local writes. AC never breaks or rewrites AS's symlinks
+   itself, and the check is topology-free: AC does not need to
+   understand AS's share model.
+3. **Accepts a host-supplied config root.** AS (or any host) can spawn
+   AC with `--config-root <path>` or `EVENT4U_CONFIG_HOME`, so AC's own
+   settings, state, and tokens are profile-scoped instead of colliding
+   in the global `~/.event4u/agent-config/`. The capability is
+   discoverable — `agent-config --version --json` and
+   `GET /api/v1/ping` advertise `capabilities.configRoot` — so an older
+   AS against a newer AC (or vice versa) degrades to a clear
+   "not supported" instead of silent breakage.
+
+## Boundaries
+
+- Exactly **one** recommendation surface in AC (the wizard tooling row).
+- AC never auto-installs agent-switch.
+- AC never reports on agent-switch's version currency.
+- The profile-awareness above ships and works whether or not the
+  recommendation row exists — it is correctness work, valuable on its own.
+
+agent-switch's own README carries the mirror-image mention of
+agent-config; the long-form description of the composition lives here, on
+purpose, so the two descriptions cannot drift into contradiction.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -90,6 +90,11 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Guides',
+          collapsed: true,
+          items: [{ label: 'Works with agent-switch', slug: 'works-with-agent-switch' }],
+        },
+        {
           label: 'Reference',
           collapsed: true,
           items: [

--- a/site/sync-docs.mjs
+++ b/site/sync-docs.mjs
@@ -24,6 +24,11 @@ const PAGES = [
   { src: 'benchmark.md', slug: 'benchmark', title: 'Discipline-axis benchmark' },
   { src: 'CLAIMS.md', slug: 'claims', title: 'Claims ledger' },
   { src: 'catalog.md', slug: 'catalog', title: 'Catalog' },
+  {
+    src: 'guides/works-with-agent-switch.md',
+    slug: 'works-with-agent-switch',
+    title: 'Works with agent-switch',
+  },
 ];
 const BASE = '/agent-config';
 // The catalog links to source files (../dist/…, ../docs/…, ../README.md) that

--- a/src/install/agentSwitchDetection.ts
+++ b/src/install/agentSwitchDetection.ts
@@ -1,0 +1,90 @@
+/**
+ * agent-switch detection — passive wizard recommendation (S0.1 honest-null
+ * council verdict, 2026-07-28: PASSIVE ROW ONLY, never a proactive card).
+ *
+ * agent-switch (https://github.com/event4u-app/agent-switch,
+ * `@event4u/agent-switch` on npm) isolates multiple agent accounts into
+ * per-account profiles (`CLAUDE_CONFIG_DIR`) so switching accounts never
+ * requires a re-login. Unlike rtk, the install command is npm-global and
+ * identical on every OS — no per-OS command map, no name collision to
+ * disambiguate.
+ *
+ * Two independent installed-signals, either is sufficient:
+ *   - the `agent-switch` binary is resolvable on PATH (the documented
+ *     npm-global install), OR
+ *   - `~/.agent-switch/` exists — a user who installed it another way must
+ *     never be told to install it again.
+ *
+ * Version is only probed when the binary is on PATH (the directory-only
+ * signal carries no version information — reported as `null`). There is
+ * deliberately NO version-currency check and NO network call here — the
+ * wizard only ever answers "installed or not", never "up to date" (roadmap
+ * acceptance criterion: this module does not report on agent-switch's
+ * version currency).
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { resolveBinaryOnPath } from './rtkDetection.js';
+
+export const AGENT_SWITCH_REPO = 'event4u-app/agent-switch';
+export const AGENT_SWITCH_NPM = '@event4u/agent-switch';
+export const AGENT_SWITCH_INSTALL_COMMAND = 'npm install -g @event4u/agent-switch';
+
+export interface AgentSwitchDetection {
+    installed: boolean;
+    version: string | null;
+}
+
+export interface DetectAgentSwitchOptions {
+    /** Override the home directory (tests). */
+    home?: string;
+    /** Override PATH (tests). */
+    pathEnv?: string;
+    /** Override the version probe (tests). Receives the resolved binary path. */
+    probeVersion?: (bin: string) => string | null;
+}
+
+const PROBE_TIMEOUT_MS = 2000;
+
+/** First dotted-number token in `output`, or `null` when none is present. */
+export function parseVersionOutput(output: string): string | null {
+    const m = /(\d+\.\d+(?:\.\d+)?)/.exec(output);
+    return m?.[1] ?? null;
+}
+
+function defaultProbeVersion(bin: string): string | null {
+    try {
+        const res = spawnSync(bin, ['--version'], {
+            timeout: PROBE_TIMEOUT_MS,
+            encoding: 'utf-8',
+            windowsHide: true,
+        });
+        if (res.error !== undefined || res.signal !== null) return null;
+        return parseVersionOutput(`${res.stdout ?? ''}\n${res.stderr ?? ''}`);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Detect agent-switch installation. Never throws — every failure mode
+ * (spawn error, timeout, unparsable output) collapses to `version: null`.
+ */
+export function detectAgentSwitch(options: DetectAgentSwitchOptions = {}): AgentSwitchDetection {
+    const binPath = resolveBinaryOnPath('agent-switch', options.pathEnv);
+    if (binPath !== null) {
+        const probe = options.probeVersion ?? defaultProbeVersion;
+        let version: string | null;
+        try {
+            version = probe(binPath);
+        } catch {
+            version = null;
+        }
+        return { installed: true, version };
+    }
+    const home = options.home ?? homedir();
+    const dirInstalled = existsSync(join(home, '.agent-switch'));
+    return { installed: dirInstalled, version: null };
+}

--- a/src/install/agentSwitchProfile.ts
+++ b/src/install/agentSwitchProfile.ts
@@ -1,0 +1,131 @@
+/**
+ * Detect whether AC is currently running under an agent-switch (AS)
+ * profile (`road-to-reciprocal-ecosystem.md` Phase 2 — correctness
+ * work, not the Phase 1 promotion card).
+ *
+ * Pure and injectable: reads only the supplied environment map, no
+ * filesystem I/O. Detection is deliberately topology-free — it never
+ * needs to understand AS's on-disk share model (that lives in
+ * `sharedWriteCheck.ts`, which DOES touch disk via `lstat`).
+ *
+ * AS root resolution mirrors `agent-switch/src/profiles.ts:11`:
+ * `AGENT_SWITCH_HOME` env override, else `~/.agent-switch`. Profile
+ * config dirs live at `<ROOT>/<provider>/<name>/config` (profiles.ts
+ * :143-145). Provider env vars mirror `agent-switch/src/providers.ts`:
+ * claude → `CLAUDE_CONFIG_DIR`, codex → `CODEX_HOME`. `HOME`
+ * (antigravity's provider var) is deliberately NOT checked here — it
+ * is set on every process, so treating it as an AS signal would
+ * false-positive constantly; antigravity profile detection is left to
+ * a future, more specific probe.
+ */
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+
+export interface AgentSwitchProfile {
+    active: boolean;
+    provider: string | null;
+    profile: string | null;
+}
+
+const INACTIVE: AgentSwitchProfile = { active: false, provider: null, profile: null };
+
+/** Provider env vars checked, in priority order (claude wins on a tie). */
+const PROVIDER_ENV_VARS: readonly string[] = ['CLAUDE_CONFIG_DIR', 'CODEX_HOME'];
+
+interface AgentSwitchMatch {
+    /** The resolved AS root implied by the matching env var. */
+    root: string;
+    /** Path segments below `root` (e.g. `[provider, profile, 'config']`). */
+    afterRoot: string[];
+}
+
+/** Expand a leading `~` the way a shell would, for env values set programmatically. */
+function expandTilde(p: string): string {
+    if (p === '~') return homedir();
+    if (p.startsWith('~/') || (process.platform === 'win32' && p.startsWith('~\\'))) {
+        return path.join(homedir(), p.slice(2));
+    }
+    return p;
+}
+
+function normalize(p: string): string {
+    return path.resolve(expandTilde(p));
+}
+
+function nonEmpty(v: string | undefined): v is string {
+    return typeof v === 'string' && v.trim() !== '';
+}
+
+/**
+ * Find the first provider env var whose (normalized) value lies
+ * inside the AS root, and return the root + the path segments below
+ * it. Shared by `detectAgentSwitchProfile` and `resolveAgentSwitchRoot`
+ * so both stay in lockstep with a single matching rule.
+ */
+function resolveMatch(env: NodeJS.ProcessEnv): AgentSwitchMatch | null {
+    const overrideRaw = env['AGENT_SWITCH_HOME'];
+    const overrideRoot = nonEmpty(overrideRaw) ? normalize(overrideRaw) : null;
+
+    for (const varName of PROVIDER_ENV_VARS) {
+        const raw = env[varName];
+        if (!nonEmpty(raw)) continue;
+        const candidate = normalize(raw);
+
+        let root: string | null = null;
+        if (overrideRoot !== null) {
+            if (candidate === overrideRoot || candidate.startsWith(overrideRoot + path.sep)) {
+                root = overrideRoot;
+            }
+        } else {
+            const bareMarker = `${path.sep}.agent-switch`;
+            const nestedMarker = `${bareMarker}${path.sep}`;
+            if (candidate.endsWith(bareMarker)) {
+                root = candidate;
+            } else {
+                const idx = candidate.indexOf(nestedMarker);
+                if (idx !== -1) root = candidate.slice(0, idx + bareMarker.length);
+            }
+        }
+        if (root === null) continue;
+
+        const rest = candidate === root ? '' : candidate.slice(root.length + 1);
+        const afterRoot = rest === '' ? [] : rest.split(path.sep).filter((s) => s.length > 0);
+        return { root, afterRoot };
+    }
+    return null;
+}
+
+/**
+ * Detect the active AS profile (if any) from the current environment.
+ *
+ * - Not inside `.agent-switch` at all → `{ active: false, ... }`.
+ * - Inside the AS root, but the env var points AT the root itself
+ *   (no `<provider>/<profile>` segments below it) → treated as
+ *   inactive; an env var pointing at the bare root is not a profile
+ *   directory.
+ * - Inside the AS root with only one segment below it (a provider dir
+ *   with no profile name) → active, but unparseable (`provider`/
+ *   `profile` both `null`).
+ * - Inside the AS root with `<provider>/<profile>/...` below it →
+ *   active, with `provider`/`profile` parsed from the first two
+ *   segments.
+ */
+export function detectAgentSwitchProfile(env: NodeJS.ProcessEnv = process.env): AgentSwitchProfile {
+    const match = resolveMatch(env);
+    if (match === null) return INACTIVE;
+    if (match.afterRoot.length === 0) return INACTIVE;
+    if (match.afterRoot.length < 2) return { active: true, provider: null, profile: null };
+    // `length >= 2` guaranteed above — `??` only satisfies noUncheckedIndexedAccess.
+    return { active: true, provider: match.afterRoot[0] ?? null, profile: match.afterRoot[1] ?? null };
+}
+
+/**
+ * Resolve the AS root directory implied by the environment (the same
+ * matching rule `detectAgentSwitchProfile` uses), for callers that
+ * need a boundary to stop an upward filesystem walk at — see
+ * `sharedWriteCheck.ts`. Returns `null` when no provider env var
+ * resolves inside an AS tree.
+ */
+export function resolveAgentSwitchRoot(env: NodeJS.ProcessEnv = process.env): string | null {
+    return resolveMatch(env)?.root ?? null;
+}

--- a/src/install/wizardDismissals.ts
+++ b/src/install/wizardDismissals.ts
@@ -1,0 +1,60 @@
+/**
+ * Permanent wizard-recommendation dismissals, persisted at
+ * `~/.event4u/agent-config/wizard-dismissals.json`.
+ *
+ * A dismissed recommendation (e.g. `"agent-switch"`) never returns — there
+ * is deliberately NO un-dismiss function (S0.1 council verdict, 2026-07-28:
+ * a passive row the user closed once stays closed). The file lives in the
+ * user-global config root, not inside the installed package, so a
+ * dismissal survives package updates.
+ *
+ * `AGENT_CONFIG_WIZARD_DISMISSALS` overrides the path (tests only).
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve, dirname } from 'node:path';
+
+function wizardDismissalsPath(): string {
+    const override = process.env['AGENT_CONFIG_WIZARD_DISMISSALS'];
+    if (override !== undefined && override.length > 0) return override;
+    return resolve(homedir(), '.event4u', 'agent-config', 'wizard-dismissals.json');
+}
+
+interface DismissalsFile {
+    dismissed?: unknown;
+}
+
+/**
+ * Return the recorded dismissal ids, or `[]` when absent / unreadable.
+ * Best-effort: a missing or corrupted file behaves as "nothing dismissed
+ * yet" rather than throwing.
+ */
+export function readDismissedRecommendations(): readonly string[] {
+    try {
+        const raw = readFileSync(wizardDismissalsPath(), 'utf8');
+        const parsed = JSON.parse(raw) as DismissalsFile;
+        return Array.isArray(parsed.dismissed)
+            ? parsed.dismissed.filter((d): d is string => typeof d === 'string')
+            : [];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Record `id` as permanently dismissed. Idempotent — a repeat call for an
+ * already-dismissed id is a no-op.
+ */
+export function dismissRecommendation(id: string): void {
+    try {
+        const existing = readDismissedRecommendations();
+        if (existing.includes(id)) return;
+        const path = wizardDismissalsPath();
+        mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+        const record = { dismissed: [...existing, id] };
+        writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+    } catch {
+        // Best-effort: a failed write just means the recommendation may
+        // resurface on the next load — never throw out of a dismiss action.
+    }
+}

--- a/src/server/io/sharedWriteCheck.ts
+++ b/src/server/io/sharedWriteCheck.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared-write collision detector for the settings / user-md write
+ * routes (`road-to-reciprocal-ecosystem.md` Phase 2).
+ *
+ * When AC runs under an agent-switch (AS) profile with `share on`, AS
+ * symlinks certain files/dirs (`settings.json`, `keybindings.json`,
+ * `CLAUDE.md`, `skills/`, `commands/`, `agents/`) across profiles
+ * (`agent-switch/src/share.ts:37-43`). A write AC believes is
+ * profile-local can land through such a symlink and change every
+ * profile that shares it.
+ *
+ * Detection is AC-local and topology-free: `lstat`-walk from the write
+ * target up to the AS root, looking for a symlink component. AC never
+ * needs to understand AS's share manifest to guard against this, and
+ * never breaks AS's symlinks itself — `resolveThroughSymlinks` below
+ * follows a detected symlink to its real target rather than letting a
+ * naive atomic write clobber the symlink in place.
+ */
+import { lstatSync, realpathSync } from 'node:fs';
+import * as path from 'node:path';
+import { detectAgentSwitchProfile, resolveAgentSwitchRoot } from '../../install/agentSwitchProfile.js';
+
+const MAX_WALK_DEPTH = 32;
+
+function isSymlink(p: string): boolean {
+    try {
+        return lstatSync(p).isSymbolicLink();
+    } catch {
+        // Component doesn't exist yet — not a symlink; the walk keeps
+        // climbing to check existing ancestors.
+        return false;
+    }
+}
+
+/** `true` when `p` is `root` itself or lies strictly inside it. */
+function isInsideRoot(p: string, root: string): boolean {
+    return p === root || p.startsWith(root + path.sep);
+}
+
+/**
+ * Returns the symlinked path (the write target itself, or the nearest
+ * symlinked ancestor between `target` and the AS root) when AC is
+ * running under an active AS profile, the write target actually lies
+ * inside the AS root, AND a symlink sits somewhere on the path between
+ * them. Returns `null` when no AS profile is active, when the target
+ * isn't inside the AS tree at all, or when no symlink is found before
+ * reaching the AS root.
+ *
+ * The inside-root check comes BEFORE any filesystem walk, and the walk
+ * itself stops at the AS root (inclusive): AS could not have placed a
+ * shared symlink outside its own tree, so a target outside it is
+ * never a collision candidate — regardless of an unrelated ancestor
+ * symlink further up the filesystem (e.g. macOS's `/var` ->
+ * `/private/var`, `/tmp` -> `/private/tmp`). Without this bound, an
+ * unrouted write target (AC not yet wired to a profile-scoped config
+ * root — see Phase 3) would walk all the way to the filesystem root
+ * looking for a symlink that could never be AS's.
+ */
+export function sharedWriteTarget(target: string, env: NodeJS.ProcessEnv = process.env): string | null {
+    const profile = detectAgentSwitchProfile(env);
+    if (!profile.active) return null;
+
+    const root = resolveAgentSwitchRoot(env);
+    const absTarget = path.resolve(target);
+    if (root === null || !isInsideRoot(absTarget, root)) return null;
+
+    let current = absTarget;
+    for (let depth = 0; depth < MAX_WALK_DEPTH; depth++) {
+        if (isSymlink(current)) return current;
+        if (current === root) return null;
+        const parent = path.dirname(current);
+        if (parent === current) return null; // filesystem root reached — should not happen once bounded by root
+        current = parent;
+    }
+    return null;
+}
+
+/**
+ * Resolve `target` all the way through any symlinks on its path,
+ * tolerating a not-yet-existing leaf (or a not-yet-existing chain of
+ * ancestors) by resolving the nearest existing ancestor and
+ * re-appending the missing segments verbatim. Used by the write
+ * routes so a confirmed shared write lands on the real file a
+ * detected symlink points at, rather than replacing the symlink
+ * itself with a private copy.
+ */
+export function resolveThroughSymlinks(target: string): string {
+    const abs = path.resolve(target);
+    try {
+        return realpathSync(abs);
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        const parent = path.dirname(abs);
+        if (parent === abs) return abs; // filesystem root; nothing left to resolve
+        const base = path.basename(abs);
+        return path.join(resolveThroughSymlinks(parent), base);
+    }
+}

--- a/src/server/routes/ping.ts
+++ b/src/server/routes/ping.ts
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import { userInfo } from 'node:os';
 import { PACKAGE_JSON } from '../../cli/paths.js';
 import { CAPABILITIES } from '../../shared/capabilities.js';
+import { detectAgentSwitchProfile } from '../../install/agentSwitchProfile.js';
 
 function systemUserName(): string {
     try {
@@ -77,6 +78,18 @@ export const PingResponseSchema = z.object({
             features: z.array(z.enum(['theme', 'deepLink'])),
         }),
     }),
+    /**
+     * Whether this server process is currently running under an
+     * agent-switch (AS) profile (`road-to-reciprocal-ecosystem.md`
+     * Phase 2), and which one. Lets the GUI say which profile is
+     * active so a user who switches profiles and sees different
+     * settings does not mistake profile-scoping for lost config.
+     */
+    agentSwitchProfile: z.object({
+        active: z.boolean(),
+        provider: z.string().nullable(),
+        profile: z.string().nullable(),
+    }),
 });
 
 export type PingResponse = z.infer<typeof PingResponseSchema>;
@@ -119,6 +132,7 @@ export function pingRoute(opts: PingRouteOptions): FastifyPluginAsync {
                 projectSurface: opts.projectSurface === true,
                 devSurfaces: (process.env['AGENT_CONFIG_DEV_MODE'] ?? '') === '1',
                 capabilities: { ...CAPABILITIES },
+                agentSwitchProfile: detectAgentSwitchProfile(),
             };
             return response;
         });

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -24,7 +24,16 @@ import { zodToJsonSchema } from 'zod-to-json-schema';
 import { settingsSchema } from '../schemas/settings.js';
 import { parseYaml, mergeIntoTemplate, diffValues, deepMerge } from '../io/yamlIO.js';
 import { writeAtomic } from '../io/atomicWrite.js';
+import { sharedWriteTarget, resolveThroughSymlinks } from '../io/sharedWriteCheck.js';
 import { PACKAGE_ROOT } from '../../cli/paths.js';
+
+/**
+ * Shared-write collision message (road-to-reciprocal-ecosystem Phase 2)
+ * — surfaced verbatim in the 409 body the GUI's blocking confirm reads.
+ */
+const SHARED_WRITE_MESSAGE =
+    'This write lands through an agent-switch shared symlink and affects ALL profiles. ' +
+    'Re-send with confirmSharedWrite:true to proceed, or run `agent-switch share off` for profile-local writes.';
 
 // Installer placeholders in `src/config/agent-settings.template.yml` that
 // `scripts/install.py` substitutes per-user. The TypeScript defaults layer
@@ -363,7 +372,7 @@ export function settingsRoute(opts: SettingsRouteOptions): FastifyPluginAsync {
                 await reply.code(412).send({ error: { code: 'PRECONDITION_REQUIRED', message: 'If-Unmodified-Since header required' } });
                 return reply;
             }
-            const body = (request.body ?? {}) as { values?: unknown };
+            const body = (request.body ?? {}) as { values?: unknown; confirmSharedWrite?: unknown };
             const parsed = settingsSchema.safeParse(body.values);
             if (!parsed.success) {
                 await reply.code(422).send({
@@ -395,10 +404,20 @@ export function settingsRoute(opts: SettingsRouteOptions): FastifyPluginAsync {
                         preview: { path: SETTINGS_RELATIVE, body: merged },
                     };
                 }
-                const path = settingsPath(opts.writeRoot);
-                await fs.mkdir(dirname(path), { recursive: true, mode: 0o700 });
-                await writeAtomic(path, merged, { mode: 0o600 });
-                const stat = await fs.stat(path);
+                const targetPath = settingsPath(opts.writeRoot);
+                // Shared-write collision gate (road-to-reciprocal-ecosystem
+                // Phase 2) — a write that would land through an agent-switch
+                // shared symlink needs an explicit confirm; see
+                // `sharedWriteCheck.ts` for the detection contract.
+                const sharedPath = sharedWriteTarget(targetPath);
+                if (sharedPath !== null && body.confirmSharedWrite !== true) {
+                    await reply.code(409).send({ error: 'shared-write', sharedPath, message: SHARED_WRITE_MESSAGE });
+                    return reply;
+                }
+                const writePath = sharedPath !== null ? resolveThroughSymlinks(targetPath) : targetPath;
+                await fs.mkdir(dirname(writePath), { recursive: true, mode: 0o700 });
+                await writeAtomic(writePath, merged, { mode: 0o600 });
+                const stat = await fs.stat(writePath);
                 return { lastModified: Math.trunc(stat.mtimeMs), writtenPaths: [SETTINGS_RELATIVE] };
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'atomic write failed';

--- a/src/server/routes/userMd.ts
+++ b/src/server/routes/userMd.ts
@@ -27,7 +27,16 @@ import {
     parseUserIdentity,
 } from '../../shared/userMd/utils.js';
 import { writeAtomic } from '../io/atomicWrite.js';
+import { sharedWriteTarget, resolveThroughSymlinks } from '../io/sharedWriteCheck.js';
 import { PACKAGE_ROOT } from '../../cli/paths.js';
+
+/**
+ * Shared-write collision message (road-to-reciprocal-ecosystem Phase 2)
+ * — surfaced verbatim in the 409 body the GUI's blocking confirm reads.
+ */
+const SHARED_WRITE_MESSAGE =
+    'This write lands through an agent-switch shared symlink and affects ALL profiles. ' +
+    'Re-send with confirmSharedWrite:true to proceed, or run `agent-switch share off` for profile-local writes.';
 
 export interface UserMdRouteOptions {
     /** Write root — every PUT lands here as `settings/.agent-user.yml`. */
@@ -146,7 +155,7 @@ export function userMdRoute(opts: UserMdRouteOptions): FastifyPluginAsync {
         });
 
         app.put('/api/v1/user-md', async (request, reply) => {
-            const body = (request.body ?? {}) as { identity?: unknown };
+            const body = (request.body ?? {}) as { identity?: unknown; confirmSharedWrite?: unknown };
             const parsed = userIdentitySchema.safeParse(body.identity);
             if (!parsed.success) {
                 await reply.code(422).send({
@@ -182,10 +191,20 @@ export function userMdRoute(opts: UserMdRouteOptions): FastifyPluginAsync {
                         preview: { path: USER_IDENTITY_RELATIVE, identity: parsed.data, body: yamlBody },
                     };
                 }
-                const path = join(opts.writeRoot, USER_IDENTITY_RELATIVE);
-                await fs.mkdir(dirname(path), { recursive: true, mode: 0o700 });
-                await writeAtomic(path, yamlBody, { mode: 0o600 });
-                const stat = await fs.stat(path);
+                const targetPath = join(opts.writeRoot, USER_IDENTITY_RELATIVE);
+                // Shared-write collision gate (road-to-reciprocal-ecosystem
+                // Phase 2) — see settings.ts's PUT handler for the same gate;
+                // kept in lockstep intentionally rather than factored out,
+                // since the two routes' surrounding try/catch shapes differ.
+                const sharedPath = sharedWriteTarget(targetPath);
+                if (sharedPath !== null && body.confirmSharedWrite !== true) {
+                    await reply.code(409).send({ error: 'shared-write', sharedPath, message: SHARED_WRITE_MESSAGE });
+                    return reply;
+                }
+                const writePath = sharedPath !== null ? resolveThroughSymlinks(targetPath) : targetPath;
+                await fs.mkdir(dirname(writePath), { recursive: true, mode: 0o700 });
+                await writeAtomic(writePath, yamlBody, { mode: 0o600 });
+                const stat = await fs.stat(writePath);
                 return { lastModified: Math.trunc(stat.mtimeMs), writtenPaths: [USER_IDENTITY_RELATIVE] };
             } catch (err) {
                 const message = err instanceof Error ? err.message : 'atomic write failed';

--- a/src/server/routes/wizard.ts
+++ b/src/server/routes/wizard.ts
@@ -33,6 +33,8 @@ import { writeAtomic } from '../io/atomicWrite.js';
 import { detectInstalledTools, knownToolIds } from '../../install/toolDetection.js';
 import { detectRtk, rtkInstallCommands, RTK_UPSTREAM_REPO } from '../../install/rtkDetection.js';
 import { readSelectedTools, readSelectedPacks, writeSelectedTools } from '../../install/selectedTools.js';
+import { detectAgentSwitch, AGENT_SWITCH_INSTALL_COMMAND, AGENT_SWITCH_REPO } from '../../install/agentSwitchDetection.js';
+import { readDismissedRecommendations, dismissRecommendation } from '../../install/wizardDismissals.js';
 
 export interface WizardRouteOptions {
     /** Write root — every on-disk artefact (state, settings, user-md) resolves under this. */
@@ -627,6 +629,14 @@ const aiCouncilPayloadSchema = z.object({
     decision: z.record(z.enum(['agent', 'council', 'user'])).optional(),
 }).strict();
 
+// road-to-reciprocal-ecosystem § Phase 1 — the closed set of dismissible
+// passive-row recommendations. `agent-switch` is the only member today;
+// widen the enum (never a bare `z.string()`) when a second passive
+// recommendation ships.
+const dismissRecommendationPayloadSchema = z.object({
+    id: z.enum(['agent-switch']),
+}).strict();
+
 export function wizardRoute(opts: WizardRouteOptions & { packageRoot: string }): FastifyPluginAsync {
     const extended = opts.extendedSteps === true;
     const totalSteps = opts.totalSteps ?? (extended ? EXTENDED_TOTAL_STEPS : DEFAULT_TOTAL_STEPS);
@@ -731,6 +741,41 @@ export function wizardRoute(opts: WizardRouteOptions & { packageRoot: string }):
                 installCommand: detection.present ? null : commands.recommended,
                 installCommands: detection.present ? null : commands,
             };
+        });
+
+        // road-to-reciprocal-ecosystem § Phase 1 — agent-switch passive-row
+        // recommendation (S0.1 honest-null council verdict, 2026-07-28: a
+        // PASSIVE ROW ONLY, never a proactive card). Exactly two states —
+        // not installed → recommend the (single, OS-independent) install
+        // command; installed (binary on PATH OR the `~/.agent-switch/`
+        // directory) → the row disappears. No outdated state is ever
+        // reported — detection does not probe version currency — and the
+        // AC never auto-installs; the command is surfaced for copy only,
+        // the same stance as rtk above. Read-only; available in BOTH
+        // wizard modes, same reasoning as detect-rtk.
+        app.get('/api/v1/wizard/detect-agent-switch', async () => {
+            const detection = detectAgentSwitch();
+            return {
+                installed: detection.installed,
+                version: detection.version,
+                installCommand: detection.installed ? null : AGENT_SWITCH_INSTALL_COMMAND,
+                repo: AGENT_SWITCH_REPO,
+                dismissed: readDismissedRecommendations().includes('agent-switch'),
+            };
+        });
+
+        // Permanent dismissal for a passive-row recommendation — see
+        // `wizardDismissals.ts`: there is no un-dismiss, by design.
+        app.post('/api/v1/wizard/dismiss-recommendation', async (request, reply) => {
+            const parsed = dismissRecommendationPayloadSchema.safeParse(request.body ?? {});
+            if (!parsed.success) {
+                await reply.code(422).send({
+                    error: { code: 'VALIDATION', message: 'invalid dismiss-recommendation payload', fields: zodIssuesToFields(parsed.error.issues) },
+                });
+                return reply;
+            }
+            dismissRecommendation(parsed.data.id);
+            return { ok: true, dismissed: readDismissedRecommendations() };
         });
 
         // road-to-wizard-ux-improvements § Phase 8 — AI Council config.

--- a/src/ui/pages/SettingsHubPage.tsx
+++ b/src/ui/pages/SettingsHubPage.tsx
@@ -30,6 +30,7 @@ import {
 import { isBasicPath } from '../settings/basicPaths.js';
 import { topLevelCopy, fieldErrorMap } from '../copyErrors.js';
 import { SettingsChangesBanner } from './SettingsChangesPage.js';
+import { serverStatus } from '../serverStatus.js';
 
 interface SettingsGetResponse {
     values: Record<string, JsonValue>;
@@ -55,6 +56,13 @@ const errors = signal<Record<string, string>>({});
 const banner = signal<string | null>(null);
 const saving = signal(false);
 const pendingDiff = signal<DiffChange[] | null>(null);
+/**
+ * Set when a PUT is blocked by the shared-write collision gate
+ * (road-to-reciprocal-ecosystem Phase 2) — renders `SharedWriteModal`
+ * instead of silently failing or (worse) a toast a user could miss
+ * while a write affects every agent-switch profile.
+ */
+const sharedWriteBlock = signal<{ sharedPath: string; message: string } | null>(null);
 const searchQuery = signal('');
 const modifiedOnly = signal(false);
 /** Per-section advanced-disclosure state, keyed by section path. */
@@ -131,19 +139,34 @@ async function preview(): Promise<void> {
     }
 }
 
-async function commit(): Promise<void> {
+async function commit(confirmSharedWrite = false): Promise<void> {
     saving.value = true;
     try {
         const res = await apiFetch<{ lastModified: number; writtenPaths: string[] }>('/api/v1/settings', {
             method: 'PUT',
             headers: { 'If-Unmodified-Since': String(lastModified.value) },
-            body: { values: values.value },
+            body: confirmSharedWrite ? { values: values.value, confirmSharedWrite: true } : { values: values.value },
         });
         lastModified.value = res.lastModified;
         pendingDiff.value = null;
+        sharedWriteBlock.value = null;
         banner.value = `Saved (${res.writtenPaths.join(', ')}).`;
     } catch (err) {
         if (err instanceof ApiCallError) {
+            // Shared-write collision (road-to-reciprocal-ecosystem Phase 2)
+            // — a distinct 409 shape (`error` is the literal string
+            // 'shared-write', not the usual `{ code, message }` object).
+            // Route to the blocking confirm modal instead of the generic
+            // error-banner path below.
+            const raw = err.body as { error?: unknown; sharedPath?: unknown; message?: unknown };
+            if (err.status === 409 && raw.error === 'shared-write') {
+                pendingDiff.value = null;
+                sharedWriteBlock.value = {
+                    sharedPath: typeof raw.sharedPath === 'string' ? raw.sharedPath : '',
+                    message: typeof raw.message === 'string' ? raw.message : 'This write affects a shared agent-switch profile.',
+                };
+                return;
+            }
             const ctx = err.body.error ?? { code: 'UNKNOWN', message: err.message };
             errors.value = fieldErrorMap(ctx);
             banner.value = topLevelCopy(ctx);
@@ -239,6 +262,54 @@ function toggleSection(key: string): void {
     expandedSections.value = { ...expandedSections.value, [key]: expandedSections.value[key] !== true };
 }
 
+/**
+ * Says which agent-switch (AS) profile is active, so a user who
+ * switches profiles and sees a different settings tree does not
+ * mistake profile-scoping for lost config (road-to-reciprocal-
+ * ecosystem Phase 2). Renders nothing when no AS profile is active,
+ * or against an older server bundle that omits the ping field.
+ */
+function AgentSwitchProfileBanner(): preact.JSX.Element | null {
+    const asp = serverStatus.value?.agentSwitchProfile;
+    if (asp === undefined || asp.active !== true) return null;
+    const label = asp.provider !== null && asp.profile !== null
+        ? `${asp.provider}/${asp.profile}`
+        : 'an unidentified profile';
+    return (
+        <div class="ac-banner" role="status">
+            <span>
+                Running under agent-switch profile <code>{label}</code> — settings shown and saved here are
+                profile-scoped. Switching profiles shows that profile's own settings; nothing is lost.
+            </span>
+        </div>
+    );
+}
+
+function SharedWriteModal({ block }: { block: { sharedPath: string; message: string } }): preact.JSX.Element {
+    return (
+        <div class="ac-modal" role="dialog" aria-modal="true" aria-labelledby="shared-write-title">
+            <div class="ac-modal__panel">
+                <h2 id="shared-write-title">Shared write — affects all profiles</h2>
+                <p>{block.message}</p>
+                <p><code>{block.sharedPath}</code></p>
+                <div class="ac-modal__actions">
+                    <button type="button" class="ac-button" onClick={(): void => { sharedWriteBlock.value = null; }}>
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        class="ac-button ac-button--primary"
+                        disabled={saving.value}
+                        onClick={(): void => { void commit(true); }}
+                    >
+                        {saving.value ? 'Writing…' : 'Write (affects all profiles)'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function DiffModal({ changes }: { changes: DiffChange[] }): preact.JSX.Element {
     return (
         <div class="ac-modal" role="dialog" aria-modal="true" aria-labelledby="diff-title">
@@ -299,6 +370,7 @@ export function SettingsHubPage(): preact.JSX.Element {
                 </nav>
             </header>
             <SettingsChangesBanner />
+            <AgentSwitchProfileBanner />
             <div class="ac-settings-hub__toolbar" role="search">
                 <input
                     class="ac-input ac-settings-hub__search"
@@ -357,6 +429,7 @@ export function SettingsHubPage(): preact.JSX.Element {
                 </div>
             </form>
             {pendingDiff.value !== null ? <DiffModal changes={pendingDiff.value} /> : null}
+            {sharedWriteBlock.value !== null ? <SharedWriteModal block={sharedWriteBlock.value} /> : null}
         </div>
     );
 }

--- a/src/ui/pages/WizardPage.tsx
+++ b/src/ui/pages/WizardPage.tsx
@@ -34,6 +34,12 @@ import { BackupScreen } from '../wizard/BackupScreen.js';
 import { FinishChecklist } from '../wizard/FinishChecklist.js';
 import {
     activeTotalSteps,
+    asDetectionLoaded,
+    asDismissed,
+    asInstallCommand,
+    asInstalled,
+    asRepo,
+    asVersion,
     banner,
     clampStep,
     continueAcknowledged,
@@ -290,6 +296,7 @@ async function loadAll(): Promise<void> {
         }
         if (resumed.id === 'identity') {
             void loadRtkDetectionOnce();
+            void loadAgentSwitchDetectionOnce();
         }
         if (resumed.kind === 'review') {
             void refreshDiff();
@@ -549,6 +556,37 @@ async function loadRtkDetectionOnce(): Promise<void> {
     }
 }
 
+interface DetectAgentSwitchResponse {
+    installed?: boolean;
+    version?: string | null;
+    installCommand?: string | null;
+    repo?: string;
+    dismissed?: boolean;
+}
+
+/**
+ * Detect agent-switch presence once per session
+ * (road-to-reciprocal-ecosystem § Phase 1 — S0.1 honest-null council
+ * verdict, 2026-07-28: a PASSIVE ROW, never persisted into settings — this
+ * is a recommendation, not a configuration toggle). `asDismissed` mirrors
+ * the server's permanent-dismissal record so a previously closed row stays
+ * closed after a page reload within the same session.
+ */
+async function loadAgentSwitchDetectionOnce(): Promise<void> {
+    if (asDetectionLoaded.value) return;
+    asDetectionLoaded.value = true;
+    try {
+        const res = await apiFetch<DetectAgentSwitchResponse>('/api/v1/wizard/detect-agent-switch');
+        asInstalled.value = res.installed === true;
+        asVersion.value = res.version ?? null;
+        asInstallCommand.value = res.installCommand ?? null;
+        if (typeof res.repo === 'string') asRepo.value = res.repo;
+        asDismissed.value = res.dismissed === true;
+    } catch {
+        // Detection failure → leave asInstalled null (row stays hidden until
+        // a later successful load).
+    }
+}
 
 async function persistStep(nextIndex: number, partial: Record<string, JsonValue>): Promise<void> {
     try {
@@ -625,6 +663,7 @@ async function goTo(nextIndex: number): Promise<void> {
     }
     if (next.id === 'identity') {
         void loadRtkDetectionOnce();
+        void loadAgentSwitchDetectionOnce();
     }
     if (next.kind === 'review') {
         void refreshDiff();
@@ -1417,6 +1456,69 @@ function RtkRow(): preact.JSX.Element {
     );
 }
 
+/**
+ * Permanently dismiss the agent-switch recommendation
+ * (road-to-reciprocal-ecosystem § Phase 1). Optimistic on failure the row
+ * simply reappears on the next detection load — there is nothing to roll
+ * back client-side, so a failed POST just surfaces a banner and leaves
+ * `asDismissed` untouched.
+ */
+async function dismissAgentSwitchRecommendation(): Promise<void> {
+    try {
+        await apiFetch('/api/v1/wizard/dismiss-recommendation', {
+            method: 'POST',
+            body: { id: 'agent-switch' },
+        });
+    } catch (err) {
+        banner.value = {
+            message: err instanceof Error ? err.message : String(err),
+            tone: 'error',
+        };
+        return;
+    }
+    asDismissed.value = true;
+}
+
+/**
+ * agent-switch passive-row recommendation on the identity step
+ * (road-to-reciprocal-ecosystem § Phase 1 — S0.1 honest-null council
+ * verdict, 2026-07-28: PASSIVE ROW ONLY, never a proactive card).
+ * Detection-driven, read-only, copy-only (no install button — the AC never
+ * auto-installs). Renders nothing while undetected (no flash), nothing
+ * when installed, and nothing once permanently dismissed.
+ */
+function AgentSwitchRow(): preact.JSX.Element | null {
+    if (!asDetectionLoaded.value || asInstalled.value !== false || asDismissed.value) return null;
+    return (
+        <div class="ac-rtk-row">
+            <div class="ac-rtk-row__head">
+                <span class="ac-rtk-row__label">agent-switch <small>(third-party, MIT)</small></span>
+                <span class="ac-badge ac-badge--missing">not installed</span>
+            </div>
+            <div class="ac-rtk-row__install">
+                <p class="ac-field__description">
+                    agent-switch isolates multiple agent accounts into per-account
+                    profiles (<code>CLAUDE_CONFIG_DIR</code>) so switching accounts
+                    never requires a re-login. Free and MIT-licensed.
+                </p>
+                {asInstallCommand.value !== null
+                    ? <code class="ac-rtk-row__cmd">{asInstallCommand.value}</code>
+                    : null}
+                <a class="ac-button" href={`https://github.com/${asRepo.value}`} target="_blank" rel="noreferrer noopener">
+                    Open agent-switch repo
+                </a>
+                <button
+                    type="button"
+                    class="ac-button ac-button--small"
+                    onClick={(): void => { void dismissAgentSwitchRecommendation(); }}
+                >
+                    Don't show again
+                </button>
+            </div>
+        </div>
+    );
+}
+
 function StepBody(): preact.JSX.Element | null {
     const step = stepAt(stepIndex.value, { extended: extendedSteps.value });
     // road-to-unified-setup § B5 — hard-stop continue-screen between the
@@ -1438,6 +1540,7 @@ function StepBody(): preact.JSX.Element | null {
         return (
             <>
                 {step.id === 'identity' ? <RtkRow /> : null}
+                {step.id === 'identity' ? <AgentSwitchRow /> : null}
                 <SchemaForm
                     schema={sliced}
                     values={values.value}

--- a/src/ui/serverStatus.ts
+++ b/src/ui/serverStatus.ts
@@ -32,6 +32,12 @@ export interface ServerStatus {
     projectSurface: boolean;
     /** Dev-mode surfaces (Workspace tab) — AGENT_CONFIG_DEV_MODE=1 only. */
     devSurfaces: boolean;
+    /**
+     * Active agent-switch (AS) profile, if any (road-to-reciprocal-
+     * ecosystem Phase 2). Optional — an older server bundle omits the
+     * field, and the Settings hub banner simply stays hidden.
+     */
+    agentSwitchProfile?: { active: boolean; provider: string | null; profile: string | null };
 }
 
 export const serverStatus = signal<ServerStatus | null>(null);

--- a/src/ui/wizard/state.ts
+++ b/src/ui/wizard/state.ts
@@ -323,6 +323,23 @@ export const rtkInstallTiers = signal<RtkInstallCommandTiers | null>(null);
 export const rtkRepo = signal<string>('https://github.com/rtk-ai/rtk');
 
 /**
+ * agent-switch presence on the identity step (road-to-reciprocal-ecosystem
+ * § Phase 1 — S0.1 honest-null council verdict, 2026-07-28: PASSIVE ROW
+ * ONLY). Always detected at runtime via
+ * `GET /api/v1/wizard/detect-agent-switch` — never read from settings, and
+ * unlike rtk there is no identity-collision concern, so a single boolean
+ * `asInstalled` is enough. `asDismissed` is permanent once the user closes
+ * the row (`POST /api/v1/wizard/dismiss-recommendation`) — never reset by
+ * a fresh detection load.
+ */
+export const asDetectionLoaded = signal(false);
+export const asInstalled = signal<boolean | null>(null);
+export const asVersion = signal<string | null>(null);
+export const asInstallCommand = signal<string | null>(null);
+export const asRepo = signal<string>('event4u-app/agent-switch');
+export const asDismissed = signal(false);
+
+/**
  * AI Council step (road-to-wizard-ux-improvements § Phase 8). The
  * wizard-controlled scalar subset of `.ai-council.yml`, loaded from
  * `GET /api/v1/wizard/ai-council` and persisted on finish via POST. Only the

--- a/tests/install/agentSwitchDetection.test.ts
+++ b/tests/install/agentSwitchDetection.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for agent-switch detection (road-to-reciprocal-ecosystem § Phase 1
+ * — S0.1 honest-null council verdict, 2026-07-28: a PASSIVE ROW ONLY, never
+ * a proactive card). Two independent installed-signals — a binary on PATH,
+ * or the `~/.agent-switch/` directory — and no network / version-currency
+ * check at all.
+ *
+ * See src/install/agentSwitchDetection.ts for the module under test.
+ */
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    AGENT_SWITCH_INSTALL_COMMAND,
+    AGENT_SWITCH_NPM,
+    AGENT_SWITCH_REPO,
+    detectAgentSwitch,
+    parseVersionOutput,
+} from '../../src/install/agentSwitchDetection.js';
+
+/** Write an executable stub file (POSIX mode bits) and return its path. */
+function writeExecutable(dir: string, name: string, contents: string): string {
+    const filePath = join(dir, name);
+    writeFileSync(filePath, contents, 'utf-8');
+    chmodSync(filePath, 0o755);
+    return filePath;
+}
+
+describe('parseVersionOutput', () => {
+    it('parses "agent-switch 1.6.1" to "1.6.1"', () => {
+        expect(parseVersionOutput('agent-switch 1.6.1')).toBe('1.6.1');
+    });
+
+    it('parses "v1.6.1" to "1.6.1"', () => {
+        expect(parseVersionOutput('v1.6.1')).toBe('1.6.1');
+    });
+
+    it('returns null for output with no dotted-number token', () => {
+        expect(parseVersionOutput('command not found')).toBeNull();
+    });
+
+    it('returns null for empty output', () => {
+        expect(parseVersionOutput('')).toBeNull();
+    });
+});
+
+describe('detectAgentSwitch', () => {
+    let home: string;
+    let binDir: string;
+
+    beforeEach(() => {
+        home = mkdtempSync(join(tmpdir(), 'as-detect-home-'));
+        binDir = mkdtempSync(join(tmpdir(), 'as-detect-bin-'));
+    });
+    afterEach(() => {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(binDir, { recursive: true, force: true });
+    });
+
+    it('reports not installed when neither the binary nor ~/.agent-switch/ is present', () => {
+        expect(detectAgentSwitch({ home, pathEnv: binDir })).toEqual({ installed: false, version: null });
+    });
+
+    it('reports installed with version null when only ~/.agent-switch/ exists (no binary on PATH)', () => {
+        mkdirSync(join(home, '.agent-switch'));
+        expect(detectAgentSwitch({ home, pathEnv: binDir })).toEqual({ installed: true, version: null });
+    });
+
+    it('reports installed when the binary is on PATH, probing version via the injected probe', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\nexit 0\n');
+        const probeVersion = (): string => '1.6.1';
+        const result = detectAgentSwitch({ home, pathEnv: binDir, probeVersion });
+        expect(result).toEqual({ installed: true, version: '1.6.1' });
+    });
+
+    it('binary-on-PATH takes precedence even when ~/.agent-switch/ also exists', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\nexit 0\n');
+        mkdirSync(join(home, '.agent-switch'));
+        const probeVersion = (): string => '2.0.0';
+        const result = detectAgentSwitch({ home, pathEnv: binDir, probeVersion });
+        expect(result).toEqual({ installed: true, version: '2.0.0' });
+    });
+
+    it('parses the real spawned --version output ("agent-switch 1.6.1" shape) with no probeVersion override', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\necho "agent-switch 1.6.1"\nexit 0\n');
+        const result = detectAgentSwitch({ home, pathEnv: binDir });
+        expect(result).toEqual({ installed: true, version: '1.6.1' });
+    });
+
+    it('parses a "v1.6.1"-shaped real spawned --version output with no probeVersion override', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\necho "v1.6.1"\nexit 0\n');
+        const result = detectAgentSwitch({ home, pathEnv: binDir });
+        expect(result).toEqual({ installed: true, version: '1.6.1' });
+    });
+
+    it('reports version null for garbage --version output with no probeVersion override', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\necho "command not found"\nexit 1\n');
+        const result = detectAgentSwitch({ home, pathEnv: binDir });
+        expect(result).toEqual({ installed: true, version: null });
+    });
+
+    it('reports version null when the injected probeVersion throws', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\nexit 0\n');
+        const probeVersion = (): string => { throw new Error('boom'); };
+        const result = detectAgentSwitch({ home, pathEnv: binDir, probeVersion });
+        expect(result).toEqual({ installed: true, version: null });
+    });
+
+    it('reports version null when the injected probeVersion itself returns null (e.g. timeout)', () => {
+        writeExecutable(binDir, 'agent-switch', '#!/bin/sh\nexit 0\n');
+        const probeVersion = (): null => null;
+        const result = detectAgentSwitch({ home, pathEnv: binDir, probeVersion });
+        expect(result).toEqual({ installed: true, version: null });
+    });
+});
+
+describe('agent-switch constants', () => {
+    it('install command is npm-global and identical across every OS (no per-OS map, unlike rtk)', () => {
+        expect(AGENT_SWITCH_INSTALL_COMMAND).toBe('npm install -g @event4u/agent-switch');
+    });
+
+    it('carries the npm package name and the repo slug used to build the GitHub URL', () => {
+        expect(AGENT_SWITCH_NPM).toBe('@event4u/agent-switch');
+        expect(AGENT_SWITCH_REPO).toBe('event4u-app/agent-switch');
+    });
+});

--- a/tests/install/agentSwitchProfile.test.ts
+++ b/tests/install/agentSwitchProfile.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for `detectAgentSwitchProfile` / `resolveAgentSwitchRoot`
+ * (road-to-reciprocal-ecosystem.md Phase 2).
+ *
+ * See src/install/agentSwitchProfile.ts for the module under test.
+ */
+import { join, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { detectAgentSwitchProfile, resolveAgentSwitchRoot } from '../../src/install/agentSwitchProfile.js';
+
+describe('detectAgentSwitchProfile', () => {
+    it('is inactive when neither provider env var is set', () => {
+        expect(detectAgentSwitchProfile({})).toEqual({ active: false, provider: null, profile: null });
+    });
+
+    it('is inactive when the provider env vars point somewhere unrelated', () => {
+        const env = { CLAUDE_CONFIG_DIR: join(sep, 'Users', 'matze', '.claude') };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: false, provider: null, profile: null });
+    });
+
+    it('detects an active claude profile from CLAUDE_CONFIG_DIR under the default ~/.agent-switch root', () => {
+        const home = process.platform === 'win32' ? 'C:\\Users\\matze' : '/Users/matze';
+        const env = { CLAUDE_CONFIG_DIR: join(home, '.agent-switch', 'claude', 'work', 'config') };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: true, provider: 'claude', profile: 'work' });
+    });
+
+    it('detects an active codex profile from CODEX_HOME', () => {
+        const home = process.platform === 'win32' ? 'C:\\Users\\matze' : '/Users/matze';
+        const env = { CODEX_HOME: join(home, '.agent-switch', 'codex', 'personal', 'config') };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: true, provider: 'codex', profile: 'personal' });
+    });
+
+    it('claude wins over codex when both env vars resolve inside the AS tree', () => {
+        const home = process.platform === 'win32' ? 'C:\\Users\\matze' : '/Users/matze';
+        const env = {
+            CLAUDE_CONFIG_DIR: join(home, '.agent-switch', 'claude', 'work', 'config'),
+            CODEX_HOME: join(home, '.agent-switch', 'codex', 'personal', 'config'),
+        };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: true, provider: 'claude', profile: 'work' });
+    });
+
+    it('respects a custom AGENT_SWITCH_HOME root', () => {
+        const root = join(sep, 'custom', 'as-root');
+        const env = {
+            AGENT_SWITCH_HOME: root,
+            CLAUDE_CONFIG_DIR: join(root, 'claude', 'work', 'config'),
+        };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: true, provider: 'claude', profile: 'work' });
+    });
+
+    it('is inactive when the env var points outside a custom AGENT_SWITCH_HOME root', () => {
+        const env = {
+            AGENT_SWITCH_HOME: join(sep, 'custom', 'as-root'),
+            CLAUDE_CONFIG_DIR: join(sep, 'somewhere', 'else', 'config'),
+        };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: false, provider: null, profile: null });
+    });
+
+    it('is inactive when the env var points AT the AS root itself (no profile segments)', () => {
+        const root = join(sep, 'custom', 'as-root');
+        const env = { AGENT_SWITCH_HOME: root, CLAUDE_CONFIG_DIR: root };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: false, provider: null, profile: null });
+    });
+
+    it('is active but unparseable when only a provider segment is present (no profile name)', () => {
+        const root = join(sep, 'custom', 'as-root');
+        const env = { AGENT_SWITCH_HOME: root, CLAUDE_CONFIG_DIR: join(root, 'claude') };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: true, provider: null, profile: null });
+    });
+
+    it('never checks HOME as a provider signal (too generic)', () => {
+        const env = { HOME: join(sep, 'Users', 'matze', '.agent-switch', 'antigravity', 'work', 'config') };
+        expect(detectAgentSwitchProfile(env)).toEqual({ active: false, provider: null, profile: null });
+    });
+});
+
+describe('resolveAgentSwitchRoot', () => {
+    it('returns null when inactive', () => {
+        expect(resolveAgentSwitchRoot({})).toBeNull();
+    });
+
+    it('returns the resolved root for a custom AGENT_SWITCH_HOME', () => {
+        const root = join(sep, 'custom', 'as-root');
+        const env = { AGENT_SWITCH_HOME: root, CLAUDE_CONFIG_DIR: join(root, 'claude', 'work', 'config') };
+        expect(resolveAgentSwitchRoot(env)).toBe(root);
+    });
+
+    it('returns the reconstructed default root when no override is set', () => {
+        const home = process.platform === 'win32' ? 'C:\\Users\\matze' : '/Users/matze';
+        const env = { CLAUDE_CONFIG_DIR: join(home, '.agent-switch', 'claude', 'work', 'config') };
+        expect(resolveAgentSwitchRoot(env)).toBe(join(home, '.agent-switch'));
+    });
+});

--- a/tests/install/wizardDismissals.test.ts
+++ b/tests/install/wizardDismissals.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for permanent wizard-recommendation dismissals
+ * (road-to-reciprocal-ecosystem § Phase 1). We point
+ * `AGENT_CONFIG_WIZARD_DISMISSALS` at a temp file so the test never touches
+ * the real `~/.event4u/agent-config/wizard-dismissals.json`. The module
+ * resolves the path lazily inside each call (never at import time), so a
+ * static top-level import is safe even though the env var is set per-test.
+ *
+ * See src/install/wizardDismissals.ts for the module under test.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { dismissRecommendation, readDismissedRecommendations } from '../../src/install/wizardDismissals.js';
+
+describe('wizardDismissals', () => {
+    let dir: string;
+    let file: string;
+    const prev = process.env['AGENT_CONFIG_WIZARD_DISMISSALS'];
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'wizard-dismissals-'));
+        file = join(dir, 'sub', 'wizard-dismissals.json');
+        process.env['AGENT_CONFIG_WIZARD_DISMISSALS'] = file;
+    });
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+        if (prev === undefined) delete process.env['AGENT_CONFIG_WIZARD_DISMISSALS'];
+        else process.env['AGENT_CONFIG_WIZARD_DISMISSALS'] = prev;
+    });
+
+    it('returns an empty list when the file does not exist yet', () => {
+        expect(readDismissedRecommendations()).toEqual([]);
+    });
+
+    it('persists a dismissal so it is readable back', () => {
+        dismissRecommendation('agent-switch');
+        expect(readDismissedRecommendations()).toEqual(['agent-switch']);
+    });
+
+    it('is idempotent — dismissing the same id twice does not duplicate it', () => {
+        dismissRecommendation('agent-switch');
+        dismissRecommendation('agent-switch');
+        expect(readDismissedRecommendations()).toEqual(['agent-switch']);
+    });
+
+    it('accumulates distinct ids across calls', () => {
+        dismissRecommendation('agent-switch');
+        dismissRecommendation('some-other-recommendation');
+        expect(readDismissedRecommendations().slice().sort()).toEqual(['agent-switch', 'some-other-recommendation']);
+    });
+
+    it('returns an empty list for a corrupted file (best-effort, never throws)', () => {
+        mkdirSync(join(dir, 'sub'), { recursive: true });
+        writeFileSync(file, 'not valid json {{{', 'utf8');
+        expect(readDismissedRecommendations()).toEqual([]);
+    });
+
+    it('returns an empty list when the "dismissed" field is not an array', () => {
+        mkdirSync(join(dir, 'sub'), { recursive: true });
+        writeFileSync(file, JSON.stringify({ dismissed: 'not-an-array' }), 'utf8');
+        expect(readDismissedRecommendations()).toEqual([]);
+    });
+
+    it('filters out non-string entries in the "dismissed" array', () => {
+        mkdirSync(join(dir, 'sub'), { recursive: true });
+        writeFileSync(file, JSON.stringify({ dismissed: ['agent-switch', 42, null] }), 'utf8');
+        expect(readDismissedRecommendations()).toEqual(['agent-switch']);
+    });
+
+    it('never throws even when the target directory cannot be created (best-effort write)', () => {
+        // Point at a path whose parent is a FILE, not a directory — mkdirSync
+        // will fail, and dismissRecommendation must swallow it.
+        const blockerFile = join(dir, 'blocker');
+        writeFileSync(blockerFile, 'x', 'utf8');
+        process.env['AGENT_CONFIG_WIZARD_DISMISSALS'] = join(blockerFile, 'wizard-dismissals.json');
+        expect(() => dismissRecommendation('agent-switch')).not.toThrow();
+    });
+});

--- a/tests/server/app.test.ts
+++ b/tests/server/app.test.ts
@@ -64,6 +64,55 @@ describe('createApp', () => {
         expect(res.json()).toMatchObject({ capabilities: { configRoot: true } });
     });
 
+    it('reports agentSwitchProfile.active=false by default (road-to-reciprocal-ecosystem Phase 2)', async () => {
+        // Clear + restore explicitly rather than trusting an ambient shell —
+        // a machine that also runs agent-switch may have these set for real.
+        const saved = {
+            AGENT_SWITCH_HOME: process.env.AGENT_SWITCH_HOME,
+            CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+            CODEX_HOME: process.env.CODEX_HOME,
+        };
+        delete process.env.AGENT_SWITCH_HOME;
+        delete process.env.CLAUDE_CONFIG_DIR;
+        delete process.env.CODEX_HOME;
+        try {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/api/v1/ping',
+                headers: { host: HOST, authorization: `Bearer ${TOKEN}` },
+            });
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toMatchObject({ agentSwitchProfile: { active: false, provider: null, profile: null } });
+        } finally {
+            for (const [key, value] of Object.entries(saved)) {
+                if (value === undefined) delete process.env[key];
+                else process.env[key] = value;
+            }
+        }
+    });
+
+    it('reports the active agent-switch profile when CLAUDE_CONFIG_DIR points inside .agent-switch', async () => {
+        const savedAgentSwitchHome = process.env.AGENT_SWITCH_HOME;
+        const savedClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+        const root = join(tmpdir(), 'app-test-agent-switch-root');
+        process.env.AGENT_SWITCH_HOME = root;
+        process.env.CLAUDE_CONFIG_DIR = join(root, 'claude', 'work', 'config');
+        try {
+            const res = await app.inject({
+                method: 'GET',
+                url: '/api/v1/ping',
+                headers: { host: HOST, authorization: `Bearer ${TOKEN}` },
+            });
+            expect(res.statusCode).toBe(200);
+            expect(res.json()).toMatchObject({ agentSwitchProfile: { active: true, provider: 'claude', profile: 'work' } });
+        } finally {
+            if (savedAgentSwitchHome === undefined) delete process.env.AGENT_SWITCH_HOME;
+            else process.env.AGENT_SWITCH_HOME = savedAgentSwitchHome;
+            if (savedClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+            else process.env.CLAUDE_CONFIG_DIR = savedClaudeConfigDir;
+        }
+    });
+
     it('accepts the token via ?token= query param', async () => {
         const res = await app.inject({
             method: 'GET',

--- a/tests/server/sharedWriteCheck.test.ts
+++ b/tests/server/sharedWriteCheck.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the shared-write collision gate (road-to-reciprocal-
+ * ecosystem.md Phase 2):
+ *
+ *   - unit tests for `sharedWriteTarget` / `resolveThroughSymlinks`
+ *     (src/server/io/sharedWriteCheck.ts)
+ *   - route-level tests for the 409 shared-write gate wired into
+ *     `PUT /api/v1/settings` (src/server/routes/settings.ts)
+ *
+ * See src/server/io/sharedWriteCheck.ts for the module under test.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync, readFileSync, lstatSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sharedWriteTarget, resolveThroughSymlinks } from '../../src/server/io/sharedWriteCheck.js';
+import { bootTestApp, authHeaders, fixtureSettings, settingsTemplate, type TestApp } from './helpers.js';
+
+const INACTIVE_ENV = {};
+
+/**
+ * Active-AS env whose root is `root` itself (via `AGENT_SWITCH_HOME`).
+ * Bounding the root at the test's own tmp dir keeps the upward `lstat`
+ * walk from ever climbing above it — real machines have incidental
+ * ancestor symlinks (macOS `/var` -> `/private/var`, `/tmp` ->
+ * `/private/tmp`) that would otherwise false-positive a "no symlink on
+ * the path" test the moment the walk is allowed to climb that far.
+ */
+function activeEnvRootedAt(root: string): NodeJS.ProcessEnv {
+    return { AGENT_SWITCH_HOME: root, CLAUDE_CONFIG_DIR: join(root, 'claude', 'work', 'config') };
+}
+
+describe('sharedWriteTarget (unit)', () => {
+    let dir: string;
+
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'shared-write-check-')); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    it('returns null when no AS profile is active, regardless of symlinks on disk', () => {
+        const source = join(dir, 'source.yml');
+        writeFileSync(source, 'a: 1\n');
+        const link = join(dir, 'settings.yml');
+        symlinkSync(source, link);
+        expect(sharedWriteTarget(link, INACTIVE_ENV)).toBeNull();
+    });
+
+    it('returns the target itself when the target IS a symlink', () => {
+        const source = join(dir, 'source.yml');
+        writeFileSync(source, 'a: 1\n');
+        const link = join(dir, 'settings.yml');
+        symlinkSync(source, link);
+        expect(sharedWriteTarget(link, activeEnvRootedAt(dir))).toBe(link);
+    });
+
+    it('returns the nearest symlinked ancestor when an ancestor dir is a symlink', () => {
+        const realBase = join(dir, 'real-base');
+        mkdirSync(join(realBase, 'nested'), { recursive: true });
+        writeFileSync(join(realBase, 'nested', 'settings.yml'), 'a: 1\n');
+        const linkedBase = join(dir, 'linked-base');
+        symlinkSync(realBase, linkedBase);
+        const target = join(linkedBase, 'nested', 'settings.yml');
+        expect(sharedWriteTarget(target, activeEnvRootedAt(dir))).toBe(linkedBase);
+    });
+
+    it('returns null when active but no symlink sits on the path', () => {
+        mkdirSync(join(dir, 'settings'), { recursive: true });
+        const target = join(dir, 'settings', 'settings.yml');
+        writeFileSync(target, 'a: 1\n');
+        expect(sharedWriteTarget(target, activeEnvRootedAt(dir))).toBeNull();
+    });
+
+    it('returns null (never throws) when the target and its ancestors do not exist yet', () => {
+        const target = join(dir, 'does', 'not', 'exist', 'settings.yml');
+        expect(() => sharedWriteTarget(target, activeEnvRootedAt(dir))).not.toThrow();
+        expect(sharedWriteTarget(target, activeEnvRootedAt(dir))).toBeNull();
+    });
+});
+
+describe('resolveThroughSymlinks (unit)', () => {
+    let dir: string;
+
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'shared-write-resolve-')); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    it('resolves a symlinked file to its real target', () => {
+        const source = join(dir, 'source.yml');
+        writeFileSync(source, 'a: 1\n');
+        const link = join(dir, 'settings.yml');
+        symlinkSync(source, link);
+        expect(resolveThroughSymlinks(link)).toBe(realpathSync(source));
+    });
+
+    it('resolves through a symlinked ancestor dir even when the leaf does not exist yet', () => {
+        const realBase = join(dir, 'real-base');
+        mkdirSync(realBase, { recursive: true });
+        const linkedBase = join(dir, 'linked-base');
+        symlinkSync(realBase, linkedBase);
+        const target = join(linkedBase, 'settings.yml'); // leaf does not exist
+        expect(resolveThroughSymlinks(target)).toBe(join(realpathSync(realBase), 'settings.yml'));
+    });
+
+    it('resolves a fully nonexistent chain against the nearest existing ancestor, no throw', () => {
+        const target = join(dir, 'a', 'b', 'c.yml');
+        expect(() => resolveThroughSymlinks(target)).not.toThrow();
+        expect(resolveThroughSymlinks(target)).toBe(join(realpathSync(dir), 'a', 'b', 'c.yml'));
+    });
+
+    it('is a no-op (modulo realpath normalization) when there are no symlinks', () => {
+        const file = join(dir, 'plain.yml');
+        writeFileSync(file, 'a: 1\n');
+        expect(resolveThroughSymlinks(file)).toBe(realpathSync(file));
+    });
+});
+
+describe('PUT /api/v1/settings — shared-write collision gate (route-level)', () => {
+    const PORT = 41703;
+    let ctx: TestApp;
+    let sourceDir: string;
+    let savedEnv: { AGENT_SWITCH_HOME: string | undefined; CLAUDE_CONFIG_DIR: string | undefined; CODEX_HOME: string | undefined };
+
+    beforeEach(() => {
+        savedEnv = {
+            AGENT_SWITCH_HOME: process.env.AGENT_SWITCH_HOME,
+            CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+            CODEX_HOME: process.env.CODEX_HOME,
+        };
+    });
+
+    afterEach(async () => {
+        for (const [key, value] of Object.entries(savedEnv)) {
+            if (value === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = value;
+            }
+        }
+        await ctx.cleanup();
+        if (sourceDir !== undefined) rmSync(sourceDir, { recursive: true, force: true });
+    });
+
+    /**
+     * Root the fake AS tree at `ctx.projectRoot` itself so the write
+     * target (inside `ctx.projectRoot`) is actually inside the AS root
+     * — `sharedWriteTarget` refuses to walk outside it (see the
+     * module doc), so an unrelated env var pointing at some unrelated
+     * `.agent-switch` tree would never trip the gate on a temp test
+     * dir.
+     */
+    function activateAsProfileRootedAtProjectRoot(): void {
+        process.env.AGENT_SWITCH_HOME = ctx.projectRoot;
+        process.env.CLAUDE_CONFIG_DIR = join(ctx.projectRoot, 'claude', 'work', 'config');
+    }
+
+    async function currentMtime(): Promise<number> {
+        const res = await ctx.app.inject({
+            method: 'GET', url: '/api/v1/settings', headers: authHeaders(ctx.token, ctx.host),
+        });
+        return (res.json() as { lastModified: number }).lastModified;
+    }
+
+    /** Seed `ctx.projectRoot/settings/.agent-settings.yml` as a symlink to a real file elsewhere. */
+    function seedSymlinkedSettings(): string {
+        sourceDir = mkdtempSync(join(tmpdir(), 'shared-write-source-'));
+        const source = join(sourceDir, '.agent-settings.yml');
+        writeFileSync(source, settingsTemplate(), { mode: 0o600 });
+        const linkPath = join(ctx.projectRoot, 'settings', '.agent-settings.yml');
+        // bootTestApp always creates `settings/` (mode 0700); no file is
+        // seeded here (seedSettings: false) so the symlink can take its place.
+        symlinkSync(source, linkPath);
+        return source;
+    }
+
+    it('blocks with 409 shared-write when an AS profile is active and the target is symlinked', async () => {
+        ctx = await bootTestApp({ port: PORT, seedSettings: false });
+        const source = seedSymlinkedSettings();
+        activateAsProfileRootedAtProjectRoot();
+
+        const ius = await currentMtime();
+        const res = await ctx.app.inject({
+            method: 'PUT',
+            url: '/api/v1/settings',
+            headers: { ...authHeaders(ctx.token, ctx.host), 'content-type': 'application/json', 'if-unmodified-since': String(ius + 5) },
+            payload: { values: fixtureSettings({ rule_loading_tier: 'minimal' }) },
+        });
+        expect(res.statusCode).toBe(409);
+        const body = res.json() as { error: string; sharedPath: string; message: string };
+        expect(body.error).toBe('shared-write');
+        expect(body.sharedPath).toBe(join(ctx.projectRoot, 'settings', '.agent-settings.yml'));
+        expect(body.message).toMatch(/agent-switch/);
+
+        // No write happened — the source file is untouched.
+        expect(readFileSync(source, 'utf8')).not.toMatch(/rule_loading_tier:\s*minimal\b/);
+    });
+
+    it('proceeds and writes through the symlink when confirmSharedWrite is true', async () => {
+        ctx = await bootTestApp({ port: PORT, seedSettings: false });
+        const source = seedSymlinkedSettings();
+        activateAsProfileRootedAtProjectRoot();
+
+        const ius = await currentMtime();
+        const res = await ctx.app.inject({
+            method: 'PUT',
+            url: '/api/v1/settings',
+            headers: { ...authHeaders(ctx.token, ctx.host), 'content-type': 'application/json', 'if-unmodified-since': String(ius + 5) },
+            payload: { values: fixtureSettings({ rule_loading_tier: 'minimal' }), confirmSharedWrite: true },
+        });
+        expect(res.statusCode).toBe(200);
+
+        // The symlink itself survives — AC never breaks AS's symlink.
+        const linkPath = join(ctx.projectRoot, 'settings', '.agent-settings.yml');
+        expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+        expect(realpathSync(linkPath)).toBe(realpathSync(source));
+        // The real source file — not the symlink slot — carries the new content.
+        expect(readFileSync(source, 'utf8')).toMatch(/^rule_loading_tier:\s*minimal\b/m);
+    });
+
+    it('does not gate the write when no AS profile is active, even with a symlinked target', async () => {
+        ctx = await bootTestApp({ port: PORT, seedSettings: false });
+        seedSymlinkedSettings();
+        delete process.env.AGENT_SWITCH_HOME;
+        delete process.env.CLAUDE_CONFIG_DIR;
+        delete process.env.CODEX_HOME;
+
+        const ius = await currentMtime();
+        const res = await ctx.app.inject({
+            method: 'PUT',
+            url: '/api/v1/settings',
+            headers: { ...authHeaders(ctx.token, ctx.host), 'content-type': 'application/json', 'if-unmodified-since': String(ius + 5) },
+            payload: { values: fixtureSettings({ rule_loading_tier: 'minimal' }) },
+        });
+        expect(res.statusCode).toBe(200);
+    });
+});

--- a/tests/server/wizard.detectAgentSwitch.test.ts
+++ b/tests/server/wizard.detectAgentSwitch.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for GET /api/v1/wizard/detect-agent-switch and
+ * POST /api/v1/wizard/dismiss-recommendation
+ * (road-to-reciprocal-ecosystem § Phase 1 — S0.1 honest-null council
+ * verdict, 2026-07-28: a PASSIVE ROW, never gated behind extended-mode —
+ * same reasoning as detect-rtk).
+ *
+ * The route calls `detectAgentSwitch()` with no injection point, so
+ * `installed`/`version` are machine-dependent — this file asserts only on
+ * response SHAPE for those two fields. `dismissed` is fully deterministic
+ * via `AGENT_CONFIG_WIZARD_DISMISSALS` pointed at a temp file.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { bootTestApp, authHeaders, type TestApp } from './helpers.js';
+
+const PORT = 41830;
+
+interface DetectAgentSwitchBody {
+    installed: boolean;
+    version: string | null;
+    installCommand: string | null;
+    repo: string;
+    dismissed: boolean;
+}
+
+describe('GET /api/v1/wizard/detect-agent-switch', () => {
+    let ctx: TestApp;
+    let dismissalsDir: string;
+    const prev = process.env['AGENT_CONFIG_WIZARD_DISMISSALS'];
+
+    afterEach(async () => {
+        if (ctx) await ctx.cleanup();
+        if (dismissalsDir) rmSync(dismissalsDir, { recursive: true, force: true });
+        if (prev === undefined) delete process.env['AGENT_CONFIG_WIZARD_DISMISSALS'];
+        else process.env['AGENT_CONFIG_WIZARD_DISMISSALS'] = prev;
+    });
+
+    function setDismissalsEnv(): void {
+        dismissalsDir = mkdtempSync(join(tmpdir(), 'wizard-dismissals-srv-'));
+        process.env['AGENT_CONFIG_WIZARD_DISMISSALS'] = join(dismissalsDir, 'wizard-dismissals.json');
+    }
+
+    it('returns the full response shape and is reachable outside extended mode', async () => {
+        setDismissalsEnv();
+        ctx = await bootTestApp({ port: PORT, extendedSteps: false });
+        const res = await ctx.app.inject({
+            method: 'GET', url: '/api/v1/wizard/detect-agent-switch', headers: authHeaders(ctx.token, ctx.host),
+        });
+        expect(res.statusCode).toBe(200);
+        const body = res.json() as DetectAgentSwitchBody;
+        expect(typeof body.installed).toBe('boolean');
+        expect(body.version === null || typeof body.version === 'string').toBe(true);
+        expect(body.installCommand === null || typeof body.installCommand === 'string').toBe(true);
+        // Self-retiring shape: an install command is present only when NOT installed.
+        expect(body.installed ? body.installCommand === null : typeof body.installCommand === 'string').toBe(true);
+        expect(body.repo).toBe('event4u-app/agent-switch');
+        expect(body.dismissed).toBe(false);
+    });
+
+    it('is also reachable in extended mode (available in BOTH wizard modes)', async () => {
+        setDismissalsEnv();
+        ctx = await bootTestApp({ port: PORT + 1, extendedSteps: true });
+        const res = await ctx.app.inject({
+            method: 'GET', url: '/api/v1/wizard/detect-agent-switch', headers: authHeaders(ctx.token, ctx.host),
+        });
+        expect(res.statusCode).toBe(200);
+    });
+
+    it('rejects an unauthenticated request with 401', async () => {
+        setDismissalsEnv();
+        ctx = await bootTestApp({ port: PORT + 2, extendedSteps: false });
+        const res = await ctx.app.inject({
+            method: 'GET', url: '/api/v1/wizard/detect-agent-switch', headers: { host: ctx.host },
+        });
+        expect(res.statusCode).toBe(401);
+    });
+
+    it('reflects a prior dismissal as dismissed:true', async () => {
+        setDismissalsEnv();
+        ctx = await bootTestApp({ port: PORT + 3, extendedSteps: false });
+        const post = await ctx.app.inject({
+            method: 'POST',
+            url: '/api/v1/wizard/dismiss-recommendation',
+            headers: authHeaders(ctx.token, ctx.host),
+            payload: { id: 'agent-switch' },
+        });
+        expect(post.statusCode).toBe(200);
+        expect((post.json() as { ok: boolean; dismissed: string[] }).ok).toBe(true);
+        expect((post.json() as { ok: boolean; dismissed: string[] }).dismissed).toContain('agent-switch');
+
+        const get = await ctx.app.inject({
+            method: 'GET', url: '/api/v1/wizard/detect-agent-switch', headers: authHeaders(ctx.token, ctx.host),
+        });
+        expect((get.json() as DetectAgentSwitchBody).dismissed).toBe(true);
+    });
+
+    it('rejects an unknown recommendation id with 422', async () => {
+        setDismissalsEnv();
+        ctx = await bootTestApp({ port: PORT + 4, extendedSteps: false });
+        const res = await ctx.app.inject({
+            method: 'POST',
+            url: '/api/v1/wizard/dismiss-recommendation',
+            headers: authHeaders(ctx.token, ctx.host),
+            payload: { id: 'not-a-real-recommendation' },
+        });
+        expect(res.statusCode).toBe(422);
+        const body = res.json() as { error?: { code?: string } };
+        expect(body.error?.code).toBe('VALIDATION');
+    });
+
+    it('rejects an unauthenticated dismiss request with 401', async () => {
+        setDismissalsEnv();
+        ctx = await bootTestApp({ port: PORT + 5, extendedSteps: false });
+        const res = await ctx.app.inject({
+            method: 'POST',
+            url: '/api/v1/wizard/dismiss-recommendation',
+            headers: { host: ctx.host, 'content-type': 'application/json' },
+            payload: { id: 'agent-switch' },
+        });
+        expect(res.statusCode).toBe(401);
+    });
+});


### PR DESCRIPTION
Closes out `road-to-reciprocal-ecosystem` (archived in this PR) — the second half of the distribution loop: agent-switch already recommends agent-config; this makes it mutual, bounded hard by the restraint rule (**one surface, self-retiring, permanently dismissible, no second placement ever**).

## Phase 0 — falsification spike (council-decided)

**Verdict B — passive row (honest null).** AI-council debate (2 rounds, unanimous round-1 convergence: claude-sonnet-4-5 + gpt-4o, 2026-07-28): AC cannot distinguish a multi-account user from a single-account user with a fixed list of stat calls — a second account via native login/logout reuses the same credential slot and leaves no fixed-path trace. A proactive card would therefore be indiscriminate promotion. Consequence: the recommendation ships **only** as a passive row among companion tools; the negative result is recorded in the roadmap.

## Phase 1 — detection + the single passive row

- `GET /api/v1/wizard/detect-agent-switch` — mirrors `detect-rtk`: installed via binary-on-PATH **or** `~/.agent-switch/` presence, local `--version` probe only, `installCommand` (`npm install -g @event4u/agent-switch`) surfaced for copy and `null` once installed.
- `POST /api/v1/wizard/dismiss-recommendation` — persists to user-global `wizard-dismissals.json`; deliberately **no un-dismiss API**, survives updates.
- `AgentSwitchRow` on the wizard identity step next to `RtkRow`: hidden until detection loads (no flash), hidden when installed (self-retiring, no "outdated" state — AS owns its updates), hidden forever once dismissed.

## Phase 2 — behave correctly under agent-switch (correctness, not promotion)

- `detectAgentSwitchProfile()` — pure env/path detection (`CLAUDE_CONFIG_DIR` / `CODEX_HOME` inside `AGENT_SWITCH_HOME ?? ~/.agent-switch`), parsed to provider + profile.
- `GET /api/v1/ping` advertises `agentSwitchProfile { active, provider, profile }`; the settings hub shows a banner naming the active profile (profile-scoped settings are not lost config).
- **Shared-write collision gate:** an lstat walk (bounded to the AS root, topology-free) detects writes that would land through an agent-switch `share on` symlink; `PUT /settings` and `PUT /user-md` answer `409 shared-write` unless `confirmSharedWrite:true`. The GUI turns that into a blocking confirm ("Write (affects all profiles)" / "Cancel", with an `agent-switch share off` pointer) — never a toast. Confirmed writes resolve **through** the symlink, so AS's links are never broken.
- Host-supplied config root (`--config-root` / `EVENT4U_CONFIG_HOME`, `capabilities.configRoot`) had already landed as `a9f003863` (2026-07-25) — verified and recorded, not re-implemented.

## Phase 3 — docs symmetry

- README `## Works with agent-switch` (short composition section, mirrors AS's mention).
- Long-form explainer `docs/guides/works-with-agent-switch.md`, published on the docs site (sync-docs `PAGES` + new **Guides** sidebar section; generated page gitignored like the other synced pages). One owner for the long form, so the two descriptions cannot drift.

## Acceptance criteria (pre-registered, all verified)

Exactly one recommendation surface (grep: 1 render site) · self-retiring · permanently dismissible across updates · never auto-installs (command display-only, grep-verified) · no version-currency reporting (no latest fetch) · Phase 2 independent of Phase 1 (zero imports, grep-verified) · honest-null path taken and recorded.

## Verification

- 41 new tests across 5 new test files + extended `tests/server/app.test.ts`; fresh run: **65 passed** (new files) + **136 passed** (touched routes/UI suites).
- `task typecheck-ts` exit 0 · `vite build` (UI) green · `task check-refs` green · `check_md_language` green on the new docs.

The roadmap's remaining blocker (`adoption-measurement`) is user-owned and gates only measurement, not build — recorded in the archived roadmap.
