### PR TITLE
fix(release): unblock 9.15.0 — shape allowlist + evaluator budget drift

### DIFF
--- a/agents/evidence/metrics/evaluator-measurements.json
+++ b/agents/evidence/metrics/evaluator-measurements.json
@@ -1,12 +1,12 @@
 {
     "schema_version": 1,
     "_comment": "Written by src/scripts/record_evaluator_measurements.mjs, invoked from src/scripts/evaluator_umbrella.sh when UMBRELLA_RECORD=1 (the nightly). check_evaluator_budgets.ts --recorded compares a fresh measurement set against this file; a contradiction on a DETERMINISTIC metric warns on main and fails on release. Do not hand-edit — refresh it from a real run.",
-    "recorded_at": "2026-08-02T13:09:10.592Z",
-    "git_sha": "352e971e3",
-    "run_url": null,
-    "conditions": "Seed record: the two metrics that are measurable without the pack->install harness. The five harness-bound metrics are absent on purpose rather than guessed; the first nightly fills them in.",
+    "recorded_at": "2026-08-03T10:40:58.458Z",
+    "git_sha": "9623fb917e26bd53299b6f8d51bfbbbb2e38b085",
+    "run_url": "https://github.com/event4u-app/agent-config/actions/runs/30796389677",
+    "conditions": "Refresh for the 80 -> 81 cli_help_command_count move (routing:doctor registration, f02db54c2). Both metrics re-measured with the pinned methods locally on this branch; identical fresh values (81/19) confirmed by the cited release-PR umbrella run. The five harness-bound metrics stay absent on purpose; the next nightly fills them in.",
     "measurements": {
-        "cli_help_command_count": 80,
+        "cli_help_command_count": 81,
         "mcp_public_tool_count": 19
     }
 }

--- a/docs/contracts/release-pr-gating.md
+++ b/docs/contracts/release-pr-gating.md
@@ -32,6 +32,8 @@ hold:
    `src/scripts/release.ts` § `_RELEASE_BRANCH_RE`.
 2. **Diff file set is a subset of the version-bump allowlist:**
    - `package.json`
+   - `package-lock.json` — version fields bumped in lockstep by
+     `release.ts` § `set_lockfile_version`
    - `CHANGELOG.md`
    - `.claude-plugin/marketplace.json`
    - `packages/*/pack.yaml`

