### PR TITLE
feat(gates): CLI registry ↔ evaluator budget sync check on every PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,6 +275,12 @@ jobs:
         # or an un-regenerated registry change both fail this gate red.
         run: ./scripts-run src/scripts/build_mcp_catalog --strict
 
+      - name: CLI registry ↔ evaluator budget sync
+        # A registry entry added without moving cli_help_command_count (budget +
+        # committed record) only WARNS on main and BLOCKS the next release —
+        # the 9.15.0 failure mode. This fails the registering PR instead.
+        run: ./scripts-run src/scripts/check_cli_registry_budget_sync
+
       - name: Build (dist/cli + UI bundle)
         # prepack-check asserts the chmod +x hook applied by build:cli.
         run: npm run build --silent

--- a/src/scripts/check_cli_registry_budget_sync.ts
+++ b/src/scripts/check_cli_registry_budget_sync.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env tsx
+/**
+ * CLI-registry ↔ evaluator-budget sync gate.
+ *
+ * The evaluator budget `cli_help_command_count` (src/config/evaluator-budgets.json)
+ * and the committed measurement record (agents/evidence/metrics/
+ * evaluator-measurements.json) are derived from `src/cli/registry.ts`, but until
+ * this gate nothing forced the PR that changes the registry to move them: the
+ * breach only WARNED on main and BLOCKED the next release. That is how 9.15.0
+ * went red — f02db54c2 registered `routing:doctor` (80 → 81 entries) and the
+ * drift surfaced days later, at release time, on an unrelated branch.
+ *
+ * This gate runs on every PR (Static Checks + `task preflight`) and fails the
+ * moment the three numbers disagree, so the registering PR carries the budget
+ * move itself.
+ *
+ * The count uses the SAME pinned method as evaluator_umbrella.sh — the number
+ * of `{ name: ` entry openers in src/cli/registry.ts (NOT --help prose
+ * parsing; methods historically disagreed 74 vs 76 vs 79).
+ *
+ * Exit codes: 0 in sync · 1 out of sync · 2 a required file is missing or
+ * unparseable (fail-closed: a gate that cannot read its inputs must not
+ * certify them).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+const REGISTRY_PATH = path.join(REPO_ROOT, 'src/cli/registry.ts');
+const BUDGETS_PATH = path.join(REPO_ROOT, 'src/config/evaluator-budgets.json');
+const RECORD_PATH = path.join(REPO_ROOT, 'agents/evidence/metrics/evaluator-measurements.json');
+
+const METRIC = 'cli_help_command_count';
+
+/** Pinned method — byte-for-byte the umbrella's CLI_COUNT probe. */
+function count_registry_entries(source: string): number {
+    return (source.match(/\{ name: /g) || []).length;
+}
+
+interface BudgetEntry {
+    max?: unknown;
+    last_measured?: unknown;
+}
+
+interface SyncInputs {
+    count: number;
+    budget: BudgetEntry | undefined;
+    recorded: unknown;
+}
+
+const REMEDY =
+    'Fix, in THIS PR (the one that moves src/cli/registry.ts):\n' +
+    `  1. src/config/evaluator-budgets.json → budgets.${METRIC}: set max +\n` +
+    '     last_measured to the new count, bump last_measured_at, and extend\n' +
+    '     baseline_note naming the commit that moves the surface.\n' +
+    '  2. Regenerate the committed record (never hand-edit):\n' +
+    '       node src/scripts/record_evaluator_measurements.mjs \\\n' +
+    '         --measurements <file with the re-measured metrics> \\\n' +
+    '         --out agents/evidence/metrics/evaluator-measurements.json \\\n' +
+    '         --sha "$(git rev-parse HEAD)"\n' +
+    'Otherwise the drift stays invisible until the next release, where the\n' +
+    'evaluator gate blocks it (the 9.15.0 failure mode this gate exists to stop).\n';
+
+/** Pure comparison — the CLI owns the filesystem. */
+function collect_findings(inputs: SyncInputs): string[] {
+    const findings: string[] = [];
+    const { count, budget, recorded } = inputs;
+
+    if (budget === undefined) {
+        findings.push(`budgets.${METRIC} is missing from evaluator-budgets.json`);
+        return findings;
+    }
+    if (budget.last_measured !== count) {
+        findings.push(
+            `registry has ${count} entries but budgets.${METRIC}.last_measured says ` +
+                `${String(budget.last_measured)}`,
+        );
+    }
+    if (typeof budget.max !== 'number' || count > budget.max) {
+        findings.push(
+            `registry has ${count} entries but budgets.${METRIC}.max is ` +
+                `${String(budget.max)}`,
+        );
+    }
+    if (recorded === undefined) {
+        findings.push(
+            `measurements.${METRIC} is missing from the committed record ` +
+                '(agents/evidence/metrics/evaluator-measurements.json)',
+        );
+    } else if (recorded !== count) {
+        findings.push(
+            `registry has ${count} entries but the committed record says ` +
+                `${String(recorded)}`,
+        );
+    }
+    return findings;
+}
+
+function _read_json(p: string): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(p, 'utf-8')) as Record<string, unknown>;
+}
+
+function main(): number {
+    let registrySource: string;
+    let budgetsDoc: Record<string, unknown>;
+    let recordDoc: Record<string, unknown>;
+    try {
+        registrySource = fs.readFileSync(REGISTRY_PATH, 'utf-8');
+        budgetsDoc = _read_json(BUDGETS_PATH);
+        recordDoc = _read_json(RECORD_PATH);
+    } catch (err) {
+        process.stderr.write(
+            `ERROR: cannot read a gate input: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return 2;
+    }
+
+    const count = count_registry_entries(registrySource);
+    const budgets = budgetsDoc['budgets'] as Record<string, BudgetEntry> | undefined;
+    const measurements = recordDoc['measurements'] as Record<string, unknown> | undefined;
+    const findings = collect_findings({
+        count,
+        budget: budgets?.[METRIC],
+        recorded: measurements?.[METRIC],
+    });
+
+    process.stdout.write('scanned: 3\n');
+    if (findings.length > 0) {
+        for (const f of findings) {
+            process.stdout.write(`❌  ${METRIC} out of sync: ${f}\n`);
+        }
+        process.stdout.write('\n' + REMEDY);
+        return 1;
+    }
+    process.stdout.write(
+        `✅  ${METRIC} in sync — registry (${count}) == budget == committed record.\n`,
+    );
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) {
+        return false;
+    }
+    const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+    if (import.meta.url === argvUrl) {
+        return true;
+    }
+    // Symlinked invocations (installed projections, macOS /var → /private/var)
+    // make the raw URLs differ — compare realpaths so the entry guard fires.
+    try {
+        const here = fs.realpathSync(fileURLToPath(import.meta.url));
+        const argvPath = fs.realpathSync(path.resolve(process.argv[1]));
+        return here === argvPath;
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry() || process.argv[1] === _HERE) {
+    process.exit(main());
+}
+
+export { collect_findings, count_registry_entries, main };

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -19,6 +19,7 @@ tasks:
       - ./scripts-run src/scripts/check_backstop_debt
       - ./scripts-run src/scripts/lint_topics_yaml
       - ./scripts-run src/scripts/build_mcp_catalog --strict
+      - ./scripts-run src/scripts/check_cli_registry_budget_sync
       - ./scripts-run src/scripts/check_safety_floor_untouched
       - ./scripts-run src/scripts/check_no_new_legacy_path
       - ./scripts-run src/scripts/check_kernel_rule_bundle

--- a/tests/scripts/check_cli_registry_budget_sync.test.ts
+++ b/tests/scripts/check_cli_registry_budget_sync.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    collect_findings,
+    count_registry_entries,
+} from '../../src/scripts/check_cli_registry_budget_sync.js';
+
+const ROOT = join(__dirname, '..', '..');
+
+describe('check_cli_registry_budget_sync — count_registry_entries', () => {
+    it('counts entry openers with the pinned umbrella method', () => {
+        const src = [
+            "const REGISTRY = [",
+            "    { name: 'roadmap:progress', disposition: 'run' },",
+            "    { name: 'routing:doctor', disposition: 'run' },",
+            "];",
+            "// a comment mentioning { name: inside prose still counts — pinned method",
+        ].join('\n');
+        expect(count_registry_entries(src)).toBe(3);
+    });
+
+    it('returns 0 on a source with no entries', () => {
+        expect(count_registry_entries('export const REGISTRY = [];')).toBe(0);
+    });
+});
+
+describe('check_cli_registry_budget_sync — collect_findings', () => {
+    const inSync = { count: 81, budget: { max: 81, last_measured: 81 }, recorded: 81 };
+
+    it('in-sync inputs produce no findings', () => {
+        expect(collect_findings(inSync)).toEqual([]);
+    });
+
+    it('registry moved without budget or record → three findings', () => {
+        const findings = collect_findings({ ...inSync, count: 82 });
+        expect(findings).toHaveLength(3);
+        expect(findings[0]).toContain('last_measured says 81');
+        expect(findings[1]).toContain('max is 81');
+        expect(findings[2]).toContain('committed record says 81');
+    });
+
+    it('stale committed record alone is a finding', () => {
+        const findings = collect_findings({ ...inSync, recorded: 80 });
+        expect(findings).toEqual([
+            'registry has 81 entries but the committed record says 80',
+        ]);
+    });
+
+    it('missing budget entry fails closed', () => {
+        const findings = collect_findings({ count: 81, budget: undefined, recorded: 81 });
+        expect(findings).toEqual([
+            'budgets.cli_help_command_count is missing from evaluator-budgets.json',
+        ]);
+    });
+
+    it('missing record key fails closed', () => {
+        const findings = collect_findings({ ...inSync, recorded: undefined });
+        expect(findings[0]).toContain('missing from the committed record');
+    });
+});
+
+describe('check_cli_registry_budget_sync — the real tree is in sync', () => {
+    it('registry, budget, and committed record agree right now', () => {
+        const count = count_registry_entries(
+            readFileSync(join(ROOT, 'src/cli/registry.ts'), 'utf-8'),
+        );
+        const budgets = JSON.parse(
+            readFileSync(join(ROOT, 'src/config/evaluator-budgets.json'), 'utf-8'),
+        ) as { budgets: Record<string, { max: number; last_measured: number }> };
+        const record = JSON.parse(
+            readFileSync(
+                join(ROOT, 'agents/evidence/metrics/evaluator-measurements.json'),
+                'utf-8',
+            ),
+        ) as { measurements: Record<string, number> };
+        expect(
+            collect_findings({
+                count,
+                budget: budgets.budgets['cli_help_command_count'],
+                recorded: record.measurements['cli_help_command_count'],
+            }),
+        ).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Problem

A `src/cli/registry.ts` entry added without moving `cli_help_command_count` (budget **and** committed measurement record) only WARNS on main and BLOCKS the next release. That is exactly how 9.15.0 went red: f02db54c2 registered `routing:doctor` (80 → 81) and the drift surfaced days later, at release time, on an unrelated branch — fixed post hoc in #1137.

## Fix

New gate `src/scripts/check_cli_registry_budget_sync.ts`: counts the registry entries with the SAME pinned method as `evaluator_umbrella.sh` (`{ name: ` openers) and fails when the count disagrees with `src/config/evaluator-budgets.json` (`max` / `last_measured`) or `agents/evidence/metrics/evaluator-measurements.json`. The failure message carries the exact two-step remedy (budget move + record regeneration via `record_evaluator_measurements.mjs`). Fail-closed on unreadable inputs; emits `scanned: 3`.

Wired both sides so CI-local parity derives without a manifest entry:
- `.github/workflows/tests.yml` → Static Checks, next to the analogous MCP-catalog drift gate
- `taskfiles/ci-fast.yml` → `task preflight`

## Verification

- `check_cli_registry_budget_sync` on the current tree — in sync (81 == 81 == 81), exit 0
- vitest `tests/scripts/check_cli_registry_budget_sync.test.ts` — 8/8 green (incl. red paths: moved registry, stale record, missing budget/record key)
- `check_ci_local_parity` — no new finding (the `rule_trigger_eval` finding pre-exists on clean main, verified via stash)
- actionlint on the touched `tests.yml` — clean
- `task typecheck-ts` + eslint on the new files — clean

Tests: 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)