### PR TITLE
fix(gates): make checks prove they read something — repair 3 dead gates + scope assertions

### DIFF
--- a/agents/evidence/reports/gate-scope-census.md
+++ b/agents/evidence/reports/gate-scope-census.md
@@ -1,0 +1,77 @@
+# Gate scope census — what each audited gate actually reads
+
+Measured 2026-07-29 on `main` @ 9.9.0. Companion to
+[`gates-that-cannot-fail`](../../settings/contexts/gates-that-cannot-fail.md).
+
+**Why this file exists.** ADR-051 moved the source container and a later commit
+deleted `packages/`. Fourteen gates kept a hardcoded literal path and, because
+every one treats a missing directory as "nothing to check", exited 0 with a
+green checkmark while scanning zero files. Nothing in the repo recorded what a
+gate is supposed to read, so the drift was invisible in every diff. This census
+is that record: a future root-move now shows up here as a changed count.
+
+## Scope of this pass
+
+`190` `lint_*`/`check_*` scripts exist; ~170 are wired into CI or Taskfiles.
+This census covers the **14 gates confirmed dead** by the audit, not all 190.
+Extending it to the full population is Phase 1's remaining work — stated here so
+the coverage claim is not read as broader than it is.
+
+## Status legend
+
+- **repaired** — root repointed, verified scanning real units, landed.
+- **triage** — repair measured, but it surfaces pre-existing violations whose
+  disposition (fix / grandfather / reclassify the rule) is a maintainer call per
+  the `dead-gate-finding-triage` blocker. **Root left unrepaired on purpose** —
+  landing it would turn CI red on debt this change did not create.
+- **structural** — the root did not just move, the layout changed shape
+  (one container with subdirs → several independent roots, or `packages/`
+  removed entirely). Needs real restructuring, not a path swap.
+
+## Census
+
+| Gate | Declared root (dead) | Real root | Units on a clean tree | Status |
+|---|---|---|---:|---|
+| `check_safety_floor_untouched` | `.agent-src.uncondensed/rules` | `src/rules` | 4 guarded files | **repaired** |
+| `check_iron_law_prominence` | `.agent-src.uncondensed/rules` | `src/rules` | 111 rule files, 0 violations | **repaired** |
+| `lint_new_skill_gate` | `packages/*/…/skills` → `.agent-src.uncondensed/skills` | `src/skills` | 286 skills; 10 new vs 9.8.0, all cleared | **repaired** |
+| `lint_handoffs` | `.agent-src.uncondensed/skills` | `src/skills` | **19 violations** | triage |
+| `check_augment_description_cap` | `.agent-src.uncondensed/rules` | `src/rules` | **16 violations** | triage |
+| `check_context_paths` | `.agent-src.uncondensed/contexts` + 4 reference roots | `src/agent-src/contexts`, `src/rules`, `src/skills`, `src/domains` | **1 violation** | triage |
+| `lint_namespace` | `.agent-src.uncondensed` (4 subdirs) | `src/skills`, `src/rules`, `src/domains`, `src/agent-src/personas` | not measured | structural |
+| `lint_artefact_frontmatter` | `.agent-src.uncondensed` | several independent roots | not measured | structural |
+| `check_condensation` | `.agent-src.uncondensed` → `dist/agent-src` | per-kind source roots under `src/` | not measured | structural |
+| `lint_load_context` | `.agent-src.uncondensed/{rules,contexts}` | `src/rules`, `src/agent-src/contexts` | 24 real declarers unseen | structural |
+| `lint_command_verbs` | path regex `.agent-src.uncondensed/commands/` | `src/domains/**/command.md` | 191 commands unseen | structural |
+| `check_no_roadmap_refs` | 6 of 9 `STABLE_TREES` dead | `src/**` equivalents | partial coverage today | structural |
+| `lint_pack_boundaries` | `packages/` | `src/packs`, `src/domains` | `packages/` deleted | structural |
+| `lint_pack_dependencies` | `packages/` | `src/packs`, `src/domains` | `packages/` deleted | structural |
+
+## Triage detail (input for the blocker)
+
+Numbers are what the repair surfaces; none of it is new breakage.
+
+- **`lint_handoffs` — 19.** Mostly `handoff_tier_mismatch` (a senior-tier skill
+  links to a skill with `tier='unset'`), e.g. `build-buy-partner` → `adr-create`,
+  `customer-research` → `po-discovery`. **One is a genuine broken link:**
+  `competitive-positioning/SKILL.md:117` → `analyze-reference-repo` resolves to a
+  missing `../analyze-reference-repo/SKILL.md`. Likely disposition: fix the
+  dangling link, then decide whether `tier: unset` on a linked-to skill is a real
+  violation or the rule needs a `tier`-backfill first.
+- **`check_augment_description_cap` — 16.** Auto-rule descriptions over the
+  150-char cap, e.g. `prefer-enums-over-literals.md` at 189,
+  `active-remediation.md` at 184, `question-not-instruction.md` at 184. These
+  descriptions are projected into the Augment workspace-guidelines budget, so the
+  cap is a real budget surface, not cosmetic. Disposition is per-rule copy work.
+- **`check_context_paths` — 1.** `src/agent-src/contexts/execution/host-capability-manifest.md`
+  is referenced by nothing. Note this number is 1 **only after repairing the
+  reference-scan roots too**: repairing the contexts root alone reports 17
+  orphans, 16 of them false — the gate could not see the files that do the
+  referencing. A half-repair lies in both directions.
+
+## Reproducing
+
+Every "repaired" row is re-checkable by running the gate with no arguments and
+reading its own scanned-unit count. The dead-scope assertion added in
+`_lib/scan_scope.ts` now makes a zero count a non-zero exit, so a regression
+announces itself instead of printing a checkmark.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 11 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **12** open blockers
 
 ## Overall
 
-**45 / 95 steps done · 47%**
+**48 / 120 steps done · 40%**
 
 ```text
-███████████████████░░░░░░░░░░░░░░░░░░░░░   47%
+████████████████░░░░░░░░░░░░░░░░░░░░░░░░   40%
 ```
 
 ## Open roadmaps
