### PR TITLE
docs: re-cut the inbox release plan against the verified tree

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 15 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **12** open blockers
+> 17 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **17** open blockers
 
 ## Overall
 
-**48 / 196 steps done · 24%**
+**48 / 243 steps done · 20%**
 
 ```text
-██████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   24%
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   20%
 ```
 
 ## Open roadmaps
@@ -31,6 +31,8 @@
 | 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 14 | [road-to-thin-flip-under-anchor-scoring.md](roadmaps/road-to-thin-flip-under-anchor-scoring.md) | 4 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 15 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 16 | [road-to-zero-ceremony-detection.md](roadmaps/road-to-zero-ceremony-detection.md) | 5 | 25 | 25 | 0 | 0 | 0 | [3](#blockers-road-to-zero-ceremony-detection) | ░░░░░░░░░░ 0% |
+| 17 | [road-to-zero-ceremony-install.md](roadmaps/road-to-zero-ceremony-install.md) | 6 | 22 | 22 | 0 | 0 | 0 | [2](#blockers-road-to-zero-ceremony-install) | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -308,6 +310,96 @@ _1 blocker resolved._
     `build_discovery_manifest.ts`, publish it, and let that date pass. The council
     ruled the date itself is not an agent decision.
   - **Resolved when:** a concrete `sunset` date is published in the manifest's `tier` deprecation entry AND that date has passed with no external breakage reported — at which point Phase 3 records the confirmation and Phase 4's external half becomes executable.
+
+### [road-to-zero-ceremony-detection.md](roadmaps/road-to-zero-ceremony-detection.md)
+
+**Road to zero-ceremony detection — detection reports, consent still decides** — 0 / 25 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | The detector module | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 2 | Make the documented transport default actually load | ⬜ not started | 8 | 0 | 0 | 0 | 0% |
+| 3 | Detection informs consent; it does not replace it | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 4 | Extend `doctor`, do not duplicate it | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 5 | Pin the `CLAUDE_CONFIG_DIR` inheritance decision | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+
+<a id="blockers-road-to-zero-ceremony-detection"></a>
+**Blockers**
+
+- **council-availability-semantics** (owner: maintainer) — blocks any removal of `members.*.enabled` (Phase 3 ships reporting and a one-line enable command instead)
+  - **What to do:**
+    1. Read the shipped council template's rationale for the flag ("installing a
+    key is not the same as wanting the agent to spend money on it") and the
+    config contract's fail-closed rules (at least one enabled member; no
+    silent skips; low-impact fast-path as a two-knob opt-in).
+    2. Decide whether detection-derived availability is acceptable given that it
+    converts "a key exists on this machine" into "this provider may be
+    called". Per ADR-049 this class of scope expansion requires a threat
+    model, not a product rationale.
+    3. If yes, write the ADR that supersedes the contract's enabled-member rules
+    and states how the ask-gate alone preserves the no-silent-spend property.
+  - **Resolved when:** an ADR exists naming the superseded contract sections, or this roadmap records the flag as retained by decision.
+- **transport-auto-default-flip** (owner: maintainer) — blocks making `auto` the effective default (Phase 2 ships it opt-in)
+  - **What to do:**
+    1. Confirm the intent: a user with both a logged-in CLI and an installed key
+    moves from per-token dollars onto subscription quota with no config edit.
+    2. If yes, authorize the breaking-change entry and the migration note, and
+    confirm `cli_call_budget` ships populated in the same change.
+  - **Resolved when:** the breaking-change entry is authorized, or `auto` is recorded as permanently opt-in.
+- **claude-config-dir-inheritance-decision** (owner: maintainer) — blocks any behaviour change to the spawn hardening's handling of `CLAUDE_CONFIG_DIR` (Phase 5 ships only the test and the documented row)
+  - **What to do:**
+    1. Read the Phase-5 threat-model row and the ADR that chose deny-by-family
+    over an allowlist.
+    2. Pick one: (a) leave inheritance as-is, keeping the row as accepted risk;
+    (b) deny the variable, accepting that a legitimate setter loses it for
+    children; (c) strip inherited and permit only a validated assignment.
+    3. If (b) or (c), record an ADR amendment — this reverses a considered
+    decision and must not land as an unexplained diff.
+  - **Resolved when:** an ADR amendment names the chosen option, or the threat-model row is marked accepted-risk with a dated rationale.
+
+### [road-to-zero-ceremony-install.md](roadmaps/road-to-zero-ceremony-install.md)
+
+**Road to zero-ceremony install — make the install claim true before making it shorter** — 0 / 22 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Make every install statement true | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 2 | Cover the npm failure mode the rescue door absorbs | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 3 | Door consolidation, gated on Phase 2 | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 4 | Payload budget with CI teeth | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 5 | Narrow emitter audit (what survives of the unification proposal) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 6 | Cold-start evidence | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+
+<a id="blockers-road-to-zero-ceremony-install"></a>
+**Blockers**
+
+- **curl-door-disposition** (owner: maintainer) — blocks Phase 3
+  - **What to do:**
+    1. Read the Phase-2 result: does the npx path now handle the registry
+    resolution failure without prose?
+    2. Decide whether a registry-independent install path is still wanted for
+    restricted networks and mirrored registries.
+    3. Note the constraint either way: the raw URL is a declared public contract
+    with CI coverage across 3 OS × 2 Node versions — it must keep resolving
+    even if the script becomes a stub.
+  - **Resolved when:** the disposition is recorded in this roadmap with its reason, and the smoke workflow reflects it.
+- **browser-handoff-default** (owner: maintainer) — blocks any change making the non-browser path the default
+  - **What to do:**
+    1. Note what is already true: the terminal path is already prompt-free, the
+    Recommended path already asks zero questions (two confirmations), and
+    detection already pre-selects. The remaining delta is the browser handoff
+    itself, not choice overload.
+    2. Note what stands in the way: an accepted ADR makes the browser handoff the
+    interactive default, and the onboarding-gate rule — tier-1, hook-enforced
+    — names the browser wizard the sole onboarding surface. Inverting this is
+    a kernel-rule edit: own PR, ≥ 24 h between merges, per the slow-rollout
+    gate.
+    3. Note what is missing: there is no usage evidence either way, because zero
+    external onboarding sessions have completed. The instrument that would
+    produce it is the recruited session already open in the adoption roadmap.
+    4. Decide: supersede the ADR and edit the rule, or keep the handoff and let
+    `--no-ui` remain the documented escape.
+  - **Resolved when:** an ADR supersession plus a kernel-rule edit PR exists, or this roadmap records the handoff as retained by decision.
 
 ---
 

--- a/agents/roadmaps/later/road-to-zero-ceremony-host-primitives.md
+++ b/agents/roadmaps/later/road-to-zero-ceremony-host-primitives.md
@@ -1,0 +1,222 @@
+---
+complexity: structural
+status: later
+execution:
+  mode: phase-checkpoints
+related_roadmaps: [road-to-zero-ceremony-detection]
+related_adrs: [ADR-035, ADR-040, ADR-109, ADR-133]
+related_contexts: [host-capability-manifest, subagent-routing, model-recommendations]
+---
+
+# Road to host-native model primitives — probe the hosts before deciding whether to emit anything
+
+> Most supported hosts now ship their own model routing — plan/execute splits,
+> effort knobs, per-account aliases, complexity auto-routers. Whether this
+> package should emit into those knobs is a question an accepted ADR already
+> answered "no" for a closely-related mechanism. Settle it with probe data, not
+> with a plan.
+
+> **Blocked until** two conditions hold: the composition-ratchet polish gate has
+> exited (feature work), and the ADR that governs tier→model mapping enters its
+> recorded review window — where revisiting is procedurally cheap rather than a
+> supersession fight. Phase 0 is the only part that produces value before then,
+> and it produces exactly the evidence that review needs.
+
+## Goal
+
+Decide, on probe evidence and inside the governing ADR's own review window,
+whether tier→host-native-primitive emission is worth its maintenance surface —
+and if it is, ship it as one independently-revertable adapter per host with a
+byte-identical fallback everywhere else.
+
+## Context
+
+Source: an external planning set, audited 2026-07-31. Corrections and refusals:
+[`zero-ceremony-inbox-cut`](../../settings/contexts/zero-ceremony-inbox-cut.md).
+
+The audit found the draft's proposed *deletions* largely unavailable and its
+proposed *emission* in direct tension with an accepted decision:
+
+- **The governing ADR rejected this mechanism by name.** It states that exactly
+  one place resolves a tier to a concrete model, that non-Claude agents are
+  suggestion-only, and that the package maintains **no per-vendor runtime
+  table** — because that creates two-clocks drift as vendors rename models. Its
+  rejected-alternatives section names "per-vendor table consumed by the rule".
+  Per-host emission adapters are a per-vendor table; storing it as probe data
+  makes it auditable, not absent. Superseding that reasoning needs an ADR, and
+  the honest argument for one is that projection-time emission is a different
+  animal from a runtime table — the same distinction another accepted ADR draws
+  for pack filtering. That argument is worth making; it is not worth assuming.
+- **The property the draft wants already ships.** The default already emits no
+  native model key and never overrides a user's own model choice, and an empty
+  tier entry already means "use the tier's runtime default, never a baked-in
+  provider model name". "Let the host decide" is the current contract.
+- **The proposed key deletions are refused.** Removing the size-fit ladder
+  deletes the council's cost-downgrade economics (the loader requires it, and
+  the ladder is what makes a too-large request cheaper rather than failed).
+  The judge-model key carries Iron-Law status in four judge skills — *never
+  silently fall back to a different model than the configured judge* — and the
+  judge-asymmetry invariant depends on it. Omitting a model for a vendor-CLI
+  member is documented as a **pin**, not "latest", deliberately.
+- **What is genuinely stale is narrower than the draft claimed:** the pinned
+  model IDs in the council template. That is a template edit, not a schema
+  deletion — and it is the whole of the verified staleness exhibit. The council
+  debate that reviewed this cut ran on those exact pins, which is the most
+  direct evidence available that they are stale.
+- **A host-lifecycle finding stands on its own merit:** sources disagree about
+  whether one supported host's CLI is current or superseded. That belongs in
+  probe data with a `lifecycle` field, not in prose — and it is an argument for
+  adapters-as-data regardless of how the emission question resolves.
+- **Starting the adapter layer is itself gated.** Under the subsystem-freeze
+  ADR, a new platform integration is a "large subsystem"; its unblock conditions
+  currently hold but one rides a defer that lapses in weeks. Probes are not a
+  subsystem; adapters are.
+
+### Gap audit against the source draft
+
+| Draft item | Verdict | Why |
+|---|---|---|
+| Per-host capability probes producing versioned records | **KEEP** | The only part that is cheap, useful, and evidence-producing regardless of outcome |
+| `lifecycle: active\|deprecated\|sunset\|unknown` per host, refreshed by probe | **KEEP** | Resolves a live source contradiction in data instead of prose |
+| Manifest model-routing fields | **KEEP, gated** | Additive and safe, but pointless until the emission question is settled |
+| Per-host emission adapters | **CUT → gated on an ADR** | The mechanism an accepted ADR rejected; needs supersession, argued on the projection-time-vs-runtime-table distinction |
+| "Ride, don't race" policy | **KEEP** | Correct, and it is the strongest argument that emission stays narrow |
+| Delete `model_ladder` | **CUT** | Deletes cost-downgrade economics the loader requires |
+| Delete the judge-model key | **CUT** | Iron-Law status in four judge skills; judge asymmetry depends on it |
+| Delete the tier→model map | **CUT** | Its empty-entry semantics already deliver the intended neutrality |
+| Optional `pin:` replacing the deleted keys | **CUT** | Re-opens the portable-frontmatter rule that forbids tool-specific keys in portable source; per-run pin escapes already exist |
+| Fix the stale pinned model IDs | **KEEP, small** | The real, verified staleness — a template edit |
+| Council api-mode catalog discovery + price banding | **KEEP, last** | Under a CLI-preferring default this is the fallback rung's helper; build only if the fallback rung sees real use |
+
+## Phase 0 — Probes (the only phase that pays before the gates lift)
+
+- [ ] One probe script per supported host under `src/scripts/host_probes/`,
+      each producing a versioned JSON capability record with a source URL and a
+      checked date. A probe is a documentation-and-flag check, never a
+      benchmark and never a paid call.
+      <!-- verify: npx vitest run tests/scripts/host_probes.test.ts -->
+- [ ] Implement the probes *inside* the shared detector from
+      `road-to-zero-ceremony-detection` — one detection module, consumed here.
+      A second detection path is the failure this sequencing exists to avoid.
+- [ ] Fill every unknown column per host; a host with unknowns in its record is
+      ineligible for emission by construction.
+- [ ] Add the `lifecycle` field and resolve the live source contradiction about
+      one host's status with a dated probe record rather than prose.
+- [ ] Add a probe-record lint: `sunset` or `unknown` lifecycle blocks new
+      emission work in CI, so a host shutdown can never strand a fresh adapter.
+      <!-- verify: npx vitest run tests/scripts/host_probes.test.ts -->
+- [ ] Make the host matrix generated output from the records — never
+      hand-maintained prose. The draft's own matrix is already a snapshot of a
+      fast-moving surface; that is the argument for generating it.
+
+**Exit criteria:** every supported host has a probe record with source and date;
+the matrix is generated; the lifecycle lint fails on a synthetic sunset record.
+**Rollback:** delete the probe scripts and records; nothing consumes them yet.
+
+## Phase 1 — Fix the verified staleness (independent of everything above)
+
+- [ ] Update the council template's pinned model IDs to current line-ups, and
+      state in the template comment that an omitted model for a vendor-CLI
+      member is a pin rather than "latest" — the behaviour is already
+      documented, but the pins being stale is what made it bite.
+- [ ] Record whether a staleness *check* is feasible without a network call at
+      lint time; if it is not, say so rather than shipping a gate that needs the
+      network to pass.
+
+**Exit criteria:** no shipped pin is more than one line-up behind at the time of
+the change; the feasibility note exists either way.
+**Rollback:** revert the template edit.
+
+## Phase 2 — The emission decision (ADR, not a step)
+
+- [ ] Write the ADR that either supersedes the tier-mapping decision for
+      projection-time emission or records emission as refused. Argue the
+      distinction explicitly: a projection-time emitter fed from the same tier
+      source is arguably one clock, whereas a runtime table consulted per call
+      is two. Name which of the two the proposal actually is.
+      <!-- blocked-by: adr-035-review-window -->
+- [ ] If superseded: extend the host-capability manifest with routing fields,
+      all-none as the safe default, and pin the degenerate all-none host as
+      byte-identical to today's behaviour — the no-regression invariant.
+      <!-- blocked-by: adr-035-review-window -->
+- [ ] Re-express judge asymmetry per capability class without weakening it:
+      model-split hosts one band up, effort-split hosts one effort rung up with
+      a floor, native-router hosts annotation-only. The invariant survives the
+      re-expression or the re-expression is wrong.
+      <!-- blocked-by: adr-035-review-window -->
+
+**Exit criteria:** an ADR exists that either authorises emission with its
+supersession named, or records refusal with its reason.
+**Rollback:** none — the ADR is the deliverable.
+
+## Phase 3 — Adapters, one host per change, only if Phase 2 authorises
+
+- [ ] One adapter per host, each independently revertable, each gated on its
+      own probe record being complete.
+      <!-- blocked-by: adr-035-review-window -->
+- [ ] No adapter writes config on a host whose own auto-router is
+      authoritative — recommendation surfaces only. Ride-don't-race is a tested
+      invariant here, not a sentence.
+      <!-- blocked-by: adr-035-review-window -->
+- [ ] Hosts without a complete probe record keep the existing suggest-mode
+      floor, documented per host.
+
+**Exit criteria:** on each adapter host, tiered work routes through that host's
+native primitive with no model ID typed by the user; on every other host,
+behaviour is byte-identical to today.
+**Rollback:** per-host revert; the suggest floor is the fallback by construction.
+
+## Blockers
+
+### blocker: adr-035-review-window
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phases 2 and 3
+- **What to do:**
+  1. Read the tier-mapping ADR's rejected-alternatives section, which names a
+     per-vendor table consumed by the rule as the rejected mechanism.
+  2. Decide whether projection-time emission is materially different from that
+     rejected runtime table — the distinction another accepted ADR already
+     draws for pack filtering is the strongest available argument that it is.
+  3. Note the timing advantage: that ADR carries a recorded review window, so
+     revisiting inside it is cheap; outside it, this is a supersession fight for
+     a feature whose user-visible benefit is "no model ID typed" on a subset of
+     hosts.
+- **Resolved when:** an ADR exists authorising or refusing emission, naming what
+  it supersedes.
+
+### blocker: polish-gate-open
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phases 2 and 3 (Phase 0 probes and Phase 1's template fix are
+  evidence and bug-fix work respectively)
+- **What to do:** confirm the gate's status; feature work waits for its exit.
+- **Resolved when:** 3 external adoptions are documented, or
+  `road-to-adoption-without-narrative-debt` is archived.
+
+## Acceptance criteria
+
+- Every supported host has a probe record with a source URL and a checked date;
+  the host matrix is generated from those records, never hand-edited.
+- The lifecycle lint blocks emission work for a host whose probe reports sunset
+  or unknown.
+- The shipped model pins are current, and whether a network-free staleness check
+  is feasible is recorded either way.
+- No key with cost-downgrade or judge-asymmetry responsibility is deleted.
+- If emission ships: an ADR names what it supersedes; the degenerate all-none
+  host is byte-identical to today; no adapter writes config on a host whose own
+  router is authoritative.
+- No adapter claims a quality win. The only claims available are mechanical:
+  zero user-typed model IDs on adapter hosts, and byte-identical behaviour
+  elsewhere. Whether native-primitive routing beats a user's manual pick belongs
+  to the parked routing-quality evaluation, not here.
+
+## Provenance
+
+Source: an external planning set delivered through the user inbox, drafted by
+an assistant that had the repository tree but not its decision memory — which is
+why its central mechanism collides with an accepted ADR it never cites. The
+host-matrix rows are doc-sourced snapshots of a fast-moving surface; Phase 0
+exists to convert them into re-runnable probes before any adapter is considered.
+Corrections and refusals:
+[`zero-ceremony-inbox-cut`](../../settings/contexts/zero-ceremony-inbox-cut.md).

