### PR TITLE
fix(design-tokens): drop the host allow-list that silenced real findings

### DIFF
--- a/dist/agent-src/skills/design-tokens/scripts/tokens.ts
+++ b/dist/agent-src/skills/design-tokens/scripts/tokens.ts
@@ -309,9 +309,6 @@ const SKIP_FILE_PATTERNS: RegExp[] = [
 ];
 const HEX_EXCEPTIONS = new Set(['#000', '#FFF', '#000000', '#FFFFFF']);
 const DEFAULT_IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'vendor']);
-const ALLOWED_HOST_HINTS = [
-    'fonts.googleapis.com', 'fonts.gstatic.com', 'unsplash.com', 'pexels.com',
-];
 
 interface Violation {
     file: string;
@@ -434,9 +431,6 @@ export function scanFile(p: string): Violation[] {
             stripped.startsWith('*') ||
             line.includes('var(--')
         ) {
-            continue;
-        }
-        if (ALLOWED_HOST_HINTS.some((host) => line.includes(host))) {
             continue;
         }
         for (const kind of Object.keys(PATTERNS)) {
@@ -902,7 +896,6 @@ export {
     SKIP_FILE_PATTERNS,
     HEX_EXCEPTIONS,
     DEFAULT_IGNORE,
-    ALLOWED_HOST_HINTS,
     MINIMAL_TOKEN_PREFIXES,
     _pyDumpsIndent2,
     _pyLen,

--- a/src/skills/design-tokens/scripts/tokens.ts
+++ b/src/skills/design-tokens/scripts/tokens.ts
@@ -309,9 +309,6 @@ const SKIP_FILE_PATTERNS: RegExp[] = [
 ];
 const HEX_EXCEPTIONS = new Set(['#000', '#FFF', '#000000', '#FFFFFF']);
 const DEFAULT_IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'vendor']);
-const ALLOWED_HOST_HINTS = [
-    'fonts.googleapis.com', 'fonts.gstatic.com', 'unsplash.com', 'pexels.com',
-];
 
 interface Violation {
     file: string;
@@ -434,9 +431,6 @@ export function scanFile(p: string): Violation[] {
             stripped.startsWith('*') ||
             line.includes('var(--')
         ) {
-            continue;
-        }
-        if (ALLOWED_HOST_HINTS.some((host) => line.includes(host))) {
             continue;
         }
         for (const kind of Object.keys(PATTERNS)) {
@@ -902,7 +896,6 @@ export {
     SKIP_FILE_PATTERNS,
     HEX_EXCEPTIONS,
     DEFAULT_IGNORE,
-    ALLOWED_HOST_HINTS,
     MINIMAL_TOKEN_PREFIXES,
     _pyDumpsIndent2,
     _pyLen,

--- a/tests/design-artifacts/eval-fixtures.md
+++ b/tests/design-artifacts/eval-fixtures.md
@@ -154,11 +154,20 @@ the criteria are the contract.
   owner (`design-fidelity-mechanics` § Asset & imagery discipline, `ADR-205`) and
   reaches non-design-artifact turns through the `ai-code-blindspots`
   surface→controls table. Remaining `fonts.googleapis.com` occurrences in the
-  tree are the corpus opt-in column, that host in `stacks/nextjs.csv`'s **Don't**
-  column, and `design-tokens/scripts/tokens.ts`'s `ALLOWED_HOST_HINTS` — the last
-  is a **false-positive suppressor** for the hardcoded-value scanner (a font URL's
-  `wght@400;500` reads as magic numbers), not a delivery endorsement, so it is
-  deliberately unchanged.
+  tree are the corpus opt-in column and that host inside `stacks/nextjs.csv`'s
+  **Don't** column — both intended.
+- **correction (same change):** an earlier revision of this note called
+  `design-tokens/scripts/tokens.ts`'s `ALLOWED_HOST_HINTS` a *false-positive
+  suppressor* (claiming a font URL's `wght@400;500` read as magic numbers) and
+  left it in place. **That claim was wrong and is refuted by measurement:** none
+  of the four token patterns matches a bare font or image URL — `pixelValue` is
+  `:\s*(\d{2,})px`, so `wght@400` never matched. The list suppressed no real
+  finding; its only measurable effect was a **false negative**, because it
+  `continue`d the whole line: a hardcoded `#abcdef` or `padding: 24px` co-located
+  with such a URL was silently dropped (measured 0 findings on 3 offending
+  lines). The list is removed and the behaviour is pinned by a regression test
+  (3 findings on the same input, and still none on a line that is only a font
+  URL).
 
 ### daf-invented-screenshot
 - **primitive:** `static_inspect`

--- a/tests/scripts/skills_design_tokens_tokens.test.ts
+++ b/tests/scripts/skills_design_tokens_tokens.test.ts
@@ -168,7 +168,7 @@ describe.runIf(runnable)('tokens — validate', () => {
                 '.exc { color: #FFF; }', // hex exception
                 '.rgb { background: rgba(1, 2, 3, 0.5); }',
                 '.rgb2 { background: rgb(10,20,30); }',
-                '.host { color: #abcdef; background: url(fonts.googleapis.com/x); }', // allowed-host skip
+                '.host { color: #abcdef; background: url(fonts.googleapis.com/x); }', // hardcoded hex is reported even next to a URL
                 '.px1 { width: 5px; }', // single digit → no pixel finding
                 '.px2 { width: 100px; }',
                 '.rem { font-size: 1.5rem; }',
@@ -202,6 +202,30 @@ describe.runIf(runnable)('tokens — validate', () => {
         const root = path.join(tmp, 'tree');
         buildTree(root);
         expectParity(['validate', '--dir', root, '--json']);
+    });
+
+    it('a hardcoded value on a line containing an external URL is still reported', () => {
+        // Regression: a host allow-list used to `continue` the WHOLE line, so any
+        // hardcoded value co-located with a font/image URL was silently dropped.
+        // The allow-list suppressed no real finding (no pattern matches a bare
+        // font/image URL) and only produced that false negative.
+        const root = path.join(tmp, 'hosts');
+        fs.mkdirSync(root, { recursive: true });
+        fs.writeFileSync(
+            path.join(root, 'a.css'),
+            [
+                '.host { color: #abcdef; background: url(fonts.googleapis.com/x); }',
+                '.img { color: #123456; background: url(https://images.unsplash.com/p?w=800); padding: 24px; }',
+                '.pure { src: url(https://fonts.gstatic.com/s/inter/v13/a.woff2); }',
+            ].join('\n') + '\n',
+            'utf-8',
+        );
+        const r = runTs(['validate', '--dir', root, '--json']);
+        expect(r.status).toBe(1);
+        const findings = JSON.parse(r.stdout) as Array<{ line: number; value: string }>;
+        expect(findings.map((f) => f.value).sort()).toEqual(['#123456', '#abcdef', '24']);
+        // A line that is ONLY an external font URL carries no hardcoded value.
+        expect(findings.some((f) => f.line === 3)).toBe(false);
     });
 
     it('--ignore (repeatable) prunes the same subtrees', () => {


### PR DESCRIPTION
## Why

Follow-up to #1082. Two things that PR got wrong or left open, split out because they are not the roadmap's subject.

### 1. The host allow-list silenced real findings

`design-tokens/scripts/tokens.ts` skipped an **entire line** whenever it mentioned one of four hosts (`fonts.googleapis.com`, `fonts.gstatic.com`, `unsplash.com`, `pexels.com`).

Measured against the four token patterns rather than assumed:

| input line | matches any pattern? |
|---|---|
| real Google-Fonts `@import` (from the corpus) | **no** |
| `src: url(https://fonts.gstatic.com/…woff2)` | **no** |
| unsplash / pexels `<img src=…>` | **no** |
| `.host { color: #abcdef; background: url(fonts.googleapis.com/x); }` | yes — `hexColor`, a **true** positive |

`pixelValue` is `:\s*(\d{2,})px`, so the `wght@400;500` in a font URL never matched anything. The list suppressed no false positive. Its only measurable effect was the inverse — a hardcoded value co-located with such a URL was dropped in silence:

```
before: 3 offending lines → 0 findings
after:  3 offending lines → 3 findings (#abcdef, #123456, 24px)
```

A line that is *only* a font URL still yields nothing, so removing the list costs no signal. Both directions are pinned by a new regression test; the old test fixture carried a `// allowed-host skip` comment that documented the hole as intended behaviour.

### 2. A claim in #1082 was wrong

That PR's `daf-webfont-delivery` fixture note called this list a *false-positive suppressor* ("a font URL's `wght@400;500` reads as magic numbers") and left it in place. I did not verify the mechanism before writing it, and the table above refutes it. **That text is on `main` now**, so the correction is the more urgent half of this PR. The note now carries the refutation and the measurement instead of the guess.

## Verification

| Probe | Result |
|---|---|
| `tests/scripts/skills_design_tokens_tokens.test.ts` | 23/23 pass, incl. the new regression test |
| `task typecheck-ts`, `eslint` on both changed files | exit 0 |
| `check-condensation`, `check-refs`, `lint-eval-fixture-citations`, `check-md-language` | exit 0 |

`ALLOWED_HOST_HINTS` was exported but referenced only by its own module and test, so the export goes with it (own-orphan cleanup, no other caller).
