### PR TITLE
fix(cli): resolve the package root by marker, not by hop count (unblocks 9.11.0)

### DIFF
--- a/dist/install/install.mjs
+++ b/dist/install/install.mjs
@@ -117,17 +117,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path13) {
-      const ctrl = callVisitor(key, node, visitor, path13);
+    function visit_(key, node, visitor, path14) {
+      const ctrl = callVisitor(key, node, visitor, path14);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path13, ctrl);
-        return visit_(key, ctrl, visitor, path13);
+        replaceNode(key, path14, ctrl);
+        return visit_(key, ctrl, visitor, path14);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path13 = Object.freeze(path13.concat(node));
+          path14 = Object.freeze(path14.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path13);
+            const ci = visit_(i, node.items[i], visitor, path14);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -138,13 +138,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path13 = Object.freeze(path13.concat(node));
-          const ck = visit_("key", node.key, visitor, path13);
+          path14 = Object.freeze(path14.concat(node));
+          const ck = visit_("key", node.key, visitor, path14);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path13);
+          const cv = visit_("value", node.value, visitor, path14);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -165,17 +165,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path13) {
-      const ctrl = await callVisitor(key, node, visitor, path13);
+    async function visitAsync_(key, node, visitor, path14) {
+      const ctrl = await callVisitor(key, node, visitor, path14);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path13, ctrl);
-        return visitAsync_(key, ctrl, visitor, path13);
+        replaceNode(key, path14, ctrl);
+        return visitAsync_(key, ctrl, visitor, path14);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path13 = Object.freeze(path13.concat(node));
+          path14 = Object.freeze(path14.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path13);
+            const ci = await visitAsync_(i, node.items[i], visitor, path14);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -186,13 +186,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path13 = Object.freeze(path13.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path13);
+          path14 = Object.freeze(path14.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path14);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path13);
+          const cv = await visitAsync_("value", node.value, visitor, path14);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -219,23 +219,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path13) {
+    function callVisitor(key, node, visitor, path14) {
       if (typeof visitor === "function")
-        return visitor(key, node, path13);
+        return visitor(key, node, path14);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path13);
+        return visitor.Map?.(key, node, path14);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path13);
+        return visitor.Seq?.(key, node, path14);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path13);
+        return visitor.Pair?.(key, node, path14);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path13);
+        return visitor.Scalar?.(key, node, path14);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path13);
+        return visitor.Alias?.(key, node, path14);
       return void 0;
     }