--- a/agents/roadmaps/later/road-to-zero-ceremony-settings.md
+++ b/agents/roadmaps/later/road-to-zero-ceremony-settings.md
@@ -1,0 +1,231 @@
+---
+complexity: structural
+status: later
+execution:
+  mode: phase-checkpoints
+related_roadmaps: [road-to-zero-ceremony-detection, road-to-zero-ceremony-install]
+related_adrs: [ADR-020, ADR-037, ADR-110]
+related_contracts: [settings-api, layered-settings]
+---
+
+# Road to zero-ceremony settings — the user's file records decisions, the template stays the defaults source
+
+> The 1,233-line template is materialised into every user's global settings
+> file, so a fresh install starts with 1,233 lines of opinions nobody formed.
+> Split the two jobs that file is doing: the template stays the package's
+> internal defaults-and-schema source; what the *user* gets becomes a sparse,
+> provenance-stamped record of decisions actually made.
+
+> **Blocked until** the composition-ratchet polish gate exits — 3 documented
+> external adoptions, or `road-to-adoption-without-narrative-debt` archived.
+> This roadmap is config-management work, which that gate names explicitly;
+> its exceptions (bug fixes, completing broken first-run flows, CI/claims
+> infrastructure) do not cover it. Parked whole rather than smuggled in as
+> "simplification", which is not one of the listed exceptions.
+
+## Goal
+
+A fresh install writes no settings opinions; the user's global settings file
+contains one entry per decision actually made, each stamped with how it was
+made — while the template↔schema parity gate that keeps the GUI honest stays
+exactly as strict as it is today.
+
+## Prerequisites
+
+- [x] Global settings root is the decided storage answer (ADR-020).
+- [x] A zod schema mirrors the template leaf-for-leaf, CI-enforced.
+- [x] Atomic-write helpers exist.
+- [x] The GUI settings editor, its schema routes, and its diff machinery exist.
+
+## Context
+
+Source: an external planning set, audited 2026-07-31. Corrections and refusals:
+[`zero-ceremony-inbox-cut`](../../settings/contexts/zero-ceremony-inbox-cut.md).
+
+The audit changed this roadmap's central claim. The draft's headline was **ship
+NO settings template**. That is not available: the template is the source of
+truth for every configurable setting, a CI parity test fails when a schema key
+has no matching template path (its own comment: *loosen it and the GUI silently
+drifts*), the installer hard-fails when the template or its placeholders are
+missing, and nine further scripts read the template path directly.
+
+But the draft's *goal* is available, because the template is doing two
+unrelated jobs:
+
+1. **package-internal**: the defaults and schema-parity source — keep, untouched;
+2. **user-facing**: materialised verbatim into the user's global settings file —
+   this is the one that should become sparse.
+
+Separating them delivers the draft's outcome (a fresh install writes no
+opinions; the file reads as a decision ledger) while every gate above stays
+green. That reframe is the whole reason this roadmap survives at all.
+
+Also verified: `settings set` does not exist (`settings` is a GUI alias, and
+only `check` / `sync` / `migrate` mutate or validate) — the writer is greenfield.
+
+### Gap audit against the source draft
+
+| Draft item | Verdict | Why |
+|---|---|---|
+| A/B/C key taxonomy as a checked-in contract, with a lint refusing unclassified keys | **KEEP** | The C class is the injection fence; no conflict |
+| `settings set` CLI: zod-validated, atomic, C-refusing, provenance-stamping, loud echo | **KEEP** | Greenfield |
+| Sparse **user** settings file; absent = documented default | **KEEP, reframed** | Applies to the materialised user file, not to the template |
+| Ship **no** settings template | **CUT** | Breaks the schema↔template parity gate, the installer invariant, and nine consumers |
+| Provenance field (`jit-answer \| gui \| manual \| auto-detected`) + timestamp | **KEEP** | No conflict anywhere |
+| Language auto-detected, never asked | **KEEP** | A question whose answer is already visible is a wasted question |
+| Nickname as the single first-run question, prefilled, activating the canary | **KEEP** | Genuinely un-inferrable; one keypress to accept |
+| B-class JIT asks with a one-ask-per-run budget + conservative-default summary | **KEEP** | The anti-nag mechanism is the load-bearing part |
+| Hook verification of consent-class settings on capable hosts | **KEEP** | Deterministic teeth where the host allows them |
+| GUI as the only C-class writer | **KEEP** | Server-side refusal mirrors the CLI's |
+
+## Phase 1 — The taxonomy contract
+
+- [ ] Classify every key in the current template into A (preferences, never
+      asked) / B (consent, JIT-asked once, persisted) / C (guarded, never
+      agent-writable) in one table, checked in as
+      `docs/contracts/settings-classes.md`.
+- [ ] Add a lint refusing any new or existing key without a class.
+      <!-- verify: npx vitest run tests/scripts/lint_settings_classes.test.ts -->
+- [ ] Put every budget-raising key, allow/deny list, kill-switch, strict mode,
+      and master flag in C — and justify each B assignment in one line, because
+      a wrong B is the only way this design can hurt someone.
+- [ ] Council-review the C list specifically: the fence is only as good as its
+      completeness, and completeness is not something a single reviewer should
+      certify alone.
+
+**Exit criteria:** the contract exists, the lint fails on a deliberately
+unclassified key, and no key with irreversible or spend-raising effect sits
+outside C.
+**Rollback:** the contract and lint are additive — delete both.
+
+## Phase 2 — The writer
+
+- [ ] `settings set <key> <value>`: zod-validated against the existing schema,
+      atomic via the existing helper, refusing every C-class key from every
+      caller, stamping `source` and a timestamp, echoing each write as one loud
+      line.
+      <!-- verify: npx vitest run tests/scripts/settings_set.test.ts -->
+- [ ] Effective-value resolution (sparse file → template defaults) sits behind
+      the existing settings read path, so every consumer stays oblivious.
+      <!-- verify: npx vitest run tests/server/schemas/parity.test.ts -->
+- [ ] Refuse C-class writes server-side in the GUI's write route too — the CLI
+      refusal must not be the only fence.
+      <!-- verify: npx vitest run tests/server/routes/settings.test.ts -->
+- [ ] Add the provenance column to the GUI's settings view.
+
+**Exit criteria:** every C-class key is refused from CLI and server routes; the
+parity test is still green; a set/read round-trip preserves provenance.
+**Rollback:** remove the command and the route guard; the file format is
+backward-compatible because absent keys already mean defaults.
+
+## Phase 3 — The user file becomes sparse
+
+- [ ] Stop materialising the full template into the user's global settings file;
+      write only what the install genuinely decided (the installer presets that
+      fill profile-dependent keys stay, and stay explicit).
+      <!-- verify: npx vitest run tests/install/settings_materialisation.test.ts -->
+- [ ] Keep the template as the package-internal defaults source: parity gate,
+      installer placeholder invariant, and every direct template reader
+      untouched. Pin this with the parity test in the same change.
+      <!-- verify: npx vitest run tests/server/schemas/parity.test.ts -->
+- [ ] Generate the human-readable reference page from the schema plus the class
+      table, so the long-form documentation survives the file shrinking.
+- [ ] Migration: an existing populated user file is honoured as-is, every entry
+      stamped `source: manual`. Nothing is rewritten under the user.
+      <!-- verify: npx vitest run tests/install/settings_materialisation.test.ts -->
+
+**Exit criteria:** a fresh install produces a user settings file whose entry
+count is bounded by what the install actually decided; the parity gate and the
+installer invariant are both still green; an existing file upgrades with zero
+behaviour change.
+**Rollback:** restore full materialisation; sparse files remain readable
+because absent means default in both directions.
+
+## Phase 4 — First run: one question, one notice
+
+- [ ] Auto-set the language from the first message's language, falling back to
+      the system locale, with a visible one-line notice and provenance
+      `auto-detected`; any later explicit statement by the user overrides it.
+- [ ] Ask the nickname once, prefilled from git user name then `$USER`, so
+      accepting is one keypress; answering activates the session canary the
+      package already ships dark.
+- [ ] Skip cleanly in non-TTY, CI, and headless contexts: no file, defaults,
+      no questions, ever.
+      <!-- verify: npx vitest run tests/scripts/first_run.test.ts -->
+
+**Exit criteria:** a fresh interactive session asks exactly one question and
+prints exactly one auto-set notice; a non-TTY session asks nothing; the
+resulting file has at most two entries, each with provenance.
+**Rollback:** disable the first-run trigger; the canary stays dark as today.
+
+## Phase 5 — The JIT protocol
+
+- [ ] One normalised B-class ask template as a single rule: what is needed, why
+      now, options with the default marked, and where the answer is stored.
+- [ ] Enforce the budget: at most ONE settings question per command execution.
+      Further undecided B keys in the same run take the conservative default
+      silently and are listed in the end-summary with the command that changes
+      them.
+      <!-- verify: npx vitest run tests/scripts/jit_ask_budget.test.ts -->
+- [ ] Migrate the three existing ask-shaped settings onto the protocol and
+      delete their bespoke per-setting prose — the pattern already exists
+      piecemeal; this universalises it.
+- [ ] On hook-capable hosts, have the consent-gated action verify the recorded
+      decision before it runs, and state the enforcement gradient honestly for
+      prose-only hosts: the ask is model-carried there, and ask-once can
+      degrade to ask-never.
+      <!-- verify: npx vitest run tests/scripts/jit_ask_budget.test.ts -->
+
+**Exit criteria:** a planted fixture needing three B decisions asks once,
+assumes two conservatively, and lists both in the summary; the gated action on a
+hook-capable host refuses to run without the record.
+**Rollback:** revert to per-setting prose; no stored data changes shape.
+
+## Blockers
+
+### blocker: polish-gate-open
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** every phase
+- **What to do:**
+  1. Confirm this is config-management work under the composition-ratchet gate
+     and therefore parked, or
+  2. grant an explicit exception on the record — noting that "simplification"
+     is not one of the gate's three listed exceptions, so an exception here is a
+     decision, not an interpretation.
+- **Resolved when:** 3 external adoptions are documented, or
+  `road-to-adoption-without-narrative-debt` is archived, or an explicit
+  exception is recorded.
+
+## Acceptance criteria
+
+- Every template key carries an A/B/C class; the lint fails on an unclassified
+  key; no spend-raising or irreversible key sits outside C.
+- `settings set` refuses every C-class key from every caller, including the
+  GUI's server route.
+- A fresh install writes no settings opinions beyond what it actually decided;
+  the template↔schema parity gate and the installer placeholder invariant are
+  both still green — pinned in the same change, not asserted.
+- An existing populated settings file upgrades with zero behaviour change and
+  is stamped `source: manual`.
+- A fresh interactive session asks exactly one question; a non-TTY session asks
+  none.
+- No command execution ever asks more than one settings question; a planted
+  three-need fixture produces one ask, two conservative defaults, and a summary
+  naming both.
+- The reference documentation is generated from the schema plus the class
+  table — one source, not a second hand-maintained page.
+- The honest non-claims are recorded in the shipped docs: no enforcement on
+  prose-only hosts, no protection against a user answering a B question badly,
+  and no shorter first *week* — the same decisions get made, later and in
+  context.
+
+## Provenance
+
+Source: an external planning set delivered through the user inbox, drafted by
+an assistant that had the repository tree but not its decision memory. The
+maintainer offered the idea explicitly for critical review; the review changed
+its shape twice — the language question was dropped as answerable by
+observation, and "ship no template" became "split the template's two jobs" once
+the parity gate and installer invariant were verified. Corrections and refusals:
+[`zero-ceremony-inbox-cut`](../../settings/contexts/zero-ceremony-inbox-cut.md).

