### PR TITLE
chore(funding): add the sponsor button and say plainly what it is

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [event4u-app, matze4u]

--- a/README.md
+++ b/README.md
@@ -612,6 +612,13 @@ the file install. Porting the bash dispatcher to native Windows is
 **demand-gated**: a named Windows adopter who cannot use WSL2 or the MCP
 path reopens it (see `agents/roadmaps/` — road-to-credible-install Phase 3).
 
+## Funding
+
+The package is free, MIT, and stays that way — no paid tier, no dual
+licensing. If it saves you time and you want to chip in, the GitHub Sponsor
+button at the top of the repo is the whole mechanism. If you would rather not,
+use it anyway; nothing here is gated on it.
+
 ## License
 
 [MIT](LICENSE).


### PR DESCRIPTION
## What this is

`.github/FUNDING.yml` plus a short funding paragraph in the README. It closes the execution half of the donation-path item in `road-to-adoption-without-narrative-debt.md:101`.

## Where it came from — the cleanup that surfaced it

The working tree of the main checkout held nine uncommitted entries. Eight of them were **a silent revert of two already-merged PRs**:

| file | working tree held | `main` holds |
|---|---|---|
| `src/skills/design-tokens/scripts/tokens.ts` | the removed host allow-list, back (3 occurrences) | 0 |
| `internal/bench/reports/kernel-prefix.json` | the stale baseline `45dc018a…` | re-anchored `8a0cefa4…` |
| `.github/workflows/rule-backstops.yml` | no kernel-prefix step | the wired step |
| + 5 more (dist projections, context, fixtures, test) | pre-#1083/#1084 content | post |

Committing those would have undone #1083 and #1084. They were **discarded**, not committed — and provably losslessly: each of the eight is byte-identical to `7a9eda4fd`, the last `main` commit before those two merged, so nothing novel existed in them. Verified after the restore: allow-list occurrences back to 0, snapshot back to `8a0cefa4…`, CI step present.

The ninth entry was this file.

## What was deliberately NOT touched

Twelve other worktrees also show uncommitted entries. None are cleanup items:

- `.augment`, `.codex`, `dist/install/*_cli.js` — **already ignored on `main`**. They surface only on branches whose `.gitignore` predates those entries, and resolve themselves on the next rebase. Confirmed per worktree with `git check-ignore`.
- `.claude/` — neither tracked nor ignored as a directory; a pre-existing gap owned by `sync:gitignore` / `check-gitignore-freshness`, not by this change.
- Two worktrees carry genuine in-progress roadmap work on their own branches. Another session's uncommitted work is not mine to commit or delete.

## The two facts the roadmap says must not be invented

Step 101 states an agent must not guess (a) whether GitHub Sponsors is enabled for the org and (b) the donation target if it is not. Both are resolved by measurement, not assumption:

```
repositoryOwner(login:"event4u-app") → Organization, hasSponsorsListing = true
repositoryOwner(login:"matze4u")     → User,         hasSponsorsListing = true
```

So (a) is yes for both accounts and (b) does not arise. The account set in the file is the maintainer's own, taken verbatim from the file they had already written locally.

## Verification

| Probe | Result |
|---|---|
| `lint-readme`, `lint-readme-size`, `check-md-language`, `check-refs` | exit 0 |
| `lint-readme-jargon`, `lint-readme-serial-comma` | red **before and after** — same finding set with and without this diff, unrelated lines |
| main checkout after cleanup | clean except this file, which becomes tracked on merge |

## Still open after this merges

Step 101 stays unchecked on purpose. Its own definition of done is *"verify by loading the rendered repo page and seeing the button"* — that can only be confirmed once the file is on the default branch, so the checkbox waits for the observation rather than for the commit.
