### PR TITLE
fix(ci): make the kernel-prefix gate able to fail, then re-anchor it

### DIFF
--- a/.github/workflows/rule-backstops.yml
+++ b/.github/workflows/rule-backstops.yml
@@ -30,6 +30,12 @@ on:
       - "docs/**"
       - "agents/**"
       - "tests/**"
+      # The kernel-prefix gate reads the PROJECTION, so a dist-only or
+      # snapshot-only change must trigger this workflow too — otherwise the
+      # gate is path-filtered into the same silence it just came out of.
+      - "dist/agent-src/rules/**"
+      - "dist/router.json"
+      - "internal/bench/reports/kernel-prefix.json"
       - ".github/workflows/rule-backstops.yml"
   push:
     branches:
@@ -42,6 +48,12 @@ on:
       - "docs/**"
       - "agents/**"
       - "tests/**"
+      # The kernel-prefix gate reads the PROJECTION, so a dist-only or
+      # snapshot-only change must trigger this workflow too — otherwise the
+      # gate is path-filtered into the same silence it just came out of.
+      - "dist/agent-src/rules/**"
+      - "dist/router.json"
+      - "internal/bench/reports/kernel-prefix.json"
       - ".github/workflows/rule-backstops.yml"
 
 permissions:
@@ -99,6 +111,16 @@ jobs:
 
       - name: persona-governance
         run: ./scripts-run src/scripts/lint_persona_governance
+
+      # The kernel bodies are the KV-cache prefix of every request, so a byte
+      # change there is a 10× cost event for every consumer. This gate existed
+      # since the token-saving work and its own header claimed "CI fails if the
+      # live prefix drifts" — but no workflow ran it, so between 2026-07-08 and
+      # 2026-07-31 all nine kernel bodies drifted across ten merged commits and
+      # nothing said a word. A gate that cannot fail is not a gate.
+      # Re-anchor procedure: contexts/authority/kernel-rule-edits.md.
+      - name: kernel-prefix byte-stability (KV-cache prefix)
+        run: ./scripts-run src/scripts/check_kernel_prefix_stability
 
       - name: secret-vcs-guard
         run: ./scripts-run src/scripts/check_secret_leak

--- a/dist/agent-src/contexts/authority/kernel-rule-edits.md
+++ b/dist/agent-src/contexts/authority/kernel-rule-edits.md
@@ -21,14 +21,30 @@ diagnosis.
 
 ## Trigger
 
-A PR is a "kernel-rule edit" iff it modifies any file in
-`.agent-src.uncondensed/rules/` that is in the locked kernel set
+A PR is a "kernel-rule edit" iff it modifies any file in `src/rules/`
+that is in the locked kernel set
 (see [`docs/contracts/kernel-membership.md`](../../../docs/contracts/kernel-membership.md)).
+(Until 2026-07-31 this named the pre-ADR-051 authoring tree, which no
+longer exists — so the trigger could not match a live file.)
 
 The CI guard (Phase 4.2 of the always-budget-relief roadmap) fails
 any PR that touches **> 1** kernel rule in the same diff. Override is
 a single PR label: `bundled-always-rules-acknowledged` — the maintainer
 records why the bundle is necessary in the PR body.
+
+## Re-anchor the cache prefix in the same PR
+
+The kernel bodies are the KV-cache prefix of every request, so editing
+one invalidates that cache for every consumer. `check_kernel_prefix_stability`
+(Rule Backstops workflow) fails until the edit is recorded:
+
+```bash
+./scripts-run src/scripts/check_kernel_prefix_stability --update-baseline
+```
+
+Commit the resulting `internal/bench/reports/kernel-prefix.json` **in the
+same PR** — that is what makes a cache-invalidating change explicit in the
+diff instead of a silent 10× cost event.
 
 ## Out of scope
 

--- a/internal/bench/reports/kernel-prefix.json
+++ b/internal/bench/reports/kernel-prefix.json
@@ -10,5 +10,5 @@
     "scope-control",
     "verify-before-complete"
   ],
-  "sha256": "45dc018a070d3a99a32befe1f9f64c50c4b14096fd0f585e78cf905bbebe6f4b"
+  "sha256": "8a0cefa44535f982fcfd4d3e93967e600174ff8809616ea2d9ba496e0161254c"
 }

--- a/src/agent-src/contexts/authority/kernel-rule-edits.md
+++ b/src/agent-src/contexts/authority/kernel-rule-edits.md
@@ -21,14 +21,30 @@ diagnosis.
 
 ## Trigger
 
