### PR TITLE
docs(dedup): close the reachability strand with a maintainer refusal

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,6 +233,9 @@ tasks:
       - task: lint-pack-dependencies
       - task: lint-flows
       - task: lint-originality
+      # Advisory, never fails — it warns when the committed originality report
+      # describes an older corpus. Listed here so the warning is seen, not to
+      # gate on it: that report blocks nothing on its own by design.
       - task: check-originality-freshness
       - task: validate-flow-teams
       - task: lint-command-flow-coverage
@@ -440,6 +443,9 @@ tasks:
       - task: lint-pack-dependencies
       - task: lint-flows
       - task: lint-originality
+      # Advisory, never fails — it warns when the committed originality report
+      # describes an older corpus. Listed here so the warning is seen, not to
+      # gate on it: that report blocks nothing on its own by design.
       - task: check-originality-freshness
       - task: validate-flow-teams
       - task: lint-command-flow-coverage

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,6 +233,7 @@ tasks:
       - task: lint-pack-dependencies
       - task: lint-flows
       - task: lint-originality
+      - task: check-originality-freshness
       - task: validate-flow-teams
       - task: lint-command-flow-coverage
       - task: generate-command-flows-check
@@ -439,6 +440,7 @@ tasks:
       - task: lint-pack-dependencies
       - task: lint-flows
       - task: lint-originality
+      - task: check-originality-freshness
       - task: validate-flow-teams
       - task: lint-command-flow-coverage
       - task: generate-command-flows-check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -233,9 +233,10 @@ tasks:
       - task: lint-pack-dependencies
       - task: lint-flows
       - task: lint-originality
-      # Advisory, never fails — it warns when the committed originality report
-      # describes an older corpus. Listed here so the warning is seen, not to
-      # gate on it: that report blocks nothing on its own by design.
+      # Advisory, never fails, and self-skips on CI — it warns LOCALLY when the
+      # committed originality report describes an older corpus. Listed here so
+      # the warning is seen, not to gate on it: that report blocks nothing on
+      # its own by design, and its bytes are not reproducible across runners.
       - task: check-originality-freshness
       - task: validate-flow-teams
       - task: lint-command-flow-coverage
@@ -443,9 +444,10 @@ tasks:
       - task: lint-pack-dependencies
       - task: lint-flows
       - task: lint-originality
-      # Advisory, never fails — it warns when the committed originality report
-      # describes an older corpus. Listed here so the warning is seen, not to
-      # gate on it: that report blocks nothing on its own by design.
+      # Advisory, never fails, and self-skips on CI — it warns LOCALLY when the
+      # committed originality report describes an older corpus. Listed here so
+      # the warning is seen, not to gate on it: that report blocks nothing on
+      # its own by design, and its bytes are not reproducible across runners.
       - task: check-originality-freshness
       - task: validate-flow-teams
       - task: lint-command-flow-coverage

--- a/agents/roadmaps/archive/road-to-cache-economy.md
+++ b/agents/roadmaps/archive/road-to-cache-economy.md
@@ -450,10 +450,12 @@ governance call, and this claim does not authorise it.
 > different output. Aligning versions yields **0/110** twins, not 110/110,
 > because it only collapses body diffs into provenance diffs. The number stands
 > as measured; what it measures is the mechanism's ceiling under a condition that
-> a follow-up strand (`road-to-dedup-reachability`) must first make real. Do not
-> cite it as a realised saving. Cause and line references:
+> nothing currently makes real — and making it real was **decided against**
+> (2026-07-31), so this is a permanent condition until a reopen fires, not a
+> pending step. Do not cite it as a realised saving. Cause and line references:
 > [`cache-economy-refusals`](../../settings/contexts/cache-economy-refusals.md)
-> § Honest null.
+> § Honest null; the decision and the preserved candidate analysis:
+> [`dedup-reachability-refusal`](../../settings/contexts/dedup-reachability-refusal.md).
 
 ### Measured verdicts — 2026-07-30, host CC 2.1.220
 

--- a/agents/settings/contexts/cache-economy-refusals.md
+++ b/agents/settings/contexts/cache-economy-refusals.md
@@ -112,11 +112,14 @@ measurement (see the disabled thin projection for what the alternative costs).
 A predicate change is a design decision with its own safety argument and its own
 council pass, never a convenience fix applied to reach a target.
 
-Reachability is therefore an **open design question**, not a defect: see
-`road-to-dedup-reachability` for the two candidate mechanisms (predicate
-precision vs. writer convergence). Until one lands, `projection.scope_dedup`
-stays opt-in and inert, and the consumer-default question stays parked rather
-than carried as an open decision.
+Reachability was then **decided, not left open**: both candidate mechanisms
+(predicate precision, writer convergence) were worked out in full and both were
+declined — real safety risk in the install path against a benefit whose recipient
+set is currently empty. See
+[`dedup-reachability-refusal`](dedup-reachability-refusal.md) for the decision,
+the preserved A/B analysis, and the five reopen conditions.
+`projection.scope_dedup` stays opt-in and inert, and the consumer-default
+question stays parked rather than carried as an open decision.
 
 ## What is genuinely ours to fix
 

--- a/agents/settings/contexts/dedup-reachability-refusal.md
+++ b/agents/settings/contexts/dedup-reachability-refusal.md
@@ -1,19 +1,79 @@
----
-complexity: structural
-status: draft
----
+# Dedup reachability — closed with a refusal (2026-07-31)
 
-# Roadmap: Dedup Reachability
+Durable record of a **decided** question: scope de-duplication of the rule
+projection is measured, understood, and **not being made reachable**. Both
+candidate mechanisms were worked out in full and both were declined.
 
-> **Draft, not scheduled.** Held at `status: draft` so the dashboard skips it.
-> It exists because a measured mechanism is currently unreachable, and the
-> reason is a design decision nobody has taken yet — not a bug to fix in
-> passing. Two candidate mechanisms are worked out below to the same depth on
-> purpose: the point of this file is to make the choice, not to advocate one.
+This lives in `contexts/`, not in `agents/roadmaps/archive/`, on purpose: an
+archived roadmap reads as "work that finished", while this is a **standing
+refusal** that later proposals have to argue against. It must stay citable.
+Its sibling is [`cache-economy-refusals`](cache-economy-refusals.md), which
+records the measurements and the honest null this decision rests on.
 
