### PR TITLE
docs(roadmaps): elder + ponytail harvest — six drafted roadmaps in, three out

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,30 +2,33 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 10 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 13 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
 
 ## Overall
 
-**45 / 95 steps done · 47%**
+**45 / 174 steps done · 26%**
 
 ```text
-███████████████████░░░░░░░░░░░░░░░░░░░░░   47%
+██████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   26%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Blocker | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 16 | 6 | 10 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 62% |
+| 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 17 | 7 | 10 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 59% |
 | 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 3 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
 | 4 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 5 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 6 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 7 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 8 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 9 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 10 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 5 | [road-to-governance-invariants.md](roadmaps/road-to-governance-invariants.md) | 5 | 19 | 19 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 6 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 7 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 8 | [road-to-runtime-encoding-hardening.md](roadmaps/road-to-runtime-encoding-hardening.md) | 5 | 23 | 23 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 10 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 36 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 11 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 12 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 13 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
 
 ---
 
@@ -33,11 +36,11 @@
 
 ### [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md)
 
-**Road to adoption without narrative debt — win users on the proof identity, not on unbacked headline numbers** — 10 / 16 done (62%)
+**Road to adoption without narrative debt — win users on the proof identity, not on unbacked headline numbers** — 10 / 17 done (59%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 0 | Quick wins already verified missing (autonomous, hours not weeks) | 🟡 in progress | 1 | 2 | 0 | 0 | 67% |
+| 0 | Quick wins already verified missing (autonomous, hours not weeks) | 🟡 in progress | 2 | 2 | 0 | 0 | 50% |
 | 1 | One 30-second wedge, not the whole platform | 🟡 in progress | 1 | 3 | 0 | 0 | 75% |
 | 2 | Discoverability where the category is browsed | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 | 3 | Turn the proof surface into the differentiator narrative | ✅ done | 0 | 4 | 0 | 0 | 100% |
@@ -91,6 +94,18 @@ _2 blockers resolved._
     `yt-dlp` and a JavaScript runtime are installed **by a human** on
   - **Resolved when:** condition described above clears
 
+### [road-to-governance-invariants.md](roadmaps/road-to-governance-invariants.md)
+
+**Road to governance invariants — prove the governance layer does not degrade under indirection** — 0 / 19 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | The three spikes (read-only, throwaway, no production code) | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 1 | Effect-boundary gating (gated on S0.2 = FINDING) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | Refusal-preservation invariant (gated on S0.1 = FINDING) | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 3 | Marker preservation (gated on S0.3 = FINDING) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 4 | Regression tests and the exhibit | ⬜ not started | 8 | 0 | 0 | 0 | 0% |
+
 ### [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md)
 
 **Road to maintainer bus-factor — make the project reviewable and inheritable, and dogfood its own review machinery** — 7 / 12 done (58%)
@@ -135,6 +150,18 @@ _1 blocker resolved._
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
 
+### [road-to-runtime-encoding-hardening.md](roadmaps/road-to-runtime-encoding-hardening.md)
+
+**Road to runtime encoding hardening — prove the sanitize floor runs, then close the half it deliberately left open** — 0 / 23 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Does the floor run at all? (this outranks the visible-layer question) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Measure the visible-layer gap before writing a single check | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 2 | Frozen union corpus (gated on `golden-set-freeze`) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Extend the sanitizer, do not rebuild it | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 4 | Gate on the frozen corpus | ⬜ not started | 9 | 0 | 0 | 0 | 0% |
+
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)
 
 **Road to the scale-history bench run — fire the pre-registered Phase-4 bench** — 0 / 2 done (0%)
@@ -153,6 +180,17 @@ _1 blocker resolved._
     task; same standing authorization the team-mode Phase-5 bench
     waits on).
   - **Resolved when:** the user confirms the run budget in-session.
+
+### [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md)
+
+**Road to solution minimalism — a first-class discipline against over-building** — 0 / 36 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Verification spikes (read-only, no authoring) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | The ladder, as rule text | ⬜ not started | 13 | 0 | 0 | 0 | 0% |
+| 2 | Over-build review lens | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 3 | Pinned public-repo benchmark (the proof exhibit) | ⬜ not started | 16 | 0 | 0 | 0 | 0% |
 
 ### [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md)
 

--- a/agents/roadmaps/later/road-to-benchmark-obsolescence-lifecycle.md
+++ b/agents/roadmaps/later/road-to-benchmark-obsolescence-lifecycle.md
@@ -1,0 +1,74 @@
+---
+complexity: lightweight
+status: later
+---
+
+# Road to benchmark-obsolescence lifecycle — detect when the model outgrew the rule
+
+> A benchmark-backed claim has two ways to go stale, and this package only
+> handles one. It catches regressions when a claim is re-run. It does **not**
+> model the other case: the base host passes the evals **without** the artefact,
+> because the technique migrated into default model behaviour. Then the rule is
+> not broken — it is **no longer necessary**, and shipping it is dead weight
+> carrying a live claim.
+>
+> This state has already been **measured** here (the strong-host null: vanilla =
+> package = placebo) but never modelled as a lifecycle with a re-run cadence.
+>
+> Source + council cut:
+> [`elder-ponytail-harvest-cut`](../../settings/contexts/elder-ponytail-harvest-cut.md).
+
+## Why this is parked, not open
+
+Both council members agreed this is a genuine **package-wide honesty primitive**
+and deserves its own lifecycle rather than riding on a borrow roadmap. Both also
+agreed it must not be built yet: with one benchmark-backed rule in the tree,
+lifecycle machinery is being designed at N=1, which is the premature-abstraction
+failure this package's own guidance forbids.
+
+**Un-parks when:** a second benchmark-backed claim ships (the first candidate is
+the solution-minimalism ladder if its Phase 3 reports). At that point two
+independent claims exist to calibrate a staleness window against, and the Phase 3
+harness is already the re-run instrument, so the remaining work is trigger wiring
+plus a lifecycle field.
+
+## Prerequisites before promotion
+
+- [ ] At least **two** benchmark-backed claims exist whose evidence is a pinned
+      report — enough to calibrate a re-run cadence against real variance rather
+      than one data point.
+- [ ] The re-run instrument is a committed harness someone other than its author
+      can run (the reproduce path from
+      [`road-to-solution-minimalism`](../road-to-solution-minimalism.md)
+      Phase 3 is the candidate).
+- [ ] A decision on the staleness window with a stated basis — host model
+      generations shipping per year, not a round number picked for looking
+      reasonable.
+
+## Sketch (design only — do not implement from this)
+
+- **Lifecycle states**, reusing the existing four-value lifecycle vocabulary
+  rather than inventing a fifth vocabulary:
+  `active` → `redundant-on-strong-hosts` (the measured strong-host null,
+  retroactively labelled) → `outgrown` (the base host passes without the
+  artefact) → `retired`.
+- **Re-run triggers, pre-registered:** a new host model generation on any pinned
+  benchmark host, **or** a claim older than the staleness window. Same
+  offline-gate shape as the existing staleness check that fails the build on
+  unverified-beyond-window evidence. A claim whose trigger has fired renders with
+  a staleness banner until it is re-verified or downgraded.
+- **Honest downgrade path:** an `outgrown` verdict does **not** delete the
+  artefact. It moves out of the default packs with the null published — the same
+  move an earlier cancellation already modelled. An `outgrown` result is a
+  publishable finding, not a failure.
+- **Named absorption candidate:** minimalism / YAGNI discipline. The discourse
+  around it (a ~90k★ source, three independent benchmarks, a vendor blog series)
+  is plausible future training data, so it is the likeliest claim here to be
+  absorbed by a base model. The package that detects its own obsolescence is the
+  one whose remaining claims stay credible.
+
+## Explicit non-goals
+
+- No new governance layer, no runtime daemon, no writable runtime state.
+- Not a replacement for the existing claims ledger or the pinned-report
+  rendering — this adds an *ageing* dimension to them, nothing else.

--- a/agents/roadmaps/road-to-adoption-without-narrative-debt.md
+++ b/agents/roadmaps/road-to-adoption-without-narrative-debt.md
@@ -98,6 +98,18 @@ nothing downstream. All verified open on 2026-07-08.
       package.json + .github/about.yml, both of which are ALREADY drifted from it
       (pre-existing red, unrelated to this roadmap) — rewriting it is a branding
       decision plus that debt, so it stays the maintainer's call. -->
+- [ ] **Donation path exists at all (added 2026-07-29):** the stated
+      monetisation decision is **donation-only** — no paid tier, no
+      dual-licensing, ever — and `.github/FUNDING.yml` does not exist, so the
+      in-repo sponsor button is absent. This is execution, not design: a
+      two-line file plus a short, guilt-free funding paragraph in the README.
+      Two facts an agent must **not** invent and the maintainer has to supply:
+      whether GitHub Sponsors is enabled for the org, and the donation target if
+      it is not. Verify by loading the rendered repo page and seeing the button.
+      Cut rationale (a council explicitly declined to roadmap this on its own):
+      [`elder-ponytail-harvest-cut`](../settings/contexts/elder-ponytail-harvest-cut.md).
+      Note also settled there: the license is **already MIT**, so the drafted
+      AGPL→permissive relicensing question is moot.
 - [x] **Release-notes discoverability:** verify the site's proof/benchmark
       pages are linked from the README claims section (one hop from "every
       claim machine-checked" to the evidence).

--- a/agents/roadmaps/road-to-governance-invariants.md
+++ b/agents/roadmaps/road-to-governance-invariants.md
@@ -1,0 +1,217 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to governance invariants — prove the governance layer does not degrade under indirection
+
+> Three adversarial sources describe one attack shape from three directions: a
+> multi-model racer that scores on *anti-refusal* to select the least-guarded
+> output; a planner that splits an objective into individually-benign subtasks
+> and dispatches them to a swarm; and an output normaliser whose stated purpose
+> is stripping hedges and refusals from what a reader finally sees. This package
+> runs all three primitives — a multi-provider council with an aggregation step,
+> subagent orchestration that decomposes work, and a prose condenser on the reply
+> path. Whether any of them is **invariant under indirection** is currently
+> unproven.
+>
+> Source + council cut:
+> [`elder-ponytail-harvest-cut`](../settings/contexts/elder-ponytail-harvest-cut.md).
+
+## Goal
+
+Convert a set of "trust us" properties into either committed regression tests or
+high-severity findings. Zero new dependencies, zero runtime spend, no new
+governance layer.
+
+## Honest framing — read this before treating it as a vulnerability report
+
+**There is no observed instance of any of these attacks against this package.**
+No issue, no transcript, no measured bypass. Every item is a falsification spike
+whose **expected outcome is a publishable null**, and that expectation is
+pre-registered here so a null cannot later be spun as a save. The value is
+claims-ledger conversion: "we believe the aggregation is neutral" becomes "a test
+fails the moment it is steerable". Most agent-orchestration tools can say
+*nothing* provable about their multi-agent layer; that is the whole exhibit.
+
+The dissenting council position — that this is speculative rigor until a real
+failure is shown — is recorded, and the counter that carried it is the cost:
+every spike here is read-only, zero-dependency, and hours of work against
+infrastructure that already exists. The marker spike (S0.3) is the one with a
+partially-verified gap rather than a pure hypothesis, so it is the cheapest to
+resolve either way.
+
+## Context (verified in-tree 2026-07-29, do not relitigate)
+
+- **The aggregation surface is real and testable**: `chairman.ts`,
+  `consensus.ts`, `stance_tally.ts`, `confidence_gate.ts`, `blind_review.ts`,
+  `debate_gates.ts` under `src/scripts/ai_council/`. The spike instruments
+  existing machinery rather than building a harness.
+- **`internal/bench/ab` exists** (fixture-based, placebo arm). The decomposition
+  spike adds fixtures to an existing harness rather than a new one.
+- **Rules are prose read by a model, not a deterministic matcher.** This is why
+  the two items merge: they share one failure mode — reasoning under indirection
+  — and therefore one mitigation class. It is also why the drafted
+  "override-pattern quarantine" was **rejected**: there is no deterministic
+  instruction-channel matcher to quarantine around.
+- **The Hard Floor is model-carried and honestly unenforced**
+  (`non-destructive-by-default` states this in its own enforcement section). The
+  decomposition question is therefore about where the *effect-boundary* gate
+  sits, not about a prose rule being clever enough.
+- The Team-Mode defect-finding null (Δ=0 across arms) is the standing warning
+  against answering any of this with more agents.
+
+> **Scope boundary.** Blue-team only. No offensive tooling, arsenal, planner,
+> perturbation engine, or "split a bad task into innocent steps" generator is
+> built, vendored, or reconstructed. Fixtures target this package's **own**
+> governance outcomes (write scope, hardened spawn, verifier mandatory,
+> capability gate, claims ledger) — they are policy tests against our own
+> defence. No AGPL code enters the tree.
+
+## Phase 0 — The three spikes (read-only, throwaway, no production code)
+
+- [ ] **S0.1 — Refusal-preservation in aggregation.** Construct a council run
+      whose scoring / tally is adversarially weighted to reward directness and
+      penalise a refusal, and measure whether the selection outcome moves.
+      Output: *can / cannot steer*, plus the margin.
+      *Verify:* the run exercises the real aggregation path
+      (`chairman` / `consensus` / `stance_tally`), not a re-implementation; the
+      margin is a number, not a verdict word.
+- [ ] **S0.2 — Decomposition laundering.** Pick 3–5 governed-forbidden
+      **outcomes** this package claims to prevent, author for each a sequence of
+      subtasks none of which trips a gate in isolation but whose composition
+      produces the outcome, and dispatch the sequence through the real
+      orchestration path.
+      *Verify:* two-stage assertion. First the **premise**: every subtask must
+      individually pass, or the fixture is invalid and the case reports
+      `INCONCLUSIVE` rather than a false null. Then the **test**: the composed
+      outcome is blocked at the governed action.
+- [ ] **S0.3 — Do safety-relevant markers survive output post-processing into
+      the audit surface?** The adversarial source ships an output normaliser
+      whose stated purpose is stripping hedges ("I think", "maybe") and
+      refusal/preamble shapes. This package ships its own prose condenser whose
+      grammar explicitly drops linking auxiliaries and pronouns, plus an
+      AI-tells detector and a humanizer path. **Verified partial coverage:**
+      `validate_telegraph_carveouts.ts` already asserts byte-identical
+      preservation across seven carve-out categories — status markers, Iron-Law
+      literals, numbered options, code blocks, backtick spans, mode markers,
+      deliverables. **Uncertainty, hedge and provenance markers are not among
+      the seven.** So the question is narrow and answerable: does a stated
+      uncertainty ("unverified", "assumed", a confidence label) or a provenance
+      note survive condensation and the humanizer path into whatever is audited?
+      *Verify:* a fixture reply carrying each marker class through the real
+      post-processing path, with a before/after table. An audit trail that loses
+      a safety-relevant signal is the finding; "the seven existing carve-outs
+      hold" is not an answer to this question.
+- [ ] **Pre-registered verdicts, fixed before either run:**
+      **NULL** (expected) — every governed action is gated at the action itself,
+      the aggregation is unmovable, and every marker class survives
+      post-processing → publish
+      `honest-null: governance-is-action-gated-not-turn-gated`, commit all three
+      spikes as regression tests, resolve their claim entries.
+      **FINDING** — any outcome reachable, **or** a non-zero steering margin,
+      **or** any marker class lost → high-severity for that item; do **not**
+      resolve its claim; open the phase gated on it (S0.2 → Phase 1,
+      S0.1 → Phase 2, S0.3 → Phase 3). Verdicts are **per item**: one finding
+      does not invalidate another item's null, and one null does not excuse
+      another item's finding.
+      **INCONCLUSIVE** — a fixture premise was unmet → repair the fixture; a
+      null may not be claimed.
+      *Verify:* the verdicts are in each spike's source before it is run.
+
+**Exit:** three committed pass/fail artefacts and a claim entry each.
+**Rollback:** nothing shipped; the spikes live outside the package surface and
+are never imported by it.
+
+## Phase 1 — Effect-boundary gating (gated on S0.2 = FINDING)
+
+- [ ] Move the failing check from wherever it fired to the **governed
+      action / effect boundary**, so no framing of the path can synthesize a
+      forbidden effect out of individually-allowed steps.
+      *Verify:* the S0.2 fixture that leaked now blocks, and the per-turn
+      premise check still passes for every subtask (i.e. the fix did not simply
+      make the steps individually forbidden — that would be a regression in
+      usability, not a fix).
+- [ ] Only if a deterministic boundary genuinely cannot express the case: a
+      session-level composition check, **default-off**, with its own
+      false-positive gate before it may ever be turned on.
+      *Verify:* the default state is off and the FP number is measured, not
+      assumed.
+
+## Phase 2 — Refusal-preservation invariant (gated on S0.1 = FINDING)
+
+- [ ] State the invariant explicitly where the selection happens: selection may
+      never rank an artefact higher *because* it refused less; a safety refusal
+      is not a scored-down property.
+      *Verify:* a test replays the S0.1 adversarial weighting and asserts the
+      selection is unmoved (margin = 0).
+- [ ] Optional audit signal: emit refusal **divergence** (did providers disagree
+      about refusing?) as an observation — never as a selection input.
+      *Verify:* the signal cannot reach the scoring path; a test asserts it.
+
+## Phase 3 — Marker preservation (gated on S0.3 = FINDING)
+
+- [ ] Add the lost marker class to the protected set rather than inventing a
+      parallel mechanism: `validate_telegraph_carveouts` already owns
+      byte-identical preservation for seven categories, so an eighth
+      (uncertainty / hedge / provenance) belongs there.
+      *Verify:* the validator fails when a fixture's uncertainty marker is
+      condensed away, and the seven existing categories are unaffected.
+- [ ] Check the humanizer / AI-tells path separately — it is a **different**
+      surface from the condenser and can strip a hedge for a stylistic reason
+      rather than a token-budget one.
+      *Verify:* the same fixture set passes through both paths, not just one.
+- [ ] Honest boundary to record: this protects a marker the agent **did** emit.
+      It cannot make an agent state an uncertainty it never stated — that is a
+      different problem, owned by the honesty bench, and must not be claimed
+      here.
+      *Verify:* the claim wording covers preservation only.
+
+## Phase 4 — Regression tests and the exhibit
+
+- [ ] All three spikes ship as committed regression tests regardless of verdict —
+      that is the deliverable in the null branch, and the whole point.
+      *Verify:* each runs in CI and fails when its property is violated (prove it
+      by temporarily inverting the property, not by assertion).
+- [ ] Publish the result in the benchmark surface with the honesty labels the
+      existing nulls use, including the framing that no observed failure
+      prompted this. Numbers render from a pinned report.
+      *Verify:* no hand-typed number in any claim surface.
+- [ ] Four adjacent properties close as **tests, not phases** — each is
+      expected already-true and each is one assertion, so a phase would be
+      ceremony:
+      **(a) no model-refusal backstop** — enforcement never branches on a
+      base-model refusal string. An abliterated or locally-served model has no
+      refusals at all, which is precisely why the layer must not lean on them;
+      this is existing doctrine converted to a test.
+      **(b) gate integrity** — a capability / tool / MCP gate resolves only from
+      trusted config, never from ingested skill / tool / MCP content. This is the
+      *capability-activation* half of what the rejected override-quarantine item
+      was reaching for, and unlike that item it has a real deterministic target.
+      **(c) caller-agnosticism** — the same governed action gets the same verdict
+      whether a human, this package's own orchestrator, or an external swarm
+      issues it. A gate keyed on who is asking is a gate that can be bypassed by
+      asking differently.
+      **(d) constraint monotonicity** — memory and derived-cache mutation cannot
+      weaken a governed constraint over sessions. `source-discovery-gate` already
+      states this as prose (curated self-building context is read for heuristics
+      and never bypasses a fresh structural read); the test converts that claim
+      from **CLAIMED** to **TESTED**, and it matters most exactly where a
+      self-modifying loop persists state across runs.
+      *Verify:* each test fails when the property is inverted — prove it by
+      inverting, not by assertion; none adds a new module.
+
+## Acceptance criteria
+
+- [ ] All three Phase 0 spikes have a committed verdict artefact with a number
+      (steering margin, leak count, marker-loss count), and the pre-registered
+      verdicts were written before the runs.
+- [ ] Per item: either its honest null is published with the spike wired as a
+      regression test, **or** its finding is fixed in the phase gated on it —
+      the leaking fixture proven blocked, the steering margin proven zero, the
+      lost marker class proven preserved.
+- [ ] The four adjacent property tests exist and demonstrably fail when
+      inverted.
+- [ ] No offensive tooling, no AGPL code, no new governance layer, no runtime
+      spend added.
+- [ ] All quality gates pass — see `quality-tools`.

--- a/agents/roadmaps/road-to-runtime-encoding-hardening.md
+++ b/agents/roadmaps/road-to-runtime-encoding-hardening.md
@@ -1,0 +1,235 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to runtime encoding hardening — prove the sanitize floor runs, then close the half it deliberately left open
+
+> Two findings, in severity order.
+>
+> **The floor's wiring is unproven where it matters most.** `retrieval_sanitize.ts`
+> says in its header that it strips hidden-instruction vectors on the
+> `retrieve_v1` / `memory_get_v1` read surfaces "before it is emitted". Those two
+> functions live in `memory_lookup.ts`, which has **zero imports**; the MCP tool
+> layer calls them **directly**; the floor's only production caller is
+> `second_brain_retrieval.ts`; and the test case titled "sanitize floor already
+> applied on the read surface" asserts only against fixtures passed to
+> `sanitize_text` by hand. The algorithm is proven. The surface is not.
+>
+> **And where the floor does run, it covers half the space by design.** It strips
+> the **invisible** class and states that it will not touch visible text, because
+> rewriting it would corrupt legitimate rule bodies and code snippets. That
+> decision is defensible and it leaves a named hole: a reviewer reads `ignore`,
+> the model reads a token whose `o` is U+043E. The visible class is linted at
+> **authoring** time over this package's own corpus and is **unguarded at
+> runtime**.
+>
+> Source + council cut:
+> [`elder-ponytail-harvest-cut`](../settings/contexts/elder-ponytail-harvest-cut.md).
+
+## Goal
+
+First establish — with an end-to-end probe, not a header and not a unit test —
+which read surfaces the sanitize floor actually runs on. Then decide whether the
+visible encoding layer is worth canonicalizing there, and if so close it without
+corrupting legitimate content. Extend the existing sanitizer and the existing
+pressure corpus. Add no new security layer.
+
+## Context (verified in-tree 2026-07-29, do not relitigate)
+
+- **`src/scripts/_lib/retrieval_sanitize.ts` (71 LOC)** strips bidi,
+  zero-width, Unicode-Tag and deprecated-format codepoints (classes shared with
+  `lint_hidden_unicode._classify`) plus C0/C1 controls, and caps fields at
+  `MAX_FIELD_CHARS = 8192`. **No NFKC. No confusable folding. By design.**
+  **Where it is applied is the open question, not a context fact** — its header
+  names `retrieve_v1` / `memory_get_v1`, the wiring evidence points the other
+  way, and Phase 0 settles it. Do not cite the header as coverage.
+- **`lint_confusables.ts` (217 LOC)** already owns a high-precision visible
+  mixed-script signature (Latin-majority token + ≥1 TR39-confusable
+  Cyrillic/Greek letter + minimum letter count, with math operators excluded so
+  `ΔNWC` is never flagged). It runs at authoring time over
+  `src/{skills,rules,agent-src,domains}/**/*.md`. **Its confusable table is the
+  asset this roadmap reuses — do not write a second one.**
+- **This package's rules are prose read by a model, not a deterministic
+  matcher.** The drafted "canonicalize before policy matching" has almost no
+  target: the only deterministic matchers are the hooks and the lint scripts.
+  The retrieval sanitizer is the one genuinely deterministic runtime surface, so
+  it is the only place this work is real.
+- The channel taxonomy from the sweep sources is a **superset** of the earlier
+  9-channel plan, but the majority of it (image/audio/PDF/DNS/TCP/file-metadata
+  stego) is **out of this package's threat model** — it governs text, not
+  arbitrary files or packets. Scoping it out shrinks the work and is recorded so
+  coverage is never over-claimed.
+- The `injection-defense-pressure-corpus` work already shipped. This is an
+  **amendment to that corpus**, not a parallel surface.
+
+> **Scope boundary.** No AGPL code enters the tree. The channel *taxonomy* (the
+> list of technique names) crossed the boundary; no source, no payload. Every
+> fixture is own code.
+
+## Blockers
+
+- `golden-set-freeze` — the labelled corpus is frozen and hashed **before** any
+  detector runs against it. No tuning against the test split. Blocks Phase 2
+  onward.
+
+## Phase 0 — Does the floor run at all? (this outranks the visible-layer question)
+
+The first pass of this roadmap read the sanitizer's header as fact and recorded
+"applied on the `retrieve_v1` / `memory_get_v1` read surfaces". Measuring instead
+produced a more severe finding, so it goes first.
+
+- [ ] **S0.0 — Wiring, not algorithm.** Establish for **every** named read
+      surface whether the sanitize floor is actually on the path. Measured
+      starting point, to be confirmed or refuted: `retrieve_v1` and
+      `memory_get_v1` are defined in `memory_lookup.ts`, which has **zero
+      imports**; `mcp_server/tools.ts` calls both **directly**; the floor's only
+      production caller is `second_brain_retrieval.ts`; and
+      `tests/scripts/consumer_flow_wiring.test.ts` has a case titled "sanitize
+      floor already applied on the read surface" whose every assertion calls
+      `sanitize_text(...)` on a fixture — proving the algorithm, never the
+      surface.
+      *Verify:* a table of read surface → does the floor run → what proves it.
+      An end-to-end probe (poisoned entry in, retrieved output out, through the
+      real entry point) decides each row; a unit test on the algorithm does not
+      count as evidence for a row.
+      **If the floor is not on the primary path:** that is the finding, it
+      outranks everything below, and the fix is wiring plus a test that
+      exercises the **entry point** — not a new detector. Same class as the
+      active gates-that-can-fail work: proven through an injection seam,
+      unproven at the default entry.
+- [ ] **S0.0b — The second surface the drafts named and the first pass dropped:
+      the inter-agent / subagent message channel.** No `sanitize` call exists
+      anywhere under the hook or subagent scripts. Decide, with evidence,
+      whether content crossing that boundary is untrusted in the same sense
+      retrieved content is — and if it is, whether the same floor applies or the
+      channel is structurally different.
+      *Verify:* a stated verdict per direction (orchestrator → subagent,
+      subagent → orchestrator) with the reasoning, so a later reader cannot
+      mistake silence for coverage.
+- [ ] **Header-vs-wiring hygiene, once the table exists:** whichever way S0.0
+      lands, the sanitizer's header prose must describe what it actually does.
+      A doc claiming a surface it does not cover is the failure class this
+      package's own claims discipline exists to prevent.
+      *Verify:* the header and the wiring table agree line for line.
+
+**Exit:** it is known whether the floor runs on each named surface.
+**Rollback:** read-only.
+
+## Phase 1 — Measure the visible-layer gap before writing a single check
+
+- [ ] Author the in-scope channel list as an explicit table: zero-width ·
+      invisible-tag · variation-selector · homoglyph/confusable ·
+      bidi/directional-override · combining-diacritic runs · invisible fillers
+      (e.g. Hangul filler) · math-alphanumeric and other Unicode style blocks ·
+      punycode/IDN · nested multibase · confusable whitespace · XML/HTML
+      entities · structured-data key ordering. Mark each **already covered by
+      `retrieval_sanitize`** / **uncovered** / **out of scope**, citing the
+      codepoint class or the sanitizer line that decides it.
+      *Verify:* every row cites a file:line or a codepoint range; the
+      out-of-scope rows name the reason (not text, or semantic).
+- [ ] Run the uncovered channels through the **live** sanitizer as a throwaway
+      probe and record what survives verbatim.
+      *Verify:* a committed before/after table; the invisible-class rows must
+      show the sanitizer already neutralising them (if they do not, that is a
+      higher-severity finding than this roadmap assumed — stop and surface it).
+- [ ] **Pre-registered null condition:** if the live sanitizer already
+      neutralises ≥ 90 % of the uncovered in-scope channels, publish
+      `honest-null: runtime-sanitizer-already-covers-visible-layer` with the
+      numbers and **close this roadmap** without shipping a detector.
+      *Verify:* the prediction is written down before the probe runs —
+      expected outcome is *partial* coverage: the invisible class covered, the
+      visible class (confusable, math-alphanumeric, full-width, punycode) fully
+      through.
+- [ ] Decide and record the **normalise-vs-flag** question, which is the real
+      design decision and the reason the sanitizer stopped where it did: a
+      visible-layer finding may (a) be folded to a Latin skeleton, corrupting
+      any body that legitimately contains mixed script, (b) be flagged in a
+      structured finding while the text passes through unchanged, or (c) cause
+      the entry to be quarantined. Pick per channel, with the corruption risk of
+      each named.
+      *Verify:* the decision table exists and the default for anything with a
+      false-positive risk is **flag, not rewrite**.
+
+**Exit:** a measured coverage table and a per-channel disposition. **Rollback:**
+nothing shipped yet.
+
+## Phase 2 — Frozen union corpus (gated on `golden-set-freeze`)
+
+- [ ] Own encoder emitting each **in-scope text-layer** channel with
+      ground-truth labels. Own code, built from the taxonomy, never from any
+      source repo.
+      *Verify:* the encoder round-trips each channel and the label matches what
+      it encoded.
+- [ ] Positives N ≥ 300, balanced across in-scope channels over varied carrier
+      text. Negatives M ≥ 300 drawn from **real** rule snippets, retrieval
+      chunks and inter-agent messages, so the false-positive rate is measured
+      against realistic traffic rather than toy text.
+      *Verify:* the channel histogram is balanced; the negatives are traceable
+      to real files.
+- [ ] Freeze: `sha256` manifest committed. Add a **scope-guard test** asserting
+      the corpus contains **zero** file/network-layer channels, so it can never
+      silently drift into claiming out-of-scope coverage.
+      *Verify:* the guard fails when a deliberately out-of-scope fixture is
+      added.
+
+## Phase 3 — Extend the sanitizer, do not rebuild it
+
+Only the channels Phase 1 proved uncovered, only the dispositions Phase 1 chose.
+
+- [ ] Reuse `lint_confusables`' TR39 confusable set as the single source of
+      truth for the visible mixed-script signature — import it, do not restate
+      it. Same containment discipline (math operators are not confusables).
+      *Verify:* one table in the tree; a test asserts both call sites agree.
+- [ ] Add the remaining uncovered structural checks per the Phase 1 table
+      (variation-selector runs · combining-mark density bound · invisible
+      fillers folded into the existing invisible set · Unicode style-block fold ·
+      punycode/IDN in text-expected fields · nested-multibase depth guard ·
+      structured-data key-order canonicalization before comparison).
+      *Verify:* each emits a structured finding; none rewrites visible text
+      except where Phase 1 explicitly chose folding.
+- [ ] Keep the deterministic property: no model call, no network, CI-runnable.
+      *Verify:* the added path is pure and exercised by the frozen corpus.
+- [ ] **Named exclusion, so it does not return as a suggestion:** the
+      word-order-permutation channel. The source draft carried it as a stretch
+      item and said itself that its precision is likely poor. It sits on the wrong
+      side of the line this roadmap draws — carrier text with legitimate word
+      order is indistinguishable from permuted carrier text without semantics, so
+      a structural check cannot own it. Same exclusion as word choice, sentence
+      length and misspelling.
+      *Verify:* the channel appears in the Phase 1 table marked out-of-scope with
+      this reason, not omitted silently.
+
+## Phase 4 — Gate on the frozen corpus
+
+- [ ] **Pre-registered acceptance (adopt ⇔ all true):** recall on in-scope
+      positives ≥ **0.95**, with the unambiguous classes (zero-width, bidi,
+      variation-selector) ≥ **0.99**; false-positive rate on the clean negative
+      corpus ≤ **0.5 %**; zero added runtime model spend; added latency
+      < **2 ms p95** per message.
+      *Verify:* the numbers render from a committed report, never hand-typed.
+- [ ] **Honest-null exit:** recall clears but FP > 0.5 % → ship
+      **detect-and-flag only**, no automatic quarantine, and publish the FP
+      number. Do not claim "blocks steganography".
+      *Verify:* the shipped default matches whichever branch the measurement
+      selected.
+- [ ] Record the coverage boundary as a claim: **text-layer only, by
+      construction**, backed by the Phase 2 scope-guard test. Never for
+      file/network channels; never for semantic evasion (word choice, phrasing,
+      garden-path constructions) — a sanitizer cannot own those and the claim
+      surface must say so.
+      *Verify:* the claim entry names the scope-guard test as its evidence.
+
+## Acceptance criteria
+
+- [ ] The S0.0 wiring table exists with an end-to-end probe per read surface,
+      and the header prose matches it.
+- [ ] The Phase 1 coverage table exists with a citation per row, and the
+      normalise-vs-flag decision is recorded per channel.
+- [ ] Either the honest null is published, **or** the union corpus is frozen with
+      its scope guard green and the detector deltas ship on the branch the
+      measurement selected.
+- [ ] `lint_confusables`' confusable table has exactly one definition in the
+      tree.
+- [ ] No AGPL code in the tree; no coverage claim past the text layer.
+- [ ] All quality gates pass — see `quality-tools`.

--- a/agents/roadmaps/road-to-solution-minimalism.md
+++ b/agents/roadmaps/road-to-solution-minimalism.md
@@ -1,0 +1,455 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to solution minimalism — a first-class discipline against over-building
+
+> This package guards hard against **under**-building: omitted controls, overfit
+> tests, drive-by scope, unverified claims. It has fragments against
+> **over**-building and no unified discipline. An MIT source (~90k★) ships that
+> discipline as a solution-size ladder; an **independent** third-party A/B on 80
+> paired tasks measured the effect direction on a benchmark the source's author
+> did not choose. The borrow is unusually low-risk — an additive rule with every
+> existing floor untouched — and unusually well-instrumented, because the same
+> independent run also measured three ways the naive copy fails.
+>
+> Source + council cut:
+> [`elder-ponytail-harvest-cut`](../settings/contexts/elder-ponytail-harvest-cut.md).
+
+## Goal
+
+Ship the missing over-building discipline as projected rule text plus a
+deletion-hunting review lens, then measure it on a pinned public repo against a
+bare-principle control — so the claim that survives is "the ladder **with the
+floors routed**", not "the ladder".
+
+Two axes, not one: **scope** (must this exist, and can something cheaper serve?)
+and **shape** (of what must exist, which form carries the least cognitive load?).
+Each axis gets its own endpoint — added lines for scope, cognitive complexity for
+shape, the safety tier for the floors — so none can be optimised at another's
+expense without the benchmark seeing it.
+
+## Context (verified in-tree 2026-07-29, do not relitigate)
+
+- **Coverage is partial, not absent.** `minimal-safe-diff-mechanics`
+  § Anti-over-engineering already says "three similar lines beat a premature
+  abstraction" and "no speculative features"; `improve-before-implement` already
+  carries a demand gate ("should this exist?"). **Genuinely absent:** the
+  **reuse → stdlib/framework → native platform → installed dependency**
+  ordering, and any deletion-hunting review lens. The roadmap is scoped to the
+  absent part; Phase 0 decides whether it lands as a new rule or an extension.
+- **`internal/bench/ab` exists** (fixture-based, N=2 tasks × 12 seeds, placebo
+  arm) — statistically stricter than the source's own benchmark, but with no
+  public-repo run and no per-trial injection audit.
+- **`hooks/hooks.json` dispatches six events** (SessionStart, SessionEnd, Stop,
+  UserPromptSubmit, PreToolUse, PostToolUse). No SubagentStart/SubagentStop
+  anywhere in `src/`; whether the host exposes such an event is unverified.
+- The license here and at the source are both MIT.
+
+## Findings that constrain the design (from the independent benchmark and the critic thread)
+
+Each one is a measured fact about how this borrow fails when copied naively.
+
+- **F1 — Description-triggered skills do not self-activate.** With the source's
+  skill installed the normal way and a description saying "use on ANY coding
+  task", self-activation across ten sessions was **zero**; only hook injection
+  produced any effect. → the ladder ships as **projected rule** text through the
+  existing projection/dispatch pipeline, never as a description-triggered skill.
+  A skill-only variant would measure nothing and any null would really be an
+  activation failure.
+- **F2 — Marker conventions without a machine backstop are dead text.** Across
+  80 trials with the ruleset demonstrably in context, the source's deferred-
+  simplification marker was written **once**. → no marker convention ships in
+  this roadmap; it is a gated follow-up with a kill condition.
+- **F3 — Advertised vs. independently measured effect.** Source's own run: −54 %
+  lines (mean, hand-picked over-build-trap tickets, n=4). Independent run on 80
+  tasks nobody chose for the purpose: **−15.4 % code (p=0.088), −10.3 % cost
+  (p=0.004)**, −31 % on large builds, ≈0 on lean tasks, no detectable quality
+  difference (not powered for equivalence). → thresholds pre-register near the
+  **independent** numbers, never the source's headline.
+- **F4 — Small samples lie in both directions.** The same benchmark's 10-task
+  smoke run showed +9.6 % cost and collapsing quality; the full 80 showed the
+  opposite. → adopt the escalation ladder (self-test → smoke → k=3 → full) and
+  publish **nothing** below full.
+- **F5 — Effect is host-scoped and can invert.** On a terse reasoning model the
+  token effect reverses. → claims stay host-scoped, matching the existing
+  weak-host / strong-host labels.
+- **F6 — Seven words nearly match the whole artefact, until safety.** A
+  seven-word critic prompt beat the source on its own (flawed) single-shot
+  benchmark, and in the agentic rebuild was cheap, erratic on size, and **the
+  only arm that dropped a safety guard** — the ~3 lines it saved were a
+  path-traversal check. → the benchmark **must** carry a bare-principle arm, or
+  the floors' contribution is asserted rather than measured. And a size metric is
+  never a scored target.
+- **F7 — The source carries a stale claim surface.** One of its own skill files
+  still renders a retracted scoreboard while its README shows the corrected
+  figure. → every number this roadmap displays renders from a pinned report;
+  hand-typed prose numbers are forbidden.
+- **F8 — Diff size is a proxy, not ground truth** (council round-2 dissent,
+  adopted as a constraint). The ladder enforces a **search discipline**; lines-of-
+  code measures output volume. A run can shrink the diff without anyone having
+  searched for an existing solution. → Phase 3 carries a **search-adherence
+  endpoint** alongside the size endpoint, or it measures the wrong hypothesis.
+- **F9 — Minimalism has a second failure mode, and a size metric rewards it.**
+  Guard-drop (F6) is the first; **golfing** is the second — fewer lines, denser
+  and harder to read. This is measured, not theorised: LLM-generated code is on
+  average shorter but denser, with higher Halstead volume and greater token
+  variety, i.e. higher cognitive load per line. Lines-of-code as the only size
+  metric actively **rewards** that. Cognitive and cyclomatic complexity are
+  established, deterministic, per-stack-tooled instruments in exactly this
+  literature. → the size claim becomes a **metric pair** (Phase 3), and the rule
+  gains a *shape* axis distinct from its *scope* axis (Phase 1). Independent
+  arrival at the same conclusion as F8, from the opposite direction.
+
+## Design constraints
+
+1. **No floor is touched.** The ladder is additive prompt-side discipline that
+   **routes to** `engineering-safety-floor`, `senior-engineering-discipline` and
+   `security-sensitive-stop`. It never restates or weakens them. Disjointness
+   with `minimal-safe-diff` is written down: that rule bounds **which lines
+   change**; this one bounds **how much solution gets built**.
+2. **No effect claim ships before Phase 3 reports.** The rule text may ship as
+   discipline; the number may not.
+3. **All displayed numbers render from a pinned report** (F7).
+4. **License hygiene.** MIT source: mechanisms and structure are borrowed, every
+   line of text is written here, and a credits entry lands in the same change as
+   Phase 1.
+
+## Phase 0 — Verification spikes (read-only, no authoring)
+
+- [ ] **S0.1 Overlap sweep — decides new-rule-vs-extension.** Rung-by-rung grep
+      evidence against `minimal-safe-diff` (+ its mechanics guideline),
+      `senior-engineering-discipline`, `architecture`, `improve-before-implement`,
+      `supply-chain-intake`, `active-remediation`.
+      **The disjointness test** (council-agreed, apply it literally): a rung
+      lands as **new** rule text only if it fires at a *different decision point*
+      than every existing statement (before implementation: "does a cheaper
+      mechanism already do this?" vs. during design: "do not abstract yet"),
+      **and** the existing statement is not merely a weaker phrasing of the same
+      obligation. Any rung failing either half is an **extension** of the
+      colliding artefact, not new prose.
+      *Verify:* a table with one row per rung, a citation per collision, and a
+      per-rung verdict new/extend. A majority-extend outcome re-scopes Phase 1
+      into an edit of the colliding artefacts.
+      **Machine-checked, not just stated:** the sweep's acceptance includes a
+      **routing-collision check** — no two rules/skills colliding on their
+      trigger sets — so disjointness is enforced by a gate rather than asserted
+      in prose. Natural home: the existing skill linter.
+- [ ] **S0.2 Subagent rule-propagation probe.** Two questions, in order: does the
+      host expose a subagent-start event at all, and do this package's rules
+      reach a subagent's context today? One live probe with transcript evidence.
+      *Verify:* yes/no on both, with the transcript committed.
+      **Escape clause:** if the event exists **and** rules do not reach
+      subagents, this is not a step in this roadmap — it affects **every** rule's
+      propagation and leaves as its own change. Record and hand back; do not fix
+      it here.
+- [ ] **S0.3 Harness feasibility + cost sheet.** Can `internal/bench/ab` run
+      arm-isolated headless sessions against a pinned public repo with a
+      per-trial injection audit in **both** directions (treatment trials prove
+      the ruleset reached the model; control trials prove it did not)? Estimate
+      cost per (task × arm × k). **No paid full runs in this phase.**
+      *Verify:* go/no-go plus a cost sheet that the Phase 3 spend authorization
+      can be granted against.
+
+**Exit:** the authoring decision is evidence-backed and the benchmark cost is
+known. **Rollback:** nothing shipped.
+
+## Phase 1 — The ladder, as rule text
+
+Shape decided by S0.1. If new: same projection class as `minimal-safe-diff`, so
+it is always-on where it matters (F1). If extension: the colliding artefacts are
+edited in place and no new file appears.
+
+- [ ] The ordering, in house voice: need-to-exist → reuse-in-repo → stdlib /
+      framework → native platform → installed dependency → smallest working
+      form. Explicitly ordered **after** comprehension — the ladder shortens the
+      solution, never the reading.
+      *Verify:* the text contains no rung that S0.1 marked as an existing
+      statement.
+- [ ] **The shape axis, distinct from the scope axis (F9).** The ladder above is
+      *scope*: must this exist, and can something cheaper serve? The shape axis
+      is: of what must exist, which form carries the least cognitive load —
+      explicitly **not** the fewest keystrokes. Simple is not the same as short:
+      a flat version one line longer beats a dense clever one. This clause is
+      what keeps the smallest-working-form rung honest — a one-liner qualifies
+      only if it is also the *simplest* form, not merely the shortest.
+      *Verify:* the rung text cannot be satisfied by compression alone.
+- [ ] **Principle-precedence table** — the thing every principle collection
+      omits, and the reason they produce contradictory simultaneous instructions:
+      floors win → then explicit user-fenced scope → then shape (simplicity) →
+      then scope (don't build it) → then de-duplication, with the Rule of Three
+      as the de-duplication gate. One table, stated once.
+      *Verify:* every principle named anywhere in the rule appears in the
+      precedence order; a reviewer can resolve any pair from the table alone.
+- [ ] **Rule of Three as the abstraction trigger, and known-constraints-only as
+      the architecture trigger** — no extraction before the third occurrence
+      confirms the pattern; architect for measured constraints (load, latency,
+      team size), never for speculative scale. These give the first and last rung
+      a checkable form instead of a vibe.
+      *Verify:* both triggers are stated as conditions a reviewer can apply.
+- [ ] **Reversibility clause (two-way doors).** The lazy rung is *preferred*
+      where the choice is reversible; a one-way door — public API, DB schema,
+      migration, wire format — always gets the full treatment. Corollary that
+      keeps a later follow-up honest: a deferred-simplification marker is valid
+      only on a **reversible** cut; an irreversible shortcut is not a defer, it
+      is a decision, and it routes to the decision-record surface.
+      *Verify:* the clause names the one-way-door categories explicitly rather
+      than leaving "important" to judgement.
+- [ ] **Interface-surface rationale (Hyrum's Law), one paragraph.** Every
+      observable behaviour eventually becomes a contract somebody depends on, so
+      a smaller surface is fewer accidental contracts. Dual use: it justifies
+      interface minimalism *and* warns the deleter — removing observable
+      behaviour breaks someone.
+      *Verify:* it reads as rationale, not as a new obligation.
+- [ ] **Rewrite-context trigger (second-system effect).** Rewrites, v2s and
+      large refactors are the peak over-build context; add those trigger keywords
+      and one sentence naming the effect.
+      *Verify:* the trigger set includes the rewrite vocabulary.
+- [ ] **Profiler-gated optimization clause.** Performance complexity is a
+      *claim* and needs measurement evidence: no cache, no index, no
+      denormalisation until a profiler says so. This matches the house claims
+      culture exactly rather than importing a new one.
+      *Verify:* the clause demands evidence, not restraint.
+- [ ] Iron-Law block ending in **routing, not restatement**: floors win,
+      invisible cross-cutting controls win, user-fenced scope wins.
+      *Verify:* zero safety-floor files change in the same commit.
+- [ ] A "relationship to existing rules" section written from the S0.1 table.
+      *Verify:* every collision from S0.1 appears with its resolution.
+- [ ] Examples in this repo's own stacks rather than the source's.
+      *Verify:* framework-neutrality lint passes.
+- [ ] Credits entry lands in the same change.
+      *Verify:* the borrow-check / credits gate passes.
+- [ ] **No effect claim anywhere in this phase.**
+      *Verify:* grep the diff for a percentage; there must be none.
+
+## Phase 2 — Over-build review lens
+
+- [ ] A deletion-hunting review lens with a terse tag grammar — delete · stdlib ·
+      native · yagni · shrink · **flatten** — one line per finding, a
+      net-lines-removable summary, and a **mandatory honest-null output** when
+      there is nothing to cut. `flatten:` is the shape-axis inverse of `shrink:`
+      (F9): same logic, simpler form, **even when that costs a line or two**.
+      Without it the lens only ever argues downward and becomes a golfing engine.
+      *Verify:* the scope fence is explicit — correctness, security and
+      performance are **out of scope** for this lens and route to the normal
+      review pass; the minimum runnable check is never flagged for deletion. A
+      fixture where the simpler form is *longer* must produce `flatten:`, not
+      silence.
+- [ ] **Every `delete:` finding carries a mandatory fence line** (Chesterton's
+      Fence). Agents are documented as especially fence-blind: they see complex
+      code and want to simplify it, when the complexity may exist for a reason
+      they have no context for. The line states **why the code existed** —
+      blame, tests, issue archaeology — and the **evidence that removal is
+      safe**. This operationalises `minimal-safe-diff`'s existing "never delete
+      code that *looks* dead without proof" clause inside the lens; it does not
+      restate it.
+      *Verify:* a `delete:` finding without a fence line is rejected by the
+      lens's own output contract, and a fixture whose complexity has a
+      non-obvious reason must survive the lens.
+- [ ] **Test coverage of the deleted path is the deterministic fence signal**
+      (Beyoncé rule: if you liked it, put a test on it). Deleting *tested*
+      behaviour trips a test and is visible; deleting *untested* behaviour breaks
+      silently. So the fence line records whether the removed path was covered —
+      the one machine-checkable input to an otherwise archaeological judgement.
+      *Verify:* the fence line has a coverage field, and an uncovered deletion is
+      surfaced as higher-risk rather than treated as equivalent.
+- [ ] Golden-set gate: ≥3 seeded over-built fixtures where the lens must find
+      the plant, **plus ≥1 deliberately lean fixture where it must emit the null
+      instead of inventing a finding.** The lean fixture is the gate — a lens
+      that cannot say "nothing to cut" is a finding generator.
+      *Verify:* the lean-fixture case fails the build if the lens invents a
+      finding.
+
+## Phase 3 — Pinned public-repo benchmark (the proof exhibit)
+
+Blocked on `benchmark-spend-authorization` (needs the S0.3 cost sheet) and on
+the standing model-id verification blocker.
+
+- [ ] **Repo:** one public OSS repo pinned at a SHA. A second repo on this
+      package's home stack is optional and cost-gated.
+      *Verify:* the SHA is recorded in the pinned report.
+- [ ] **Tasks:** deliberately mixed — over-build-trap tickets **and** irreducible
+      CRUD **and** this package's own discipline family — so the report can show
+      where the effect lives and where it is honestly zero.
+      *Verify:* the per-task table shows both.
+- [ ] **Arms:** vanilla · package (ladder off) · package + ladder ·
+      **bare-principle control** (the seven-word prompt, F6 — isolates what the
+      routed floors add over the naked principle; its safety-tier result is the
+      exhibit for why the floors exist) · inert-prose placebo.
+      *Verify:* per-trial injection audit in both directions for every arm.
+- [ ] **Endpoints:** added lines from `git diff`; tokens as the **sum** of
+      input + cache + output (a metric mismatch here is the known reporting
+      trap); cost; wall-clock; the existing discipline rubric; a **safety tier**
+      (adversarial-input execution on surgical tasks); and — per F8 — a
+      **search-adherence endpoint**: did the run demonstrably consider a cheaper
+      existing mechanism before writing new code (rubric-judged, k=2)?
+      *Verify:* the search-adherence endpoint is defined and pre-registered
+      before the first paid run; a size-only report does not satisfy this step.
+- [ ] **Hygiene:** escalation ladder self-test → 10-task smoke → k=3 → full,
+      **publishing nothing below full** (F4); paired non-parametric tests;
+      errored pairs dropped from both arms.
+      *Verify:* the report states which tier it is from.
+- [ ] **Reproducibility deliverables, first-class not afterthoughts:** a no-API
+      `--selftest` entry point, the pinned SHA, preserved per-run workspaces for
+      offline re-scoring, and a one-page reproduce doc. The record shows the
+      harshest critic becomes the most-cited validator once handed the
+      reproduction path.
+      *Verify:* `--selftest` runs green with no network and no key.
+- [ ] **The size claim is a metric PAIR, not a single number (F9).** The ladder
+      arm must lower added lines **without raising median cognitive complexity
+      per changed function**. Lines down **and** complexity up is golfing, and it
+      **fails the size criterion** even at p<0.05 on lines alone. Cognitive
+      complexity is computed deterministically per stack by mature tooling, needs
+      no model call, and — because the per-run workspaces are preserved — can be
+      **retro-fitted onto already-completed runs** via offline re-scoring. The
+      anti-golfing gate therefore costs almost nothing to add.
+      *Verify:* the scorer refuses to report a size win when the complexity arm
+      regressed; prove it by feeding it a deliberately golfed fixture.
+- [ ] **Pre-registered thresholds (F3-calibrated, weak-host arm):** ladder arm
+      vs. package arm — median added lines ≤ **−10 %** at p<0.05, **and** no
+      significant rise in median cognitive complexity per changed function,
+      **and** no significant regression on the discipline rubric, the safety
+      tier, or the search-adherence endpoint → the ladder graduates to
+      default-on. Miss any one → it stays opt-in and the null is published with
+      the same honesty labels the existing nulls carry.
+      *Verify:* thresholds are committed before the full run.
+- [ ] **Goodhart guard (hard, applies to any competitive setup, agent or human):**
+      a size metric is a **measurement**, never a **scored target**. The safety
+      tier is a disqualifier, not a side metric: an arm that saves a line and
+      drops a guard has lost, not won (F6).
+      *Verify:* the scoring code cannot rank an arm above another on size alone
+      when its safety tier regressed.
+
+## The principle-admission gate (this table is the scope boundary)
+
+A minimalism rule attracts principles. Collecting them is how it becomes the
+principle soup it exists to replace, so admission is a test, not a preference:
+**a disjoint axis** (not already carried by scope, shape, or the floors)
+**+ measurable or machine-checkable + maps onto infrastructure that already
+exists here.**
+
+Six admissions are folded into Phases 1–3 above: the fence and the coverage
+signal (deletion side), reversibility (decision weight), the interface-surface
+rationale, the rewrite-context trigger, and the profiler clause. A seventh —
+**Gall's Law** (a working complex system evolves from a working simple one, never
+from a designed-complex one) — passed the test as *rationale* but its only
+landing site is the thinnest-vertical-slice argument in the **parked** product
+vertical, so it is admitted and parked with its phase rather than smuggled into
+the engineering rule where it has no work to do.
+
+Everything below was tested and **rejected**, with the reason, so it does not
+come back as a suggestion:
+
+| Rejected | Why |
+|---|---|
+| **Boy Scout Rule** ("leave the code better than you found it") | An **anti-borrow**, and the most interesting result of the sweep: excellent for humans, and in agent hands it is *institutionalised scope creep*. It collides head-on with `minimal-safe-diff`'s no-drive-by-edits rule. |
+| Occam's razor · not-invented-here avoidance · Muntzing | Restatements of ladder rungs already in Phase 1. |
+| Principle of least astonishment · CUPID · "write idiomatic code" | Already carried by `standards-from-config` plus house conventions. |
+| Postel's Law ("be liberal in what you accept") | Modern security guidance **inverts** it — be strict in what you accept. Admitting it would fight the floors. |
+| SOLID · Law of Demeter, as rules | Per-principle injection is rejected outright (see non-goals); these are linter territory, not rule text. |
+| Worse-is-better · Wirth's law · "grug-brained developer" | Philosophy and culture, not checkable. The last is licensed as *tone* material for a future review persona and nothing more. |
+
+**Closure:** every direction of the minimalism space now has a named guard and
+each guard has a check — under-building → floors + safety tier; over-building →
+scope ladder + added lines; over-dense building → shape axis + cognitive
+complexity; wrong deletion → fence + coverage signal; irreversible shortcut →
+reversibility clause + decision-record routing; rewrite euphoria →
+second-system trigger. Further principles enter only through the test above.
+
+The next candidate axis, if one is ever wanted, is **duplication as a measured
+endpoint** (a copy-paste detector rather than a DRY slogan) — and it is
+explicitly not to be touched before Phase 3 has run, because adding a fourth
+axis to an unmeasured rule is the planning-instead-of-executing failure this
+whole roadmap argues against.
+
+## Gated follow-ups (not open work — do not start these)
+
+Named here so the information is not lost, each with the condition that un-parks
+it. None is a step in this roadmap.
+
+- **Deferred-simplification marker, enforce-or-kill.** Un-parks only after
+  Phase 3, whose transcripts are the free adherence sample. Pre-registered kill
+  condition: marker adherence below a threshold materially better than the
+  independently measured 1-in-80 means prompt-side paperwork does not happen —
+  publish that number and ship the convention as human/reviewer tooling only.
+  A deterministic pattern detector is a further spike behind its own precision
+  gate, and a per-project allowlist is load-bearing: a nudge tool without a
+  false-positive escape hatch trains users to ignore it. If that detector is ever
+  built, its **strongest signal is a cognitive-complexity threshold** — the one
+  part of over-build detection that needs no heuristic at all, because the
+  per-stack tooling is mature and deterministic. Heuristic shapes
+  (single-implementation interface, config key nobody reads, wrapper that only
+  delegates, dead flag) rank below it, not above.
+- **Adoption exhibit.** Un-parks on Phase 3 passing. It does **not** get its own
+  roadmap — the transcript pair and the rendered artefact belong to
+  [`road-to-adoption-without-narrative-debt`](road-to-adoption-without-narrative-debt.md),
+  whose distribution steps are already open. The framing recorded from the
+  sources: the ecosystem's second-most-upvoted unanswered question is "how are
+  you testing skills / ensuring quality?", and this package is the answer by
+  existing — so the percentage is supporting evidence, never the headline.
+- **Benchmark-obsolescence lifecycle** —
+  [`later/road-to-benchmark-obsolescence-lifecycle`](later/road-to-benchmark-obsolescence-lifecycle.md).
+
+## Non-goals (decided, with reasons)
+
+- **Runtime intensity levels / statusline / mode flag file.** A writable runtime
+  state surface contradicts the machine-checked zero-runtime-daemon posture; the
+  install-time discipline profile already covers the knob. Revisit only if a user
+  asks.
+- **Host-adapter breadth race.** Every extra adapter is standing drift debt.
+  Demand-driven only — the ladder's own first rung applies to this roadmap.
+- **Product / PO vertical pilot.** The artifact-creation pattern does generalize
+  (does it need to exist → does it already exist → does a standard mechanism
+  cover it → thinnest form → full build), and the story-shaped anti-patterns are
+  real. But a second vertical before the engineering one has any result is
+  exactly the speculative breadth the first rung forbids — and its evidence class
+  is weaker (rubric, not diff: story counts are gameable proxies). Un-parks on a
+  published Phase 3 result, and its floors would have to be re-derived per
+  domain, never copied from the engineering list.
+- **Adversarial builder/deleter pairing and Council minimalism seat.** Same
+  speculative-breadth reason, plus the standing Team-Mode Δ=0 null: multi-agent
+  setups do not automatically beat a single agent with a good rule. If ever
+  revisited, it must be **asymmetric** (a review pass, not a second builder) and
+  clear a **cost-normalised** gate against the plain ladder arm. Symmetric
+  builder-vs-builder competition is rejected outright: it doubles build cost
+  against prior evidence.
+- **A separate shape rule, or a skill per principle.** KISS does **not** get its
+  own rule — it enters as the shape clause plus the precedence table inside the
+  one rule, because the whole failure mode being avoided is parallel principles
+  with no resolution order. One collection in the wild ships a separate skill
+  for each of KISS, DRY, SOLID, YAGNI, Law of Demeter, Boy Scout and more. Two
+  reasons that is the wrong shape, not merely a different one: the principles
+  **overlap**, so parallel injection with no precedence rule produces
+  contradictory simultaneous instructions; and **none of them publishes an
+  evaluation result**, so the breadth is unfalsifiable. One rule, two axes, one
+  precedence table — and the admission gate above keeps it that way.
+- **Copying the source's benchmark statistics.** n=4 means on hand-picked
+  tickets is below this package's bar. The setup is borrowed; the statistics stay
+  the existing harness's.
+- **Uninstall-completeness audit.** A real hygiene question raised by the same
+  source (does uninstall remove state written outside the package dir, and only
+  when it provably points at our own script?) but unrelated to minimalism.
+  Recorded here, owned nowhere yet — it is not scope for this roadmap.
+
+## Acceptance criteria
+
+- [ ] S0.1 produced a rung-by-rung table and the new-vs-extend decision follows
+      the stated disjointness test, not preference.
+- [ ] S0.2 answered both questions with committed transcript evidence, and any
+      real subagent-propagation gap left as its own change rather than being
+      fixed here.
+- [ ] The ladder ships as projected rule text (never a description-triggered
+      skill), carrying **both axes** and the precedence table, with floors
+      routed, zero safety-floor files touched, credits landed, and no effect
+      claim anywhere.
+- [ ] The review lens passes its golden set **including** the lean fixture where
+      it must emit the null and the fixture where the simpler form is longer, and
+      no `delete:` finding can be emitted without its fence line.
+- [ ] Phase 3 either reports from the full tier with every pre-registered
+      endpoint — added lines **paired** with cognitive complexity, plus
+      search-adherence and the safety tier — or publishes the null; no number
+      appears anywhere except rendered from the pinned report.
+- [ ] The scorer demonstrably refuses a size win that came with a complexity
+      regression (proven on a golfed fixture, not asserted).
+- [ ] All quality gates pass — see `quality-tools`.

--- a/agents/settings/contexts/elder-ponytail-harvest-cut.md
+++ b/agents/settings/contexts/elder-ponytail-harvest-cut.md
@@ -29,13 +29,41 @@ unrelated roadmap's S0.1 step; no roadmap follows from it.
    guessed at a differently-named file). It strips the **invisible** class
    (bidi, zero-width, Unicode-Tag, deprecated-format — codepoint classes shared
    with `lint_hidden_unicode._classify`) plus C0/C1 controls, and caps fields at
-   8192 chars, on the `retrieve_v1` / `memory_get_v1` read surfaces. Its header
-   records a **deliberate** decision not to rewrite visible text, because that
-   would corrupt legitimate rule bodies and code snippets.
-   → invisible layer already covered at runtime; **visible layer
-   (homoglyph/confusable, math-alphanumeric, full-width, punycode) is not, by
-   design**. That design tension — normalise vs. corrupt — is the real question,
-   not "is there a sanitizer".
+   8192 chars. Its header records a **deliberate** decision not to rewrite
+   visible text, because that would corrupt legitimate rule bodies and code
+   snippets.
+   → the **visible layer** (homoglyph/confusable, math-alphanumeric,
+   full-width, punycode) is not covered, by design. That design tension —
+   normalise vs. corrupt — is a real question.
+
+   **1b. CORRECTION to my own first pass, and the more severe finding.** The
+   sentence above originally continued "…on the `retrieve_v1` / `memory_get_v1`
+   read surfaces", because that is what the sanitizer's header prose says. Read
+   as fact, it is exactly the error this whole harvest is about. Measured
+   instead:
+   - `retrieve_v1` and `memory_get_v1` are defined in `memory_lookup.ts`, and
+     **`memory_lookup.ts` has zero imports** — it cannot be applying the
+     sanitizer.
+   - `mcp_server/tools.ts` calls `memoryLookup.retrieve_v1(...)` and
+     `memoryLookup.memory_get_v1(...)` **directly**, with no sanitize call in
+     that file.
+   - The sanitizer's only production caller is `second_brain_retrieval.ts`.
+   - `tests/scripts/consumer_flow_wiring.test.ts` has a case literally titled
+     "sanitize floor **already applied on the read surface**" — and every
+     assertion in it calls `sanitize_text(...)` on a fixture directly. It proves
+     the **algorithm**; it does not exercise the read surface at all.
+
+   So the honest state is: **the algorithm is proven, its wiring into the
+   primary read path is unasserted and appears absent, and the header claims
+   otherwise.** This is the same class the active gates-that-can-fail work
+   named — proven through an injection seam, unproven at the default entry
+   point — applied to a security floor rather than a lint. It outranks the
+   visible-layer question, because "the invisible layer is already handled at
+   runtime" is only true on the paths that actually call the floor.
+
+   The drafts also named a **second** threat surface which I initially dropped:
+   the **inter-agent / subagent message channel**. It has no sanitizer at all —
+   no `sanitize` call anywhere under the hook or subagent scripts.
 2. **`lint_confusables.ts` + `lint_hidden_unicode.ts` are authoring-time CI
    linters** over `src/{skills,rules,agent-src,domains}/**/*.md`. They protect
    this package's own corpus, not runtime retrieved content. The
@@ -81,11 +109,14 @@ unrelated roadmap's S0.1 step; no roadmap follows from it.
 
 **Three roadmaps land, not six.**
 
-- **`road-to-visible-layer-encoding-hardening`** — absorbs conlang Track A +
+- **`road-to-runtime-encoding-hardening`** — absorbs conlang Track A +
   jailbreak-frontend T1 + the encoding-corpus consolidation. All three address
   one surface: text normalisation before the model reads it. Amendment-shaped:
   the infrastructure and the design decision exist; this closes the visible-layer
   gap against a verified channel taxonomy, with file/network stego scoped out.
+  **Re-scoped after finding 1b** — its first phase now proves the floor runs at
+  all, because the visible-layer question is meaningless on a surface the floor
+  never touches.
 - **`road-to-governance-invariants`** — absorbs the council anti-refusal
   question + the decomposition-laundering question. Both ask the same
   meta-question: *do the governance mechanisms degrade when the violation
@@ -176,6 +207,31 @@ against this package. Both spikes therefore run as falsifications whose expected
 outcome is a publishable null, and the roadmap says so up front rather than
 implying a known vulnerability.
 
+### Considered and deliberately left with no roadmap home
+
+Recorded so a later reader can tell "we decided against it" from "we missed it":
+
+- **A leaked host system prompt** from the same sweep. Useful only to understand
+  which host prompt these projections run *alongside* — but it is an unverified
+  leak, so nothing here may be hard-coded against it. Reference, never a
+  dependency.
+- **A Selenium-driven red-team harness** (permissively licensed, so no copyleft
+  obstacle) — but it drives a vendor chat UI and is stale; the technique does not
+  align with this package's bench. No adoption.
+- **A leaderboard/consensus mechanic** from the same author set: it is the
+  concrete implementation of the telemetry/leaderboard pattern the abliteration
+  draft already proposed and the council already rejected. Cross-reference only;
+  a separate roadmap would be duplicate planning twice over.
+- **Off-domain repos** in the sweep (image watermarking, personal projects): not
+  package-relevant. One of them is interesting to the maintainer personally and
+  is noted as such, not as work.
+- **A stale council question** about an unrelated roadmap's S0.1 disposition.
+  Verified closed: that roadmap is archived, with its commit stating the QA
+  matrix was recorded at closure. No action — checked, not assumed.
+- **A local benchmark artefact directory** left in the inbox (probe and question
+  YAMLs plus a run detail file). Not feedback prose; left where it was rather
+  than swept, since only the named feedback files were consumed.
+
 ### Also recorded from the sources (no build attached)
 
 - The highest-quality repo in the adversarial set independently ships this
@@ -261,6 +317,6 @@ rounds violate the first rung. Folded in directly, recorded here:
 
 ## See also
 
-- [`road-to-visible-layer-encoding-hardening`](../../roadmaps/road-to-visible-layer-encoding-hardening.md)
+- [`road-to-runtime-encoding-hardening`](../../roadmaps/road-to-runtime-encoding-hardening.md)
 - [`road-to-governance-invariants`](../../roadmaps/road-to-governance-invariants.md)
 - [`road-to-solution-minimalism`](../../roadmaps/road-to-solution-minimalism.md)

--- a/agents/settings/contexts/elder-ponytail-harvest-cut.md
+++ b/agents/settings/contexts/elder-ponytail-harvest-cut.md
@@ -1,0 +1,266 @@
+# Elder / ponytail harvest — the roadmap cut (2026-07-29)
+
+> Durable record of the council convergence that turned **six externally-drafted
+> roadmaps into three**, plus the rejected items and the verified findings that
+> falsified several drafts' premises. Cite this file, not the transient inbox
+> files or the council response directory.
+
+## What was analysed
+
+Five substantive external analyses arrived as inbox files, each carrying a
+finished `road-to-*` draft written by an assistant that **did not have this
+repo's source in context** (every "AC today" cell self-labelled `UNVERIFIED` /
+`[ASSUMED]`):
+
+| Source | Draft proposed | License posture |
+|---|---|---|
+| A conlang / xenolinguistics engine | `road-to-adversarial-conlang` (Track A hardening + Track B token-efficiency reject) | AGPL — threat spec only, never vendored |
+| A jailbreak chat frontend | `road-to-adversarial-input-hardening` (T1 canonicalization · T2 override-quarantine · **T3 council anti-refusal** · T5 marker preservation · T4/T6 expected null) | AGPL — threat spec only |
+| An abliteration toolkit | `road-to-adoption-signal` (telemetry · onboarding ladder · license note · "post the announcement") | AGPL — threat spec only |
+| A 45-repo sweep of the same author (multi-agent red-team platform + two stego/transform suites) | `road-to-swarm-resistant-enforcement` (**P0-S1 decomposition laundering**) + `road-to-encoding-corpus-consolidation` (self-labelled amendment) | AGPL — threat spec only |
+| A minimalism coding skill (MIT, ~90k★) + an independent third-party A/B benchmark + a seven-word critic prompt | `road-to-solution-minimalism` (9 phases) | MIT — mechanisms borrowed, own text, CREDITS entry required |
+
+A sixth file was a stale council question from a prior session about an
+unrelated roadmap's S0.1 step; no roadmap follows from it.
+
+## Verified findings that override the drafts (measured in-tree 2026-07-29)
+
+1. **`src/scripts/_lib/retrieval_sanitize.ts` exists** (71 LOC; the drafts
+   guessed at a differently-named file). It strips the **invisible** class
+   (bidi, zero-width, Unicode-Tag, deprecated-format — codepoint classes shared
+   with `lint_hidden_unicode._classify`) plus C0/C1 controls, and caps fields at
+   8192 chars, on the `retrieve_v1` / `memory_get_v1` read surfaces. Its header
+   records a **deliberate** decision not to rewrite visible text, because that
+   would corrupt legitimate rule bodies and code snippets.
+   → invisible layer already covered at runtime; **visible layer
+   (homoglyph/confusable, math-alphanumeric, full-width, punycode) is not, by
+   design**. That design tension — normalise vs. corrupt — is the real question,
+   not "is there a sanitizer".
+2. **`lint_confusables.ts` + `lint_hidden_unicode.ts` are authoring-time CI
+   linters** over `src/{skills,rules,agent-src,domains}/**/*.md`. They protect
+   this package's own corpus, not runtime retrieved content. The
+   injection-defense pressure corpus already shipped.
+3. **This package's rules are prompt-side prose read by a model, not a
+   deterministic string matcher.** "Obfuscation evades the Iron-Law keyword
+   check" therefore mostly has **no target**. The deterministic matchers that do
+   exist are the hooks (e.g. the `--no-verify` PreToolUse guard) and the lint
+   scripts — a far smaller, concrete surface than the drafts assume. This single
+   finding is what killed the largest slice of the drafted work.
+4. **`hooks/hooks.json` dispatches exactly six events**: SessionStart,
+   SessionEnd, Stop, UserPromptSubmit, PreToolUse, PostToolUse. No
+   SubagentStart/SubagentStop entry exists anywhere in `src/`. Whether the host
+   exposes such an event is itself unverified.
+5. **The license is already MIT** — the drafted AGPL→permissive relicensing
+   side-note is moot.
+6. **`.github/FUNDING.yml` does not exist**, while the maintainer's stated
+   monetisation decision is donation-only (no paid tier, no dual-licensing).
+7. **`src/scripts/adoption_snapshot.ts` already exists** with a pinned contract
+   (`docs/contracts/adoption-signal-floor.md`): npm installs, version
+   distribution, stars/forks, topic-search rank → dated JSONL. The drafted
+   "passive-signal audit" is already built.
+8. **`road-to-adoption-without-narrative-debt.md` is active** and already
+   carries the open steps "publish ONE launch story built entirely on
+   reproducible artifacts", "submit to the third-party surfaces the competitors
+   appear in", and a human-gated step needing a real external person. The
+   abliteration draft's load-bearing action ("post the announcement") is a
+   **duplicate of an already-open step**, not a new finding.
+9. **The council aggregation surface is real and testable**: `chairman.ts`,
+   `consensus.ts`, `stance_tally.ts`, `confidence_gate.ts`, `blind_review.ts`,
+   `debate_gates.ts`.
+10. **Over-building coverage is partial, not absent** (the minimalism draft
+    claimed "no equivalent"): `minimal-safe-diff-mechanics` § Anti-over-engineering
+    already states "three similar lines beat a premature abstraction" and "no
+    speculative features"; `improve-before-implement` already carries a demand
+    gate ("should this exist?"). What is genuinely absent is the
+    **reuse → stdlib → native-platform → dependency ordering** and any
+    deletion-hunting review lens.
+11. `internal/bench/ab` exists (fixture-based, placebo arm) — a public-repo
+    agentic benchmark is an extension of it, not new infrastructure.
+
+## Council convergence (2 members × 2 rounds, $0.11)
+
+**Three roadmaps land, not six.**
+
+- **`road-to-visible-layer-encoding-hardening`** — absorbs conlang Track A +
+  jailbreak-frontend T1 + the encoding-corpus consolidation. All three address
+  one surface: text normalisation before the model reads it. Amendment-shaped:
+  the infrastructure and the design decision exist; this closes the visible-layer
+  gap against a verified channel taxonomy, with file/network stego scoped out.
+- **`road-to-governance-invariants`** — absorbs the council anti-refusal
+  question + the decomposition-laundering question. Both ask the same
+  meta-question: *do the governance mechanisms degrade when the violation
+  becomes indirect?* Merged because finding 3 makes them share one failure mode
+  (model reasoning under indirection), so they need the same mitigation class,
+  not separate lifecycles.
+- **`road-to-solution-minimalism`** — the minimalism borrow, truncated to the
+  falsifiable engineering vertical (ladder rule → over-build review lens →
+  public-repo benchmark).
+
+**Rejected outright** (do not re-open without new evidence):
+
+- **Conlang token-efficiency track** — pre-registered as a reject by its own
+  author; a novel-orthography vocabulary fragments toward byte level in a
+  tokenizer aligned to English/code, and the ~8k-token teaching artefact has no
+  break-even when the per-message saving is negative. Direction of the idea is
+  wrong, not merely unproven.
+- **The whole adoption-signal draft** (telemetry endpoint, leaderboard,
+  onboarding ladder, "post the announcement") — findings 7 + 8: the passive
+  signal is built and the load-bearing action is already an open step in an
+  active roadmap. Building instruments for an unmeasured funnel is the known
+  displacement failure.
+- **Override-pattern quarantine** — finding 3: there is no deterministic
+  instruction-channel matcher to quarantine around; the draft assumes an
+  enforcement architecture this package does not have.
+- **Sampling-parameter steering + telemetry-exfiltration differential** —
+  self-labelled "expected null" by the draft.
+- **Runtime intensity levels / statusline / mode flag file** — a writable
+  runtime state surface contradicts the machine-checked zero-runtime-daemon
+  posture; the install-time discipline profile already covers the knob.
+- **Host-adapter breadth race** — every extra adapter is standing drift debt;
+  demand-driven only.
+- **Product-vertical pilot + adversarial builder/deleter pairing + symmetric
+  builder competition** — speculative breadth before the engineering vertical
+  has any result; the symmetric variant additionally contradicts the measured
+  team-mode Δ=0 null. Revisit only on a large cost-normalised win a single
+  review pass cannot explain.
+- **File/network stego channels** (image/audio/PDF/DNS/TCP/metadata) — out of
+  this package's threat model; it governs text, not arbitrary files or packets.
+  Recorded as out so coverage is never over-claimed.
+
+**Not roadmap work** (both members agreed):
+
+- **The SubagentStart finding is a verification task, not a roadmap** — a
+  host-capability probe with a yes/no answer. It rides as one Phase-0 step in
+  the minimalism roadmap and escapes to its own change **only if the event turns
+  out to exist and rules do not reach subagents**, because then it affects every
+  rule, not this borrow.
+- **`.github/FUNDING.yml` is a direct commit, not a plan** — the decision is
+  already made; the gap is execution. It rides as one step in the active
+  adoption roadmap's Phase 0 ("quick wins already verified missing"), with the
+  one thing an agent must not invent named as an open question: whether Sponsors
+  is enabled for the org and what the donation target is.
+
+**Deferred to `later/`** — **`road-to-benchmark-obsolescence-lifecycle`**: the
+lifecycle states (`active → redundant-on-strong-hosts → outgrown → retired`),
+re-run triggers on a staleness window, applied to every benchmark-backed claim.
+Genuine package-wide honesty infrastructure — but building lifecycle machinery
+with N=1 benchmark-backed rule is premature. Un-parks when a second
+benchmark-backed claim ships.
+
+### Residual disagreement (recorded, not papered over)
+
+Round 1 converged 2/2 that the **ladder rule is the highest-value first
+commit**: falsifiable today, verified gap (finding 10), low blast radius, and
+the governance questions are documented adversarial techniques rather than
+observed failures of this package.
+
+Round 2 produced a real rebuttal of that ordering: the governance work's
+infrastructure gap is **smaller** than round 1 claimed (findings 9 + 11 — it
+instruments existing council machinery and adds fixtures to an existing
+harness), and its blast radius is larger (if council selection is steerable
+toward less-safe output, every council-gated decision is compromised).
+
+**Convener's resolution, and why:** the round-1 ordering stands — the ladder is
+the first *authoring* commit — but the rebuttal is folded in as a binding design
+constraint rather than discarded, because its methodological core is correct:
+**diff size is a proxy, not ground truth, for what the ladder actually changes.**
+The ladder enforces a *search discipline*; LOC measures output volume. So the
+minimalism roadmap's benchmark must carry a search-adherence endpoint, not only
+a size endpoint, or it measures the wrong hypothesis. Separately, the governance
+spikes are read-only and zero-dependency, so they do not have to queue behind
+authoring work — they sequence first *inside their own roadmap*.
+
+The honest framing for the governance roadmap, taken from the dissent's own
+"what would change my mind": there is **no observed instance** of either attack
+against this package. Both spikes therefore run as falsifications whose expected
+outcome is a publishable null, and the roadmap says so up front rather than
+implying a known vulnerability.
+
+### Also recorded from the sources (no build attached)
+
+- The highest-quality repo in the adversarial set independently ships this
+  package's own methodology — re-derivable scores, a stable/experimental/roadmap
+  status table, "a claim that can't be reproduced doesn't ship" — paired with a
+  loud mission and thousands of stars. **Convergent validation that the
+  discipline is right, and a reminder that discipline is table-stakes, not a
+  moat.** It re-points at reach, and nothing in these three roadmaps fixes that.
+- The minimalism source carries a **stale claim surface**: one of its own skill
+  files still renders a retracted scoreboard while its README shows the
+  corrected figure. That is exactly the failure class the claims-ledger + pinned
+  report rendering exists to prevent, and it is why every number these roadmaps
+  display must render from a pinned report rather than hand-typed prose.
+- An independent benchmark of the minimalism source measured **zero
+  self-activation** of a description-triggered skill across ten sessions — only
+  hook injection produced any effect. Consequence: the ladder ships as a
+  projected rule, never as a description-triggered skill, or a null would really
+  be an activation failure.
+- The same benchmark measured the source's marker convention being written
+  **once in eighty trials**. Prompt-side paperwork does not happen without a
+  machine backstop.
+- The bare seven-word critic prompt nearly matched the full artefact on size —
+  and was the **only arm that dropped a safety guard** (the lines it saved were
+  a path-traversal check). Consequence: what is worth shipping is not the ladder
+  text but *the ladder with the floors routed*, and the benchmark must include a
+  bare-principle arm so the floors' contribution is measured rather than
+  asserted. A size metric is never a scored target.
+
+## Late arrival — two further research rounds, folded in without a second council
+
+A further inbox file landed **mid-task**, carrying rounds 3 and 4 of the same
+minimalism analysis. It changes **no council decision**: it proposes no new
+roadmap, contradicts no rejection, and enriches exactly one of the three
+roadmaps. Convening a second council for an in-roadmap enrichment would be
+process theater — and the source's own closing advice is that further planning
+rounds violate the first rung. Folded in directly, recorded here:
+
+- **Round 3 (KISS) — the load-bearing addition.** KISS is not YAGNI: YAGNI is
+  the **scope** axis ("must it exist?"), KISS the **shape** axis ("of what must
+  exist, the simplest form"). The drafts covered scope thoroughly and shape
+  barely. That gap matters because minimalism has a **second** failure mode
+  beside dropping a guard: **golfing** — fewer lines, denser, harder to read.
+  It is measured, not theorised (LLM code is shorter but denser, higher Halstead
+  volume), and **a lines-of-code metric actively rewards it**. So the size claim
+  becomes a **metric pair**: lines down *without* median cognitive complexity per
+  changed function going up; lines down + complexity up fails the size criterion
+  outright. Cognitive complexity is deterministic, per-stack tooled, and
+  retro-fittable onto completed runs from preserved workspaces — the anti-golfing
+  gate is nearly free. This arrives **independently at the same conclusion** as
+  the council's round-2 dissent (a size metric is a proxy), from the opposite
+  direction, which is why both are now constraints rather than opinions.
+- **Round 3 also supplies the missing precedence rule:** floors → explicit
+  user-fenced scope → shape → scope → de-duplication, with Rule of Three as the
+  de-duplication gate. Every principle collection in the wild omits this, which
+  is exactly why parallel per-principle injection produces contradictory
+  simultaneous instructions.
+- **Round 4 — the admission gate.** Rather than collecting more principles, the
+  round applied a test (**disjoint axis + measurable + maps onto existing
+  infrastructure**) and admitted six: Chesterton's Fence (the missing *deletion*
+  side — agents are documented as especially fence-blind, so every deletion
+  finding now carries a why-did-this-exist line), the Beyoncé rule (test coverage
+  of the deleted path as the deterministic fence signal), two-way-door
+  reversibility (when laziness is allowed at all — and a deferred cut is valid
+  only on a reversible one, else it is a decision), Hyrum's Law (interface
+  minimalism rationale + deletion caution), the second-system effect (rewrite
+  contexts are peak over-build risk), and profiler-gated optimisation
+  (performance complexity is a claim needing evidence).
+- **Round 4's best result is a rejection.** The **Boy Scout Rule** is an
+  *anti-borrow*: excellent for humans, and in agent hands institutionalised scope
+  creep that collides head-on with `minimal-safe-diff`. Also rejected with
+  reasons recorded so they do not return: Occam / NIH-avoidance / Muntzing
+  (restatements), least-astonishment / CUPID / "idiomatic" (already carried),
+  Postel's Law (inverted by modern security guidance), SOLID / Law of Demeter as
+  rules (linter territory), worse-is-better / Wirth / grug (not checkable; grug
+  licensed as persona *tone* only). **The admission table is now the scope
+  boundary** — further principles enter only through its test.
+- **One process borrow:** a routing-collision check in CI (no two rules/skills
+  colliding on trigger sets) as an acceptance criterion for the overlap sweep, so
+  disjointness is machine-checked rather than asserted in prose.
+- **Next candidate axis, explicitly parked:** duplication as a measured endpoint
+  (a copy-paste detector, not a DRY slogan) — not before the benchmark has run,
+  because a fourth axis on an unmeasured rule is planning instead of executing.
+
+## See also
+
+- [`road-to-visible-layer-encoding-hardening`](../../roadmaps/road-to-visible-layer-encoding-hardening.md)
+- [`road-to-governance-invariants`](../../roadmaps/road-to-governance-invariants.md)
+- [`road-to-solution-minimalism`](../../roadmaps/road-to-solution-minimalism.md)


### PR DESCRIPTION
## What this is

Six externally-drafted `road-to-*` roadmaps arrived as inbox files. Each was
written by an assistant that **did not have this repo's source in context** and
self-labelled every "AC today" cell `UNVERIFIED` / `[ASSUMED]`. This PR converts
them into the minimum honest set: **three roadmaps, one parked, two items
deliberately not roadmapped**, with every rejection recorded and reasoned.

The cut was decided by a council pass (2 members × 2 rounds, $0.11) against
eleven findings measured in-tree, not against the drafts' assumptions.

## The findings that did the work

| Finding | Consequence |
|---|---|
| This package's rules are **prose read by a model, not a deterministic matcher** | Killed the largest slice of the drafted work — "canonicalize before policy matching" has almost no target |
| The runtime sanitize floor's **wiring is unproven where it matters** — `retrieve_v1`/`memory_get_v1` live in a file with zero imports, the MCP layer calls them directly, and the test named "already applied on the read surface" only exercises the algorithm | Became the **first phase** of the encoding roadmap, ahead of the visible-layer question it was originally about |
| The **inter-agent / subagent channel** has no sanitizer at all | Added as a step after the first pass dropped it |
| The **licence is already MIT**; `.github/FUNDING.yml` does not exist | Relicensing question moot; donation path is execution, not planning |
| `adoption_snapshot.ts` + an **active** adoption roadmap already carry the drafted telemetry and "post the announcement" work | Whole adoption-signal draft rejected as duplicate |
| Over-building coverage is **partial, not absent** | The minimalism rule is scoped to the genuinely missing part, and Phase 0 decides new-rule vs extension by a stated disjointness test |

## What lands

- **`road-to-runtime-encoding-hardening`** — prove the floor runs, then close the visible layer it deliberately left open. File/network stego scoped out and recorded as out, so coverage is never over-claimed.
- **`road-to-governance-invariants`** — three read-only spikes: refusal preservation in council aggregation, decomposition laundering, and marker survival through the reply-path condenser. Each pre-registers a **null** as the expected outcome, and the roadmap says up front that no observed failure prompted it.
- **`road-to-solution-minimalism`** — the MIT borrow on **two** axes (scope + shape) because minimalism has two failure modes: a bare seven-word variant of the principle was the only benchmark arm that dropped a safety guard, and LLM output is documented as shorter *but denser*. The size claim is therefore a metric **pair** — lines down without cognitive complexity going up; golfing fails the criterion even at p<0.05 on lines.
- **`later/road-to-benchmark-obsolescence-lifecycle`** — parked. Designing an obsolescence lifecycle at N=1 benchmark-backed claim is the premature abstraction this package forbids.

## What is rejected, on the record

Conlang token-efficiency (wrong direction, not merely unproven) · the entire
adoption-signal draft · override-pattern quarantine (no matcher to quarantine
around) · runtime intensity levels (contradicts the zero-runtime-daemon posture)
· host-adapter breadth · product-vertical pilot and builder/deleter pairing
(speculative breadth before the first vertical has a result) · file/network stego
· the Boy Scout Rule as an **anti-borrow** — excellent for humans, and in agent
hands it licenses exactly the drive-by edits `minimal-safe-diff` forbids.

## Not roadmapped, by council agreement

- The **subagent rule-propagation probe** rides as one Phase-0 step and escapes to its own change only if the event exists *and* rules do not reach subagents.
- The **donation path** rides in the active adoption roadmap's quick-wins phase — with the two facts an agent must not invent (is Sponsors enabled, what is the target) named as open questions for the maintainer.

## Verification

`lint_roadmap_complexity` (16 clean) · `check_no_roadmap_refs` ·
`check_council_references` · `check_references` · `check_md_language` — all green
on this branch. No source, skill, rule or script changed; this is roadmap and
context prose only.

Two honest notes for the reviewer. A further inbox file landed **mid-task**
carrying two more research rounds; it changed no council decision and enriched
one roadmap, so it was folded in without a second council — recorded as such in
the context file. And the second commit **corrects a claim I made in the first**:
I had written the sanitizer's header prose down as verified coverage, which is
precisely the error class this harvest is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
