### PR TITLE
docs(roadmap): unblock the UI measurements — bench:ui as the port verify stage

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**48 / 220 steps done · 22%**
+**48 / 213 steps done · 23%**
 
 ```text
-██████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   24%
+█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   23%
 ```
 
 ## Open roadmaps
@@ -24,14 +24,13 @@
 | 6 | [road-to-governance-invariants.md](roadmaps/road-to-governance-invariants.md) | 5 | 19 | 19 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 9 | [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md) | 4 | 22 | 22 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md) | 5 | 27 | 27 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 36 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 14 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
 | 15 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 16 | [road-to-webfont-delivery-ownership.md](roadmaps/road-to-webfont-delivery-ownership.md) | 3 | 12 | 12 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -189,7 +188,7 @@ _1 blocker resolved._
 
 ### [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md)
 
-**Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated** — 0 / 22 done (0%)
+**Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated** — 0 / 27 done (0%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -197,6 +196,7 @@ _1 blocker resolved._
 | 1 | Routing: the rule fires for the prompts people actually write | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 2 | Refuse honestly, or honour a supplied contract | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
 | 3 | Precedence: a provided spec is not an impulse | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 4 | `bench:ui`: the diff machinery, maintainer-side | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)
 

--- a/agents/roadmaps/road-to-provided-artifact-honesty.md
+++ b/agents/roadmaps/road-to-provided-artifact-honesty.md
@@ -236,6 +236,47 @@ the loss is stated before the work happens.
 **Exit:** a port carrying the Claude-Design house aesthetic survives review and
 polish unchanged.
 
+## Phase 4 — `bench:ui`: the diff machinery, maintainer-side
+
+> Authorised 2026-08-01. The measurements in
+> `road-to-ui-track-integrity-followup` are blocked on a harness that scores
+> generated UI; this roadmap needs the same diff machinery for its own port
+> fixtures. Building it once, here, serves both — which is precisely the
+> "if such a harness lands for another reason, this roadmap unblocks for free"
+> clause, taken up rather than worked around.
+
+**The lock is not engaged, and that is a finding, not a permission.** The
+2026-06-28 lock forbids the package *shipping* a crawler, a Playwright runtime,
+or a font-bundler. `@playwright/test ^1.60.0` is already a **devDependency**, and
+`package.json` `files[]` ships neither `tests/` nor `internal/` — so a bench that
+lives beside `bench:ab` and `bench-quality-run` distributes nothing to a
+consumer. No reopening was required; the maintainer offered to lift the lock and
+the lift turned out to be unnecessary. The consumer-side verify stage stays
+gated, unchanged (see below).
+
+- [ ] `bench:ui` under `internal/bench/`, alongside the two existing benches.
+      Scores a produced UI against a provided `design.html` as ground truth.
+- [ ] **No model in the scoring path.** Four deterministic components, weights
+      **pre-registered before the first run**:
+      1. perceptual screenshot diff per breakpoint (375 / 768 / 1280) — SSIM or
+         pixelmatch **with a threshold**, never raw pixel equality, which would
+         measure font antialiasing rather than fidelity;
+      2. DOM-structure comparison of the component inventory;
+      3. token-mapping score (parseable — hex/spacing/radius resolved to tokens
+         or flagged);
+      4. interaction checklist driven by Playwright.
+- [ ] Rationale recorded with the harness, because it is the reason it exists in
+      this shape: an LLM judge for "is this frontend better" imports judge
+      variance and **circularity** — Opus grading Opus — into the one measurement
+      that has to decide Opus vs Sonnet. The port case is the single place a
+      ground truth already exists, so the question can be measured instead of
+      adjudicated.
+- [ ] Feed it from this roadmap's Phase-0 port fixtures; no second fixture set.
+- [ ] Wire as `bench:ui` so it is invocable the way the sibling benches are.
+
+**Exit:** a port produces a diff-distance score from four deterministic
+components, reproducibly, with no model in the scoring path.
+
 ## Gated follow-ups (not open work — do not start these)
 
 - **`--fidelity-source` suppression flag for `lint_design_slop`.**
