### PR TITLE
fix(hooks): resolve the session-canary name user-globally, not per project

### DIFF
--- a/dist/agent-src/rules/session-canary.md
+++ b/dist/agent-src/rules/session-canary.md
@@ -21,7 +21,12 @@ two small, always-expected reply markers whose **silent disappearance** tells
 the user the conversation is degrading and it is time for a fresh session —
 long before the agent visibly starts making mistakes.
 
-Read `personal.canary_name` from `.agent-settings.yml`. Empty or missing →
+The canary is a **personal, user-global** concern — the name resolves through
+three layers, first non-empty wins: project `.agent-settings.yml` →
+`personal.canary_name` (override only) · user-global
+`settings/.agent-settings.yml` → `personal.canary_name` · user-global
+`settings/.agent-user.yml` → `identity.name` (the name the setup wizard
+already collects — never duplicate it per project). No name on any layer →
 rule is inert.
 
 ## The Iron Law
@@ -55,7 +60,8 @@ name it and suggest a fresh session or `/agent-handoff`, per
 
 ## When NOT to fire
 
-- `personal.canary_name` empty or missing — fully inert, no greeting.
+- No name on any layer (`personal.canary_name` project + user-global, global
+  `identity.name`) — fully inert, no greeting.
 - Intermediate replies inside an ongoing task (greeting only at task start).
 - The greeting never substitutes for substance — it prefixes the answer, it is
   not the answer.

