### PR TITLE
chore(budgets): drop the unpacked_size_mb release gate

### DIFF
--- a/docs/decisions/ADR-204-precompile-cli-delegate-commands.md
+++ b/docs/decisions/ADR-204-precompile-cli-delegate-commands.md
@@ -23,6 +23,14 @@ review_trigger: >-
 
 Accepted 2026-07-31.
 
+> **Update 2026-08-04:** review_trigger (a) fired — the first real packed
+> measurement at the 9.17.0 release came in at 28.22 MB against max 28. The
+> maintainer resolved it by **removing the `unpacked_size_mb` budget key**
+> (tarball size is no longer gated; the umbrella still measures it as
+> evidence), not by cutting the `dist/cli-delegate/` bundle. References in
+> this ADR to that gate as "the confirming measurement" describe the state
+> at acceptance time.
+
 ## Context
 
 `tsx` is a devDependency, so the published package ships no `tsx`. That is

--- a/src/config/evaluator-budgets.json
+++ b/src/config/evaluator-budgets.json
@@ -27,13 +27,8 @@
         },
         "not_re_measured": "unpacked_size_mb, node_modules_mb, runtime_dep_count, cli_version_cold_ms, mcp_boot_to_initialize_ms. All five require the packed-tarball harness (npm pack of a fully built tree, then a clean `npm install --omit=dev <tarball>` into a scratch project) that evaluator_umbrella.sh runs in CI. They were NOT re-measured in this pass and their values remain the 2026-07-27 acceptance numbers — stated rather than invented. The next nightly writes the real numbers into measurement_record, and the drift check then reports any contradiction with last_measured on the PR that carries it."
     },
+    "removed_2026_08_04": "unpacked_size_mb (max 28) — removed by maintainer decision at the 9.17.0 release: the gate turned every legitimate payload addition into a blocked release (measured 28.22 vs max 28 with all functional gates green), and the maintainer judged tarball size not worth gating. evaluator_umbrella.sh still MEASURES and records unpacked_size_mb as evidence; only the budget enforcement is gone. ADR-204 review_trigger (a) fired and was resolved this way.",
     "budgets": {
-        "unpacked_size_mb": {
-            "max": 28,
-            "last_measured": 26.05,
-            "last_measured_at": "2026-07-27",
-            "method": "npm pack --json → dist.unpackedSize / 1e6 — includes the Phase-1 precompiled bundles (dist/hooks/dispatch.js + dist/mcp/server.mjs, ~2.1 MB) that bought the 23x hook-latency win and the tsx removal, plus dist/cli-delegate/ (~1.40 MB, ADR-204) which finished that removal for the consumer command surface. This gate is the ONLY size trip-wire on those bundles by design: a dedicated per-bundle budget key would need its own measurement wired into evaluator_umbrella.sh, and an unwired key fails check_evaluator_budgets with 'no measurement supplied' instead of guarding anything. ADR-204 projected 27.45 against max 28 without packing — the next real measurement here is the confirming one, and headroom is thin"
-        },
         "node_modules_mb": {
             "max": 140,
             "last_measured": 127,

--- a/src/scripts/check_pack_size.ts
+++ b/src/scripts/check_pack_size.ts
@@ -10,9 +10,10 @@
  *   2. PER-SKILL share of the skills subtree — no single skill may silently
  *      reclaim space freed elsewhere. Named exceptions carry a reason.
  *
- * The UNPACKED size is deliberately NOT re-gated here: it is already owned by
- * `evaluator-budgets.unpacked_size_mb`, measured at release time on the BUILT
- * artifact. Two gates for one lever is how conflicting numbers start.
+ * The UNPACKED size is deliberately NOT gated here — and since 2026-08-04 not
+ * anywhere: the former `evaluator-budgets.unpacked_size_mb` key was removed by
+ * maintainer decision (see `removed_2026_08_04` in evaluator-budgets.json);
+ * the evaluator umbrella still measures it as evidence.
  *
  * Usage:
  *   ./scripts-run src/scripts/check_pack_size [--json]

--- a/tests/scripts/check_evaluator_budgets.test.ts
+++ b/tests/scripts/check_evaluator_budgets.test.ts
@@ -53,7 +53,9 @@ describe('check_evaluator_budgets', () => {
     });
 
     it('committed budgets: every entry carries max, last_measured and a pinned method', () => {
-        expect(Object.keys(BUDGETS.budgets).length).toBeGreaterThanOrEqual(7);
+        // 7 → 6 on 2026-08-04: unpacked_size_mb removed by maintainer decision
+        // (see removed_2026_08_04 in evaluator-budgets.json).
+        expect(Object.keys(BUDGETS.budgets).length).toBeGreaterThanOrEqual(6);
         for (const [name, entry] of Object.entries(BUDGETS.budgets)) {
             expect(entry.max, name).toBeGreaterThan(0);
             expect(entry.last_measured, name).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Removes the `unpacked_size_mb` budget key from `src/config/evaluator-budgets.json`. The evaluator umbrella still **measures** and records unpacked size as evidence — only the enforcement is gone.

## Why

Maintainer decision at the 9.17.0 release: the first real packed measurement came in at 28.22 MB against max 28 and blocked the release while every functional gate was green. A size cap that trips on every legitimate payload addition forces a budget-bump ritual per release without protecting anything the maintainer values.

## Downstream

- `tests/scripts/check_evaluator_budgets.test.ts` — key-count pin 7 → 6.
- `src/scripts/check_pack_size.ts` — header comment no longer claims the evaluator gate owns unpacked size (its own compressed-tarball budget is unchanged).
- `docs/decisions/ADR-204` — status note: review_trigger (a) fired and was resolved by removing the gate.
- `removed_2026_08_04` note in the budgets JSON records the decision in place.

## Verification

- `check_evaluator_budgets --measurements <9.17.0 CI numbers> --posture fail` → green (6 metrics).
- `vitest run` on the two touched test files → 34/34 green.
- `lint_budget_ownership` → OK; `eslint` on touched files → clean.

Unblocks release PR #1152 (after merging main into `release/9.17.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)