### PR TITLE
fix(release): derive the head in --dry-run too, so the preview matches

### DIFF
--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -2372,9 +2372,14 @@ function main(argv: readonly string[] | null = null): number {
     // (~15s+), which `--dry-run exits 0 without needing …` contracts (and
     // the release test) assume never runs. Real releases compute it.
     const test_trend_line = args.dry_run ? null : _render_test_trend_line(prev);
+    // Derived unconditionally, dry-run included: it is one `git log` (~25 ms),
+    // not the trend line's full vitest collection. Skipping it on `--dry-run`
+    // made the preview print the `_none_` skeleton while the real run wrote
+    // pre-filled lines — a preview that contradicts its own output, which is
+    // the exact class of surface disagreement this pre-fill exists to end.
     const [full, body] = render_changelog_entry(target, prev, commits, today, {
         test_trend_line,
-        head: args.dry_run ? {} : _derive_head_prefill(prev),
+        head: _derive_head_prefill(prev),
     });
 
     // Era-split planning — gate on the POST-release view (2026-07-07 fix).


### PR DESCRIPTION
Follow-up to #1161, found while previewing the test release it was meant to unblock.

## The defect

`_derive_head_prefill` was skipped under `--dry-run`:

```ts
head: args.dry_run ? {} : _derive_head_prefill(prev),
```

That copied the cost argument from the test-trend footer, and the argument does not transfer. The trend line runs a full vitest collection; this is one `git log`, measured at **25 ms**. The consequence was a `--dry-run` preview printing the `_none_` skeleton while the real run wrote pre-filled lines — a preview that contradicts its own output, which is precisely the class of surface disagreement #1161 exists to end.

## Measured, before and after

`9.18.0..HEAD`, same command (`task release -- --dry-run`):

| | Behaviour changes | Honest nulls |
|---|---|---|
| before | `_none_` | `_none_` |
| after | `_none_` | `_auto-derived, …_ commits carrying an honest-null marker in 55dc01d, d56c0be.` |

Both cited commits were checked to actually carry the marker — `55dc01d` and `d56c0be` each contain `honest-null` in the body, so the derivation is right and `_none_` on the other four labels is right too (this span has no `src/rules/` or schema diffs).

## Verification

- 110 tests green (`release_head_prefill`, `check_release_highlights`, `release`).
- `task typecheck-ts` exit 0; `eslint src/scripts/release.ts` exit 0.
- Preview re-run by hand before and after the one-line change; the table above is that output.
