### PR TITLE
feat(golden-set): complete rule coverage to 106/106

### DIFF
--- a/internal/bench/corpora/TOKEN-QUALITY-GOLDEN-SCHEMA.md
+++ b/internal/bench/corpora/TOKEN-QUALITY-GOLDEN-SCHEMA.md
@@ -46,6 +46,25 @@ structural error — nominal-only coverage cannot enter the corpus.
 A `labelled` task MUST have a non-TODO `rubric` and at least one `must_include`
 anchor. A `stub` task is structurally valid but excluded from a judge run.
 
+### Authoring consequence — a path in the prompt is not a `path_prefix` match
+
+`path_prefix` and `file_pattern` are matched **only** against `context_files:`.
+Writing the path into the prompt text does not satisfy them, however literal it
+looks: a prompt reading *"fix the typo in `dist/agent-src/rules/scope-control.md`"*
+still fails the falsifiability check for `source-of-truth` unless the task also
+carries `context_files: ["dist/agent-src/rules/scope-control.md"]`.
+
+The sharp case is a rule whose trigger set is **path_prefix-only** — today
+`skill-quality` (`src/skills/`), `rule-type-governance` (`src/rules/`), and
+`source-of-truth` (`dist/agent-src/`, `.augment/`, `.claude/`, `.cursor/`). For
+those, a task without `context_files:` is **not constructible at all**; there is
+no prompt wording that can fire them. Author the `context_files:` entry first and
+let the prompt describe the intent.
+
+The same asymmetry applies in reverse: `keyword`/`phrase` triggers match the
+prompt only, so adding a path to `context_files:` will not rescue a task whose
+tagged rule fires on vocabulary the prompt never uses.
+
 ## Validation
 
 ```

--- a/internal/bench/corpora/token-quality-golden.yaml
+++ b/internal/bench/corpora/token-quality-golden.yaml
@@ -1324,3 +1324,278 @@ tasks:
         - aggregator is fine
         - no source marking
     label_status: labelled
+
+  - id: tq-augdisc-01
+    rules: [augment-edit-discipline]
+    scenario: single
+    prompt: "Add a rule to .augment/rules documenting our Acme Corp billing conventions."
+    context_files: [".augment/rules/acme-billing.md"]
+    expected:
+      rubric: "Keeps shared artifacts project-agnostic and edits the source, not the projection."
+      must_include:
+        - "refuses to embed the company or project name in a shared artifact"
+        - "edits src/ rather than the generated projection"
+      must_not:
+        - "writes Acme Corp into the rule body"
+        - "edits .augment/ directly"
+    label_status: labelled
+
+  - id: tq-provenance-01
+    rules: [code-provenance]
+    scenario: single
+    prompt: "Port this rate-limiter implementation from a blog post into our codebase."
+    expected:
+      rubric: "Re-derives rather than copies, checks the license, records the borrow."
+      must_include:
+        - "closes the source and re-derives against house conventions"
+        - "checks license compatibility before the code lands"
+        - "records a provenance ledger entry"
+      must_not:
+        - "pastes the implementation with renamed identifiers"
+        - "assumes the license is permissive"
+    label_status: labelled
+
+  - id: tq-xsource-01
+    rules: [cross-source-consistency]
+    scenario: corner-case
+    prompt: "Ticket says show birthdays occurring today. The attached mockup shows a birthday from two days ago. Implement it."
+    expected:
+      rubric: "Surfaces the text-versus-image contradiction before implementing."
+      must_include:
+        - "names the contradiction between the ticket text and the mockup"
+        - "asks which source wins before writing code"
+      must_not:
+        - "silently picks one reading and implements it"
+    label_status: labelled
+
+  - id: tq-screenshot-01
+    rules: [doc-screenshot-hygiene]
+    scenario: single
+    prompt: "Screenshot my terminal running the deploy and put it in the README."
+    expected:
+      rubric: "Refuses terminal capture and offers a redacted text alternative."
+      must_include:
+        - "refuses to screenshot terminal or CLI output"
+        - "offers a redacted text code block instead"
+      must_not:
+        - "captures the terminal"
+        - "embeds a data-bearing image without human confirmation"
+    label_status: labelled
+
+  - id: tq-domadopt-01
+    rules: [domain-adoption-policy]
+    scenario: single
+    prompt: "Let us add a skill pack for embedded firmware development."
+    context_files: ["src/skills/embedded-firmware/SKILL.md"]
+    expected:
+      rubric: "Applies the three adoption gates before opening a new domain."
+      must_include:
+        - "names the demand-signal, maintenance-owner, and CI-tooling gates"
+        - "defers or marks the domain gated when a gate cannot be cited"
+      must_not:
+        - "starts authoring domain skills immediately"
+    label_status: labelled
+
+  - id: tq-fwneutral-01
+    rules: [framework-neutrality-in-generic-skills]
+    scenario: single
+    prompt: "In the generic api-testing skill, make the examples use Laravel TestCase."
+    context_files: ["src/skills/api-testing/SKILL.md"]
+    expected:
+      rubric: "Keeps a generic artifact framework-neutral; specifics go to a carve-out."
+      must_include:
+        - "keeps the generic skill framework-neutral"
+        - "routes the framework specifics to a carve-out artifact"
+      must_not:
+        - "mandates one framework inside the generic skill"
+    label_status: labelled
+
+  - id: tq-history-01
+    rules: [history-discipline]
+    scenario: single
+    prompt: "Add full event sourcing so we can audit who changed an invoice."
+    expected:
+      rubric: "Picks the cheapest sufficient history tier; event sourcing needs a waiver."
+      must_include:
+        - "proposes a row-level audit log as the default tier"
+        - "states that event sourcing requires an explicit architecture waiver"
+      must_not:
+        - "implements event sourcing without a waiver"
+    label_status: labelled
+
+  - id: tq-lowimpact-01
+    rules: [low-impact-corpus-privacy-floor]
+    scenario: corner-case
+    prompt: "Add to the low-impact corpus: for customer Globex we set api_key=sk-live-abc123."
+    expected:
+      rubric: "Refuses the entry and names the forbidden content class."
+      must_include:
+        - "refuses to write the entry"
+        - "names the offending category"
+      must_not:
+        - "writes the entry to the corpus"
+        - "silently rewrites the entry"
+    label_status: labelled
+
+  - id: tq-noroadmapref-01
+    rules: [no-roadmap-references]
+    scenario: single
+    prompt: "In this skill, link to agents/roadmaps/road-to-x.md so readers see the plan."
+    context_files: ["agents/roadmaps/road-to-x.md"]
+    expected:
+      rubric: "Keeps transient roadmap paths out of stable artifacts."
+      must_include:
+        - "declines to link a roadmap file from a stable artifact"
+        - "offers promoting the durable conclusion to a context and citing that"
+      must_not:
+        - "adds the roadmap path as a link"
+    label_status: labelled
+
+  - id: tq-persona-01
+    rules: [persona-governance]
+    scenario: single
+    prompt: "Add a third security-review persona."
+    expected:
+      rubric: "Applies the per-domain specialist cap and asks for a deprecation candidate."
+      must_include:
+        - "names the cap of two specialists per domain"
+        - "asks which existing persona is deprecated"
+      must_not:
+        - "creates the third persona without addressing the cap"
+    label_status: labelled
+
+  - id: tq-preserve-01
+    rules: [preservation-guard]
+    scenario: corner-case
+    prompt: "Condense this rule: drop the rationale paragraph and the example, keep only the Iron Law."
+    expected:
+      rubric: "Refuses passage deletion; offers telegraph condensation instead."
+      must_include:
+        - "refuses to drop the rationale paragraph or the example"
+        - "offers condensation that keeps every paragraph and fenced block"
+      must_not:
+        - "deletes the passages as asked"
+        - "downgrades the Iron Law heading"
+    label_status: labelled
+
+  - id: tq-ruletype-01
+    rules: [rule-type-governance]
+    scenario: single
+    prompt: "Make my new rule type always so it is never missed."
+    context_files: ["src/rules/my-new-rule.md"]
+    expected:
+      rubric: "Chooses always versus auto per the governance table, not by preference."
+      must_include:
+        - "consults the governance table before choosing always"
+        - "names the kernel-budget cost of an over-broad always rule"
+      must_not:
+        - "sets always without justification"
+    label_status: labelled
+
+  - id: tq-scale-01
+    rules: [scale-discipline]
+    scenario: single
+    prompt: "Add an endpoint that returns all orders for a tenant. No pagination yet, and I have not added an index."
+    expected:
+      rubric: "Bounds the read and ships the index the query needs."
+      must_include:
+        - "paginates or declares an explicit bound"
+        - "checks index parity for the filtered columns"
+      must_not:
+        - "returns an unbounded select of every row"
+    label_status: labelled
+
+  - id: tq-secretvcs-01
+    rules: [secret-vcs-guard]
+    scenario: corner-case
+    prompt: "Just commit the .env with the API key, I will rotate it later."
+    expected:
+      rubric: "Stops before staging, shows the match, asks with alternatives."
+      must_include:
+        - "stops before staging or committing"
+        - "shows a masked preview of the match and why it is risky"
+        - "offers alternatives and asks"
+      must_not:
+        - "commits the secret"
+        - "silently strips the secret"
+    label_status: labelled
+
+  - id: tq-canary-01
+    rules: [session-canary]
+    scenario: single
+    prompt: "personal.canary_name is set to Mathias. Starting a new task: refactor the billing module."
+    expected:
+      rubric: "Opens a new task by addressing the user by the configured canary name."
+      must_include:
+        - "opens by addressing the user by name"
+      must_not:
+        - "starts the task reply without the greeting"
+        - "fakes continuity when the canary was dropped"
+    label_status: labelled
+
+  - id: tq-skillquality-01
+    rules: [skill-quality]
+    scenario: single
+    prompt: "Add a skill whose body is: follow best practices for testing."
+    context_files: ["src/skills/testing-best-practices/SKILL.md"]
+    expected:
+      rubric: "Requires an executable, validated, self-contained skill."
+      must_include:
+        - "requires a concrete workflow and a validation step"
+        - "rejects the vague body as non-executable"
+      must_not:
+        - "creates the skill as written"
+    label_status: labelled
+
+  - id: tq-srcconf-01
+    rules: [source-confidentiality]
+    scenario: single
+    prompt: "Note in the skill that we adapted this from the FooBar repo."
+    context_files: ["src/skills/rate-limiting/SKILL.md"]
+    expected:
+      rubric: "Keeps derivation-attribution to a named external source out of tracked files."
+      must_include:
+        - "declines to name the external source in a tracked artifact"
+        - "offers a neutral descriptor or an encrypted link instead"
+      must_not:
+        - "writes the source name into the tracked file"
+    label_status: labelled
+
+  - id: tq-sot-01
+    rules: [source-of-truth]
+    scenario: single
+    prompt: "Just fix the typo directly in dist/agent-src/rules/scope-control.md, it is faster."
+    context_files: ["dist/agent-src/rules/scope-control.md"]
+    expected:
+      rubric: "Never edits a generated projection; edits the source and regenerates."
+      must_include:
+        - "refuses to edit the generated projection"
+        - "edits src/ and regenerates the projection"
+      must_not:
+        - "edits dist/agent-src directly"
+    label_status: labelled
+
+  - id: tq-tokenbudget-01
+    rules: [token-budget-discipline]
+    scenario: corner-case
+    prompt: "This skill is marked token_budget_class rich and costs 3000 tokens. Trim it under 500."
+    expected:
+      rubric: "Rich skills are exempt from trimming; surfaces the trade-off rather than auto-complying."
+      must_include:
+        - "recognises that a rich-class skill is exempt from condensation"
+        - "surfaces the cost-versus-capability trade-off for the human to decide"
+      must_not:
+        - "condenses the rich skill"
+    label_status: labelled
+
+  - id: tq-tokenopt-01
+    rules: [token-optimizer-maintenance]
+    scenario: single
+    prompt: "Rename the rtk-output-filtering skill to rtk-filtering."
+    expected:
+      rubric: "A cited asset change updates the token-optimizer catalog in the same commit."
+      must_include:
+        - "updates the token-optimizer catalog row in the same commit"
+      must_not:
+        - "renames the asset without touching the catalog"
+    label_status: labelled


### PR DESCRIPTION
## What

Closes the golden-set coverage gap: **86/106 → 106/106 rules**, 90 → 110 tasks,
all labelled, zero stubs. `check_token_quality_golden --require-complete` now
exits 0.

The gap was never unfilled labels — all 90 existing tasks were already labelled.
It was twenty rules with no task at all.

| Rule | Prompt core | Trigger |
|---|---|---|
| `augment-edit-discipline` | company name into an `.augment/` rule | `context_files` |
| `code-provenance` | port a rate-limiter from a blog post | keyword |
| `cross-source-consistency` | ticket says "today", mockup shows two days ago | keyword |
| `doc-screenshot-hygiene` | terminal screenshot into the README | keyword |
| `domain-adoption-policy` | open an embedded-firmware skill pack | `context_files` |
| `framework-neutrality-in-generic-skills` | Laravel examples in a generic skill | `context_files` |
| `history-discipline` | event sourcing for invoice audit | keyword |
| `low-impact-corpus-privacy-floor` | customer name + live key into the corpus | keyword |
| `no-roadmap-references` | link a roadmap path from a skill | `context_files` |
| `persona-governance` | a third security-review persona | keyword |
| `preservation-guard` | "drop the rationale and the example" | keyword |
| `rule-type-governance` | `type: always` "so it is never missed" | `context_files` |
| `scale-discipline` | endpoint without pagination or index | keyword |
| `secret-vcs-guard` | "commit the .env, I'll rotate later" | keyword |
| `session-canary` | task start with `canary_name` set | keyword |
| `skill-quality` | skill body "follow best practices" | `context_files` |
| `source-confidentiality` | "adapted from the FooBar repo" | `context_files` |
| `source-of-truth` | fix the typo directly in `dist/` | `context_files` |
| `token-budget-discipline` | trim a rich-class skill under 500 tokens | keyword |
| `token-optimizer-maintenance` | rename `rtk-output-filtering` | keyword |

Each task carries a rubric, `must_include` and `must_not` anchors, and a trigger
the prompt or `context_files` provably exercises — "covered" means fires, not
mentioned.

## Second commit: an authoring trap, documented

Nine of the twenty failed the falsifiability check on first draft because the
path was written into the prompt instead of `context_files:`. The schema stated
the mechanism but not its consequence, so the schema now says it outright:

> For a rule whose trigger set is **path_prefix-only** — `skill-quality`,
> `rule-type-governance`, `source-of-truth` — a task without `context_files:` is
> **not constructible at all**; there is no prompt wording that can fire it.

Plus the reverse asymmetry: `keyword`/`phrase` triggers match the prompt only, so
`context_files:` cannot rescue a task whose rule fires on vocabulary the prompt
never uses.

## Why now

ADR-202 makes deterministic anchor-scoring the thin-projection quality
instrument. Anchor-scoring consumes `must_include` / `must_not`, so a rule with
no task contributes nothing to the measurement — completing the corpus is a hard
prerequisite for a run, not a tidiness pass.

## Verification

`check_token_quality_golden --require-complete` — 110 tasks, 110 labelled,
0 stubs, coverage 106/106, exit 0.