### PR TITLE
docs: four roadmaps from the 9.x feedback disposition

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,39 +2,52 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 15 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **12** open blockers
+> 19 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **12** open blockers
 
 ## Overall
 
-**48 / 215 steps done · 22%**
+**48 / 252 steps done · 19%**
 
 ```text
-█████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   22%
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   19%
 ```
 
 ## Open roadmaps
 
 | # | Roadmap | Phases | Steps | Open | Done | Deferred | Cancelled | Blocker | Progress |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
-| 1 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 17 | 7 | 10 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 59% |
-| 2 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 3 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
-| 4 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 5 | [road-to-gates-that-can-fail.md](roadmaps/road-to-gates-that-can-fail.md) | 7 | 27 | 22 | 3 | 2 | 0 | [2](#blockers-road-to-gates-that-can-fail) | █░░░░░░░░░ 12% |
-| 6 | [road-to-governance-invariants.md](roadmaps/road-to-governance-invariants.md) | 5 | 19 | 19 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 9 | [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md) | 5 | 29 | 29 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 36 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 14 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
-| 15 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 1 | [road-to-activation-evidence-or-refusal.md](roadmaps/road-to-activation-evidence-or-refusal.md) | 2 | 7 | 7 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 2 | [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md) | 5 | 17 | 7 | 10 | 0 | 0 | [1](#blockers-road-to-adoption-without-narrative-debt) | ██████░░░░ 59% |
+| 3 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 4 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
+| 5 | [road-to-dead-surface-removal.md](roadmaps/road-to-dead-surface-removal.md) | 3 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 6 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
+| 7 | [road-to-gates-that-can-fail.md](roadmaps/road-to-gates-that-can-fail.md) | 7 | 27 | 22 | 3 | 2 | 0 | [2](#blockers-road-to-gates-that-can-fail) | █░░░░░░░░░ 12% |
+| 8 | [road-to-governance-invariants.md](roadmaps/road-to-governance-invariants.md) | 5 | 19 | 19 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 10 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 11 | [road-to-overlap-truth-and-skill-cut.md](roadmaps/road-to-overlap-truth-and-skill-cut.md) | 6 | 14 | 14 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 12 | [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md) | 5 | 29 | 29 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 13 | [road-to-release-shape-honesty.md](roadmaps/road-to-release-shape-honesty.md) | 3 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 14 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 15 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 36 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 16 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 17 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 18 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 19 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
 
 ## Per-roadmap phase breakdown
+
+### [road-to-activation-evidence-or-refusal.md](roadmaps/road-to-activation-evidence-or-refusal.md)
+
+**Road to activation evidence — produce the red baseline or refuse the resolver permanently** — 0 / 7 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Produce the corpus, or fail to | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 1 | The verdict, both branches pre-written | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 
 ### [road-to-adoption-without-narrative-debt.md](roadmaps/road-to-adoption-without-narrative-debt.md)
 
@@ -79,6 +92,16 @@ _2 blockers resolved._
 | 1 | Protocol diff (no model calls) | ✅ done | 0 | 2 | 0 | 0 | 100% |
 | 2 | Re-run test on existing artifacts (minimal spend) | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |
 | 3 | Landing & close | ⬜ not started | 1 | 0 | 0 | 1 | 0% |
+
+### [road-to-dead-surface-removal.md](roadmaps/road-to-dead-surface-removal.md)
+
+**Road to dead-surface removal — apply the package's own null rule to the package's own code** — 0 / 8 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Code-intelligence engine out of core | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Remove the `intent:` trigger type | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Per-pack `version:` removal | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 
 ### [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md)
 
@@ -186,6 +209,19 @@ _1 blocker resolved._
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
 
+### [road-to-overlap-truth-and-skill-cut.md](roadmaps/road-to-overlap-truth-and-skill-cut.md)
+
+**Road to overlap truth — repair the instrument, then cut the skills it was supposed to find** — 0 / 14 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Make the instrument capable of failing | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 2 | Re-measure with the canonical tool | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 3 | The router defect (not a preference) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 4 | Execute the confirmed merges | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 5 | Description disambiguation on the confirmed clusters only | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 6 | Stop the count from regrowing | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+
 ### [road-to-provided-artifact-honesty.md](roadmaps/road-to-provided-artifact-honesty.md)
 
 **Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated** — 0 / 29 done (0%)
@@ -197,6 +233,16 @@ _1 blocker resolved._
 | 2 | Refuse honestly, or honour a supplied contract | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
 | 3 | Precedence: a provided spec is not an impulse | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 4 | `bench:ui`: the diff machinery, maintainer-side | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
+
+### [road-to-release-shape-honesty.md](roadmaps/road-to-release-shape-honesty.md)
+
+**Road to release-shape honesty — lint the release that shipped, and describe it truthfully** — 0 / 8 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Release checks must see the release diff | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Release notes state impact, not commit count | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 3 | Correct the standing claims | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)
 

--- a/agents/roadmaps/road-to-activation-evidence-or-refusal.md
+++ b/agents/roadmaps/road-to-activation-evidence-or-refusal.md
@@ -1,0 +1,153 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to activation evidence — produce the red baseline or refuse the resolver permanently
+
+> Operator-stated problem (2026-07-31): *"Skills and rules do not always fire,
+> and not correctly."* A source-level analysis against four public reference
+> suites located the cause architecturally: this package compiles activation
+> declarations and never evaluates them at runtime. But this package has already
+> **built, measured and torn down** a reminder-injection apparatus — Δ = 0 pp on
+> both hosts, teardown pre-committed and executed, the third consecutive null in
+> the same family. Its written revisit condition is a *produced* red-baseline
+> corpus, not a claim. Council cut + verified repository state:
+> [`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md),
+> prior verdict: [`reminder-injection-verdict`](../settings/contexts/reminder-injection-verdict.md).
+
+## Goal
+
+Decide the activation question with evidence instead of architecture. Produce the
+red-baseline corpus the prior null's revisit condition demands — from session logs
+that already exist on disk — and then either re-open the mechanism under the full
+pre-registered design, or **refuse it permanently and delete the standing design
+document**. This roadmap contains **no resolver code**; its most likely outcome is
+a deletion.
+
+## Context (verified 2026-08-01, do not relitigate)
+
+- `docs/contracts/rule-router.md:120`: **"no runtime resolver."** Activation is a
+  projection-time artifact.
+- No hook reads `dist/router.json`. `user_prompt_submit` runs
+  `[chat-history, verify-before-complete, minimal-safe-diff]` — all state recorders.
+- Trigger-match semantics live only in `router_telemetry.ts` and
+  `trigger_coverage.ts` (offline). Nothing applies them to a live prompt.
+- ADR-054 is `status: proposed`, ~2 months old, unimplemented.
+- Prior null (settled by evidence): 12 live sessions, 2 scenarios × 3 arms
+  (kernel-only · targeted · random-equal-length negative control) × 2 host tiers.
+  **Strong host 6/6 comply, weak host 6/6 comply, all arms indistinguishable.**
+  Single-turn probes, rule ~600 words back. Pre-committed <5 pp → teardown, executed.
+- The pilot's shape is **not** the operator's shape: multi-turn, long session,
+  ≥3K-token distance was never tested. This makes the revisit condition
+  **eligible**, not satisfied.
+- `agents/runtime/` already carries redacted chat-history JSONL — the corpus
+  source exists; no new instrumentation is required to look.
+
+> **Scope boundary.** This roadmap does not reopen the rejected enforcement-first
+> architecture, does not resurrect thin projection (`eager-all` stays the default
+> and the quality-floor decision stands), and does not reopen the rejected
+> deferred/lazy rule-retrieval mechanism. It adds **no** runtime surface in any
+> phase. Learned activation weights (confidence loops, instinct promotion) are not
+> in scope at any point in this file.
+
+## Phase 0 — Produce the corpus, or fail to
+
+The whole roadmap is this phase. It is a search for a red baseline in data that
+already exists.
+
+- [ ] Pre-register the search **before looking**: the bar is ≥ 5 sessions, ≥ 8
+      turns each, each showing a kernel or tier-2 rule whose obligation was
+      objectively violated at a turn where the rule was **manually verified as
+      still in context**, with turn-by-turn token accounting proving ≥ 3K tokens
+      of distance at the failure, and the host tier named.
+      *Verify:* the registration commit predates the first analysis commit. Do not
+      edit the bar after reading the data.
+- [ ] Sweep the existing redacted chat-history JSONL for candidate failures.
+      Machine-checkable obligations only (a completion claim with no verification
+      evidence recorded that turn; a diff touching files the stated task never
+      named; a commit shape the policy forbids) — no judgement calls, so the
+      finding cannot be argued into existence.
+      *Verify:* candidate list committed under
+      `agents/evidence/analysis/activation-red-baseline.md` with one row per
+      candidate: session, turn, rule id, obligation, distance in tokens, host.
+- [ ] For each candidate, confirm the rule was actually in context at the failing
+      turn. A rule that was **not projected** into that session is a
+      scoping/projection defect and belongs to a different fix — record it
+      separately and remove it from the activation corpus.
+      *Verify:* every row is classified `in-context-and-violated`,
+      `not-projected` (→ separate defect), or `rejected` with the reason.
+- [ ] Classify what remains by host tier. Failures confined to a host tier weaker
+      than the pilot's weak host are already covered by the prior verdict's second
+      revisit path and do **not** justify a resolver.
+      *Verify:* per-tier counts stated in the report.
+
+## Phase 1 — The verdict, both branches pre-written
+
+- [ ] **Branch A — no red baseline found** (the expected outcome): record it in the
+      report as a fourth null-adjacent finding, move ADR-054 to `rejected` citing
+      this attempt, and decide the offline matcher's fate in the same pass — either
+      it keeps earning its place as a CI coverage floor (`trigger_coverage`) or it
+      goes with the ADR. **D1 is then refused permanently**; a later re-open needs
+      a materially weaker host tier entering the consumer set, or an explicitly
+      funded full n≈50/arm run.
+      *Verify:* ADR-054 status changed, the refusal recorded in
+      [`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md),
+      and no resolver code exists anywhere in the tree.
+- [ ] **Branch B — red baseline found**: the question re-opens, and the *cheapest*
+      candidates are tried first, in this order — the runtime resolver is last,
+      not first.
+      1. **Written-down state.** The obligation is written into a project-visible
+         file the agent reads with existing filesystem tools; no hook, no
+         injection, no new concern. (This is how the zero-hook reference suite
+         solves "the agent forgot".)
+      2. **Generated file→skill table** in the projected root instruction files,
+         derived from the router's path-shaped triggers, regenerated by the
+         existing build step so it cannot drift. Static text, no host support
+         needed, ~12 rows at consumer scope after collapsing multi-row rules and
+         filtering maintainer-only scope. Rows are filtered through the same scope
+         predicate the rule projection uses — a consumer must never be taught
+         maintainer paths.
+      3. **Stop-event consumer** for the already-recorded verification state (the
+         state file is written today and nothing reads it) — warn, never block.
+      4. Only if 1–3 measurably fail on the *same corpus*: the prompt-time
+         resolver, under the full pre-registered n≈50/arm design, default-OFF,
+         one-line pointers only, kernel roster on decay milestones and never
+         per-turn.
+      *Verify:* each candidate is measured against the Phase-0 corpus before the
+      next one is built; the first that closes the gap ends the branch.
+- [ ] Either branch: publish the outcome where the other nulls live, so the family
+      count stays honest.
+      *Verify:* the entry names the shape tested and the shape not tested.
+
+## Non-goals (recorded refusals)
+
+- **No fact-forcing gate.** Blocking the first Edit/Write per file until
+  investigation facts are presented is enforcement-first architecture behind a
+  settings knob; the locked refusal applies. Two sibling blocking gates already
+  shipping is debt, not precedent.
+- **No `intent:` implementation.** The dead trigger type is *removed*, not built
+  — owned by [`road-to-dead-surface-removal`](road-to-dead-surface-removal.md).
+- **No learned activation** (confidence loops, instinct promotion). Both reference
+  implementations ship the loop with zero published evaluation of the loop itself.
+- **No adoption-conditioned work.** Two of the four source documents make an
+  external-adoption deadline their top phase; the operator ruled external adoption
+  out of scope, so those phases are dropped wholesale rather than deferred.
+
+## Surface delta
+
+Phase 0 + Branch A: **−1 ADR, possibly −2 offline scripts, +1 evidence report.**
+Net negative. Branch B adds surface only after the corpus proves a gap, cheapest
+mechanism first.
+
+## Provenance
+
+Source: `agents/tmp.old/skill-rule-routing.txt` (operator-owned; source-level
+comparison against four public reference suites plus a pre-drafted roadmap, which
+this file deliberately restructures rather than adopts — the draft's Phase 0 tested
+*mechanism feasibility*, while the prior null makes *whether a gap exists at all*
+the first question). Disposition: council 2026-08-01
+(`anthropic/claude-sonnet-4-5` + `openai/gpt-4o`, 2 rounds, $0.14) —
+[`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md).
+Repository claims re-verified against the working tree on 2026-08-01, not taken
+from the source document.

--- a/agents/roadmaps/road-to-dead-surface-removal.md
+++ b/agents/roadmaps/road-to-dead-surface-removal.md
@@ -28,9 +28,13 @@ is smaller afterwards.
   auto-matches."* It does nothing at runtime and no planned mechanism would change
   that. Its only effect is giving rule authors false confidence that an activation
   path exists.
-- **Per-pack `version:`:** 12 `src/domains/*/pack.yaml` files still carry a
-  `version:` line. The release-time lockstep bump (56 files per release) was fixed
-  — the duplicated field it bumped was not. Half a fix.
+- **Per-pack `version:`:** **28** pack manifests still carry a `version:` line —
+  12 under `src/domains/*/pack.yaml` and 16 under `src/packs/*/pack.yaml`. The
+  release-time lockstep bump was reported as fixed for the *release PR's own
+  diff*, but the duplicated field it bumped was never removed, and the bump still
+  happens upstream of the release cut: the 9.11.x fan-out merged into this branch
+  on 2026-08-01 touched all 16 `src/packs` manifests plus their READMEs in
+  lockstep. Half a fix, and the half that remains is still firing.
 
 > **Scope boundary.** This roadmap removes; it does not redesign. The engine's
 > re-open condition stays exactly as recorded (a consumer case the graph answers
@@ -73,8 +77,10 @@ is smaller afterwards.
 
 ## Phase 3 — Per-pack `version:` removal
 
-- [ ] Remove the `version:` field from all 12 `src/domains/*/pack.yaml` files;
-      the package version is the single version.
+- [ ] Remove the `version:` field from all 28 pack manifests — both
+      `src/domains/*/pack.yaml` (12) and `src/packs/*/pack.yaml` (16); the package
+      version is the single version. Check the pack READMEs that are bumped in the
+      same lockstep for a rendered version string with the same problem.
       *Verify:* pack schema validation passes without the field, any consumer of
       it reads the package version instead, and a release cut touches zero
       `pack.yaml` files.
@@ -93,7 +99,7 @@ is smaller afterwards.
 
 ## Surface delta
 
-**−2 core dependencies, −1 schema trigger type, −12 duplicated version fields,
+**−2 core dependencies, −1 schema trigger type, −28 duplicated version fields,
 −1 dead fallback path.** Zero additions. This is the only roadmap in this batch
 whose delta is unconditionally negative.
 

--- a/agents/roadmaps/road-to-dead-surface-removal.md
+++ b/agents/roadmaps/road-to-dead-surface-removal.md
@@ -1,0 +1,107 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to dead-surface removal — apply the package's own null rule to the package's own code
+
+> Every 9.9.0 and 9.10.0 review converges on one sentence: *null results must
+> produce physical removal, not just a disabled flag.* Three surfaces currently
+> fail that rule inside this repository. Council cut:
+> [`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md).
+
+## Goal
+
+Delete three dead or half-removed surfaces. No new mechanism, no new gate, no
+replacement. Every phase is a deletion whose success criterion is that something
+is smaller afterwards.
+
+## Context (verified 2026-08-01, do not relitigate)
+
+- **Code-intelligence engine:** permanently `enabled: false` (measured recall
+  0.365 vs grep 0.797 — −43.2 pp against a +10 pp threshold), deprecation recorded
+  for the next major, removal after. Yet `web-tree-sitter` (0.24.7) and
+  `tree-sitter-wasms` (0.1.13) **still ship as core dependencies today**, so every
+  consumer installs a parser stack for an engine that cannot run.
+- **`intent:` trigger:** present in the schema, declared by rule authors, and
+  documented in `router_telemetry.ts` as *"informational only — never
+  auto-matches."* It does nothing at runtime and no planned mechanism would change
+  that. Its only effect is giving rule authors false confidence that an activation
+  path exists.
+- **Per-pack `version:`:** 12 `src/domains/*/pack.yaml` files still carry a
+  `version:` line. The release-time lockstep bump (56 files per release) was fixed
+  — the duplicated field it bumped was not. Half a fix.
+
+> **Scope boundary.** This roadmap removes; it does not redesign. The engine's
+> re-open condition stays exactly as recorded (a consumer case the graph answers
+> and grep cannot). Removing `intent:` is not a decision about activation
+> architecture — that question is owned by
+> [`road-to-activation-evidence-or-refusal`](road-to-activation-evidence-or-refusal.md),
+> which independently refuses to *implement* the trigger.
+
+## Phase 1 — Code-intelligence engine out of core
+
+- [ ] Move `web-tree-sitter` and `tree-sitter-wasms` out of `dependencies`.
+      Engine, CLI leaves, cache, twin, and the routing skill go to an optional
+      package/plugin per the classification already recorded for it.
+      *Verify:* a fresh consumer install resolves neither parser package; the
+      install-payload delta is measured and stated in the PR body. **Pin the ABI
+      pair (`web-tree-sitter@0.24.7` / `tree-sitter-wasms@0.1.13`) in the optional
+      package** — this pair is version-coupled and has a known teardown trap.
+- [ ] Keep the disabled-by-default settings key and the recorded re-open condition
+      intact; the flag is not what is being deleted.
+      *Verify:* the template still carries the key with its permanent `false`,
+      and the deprecation note points at the optional package.
+- [ ] Confirm nothing in the always-loaded surface still routes to the engine.
+      *Verify:* grep for the engine's skill id and CLI leaf names returns only
+      the optional package and the deprecation note.
+
+## Phase 2 — Remove the `intent:` trigger type
+
+- [ ] Delete `intent:` from the trigger schema and from every rule that declares
+      it; the surrounding prose keeps whatever the rule actually needed to say.
+      *Verify:* schema validation fails on an `intent:` trigger; a repo-wide grep
+      for the trigger key in rule frontmatter returns zero.
+- [ ] Update the offline tooling that counted `intent` separately, and the router
+      contract's trigger-type table.
+      *Verify:* `trigger_coverage` and the router contract no longer document a
+      trigger type that does not exist; both stay green.
+- [ ] State the removal in the contract in one line, so a future author does not
+      reintroduce it as a "missing" feature.
+      *Verify:* the line names why (never auto-matched at runtime, gave authors
+      false confidence).
+
+## Phase 3 — Per-pack `version:` removal
+
+- [ ] Remove the `version:` field from all 12 `src/domains/*/pack.yaml` files;
+      the package version is the single version.
+      *Verify:* pack schema validation passes without the field, any consumer of
+      it reads the package version instead, and a release cut touches zero
+      `pack.yaml` files.
+- [ ] Confirm the field cannot come back silently.
+      *Verify:* the pack schema rejects `version:` rather than ignoring it.
+
+## Non-goals (recorded refusals)
+
+- **No engine deletion.** The re-open condition stands; extraction is what the
+  recorded disposition asks for.
+- **No `intent:` implementation.** Removal is the decision; token-overlap matching
+  would be a fourth activation instrument in a family that has produced three
+  consecutive nulls.
+- **No per-pack independent versioning.** The question "individually versioned or
+  not" is answered here as *not* — the removal is the answer, not a deferral.
+
+## Surface delta
+
+**−2 core dependencies, −1 schema trigger type, −12 duplicated version fields,
+−1 dead fallback path.** Zero additions. This is the only roadmap in this batch
+whose delta is unconditionally negative.
+
+## Provenance
+
+Sources: `agents/tmp.old/feedback-9.9.0-1.txt`,
+`agents/tmp.old/feedback-9.10.0-1.txt`, `agents/tmp.old/feedback-9.9.0-2.txt`,
+`agents/tmp.old/skill-rule-routing.txt` (all operator-owned). Disposition: council
+2026-08-01 (`anthropic/claude-sonnet-4-5` + `openai/gpt-4o`, 2 rounds) —
+[`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md). All
+three surfaces were confirmed still present in the working tree on 2026-08-01.

--- a/agents/roadmaps/road-to-overlap-truth-and-skill-cut.md
+++ b/agents/roadmaps/road-to-overlap-truth-and-skill-cut.md
@@ -1,0 +1,164 @@
+---
+complexity: structural
+status: ready
+---
+
+# Road to overlap truth — repair the instrument, then cut the skills it was supposed to find
+
+> The canonical skill-overlap tool has been scanning a directory that does not
+> exist. `audit_skill_overlap.ts` still roots at `.agent-src.uncondensed/skills`,
+> the tree ADR-051 emptied — **verified absent 2026-08-01**. It carries no
+> scan-scope assertion and is not wired into CI, so it reports "no overlap" for a
+> 287-skill corpus. This is the exact silent-green class
+> [`road-to-gates-that-can-fail`](road-to-gates-that-can-fail.md) exists to kill,
+> found in the one instrument two separate feedback tracks depend on. Council cut:
+> [`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md).
+
+## Goal
+
+Make the overlap instrument capable of failing, re-measure the corpus with the
+canonical tool, fix the one finding that is a defect rather than a preference —
+the routing skill overlapping its own fallback target — and then execute the
+merges the canonical tool confirms. Skills go **down**, not just sideways.
+
+## Context (verified 2026-08-01, do not relitigate)
+
+- `.agent-src.uncondensed/skills` **does not exist**; the tool's root resolves to
+  nothing. No `assertScanned`, no CI wiring, no task entry.
+- 287 skills in `src/skills/`.
+- An external replication of the canonical metric (keyword cosine over the body
+  with frontmatter stripped, same stopword list, same token regex, threshold 0.70)
+  reported: **3 pairs ≥ 0.70**, 42 pairs in a 0.55–0.70 watch band, 6
+  description-only pairs ≥ 0.50. It deliberately diverged from the canonical tool
+  in two ways (root, and a minimal hand parser for `packs:` only) — so it
+  **selects candidates; it does not confirm them**.
+- The external run's honest self-correction: the review-skill family
+  (`code-review` / `adversarial-review` / `architecture-review-lens`) appears
+  **nowhere above 0.55** on either metric. The description linter already did its
+  job there. The risk is concentrated, not spread.
+- Most consequential single finding: **`analysis-skill-router` ↔
+  `universal-project-analysis` at 0.709** — the router reads like its own broad
+  fallback, which is the exact pair it exists to disambiguate.
+- `lint_skill_descriptions` today checks **absence of defects** (a–d), not
+  presence of the disambiguation conventions.
+
+> **Scope boundary.** Command surface is not in scope — that belongs to
+> [`road-to-surface-consolidation`](road-to-surface-consolidation.md), which works
+> by demotion rather than deletion. This roadmap deletes *skills*. No merge lands
+> on the external report's numbers alone.
+
+## Phase 1 — Make the instrument capable of failing
+
+- [ ] Re-root `audit_skill_overlap.ts` at `src/skills` (or give it `--root` with
+      that default) and delete the dead legacy-root fallback path rather than
+      leaving it as a silent branch.
+      *Verify:* the tool reports a non-zero scanned count on a clean checkout;
+      the old root appears nowhere in the file.
+- [ ] Register the tool in the scan-scope regime: zero skills scanned is a
+      failure, not an empty result.
+      *Verify:* a fixture run against an empty root exits non-zero with a
+      dead-scope message, and the assertion is exercised by a test.
+- [ ] Wire it into `task ci` as an **advisory report** first (it must not block
+      before the corpus is cleaned).
+      *Verify:* a CI run prints the pair table with real counts.
+- [ ] Add a regression test pinning the scanned-count floor, so a future container
+      move re-breaks loudly instead of silently.
+      *Verify:* the test fails when the root is pointed at a non-existent path.
+
+## Phase 2 — Re-measure with the canonical tool
+
+- [ ] Run the repaired canonical tool over `src/skills` and publish the pair table
+      as `agents/evidence/reports/skill-overlap-canonical.md`, alongside the
+      external report's candidates, with a **confirmed / refuted** column per pair.
+      *Verify:* every candidate from the external report appears with a canonical
+      score; divergences are stated, not smoothed.
+- [ ] Add the description-only cosine as a **separate, explicitly non-canonical**
+      measurement, because routing happens on descriptions and body similarity
+      does not measure it.
+      *Verify:* the report labels it non-canonical and does not mix it into the
+      merge threshold.
+
+## Phase 3 — The router defect (not a preference)
+
+- [ ] Strip analysis *procedure* out of `analysis-skill-router` so it carries
+      routing logic only — scope classification, framework detection, the decision
+      table. Procedure stays in `universal-project-analysis`.
+      *Verify:* canonical re-measure of the pair lands < 0.55; a chooser that reads
+      like its own fallback is a defect and this is its fix, not a cleanup.
+
+## Phase 4 — Execute the confirmed merges
+
+- [ ] Merge only pairs/families the canonical tool confirms, one PR per family,
+      with before/after canonical scores in the body. Candidate families from the
+      external report, to be confirmed first: the video/story trio, the readme
+      family, the roadmap pair, the worktree pair, the rule-writing pair, the
+      bug-analyzer/systematic-debugging pair, the brand pair, the
+      learning/pipeline pair, the NDA/intake pair, and folding
+      `testing-anti-patterns` into the TDD skill.
+      *Verify:* each merged-away skill's distinctive trigger phrases survive in
+      the surviving skill's description, so existing muscle memory still routes;
+      every downstream reference (rules, commands, contexts, docs, router entries)
+      is updated in the same change.
+- [ ] Record the families the canonical tool **refutes** as explicitly kept, with
+      the score — so the next sweep does not re-propose them.
+      *Verify:* a kept-with-reason list exists.
+- [ ] Keep, and do not merge, the families whose similarity is structural by
+      design (the persona-parallel judge family; genuinely distinct framework
+      surfaces) — but move the shared boilerplate that drives their score into a
+      referenced common preamble instead of repeating it.
+      *Verify:* scores drop without a skill being deleted.
+
+## Phase 5 — Description disambiguation on the confirmed clusters only
+
+- [ ] For each canonical-confirmed cluster, retrofit the `description:` with (a)
+      at least one **quoted literal user phrase** in the user's own words, and (b)
+      a **sibling negative-routing sentence** per overlapping neighbour, kept
+      mutually consistent across the cluster.
+      *Verify:* the diff touches frontmatter only; no sibling pair routes the same
+      phrase to both members.
+- [ ] Extend `lint_skill_descriptions` with two **positive** checks scoped to
+      clustered skills only: missing sibling-routing when the canonical tool pairs
+      the skill above threshold, and no quoted phrase in a clustered skill. Same
+      allowlist-with-cap regime as the existing checks.
+      *Verify:* red on a synthetic clustered skill missing both, green on the
+      retrofitted corpus, wired into `task ci`. A quoted-phrase mandate on all 287
+      skills is explicitly out of scope — that is noise, not routing.
+- [ ] Adopt the sibling-consistency obligation as an authoring rule in the
+      agent-docs authoring skill: editing one sibling's routing sentence obliges
+      checking the others.
+      *Verify:* the obligation is one paragraph, not a new artifact.
+
+## Phase 6 — Stop the count from regrowing
+
+- [ ] After the merges land, flip the canonical tool from advisory to blocking at
+      the canonical 0.70 threshold for **same-pack pairs only**. A new skill above
+      threshold must merge or carry a reviewed justification under the same
+      allowlist-with-cap regime — the cap forces periodic re-litigation instead of
+      silent growth.
+      *Verify:* a synthetic above-threshold same-pack addition fails CI.
+
+## Non-goals (recorded refusals)
+
+- **No merges on the external report's numbers.** The report selects; the
+  canonical tool confirms. This is the whole reason Phase 1 precedes Phase 4.
+- **No cross-pack merges.** Every confirmed candidate is same-pack; a cross-pack
+  merge changes install shape and is a different decision.
+- **No quoted-phrase mandate corpus-wide.**
+- **No gate manifest, no gate mutation tests.** Council refused both as governance
+  about governance; the scan-scope assertion in Phase 1 already kills the class.
+
+## Surface delta
+
+**−12 skills** if all candidate families confirm (287 → 275), **+2 linter checks,
++1 evidence report, +1 blocking threshold**, and one instrument that goes from
+structurally-incapable-of-failing to load-bearing. Net negative in the unit that
+costs routing quality every session.
+
+## Provenance
+
+Source: `agents/tmp.old/skill-rule-routing.txt` (operator-owned; contains the
+external overlap replication whose candidate pairs Phase 2 must confirm or refute).
+Disposition: council 2026-08-01 (`anthropic/claude-sonnet-4-5` + `openai/gpt-4o`,
+2 rounds) — [`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md).
+The dead-root finding in Phase 1 was verified directly against the working tree on
+2026-08-01, not reported by the source document.

--- a/agents/roadmaps/road-to-release-shape-honesty.md
+++ b/agents/roadmaps/road-to-release-shape-honesty.md
@@ -1,0 +1,129 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to release-shape honesty — lint the release that shipped, and describe it truthfully
+
+> Five independent reviews of 9.9.0 and 9.10.0 raised the same two release
+> defects. The first is a correctness hole: a 179-commit release ran its skill
+> lint over the release-metadata diff, reported **"0 skills checked, INCONCLUSIVE"**,
+> and merged. The second is a truthfulness hole: a headline claims a 38 %
+> reduction that a later measurement found unreachable in production installs, and
+> the changelog headline still reads as an achieved win. Council cut:
+> [`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md).
+
+## Goal
+
+Make release-time checks see the release, and make release notes state what a
+reader would be misled about otherwise. Two defects, one truthfulness pass, no new
+governance layer — the reviews' proposed release-budget gate is deliberately folded
+into an existing checklist rather than built.
+
+## Context (verified from the review set, 2026-08-01)
+
+- The release PR's own diff is version, changelog, pack metadata and marketplace
+  files. The substantive work arrives in the preceding commits, so every check
+  scoped to "files changed in this PR" measures the release wrapper, not the
+  release. The visible consequence: `0 skills checked` on a release containing
+  many skill changes, correctly labelled `INCONCLUSIVE` and merged anyway.
+- The scope-dedup measurement: **38.0 % of median cold-start tokens** (87,677 of
+  230,556) against a pre-registered 15 % bar — measured on a byte-identical
+  fixture. In the real install model, global files carry additional ownership
+  metadata and are therefore *not* byte-identical to project projections, so the
+  byte-identity gate correctly refuses to dedup and the recipient set is empty.
+  This was recorded as an honest null. **The changelog headline was not updated.**
+- Release notes are a generated commit log: reviewers repeatedly could not tell
+  which entries change consumer behaviour, which need migration, which are
+  internal gate repairs, and which ended as nulls.
+- One release cycle lost a changelog footer because a probe buffered `vitest list`
+  output through a 1 MiB default and the suite listing had grown to 1,254,812
+  bytes — ENOBUFS degraded the probe silently to zero. Same silent-drop symptom
+  class as a prior incident, different cause.
+
+> **Scope boundary.** No release-budget *gate*. The reviews' "one capability track
+> per minor" recommendation folds into the existing release checklist and
+> self-review prompt; a new blocking gate is precisely the governance inflation the
+> same reviews condemn. Release *size* is a planning decision, not a machine check.
+
+## Phase 1 — Release checks must see the release diff
+
+- [ ] Make the release-PR check scope resolve to `previous_release_tag...release_head`
+      rather than the PR's own file list, for the content checks that are
+      diff-scoped (skill lint, rule lint, portability, claim impact).
+      *Verify:* re-running the check on the last release reports a non-zero
+      checked count; a synthetic skill defect introduced anywhere in the tag span
+      turns it red.
+- [ ] `INCONCLUSIVE` on a release PR is a failure, not an outcome — a release
+      check that examined nothing must block the release, matching the scan-scope
+      regime already adopted for the other gates.
+      *Verify:* a fixture release PR with an empty resolved scope exits non-zero.
+- [ ] Fix the silent-probe class the footer incident exposed: any probe that
+      shells out for a count must fail loudly on buffer overflow rather than
+      degrading to zero.
+      *Verify:* a fixture whose output exceeds the buffer produces an error, not a
+      zero; the footer gate stays green for the right reason.
+
+## Phase 2 — Release notes state impact, not commit count
+
+- [ ] Give the release notes a fixed curated head above the generated log, in this
+      order: **behaviour changes · default changes + migration · security and
+      correctness · honest nulls · known limitations**, capped at roughly ten
+      operator-relevant lines. The full generated log stays below it, unchanged.
+      *Verify:* the next release's head section fits the cap and every default
+      change appears in it; the generator emits the section skeleton so it cannot
+      be forgotten.
+- [ ] Deduplicate repeated commit lines in the generated section.
+      *Verify:* no line appears twice in the last release's regenerated notes.
+
+## Phase 3 — Correct the standing claims
+
+- [ ] Amend the scope-dedup changelog and claim entries so the condition travels
+      with the number: the 38 % is fixture-measured and **currently unreachable for
+      production installs** because global and project projections are not
+      byte-identical. The honest-null record already says this; the headline must
+      not outrun it.
+      *Verify:* the claims ledger and the changelog agree, and neither states an
+      unconditioned 38 % win.
+- [ ] Give every claim whose backing trigger is outside maintainer control an
+      honest lifecycle status (`untestable without external adoption` or
+      equivalent) instead of an indefinite `unbacked pending`. Debt that cannot
+      structurally shrink is a misfiled blocker, not debt.
+      *Verify:* no claim remains in a pending state whose precondition the
+      maintainer cannot satisfy; the count of genuinely open items drops.
+- [ ] Fold the release-shape recommendations into the existing release checklist:
+      one capability track per minor, security/fix releases cut separately, and a
+      pre-version-PR dry run of the actual artifact (pack → install → hooks →
+      upgrade → uninstall).
+      *Verify:* the checklist lines exist and no new gate was created.
+
+## Non-goals (recorded refusals)
+
+- **No release-budget gate.** Folded into the checklist, per the reviews' own
+  no-new-governance rule.
+- **No adoption-conditioned work.** Launch posts, registry submissions, external
+  recruiting and the adoption deadlines that two source documents make their top
+  phase are out of scope by operator decision; the claim-lifecycle item above is
+  the *only* adoption-adjacent work retained, and it exists to close the ledger
+  honestly rather than to pursue adoption.
+- **No release splitting enforced by machine.** Naming it in the checklist is the
+  intervention; a gate that counts commits would block work for a planning
+  preference.
+
+## Surface delta
+
+**+3 checklist lines, +1 generated notes section, 0 new gates**, and a claims
+ledger that shrinks because structurally-unclosable entries stop being counted as
+open. Two correctness defects (blind release lint, silent probe overflow) are
+closed.
+
+## Provenance
+
+Sources: `agents/tmp.old/feedback-9.10.0-1.txt` (five independent reviews of PR
+#1069 / 9.10.0), `agents/tmp.old/feedback-9.9.0-1.txt` (six reviews of 9.9.0),
+`agents/tmp.old/feedback-9.9.0-2.txt` (their cross-checked consolidation) — all
+operator-owned. Disposition: council 2026-08-01 (`anthropic/claude-sonnet-4-5` +
+`openai/gpt-4o`, 2 rounds) —
+[`feedback-9x-council-cut`](../settings/contexts/feedback-9x-council-cut.md).
+The consolidation document's own Phase 0 (an adoption deadline) is dropped rather
+than deferred, per the operator's out-of-scope decision on external adoption.

--- a/agents/roadmaps/road-to-reproducible-artefact-counts.md
+++ b/agents/roadmaps/road-to-reproducible-artefact-counts.md
@@ -1,5 +1,5 @@
 ---
-complexity: contained
+complexity: lightweight
 status: draft
 ---
 

--- a/agents/roadmaps/road-to-ui-track-integrity-followup.md
+++ b/agents/roadmaps/road-to-ui-track-integrity-followup.md
@@ -1,5 +1,5 @@
 ---
-complexity: contained
+complexity: lightweight
 status: ready
 parent_roadmap: road-to-ui-track-integrity
 ---

--- a/agents/roadmaps/road-to-worktree-hygiene.md
+++ b/agents/roadmaps/road-to-worktree-hygiene.md
@@ -1,5 +1,5 @@
 ---
-complexity: contained
+complexity: lightweight
 status: draft
 ---
 

--- a/agents/settings/contexts/feedback-9x-council-cut.md
+++ b/agents/settings/contexts/feedback-9x-council-cut.md
@@ -26,8 +26,10 @@ review claims were already stale.
   exists to kill.**
 - `web-tree-sitter` + `tree-sitter-wasms` still ship as **core dependencies**
   for a permanently `enabled: false` engine.
-- 12 `src/domains/*/pack.yaml` still carry a `version:` line (the release-time
-  lockstep bump was fixed; the duplication was not).
+- 28 pack manifests still carry a `version:` line — 12 under `src/domains/` and
+  16 under `src/packs/`. The release-time lockstep bump was fixed for the release
+  PR's own diff; the duplicated field was not removed and still bumps upstream of
+  the cut (the 9.11.x fan-out touched all 16 `src/packs` manifests).
 - 287 skills.
 - `road-to-gates-that-can-fail`: 22 open / 3 done.
 

--- a/agents/settings/contexts/feedback-9x-council-cut.md
+++ b/agents/settings/contexts/feedback-9x-council-cut.md
@@ -1,0 +1,131 @@
+# Feedback-9x disposition — council cut (2026-08-01)
+
+Council: `anthropic/claude-sonnet-4-5` + `openai/gpt-4o`, 2-round debate,
+actual cost $0.14. Artefact: a neutral disposition question built from four
+operator-supplied review documents (two release reviews of 9.9.0 / 9.10.0, one
+six-review consolidation, one source-level routing analysis against four public
+reference suites). All load-bearing claims in the question were verified against
+the repository first; the verified findings are restated below because several
+review claims were already stale.
+
+## Verified repository state (2026-08-01, do not re-verify from the reviews)
+
+- `docs/contracts/rule-router.md:120` states verbatim: **"no runtime resolver."**
+- **No hook consumes `dist/router.json`.** `user_prompt_submit` runs
+  `[chat-history, verify-before-complete, minimal-safe-diff]` — state recorders only.
+- Trigger-match logic exists only in `router_telemetry.ts` (corpus replay) and
+  `trigger_coverage.ts` (CI floor) — offline simulation, never applied live.
+- ADR-054 (decay-triggered re-state + per-prompt pointers) is **`status: proposed`**
+  and unimplemented.
+- `intent:` is dead schema — `router_telemetry.ts` documents it as
+  "informational only — never auto-matches."
+- `audit_skill_overlap.ts` still roots at `.agent-src.uncondensed/skills`, a
+  directory ADR-051 emptied and which **does not exist**. No scan-scope
+  assertion, not wired into CI → it scans 0 skills and reports no overlap.
+  **A live silent-green gate of exactly the class `road-to-gates-that-can-fail`
+  exists to kill.**
+- `web-tree-sitter` + `tree-sitter-wasms` still ship as **core dependencies**
+  for a permanently `enabled: false` engine.
+- 12 `src/domains/*/pack.yaml` still carry a `version:` line (the release-time
+  lockstep bump was fixed; the duplication was not).
+- 287 skills.
+- `road-to-gates-that-can-fail`: 22 open / 3 done.
+
+## The load-bearing verdict — D1 (runtime resolver) is barred pending evidence
+
+Both members, both rounds, converged: the operator's stated problem ("skills and
+rules do not always fire") is an **unmeasured claim**, and the prior
+reminder-injection null (Δ=0 pp on both hosts, teardown pre-committed and
+executed, third null in the family) **holds until a red baseline is produced**.
+
+The written revisit condition is *"someone **produces** a scenario corpus where
+the kernel-only baseline demonstrably FAILS"* — not *"someone claims"*. The
+operator's complaint does describe the one shape the pilot could not test
+(genuine multi-turn, >3K-token distance vs. the pilot's single-turn ~600-word
+probes), so the condition is **eligible**, not satisfied.
+
+Pre-registered evidence bar, adopted verbatim from the council:
+
+- ≥ 5 anonymised session logs, ≥ 8 turns each;
+- a kernel/tier-2 rule declared early and **manually verified as still in-context**
+  at the failing turn;
+- turn-by-turn token accounting proving ≥ 3K tokens of distance at the failure;
+- host tier identified (if failures are weak-host-only, revisit path 2 already
+  covers it and the resolver is still not the answer).
+
+**Consequence if the corpus cannot be produced:** D1 is refused **permanently**,
+ADR-054 is moved to `rejected` with the evidence attempt recorded, and the
+offline matcher's fate is decided in the same pass. Building the resolver on an
+assertion would set the precedent that an honest null can be overridden by
+claim — the one thing the pre-committed teardown exists to prevent.
+
+## Adopted
+
+| Item | Disposition | Note |
+|---|---|---|
+| Fix `audit_skill_overlap` root + scan assertion | **Defect, not feature** | Both members; gpt-4o flipped in R2 to agree it must precede any skill merge |
+| Physical removal of the dead engine's core deps | Adopt | "Apply the operator's own rule to the operator's own code" |
+| Remove `intent:` from the schema | Adopt — **remove, do not implement** | Both members chose removal over building a fourth activation instrument |
+| Per-pack `version:` removal | Adopt | completes a half-fix |
+| Scan-scope assertions for every checker | Adopt (already owned by `road-to-gates-that-can-fail`) | no new roadmap |
+| Skill merges + description disambiguation | Adopt, **hard-gated** on the overlap tool being fixed and the pairs re-confirmed by the canonical tool | the external report selects; the canonical tool confirms |
+| Tag-aware release lint | Adopt | a 179-commit release lint-checked 0 skills and reported INCONCLUSIVE |
+
+## Refused (recorded refusals — do not re-plan without the named trigger)
+
+- **Fact-forcing gate** (first Edit/Write per file blocked until investigation
+  facts are presented). Judged *enforcement-first architecture wearing a
+  settings-knob disguise* — the locked refusal against replacing rule prose with
+  compiled enforcement applies. Two sibling blocking gates already shipping is
+  technical debt, not a licence for a third.
+- **Implementing `intent:` matching.** Removal instead.
+- **The full memory default-on checklist** (list/inspect/forget/export commands,
+  per-entry provenance + confidence + TTL, observed→candidate→confirmed→
+  contradicted state model, adversarial pass). Council: that checklist is what a
+  **public API** requires; for an internal-only, single-maintainer package the
+  operator inspects the store directly. Re-open trigger: the external-adoption
+  question being explicitly re-opened (currently out of scope by operator
+  decision).
+  - **Checked before accepting the refusal:** the one checklist item that would
+    have been a safety floor regardless of adoption — a secret/PII write-gate on
+    memory intake — **already ships**. `_lib/user_global_observations.ts` runs
+    `redaction_scan` on every capture and *refuses outright* rather than
+    redacting-then-storing (the low-impact-corpus discipline applied to memory),
+    and `mine_session.ts` carries its own redaction gate. No carve-out from the
+    refusal is needed; the whole checklist stays refused.
+- **Machine-readable gate manifest + gate mutation tests.** "Governance about
+  governance"; the scan-scope assertion already kills the class.
+- **Anything justified by external adoption** — launch, taster plugins, registry
+  submissions, recruiting external testers, adoption deadlines. Several review
+  documents make an adoption deadline their top phase; the operator ruled this
+  out of scope. Two of the four documents' Phase 0 is therefore dropped wholesale.
+
+## The R2 self-correction worth keeping
+
+The strongest round-2 argument was against round 1's own adoption list: a plan
+that "removes 14 items and adopts 5" claims net −9 only against a fictional
+baseline of *adopt-everything*. **The real baseline is the current repository.**
+Refusing to build something is staying at zero, not shrinking. Only physical
+deletion shrinks. Every roadmap below therefore states its surface delta as
+components **added minus components deleted**, against today's tree.
+
+The same round also produced the best alternative to a runtime resolver: the
+zero-hook reference suite solves "the agent forgot" by **writing the next
+obligation into a file in the project**, not by injecting a reminder at prompt
+time. If a red baseline is ever found, written-down state is the first candidate
+and the resolver is the second.
+
+## Contested, resolved by the maintainer
+
+- **Stop-event consumer for the recorded verification state** (the state file is
+  written today and nothing reads it). R1 adopted it as the highest
+  effort/value item; R2 argued it fails the *same* evidence standard it applies
+  to D1 — a warning built on an unmeasured belief that agents claim done without
+  verifying, with the same habituation failure mode. Resolved: **gated on the
+  same corpus** as D1, and if a gap is found the written-down-state variant is
+  tried before a new hook concern.
+- **Generated file→skill table in the projected root files.** Static text, no
+  hook, no host support needed, derived from the router's path-shaped triggers
+  (~44 raw rows → ~12 at consumer scope). R1 did not adopt it; gpt-4o deferred it
+  on complexity-vs-need. Resolved: **kept in the same evidence-gated roadmap** as
+  the cheapest non-runtime answer, not shipped speculatively.


### PR DESCRIPTION
## What this is

Four operator-supplied review documents (9.9.0, 9.10.0, a cross-checked
six-review consolidation, and a source-level routing analysis against four
public reference suites) turned into four executable roadmaps, with the
disposition decided by a 2-round AI council (`claude-sonnet-4-5` + `gpt-4o`,
$0.14) rather than by adopting the drafts the documents shipped with.

No behaviour changes. Documentation and planning only.

## Why the pre-drafted roadmap was restructured, not adopted

The routing analysis correctly diagnoses that activation is a projection-time
artifact with no runtime resolver — verified: `docs/contracts/rule-router.md:120`
says so verbatim, no hook reads `dist/router.json`, and ADR-054 has been
`status: proposed` for ~2 months.

But this package already **built, measured and tore down** that mechanism:
Δ = 0 pp on both host tiers, teardown pre-committed and executed, the third
consecutive null in the same family. Its written revisit condition is a
*produced* red-baseline corpus, not a claim. The operator's stated failure does
describe the one shape the pilot could not test (multi-turn, >3K-token distance
vs. single-turn ~600-word probes), which makes the condition **eligible, not
satisfied**.

So the activation roadmap is an **evidence search with two pre-written outcomes** and
contains no resolver code; its expected outcome is a deletion. Building on an
assertion would have set the precedent that an honest null can be overridden by
claim.

## Findings verified against the tree, not taken from the reviews

Several review claims were already stale (the repo is on 9.11.0; the 9.10.0
pre-merge P0s are moot). Two were live and worse than described:

- **`audit_skill_overlap.ts` is a live silent-green gate.** It roots at
  `.agent-src.uncondensed/skills` — the tree ADR-051 emptied, which does not
  exist. No scan-scope assertion, not wired into CI. It reports "no overlap" for
  287 skills, and both the skill-cut and description-disambiguation tracks depend
  on its output.
- **The per-pack `version:` duplication is 28 files, not 12** (12 `src/domains/`
  + 16 `src/packs/`), and the lockstep is still firing: the 9.11.x fan-out merged
  into this branch bumped all 16 `src/packs` manifests plus their READMEs.

## The four roadmaps

| Roadmap | Core | Surface delta |
|---|---|---|
| `road-to-activation-evidence-or-refusal` | Produce the red-baseline corpus from session logs already on disk; then re-open cheapest-first or refuse permanently and move ADR-054 to `rejected` | −1 ADR, possibly −2 scripts |
| `road-to-overlap-truth-and-skill-cut` | Repair the instrument so it can fail → re-measure canonically → fix the router that overlaps its own fallback at 0.709 → execute only confirmed merges | −12 skills, +2 linter checks |
| `road-to-dead-surface-removal` | Parser deps out of core, `intent:` out of the schema, 28 `version:` fields | unconditionally negative |
| `road-to-release-shape-honesty` | Release checks resolve the tag span (a 179-commit release lint-checked 0 skills), notes sectioned by impact, the 38% headline conditioned on its fixture-only reach | 0 new gates |

Every roadmap states its delta as components **added minus deleted against
today's tree** — per the council's round-2 self-correction that refusing to build
something is staying at zero, not shrinking.

## Recorded refusals

- **Fact-forcing gate** (block the first Edit/Write per file) — enforcement-first
  architecture behind a settings knob; the locked refusal applies.
- **Implementing `intent:` matching** — removed instead; a fourth activation
  instrument in a family with three consecutive nulls.
- **The full memory default-on checklist** — that is what a public API needs.
  Before accepting this, the one item that would be a safety floor regardless of
  adoption was checked: the secret/PII write-gate **already ships**
  (`_lib/user_global_observations.ts` runs `redaction_scan` and refuses outright).
- **Gate manifest + gate mutation tests** — governance about governance.
- **Everything justified by external adoption.** Two of the four documents lead
  with an adoption deadline as Phase 0; dropped wholesale, not deferred.

## Also in this PR

`complexity: contained` was an illegal value in three active roadmaps
(`lint_roadmap_complexity` accepts only `lightweight` / `structural`, so it
reported them as missing the field and they had been failing the gate).
`lightweight` is derived from the linter's own caps, not picked: 63 / 192 / 62
lines against a 600-line cap, 0 / 1 / 0 phases against a 6-phase cap, no
council-round or verdict blocks. Repo-wide: **24/24 complexity-clean**.

## Verification

`check_md_language`, `check_references`, `check_no_roadmap_refs`,
`check_council_references`, `lint_roadmap_complexity`, `check_roadmap_trackable`,
`lint_empty_roadmaps`, `lint_roadmap_blockers`, `lint_roadmap_later_disposition`,
`lint_marketplace`, and the roadmap-dashboard `--check` gate all green on the
final head. `origin/main` merged in first; tree clean.

All three copies of `update_roadmap_progress.ts` (`src/agent-src/`, `dist/agent-src/`, `.augment/`) are byte-identical at this head, and `./agent-config roadmap:progress` reproduces the committed dashboard exactly — including the `## Ticket bundles` section.
