### PR TITLE
docs(roadmap): close surface-consolidation on measured evidence; repoint stale era-test refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > History is split into **eras**. The current era keeps full entries
 > inline; prior eras collapse into a single pointer to an archive file
 > under [`docs/archive/`](docs/archive/). A drift test
-> (`tests/test_changelog_eras.py`) forces an era split before the
+> (`tests/lib/changelog_eras.test.ts`) forces an era split before the
 > current era grows past 250 lines.
 
 ## [Unreleased]
@@ -125,7 +125,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-5.4.0 — archived
 
@@ -134,7 +134,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-5.9.0 — archived
 
@@ -143,7 +143,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-6.0.0 — archived
 
@@ -152,7 +152,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-7.0.0 — archived
 
@@ -161,7 +161,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-8.0.0 — archived
 
@@ -170,7 +170,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-8.1.0 — archived
 
@@ -179,7 +179,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-8.9.0 — archived
 
@@ -188,7 +188,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-8.12.0 — archived
 
@@ -197,7 +197,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-9.2.0 — archived
 
@@ -206,7 +206,7 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > The archive is read-only; git tags remain the canonical
 > source for what shipped. Splitting them out of the main file
 > keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: 9.2.x — current
 
@@ -517,7 +517,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `3.2.0` and `3.3.0` remain the
 > canonical source for what shipped. Splitting them out of the main
 > file keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-3.2.0 — archived
 
@@ -526,7 +526,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `3.1.0` and `3.1.1` remain the
 > canonical source for what shipped. Splitting them out of the main
 > file keeps the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-3.1.0 — archived
 
@@ -535,7 +535,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tag `3.0.0` remains the canonical
 > source for what shipped. Splitting it out of the main file keeps
 > the active era under the 250-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-3.0.0 — archived
 
@@ -544,7 +544,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.26.0` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.25.0 — archived
 
@@ -553,7 +553,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.24.0` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.20.0 — archived
 
@@ -562,7 +562,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.19.0` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.17.0 — archived
 
@@ -571,7 +571,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tag `2.16.0` remains the canonical
 > source for what shipped. Splitting these out of the main file keeps
 > the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.16.0 — archived
 
@@ -580,7 +580,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tag `2.15.0` remains the canonical
 > source for what shipped. Splitting these out of the main file keeps
 > the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.15.0 — archived
 
@@ -589,7 +589,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.14.0` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.11.0 — archived
 
@@ -598,7 +598,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.10.0` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 
 # Era: pre-2.7.0 — archived
@@ -608,7 +608,7 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.6.1` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.
 
 # Era: pre-2.2.0 — archived
 
@@ -617,4 +617,4 @@ Tests: 7764 (+27 since 9.1.0)
 > The archive is read-only; git tags `2.1.0` and prior remain the
 > canonical source for what shipped. Splitting these out of the main
 > file keeps the active era under the 200-line drift cap enforced by
-> `tests/test_changelog_eras.py`.
+> `tests/lib/changelog_eras.test.ts`.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**39 / 94 steps done · 41%**
+**45 / 95 steps done · 47%**
 
 ```text
-████████████████░░░░░░░░░░░░░░░░░░░░░░░░   41%
+███████████████████░░░░░░░░░░░░░░░░░░░░░   47%
 ```
 
 ## Open roadmaps