--- a/agents/roadmaps/road-to-zero-ceremony-detection.md
+++ b/agents/roadmaps/road-to-zero-ceremony-detection.md
@@ -1,0 +1,328 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+related_roadmaps: [road-to-zero-ceremony-install]
+related_adrs: [ADR-049, ADR-104, ADR-123]
+related_contracts: [ai-council-config]
+---
+
+# Road to zero-ceremony detection — detection reports, consent still decides
+
+> One read-only, spend-free detector becomes the single input for transport
+> selection and the existing `doctor` surface, and the council's documented
+> transport default starts actually being read — without weakening a single
+> spend gate.
+
+## Goal
+
+Reduce the configuration a working setup requires to the decisions that carry
+consent, by making everything *detectable* visible and pre-filled: after this
+roadmap, `doctor` explains every available and unavailable capability with a
+reason and a fix, transport resolves itself, and the only thing a user must
+still say "yes" to is spending money.
+
+## Prerequisites
+
+- [x] `doctor` command family exists (4 commands; the main module already
+      performs a read-only `auth.json` probe).
+- [x] A pure transport-mode resolver exists (`src/scripts/ai_council/modes.ts`).
+- [x] Host-presence signal table exists for 23 hosts
+      (`src/install/toolDetection.ts`, test-pinned).
+- [x] `cli_call_budget` is implemented in the loader and consumed by council and
+      team dispatch — commented out in the template only.
+
+## Context
+
+Source: an external planning set, audited against the tree on 2026-07-31. The
+disposition table, the refused items, and the corrected numbers live in
+[`zero-ceremony-inbox-cut`](../settings/contexts/zero-ceremony-inbox-cut.md).
+Read it first — it is why this roadmap is smaller than the source draft and why
+its centrepiece is a bugfix.
+
+Verified starting position:
+
+- **Nothing named `environment_detector.ts` exists** — greenfield.
+  `toolDetection.ts` ("is the tool installed on this machine") and `detect.ts`
+  ("does this project carry a bridge dir") deliberately answer different
+  questions; the new module composes them and replaces neither.
+- **`doctor` is not new.** The visible surface exists and is large. Extend it;
+  a parallel status command is out of scope.
+- **A live two-clocks bug:** `src/scripts/council_cli.ts` reads
+  `ai_council.mode` while the template ships `ai_council.defaults.mode`, so on
+  that path the documented `api` default is never consulted and resolution
+  falls through to the built-in `manual`. The contract and the pure resolver
+  also disagree on the built-in fallback (`api` vs `manual`).
+- **Auth probing already exists in two shapes** (a council lazy-probe with
+  cache and timeout; doctor's read-only `auth.json` probe). A third shape must
+  not appear.
+- **The council template contradicts itself:** it ships `enabled: true` and
+  `participate_low_impact: true` while its own comments claim both default to
+  false. The example file is additionally unreachable for consumers — `agents/`
+  is absent from the npm `files` allowlist, so the settings template points at
+  a file npm never delivers.
+
+### Gap audit against the source draft
+
+| Draft item | Verdict | Why |
+|---|---|---|
+| One read-only detector module | **KEEP** | Greenfield; consumers named below |
+| `doctor` as "the NEW visible surface" | **FOLD** | Already exists — extend, never duplicate |
+| Auth-source probes as new work | **FOLD** | Two probe shapes already exist |
+| Per-host `--version` extraction | **KEEP** | Needed for `doctor` display and later version gates |
+| Billing classified from auth source, never transport | **KEEP** | Correct and additive; becomes a static invariant |
+| Failure-class-gated mid-flight fallback | **KEEP** | The double-spend guard |
+| `transport.mode` as a NEW global key replacing `defaults.mode` | **CUT → reduce** | The global knob already exists as `defaults.mode`; the draft's three values silently delete `manual` (`billable=False`, the safest transport) and the per-member override the billing rules depend on. Ship `auto` as an added VALUE of the existing key, keep `manual`, keep per-member precedence |
+| Remove `members.*.enabled` | **CUT → blocker** | That flag is a spend gate, not ergonomics: the shipped template says "installing a key is not the same as wanting the agent to spend money on it", the config contract fails closed with no enabled member and forbids silent skips, and detection-derived availability is exactly the escalation ADR-049 says needs a threat model, not a product rationale |
+| Live-completion test at install time | **CUT** | That is spend at install time; lazy first-use probing stays |
+
+## Phase 1 — The detector module
+
+- [ ] Add `src/scripts/_lib/environment_detector.ts`: pure, read-only, cached
+      per process, zero network, zero spend. Records: `hosts` (id, binary path,
+      version), `auth` (provider, source ∈ `cli-subscription | cli-api-key |
+      key-file | env-key`, evidence path — presence only, never a validity
+      claim), `keys` (provider, ref).
+      <!-- verify: npx vitest run tests/scripts/_lib/environment_detector.test.ts -->
+- [ ] Compose existing signals instead of re-implementing them; record in the
+      module header which existing probe each field absorbs, so the "no third
+      probe shape" property is auditable.
+- [ ] Fixture suite over synthetic machines: bare · cli-only · keys-only ·
+      mixed · unreadable-credential-file.
+      <!-- verify: npx vitest run tests/scripts/_lib/environment_detector.test.ts -->
+- [ ] Static property check: the module imports nothing that performs network
+      I/O or spawns a billable call.
+      <!-- verify: npx vitest run tests/scripts/_lib/environment_detector.test.ts -->
+- [ ] Per-host `--version` extraction with output shapes fixture-pinned; an
+      unparseable version degrades to `unknown`, never throws.
+
+**Exit criteria:** the fixture suite is green on all five synthetic machines;
+the static check fails when a network import is added.
+**Rollback:** no consumers yet — delete the file.
+
+## Phase 2 — Make the documented transport default actually load
+
+This phase is a bugfix plus one additive value. It does not remove a key, a
+transport, or a precedence layer.
+
+- [ ] Pin the precedence chain in a test that FAILS against today's code:
+      invocation flag > per-member `mode` > `defaults.mode` > built-in.
+      <!-- verify: npx vitest run tests/scripts/ai_council/modes.test.ts -->
+- [ ] Fix the key read so the council path consults `ai_council.defaults.mode`.
+      <!-- verify: npx vitest run tests/scripts/ai_council/modes.test.ts -->
+- [ ] Reconcile the built-in fallback: the config contract says `api`, the pure
+      resolver says `manual`. Pick one, state it in the contract, pin it.
+      <!-- verify: npx vitest run tests/scripts/ai_council/modes.test.ts -->
+- [ ] Add `auto` as a fourth accepted VALUE of the existing `mode` key
+      (`api | manual | cli | auto`). `auto` resolves per provider per
+      invocation: binary resolves AND authenticated → cli; else a key resolves
+      → api; else unavailable with a one-line reason. `manual` is never part of
+      the `auto` chain — explicit opt-in only. Per-member `mode` keeps
+      overriding it.
+      <!-- verify: npx vitest run tests/scripts/ai_council/transport_resolver.test.ts -->
+- [ ] Classify **billing** from (provider, detected auth source), never from
+      transport; unknown source ⇒ per-token ⇒ over-gated. Pin as a static check
+      that the resolver's inputs carry no transport-derived billing term — this
+      is what keeps the existing per-provider rules (vendor-official CLI
+      unbilled, community CLI billed) intact under `auto`.
+      <!-- verify: npx vitest run tests/scripts/ai_council/transport_resolver.test.ts -->
+- [ ] Failure-class-gated mid-flight fallback: binary-missing, auth-rejected,
+      and cli-unsupported fall through to the api rung once within the same
+      invocation; timeouts and 5xx do **not**. Pin both directions — a
+      half-completed CLI call must never be double-spent.
+      <!-- verify: npx vitest run tests/scripts/ai_council/transport_resolver.test.ts -->
+- [ ] Populate `cli_call_budget` in the template with a conservative default:
+      it is the quota guard for the path `auto` prefers, and shipping that path
+      unguarded would be the whole point missed.
+- [ ] Decide `auto`'s status as a *default* separately from its existence as a
+      value, and record the decision: flipping the effective default moves
+      existing users' spend from per-token dollars onto subscription quota
+      without them editing anything. Until that decision lands, `auto` ships
+      opt-in.
+
+**Exit criteria:** the precedence test fails on pre-fix code and passes after;
+`auto` resolves correctly on all five fixture machines; a planted
+auth-rejection falls back exactly once and a planted timeout does not;
+`cost_budget` is untouched on a cli/subscription resolution and still applies
+to community-CLI members.
+**Rollback:** each step is independently revertable; the bugfix is keepable on
+its own even if `auto` is dropped.
+
+## Phase 3 — Detection informs consent; it does not replace it
+
+The draft's deletion of `members.*.enabled` is refused (see the gap audit).
+What ships instead removes the *work* of enabling without removing the *record*
+of consent.
+
+- [ ] `doctor` reports, per provider: detected · authenticated · auth source ·
+      billing class · enabled-in-config — so the gap between "could work" and
+      "allowed to spend" is visible rather than mysterious.
+      <!-- verify: npx vitest run tests/scripts/_cli/cmd_doctor.test.ts -->
+- [ ] When a provider is detected but not enabled, `doctor` prints the exact
+      one-line command that enables it. Discovery becomes zero-effort; consent
+      stays explicit.
+- [ ] Resolve the template's self-contradiction: the shipped values
+      (`enabled: true`, `participate_low_impact: true`) and the comments
+      claiming both default to false cannot both be right. Make them agree and
+      pin the shipped default.
+      <!-- verify: npx vitest run tests/scripts/ai_council/config.test.ts -->
+- [ ] Fix the dangling pointer: the settings template references a council
+      example file that npm does not ship. Either add it to the allowlist or
+      stop pointing at it.
+      <!-- verify: npx vitest run tests/scripts/install/files_allowlist.test.ts -->
+- [ ] Rewrite the council template's framing from "enable and configure each
+      member" to "detection fills this in; you decide what may spend". Record
+      the before/after line count as the shipped metric.
+- [ ] Open the availability-semantics question as a blocker rather than
+      answering it in a roadmap step.
+
+**Exit criteria:** on a machine with a logged-in provider CLI and no config
+file, `doctor` names every detected provider, its billing class, and the
+one-line command to allow it; ask-before-spend behaviour is byte-identical.
+**Rollback:** the `doctor` section is additive; the template rewrite is a
+text-only revert.
+
+## Phase 4 — Extend `doctor`, do not duplicate it
+
+- [ ] Add the detection section to the existing `doctor`: hosts + versions, the
+      provider → transport → billing-class table, budgets active, and a
+      one-line reason plus one-line fix for every unavailable capability.
+- [ ] Render the first-invocation spend disclosure from the SAME code path as
+      that table — one renderer, not two, so the disclosure cannot drift from
+      the report.
+      <!-- verify: npx vitest run tests/scripts/_cli/cmd_doctor.test.ts -->
+- [ ] Fixture-pin the `doctor --json` shape for the new section (the agent and
+      GUI contract).
+      <!-- verify: npx vitest run tests/scripts/_cli/cmd_doctor.test.ts -->
+
+**Exit criteria:** `doctor --json` shape is fixture-pinned; every unavailable
+capability in the fixture machines carries a non-empty fix line.
+**Rollback:** drop the section; the rest of `doctor` is untouched.
+
+## Phase 5 — Pin the `CLAUDE_CONFIG_DIR` inheritance decision
+
+Co-located here because the detector produces the validated path set any future
+assignment rule would draw from. This phase ships **no behaviour change**: it
+makes current behaviour explicit and routes the trade-off to the threat model.
+
+- [ ] Add a test pinning today's behaviour: the spawn hardening is
+      deny-by-family, so an inherited `CLAUDE_CONFIG_DIR` reaches children
+      unchanged. Nothing asserts this either way today.
+      <!-- verify: npx vitest run tests/scripts/ai_council/spawn_env.test.ts -->
+- [ ] Add the candidate row to the threat model with its precondition stated
+      honestly: an actor who can set the orchestrator's environment
+      (compromised CI runner, poisoned shell profile) but cannot write the real
+      config dir can redirect a child to a config directory of their choosing,
+      and that directory carries instruction-bearing content.
+- [ ] Record the counter-argument in the same row: deny-by-family is
+      deliberate because provider CLIs legitimately need arbitrary env, and
+      denying this variable breaks any user who legitimately sets it. Name the
+      third option — strip inherited, permit only an assignment drawn from a
+      validated set — and what it costs.
+
+**Exit criteria:** behaviour is test-pinned; the threat-model row carries
+precondition, counter-argument, and three options; the blocker below is open.
+**Rollback:** none needed — a test and a documented row are additive.
+
+## Blockers
+
+### blocker: council-availability-semantics
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** any removal of `members.*.enabled` (Phase 3 ships reporting and
+  a one-line enable command instead)
+- **What to do:**
+  1. Read the shipped council template's rationale for the flag ("installing a
+     key is not the same as wanting the agent to spend money on it") and the
+     config contract's fail-closed rules (at least one enabled member; no
+     silent skips; low-impact fast-path as a two-knob opt-in).
+  2. Decide whether detection-derived availability is acceptable given that it
+     converts "a key exists on this machine" into "this provider may be
+     called". Per ADR-049 this class of scope expansion requires a threat
+     model, not a product rationale.
+  3. If yes, write the ADR that supersedes the contract's enabled-member rules
+     and states how the ask-gate alone preserves the no-silent-spend property.
+- **Resolved when:** an ADR exists naming the superseded contract sections, or
+  this roadmap records the flag as retained by decision.
+
+### blocker: transport-auto-default-flip
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** making `auto` the effective default (Phase 2 ships it opt-in)
+- **What to do:**
+  1. Confirm the intent: a user with both a logged-in CLI and an installed key
+     moves from per-token dollars onto subscription quota with no config edit.
+  2. If yes, authorize the breaking-change entry and the migration note, and
+     confirm `cli_call_budget` ships populated in the same change.
+- **Resolved when:** the breaking-change entry is authorized, or `auto` is
+  recorded as permanently opt-in.
+
+### blocker: claude-config-dir-inheritance-decision
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** any behaviour change to the spawn hardening's handling of
+  `CLAUDE_CONFIG_DIR` (Phase 5 ships only the test and the documented row)
+- **What to do:**
+  1. Read the Phase-5 threat-model row and the ADR that chose deny-by-family
+     over an allowlist.
+  2. Pick one: (a) leave inheritance as-is, keeping the row as accepted risk;
+     (b) deny the variable, accepting that a legitimate setter loses it for
+     children; (c) strip inherited and permit only a validated assignment.
+  3. If (b) or (c), record an ADR amendment — this reverses a considered
+     decision and must not land as an unexplained diff.
+- **Resolved when:** an ADR amendment names the chosen option, or the
+  threat-model row is marked accepted-risk with a dated rationale.
+
+## Acceptance criteria
+
+- The transport precedence test fails against pre-fix code — the bug is
+  demonstrated, not asserted — and passes after.
+- The contract and the resolver agree on the built-in fallback.
+- `auto` exists as an accepted value, resolves correctly on all five fixture
+  machines, and does not remove `manual` or the per-member override.
+- Billing classification is never derived from transport anywhere (static
+  check); vendor-official-CLI and community-CLI billing rules are unchanged.
+- A planted auth-rejection falls back exactly once; a planted timeout does not.
+- The detector is provably read-only and spend-free; install time never runs a
+  completion.
+- Ask-before-spend behaviour is byte-identical; no spend gate is removed by any
+  step in this roadmap.
+- `doctor` names every detected provider with its billing class and, when not
+  enabled, the one-line command that enables it; `--json` shape is
+  fixture-pinned; the spend disclosure renders from the same code path.
+- The council template's shipped values and its comments agree, and its
+  example-file pointer either resolves or is removed.
+- `CLAUDE_CONFIG_DIR` inheritance is test-pinned and its decision is an open
+  blocker, not an unrecorded assumption.
+- No claim asserts better answers, better routing, or better judgement. The
+  shipped claims are mechanical: a demonstrated bugfix, a spend-free detector,
+  template line-count reduction, and a fixture-pinned report shape.
+
+## Gate compliance, stated
+
+The composition-ratchet polish gate is OPEN (the adoption roadmap has 7 open
+steps and zero documented external adoptions). Its exceptions are bug fixes,
+completing broken first-run flows, and CI/claims infrastructure. Phase 2 is a
+bug fix. Phases 1, 4, and 5 are CI/claims infrastructure (a fixture-pinned
+report shape, a pinned security behaviour, a documented threat-model row).
+Phase 3 is the one that needs the argument: it ships reporting and a one-line
+command, not a settings-UI feature, and it removes no gate. If the maintainer
+reads Phase 3 as config-management polish, it defers without blocking the rest.
+
+## Provenance
+
+Source: an external planning set delivered through the user inbox, drafted by
+an assistant that had the repository tree but not its decision memory. Every
+in-tree premise was re-verified on 2026-07-31; corrections and refusals are
+recorded in
+[`zero-ceremony-inbox-cut`](../settings/contexts/zero-ceremony-inbox-cut.md).
+
+Council 2026-07-31 (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2 rounds,
+$0.14) — relevant convergence: the `CLAUDE_CONFIG_DIR` correction should be
+treated on its own timeline rather than riding the deferred cross-profile work
+(both members, both rounds). The council argued for shipping a behaviour fix
+immediately; this roadmap ships the pinning test and the documented decision
+instead, because reversing a considered design belongs in an ADR amendment.
+One member's argument step conflated a skill's bulk data directory with the
+config directory — the conclusion survives, that step does not.

