### PR TITLE
ci(static-checks): fail the build when dist/install drifts from its source

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,9 @@ jobs:
       # The committed dist/install/install.mjs is the raw-source consumer
       # bridge runner (node, no tsx) used by setup.sh. Rebuild it and assert
       # no drift — a stale bundle ships old install behavior to consumers.
+      # Scope note: esbuild only, so this covers install.mjs and NOT the tsc
+      # output in the same directory — that is the static-checks job's
+      # "Committed build output is fresh (dist/install/)" gate.
       - name: Install bundle is fresh (dist/install/install.mjs)
         run: |
           npm run build:install-bundle
@@ -267,6 +270,31 @@ jobs:
       - name: Build (dist/cli + UI bundle)
         # prepack-check asserts the chmod +x hook applied by build:cli.
         run: npm run build --silent
+
+      # dist/install/ is a TRACKED, npm-shipped tree (package.json `files`), and
+      # the build above emits tsc output straight into it — but nothing asserted
+      # the committed output still derives from src/install/. Two drift classes
+      # shipped to consumers before PR #1052 caught them by hand: rule_scope.js
+      # built without the `roles` scope dimension (so the shipped build ignored
+      # `rule_roles` while the source honoured it), and three sources
+      # (agentSwitchDetection, agentSwitchProfile, wizardDismissals) with no
+      # compiled counterpart at all.
+      #
+      # Neither was visible: the sibling "Install bundle is fresh" gate in
+      # install-aux-tests rebuilds only install.mjs via esbuild, so it never
+      # exercises the tsc side, and node-tests runs build:cli without asserting
+      # drift. `--porcelain` over `git diff --exit-code` on purpose — diff sees
+      # modified files only, and MISSING output is untracked, not modified.
+      # Free ride: this reuses the build already run above, no extra compile.
+      - name: Committed build output is fresh (dist/install/)
+        run: |
+          drift="$(git status --porcelain -- dist/install/)"
+          if [ -n "$drift" ]; then
+            echo "::error::dist/install/ no longer derives from src/install/. Run 'npm run build:cli' and commit the result."
+            echo "$drift"
+            git --no-pager diff -- dist/install/
+            exit 1
+          fi
 
       - name: prepack-check (compiled bin shape + shipped-import completeness)
         # Dry-run of the publish gate on every PR: also asserts every relative


### PR DESCRIPTION
Follow-up to #1052, which fixed the drift by hand and left the gate open.

## Why nothing caught it

`dist/install/` is a tracked, npm-shipped tree (`package.json` `files`) that `npm run build` emits tsc output into. No gate asserted the committed output still derives from `src/install/`:

- ***Install bundle is fresh* (`install-aux-tests`)** rebuilds only `install.mjs` via esbuild before its `git diff --exit-code -- dist/install/`. The path filter looks whole-directory, but the rebuild never touches the tsc side, so stale `.js` there always passed.
- **`node-tests`** runs `build:cli` and asserts nothing.
- **`git diff` cannot see the second class at all.** Missing output is *untracked*, not modified — which is exactly why three modules with no compiled counterpart stayed invisible for weeks.

## The gate

One step in `static-checks`, immediately after that job's existing `npm run build`:

```yaml
- name: Committed build output is fresh (dist/install/)
  run: |
    drift="$(git status --porcelain -- dist/install/)"
    if [ -n "$drift" ]; then
      echo "::error::dist/install/ no longer derives from src/install/. Run 'npm run build:cli' and commit the result."
      echo "$drift"
      git --no-pager diff -- dist/install/
      exit 1
    fi
```

- **`--porcelain`, not `--exit-code`** — catches modified *and* untracked, i.e. both drift classes.
- **Placement is free** — reuses the compile `static-checks` already runs, so no added CI minutes. Ubuntu-only matches that job's stated purpose for OS-independent whole-tree gates.
- Also added a scope note to the `install-aux-tests` comment so it stops reading like whole-directory coverage.

## Verification

Run against a real `npm run build:cli` in a clean worktree off `main`:

| Case | Expected | Result |
|---|---|---|
| Synced tree | green | green |
| Tracked artefact modified (the `rule_scope.js` class) | red | red, names the file |
| Untracked artefact present (the missing-output class) | red | red, names the file |
| Gitignored `dist/install/*_cli.js` on disk | green | green — no false positive |

Also: `.github/workflows/tests.yml` parses and the `static-checks` step order is as intended; `check_ci_local_parity` green (222 CI gates / 203 local, 20 declared CI-only, 1 local-only — this step invokes no `src/scripts/` gate, so it needs no manifest entry).

`actionlint` is not installed here and is not used by this repo, so the workflow was validated by YAML parse plus direct execution of the step's shell logic in all four states above rather than by a linter.

## Not included

No local `task ci` counterpart. This gate needs an emitting build, which `task ci` deliberately does not run; if you want a pre-push equivalent that is a separate call about pre-push budget.
