### PR TITLE
docs(roadmap): close and archive road-to-package-renewal (central)

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,11 +2,11 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 15 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 14 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
 
 ## Overall
 
-**98 / 191 steps done · 51%**
+**92 / 182 steps done · 51%**
 
 ```text
 ████████████████████░░░░░░░░░░░░░░░░░░░░   51%
@@ -23,14 +23,13 @@
 | 5 | [road-to-gates-that-can-fail.md](roadmaps/road-to-gates-that-can-fail.md) | 7 | 27 | 2 | 24 | 1 | 0 | 0 | █████████░ 92% |
 | 6 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 7 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 8 | [road-to-package-renewal.md](roadmaps/road-to-package-renewal.md) | 2 | 9 | 3 | 6 | 0 | 0 | 0 | ███████░░░ 67% |
-| 9 | [road-to-routing-correctness.md](roadmaps/road-to-routing-correctness.md) | 4 | 15 | 15 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
-| 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 14 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
-| 15 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 8 | [road-to-routing-correctness.md](roadmaps/road-to-routing-correctness.md) | 4 | 15 | 15 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 10 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
+| 11 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 12 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 13 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 14 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -153,15 +152,6 @@ _1 blocker resolved._
     the post-ADR-117 default (`subagents.auto: on`), then check
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
-
-### [road-to-package-renewal.md](roadmaps/road-to-package-renewal.md)
-
-**Road to package renewal — central roadmap (2026-08)** — 6 / 9 done (67%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | this PR | ✅ done | 0 | 6 | 0 | 0 | 100% |
-| 2 | steering (after this PR merges) | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 
 ### [road-to-routing-correctness.md](roadmaps/road-to-routing-correctness.md)
 

--- a/agents/roadmaps/archive/road-to-package-renewal.md
+++ b/agents/roadmaps/archive/road-to-package-renewal.md
@@ -130,9 +130,9 @@ this central roadmap steering three sub-roadmaps.
 
 | Sub-roadmap | Scope | Status |
 |---|---|---|
-| [`road-to-renewal-foundation.md`](archive/road-to-renewal-foundation.md) | CI oracle repair, dead-tree sweep, token quick wins (pack-gated floors, MCP trim), runtime-activation spike (phase-gated) | **complete 2026-08-02** — archived. Phase 3's spike steps closed `[-]` as infeasible-as-specified (no per-prompt injection transport; corpus covers 10 of 97 rules); reopen terms in `internal/bench/layer1-resolver-PREREG.md` |
-| [`archive/road-to-renewal-leverage.md`](archive/road-to-renewal-leverage.md) | Execution flows (work-engine batching, parallel dispatch, cadence flip, hub generation, hook-fan-out trim) + three documented-failure fixes with borrowed shape + tracker-convention docs | **COMPLETE + archived 2026-08-02.** Shipped: `dashboard_regen_cadence` default → `every_5_steps`; worktree seeding allow/deny list; the `## Blockers` awaiting-evidence convention; `block-config-weakening` PreToolUse guard; `check_cluster_patterns` filesystem enumeration + the 9 drifting hubs fixed. Refused with evidence (5 of 12): work-engine batching (premise falsified — 4 of 24 directives are no-op gates and they already cost nothing; the real cost is 87% transport), parallel step dispatch (incompatible with the atomic-flip law + step interdependence), hub-body generation (51% of hubs carry non-generatable prose; a checker extension removes the same drift), `post_tool_use` trim (all 7 concerns cost ~10 ms against a 250 ms budget — 88% is the dispatcher floor), Inline-Brief fallback (its incident is already closed by `lint_ui_stack_bundles`). Two transport findings recorded for a future step: the work engine is the one Tier-0 flow with no `dist/cli-delegate` bundle (blocked on 13 unguarded `_isCliEntry()` modules), and the hook dispatcher's 70 ms floor |
-| [`road-to-renewal-adr-hygiene.md`](archive/road-to-renewal-adr-hygiene.md) | Drive-loop era batch disposition, ADR-085 amendment, perma-proposed sweep, ADR-201 resolution | **complete 2026-08-03** — archived; executed as its own PR (ADR-206–210, 40-rule self-contained certification, review_trigger retrofit, dead-tree sweep) |
+| [`road-to-renewal-foundation.md`](road-to-renewal-foundation.md) | CI oracle repair, dead-tree sweep, token quick wins (pack-gated floors, MCP trim), runtime-activation spike (phase-gated) | **complete 2026-08-02** — archived. Phase 3's spike steps closed `[-]` as infeasible-as-specified (no per-prompt injection transport; corpus covers 10 of 97 rules); reopen terms in `internal/bench/layer1-resolver-PREREG.md` |
+| [`road-to-renewal-leverage.md`](road-to-renewal-leverage.md) | Execution flows (work-engine batching, parallel dispatch, cadence flip, hub generation, hook-fan-out trim) + three documented-failure fixes with borrowed shape + tracker-convention docs | **COMPLETE + archived 2026-08-02.** Shipped: `dashboard_regen_cadence` default → `every_5_steps`; worktree seeding allow/deny list; the `## Blockers` awaiting-evidence convention; `block-config-weakening` PreToolUse guard; `check_cluster_patterns` filesystem enumeration + the 9 drifting hubs fixed. Refused with evidence (5 of 12): work-engine batching (premise falsified — 4 of 24 directives are no-op gates and they already cost nothing; the real cost is 87% transport), parallel step dispatch (incompatible with the atomic-flip law + step interdependence), hub-body generation (51% of hubs carry non-generatable prose; a checker extension removes the same drift), `post_tool_use` trim (all 7 concerns cost ~10 ms against a 250 ms budget — 88% is the dispatcher floor), Inline-Brief fallback (its incident is already closed by `lint_ui_stack_bundles`). Two transport findings recorded for a future step: the work engine is the one Tier-0 flow with no `dist/cli-delegate` bundle (blocked on 13 unguarded `_isCliEntry()` modules), and the hook dispatcher's 70 ms floor |
+| [`road-to-renewal-adr-hygiene.md`](road-to-renewal-adr-hygiene.md) | Drive-loop era batch disposition, ADR-085 amendment, perma-proposed sweep, ADR-201 resolution | **complete 2026-08-03** — archived; executed as its own PR (ADR-206–210, 40-rule self-contained certification, review_trigger retrofit, dead-tree sweep) |
 
 Ordering (council-locked): Foundation Phase 1 (CI oracle) gates everything —
 a broken validator cannot validate its own fix. Leverage starts only after