--- a/agents/roadmaps/road-to-zero-ceremony-install.md
+++ b/agents/roadmaps/road-to-zero-ceremony-install.md
@@ -1,0 +1,290 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+related_roadmaps: [road-to-zero-ceremony-detection]
+related_adrs: [ADR-033, ADR-036, ADR-133, ADR-200, ADR-201]
+related_contracts: [gui-wizard]
+---
+
+# Road to zero-ceremony install — make the install claim true before making it shorter
+
+> The quickstart promises five minutes, documents its own npm failure mode
+> inline, and advertises a flag that does not exist. Close the gap between what
+> the install says and what it does, budget the payload that dominates the
+> wall-clock, and only then reduce the number of doors.
+
+## Goal
+
+Every statement the install surfaces makes is true of the code that runs, the
+npm payload is bounded by a pre-registered budget enforced in CI, and door
+retirement happens only after the failure mode that door exists to absorb is
+demonstrably covered elsewhere.
+
+## Prerequisites
+
+- [x] Host detection exists for 23 hosts and already pre-selects on first run.
+- [x] The wizard's "Recommended" path already runs detection-driven with zero
+      user *decisions* — two confirmations, no choices.
+- [x] A non-interactive install path already exists and is unit-tested
+      (skipped GUI on CI, non-TTY, headless, or any of a dozen flags).
+- [x] `setup.sh` is CI-smoked across 3 OS × 2 Node versions.
+
+## Context
+
+Source: an external planning set, audited against the tree on 2026-07-31.
+Corrections and refusals: [`zero-ceremony-inbox-cut`](../settings/contexts/zero-ceremony-inbox-cut.md).
+
+What the audit changed about this roadmap's shape:
+
+- **The doors are not equivalent.** The draft's verdict was "same Node ≥20
+  requirement, zero unique capability". False: the curl door fetches a GitHub
+  tarball and runs a dependency-inlined bundle via plain `node`, bypassing npm
+  dependency resolution entirely — which is precisely the failure the
+  quickstart's own `ETARGET` block documents. The npx door goes through the
+  registry and can hit that failure. So the curl door is a **rescue path**, and
+  retiring it before the npm path is safe re-breaks exactly the users who need
+  it. The council converged on this coupling independently.
+- **Its stated rationale has nonetheless rotted.** The installation docs still
+  headline the curl door as "no Node required" while the script now requires
+  `node`. The differentiator it was documented for is gone even though a real
+  one remains. Both facts have to appear in the same breath or the decision gets
+  made on a false premise in either direction.
+- **"Zero prompts" is already true of the terminal.** An accepted ADR already
+  makes the interactive global install zero-terminal-interaction — it hands off
+  to the browser instead. The prompts the draft wants to remove are in the
+  browser, not the shell. The honest goal is therefore "no browser handoff on
+  the default path", which is a different and larger claim.
+- **That flip touches a tier-1 rule.** The onboarding gate rule names the
+  browser wizard the *sole* onboarding surface and is hook-enforced. Inverting
+  the default is a kernel-rule edit under the slow-rollout gate, not a flag
+  change — so it lands here as a blocker with the path named, not as a step.
+- **`--gui` does not exist.** The README documents it anyway. Doc↔code
+  convergence is mandatory regardless of which way the default goes.
+- **No `npm pack` size gate exists** anywhere in CI. The payload budget is
+  genuinely new work with no conflict.
+
+### Gap audit against the source draft
+
+| Draft item | Verdict | Why |
+|---|---|---|
+| README quickstart honesty (drop "Five minutes", move `ETARGET` out) | **KEEP, resequenced** | The block may only leave the quickstart once the failure it documents is covered |
+| Fix stale installation docs ("no Node required") | **KEEP, new** | Not in the draft; found by audit; a false premise for the door decision |
+| `--gui` flag: implement, and converge docs with code | **KEEP** | The flag is documented and absent — a defect either way |
+| Retire `setup.sh` | **KEEP, gated** | No ADR conflict, but a declared public-URL contract with 6-leg CI, and a real rescue path — gated on npm-path coverage |
+| Zero-prompt (no browser handoff) as the default | **CUT → blocker** | Conflicts with an accepted ADR and a hook-enforced tier-1 rule; needs a kernel-rule edit under slow rollout |
+| Payload budget + `npm pack` size gate | **KEEP** | Nothing enforces size today |
+| Bulk-asset diet for the largest skill data dir | **KEEP** | 864 KB of an 8.9 MB payload, measured |
+| Merge "Pipeline A/B" into one emitter | **CUT → reduce** | The draft's labels are not this repo's (the repo's Pipeline B is projection→`.augment/`, not the consumer installer); the rule-layer drift it targets is already prevented by a shared predicate; and collapsing `dist/agent-src/` was decided against on scope-discipline grounds. What remains is a narrow audit, below |
+| Profile/pack questions deferred to point of need | **CUT** | Already true: packs prefill from the manifest and the Recommended path asks no questions |
+| Cold-start wall-clock published as evidence | **KEEP** | Honest structural metric; never a guaranteed number |
+
+## Phase 1 — Make every install statement true
+
+Pure doc↔code convergence. Each item is a defect today.
+
+- [ ] Remove "Five minutes" from the quickstart self-description; state what is
+      structurally guaranteed instead (one command, detection-driven, nothing
+      written before confirmation).
+- [ ] Correct the installation docs' "no Node required" headline for the curl
+      door — the script requires `node` today.
+- [ ] Correct the installation docs' description of the retired installer
+      scripts (they still describe entry points a prior ADR removed).
+- [ ] Implement `--gui` as an explicit opt-in flag that forces the wizard, and
+      make the README's description of it true. This is additive and does not
+      change any default.
+      <!-- verify: npx vitest run tests/cli/initRouting.test.ts -->
+- [ ] Document the real opt-out set in one place (the non-interactive path
+      already skips the GUI on CI, non-TTY, headless, and a dozen flags) — today
+      a reader has to infer it from code.
+      <!-- verify: npx vitest run tests/cli/initRouting.test.ts -->
+
+**Exit criteria:** no install-surface sentence contradicts the code path it
+describes; `--gui` exists and does what the README says; the opt-out set is
+documented in one place.
+**Rollback:** text-only reverts plus dropping one flag.
+
+## Phase 2 — Cover the npm failure mode the rescue door absorbs
+
+The `ETARGET` block is evidence, not clutter. It leaves the quickstart when the
+failure stops happening — not before.
+
+- [ ] Reproduce the documented failure deterministically in CI: an `.npmrc`
+      with `prefer-offline=true` plus stale cached metadata, asserting the
+      current error.
+      <!-- verify: npx vitest run tests/install/npm_resolution.test.ts -->
+- [ ] Make the npx path handle it without the user reading prose: detect the
+      resolution failure and either retry with fresh metadata or fail with the
+      exact one-line remedy. A troubleshooting paragraph is not a fix.
+      <!-- verify: npx vitest run tests/install/npm_resolution.test.ts -->
+- [ ] Only once that test is green: move the remaining `ETARGET` prose out of
+      the quickstart into a troubleshooting page.
+- [ ] Record what the curl door still uniquely provides after this phase — a
+      registry-independent path — so the retirement decision in Phase 3 is made
+      against the post-fix reality rather than today's.
+
+**Exit criteria:** the planted-stale-metadata test reproduces the failure on
+pre-fix code and passes after; the quickstart no longer carries recovery prose.
+**Rollback:** revert the retry/error change; restore the prose block.
+
+## Phase 3 — Door consolidation, gated on Phase 2
+
+- [ ] Decide the curl door's disposition against the Phase-2 result, and record
+      the decision with its reason. Blocker below carries the decision.
+      <!-- blocked-by: curl-door-disposition -->
+- [ ] If retired: keep the public URL alive as a stub that prints the npx
+      one-liner and exits non-zero, add the breaking-change and migration
+      entries, and keep the smoke workflow green against the stub rather than
+      deleting the workflow.
+      <!-- blocked-by: curl-door-disposition -->
+- [ ] If retained: fix its documentation to describe what it actually is (a
+      registry-independent rescue path that requires `node`) and stop counting
+      it as redundant surface.
+      <!-- blocked-by: curl-door-disposition -->
+
+**Exit criteria:** the door's disposition is recorded with a reason; the public
+URL still resolves either way; the smoke workflow is green.
+**Rollback:** restore the script from history; the URL contract was never
+broken.
+
+## Phase 4 — Payload budget with CI teeth
+
+- [ ] Measure and pre-register the tarball budget from the current measured
+      size; record the measurement conditions alongside the number.
+- [ ] Add an `npm pack` size gate to CI that fails above the budget. Nothing
+      enforces size today.
+      <!-- verify: npx vitest run tests/scripts/check_pack_size.test.ts -->
+- [ ] Move the largest skill's bulk data directory (864 KB of an 8.9 MB
+      payload) behind a checksum-pinned, versioned lazy fetch on first skill
+      use; the skill degrades with a stated reason when the asset is absent and
+      the network is unavailable.
+      <!-- verify: npx vitest run tests/skills/lazy_assets.test.ts -->
+- [ ] Audit the next two largest data directories and record the result —
+      measured, not assumed.
+- [ ] Add a per-skill payload-share cap to the same gate so no single skill can
+      silently reclaim the space.
+      <!-- verify: npx vitest run tests/scripts/check_pack_size.test.ts -->
+
+**Exit criteria:** the gate fails on a deliberately oversized fixture and
+passes on the real tree; the lazy-fetch path is exercised offline with a stated
+degradation.
+**Rollback:** drop the gate; restore the data directory to the payload.
+
+## Phase 5 — Narrow emitter audit (what survives of the unification proposal)
+
+- [ ] Audit which consumer-install emitters lack the projection-side predicate
+      the rule layer already shares, and list each divergence with its file.
+      This is the real content of the draft's "one pipeline" item once the
+      already-shared rule predicate is accounted for.
+- [ ] For each divergence found, either route it through the shared predicate
+      or record why it must differ. Do not collapse the projected tree — that
+      was decided against on scope-discipline grounds, and the byte-equality
+      invariant between source and projection must survive untouched.
+      <!-- verify: npx vitest run tests/install/emit_host_rules.test.ts -->
+- [ ] Use this repo's own pipeline names in every artefact this phase touches;
+      the source draft's A/B labels mean something different here and a drift
+      check reads those names.
+
+**Exit criteria:** every divergence is either routed through the shared
+predicate or documented with a reason; the source↔projection byte-equality
+check is still green.
+**Rollback:** per-emitter reverts; no shared state changed.
+
+## Phase 6 — Cold-start evidence
+
+- [ ] Wall-clock a containerized bare-machine run (install → `doctor` green) in
+      CI and publish it as a tracked number with its measurement conditions.
+- [ ] State the structural guarantee separately from the number: one command,
+      detection-driven, a bounded payload. The wall-clock is evidence, never a
+      promise — network and registry latency are not ours to guarantee.
+
+**Exit criteria:** the number is produced by CI with its conditions recorded
+next to it.
+**Rollback:** remove the job; no shipped claim depends on it.
+
+## Blockers
+
+### blocker: curl-door-disposition
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 3
+- **What to do:**
+  1. Read the Phase-2 result: does the npx path now handle the registry
+     resolution failure without prose?
+  2. Decide whether a registry-independent install path is still wanted for
+     restricted networks and mirrored registries.
+  3. Note the constraint either way: the raw URL is a declared public contract
+     with CI coverage across 3 OS × 2 Node versions — it must keep resolving
+     even if the script becomes a stub.
+- **Resolved when:** the disposition is recorded in this roadmap with its
+  reason, and the smoke workflow reflects it.
+
+### blocker: browser-handoff-default
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** any change making the non-browser path the default
+- **What to do:**
+  1. Note what is already true: the terminal path is already prompt-free, the
+     Recommended path already asks zero questions (two confirmations), and
+     detection already pre-selects. The remaining delta is the browser handoff
+     itself, not choice overload.
+  2. Note what stands in the way: an accepted ADR makes the browser handoff the
+     interactive default, and the onboarding-gate rule — tier-1, hook-enforced
+     — names the browser wizard the sole onboarding surface. Inverting this is
+     a kernel-rule edit: own PR, ≥ 24 h between merges, per the slow-rollout
+     gate.
+  3. Note what is missing: there is no usage evidence either way, because zero
+     external onboarding sessions have completed. The instrument that would
+     produce it is the recruited session already open in the adoption roadmap.
+  4. Decide: supersede the ADR and edit the rule, or keep the handoff and let
+     `--no-ui` remain the documented escape.
+- **Resolved when:** an ADR supersession plus a kernel-rule edit PR exists, or
+  this roadmap records the handoff as retained by decision.
+
+## Acceptance criteria
+
+- No sentence on any install surface contradicts the code path it describes —
+  checked per surface, not asserted globally.
+- `--gui` exists and behaves as documented; the opt-out set is documented once.
+- The npm resolution failure is reproduced by a test that fails pre-fix, and
+  the quickstart carries no recovery prose after it passes.
+- The curl door's disposition is recorded with a reason, and its public URL
+  resolves either way.
+- An `npm pack` size gate exists, fails on an oversized fixture, and carries a
+  pre-registered budget with its measurement conditions.
+- No single skill exceeds its pre-registered payload share.
+- Every emitter divergence from the shared projection predicate is routed or
+  documented; source↔projection byte equality is untouched.
+- A cold-start wall-clock exists as a CI-produced number with conditions
+  attached, and no shipped claim states it as a guarantee.
+- The install story's shipped claims stay mechanical: one command, bounded
+  payload, nothing written before confirmation. No claim that the install is
+  fastest, easiest, or better than any alternative.
+
+## Gate compliance, stated
+
+The composition-ratchet polish gate is OPEN. Phases 1–2 are bug fixes (false
+documentation, an unhandled failure the docs work around by hand). Phases 4–6
+are CI/claims infrastructure. Phase 3 is a surface *retirement*, which reduces
+rather than adds. Phase 5 is a divergence audit. The one item the gate would
+genuinely bite — inverting the browser-handoff default — is deliberately a
+blocker and not a step.
+
+## Provenance
+
+Source: an external planning set delivered through the user inbox, drafted by
+an assistant that had the repository tree but not its decision memory. Every
+in-tree premise was re-verified on 2026-07-31; corrections and refusals are in
+[`zero-ceremony-inbox-cut`](../settings/contexts/zero-ceremony-inbox-cut.md).
+
+Council 2026-07-31 (anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2 rounds,
+$0.14). Round 1 leaned toward splitting the arc into independent releases;
+round 2 reversed on one specific coupling: retiring the curl door and covering
+the npm failure mode are the same change, because the door's users are the
+users the failure hits. That coupling is why Phase 3 is gated on Phase 2 rather
+than sequenced beside it. Both members also converged that the browser-handoff
+flip is a default inversion requiring the gate, not a small additive delta —
+adopted verbatim as the blocker above. The council framed its answers as
+release packaging; that framing is dropped, since roadmaps describe work and
+release decisions are taken outside them.

