### PR TITLE
fix(ci): mark the workspace safe for git in the containerized evaluator

### DIFF
--- a/.github/workflows/evaluator-umbrella.yml
+++ b/.github/workflows/evaluator-umbrella.yml
@@ -37,6 +37,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # This job runs INSIDE a container, so the checkout is owned by a
+      # different UID than the container user and git refuses every command
+      # with "fatal: detected dubious ownership". The umbrella shells out to
+      # git for its staleness lints (lint_pre_migration_refs), so mark the
+      # workspace safe before anything reaches git. Non-containerized jobs
+      # never hit this, which is why it surfaced only when this job first ran
+      # on a release PR.
+      - name: Mark the workspace safe for git (containerized checkout)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Install dependencies (build toolchain for npm pack's prepack chain)
         run: |
           npm ci --no-audit --no-fund --fetch-retries=5 --fetch-retry-mintimeout=10000 \


### PR DESCRIPTION
Second and final blocker on the 9.9.0 release PR (#1040). With the JSON-parse fix from #1041 in place the evaluator umbrella got further and then died in `lint_pre_migration_refs.ts` with status 128:

```
fatal: detected dubious ownership in repository at '/__w/agent-config/agent-config'
To add an exception for this directory, call:
        git config --global --add safe.directory /__w/agent-config/agent-config
```

## Cause

`Packed-artifact evaluation` is the only job that runs inside `container: node:20-bullseye`. GitHub checks the repo out as a different UID than the container user, so git's ownership guard refuses every command. The umbrella shells out to git for its staleness lints, so the whole job fails.

Non-containerized jobs never hit this. The job is nightly + release-PR gated and shipped after 9.8.0, so 9.9.0 is the first release PR it has ever run on — same first-contact pattern as the two issues in #1041.

## Fix

The standard `safe.directory` exception, added immediately after checkout so it covers every git-backed step in the job. YAML validated and step order confirmed (checkout → safe.directory → npm ci → umbrella).

This is a CI-environment fix only — no runtime, script, or package change.