-Source: the honest null recorded in
-[`cache-economy-refusals`](../settings/contexts/cache-economy-refusals.md)
-§ Honest null, 2026-07-31.
+## Decision — reject both. Maintainer verdict, not a council verdict.
+
+**Why it is recorded as the maintainer's, not the council's.** The council pass
+of 2026-07-31 (one round, cap 0.10 USD, actual 0.0357) was **budget-truncated**:
+`claude-sonnet-4-5` answered, `openai/gpt-4o` returned `cost_budget_exceeded`
+with zero tokens — one member, not two. Its verdict was also reject-both, but
+its two headline premises are refuted against this repo's own measurements
+(§ Council pass below): it confused a transport saving with an execution saving,
+and read a quality win-rate as a payload reduction. A verdict resting on refuted
+premises cannot be cited as the reason, even when its conclusion survives. The
+conclusion is therefore carried as a maintainer decision, with the reasoning
+below — which is *not* the council's reasoning.
+
+**The load-bearing reason: real risk against an empty recipient set.**
+
+The risk side of both mechanisms is real and was not talked down:
+
+- **A** carries a cross-parser risk. Excluding the ownership keys schema-exactly
+  turns byte equality into "byte equality modulo a parse", and the parse that
+  matters is the **host's** reader, not ours. Agreement on BOM, CRLF inside
+  frontmatter, block scalars, duplicate keys and key-prefix collisions is not
+  something a property test over our own parser can establish.
+- **B** carries manifest drift (four sub-cases, each able to delete or preserve
+  the wrong file), the rename exhaustion below (path-keyed ownership cannot
+  distinguish "package renamed a rule" from "user authored a matching file"
+  without reintroducing the divergence B exists to remove), and a real migration
+  for every already-stamped installation, with two ownership paths supported for
+  at least one deprecation cycle.
+
+The benefit side currently has an **empty recipient set**. The ≈86.8k tokens per
+spawn are only paid by a **dual-scope** installation — the same rule set present
+at user scope *and* project scope. No external consumer with such an
+installation is known to exist. The one dual-scope machine that does exist is a
+development checkout, and there the dedup is **correctly inert** because the two
+scopes hold different releases.
+
+So the decision is **sequencing, not a judgement on the mechanisms**: neither is
+wrong, both are premature. Nobody is paying the cost the mechanism would remove,
+while both mechanisms would put a real safety risk into the install path today.
+If a consumer with a dual-scope installation appears, this reopens on its merits
+and the work below is waiting.
+
+**What is explicitly NOT done as a consequence:** no change to the byte-identity
+predicate, no change to `install.ts`, no implementation of A or B, no further
+council pass. `projection.scope_dedup` stays shipped-but-opt-in and inert.
+
+## Reopen conditions (all five recorded; any one is enough to reopen)
+
+1. A profile showing rule loading is IO-bound on the duplicate bytes **and**
+   that removing them measurably cuts cold-start time — not just payload size.
+2. Telemetry from a network-constrained consumer where the reduction changes
+   behaviour (adoption, spawn frequency).
+3. A measurement invalidating the quality floor that governs payload-shaping
+   experiments in this suite.
+4. **Perceptibility** — evidence that the saving is user-perceptibly faster,
+   not merely cheaper. A sub-100 ms improvement is not worth either risk.
+5. **≥ 1 external consumer with a demonstrated dual-scope installation** — the
+   condition that closes the empty-recipient-set argument above, and the most
+   likely of the five to fire first.
+
+Reopening means re-deciding A vs B vs reject with the analysis below as the
+starting point. It does **not** mean re-deriving the honest null: the cause is
+settled (see `cache-economy-refusals` § Honest null) and the
+"align the versions" hypothesis is refuted, not open.
 
 ## The problem, stated as measurements
 
@@ -156,9 +216,9 @@ where a stale package file survives silently. Any user-data loss kills B
 outright, no mitigation: a reaper that can eat a user's edited file is worse
 than a dedup that never ships.
 
-## The decision this file exists to make
+## The trade that was weighed
 
-Not "which is nicer" but which trade the maintainer wants:
+Not "which is nicer" but which trade to take — and the answer was neither:
 
 | | A — predicate precision | B — writer convergence |
 |---|---|---|
@@ -169,10 +229,11 @@ Not "which is nicer" but which trade the maintainer wants:
 | Blast radius if wrong | a rule silently missing | user data lost |
 | Effort | small | substantial |
 
-Rejecting both is a legitimate outcome: it means `projection.scope_dedup` stays
-a measured-but-dormant mechanism, the 38.0% stays recorded as a ceiling that was
-never realised, and the honest null above is the end of the strand. That is
-cheaper than either candidate and costs nothing but the saving.
+Both columns cost something real. Neither column has anyone in it yet. That
+asymmetry — not a defect in either design — is what decided it: rejecting both
+leaves `projection.scope_dedup` a measured-but-dormant mechanism and the 38.0% an
+unrealised ceiling, which costs nothing but a saving nobody is currently paying
+for.
 
 ## Council pass — 2026-07-31, one round, cap 0.10 USD (actual 0.0357)
 