--- a/src/config/evaluator-budgets.json
+++ b/src/config/evaluator-budgets.json
@@ -61,11 +61,11 @@
             "deterministic": false
         },
         "cli_help_command_count": {
-            "max": 80,
-            "last_measured": 80,
-            "last_measured_at": "2026-08-02",
+            "max": 81,
+            "last_measured": 81,
+            "last_measured_at": "2026-08-03",
             "method": "registry enumeration — count of `{ name: '...', disposition` entries in src/cli/registry.ts (NOT --help prose parsing; methods historically disagreed 74 vs 76 vs 79)",
-            "baseline_note": "79 → 80 on 2026-07-29 (9.9.0). This RECORDS growth that already shipped through its own reviewed PRs; it does not authorize new surface. Net +6 registry entries since the 9.8.0 tag (7 added — code-graph, knowledge, analytics, memory:get, memory:learn, rtk:detect, dispatch:hook; 1 removed — the old dispatch:hook entry), and the frozen 79 was never re-measured after them. The gate did its job: it made the drift visible at release time rather than letting it accrue silently. Next addition breaches again by design — under the posture above that breach WARNS on main and BLOCKS on release, which is the conscious-decision point rather than a silently raised cap. Re-measured 2026-08-02: still 80, so max and last_measured are both current and headroom is zero."
+            "baseline_note": "80 → 81 on 2026-08-03 (release 9.15.0 gate). This RECORDS growth that already shipped through its own reviewed PR; it does not authorize new surface. The +1 is f02db54c2 (fix(cli): register routing:doctor in the CLI registry) — the command existed, only its registry entry was missing, and the registering PR did not move this budget. The gate did its job again: breach WARNS on main and BLOCKS on release, which is the conscious-decision point rather than a silently raised cap. Re-measured 2026-08-03 via the pinned method: 81. Headroom stays zero by design — the next registry addition must move this number in its own PR."
         },
         "mcp_public_tool_count": {
             "max": 19,

--- a/src/scripts/check_release_pr_shape.ts
+++ b/src/scripts/check_release_pr_shape.ts
@@ -24,6 +24,9 @@ const _HERE = fileURLToPath(import.meta.url);
 
 const ALLOWLIST_GLOBS = [
     'package.json',
+    // Lockfile version fields — bumped by release.ts set_lockfile_version in
+    // lockstep with package.json (road-to-gates-that-can-fail Phase 5).
+    'package-lock.json',
     'CHANGELOG.md',
     '.claude-plugin/marketplace.json',
     'src/packs/*/pack.yaml',

--- a/tests/scripts/check_release_pr_shape.test.ts
+++ b/tests/scripts/check_release_pr_shape.test.ts
@@ -23,6 +23,7 @@ describe('check_release_pr_shape — check() (ported pytest)', () => {
     it('real 3.3.0 release-PR shape passes', () => {
         const files = [
             'package.json',
+            'package-lock.json',
             'CHANGELOG.md',
             '.claude-plugin/marketplace.json',
             'src/packs/core/pack.yaml',
@@ -106,6 +107,8 @@ describe('check_release_pr_shape — check() (ported pytest)', () => {
         expect(shape._matches('src/packs/core/installer/foo.ts')).toBe(false);
         expect(shape._matches('docs/archive/some-other-doc.md')).toBe(false);
         expect(shape._matches('package.json')).toBe(true);
+        expect(shape._matches('package-lock.json')).toBe(true);
+        expect(shape._matches('src/some/nested/package-lock.json')).toBe(false);
         expect(shape._matches('src/packs/core/pack.yaml')).toBe(true);
         expect(shape._matches('src/packs/core/README.md')).toBe(true);
         expect(shape._matches('docs/archive/CHANGELOG-pre-5.4.0.md')).toBe(true);


### PR DESCRIPTION
Release 9.15.0 (PR #1134) is blocked by two gates that lag behind changes already merged to main. Per docs/contracts/release-pr-gating.md § Mid-release fixes, both land here on main; merging main into release/9.15.0 afterwards empties their release-PR diff.

## 1. Release-PR shape detector: OUT-OF-SHAPE: package-lock.json

3bba94e2e (road-to-gates-that-can-fail Phase 5) made release.ts bump the lockfile version fields in lockstep with package.json, but the shape detector's allowlist was not moved with it. Every release PR now carries a two-line package-lock.json diff and fails the gate.

- src/scripts/check_release_pr_shape.ts — add package-lock.json to ALLOWLIST_GLOBS
- tests/scripts/check_release_pr_shape.test.ts — cover it (incl. nested-path rejection)
- docs/contracts/release-pr-gating.md — allowlist doc updated in the same change

## 2. Packed-artifact evaluation: cli_help_command_count 81 vs budget 80

f02db54c2 registered routing:doctor in the CLI registry (+1 entry) without moving the budget or the committed measurement record — warn on main, block on release, by design. This PR is the conscious-decision point the gate exists for.

- src/config/evaluator-budgets.json — max/last_measured 80 → 81, baseline note names the moving commit
- agents/evidence/metrics/evaluator-measurements.json — regenerated via record_evaluator_measurements.mjs; both deterministic metrics re-measured with the pinned methods (81/19), matching the fresh values from the failing umbrella run

## Verification

- vitest tests/scripts/check_release_pr_shape.test.ts — 13/13 green
- check_release_pr_shape --files <actual 9.15.0 file set incl. package-lock.json> — SHAPE-CLEAN
- check_evaluator_budgets --posture fail with today's full CI measurement set + new budget/record — green (7 metrics)
- task typecheck-ts + eslint on changed files — clean

After merge: `git checkout release/9.15.0 && git merge origin/main && git push`, then `task release -- --resume --yes`.

Tests: 13

🤖 Generated with [Claude Code](https://claude.com/claude-code)