### PR TITLE
feat(release): name failing checks + mid-release-fix guidance at the failure point

### DIFF
--- a/docs/contracts/release-pr-gating.md
+++ b/docs/contracts/release-pr-gating.md
@@ -47,6 +47,31 @@ out-of-allowlist entry otherwise. It reads the diff shape only — it does
 not check the PR author, so it passes identically for a `task
 release`-opened PR and a `release.yml`-opened one.
 
+## Mid-release fixes — land on main, never on the release branch
+
+A fix discovered while a release PR is red (a broken gate, a CI bug) must
+**not** be committed onto `release/X.Y.Z`: any non-allowlist file makes the
+shape detector red by design, because the cut surface below skips the heavy
+test matrix on `release/*` heads — code riding a release PR would bypass it.
+There is deliberately no escape hatch or override label.
+
+The conforming procedure:
+
+1. Branch off `origin/main`, cherry-pick (or author) the fix, open its own
+   PR — the full test matrix runs there.
+2. After that PR merges: `git checkout release/X.Y.Z && git merge
+   origin/main && git push`. The fix files are now identical on both sides
+   of the release PR, so its diff shrinks back to the allowlist and the
+   shape detector goes green — while the fix is present at the release
+   head for every other gate.
+3. Extend the release's CHANGELOG entry with the post-cut commits
+   (`CHANGELOG.md` is on the allowlist) and refresh the `Tests: N` footer.
+4. Resume with `task release -- --resume --yes`.
+
+Both failure surfaces point here: `check_release_pr_shape.ts` prints this
+procedure under its `OUT-OF-SHAPE` findings, and `release.ts` §
+`watch_pr_checks` names the failing checks and repeats the resume command.
+
 ## Cut surface — heavy jobs that skip on release PRs
 
 Skipped via `if: !startsWith(github.head_ref, 'release/')` guards on the

