### PR TITLE
fix(release): raise the test-count probe buffer past 1 MiB

### DIFF
--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -772,10 +772,70 @@ function _changelog_line(c: Commit): string {
 const _TEST_COUNT_LINE_RE = /^Tests:\s+(\d+)/m;
 
 /**
+ * Buffer ceiling for the `vitest list` probe, in bytes.
+ *
+ * `spawnSync` buffers the child's whole stdout in memory and fails with
+ * ENOBUFS past `maxBuffer`, whose default is 1 MiB. The probe emits one line
+ * per test case, so its output grows with the suite: at 9470 cases the listing
+ * is ~1.25 MB, i.e. already past the default. That is what silently dropped
+ * the footer from the 9.10.0 notes and turned the `changelog-entry` gate red.
+ * 64 MiB is ~50× the current listing — headroom for a suite many times this
+ * size, at no cost when the output is small.
+ */
+const _TEST_LIST_MAX_BUFFER = 64 * 1024 * 1024;
+
+/**
+ * Count test cases from a finished `vitest list` spawn result, or return null
+ * when the probe did not produce a usable listing.
+ *
+ * Split out from `_count_tests_current` so the failure modes are testable
+ * without spawning the real (~14s, >1 MB) collection. `warn` is injected for
+ * the same reason; it defaults to stderr.
+ */
+function _count_from_list_result(
+    res: {
+        error?: (Error & { code?: string }) | undefined;
+        status: number | null;
+        stdout: string | null;
+    },
+    warn: (msg: string) => void = (msg) => void process.stderr.write(msg),
+): number | null {
+    // The trend line is informational and never blocks a release — but a
+    // SILENT drop is what shipped 9.8.0 and 9.10.0 without a footer, so every
+    // degradation says why. The `changelog-entry` CI gate treats a missing
+    // footer as fatal, so this warning is the difference between fixing the
+    // probe now and finding out from a red release PR.
+    if (res.error) {
+        // ENOENT (no npx) · ETIMEDOUT · ENOBUFS (listing past maxBuffer).
+        const code = res.error.code ?? res.error.message;
+        warn(
+            `⚠️  test-count probe failed (${code}) — the \`Tests:\` footer will ` +
+                `be omitted from the release notes, which fails the ` +
+                `\`CHANGELOG entry exists for head version\` gate.\n`,
+        );
+        return null;
+    }
+    if ((res.status ?? 1) !== 0) {
+        warn(
+            `⚠️  test-count probe exited ${res.status ?? '(null)'} — the ` +
+                `\`Tests:\` footer will be omitted from the release notes.\n`,
+        );
+        return null;
+    }
+    const lines = (res.stdout ?? '').split('\n').filter((l) => l.trim().length > 0);
+    if (lines.length === 0) {
+        warn('⚠️  test-count probe listed 0 cases — the `Tests:` footer will be omitted.\n');
+        return null;
+    }
+    return lines.length;
+}
+
+/**
  * Return the collected vitest test-case count on the current tree
  * (`npx vitest list`, one line per case; ~14s wall). Returns null when
  * collection fails — the trend line is informational, never a release
- * blocker. (Replaced the dead `pytest --collect-only` probe on 2026-07-08,
+ * blocker, but every failure warns (see `_count_from_list_result`).
+ * (Replaced the dead `pytest --collect-only` probe on 2026-07-08,
  * road-to-truth-and-reference-hygiene Phase 3: the Python suite was retired
  * with ADR-200, so the old probe always degraded to null and the `Tests:`
  * footer silently vanished from release notes.)
@@ -794,16 +854,9 @@ function _count_tests_current(): number | null {
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: 180_000,
+        maxBuffer: _TEST_LIST_MAX_BUFFER,
     });
-    if (res.error) {
-        // ENOENT or ETIMEDOUT → null (informational line dropped).
-        return null;
-    }
-    if ((res.status ?? 1) !== 0) {
-        return null;
-    }
-    const lines = (res.stdout ?? '').split('\n').filter((l) => l.trim().length > 0);
-    return lines.length > 0 ? lines.length : null;
+    return _count_from_list_result(res);
 }
 
 /**
@@ -1986,6 +2039,8 @@ export {
     latest_tag,
     _render_test_trend_line,
     _previous_test_count_from_changelog,
+    _count_from_list_result,
+    _TEST_LIST_MAX_BUFFER,
     Commit,
     Plan,
     SystemExitError,

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -37,6 +37,8 @@ import {
     set_package_version,
     set_marketplace_version,
     _previous_test_count_from_changelog,
+    _count_from_list_result,
+    _TEST_LIST_MAX_BUFFER,
     _detect_in_flight_target,
     Commit,
     SystemExitError,
@@ -239,6 +241,73 @@ describe('render_changelog_entry', () => {
             test_trend_line: null,
         });
         expect(body).not.toContain('Tests:');
+    });
+});
+
+// Regression cover for the 9.10.0 release failure: `_count_tests_current`
+// buffers `npx vitest list` through spawnSync, whose default maxBuffer is
+// 1 MiB. The listing crossed that (~1.25 MB at 9470 cases), the spawn failed
+// with ENOBUFS, the probe degraded to null, and the release notes shipped
+// without the `Tests:` footer — which the `changelog-entry` CI gate treats as
+// fatal. These pin the ceiling AND the now-loud degradation.
+describe('test-count probe buffering', () => {
+    it('counts a listing larger than the 1 MiB spawnSync default', () => {
+        // 40k lines × ~33 B ≈ 1.3 MB — comparable to the real listing (1.25 MB
+        // at 9470 cases, whose paths are longer) and past the 1 MiB default.
+        // With the pre-fix options this spawn fails ENOBUFS and the assertions
+        // below see an error plus a null count. The byte assertion is kept so
+        // the case cannot silently stop exercising the overflow.
+        const lines = 40_000;
+        const res = spawnSync(
+            process.execPath,
+            [
+                '-e',
+                `const o=[];for(let i=0;i<${lines};i++)o.push("tests/lib/x.test.ts > case "+i);` +
+                    'process.stdout.write(o.join("\\n")+"\\n");',
+            ],
+            {
+                encoding: 'utf-8',
+                stdio: ['ignore', 'pipe', 'pipe'],
+                maxBuffer: _TEST_LIST_MAX_BUFFER,
+            },
+        );
+        expect(res.error).toBeUndefined();
+        expect((res.stdout ?? '').length).toBeGreaterThan(1024 * 1024);
+        expect(_count_from_list_result(res)).toBe(lines);
+    });
+
+    it('ceiling clears the 1 MiB default that broke 9.10.0', () => {
+        expect(_TEST_LIST_MAX_BUFFER).toBeGreaterThan(1024 * 1024);
+    });
+
+    it('ENOBUFS degrades to null AND warns', () => {
+        const warnings: string[] = [];
+        const err = Object.assign(new Error('spawnSync ENOBUFS'), { code: 'ENOBUFS' });
+        const got = _count_from_list_result({ error: err, status: null, stdout: null }, (m) =>
+            warnings.push(m),
+        );
+        expect(got).toBeNull();
+        expect(warnings.join('')).toContain('ENOBUFS');
+    });
+
+    it('non-zero exit degrades to null AND warns', () => {
+        const warnings: string[] = [];
+        expect(
+            _count_from_list_result({ status: 1, stdout: 'partial\n' }, (m) => warnings.push(m)),
+        ).toBeNull();
+        expect(warnings.join('')).toContain('Tests:');
+    });
+
+    it('empty listing degrades to null AND warns', () => {
+        const warnings: string[] = [];
+        expect(
+            _count_from_list_result({ status: 0, stdout: '  \n\n' }, (m) => warnings.push(m)),
+        ).toBeNull();
+        expect(warnings.join('')).toContain('0 cases');
+    });
+
+    it('blank lines are not counted as cases', () => {
+        expect(_count_from_list_result({ status: 0, stdout: 'a\n\n  \nb\n' })).toBe(2);
     });
 });
 
@@ -518,21 +587,6 @@ describe('release --ci — flag parses, --dry-run short-circuits before any CI-s
         expect(r.stderr).toContain('--ci');
     });
 });
-
-/**
- * Normalise --dry-run preview output for cross-runtime comparison:
- *  - the `({today})` date in the changelog heading (a day rollover between the
- *    two spawns could differ);
- *  - 40-hex full SHAs and 7-hex short SHAs in commit-link bullets;
- *  These come from live git and are identical between back-to-back runs, but
- *  normalised defensively. Both runtimes read the same repo at the same instant.
- */
-function normalizeDryRun(s: string): string {
-    return s
-        .replace(/\(\d{4}-\d{2}-\d{2}\)/g, '(DATE)') // normalize: date heading / day-rollover
-        .replace(/[0-9a-f]{40}/g, 'SHA40') // normalize: full commit SHA
-        .replace(/[0-9a-f]{7}\b/g, 'SHA7'); // normalize: short SHA
-}
 
 // ─── era-split gate — newest-release exemption (regression) ───────────────────
 // A PATCH release must never hard-die just because the era's newest section


### PR DESCRIPTION
## Why

`task release` for 9.10.0 aborted with `error: PR checks failed (exit 1)`. The
red check was `CHANGELOG entry exists for head version`:

```
##[error]CHANGELOG section for 9.10.0 is missing the `Tests: N (+M since PREV)` footer line.
```

The changelog was a symptom. The cause is in `release.ts`.

`_count_tests_current()` buffers `npx vitest list` through `spawnSync` without
setting `maxBuffer`, so it inherits Node's **1 MiB** default. The probe prints
one line per test case, so its output scales with the suite — and the suite has
now outgrown the ceiling:

| | bytes |
|---|---|
| `npx vitest list` output (9470 cases) | 1,254,812 |
| `spawnSync` default `maxBuffer` | 1,048,576 |

So the spawn fails with `ENOBUFS`, `res.error` is set, the probe returns `null`
by design, `render_changelog_entry` omits the footer — and the `changelog-entry`
gate, which treats a missing footer as fatal, goes red. Every release from here
on would have failed the same way.

This is the second time the footer vanished silently (9.8.0 was the first, from
the then-dead `pytest --collect-only` probe). The gate was added *because* of
that. The gate worked; the probe regressed for a new reason.

## What changed

- **`maxBuffer: 64 MiB`** on the probe spawn — ~50× the current listing, so it
  survives a suite many times this size. Measured both ways at 40k lines: the
  default spawn returns `ENOBUFS` with a truncated buffer, the raised one
  returns the full 1.31 MB.
- **Degradations warn instead of failing silently.** The footer is still never
  a release blocker, but since the CI gate *is* fatal, a silent null guarantees
  a red release PR discovered after the fact. The warning names the reason
  (`ENOBUFS`, exit code, empty listing) at release time.
- Result handling split into **`_count_from_list_result`** so the failure modes
  are testable without a ~14s, >1 MB real collection.

## Tests

Six new cases in `tests/scripts/release.test.ts`:

- a 40k-line (~1.3 MB) listing is counted, **not** dropped — this case fails
  against the pre-fix options (`ENOBUFS` → `null`), so it genuinely pins the
  bug rather than restating the fix;
- the ceiling clears 1 MiB;
- `ENOBUFS`, non-zero exit, and empty listing each degrade to `null` **and**
  warn;
- blank lines are not counted as cases.

`npx vitest run tests/scripts/release.test.ts` → 73 passed. ESLint + `tsc`
clean on both changed files.

## Scope notes

- **Not folded into the 9.10.0 release PR on purpose:** `src/scripts/**` is
  outside `check_release_pr_shape`'s allowlist, so shipping it there would fail
  the shape detector. 9.10.0 carries only the restored footer line
  (`CHANGELOG.md` is allowlisted); this PR carries the actual fix.
- **`normalizeDryRun` removed** — dead since the python-vs-tsx golden-parity
  comparison was retired with ADR-200 (its only reference in the tree was its
  own definition). Removed here because it *blocks* this change: the pre-push
  hook lints every changed `.ts`, so its pre-existing `no-unused-vars` error
  surfaces the moment this file is touched.

## Adjacent gap, deliberately not fixed here

CI never caught that dead helper because `lint:ts` scopes ESLint to
`src/**/*.ts`, while `eslint.config.js` declares `tests/**/*.ts` in scope too.
So the local pre-push hook lints test files and CI does not — anything in
`tests/**` can only ever fail locally. Worth closing, but it is a separate
change from this one.