-A PR is a "kernel-rule edit" iff it modifies any file in
-`.agent-src.uncondensed/rules/` that is in the locked kernel set
+A PR is a "kernel-rule edit" iff it modifies any file in `src/rules/`
+that is in the locked kernel set
 (see [`docs/contracts/kernel-membership.md`](../../../docs/contracts/kernel-membership.md)).
+(Until 2026-07-31 this named the pre-ADR-051 authoring tree, which no
+longer exists — so the trigger could not match a live file.)
 
 The CI guard (Phase 4.2 of the always-budget-relief roadmap) fails
 any PR that touches **> 1** kernel rule in the same diff. Override is
 a single PR label: `bundled-always-rules-acknowledged` — the maintainer
 records why the bundle is necessary in the PR body.
+
+## Re-anchor the cache prefix in the same PR
+
+The kernel bodies are the KV-cache prefix of every request, so editing
+one invalidates that cache for every consumer. `check_kernel_prefix_stability`
+(Rule Backstops workflow) fails until the edit is recorded:
+
+```bash
+./scripts-run src/scripts/check_kernel_prefix_stability --update-baseline
+```
+
+Commit the resulting `internal/bench/reports/kernel-prefix.json` **in the
+same PR** — that is what makes a cache-invalidating change explicit in the
+diff instead of a silent 10× cost event.
 
 ## Out of scope
 


### PR DESCRIPTION
## The defect

`check_kernel_prefix_stability` guards the **KV-cache prefix**: the nine always-loaded kernel bodies that sit at the front of every request, where one changed byte re-bills every consumer at roughly 10× on every call. Its own file header states the contract:

> a committed snapshot … **CI fails** if the live prefix drifts from the snapshot

No workflow ran it. It lived in the Taskfile only, so it fired when a human typed the command — and nobody did.

## What that cost, measured

Against the snapshot's own anchor commit (`98ee05a18`, 2026-07-08):

| kernel rule | commits since the anchor |
|---|---|
| `non-destructive-by-default` | 4 |
| `verify-before-complete` | 4 |
| `no-cheap-questions` | 2 |
| `agent-authority`, `ask-when-uncertain`, `commit-policy`, `direct-answers`, `language-and-tone`, `scope-control` | 1 each |

**All nine drifted, across ten merged commits, over three weeks, in silence.** Each of those PRs was reviewed on its own merits; none could have known it invalidated the cache prefix, because the only thing that would have said so ran nowhere.

## Three changes

1. **Wire the gate into Rule Backstops** — the workflow that exists *precisely* because gates named as backstops were not running in CI. Its path filters gain `dist/agent-src/rules/**`, `dist/router.json` and the snapshot itself: the gate reads the **projection**, so a dist-only change (one of the ten commits was exactly that) would otherwise path-filter it straight back into silence.
2. **Re-anchor the snapshot** to current `main`. The drifted content was already reviewed and merged, so this records reality rather than approving anything new. The ten commits are named in the commit message so the re-anchor is **auditable** instead of a silent absorption of three weeks of edits.
3. **Document the obligation where an author hits it** — `kernel-rule-edits` now carries the `--update-baseline` step and says to commit the snapshot in the same PR. Without this, the new CI failure would arrive with no documented remedy.

## Bonus: that context's trigger could not match a file

While adding the obligation I found the slow-rollout guarantee's own trigger definition pointing at the pre-ADR-051 authoring tree, which no longer exists — so *"a PR is a kernel-rule edit iff it modifies …"* matched nothing. Repointed at `src/rules/`. Same defect class as the gate itself, one line away from it.

## Verification

| Probe | Result |
|---|---|
| **Mutation probe — can it fail?** plant one comment line in a kernel body | **exit 2**; restore → **exit 0**, tree clean |
| `rule_backstops_ci_wired.test.ts` + `check_kernel_prefix_stability.test.ts` | 29/29 pass |
| Workflow YAML: parse + duplicate-key + duplicate-step-name check | ok, 21 steps, both path blocks patched |
| `check-no-new-legacy-path` | exit 0 — the pre-push preflight caught my first draft, which quoted the retired path as a literal; reworded |
| `check-refs`, `check-condensation`, `check-md-language`, `typecheck-ts`, `check-enforcement-coverage` | exit 0 |

`actionlint` is not installed locally and I did not install it (per `missing-tool-handling`); CI lints the changed workflow. The YAML checks above cover the duplicate-key class that workflow's own comment warns about.

## Note for the reviewer

Every future PR that edits a kernel body now fails this gate until it re-anchors. That is the designed contract (`kernel-rule-edits` slow-rollout) and the reason the gate was written — but it is a real change in what CI demands, so it belongs in its own revert unit rather than bundled with anything else.