--- a/src/scripts/check_release_pr_shape.ts
+++ b/src/scripts/check_release_pr_shape.ts
@@ -131,6 +131,16 @@ function check(files: readonly string[]): number {
         for (const f of bad) {
             process.stdout.write(`OUT-OF-SHAPE: ${f}\n`);
         }
+        process.stdout.write(
+            '\n' +
+                'A release PR may only contain the version-bump allowlist — the heavy\n' +
+                'test matrix skips on release/* heads, so code must not ride a release PR\n' +
+                '(docs/contracts/release-pr-gating.md § Mid-release fixes).\n' +
+                'Fix: land the files above on main via their own PR, then\n' +
+                '  git checkout release/X.Y.Z && git merge origin/main && git push\n' +
+                '— their release-PR diff becomes empty and this check goes green.\n' +
+                'Then resume with: task release -- --resume --yes\n',
+        );
         return 1;
     }
     process.stdout.write(

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -563,6 +563,65 @@ function git(args: readonly string[], opts: { capture?: boolean } = {}): string 
 }
 
 /**
+ * One name per failing check, from `gh pr checks --json name,bucket` output.
+ *
+ * Pure over the JSON text so the shape is testable without gh. Returns []
+ * when the payload is unparseable or nothing sits in the `fail` bucket —
+ * the caller then falls back to the raw watch output alone.
+ */
+export function _failed_check_names(jsonText: string): string[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(jsonText);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) {
+        return [];
+    }
+    const names: string[] = [];
+    for (const entry of parsed) {
+        if (typeof entry !== 'object' || entry === null) {
+            continue;
+        }
+        const e = entry as Record<string, unknown>;
+        if (e['bucket'] === 'fail' && typeof e['name'] === 'string') {
+            names.push(e['name']);
+        }
+    }
+    return names;
+}
+
+/**
+ * Remediation lines for a set of failing check names.
+ *
+ * The watch table scrolls failures out of view on a busy PR, so the operator
+ * repeatedly saw only `pass`/`skipping` rows plus "PR checks failed" — the
+ * 9.14.0 failure mode, twice. Name the red checks explicitly and, for the
+ * shape detector, say where the fix belongs (main, never the release branch).
+ */
+export function _failed_checks_report(names: readonly string[]): string {
+    if (names.length === 0) {
+        return '';
+    }
+    const lines: string[] = ['', 'Failing check(s):'];
+    for (const name of names) {
+        lines.push(`  ❌ ${name}`);
+    }
+    if (names.includes('Release-PR shape detector')) {
+        lines.push(
+            '',
+            'Release-PR shape: a release PR may only contain the version-bump',
+            'allowlist. Land the out-of-shape files on main via their own PR, then',
+            'merge main into the release branch — their release-PR diff becomes',
+            'empty (docs/contracts/release-pr-gating.md § Mid-release fixes).',
+        );
+    }
+    lines.push('', 'After fixing, resume with: task release -- --resume --yes', '');
+    return lines.join('\n');
+}
+
+/**
  * Watch PR checks and tolerate the 'no checks' case.
  *
  * `gh pr checks --watch` exits 1 both on real failures and when no checks are
@@ -605,6 +664,15 @@ function watch_pr_checks(): void {
     }
     if (output) {
         process.stderr.write(output + '\n');
+    }
+    const summary = spawnSync('gh', ['pr', 'checks', '--json', 'name,bucket'], {
+        cwd: REPO_ROOT,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const report = _failed_checks_report(_failed_check_names(summary.stdout ?? ''));
+    if (report) {
+        process.stderr.write(report + '\n');
     }
     die(`PR checks failed (exit ${returncode})`);
 }

--- a/tests/scripts/check_release_pr_shape.test.ts
+++ b/tests/scripts/check_release_pr_shape.test.ts
@@ -1,18 +1,7 @@
 
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import * as shape from '../../src/scripts/check_release_pr_shape.js';
-
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'check_release_pr_shape.ts');
-const TSX_BIN = path.join(
-    REPO_ROOT,
-    'node_modules',
-    '.bin',
-    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
 
 function runCheck(files: readonly string[]): { code: number; out: string } {
     const out: string[] = [];
@@ -120,5 +109,21 @@ describe('check_release_pr_shape — check() (ported pytest)', () => {
         expect(shape._matches('src/packs/core/pack.yaml')).toBe(true);
         expect(shape._matches('src/packs/core/README.md')).toBe(true);
         expect(shape._matches('docs/archive/CHANGELOG-pre-5.4.0.md')).toBe(true);
+    });
+});
+
+describe('check_release_pr_shape — mid-release-fix remediation hint', () => {
+    it('an out-of-shape finding carries the land-on-main procedure', () => {
+        const { code, out } = runCheck(['package.json', 'src/scripts/skill_linter.ts']);
+        expect(code).toBe(1);
+        expect(out).toContain('OUT-OF-SHAPE: src/scripts/skill_linter.ts');
+        expect(out).toContain('land the files above on main via their own PR');
+        expect(out).toContain('task release -- --resume --yes');
+    });
+
+    it('a shape-clean diff carries no remediation prose', () => {
+        const { code, out } = runCheck(['package.json', 'CHANGELOG.md']);
+        expect(code).toBe(0);
+        expect(out).not.toContain('land the files above on main');
     });
 });

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -44,6 +44,8 @@ import {
     _count_from_list_result,
     _TEST_LIST_MAX_BUFFER,
     _detect_in_flight_target,
+    _failed_check_names,
+    _failed_checks_report,
     Commit,
     SystemExitError,
     CONVENTIONAL_RE,
@@ -783,5 +785,44 @@ describe('dedupe_commit_lines', () => {
         const bullets = body.split('\n').filter((l) => l.startsWith('* '));
         expect(new Set(bullets).size).toBe(bullets.length);
         expect(bullets).toHaveLength(1);
+    });
+});
+
+describe('watch_pr_checks — failing-check summary (the scrolled-away-failure fix)', () => {
+    it('extracts only fail-bucket names from gh pr checks --json output', () => {
+        const payload = JSON.stringify([
+            { bucket: 'pass', name: 'skill-lint' },
+            { bucket: 'fail', name: 'Release-PR shape detector' },
+            { bucket: 'skipping', name: 'Node Tests (${{ matrix.os }}, shard ${{ matrix.shard }}/4)' },
+            { bucket: 'fail', name: 'originality-gate' },
+        ]);
+        expect(_failed_check_names(payload)).toEqual([
+            'Release-PR shape detector',
+            'originality-gate',
+        ]);
+    });
+
+    it('degrades to [] on unparseable or non-array payloads', () => {
+        expect(_failed_check_names('')).toEqual([]);
+        expect(_failed_check_names('not json')).toEqual([]);
+        expect(_failed_check_names('{"bucket":"fail"}')).toEqual([]);
+    });
+
+    it('names every failing check and always carries the resume command', () => {
+        const report = _failed_checks_report(['skill-lint', 'originality-gate']);
+        expect(report).toContain('❌ skill-lint');
+        expect(report).toContain('❌ originality-gate');
+        expect(report).toContain('task release -- --resume --yes');
+        expect(report).not.toContain('Release-PR shape:');
+    });
+
+    it('adds the land-on-main procedure only when the shape detector failed', () => {
+        const report = _failed_checks_report(['Release-PR shape detector']);
+        expect(report).toContain('Release-PR shape:');
+        expect(report).toContain('merge main into the release branch');
+    });
+
+    it('an empty name list yields an empty report — raw watch output stands alone', () => {
+        expect(_failed_checks_report([])).toBe('');
     });
 });


### PR DESCRIPTION
## Problem

Twice during the 9.14.0 release the operator saw only `pass`/`skipping` rows plus `error: PR checks failed (exit 1)` — the actual failing checks had scrolled out of the `gh pr checks --watch` table. And when the failing check was the Release-PR shape detector, its output named the out-of-shape files but not the (deliberately escape-hatch-free) remediation, inviting exactly the wrong fix: committing onto the release branch.

## Change

- **`release.ts` § `watch_pr_checks`** — on failure, fetch `gh pr checks --json name,bucket` and print every fail-bucket check by name; when `Release-PR shape detector` is among them, append the land-on-main procedure; always close with the resume command (`task release -- --resume --yes`). Extracted as two pure helpers (`_failed_check_names`, `_failed_checks_report`) so the shape is test-pinned without gh.
- **`check_release_pr_shape.ts`** — `OUT-OF-SHAPE` findings now carry the remediation block (fixes land on main via their own PR, then merge main into the release branch; the release-PR diff shrinks back to the allowlist). Shape-clean output is unchanged.
- **`docs/contracts/release-pr-gating.md`** — new § *Mid-release fixes — land on main, never on the release branch* documenting the 4-step procedure both failure surfaces point at.
- **`tests/scripts/check_release_pr_shape.test.ts`** — removed the dead `TS_SCRIPT`/`TSX_BIN` py2ts-port leftovers; the changed-files lint now covers this file and flags them.

## Verification

- 7 new tests (5 release.ts helper pins, 2 shape-hint pins); release suite 88 → 93, shape suite 11 → 13, all green
- `task typecheck-ts` + ESLint on the changed files clean