### PR TITLE
chore(deps): group dependabot majors + repair the visibility-sync channel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,14 +43,30 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
-    # web-tree-sitter is ABI-pinned to the tree-sitter-wasms grammars
-    # (0.24.7 ↔ 0.1.13, ABI 14). 0.25+ changes the load API and 0.26.x
-    # fails Language.load on the 0.1.13 grammars (tree-sitter #5171) —
-    # the code-graph ABI smoke test (tests/scripts/code_graph.test.ts)
-    # is the gate that catches it. Bump both packages together,
-    # deliberately, never via a scheduled group PR.
     ignore:
+      # web-tree-sitter is ABI-pinned to the tree-sitter-wasms grammars
+      # (0.24.7 ↔ 0.1.13, ABI 14). 0.25+ changes the load API and 0.26.x
+      # fails Language.load on the 0.1.13 grammars (tree-sitter #5171) —
+      # the code-graph ABI smoke test (tests/scripts/code_graph.test.ts)
+      # is the gate that catches it. Bump both packages together,
+      # deliberately, never via a scheduled group PR.
       - dependency-name: web-tree-sitter
+      # execa 10 raises the dependency's Node floor to >=22 while this
+      # package supports and CI-tests Node 20 (engines >=20.11.0). Taking
+      # it is a Node-baseline decision, not a dependency bump — lift this
+      # ignore when the package raises its Node floor (PR #1115).
+      - dependency-name: execa
+        update-types: ["version-update:semver-major"]
+      # zod 4 is a real migration: zod-to-json-schema call sites and the
+      # server route/wizard schemas break (26 typecheck errors), and the
+      # committed install bundle embeds zod. Migrate deliberately to zod 4's
+      # native z.toJSONSchema in its own PR, then lift this (PR #1131).
+      - dependency-name: zod
+        update-types: ["version-update:semver-major"]
+    # Majors are grouped too (npm-majors below): one collected weekly PR
+    # instead of one PR per major — the 2026-08-03 flood (execa, zod,
+    # @types/node, @inquirer/prompts, typescript, …) arrived as singles
+    # because the original groups only covered minor+patch.
     groups:
       npm-production:
         applies-to: version-updates
@@ -64,6 +80,10 @@ updates:
         update-types:
           - minor
           - patch
+      npm-majors:
+        applies-to: version-updates
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /
@@ -80,9 +100,14 @@ updates:
       prefix: chore
       include: scope
     groups:
+      # One collected PR for ALL action updates, majors included — action
+      # majors are runner-config changes, reviewable together; singles like
+      # setup-node 4→7 and sticky-pull-request-comment 2→3 each re-lint
+      # every touched workflow for no added review value.
       github-actions:
         applies-to: version-updates
         update-types:
+          - major
           - minor
           - patch
 
@@ -103,6 +128,7 @@ updates:
       site:
         applies-to: version-updates
         update-types:
+          - major
           - minor
           - patch
 
@@ -120,5 +146,6 @@ updates:
       telemetry-worker:
         applies-to: version-updates
         update-types:
+          - major
           - minor
           - patch

--- a/.github/workflows/sync-visibility.yml
+++ b/.github/workflows/sync-visibility.yml
@@ -30,9 +30,15 @@ on:
           - "true"
           - "false"
 
+# NOTE: `administration` is NOT a valid workflow permissions key — listing it
+# made the whole workflow unparseable, so `workflow_dispatch` returned HTTP 422
+# and the sync channel was dead (found 2026-08-03 while repairing an
+# about-description drift by hand). Repo metadata writes (PATCH /repos,
+# PUT /topics) need repo-admin rights the Actions GITHUB_TOKEN cannot carry;
+# the apply step fails with a clear API error in that case — dispatchable and
+# honest beats unparseable.
 permissions:
-  contents: write       # commit the audit log
-  administration: write # required for PUT /repos/{owner}/{repo}/topics
+  contents: write # commit the audit log
 
 concurrency:
   group: visibility-sync


### PR DESCRIPTION
## Dependabot — stop the single-PR flood

Majors fell outside every configured group (they covered only minor+patch), so each major arrived as its own PR — the 2026-08-03 flood (execa, zod, @types/node, @inquirer/prompts, typescript, setup-node, sticky-pull-request-comment) was seven separate PRs for one review sitting. Now:

- **Root npm:** new `npm-majors` group — all majors collected into ONE weekly PR; minor+patch keep their production/development groups.
- **github-actions:** the single group now takes majors too — one collected actions PR per cycle (action majors are runner-config changes; each single re-lints every touched workflow for no added review value).
- **site/ + telemetry-worker:** majors folded into the existing monthly single-group PRs.
- The command-issued ignores are now VISIBLE in the file with their lift conditions: `execa` major (Node-20 baseline, PR #1115) and `zod` major (zod-4 migration owed, PR #1131); `web-tree-sitter` stays fully ignored (ABI pin, PR #1114).

Net effect: at most one collected PR per ecosystem per cycle (weekly root npm + actions, monthly site + worker) instead of per-package singles.

## sync-visibility workflow was un-dispatchable

`administration: write` is not a valid workflow permissions key — the workflow failed to parse and `workflow_dispatch` returned HTTP 422, so the contract channel for repo-metadata sync was dead. Found while repairing the about-description drift by hand (someone had edited the description in the GitHub UI; `gh repo edit` restored the committed `about.yml` state — that unblocked the `drift-check` gate on PR #1132). The invalid key is removed with a NOTE; repo-metadata writes need admin rights the Actions GITHUB_TOKEN cannot carry, so the apply step now fails with a clear API error instead of the workflow being un-dispatchable.