--- a/agents/settings/contexts/zero-ceremony-inbox-cut.md
+++ b/agents/settings/contexts/zero-ceremony-inbox-cut.md
@@ -1,0 +1,324 @@
+# Zero-ceremony inbox — the roadmap cut (2026-07-31)
+
+> Durable record of the evidence audit and council convergence that turned an
+> **eight-document externally-drafted release plan into three active roadmaps,
+> two deferred ones, and five explicit refusals**. Cite this file — not the
+> transient inbox files, not the council response directory.
+
+## What arrived
+
+One inbox set (8 documents + a chat transcript + a zip), consumed from the local
+inbox and archived to `agents/tmp.old/road-to-v10/` — gitignored, so this record
+is the only tracked account of what arrived. It was drafted in a session
+that had the repo's **tree** but not its **decision memory**: no ADR index, no
+council locks, no honest-null records. The drafts are strong on direction and
+stale on fact — the same failure shape recorded in
+[`elder-ponytail-harvest-cut`](elder-ponytail-harvest-cut.md).
+
+| Draft | Proposed | Disposition |
+|---|---|---|
+| master orchestrator | decision ledger D1–D12, waves W0–W5, "this arc IS the major" | **CUT as a document** — version framing violates roadmap template rule 13; waves re-cut below |
+| findings record | F0–F6 leverage ranking + external evidence | **KEEP as evidence**, re-based; F2c and F6 refused |
+| zero-config detection | one read-only detector, detection-based availability, `doctor` | **KEEP** → detection roadmap |
+| cli-first transport | one `transport.mode`, billing untangled from transport | **KEEP + upgrade** (a live bug found) → detection roadmap |
+| one-minute install | zero-prompt init, door consolidation, emitter unification | **KEEP, split** → install roadmap; emitter unification downgraded |
+| just-in-time settings | no shipped template, sparse decision file, A/B/C classes | **KEEP** → settings roadmap |
+| native model primitives | per-host emission of native routing knobs | **DEFER** (adoption-gated) → `later/` |
+| cross-profile dispatch | role-pinned subagent lanes across Claude profiles | **DEFER + correct premise** → `later/` |
+
+## Verified findings that override the drafts (measured in-tree 2026-07-31)
+
+Every item below was checked against the live tree. The drafts assert the
+opposite or assert novelty where the mechanism already exists.
+
+### 1. Consumer rule filtering already shipped — the headline number is not ours to claim
+
+The drafts' load-bearing exhibit is "consumers install **94/95 rules
+unfiltered**; scoping identified ~32 as relevant; the **82.6%** measured saving
+finally lands where users are." Three separate errors:
+
+- **Filtering shipped 2026-07-13 and is on by default.** `rule_workspaces` in
+  `src/config/agent-settings.template.yml` lists every consumer workspace;
+  **15 of 110** rules are excluded from a consumer install. `src/install/rule_scope.ts`
+  delegates to the projection predicate so *install semantics cannot drift from
+  projection semantics* — the divergence the drafts want to fix by unifying
+  emitters is, for the rule layer, already fixed by a shared predicate.
+- **The `~32`-relevant figure was superseded in-tree.** The audit corrected the
+  maintainer-only set from 63 rules to **16 rules ≈ 13.9k tokens**; the measured
+  flip delta is **15 rules / 9,880 GPT tok / 13.1%**. `~32` survives only in a
+  stale goal line.
+- **The 82.6% belongs to a different, DISABLED lever.** It measures *thin
+  projection*, not install-time scoping — a three-stage pipeline whose stages
+  have independent inputs and failure modes. Thin failed a pre-registered 48%
+  win-rate floor at **36.2%**; the length-neutral rerun was inconclusive
+  (κ=0.46); and the replacement deterministic instrument recorded its own
+  **honest null on 2026-07-31** (inter-evaluator κ=0.700 against a registered
+  0.800 floor — failing on the *easiest* fixtures, with 0 of 255 `must_include`
+  anchors carrying a literal token). Presenting 82.6% as a consumer benefit is
+  precisely the claims-ledger violation the house law forbids.
+
+**Consequence:** the "one pipeline / 94→32" release criterion is deleted. What
+survives is number hygiene: **82.6% / 81.6% / 65.6% all circulate in-tree for
+this one lever** — one measurement, one citation, everywhere.
+
+### 2. `doctor` is not new
+
+The detection draft specifies `doctor` as "NEW, the visible surface." Four
+doctor-family commands already ship (`doctor`, `doctor-shell`, `hooks:doctor`,
+`reach:doctor`); the main module is ~124 KB and already performs a read-only
+`auth.json` probe. A transport-mode resolver already exists as a pure function,
+and auth probing exists in **two** shapes (a council lazy-probe with cache and
+timeout, and doctor's read-only probe). The work is **extension**, not creation
+— and a third probe shape must not be added.
+
+### 3. The cross-profile security fence points the wrong way
+
+The draft states that `hardenedSpawnEnv` strips `CLAUDE_CONFIG_DIR`, that the
+change needed is "one narrow assignment rule", and that "inheritance from the
+orchestrator's environment stays stripped."
+
+Reality: the function is **deny-by-family, not allowlist** — a documented
+design choice, because the provider CLIs legitimately need arbitrary env.
+`CLAUDE_CONFIG_DIR` matches no deny family, so it is **inherited unchanged
+today**, and assignment already works through the overrides path. No test pins
+its behaviour either way.
+
+So the draft's "narrow extension" is actually a **new restriction to add**
+(strip inherited, permit only a validated assignment), and its stated invariant
+is currently false. This inverts the risk conversation: the exposure, such as
+it is, exists **today and independently of the deferred feature**.
+
+### 4. `--gui` does not exist
+
+The install draft demotes the wizard "to `--gui`". No such flag exists in any
+code path — while `README.md` documents it. Today the wizard is the **default**
+on an interactive TTY and is suppressed by `--no-ui` / `AGENT_CONFIG_NO_UI=1` /
+CI / non-TTY / any of a dozen flags. So *some* doc↔code convergence is
+mandatory regardless of whether the default is inverted.
+
+### 5. A live two-clocks bug in the transport key
+
+`src/scripts/council_cli.ts` reads `ai_council.mode` (top level) while the
+template ships `ai_council.defaults.mode`. On that path the key is never
+consulted and the effective default falls through to `manual` — not the `api`
+the template comment and the config contract both promise. The transport
+untangling therefore lands as **a bugfix first**, a default-flip second.
+
+### 6. Smaller premise corrections
+
+- Host-detection table covers **23** hosts, not 24 — test-pinned and
+  claim-bound in the proof surface.
+- `setup.sh` is **live and CI-smoked**, not a deprecated stub — retiring it is
+  real work with a real consumer.
+- The marketplace plugin is **not "deliberately empty"**: it carries 6 hook
+  dispatch entries that are a hard requirement. Removing it silences
+  hot-context, chat-history capture, context-hygiene, no-verify blocking, and
+  the roadmap flip-guard.
+- Settings template is **1,233** lines and **is** shipped (`src/config/` is in
+  the npm `files` allowlist).
+- `environment_detector.ts` does **not** exist — greenfield, not an extension
+  point. `toolDetection.ts` ("is the tool installed on this machine") and
+  `detect.ts` ("does this project have a bridge dir") deliberately answer
+  different questions; collapsing them would erase that distinction.
+- `settings set` does **not** exist — `settings` is a GUI alias. Greenfield.
+- `cli_call_budget` is **fully implemented** and merely commented out in the
+  template — populating it is a template edit, not a build.
+- `subagents.auto` already defaults to `on`.
+
+## What the drafts got right (kept without change)
+
+The settings template really is 1,233 shipped lines; the council template
+really pins stale model IDs and hand-maintained ladders; the README really says
+"Three steps. Five minutes." and really carries an `npm error ETARGET`
+troubleshooting block **inside** the install instructions; the interactive
+install really boots a loopback HTTP server so a human can tick tool
+checkboxes; there really are three install doors; there is **no** `npm pack`
+size gate anywhere in CI; one skill's bulk data dir is 864 KB of an 8.9 MB
+payload.
+
+The staleness exhibit is self-demonstrating: the council debate that reviewed
+this cut ran on `claude-sonnet-4-5` and `gpt-4o` — the two stale pins the
+settings work deletes.
+
+## Standing decisions each proposal runs into
+
+Audited 2026-07-31. "Lock" below means an accepted ADR, a locked contract, or a
+CI-enforced check — not an opinion.
+
+| Proposal | Runs into | Verdict |
+|---|---|---|
+| Plugins as a content channel | The 2026-07-07 single-surface decision (marketplace-primary explicitly rejected, don't relitigate) · the locked one-canonical-channel-per-tool contract · the machine-checked surface matrix · **a CI lint that FAILS on any repopulated plugin skills list** | **Refused** — R1 |
+| Zero-prompt install by default | An accepted ADR making the browser handoff the interactive default · the onboarding-gate rule (tier-1, hook-enforced) naming the wizard the *sole* onboarding surface | **Blocker** — needs a kernel-rule edit under slow rollout |
+| Retire the curl door | No ADR conflict · but a declared public-URL contract with 6-leg CI, and it is a real rescue path | **Kept, gated** on covering the npm failure first |
+| Ship no settings template | The template↔schema parity gate ("loosen it and the GUI silently drifts") · an installer hard-fail on a missing template · nine further direct readers | **Reframed** — split the template's two jobs |
+| Remove `members.*.enabled` | The shipped template's own rationale ("installing a key is not the same as wanting the agent to spend money on it") · the config contract's fail-closed rules and no-silent-skips clause · the ADR requiring a threat model for this class of scope expansion | **Blocker** — it is a spend gate, not ergonomics |
+| One global `transport.mode` replacing `defaults.mode` | The three-valued `mode` (the draft's values silently delete `manual`, the safest transport) · the per-member override the per-provider billing rules depend on · and the global knob already exists | **Reduced** to a bugfix plus one added value |
+| Delete the static model keys | The tier-mapping ADR, whose rejected-alternatives section names a per-vendor table as the rejected mechanism · the ladder the loader requires for cost downgrade · the judge-model key's Iron-Law status in four judge skills | **Mostly refused**; the real staleness is the pinned IDs |
+| One emitter library | No lock against a shared-emitter refactor · but the draft's pipeline labels are not this repo's, and collapsing the projected tree was decided against on scope-discipline grounds | **Reduced** to a divergence audit |
+| Cross-profile dispatch, default ON | The subagent-boundary contract's core invariant — *a subagent cannot do what its parent may not* — plus its explicit non-claim about host-spawned subagents | **Deferred**; premise corrected, see below |
+
+A further cross-cutting gate applies to the set as a whole: the subsystem-freeze
+ADR forbids starting a new large subsystem — a new platform integration among
+them — while any of its unblock conditions is open. Those conditions currently
+hold, but one rides a defer that lapses in weeks. The plugin channel is a new
+platform integration by that ADR's own definition.
+
+## Cross-profile dispatch — deferred, with its premise corrected and no roadmap file
+
+The design is sound and the drafts' honesty about it is good: it claims
+configuration isolation, separate quota pools, and per-lane rate-limit blast
+radius, and explicitly refuses a defect-finding quality claim. It is deferred
+anyway, for three reasons the drafts could not see:
+
+1. Its security premise is inverted (finding 3) — the fence it calls a narrow
+   relaxation is actually a restriction that does not exist yet.
+2. Dispatching a child into a different config directory means the child
+   resolves a different profile's rules, settings, and floors. The
+   subagent-boundary contract's invariant is that a subagent cannot do what its
+   parent may not, and it already declines to claim anything about subagents
+   spawned by host primitives outside this package's templates. A default-ON
+   flip is materially wider than the bounded, N=2 evidence that justified the
+   last orchestration default flip.
+3. The audience is approximately the maintainer, while the adoption gate is open.
+
+No roadmap file is opened for it: the only part worth doing now is
+decision-neutral and has landed as Phase 5 of the detection roadmap — pin the
+current inheritance behaviour with a test, write the attack chain and its
+counter-argument into the threat model, and route the trade-off to an ADR
+amendment. Re-open the feature when the adoption gate exits and that decision
+has landed.
+
+## Refusals — items that do not become work
+
+### R1 — Plugins as a content channel: REFUSED, revisit bar not cleared
+
+The drafts propose making marketplace plugins first-class content (a wedge
+plugin plus one plugin per pack), calling the prior decision "tipped".
+
+It is not tipped. A 2026-07-07 council converged on *projection-primary, plugin
+retired*, explicitly **rejecting** marketplace-primary because SHA-snapshot
+staleness would own the only content path and offline installs would be lost.
+An accepted ADR independently says *"Keep `source: './'`. Do not restructure
+the marketplace source."* Three revisit triggers were pre-registered: the host
+changes plugin/marketplace semantics · delisting measurably hurts adoption ·
+>40% of installs arrive via marketplace search. **None has fired.**
+
+The new evidence offered is external market data about the *channel* (a
+tech-radar "Adopt" rating; ~300k monthly browsing developers; the channel being
+publicly unsigned and unaudited, making a provenance-bound plugin an unoccupied
+wedge). That is a real argument and it is **orthogonal to the prior decision's
+actual reason** — channel attractiveness does not answer content-path
+staleness. Per the decision-revisit gate the mechanism must match, so this is
+surfaced rather than silently executed, and refused rather than silently
+dropped: the honest next step is the **cheap measurement that would produce a
+qualifying trigger**, not the build.
+
+### R2 — The 82.6% as a shipped consumer benefit: REFUSED (see finding 1)
+
+### R3 — A rules-budget ADR plus verifier wiring: REFUSED as already-built
+
+`src/scripts/check_always_budget.ts` runs in CI with a 49,000-char total cap,
+a per-rule cap, single-rule (12%) and top-3 (30%) concentration caps, and a
+`load_context` nesting limit. The draft proposes creating what exists.
+
+### R4 — The 90-minute human gate as new work: REFUSED as duplication
+
+The launch story, the directory listings, the recruited external session, and
+`FUNDING.yml` are **already open steps** in `road-to-adoption-without-narrative-debt`,
+with a structured `real-external-participant` blocker owned by the user.
+Restating them here would create two clocks for one gate. The drafts are right
+that this is the highest-leverage item; the correct action is to execute the
+existing roadmap, not to re-plan it.
+
+### R5 — A roadmap WIP cap and new governance lint: REFUSED, already decided
+
+19 active roadmaps for a solo maintainer is real debt, and the drafts are right
+to name it. But a standing WIP cap was **already proposed and rejected** by
+council in the subsystem-freeze ADR: *caps measure concurrency, not doneness;
+for a solo maintainer they add accounting without changing behavior.* The
+substitute that shipped instead is that ADR's unblock-list freeze. Re-proposing
+the rejected mechanism is not new evidence.
+
+`road-to-surface-consolidation` independently carries the governing precedent —
+*fold the proposed complexity-budget into an existing checklist, zero new
+surface.* Folded there; no new lint, no new roadmap. Adding a mechanism about
+roadmap-count while adding roadmaps would also have been self-refuting.
+
+### R6 — The ADR `review_date` sweep: REFUSED by current policy
+
+The drafts call for running the ADR `review_date` sweep. Three review dates are
+indeed overdue with no recorded action — but the current policy deprecated
+calendar review in favour of event triggers: *ADRs name a revisit condition, not
+a cadence; a bare "annually" is rejected — a calendar review is ignored, an
+event fires.* The frontmatter gate deliberately does not chase `review_date`,
+and grandfathers older ADRs. So the overdue dates are legacy artefacts of a
+superseded policy, not a live obligation. What would be worth doing — attaching
+`review_trigger` values to the 114 ADRs that carry neither — is a different
+task, and one nobody asked for.
+
+## The version framing itself is refused
+
+The master draft is titled around a version, declares "release criteria", marks
+where the version "SHIPS", and argues the arc *is* the major. Roadmap template
+rule 13 forbids exactly this: roadmaps describe work, not shipping; release and
+tag decisions belong to the user and are taken outside the roadmap. The arc is
+therefore re-cut around its **outcome** — install and use without ceremony —
+and the breaking-change inventory is preserved as a roadmap section rather than
+as release notes.
+
+## Council convergence (2026-07-31)
+
+anthropic/claude-sonnet-4-5 + openai/gpt-4o, 2 rounds, $0.14 actual against a
+$0.84 cap projection. The debate ran on the two stale pins the model work
+targets — the most direct staleness evidence available.
+
+- **Container.** Round 1 both leaned toward splitting the arc into independent
+  releases; round 2 reversed on one specific coupling, and that reversal is the
+  session's most useful finding: **retiring the curl door and covering the npm
+  failure mode are the same change**, because the door's users are precisely the
+  users the failure hits. Adopted as a phase dependency. The members' release
+  packaging is dropped — roadmaps describe work, and release decisions are taken
+  outside them.
+- **Plugins.** One member firmly against reopening (the new evidence is about
+  channel *reach*; the prior decision turned on *content-path staleness*, and a
+  byte-equality test detects staleness rather than preventing it). The other
+  called it reopenable but conditional on proving staleness control. Both
+  independently proposed the same cheap qualifying experiment: instrument the
+  existing shim's install pointer with a provenance marker, wait, and measure
+  the marketplace share of installs — which is exactly the pre-registered
+  >40%-via-marketplace trigger. Recorded as the honest next step in R1; not
+  scheduled, because it is a measurement the maintainer starts, not agent work.
+- **Zero-prompt default.** Both members, both rounds: a default inversion
+  requiring the gate, not a small additive delta. One offered a falsifier — *if
+  the shipped "Recommended" path was already zero-prompt, it IS just
+  make-Recommended-default.* Checked: it is a **two-confirmation** path with
+  detection-driven pre-selection and "nothing is written until you confirm".
+  So the falsifier does not fire, and the real remaining delta is the browser
+  handoff itself, not choice overload.
+- **The security correction.** Both members, both rounds: treat it on its own
+  timeline rather than riding the deferred feature. The council argued for
+  shipping a behaviour fix immediately; the roadmaps ship the pinning test plus
+  the documented decision instead, because reversing a considered design belongs
+  in an ADR amendment. One member's argument step conflated a skill's bulk data
+  directory with the config directory — the conclusion survives, that step does
+  not.
+
+## A note for whoever moves these drafts
+
+The inbox drafts cite ADR numbers from an external project as though they were
+this repo's (this repo's numbering does not reach them). Copying those citations
+into the tracked tree unanonymised would breach the source-confidentiality rule.
+Nothing in this cut or the roadmaps it spawned carries them.
+
+## Honest framing of this cut
+
+Two things this record does not establish. First, the install-simplification
+arc rests on maintainer judgement plus self-evident defects (a troubleshooting
+block inside the quickstart, three doors, a five-minute self-description), not
+on measured user friction — the instrument that would measure it is the same
+unrecruited external session R4 points at, so this work is sequenced *before*
+its own evidence. That is a deliberate, stated trade, not an oversight.
+Second, a prior council deferred "simple/expert mode" for want of evidence that
+rule-count rather than install ceremony is the adoption blocker; this cut bets
+on ceremony without settling that question. If the recruited session says
+otherwise, the install roadmap is the one that loses.


### PR DESCRIPTION
## What this is

An externally-drafted 8-document release plan arrived through the user inbox,
written by an assistant that had this repo's tree but **not** its decision
memory — no ADR index, no council locks, no honest-null records. This PR is the
result of auditing every load-bearing in-tree premise, then re-cutting the plan
against what is actually true.

**Outcome: 8 drafts → 2 active roadmaps, 2 parked in `later/`, 6 refusals, 1 durable cut record.** No `src/` change; this PR plans work, it does not execute it.

## The premises that did not survive

| Draft premise | Reality |
|---|---|
| "Consumers install 94/95 rules unfiltered" | Filtering shipped 2026-07-13, on by default — 15/110 excluded. Stale by three weeks. |
| "~32 rules are consumer-relevant" | Already corrected in-tree to **16 rules / 13.9k tok**; `~32` survives only in a stale goal line. |
| "The 82.6% saving finally lands where users are" | That number belongs to the **thin projector**, not the install-time scoper. Thin failed a pre-registered 48% floor at 36.2%, and its replacement instrument recorded its own honest null **on 2026-07-31** (evaluator κ=0.700 vs a 0.800 floor). Shipping it as a consumer benefit is the claims-ledger violation the house law forbids. |
| "`doctor` (NEW, the visible surface)" | Already exists — 4 commands, the main module ~124 KB, already probing auth read-only. So does a transport resolver, and two auth-probe shapes. |
| "`hardenedSpawnEnv` strips `CLAUDE_CONFIG_DIR`; we need one narrow assignment rule" | It is deny-by-**family**, so the variable is **inherited unchanged today**. The "narrow relaxation" is actually a restriction that does not exist yet, and the draft's stated invariant is currently false. |
| "Demote the wizard to `--gui`" | `--gui` does not exist in code. The README documents it anyway. |
| "24 detected hosts" | 23 — test-pinned and claim-bound. |

Also found en route: a live two-clocks bug (the council path reads
`ai_council.mode` while the template ships `ai_council.defaults.mode`, so the
documented `api` default is never consulted), and the council template shipping
`enabled: true` against its own comment claiming it defaults to false.

## What is refused, and against what

Not preferences — standing decisions:

- **Plugins as a content channel** — marketplace-primary was explicitly rejected (staleness would own the only content path), the one-canonical-channel-per-tool contract is locked, and **a CI lint fails on any repopulated plugin skills list**. None of the three pre-registered revisit triggers has fired; the new evidence is about channel *reach*, which is orthogonal to the original reason. The cheap experiment that *would* produce a qualifying trigger is recorded instead.
- **A rules-budget verifier** — already in CI, with per-rule and concentration caps.
- **The 90-minute human gate as new work** — already open steps in `road-to-adoption-without-narrative-debt`, with a structured blocker owned by the user. Re-planning it would create two clocks for one gate.
- **A roadmap WIP cap** — already proposed and rejected: *caps measure concurrency, not doneness.*
- **The ADR `review_date` sweep** — current policy replaced cadence with event triggers.
- **The version framing itself** — roadmap template rule 13: roadmaps describe work, not shipping. Hence `zero-ceremony`, not a version number.

## What ships as plans

**`road-to-zero-ceremony-detection.md`** (active) — a greenfield read-only
detector; the transport **bugfix** as the centrepiece, pinned by a test that
fails against today's code; transport reduced from the draft's "new global key"
to one added *value*, because the draft's three values silently deleted `manual`
(the safest transport) and the per-member override the billing rules depend on;
`doctor` extended rather than duplicated; `CLAUDE_CONFIG_DIR` inheritance pinned
by test with its trade-off routed to an ADR amendment. Removing
`members.*.enabled` is refused into a blocker — that flag is a spend gate, not
ergonomics.

**`road-to-zero-ceremony-install.md`** (active) — doc-vs-code defects first;
then the finding that changed the plan: **the curl door bypasses npm resolution
entirely**, so it is a rescue path for exactly the failure the quickstart's own
`ETARGET` block documents. Retirement is gated on covering that failure, not
sequenced beside it. Plus a payload budget with an `npm pack` size gate (nothing
enforces size today). Inverting the browser-handoff default is a blocker, not a
step — it needs a kernel-rule edit under the slow-rollout gate.

**`later/road-to-zero-ceremony-settings.md`** — "ship no settings template" is
unavailable (it is the schema-parity source; a CI test fails when a schema key
has no template path). But the *goal* is: the template does two unrelated jobs,
so keep it package-internal and make the materialised **user** file sparse.
Parked because it is config-management work under the open composition-ratchet
gate, whose exceptions do not cover it — parked whole rather than smuggled in as
"simplification".

**`later/road-to-zero-ceremony-host-primitives.md`** — the draft's mechanism is
what the tier-mapping ADR rejected by name. Phase 0 probes are the only part
that pays before the gates lift, and they produce exactly the evidence that
ADR's review window needs.

Cross-profile dispatch gets no file: its only decision-neutral piece landed as
detection Phase 5, and the feature collides with the subagent-boundary invariant
that *a subagent cannot do what its parent may not.*

## Verification

- `lint_roadmap_complexity` — both new active roadmaps pass `[structural]`
- `lint_roadmap_blockers` — 21 roadmaps blocker-contract-clean
- `lint_roadmap_later_disposition` — both `later/` roadmaps parked with resume conditions
- `check_references` — no broken references
- `check_no_roadmap_refs` — no transient references from stable artifacts
- `check_no_external_sources` — clean
- `check_md_language` — clean on all five new files
- Dashboard regenerated via `./agent-config roadmap:progress`

**Pre-existing, not from this PR:** `lint_roadmap_complexity` fails on
`road-to-local-ci-trust.md` and `road-to-thin-flip-under-anchor-scoring.md` —
both missing a valid `complexity:` value on `main`. Left untouched as
pre-existing debt in files this diff has no task-aligned reason to edit.

## Council

2026-07-31, 2 members, 2 rounds, $0.14 actual (cap projection $0.84) — inlined
in the cut record. It ran on the two stale model pins the plan targets, which is
the most direct staleness evidence available. Its most useful contribution was
the curl-door coupling above; both members also converged that the zero-prompt
flip is a default inversion requiring the gate, and that the
`CLAUDE_CONFIG_DIR` correction belongs on its own timeline.

## Honest framing

The install work rests on maintainer judgement plus self-evident defects, **not**
on measured user friction — the instrument that would measure it is the same
unrecruited external session the refused human gate points at. So this work is
sequenced before its own evidence. That is a stated trade, not an oversight. And
the audit's blunt conclusion stands: the highest-leverage item in the whole set
is still the ~90 minutes only the maintainer can spend.
