### PR TITLE
fix(ci): record the CLI surface growth in the evaluator budget (79 → 80)

### DIFF
--- a/src/config/evaluator-budgets.json
+++ b/src/config/evaluator-budgets.json
@@ -33,9 +33,10 @@
             "regression_pct": 200
         },
         "cli_help_command_count": {
-            "max": 79,
-            "last_measured": 79,
-            "method": "registry enumeration — count of `{ name: '...', disposition` entries in src/cli/registry.ts (NOT --help prose parsing; methods historically disagreed 74 vs 76 vs 79)"
+            "max": 80,
+            "last_measured": 80,
+            "method": "registry enumeration — count of `{ name: '...', disposition` entries in src/cli/registry.ts (NOT --help prose parsing; methods historically disagreed 74 vs 76 vs 79)",
+            "baseline_note": "79 → 80 on 2026-07-29 (9.9.0). This RECORDS growth that already shipped through its own reviewed PRs; it does not authorize new surface. Net +6 registry entries since the 9.8.0 tag (7 added — code-graph, knowledge, analytics, memory:get, memory:learn, rtk:detect, dispatch:hook; 1 removed — the old dispatch:hook entry), and the frozen 79 was never re-measured after them. The gate did its job: it made the drift visible at release time rather than letting it accrue silently. Next addition breaches again by design."
         },
         "mcp_public_tool_count": {
             "max": 19,


### PR DESCRIPTION
Final blocker on the 9.9.0 release PR (#1040):

```
❌  evaluator budget: cli_help_command_count: measured 80 exceeds budget 79
```

## The growth is real and already shipped

`src/cli/registry.ts` held **74** entries at the `9.8.0` tag and holds **80** today — 7 added (`code-graph`, `knowledge`, `analytics`, `memory:get`, `memory:learn`, `rtk:detect`, `dispatch:hook`) against 1 removed, each through its own reviewed PR.

The budget was frozen at 79 during road-to-credible-install Phase 6 and never re-measured after those merges. 9.9.0 is the first release PR to run the evaluator umbrella, so it surfaced the accumulated drift all at once. **The gate did its job** — it made the drift visible at release time instead of letting it accrue silently.

## What this does

Moves `max` to **exactly** the measured 80, not a cushion, so the next addition breaches again by design. Adds a `baseline_note` recording what grew, when, and why, so the next reader doesn't have to re-derive it from git history.

This **records** growth that already shipped. It does not authorize new surface.

## Verified

Against the exact measurement set the failing CI run reported (`unpacked_size_mb: 25.299003`, `node_modules_mb: 133`, `runtime_dep_count: 187`, `cli_version_cold_ms: 330`, `mcp_boot_to_initialize_ms: 361`, `cli_help_command_count: 80`, `mcp_public_tool_count: 19`):

- `check_evaluator_budgets --measurements` → `✅ evaluator budgets met (7 metrics)`
- `lint_budget_ownership` → `✅ budget ownership OK` (the added field doesn't break the schema)

Every other metric has headroom; `unpacked_size_mb` actually came **down** (26.05 → 25.30).

## Not done here

Reducing the surface instead of recording it. That's a legitimate alternative, but it's a product decision about which of seven deliberately-shipped commands to withdraw — not something to settle on a blocked release's critical path.