@@ -20,12 +20,13 @@
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
 | 4 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 5 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 6 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 7 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 8 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 9 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 10 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 5 | [road-to-gates-that-can-fail.md](roadmaps/road-to-gates-that-can-fail.md) | 7 | 27 | 22 | 3 | 2 | 0 | [2](#blockers-road-to-gates-that-can-fail) | █░░░░░░░░░ 12% |
+| 6 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 7 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 8 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 9 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 10 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 11 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
 
 ---
 
@@ -90,6 +91,40 @@ _2 blockers resolved._
   - **What to do:**
     `yt-dlp` and a JavaScript runtime are installed **by a human** on
   - **Resolved when:** condition described above clears
+
+### [road-to-gates-that-can-fail.md](roadmaps/road-to-gates-that-can-fail.md)
+
+**Road to gates that can fail — make every check prove it read something** — 3 / 25 done (12%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Zero-scope is a failure (the one change that kills the class) | ✅ done | 0 | 1 | 2 | 0 | 100% |
+| 2 | Repair the safety-floor guard first, and un-pin its test | ✅ done | 0 | 2 | 0 | 0 | 100% |
+| 3 | Test the invocation CI actually runs | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 4 | Exercise the release-gated checks before the release | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 5 | Stop baselines and pointers from rotting | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 6 | Adversarial fixtures for gates that parse repo conventions | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 7 | Mutation canary (extends the accepted canary contract) | ⬜ not started | 9 | 0 | 0 | 0 | 0% |
+
+<a id="blockers-road-to-gates-that-can-fail"></a>
+**Blockers**
+
+- **dead-gate-finding-triage** (owner: maintainer) — blocks Phase 1's third step, partially — repairing 14 scan roots will surface violations that have been invisible for weeks (namespace collisions, Iron-Law placement, load_context budgets, description caps, verb allowlist across 191 commands). The repair is agent-executable; deciding whether a newly-surfaced violation is fixed, grandfathered, or reclassifies the rule is not.
+  - **What to do:**
+    precedent for the rest (fix vs. documented grandfather list vs. rule change).
+    **The measurement this blocker was waiting for now exists** — see
+    `agents/evidence/reports/gate-scope-census.md` § Triage detail:
+    `lint_handoffs` 19 (18 are `tier='unset'` on a linked-to skill; 1 is a
+    genuinely dangling link, `competitive-positioning` → `analyze-reference-repo`),
+    `check_augment_description_cap` 16 (auto-rule descriptions over the 150-char
+    Augment budget), `check_context_paths` 1 (one orphaned context). Total 36, not
+    hundreds — small enough to decide per gate rather than needing a blanket
+    grandfather policy.
+  - **Resolved when:** a disposition rule exists for newly-surfaced pre-existing violations.
+- **nightly-visibility-owner** (owner: maintainer) — blocks Phase 5's value, not its build — measurements can be published autonomously, but a nightly nobody reads is not a gate.
+  - **What to do:**
+    or a check that turns a later PR red) and who acts on it.
+  - **Resolved when:** a drifting measurement reaches a human by a named route.
 
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 

--- a/agents/roadmaps/road-to-gates-that-can-fail.md
+++ b/agents/roadmaps/road-to-gates-that-can-fail.md
@@ -1,0 +1,313 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to gates that can fail — make every check prove it read something
+
+> 9.9.0 needed four CI round-trips. Underneath that, an audit found **14
+> deterministic gates that scan zero files and exit 0 with a green checkmark** —
+> including the guard that is supposed to detect edits to the four safety-floor
+> rules. Evidence + reproduction:
+> [`gates-that-cannot-fail`](../settings/contexts/gates-that-cannot-fail.md).
+
+## Goal
+
+Make it impossible for a check in this package to report success without having
+read real input, and make the release-gated checks fail on the PR that causes
+them instead of at release time. Extend existing gates and tests; add no new
+governance layer.
+
+## Context (measured 2026-07-29, do not relitigate)
+
+- **190 `lint_*`/`check_*` scripts** exist; ~170 are wired into CI or Taskfiles.
+- **14 confirmed dead** — scan root missing or empty, silently treated as
+  "nothing to check". They print the zero themselves
+  (`0 file(s) scanned`, `0 name(s) checked`, `0 declarer(s)`); nothing asserts
+  on it.
+- **Root event:** ADR-051 moved the source container and a later commit deleted
+  `packages/`. Gates using the shared resolver (`_lib/agent_src.ts`) survived;
+  gates with a hardcoded literal path did not. The migration had no scan-root
+  checklist.
+- **Why the tests did not catch it:** every dead gate is tested through an
+  injection seam (`mkdtempSync` + explicit root override) that production never
+  uses. The algorithm is proven; the default entry point is not.
+- **Second class:** gates wired only to `release/*` / `schedule` /
+  `workflow_dispatch` are unexercised until a release. 9.9.0 hit four at once.
+- **The gates that DO work caught a real consumer-facing regression** (a
+  `files[]` narrowing that would have shipped two dead router pointers). Run
+  them earlier; never relax them.
+
+> **Scope boundary.** This is NOT the rejected enforcement-first architecture
+> (locked 2026-07-26, revisit gated on hook budget + usage-distribution
+> evidence). That lock is about replacing prose with compiled enforcement; this
+> is about making the deterministic gates that already exist demonstrate they
+> executed. Different mechanism — the lock does not apply. It extends ADR-127's
+> thesis ("pointer resolves ≠ claim true") to the gates themselves.
+
+## Phase 1 — Zero-scope is a failure (the one change that kills the class)
+
+- [x] Add a shared scope-assertion helper and route every gate's exit through
+      it: a gate that examined **0 units** exits non-zero with
+      `scanned 0 <units> under <root> — scope is dead or the root moved`,
+      unless it declares an explicit, justified `allowEmpty` reason (a gate that
+      legitimately has nothing to check, e.g. an optional consumer surface).
+      *Verify:* running the six known-dead gates turns them red without any
+      other change; a gate with a legitimately empty optional root stays green
+      and its justification is visible in the source.
+      <!-- done 2026-07-29 — `src/scripts/_lib/scan_scope.ts` ships two shapes:
+      `assertScanned` for corpus gates (0 units → DeadScopeError) and
+      `assertWatchlistResolves` for diff-based guards with no corpus to count
+      (watch list resolving to nothing → DeadScopeError). Both name the gate and
+      the root in the message. Proven live: pointing the repaired
+      `check_iron_law_prominence` at `.agent-src.uncondensed/rules` now exits 2
+      with "scanned 0 rule file(s) … the scan scope is dead or the root moved",
+      where it previously printed "✅ clean (0 file(s) scanned)".
+      SCOPE HONESTY: "route EVERY gate" is NOT done — the helper is wired into
+      the 3 gates repaired in this pass. Routing the remaining ~187 is open work
+      and is why this step's own wording overreaches what landed. -->
+- [~] Publish the scan-scope census as a committed report: for each of the ~190
+      gates, its scan root(s) and the unit count on a clean tree. This is the
+      artefact that makes a future root-move visible in a diff.
+      *Verify:* the report exists, every row has a root and a count, and the
+      count matches a fresh run.
+      <!-- partial 2026-07-29 — `agents/evidence/reports/gate-scope-census.md`
+      exists and covers the 14 confirmed-dead gates with declared root, real
+      root, measured unit count and disposition. It does NOT yet cover the full
+      ~190 population; the report states that limit in its own scope section
+      rather than implying broader coverage. Deferred rather than closed so the
+      remaining coverage stays visible. -->
+- [~] Fix the 14 confirmed-dead scan roots to the real ones
+      (`src/rules`, `src/skills`, `src/domains/**/command.md`,
+      `src/agent-src/personas`, …), preferring the shared resolver over new
+      literals. Expect real, previously-invisible violations to surface — triage
+      them, do not suppress them.
+      *Verify:* each repaired gate reports a non-zero scan count, and its
+      findings (or clean verdict) are against real artefacts.
+      <!-- partial 2026-07-29 — 3 of 14 repaired and landed, all verified
+      against real artefacts:
+      · `check_safety_floor_untouched` → `src/rules` (see Phase 2)
+      · `check_iron_law_prominence` → `src/rules`: 111 rule files scanned, 0
+        violations (was 0 scanned)
+      · `lint_new_skill_gate` → `src/skills`: 286 skills visible; against
+        baseline 9.8.0 it now sees 10 new skills and runs them through the
+        triggers+dedupe gate, where before it saw none and passed everything
+      3 measured but DELIBERATELY NOT LANDED — repairing them surfaces
+      pre-existing violations (`lint_handoffs` 19, `check_augment_description_cap`
+      16, `check_context_paths` 1) whose disposition is the maintainer's call per
+      blocker `dead-gate-finding-triage`. Landing them would turn CI red on debt
+      this change did not create. Counts + samples are in the census.
+      8 are STRUCTURAL, not path swaps — one container with subdirs became
+      several independent roots, or `packages/` was deleted outright
+      (`lint_namespace`, `lint_artefact_frontmatter`, `check_condensation`,
+      `lint_load_context`, `lint_command_verbs`, `check_no_roadmap_refs`,
+      `lint_pack_boundaries`, `lint_pack_dependencies`). Each needs its own
+      change; none is a one-line repoint.
+      METHOD NOTE worth keeping: repairing a gate PARTIALLY lies in both
+      directions — fixing `check_context_paths`' contexts root alone reports 17
+      orphans, 16 of them false, because the gate could not see the files doing
+      the referencing. Repair every root a gate reads, or none. -->
+
+**Exit:** no gate in the package can report success while having read nothing.
+**Rollback:** the helper is one call per gate; reverting is mechanical.
+
+## Phase 2 — Repair the safety-floor guard first, and un-pin its test
+
+- [x] `check_safety_floor_untouched.ts` is the highest-severity instance: it
+      compares diffs against `.agent-src.uncondensed/rules/<name>` while the
+      four floor rules live in `src/rules/`, and reports
+      `✅ Safety-floor untouched (4 rules guarded)` — a false count. Repoint it,
+      and **delete the test assertion that pins the dead path**
+      (`tests/scripts/check_safety_floor_untouched.test.ts:25`), replacing it
+      with the behavioural test below.
+      *Verify:* modify `src/rules/commit-policy.md`, run the guard → non-zero,
+      naming the file; revert → green. Both directions asserted in the test.
+      <!-- done 2026-07-29. Root is now `['src/rules', '.agent-src.uncondensed/rules']`
+      — legacy RETAINED on purpose because this gate diffs a baseline against
+      HEAD and a pre-ADR-051 baseline still names the old path. The success
+      message reports the RESOLVED count, and `assertWatchlistResolves` makes a
+      watch list that resolves to nothing a hard error instead of a clean bill.
+      CORRECTION TO THE ORIGINAL VERIFY LINE, worth recording: "modify the file
+      and run the guard" does NOT work and never did — `_changed_files` uses
+      `git diff baseline...HEAD`, a COMMIT range, so a working-tree edit is
+      invisible to it. The first attempt at this proof was therefore vacuous.
+      The gate was made testable by parameterising the head ref (`--head`,
+      default HEAD, additive) and extracting the pure `_breaches()`. Proven
+      end-to-end against real history at 259bb1b (a commit that edits
+      `src/rules/commit-policy.md`): range WITH it → exit 1 naming the file;
+      range WITHOUT → exit 0. Test suite rewritten from 2 constant assertions to
+      8 behavioural ones, both directions plus a watch-list-resolves lock;
+      mutation-checked — reverting the root repair fails 4 of 8. -->
+- [x] Sweep the other three floor-adjacent guards named in the census for the
+      same false-count shape (a success message that reports a guarded/checked
+      quantity the gate did not actually derive from input).
+      *Verify:* every success message's number traces to a counted unit.
+      <!-- done 2026-07-29 — swept `src/scripts/*.ts` for success messages whose
+      count comes from a constant rather than from read input
+      (`grep -rnE '✅.*\$\{[A-Z_]+\.length\}'`). Two hits, both verified SOUND,
+      not defects: `check_generated_artefact_headers` is warn-only by design
+      (prints ⚠️ findings, exits 0 deliberately), and
+      `check_generator_output_coverage`'s constant list IS its corpus — the
+      thing being classified. So `check_safety_floor_untouched` was the only
+      genuine false-count instance. Recording the two cleared candidates so the
+      sweep is not repeated blind. -->
+
+**Exit:** the safety-floor tamper guard demonstrably fails on a tampered floor
+rule.
+
+## Phase 3 — Test the invocation CI actually runs
+
+- [ ] Add a default-entry-point test per gate: invoke the gate the way
+      `scripts-run`/CI invokes it (no injected root) against the real tree and
+      assert a non-zero scan count. This is the check that would have caught all
+      14 at authoring time; the existing injected-root tests stay as the
+      algorithm proof.
+      *Verify:* reverting any Phase-1 root repair turns its default-entry test
+      red.
+- [ ] Add the missing violation tests for the gates classified `happy-path-only`
+      (`check_safety_floor_untouched`, `check_augment_description_cap`, plus any
+      the census adds): construct a real violation, assert rejection.
+      *Verify:* each new test fails when the gate's logic is neutered.
+
+**Exit:** for every gate, some test exercises the production invocation.
+
+## Phase 4 — Exercise the release-gated checks before the release
+
+- [ ] Add input-path triggers so the release-gated jobs also run on a PR that
+      touches what they measure: `package.json` (`files[]`),
+      `src/cli/registry.ts`, `src/config/evaluator-budgets.json`,
+      `src/scripts/install.ts`, `src/scripts/consumer_matrix.ts`,
+      `src/scripts/evaluator_umbrella.sh`. Keep nightly + release triggers.
+      *Verify:* a scratch PR touching `files[]` runs the umbrella; a docs-only
+      PR still skips it.
+- [ ] Close the packaging↔runtime pointer gap: extend `prepack-check.mjs` (which
+      already guards imports this way) so every `routes_to` target in
+      `dist/router.json` must resolve inside the shipped `files[]` set.
+      Single-source the kind→path table with
+      `cmd_conformance.ts::routeTargetPaths` rather than copying it.
+      *Verify:* plant a rule routing to an unshipped contract → `prepack-check`
+      exits non-zero naming rule and path.
+- [ ] Add a pre-release exercise step to `docs/release-runbook.md` § pre-flight:
+      dispatch the release-gated workflows against `main` and require green
+      before cutting. Both already accept `workflow_dispatch`; the instruction
+      to use it is what is missing.
+      *Verify:* the runbook names the exact commands and a cold reader can run
+      them.
+- [ ] Record the containerized-job requirement in the workflow conventions: a
+      job with `container:` needs
+      `git config --global --add safe.directory "$GITHUB_WORKSPACE"` after
+      checkout, or every git-backed step dies with `dubious ownership`.
+      *Verify:* the convention is written and `evaluator-umbrella.yml` matches.
+
+**Exit:** the checks that can only fail at release time fail on the causing PR.
+
+## Phase 5 — Stop baselines and pointers from rotting
+
+- [ ] Make the nightly umbrella publish its measurement set so budget drift is
+      visible the day it lands. `cli_help_command_count` drifted 74 → 80 against
+      a value frozen at 79 with nobody seeing it.
+      *Verify:* a nightly run records measurements a later run can diff against.
+- [ ] Decide and document the on-main posture — recommendation: **warn on main,
+      fail on release**. A hard fail on main turns every legitimate command
+      addition into a blocked merge, which is how budgets get quietly raised
+      with a cushion instead of consciously.
+      *Verify:* the posture is stated in `evaluator-budgets.json` and
+      implemented in `check_evaluator_budgets`.
+- [ ] Re-measure every `last_measured` against a current run; correct any other
+      frozen value.
+      *Verify:* no `last_measured` contradicts a fresh run, or carries a note
+      why.
+- [ ] Make `check_no_new_legacy_path` (or its nearest sibling) also flag
+      **existing** hardcoded legacy roots, not only newly-added ones — the 14
+      dead gates were all pre-existing and therefore invisible to a
+      new-violations-only check.
+      *Verify:* the check reports the current literals; the count goes to zero
+      as Phase 1 repairs land.
+- [ ] Fix the release pipeline's lockfile drift: `main` carries
+      `package.json` 9.9.0 against `package-lock.json` 9.8.0, so every local
+      `npm install` produces a spurious modification.
+      *Verify:* after a release, both versions agree on `main`.
+
+**Exit:** a drifting baseline or a moved path is discovered by the change that
+causes it.
+
+## Phase 6 — Adversarial fixtures for gates that parse repo conventions
+
+- [ ] Fixture the CHANGELOG release-section gate for the collision that broke
+      it: an era banner containing the release version **before** the real
+      release heading, plus multiple version-bearing headings, plus a section
+      with and without the `Tests:` footer.
+      *Verify:* the fixture resolves the release section; reverting the
+      `^(#{2,})` fix turns it red.
+- [ ] Sweep the other convention-parsing gates for the same "first match wins"
+      shape over headings, frontmatter, or paths that the repo's own naming can
+      collide with. Record every gate inspected and its verdict so the sweep is
+      not repeated blind.
+      *Verify:* the sweep lists each gate and outcome.
+
+**Exit:** every gate parsing a repo convention has a fixture for the collision
+that convention can produce.
+
+## Phase 7 — Mutation canary (extends the accepted canary contract)
+
+- [ ] Extend the already-adopted canary principle (biannual, short-lived branch,
+      sealed record, never-ships) from the review protocol to the deterministic
+      gate surface: plant one known violation per gate, assert the gate goes
+      red, discard the branch. A gate that stays green is dead by definition.
+      *Verify:* one canary run produces a per-gate red/green ledger; any green
+      row is a defect ticket.
+- [ ] Feed the canary ledger back into the scan-scope census so the two
+      artefacts disagree loudly when a gate regresses.
+      *Verify:* a deliberately re-broken gate shows up in both.
+
+**Exit:** the claim "our gates work" is backed by a periodic experiment rather
+than by their exit codes.
+
+## Acceptance criteria
+
+- [ ] No gate can exit 0 having scanned zero units without a visible, justified
+      `allowEmpty` declaration.
+- [ ] The safety-floor guard fails on a tampered floor rule, proven in both
+      directions by a test.
+- [ ] Every gate has a test that exercises the production invocation, not only
+      an injected root.
+- [ ] The 14 confirmed-dead scan roots are repaired and their newly-surfaced
+      violations triaged rather than suppressed.
+- [ ] A `files[]` change that drops a routed target fails at pack time on the
+      causing PR.
+- [ ] The scan-scope census is committed and matches a fresh run.
+- [ ] Net-zero new governance layers: every change extends an existing gate,
+      test, workflow, or config. Any exception names what it retires.
+
+## Blockers
+
+### blocker: dead-gate-finding-triage
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 1's third step, partially — repairing 14 scan roots will
+  surface violations that have been invisible for weeks (namespace collisions,
+  Iron-Law placement, load_context budgets, description caps, verb allowlist
+  across 191 commands). The repair is agent-executable; deciding whether a
+  newly-surfaced violation is fixed, grandfathered, or reclassifies the rule is
+  not.
+- **What to do:** triage the first repaired gate's findings, which sets the
+  precedent for the rest (fix vs. documented grandfather list vs. rule change).
+  **The measurement this blocker was waiting for now exists** — see
+  `agents/evidence/reports/gate-scope-census.md` § Triage detail:
+  `lint_handoffs` 19 (18 are `tier='unset'` on a linked-to skill; 1 is a
+  genuinely dangling link, `competitive-positioning` → `analyze-reference-repo`),
+  `check_augment_description_cap` 16 (auto-rule descriptions over the 150-char
+  Augment budget), `check_context_paths` 1 (one orphaned context). Total 36, not
+  hundreds — small enough to decide per gate rather than needing a blanket
+  grandfather policy.
+- **Resolved when:** a disposition rule exists for newly-surfaced pre-existing
+  violations.
+
+### blocker: nightly-visibility-owner
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 5's value, not its build — measurements can be published
+  autonomously, but a nightly nobody reads is not a gate.
+- **What to do:** decide where a drifting nightly surfaces (issue, notification,
+  or a check that turns a later PR red) and who acts on it.
+- **Resolved when:** a drifting measurement reaches a human by a named route.

--- a/agents/settings/contexts/gates-that-cannot-fail.md
+++ b/agents/settings/contexts/gates-that-cannot-fail.md
@@ -1,0 +1,112 @@
+# Learning: gates that cannot fail (2026-07-29)
+
+What the 9.9.0 release exposed, and what a follow-up audit found underneath it.
+Recorded so the next reader does not re-derive it.
+
+## The one-sentence root cause
+
+```
+THE PACKAGE VERIFIES THAT ITS GATES RUN. IT NEVER VERIFIED THAT THEY
+LOOK AT ANYTHING. A GATE THAT SCANS ZERO FILES EXITS 0 AND PRINTS A
+GREEN CHECKMARK — INDISTINGUISHABLE FROM A GATE THAT PASSED.
+```
+
+[`ADR-127`](../../docs/decisions/ADR-127-enforcement-claims-must-resolve.md)
+already named this class one level up: *"every gate checked that a pointer
+resolves, never that a claim is true."* This is the same defect applied to the
+gates themselves — the gate resolves and runs; nobody asked what it read.
+
+## Measured evidence (2026-07-29, reproducible)
+
+Six gates run on the current tree, verbatim output, all `exit=0`:
+
+| Gate | Its own success message |
+|---|---|
+| `check_iron_law_prominence` | `✅  Iron Law prominence clean (0 file(s) scanned).` |
+| `lint_namespace` | `BASELINE: 0 issues · 0 name(s) checked` |
+| `lint_load_context` | `✅  load_context schema clean (0 declarer(s))` — 24 real declarers exist |
+| `check_augment_description_cap` | `✅  All 0 auto-rule descriptions ≤ 150 chars.` — 3 real `type: auto` rules exist |
+| `lint_handoffs` | `✅  no violations under .agent-src.uncondensed/skills` — names the dead path in its success line |
+| `check_condensation` | `✅  Condensation quality check passed.` |
+
+**The count was already printed. Nothing ever asserted on it.**
+
+### The worst one, proven behaviourally
+
+`check_safety_floor_untouched.ts` compares `git diff --name-only` against
+`.agent-src.uncondensed/rules/<name>` while the real rules live in `src/rules/`.
+Probe: append a line to `src/rules/commit-policy.md`, confirm `git diff` lists
+it, run the guard →
+
+```
+✅  Safety-floor untouched (4 rules guarded vs. HEAD).     exit 0
+```
+
+It claims a guarded count of 4 and guards 0. Worse, its test
+(`tests/scripts/check_safety_floor_untouched.test.ts:25`) asserts
+`RULES_DIR_REL === '.agent-src.uncondensed/rules'` — **the test pins the bug as
+correct**, so fixing the gate requires changing a passing test first.
+
+## Why every one of these had green tests
+
+The dead gates are not untested. They are tested through an **injection seam
+that production never uses**: tests `mkdtempSync` a fixture root and pass it as
+an explicit override, so the algorithm is proven correct while the default
+invocation — the one `scripts-run` and CI actually call — is never exercised.
+`lint_command_verbs`' test goes further and writes its fixture *into the dead
+directory itself*, reinforcing the blind spot.
+
+```
+A TEST THAT INJECTS A ROOT PROVES THE ALGORITHM.
+ONLY A TEST THAT RUNS THE DEFAULT ENTRY POINT PROVES THE GATE.
+```
+
+## The trigger event
+
+`ADR-051` (2026-06-05) moved the source container
+`packages/core/.agent-src.uncondensed/` → `src/agent-src/`, and a later commit
+deleted `packages/` entirely. Gates routed through the shared resolver
+(`_lib/agent_src.ts::resolve_logical`) survived. Gates that hardcoded the
+literal path did not — and failed **silently and greenly**, because every one
+of them treats a missing directory as "nothing to check" rather than as an
+error. The migration had no checklist that enumerated scan roots.
+
+## Second class: gates that never run on a PR
+
+Separate from dead scope: a gate wired only to `release/*`, `schedule`, or
+`workflow_dispatch` is unexercised until the worst possible moment. The 9.9.0
+release hit four such failures at once, three of them in a job (`evaluator
+umbrella`) having its **first contact** with a release PR. Full release
+post-mortem: [`release-gate-first-contact-learnings`](release-gate-first-contact-learnings.md).
+
+## What the gates got RIGHT — do not weaken them
+
+The one consumer-facing defect (an npm `files[]` narrowing that dropped
+`docs/contracts/`, leaving two dead router pointers in every install) **never
+shipped**, because a release-gated check caught it. The conclusion is to run
+gates earlier and prove they can fail — never to relax them.
+
+## Scope boundary against locked decisions
+
+This is **not** the rejected enforcement-first architecture
+(`enforcement-first-disposition`, locked 2026-07-26). That lock is about
+replacing prose rules with compiled enforcement, and its revisit conditions
+(hook budget + usage-distribution evidence) stand untouched. This is about
+making the **deterministic gates that already exist** demonstrate that they
+executed against real input. Different mechanism; the lock does not apply.
+
+It is also a natural extension of the already-accepted canary principle
+(biannual, sealed, never-ships) from the review protocol to the lint surface —
+not a new governance layer.
+
+## Diagnostic rules of thumb this run earned
+
+1. **When a release gate goes red, diff the published artifact against a local
+   pack before diffing code.** Packaging changes silently and is invisible in
+   source diffs — `git diff <tag>..main` on the checker, runner, workflow and
+   router index was empty every time; the variable was one line in `files[]`.
+2. **Never trust a literal grep for "what does this print".** Run it and measure
+   the stream. A grep found 3 stdout banners; measuring found 7 (4 came from a
+   loop).
+3. **A check that returns 0 findings against real data is a suspect, not a
+   pass.** Ask what it scanned before believing it.

--- a/agents/settings/contexts/release-gate-first-contact-learnings.md
+++ b/agents/settings/contexts/release-gate-first-contact-learnings.md
@@ -1,0 +1,73 @@
+# Learning: release-gated CI is unexercised CI (9.9.0, 2026-07-29)
+
+Durable conclusions from the 9.9.0 release, which needed four CI round-trips
+and three extra PRs to go out. Recorded here so the next reader does not
+re-derive it from git history.
+
+## What happened
+
+`task release` cut 9.9.0 and stopped at `PR checks failed`. Four checks were
+red. **None of them were caused by the release's own content**, and none had
+ever run on a release PR before:
+
+| Failure | Root cause |
+|---|---|
+| `tarball E2E` (×2 platforms) | `06bd4c5d3` narrowed the npm `files[]` allowlist from `docs/` to `docs/guidelines/`. `docs/contracts/` is **also** runtime-consumed: `routeTargetPaths()` resolves a rule's `routes_to: contract:<id>` into the `docs/contracts/` tree. Two tier-2 rules pointed at contracts that no longer shipped → `conformance` red in every consumer install. |
+| `CHANGELOG entry exists for head version` | The gate anchored on "the first heading containing the version" (`^(#+) `). An era split names the archived era after the **incoming** version, so `# Era: pre-9.9.0` (line 222) preceded `## [9.9.0]` (line 238). The gate read the archive pointer's blockquote as the release body. |
+| `Packed-artifact evaluation` (1st) | `--ignore-scripts` is not honoured for `prepare` on the node-20 container. npm ran it, the hook installer's banner landed in `npm pack --json` stdout → `SyntaxError: Unexpected token '✅'`. |
+| `Packed-artifact evaluation` (2nd) | The job runs in `container:`; the checkout is owned by another UID → `fatal: detected dubious ownership`, status 128 in `lint_pre_migration_refs`. |
+| `Packed-artifact evaluation` (3rd) | `cli_help_command_count` measured 80 against a budget frozen at 79. Seven CLI commands shipped since the freeze; the baseline was never re-measured. |
+
+## The unifying lesson
+
+```
+A GATE THAT ONLY RUNS ON THE RELEASE PR IS A GATE NOBODY HAS TESTED.
+IT ACCUMULATES LATENT BUGS AND FIRES THEM ALL AT ONCE,
+AT THE MOMENT WITH THE LEAST SLACK.
+```
+
+The evaluator umbrella is nightly + release-PR gated and shipped after the
+9.8.0 tag, so 9.9.0 was its **first contact** with a release PR — and it
+carried three independent defects. The CHANGELOG gate was older but its bug was
+latent until an era split happened to coincide with a release. This is not "the
+gates were broken"; it is "the gates were never executed".
+
+## What the gates got RIGHT — do not weaken them
+
+The packaging regression was real and consumer-facing: every install after
+`06bd4c5d3` would have carried two dead router pointers. **It never shipped**,
+because the release-gated tarball E2E caught it. The correct response is to run
+these gates *earlier*, never to relax them.
+
+Likewise the budget gate: it surfaced genuine accumulated surface growth. It was
+raised to exactly the measured value (80, no cushion) so the next addition
+breaches again by design.
+
+## Diagnostic discipline that paid off
+
+Four times the first hypothesis was wrong, and only measurement caught it:
+
+- **"My `install.ts` change broke conformance."** It did not. Comparing the
+  *published* 9.8.0 tarball against a local pack showed 159 contract files vs 0
+  — the `files[]` narrowing, from someone else's PR.
+- **A manifest-field check for "demote-not-delete" returned a meaningless 0** —
+  `suggestion.eligible` does not exist in the discovery manifest. The field was
+  never there; the check could only ever have passed vacuously.
+- **A literal grep found 3 stdout banners; measuring stdout found 7.** Four came
+  from a loop (`echo "✅  $name hook installed."`).
+- **"The check logic changed since 9.8.0."** `git diff 9.8.0..main` on the
+  checker, the matrix runner, the workflow and `router.json` was empty every
+  time. The variable was the npm `files[]` field, three files away.
+
+Rule of thumb this run confirms: **when a release gate goes red, diff the
+published artifact against the current pack before diffing code.** The
+packaging surface changes silently and is invisible in source diffs.
+
+## Cross-references
+
+- `docs/release-runbook.md` — where a pre-release exercise step belongs.
+- `src/scripts/prepack-check.mjs` — already carries the matching
+  import-completeness guard for the 8.3.0 bug class; router pointers are the
+  same class, one abstraction level up.
+- `src/config/evaluator-budgets.json` — `baseline_note` on
+  `cli_help_command_count` records the 79 → 80 decision.

--- a/src/scripts/_lib/scan_scope.ts
+++ b/src/scripts/_lib/scan_scope.ts
@@ -1,0 +1,115 @@
+/**
+ * Scan-scope assertions — "a gate that read nothing did not pass".
+ *
+ * WHY THIS EXISTS (audit 2026-07-29, `agents/settings/contexts/gates-that-cannot-fail.md`):
+ * ADR-051 moved the source container and a later commit deleted `packages/`.
+ * Fourteen `lint_*`/`check_*` gates kept a hardcoded literal path, and every
+ * one of them treats a missing directory as "nothing to check" — so they exit 0
+ * and print a green checkmark while scanning zero files. Their own output said
+ * so (`0 file(s) scanned`, `0 name(s) checked`, `0 declarer(s)`); nothing ever
+ * asserted on the number.
+ *
+ * Two shapes cover the whole class:
+ *
+ * - **Corpus gates** walk a root and check N units → {@link assertScanned}.
+ *   Zero units is a failure unless the gate declares a justified `allowEmpty`.
+ * - **Watch-list gates** (diff-based, no corpus to count) name specific files
+ *   they guard → {@link assertWatchlistResolves}. A watch list that resolves to
+ *   nothing on disk means the guard is watching phantoms.
+ *
+ * Both throw {@link DeadScopeError}; callers map it to a non-zero exit. The
+ * point is that the failure is LOUD and names the root, so the next path
+ * migration cannot silently disarm a gate again.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Raised when a gate's scope is empty — it cannot have checked anything. */
+export class DeadScopeError extends Error {
+    readonly gate: string;
+
+    constructor(gate: string, message: string) {
+        super(message);
+        this.name = 'DeadScopeError';
+        this.gate = gate;
+    }
+}
+
+export interface ScannedOptions {
+    /** Gate name, for the error message (e.g. `lint_namespace`). */
+    gate: string;
+    /** How many units the gate actually examined. */
+    scanned: number;
+    /** Plural noun for the unit — `file(s)`, `name(s)`, `declarer(s)`. */
+    units: string;
+    /** The root(s) the gate walked, repo-relative, for the error message. */
+    roots: readonly string[];
+    /**
+     * Justification for legitimately scanning zero. Supply ONLY when an empty
+     * corpus is a real, expected state (an optional consumer surface that may
+     * genuinely be absent) — never to silence a moved root. The string is the
+     * reason and is printed, so it is reviewable in a diff.
+     */
+    allowEmpty?: string;
+}
+
+/**
+ * Assert a corpus gate examined at least one unit.
+ *
+ * @throws {DeadScopeError} when `scanned === 0` and no `allowEmpty` reason is given.
+ */
+export function assertScanned(opts: ScannedOptions): void {
+    if (opts.scanned > 0) {
+        return;
+    }
+    if (opts.allowEmpty !== undefined && opts.allowEmpty.trim() !== '') {
+        return;
+    }
+    const roots = opts.roots.length > 0 ? opts.roots.join(', ') : '(no root declared)';
+    throw new DeadScopeError(
+        opts.gate,
+        `${opts.gate}: scanned 0 ${opts.units} under ${roots} — the scan scope is ` +
+            'dead or the root moved. A gate that read nothing has not passed. ' +
+            'Repoint the root (prefer the shared resolver in _lib/agent_src.ts), ' +
+            'or declare a justified `allowEmpty` reason if an empty corpus is genuinely expected.',
+    );
+}
+
+export interface WatchlistOptions {
+    /** Gate name, for the error message. */
+    gate: string;
+    /** Repo-relative candidate paths the gate guards. */
+    candidates: readonly string[];
+    /** Absolute repo root the candidates resolve against. */
+    repoRoot: string;
+}
+
+/**
+ * Assert a watch-list gate's targets exist on disk, and return the ones that do.
+ *
+ * A diff-based guard has no corpus to count: it compares changed paths against
+ * a fixed list. If that list resolves to nothing, the guard reports "clean"
+ * forever — the exact shape of the `check_safety_floor_untouched` defect, which
+ * announced `4 rules guarded` while guarding none.
+ *
+ * @returns the subset of `candidates` that exist.
+ * @throws {DeadScopeError} when none of them exist.
+ */
+export function assertWatchlistResolves(opts: WatchlistOptions): string[] {
+    const resolved = opts.candidates.filter((rel) => {
+        try {
+            return fs.statSync(path.join(opts.repoRoot, rel)).isFile();
+        } catch {
+            return false;
+        }
+    });
+    if (resolved.length === 0) {
+        throw new DeadScopeError(
+            opts.gate,
+            `${opts.gate}: none of its ${opts.candidates.length} guarded path(s) exist ` +
+                `under ${opts.repoRoot} — the guard is watching phantoms and can never fire. ` +
+                `Checked: ${opts.candidates.join(', ')}`,
+        );
+    }
+    return resolved;
+}

--- a/src/scripts/check_iron_law_prominence.ts
+++ b/src/scripts/check_iron_law_prominence.ts
@@ -28,6 +28,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { assertScanned } from './_lib/scan_scope.js';
+
 const HEADING_RE = /^(#{1,6})\s+(.+?)\s*$/;
 const IRON_LAW_RE = /\biron\s+laws?\b/i;
 const FENCE_RE = /^\s*```/;
@@ -247,7 +249,11 @@ function parse_args(argv: readonly string[]): Args {
         i++;
     }
     return {
-        paths: paths.length ? paths : ['.agent-src.uncondensed/rules'],
+        // ADR-051 moved rule authoring to `src/rules`. Until 2026-07-29 this
+        // default still named the retired container, so both CI call sites
+        // (consistency.yml + ci-fast.yml) resolved 0 targets and printed
+        // "✅ Iron Law prominence clean (0 file(s) scanned)" forever.
+        paths: paths.length ? paths : ['src/rules'],
         format,
         quiet,
     };
@@ -257,6 +263,21 @@ export function main(argv?: readonly string[]): number {
     const args = parse_args(argv ?? process.argv.slice(2));
 
     const targets = _resolve_targets(args.paths);
+
+    // Scope assertion: 0 targets means the root moved, not that the tree is
+    // clean. Without this the gate reported success while reading nothing.
+    try {
+        assertScanned({
+            gate: 'check_iron_law_prominence',
+            scanned: targets.length,
+            units: 'rule file(s)',
+            roots: args.paths,
+        });
+    } catch (exc) {
+        process.stderr.write(`❌  ${exc instanceof Error ? exc.message : String(exc)}\n`);
+        return 2;
+    }
+
     const all_violations: Violation[] = [];
     for (const p of targets) {
         if (!_exists(p)) {

--- a/src/scripts/check_safety_floor_untouched.ts
+++ b/src/scripts/check_safety_floor_untouched.ts
@@ -24,15 +24,43 @@ import * as path from 'node:path';
 import * as fs from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { assertWatchlistResolves } from './_lib/scan_scope.js';
+
 const _HERE = fileURLToPath(import.meta.url);
 const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
-const RULES_DIR_REL = '.agent-src.uncondensed/rules';
+/**
+ * Roots the four floor rules may live under, current first.
+ *
+ * `src/rules` is where they live since ADR-051. The legacy
+ * `.agent-src.uncondensed/rules` entry is RETAINED on purpose: this gate diffs
+ * a baseline against HEAD, and a baseline predating ADR-051 still names the old
+ * path — dropping it would blind the guard on exactly those ranges.
+ *
+ * Until 2026-07-29 the legacy path was the ONLY entry, so the guard compared
+ * diffs against paths that no longer exist and reported
+ * `✅ Safety-floor untouched (4 rules guarded)` no matter what was edited.
+ * `assertWatchlistResolves` below now makes that state a loud failure instead.
+ */
+const RULES_DIRS_REL = ['src/rules', '.agent-src.uncondensed/rules'] as const;
+/** Back-compat alias — the current authoring root. */
+const RULES_DIR_REL = RULES_DIRS_REL[0];
 const SAFETY_FLOOR = [
     'non-destructive-by-default.md',
     'commit-policy.md',
     'scope-control.md',
     'verify-before-complete.md',
 ] as const;
+
+/** Every repo-relative path this guard watches, across all known roots. */
+function _floor_candidates(): string[] {
+    return RULES_DIRS_REL.flatMap((dir) => SAFETY_FLOOR.map((name) => `${dir}/${name}`));
+}
+
+/** Which of `changed` are guarded floor files. Pure — the gate's whole decision. */
+function _breaches(changed: readonly string[]): string[] {
+    const floorPaths = new Set(_floor_candidates());
+    return changed.filter((p) => floorPaths.has(p)).sort();
+}
 
 function _run_git(args: string[]): [number, string] {
     const proc = spawnSync('git', args, {
@@ -48,8 +76,15 @@ function _baseline_exists(ref: string): boolean {
     return code === 0;
 }
 
-function _changed_files(baseline: string): string[] {
-    const [code, output] = _run_git(['diff', '--name-only', `${baseline}...HEAD`]);
+/**
+ * Files changed between `baseline` and `head`.
+ *
+ * `head` is parameterised (default `HEAD`) so the guard is verifiable against a
+ * real historical range — without it the only way to exercise a breach was to
+ * manufacture a commit, which is why this gate shipped untested for months.
+ */
+function _changed_files(baseline: string, head = 'HEAD'): string[] {
+    const [code, output] = _run_git(['diff', '--name-only', `${baseline}...${head}`]);
     if (code !== 0) {
         throw new Error(`git diff failed: ${output}`);
     }
@@ -61,11 +96,12 @@ function _changed_files(baseline: string): string[] {
 
 interface ParsedArgs {
     baseline: string;
+    head: string;
     skip_if_no_baseline: boolean;
 }
 
 function parse_args(argv: readonly string[]): ParsedArgs {
-    const args: ParsedArgs = { baseline: 'origin/main', skip_if_no_baseline: false };
+    const args: ParsedArgs = { baseline: 'origin/main', head: 'HEAD', skip_if_no_baseline: false };
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i]!;
         if (arg === '--baseline') {
@@ -79,11 +115,22 @@ function parse_args(argv: readonly string[]): ParsedArgs {
             args.baseline = v;
         } else if (arg.startsWith('--baseline=')) {
             args.baseline = arg.slice('--baseline='.length);
+        } else if (arg === '--head') {
+            const v = argv[++i];
+            if (v === undefined) {
+                process.stderr.write(
+                    'check_safety_floor_untouched: error: argument --head: expected one argument\n',
+                );
+                process.exit(2);
+            }
+            args.head = v;
+        } else if (arg.startsWith('--head=')) {
+            args.head = arg.slice('--head='.length);
         } else if (arg === '--skip-if-no-baseline') {
             args.skip_if_no_baseline = true;
         } else if (arg === '-h' || arg === '--help') {
             process.stdout.write(
-                'usage: check_safety_floor_untouched [-h] [--baseline BASELINE] [--skip-if-no-baseline]\n',
+                'usage: check_safety_floor_untouched [-h] [--baseline BASELINE] [--head HEAD] [--skip-if-no-baseline]\n',
             );
             process.exit(0);
         } else {
@@ -118,15 +165,30 @@ function main(): number {
 
     let changed: string[];
     try {
-        changed = _changed_files(args.baseline);
+        changed = _changed_files(args.baseline, args.head);
     } catch (exc) {
         const msg = exc instanceof Error ? exc.message : String(exc);
         process.stderr.write(`❌  ${msg}\n`);
         return 3;
     }
 
-    const floorPaths = new Set(SAFETY_FLOOR.map((name) => `${RULES_DIR_REL}/${name}`));
-    const breaches = changed.filter((p) => floorPaths.has(p)).sort();
+    // Scope assertion BEFORE the comparison: if none of the guarded paths exist
+    // on disk, this guard cannot fire and must say so loudly rather than
+    // reporting a clean floor it never looked at.
+    let guarded: string[];
+    try {
+        guarded = assertWatchlistResolves({
+            gate: 'check_safety_floor_untouched',
+            candidates: _floor_candidates(),
+            repoRoot: REPO_ROOT,
+        });
+    } catch (exc) {
+        const msg = exc instanceof Error ? exc.message : String(exc);
+        process.stderr.write(`❌  ${msg}\n`);
+        return 3;
+    }
+
+    const breaches = _breaches(changed);
 
     if (breaches.length) {
         process.stderr.write(
@@ -144,8 +206,11 @@ function main(): number {
         return 1;
     }
 
+    // Report the RESOLVED count, not the declared one — the old message printed
+    // `SAFETY_FLOOR.length` unconditionally, so it claimed 4 guarded rules while
+    // guarding zero.
     process.stdout.write(
-        `✅  Safety-floor untouched (${SAFETY_FLOOR.length} rules guarded ` +
+        `✅  Safety-floor untouched (${guarded.length} rule file(s) guarded ` +
             `vs. ${args.baseline}).\n`,
     );
     return 0;
@@ -177,4 +242,14 @@ if (_isCliEntry() || process.argv[1] === _HERE) {
     process.exit(main());
 }
 
-export { REPO_ROOT, RULES_DIR_REL, SAFETY_FLOOR, _baseline_exists, _changed_files, main };
+export {
+    REPO_ROOT,
+    RULES_DIR_REL,
+    RULES_DIRS_REL,
+    SAFETY_FLOOR,
+    _baseline_exists,
+    _breaches,
+    _changed_files,
+    _floor_candidates,
+    main,
+};

--- a/src/scripts/check_safety_floor_untouched.ts
+++ b/src/scripts/check_safety_floor_untouched.ts
@@ -29,21 +29,22 @@ import { assertWatchlistResolves } from './_lib/scan_scope.js';
 const _HERE = fileURLToPath(import.meta.url);
 const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
 /**
- * Roots the four floor rules may live under, current first.
+ * Root the four floor rules live under (ADR-051).
  *
- * `src/rules` is where they live since ADR-051. The legacy
- * `.agent-src.uncondensed/rules` entry is RETAINED on purpose: this gate diffs
- * a baseline against HEAD, and a baseline predating ADR-051 still names the old
- * path — dropping it would blind the guard on exactly those ranges.
- *
- * Until 2026-07-29 the legacy path was the ONLY entry, so the guard compared
- * diffs against paths that no longer exist and reported
+ * Until 2026-07-29 this named the retired source container, so the guard
+ * compared diffs against paths absent from every commit and reported
  * `✅ Safety-floor untouched (4 rules guarded)` no matter what was edited.
- * `assertWatchlistResolves` below now makes that state a loud failure instead.
+ * `assertWatchlistResolves` below now makes that state a loud failure instead
+ * of a clean bill of health.
+ *
+ * A first pass also kept the legacy path "in case a pre-ADR-051 baseline names
+ * it". That was speculative — CI always diffs against current `main` — and it
+ * tripped `check_no_new_legacy_path`, which is right: the source of truth is
+ * `src/`, and a dead path kept alive for an unmeasured scenario is how the
+ * original defect survived.
  */
-const RULES_DIRS_REL = ['src/rules', '.agent-src.uncondensed/rules'] as const;
-/** Back-compat alias — the current authoring root. */
-const RULES_DIR_REL = RULES_DIRS_REL[0];
+const RULES_DIR_REL = 'src/rules';
+const RULES_DIRS_REL = [RULES_DIR_REL] as const;
 const SAFETY_FLOOR = [
     'non-destructive-by-default.md',
     'commit-policy.md',

--- a/src/scripts/lint_new_skill_gate.ts
+++ b/src/scripts/lint_new_skill_gate.ts
@@ -108,16 +108,11 @@ function _skill_roots(): string[] {
     // ADR-051 moved skill authoring to `src/skills`; a later commit deleted
     // `packages/` entirely. Until 2026-07-29 the only fallback was the retired
     // container, so this resolved to [] and the overlap gate silently passed
-    // every new skill. Current root first, legacy kept for old checkouts.
+    // every new skill.
     if (roots.length === 0) {
-        for (const cand of [
-            path.join(ROOT, 'src', 'skills'),
-            path.join(ROOT, '.agent-src.uncondensed', 'skills'),
-        ]) {
-            if (_isDir(cand)) {
-                roots = [cand];
-                break;
-            }
+        const cand = path.join(ROOT, 'src', 'skills');
+        if (_isDir(cand)) {
+            roots = [cand];
         }
     }
     return roots;

--- a/src/scripts/lint_new_skill_gate.ts
+++ b/src/scripts/lint_new_skill_gate.ts
@@ -105,9 +105,20 @@ function _skill_roots(): string[] {
             }
         }
     }
-    const legacy = path.join(ROOT, '.agent-src.uncondensed', 'skills');
-    if (roots.length === 0 && _isDir(legacy)) {
-        roots = [legacy];
+    // ADR-051 moved skill authoring to `src/skills`; a later commit deleted
+    // `packages/` entirely. Until 2026-07-29 the only fallback was the retired
+    // container, so this resolved to [] and the overlap gate silently passed
+    // every new skill. Current root first, legacy kept for old checkouts.
+    if (roots.length === 0) {
+        for (const cand of [
+            path.join(ROOT, 'src', 'skills'),
+            path.join(ROOT, '.agent-src.uncondensed', 'skills'),
+        ]) {
+            if (_isDir(cand)) {
+                roots = [cand];
+                break;
+            }
+        }
     }
     return roots;
 }

--- a/tests/scripts/check_safety_floor_untouched.test.ts
+++ b/tests/scripts/check_safety_floor_untouched.test.ts
@@ -1,15 +1,21 @@
-// Tests for src/scripts/check_safety_floor_untouched.ts (py2ts Phase 4 / Wave 4c).
+// Tests for src/scripts/check_safety_floor_untouched.ts.
 //
-// No pytest suite exists for this module, so this is a focused differential
-// suite over the constants plus a golden-parity layer that runs python3 vs
-// tsx on the REAL REPO (skipped without python3). The worktree branch does
-// not touch the four safety-floor rules, so vs. its merge-base the gate is
-// clean — and `--skip-if-no-baseline` on a bogus ref is a deterministic skip.
+// HISTORY (2026-07-29 audit, agents/settings/contexts/gates-that-cannot-fail.md):
+// this suite used to assert `RULES_DIR_REL === '.agent-src.uncondensed/rules'` —
+// i.e. it PINNED the defect. That path stopped existing at ADR-051, so the guard
+// compared diffs against paths absent from every commit and reported
+// "✅ Safety-floor untouched (4 rules guarded)" no matter what was edited. The
+// gate was structurally incapable of failing, and this file made fixing it look
+// like a regression.
+//
+// The replacement asserts BEHAVIOUR in both directions: a changed-file set that
+// touches a floor rule must be rejected, one that does not must pass, and the
+// guarded paths must resolve on disk.
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import * as sf from '../../src/scripts/check_safety_floor_untouched.js';
-
-
 
 describe('check_safety_floor_untouched — behavioural spec', () => {
     it('guards exactly the four safety-floor rules', () => {
@@ -21,10 +27,53 @@ describe('check_safety_floor_untouched — behavioural spec', () => {
         ]);
     });
 
-    it('rules dir is the legacy uncondensed tree', () => {
-        expect(sf.RULES_DIR_REL).toBe('.agent-src.uncondensed/rules');
+    it('watches the CURRENT authoring root, and keeps the legacy one for old ranges', () => {
+        // Current first — a diff naming src/rules/* is what today's edits produce.
+        expect(sf.RULES_DIR_REL).toBe('src/rules');
+        // Legacy retained on purpose: a baseline predating ADR-051 still names it,
+        // and dropping it would blind the guard on exactly those ranges.
+        expect([...sf.RULES_DIRS_REL]).toContain('.agent-src.uncondensed/rules');
+    });
+
+    it('every guarded floor file resolves on disk (the guard is not watching phantoms)', () => {
+        // This is the assertion whose absence let the gate die silently: if the
+        // rules move again, this fails instead of the guard going quietly green.
+        const present = sf.SAFETY_FLOOR.filter((name) =>
+            fs.existsSync(path.join(sf.REPO_ROOT, sf.RULES_DIR_REL, name)),
+        );
+        expect(present).toHaveLength(sf.SAFETY_FLOOR.length);
+    });
+
+    it('REJECTS a changed-file set that touches a floor rule', () => {
+        const breaches = sf._breaches([
+            'README.md',
+            'src/rules/commit-policy.md',
+            'src/scripts/whatever.ts',
+        ]);
+        expect(breaches).toEqual(['src/rules/commit-policy.md']);
+    });
+
+    it('rejects a floor rule named under the legacy root too', () => {
+        expect(sf._breaches(['.agent-src.uncondensed/rules/scope-control.md'])).toEqual([
+            '.agent-src.uncondensed/rules/scope-control.md',
+        ]);
+    });
+
+    it('PASSES a changed-file set that touches no floor rule', () => {
+        expect(
+            sf._breaches(['README.md', 'src/rules/telegraph-speak.md', 'docs/proof.md']),
+        ).toEqual([]);
+    });
+
+    it('does not confuse a same-named rule outside the guarded roots', () => {
+        // A projection copy is not the source of truth and must not trip the gate.
+        expect(sf._breaches(['dist/agent-src/rules/commit-policy.md'])).toEqual([]);
+    });
+
+    it('regression lock: the guarded set is non-empty', () => {
+        // The whole defect class in one line — an empty candidate set means the
+        // gate can never fire, which is exactly how it shipped for months.
+        expect(sf._floor_candidates().length).toBeGreaterThan(0);
+        expect(sf._floor_candidates()).toContain('src/rules/commit-policy.md');
     });
 });
-
-// --- Golden parity on the REAL REPO -----------------------------------------
-

--- a/tests/scripts/check_safety_floor_untouched.test.ts
+++ b/tests/scripts/check_safety_floor_untouched.test.ts
@@ -27,12 +27,14 @@ describe('check_safety_floor_untouched — behavioural spec', () => {
         ]);
     });
 
-    it('watches the CURRENT authoring root, and keeps the legacy one for old ranges', () => {
-        // Current first — a diff naming src/rules/* is what today's edits produce.
+    it('watches the CURRENT authoring root only — no retired container', () => {
         expect(sf.RULES_DIR_REL).toBe('src/rules');
-        // Legacy retained on purpose: a baseline predating ADR-051 still names it,
-        // and dropping it would blind the guard on exactly those ranges.
-        expect([...sf.RULES_DIRS_REL]).toContain('.agent-src.uncondensed/rules');
+        // The retired source container must not creep back in: a dead path kept
+        // alive for an unmeasured scenario is how the original defect survived
+        // (and `check_no_new_legacy_path` enforces the same thing repo-wide).
+        expect(sf._floor_candidates().every((p) => !p.includes('.agent-src.uncondensed'))).toBe(
+            true,
+        );
     });
 
     it('every guarded floor file resolves on disk (the guard is not watching phantoms)', () => {
@@ -53,9 +55,12 @@ describe('check_safety_floor_untouched — behavioural spec', () => {
         expect(breaches).toEqual(['src/rules/commit-policy.md']);
     });
 
-    it('rejects a floor rule named under the legacy root too', () => {
-        expect(sf._breaches(['.agent-src.uncondensed/rules/scope-control.md'])).toEqual([
-            '.agent-src.uncondensed/rules/scope-control.md',
+    it('rejects every guarded floor rule, not just the first', () => {
+        expect(sf._breaches(['src/rules/scope-control.md'])).toEqual([
+            'src/rules/scope-control.md',
+        ]);
+        expect(sf._breaches(['src/rules/verify-before-complete.md'])).toEqual([
+            'src/rules/verify-before-complete.md',
         ]);
     });
 


### PR DESCRIPTION
Phases 1 and 2 of [`road-to-gates-that-can-fail`](../blob/feat/gates-that-can-fail/agents/roadmaps/road-to-gates-that-can-fail.md).

## The defect class

An audit after 9.9.0 found **14 deterministic gates that scan zero files and exit 0 with a green checkmark**. ADR-051 moved the source container and a later commit deleted `packages/`; gates that hardcoded a literal path kept pointing at it, and every one treats a missing directory as *"nothing to check"* rather than as an error.

They printed the zero themselves. Nothing asserted on it:

```
✅  Iron Law prominence clean (0 file(s) scanned).
    BASELINE: 0 issues · 0 name(s) checked
✅  load_context schema clean (0 declarer(s))          ← 24 real declarers exist
✅  no violations under .agent-src.uncondensed/skills  ← names the dead path in its success line
```

**The worst instance:** `check_safety_floor_untouched` compared diffs against `.agent-src.uncondensed/rules/<name>` while the four floor rules live in `src/rules/`, reporting `✅ Safety-floor untouched (4 rules guarded)` — a count printed from a constant, never derived from input. Its own test asserted the dead path was correct, so fixing it required breaking a passing test first.

## What lands

| | |
|---|---|
| `_lib/scan_scope.ts` | `assertScanned` (corpus gates: 0 units → throw) and `assertWatchlistResolves` (diff-based guards: watch list resolving to nothing → throw). A justified `allowEmpty` string is printed, so waiving is visible in a diff. |
| `check_safety_floor_untouched` | Repaired, un-pinned, made testable. |
| `check_iron_law_prominence` | 0 → **111 rule files** scanned, 0 violations. |
| `lint_new_skill_gate` | 0 roots → **286 skills**; sees 10 new skills vs 9.8.0 and actually gates them. |

## Verification

**Safety floor, end-to-end against real history** at `259bb1b` (a commit editing `src/rules/commit-policy.md`):

```
range WITH the change    → exit 1: "src/rules/commit-policy.md"
range WITHOUT            → exit 0: "4 rule file(s) guarded"
```

Getting there required a correction worth recording: `_changed_files` uses `git diff baseline...HEAD`, a **commit range** — so the obvious "edit the file and run the guard" check is vacuous, because a working-tree edit is invisible to it. That is why this gate shipped unverified for months, and the roadmap's original verify line was wrong. Added `--head` (default `HEAD`, additive) and a pure `_breaches()` to make it testable at all.

Test suite: 2 constant assertions → **8 behavioural** ones, both directions plus a watch-list-resolves lock. **Mutation-checked** — reverting the root repair fails 4 of 8.

Scope assertion proven live: pointing the repaired iron-law gate at the dead root now exits 2 with `scanned 0 rule file(s) … the scan scope is dead or the root moved`.

Also: `task typecheck-ts` 0 · eslint 0 · 60 tests green across 7 gate suites · check-refs · check-md-language.

## What deliberately does NOT land

**3 gates measured but not repaired here.** Repairing them surfaces pre-existing violations — `lint_handoffs` 19, `check_augment_description_cap` 16, `check_context_paths` 1 — whose disposition (fix / grandfather / reclassify the rule) belongs to the maintainer per the `dead-gate-finding-triage` blocker. Landing them would turn CI red on debt this change did not create. The blocker now carries the measurement it was waiting for: **36 total, not hundreds** — small enough to decide per gate instead of needing a blanket grandfather policy.

**8 are structural**, not path swaps — one container with subdirs became several independent roots, or `packages/` was deleted outright.

**Phase 1 is marked partial, not done.** Its own step text says "route *every* gate through the helper"; three are wired. That overreach is recorded in the roadmap rather than ticked off.

## Method note carried into the census

A **partial** repair lies in both directions. Fixing `check_context_paths`' contexts root alone reports 17 orphans, **16 of them false**, because the gate could not see the files doing the referencing. Repair every root a gate reads, or none.

## Scope boundary

This is **not** the rejected enforcement-first architecture (locked 2026-07-26; revisit gated on hook budget + usage-distribution evidence). That lock is about replacing prose rules with compiled enforcement. This is about making the deterministic gates that already exist demonstrate they executed — different mechanism, lock does not apply. It extends ADR-127's thesis (*"pointer resolves ≠ claim is true"*) to the gates themselves.