@@ -226,7 +287,7 @@ verdict may still be right while its stated reasoning is not:
    written at all, so the preamble carries **one** rule set instead of two. The
    duplication is measured *in the billed write volume*, from transcripts:
    `110 shared filenames, ≈86.8k redundant tokens per spawn, ≈38% of subagent
-   write volume` ([`cache-economy-refusals`](../settings/contexts/cache-economy-refusals.md)).
+   write volume` ([`cache-economy-refusals`](cache-economy-refusals.md)).
    Tokens billed twice today would be billed once. That is not transport.
 2. **"A larger, simpler reduction (36.2%) was already disabled, so 38% is below
    the threshold for mattering."** Two errors in one sentence. 36.2% is a
@@ -252,26 +313,6 @@ consumers, and the store's persistence is fragile where `~/.claude/` is ephemera
 (CI runners, containers) — cases the in-file stamp survives because ownership
 travels with the file. Recorded so it is not re-proposed as new.
 
-## Phase 1 — decide (nothing is implemented before this closes)
-
-- [x] Council pass on this draft, one round, budget cap 0.10 USD, explicit
-      question: **A vs B vs reject both**. Done 2026-07-31 — one member (cap
-      bound the second), verdict reject-both, two headline premises refuted
-      above.
-- [x] Fold the council's objections into this file (not into a separate
-      review artefact), then hand it to the maintainer for the implementation
-      decision. Done — accepted objections tightened A's kill criterion and
-      B's rename cost; rejected premises recorded with their counter-evidence.
-- [ ] Record the decision. Reject-both → this file goes to `skipped/` with the
-      reason; A or B → the chosen candidate's phase below is written out and
-      the file leaves `draft`.
-
-## Phase 2 — implement the chosen candidate (blocked on Phase 1)
-
-- [ ] Written only after Phase 1 closes. Deliberately empty: writing an
-      implementation plan for both candidates before the choice is made is how a
-      draft turns into advocacy for whichever one got written first.
-
 ## Parked decisions
 
 - **Consumer default for `projection.scope_dedup`** — recommendation on record
@@ -279,16 +320,12 @@ travels with the file. Recorded so it is not re-proposed as new.
   `revisit-if`: reachability is established (A or B lands). Until then the
   setting is inert for consumers by construction, so a default-on flip would
   advertise a switch that does nothing and would read as "active" in the census.
-- **Reopen conditions for the strand as a whole** (from the council pass, kept
-  even if reject-both is chosen): a profile showing rule loading is IO-bound on
-  the duplicate bytes *and* that removing them measurably cuts cold-start time;
-  telemetry from a network-constrained consumer where the reduction changes
-  behaviour; or a measurement showing the saving is **user-perceptibly** faster
-  rather than only cheaper. Absent all three, the mechanism stays recorded and
-  dormant.
+- **Reopen conditions for the strand as a whole** — see § Reopen conditions at
+  the top of this file; all five live there so a reader hits them before the
+  analysis, not after.
 
 ## See also
 
-- [`cache-economy-refusals`](../settings/contexts/cache-economy-refusals.md) — the honest null, with line references.
-- [`archive/road-to-cache-economy.md`](archive/road-to-cache-economy.md) — where the 38.0% was measured and pre-registered, now carrying its condition.
+- [`cache-economy-refusals`](cache-economy-refusals.md) — the honest null this decision rests on, with `install.ts` line references.
+- The 38.0% was pre-registered before it was measured, and the archived roadmap that recorded it now carries the fixture condition inline. That roadmap is transient by design, so it is deliberately not linked from here — the durable version of everything it concluded lives in `cache-economy-refusals` above.
 - `src/scripts/measure_scope_dedup.ts` — the live reachability split; run it before trusting any number in this file.

--- a/agents/settings/contexts/dedup-reachability-refusal.md
+++ b/agents/settings/contexts/dedup-reachability-refusal.md
@@ -39,12 +39,18 @@ The risk side of both mechanisms is real and was not talked down:
   for every already-stamped installation, with two ownership paths supported for
   at least one deprecation cycle.
 
-The benefit side currently has an **empty recipient set**. The ≈86.8k tokens per
-spawn are only paid by a **dual-scope** installation — the same rule set present
-at user scope *and* project scope. No external consumer with such an
-installation is known to exist. The one dual-scope machine that does exist is a
-development checkout, and there the dedup is **correctly inert** because the two
-scopes hold different releases.
+The benefit side has **no known recipient**. The ≈86.8k tokens per spawn are only
+paid by a **dual-scope** installation — the same rule set present at user scope
+*and* project scope. No such external consumer is known to exist.
+
+**Stated honestly, because this is an absence claim and absence claims are the
+weakest kind:** we have no consumer telemetry, so "no known recipient" means
+exactly that — not "no recipient exists". What is *measured* rather than assumed
+is the other half: on the one dual-scope machine that does exist (a development
+checkout) the dedup is **correctly inert**, because the two scopes hold different
+releases. So the honest form of the argument is: the cost is real and immediate,
+the benefit is unevidenced, and the cheapest way to settle it is reopen
+condition 5 — a single demonstrated dual-scope consumer flips it.
 
 So the decision is **sequencing, not a judgement on the mechanisms**: neither is
 wrong, both are premature. Nobody is paying the cost the mechanism would remove,
@@ -82,7 +88,7 @@ of the median cold-start payload. It is nonetheless **inert for every consumer**
 
 | measurement | value | how to reproduce |
 |---|---|---|
-| installed rules carrying `package:` / `source_path:` | 110 / 110 | `measure_scope_dedup` § REACHABILITY |
+| installed rules carrying `package:` / `source_path:` | 110 / 110 | `src/scripts/measure_scope_dedup.ts` § REACHABILITY |
 | in-repo project-scope rules carrying the same | 0 / 110 | same |
 | differ only in the ownership stamp | 61 / 110 | same |
 | differ in body **and** stamp | 49 / 110 | same |

--- a/src/scripts/check_originality_freshness.ts
+++ b/src/scripts/check_originality_freshness.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+/**
+ * Freshness check for the committed originality report.
+ *
+ * `agents/reports/originality.{json,md}` is a committed artefact that nothing
+ * regenerates on a schedule, and the report itself "blocks NOTHING on its own" —
+ * so it can drift silently. It did: on 2026-07-31 the committed copy read 507
+ * artifacts while the identical corpus produced 508, meaning it predated an
+ * artefact and nobody noticed.
+ *
+ * This check regenerates the report, compares it against the committed bytes,
+ * restores the committed bytes either way, and **always exits 0**. Warning, not
+ * a gate — the report's non-blocking character is deliberate, and turning a
+ * stale doc into a red build would be a worse trade than a visible warning.
+ *
+ * Restoring is what keeps it safe to run inside a pipeline: the working tree is
+ * byte-identical afterwards, so no later step sees a spurious diff.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { main as runOriginality } from './lint_originality.js';
+
+const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const REPORTS = [
+    path.join(REPO_ROOT, 'agents', 'reports', 'originality.json'),
+    path.join(REPO_ROOT, 'agents', 'reports', 'originality.md'),
+];
+
+/** `null` for a report that is not committed yet — absence is not drift. */
+function snapshot(files: readonly string[]): Map<string, Buffer | null> {
+    const out = new Map<string, Buffer | null>();
+    for (const f of files) {
+        try {
+            out.set(f, fs.readFileSync(f));
+        } catch {
+            out.set(f, null);
+        }
+    }
+    return out;
+}
+
+function restore(before: Map<string, Buffer | null>): void {
+    for (const [f, buf] of before) {
+        if (buf === null) {
+            fs.rmSync(f, { force: true });
+        } else {
+            fs.writeFileSync(f, buf);
+        }
+    }
+}
+
+export function checkFreshness(files: readonly string[] = REPORTS): {
+    drifted: string[];
+    missing: string[];
+} {
+    const before = snapshot(files);
+    try {
+        runOriginality(['--quiet']);
+    } catch {
+        // A sweep that cannot run is not a drift signal; leave the tree as found.
+        restore(before);
+        return { drifted: [], missing: [] };
+    }
+    const drifted: string[] = [];
+    const missing: string[] = [];
+    for (const [f, buf] of before) {
+        let now: Buffer | null;
+        try {
+            now = fs.readFileSync(f);
+        } catch {
+            now = null;
+        }
+        if (buf === null) {
+            if (now !== null) missing.push(f);
+            continue;
+        }
+        if (now === null || !now.equals(buf)) drifted.push(f);
+    }
+    restore(before);
+    return { drifted, missing };
+}
+
+export function main(): number {
+    const { drifted, missing } = checkFreshness();
+    const rel = (f: string): string => path.relative(REPO_ROOT, f);
+
+    if (missing.length > 0) {
+        process.stdout.write(
+            `⚠️  originality report is not committed yet: ${missing.map(rel).join(', ')}\n` +
+                '    Run `./scripts-run src/scripts/lint_originality` and commit the result.\n',
+        );
+    }
+    if (drifted.length === 0 && missing.length === 0) {
+        process.stdout.write('✅  originality report is fresh.\n');
+        return 0;
+    }
+    if (drifted.length > 0) {
+        process.stdout.write(
+            `⚠️  originality report is STALE: ${drifted.map(rel).join(', ')}\n` +
+                '    Regenerating from the current corpus produces different bytes, so the\n' +
+                '    committed numbers describe an older corpus. Not a build failure — this\n' +
+                '    report blocks nothing on its own — but the counts should not be quoted\n' +
+                '    until refreshed: `./scripts-run src/scripts/lint_originality`.\n',
+        );
+    }
+    // Always 0: this is a warning surface by design.
+    return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+    process.exit(main());
+}

--- a/src/scripts/check_originality_freshness.ts
+++ b/src/scripts/check_originality_freshness.ts
@@ -22,7 +22,7 @@ import * as path from 'node:path';
 import { main as runOriginality } from './lint_originality.js';
 
 const REPO_ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
-const REPORTS = [
+export const REPORTS = [
     path.join(REPO_ROOT, 'agents', 'reports', 'originality.json'),
     path.join(REPO_ROOT, 'agents', 'reports', 'originality.md'),
 ];
@@ -66,13 +66,31 @@ function restore(before: Map<string, Buffer | null>): void {
     }
 }
 
-export function checkFreshness(files: readonly string[] = REPORTS): {
+/** Default regeneration: the real sweep, which writes into `REPORTS`. */
+function regenerateReports(): void {
+    runOriginality(['--quiet']);
+}
+
+/**
+ * `regenerate` is injectable for one reason: a test that exercised the drift
+ * path against the real reports would have to write a stale version into a
+ * TRACKED file, and vitest runs suites in parallel — any sibling test asserting
+ * "the working tree is clean" would see that transient write and fail. (It did:
+ * `backfill_model_tier`'s dry-run purity check caught exactly that.) With the
+ * hook, drift and restore behaviour is provable entirely in temp space, and the
+ * real wiring stays covered by the fresh-path test, which is tree-neutral
+ * because rewriting identical bytes is invisible to git.
+ */
+export function checkFreshness(
+    files: readonly string[] = REPORTS,
+    regenerate: () => void = regenerateReports,
+): {
     drifted: string[];
     missing: string[];
 } {
     const before = snapshot(files);
     try {
-        runOriginality(['--quiet']);
+        regenerate();
     } catch {
         // A sweep that cannot run is not a drift signal; leave the tree as found.
         restore(before);

--- a/src/scripts/check_originality_freshness.ts
+++ b/src/scripts/check_originality_freshness.ts
@@ -40,12 +40,28 @@ function snapshot(files: readonly string[]): Map<string, Buffer | null> {
     return out;
 }
 
+/**
+ * Put the committed bytes back. Best-effort per file and never throwing: this
+ * check runs inside pipelines, so a restore failure (read-only mount, a
+ * concurrent writer) must not become the exception that fails the build for an
+ * advisory. A file it could not restore is named loudly instead — that is the
+ * one case where the tree is left dirty, and the reader has to know.
+ */
 function restore(before: Map<string, Buffer | null>): void {
     for (const [f, buf] of before) {
-        if (buf === null) {
-            fs.rmSync(f, { force: true });
-        } else {
-            fs.writeFileSync(f, buf);
+        try {
+            if (buf === null) {
+                fs.rmSync(f, { force: true });
+            } else {
+                fs.writeFileSync(f, buf);
+            }
+        } catch (err) {
+            const why = err instanceof Error ? err.message : String(err);
+            process.stdout.write(
+                `⚠️  could not restore ${f} after the freshness sweep: ${why}\n` +
+                    '    The working tree now holds a REGENERATED report. Restore it with\n' +
+                    `    \`git checkout -- ${f}\` if that was not intended.\n`,
+            );
         }
     }
 }

