### PR TITLE
fix(ci): discriminate dead scope from verified-empty release in corpus gates

### DIFF
--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -256,20 +256,41 @@ jobs:
           # Release-aware: on a release PR the base widens to the previous
           # release tag, because the PR's own diff is the version bump.
           BASE="$(./scripts-run src/scripts/resolve_lint_scope --base-ref "origin/${{ github.base_ref }}")"
-          CHANGED=$(git diff --name-only --diff-filter=ACMR "${BASE}...HEAD" -- \
+          # The diff must run cleanly — a missing tag object or bad ref would
+          # otherwise be swallowed into an empty change set and be
+          # indistinguishable from a genuinely empty span.
+          if ! DIFF_OUT=$(git diff --name-only --diff-filter=ACMR "${BASE}...HEAD" -- \
             'src/skills/*/SKILL.md' \
             'src/agent-src/personas/*.md' \
-            'src/domains/**/command.md' \
-            | grep -v '^src/agent-src/personas/_' || true)
+            'src/domains/**/command.md'); then
+            echo "::error::git diff for ${BASE}...HEAD failed — the scope is unresolvable, not empty."
+            exit 1
+          fi
+          CHANGED=$(printf '%s\n' "$DIFF_OUT" | grep -v '^src/agent-src/personas/_' || true)
           if [ -z "$CHANGED" ]; then
             # Same guard shape as the skill-lint PR summary: an empty changed
             # set means the gate checked nothing — report it, never claim a pass.
             echo "⚠️ INCONCLUSIVE — 0 changed corpus files (skills / personas / domain commands); the originality gate checked nothing. This is not a pass."
-            # On a release PR it is also not an outcome. The scope resolved to a
-            # whole tag span; matching nothing there means the gate is blind,
-            # which is precisely what shipped a 179-commit release unchecked.
+            # On a release PR the scope resolved to a whole tag span. Matching
+            # nothing there is EITHER a blind gate (the shape that shipped a
+            # 179-commit release unchecked — dead pathspec, empty span) OR a
+            # release that genuinely changes no corpus file (scripts-/docs-only
+            # release). Discriminate instead of failing both: the pathspecs
+            # must still resolve to tracked files at HEAD (a moved corpus root
+            # fails this probe exactly as it would blind the diff), and the
+            # span must contain real commits.
             if [ "${BASE}" != "origin/${{ github.base_ref }}" ]; then
-              echo "::error::Release PR resolved scope ${BASE}...HEAD and still matched 0 corpus files — a release check that examined nothing must not pass."
+              LIVE=$(git ls-files -- \
+                'src/skills/*/SKILL.md' \
+                'src/agent-src/personas/*.md' \
+                'src/domains/**/command.md' \
+                | grep -cv '^src/agent-src/personas/_' || true)
+              SPAN=$(git rev-list --count "${BASE}..HEAD")
+              if [ "${LIVE}" -gt 0 ] && [ "${SPAN}" -gt 0 ]; then
+                echo "✅ Verified-empty release scope: ${SPAN} commit(s) in ${BASE}...HEAD touch none of the ${LIVE} tracked corpus files — the pathspecs are alive at HEAD, so the gate is not blind; this release genuinely contains no corpus changes."
+                exit 0
+              fi
+              echo "::error::Release PR resolved scope ${BASE}...HEAD and matched 0 corpus files while the corpus pathspecs resolve to ${LIVE} tracked file(s) and the span holds ${SPAN} commit(s) — the scope is dead, not empty."
               exit 1
             fi
             exit 0

