### PR TITLE
fix(tests): expect qa persona in the developer seed shape

### DIFF
--- a/tests/scripts/config_profiles.test.ts
+++ b/tests/scripts/config_profiles.test.ts
@@ -131,7 +131,9 @@ describe('config/profiles — resolution chain', () => {
     it('developer seed shape', () => {
         const r = resolve_profile({ project_root: SEED_ROOT, runtime_id: 'developer' });
         expect(r.preset_id).toBe('balanced');
-        expect(r.personas).toContain('reviewer');
+        // 'reviewer' was never a shipped persona id — the review lens is `qa`;
+        // lint_profile_personas (2da00ad41) remapped the seeds to real ids.
+        expect(r.personas).toContain('qa');
         expect(r.commands_hint).toContain('work');
         expect(r.audience['readme_anchor']).toBe('developer');
         expect(r.docs_first_pointer).not.toBeNull();


### PR DESCRIPTION
## What

One-line test fix: `config_profiles.test.ts > developer seed shape` expects `'reviewer'` in the resolved personas — that id never existed in the persona catalog. The review lens is `qa`.

## Why

2da00ad41 (`lint_profile_personas`) remapped every profile seed from nonexistent persona ids to real ones (`reviewer` → `qa`, `security` → `security-engineer`) but missed this test expectation. Node Tests shard 3/4 has been red on the trunk since — it also shows up as a false red on unrelated PRs (e.g. #1153).

## Verification

`vitest run tests/scripts/config_profiles.test.ts` → 22/22 green on this branch (1 failed on clean origin/main before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)