### PR TITLE
fix(ci): repair the Consistency workflow — a duplicate run: key broke it

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -200,18 +200,7 @@ jobs:
         # `task ci`, which is why a +10.3% eager-rule drift went unseen for 23 days.
         run: task check-token-regression
 
-      - name: Kernel-rule budget (bucket + per-rule caps)
-        # Closes the asymmetry the 2026-07-30 council flagged from both sides:
-        # this gate DECIDES whether kernel rules must be edited, while
-        # `check_safety_floor_untouched` — which BLOCKS those edits — is
-        # CI-enforced. A deciding gate that only ever runs on one contributor's
-        # laptop cannot arbitrate against a gate that runs on every PR.
-        #
-        # WILL FAIL until the kernel-bucket overflow is resolved (27,521/26,000;
-        # non-destructive-by-default 4,770/4,000; verify-before-complete
-        # 2,865/2,500 — both guarded files). Merging this step before that
-        # decision lands turns `main` red on purpose, so it must not merge alone.
-        run: task lint-rule-budget
+      - name: Check kernel-rule bundle (one rule per PR; label override)
         # Phase 4.2 of road-to-always-budget-relief — slow-rollout guarantee.
         # Override: PR label `bundled-always-rules-acknowledged`.
         # actions/checkout@v4 uses a shallow PR-merge fetch, so `git fetch


### PR DESCRIPTION
## main is broken right now

The Consistency run on `main` at 19:54 did not fail on a gate. GitHub reports
**"This run likely failed because of a workflow file issue"** — the workflow file
does not parse.

## What I broke, in #1059

That PR inserted a `Kernel-rule budget` step directly above the kernel-rule-bundle
guard and, in doing so, **dropped that guard's `- name:` line**. The result was a
single step carrying two `run:` keys — the intended `task lint-rule-budget`, then
the bundle guard's script block — with the guard's `if:` and `env:` left hanging
under the wrong name.

Two consequences, both worse than the gate the PR meant to add:

- The **REQUIRED Consistency check is dead on `main`**, and would be dead on every
  branch cut from it.
- **`task lint-rule-budget` never ran at all.** The step's effective `run:` was the
  bundle guard's script, because a later duplicate key wins.

## Why my validation passed anyway

I validated with `yaml.safe_load`, which **tolerates duplicate keys and silently
keeps the last one**. It reported "YAML OK · 35 steps" on a file GitHub Actions
rejects. The step count staying at 35 across an added step was the tell, and I
read past it.

Re-validated here with a duplicate-key-detecting loader:

```
OK — no duplicate keys · steps: 35
bundle guard present: True
budget step present : False
```

## What this changes

The file is restored to its **pre-#1059 state, byte-for-byte** — the bundle guard
gets its name, `if:`, `env:` and script back. The budget step is **removed rather
than repaired**, for two reasons:

1. It is red until the kernel-bucket overflow is resolved (27,521 / 26,000, with
   both over-cap rules guarded by `check_safety_floor_untouched`), so re-landing
   it now would trade a broken workflow for a permanently failing one.
2. #1059 was opened as a **draft marked do-not-merge-alone** precisely because of
   that. Re-landing the wiring belongs with the bucket decision, not before it.

The council's convergence — that the deciding gate should not stay local-only —
still stands and is unaffected by this repair.

## Verification

Duplicate-key loader clean · 35 steps · bundle guard restored · `diff` against the
pre-merge version reports no difference.