@@ -247,11 +288,12 @@ polish unchanged.
   the 2026-06-28 lock, which requires evidence this roadmap does not have — more
   than one consumer, and a demonstration that the accept-side fix (Phase 2) left
   material value unclaimed.
-- **Playwright screenshot/DOM diff against the artifact as ground truth.**
-  **Gate:** same lock, plus the no-new-binary-dependency constraint. Note the
-  package already has an honest-degrade pattern for browser-dependent
-  verification; the missing piece is the runtime, and the runtime is the thing
-  the lock excludes.
+- **Consumer-side Playwright verify stage** — the agent rendering and diffing a
+  port inside the *consumer's* project. **Gate: unchanged.** This is what the
+  2026-06-28 lock excludes: it needs a browser runtime at the consumer, and the
+  package's honest-degrade pattern for browser-dependent verification stays the
+  answer. Not to be confused with the maintainer-side bench below, which the
+  lock does not touch.
 - **Tailwind v4→v3 translation, inline-CSS → scoped component CSS, standalone-JS
   → framework idiom.** Verified thin: total v4 knowledge is three CSV rows plus
   one parenthetical in `tailwind-engineer/SKILL.md:47`. **Gate:** Phase 2 ships
@@ -262,6 +304,15 @@ polish unchanged.
   generalises beyond this one rule.
 
 ## Non-goals (decided, with reasons)
+
+> **Amended 2026-08-01 — the one-question-harness objection is discharged, not
+> bypassed.** The predecessor's non-goal was "do not build a UI-quality harness
+> to answer one frontmatter question". `bench:ui` has three customers: this
+> roadmap's own acceptance criteria, the two parked measurements, and — after the
+> session — a standing regression watch for every future change to the UI skills,
+> which becomes diff-measurable instead of arguable. That is the verify stage of
+> a shipped feature, reused as a bench; the non-goal was aimed at a
+> single-purpose benchmark subsystem and still holds against one.
 
 - **No design runtime, no reimplementation of any external design tool.**
 - **No parallel generative pipeline** for the port case — the council rejected

--- a/agents/roadmaps/road-to-ui-track-integrity-followup.md
+++ b/agents/roadmaps/road-to-ui-track-integrity-followup.md
@@ -34,45 +34,50 @@ measured rather than argued: `accessibility-auditor` is a `medium` reviewer and
 `ui-component-architect` a `high` builder, so a blanket flip would flatten a
 distinction that may well be deliberate.
 
-> **Blocked until a harness exists that scores generated UI** (or one run is
-> deliberately funded as a one-off). Execution starts when that condition
-> clears — see Prerequisites for why neither existing harness qualifies.
+> **UNBLOCKED 2026-08-01.** The harness is being built — as `bench:ui`, the
+> maintainer-side diff machinery in `road-to-provided-artifact-honesty` Phase 4,
+> fed by that roadmap's own port fixtures. Both measurements below ride on it.
+> This is the "if such a harness lands for another reason, this roadmap unblocks
+> for free" clause being taken up, not worked around.
 >