--- a/src/scripts/check_originality_freshness.ts
+++ b/src/scripts/check_originality_freshness.ts
@@ -115,7 +115,27 @@ export function checkFreshness(
     return { drifted, missing };
 }
 
+/**
+ * LOCAL-ONLY, established empirically. On a CI runner the sweep produced
+ * different bytes than the committed report even with a byte-identical corpus
+ * (verified: 508 members on both this branch and `main`, report fresh locally,
+ * both files reported stale in `Node Tests`). Something in the CI environment
+ * moves the output, and chasing it would mean designing a reproducibility gate
+ * for a report that "blocks nothing on its own" — a bad trade for a warning.
+ *
+ * So this stays a developer-side surface. A freshness warning that fires on
+ * every PR regardless of staleness is exactly the never-turns-off warning this
+ * check was written to remove.
+ */
 export function main(): number {
+    if (process.env['CI'] !== undefined && process.env['CI'] !== '') {
+        process.stdout.write(
+            'ℹ️  originality freshness: skipped on CI — the sweep is not byte-reproducible\n' +
+                '    across environments, so a CI warning here would fire regardless of\n' +
+                '    staleness. Run it locally before quoting the report numbers.\n',
+        );
+        return 0;
+    }
     const { drifted, missing } = checkFreshness();
     const rel = (f: string): string => path.relative(REPO_ROOT, f);
 

--- a/src/scripts/measure_scope_dedup.ts
+++ b/src/scripts/measure_scope_dedup.ts
@@ -199,7 +199,10 @@ function main(argv: readonly string[]): number {
         lines.push('     stamp, so the reachable twin count is 0, NOT the fixture\'s figure.');
         lines.push('     install.ts:2723/2725 stamp package:/source_path: into every installed');
         lines.push('     rule unconditionally; the in-repo projection stamps nothing. Two');
-        lines.push('     writers, deliberately different output — see road-to-dedup-reachability.');
+        lines.push('     writers, deliberately different output. Making this reachable was');
+        lines.push('     DECIDED AGAINST on 2026-07-31 (real install-path risk, empty recipient');
+        lines.push('     set) — see contexts/dedup-reachability-refusal.md for the analysis and');
+        lines.push('     the five reopen conditions. This 0 is expected, not a defect.');
         lines.push('     Do NOT relax the byte predicate to make this number move: that');
         lines.push('     predicate IS the content-neutrality argument.');
     }

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -336,7 +336,7 @@ tasks:
 
   check-originality-freshness:
     silent: true
-    desc: "Advisory — regenerates the originality report, diffs it against the committed bytes, restores them, and WARNS on drift. Never fails: the report blocks nothing on its own, so staleness is a visible warning, not a red build."
+    desc: "Advisory, LOCAL ONLY — regenerates the originality report, diffs it against the committed bytes, restores them, and WARNS on drift. Never fails, and skips when CI is set: the sweep is not byte-reproducible across environments, so a CI warning would fire regardless of staleness."
     cmd: ./scripts-run src/scripts/check_originality_freshness {{.QUIET_FLAG}}
 
   validate-flow-teams:

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -334,6 +334,11 @@ tasks:
     desc: "Anti-reskin gate — entity-neutralized shingle overlap over skills/personas/commands; blocks find-replace re-skins (FAIL 60, calibrated). Full audit writes agents/reports/originality.md; --changed <file...> for a PR-scoped check."
     cmd: ./scripts-run src/scripts/lint_originality {{.QUIET_FLAG}}
 
+  check-originality-freshness:
+    silent: true
+    desc: "Advisory — regenerates the originality report, diffs it against the committed bytes, restores them, and WARNS on drift. Never fails: the report blocks nothing on its own, so staleness is a visible warning, not a red build."
+    cmd: ./scripts-run src/scripts/check_originality_freshness {{.QUIET_FLAG}}
+
   validate-flow-teams:
     silent: true
     desc: "Advisory — every flow `team:` annotation resolves to a real persona id and skill slug (demand-probe primitive; formalize a roster schema only on organic use)."

--- a/tests/scripts/check_originality_freshness.test.ts
+++ b/tests/scripts/check_originality_freshness.test.ts
@@ -53,6 +53,28 @@ describe('originality freshness — detection', () => {
     });
 });
 
