### PR TITLE
docs(roadmap): pre-registration covers the inputs, not only the scoring

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**48 / 213 steps done · 23%**
+**48 / 215 steps done · 22%**
 
 ```text
-█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   23%
+█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   22%
 ```
 
 ## Open roadmaps
@@ -24,7 +24,7 @@
 | 6 | [road-to-governance-invariants.md](roadmaps/road-to-governance-invariants.md) | 5 | 19 | 19 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 9 | [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md) | 5 | 27 | 27 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md) | 5 | 29 | 29 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 36 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
@@ -188,7 +188,7 @@ _1 blocker resolved._
 
 ### [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md)
 
-**Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated** — 0 / 27 done (0%)
+**Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated** — 0 / 29 done (0%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
@@ -196,7 +196,7 @@ _1 blocker resolved._
 | 1 | Routing: the rule fires for the prompts people actually write | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 | 2 | Refuse honestly, or honour a supplied contract | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
 | 3 | Precedence: a provided spec is not an impulse | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
-| 4 | `bench:ui`: the diff machinery, maintainer-side | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 4 | `bench:ui`: the diff machinery, maintainer-side | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
 
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)
 

--- a/agents/roadmaps/road-to-provided-artifact-honesty.md
+++ b/agents/roadmaps/road-to-provided-artifact-honesty.md
@@ -272,6 +272,29 @@ gated, unchanged (see below).
       ground truth already exists, so the question can be measured instead of
       adjudicated.
 - [ ] Feed it from this roadmap's Phase-0 port fixtures; no second fixture set.
+- [ ] **Freeze the fixtures before the first scored run.** Commit them and
+      SHA-pin the set; record the pin next to the weights. A fixture set nudged
+      after a first bad run contaminates both measurements exactly the way a
+      threshold chosen after seeing the distribution does — the pre-registration
+      is worthless if the *inputs* stay editable while the outputs are watched.
+      Extensions are allowed and are a **new set, scored separately**, never a
+      revision of the pinned one.
+- [ ] **Make the fixtures render deterministically.** A screenshot diff is only
+      reproducible if the render environment is:
+      - **Browser pinned** — use the version the existing `@playwright/test`
+        devDependency resolves, and record it with the run. A browser bump is a
+        new scoring epoch, not a free upgrade.
+      - **Fonts embedded in the fixture, never hotlinked.** A
+        `fonts.googleapis.com` `@import` inside a `design.html` makes the SSIM
+        score a function of the CI runner's network and font fallback — the
+        harness would be measuring the runner, not the port. Self-host or
+        base64-embed the faces in the fixture itself.
+      - Animations and transitions disabled at capture; fixed viewport per
+        breakpoint; no `Date`/random content in the fixture markup.
+      The self-hosted route this needs already exists: the corpus carries a
+      `Self-Hosted Route` column (`font-pairings-reference.csv`) from the
+      completed webfont-delivery work, so the fixtures consume it rather than
+      waiting on it.
 - [ ] Wire as `bench:ui` so it is invocable the way the sibling benches are.
 
 **Exit:** a port produces a diff-distance score from four deterministic

--- a/agents/roadmaps/road-to-ui-track-integrity-followup.md
+++ b/agents/roadmaps/road-to-ui-track-integrity-followup.md
@@ -65,6 +65,19 @@ distinction that may well be deliberate.
       needs a fixture set or a scorer of its own.
 - [ ] The four component weights and the Measurement-B tolerance are fixed and
       written down **before** the first scored run.
+- [ ] **The fixture set is committed and SHA-pinned** before Measurement A
+      starts, with the pin recorded beside the weights. Pre-registering the
+      scoring while leaving the *inputs* editable would contaminate both
+      measurements exactly as a post-hoc threshold does. Any fixture added later
+      forms a new set, scored separately — never a revision of the pinned one.
+- [ ] **The render environment is pinned and the fixtures render
+      deterministically** — browser version from the `@playwright/test`
+      devDependency recorded with the run, fonts embedded in the fixtures rather
+      than hotlinked, animations disabled at capture. A `fonts.googleapis.com`
+      import inside a fixture would make the SSIM score a function of the CI
+      runner's network and font fallback, i.e. the harness would measure the
+      runner. The self-hosted route needed for this already shipped with the
+      webfont-delivery work.
 - [ ] Confirm the cost asymmetry still holds of the pipeline: builders run first,
       run longest, and re-run up to `POLISH_CEILING` times, so raising them is the
       expensive direction. If the pipeline shape changed, re-derive it before