@@ -24,7 +24,7 @@
 | 6 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
 | 7 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 8 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 9 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 6 | 6 | 2 | 0 | [3](#blockers-road-to-surface-consolidation) | █████░░░░░ 50% |
+| 9 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 10 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
 
 ---
@@ -180,13 +180,13 @@ _1 blocker resolved._
 
 ### [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md)
 
-**Road to surface consolidation — collapse the proactive mental surface, remove don't add** — 6 / 12 done (50%)
+**Road to surface consolidation — collapse the proactive mental surface, remove don't add** — 12 / 13 done (92%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Collapse the proactive suggestion surface (the core) | ✅ done | 0 | 3 | 0 | 0 | 100% |
-| 2 | Supporting net-reductions (remove / fold, never add) | ✅ done | 0 | 3 | 2 | 0 | 100% |
-| 3 | Utilization-window disposition sweep (re-homed 2026-07-28) | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 2 | Supporting net-reductions (remove / fold, never add) | ✅ done | 0 | 4 | 1 | 0 | 100% |
+| 3 | Utilization-window disposition sweep (re-homed 2026-07-28) | 🟡 in progress | 1 | 5 | 0 | 0 | 83% |
 
 <a id="blockers-road-to-surface-consolidation"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-surface-consolidation.md
+++ b/agents/roadmaps/road-to-surface-consolidation.md
@@ -102,9 +102,22 @@ command deleted. Rollback: the flip is a single reversible frontmatter field.
 
 ## Phase 2 — Supporting net-reductions (remove / fold, never add)
 
-- [~] **Fossil drain:** the CHANGELOG `## [Unreleased]` still opens with
+- [x] **Fossil drain:** the CHANGELOG `## [Unreleased]` still opens with
       "6.0.0 at a glance"; move that era block behind the era split and add the
       one-sentence guard to the era-split test so `[Unreleased]` starts clean. <!-- deferred 2026-07-20: correct fix is an era-split of the 6.0.0 block; doing it blind risks the era-split drift test (tests/test_changelog_eras). P3 nicety — separated to avoid coupling a CHANGELOG-history restructure to the surface-consolidation diff. -->
+      <!-- done — resolved 2026-07-28 by verification, not by new work: the
+      deferral was STALE. Both halves already shipped under
+      `road-to-changelog-unreleased-drain` on 2026-07-21.
+      (a) The block was moved to `docs/archive/CHANGELOG-6.0.0-overview.md`,
+      with a pointer note left at CHANGELOG.md:118; `## [Unreleased]` now opens
+      on `### Added`, and this step's own verify command passes.
+      (b) The guard exists as `test_unreleased_carries_no_at_a_glance_fossil`
+      in `tests/lib/changelog_eras.test.ts:113` — it asserts the region between
+      `## [Unreleased]` and the first `# Era:` header carries no
+      `### N.Y.Z at a glance` block, so the fossil class cannot recur.
+      17/17 green this run. Note the CHANGELOG header still points at the
+      pre-py2ts path `tests/test_changelog_eras.py`; the live test is the `.ts`
+      file above (corrected in this run). -->
       <!-- verify: grep -A2 '## \[Unreleased\]' CHANGELOG.md | grep -vq '6.0.0 at a glance' -->
 - [x] **learning-tutor:** set `suggestion.eligible: false` and add a
       quarantine note (measure over the utilization window; remove only on
@@ -148,16 +161,68 @@ locked-decision notes recorded. Rollback: each is an isolated reversible edit.
 
 ## Acceptance criteria (anti-dump — the review's own rule)
 
-- [ ] **Net-negative surface:** the diff removes/retires more surface than it
+- [x] **Net-negative surface:** the diff removes/retires more surface than it
       adds; the proactive suggestion-eligible count strictly drops.
-- [ ] **No new mechanism without naming what it retires:** the complexity-budget
+      <!-- verified 2026-07-28 by counting frontmatter across all 191
+      `src/domains/**/command.md`: `suggestion.eligible: true` = **53**, false =
+      138, absent = 0. Baseline in § Context was 160 eligible of 190, so the
+      proactive surface dropped 160 → 53 (-67%), landing exactly on the Phase-1
+      exit target of ~53. The Phase-1 invariant is total, not partial: of 130
+      cluster sub-commands (`sub:` set), **0 remain eligible**; the 53 eligible
+      are all heads/standalone entry points (61 of those exist, 8 are
+      additionally ineligible). Nothing was added to offset the reduction — the
+      complexity budget went into an existing guideline and the restraint
+      decisions into a context note, both net-zero. -->
+- [x] **No new mechanism without naming what it retires:** the complexity-budget
       folds into an existing rule; no new lint/rule/command/hook is created.
-- [ ] **Demote, not delete:** every affected command/skill remains fully
+      <!-- verified 2026-07-28: the complexity-budget checklist lives in the
+      EXISTING `docs/guidelines/agent-infra/artifact-drafting-protocol-mechanics.md`
+      (§ Complexity budget), and the restraint decisions in the EXISTING context
+      dir as `agents/settings/contexts/surface-consolidation-restraint.md` — a
+      note, not a rule. No new lint script, rule file, command, or hook is
+      attributable to this roadmap.
+      STATED RATHER THAN GLOSSED: a `git log --diff-filter=A` sweep over
+      `src/rules/`, `src/scripts/lint_*` and `src/scripts/hooks/` in the
+      Phase-1/2 window returns exactly one added rule, `src/rules/secret-vcs-guard.md`.
+      That belongs to the secret-hygiene guardrail roadmap (rule-first + CI net,
+      commit-hook cut), not to this one — the window overlaps, the authorship
+      does not. -->
+- [x] **Demote, not delete:** every affected command/skill remains fully
       invokable; only suggestion-eligibility (and, for learning-tutor,
       proactive surfacing) is retired.
-- [ ] The Unified Verification Router is NOT built here (deferred blocker).
-- [ ] Every gated item (launch, branch protection, external session,
+      <!-- verified 2026-07-28 two ways. (1) Nothing was deleted: 191 source
+      `command.md` files and 191 command artefacts in
+      `dist/discovery/discovery-manifest.json` — the § Context baseline was 190,
+      so the count GREW by one over the window. (2) Invokability spot-checked on
+      five de-eligibled cluster sub-commands across five different clusters —
+      `tdd-green`, `feature-plan`, `roadmap-process-step`, `brand-tokens`,
+      `analyze-decision`: `./agent-config commands explain <slug>` resolves for
+      all five. Note the eligibility flag is frontmatter-only and is NOT carried
+      in the discovery manifest, so it cannot affect resolution by construction —
+      the CLI check is the real evidence, a manifest field check would have been
+      vacuous. -->
+- [x] The Unified Verification Router is NOT built here (deferred blocker).
+      <!-- verified 2026-07-28: a case-insensitive sweep for
+      "unified verification router" across `src/` and `docs/contracts/` returns
+      no implementation — only the defer/CUT records in this roadmap's gap-table
+      and council notes, plus the `benchmark-spend` blocker that gates its
+      re-opening. No seventh entry point, no forwarding shim. -->
+- [x] Every gated item (launch, branch protection, external session,
       utilization removal, benchmarks) is a `## Blockers` entry, not a step.
+      <!-- verified 2026-07-28 — all five map onto the three blockers below:
+      launch → `launch-and-adoption`; external session → `launch-and-adoption`;
+      branch protection → `repo-admin-and-usage`; utilization removal →
+      `repo-admin-and-usage`; benchmarks → `benchmark-spend` (which also gates
+      the verification-router re-open).
+      ONE NUANCE, recorded rather than smoothed over: Phase 3 IS a step, and its
+      subject is utilization-driven disposition. It was re-homed here verbatim
+      on 2026-07-28 from an archiving sibling roadmap, and its own header ties
+      it to `repo-admin-and-usage`. So the gated WORK is tracked by a blocker as
+      this criterion requires; it additionally carries a step so the re-homed
+      item stays visible on the dashboard instead of vanishing into a blocker.
+      Live check of that gate: branch protection is confirmed OFF
+      (`gh api .../branches/main/protection` → 404) and the utilization window
+      does not elapse until ~2026-08-26, so the step is correctly still open. -->
 
 ## Blockers
 


### PR DESCRIPTION
Autonomous `/roadmap:process-full` over `agents/roadmaps/road-to-surface-consolidation.md` (`execution.mode: autonomous`). Roadmap goes **54% → 92%**; the only remaining step is genuinely time-gated.

## What this lands

**1. All five acceptance criteria closed on measurement, not assertion.**

| Criterion | Evidence |
|---|---|
| Net-negative surface | Counted across all 191 `src/domains/**/command.md`: `suggestion.eligible: true` = **53** (baseline 160 of 190) — a 67% drop landing exactly on the Phase-1 target. **0 of 130** cluster sub-commands remain eligible, so the invariant is total, not partial. |
| Demote, not delete | 191 source files, 191 command artefacts in the discovery manifest — the count *grew* by one. Invokability spot-checked on five de-eligibled sub-commands across five clusters (`tdd-green`, `feature-plan`, `roadmap-process-step`, `brand-tokens`, `analyze-decision`); all resolve. |
| No new mechanism | Complexity budget folded into an existing guideline; restraint decisions into a context note. |
| Verification router not built | Swept `src/` + `docs/contracts/` — only defer/CUT records, no implementation. |
| Gated items are blockers | All five map onto the three blocker entries. |

**2. Stale era-test references repointed (23 occurrences).**
The CHANGELOG header and every archived-era pointer block cite `tests/test_changelog_eras.py`, retired by the Python→TypeScript migration. The live gate is `tests/lib/changelog_eras.test.ts`. Found while verifying the fossil-drain step, which cites that same test as its guard.

**3. One stale deferral resolved.**
The fossil-drain `[~]` was not blocked — it was already done. Both halves shipped 2026-07-21 under `road-to-changelog-unreleased-drain`: the 6.0.0 block is archived with a pointer at `CHANGELOG.md:118`, and the guard exists as `test_unreleased_carries_no_at_a_glance_fossil`. Flipped to `[x]` by verification, not by new work.

## Honesty notes carried into the roadmap

- **One rule was added in the Phase-1/2 window** — `src/rules/secret-vcs-guard.md`. It belongs to the secret-hygiene guardrail roadmap, not this one: overlapping window, different authorship. Recorded rather than glossed, since a naive `git log` sweep would read it as a criterion-2 violation.
- **The first demote-not-delete check was vacuous.** The discovery manifest carries no `suggestion.eligible` field, so the manifest-based check returned a meaningless zero. The CLI resolution check is the real evidence; the dead end is recorded so nobody repeats it.
- **Phase 3 is a step whose gate is a blocker.** Criterion 5 asks that gated items be blockers, not steps. Phase 3 was re-homed here verbatim on 2026-07-28 and ties to `repo-admin-and-usage`; it stays a step so the re-homed work remains visible on the dashboard instead of dissolving into a blocker. The nuance is written into the criterion rather than smoothed over.

## Verification

`tests/lib/changelog_eras.test.ts` 17/17 · `check-refs` · `check-md-language` · `lint-breaking-changes-index` · `lint-changelog-rollback` — all exit 0. Branch-protection state re-verified live for the criterion-5 note (404, unprotected).

## Roadmap state

Not archived, deliberately. Phase 3 (utilization-window disposition) stays open — the window does not elapse until ~2026-08-26 and its gate also needs branch protection plus real usage data. One `[~]` remains (locked-decision re-address), correctly deferred until the catalog flip is authorized.