+describe('originality freshness — the DEFAULT report set, not just one path', () => {
+    // Every test above passes an explicit single-file list, which would leave the
+    // shipped default (both the .json and the .md) unexercised — so a future edit
+    // could drop the .md from REPORTS and no test would notice.
+    it('checks both committed reports when called with no argument', () => {
+        const md = path.join(REPO, 'agents', 'reports', 'originality.md');
+        const savedMd = fs.readFileSync(md);
+        try {
+            fs.writeFileSync(md, `${savedMd.toString('utf-8')}\nstale trailer\n`);
+            // Only the .md was touched, so only the .md may be reported — which
+            // also proves the default set includes it.
+            expect(checkFreshness().drifted).toEqual([md]);
+        } finally {
+            fs.writeFileSync(md, savedMd);
+        }
+    });
+
+    it('reports a fresh default set as clean', () => {
+        expect(checkFreshness()).toEqual({ drifted: [], missing: [] });
+    });
+});
+
 describe('originality freshness — the tree is restored either way', () => {
     it('leaves a FRESH report byte-identical', () => {
         const before = fs.readFileSync(REPORT);

--- a/tests/scripts/check_originality_freshness.test.ts
+++ b/tests/scripts/check_originality_freshness.test.ts
@@ -11,8 +11,8 @@
 // test asserting a clean worktree (`backfill_model_tier`'s dry-run purity check)
 // observed the transient write and failed. Shared tracked state is not a fixture.
 // Drift and restore are therefore proven on temp files via the injectable
-// `regenerate` hook; only the fresh path touches the real reports, and that is
-// safe because rewriting identical bytes is invisible to git.
+// `regenerate` hook, and no case here runs the real sweep at all — see the note
+// at the bottom for why report freshness is not a testable property.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -113,10 +113,12 @@ describe('originality freshness — the real wiring', () => {
         ]);
     });
 
-    it('runs the real sweep against the committed reports and finds them fresh', () => {
-        // The one test that touches tracked files. Safe by construction: the
-        // sweep rewrites identical bytes when the report is current, which git
-        // cannot see — and if it were NOT current, this failing is the point.
-        expect(checkFreshness()).toEqual({ drifted: [], missing: [] });
-    });
+    // There is deliberately NO test asserting the committed reports are fresh.
+    // One existed and CI refuted it: on a runner the sweep produced different
+    // bytes for both reports even though the corpus was byte-identical to `main`
+    // (508 members on both sides, fresh locally). Report freshness is therefore
+    // not a property a test can assert portably — asserting it would make every
+    // PR depend on an environment difference nobody has characterised. The check
+    // ships as a local advisory that skips on CI, and this comment is the reason,
+    // so the test does not get "helpfully" re-added later.
 });

--- a/tests/scripts/check_originality_freshness.test.ts
+++ b/tests/scripts/check_originality_freshness.test.ts
@@ -4,93 +4,119 @@
 // a pipeline: it must DETECT drift, and it must leave the working tree exactly
 // as it found it (otherwise a later CI step sees a spurious diff and the check
 // becomes the thing that breaks the build it was supposed to warn about).
+//
+// NOT-NEGOTIABLE for this file: nothing here writes to a TRACKED path. An
+// earlier version wrote a stale report into `agents/reports/originality.json` to
+// exercise the drift path, and because vitest runs suites in parallel, a sibling
+// test asserting a clean worktree (`backfill_model_tier`'s dry-run purity check)
+// observed the transient write and failed. Shared tracked state is not a fixture.
+// Drift and restore are therefore proven on temp files via the injectable
+// `regenerate` hook; only the fresh path touches the real reports, and that is
+// safe because rewriting identical bytes is invisible to git.
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { checkFreshness } from '../../src/scripts/check_originality_freshness.js';
+import { REPORTS, checkFreshness } from '../../src/scripts/check_originality_freshness.js';
 
-const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
-const REPORT = path.join(REPO, 'agents', 'reports', 'originality.json');
+const tmps: string[] = [];
 
-let saved: Buffer | null = null;
+function tmpdir(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'originality-freshness-'));
+    tmps.push(d);
+    return d;
+}
 
 afterEach(() => {
-    if (saved !== null) {
-        fs.writeFileSync(REPORT, saved);
-        saved = null;
-    }
+    while (tmps.length) fs.rmSync(tmps.pop() as string, { recursive: true, force: true });
 });
 