-> **Candidate harness — `road-to-provided-artifact-honesty`, in two halves that
-> are NOT equally available.** Its Phase 0 fixture `daf-port-baseline` supplies
-> the half this roadmap lacks as *scheduled* work: a standalone `design.html`
-> plus a port prompt, i.e. a real UI-generation task with pass criteria. The
-> other half — rendering both outputs and diffing them — is a **gated
-> follow-up** there ("Playwright screenshot/DOM diff against the artifact as
-> ground truth"), behind the 2026-06-28 lock plus the no-new-binary-dependency
-> constraint. A conditional chain, not a queue: Phase 0 landing is not
-> sufficient, and nothing here argues for reopening that lock.
+> **The 2026-06-28 lock was never engaged by this path.** The maintainer offered
+> to lift it; the lift turned out to be unnecessary. The lock forbids the package
+> *shipping* a Playwright runtime — `@playwright/test` is already a
+> **devDependency**, and `files[]` ships neither `tests/` nor `internal/`, so a
+> bench beside `bench:ab` distributes nothing. The consumer-side verify stage,
+> which would need a browser at the consumer, stays gated and unchanged. Recorded
+> because a lock that did not need reopening must not be logged as reopened.
 >
-> That cross-reference now counts **twice over**: if the port roadmap unblocks,
-> it unblocks *both* measurements below at once.
->
-> **If it ever does unblock, prefer diff-distance over a quality rubric.** Same
-> port prompt, score = distance from the provided artifact. Objective, and needs
-> **no LLM judge** — the port case is the one place a ground truth already
-> exists, so both questions can be answered by measuring against it rather than
-> asking a model which output it prefers.
+> **Judge-free by construction.** Scoring is a diff-distance against
+> `design.html` as ground truth, from four deterministic components with
+> pre-registered weights — perceptual screenshot diff per breakpoint (SSIM /
+> pixelmatch **with a threshold**, never raw pixels, which would measure font
+> antialiasing), DOM-structure comparison, token-mapping score, Playwright
+> interaction checklist. No model in the scoring path. An LLM judge would import
+> variance and **circularity** — Opus grading Opus — into the very measurement
+> that decides Opus vs Sonnet.
 
 ## Prerequisites
 
 - [ ] Read `AGENTS.md` and the parent's archive entry.
-- [ ] Confirm the blocker still holds. Neither existing harness answers "is this
-      frontend better":
-      - `bench:ab` (`internal/bench/corpora/ab-track{a,b}.yaml`) measures
-        **surface presence** — whether a rule or skill fires at all.
-      - `bench-quality-run` (`token-quality-golden.yaml`, 110 tasks) judges
-        **rule compliance** — "stayed in scope", "ran the audit before creating
-        a component" — not the quality of what was emitted.
-      A tier benchmark needs a third thing: UI-generation prompts, a rendering
-      step, and a visual/structural rubric.
-- [ ] Confirm the cost asymmetry is still true of the pipeline: builders run
-      first, run longest, and re-run up to `POLISH_CEILING` times, so raising
-      them is the expensive direction. If the pipeline shape changed, re-derive
-      this before spending anything.
+- [ ] `road-to-provided-artifact-honesty` Phase 0 (port fixtures) and Phase 4
+      (`bench:ui`) have landed. Both measurements below consume them; neither
+      needs a fixture set or a scorer of its own.
+- [ ] The four component weights and the Measurement-B tolerance are fixed and
+      written down **before** the first scored run.
+- [ ] Confirm the cost asymmetry still holds of the pipeline: builders run first,
+      run longest, and re-run up to `POLISH_CEILING` times, so raising them is the
+      expensive direction. If the pipeline shape changed, re-derive it before
+      spending anything.
+
+**Historical note — why this was blocked, and what closed it.** Neither existing
+harness answers "is this frontend better": `bench:ab` measures surface presence
+(whether a rule or skill fires), and `bench-quality-run` judges rule compliance
+("stayed in scope", "ran the audit first"). The missing third thing was named as
+"UI-generation prompts, a rendering step, and a visual/structural rubric" — and
+the rubric half was the trap. The port case dissolves it: `design.html` **is** the
+expected output modulo stack translation, so the third thing is a diff, not a
+judgement.
 
 ## Phase 1: Two measurements against the same harness
 
@@ -84,14 +89,14 @@ a release later.
 
 Holds the lane constant, varies the model tier.
 
-- [ ] Run the lane fixtures with the current allocation (builders `medium` /
-      reviewers `high`) and with builders raised, scoring output quality **and**
-      per-run cost.
-      <!-- carried from road-to-ui-track-integrity Phase 5 -->
-- [ ] Include the two outliers in the read — `accessibility-auditor` (medium
+- [ ] Run the **port fixtures** with builders at `medium` and at `high`, lane
+      held constant. Score = diff-distance to ground truth. Put the delta in
+      diff-distance against the delta in cost.
+      <!-- carried from road-to-ui-track-integrity Phase 5; reformulated 2026-08-01 as a fidelity task so it needs no rubric -->
+- [ ] Run the two outliers as their own arms — `accessibility-auditor` (medium
       reviewer) and `ui-component-architect` (high builder) — so a flip cannot
-      silently erase a deliberate distinction.
-      <!-- carried from road-to-ui-track-integrity Phase 5 -->
+      silently erase a distinction that may be deliberate.
+      <!-- carried from road-to-ui-track-integrity Phase 5; separate arms rather than a note, since the harness makes that nearly free -->
 
 **The verified finding.** Every skill that writes UI is `model_tier: medium` —
 `fe-design`, `blade-ui`, `react-shadcn-ui`, `flux`, `livewire`,
@@ -107,16 +112,34 @@ Holds the model tier constant, varies the lane. Introduced by
 `road-to-universal-stack-coverage` Phase 0, whose benchmark criterion could not
 be met for exactly the same reason.
 
-- [ ] Run the apply fixtures through the generic lane (`ui-apply-generic` plus
-      its corpus query) and through a framework lane, at one fixed tier, scoring
-      output quality.
+- [ ] Run the same fixtures on the two stacks where **both** lanes exist, tier
+      held constant: once with the legacy full-match bundle, once with the
+      generic lane forced. Thanks to the composition landed in
+      `road-to-universal-stack-coverage`, that is a switch rather than a rebuild.
+      Score = the same diff-distance.
       <!-- carried from road-to-universal-stack-coverage acceptance criteria -->
 - [ ] Report per stack whether the corpus query actually changed the output, not
       only that it ran. A query whose rows never alter a decision is grounding
       theatre and should be measurable as such.
-- [ ] Publish both results either way. If neither lift clears its cost, record
-      the honest-null and change nothing.
+- [ ] Publish both results either way.
       <!-- covers A and B; a null on one is not a null on the other -->
+
+### Pre-registered null paths (written before the run, on purpose)
+
+Both are stated in advance so a null cannot be reinterpreted as a
+disappointment after the numbers land.
+
+- **A null:** the `high` lift does not clear the cost difference → the tiers stay
+  as they are and the null is published. Builders run first, longest, and up to
+  `POLISH_CEILING` times, so the cost side is the expensive one by construction.
+- **B null — and it is not a failure.** If the generic lane lands within a
+  **tolerance fixed before the run** of the framework lane, that is a strong
+  positive result, not a shortfall: it would mean the floor carries, and overlays
+  then justify themselves only on their specialist subject rather than by
+  default. Naming this in advance is what keeps it from being read as the generic
+  lane "losing".
+- Fix the B tolerance and the four component weights **before the first scored
+  run**. A threshold chosen after seeing the distribution is not a threshold.
 
 **The verified finding.** The detection half of universal stack coverage is fully
 measured — the Phase-0 and Phase-1 tables in that roadmap. What is unmeasured is

--- a/agents/roadmaps/road-to-worktree-hygiene.md
+++ b/agents/roadmaps/road-to-worktree-hygiene.md
@@ -1,0 +1,62 @@
+---
+complexity: contained
+status: draft
+---
+
+# Road to worktree hygiene — 209 worktrees, one prune, no inventory
+
+> Planned, not scheduled, and deliberately kept out of the session that found it.
+> A bulk branch/worktree sweep is exactly the kind of work that must not ride
+> along on an unrelated change.
+
+## The finding
+
+`git worktree list` reports **209** entries in this checkout. They accumulate one
+per feature branch and are never removed on merge; `git worktree prune` only
+clears registrations whose directory is already gone, so it does nothing for the
+real ones. Disk cost aside, the practical cost is that a stale worktree is a
+second copy of the repo that can hold an old `.agent-settings.yml`, a stale
+`node_modules` symlink, or a branch that looks alive in `git branch` long after
+its PR merged.
+
+Nothing here is broken. This is hygiene, and it is filed so the number does not
+quietly become 400.
+
+## Why it is not a one-liner
+
+Every removal is a deletion, and deletions in this repo carry a verification
+duty, not just a permission gate:
+
+- A worktree's branch may hold commits that never reached `main` — a cherry-pick
+  gives the same content a different SHA, so `git rev-list --count main..branch`
+  alone proves nothing. Content has to be checked, as it was for the four
+  branches removed on 2026-07-31.
+- A worktree may hold **uncommitted** work. `git status --porcelain` per worktree
+  is the floor before any removal.
+- Some worktrees belong to concurrent sessions. A sweep run while another agent
+  or terminal is working in one destroys live state.
+
+## What a pass would do
+
+- [ ] Inventory: per worktree — path, branch, dirty?, commits not on `main`,
+      whether that content is reachable on `main` anyway, PR state if any.
+- [ ] Classify: **safe** (clean, merged, content on `main`) · **review**
+      (unique commits or dirty) · **live** (another session's).
+- [ ] Present the safe set as a list and remove **only after explicit approval** —
+      per `scope-control`, branch and worktree deletion is permission-gated, and
+      a bulk sweep does not inherit a single earlier approval.
+- [ ] Leave the review set untouched with its reason recorded, so the next pass
+      starts from a shorter list rather than the same 209.
+- [ ] Record whatever count remains, so a later pass can tell growth from
+      residue.
+
+## Non-goals
+
+- **No automatic pruning on merge.** A hook that deletes worktrees is exactly the
+  wrong place for irreversible cleanup; the sweep stays deliberate and reviewed.
+- **Not a git-hygiene framework.** One inventory script and a reviewed list.
+
+## Why `draft`
+
+Nothing is failing. Promote when the count materially affects clone size, disk,
+or a tool that walks worktrees — or simply when a maintainer wants the list.

--- a/agents/settings/contexts/frontend-fidelity-cut.md
+++ b/agents/settings/contexts/frontend-fidelity-cut.md
@@ -126,3 +126,54 @@ projects. It lands with the detection work, not the dispatch work.
 - Removal over addition (the C1 verdict is an instance).
 - No new binary/runtime dependency in the package (E1).
 - The three roadmaps plan work, not releases — no version pins, no commit steps.
+
+## Amendment 2 — the harness question, resolved (maintainer, 2026-08-01)
+
+The council's refusal to build a UI-quality harness for one frontmatter question
+stands. What changed is that the harness stopped being for one question.
+
+**Decision.** Build the diff machinery as `bench:ui`, maintainer-side, as Phase 4
+of `road-to-provided-artifact-honesty`, fed by that roadmap's port fixtures. The
+two parked measurements ride on it. Rationale: the port defect is the original
+reported fault of this whole analysis series, that roadmap needs the machinery
+for its own acceptance criteria, and its non-goal already carried the clause
+"if such a harness lands for another reason, this roadmap unblocks for free".
+
+**The 2026-06-28 lock was never engaged, and that is worth recording precisely.**
+The maintainer offered to lift it. Checking first showed the lift was
+unnecessary: the lock forbids the package *shipping* a crawler / Playwright
+runtime / font-bundler, `@playwright/test` is already a devDependency, and
+`package.json` `files[]` ships neither `tests/` nor `internal/`. A bench beside
+`bench:ab` distributes nothing to a consumer. The **consumer-side** verify stage —
+the agent rendering a port inside a consumer's project — does need a browser
+there, and stays gated with the honest-degrade pattern unchanged. A lock that
+did not need reopening must not be logged as reopened.
+
+**Scoring is judge-free, and that is the load-bearing design choice.** Four
+deterministic components with weights pre-registered before the first run:
+perceptual screenshot diff per breakpoint (SSIM/pixelmatch with a threshold —
+raw pixel equality would measure font antialiasing), DOM-structure comparison,
+token-mapping score, Playwright interaction checklist. No model in the scoring
+path. An LLM judge would import variance and **circularity** — Opus grading Opus —
+into the one measurement that has to decide Opus vs Sonnet. The port case is the
+single place a ground truth already exists, so the question is measured rather
+than adjudicated.
+
+**Both measurements are fidelity tasks, so one session answers both.**
+A: same fixtures, builders `medium` vs `high`, lane fixed — diff-distance delta
+against cost delta. B: same fixtures on the two stacks where both lanes exist,
+tier fixed, legacy bundle vs forced generic lane — a switch, not a rebuild, since
+the composition landed. The two tier outliers run as their own arms.
+
+**Two null paths are pre-registered.** A null: the `high` lift does not clear the
+cost delta → tiers unchanged, null published. B null: the generic lane lands
+within a pre-fixed tolerance of the framework lane → **a strong positive**, not a
+shortfall — the floor carries, and overlays justify themselves only on their
+specialist subject. Naming that in advance is what stops it being read as the
+generic lane losing.
+
+**The one-question-harness non-goal is discharged, not bypassed.** `bench:ui` has
+a third customer after the session: a standing regression watch for every future
+change to the UI skills, which becomes diff-measurable instead of arguable. The
+non-goal was aimed at a single-purpose benchmark subsystem and still holds
+against one.


### PR DESCRIPTION
Decision record only — no behaviour change. Implementation is explicitly the
next session.

## The decision

Build the diff machinery as **`bench:ui`**, maintainer-side, as Phase 4 of
`road-to-provided-artifact-honesty`, fed by that roadmap's port fixtures. The two
measurements parked in `road-to-ui-track-integrity-followup` ride on it and are
unblocked.

## The lock was never engaged

The maintainer offered to lift the 2026-06-28 council lock to make this possible.
Checking first showed **the lift is unnecessary**:

- The lock forbids the package **shipping** a crawler, a Playwright runtime, or a
  font-bundler.
- `@playwright/test ^1.60.0` is already a **devDependency**.
- `package.json` `files[]` ships neither `tests/` nor `internal/`.

So a bench living beside `bench:ab` and `bench-quality-run` distributes nothing
to a consumer. The **consumer-side** verify stage — the agent rendering a port
inside a consumer's project — genuinely does need a browser there, and stays
gated with the honest-degrade pattern unchanged.

Recorded explicitly, because a lock that did not need reopening must not be
logged as reopened; the two cases are now separate entries in the roadmap rather
than one.

## Judge-free scoring

Four deterministic components, weights **pre-registered before the first run**:

1. perceptual screenshot diff per breakpoint (375/768/1280) — SSIM or pixelmatch
   **with a threshold**, never raw pixel equality, which would measure font
   antialiasing rather than fidelity
2. DOM-structure comparison of the component inventory
3. token-mapping score (parseable)
4. Playwright interaction checklist

No model in the scoring path. An LLM judge would import judge variance and
**circularity** — Opus grading Opus — into the one measurement that has to decide
Opus vs Sonnet. The port case is the single place a ground truth already exists,
so the question is measured rather than adjudicated.

## Both measurements become fidelity tasks

- **A — tier:** same port fixtures, builders `medium` vs `high`, lane fixed.
  Diff-distance delta against cost delta.
- **B — lane:** same fixtures on the two stacks where both lanes exist, tier
  fixed, legacy full-match bundle vs forced generic lane. A switch rather than a
  rebuild, because the composition from #1081 landed.
- The two tier outliers (`accessibility-auditor`, `ui-component-architect`) run
  as their own arms.

## Two pre-registered null paths

- **A null:** the `high` lift does not clear the cost delta → tiers unchanged,
  null published.
- **B null is a strong positive, not a shortfall.** If the generic lane lands
  within a pre-fixed tolerance of the framework lane, the floor carries and
  overlays justify themselves only on their specialist subject. Naming that in
  advance is what stops it being read later as the generic lane "losing".
- Weights and tolerance are fixed **before** the first scored run — a threshold
  chosen after seeing the distribution is not a threshold.

## The non-goal is discharged, not bypassed

The predecessor's non-goal was "do not build a UI-quality harness to answer one
frontmatter question". `bench:ui` has three customers: the port roadmap's own
acceptance criteria, the two measurements, and — after the session — a standing
regression watch over the UI skills, making every future change diff-measurable
instead of arguable. The non-goal was aimed at a single-purpose benchmark
subsystem and still holds against one.

## Also in here

- **`road-to-worktree-hygiene`** (draft) for the 209 accumulated worktrees, kept
  deliberately out of the session that found it. It spells out the per-branch
  verification duty: a cherry-pick gives the same content a different SHA, so a
  commit count alone proves nothing — content has to be checked, as it was for
  the four branches removed on 2026-07-31.
- Branch cleanup executed under the maintainer's release: `p4`,
  `feat/design-fidelity-rule`, `feat/design-artifact-fidelity` and its worktree,
  plus `feat/universal-stack-coverage`. Each verified content-reachable on `main`
  before deletion.

## Verification

- `sync-check`, `roadmap-progress-check`, `check-no-roadmap-refs` clean.
- Docs-only change; no code touched, so no test delta expected.