--- a/dist/install/install.mjs
+++ b/dist/install/install.mjs
@@ -14394,7 +14394,7 @@ var settingsSchema = external_exports.object({
       "Prefer short bullets and tables (true, default) vs verbose prose with rationale (false). Affects every chat reply; flip to false during debugging when you want the agent to think out loud."
     ),
     canary_name: external_exports.string().default("").describe(
-      'Session canary \u2014 the name the agent addresses you with at the start of every new task (e.g. "Alex"). When the greeting silently disappears, the context window is degrading: start a fresh conversation. Also keeps the reply-close markers (end-summary, PR URL as literal last line) alive. Empty = off. See rules/session-canary.md.'
+      'Session canary \u2014 the name the agent addresses you with at the start of every new task (e.g. "Alex"). When the greeting silently disappears, the context window is degrading: start a fresh conversation. Also keeps the reply-close markers (end-summary, PR URL as literal last line) alive. Empty = fall back to the user-global canary_name, then to identity.name from the setup wizard; no name anywhere = off. See rules/session-canary.md.'
     ),
     play_by_play: external_exports.boolean().default(false).describe(
       `Narrate intermediate findings between tool calls ("Found it.", "Let me check Y."). Off by default \u2014 most users find it noisy. Turn on when you want to follow the agent's reasoning step by step.`

--- a/src/config/agent-settings.template.yml
+++ b/src/config/agent-settings.template.yml
@@ -275,7 +275,11 @@ personal:
   # greeting silently disappears, the context window is degrading and it is
   # time for a fresh conversation. Also keeps the reply-close markers alive
   # (ONE end-summary; PR URL as the literal last line).
-  # Empty = feature off. See rules/session-canary.md.
+  # Personal concern, resolved user-globally: empty here falls back to the
+  # user-global settings' personal.canary_name and then to identity.name in
+  # the wizard's settings/.agent-user.yml — set this key only to OVERRIDE
+  # the global name per project. No name on any layer = feature off.
+  # See rules/session-canary.md.
   canary_name: ""
 
   # Prefix PR comment replies with a bot icon 🤖 (true, false)

--- a/src/rules/session-canary.md
+++ b/src/rules/session-canary.md
@@ -21,7 +21,12 @@ two small, always-expected reply markers whose **silent disappearance** tells
 the user the conversation is degrading and it is time for a fresh session —
 long before the agent visibly starts making mistakes.
 
-Read `personal.canary_name` from `.agent-settings.yml`. Empty or missing →
+The canary is a **personal, user-global** concern — the name resolves through
+three layers, first non-empty wins: project `.agent-settings.yml` →
+`personal.canary_name` (override only) · user-global
+`settings/.agent-settings.yml` → `personal.canary_name` · user-global
+`settings/.agent-user.yml` → `identity.name` (the name the setup wizard
+already collects — never duplicate it per project). No name on any layer →
 rule is inert.
 
 ## The Iron Law
@@ -55,7 +60,8 @@ name it and suggest a fresh session or `/agent-handoff`, per
 
 ## When NOT to fire
 
-- `personal.canary_name` empty or missing — fully inert, no greeting.
+- No name on any layer (`personal.canary_name` project + user-global, global
+  `identity.name`) — fully inert, no greeting.
 - Intermediate replies inside an ongoing task (greeting only at task start).
 - The greeting never substitutes for substance — it prefixes the answer, it is
   not the answer.

--- a/src/scripts/session_canary_hook.ts
+++ b/src/scripts/session_canary_hook.ts
@@ -19,14 +19,25 @@
  * new conversation on hook-capable hosts. Copilot (no hook surface) falls back
  * to the rule alone.
  *
- * Gate: `personal.canary_name` non-empty. Missing settings file, missing key,
- * or empty value → clean no-op (exit 0, no stdout). Never blocks
+ * Gate + name resolution (first non-empty wins — the canary is a PERSONAL,
+ * user-global concern; the project file is only an override):
+ *
+ *   1. `<workspace_root>/.agent-settings.yml`            → `personal.canary_name`
+ *   2. `<event4u_root>/settings/.agent-settings.yml`     → `personal.canary_name`
+ *      (the wizard-managed user-global settings; legacy XDG root read as
+ *      fallback via `user_global_paths.resolve_with_fallback`)
+ *   3. `<event4u_root>/settings/.agent-user.yml`         → `identity.name`
+ *      (the global user identity the setup wizard already collects — no
+ *      per-project duplication of the name)
+ *
+ * No name anywhere → clean no-op (exit 0, no stdout). Never blocks
  * (fail_closed: false).
  */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { readHookStdin } from "./hooks/hook_stdin.js";
+import { resolve_with_fallback } from "./_lib/user_global_paths.js";
 
 const EXIT_ALLOW = 0;
 
@@ -71,6 +82,72 @@ export function read_canary_name(settings_path: string): string | null {
     }
   }
   return null;
+}
+
+/**
+ * Line-walker for `identity.name` in the wizard's user-global
+ * `settings/.agent-user.yml` — same no-YAML-dependency approach as
+ * `read_canary_name`. Returns the raw scalar or null when absent.
+ */
+export function read_identity_name(user_yml_path: string): string | null {
+  let text: string;
+  try {
+    if (!fs.statSync(user_yml_path).isFile()) {
+      return null;
+    }
+    text = fs.readFileSync(user_yml_path, "utf-8");
+  } catch {
+    return null;
+  }
+  let in_identity = false;
+  for (const line of text.split(/\r?\n/)) {
+    if (/^identity\s*:\s*(?:#.*)?$/.test(line)) {
+      in_identity = true;
+      continue;
+    }
+    if (in_identity && /^\S/.test(line)) {
+      in_identity = false; // left the identity: block
+    }
+    if (in_identity) {
+      const m = /^\s+name\s*:\s*(.*?)\s*(?:#.*)?$/.exec(line);
+      if (m && m[1] !== undefined) {
+        return m[1].trim();
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the canary name across the three layers (project override →
+ * user-global settings → user-global identity). First non-empty wins;
+ * an empty scalar at a layer means "not set here", not "feature off",
+ * so the walk continues to the next layer.
+ */
+export function resolve_canary_name(workspace_root: string): string {
+  const project = sanitize_name(
+    read_canary_name(path.join(workspace_root, SETTINGS_FILE)),
+  );
+  if (project) {
+    return project;
+  }
+  const global_settings = resolve_with_fallback(
+    path.join("settings", ".agent-settings.yml"),
+  );
+  if (global_settings) {
+    const name = sanitize_name(read_canary_name(global_settings));
+    if (name) {
+      return name;
+    }
+  }
+  const global_user = resolve_with_fallback(path.join("settings", ".agent-user.yml"));
+  if (global_user) {
+    const name = sanitize_name(read_identity_name(global_user));
+    if (name) {
+      return name;
+    }
+  }
+  return "";
 }
 
 /**
@@ -135,9 +212,9 @@ export function main(): number {
   }
 
   const root = _workspaceRoot(env);
-  const name = sanitize_name(read_canary_name(path.join(root, SETTINGS_FILE)));
+  const name = resolve_canary_name(root);
   if (!name) {
-    return EXIT_ALLOW; // canary not configured — clean no-op
+    return EXIT_ALLOW; // canary not configured on any layer — clean no-op
   }
 
   process.stdout.write(

--- a/src/server/schemas/settings.ts
+++ b/src/server/schemas/settings.ts
@@ -103,7 +103,7 @@ export const settingsSchema = z.object({
             'Prefer short bullets and tables (true, default) vs verbose prose with rationale (false). Affects every chat reply; flip to false during debugging when you want the agent to think out loud.',
         ),
         canary_name: z.string().default('').describe(
-            'Session canary — the name the agent addresses you with at the start of every new task (e.g. "Alex"). When the greeting silently disappears, the context window is degrading: start a fresh conversation. Also keeps the reply-close markers (end-summary, PR URL as literal last line) alive. Empty = off. See rules/session-canary.md.',
+            'Session canary — the name the agent addresses you with at the start of every new task (e.g. "Alex"). When the greeting silently disappears, the context window is degrading: start a fresh conversation. Also keeps the reply-close markers (end-summary, PR URL as literal last line) alive. Empty = fall back to the user-global canary_name, then to identity.name from the setup wizard; no name anywhere = off. See rules/session-canary.md.',
         ),
         play_by_play: z.boolean().default(false).describe(
             'Narrate intermediate findings between tool calls ("Found it.", "Let me check Y."). Off by default — most users find it noisy. Turn on when you want to follow the agent\'s reasoning step by step.',

--- a/tests/scripts/session_canary_hook.test.ts
+++ b/tests/scripts/session_canary_hook.test.ts
@@ -30,6 +30,28 @@ function makeWorkspace(settingsYaml: string | null): string {
   return dir;
 }
 
+/**
+ * Isolated user-global root (EVENT4U_CONFIG_HOME target). Empty by default so
+ * the pre-existing project-layer tests keep their no-global semantics; pass
+ * file contents to exercise the global fallback layers.
+ */
+function makeGlobalRoot(files: {
+  settingsYaml?: string;
+  userYaml?: string;
+} = {}): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-canary-global-"));
+  tmpDirs.push(dir);
+  const settingsDir = path.join(dir, "settings");
+  fs.mkdirSync(settingsDir, { recursive: true });
+  if (files.settingsYaml !== undefined) {
+    fs.writeFileSync(path.join(settingsDir, ".agent-settings.yml"), files.settingsYaml, "utf-8");
+  }
+  if (files.userYaml !== undefined) {
+    fs.writeFileSync(path.join(settingsDir, ".agent-user.yml"), files.userYaml, "utf-8");
+  }
+  return dir;
+}
+
 afterEach(() => {
   while (tmpDirs.length > 0) {
     const dir = tmpDirs.pop();
@@ -39,11 +61,17 @@ afterEach(() => {
   }
 });
 
-function run(envelope: unknown): { stdout: string; status: number | null } {
+function run(
+  envelope: unknown,
+  globalRoot?: string,
+): { stdout: string; status: number | null } {
   const r = spawnSync(TSX_BIN, [TS_SCRIPT], {
     encoding: "utf8",
     cwd: REPO_ROOT,
     input: typeof envelope === "string" ? envelope : JSON.stringify(envelope),
+    // Always pin the user-global root: without this, the dev machine's real
+    // ~/.event4u/agent-config/ would leak into the global-fallback layers.
+    env: { ...process.env, EVENT4U_CONFIG_HOME: globalRoot ?? makeGlobalRoot() },
   });
   expect(r.status).not.toBeNull();
   return { stdout: r.stdout as string, status: r.status };
@@ -119,5 +147,65 @@ describe("session_canary_hook", () => {
   it("survives a malformed envelope without blocking (exit 0)", () => {
     const { status } = run("this is not json");
     expect(status).toBe(0);
+  });
+
+  it("falls back to the user-global settings canary_name when the project has none", () => {
+    const root = makeWorkspace("quality:\n  local_auto_run: false\n");
+    const globalRoot = makeGlobalRoot({
+      settingsYaml: 'personal:\n  canary_name: "Globala"\n',
+    });
+    const out = JSON.parse(
+      run({ event: "session_start", workspace_root: root }, globalRoot).stdout,
+    );
+    expect(out.context).toContain('"Globala"');
+  });
+
+  it("falls back to the global identity.name when no canary_name is set anywhere", () => {
+    const root = makeWorkspace(null);
+    const globalRoot = makeGlobalRoot({
+      settingsYaml: 'personal:\n  canary_name: ""\n',
+      userYaml: "version: 1\nidentity:\n  name: Matze\nlanguage: de\n",
+    });
+    const out = JSON.parse(
+      run({ event: "session_start", workspace_root: root }, globalRoot).stdout,
+    );
+    expect(out.context).toContain('"Matze"');
+  });
+
+  it("project canary_name overrides both global layers", () => {
+    const root = makeWorkspace(SETTINGS_WITH_NAME);
+    const globalRoot = makeGlobalRoot({
+      settingsYaml: 'personal:\n  canary_name: "Globala"\n',
+      userYaml: "identity:\n  name: Matze\n",
+    });
+    const out = JSON.parse(
+      run({ event: "session_start", workspace_root: root }, globalRoot).stdout,
+    );
+    expect(out.context).toContain('"Mathias"');
+    expect(out.context).not.toContain("Globala");
+  });
+
+  it("ignores a top-level name key outside the identity: block", () => {
+    const root = makeWorkspace(null);
+    const globalRoot = makeGlobalRoot({
+      userYaml: "name: dev\nstyle:\n  name: fancy\n",
+    });
+    const { stdout, status } = run(
+      { event: "session_start", workspace_root: root },
+      globalRoot,
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("no-ops when all three layers are empty or missing", () => {
+    const root = makeWorkspace('personal:\n  canary_name: ""\n');
+    const globalRoot = makeGlobalRoot({});
+    const { stdout, status } = run(
+      { event: "session_start", workspace_root: root },
+      globalRoot,
+    );
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe("");
   });
 });


### PR DESCRIPTION
## Problem

The session-canary greeting never fired even though the setup wizard had already collected the user's name globally. `session_canary_hook.ts` only read `<workspace_root>/.agent-settings.yml` — a project-root-only lookup for what is a personal, user-global feature — so the canary required duplicating the name into every project's settings file.

## Fix

Name resolution is now a three-layer chain, first non-empty wins:

1. project `.agent-settings.yml` → `personal.canary_name` (override only)
2. user-global `settings/.agent-settings.yml` → `personal.canary_name`
3. user-global `settings/.agent-user.yml` → `identity.name` (the wizard identity — no per-project duplication)

Paths resolve via `user_global_paths.resolve_with_fallback`, so `EVENT4U_CONFIG_HOME` and the legacy XDG root keep working. An empty scalar on a layer means "not set here" and the walk continues; no name on any layer stays a clean no-op.

Docs updated to match: rule `session-canary.md`, the settings-template comment, and the wizard schema description (which is embedded in `dist/install/install.mjs` — bundle rebuilt, path-leakage and import-purity gates green).

## Tests

- 5 new cases: global-settings fallback, `identity.name` fallback, project override wins, no leak of `name:` keys outside the `identity:` block, all-layers-empty no-op.
- Every spawn now pins `EVENT4U_CONFIG_HOME` to an isolated temp root so the build machine's real `~/.event4u/agent-config/` cannot leak into fixtures.
- 13/13 green; `task typecheck-ts` green; projections in sync (`condense.sh --changed` clean).

Live probe with zero project config resolves the wizard identity: `session-canary: active for "Matze"`.