-    function replaceNode(key, path13, node) {
-      const parent = path13[path13.length - 1];
+    function replaceNode(key, path14, node) {
+      const parent = path14[path14.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -845,10 +845,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path13, value) {
+    function collectionFromPath(schema, path14, value) {
       let v = value;
-      for (let i = path13.length - 1; i >= 0; --i) {
-        const k = path13[i];
+      for (let i = path14.length - 1; i >= 0; --i) {
+        const k = path14[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -867,7 +867,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path13) => path13 == null || typeof path13 === "object" && !!path13[Symbol.iterator]().next().done;
+    var isEmptyPath = (path14) => path14 == null || typeof path14 === "object" && !!path14[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -897,11 +897,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path13, value) {
-        if (isEmptyPath(path13))
+      addIn(path14, value) {
+        if (isEmptyPath(path14))
           this.add(value);
         else {
-          const [key, ...rest] = path13;
+          const [key, ...rest] = path14;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -915,8 +915,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path13) {
-        const [key, ...rest] = path13;
+      deleteIn(path14) {
+        const [key, ...rest] = path14;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -930,8 +930,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path13, keepScalar) {
-        const [key, ...rest] = path13;
+      getIn(path14, keepScalar) {
+        const [key, ...rest] = path14;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -949,8 +949,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path13) {
-        const [key, ...rest] = path13;
+      hasIn(path14) {
+        const [key, ...rest] = path14;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -960,8 +960,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path13, value) {
-        const [key, ...rest] = path13;
+      setIn(path14, value) {
+        const [key, ...rest] = path14;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3476,9 +3476,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path13, value) {
+      addIn(path14, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path13, value);
+          this.contents.addIn(path14, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3553,14 +3553,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path13) {
-        if (Collection.isEmptyPath(path13)) {
+      deleteIn(path14) {
+        if (Collection.isEmptyPath(path14)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path13) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path14) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3575,10 +3575,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path13, keepScalar) {
-        if (Collection.isEmptyPath(path13))
+      getIn(path14, keepScalar) {
+        if (Collection.isEmptyPath(path14))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path13, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path14, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3589,10 +3589,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path13) {
-        if (Collection.isEmptyPath(path13))
+      hasIn(path14) {
+        if (Collection.isEmptyPath(path14))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path13) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path14) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3609,13 +3609,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path13, value) {
-        if (Collection.isEmptyPath(path13)) {
+      setIn(path14, value) {
+        if (Collection.isEmptyPath(path14)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path13), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path14), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path13, value);
+          this.contents.setIn(path14, value);
         }
       }
       /**
@@ -5575,9 +5575,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path13) => {
+    visit.itemAtPath = (cst, path14) => {
       let item = cst;
-      for (const [field, index] of path13) {
+      for (const [field, index] of path14) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5586,23 +5586,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path13) => {
-      const parent = visit.itemAtPath(cst, path13.slice(0, -1));
-      const field = path13[path13.length - 1][0];
+    visit.parentCollection = (cst, path14) => {
+      const parent = visit.itemAtPath(cst, path14.slice(0, -1));
+      const field = path14[path14.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path13, item, visitor) {
-      let ctrl = visitor(item, path13);
+    function _visit(path14, item, visitor) {
+      let ctrl = visitor(item, path14);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path13.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path14.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5613,10 +5613,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path13);
+            ctrl = ctrl(item, path14);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path13) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path14) : ctrl;
     }
     exports.visit = visit;
   }
@@ -6918,14 +6918,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs15 = this.flowScalar(this.type);
+              const fs16 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs15, sep: [] });
+                map.items.push({ start, key: fs16, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs15);
+                this.stack.push(fs16);
               } else {
-                Object.assign(it, { key: fs15, sep: [] });
+                Object.assign(it, { key: fs16, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -7053,13 +7053,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs15 = this.flowScalar(this.type);
+              const fs16 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs15, sep: [] });
+                fc.items.push({ start: [], key: fs16, sep: [] });
               else if (it.sep)
-                this.stack.push(fs15);
+                this.stack.push(fs16);
               else
-                Object.assign(it, { key: fs15, sep: [] });
+                Object.assign(it, { key: fs16, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -7370,11 +7370,11 @@ var require_dist = __commonJS({
 // src/scripts/install.ts
 import { spawn, spawnSync as spawnSync2 } from "node:child_process";
 import * as crypto3 from "node:crypto";
-import * as fs14 from "node:fs";
+import * as fs15 from "node:fs";
 import * as os7 from "node:os";
-import * as path12 from "node:path";
+import * as path13 from "node:path";
 import process3 from "node:process";
-import { fileURLToPath as fileURLToPath3, pathToFileURL as pathToFileURL2 } from "node:url";
+import { fileURLToPath as fileURLToPath4, pathToFileURL as pathToFileURL2 } from "node:url";
 
 // src/scripts/_lib/json_pointers.ts
 import { createHash } from "node:crypto";
@@ -7872,8 +7872,8 @@ function lockfile_write_path(env) {
   }
   return write_target("installed.lock", { env: env ?? null });
 }
-function read_lockfile(path13) {
-  const target = path13 ?? lockfile_path();
+function read_lockfile(path14) {
+  const target = path14 ?? lockfile_path();
   let text;
   try {
     text = fs2.readFileSync(target, { encoding: "utf-8" });
@@ -8741,18 +8741,18 @@ function manifest_path(project_root, env) {
 var _TOP_KEY_RE = /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*"?([^"\n]*?)"?\s*$/;
 var _LIST_DASH_RE = /^\s*-\s*(.+?)\s*$/;
 var _INDENT_KEY_RE = /^\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*"?([^"\n]*?)"?\s*$/;
-function read_manifest(path13) {
+function read_manifest(path14) {
   let text;
   try {
-    text = require_read_text(path13);
+    text = require_read_text(path14);
   } catch {
     return null;
   }
   const data = _parse_manual(text);
   return _normalise_v2_shape(data);
 }
-function require_read_text(path13) {
-  return fs6.readFileSync(path13, { encoding: "utf-8" });
+function require_read_text(path14) {
+  return fs6.readFileSync(path14, { encoding: "utf-8" });
 }
 function _normalise_v2_shape(data) {
   if (data["tools"] === void 0 || data["tools"] === null) {
@@ -8933,9 +8933,9 @@ function stable_sort(items, key) {
     return a.index - b.index;
   }).map((entry) => entry.item);
 }
-function write_manifest(path13, version, tools, options = {}) {
+function write_manifest(path14, version, tools, options = {}) {
   const rendered = _render2(version, tools, { deploy_roots: options.deploy_roots ?? null });
-  return write_atomic(path13, rendered);
+  return write_atomic(path14, rendered);
 }
 var ScopeMismatchError = class extends Error {
   name_;
@@ -10529,8 +10529,8 @@ function getErrorMap() {
 
 // node_modules/zod/v3/helpers/parseUtil.js
 var makeIssue = (params) => {
-  const { data, path: path13, errorMaps, issueData } = params;
-  const fullPath = [...path13, ...issueData.path || []];
+  const { data, path: path14, errorMaps, issueData } = params;
+  const fullPath = [...path14, ...issueData.path || []];
   const fullIssue = {
     ...issueData,
     path: fullPath
@@ -10646,11 +10646,11 @@ var errorUtil;
 
 // node_modules/zod/v3/types.js
 var ParseInputLazyPath = class {
-  constructor(parent, value, path13, key) {
+  constructor(parent, value, path14, key) {
     this._cachedPath = [];
     this.parent = parent;
     this.data = value;
-    this._path = path13;
+    this._path = path14;
     this._key = key;
   }
   get path() {
@@ -16008,10 +16008,42 @@ function render_native_model_md(text, tier) {
 
 // src/scripts/_cli/cmd_migrate.ts
 import { spawnSync } from "node:child_process";
+import * as fs14 from "node:fs";
+import * as path12 from "node:path";
+import process2 from "node:process";
+import { fileURLToPath as fileURLToPath3, pathToFileURL } from "node:url";
+
+// src/scripts/_lib/package_root.ts
 import * as fs13 from "node:fs";
 import * as path11 from "node:path";
-import process2 from "node:process";
-import { fileURLToPath as fileURLToPath2, pathToFileURL } from "node:url";
+import { fileURLToPath as fileURLToPath2 } from "node:url";
+var PACKAGE_NAME = "@event4u/agent-config";
+var MAX_ASCENT = 16;
+function resolvePackageRoot(fromUrlOrPath, legacyHops = 3) {
+  const start = fromUrlOrPath.startsWith("file:") ? fileURLToPath2(fromUrlOrPath) : fromUrlOrPath;
+  const startDir = path11.dirname(start);
+  let dir = startDir;
+  for (let i = 0; i < MAX_ASCENT; i++) {
+    const manifest = path11.join(dir, "package.json");
+    if (fs13.existsSync(manifest)) {
+      try {
+        const parsed = JSON.parse(fs13.readFileSync(manifest, "utf8"));
+        if (parsed.name === PACKAGE_NAME) {
+          return dir;
+        }
+      } catch {
+      }
+    }
+    const parent = path11.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return path11.resolve(startDir, ...Array.from({ length: legacyHops }, () => ".."));
+}
+
+// src/scripts/_cli/cmd_migrate.ts
 var PACKAGE_NAME_NPM = "@event4u/agent-config";
 var PACKAGE_NAME_COMPOSER = "event4u/agent-config";
 var LEGACY_DIRS = ["vendor", "node_modules"];
@@ -16029,7 +16061,7 @@ var LEGACY_SETTINGS_FILES = [".agent-settings.yml", ".agent-user.yml"];
 var LEGACY_STATE_FILENAME = ".implement-ticket-state.json";
 var LEGACY_STATE_V1_FILENAME = ".work-state.json";
 var LEGACY_AGENT_CONFIG_SHELL = "agent-config";
-var _HERE_DIR = path11.dirname(fileURLToPath2(import.meta.url));
+var _HERE_DIR = path12.dirname(fileURLToPath3(import.meta.url));
 var ArgparseExit = class extends Error {
   code;
   constructor(code) {
@@ -16128,38 +16160,38 @@ function _jsonDumpsIndentAscii(value, indent) {
 }
 function _isFile2(p) {
   try {
-    return fs13.statSync(p).isFile();
+    return fs14.statSync(p).isFile();
   } catch {
     return false;
   }
 }
 function _isDir2(p) {
   try {
-    return fs13.statSync(p).isDirectory();
+    return fs14.statSync(p).isDirectory();
   } catch {
     return false;
   }
 }
 function _isSymlink(p) {
   try {
-    return fs13.lstatSync(p).isSymbolicLink();
+    return fs14.lstatSync(p).isSymbolicLink();
   } catch {
     return false;
   }
 }
 function _exists2(p) {
   try {
-    fs13.lstatSync(p);
+    fs14.lstatSync(p);
     return true;
   } catch {
     return false;
   }
 }
 function _readText(p) {
-  return fs13.readFileSync(p, { encoding: "utf-8" });
+  return fs14.readFileSync(p, { encoding: "utf-8" });
 }
 function _writeText(p, text) {
-  fs13.writeFileSync(p, text, { encoding: "utf-8" });
+  fs14.writeFileSync(p, text, { encoding: "utf-8" });
 }
 function _jsonLoadFile(p) {
   return JSON.parse(_readText(p));
@@ -16215,7 +16247,7 @@ function _classify_symlink(link) {
   }
   let target;
   try {
-    target = fs13.readlinkSync(link);
+    target = fs14.readlinkSync(link);
   } catch {
     return null;
   }
@@ -16226,16 +16258,16 @@ function _classify_symlink(link) {
   return "user";
 }
 function _detect_legacy_state(project) {
-  return _isFile2(path11.join(project, LEGACY_STATE_FILENAME));
+  return _isFile2(path12.join(project, LEGACY_STATE_FILENAME));
 }
 function _detect_legacy_settings(project) {
   const found = [];
   for (const name of LEGACY_SETTINGS_FILES) {
-    const flat = path11.join(project, name);
+    const flat = path12.join(project, name);
     if (_isFile2(flat)) {
       found.push(flat);
     }
-    const typed = path11.join(project, "settings", name);
+    const typed = path12.join(project, "settings", name);
     if (_isFile2(typed)) {
       found.push(typed);
     }
@@ -16243,25 +16275,25 @@ function _detect_legacy_settings(project) {
   return found;
 }
 function _detect_empty_shell(project) {
-  const shell = path11.join(project, LEGACY_AGENT_CONFIG_SHELL);
+  const shell = path12.join(project, LEGACY_AGENT_CONFIG_SHELL);
   if (!_isDir2(shell) || _isSymlink(shell)) {
     return false;
   }
   try {
-    return fs13.readdirSync(shell).length === 0;
+    return fs14.readdirSync(shell).length === 0;
   } catch {
     return false;
   }
 }
 function _detect_already_migrated(project) {
-  if (_detect_npm(path11.join(project, "package.json"))) {
+  if (_detect_npm(path12.join(project, "package.json"))) {
     return false;
   }
-  if (_detect_composer(path11.join(project, "composer.json"))) {
+  if (_detect_composer(path12.join(project, "composer.json"))) {
     return false;
   }
   for (const name of MANAGED_SYMLINKS) {
-    if (_classify_symlink(path11.join(project, name)) === "legacy") {
+    if (_classify_symlink(path12.join(project, name)) === "legacy") {
       return false;
     }
   }
@@ -16332,11 +16364,11 @@ function _purge_legacy_symlinks(project) {
   const removed = [];
   const preserved = [];
   for (const name of MANAGED_SYMLINKS) {
-    const link = path11.join(project, name);
+    const link = path12.join(project, name);
     const kind = _classify_symlink(link);
     if (kind === "legacy") {
       try {
-        fs13.unlinkSync(link);
+        fs14.unlinkSync(link);
         removed.push(name);
       } catch {
         preserved.push(name);
@@ -16348,14 +16380,14 @@ function _purge_legacy_symlinks(project) {
   return [removed, preserved];
 }
 function _migrate_state_file(project) {
-  const source = path11.join(project, LEGACY_STATE_FILENAME);
+  const source = path12.join(project, LEGACY_STATE_FILENAME);
   if (!_isFile2(source)) {
     return null;
   }
-  const target = path11.join(project, LEGACY_STATE_V1_FILENAME);
+  const target = path12.join(project, LEGACY_STATE_V1_FILENAME);
   if (_exists2(target)) {
     try {
-      fs13.unlinkSync(source);
+      fs14.unlinkSync(source);
       return `removed stale ${LEGACY_STATE_FILENAME} (v1 already present)`;
     } catch {
       return null;
@@ -16369,8 +16401,8 @@ function _migrate_state_file(project) {
   return `migrated ${LEGACY_STATE_FILENAME} \u2192 ${LEGACY_STATE_V1_FILENAME}`;
 }
 function _load_state_migrator() {
-  const pkg_root = path11.resolve(_HERE_DIR, "..", "..", "..");
-  const rel = path11.join(
+  const pkg_root = resolvePackageRoot(import.meta.url);
+  const rel = path12.join(
     "agent-src",
     "templates",
     "scripts",
@@ -16378,8 +16410,8 @@ function _load_state_migrator() {
     "migration",
     "v0_to_v1.ts"
   );
-  const driver = [path11.join(pkg_root, "dist", rel), path11.join(pkg_root, "src", rel)].find(
-    (p) => fs13.existsSync(p)
+  const driver = [path12.join(pkg_root, "dist", rel), path12.join(pkg_root, "src", rel)].find(
+    (p) => fs14.existsSync(p)
   ) ?? null;
   if (driver === null) {
     return null;
@@ -16387,12 +16419,12 @@ function _load_state_migrator() {
   const binName = process2.platform === "win32" ? "tsx.cmd" : "tsx";
   let tsxBin = null;
   for (let dir = pkg_root; ; ) {
-    const cand = path11.join(dir, "node_modules", ".bin", binName);
-    if (fs13.existsSync(cand)) {
+    const cand = path12.join(dir, "node_modules", ".bin", binName);
+    if (fs14.existsSync(cand)) {
       tsxBin = cand;
       break;
     }
-    const parent = path11.dirname(dir);
+    const parent = path12.dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
@@ -16419,17 +16451,17 @@ function _delete_legacy_settings(project) {
   const removed = [];
   for (const p of _detect_legacy_settings(project)) {
     try {
-      fs13.unlinkSync(p);
-      removed.push(path11.relative(project, p));
+      fs14.unlinkSync(p);
+      removed.push(path12.relative(project, p));
     } catch {
       continue;
     }
   }
-  const settings_dir = path11.join(project, "settings");
+  const settings_dir = path12.join(project, "settings");
   if (_isDir2(settings_dir) && !_isSymlink(settings_dir)) {
     try {
-      if (fs13.readdirSync(settings_dir).length === 0) {
-        fs13.rmdirSync(settings_dir);
+      if (fs14.readdirSync(settings_dir).length === 0) {
+        fs14.rmdirSync(settings_dir);
         removed.push("settings/");
       }
     } catch {
@@ -16438,12 +16470,12 @@ function _delete_legacy_settings(project) {
   return removed;
 }
 function _remove_empty_shell(project) {
-  const shell = path11.join(project, LEGACY_AGENT_CONFIG_SHELL);
+  const shell = path12.join(project, LEGACY_AGENT_CONFIG_SHELL);
   if (!_detect_empty_shell(project)) {
     return false;
   }
   try {
-    fs13.rmdirSync(shell);
+    fs14.rmdirSync(shell);
   } catch {
     return false;
   }
@@ -16453,7 +16485,7 @@ function _reEscape(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 function _update_gitignore(project) {
-  const gitignore = path11.join(project, ".gitignore");
+  const gitignore = path12.join(project, ".gitignore");
   const block = `${GITIGNORE_BLOCK_START}
 ${GITIGNORE_NEW_BODY}${GITIGNORE_BLOCK_END}
 `;
@@ -16484,16 +16516,16 @@ ${GITIGNORE_NEW_BODY}${GITIGNORE_BLOCK_END}
 }
 function _build_plan(project) {
   return {
-    npm: _detect_npm(path11.join(project, "package.json")),
-    composer: _detect_composer(path11.join(project, "composer.json")),
+    npm: _detect_npm(path12.join(project, "package.json")),
+    composer: _detect_composer(path12.join(project, "composer.json")),
     symlinks_legacy: MANAGED_SYMLINKS.filter(
-      (name) => _classify_symlink(path11.join(project, name)) === "legacy"
+      (name) => _classify_symlink(path12.join(project, name)) === "legacy"
     ),
     symlinks_user: MANAGED_SYMLINKS.filter(
-      (name) => _classify_symlink(path11.join(project, name)) === "user"
+      (name) => _classify_symlink(path12.join(project, name)) === "user"
     ),
-    state_file: _isFile2(path11.join(project, LEGACY_STATE_FILENAME)),
-    settings_files: _detect_legacy_settings(project).map((p) => path11.relative(project, p)),
+    state_file: _isFile2(path12.join(project, LEGACY_STATE_FILENAME)),
+    settings_files: _detect_legacy_settings(project).map((p) => path12.relative(project, p)),
     empty_shell: _detect_empty_shell(project)
   };
 }
@@ -16557,10 +16589,10 @@ function _warn_on_major_mismatch(from_major, plan, out) {
 }
 function _apply(project, out, err) {
   const summary = [];
-  if (_strip_npm_entry(path11.join(project, "package.json"))) {
+  if (_strip_npm_entry(path12.join(project, "package.json"))) {
     summary.push(`removed ${PACKAGE_NAME_NPM} from package.json`);
   }
-  if (_strip_composer_entry(path11.join(project, "composer.json"))) {
+  if (_strip_composer_entry(path12.join(project, "composer.json"))) {
     summary.push(`removed ${PACKAGE_NAME_COMPOSER} from composer.json`);
   }
   const [removed_links, preserved_links] = _purge_legacy_symlinks(project);
@@ -16681,18 +16713,18 @@ function main(argv = null, options = {}) {
   return _apply(project, out, err);
 }
 var _bundled = true;
-var _HERE = fileURLToPath2(import.meta.url);
+var _HERE = fileURLToPath3(import.meta.url);
 function _isCliEntry() {
   if (process2.argv[1] === void 0) {
     return false;
   }
-  const argvUrl = pathToFileURL(path11.resolve(process2.argv[1])).href;
+  const argvUrl = pathToFileURL(path12.resolve(process2.argv[1])).href;
   if (import.meta.url === argvUrl) {
     return true;
   }
   try {
-    const here = fs13.realpathSync(fileURLToPath2(import.meta.url));
-    const argv = fs13.realpathSync(path11.resolve(process2.argv[1]));
+    const here = fs14.realpathSync(fileURLToPath3(import.meta.url));
+    const argv = fs14.realpathSync(path12.resolve(process2.argv[1]));
     return here === argv;
   } catch {
     return false;
@@ -16711,7 +16743,7 @@ if (!_bundled && (_isCliEntry() || process2.argv[1] === _HERE)) {
 }
 
 // src/scripts/install.ts
-var _HERE2 = fileURLToPath3(import.meta.url);
+var _HERE2 = fileURLToPath4(import.meta.url);
 var SystemExitError = class extends Error {
   constructor(code) {
     super(`system-exit-${code}`);
@@ -16729,34 +16761,34 @@ var ArgparseExit2 = class extends Error {
 function expanduser6(p) {
   if (p === "~") return os7.homedir();
   if (p.startsWith("~/") || p.startsWith("~\\")) {
-    return path12.join(os7.homedir(), p.slice(2));
+    return path13.join(os7.homedir(), p.slice(2));
   }
   return p;
 }
 function resolvePath(p) {
   try {
-    return fs14.realpathSync(path12.resolve(p));
+    return fs15.realpathSync(path13.resolve(p));
   } catch {
-    return path12.resolve(p);
+    return path13.resolve(p);
   }
 }
 function isFile(p) {
   try {
-    return fs14.statSync(p).isFile();
+    return fs15.statSync(p).isFile();
   } catch {
     return false;
   }
 }
 function isDir(p) {
   try {
-    return fs14.statSync(p).isDirectory();
+    return fs15.statSync(p).isDirectory();
   } catch {
     return false;
   }
 }
 function pathExists(p) {
   try {
-    fs14.statSync(p);
+    fs15.statSync(p);
     return true;
   } catch {
     return false;
@@ -16764,24 +16796,24 @@ function pathExists(p) {
 }
 function isSymlink(p) {
   try {
-    return fs14.lstatSync(p).isSymbolicLink();
+    return fs15.lstatSync(p).isSymbolicLink();
   } catch {
     return false;
   }
 }
 function readText(p) {
-  return fs14.readFileSync(p, "utf-8");
+  return fs15.readFileSync(p, "utf-8");
 }
 function writeText(p, content) {
-  fs14.writeFileSync(p, content, "utf-8");
+  fs15.writeFileSync(p, content, "utf-8");
 }
 function mkdirp(p) {
-  fs14.mkdirSync(p, { recursive: true });
+  fs15.mkdirSync(p, { recursive: true });
 }
 function sortedGlobStems(directory, suffix) {
   let entries;
   try {
-    entries = fs14.readdirSync(directory);
+    entries = fs15.readdirSync(directory);
   } catch {
     return [];
   }
@@ -16801,7 +16833,7 @@ function sortedGlobStems(directory, suffix) {
 function countZips(directory) {
   if (!isDir(directory)) return 0;
   let n = 0;
-  for (const name of fs14.readdirSync(directory)) {
+  for (const name of fs15.readdirSync(directory)) {
     if (name.endsWith(".zip")) n += 1;
   }
   return n;
@@ -16809,35 +16841,35 @@ function countZips(directory) {
 function sha256OfFile(p) {
   let data;
   try {
-    data = fs14.readFileSync(p);
+    data = fs15.readFileSync(p);
   } catch {
     return null;
   }
   return crypto3.createHash("sha256").update(data).digest("hex");
 }
 function atomicWrite0644(target, body, prefix) {
-  const dir = path12.dirname(target);
-  const tmpName = path12.join(
+  const dir = path13.dirname(target);
+  const tmpName = path13.join(
     dir,
     `${prefix}${process3.pid}.${crypto3.randomBytes(6).toString("hex")}.yml.tmp`
   );
   let fd = null;
   try {
-    fd = fs14.openSync(tmpName, "wx", 420);
-    fs14.writeFileSync(fd, body, "utf-8");
-    fs14.closeSync(fd);
+    fd = fs15.openSync(tmpName, "wx", 420);
+    fs15.writeFileSync(fd, body, "utf-8");
+    fs15.closeSync(fd);
     fd = null;
-    fs14.chmodSync(tmpName, 420);
-    fs14.renameSync(tmpName, target);
+    fs15.chmodSync(tmpName, 420);
+    fs15.renameSync(tmpName, target);
   } catch (err) {
     if (fd !== null) {
       try {
-        fs14.closeSync(fd);
+        fs15.closeSync(fd);
       } catch {
       }
     }
     try {
-      fs14.unlinkSync(tmpName);
+      fs15.unlinkSync(tmpName);
     } catch {
     }
     throw err;
@@ -16961,12 +16993,12 @@ var LEGACY_SETTINGS_FILE = ".agent-settings";
 var LEGACY_BACKUP_FILE = ".agent-settings.backup.key-value";
 var SETTINGS_SUBDIR = ["agents", "settings"];
 function _canonical_settings_target(project_root) {
-  return path12.join(project_root, ...SETTINGS_SUBDIR, SETTINGS_FILE);
+  return path13.join(project_root, ...SETTINGS_SUBDIR, SETTINGS_FILE);
 }
 function _resolve_settings_read(project_root) {
   const canonical = _canonical_settings_target(project_root);
   if (pathExists(canonical)) return canonical;
-  const legacy = path12.join(project_root, SETTINGS_FILE);
+  const legacy = path13.join(project_root, SETTINGS_FILE);
   if (pathExists(legacy)) return legacy;
   return canonical;
 }
@@ -17030,9 +17062,9 @@ function fail(msg) {
   throw new SystemExitError(1);
 }
 function detect_package_root(project_root) {
-  const npm_path = path12.join(project_root, "node_modules", "@event4u", "agent-config");
+  const npm_path = path13.join(project_root, "node_modules", "@event4u", "agent-config");
   if (isDir(npm_path)) return resolvePath(npm_path);
-  if (pathExists(path12.join(project_root, "src", "config", "profiles", "minimal.ini"))) {
+  if (pathExists(path13.join(project_root, "src", "config", "profiles", "minimal.ini"))) {
     return project_root;
   }
   fail(
@@ -17040,12 +17072,12 @@ function detect_package_root(project_root) {
   );
 }
 function detect_package_type(package_root) {
-  if (package_root.split(path12.sep).includes("node_modules")) return "npm";
+  if (package_root.split(path13.sep).includes("node_modules")) return "npm";
   return "local";
 }
 function detect_package_type_for_project(project_root, package_root) {
   const npm_path = resolvePath(
-    path12.join(project_root, "node_modules", "@event4u", "agent-config")
+    path13.join(project_root, "node_modules", "@event4u", "agent-config")
   );
   const package_resolved = resolvePath(package_root);
   if (package_resolved === npm_path) return "npm";
@@ -17065,7 +17097,7 @@ function ensure_directory(p) {
   mkdirp(p);
 }
 function write_file(p, content) {
-  ensure_directory(path12.dirname(p));
+  ensure_directory(path13.dirname(p));
   writeText(p, content);
 }
 function read_json_file(p) {
@@ -17236,7 +17268,7 @@ function _append_unknown_legacy(rendered, legacy_values, unknown_keys) {
   return rendered + "\n" + suffix;
 }
 function _migrate_legacy_if_present(project_root, template_body) {
-  const legacy_target = path12.join(project_root, LEGACY_SETTINGS_FILE);
+  const legacy_target = path13.join(project_root, LEGACY_SETTINGS_FILE);
   if (!isFile(legacy_target)) return null;
   const legacy_text = readText(legacy_target);
   const [values, unknown] = _parse_legacy_settings(legacy_text);
@@ -17251,9 +17283,9 @@ function _migrate_legacy_if_present(project_root, template_body) {
     }
   }
   rendered = _append_unknown_legacy(rendered, values, unknown);
-  const backup_target = path12.join(project_root, LEGACY_BACKUP_FILE);
+  const backup_target = path13.join(project_root, LEGACY_BACKUP_FILE);
   writeText(backup_target, legacy_text);
-  fs14.unlinkSync(legacy_target);
+  fs15.unlinkSync(legacy_target);
   info(`Migrated legacy ${LEGACY_SETTINGS_FILE} \u2192 ${SETTINGS_FILE}`);
   info(`Backup saved to ${LEGACY_BACKUP_FILE}`);
   if (unknown.length > 0) {
@@ -17288,7 +17320,7 @@ function _render_template(template, profile_values) {
   return body;
 }
 function _load_valid_user_types(package_root) {
-  const directory = path12.join(package_root, USER_TYPES_DIR);
+  const directory = path13.join(package_root, USER_TYPES_DIR);
   if (!isDir(directory)) return [];
   return sortedGlobStems(directory, ".yml");
 }
@@ -17345,8 +17377,8 @@ function splitlinesKeepends(text) {
 }
 function ensure_agent_settings(project_root, package_root, profile, force, user_type = "", packs = null) {
   const target = _canonical_settings_target(project_root);
-  const profile_source = path12.join(package_root, "src", "config", "profiles", `${profile}.ini`);
-  const template_source = path12.join(package_root, "src", "config", "agent-settings.template.yml");
+  const profile_source = path13.join(package_root, "src", "config", "profiles", `${profile}.ini`);
+  const template_source = path13.join(package_root, "src", "config", "agent-settings.template.yml");
   if (!pathExists(profile_source)) fail(`Missing profile preset: ${profile_source}`);
   if (!pathExists(template_source)) fail(`Missing settings template: ${template_source}`);
   const template = readText(template_source);
@@ -17360,21 +17392,21 @@ function ensure_agent_settings(project_root, package_root, profile, force, user_
   if (profile_values["rule_loading_tier"] !== profile) {
     const got = "rule_loading_tier" in profile_values ? `'${profile_values["rule_loading_tier"]}'` : "None";
     fail(
-      `Profile preset ${path12.basename(profile_source)} has rule_loading_tier=${got} but --profile=${profile}`
+      `Profile preset ${path13.basename(profile_source)} has rule_loading_tier=${got} but --profile=${profile}`
     );
   }
   profile_values["user_type"] = _validate_user_type(package_root, user_type);
   let template_body = _render_template(template, profile_values);
   template_body = _inject_packs(template_body, packs ?? []);
-  const legacy_root = path12.join(project_root, SETTINGS_FILE);
+  const legacy_root = path13.join(project_root, SETTINGS_FILE);
   if (isFile(legacy_root) && !pathExists(target)) {
-    mkdirp(path12.dirname(target));
+    mkdirp(path13.dirname(target));
     writeText(target, readText(legacy_root));
-    fs14.unlinkSync(legacy_root);
+    fs15.unlinkSync(legacy_root);
     success(`Migrated ${SETTINGS_FILE} \u2192 agents/settings/${SETTINGS_FILE} (ADR-038)`);
     return;
   }
-  const legacy_target = path12.join(project_root, LEGACY_SETTINGS_FILE);
+  const legacy_target = path13.join(project_root, LEGACY_SETTINGS_FILE);
   if (isFile(legacy_target) && pathExists(target)) {
     warn(
       `Both ${SETTINGS_FILE} and legacy ${LEGACY_SETTINGS_FILE} exist. Skipping migration to avoid overwriting ${SETTINGS_FILE}. Delete one of them manually and re-run.`
@@ -17391,7 +17423,7 @@ function ensure_agent_settings(project_root, package_root, profile, force, user_
     skip(`${SETTINGS_FILE} already exists`);
     return;
   }
-  mkdirp(path12.dirname(target));
+  mkdirp(path13.dirname(target));
   write_file(target, template_body);
   const user_type_value = profile_values["user_type"] ?? "";
   const suffix = user_type_value ? `, user_type=${user_type_value}` : "";
@@ -17404,7 +17436,7 @@ function ensure_vscode_bridge(project_root, package_type, force) {
   const plugin_path = plugin_paths[package_type] ?? "./plugin/agent-config";
   const bridge = { "chat.pluginLocations": { [plugin_path]: true } };
   merge_json_file(
-    path12.join(project_root, ".vscode", "settings.json"),
+    path13.join(project_root, ".vscode", "settings.json"),
     bridge,
     force,
     ".vscode/settings.json"
@@ -17413,14 +17445,14 @@ function ensure_vscode_bridge(project_root, package_type, force) {
 function ensure_augment_bridge(project_root, force) {
   const bridge = { enabledPlugins: { "agent-config@event4u": true } };
   return merge_json_file(
-    path12.join(project_root, ".augment", "settings.json"),
+    path13.join(project_root, ".augment", "settings.json"),
     bridge,
     force,
     ".augment/settings.json"
   );
 }
-var AUGMENT_USER_DIR = path12.join(os7.homedir(), ".augment");
-var AUGMENT_USER_HOOKS_DIR = path12.join(AUGMENT_USER_DIR, "hooks");
+var AUGMENT_USER_DIR = path13.join(os7.homedir(), ".augment");
+var AUGMENT_USER_HOOKS_DIR = path13.join(AUGMENT_USER_DIR, "hooks");
 var AUGMENT_DISPATCHER_TRAMPOLINE = "augment-dispatcher.sh";
 var AUGMENT_LEGACY_TRAMPOLINES = [
   "augment-chat-history.sh",
@@ -17436,29 +17468,29 @@ var AUGMENT_DISPATCHER_BINDINGS = [
   ["post_tool_use", "PostToolUse"]
 ];
 function _deploy_augment_trampoline(package_root, name, force) {
-  const src = path12.join(package_root, "scripts", "hooks", name);
+  const src = path13.join(package_root, "scripts", "hooks", name);
   if (!pathExists(src)) {
     skip(`augment trampoline missing in package: ${src}`);
     return null;
   }
   mkdirp(AUGMENT_USER_HOOKS_DIR);
-  const dst = path12.join(AUGMENT_USER_HOOKS_DIR, name);
+  const dst = path13.join(AUGMENT_USER_HOOKS_DIR, name);
   const src_text = readText(src);
   if (pathExists(dst) && readText(dst) === src_text && !force) {
     skip(`~/.augment/hooks/${name} already up to date`);
   } else {
     writeText(dst, src_text);
-    fs14.chmodSync(dst, 493);
+    fs15.chmodSync(dst, 493);
     success(`~/.augment/hooks/${name} installed`);
   }
   return dst;
 }
 function _remove_legacy_augment_trampolines() {
   for (const name of AUGMENT_LEGACY_TRAMPOLINES) {
-    const legacy = path12.join(AUGMENT_USER_HOOKS_DIR, name);
+    const legacy = path13.join(AUGMENT_USER_HOOKS_DIR, name);
     try {
       if (isFile(legacy)) {
-        fs14.unlinkSync(legacy);
+        fs15.unlinkSync(legacy);
         skip(`removed legacy ~/.augment/hooks/${name}`);
       }
     } catch {
@@ -17477,7 +17509,7 @@ function ensure_augment_user_hooks(package_root, force) {
   }
   const settings_patch = { hooks: per_event };
   return merge_json_file(
-    path12.join(AUGMENT_USER_DIR, "settings.json"),
+    path13.join(AUGMENT_USER_DIR, "settings.json"),
     settings_patch,
     force,
     "~/.augment/settings.json"
@@ -17502,7 +17534,7 @@ function _heal_legacy_claude_plugin_ids(p) {
   return removed;
 }
 function ensure_claude_bridge(project_root, force) {
-  const target = path12.join(project_root, ".claude", "settings.json");
+  const target = path13.join(project_root, ".claude", "settings.json");
   const healed = _heal_legacy_claude_plugin_ids(target);
   for (const pid of healed) {
     success(`.claude/settings.json: removed stale plugin id \`${pid}\``);
@@ -17527,29 +17559,29 @@ function ensure_cursor_bridge(project_root, force) {
   }
   const bridge = { version: 1, hooks };
   return merge_json_file(
-    path12.join(project_root, ".cursor", "hooks.json"),
+    path13.join(project_root, ".cursor", "hooks.json"),
     bridge,
     force,
     ".cursor/hooks.json"
   );
 }
-var CURSOR_USER_DIR = path12.join(os7.homedir(), ".cursor");
-var CURSOR_USER_HOOKS_DIR = path12.join(CURSOR_USER_DIR, "hooks");
+var CURSOR_USER_DIR = path13.join(os7.homedir(), ".cursor");
+var CURSOR_USER_HOOKS_DIR = path13.join(CURSOR_USER_DIR, "hooks");
 var CURSOR_DISPATCHER_TRAMPOLINE = "cursor-dispatcher.sh";
 function ensure_cursor_user_hooks(package_root, force) {
-  const src = path12.join(package_root, "scripts", "hooks", CURSOR_DISPATCHER_TRAMPOLINE);
+  const src = path13.join(package_root, "scripts", "hooks", CURSOR_DISPATCHER_TRAMPOLINE);
   if (!pathExists(src)) {
     skip(`cursor trampoline missing in package: ${src}`);
     return [];
   }
   mkdirp(CURSOR_USER_HOOKS_DIR);
-  const dst = path12.join(CURSOR_USER_HOOKS_DIR, CURSOR_DISPATCHER_TRAMPOLINE);
+  const dst = path13.join(CURSOR_USER_HOOKS_DIR, CURSOR_DISPATCHER_TRAMPOLINE);
   const src_text = readText(src);
   if (pathExists(dst) && readText(dst) === src_text && !force) {
     skip(`~/.cursor/hooks/${CURSOR_DISPATCHER_TRAMPOLINE} already up to date`);
   } else {
     writeText(dst, src_text);
-    fs14.chmodSync(dst, 493);
+    fs15.chmodSync(dst, 493);
     success(`~/.cursor/hooks/${CURSOR_DISPATCHER_TRAMPOLINE} installed`);
   }
   const hooks = {};
@@ -17558,7 +17590,7 @@ function ensure_cursor_user_hooks(package_root, force) {
   }
   const settings_patch = { version: 1, hooks };
   return merge_json_file(
-    path12.join(CURSOR_USER_DIR, "hooks.json"),
+    path13.join(CURSOR_USER_DIR, "hooks.json"),
     settings_patch,
     force,
     "~/.cursor/hooks.json"
@@ -17601,12 +17633,12 @@ exit 0
 `;
 }
 function ensure_cline_bridge(project_root, force) {
-  const hooks_dir = path12.join(project_root, ".clinerules", "hooks");
+  const hooks_dir = path13.join(project_root, ".clinerules", "hooks");
   mkdirp(hooks_dir);
   const workspace_quoted = shlexQuote(resolvePath(project_root));
   let written = 0;
   for (const [ac_event, native_event] of CLINE_DISPATCHER_BINDINGS) {
-    const target = path12.join(hooks_dir, native_event);
+    const target = path13.join(hooks_dir, native_event);
     const body = clineProjectHookBody(native_event, ac_event, workspace_quoted);
     if (pathExists(target) && readText(target) === body && !force) {
       continue;
@@ -17616,7 +17648,7 @@ function ensure_cline_bridge(project_root, force) {
       continue;
     }
     writeText(target, body);
-    fs14.chmodSync(target, 493);
+    fs15.chmodSync(target, 493);
     written += 1;
   }
   if (written) {
@@ -17625,27 +17657,27 @@ function ensure_cline_bridge(project_root, force) {
     skip(".clinerules/hooks/ already up to date");
   }
 }
-var CLINE_USER_DIR = path12.join(os7.homedir(), "Documents", "Cline", "Hooks");
+var CLINE_USER_DIR = path13.join(os7.homedir(), "Documents", "Cline", "Hooks");
 var CLINE_DISPATCHER_TRAMPOLINE = "cline-dispatcher.sh";
 function ensure_cline_user_hooks(package_root, force) {
-  const src = path12.join(package_root, "scripts", "hooks", CLINE_DISPATCHER_TRAMPOLINE);
+  const src = path13.join(package_root, "scripts", "hooks", CLINE_DISPATCHER_TRAMPOLINE);
   if (!pathExists(src)) {
     skip(`cline trampoline missing in package: ${src}`);
     return;
   }
   mkdirp(CLINE_USER_DIR);
-  const trampoline = path12.join(CLINE_USER_DIR, CLINE_DISPATCHER_TRAMPOLINE);
+  const trampoline = path13.join(CLINE_USER_DIR, CLINE_DISPATCHER_TRAMPOLINE);
   const src_text = readText(src);
   if (pathExists(trampoline) && readText(trampoline) === src_text && !force) {
     skip(`~/Documents/Cline/Hooks/${CLINE_DISPATCHER_TRAMPOLINE} already up to date`);
   } else {
     writeText(trampoline, src_text);
-    fs14.chmodSync(trampoline, 493);
+    fs15.chmodSync(trampoline, 493);
     success(`~/Documents/Cline/Hooks/${CLINE_DISPATCHER_TRAMPOLINE} installed`);
   }
   const trampoline_quoted = shlexQuote(trampoline);
   for (const [ac_event, native_event] of CLINE_DISPATCHER_BINDINGS) {
-    const wrapper = path12.join(CLINE_USER_DIR, native_event);
+    const wrapper = path13.join(CLINE_USER_DIR, native_event);
     const body = `#!/usr/bin/env bash
 # Generated by event4u/agent-config install.py \u2014 DO NOT EDIT.
 # User-scope Cline hook for ${native_event} \u2192 agent-config ${ac_event}.
@@ -17655,7 +17687,7 @@ exec ${trampoline_quoted} ${ac_event} ${native_event}
       continue;
     }
     writeText(wrapper, body);
-    fs14.chmodSync(wrapper, 493);
+    fs15.chmodSync(wrapper, 493);
   }
 }
 var WINDSURF_DISPATCHER_BINDINGS = [
@@ -17676,29 +17708,29 @@ function ensure_windsurf_bridge(project_root, force) {
   }
   const bridge = { hooks };
   return merge_json_file(
-    path12.join(project_root, ".windsurf", "hooks.json"),
+    path13.join(project_root, ".windsurf", "hooks.json"),
     bridge,
     force,
     ".windsurf/hooks.json"
   );
 }
-var WINDSURF_USER_DIR = path12.join(os7.homedir(), ".codeium", "windsurf");
-var WINDSURF_USER_HOOKS_DIR = path12.join(WINDSURF_USER_DIR, "hooks");
+var WINDSURF_USER_DIR = path13.join(os7.homedir(), ".codeium", "windsurf");
+var WINDSURF_USER_HOOKS_DIR = path13.join(WINDSURF_USER_DIR, "hooks");
 var WINDSURF_DISPATCHER_TRAMPOLINE = "windsurf-dispatcher.sh";
 function ensure_windsurf_user_hooks(package_root, force) {
-  const src = path12.join(package_root, "scripts", "hooks", WINDSURF_DISPATCHER_TRAMPOLINE);
+  const src = path13.join(package_root, "scripts", "hooks", WINDSURF_DISPATCHER_TRAMPOLINE);
   if (!pathExists(src)) {
     skip(`windsurf trampoline missing in package: ${src}`);
     return [];
   }
   mkdirp(WINDSURF_USER_HOOKS_DIR);
-  const dst = path12.join(WINDSURF_USER_HOOKS_DIR, WINDSURF_DISPATCHER_TRAMPOLINE);
+  const dst = path13.join(WINDSURF_USER_HOOKS_DIR, WINDSURF_DISPATCHER_TRAMPOLINE);
   const src_text = readText(src);
   if (pathExists(dst) && readText(dst) === src_text && !force) {
     skip(`~/.codeium/windsurf/hooks/${WINDSURF_DISPATCHER_TRAMPOLINE} already up to date`);
   } else {
     writeText(dst, src_text);
-    fs14.chmodSync(dst, 493);
+    fs15.chmodSync(dst, 493);
     success(`~/.codeium/windsurf/hooks/${WINDSURF_DISPATCHER_TRAMPOLINE} installed`);
   }
   const hooks = {};
@@ -17710,7 +17742,7 @@ function ensure_windsurf_user_hooks(package_root, force) {
   }
   const settings_patch = { hooks };
   return merge_json_file(
-    path12.join(WINDSURF_USER_DIR, "hooks.json"),
+    path13.join(WINDSURF_USER_DIR, "hooks.json"),
     settings_patch,
     force,
     "~/.codeium/windsurf/hooks.json"
@@ -17739,43 +17771,43 @@ function _gemini_hooks_dict(command_factory) {
 function ensure_gemini_bridge(project_root, force) {
   const bridge = { hooks: _gemini_hooks_dict(_gemini_dispatch_command) };
   return merge_json_file(
-    path12.join(project_root, ".gemini", "settings.json"),
+    path13.join(project_root, ".gemini", "settings.json"),
     bridge,
     force,
     ".gemini/settings.json"
   );
 }
-var GEMINI_USER_DIR = path12.join(os7.homedir(), ".gemini");
-var GEMINI_USER_HOOKS_DIR = path12.join(GEMINI_USER_DIR, "hooks");
+var GEMINI_USER_DIR = path13.join(os7.homedir(), ".gemini");
+var GEMINI_USER_HOOKS_DIR = path13.join(GEMINI_USER_DIR, "hooks");
 var GEMINI_DISPATCHER_TRAMPOLINE = "gemini-dispatcher.sh";
 function ensure_gemini_user_hooks(package_root, force) {
-  const src = path12.join(package_root, "scripts", "hooks", GEMINI_DISPATCHER_TRAMPOLINE);
+  const src = path13.join(package_root, "scripts", "hooks", GEMINI_DISPATCHER_TRAMPOLINE);
   if (!pathExists(src)) {
     skip(`gemini trampoline missing in package: ${src}`);
     return [];
   }
   mkdirp(GEMINI_USER_HOOKS_DIR);
-  const dst = path12.join(GEMINI_USER_HOOKS_DIR, GEMINI_DISPATCHER_TRAMPOLINE);
+  const dst = path13.join(GEMINI_USER_HOOKS_DIR, GEMINI_DISPATCHER_TRAMPOLINE);
   const src_text = readText(src);
   if (pathExists(dst) && readText(dst) === src_text && !force) {
     skip(`~/.gemini/hooks/${GEMINI_DISPATCHER_TRAMPOLINE} already up to date`);
   } else {
     writeText(dst, src_text);
-    fs14.chmodSync(dst, 493);
+    fs15.chmodSync(dst, 493);
     success(`~/.gemini/hooks/${GEMINI_DISPATCHER_TRAMPOLINE} installed`);
   }
   const settings_patch = {
     hooks: _gemini_hooks_dict((ac_event, native) => `${dst} ${ac_event} ${native}`)
   };
   return merge_json_file(
-    path12.join(GEMINI_USER_DIR, "settings.json"),
+    path13.join(GEMINI_USER_DIR, "settings.json"),
     settings_patch,
     force,
     "~/.gemini/settings.json"
   );
 }
 function ensure_copilot_bridge(project_root, force) {
-  const target = path12.join(project_root, ".github", "plugin", "marketplace.json");
+  const target = path13.join(project_root, ".github", "plugin", "marketplace.json");
   const bridge = {
     marketplace: {
       name: "event4u-agent-marketplace",
@@ -17818,7 +17850,7 @@ See \`docs/setup/per-ide/roocode.md\` for the full activation guide.
 Run \`./agent-config --help\` for available commands.
 `;
 function ensure_roocode_bridge(project_root, force) {
-  const target = path12.join(project_root, ".roo", "rules", "agent-config.md");
+  const target = path13.join(project_root, ".roo", "rules", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".roo/rules/agent-config.md already exists");
     return;
@@ -17840,7 +17872,7 @@ To wire Claude Desktop to this project's rules, run:
 Canonical rule and skill source: \`.augment/\` (see \`AGENTS.md\`).
 `;
 function ensure_claude_desktop_bridge(project_root, force) {
-  const target = path12.join(project_root, ".claude-desktop", "agent-config.md");
+  const target = path13.join(project_root, ".claude-desktop", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".claude-desktop/agent-config.md already exists");
     return;
@@ -17865,7 +17897,7 @@ Or pass \`--read .aider/agent-config.md\` on the command line.
 Canonical rule and skill source: \`.augment/\` (see \`AGENTS.md\`).
 `;
 function ensure_aider_bridge(project_root, force) {
-  const target = path12.join(project_root, ".aider", "agent-config.md");
+  const target = path13.join(project_root, ".aider", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".aider/agent-config.md already exists");
     return;
@@ -17884,7 +17916,7 @@ developers where the rules and skills live.
 Canonical rule and skill source: \`.augment/\` (see project \`AGENTS.md\`).
 `;
 function ensure_codex_bridge(project_root, force) {
-  const target = path12.join(project_root, ".codex", "agent-config.md");
+  const target = path13.join(project_root, ".codex", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".codex/agent-config.md already exists");
     return;
@@ -17902,7 +17934,7 @@ rules per session. The canonical rule and skill source lives under
 orientation).
 `;
 function ensure_continue_bridge(project_root, force) {
-  const target = path12.join(project_root, ".continue", "rules", "agent-config.md");
+  const target = path13.join(project_root, ".continue", "rules", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".continue/rules/agent-config.md already exists");
     return;
@@ -17933,7 +17965,7 @@ orientation).
 See \`docs/setup/per-ide/kilocode.md\` for the full activation guide.
 `;
 function ensure_kilocode_bridge(project_root, force) {
-  const target = path12.join(project_root, ".kilocode", "rules", "agent-config.md");
+  const target = path13.join(project_root, ".kilocode", "rules", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".kilocode/rules/agent-config.md already exists");
     return;
@@ -17960,7 +17992,7 @@ canonical source (or symlink it):
 Canonical rule and skill source: \`.augment/\` (see \`AGENTS.md\`).
 `;
 function ensure_zed_bridge(project_root, force) {
-  const target = path12.join(project_root, ".zed", "agent-config.md");
+  const target = path13.join(project_root, ".zed", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".zed/agent-config.md already exists");
     return;
@@ -17981,7 +18013,7 @@ rules into your JetBrains profile.
 Canonical rule and skill source: \`.augment/\` (see \`AGENTS.md\`).
 `;
 function ensure_jetbrains_bridge(project_root, force) {
-  const target = path12.join(project_root, ".jetbrains", "agent-config.md");
+  const target = path13.join(project_root, ".jetbrains", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".jetbrains/agent-config.md already exists");
     return;
@@ -18012,7 +18044,7 @@ session. The canonical rule and skill source lives under \`.augment/\`
 See \`docs/setup/per-ide/kiro.md\` for the full activation guide.
 `;
 function ensure_kiro_bridge(project_root, force) {
-  const target = path12.join(project_root, ".kiro", "steering", "agent-config.md");
+  const target = path13.join(project_root, ".kiro", "steering", "agent-config.md");
   if (pathExists(target) && !force) {
     skip(".kiro/steering/agent-config.md already exists");
     return;
@@ -18038,35 +18070,35 @@ var SMOKE_BRIDGE_PATHS = {
 };
 function dirHasEntries(p) {
   try {
-    return fs14.readdirSync(p).length > 0;
+    return fs15.readdirSync(p).length > 0;
   } catch {
     return false;
   }
 }
 function _resolve_tsx_invocation(scriptPath, scriptArgs) {
   const binName = process3.platform === "win32" ? "tsx.cmd" : "tsx";
-  let dir = path12.dirname(scriptPath);
+  let dir = path13.dirname(scriptPath);
   for (; ; ) {
-    const candidate = path12.join(dir, "node_modules", ".bin", binName);
+    const candidate = path13.join(dir, "node_modules", ".bin", binName);
     if (isFile(candidate)) {
       return { command: candidate, args: [scriptPath, ...scriptArgs] };
     }
-    const parent = path12.dirname(dir);
+    const parent = path13.dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
   return { command: "npx", args: ["tsx", scriptPath, ...scriptArgs] };
 }
 function _smoke_test_hooks(project_root, package_root) {
-  const dispatcher = path12.join(package_root, "scripts", "hooks", "dispatch_hook.ts");
-  const manifest = path12.join(package_root, "scripts", "hook_manifest.yaml");
+  const dispatcher = path13.join(package_root, "scripts", "hooks", "dispatch_hook.ts");
+  const manifest = path13.join(package_root, "scripts", "hook_manifest.yaml");
   if (!isFile(dispatcher) || !isFile(manifest)) return 0;
   const failed = [];
   const skipped = [];
   const passed = [];
   for (const [platform, native] of SMOKE_PROBE_EVENTS) {
     const rel_bridge = SMOKE_BRIDGE_PATHS[platform] ?? "";
-    const bridge_path = rel_bridge ? path12.join(project_root, rel_bridge) : null;
+    const bridge_path = rel_bridge ? path13.join(project_root, rel_bridge) : null;
     const bridge_present = Boolean(
       bridge_path && (isFile(bridge_path) || isDir(bridge_path) && dirHasEntries(bridge_path))
     );
@@ -18266,9 +18298,9 @@ To remove this marker, delete this file.
 `;
 }
 var _CLAUDE_DESKTOP_BUNDLES_SUBPATH = "claude-desktop/bundles";
-var GLOBAL_ROOT = path12.join(os7.homedir(), ".event4u", "agent-config");
-var GLOBAL_USER_SETTINGS_PATH = path12.join(GLOBAL_ROOT, ".agent-user.yml");
-var GLOBAL_AGENT_SETTINGS_PATH = path12.join(GLOBAL_ROOT, ".agent-settings.yml");
+var GLOBAL_ROOT = path13.join(os7.homedir(), ".event4u", "agent-config");
+var GLOBAL_USER_SETTINGS_PATH = path13.join(GLOBAL_ROOT, ".agent-user.yml");
+var GLOBAL_AGENT_SETTINGS_PATH = path13.join(GLOBAL_ROOT, ".agent-settings.yml");
 function _bridge_marker(tool_id, scope) {
   if (scope === "global") return USER_SCOPE_PATHS[tool_id] ?? "";
   return PROJECT_BRIDGE_MARKERS[tool_id] ?? "";
@@ -18317,7 +18349,7 @@ function _load_yaml_doc(p) {
   return _isPlainObject2(data) ? data : {};
 }
 function _load_default_settings(package_root) {
-  const template_source = path12.join(package_root, "src", "config", "agent-settings.template.yml");
+  const template_source = path13.join(package_root, "src", "config", "agent-settings.template.yml");
   if (!pathExists(template_source)) return {};
   let text;
   try {
@@ -18405,9 +18437,9 @@ function detect_scope(cwd) {
   if (pathExists(_resolve_settings_read(cwd))) {
     return ["project", `existing ${SETTINGS_FILE}`];
   }
-  const has_manifest = SCOPE_DETECT_MANIFESTS.find((m) => pathExists(path12.join(cwd, m))) ?? null;
-  const has_ai_dir = SCOPE_DETECT_AI_DIRS.find((d) => isDir(path12.join(cwd, d))) ?? null;
-  const has_ai_file = SCOPE_DETECT_AI_FILES.find((f) => pathExists(path12.join(cwd, f))) ?? null;
+  const has_manifest = SCOPE_DETECT_MANIFESTS.find((m) => pathExists(path13.join(cwd, m))) ?? null;
+  const has_ai_dir = SCOPE_DETECT_AI_DIRS.find((d) => isDir(path13.join(cwd, d))) ?? null;
+  const has_ai_file = SCOPE_DETECT_AI_FILES.find((f) => pathExists(path13.join(cwd, f))) ?? null;
   if (has_manifest && (has_ai_dir || has_ai_file)) {
     const marker = has_ai_dir || has_ai_file;
     return ["prompt", `manifest (${has_manifest}) + AI-tool config (${marker})`];
@@ -18428,7 +18460,7 @@ function readLineSyncRaw(promptText) {
   for (; ; ) {
     let n;
     try {
-      n = fs14.readSync(0, buf, 0, 1, null);
+      n = fs15.readSync(0, buf, 0, 1, null);
     } catch (err) {
       const code = err.code;
       if (code === "EAGAIN") {
@@ -18503,8 +18535,8 @@ function _files_by_tool_from_bridges(tools, project_root, scope) {
     const marker = _bridge_marker(tool_id, scope);
     if (!marker) continue;
     let marker_path = marker;
-    if (!path12.isAbsolute(marker_path)) {
-      marker_path = path12.join(project_root, marker_path);
+    if (!path13.isAbsolute(marker_path)) {
+      marker_path = path13.join(project_root, marker_path);
     }
     out[tool_id] = [_file_entry(marker_path, "bridge", false)];
   }
@@ -18543,26 +18575,26 @@ function _update_installed_tools_manifest(project_root, tools, scope, force, fil
   }
   write_manifest(target, version, entries);
   if (!state.QUIET) {
-    const rel = isRelativeTo(target, project_root) ? path12.relative(project_root, target) : target;
+    const rel = isRelativeTo(target, project_root) ? path13.relative(project_root, target) : target;
     info(`Manifest updated: ${rel}`);
   }
   return 0;
 }
 function isRelativeTo(child, parent) {
-  const rel = path12.relative(parent, child);
-  return rel === "" || !rel.startsWith("..") && !path12.isAbsolute(rel);
+  const rel = path13.relative(parent, child);
+  return rel === "" || !rel.startsWith("..") && !path13.isAbsolute(rel);
 }
 function _resolve_package_root_for_global() {
   const here = resolvePath(_HERE2);
-  const candidate = path12.dirname(path12.dirname(path12.dirname(here)));
-  if (!pathExists(path12.join(candidate, "src", "config", "profiles", "minimal.ini"))) {
+  const candidate = path13.dirname(path13.dirname(path13.dirname(here)));
+  if (!pathExists(path13.join(candidate, "src", "config", "profiles", "minimal.ini"))) {
     fail(
       `Could not locate agent-config package root from ${here}. Expected src/config/profiles/minimal.ini at the parent directory.`
     );
   }
   return candidate;
 }
-var CONSUMER_BRIDGE_MARKER_RELPATH = path12.join("agents", ".event4u-bridge.yml");
+var CONSUMER_BRIDGE_MARKER_RELPATH = path13.join("agents", ".event4u-bridge.yml");
 var MIGRATE_LEGACY_YAML_FILES = [".agent-settings.yml", ".agent-user.yml"];
 var MIGRATE_LEGACY_TOOL_DIRS = [".augment", ".claude", ".cursor"];
 var AGENT_CONFIG_PACKAGE_NAME = "@event4u/agent-config";
@@ -18570,7 +18602,7 @@ function _is_agent_config_source_repo(project_root) {
   if (process3.env["AGENT_CONFIG_CONSUMER_MODE"] === "1") {
     return [false, "consumer-mode-override"];
   }
-  const pkg_json = path12.join(project_root, "package.json");
+  const pkg_json = path13.join(project_root, "package.json");
   if (isFile(pkg_json)) {
     let data = {};
     try {
@@ -18582,18 +18614,18 @@ function _is_agent_config_source_repo(project_root) {
       return [true, "package.json:name"];
     }
   }
-  if (isDir(path12.join(project_root, ".agent-src.uncondensed"))) {
+  if (isDir(path13.join(project_root, ".agent-src.uncondensed"))) {
     return [true, ".agent-src.uncondensed/"];
   }
-  const packages_dir = path12.join(project_root, "packages");
+  const packages_dir = path13.join(project_root, "packages");
   if (isDir(packages_dir)) {
-    for (const child of fs14.readdirSync(packages_dir)) {
-      if (isDir(path12.join(packages_dir, child, ".agent-src.uncondensed"))) {
+    for (const child of fs15.readdirSync(packages_dir)) {
+      if (isDir(path13.join(packages_dir, child, ".agent-src.uncondensed"))) {
         return [true, `packages/${child}/.agent-src.uncondensed/`];
       }
     }
   }
-  const installer_self = path12.join(project_root, "scripts", "install.py");
+  const installer_self = path13.join(project_root, "scripts", "install.py");
   try {
     if (isFile(installer_self) && resolvePath(installer_self) === resolvePath(_HERE2)) {
       return [true, "src/scripts/install.py (self)"];
@@ -18613,17 +18645,17 @@ function _detect_legacy_for_migration(project_root) {
     }
     return [];
   }
-  if (isFile(path12.join(project_root, INSTALL_MODE_MARKER_REL))) return [];
+  if (isFile(path13.join(project_root, INSTALL_MODE_MARKER_REL))) return [];
   const found = [];
   for (const name of MIGRATE_LEGACY_YAML_FILES) {
-    if (isFile(path12.join(project_root, name))) {
+    if (isFile(path13.join(project_root, name))) {
       found.push(name);
-    } else if (isFile(path12.join(project_root, "settings", name))) {
+    } else if (isFile(path13.join(project_root, "settings", name))) {
       found.push(`settings/${name}`);
     }
   }
   for (const name of MIGRATE_LEGACY_TOOL_DIRS) {
-    const p = path12.join(project_root, name);
+    const p = path13.join(project_root, name);
     if (isDir(p) && !isSymlink(p)) {
       found.push(`${name}/`);
     }
@@ -18635,7 +18667,7 @@ function _prompt_migrate_to_global(project_root, artefacts) {
     process3.stdout.write("\n");
     warn("Legacy project-local artefacts detected \u2014 pre-ADR-020 layout:");
     for (const rel of artefacts) {
-      info(`  ${path12.join(project_root, rel)}`);
+      info(`  ${path13.join(project_root, rel)}`);
     }
     info("The unified `agent-config migrate` sweeps these in one pass.");
     info("The wizard recreates fresh config afterwards.");
@@ -18666,20 +18698,20 @@ function _run_migrate_to_global(project_root) {
 function _format_global_root_for_marker(global_root) {
   const home = resolvePath(os7.homedir());
   const resolved = resolvePath(global_root);
-  const rel = path12.relative(home, resolved);
-  if (rel === "" || rel.startsWith("..") || path12.isAbsolute(rel)) {
+  const rel = path13.relative(home, resolved);
+  if (rel === "" || rel.startsWith("..") || path13.isAbsolute(rel)) {
     return global_root;
   }
-  return `~/${rel.split(path12.sep).join("/")}`;
+  return `~/${rel.split(path13.sep).join("/")}`;
 }
 function _remove_legacy_consumer_bridge_marker(project_root, env = null) {
   const env_map = env ?? process3.env;
   if (env_map["AGENT_CONFIG_DEV_MODE"] === "1") return null;
-  if (isDir(path12.join(project_root, ".agent-src.uncondensed"))) return null;
-  const target = path12.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
+  if (isDir(path13.join(project_root, ".agent-src.uncondensed"))) return null;
+  const target = path13.join(project_root, CONSUMER_BRIDGE_MARKER_RELPATH);
   if (!isFile(target)) return null;
   try {
-    fs14.rmSync(target);
+    fs15.rmSync(target);
   } catch {
     return null;
   }
@@ -18693,7 +18725,7 @@ var PROJECT_ANCHOR_TOOLS = {
 function _write_per_tool_project_anchors(project_root, tools, env = null, now = null) {
   const env_map = env ?? process3.env;
   if (env_map["AGENT_CONFIG_DEV_MODE"] === "1") return [];
-  if (isDir(path12.join(project_root, ".agent-src.uncondensed"))) return [];
+  if (isDir(path13.join(project_root, ".agent-src.uncondensed"))) return [];
   const global_root_str = _format_global_root_for_marker(
     event4u_root(env_map)
   );
@@ -18702,8 +18734,8 @@ function _write_per_tool_project_anchors(project_root, tools, env = null, now = 
   for (const tool_id of Object.keys(PROJECT_ANCHOR_TOOLS).sort()) {
     const rel_path = PROJECT_ANCHOR_TOOLS[tool_id];
     if (!tools.has(tool_id)) continue;
-    const target = path12.join(project_root, rel_path);
-    mkdirp(path12.dirname(target));
+    const target = path13.join(project_root, rel_path);
+    mkdirp(path13.dirname(target));
     const body = `# event4u/agent-config \u2014 per-tool project anchor (auto-written).
 # Spec: docs/contracts/consumer-bridge.md \xA7 Per-tool anchor strategy.
 # Tool: ${tool_id}. Resolves the global install directly \u2014 no
@@ -18721,7 +18753,7 @@ installed_at: ${stamp}
 }
 var PACKAGE_TAG_ID = "event4u/agent-config";
 function _inject_package_tag(target, source, package_root) {
-  if (path12.extname(target) !== ".md") return;
+  if (path13.extname(target) !== ".md") return;
   let text;
   try {
     text = readText(target);
@@ -18749,8 +18781,8 @@ function _inject_package_tag(target, source, package_root) {
       resolved_src = source;
     }
     if (package_root !== null) {
-      const rel = path12.relative(resolvePath(package_root), resolved_src);
-      if (rel !== "" && !rel.startsWith("..") && !path12.isAbsolute(rel)) {
+      const rel = path13.relative(resolvePath(package_root), resolved_src);
+      if (rel !== "" && !rel.startsWith("..") && !path13.isAbsolute(rel)) {
         source_value = rel;
       } else {
         source_value = resolved_src;
@@ -18787,10 +18819,10 @@ function _copy_dir_dereferencing_symlinks(src, dest, force, package_root = null)
   const written_paths = [];
   if (!pathExists(src)) return [0, 0, written_paths];
   if (!isDir(src)) {
-    mkdirp(path12.dirname(dest));
+    mkdirp(path13.dirname(dest));
     const decision = _resolve_file_conflict(dest, force);
     if (decision === "skip") return [0, 1, written_paths];
-    fs14.copyFileSync(src, dest);
+    fs15.copyFileSync(src, dest);
     _inject_package_tag(dest, src, package_root);
     written_paths.push(dest);
     return [1, 0, written_paths];
@@ -18798,11 +18830,11 @@ function _copy_dir_dereferencing_symlinks(src, dest, force, package_root = null)
   mkdirp(dest);
   const walk = (node) => {
     const acc = [];
-    const names = fs14.readdirSync(node).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
+    const names = fs15.readdirSync(node).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
     for (const name of names) {
-      const entry = path12.join(node, name);
+      const entry = path13.join(node, name);
       acc.push(entry);
-      const lst = fs14.lstatSync(entry);
+      const lst = fs15.lstatSync(entry);
       if (lst.isDirectory() && !lst.isSymbolicLink()) {
         acc.push(...walk(entry));
       }
@@ -18810,9 +18842,9 @@ function _copy_dir_dereferencing_symlinks(src, dest, force, package_root = null)
     return acc;
   };
   for (const entry of walk(src)) {
-    const rel = path12.relative(src, entry);
-    const target = path12.join(dest, rel);
-    const lst = fs14.lstatSync(entry);
+    const rel = path13.relative(src, entry);
+    const target = path13.join(dest, rel);
+    const lst = fs15.lstatSync(entry);
     if (lst.isDirectory() && !lst.isSymbolicLink()) {
       mkdirp(target);
       continue;
@@ -18820,8 +18852,8 @@ function _copy_dir_dereferencing_symlinks(src, dest, force, package_root = null)
     let resolvedIsDir = false;
     let resolved = entry;
     try {
-      resolved = fs14.realpathSync(entry);
-      resolvedIsDir = fs14.statSync(entry).isDirectory();
+      resolved = fs15.realpathSync(entry);
+      resolvedIsDir = fs15.statSync(entry).isDirectory();
     } catch {
       resolvedIsDir = false;
     }
@@ -18843,8 +18875,8 @@ function _copy_dir_dereferencing_symlinks(src, dest, force, package_root = null)
       skipped += 1;
       continue;
     }
-    mkdirp(path12.dirname(target));
-    fs14.copyFileSync(resolved, target);
+    mkdirp(path13.dirname(target));
+    fs15.copyFileSync(resolved, target);
     _inject_package_tag(target, resolved, package_root);
     written += 1;
     written_paths.push(target);
@@ -18856,7 +18888,7 @@ function _claude_desktop_bundles_dir() {
 }
 function _write_claude_desktop_marker(_force, lockfile_path2, bundles_dir, bundle_count) {
   const anchor = expanduser6(USER_SCOPE_PATHS["claude-desktop"]);
-  const target = path12.join(anchor, "agent-config.md");
+  const target = path13.join(anchor, "agent-config.md");
   mkdirp(anchor);
   const body = claudeDesktopMarkerBody(lockfile_path2, anchor, bundles_dir, bundle_count);
   writeText(target, body);
@@ -18880,23 +18912,23 @@ function _apply_claude_flat_command_wrappers(anchor, package_root, current_files
   const wrapped = [];
   const collisions = [];
   const reserved = [];
-  const commands_dir = path12.join(anchor, "commands");
+  const commands_dir = path13.join(anchor, "commands");
   let flat_entries = [];
   try {
-    flat_entries = fs14.readdirSync(commands_dir).filter((f) => f.endsWith(".md"));
+    flat_entries = fs15.readdirSync(commands_dir).filter((f) => f.endsWith(".md"));
   } catch {
   }
   for (const fname of flat_entries.sort()) {
     const slug = fname.slice(0, -".md".length);
     if (!is_claude_builtin_name(slug)) continue;
-    fs14.rmSync(path12.join(commands_dir, fname), { force: true });
+    fs15.rmSync(path13.join(commands_dir, fname), { force: true });
     current_files.delete(`commands/${fname}`);
     reserved.push(slug);
   }
   const eligible = new Set(_CLAUDE_FLAT_WRAPPER_EXTRA);
   try {
     const manifest = JSON.parse(
-      fs14.readFileSync(path12.join(package_root, "dist", "discovery", "discovery-manifest.json"), "utf8")
+      fs15.readFileSync(path13.join(package_root, "dist", "discovery", "discovery-manifest.json"), "utf8")
     );
     for (const a of manifest.artefacts ?? []) {
       if (a.category !== "command" || typeof a.slug !== "string") continue;
@@ -18907,22 +18939,22 @@ function _apply_claude_flat_command_wrappers(anchor, package_root, current_files
   }
   for (const slug of [...eligible].sort()) {
     const flat_rel = `commands/${slug}.md`;
-    const flat_abs = path12.join(anchor, "commands", `${slug}.md`);
-    if (!fs14.existsSync(flat_abs)) continue;
-    const skill_dir = path12.join(anchor, "skills", slug);
-    if (fs14.existsSync(skill_dir)) {
+    const flat_abs = path13.join(anchor, "commands", `${slug}.md`);
+    if (!fs15.existsSync(flat_abs)) continue;
+    const skill_dir = path13.join(anchor, "skills", slug);
+    if (fs15.existsSync(skill_dir)) {
       collisions.push(slug);
       continue;
     }
-    let body = fs14.readFileSync(flat_abs, "utf8");
+    let body = fs15.readFileSync(flat_abs, "utf8");
     if (body.startsWith("---\n") && !/^name:/m.test(body.split("\n---")[0] ?? "")) {
       body = body.replace("---\n", `---
 name: ${slug}
 `);
     }
-    fs14.mkdirSync(skill_dir, { recursive: true });
-    fs14.writeFileSync(path12.join(skill_dir, "SKILL.md"), body, "utf8");
-    fs14.rmSync(flat_abs, { force: true });
+    fs15.mkdirSync(skill_dir, { recursive: true });
+    fs15.writeFileSync(path13.join(skill_dir, "SKILL.md"), body, "utf8");
+    fs15.rmSync(flat_abs, { force: true });
     current_files.delete(flat_rel);
     current_files.add(`skills/${slug}/SKILL.md`);
     wrapped.push(slug);
@@ -18953,8 +18985,8 @@ function _deploy_global_content(tools, force, package_root, lockfile_path2) {
     const written_paths = [];
     let current_files = /* @__PURE__ */ new Set();
     for (const [src_rel, dest_sub] of plan) {
-      const src = path12.join(package_root, src_rel);
-      const dest = dest_sub ? path12.join(anchor, dest_sub) : anchor;
+      const src = path13.join(package_root, src_rel);
+      const dest = dest_sub ? path13.join(anchor, dest_sub) : anchor;
       const [w, s, paths] = _copy_dir_dereferencing_symlinks(src, dest, force, package_root);
       written_total += w;
       skipped_total += s;
@@ -19017,10 +19049,10 @@ function _deploy_global_content(tools, force, package_root, lockfile_path2) {
     results[tool_id] = [written_total, skipped_total, "deployed", written_paths];
     if (tool_id === "claude-code") {
       try {
-        const manifest = path12.join(package_root, "src", "scripts", "hook_manifest.yaml");
+        const manifest = path13.join(package_root, "src", "scripts", "hook_manifest.yaml");
         const matrix = build_claude_hook_matrix(manifest);
         const res = ensure_managed_hooks(
-          path12.join(anchor, "settings.json"),
+          path13.join(anchor, "settings.json"),
           matrix
         );
         if (!state.QUIET) {
@@ -19056,7 +19088,7 @@ function _preview_global_reap(tools, package_root) {
     const anchor = expanduser6(anchor_raw);
     let current_files = /* @__PURE__ */ new Set();
     for (const [src_rel, dest_sub] of plan) {
-      const src = path12.join(package_root, src_rel);
+      const src = path13.join(package_root, src_rel);
       current_files = setUnion(
         current_files,
         expected_deploy_files(src, dest_sub ? dest_sub : "")
@@ -19086,14 +19118,14 @@ function _preview_global_reap(tools, package_root) {
 function _verify_deploy_targets(anchor, plan) {
   const missing = [];
   for (const [, dest_sub] of plan) {
-    const target = dest_sub ? path12.join(anchor, dest_sub) : anchor;
+    const target = dest_sub ? path13.join(anchor, dest_sub) : anchor;
     const label = dest_sub || ".";
     if (!isDir(target)) {
       missing.push(label);
       continue;
     }
     try {
-      const entries = fs14.readdirSync(target);
+      const entries = fs15.readdirSync(target);
       if (entries.length === 0) missing.push(label);
     } catch {
       missing.push(label);
@@ -19108,13 +19140,13 @@ function _prune_modules_by(deploy_results, is_pruned) {
     const [written, skipped, status, paths] = deploy_results[tool_id];
     const pruned_skill_dirs = /* @__PURE__ */ new Set();
     for (const p of paths) {
-      const parts = p.split(path12.sep);
+      const parts = p.split(path13.sep);
       if (parts.includes("skills")) {
         const i = parts.indexOf("skills");
         if (i + 1 < parts.length) {
-          const skill_root = parts.slice(0, i + 2).join(path12.sep);
+          const skill_root = parts.slice(0, i + 2).join(path13.sep);
           if (!pruned_skill_dirs.has(skill_root)) {
-            const skillmd = path12.join(skill_root, "SKILL.md");
+            const skillmd = path13.join(skill_root, "SKILL.md");
             if (pathExists(skillmd) && is_pruned(skillmd)) {
               pruned_skill_dirs.add(skill_root);
             }
@@ -19125,25 +19157,25 @@ function _prune_modules_by(deploy_results, is_pruned) {
     const keep = [];
     const delete_files = [];
     for (const p of paths) {
-      const parts = p.split(path12.sep);
+      const parts = p.split(path13.sep);
       let is_target = false;
       if (parts.includes("skills")) {
         const i = parts.indexOf("skills");
-        if (i + 1 < parts.length && pruned_skill_dirs.has(parts.slice(0, i + 2).join(path12.sep))) {
+        if (i + 1 < parts.length && pruned_skill_dirs.has(parts.slice(0, i + 2).join(path13.sep))) {
           is_target = true;
         }
-      } else if (parts.includes("commands") && path12.extname(p) === ".md" && is_pruned(p)) {
+      } else if (parts.includes("commands") && path13.extname(p) === ".md" && is_pruned(p)) {
         is_target = true;
       }
       (is_target ? delete_files : keep).push(p);
     }
     for (const d of pruned_skill_dirs) {
-      fs14.rmSync(d, { recursive: true, force: true });
+      fs15.rmSync(d, { recursive: true, force: true });
     }
     for (const p of delete_files) {
-      if (p.split(path12.sep).includes("commands") && pathExists(p)) {
+      if (p.split(path13.sep).includes("commands") && pathExists(p)) {
         try {
-          fs14.unlinkSync(p);
+          fs15.unlinkSync(p);
         } catch {
         }
       }
@@ -19158,7 +19190,7 @@ function _prune_lab_modules(deploy_results, lab_ids) {
 }
 var SCOPED_ACTIVE_WORKSPACES = /* @__PURE__ */ new Set(["engineering", "agent-config-maintainer"]);
 function _load_packs_registry(package_root) {
-  const vocab_path = path12.join(package_root, "src", "config", "discovery", "packs.yml");
+  const vocab_path = path13.join(package_root, "src", "config", "discovery", "packs.yml");
   const data = yamlSafeLoad(readText(vocab_path));
   if (!Array.isArray(data)) {
     throw new Error(`packs.yml did not parse to a list: ${vocab_path}`);
@@ -19207,9 +19239,9 @@ function _compute_active_pack_ids(packs, runtime_active_packs) {
 }
 function _resolve_global_settings_doc() {
   const root = event4u_root();
-  const canonical = path12.join(root, "settings", SETTINGS_FILE);
+  const canonical = path13.join(root, "settings", SETTINGS_FILE);
   if (pathExists(canonical)) return _load_yaml_doc(canonical);
-  const legacy = path12.join(root, SETTINGS_FILE);
+  const legacy = path13.join(root, SETTINGS_FILE);
   if (pathExists(legacy)) return _load_yaml_doc(legacy);
   return null;
 }
@@ -19286,7 +19318,7 @@ function install_global(tools, force, project_root = null, core_only = false) {
     info(`  schema_version=1, agent_config_version=${installed_version}`);
     info(`  tools=${merged_tools.join(",")}`);
   }
-  if (project_root !== null && pathExists(_resolve_settings_read(project_root)) && !isDir(path12.join(project_root, ".agent-src.uncondensed"))) {
+  if (project_root !== null && pathExists(_resolve_settings_read(project_root)) && !isDir(path13.join(project_root, ".agent-src.uncondensed"))) {
     const drift = collect_drift(project_root);
     if (!state.QUIET) {
       process3.stdout.write("\n");
@@ -19386,19 +19418,19 @@ function install_global(tools, force, project_root = null, core_only = false) {
       }
     }
   }
-  if (project_root !== null && pathExists(_resolve_settings_read(project_root)) && !isDir(path12.join(project_root, ".agent-src.uncondensed"))) {
+  if (project_root !== null && pathExists(_resolve_settings_read(project_root)) && !isDir(path13.join(project_root, ".agent-src.uncondensed"))) {
     const files_by_tool = _files_by_tool_from_deploy(deploy_results);
     const rc = _update_installed_tools_manifest(project_root, tools, "global", force, files_by_tool);
     if (rc !== 0) return rc;
     const removed_marker = _remove_legacy_consumer_bridge_marker(project_root);
     if (removed_marker !== null && !state.QUIET) {
-      const rel = isRelativeTo(removed_marker, project_root) ? path12.relative(project_root, removed_marker) : removed_marker;
+      const rel = isRelativeTo(removed_marker, project_root) ? path13.relative(project_root, removed_marker) : removed_marker;
       info(`Removed legacy bridge marker: ${rel}`);
     }
     const anchor_paths = _write_per_tool_project_anchors(project_root, tools);
     if (anchor_paths.length > 0 && !state.QUIET) {
       for (const p of anchor_paths) {
-        const rel = isRelativeTo(p, project_root) ? path12.relative(project_root, p) : p;
+        const rel = isRelativeTo(p, project_root) ? path13.relative(project_root, p) : p;
         info(`Project anchor written: ${rel}`);
       }
     }
@@ -19415,8 +19447,8 @@ function install_global(tools, force, project_root = null, core_only = false) {
   }
   return 0;
 }
-var SETTINGS_SURFACE_REL = path12.join("state", "settings-surface.json");
-var SETTINGS_DELTA_REL = path12.join("state", "settings-delta.json");
+var SETTINGS_SURFACE_REL = path13.join("state", "settings-surface.json");
+var SETTINGS_DELTA_REL = path13.join("state", "settings-delta.json");
 function _current_settings_surface(version) {
   const jsonSchema = zodToJsonSchema(settingsSchema, {
     name: "AgentSettings",
@@ -19427,20 +19459,20 @@ function _current_settings_surface(version) {
 }
 function _write_settings_surface_snapshot(installed_version) {
   const root = event4u_root();
-  const surface_path = path12.join(root, SETTINGS_SURFACE_REL);
-  const delta_path = path12.join(root, SETTINGS_DELTA_REL);
+  const surface_path = path13.join(root, SETTINGS_SURFACE_REL);
+  const delta_path = path13.join(root, SETTINGS_DELTA_REL);
   const next = _current_settings_surface(installed_version);
   let previous = null;
   try {
-    const parsed = JSON.parse(fs14.readFileSync(surface_path, "utf8"));
+    const parsed = JSON.parse(fs15.readFileSync(surface_path, "utf8"));
     if (parsed !== null && typeof parsed === "object" && parsed.entries !== void 0) previous = parsed;
   } catch {
   }
   if (previous !== null && previous.version !== next.version) {
     const delta = computeSurfaceDelta(previous, next);
     if (delta.changes.length > 0) {
-      fs14.mkdirSync(path12.dirname(delta_path), { recursive: true, mode: 448 });
-      fs14.writeFileSync(delta_path, `${JSON.stringify(delta, null, 2)}
+      fs15.mkdirSync(path13.dirname(delta_path), { recursive: true, mode: 448 });
+      fs15.writeFileSync(delta_path, `${JSON.stringify(delta, null, 2)}
 `, { mode: 384 });
       if (!state.QUIET) {
         const counts = {};
@@ -19452,8 +19484,8 @@ function _write_settings_surface_snapshot(installed_version) {
       }
     }
   }
-  fs14.mkdirSync(path12.dirname(surface_path), { recursive: true, mode: 448 });
-  fs14.writeFileSync(surface_path, `${JSON.stringify(next, null, 2)}
+  fs15.mkdirSync(path13.dirname(surface_path), { recursive: true, mode: 448 });
+  fs15.writeFileSync(surface_path, `${JSON.stringify(next, null, 2)}
 `, { mode: 384 });
 }
 function arrayStrEqual(a, b) {
@@ -19665,13 +19697,13 @@ function _minimal_templates_root() {
   const chain = [start];
   let cur = start;
   for (; ; ) {
-    const parent = path12.dirname(cur);
+    const parent = path13.dirname(cur);
     if (parent === cur) break;
     chain.push(parent);
     cur = parent;
   }
   for (const ancestor of chain) {
-    const candidate = path12.join(ancestor, "src", "templates", "minimal");
+    const candidate = path13.join(ancestor, "src", "templates", "minimal");
     if (isDir(candidate)) return candidate;
   }
   fail("Could not locate src/templates/minimal/ \u2014 package install is corrupt.");
@@ -19679,9 +19711,9 @@ function _minimal_templates_root() {
 var INSTALL_MODE_MARKER_REL = "agents/.agent-state/install-mode.txt";
 function _write_install_mode_marker(project_root, mode) {
   if (mode !== "minimal" && mode !== "full") return;
-  const marker = path12.join(project_root, INSTALL_MODE_MARKER_REL);
+  const marker = path13.join(project_root, INSTALL_MODE_MARKER_REL);
   try {
-    mkdirp(path12.dirname(marker));
+    mkdirp(path13.dirname(marker));
     writeText(marker, `${mode}
 `);
   } catch {
@@ -19690,7 +19722,7 @@ function _write_install_mode_marker(project_root, mode) {
 function install_minimal(target_root_in, force, user_type = "") {
   let target_root = resolvePath(target_root_in);
   mkdirp(target_root);
-  const parent = path12.dirname(target_root);
+  const parent = path13.dirname(target_root);
   if (parent !== target_root) {
     const existing = find_project_root_with_anchor(parent);
     if (existing !== null && existing[0] !== target_root) {
@@ -19701,21 +19733,21 @@ function install_minimal(target_root_in, force, user_type = "") {
     }
   }
   const templates = _minimal_templates_root();
-  const settings_src = path12.join(templates, SETTINGS_FILE);
-  const overrides_gitkeep_src = path12.join(templates, "overrides-gitkeep");
-  const overrides_readme_src = path12.join(templates, "agents-overrides-readme.md");
+  const settings_src = path13.join(templates, SETTINGS_FILE);
+  const overrides_gitkeep_src = path13.join(templates, "overrides-gitkeep");
+  const overrides_readme_src = path13.join(templates, "agents-overrides-readme.md");
   if (!isFile(settings_src)) fail(`Bundled minimal settings template missing under ${templates}`);
   if (!isFile(overrides_gitkeep_src) || !isFile(overrides_readme_src)) {
     fail(`Bundled overrides scaffold templates missing under ${templates}`);
   }
   info(`Minimal init \u2192 ${target_root}`);
-  const overrides_root = path12.join(target_root, "agents", "overrides");
+  const overrides_root = path13.join(target_root, "agents", "overrides");
   mkdirp(overrides_root);
   const gitkeep_body = readText(overrides_gitkeep_src);
   for (const sub of ["rules", "skills", "commands"]) {
-    const sub_dir = path12.join(overrides_root, sub);
+    const sub_dir = path13.join(overrides_root, sub);
     mkdirp(sub_dir);
-    const gitkeep_dst = path12.join(sub_dir, ".gitkeep");
+    const gitkeep_dst = path13.join(sub_dir, ".gitkeep");
     if (pathExists(gitkeep_dst) && !force) {
       skip(`agents/overrides/${sub}/.gitkeep already exists (use --force to overwrite)`);
     } else {
@@ -19723,7 +19755,7 @@ function install_minimal(target_root_in, force, user_type = "") {
       success(`Wrote agents/overrides/${sub}/.gitkeep`);
     }
   }
-  const readme_dst = path12.join(overrides_root, "README.md");
+  const readme_dst = path13.join(overrides_root, "README.md");
   if (pathExists(readme_dst) && !force) {
     skip("agents/overrides/README.md already exists (use --force to overwrite)");
   } else {
@@ -19741,14 +19773,14 @@ function install_minimal(target_root_in, force, user_type = "") {
 personal:
   user_type: ${user_type}
 `;
-      mkdirp(path12.dirname(settings_dst));
+      mkdirp(path13.dirname(settings_dst));
       writeText(settings_dst, body);
       success(`Wrote ${SETTINGS_FILE} (user_type=${user_type})`);
     }
   }
   const removed_marker = _remove_legacy_consumer_bridge_marker(target_root);
   if (removed_marker !== null) {
-    const rel = isRelativeTo(removed_marker, target_root) ? path12.relative(target_root, removed_marker) : removed_marker;
+    const rel = isRelativeTo(removed_marker, target_root) ? path13.relative(target_root, removed_marker) : removed_marker;
     success(`Removed legacy bridge marker: ${rel}`);
   }
   _write_install_mode_marker(target_root, "minimal");
@@ -19822,7 +19854,7 @@ function run_interactive_init(project_root, force) {
     );
     return 0;
   }
-  const target = path12.join(project_root, _LOCAL_CONFIG_FILE);
+  const target = path13.join(project_root, _LOCAL_CONFIG_FILE);
   if (pathExists(target) && !force) {
     warn(
       `${_LOCAL_CONFIG_FILE} already exists; re-run with --force to overwrite. Skipping interactive init.`
@@ -19849,7 +19881,7 @@ function run_interactive_init(project_root, force) {
     warn(`Could not write ${target}: ${String(exc)}`);
     return 1;
   }
-  success(`Wrote ${path12.relative(project_root, target)} (${user_type} / ${stack} / ${verbosity})`);
+  success(`Wrote ${path13.relative(project_root, target)} (${user_type} / ${stack} / ${verbosity})`);
   return 0;
 }
 var _WIZARD_READY_RE = /^WIZARD_READY (http:\/\/(?:127\.0\.0\.1|localhost):\d+\/\S*)\r?$/;
@@ -19867,12 +19899,12 @@ function _wizard_should_launch(opts) {
   return [true, ""];
 }
 function _wizard_cli_dist(_project_root) {
-  const package_root = path12.dirname(path12.dirname(path12.dirname(resolvePath(_HERE2))));
-  const cli = path12.join(package_root, "dist", "cli", "agent-config.js");
+  const package_root = path13.dirname(path13.dirname(path13.dirname(resolvePath(_HERE2))));
+  const cli = path13.join(package_root, "dist", "cli", "agent-config.js");
   return pathExists(cli) ? cli : null;
 }
 function _server_info_path() {
-  return path12.join(os7.homedir(), ".event4u", "agent-config", "local-server.json");
+  return path13.join(os7.homedir(), ".event4u", "agent-config", "local-server.json");
 }
 function _pid_is_agent_config(pid) {
   let res;
@@ -19889,7 +19921,7 @@ function _pid_is_agent_config(pid) {
 }
 function unlinkMissingOk(p) {
   try {
-    fs14.unlinkSync(p);
+    fs15.unlinkSync(p);
   } catch {
   }
 }
@@ -19967,14 +19999,14 @@ function _wizard_spawn(project_root, pass_project_root = true) {
 }
 function _wizard_run_sync(cmd, env, cli) {
   const total = _WIZARD_TIMEOUTS.reduce((a, b) => a + b, 0);
-  const log_path = path12.join(
+  const log_path = path13.join(
     os7.tmpdir(),
     `agent-config-wizard-${process3.pid}-${Date.now()}.log`
   );
   let child;
   let log_fd = null;
   try {
-    log_fd = fs14.openSync(log_path, "w");
+    log_fd = fs15.openSync(log_path, "w");
     child = spawn(cmd[0], cmd.slice(1), {
       env,
       detached: true,
@@ -19992,7 +20024,7 @@ function _wizard_run_sync(cmd, env, cli) {
   } finally {
     if (log_fd !== null) {
       try {
-        fs14.closeSync(log_fd);
+        fs15.closeSync(log_fd);
       } catch {
       }
     }
@@ -20242,8 +20274,8 @@ function main2(argv) {
     const target_root = resolvePath(
       opts.custom_path || opts.project || process3.env["PROJECT_ROOT"] || process3.cwd()
     );
-    const minimal_package_root = path12.dirname(
-      path12.dirname(path12.dirname(_minimal_templates_root()))
+    const minimal_package_root = path13.dirname(
+      path13.dirname(path13.dirname(_minimal_templates_root()))
     );
     const validated_user_type = _validate_user_type(minimal_package_root, opts.user_type);
     return install_minimal(target_root, opts.force, validated_user_type);
@@ -20272,7 +20304,7 @@ function main2(argv) {
     return rc2;
   }
   const project_root = custom_path || resolvePath(opts.project || process3.env["PROJECT_ROOT"] || process3.cwd());
-  const is_first_run = !pathExists(path12.join(project_root, SETTINGS_FILE));
+  const is_first_run = !pathExists(path13.join(project_root, SETTINGS_FILE));
   const rc = _main_project_install(opts, project_root, parsed_tools, is_first_run);
   if (rc === 0 && opts.interactive) {
     run_interactive_init(project_root, opts.force);
@@ -20336,16 +20368,16 @@ function _team_setup_hint_line(project_root) {
   return "  \u2022 Claude Code team mode (optional cross-model review via the official codex plugin): run `agent-config doctor --check team` for setup status.";
 }
 function finalize_claude_model_tiers(project_root) {
-  const claude_skills = path12.join(project_root, ".claude", "skills");
-  const augment_skills = path12.join(project_root, ".augment", "skills");
+  const claude_skills = path13.join(project_root, ".claude", "skills");
+  const augment_skills = path13.join(project_root, ".augment", "skills");
   if (!isDir(claude_skills) || !isDir(augment_skills)) return 0;
   if (_read_consumer_auto_switch(project_root) !== "auto") return 0;
   let rendered = 0;
-  const entries = fs14.readdirSync(claude_skills).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
+  const entries = fs15.readdirSync(claude_skills).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
   for (const name of entries) {
-    const entry = path12.join(claude_skills, name);
-    const src_dir = path12.join(augment_skills, name);
-    const src_md = path12.join(src_dir, "SKILL.md");
+    const entry = path13.join(claude_skills, name);
+    const src_dir = path13.join(augment_skills, name);
+    const src_md = path13.join(src_dir, "SKILL.md");
     let tier;
     try {
       tier = read_model_tier(src_md);
@@ -20354,22 +20386,22 @@ function finalize_claude_model_tiers(project_root) {
     }
     if (tier === null || !(tier in TIER_TO_CLAUDE_MODEL) || !isDir(src_dir)) continue;
     if (isSymlink(entry) || isFile(entry)) {
-      fs14.unlinkSync(entry);
+      fs15.unlinkSync(entry);
     } else if (isDir(entry)) {
-      fs14.rmSync(entry, { recursive: true, force: true });
+      fs15.rmSync(entry, { recursive: true, force: true });
     }
     mkdirp(entry);
-    const srcFiles = fs14.readdirSync(src_dir).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
+    const srcFiles = fs15.readdirSync(src_dir).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
     for (const fname of srcFiles) {
       if (fname === "SKILL.md") {
         writeText(
-          path12.join(entry, "SKILL.md"),
+          path13.join(entry, "SKILL.md"),
           render_native_model_md(readText(src_md), tier)
         );
       } else {
-        fs14.symlinkSync(
-          path12.join("../../../.augment/skills", name, fname),
-          path12.join(entry, fname)
+        fs15.symlinkSync(
+          path13.join("../../../.augment/skills", name, fname),
+          path13.join(entry, fname)
         );
       }
     }
@@ -20387,7 +20419,7 @@ function _main_project_install(opts, project_root, parsed_tools, is_first_run) {
   let package_type;
   if (opts.package) {
     package_root = resolvePath(opts.package);
-    if (!pathExists(path12.join(package_root, "src", "config", "profiles", "minimal.ini"))) {
+    if (!pathExists(path13.join(package_root, "src", "config", "profiles", "minimal.ini"))) {
       fail(`Invalid --package path (missing src/config/profiles/minimal.ini): ${package_root}`);
     }
     package_type = detect_package_type_for_project(project_root, package_root);
@@ -20522,9 +20554,9 @@ function _main_project_install(opts, project_root, parsed_tools, is_first_run) {
 function _resolvedArgv1() {
   if (process3.argv[1] === void 0) return void 0;
   try {
-    return fs14.realpathSync(path12.resolve(process3.argv[1]));
+    return fs15.realpathSync(path13.resolve(process3.argv[1]));
   } catch {
-    return path12.resolve(process3.argv[1]);
+    return path13.resolve(process3.argv[1]);
   }
 }
 var _argv1 = _resolvedArgv1();

--- a/src/scripts/_cli/cmd_conformance.ts
+++ b/src/scripts/_cli/cmd_conformance.ts
@@ -37,6 +37,7 @@ import * as installed_tools from '../_lib/installed_tools.js';
 import { atomicAppendLine } from '../../install/atomic.js';
 import { readRecentEntries } from '../../install/txlog.js';
 import { detectToolPresence } from '../../install/detect.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 import {
     _classify,
     _collect_manifest_entries,
@@ -56,7 +57,7 @@ type Dict = Record<string, unknown>;
 const _HERE = fileURLToPath(import.meta.url);
 
 /** Package root — two levels above `src/scripts/_cli/`. */
-export const PACKAGE_ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
+export const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 /** Ordered registry of conformance check identifiers. */
 export const CONFORMANCE_CHECK_IDS = [

--- a/src/scripts/_cli/cmd_converge.ts
+++ b/src/scripts/_cli/cmd_converge.ts
@@ -39,6 +39,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import * as YAML from 'yaml';
 
 import * as user_global_paths from '../_lib/user_global_paths.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
 type Dict = Record<string, unknown>;
 
@@ -67,7 +68,7 @@ const _HERE = fileURLToPath(import.meta.url);
 
 /** Resolve the @event4u/agent-config package root (this repo). */
 function _package_root(): string {
-    return path.resolve(path.dirname(_HERE), '..', '..', '..');
+    return resolvePackageRoot(import.meta.url);
 }
 
 const SETTINGS_FILENAME = 'agent-settings.yml';

--- a/src/scripts/_cli/cmd_doctor.ts
+++ b/src/scripts/_cli/cmd_doctor.ts
@@ -117,6 +117,7 @@ import {
     type DetectionReport,
 } from './detection_report.js';
 import { review_gate_doctor_signal } from '../ai_team/review_gate.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 import {
     LEGACY_ALL,
     excludedRuleBasenames,
@@ -1010,7 +1011,7 @@ function _check_manifest_integrity(manifest: Dict): Dict {
 /** Resolve the @event4u/agent-config package root (this repo). */
 function _package_root(): string {
     // cmd_doctor lives at src/scripts/_cli/cmd_doctor.{py,ts}; parents[3] = repo.
-    return path.resolve(path.dirname(_HERE), '..', '..', '..');
+    return resolvePackageRoot(import.meta.url);
 }
 
 /** Read `version` from this package's package.json; null on error. */

--- a/src/scripts/_cli/cmd_export.ts
+++ b/src/scripts/_cli/cmd_export.ts
@@ -44,6 +44,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
 import {
     AIDER_MARKER,
@@ -57,7 +58,7 @@ import {
     ZED_MARKER,
 } from '../install.js';
 
-const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 const TEMPLATES_DIR = path.join(PACKAGE_ROOT, 'dist/agent-src', 'templates');
 
 // ---------------------------------------------------------------------------

--- a/src/scripts/_cli/cmd_fleet.ts
+++ b/src/scripts/_cli/cmd_fleet.ts
@@ -32,9 +32,10 @@ import * as YAML from 'yaml';
 
 import { runPreflight, hasBlockingFinding, type PreflightFinding } from '../../install/preflight.js';
 import type { ConflictPolicy } from '../../install/types.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
 const _HERE = fileURLToPath(import.meta.url);
-const PACKAGE_ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 /** One fleet target, parsed from `fleet.yaml`. */
 export interface FleetRepo {

--- a/src/scripts/_cli/cmd_migrate.ts
+++ b/src/scripts/_cli/cmd_migrate.ts
@@ -75,6 +75,7 @@ import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { resolve_project_root } from '../_lib/agent_settings.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 // NOTE: the v0→v1 migrator is NOT statically imported. It lives in the
 // consumer-shipped work_engine template, which ships as `.ts` (run via tsx),
 // while this CLI is compiled to `dist/cli/*.js` and run under plain `node` in
@@ -521,7 +522,7 @@ function _load_state_migrator(): StateMigrator | null {
     // Locate the shipped v0→v1 migration driver (`.ts`). Prefer the shipped
     // `dist/` tree; fall back to the dev `src/` tree. A stripped install with
     // no engine yields `null` (Python ImportError parity).
-    const pkg_root = path.resolve(_HERE_DIR, '..', '..', '..');
+    const pkg_root = resolvePackageRoot(import.meta.url);
     const rel = path.join(
         'agent-src', 'templates', 'scripts', 'work_engine', 'migration', 'v0_to_v1.ts',
     );

--- a/src/scripts/_cli/cmd_preflight.ts
+++ b/src/scripts/_cli/cmd_preflight.ts
@@ -28,11 +28,12 @@ import {
 } from '../../install/preflight.js';
 import { GLOBAL_DEPLOY_SOURCES, expandWizardSources } from '../../install/wizard-plan.js';
 import type { ConflictPolicy } from '../../install/types.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
 const _HERE = fileURLToPath(import.meta.url);
 
 /** Package root — three levels above `src/scripts/_cli/`. */
-const PACKAGE_ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 const USAGE =
     'usage: cmd_preflight [-h] [--tools a,b,...] [--target DIR] [--json]\n';

--- a/src/scripts/_cli/cmd_refresh.ts
+++ b/src/scripts/_cli/cmd_refresh.ts
@@ -69,8 +69,9 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import * as cli_wrapper from '../_lib/cli_wrapper.js';
 import * as sync_gitignore from '../sync_gitignore.js';
 import * as sync_gitattributes from '../sync_gitattributes.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
-const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 // ---------------------------------------------------------------------------
 // Parity primitives (ADR-200).

--- a/src/scripts/_cli/cmd_update.ts
+++ b/src/scripts/_cli/cmd_update.ts
@@ -67,6 +67,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import * as installed_lock from '../_lib/installed_lock.js';
 import * as update_check from '../_lib/update_check.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 import {
     DEFAULT_PROJECT_FILE,
     LOCAL_PROJECT_FILE,
@@ -550,7 +551,7 @@ function _refresh_global_lockfile(version: string, out: OutSink): void {
 
 /** Read `version` from the package's own `package.json`. */
 function _detect_installed_version(): string {
-    const pkg_json = path.join(path.resolve(_HERE_DIR, '..', '..', '..'), 'package.json');
+    const pkg_json = path.join(resolvePackageRoot(import.meta.url), 'package.json');
     try {
         const data = JSON.parse(fs.readFileSync(pkg_json, { encoding: 'utf-8' })) as Record<
             string,

--- a/src/scripts/_cli/cmd_upgrade.ts
+++ b/src/scripts/_cli/cmd_upgrade.ts
@@ -93,9 +93,10 @@ import * as claude_plugin from '../_lib/claude_plugin.js';
 import { event4u_root, write_target } from '../_lib/user_global_paths.js';
 import { project_settings_path } from '../_lib/agent_settings.js';
 import { _is_source_repo } from './cmd_refresh.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
 const PACKAGE_NAME = '@event4u/agent-config';
-const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 // ---------------------------------------------------------------------------
 // Parity primitives (ADR-200).

--- a/src/scripts/_cli/cmd_versions.ts
+++ b/src/scripts/_cli/cmd_versions.ts
@@ -47,6 +47,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { project_settings_path, resolve_project_root } from '../_lib/agent_settings.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
 const PACKAGE_NAME = '@event4u/agent-config';
 
@@ -171,7 +172,7 @@ function _project_root(): string {
 /** Return `version` from the local `package.json`, or `""` if absent. */
 function _local_package_version(): string {
     const candidates = [
-        path.join(path.resolve(_HERE_DIR, '..', '..', '..'), 'package.json'),
+        path.join(resolvePackageRoot(import.meta.url), 'package.json'),
         path.join(_project_root(), 'package.json'),
     ];
     for (const p of candidates) {

--- a/src/scripts/_lib/package_root.ts
+++ b/src/scripts/_lib/package_root.ts
@@ -1,0 +1,72 @@
+/**
+ * Layout-independent package-root resolution for the `_cli` delegate commands.
+ *
+ * `src/scripts/_cli/*.ts` sits three levels below the package root, so every
+ * delegate command derived the root with three hard-coded parent hops. Then the
+ * delegate precompile (`fa51c5a54`) started bundling those same modules into
+ * `dist/cli-delegate/*.js` — **two** levels below the root. Fixed hop counts are
+ * correct in exactly one of the two layouts, and nothing failed loudly: three
+ * hops from the bundle lands on `<pkg>/..`, which for a scoped install is
+ * `node_modules/@event4u`. `conformance` then reported `dist/router.json` and
+ * `src/scripts/hook_manifest.yaml` as missing — files that ship fine — and the
+ * 9.11.0 release PR's `tarball E2E` went red on both Node majors.
+ *
+ * The fix is to stop counting hops. Anchor on the marker that actually defines
+ * the root: the `package.json` whose `name` is this package. That answer holds
+ * for the source tree, for any bundle depth, for npm-global, npx, and
+ * vendor/bin symlink invocations — and it keeps holding if either directory
+ * ever moves.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** `name` in this package's own package.json — the root marker. */
+export const PACKAGE_NAME = '@event4u/agent-config';
+
+/**
+ * Bound on the upward walk. Deep enough for any real install path, finite so a
+ * malformed start value can never spin.
+ */
+const MAX_ASCENT = 16;
+
+/**
+ * Absolute package root for the module at `fromUrlOrPath` (pass
+ * `import.meta.url`).
+ *
+ * Walks up looking for the package.json whose `name` is {@link PACKAGE_NAME}.
+ * A consumer's own package.json encountered on the way is skipped by that name
+ * check, so an install nested under another project resolves correctly.
+ *
+ * `legacyHops` is the pre-existing hop count for the *source* layout and is
+ * used only if no marker is found. Falling back beats throwing during CLI
+ * startup: a wrong path yields one actionable "missing file" message, while an
+ * exception takes down every command in the delegate.
+ */
+export function resolvePackageRoot(fromUrlOrPath: string, legacyHops = 3): string {
+    const start = fromUrlOrPath.startsWith('file:') ? fileURLToPath(fromUrlOrPath) : fromUrlOrPath;
+    const startDir = path.dirname(start);
+
+    let dir = startDir;
+    for (let i = 0; i < MAX_ASCENT; i++) {
+        const manifest = path.join(dir, 'package.json');
+        if (fs.existsSync(manifest)) {
+            try {
+                const parsed = JSON.parse(fs.readFileSync(manifest, 'utf8')) as { name?: unknown };
+                if (parsed.name === PACKAGE_NAME) {
+                    return dir;
+                }
+            } catch {
+                // Unreadable / unparseable manifest — not our marker; keep ascending.
+            }
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            break; // filesystem root
+        }
+        dir = parent;
+    }
+
+    return path.resolve(startDir, ...(Array.from({ length: legacyHops }, () => '..') as string[]));
+}

--- a/tests/lib/package_root.test.ts
+++ b/tests/lib/package_root.test.ts
@@ -1,0 +1,111 @@
+// Regression cover for the 9.11.0 release failure.
+//
+// `src/scripts/_cli/*.ts` sits 3 levels below the package root, so all 11
+// delegate call sites derived the root with 3 hard-coded parent hops. The
+// delegate precompile (fa51c5a54) then bundled those modules into
+// `dist/cli-delegate/*.js` — 2 levels below the root. 3 hops from there lands
+// on `<pkg>/..`, i.e. `node_modules/@event4u` for a scoped install, so
+// `conformance` declared `dist/router.json` and `src/scripts/hook_manifest.yaml`
+// missing and `tarball E2E` went red on both Node majors.
+//
+// The bundle-layout and nested-consumer cases below fail against the old
+// 3-hop math, so they pin the bug rather than restate the fix.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PACKAGE_NAME, resolvePackageRoot } from '../../src/scripts/_lib/package_root.js';
+
+let tmp: string;
+
+/** Stage a package root whose package.json carries the real marker name. */
+function stagePackage(root: string, name: string = PACKAGE_NAME): void {
+    fs.mkdirSync(root, { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name }), 'utf-8');
+}
+
+function stageFile(p: string): string {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, '// stub\n', 'utf-8');
+    return p;
+}
+
+describe('resolvePackageRoot', () => {
+    beforeEach(() => {
+        // realpath: macOS /var → /private/var, which would break path equality.
+        tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-root-')));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('resolves the source layout (src/scripts/_cli → root)', () => {
+        const root = path.join(tmp, 'repo');
+        stagePackage(root);
+        const mod = stageFile(path.join(root, 'src', 'scripts', '_cli', 'cmd_x.ts'));
+        expect(resolvePackageRoot(pathToFileURL(mod).href)).toBe(root);
+    });
+
+    it('resolves the bundled layout (dist/cli-delegate → root)', () => {
+        // 3 fixed hops from here would return `tmp`, not `root`.
+        const root = path.join(tmp, 'repo');
+        stagePackage(root);
+        const mod = stageFile(path.join(root, 'dist', 'cli-delegate', 'cmd_x.js'));
+        expect(resolvePackageRoot(pathToFileURL(mod).href)).toBe(root);
+    });
+
+    it('resolves a scoped install nested in a consumer, skipping its manifest', () => {
+        // The exact production shape: 3 hops returned `node_modules/@event4u`.
+        const consumer = path.join(tmp, 'project');
+        stagePackage(consumer, 'consumer-app');
+        const pkg = path.join(consumer, 'node_modules', '@event4u', 'agent-config');
+        stagePackage(pkg);
+        const mod = stageFile(path.join(pkg, 'dist', 'cli-delegate', 'cmd_x.js'));
+        const got = resolvePackageRoot(pathToFileURL(mod).href);
+        expect(got).toBe(pkg);
+        expect(got).not.toBe(path.join(consumer, 'node_modules', '@event4u'));
+    });
+
+    it('is depth-independent — an extra nesting level does not shift the answer', () => {
+        const root = path.join(tmp, 'repo');
+        stagePackage(root);
+        const mod = stageFile(path.join(root, 'dist', 'a', 'b', 'c', 'cmd_x.js'));
+        expect(resolvePackageRoot(pathToFileURL(mod).href)).toBe(root);
+    });
+
+    it('accepts a plain path as well as a file: URL', () => {
+        const root = path.join(tmp, 'repo');
+        stagePackage(root);
+        const mod = stageFile(path.join(root, 'dist', 'cli-delegate', 'cmd_x.js'));
+        expect(resolvePackageRoot(mod)).toBe(root);
+    });
+
+    it('ignores an unparseable package.json on the way up', () => {
+        const root = path.join(tmp, 'repo');
+        stagePackage(root);
+        const mid = path.join(root, 'dist');
+        fs.mkdirSync(mid, { recursive: true });
+        fs.writeFileSync(path.join(mid, 'package.json'), '{ not json', 'utf-8');
+        const mod = stageFile(path.join(mid, 'cli-delegate', 'cmd_x.js'));
+        expect(resolvePackageRoot(pathToFileURL(mod).href)).toBe(root);
+    });
+
+    it('falls back to the legacy hop count when no marker exists', () => {
+        // No package.json anywhere: never throw during CLI startup.
+        const mod = stageFile(path.join(tmp, 'a', 'b', 'c', 'cmd_x.js'));
+        expect(resolvePackageRoot(pathToFileURL(mod).href, 3)).toBe(tmp);
+        expect(resolvePackageRoot(pathToFileURL(mod).href, 2)).toBe(path.join(tmp, 'a'));
+    });
+
+    it('the real package resolves to this repo root', () => {
+        const root = resolvePackageRoot(new URL('../../src/scripts/_lib/package_root.ts', import.meta.url).href);
+        const manifest = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8')) as {
+            name?: string;
+        };
+        expect(manifest.name).toBe(PACKAGE_NAME);
+    });
+});


### PR DESCRIPTION
Unblocks the 9.11.0 release: `tarball E2E` is red on **both** Node 20 and 22.

## What broke

The delegate precompile (`fa51c5a54`, landed after 9.10.0) bundles
`src/scripts/_cli/*.ts` into `dist/cli-delegate/*.js`. The source dir sits **3**
levels below the package root; the bundle dir sits **2**. All **11** delegate
call sites hard-coded 3 parent hops.

So in every consumer install the root resolved to `<pkg>/..` — for a scoped
package, `node_modules/@event4u`. `conformance` then reported files that ship
perfectly fine as missing:

```
❌ router-pointers: router index missing: …/node_modules/@event4u/dist/router.json
❌ hook-wiring:     ENOENT …/node_modules/@event4u/src/scripts/hook_manifest.yaml
❌ hook-dispatcher: dispatcher returned exit 1 for synthetic session_start
```

Confirmed a **regression, not old breakage**: the same legs were green on the
9.10.0 release PR (`tarball E2E · node 20` and `· node 22` both SUCCESS).

Also confirmed it is **not** a packaging problem — I packed and installed the
tarball locally first: `dist/router.json` is present at
`node_modules/@event4u/agent-config/dist/router.json`. Only the resolution was
wrong.

## Why no gate caught it

`tarball E2E` runs **only on release PRs**. The delegate-precompile PR never
executed the installed-consumer path, so a change that broke every consumer
install looked green all the way to the release. Same class as the notes in
#1070 (ESLint skips `tests/**` in CI) and #1072 (actionlint lints only changed
workflows) — a gate whose scope excludes the thing being changed.

## Fix

Stop counting hops. `resolvePackageRoot` ascends to the `package.json` whose
`name` is `@event4u/agent-config`:

- independent of nesting depth — source tree, any bundle layout, npm-global,
  npx, symlinked `vendor/bin` invocations;
- a consumer's own `package.json` on the way up is skipped by the name check, so
  a scoped install nested in another project resolves correctly;
- no marker found falls back to the legacy hop count instead of throwing: a
  wrong path yields one actionable "missing file" message, an exception takes
  down every command in the delegate.

Applied to **all 11 sites**, not only the two that were red — they share one
mechanism, and the other 9 would each have surfaced on some later release.

## Verification

- **End-to-end against a real packed + installed tarball** (the thing CI does):
  `agent-config conformance` → **exit 0**, zero `@event4u/{src,dist}` paths,
  `router-pointers` (106 rule ids + 91 targets resolve) and `hook-wiring` both
  green. Reproduced the failure the same way first, so before/after is measured,
  not argued.
- **Falsifiable tests:** 8 cases; **5 fail against the pre-fix fixed-hop math**,
  including both production shapes (bundled layout, scoped install nested in a
  consumer).
- 26 `_cli` suites (384 tests) and 48 lib/cli files (764 tests) pass; ESLint and
  `tsc` clean.
- `dist/install/install.mjs` regenerated — it inlines the patched modules, so the
  consistency gate needs it in the same change.

## Follow-up worth doing separately

Three incidents in a row now trace to gates whose scope excludes the changed
surface. Running the consumer-matrix conformance leg on PRs that touch
`src/scripts/_cli/**` or the bundle config would have caught this one at
authoring time instead of at release time.