--- a/agents/settings/contexts/frontend-fidelity-cut.md
+++ b/agents/settings/contexts/frontend-fidelity-cut.md
@@ -177,3 +177,33 @@ a third customer after the session: a standing regression watch for every future
 change to the UI skills, which becomes diff-measurable instead of arguable. The
 non-goal was aimed at a single-purpose benchmark subsystem and still holds
 against one.
+
+## Amendment 3 — pre-registration covers the inputs, not only the scoring (2026-08-01)
+
+Two clauses added after the harness decision, both closing the same leak: a
+pre-registration that fixes the *scoring* while leaving the *inputs* editable is
+not a pre-registration.
+
+**The fixture set is frozen.** Committed and SHA-pinned before Measurement A
+starts, pin recorded beside the weights. A fixture set nudged after a first bad
+run contaminates both measurements exactly the way a threshold chosen after
+seeing the distribution does. Extensions are permitted and form a **new set,
+scored separately** — never a revision of the pinned one.
+
+**The render environment is pinned.** A screenshot diff is only reproducible if
+the renderer is: browser version from the existing `@playwright/test`
+devDependency, recorded with the run (a browser bump is a new scoring epoch);
+animations disabled at capture; fixed viewport per breakpoint; no time- or
+random-dependent content in fixture markup.
+
+**Fonts are embedded in the fixtures, never hotlinked.** A
+`fonts.googleapis.com` `@import` inside a `design.html` makes the SSIM score a
+function of the CI runner's network and font fallback — the harness would be
+measuring the runner rather than the port. This is the same concern as the
+webfont-delivery finding, arriving from the measurement side.
+
+**That dependency is already satisfied**, checked rather than assumed: the
+webfont-delivery roadmap completed (12/12, archived), and
+`font-pairings-reference.csv` now carries `Self-Hosted Route` and
+`AI-Default Flag` columns. The fixtures consume that route instead of waiting on
+it — the precondition is met, not pending.


### PR DESCRIPTION
Follow-on to #1085. Decision record only; implementation is still the next
session.

## The leak this closes

#1085 pre-registered the four component weights and the Measurement-B tolerance.
That fixes the **scoring** and leaves the **inputs** editable — which is not a
pre-registration. A fixture set nudged after a first bad run contaminates both
measurements exactly the way a post-hoc threshold does.

## Fixture freeze

- The `design.html` set is committed and **SHA-pinned before Measurement A
  starts**, with the pin recorded beside the weights.
- Extensions are allowed and form a **new set, scored separately** — never a
  revision of the pinned one.

## Render determinism

A screenshot diff is reproducible only if the renderer is pinned:

- **Browser version** from the existing `@playwright/test` devDependency,
  recorded with the run. A browser bump is a **new scoring epoch**, not a free
  upgrade.
- **Fonts embedded in the fixture, never hotlinked.** A `fonts.googleapis.com`
  `@import` inside a `design.html` makes the SSIM score a function of the CI
  runner's network and font fallback — the harness would be measuring the runner
  rather than the port.
- Animations disabled at capture, fixed viewport per breakpoint, no time- or
  random-dependent content in fixture markup.

## The font dependency is already met — checked, not assumed

The review connected this to the webfont finding, expecting the self-hosting
route to be prerequisite work. It has already shipped:

- `road-to-webfont-delivery-ownership` completed 12/12 and was archived
  2026-07-31.
- `font-pairings-reference.csv` now carries a **`Self-Hosted Route`** column and
  an **`AI-Default Flag`** column.

So the fixtures consume that route rather than waiting on it. The 73 remaining
`fonts.googleapis.com` entries in the corpus are the discovery URLs that roadmap
deliberately kept — the delivery answer travels in the new column beside them.

## Verification

- `sync-check`, `roadmap-progress-check`, `check-no-roadmap-refs` clean.
- Docs-only; no code touched.
