### PR TITLE
fix(gates): make the lint-regression baseline actually collect and compare

### DIFF
--- a/src/scripts/lint_regression.ts
+++ b/src/scripts/lint_regression.ts
@@ -64,6 +64,65 @@ const STATUS_ORDER: Record<string, number> = { pass: 0, pass_with_warnings: 1, f
  * baseline worktree-add failure (→ exit 2 in main). */
 class CalledProcessError extends Error {}
 
+/** The baseline ran but produced nothing usable (→ exit 2 in main).
+ *
+ * Distinct from the two DOCUMENTED empty-baseline degradations (no linter file
+ * in the ref; a pre-migration `.py` baseline with no python3). Those are
+ * deliberate. This one is a broken run, and returning an empty baseline for it
+ * silently reclassifies every existing finding as a "new file" — the gate then
+ * fires on an unmodified tree and can never report a real regression, because a
+ * regression needs the file present in both maps. */
+class BaselineCollectionError extends Error {}
+
+/** Give the detached baseline worktree a resolvable module context.
+ *
+ * `git worktree add` checks out tracked files only, so the temp tree has no
+ * `node_modules` and the linter dies on its first bare import. Symlinking the
+ * repo's own install is enough — the baseline runs the ref's linter source
+ * against the ref's artefacts; only the dependency resolution is borrowed. */
+function _link_node_modules(tmpdir: string, repo_root: string): void {
+    const target = path.join(repo_root, 'node_modules');
+    const link = path.join(tmpdir, 'node_modules');
+    if (fs.existsSync(link) || !fs.existsSync(target)) {
+        return;
+    }
+    try {
+        fs.symlinkSync(target, link, 'dir');
+    } catch {
+        // Non-fatal here: a failed link surfaces as a failed baseline run
+        // below, which raises with the real cause rather than degrading.
+    }
+}
+
+/** Re-root the baseline's file keys onto the repo-relative paths the working-tree
+ * run emits.
+ *
+ * The baseline runs with `--repo-root <tmpdir>` and reports absolute paths under
+ * that temp worktree; the working-tree run reports paths relative to the repo.
+ * Left as-is the two maps share no key, so every comparison is vacuous — the
+ * disjoint guard would reject the run outright once the baseline is non-empty. */
+function _relativise(data: LinterJson, tmpdir: string): LinterJson {
+    const roots = new Set<string>([tmpdir]);
+    try {
+        roots.add(fs.realpathSync(tmpdir));
+    } catch {
+        /* the temp dir is about to be removed; the literal prefix still applies */
+    }
+    const strip = (f: string): string => {
+        for (const r of roots) {
+            const prefix = r.endsWith(path.sep) ? r : r + path.sep;
+            if (f.startsWith(prefix)) {
+                return f.slice(prefix.length);
+            }
+        }
+        return f;
+    };
+    return {
+        ...data,
+        results: (data.results ?? []).map((e) => ({ ...e, file: strip(e.file) })),
+    };
+}
+
 /** Run the linter and return parsed JSON. If ref is null, run on working tree.
  *
  * Mirrors `run_linter_json`: for a ref, add a detached temp worktree, run the
@@ -91,6 +150,7 @@ function run_linter_json(ref: string | null, repo_root: string): LinterJson {
             );
         }
         try {
+            _link_node_modules(tmpdir, repo_root);
             // The baseline ref may be pre-migration (`.py`, run via python3) or
             // post-migration (`.ts`, run via tsx). Probe both extensions in both
             // locations and spawn by extension. A historical `.py` ref genuinely
@@ -139,7 +199,17 @@ function run_linter_json(ref: string | null, repo_root: string): LinterJson {
                       encoding: 'utf8',
                   });
             const out = result.stdout ?? '';
-            return out.trim() ? (JSON.parse(out) as LinterJson) : { results: [], summary: {} };
+            if (!out.trim()) {
+                const why =
+                    result.status === 0
+                        ? 'it exited 0 but printed nothing'
+                        : `it exited ${result.status ?? 'null'}`;
+                throw new BaselineCollectionError(
+                    `the baseline linter for '${ref}' produced no output — ${why}.\n` +
+                        `stderr: ${(result.stderr ?? '').trim().split('\n').slice(-6).join('\n')}`,
+                );
+            }
+            return _relativise(JSON.parse(out) as LinterJson, tmpdir);
         } finally {
             spawnSync('git', ['-C', repo_root, 'worktree', 'remove', '--force', tmpdir], {
                 encoding: 'utf8',
@@ -433,6 +503,10 @@ function main(): number {
             );
             return 2;
         }
+        if (e instanceof BaselineCollectionError) {
+            process.stderr.write(`Error: ${e.message}\n`);
+            return 2;
+        }
         throw e;
     }
 
@@ -450,6 +524,22 @@ function main(): number {
         process.stderr.write(
             'Error: baseline and current lint results share no files — ' +
                 'runs are not comparable; refusing to report.\n',
+        );
+        return 2;
+    }
+
+    // The same guard's blind spot: an EMPTY baseline against a populated
+    // current tree is not comparable either, and it is the worse failure —
+    // every existing finding is then reported as a "new file", so the gate
+    // fires on an unmodified tree and no real regression can ever surface.
+    // The documented empty-baseline degradations (no linter in the ref; a
+    // pre-migration `.py` baseline with no python3) print their own warning
+    // above and land here on purpose.
+    if (!baseKeys.length && currKeys.length) {
+        process.stderr.write(
+            `Error: the baseline '${args.baseline}' produced no lint results while the ` +
+                `current tree produced ${currKeys.length} — runs are not comparable; ` +
+                'refusing to report. Every finding would be misreported as new.\n',
         );
         return 2;
     }
@@ -528,4 +618,5 @@ export {
     format_text,
     format_markdown,
     main,
+    _relativise,
 };

--- a/tests/scripts/lint_regression.test.ts
+++ b/tests/scripts/lint_regression.test.ts
@@ -129,3 +129,77 @@ describe('lint_regression — formatters + status map', () => {
 
 // --- Golden parity on the REAL REPO ----------------------------------------
 
+
+// --- Baseline-collection integrity -----------------------------------------
+//
+// The gate reported a "new file with issues" on an UNMODIFIED tree for as long
+// as two defects stacked: the baseline linter died in the detached worktree
+// (no node_modules) and a failed run silently became an empty baseline, which
+// the disjoint guard exempts; and once the baseline did collect, its keys were
+// absolute paths under the temp dir while the working-tree run emitted
+// repo-relative ones, so the two maps shared no key. Either defect alone makes
+// every real regression unreportable — a regression needs the file present in
+// both maps.
+
+describe('lint_regression baseline key normalisation', () => {
+    it('strips the temp-worktree prefix so baseline keys match working-tree keys', () => {
+        const out = reg._relativise(
+            {
+                results: [
+                    { file: '/tmp/lint-baseline-abc/src/rules/a.md', status: 'pass_with_warnings' },
+                    { file: '/tmp/lint-baseline-abc/src/rules/b.md', status: 'pass' },
+                ],
+            },
+            '/tmp/lint-baseline-abc',
+        );
+        expect((out.results ?? []).map((r) => r.file)).toEqual(['src/rules/a.md', 'src/rules/b.md']);
+    });
+
+    it('leaves already-relative keys untouched', () => {
+        const out = reg._relativise(
+            { results: [{ file: 'src/rules/a.md', status: 'pass' }] },
+            '/tmp/lint-baseline-abc',
+        );
+        expect((out.results ?? [])[0]?.file).toBe('src/rules/a.md');
+    });
+
+    it('does not strip a path that merely shares a prefix segment', () => {
+        const out = reg._relativise(
+            { results: [{ file: '/tmp/lint-baseline-abcdef/src/a.md', status: 'pass' }] },
+            '/tmp/lint-baseline-abc',
+        );
+        expect((out.results ?? [])[0]?.file).toBe('/tmp/lint-baseline-abcdef/src/a.md');
+    });
+
+    it('preserves status and issues while re-rooting', () => {
+        const out = reg._relativise(
+            {
+                results: [
+                    {
+                        file: '/tmp/wt/src/rules/a.md',
+                        status: 'fail',
+                        issues: [{ code: 'missing_frontmatter' }],
+                    },
+                ],
+            },
+            '/tmp/wt',
+        );
+        const map = reg.build_status_map(out);
+        expect(map['src/rules/a.md']?.status).toBe('fail');
+        expect([...(map['src/rules/a.md']?.codes ?? [])]).toEqual(['missing_frontmatter']);
+    });
+});
+
+describe('lint_regression empty-baseline guard', () => {
+    it('an empty baseline against a populated tree is not comparable', () => {
+        // The pre-fix behaviour: compare() reports every current finding as a
+        // "new file", which is what made the gate fire on an unmodified tree.
+        // main() now refuses the run instead; this pins the shape the guard
+        // exists to reject.
+        const delta = reg.compare({}, {
+            'src/rules/a.md': { status: 'pass_with_warnings', codes: new Set(['long_rule']) },
+        });
+        expect(delta.new_files.map((nf) => nf.file)).toEqual(['src/rules/a.md']);
+        expect(delta.regressions).toEqual([]);
+    });
+});


### PR DESCRIPTION
`task preflight` reported `1 new file(s) with issues: src/rules/preservation-guard.md` on an **unmodified tree** — reproducible on a clean `main` checkout, not just on a branch. Two defects were stacked, and either one alone makes every real regression unreportable, because a regression requires the file to be present in both maps.

## Defect 1 — the baseline never ran

`git worktree add` checks out tracked files only, so the detached baseline worktree has no `node_modules` and the linter dies on its first bare import:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yaml' imported from
  /tmp/lint-baseline-XXXX/src/scripts/validate_frontmatter.ts
```

`run_linter_json` then returned `{results: [], summary: {}}` for that failure — the **same** value it returns for the two deliberate degradations (no linter in the ref; a pre-migration `.py` baseline with no `python3`). A broken run was therefore indistinguishable from "nothing to compare".

With an empty baseline, `compare()` classifies every current finding as a *new file*. The repo has exactly one non-pass file (429 pass / 1 `pass_with_warnings` out of 430), so the gate reported exactly that one, every time, on every branch.

## Defect 2 — the keys never matched

Once the baseline does collect, it runs with `--repo-root <tmpdir>` and emits absolute paths, while the working-tree run emits repo-relative ones:

```
BASELINE  /private/tmp/lb-XXXX/src/agent-src/personas/ai-agent.md
CURRENT   src/agent-src/personas/ai-agent.md
```

The two maps share no key at all, so every comparison was vacuous.

## Why the existing guard caught neither

The disjoint-result guard fires only when **both** sides are non-empty:

```ts
if (baseKeys.length && currKeys.length && !shared) { ... return 2; }
```

An empty baseline is exactly the case it exempts — and it is the worse failure of the two.

## The fix

- Symlink the repo's `node_modules` into the baseline worktree so the baseline linter can resolve its imports. Only dependency resolution is borrowed; the baseline still runs the ref's own linter against the ref's own artefacts.
- Raise `BaselineCollectionError` (exit 2, with the real stderr) when a spawned baseline produces no output, instead of degrading to an empty baseline. The two documented empty-baseline paths keep their behaviour unchanged.
- Re-root baseline keys onto repo-relative paths (`_relativise`), with prefix matching on a path separator so a sibling directory sharing a name prefix is not stripped.
- Close the guard's blind spot: an empty baseline against a populated current tree is refused rather than reported.

## Verified both directions on the real repo

| Scenario | Before | After |
|---|---|---|
| Unmodified branch vs `main` | `1 new file(s) with issues` (false red) | `No regressions detected` |
| A deliberately broken new rule file | would also report 1 (indistinguishable) | `src/rules/zzz-probe.md: fail [missing_frontmatter]` |

The probe file was created, observed, and removed; the tree is clean. This PR's own push passed the pre-push preflight, which is the fix exercising itself.

## Tests

Five new assertions covering prefix stripping, already-relative keys, the sibling-prefix near-miss, status/issue preservation through the re-rooting, and the empty-baseline shape the guard now rejects. `tests/scripts/lint_regression.test.ts`: 17 passed. Typecheck and ESLint clean on both changed files.