--- a/src/scripts/skill_linter.ts
+++ b/src/scripts/skill_linter.ts
@@ -4231,11 +4231,9 @@ function _release_scope_requires_findings(root: string, since?: string | null): 
  * "empty because nothing changed".
  */
 function _changed_filter_matches_head(root: string): boolean {
-    const result = runCountedProbe(
-        'git',
-        ['ls-files', '--', 'dist/agent-src', '.agent-src.uncondensed'],
-        { cwd: root },
-    );
+    // Probes the canonical projection root only (ADR-051): a corpus that
+    // exists solely under a legacy path counts as dead, not alive.
+    const result = runCountedProbe('git', ['ls-files', '--', 'dist/agent-src'], { cwd: root });
     if (!result.ok) {
         return false;
     }
@@ -4244,12 +4242,7 @@ function _changed_filter_matches_head(root: string): boolean {
         if (!norm || norm.includes('/evals/')) {
             continue;
         }
-        const inSource =
-            norm.startsWith('.agent-src.uncondensed/') ||
-            norm.startsWith('dist/agent-src/') ||
-            norm.includes('/.agent-src.uncondensed/') ||
-            norm.includes('/dist/agent-src/');
-        if (!inSource) {
+        if (!norm.startsWith('dist/agent-src/') && !norm.includes('/dist/agent-src/')) {
             continue;
         }
         if (

--- a/src/scripts/skill_linter.ts
+++ b/src/scripts/skill_linter.ts
@@ -2440,6 +2440,16 @@ export function gather_candidate_files_under(srcRoot: string): string[] {
 export let last_changed_scope_reason = '';
 
 /**
+ * Whether the base-span diff (`base...HEAD`) itself ran cleanly.
+ *
+ * The verified-empty release outcome (see `main`) may only rest on an empty
+ * change set that was actually COMPUTED — a base diff that errored (missing
+ * tag object, corrupt ref) degrades to the worktree fallbacks and would
+ * otherwise be indistinguishable from a genuinely empty span.
+ */
+export let last_changed_base_diff_ok = false;
+
+/**
  * Candidate files changed against the resolved base.
  *
  * The base is release-aware (`_lib/release_scope.ts`): on a release PR it
@@ -2454,6 +2464,7 @@ export let last_changed_scope_reason = '';
 export function gather_changed_candidate_files(root: string, since?: string | null): string[] {
     const scope = resolveContentLintScope({ cwd: root, since: since ?? null });
     last_changed_scope_reason = scope.reason;
+    last_changed_base_diff_ok = false;
     const diffCommands = [
         ['git', 'diff', '--name-only', `${scope.base}...HEAD`],
         ['git', 'diff', '--name-only', '--cached', 'HEAD'],
@@ -2461,10 +2472,15 @@ export function gather_changed_candidate_files(root: string, since?: string | nu
     ];
     try {
         let rawLines: string[] = [];
+        let first = true;
         for (const cmd of diffCommands) {
             // A truncated diff would silently shrink the change set — the same
             // degrade-to-zero shape this roadmap closes elsewhere.
             const result = runCountedProbe(cmd[0] as string, cmd.slice(1), { cwd: root });
+            if (first) {
+                last_changed_base_diff_ok = result.ok;
+                first = false;
+            }
             if (result.ok && result.stdout.trim()) {
                 rawLines = splitlines(result.stdout);
                 break;
@@ -4202,6 +4218,50 @@ function _release_scope_requires_findings(root: string, since?: string | null): 
     return scope.isRelease && scope.previousTag !== null;
 }
 
+/**
+ * True when the `--changed` corpus filter still matches tracked files at HEAD.
+ *
+ * The discriminator between a DEAD scope and a VERIFIED-EMPTY release span.
+ * A release that touches no skill/rule file is a legitimate outcome — but only
+ * provably so when the exact predicate `gather_changed_candidate_files`
+ * applies to diff lines demonstrably still sees the corpus. Probing
+ * `git ls-files` with that same predicate means a moved projection root
+ * (the ADR-051 blindness class) fails this probe exactly as it would blind
+ * the diff — so "empty because the root moved" cannot masquerade as
+ * "empty because nothing changed".
+ */
+function _changed_filter_matches_head(root: string): boolean {
+    const result = runCountedProbe(
+        'git',
+        ['ls-files', '--', 'dist/agent-src', '.agent-src.uncondensed'],
+        { cwd: root },
+    );
+    if (!result.ok) {
+        return false;
+    }
+    for (const raw of splitlines(result.stdout)) {
+        const norm = raw.trim().replace(/\\/g, '/');
+        if (!norm || norm.includes('/evals/')) {
+            continue;
+        }
+        const inSource =
+            norm.startsWith('.agent-src.uncondensed/') ||
+            norm.startsWith('dist/agent-src/') ||
+            norm.includes('/.agent-src.uncondensed/') ||
+            norm.includes('/dist/agent-src/');
+        if (!inSource) {
+            continue;
+        }
+        if (
+            norm.endsWith('/SKILL.md') ||
+            (norm.endsWith('.md') && (norm.includes('/rules/') || norm.includes('/commands/')))
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export function main(argv: string[]): number {
     let args: Args;
     try {
@@ -4244,25 +4304,39 @@ export function main(argv: string[]): number {
                 process.stdout.write(`${format_json([])}\n`);
             }
             // A release PR that resolved a real tag span and still matched
-            // nothing has not passed — it examined nothing. Mirrors the
-            // scan-scope regime the other gates already adopted
+            // nothing needs a discriminator: DEAD scope (the diff errored, or
+            // the corpus filter no longer matches anything at HEAD — the
+            // ADR-051 moved-root blindness) fails; VERIFIED-EMPTY (the base
+            // diff ran cleanly AND the filter provably still sees tracked
+            // corpus files) is a legitimate release that simply changed no
+            // skill/rule — failing it would red every scripts-/docs-only
+            // release forever. Mirrors the scan-scope regime
             // (`_lib/scan_scope.ts`; exit 2, as `check_iron_law_prominence`).
             // Ordinary PRs keep the historical exit 0: a change set with no
             // skill or rule in it is a legitimate empty scope, not a dead one.
             if (args.changed && _release_scope_requires_findings(root, args.since)) {
-                try {
-                    assertScanned({
-                        gate: 'skill_linter --changed (release PR)',
-                        scanned: 0,
-                        units: 'skill/rule files',
-                        roots: [last_changed_scope_reason],
-                    });
-                } catch (exc) {
-                    if (exc instanceof DeadScopeError) {
-                        process.stderr.write(`❌  ${exc.message}\n`);
-                        return 2;
+                if (last_changed_base_diff_ok && _changed_filter_matches_head(root)) {
+                    process.stderr.write(
+                        '✅  verified-empty release scope: the base-span diff ran cleanly and ' +
+                            'the corpus filter still matches tracked files at HEAD — this ' +
+                            'release genuinely changes no skill/rule file. The gate is alive, ' +
+                            'not blind.\n',
+                    );
+                } else {
+                    try {
+                        assertScanned({
+                            gate: 'skill_linter --changed (release PR)',
+                            scanned: 0,
+                            units: 'skill/rule files',
+                            roots: [last_changed_scope_reason],
+                        });
+                    } catch (exc) {
+                        if (exc instanceof DeadScopeError) {
+                            process.stderr.write(`❌  ${exc.message}\n`);
+                            return 2;
+                        }
+                        throw exc;
                     }
-                    throw exc;
                 }
             }
             process.stderr.write('No matching skill/rule files found.\n');

--- a/tests/scripts/skill_linter.test.ts
+++ b/tests/scripts/skill_linter.test.ts
@@ -7,10 +7,11 @@
 // The golden-parity tests against the Python original were removed with the
 // depythonization; their `spawnSync` + `TSX_BIN` helpers were left behind as
 // orphans and are removed here.
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     type Issue,
@@ -21,6 +22,7 @@ import {
     format_json,
     lint_file,
     lint_output_schema,
+    main,
     parse_output_schema,
     validate_evals_json,
     _resetRoleContractCacheForTest,
@@ -2281,3 +2283,88 @@ describe('skill_linter — structural malice', () => {
 });
 
 
+
+describe('skill_linter --changed — release-PR empty-scope discriminator', () => {
+    function gitq(cwd: string, ...args: string[]): void {
+        execFileSync('git', args, { cwd, encoding: 'utf-8' });
+    }
+
+    /**
+     * A release-PR repo (prior tag + version bump) whose release span contains
+     * NO skill/rule change. With `corpus: true` a tracked SKILL.md exists at
+     * HEAD (unchanged since the prior tag) — the filter is provably alive and
+     * the empty span is VERIFIED-EMPTY. With `corpus: false` the filter
+     * matches nothing at HEAD — the DEAD-scope shape (ADR-051 moved root).
+     */
+    function releaseRepoWithoutCorpusChange(opts: { corpus: boolean }): string {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'linter-release-'));
+        gitq(root, 'init', '-q', '-b', 'main');
+        gitq(root, 'config', 'user.email', 't@example.com');
+        gitq(root, 'config', 'user.name', 'T');
+
+        fs.writeFileSync(path.join(root, 'package.json'), '{\n  "version": "9.11.0"\n}\n');
+        fs.writeFileSync(
+            path.join(root, 'CHANGELOG.md'),
+            '# Changelog\n\n## [9.11.0](x) (2026-01-01)\n',
+        );
+        if (opts.corpus) {
+            const skillDir = path.join(root, 'dist', 'agent-src', 'skills', 'sample');
+            fs.mkdirSync(skillDir, { recursive: true });
+            fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# sample\n');
+        }
+        fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'src', 'a.txt'), 'one\n');
+        gitq(root, 'add', '-A');
+        gitq(root, 'commit', '-qm', 'base');
+        gitq(root, 'tag', '9.11.0');
+
+        // Substantive release work — deliberately NOT a corpus file.
+        fs.writeFileSync(path.join(root, 'src', 'a.txt'), 'one\ntwo\n');
+        gitq(root, 'commit', '-aqm', 'feat: scripts-only work');
+
+        // `main` invokes the resolver with its default base `origin/main`;
+        // give the fixture that ref so release detection has a base to diff.
+        gitq(root, 'update-ref', 'refs/remotes/origin/main', 'refs/heads/main');
+
+        gitq(root, 'checkout', '-qb', 'release/9.12.0');
+        fs.writeFileSync(path.join(root, 'package.json'), '{\n  "version": "9.12.0"\n}\n');
+        fs.writeFileSync(
+            path.join(root, 'CHANGELOG.md'),
+            '# Changelog\n\n## [9.12.0](x) (2026-02-01)\n\n## [9.11.0](x) (2026-01-01)\n',
+        );
+        gitq(root, 'commit', '-aqm', 'release: 9.12.0');
+        return root;
+    }
+
+    it('a release that changes no skill/rule passes as VERIFIED-EMPTY when the corpus filter is alive at HEAD', () => {
+        const root = releaseRepoWithoutCorpusChange({ corpus: true });
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+        try {
+            const code = main(['--changed', '--repo-root', root]);
+            const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+            expect(code).toBe(0);
+            expect(stderr).toContain('verified-empty release scope');
+        } finally {
+            stderrSpy.mockRestore();
+            stdoutSpy.mockRestore();
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('a release span matching nothing while the corpus filter matches nothing at HEAD stays a DEAD-scope failure (exit 2)', () => {
+        const root = releaseRepoWithoutCorpusChange({ corpus: false });
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+        const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+        try {
+            const code = main(['--changed', '--repo-root', root]);
+            const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+            expect(code).toBe(2);
+            expect(stderr).toContain('scanned 0 skill/rule files');
+        } finally {
+            stderrSpy.mockRestore();
+            stdoutSpy.mockRestore();
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Problem

`skill-lint` and `originality-gate` widen their scope on a release PR to `prev_tag...HEAD` and treat 0 matched corpus files as a hard failure (the anti-blindness guard added after the 179-commit unchecked release). A release that legitimately changes no skill/rule/persona/command file — a scripts- or docs-only release like 9.14.0 — can therefore never go green, and `task release` fails with "PR checks failed".

## Fix

Both gates now discriminate a DEAD scope from a VERIFIED-EMPTY release span instead of failing both:

- **`skill_linter --changed`** — an empty release span passes only when the base-span diff ran cleanly (`last_changed_base_diff_ok`) AND the exact `--changed` corpus predicate still matches tracked files at HEAD via `git ls-files` (`_changed_filter_matches_head`, canonical `dist/agent-src` root only per ADR-051). A moved corpus root or a failed diff keeps the exit-2 dead-scope failure.
- **`originality-gate`** (`skill-lint.yml`) — same discriminator in shell: pathspecs must resolve to >0 tracked files at HEAD and the span must hold >0 commits. Additionally, an error from `git diff` itself is no longer swallowed into an empty change set (`|| true` removed from the diff invocation) — an unresolvable scope now fails distinctly instead of masquerading as empty.

## Verification

- 2 new tests pin both paths (verified-empty exit 0 / dead-scope exit 2) — `tests/scripts/skill_linter.test.ts` § "release-PR empty-scope discriminator"
- All 134 skill_linter tests, release_scope + lint_originality suites green; typecheck-ts + ESLint clean
- Live on `release/9.14.0`: `skill_linter --changed` → verified-empty, exit 0; Skill Lint workflow run 30747897964 green with these changes at HEAD