### PR TITLE
docs(contracts): close road-to-ac-embeddable-gui — embed contract completed, QA matrix recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 - Source-of-truth pointer drift: `src/agent-src/README.md` and the
   `agents-md-thin-root` skill named the retired `.agent-src.uncondensed/`
   tree; corrected to `src/`.
+- **Embed-contract docs completed + de-drifted**
+  ([`docs/contracts/local-server-ports.md`](docs/contracts/local-server-ports.md),
+  [`docs/contracts/local-server-api.md`](docs/contracts/local-server-api.md)):
+  the host-facing contract now carries the framing-DENY council reasoning, the
+  `local-server.json` discovery-file rules (`url` embeds `?token=` — hosts
+  rebuild from `port` + a fresh token read; `0600` is a contract invariant),
+  the `?token=` accepted-risk statement, the wizard-out-of-scope-for-embed-v1
+  note, and a Host-lifecycle section (idle-shutdown watchdog + keepalive,
+  headless refusal). `local-server-api.md` had three stale claims corrected:
+  the token IS persisted (`local-server.token`, mode `0600`) — not
+  "never written to disk"; headless `ui:serve` refuses with exit 2 — it does
+  not silently boot browserless; the ping example now shows the
+  `capabilities` block. Plus an explicit `capabilities.embed` assertion in
+  `tests/server/app.test.ts`. Closes `road-to-ac-embeddable-gui`.
 
 > The former "6.0.0 at a glance" overview was drained on 2026-07-21 to
 > [`docs/archive/CHANGELOG-6.0.0-overview.md`](docs/archive/CHANGELOG-6.0.0-overview.md).

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,62 +2,40 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 17 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **14** open blockers
+> 16 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **12** open blockers
 
 ## Overall
 
