### PR TITLE
fix(ci): give release-drift its dependencies so the gate can run at all

### DIFF
--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -53,6 +53,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+
+      # `./scripts-run` execs node_modules/.bin/tsx. Without this step the job
+      # died at exit 127 ("No such file or directory") on EVERY scheduled run —
+      # so the only backstop for "release merged but never tagged/published"
+      # reported red for its own missing dependency, and a real drift would have
+      # been indistinguishable from the daily noise.
+      - name: Install Node deps
+        run: |
+          npm ci --no-audit --no-fund --fetch-retries=5 --fetch-retry-mintimeout=10000 \
+            || (sleep 10 && npm ci --no-audit --no-fund --fetch-retries=5 --fetch-retry-mintimeout=10000)
 
       - name: Detect release-published drift (read-only)
         run: ./scripts-run src/scripts/check_release_published --strict --check-npm --require-main

--- a/tests/scripts/workflow_scripts_run_deps.test.ts
+++ b/tests/scripts/workflow_scripts_run_deps.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `./scripts-run` execs `node_modules/.bin/tsx`. A workflow that invokes it
+ * without installing dependencies first cannot pass — it dies at exit 127
+ * before the gate it wraps ever runs.
+ *
+ * `release-drift.yml` did exactly that on every scheduled run from at least
+ * 2026-07-26 to 2026-07-31: six consecutive daily failures, all
+ * "node_modules/.bin/tsx: No such file or directory". The workflow is the only
+ * backstop for "release merged but never tagged/published", so its own missing
+ * dependency made a real release drift indistinguishable from the daily noise.
+ *
+ * This is the same class as a gate that scans nothing and exits 0 — here it is
+ * a gate that scans nothing and exits 127. Both report a state they never
+ * measured.
+ */
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const WORKFLOW_DIR = path.join(REPO_ROOT, '.github', 'workflows');
+
+function workflowFiles(): string[] {
+    if (!fs.existsSync(WORKFLOW_DIR)) return [];
+    return fs
+        .readdirSync(WORKFLOW_DIR)
+        .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+        .sort();
+}
+
+/** A workflow "runs scripts-run" only when it appears in a `run:` context. */
+function invokesScriptsRun(text: string): boolean {
+    return /(^|\s)\.\/scripts-run\s/m.test(text);
+}
+
+function installsDeps(text: string): boolean {
+    // `npm ci` is the house pattern; accept `npm install` for completeness.
+    return /npm\s+(ci|install)\b/.test(text);
+}
+
+describe('workflows that call ./scripts-run install their dependencies', () => {
+    it('every scripts-run workflow runs npm ci — otherwise it exits 127', () => {
+        const offenders: string[] = [];
+        for (const f of workflowFiles()) {
+            const text = fs.readFileSync(path.join(WORKFLOW_DIR, f), 'utf-8');
+            if (invokesScriptsRun(text) && !installsDeps(text)) offenders.push(f);
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    it('release-drift.yml specifically — the workflow this regression came from', () => {
+        const p = path.join(WORKFLOW_DIR, 'release-drift.yml');
+        expect(fs.existsSync(p)).toBe(true);
+        const text = fs.readFileSync(p, 'utf-8');
+        expect(invokesScriptsRun(text)).toBe(true);
+        expect(installsDeps(text)).toBe(true);
+        // The install must come BEFORE the invocation, or it is decoration.
+        expect(text.indexOf('npm ci')).toBeLessThan(text.search(/(^|\s)\.\/scripts-run\s/m));
+    });
+
+    it('the detector actually fires — a scripts-run workflow without npm ci is caught', () => {
+        // Pins the negative direction: without this, a broken matcher would
+        // report an empty offender list forever and the test would pass blind.
+        const broken = [
+            'name: Probe',
+            'jobs:',
+            '  x:',
+            '    steps:',
+            '      - run: ./scripts-run src/scripts/whatever',
+        ].join('\n');
+        expect(invokesScriptsRun(broken)).toBe(true);
+        expect(installsDeps(broken)).toBe(false);
+    });
+});


### PR DESCRIPTION
## The defect

`release-drift.yml` checks out, sets up Node, then calls `./scripts-run` — which execs `node_modules/.bin/tsx`. It never installs dependencies.

```
./scripts-run: line 9: …/node_modules/.bin/tsx: No such file or directory
##[error]Process completed with exit code 127.
```

Every **scheduled** run has died there. Six consecutive daily failures observed (2026-07-26 → 2026-07-31), all identical, all before the check it wraps ever executed.

## Why it matters more than a red badge

This workflow is the **only** backstop for *"release merged but never tagged/published"*. Its own header says so, and says it plainly after an earlier correction:

> What actually holds the tag invariant today: this workflow's daily schedule plus manual dispatch. That is a 24h detection window, not a merge-time gate.

The 24h detection window did not exist. The workflow reported red every day for its own missing dependency, so a genuine release drift would have produced the same red as the six days before it — indistinguishable from noise. This is the sibling of a gate that scans nothing and exits 0; here it scans nothing and exits 127.

It also explains one of the failing checks on recent `main` merge commits: `drift-check` on `3aea0338a` is this workflow's scheduled run attached to that SHA, not something that PR did.

## Not masking a real signal

The check passes the moment dependencies exist — run locally against current `main`:

```
✅  release-published: 9.11.0 is tagged + npm and in sync.     (exit 0)
```

So the install step is the entire fix; there is no drift being papered over.

## The test pins the class, not the instance

`tests/scripts/workflow_scripts_run_deps.test.ts`:

1. every workflow invoking `./scripts-run` also runs `npm ci`/`npm install`;
2. for `release-drift.yml` specifically, the install **precedes** the invocation (an install after the call is decoration);
3. the detector is exercised against a synthetic broken workflow — without this, a mis-written matcher would return an empty offender list forever and the suite would pass blind.

Verified in both directions: against the pre-fix workflow **2 of 3 cases fail**; after the fix, 3/3 pass.

`release-drift.yml` was the only offender in `.github/workflows/` at the time of writing.

## Verification

| Probe | Result |
|---|---|
| new test, post-fix | 3/3 pass |
| new test, pre-fix (workflow stashed) | 2 failed / 1 passed — the intended red |
| `check_release_published --strict --check-npm --require-main` locally | exit 0 |
| workflow YAML parse + duplicate-key + step order | ok — 4 steps, install at position 3 |
| `eslint`, `task typecheck-ts` | exit 0 |
