### PR TITLE
fix(release): unblock two first-contact failures blocking the 9.9.0 release

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -113,8 +113,16 @@ jobs:
           const version = process.argv[1];
           const text = fs.readFileSync("CHANGELOG.md", "utf8");
           const esc = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          // Find the first heading line containing the version as a whole word.
-          const pat = new RegExp(`^(#+) [^\\n]*\\b${esc}\\b[^\\n]*$`, "m");
+          // Find the first RELEASE heading containing the version as a whole
+          // word. Release entries are `## [X.Y.Z](...)` — level 2 or deeper.
+          // Level-1 headings are era banners (`# Era: pre-9.9.0 — archived`,
+          // `# Era: 9.9.x — current`), and an era split names the archived era
+          // after the INCOMING version, so a `#+` match would anchor on the
+          // archive pointer — whose body is a two-line blockquote with no
+          // Tests: footer — and fail a perfectly good release section. That is
+          // exactly what happened on 9.9.0, the first release whose era split
+          // produced a `pre-<this version>` banner.
+          const pat = new RegExp(`^(#{2,}) [^\\n]*\\b${esc}\\b[^\\n]*$`, "m");
           const m = pat.exec(text);
           if (!m) {
             console.error(`::error::Could not re-locate ${version} heading in CHANGELOG.md`);

--- a/src/scripts/evaluator_umbrella.sh
+++ b/src/scripts/evaluator_umbrella.sh
@@ -53,8 +53,13 @@ fi
 step "publint (published-package shape)"
 npm run lint:publint --silent
 
+# `--ignore-scripts` is NOT honoured for `prepare` by every npm version: on the
+# node-20 container npm still runs it, and this repo's prepare installs the git
+# hooks and prints a banner — straight into the `--json` stdout we parse. Slice
+# from the first `[` so any lifecycle banner ahead of the payload is tolerated
+# instead of turning into `SyntaxError: Unexpected token '✅'`.
 UNPACKED_BYTES="$(npm pack --dry-run --json --ignore-scripts --silent 2>/dev/null \
-  | node -e 'let b="";process.stdin.on("data",c=>b+=c).on("end",()=>{const j=JSON.parse(b);console.log(j[0].unpackedSize)})')"
+  | node -e 'let b="";process.stdin.on("data",c=>b+=c).on("end",()=>{const i=b.indexOf("[");const j=JSON.parse(i>=0?b.slice(i):b);console.log(j[0].unpackedSize)})')"
 
 # ------------------------------------------------------- 3. headless install
 step "headless consumer install from the tarball"

--- a/src/scripts/install-hooks.sh
+++ b/src/scripts/install-hooks.sh
@@ -91,7 +91,7 @@ fi
 EOF
 
 chmod +x "$HOOKS_DIR/pre-push"
-echo "✅  Pre-push hook installed."
+echo "✅  Pre-push hook installed." >&2
 
 # Pre-commit: marketplace consistency -----------------------------------------
 #
@@ -184,7 +184,7 @@ fi
 EOF
 
 chmod +x "$HOOKS_DIR/pre-commit"
-echo "✅  Pre-commit hook installed."
+echo "✅  Pre-commit hook installed." >&2
 
 # Chat-history bridge hooks ----------------------------------------------------
 #
@@ -218,7 +218,7 @@ fi
 # command above is guarded by "|| true", so the implicit exit is 0.
 EOF
     chmod +x "$HOOKS_DIR/$name"
-    echo "✅  $name hook installed."
+    echo "✅  $name hook installed." >&2
 }
 
 write_chat_history_hook "post-commit"   "git:post-commit"
@@ -275,4 +275,4 @@ EOF
 
 append_auto_sync_block "post-merge"    "1"
 append_auto_sync_block "post-checkout" "3"
-echo "✅  Auto-sync block appended to post-merge / post-checkout hooks."
+echo "✅  Auto-sync block appended to post-merge / post-checkout hooks." >&2


### PR DESCRIPTION
The 9.9.0 release PR (#1040) is blocked by two gates that are red for reasons unrelated to that release's content. Neither can be fixed from the release branch — the release-PR shape allowlist permits only `package.json`, `CHANGELOG.md`, pack manifests and the template pin — so they land here first.

## 1. CHANGELOG footer gate anchored on the wrong heading

The gate located *"the first heading line containing the version"* with `^(#+) `. An era split names the archived era after the **incoming** version, so 9.9.0's CHANGELOG opens with:

```
222: # Era: pre-9.9.0 — archived      ← matched first
238: ## [9.9.0](...) (2026-07-29)     ← the actual release section
```

It read the archive pointer's two-line blockquote as the release body, found no `Tests:` footer, and failed a perfectly correct section. 9.8.0 passed only because no `pre-9.8.0` era banner existed — this is the first release whose era split produced a `pre-<this version>` banner.

Release entries are always level 2+, era banners always level 1, so requiring `^(#{2,}) ` anchors correctly.

**Verified against the real release CHANGELOG**, both patterns run side by side:

| pattern | anchors on | `Tests:` footer found |
|---|---|---|
| `^(#+) ` (old) | `# Era: pre-9.9.0 — archived` | no |
| `^(#{2,}) ` (new) | `## [9.9.0](...)` | yes |

## 2. Packed-artifact evaluation died parsing npm's JSON

This job is new (shipped with the evaluator umbrella) and had never run on a release PR. `npm pack --dry-run --json --ignore-scripts` is piped into `JSON.parse`, but **`--ignore-scripts` is not honoured for `prepare`** on the node-20 container: npm ran it, this repo's `prepare` installs the git hooks, and its banner landed in the parsed stdout — `SyntaxError: Unexpected token '✅'`.

Fixed at the root: a lifecycle script must not write to stdout when a `--json` consumer may be reading it. All **7** installer banners now go to stderr. The parse is additionally sliced from the first `[`, so future lifecycle noise degrades instead of crashing a release.

**Verified:** ran the installer and measured stdout at **0 bytes** (was 134), with `pre-push` and `pre-commit` still installed and executable; the defensive parse returns the right size on both a polluted and a clean stream; `bash -n` clean on both scripts.

One catch worth recording: four of the seven banners came from a loop (`echo "✅  $name hook installed."`) that a literal grep missed. Measuring stdout rather than trusting the grep is what caught them.

## Not included

The durable guard for the *other* 9.9.0 failure — router `routes_to` targets that don't ship — is deliberately left out. `prepack-check.mjs` already carries the matching import-completeness guard for the 8.3.0 bug class, and extending it to router pointers is the right follow-up, but adding a new gate while a release is blocked risks a fresh failure on the critical path.