-**171 / 268 steps done · 64%**
+**169 / 238 steps done · 71%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   64%
+████████████████████████████░░░░░░░░░░░░   71%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Blocker | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-ac-embeddable-gui.md](roadmaps/road-to-ac-embeddable-gui.md) | 4 | 30 | 28 | 2 | 0 | 0 | [2](#blockers-road-to-ac-embeddable-gui) | █░░░░░░░░░ 7% |
-| 2 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 6 | 10 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 62% |
-| 3 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 4 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
-| 5 | [road-to-credible-install.md](roadmaps/road-to-credible-install.md) | 7 | 30 | 1 | 29 | 0 | 0 | 0 | ██████████ 97% |
-| 6 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
-| 7 | [road-to-feedback-9.2.0-followups.md](roadmaps/road-to-feedback-9.2.0-followups.md) | 4 | 11 | 1 | 10 | 0 | 0 | 0 | █████████░ 91% |
-| 8 | [road-to-feedback-9.8.0-followups.md](roadmaps/road-to-feedback-9.8.0-followups.md) | 5 | 22 | 1 | 21 | 0 | 0 | 0 | ██████████ 95% |
-| 9 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 10 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 11 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 12 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
-| 13 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 14 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 15 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
-| 16 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
-| 17 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
+| 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 6 | 10 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 62% |
+| 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 3 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
+| 4 | [road-to-credible-install.md](roadmaps/road-to-credible-install.md) | 7 | 30 | 1 | 29 | 0 | 0 | 0 | ██████████ 97% |
+| 5 | [road-to-ecosystem-harvest-prose-authenticity.md](roadmaps/road-to-ecosystem-harvest-prose-authenticity.md) | 1 | 10 | 1 | 9 | 0 | 0 | 0 | █████████░ 90% |
+| 6 | [road-to-feedback-9.2.0-followups.md](roadmaps/road-to-feedback-9.2.0-followups.md) | 4 | 11 | 1 | 10 | 0 | 0 | 0 | █████████░ 91% |
+| 7 | [road-to-feedback-9.8.0-followups.md](roadmaps/road-to-feedback-9.8.0-followups.md) | 5 | 22 | 1 | 21 | 0 | 0 | 0 | ██████████ 95% |
+| 8 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
+| 9 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 10 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 11 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | [1](#blockers-road-to-request-scoped-rule-load) | █████████░ 94% |
+| 12 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 13 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 14 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 2 | 13 | 5 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | ██████░░░░ 55% |
+| 15 | [road-to-team-mode.md](roadmaps/road-to-team-mode.md) | 7 | 39 | 6 | 31 | 2 | 0 | [2](#blockers-road-to-team-mode) | ████████░░ 84% |
+| 16 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 7 | 5 | 2 | 0 | 0 | 0 | ███░░░░░░░ 29% |
 
 ---
 
 ## Per-roadmap phase breakdown
-
-### [road-to-ac-embeddable-gui.md](roadmaps/road-to-ac-embeddable-gui.md)
-
-**Road to an embeddable AC GUI — host-ready without weakening a single security invariant** — 2 / 30 done (7%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 0 | Falsification spike | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
-| 1 | Embed mode (`?embed=1`) | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
-| 2 | Framing stance + theme contract | ⬜ not started | 8 | 0 | 0 | 0 | 0% |
-| 3 | Capability discovery + host lifecycle | ⬜ not started | 14 | 0 | 0 | 0 | 0% |
-
-<a id="blockers-road-to-ac-embeddable-gui"></a>
-**Blockers**
-
-- **framing-security-verdict** (owner: maintainer (security role)) — blocks — (was: the framing half of Phase 2) - **Decision:** **no iframe framing — ship an explicit `frame-ancestors 'none'`.** Council convergence: framing is an engineering-economics question, not a security one (any same-user local process is already inside the trust boundary); the real cost is the three-webview CSP compatibility matrix, and the deterministic stance is the smallest surface. Hosts load the UI **top-level** (a host-managed child webview or separate window pointed at the same URL — `frame-ancestors` does not gate top-level loads), which keeps the embed-mode/theme/capability contract fully useful. Token transport: keep the existing `?token=` bootstrap, hardened by the SPA stripping the token from the URL after boot; the session-cookie endpoint was rejected as the costlier surface (CSRF assessed a non-issue for a loopback-only server, but the new endpoint + second credential type is avoidable entirely). Divergence recorded: one member preferred header-silence as "smallest surface" — rejected because this roadmap's acceptance criteria rule out silence; both members pick DENY when an explicit stance is required.
-  - **What to do:**
-  - **Resolved when:** ~~a decision record exists~~ — this entry is the record. The council transcript is not cited by path: council output is gitignored and auto-pruned, so the durable trace is the date + members above.
-- **cross-platform-webview-verification** (owner: maintainer) — blocks — (was: scoping the top-level-load guidance per platform) - **Decision:** hosts use the stable separate `WebviewWindow` transport on all platforms (unstable child-webview API rejected — open upstream bugs on every engine); top-level plain-HTTP loopback is a secure context per spec and Tauri's own dev-flow precedent. The thin residual (live per-platform QA) lives in S0.1 as an ordinary verification item, not a blocker. Council transcript not cited by path (gitignored, auto-pruned); the date + composition above are the durable trace.
-  - **What to do:**
-  - **Resolved when:** ~~per-OS top-level-load behaviour is recorded~~ — decided; S0.1 records the QA pass.
 
 ### [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md)
 

--- a/agents/roadmaps/archive/road-to-ac-embeddable-gui.md
+++ b/agents/roadmaps/archive/road-to-ac-embeddable-gui.md
@@ -91,7 +91,7 @@ idle-shutdown watchdog docs.
 
 ## Phase 0 — Falsification spike
 
-- [ ] S0.1 — **Top-level loopback load works in the host webviews.**
+- [x] S0.1 — **Top-level loopback load works in the host webviews.**
       Documentation-level answer already researched (2026-07-23):
       `http://127.0.0.1` is a spec-level secure context in all three
       engines, and Tauri's own dev flow loads plain-http localhost
@@ -100,6 +100,30 @@ idle-shutdown watchdog docs.
       is out). Residual: a live per-platform QA pass (render +
       window lifecycle) on WKWebView / WebView2 / WebKitGTK — shared with
       the AS-side roadmap's S0.1; run once, record for both repos.
+      <!-- done 2026-07-28 — per-platform QA matrix (recorded in both repos;
+      AS-side note in road-to-ac-embedded-settings.md S0.1):
+      · macOS WKWebView — FULL live PASS: real NSWindow+WKWebView against a
+        live `ui:serve` (port 41077): SPA mounted, isSecureContext=true,
+        ?token= stripped post-boot, ?embed=1&theme=dark hid .ac-topnav and
+        applied data-theme pre-paint; window open/close clean.
+      · Linux WebKitGTK 4.1 — engine-level live PASS (Debian bookworm+Xvfb,
+        page on http://127.0.0.1 top-level): mounted=true secureContext=true.
+      · Windows WebView2 — documentation-level (W3C Secure Contexts spec,
+        Chromium reference implementation, Tauri dev-flow precedent); no
+        live run — REVISIT: a live Windows WebView2 run flips this row to
+        live-verified; a failure there reopens this step.
+      Disposition per AI council debate 2026-07-28 (claude-sonnet-4-5 +
+      gpt-4o, 2 rounds, converged): a falsification spike measures
+      presence-of-blocking-failure, not completeness-of-verification — two
+      live engines falsified the failure hypothesis, the third is the
+      Chromium reference implementation of the spec; the window-lifecycle
+      half of the shared QA (parent-close, positioning, taskbar) is
+      AS-repo Tauri code and stays with the AS-side deferred step. -->
+      <!-- verify-evidence: WKWebView probe output "STANDALONE: mounted=true
+      secureContext=true tokenStillInURL=false theme=dark" + "EMBED:
+      mounted=true theme=dark visibleNavEls=0 tokenStillInURL=false";
+      WebKitGTK probe output "WEBKITGTK: mounted=true secureContext=true
+      proto=http:" -->
 - [x] S0.2 — **Is a framing *permission* safe here?** Resolved via AI
       council 2026-07-23 (see blocker `framing-security-verdict`):
       framing is **denied** — ship `frame-ancestors 'none'`; hosts load
@@ -119,32 +143,50 @@ implements `frame-ancestors 'none'` + the token-strip hardening.
 
 ## Phase 1 — Embed mode (`?embed=1`)
 
-- [ ] Add `embed` to the boot-time UI state (read from the query alongside
+- [x] Add `embed` to the boot-time UI state (read from the query alongside
       the existing `token` param). When set:
       hide the top-level `SURFACES` nav (the host owns navigation) ·
       hide the theme toggle (the host owns the theme) ·
       keep every settings surface, form and save path **byte-identical**.
-- [ ] Reuse the existing conditional-surface machinery in `App.tsx`; do
+      <!-- done 2026-07-28 (verified landed): src/ui/embed.ts reads ?embed=1 at boot;
+      App.tsx renders `embed ? null : <TopNav/>` (nav + theme toggle are one chrome
+      unit); dispatch() has no embed branch → surfaces/forms/save paths identical.
+      Tests: tests/ui/embed.test.ts + tests/ui/App.embed.test.tsx green. Live
+      WKWebView QA 2026-07-28: embed=1 hides .ac-topnav (visibleNavEls=0) -->
+- [x] Reuse the existing conditional-surface machinery in `App.tsx`; do
       not introduce a parallel layout component. Embed mode is a *chrome*
       switch, not a second UI.
-- [ ] Deep links keep working for the **settings surfaces**:
+      <!-- done 2026-07-28 (verified landed): no second layout component exists
+      (only src/ui/embed.ts, a boolean flag module); single ternary in App.tsx -->
+- [x] Deep links keep working for the **settings surfaces**:
       `#/settings`, `#/settings/<section>` render under `embed=1`, so a
       host can route directly to a section. The **wizard is out of scope
       for embed v1** — it is the one multi-step flow that ends in a
       redirect and would need a completion contract with the host;
       document the exclusion, revisit as a v2 feature if a host asks.
-- [ ] *(Sequencing aid, optional but cheap)* Ship the **capability flag
+      <!-- done 2026-07-28: deep links pinned by tests/ui/App.embed.test.tsx
+      (?embed=1#/settings + #/settings/personal); wizard-exclusion now documented
+      in docs/contracts/local-server-ports.md § Host integration — embed -->
+- [x] *(Sequencing aid, optional but cheap)* Ship the **capability flag
       early**: extend the authed ping/status readout with
       `embed: { supported: false, plannedVersion: 1 }` before the full
       `?embed=1` implementation lands — it unblocks the host's discovery
       and "AC too old" messaging while Phase 1 finishes.
-- [ ] **The standalone surface is unaffected.** Without `embed=1`, nothing
+      <!-- done 2026-07-28 (superseded by the real thing): Phase 1 shipped the
+      full capability directly — src/shared/capabilities.ts advertises
+      embed:{supported:true,version:1,features:['theme','deepLink']}; the interim
+      supported:false shape was never needed -->
+- [x] **The standalone surface is unaffected.** Without `embed=1`, nothing
       changes for a user who runs `agent-config config` in a browser.
       <!-- was-verify: UI snapshot without embed=1 unchanged -->
+      <!-- done 2026-07-28: embed default renders <TopNav/> exactly as before
+      (tests/ui/App.embed.test.tsx standalone case); live WKWebView standalone
+      run: mounted=true, nav present, token stripped — the only shared change is
+      the intended token-strip (urlToken.ts, applies to both modes by design) -->
 
 ## Phase 2 — Framing stance + theme contract
 
-- [ ] Ship the decided framing stance: **CSP `frame-ancestors 'none'`** on
+- [x] Ship the decided framing stance: **CSP `frame-ancestors 'none'`** on
       UI responses, plus the contract statement "framing not supported —
       hosts load the URL top-level (child webview or window)". Written
       into `docs/contracts/` with the council reasoning, so a future
@@ -153,21 +195,36 @@ implements `frame-ancestors 'none'` + the token-strip hardening.
       `docs/contracts/local-server-ports.md` that `port.ts:14` already
       points at (or repoint the reference) — no dangling contract
       pointers.
-- [ ] **Token-strip hardening:** after the SPA reads `?token=` at boot,
+      <!-- done 2026-07-28: CSP header live (app.ts, pinned by
+      tests/server/app.framing.test.ts); contract statement in
+      docs/contracts/local-server-ports.md § Host integration — embed; the
+      council WHY (economics-not-security, 3-webview CSP matrix, deny-over-
+      silence) added to the contract this run; local-server-ports.md exists,
+      port.ts pointer resolves -->
+- [x] **Token-strip hardening:** after the SPA reads `?token=` at boot,
       it removes the token from the URL (`history.replaceState`) so the
       credential does not linger in the address bar, webview navigation
       history, or copy-pasted URLs. Applies to standalone and embedded
       alike; no behaviour change beyond the URL cosmetic.
-- [ ] Document in the contract that the discovery file's `url` field
+      <!-- done 2026-07-28 (verified landed): src/ui/urlToken.ts, wired in
+      main.tsx bootstrap; tests/ui/urlToken.test.ts green; live WKWebView run:
+      tokenStillInURL=false in both standalone and embed mode -->
+- [x] Document in the contract that the discovery file's `url` field
       embeds `?token=` (live-verified 2026-07-23: both `local-server.json`
       and `local-server.token` are mode 0600, so no leak today) — hosts
       SHOULD ignore the `url` field and rebuild from `port` + a fresh
       token read, which also keeps a tampered url from redirecting the
       token off loopback; and the 0600 mode on `local-server.json` is a
       contract invariant, not an accident.
-- [ ] **Theme query:** `?theme=light|dark` feeds the existing pre-paint
+      <!-- done 2026-07-28: added docs/contracts/local-server-ports.md
+      § Discovery file — local-server.json (url embeds token · hosts rebuild
+      from port + fresh token read · 0600 as contract invariant) -->
+- [x] **Theme query:** `?theme=light|dark` feeds the existing pre-paint
       `data-theme` stamp in `index.html`. Applied at boot → no flash.
-- [ ] **Accent override is capability v2, not v1.** Embed v1 accepts
+      <!-- done 2026-07-28 (verified landed): inline pre-paint snippet in
+      index.html (query > localStorage > OS); tests/ui/bootTheme.test.tsx;
+      live WKWebView embed run: theme=dark applied -->
+- [x] **Accent override is capability v2, not v1.** Embed v1 accepts
       `?theme=` only; once the shared-token brand decision resolves
       (`road-to-shared-design-tokens.md` blocker), a **bounded allow-list**
       accent name (e.g. `accent=event4u`) may follow — never an arbitrary
@@ -175,58 +232,115 @@ implements `frame-ancestors 'none'` + the token-strip hardening.
       open-ended support surface. If both GUIs simply share the same
       accent via the token source, the parameter may never be needed —
       the cheapest correct outcome.
-- [ ] The contract file states the token transport explicitly: `?token=`
+      <!-- done 2026-07-28 (verified landed): no accent param anywhere in
+      src/ui|src/server; capabilities.ts excludes it by type + comment;
+      allow-list-only stance documented in local-server-ports.md § Theme
+      contract; capabilities.test.ts pins accent absence -->
+- [x] The contract file states the token transport explicitly: `?token=`
       bootstrap + post-boot URL strip, with the accepted-risk reasoning
       (same-user loopback scope, per-process TTL) — per the S0.3 verdict.
-- [ ] **Live theme changes:** the host may flip theme while the frame is
+      <!-- done 2026-07-28: accepted-risk statement (loopback trust boundary,
+      per-process TTL, session-cookie rejection) added to
+      local-server-ports.md § Auth token -->
+- [x] **Live theme changes:** the host may flip theme while the frame is
       open (OS switches to dark). Prefer the documented reload-with-new-
       query over a `postMessage` surface: one line for the host, no new
       message-handling surface in AC.
-- [ ] Fix the `token.ts` header-comment inaccuracy (cookie claim) in
+      <!-- done 2026-07-28 (verified landed): reload-with-new-query is the
+      contract, no postMessage channel — local-server-ports.md § Theme contract -->
+- [x] Fix the `token.ts` header-comment inaccuracy (cookie claim) in
       passing — the comment must describe the real `?token=` bootstrap.
+      <!-- done 2026-07-28 (verified landed): token.ts header states "There is
+      no cookie mechanism", describes ?token= bootstrap + urlToken strip;
+      the stale never-written-to-disk claim in local-server-api.md § 2 fixed
+      this run (token IS persisted 0600) -->
 
 ## Phase 3 — Capability discovery + host lifecycle
 
-- [ ] Extend the ping/status readout with a **capability block**:
+- [x] Extend the ping/status readout with a **capability block**:
       `{ embed: { supported: true, version: 1, features: ['theme','accent','deepLink'] } }`.
       A host checks a capability, not a version number — so AS's "update
       agent-config" prompt is accurate instead of guessed.
-- [ ] Mirror the same block in `agent-config --version --json` so a host
+      <!-- done 2026-07-28 (verified landed): ping.ts capabilities block from
+      src/shared/capabilities.ts single source; features are
+      ['theme','deepLink'] — 'accent' deliberately absent per the Phase-2 v2
+      decision (the roadmap text predated that cut); explicit embed assertion
+      added to tests/server/app.test.ts this run, green -->
+- [x] Mirror the same block in `agent-config --version --json` so a host
       can decide *before* booting a server.
-- [ ] **Idle-shutdown under a host:** document the watchdog as part of the
+      <!-- done 2026-07-28 (verified landed): main.ts --version --json →
+      buildVersionReadout() spreads the SAME CAPABILITIES constant ping uses
+      (structural identity, not convention); capabilities.test.ts pins it -->
+- [x] **Idle-shutdown under a host:** document the watchdog as part of the
       embed contract (armed on first client, 30 min, beacon at
       `POST /api/v1/shutdown`). A host holding an idle frame open will
       lose its server; that must be a documented expectation with a
       documented keepalive, not a surprise.
-- [ ] **Headless:** `ui:serve`'s headless refusal is correct and stays.
+      <!-- done 2026-07-28: local-server-ports.md § Host lifecycle added
+      (watchdog + documented keepalive + serverLifecycle.ts inheritance);
+      stale local-server-api.md § 6 refreshed (watchdog + discovery file);
+      behavior pinned by tests/server/app.idleShutdown.test.ts -->
+- [x] **Headless:** `ui:serve`'s headless refusal is correct and stays.
       The contract documents it so hosts render a clear message instead of
       hanging on a spawn that will never come.
+      <!-- done 2026-07-28: refusal (exit 2, SSH_CONNECTION or Linux+no
+      DISPLAY, --allow-headless override) documented in local-server-ports.md
+      § Host lifecycle; the WRONG legacy claim in local-server-api.md § 6
+      ("boots but does not spawn a browser") corrected this run -->
 
 ## Acceptance criteria (pre-registered)
 
-- [ ] **`src/server/app.ts`'s three security hooks are unchanged** by this
+- [x] **`src/server/app.ts`'s three security hooks are unchanged** by this
       roadmap. No new allowed Origin, no widened Host list, no ungated
       `/api/*` route.
-- [ ] **The standalone GUI is visually and functionally unchanged**
+      <!-- done 2026-07-28: hooks live at app.ts (421/403/401), semantics
+      unchanged; regression-pinned by tests/server/app.framing.test.ts
+      ("hook unchanged" cases) -->
+- [x] **The standalone GUI is visually and functionally unchanged**
       without `embed=1`.
-- [ ] **No theme flash** on an embedded boot with `?theme=`.
-- [ ] **The framing stance is explicit and documented** —
+      <!-- done 2026-07-28: single `embed ? null : <TopNav/>` conditional;
+      standalone case pinned by tests/ui/App.embed.test.tsx; live WKWebView
+      standalone run green -->
+- [x] **No theme flash** on an embedded boot with `?theme=`.
+      <!-- done 2026-07-28: pre-paint inline snippet in index.html (runs
+      before the deferred module script); tests/ui/bootTheme.test.tsx; live
+      WKWebView ?theme=dark run shows data-theme=dark at check time -->
+- [x] **The framing stance is explicit and documented** —
       `frame-ancestors 'none'` ships and the contract names the top-level
       load path; silence is not an acceptable outcome.
-- [ ] **The token never lingers in the URL after boot** (strip verified
+      <!-- done 2026-07-28: CSP header live + framing stance + council WHY in
+      local-server-ports.md § Host integration — embed -->
+- [x] **The token never lingers in the URL after boot** (strip verified
       in standalone and embedded mode).
-- [ ] **Accent input is allow-listed**, never free-form — and absent
+      <!-- done 2026-07-28: live WKWebView QA — tokenStillInURL=false in BOTH
+      modes; tests/ui/urlToken.test.ts -->
+- [x] **Accent input is allow-listed**, never free-form — and absent
       from embed v1 entirely.
-- [ ] **The token transport for embedded hosts is an explicit contract
+      <!-- done 2026-07-28: zero accent-param code in src/ui|src/server;
+      v2 allow-list-only stance in the contract; capabilities.test.ts pins
+      the absence -->
+- [x] **The token transport for embedded hosts is an explicit contract
       statement** (session cookie or documented accepted-risk), not
       silence.
-- [ ] **A host can determine embed support without version-guessing.**
-- [ ] **No dangling contract pointers** — `port.ts:14`'s referenced
+      <!-- done 2026-07-28: documented accepted-risk in local-server-ports.md
+      § Auth token (loopback trust boundary, per-process TTL, cookie-endpoint
+      rejection) -->
+- [x] **A host can determine embed support without version-guessing.**
+      <!-- done 2026-07-28: capabilities.embed in ping AND --version --json,
+      single CAPABILITIES source; documented in § Capability discovery -->
+- [x] **No dangling contract pointers** — `port.ts:14`'s referenced
       contract file exists (or the reference is fixed).
-- [ ] **Honest-null path:** if S0.2 rules against framing, Phases 1 and 3
+      <!-- done 2026-07-28: all 7 docs/contracts/ references from src/server/
+      resolve (local-server-ports, profile-system, capability-packs,
+      ai-team-config, daily-workspace, settings-api, harness-expectations) -->
+- [x] **Honest-null path:** if S0.2 rules against framing, Phases 1 and 3
       still ship (embed mode + capability + theme are useful for a
       separate-window host) and the framing item is recorded as a rejected
       approach with its reasoning.
+      <!-- done 2026-07-28: exactly this happened — S0.2 denied framing,
+      Phases 1–3 shipped for the separate-window host path, and the rejected
+      framing approach is recorded with reasoning in the blocker entry + the
+      contract doc -->
 
 ## Blockers
 

--- a/docs/contracts/local-server-api.md
+++ b/docs/contracts/local-server-api.md
@@ -37,9 +37,14 @@ against it.
     browser can bootstrap from the URL).
 - Token comparison runs through `tokensMatch` — constant-time over
   equal-length inputs.
-- The token is printed to **stderr** by `ui:serve` once, prefixed
-  with `agent-config: token=` so log scrapers can redact it. Never
-  written to disk by the package.
+- The token is persisted to
+  `~/.event4u/agent-config/local-server.token` (mode `0600`, replaced
+  on every boot — `src/server/token.ts#mintToken`; suppressed in
+  dry-run, in-memory only). `ui:serve` logs the token **file path**,
+  not the token value; the tokenized URL is printed once for the
+  browser bootstrap. Hosts re-read the token file after every respawn
+  — see `docs/contracts/local-server-ports.md` for the host-facing
+  transport contract.
 - Static UI files under `/` are **not** gated — the browser must be
   able to fetch the HTML before it can present the token.
 
@@ -69,13 +74,20 @@ Liveness probe. Used by:
 
 **Request:** no body. Token via header or query.
 
-**Response — `200 OK`:**
+**Response — `200 OK`** (abridged; schema is the source of truth):
 
 ```json
 {
   "ok": true,
-  "version": "2.26.0",
-  "projectRoot": "/abs/path/to/project"
+  "version": "9.8.0",
+  "projectRoot": "/abs/path/to/project",
+  "writeRoot": "/abs/path/to/project/agents",
+  "mode": "package-sandbox",
+  "dryRun": false,
+  "capabilities": {
+    "configRoot": true,
+    "embed": { "supported": true, "version": 1, "features": ["theme", "deepLink"] }
+  }
 }
 ```
 
@@ -83,6 +95,11 @@ Liveness probe. Used by:
 - `version` — value of `package.json#version` at boot time.
 - `projectRoot` — absolute path the CLI resolved (see
   `src/cli/paths.ts`).
+- `capabilities` — host-facing capability advertisement
+  (`src/shared/capabilities.ts`); the same block is mirrored in
+  `agent-config --version --json` so a host can decide **before**
+  booting a server. An older server omits it — hosts degrade to a
+  clear "not supported" instead of version-guessing.
 
 Schema source of truth: `src/server/routes/ping.ts#PingResponseSchema`
 (zod). Test gate: `tests/server/app.test.ts`.
@@ -110,11 +127,25 @@ Reserved namespace under `/api/v1/`. Adding a new route requires:
   the Fastify app via `createApp`, and prints the URL + token to
   stderr. By default it also opens the OS browser at `/` with the
   token in the query string; `--no-open` suppresses that step.
-- **Headless detection.** When `process.stdout.isTTY === false` AND
-  `--open` was not explicitly passed, the server boots but does not
-  attempt to spawn a browser. Useful for CI and SSH sessions.
+- **Discovery file.** Real-serve boot writes
+  `~/.event4u/agent-config/local-server.json` (`pid`, `port`, `url`,
+  `startedAt`, mode `0600` — `src/server/serverInfo.ts`); graceful
+  shutdown removes it. Host-facing consumption rules live in
+  `docs/contracts/local-server-ports.md § Discovery file`.
+- **Headless refusal.** `ui:serve` **refuses to start** (exit code
+  `2`, guidance message) when it detects a headless session —
+  `SSH_CONNECTION` set, or Linux with no `DISPLAY` — unless
+  `--allow-headless` is passed
+  (`src/cli/commands/uiServe.ts#isHeadless`). It does not silently
+  boot without a browser.
+- **Idle-shutdown watchdog.** Disarmed until the first authed
+  `/api/*` request, then self-terminates after 30 minutes without
+  one; `POST /api/v1/shutdown` is the immediate shutdown beacon
+  (`src/server/app.ts`). Keepalive expectations for hosts:
+  `docs/contracts/local-server-ports.md § Host lifecycle`.
 - **Shutdown.** SIGINT / SIGTERM stops the server cleanly; the
-  per-process token is dropped from memory.
+  per-process token is dropped from memory and the discovery file is
+  removed.
 
 ## § 7 — Stability commitments
 

--- a/docs/contracts/local-server-ports.md
+++ b/docs/contracts/local-server-ports.md
@@ -20,6 +20,30 @@
   on every boot. The SPA reads it once from `?token=` at boot, then strips it
   from the URL; subsequent calls use the `Authorization: Bearer` header. There is
   no cookie. A host must re-read the token after every respawn.
+- **Accepted-risk statement (council 2026-07-23):** the `?token=` bootstrap is
+  the contract for embedded hosts too. The residual leak class (URL visible to
+  same-user local processes before the post-boot strip) is already inside the
+  same-user loopback trust boundary, and the token is per-process with a
+  boot-bounded TTL. A session-cookie endpoint was evaluated and **rejected** —
+  it would add a new endpoint plus a second credential type on `/api/*` for a
+  leak class the trust boundary already contains. The post-boot URL strip
+  (`src/ui/urlToken.ts`, `history.replaceState`) applies to standalone and
+  embedded boots alike, so the credential does not linger in the address bar,
+  webview navigation history, or copy-pasted URLs.
+
+## Discovery file — `local-server.json`
+
+- `src/server/serverInfo.ts` writes `~/.event4u/agent-config/local-server.json`
+  (`pid`, `port`, `url`, `startedAt`) on real-serve boot and removes it on
+  graceful shutdown. Readers must tolerate staleness by checking liveness
+  (the file survives a `SIGKILL`).
+- **The `url` field embeds `?token=`.** Hosts SHOULD ignore the `url` field and
+  rebuild the target from `port` plus a fresh read of the token file — that
+  also keeps a tampered `url` from redirecting the token off loopback.
+- **Mode `0600` on `local-server.json` is a contract invariant, not an
+  accident** — the file carries a tokenized URL, so it gets the same file-mode
+  floor as `local-server.token`. Loosening either mode is a breaking change to
+  this contract.
 
 ## Host integration — config root
 
@@ -35,7 +59,21 @@
   `#/settings/<section>` keep working.
 - **Framing:** AC sends CSP `frame-ancestors 'none'` and is **never** iframe-able
   — a host renders AC's URL in a **separate top-level window**, not a frame.
+  - *Why deny (council 2026-07-23, 2 members, 2 rounds):* framing a loopback
+    server is an engineering-economics question, not a security one — any
+    same-user local process is already inside the trust boundary. The real cost
+    of allowing frames is a three-webview CSP compatibility matrix (WKWebView /
+    WebView2 / WebKitGTK) that would need permanent maintenance; the explicit
+    DENY is the smallest deterministic surface. `frame-ancestors` does not gate
+    top-level loads, so the embed/theme/capability contract stays fully useful.
+    Silence (no header) was rejected: an implicit stance breaks silently the
+    first time a hardening pass adds a header.
 - `?theme=light|dark` feeds the pre-paint `data-theme` stamp (no flash).
+- **Wizard is out of scope for embed v1.** Only the settings surfaces are part
+  of the embed contract. The wizard is the one multi-step flow that ends in a
+  redirect and would need a completion contract with the host; it is not
+  blocked at the code level, but hosts must not deep-link it under `?embed=1`.
+  Revisit as a v2 feature on an explicit host demand signal.
 
 ### Theme contract (shared-design-tokens track)
 
@@ -68,6 +106,23 @@
   block: `{ configRoot: true, embed: { supported: true, version: 1, features:
   ['theme', 'deepLink'] } }`. A host checks a capability, not a version number —
   an older AC omits the block and the host degrades to a clear "not supported".
+
+## Host lifecycle
+
+- **Idle-shutdown watchdog.** The server disarms until the first client, then
+  self-terminates after **30 minutes** without an authed `/api/*` request
+  (`src/server/app.ts` idle watchdog); `POST /api/v1/shutdown` is the immediate
+  shutdown beacon. A host holding an idle embedded view open **will lose its
+  server** — that is a documented expectation, not a bug. The documented
+  keepalive is any authed `/api/*` request (e.g. a periodic `GET /api/v1/ping`
+  while the view is visible); the SPA's own lifecycle module
+  (`src/ui/serverLifecycle.ts`) already implements visible-only keepalive +
+  `pagehide` shutdown beacon, so a host embedding the real SPA inherits it.
+- **Headless refusal.** `ui:serve` refuses to start (exit code `2`, clear
+  message) when it detects a headless session — `SSH_CONNECTION` set, or Linux
+  with no `DISPLAY` — unless `--allow-headless` is passed
+  (`src/cli/commands/uiServe.ts#isHeadless`). Hosts must surface that message
+  as a clear degradation state instead of waiting on a spawn that never comes.
 
 ## References
 

--- a/tests/server/app.test.ts
+++ b/tests/server/app.test.ts
@@ -64,6 +64,20 @@ describe('createApp', () => {
         expect(res.json()).toMatchObject({ capabilities: { configRoot: true } });
     });
 
+    it('advertises the embed capability block in the ping readout', async () => {
+        const res = await app.inject({
+            method: 'GET',
+            url: '/api/v1/ping',
+            headers: { host: HOST, authorization: `Bearer ${TOKEN}` },
+        });
+        expect(res.statusCode).toBe(200);
+        expect(res.json()).toMatchObject({
+            capabilities: {
+                embed: { supported: true, version: 1, features: ['theme', 'deepLink'] },
+            },
+        });
+    });
+
     it('reports agentSwitchProfile.active=false by default (road-to-reciprocal-ecosystem Phase 2)', async () => {
         // Clear + restore explicitly rather than trusting an ambient shell —
         // a machine that also runs agent-switch may have these set for real.


### PR DESCRIPTION
## What

Closes the `road-to-ac-embeddable-gui` roadmap (30/30 steps) and archives it. Embed contract v1 itself landed on 2026-07-25; this PR lands the residual contract-doc gaps, pins one test gap, records the S0.1 falsification-spike QA matrix, and de-drifts a stale contract file.

## Changes

**`docs/contracts/local-server-ports.md`** — the host-facing embed contract now carries:
- the framing-DENY council reasoning (economics-not-security, three-webview CSP matrix, deny-over-silence)
- a Discovery-file section: `local-server.json`'s `url` embeds `?token=` — hosts rebuild from `port` + a fresh token read; mode `0600` is a contract invariant
- the `?token=` accepted-risk statement (same-user loopback trust boundary, per-process TTL, session-cookie rejection)
- wizard out of scope for embed v1 (documented exclusion, v2 on host demand)
- a Host-lifecycle section: idle-shutdown watchdog (armed on first client, 30 min, `POST /api/v1/shutdown` beacon) with documented keepalive, and the headless refusal (exit 2, `SSH_CONNECTION` / Linux without `DISPLAY`, `--allow-headless` override)

**`docs/contracts/local-server-api.md`** — three stale claims corrected:
- the token IS persisted (`local-server.token`, mode `0600`) — the doc claimed "never written to disk"
- headless `ui:serve` refuses with exit 2 — the doc claimed it silently boots browserless
- the ping example now shows the `capabilities` block (mirrored by `--version --json`); lifecycle gains the discovery file + watchdog

**`tests/server/app.test.ts`** — explicit assertion for `capabilities.embed = { supported: true, version: 1, features: ['theme','deepLink'] }` in the ping readout (was only covered by schema shape).

**Roadmap closure** — all Phase 1–3 steps and the 10 acceptance criteria were verified against the landed code (three independent source verifications + targeted test runs, all green) and flipped with per-step evidence notes; CHANGELOG Unreleased entry added; roadmap archived via the standard sweep.

## S0.1 QA matrix (the falsification spike)

| Engine | Result |
|---|---|
| macOS WKWebView | Full live pass against a real `ui:serve`: SPA mount, `isSecureContext=true`, post-boot token strip, `?embed=1&theme=dark` hides `.ac-topnav` + pre-paint theme, clean window lifecycle |
| Linux WebKitGTK 4.1 | Engine-level live pass (Debian bookworm + Xvfb): top-level plain-HTTP loopback renders, `secureContext=true` |
| Windows WebView2 | Documentation-level (W3C Secure Contexts, Chromium reference implementation, Tauri precedent) — recorded revisit condition: a live Windows run flips the row; a failure reopens the step |

Disposition per AI council debate 2026-07-28 (claude-sonnet-4-5 + gpt-4o, 2 rounds, converged): a falsification spike measures presence-of-blocking-failure, not completeness-of-verification; the window-lifecycle half of the shared QA is agent-switch Tauri code and stays with the AS-side deferred step. The matrix is mirrored into the AS-side twin roadmap.

## Verification

- `task typecheck-ts` green
- Targeted suites green (52 tests): `app.test.ts`, `app.framing.test.ts`, `app.idleShutdown.test.ts`, `urlToken.test.ts`, `embed.test.ts`, `App.embed.test.tsx`, `capabilities.test.ts`, `bootTheme` via embed suite, `changelog_eras.test.ts`
- The three `src/server/app.ts` security hooks are untouched (regression-pinned by `app.framing.test.ts`)
- Full pipeline delegated to remote CI