@@ -241,12 +241,33 @@ Foundation Phase 1 is green. ADR hygiene chips alongside any PR.
 
 ## Phase 2 — steering (after this PR merges)
 
-- [ ] Foundation Phase 1 (CI oracle) executed and verified → unblock Leverage
-- [ ] Re-measure token footprint after Foundation Phase 2; decide
+- [x] Foundation Phase 1 (CI oracle) executed and verified → unblock Leverage
+      — verified 2026-08-04: all three sub-roadmaps sit in `archive/` with
+      zero open steps (Foundation PR #1117, Leverage 2026-08-02, ADR-hygiene
+      PR #1123); Leverage was unblocked AND completed
+- [x] Re-measure token footprint after Foundation Phase 2; decide
       runtime-activation spike go/no-go on the recorded thresholds
-- [ ] Record the renewal-cadence decision (when/whether to re-invoke
+      — re-measured 2026-08-04 (`audit_initial_context` at 5d2065207):
+      `.claude`/`.cursor`/`.augment` rules 86,266 GPT tok (shipped-default
+      after was 85,880; +386 is content landed since, not regression),
+      `.windsurfrules` 69,716, skills catalog 13,792 (−4,213 held), MCP
+      worker 4,174 / stdio 3,074 (−665 held). The pack-axis flip
+      (−8,110) stays behind its human gate, unchanged. Spike decision
+      (council 2026-08-04, sonnet-4-5 + gpt-4o): **NO-GO (prerequisites
+      unmet, not executed)** — P1: no per-prompt injection transport in
+      the hook layer; P2: labelled corpus 10/97 rules (no statistical
+      power for T3). The pre-registered measurement was never produced;
+      `internal/bench/layer1-resolver-PREREG.md` holds sole reopen
+      authority (P1/P2/P3). No default changes, no new threshold set.
+- [x] Record the renewal-cadence decision (when/whether to re-invoke
       `/optimize:deep` against this roadmap set) as a one-line decision note
       here — the recurring re-run itself is cadence, not a checkbox
+      — **Decision (council 2026-08-04): event-triggered with a 6-month
+      backstop** — re-invoke `/optimize:deep` on a new operator performance
+      report, a major host-capability shift, the first external adopter, or
+      a release review surfacing systemic drift; if no event fires for 6
+      months, run a drift audit (invoke + decide, no auto-commit to
+      refinement loops).
 
 ## Cadence
 


### PR DESCRIPTION
## Summary

Closes the central renewal steering roadmap — all three sub-roadmaps were already complete and archived (Foundation #1117, Leverage 2026-08-02, ADR-hygiene #1123), so the three Phase 2 steering steps resolve and the file archives.

- **Step 1 (verified):** Foundation Phase 1 executed → Leverage was unblocked AND completed; all three sub-roadmaps sit in `archive/` with zero open steps.
- **Step 2 (measured + decided):** fresh `audit_initial_context` re-measurement at 5d2065207 — rules surface 86,266 GPT tok (shipped-default after Foundation Phase 2 was 85,880; +386 is content landed since), `.windsurfrules` 69,716, skills catalog 13,792 (−4,213 held), MCP worker 4,174 / stdio 3,074 (−665 held). Runtime-activation spike disposition: **NO-GO (prerequisites unmet, not executed)** — P1 no per-prompt injection transport, P2 corpus 10/97 rules; `internal/bench/layer1-resolver-PREREG.md` holds sole reopen authority (P1/P2/P3). Council 2026-08-04 (claude-sonnet-4-5 + gpt-4o).
- **Step 3 (decided):** renewal cadence — **event-triggered with a 6-month backstop**: re-invoke `/optimize:deep` on a new operator performance report, a major host-capability shift, the first external adopter, or a release review surfacing systemic drift; if no event fires for 6 months, run a drift audit (invoke + decide, no auto-commit to refinement loops). Council 2026-08-04.

Archived via `archive_completed_roadmaps` (count_open=0, count_deferred=0); sub-roadmap table links rewritten relative to `archive/`; dashboard regenerated (`roadmap:progress-check` green).

## Test plan

- [x] `roadmap:progress-check` green locally
- [ ] Remote CI green (authoritative gate)