### PR TITLE
fix(roadmap): drop an illegal status value from the archived local-ci-trust plan

### DIFF
--- a/agents/roadmaps/archive/road-to-local-ci-trust.md
+++ b/agents/roadmaps/archive/road-to-local-ci-trust.md
@@ -1,5 +1,4 @@
 ---
-status: active
 complexity: lightweight
 ---
 


### PR DESCRIPTION
## What

Removes `status: active` from `agents/roadmaps/archive/road-to-local-ci-trust.md`. One line.

## Why not "the correct archived value"

The ask was to replace it with the archived value the roadmap template defines. The template defines none, so there is nothing to replace it with.

`src/agent-src/templates/roadmaps.md:12`:

> **Status is binary: `ready` (default) or `draft`.** New roadmaps are created **ready** unless the user explicitly says draft — `ready` is implicit and need not be written. … **There are no other status values**; legacy banners like `**Status: directional**` are removed.

Line 27 adds exactly one more, scoped to its own disposition: `status: later` for `later/`. That is the whole vocabulary — `{ready, draft, later}`, with `ready` implicit.

Nothing consumes an archived value either. `check_roadmap_trackable.ts:198` is the only reader of this field in the codebase, it recognises only `draft`, and `archive/` is already in its `EXCLUDE_DIRS` (`:56`). The dashboard generator does not read `status:` at all, and `archive/` is out of its scan scope.

So `active` is not a *wrong archived value* — it is not a value in the vocabulary at all. Three ways to resolve it, and why this one:

| option | verdict |
|---|---|
| write `status: ready` | legal, but restates the default the template says is implicit and need not be written |
| write `status: archived` | mints a word the template explicitly forbids; used by exactly 1 of 219 archived files |
| **remove the line** | leaves the file at the default it already carries, adds no vocabulary |

## Scope note — deliberately not swept

45 further archived roadmaps carry a value outside `{ready, draft, later}`:

```
17 active · 12 completed · 5 done · 4 closed · 3 complete
 1 each: superseded, locked, in_progress, archived
```

`ready` (167 files) dominates the rest, which is the tell: archival simply never touches this field, so whatever a plan carried when it closed is what stayed. Normalising 45 closed plans belonging to other work is a vocabulary sweep and a separate decision, not a side effect of fixing the one file that was named.

## Verification

| Probe | Result |
|---|---|
| `check-roadmap-trackable` | exit 0 |
| `roadmap-progress-check` | exit 0 — dashboard unchanged, confirming `archive/` is out of scope |
| `lint-empty-roadmaps`, `lint-roadmap-later-disposition`, `check-refs`, `check-md-language` | exit 0 |

`lint-roadmap-complexity` is red on `main` for three untagged **active** roadmaps (`road-to-reproducible-artefact-counts`, `road-to-ui-track-integrity-followup`, `road-to-worktree-hygiene`) — unrelated to this file and unchanged by this diff.

## Note on the target PR

This was asked for "in the same PR as the sweep results" — #1086. That PR merged at 06:09Z while the work was in flight (as did #1088 at 06:07Z), so this lands as its own change against the resulting `main` rather than being pushed onto a merged branch.
