### PR TITLE
docs(roadmap): resolve the deferred tier benchmark and archive road-to-ui-track-integrity

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,19 +6,11 @@
 
 ## Overall
 
-**84 / 254 steps done · 33%**
+**48 / 224 steps done · 21%**
 
 ```text
-█████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░   33%
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   21%
 ```
-
-## ⚠️ Iron Law 3 — unresolved deferred items
-
-These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadmap-progress-sync` Iron Law 3 they do NOT auto-archive — the user must resolve the deferrals first (spawn follow-up, restore, or cancel). See [`roadmap-management § 4b`](../packages/core/.agent-src.uncondensed/skills/roadmap-management/SKILL.md).
-
-| Roadmap | Done | Deferred | Cancelled |
-|---|---:|---:|---:|
-| [road-to-ui-track-integrity.md](roadmaps/road-to-ui-track-integrity.md) | 36 | 3 | 0 |
 
 ## Open roadmaps
 
@@ -40,7 +32,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 14 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 15 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 16 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
-| 17 | [road-to-ui-track-integrity.md](roadmaps/road-to-ui-track-integrity.md) | 7 | 39 | 0 | 36 | 3 | 0 | 0 | ██████████ 100% |
+| 17 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 6 | 6 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 18 | [road-to-webfont-delivery-ownership.md](roadmaps/road-to-webfont-delivery-ownership.md) | 3 | 12 | 12 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
@@ -329,19 +321,13 @@ _1 blocker resolved._
     ruled the date itself is not an agent decision.
   - **Resolved when:** a concrete `sunset` date is published in the manifest's `tier` deprecation entry AND that date has passed with no external breakage reported — at which point Phase 3 records the confirmation and Phase 4's external half becomes executable.
 
-### [road-to-ui-track-integrity.md](roadmaps/road-to-ui-track-integrity.md)
+### [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md)
 
-**Road to UI-track integrity — the lanes the dispatcher names do not exist** — 36 / 36 done (100%)
+**Road to UI-track integrity — follow-up: is the model-tier allocation backwards?** — 0 / 6 done (0%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 0 | Baseline: what actually works today (blocking) | ✅ done | 0 | 9 | 0 | 0 | 100% |
-| 1 | Dispatch honesty (the 95 % fix) | ✅ done | 0 | 7 | 0 | 0 | 100% |
-| 2 | Detection: stop sending real stacks into the fallback | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 3 | The validation gates that do not validate | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 4 | Pack topology: the design layer ships with the stacks that need it | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 5 | Model tier: measure the inversion before flipping it | ⏭️ skipped | 0 | 0 | 3 | 0 | 0% |
-| 6 | Contract truth-up | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 1 | Measure the allocation | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 
 ### [road-to-webfont-delivery-ownership.md](roadmaps/road-to-webfont-delivery-ownership.md)
 

--- a/agents/roadmaps/archive/road-to-ui-track-integrity.md
+++ b/agents/roadmaps/archive/road-to-ui-track-integrity.md
@@ -364,7 +364,15 @@ elsewhere.
   rendered-output gate, and counted correctly in the sign-off summary.
 - Installing `laravel` alone, or `react` alone, leaves no hard reference from a
   shipped skill unresolved.
-- The tier question is answered by a published benchmark, including an
-  honest-null.
+- ~~The tier question is answered by a published benchmark, including an
+  honest-null.~~ — **carried to the follow-up**, unmet here. The measurement is
+  blocked on a harness that does not exist; the tiers are unchanged.
 - No contract in the design surface states a fixture count, halt budget, slot
   map, or cache mechanism that the tree contradicts.
+
+<!-- Deferred items migrated to agents/roadmaps/road-to-ui-track-integrity-followup.md on 2026-07-31 -->
+<!-- Resolution: option 2 (follow-up, ready + blocked). The three [~] lines in
+     Phase 5 stay visible above so the trail stays grep-able; the follow-up
+     carries the executable copy. Blocker recorded there: no harness scores
+     generated UI. -->
+

--- a/agents/roadmaps/road-to-ui-track-integrity-followup.md
+++ b/agents/roadmaps/road-to-ui-track-integrity-followup.md
@@ -1,0 +1,89 @@
+---
+complexity: contained
+status: ready
+parent_roadmap: road-to-ui-track-integrity
+---
+
+# Road to UI-track integrity — follow-up: is the model-tier allocation backwards?
+
+> Carries forward the one question `road-to-ui-track-integrity` could not
+> answer: builders run on the weaker model while reviewers run on the stronger
+> one. The finding is verified; the fix is not, because nothing in the tree can
+> measure it.
+
+## Context
+
+This roadmap collects the items deferred from
+[`agents/roadmaps/archive/road-to-ui-track-integrity.md`](archive/road-to-ui-track-integrity.md).
+See the parent's Phase 5 for the original rationale, and
+[`frontend-fidelity-cut`](../settings/contexts/frontend-fidelity-cut.md) for the
+council's refusal to treat the flip as a free one-line change.
+
+**The verified finding** (`origin/main`, 2026-07-31): every builder that writes
+UI runs on the middle tier — `fe-design`, `blade-ui`, `react-shadcn-ui`, `flux`,
+`livewire`, `tailwind-engineer` are all `model_tier: medium` — while the two
+skills that *grade* their output, `design-review` and `existing-ui-audit`, are
+`high`. Per `ADR-035-model-capability-tiers.md` § Decision 3 that resolves to
+sonnet for the builders and opus for the reviewers on Claude Code. In a domain
+where generation quality dominates and `POLISH_CEILING = 2` caps the repair
+loop, the stronger model is spending its capability on judging work the weaker
+one produced.
+
+The inversion is real but **not total**, and that is part of why it must be
+measured rather than argued: `accessibility-auditor` is a `medium` reviewer and
+`ui-component-architect` a `high` builder, so a blanket flip would flatten a
+distinction that may well be deliberate.
+
+> **Blocked until a harness exists that scores generated UI** (or one run is
+> deliberately funded as a one-off). Execution starts when that condition
+> clears — see Prerequisites for why neither existing harness qualifies.
+
+## Prerequisites
+
+- [ ] Read `AGENTS.md` and the parent's archive entry.
+- [ ] Confirm the blocker still holds. Neither existing harness answers "is this
+      frontend better":
+      - `bench:ab` (`internal/bench/corpora/ab-track{a,b}.yaml`) measures
+        **surface presence** — whether a rule or skill fires at all.
+      - `bench-quality-run` (`token-quality-golden.yaml`, 110 tasks) judges
+        **rule compliance** — "stayed in scope", "ran the audit before creating
+        a component" — not the quality of what was emitted.
+      A tier benchmark needs a third thing: UI-generation prompts, a rendering
+      step, and a visual/structural rubric.
+- [ ] Confirm the cost asymmetry is still true of the pipeline: builders run
+      first, run longest, and re-run up to `POLISH_CEILING` times, so raising
+      them is the expensive direction. If the pipeline shape changed, re-derive
+      this before spending anything.
+
+## Phase 1: Measure the allocation
+
+- [ ] Run the lane fixtures with the current allocation (builders `medium` /
+      reviewers `high`) and with builders raised, scoring output quality **and**
+      per-run cost.
+      <!-- carried from parent Phase 5 -->
+- [ ] Include the two outliers in the read — `accessibility-auditor` (medium
+      reviewer) and `ui-component-architect` (high builder) — so a flip cannot
+      silently erase a deliberate distinction.
+      <!-- carried from parent Phase 5 -->
+- [ ] Publish the result either way. If quality lift does not clear the cost
+      delta, record the honest-null and leave the tiers alone.
+      <!-- carried from parent Phase 5 -->
+
+## Non-goals
+
+- **Do not build a UI-quality harness just to answer this.** That was the
+  parent's reason for deferring rather than proceeding: a new benchmark
+  subsystem to settle one frontmatter question is the speculative scale the
+  parent's own design constraints forbid. If such a harness lands for another
+  reason, this roadmap unblocks for free.
+- **No tier change on argument.** The finding is not in doubt; only its remedy
+  is. Flipping without the measurement is precisely what the parent's Phase 5
+  existed to prevent.
+
+## Acceptance Criteria
+
+- [ ] The tier allocation for UI builders and reviewers is backed by a published
+      measurement — including an honest-null if that is what the run shows.
+- [ ] The two outliers are explicitly ruled in or out rather than left
+      unexplained.
+- [ ] All quality gates pass — see `quality-tools`.


### PR DESCRIPTION
Follow-up to #1074 (merged). That PR closed 36/36 steps of
`road-to-ui-track-integrity` and left three `[~]` deferred items, which
Iron Law 3 reserves for the maintainer to resolve. Resolution chosen:
**option 2 — follow-up roadmap, ready + blocked.**

## What this adds

`agents/roadmaps/road-to-ui-track-integrity-followup.md` carries the three
steps as the executable copy, plus the context they need to be actionable
later rather than rediscovered:

- **The verified finding.** Every skill that writes UI is
  `model_tier: medium` (`fe-design`, `blade-ui`, `react-shadcn-ui`, `flux`,
  `livewire`, `tailwind-engineer`) while the two that grade its output —
  `design-review`, `existing-ui-audit` — are `high`. Per ADR-035 § Decision 3
  that is sonnet building and opus judging, in a domain where generation
  quality dominates and `POLISH_CEILING = 2` caps the repair loop.
- **Why it is not a blanket flip.** `accessibility-auditor` is a `medium`
  reviewer and `ui-component-architect` a `high` builder, so the inversion is
  real but not total and a sweep would erase a possibly deliberate
  distinction.
- **The blocker, with why neither existing harness qualifies.** `bench:ab`
  measures surface presence — whether a rule or skill fires; `bench-quality-run`
  judges rule compliance ("stayed in scope", "ran the audit first"). Neither
  answers "is this frontend better". That needs UI-generation prompts, a
  rendering step, and a visual rubric.
- **A non-goal that protects the blocker from being routed around:** do not
  build such a harness to answer this one question — that is the speculative
  scale the parent's own design constraints forbid. If one lands for another
  reason, this roadmap unblocks for free.

## What this changes in the parent

Archived to `agents/roadmaps/archive/`. The `[~]` lines stay visible there, per
the spawn procedure, so the trail stays grep-able. Its tier acceptance
criterion is **struck through rather than dropped** — it was not met, and the
tiers are unchanged.

## Verification

- `roadmap:progress-check` clean (it failed on the unresolved deferrals before).
- `sync-check` clean; no roadmap-file references from stable artifacts.
- Nothing is claimed as measured. The finding stands without its fix, and the
  roadmap says so.