+/** A report fixture plus a regenerate hook that rewrites it with `next`. */
+function fixture(current: string, next: string): { file: string; regenerate: () => void } {
+    const file = path.join(tmpdir(), 'originality.json');
+    fs.writeFileSync(file, current, 'utf-8');
+    return { file, regenerate: () => fs.writeFileSync(file, next, 'utf-8') };
+}
+
 describe('originality freshness — detection', () => {
-    it('reports no drift when the committed report matches the corpus', () => {
-        const { drifted, missing } = checkFreshness([REPORT]);
-        expect(missing).toEqual([]);
-        expect(drifted).toEqual([]);
+    it('reports no drift when regeneration reproduces the committed bytes', () => {
+        const same = '{ "artifacts_scanned": 508 }\n';
+        const { file, regenerate } = fixture(same, same);
+
+        expect(checkFreshness([file], regenerate)).toEqual({ drifted: [], missing: [] });
     });
 
     it('reports drift when the committed report describes an older corpus', () => {
-        saved = fs.readFileSync(REPORT);
-        const doc = JSON.parse(saved.toString('utf-8')) as Record<string, unknown>;
         // The exact shape of the real 2026-07-31 staleness: a count from before
         // an artefact landed.
-        doc['artifacts_scanned'] = (doc['artifacts_scanned'] as number) - 1;
-        fs.writeFileSync(REPORT, `${JSON.stringify(doc, null, 2)}\n`);
+        const { file, regenerate } = fixture(
+            '{ "artifacts_scanned": 507 }\n',
+            '{ "artifacts_scanned": 508 }\n',
+        );
 
-        expect(checkFreshness([REPORT]).drifted).toEqual([REPORT]);
+        expect(checkFreshness([file], regenerate).drifted).toEqual([file]);
     });
 
     it('treats an absent report as missing rather than as drift', () => {
-        // A path the sweep never writes — absence must not be reported as staleness.
-        const absent = path.join(os.tmpdir(), 'originality-absent-fixture.json');
-        fs.rmSync(absent, { force: true });
+        const absent = path.join(tmpdir(), 'never-written.json');
+        const wrote = (): void => fs.writeFileSync(absent, 'fresh\n', 'utf-8');
 
-        const { drifted, missing } = checkFreshness([absent]);
+        const { drifted, missing } = checkFreshness([absent], wrote);
         expect(drifted).toEqual([]);
-        expect(missing).toEqual([]);
+        expect(missing).toEqual([absent]);
+        // Restoring "absent" means removing it again, so the tree is as found.
+        expect(fs.existsSync(absent)).toBe(false);
+    });
+
+    it('does not report drift when regeneration throws — a broken sweep is not a stale report', () => {
+        const { file } = fixture('{ "artifacts_scanned": 507 }\n', '');
+        const boom = (): void => {
+            throw new Error('sweep unavailable');
+        };
+
+        expect(checkFreshness([file], boom)).toEqual({ drifted: [], missing: [] });
+        expect(fs.readFileSync(file, 'utf-8')).toBe('{ "artifacts_scanned": 507 }\n');
     });
 });
 
-describe('originality freshness — the DEFAULT report set, not just one path', () => {
-    // Every test above passes an explicit single-file list, which would leave the
-    // shipped default (both the .json and the .md) unexercised — so a future edit
-    // could drop the .md from REPORTS and no test would notice.
-    it('checks both committed reports when called with no argument', () => {
-        const md = path.join(REPO, 'agents', 'reports', 'originality.md');
-        const savedMd = fs.readFileSync(md);
-        try {
-            fs.writeFileSync(md, `${savedMd.toString('utf-8')}\nstale trailer\n`);
-            // Only the .md was touched, so only the .md may be reported — which
-            // also proves the default set includes it.
-            expect(checkFreshness().drifted).toEqual([md]);
-        } finally {
-            fs.writeFileSync(md, savedMd);
-        }
-    });
-
-    it('reports a fresh default set as clean', () => {
-        expect(checkFreshness()).toEqual({ drifted: [], missing: [] });
-    });
-});
-
-describe('originality freshness — the tree is restored either way', () => {
+describe('originality freshness — the file is restored either way', () => {
     it('leaves a FRESH report byte-identical', () => {
-        const before = fs.readFileSync(REPORT);
-        checkFreshness([REPORT]);
-        expect(fs.readFileSync(REPORT).equals(before)).toBe(true);
+        const same = '{ "artifacts_scanned": 508 }\n';
+        const { file, regenerate } = fixture(same, same);
+
+        checkFreshness([file], regenerate);
+        expect(fs.readFileSync(file, 'utf-8')).toBe(same);
     });
 
     it('leaves a STALE report byte-identical — it warns, it does not silently fix', () => {
-        saved = fs.readFileSync(REPORT);
-        const stale = Buffer.from('{ "artifacts_scanned": 1 }\n', 'utf-8');
-        fs.writeFileSync(REPORT, stale);
+        const stale = '{ "artifacts_scanned": 1 }\n';
+        const { file, regenerate } = fixture(stale, '{ "artifacts_scanned": 508 }\n');
 
-        expect(checkFreshness([REPORT]).drifted).toEqual([REPORT]);
+        expect(checkFreshness([file], regenerate).drifted).toEqual([file]);
         // Restoring, not overwriting: a check that quietly repaired the file
         // would hide the drift it exists to surface — and would turn a
         // read-only advisory into a writer.
-        expect(fs.readFileSync(REPORT).equals(stale)).toBe(true);
+        expect(fs.readFileSync(file, 'utf-8')).toBe(stale);
+    });
+});
+
+describe('originality freshness — the real wiring', () => {
+    it('covers BOTH committed reports, not just the json', () => {
+        // Asserted rather than exercised by mutation: dropping the .md from
+        // REPORTS is the regression worth catching, and it is catchable without
+        // writing to a tracked path.
+        expect(REPORTS.map((f) => path.basename(f)).sort()).toEqual([
+            'originality.json',
+            'originality.md',
+        ]);
+    });
+
+    it('runs the real sweep against the committed reports and finds them fresh', () => {
+        // The one test that touches tracked files. Safe by construction: the
+        // sweep rewrites identical bytes when the report is current, which git
+        // cannot see — and if it were NOT current, this failing is the point.
+        expect(checkFreshness()).toEqual({ drifted: [], missing: [] });
     });
 });

--- a/tests/scripts/check_originality_freshness.test.ts
+++ b/tests/scripts/check_originality_freshness.test.ts
@@ -1,0 +1,74 @@
+// Freshness check for the committed originality report.
+//
+// The two properties worth pinning are the ones that make it safe to run inside
+// a pipeline: it must DETECT drift, and it must leave the working tree exactly
+// as it found it (otherwise a later CI step sees a spurious diff and the check
+// becomes the thing that breaks the build it was supposed to warn about).
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { checkFreshness } from '../../src/scripts/check_originality_freshness.js';
+
+const REPO = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
+const REPORT = path.join(REPO, 'agents', 'reports', 'originality.json');
+
+let saved: Buffer | null = null;
+
+afterEach(() => {
+    if (saved !== null) {
+        fs.writeFileSync(REPORT, saved);
+        saved = null;
+    }
+});
+
+describe('originality freshness — detection', () => {
+    it('reports no drift when the committed report matches the corpus', () => {
+        const { drifted, missing } = checkFreshness([REPORT]);
+        expect(missing).toEqual([]);
+        expect(drifted).toEqual([]);
+    });
+
+    it('reports drift when the committed report describes an older corpus', () => {
+        saved = fs.readFileSync(REPORT);
+        const doc = JSON.parse(saved.toString('utf-8')) as Record<string, unknown>;
+        // The exact shape of the real 2026-07-31 staleness: a count from before
+        // an artefact landed.
+        doc['artifacts_scanned'] = (doc['artifacts_scanned'] as number) - 1;
+        fs.writeFileSync(REPORT, `${JSON.stringify(doc, null, 2)}\n`);
+
+        expect(checkFreshness([REPORT]).drifted).toEqual([REPORT]);
+    });
+
+    it('treats an absent report as missing rather than as drift', () => {
+        // A path the sweep never writes — absence must not be reported as staleness.
+        const absent = path.join(os.tmpdir(), 'originality-absent-fixture.json');
+        fs.rmSync(absent, { force: true });
+
+        const { drifted, missing } = checkFreshness([absent]);
+        expect(drifted).toEqual([]);
+        expect(missing).toEqual([]);
+    });
+});
+
+describe('originality freshness — the tree is restored either way', () => {
+    it('leaves a FRESH report byte-identical', () => {
+        const before = fs.readFileSync(REPORT);
+        checkFreshness([REPORT]);
+        expect(fs.readFileSync(REPORT).equals(before)).toBe(true);
+    });
+
+    it('leaves a STALE report byte-identical — it warns, it does not silently fix', () => {
+        saved = fs.readFileSync(REPORT);
+        const stale = Buffer.from('{ "artifacts_scanned": 1 }\n', 'utf-8');
+        fs.writeFileSync(REPORT, stale);
+
+        expect(checkFreshness([REPORT]).drifted).toEqual([REPORT]);
+        // Restoring, not overwriting: a check that quietly repaired the file
+        // would hide the drift it exists to surface — and would turn a
+        // read-only advisory into a writer.
+        expect(fs.readFileSync(REPORT).equals(stale)).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes the cache-economy strand. The reachability question is **decided**, not parked: reject both mechanisms, as a maintainer verdict.

## Decision — reject both, and why it is not filed as the council's

The council pass of 2026-07-31 was **budget-truncated**: one member answered, `gpt-4o` returned `cost_budget_exceeded` at zero tokens. Its verdict was also reject-both, but its two headline premises are refuted against this repo's own measurements — it confused a transport saving with an execution saving, and read a quality win-rate (36.2%) as a payload reduction (thin projection's actual reduction was ~65.6%). A conclusion resting on refuted premises cannot be cited as the reason, even when the conclusion survives. So the verdict is carried as the **maintainer's**, with different reasoning.

**The load-bearing reason: real risk against an empty recipient set.**

The risk side is real and was not talked down. **A** carries a cross-parser risk — excluding the ownership keys turns byte equality into "byte equality modulo a parse", and the parse that matters is the *host's* reader, which no property test over our own parser can settle. **B** carries manifest drift across four sub-cases, the rename exhaustion (path-keyed ownership cannot separate "package renamed a rule" from "user authored a matching file" without reintroducing the divergence B exists to remove), and a real migration for every already-stamped installation with two ownership paths live for at least one deprecation cycle.

The benefit side has an **empty recipient set**. The ≈86.8k tokens per spawn are only paid by a **dual-scope** installation, and no external consumer with one is known to exist. The single dual-scope machine that does exist is a development checkout, where the dedup is *correctly inert* because the two scopes hold different releases.

So this is **sequencing, not a judgement on the mechanisms**: neither is wrong, both are premature. Nobody pays the cost the mechanism would remove, while both would put a real safety risk into the install path today.

**Explicitly not done:** no change to the byte-identity predicate, none to `install.ts`, no implementation of A or B, no further council pass. `projection.scope_dedup` stays shipped-but-opt-in and inert.

## Filed as a context, not a roadmap archive

An archived roadmap reads as "work that finished"; this is a **standing refusal** that later proposals must argue against, so it has to stay citable. `agents/settings/contexts/dedup-reachability-refusal.md` (git tracks it as a rename of the draft, so the history follows).

Preserved **verbatim** so a reopen does not start from zero: the full A/B analysis with attack surface, failure modes, migration path and kill criterion each; the trade table; and the council points that *were* accepted —

- A's kill criterion tightened: a property test over generated shapes is necessary but no longer sufficient; A also owes a **cross-parser agreement check against the host's own reader**.
- B's rename gap promoted from "a detail to specify later" to a **structural cost** of moving ownership out of the file, with the exhaustion argument that establishes it.
- The attack-surface discussion **reframed as safety, not security** — the threat model is "installer bug deletes a user file", not "malicious actor"; anyone who can write `~/.claude/rules/` has already won by replacing rule bodies.
- The third candidate it raised (content-addressed store + symlinks) and why it self-refuted in the same pass — recorded so it is not re-proposed as new.

Also kept: the refuted premises, with their counter-evidence, so the same argument cannot return unexamined.

## Five reopen conditions

The four existing ones (IO-bound profile · network-constrained telemetry · a measurement invalidating the payload-shaping quality floor · **perceptibility**, from the council) plus the new one this decision turns on: **≥ 1 external consumer with a demonstrated dual-scope installation** — the condition that closes the empty-recipient-set argument, and the likeliest of the five to fire first.

Every reference now points at the decision rather than at a pending strand: `cache-economy-refusals`, the archived roadmap's inline condition ("decided against, not a pending step"), and `measure_scope_dedup`'s own output, which now tells its reader that the `0/110` is *expected* and names where the decision lives.

## Originality report freshness — the cheap fix in the same theme

The committed report could drift silently, and did: 507 vs 508 on an identical corpus. `check_originality_freshness` regenerates it, diffs against the committed bytes, **restores them either way**, and **always exits 0** — the report "blocks nothing on its own", so staleness stays a visible warning rather than a red build. Wired into both pipelines; the sweep is ~1 s, so the second run is free.

Proven both directions (fresh → `✅`; a count decremented by one → `⚠️ STALE`, still exit 0) and proven tree-neutral. 5 tests pin detection *and* that a stale report is **restored, not silently repaired** — a check that quietly fixed the file would hide the drift it exists to surface, and would turn a read-only advisory into a writer.

Design notes decided in passing: absence of a report is reported as `missing`, never as drift; a sweep that throws leaves the tree as found rather than reporting a false positive.

## Verification

Typecheck clean. Green: `check-index`, `check-artefact-counts`, `build-proof-check`, `roadmap-progress-check`, `check_condensation`, `check_portability`, `check_preamble_payload_budget`, `lint_output_slop`, `check_adr_frontmatter`, `check_no_roadmap_refs`, `check_roadmap_trackable`, `check_council_references`, `lint_roadmap_ci_steps`, `check_originality_freshness`. `skill-lint` **429 pass, 0 warn, 0 fail**. Tests: **8,471 passed**, 15 skipped.

One caught in-flight and fixed here: `check_no_roadmap_refs` went red because the new context file's "See also" cited the archived roadmap by path — the rule forbids stable artifacts citing transient roadmap files, archives included. Replaced with a description of what that roadmap recorded plus a pointer to the durable version, which is the rule's intended shape rather than a suppression.

The single remaining test failure is the pre-existing, checkout-depth-dependent `reach_doctor` traversal test, left untouched by instruction: 93/93 green in the main checkout, zero diff against `origin/main`.


## Self-review gate — finding triage

Seven advisory findings, **none merge-blocking**. Four fixed, three answered.

| # | Finding | Verdict | Resolution |
|---|---|---|---|
| 1 | **medium/correctness** — "Council pass budget truncation may invalidate decision basis" | **correct, already the file's own argument** | This is precisely why the verdict is filed as the **maintainer's** with different reasoning rather than as the council's — stated in the opening section before any analysis. The finding restates the disclosure; nothing to fix. |
| 2 | **medium/correctness** — "`checkFreshness` always exits 0 but appears in the validation chain" | **intended → clarified** | The task description already said "never fails", but a reader scanning the chain sees the list, not the descriptions. Both call sites now carry an inline "advisory, never fails — listed so the warning is seen, not to gate on it". |
| 3 | **low/claim** — "unbacked claim about 'no external consumer with dual-scope installation'" | **confirmed → fixed** | It was a flat assertion, and we have no consumer telemetry. Now "no **known** recipient", with an explicit paragraph saying absence claims are the weakest kind — while separating it from the half that *is* measured (the dedup is correctly inert on the one dual-scope machine that exists). Reopen condition 5 is named as the cheap way to settle it. |
| 4 | **low/correctness** — "restore logic assumes snapshot succeeded" | **confirmed → fixed** | `restore()` is now best-effort per file and never throws: it runs inside pipelines, so a read-only mount or a concurrent writer must not turn an advisory into the exception that fails the build. A file it cannot restore is named loudly with the `git checkout --` command — the one case where the tree is left dirty, and the reader has to know. |
| 5 | **low/correctness** — "test fixture assumes single report path but code supports multiple" | **confirmed → fixed** | Fair: every test passed an explicit single-file list, so dropping the `.md` from `REPORTS` would have gone unnoticed. Two tests now exercise the no-argument default and assert the `.md` is in it (7 tests total). |
| 6 | **low/style** — "inconsistent script path reference format" | **confirmed → fixed** | One table cell used the bare script name while the rest used full paths. Normalised. |
| 7 | **low/style** — "inconsistent timestamp format in decision record" | **not reproducible** | The file carries exactly one date format — `2026-07-31`, three occurrences, no alternates. No change. |

**Escalation recommendation (full `/council:pr` on a 551-line diff): declined, with reason.** The diff is documentation plus one advisory script; the strand it closes was already put through a council pass whose result is recorded and partly refuted in-file; and the decision landing here is explicitly a *maintainer* verdict, so a paid council pass would be reviewing a decision it has no authority over. Recorded rather than silently skipped.

Re-verified after the triage: typecheck clean, `skill-lint` still **429 pass / 0 warn / 0 fail**, 26 tests green across the three touched suites, and `check-index`, `check-artefact-counts`, `build-proof-check`, `roadmap-progress-check`, `check_condensation`, `check_portability`, `check_no_roadmap_refs`, `check_originality_freshness`, `lint_output_slop`, `check_preamble_payload_budget` all ✅.

## Post-review: two defects CI caught that local runs could not

Both fixed in this PR, and both worth recording because they are structural, not typos.

**1. My test mutated tracked state; a parallel test caught it.** `Node Tests` shard 2/4 failed in an unrelated suite:

```
tsx --dry-run must not mutate tracked files:
expected '' to be 'M agents/reports/originality.json'
```

Cause was mine: to exercise the drift path, the freshness tests wrote a stale report into `agents/reports/originality.json` — a **tracked** file — and vitest runs suites in parallel, so `backfill_model_tier`'s dry-run purity check observed the transient write. Nothing was wrong with the observer; shared tracked state is not a fixture, and a one-suite-at-a-time local run can never surface this. Fixed at the cause rather than by loosening the observer: `checkFreshness` takes an injectable `regenerate` hook, and drift/restore/absence/sweep-failure are now proven entirely on temp files. Reproduced the CI condition locally (both suites in one run) before and after.

**2. The freshness assertion was not a portable property.** The follow-up run then failed on my *own* test: on the runner **both** reports came back stale, while the corpus was byte-identical to `main` (508 members each side) and the report was fresh locally. So the sweep is not byte-reproducible across environments.

I did not chase the cause — characterising it means designing a reproducibility gate for a report that "blocks nothing on its own", which is a bad trade for a warning and outside the time-box set for this side item. Consequences taken instead of papered over:

- The freshness **assertion is removed** from the suite, with a comment in its place explaining why, so it does not get helpfully re-added.
- `main()` **self-skips when `CI` is set**, printing the reason — a warning that fires on every PR regardless of staleness is exactly the never-turns-off warning this check existed to remove; shipping one would have been worse than shipping nothing.
- Task description and both pipeline call sites now say **LOCAL ONLY** and why.

What ships is the useful half: run locally it answers in ~1 s whether the committed report describes the current corpus, restores the tree either way, and never fails. 7 tests pin detection, restore-not-repair, absence handling, sweep-failure tolerance, and that both reports are in the default set — all on temp files, none touching tracked state.

This is also the honest answer to the task's own escape hatch: the CI half needed a new gate design, so it was dropped rather than forced, and the limitation is recorded at the surface instead of in a commit nobody re-reads.
