### PR TITLE
docs(gates): correct the blind-pass dispositions, carry the open items, record the fence-grammar verdict

### DIFF
--- a/agents/evidence/reviews/postmerge-blindpass-review.md
+++ b/agents/evidence/reviews/postmerge-blindpass-review.md
@@ -15,11 +15,11 @@ dispatched: 2026-08-04T14:46:17Z
 
 | # | Severity | File:Line | Finding | Status | Reason/Ref |
 |---|----------|-----------|---------|--------|------------|
-| 1 | critical | src/scripts/check_completion_review.ts:434 | The mis-pairing fail-open the change claims to close survives with a labelled opener: an unclosed labelled opener is closed by the first later BARE fence anywhere in the artefact, so every line between them is added to `fenced` (a live `open` finding row among them disappears from `rows`), `open` returns to null so `strays` stays empty and no `unbalanced-fence` is emitted, and an earlier well-formed row keeps the neither-table-nor-honest-null fallback quiet — the gate exits 0 on an unreviewed `open` finding. Fires on the exact arrangement `markdown-safe-codeblocks` prescribes: a tilde-wrapped illustration quoting an unpaired labelled opener plus any bare fence later in the file. | open | |
-| 2 | high | src/scripts/check_completion_review.ts:779 | The remediation text printed with every `unbalanced-fence` violation ("Label the opener and close it") walks the author straight into finding 1: applied to the repo's own two-stray fixture, labelling only the first stray turns it into an unclosed labelled opener that the still-bare second stray closes, swallowing the `open` row between them and flipping a blocking exit 1 into a silent pass. | open | |
-| 3 | high | docs/contracts/plan-review-gates.md:332 | The normative contract asserts "A labelled opener that is never closed is a stray too, and likewise skips nothing", which the parser does not implement — a later bare fence closes such an opener, so it skips everything up to that fence and is reported as no stray at all; the same over-claim appears in the JSDoc at `check_completion_review.ts:420`, so the doc certifies the property that would otherwise prompt the next author to test this hole. | open | |
-| 4 | medium | src/scripts/check_completion_review.ts:442 | Retroactive breaking grammar change with no migration or grandfathering: under the removed round-7 rule a closed bare pair was a valid illustrative region, and any already-committed findings artefact that quoted the six-column template inside a bare pair now emits a blocking `unbalanced-fence` (exit 1) and fails pre-push and CI for a completion whose artefact was correct when written — the §2.2 rewrite documents the new rule but records no transition for artefacts authored under the old one. | open | |
-| 5 | low | src/scripts/check_completion_review.ts:451 | `strays.sort()` is dead: bare strays can only be pushed while no opener is open, so they are appended in ascending index order, and the post-loop push of an unterminated opener is always the largest index — the sort can never reorder anything. | open | |
+| 1 | critical | src/scripts/check_completion_review.ts:434 | The mis-pairing fail-open the change claims to close survives with a labelled opener: an unclosed labelled opener is closed by the first later BARE fence anywhere in the artefact, so every line between them is added to `fenced` (a live `open` finding row among them disappears from `rows`), `open` returns to null so `strays` stays empty and no `unbalanced-fence` is emitted, and an earlier well-formed row keeps the neither-table-nor-honest-null fallback quiet — the gate exits 0 on an unreviewed `open` finding. Fires on the exact arrangement `markdown-safe-codeblocks` prescribes: a tilde-wrapped illustration quoting an unpaired labelled opener plus any bare fence later in the file. | deferred | roadmap road-to-plan-gate-fence-grammar — §2.2 grammar decision, council-routed 2026-08-04; pinned meanwhile by the KNOWN-HOLE characterization test |
+| 2 | high | src/scripts/check_completion_review.ts:779 | The remediation text printed with every `unbalanced-fence` violation ("Label the opener and close it") walks the author straight into finding 1: applied to the repo's own two-stray fixture, labelling only the first stray turns it into an unclosed labelled opener that the still-bare second stray closes, swallowing the `open` row between them and flipping a blocking exit 1 into a silent pass. | deferred | roadmap road-to-plan-gate-fence-grammar — the remediation string is rewritten together with the grammar it points at |
+| 3 | high | docs/contracts/plan-review-gates.md:332 | The normative contract asserts "A labelled opener that is never closed is a stray too, and likewise skips nothing", which the parser does not implement — a later bare fence closes such an opener, so it skips everything up to that fence and is reported as no stray at all; the same over-claim appears in the JSDoc at `check_completion_review.ts:420`, so the doc certifies the property that would otherwise prompt the next author to test this hole. | fixed | 16dace44b |
+| 4 | medium | src/scripts/check_completion_review.ts:442 | Retroactive breaking grammar change with no migration or grandfathering: under the removed round-7 rule a closed bare pair was a valid illustrative region, and any already-committed findings artefact that quoted the six-column template inside a bare pair now emits a blocking `unbalanced-fence` (exit 1) and fails pre-push and CI for a completion whose artefact was correct when written — the §2.2 rewrite documents the new rule but records no transition for artefacts authored under the old one. | deferred | roadmap road-to-plan-gate-fence-grammar — migration for artefacts authored under the old grammar is part of that decision |
+| 5 | low | src/scripts/check_completion_review.ts:451 | `strays.sort()` is dead: bare strays can only be pushed while no opener is open, so they are appended in ascending index order, and the post-loop push of an unterminated opener is always the largest index — the sort can never reorder anything. | fixed | 16dace44b |
 
 ## Provenance
 
@@ -65,12 +65,30 @@ the JSDoc at line 420, and the `strays.sort` after ascending-only pushes).
 
 ## Disposition
 
-Findings 3 and 5 are unambiguous and are fixed in this change. Findings 1, 2
-and 4 are **held open on purpose**: the obvious fix (treat a findings-shaped row
-inside a fenced region as a violation) fires on every artefact that legitimately
-quotes the template — including the skeleton the dispatcher itself writes, which
-contains `| 1 | critical | path/to/file.ts:42 | … | open | |`. Choosing between
-"declare illustrative regions explicitly" and "relax fence pairing and move the
-safety check elsewhere" changes the § 2.2 grammar, so it is a decision to make
-deliberately rather than a patch to improvise. Writing a fix whose false-positive
-rate reds every future artefact would repeat the mistake this document records.
+**2 fixed, 3 deferred, 0 open.**
+
+Findings 3 and 5 were fixed in `16dace44b` (the contract and JSDoc now describe
+what the parser actually does; the dead `strays.sort` is gone).
+
+Findings 1, 2 and 4 are **deferred to a named carrier**, not left open: the fix
+is a § 2.2 grammar decision, because the obvious guard — "a findings-shaped row
+inside a fenced region is a violation" — fires on every artefact that quotes the
+template, **including the skeleton `dispatch_r2_reviewer` itself writes**, which
+ships an example row whose status is literally `open`. Choosing between declared
+illustrative regions and moving the safety property off fence pairing changes the
+grammar for every future artefact, so it was routed to the council rather than
+improvised. Carrier: `agents/roadmaps/road-to-plan-gate-fence-grammar.md`.
+Interim anchor: the KNOWN-HOLE characterization test, which pins the current
+wrong behaviour and says what to do when it starts failing.
+
+### Correction — this table said `open` for all five rows until now
+
+Findings 3 and 5 were fixed on 2026-08-04 and still recorded `open`; 1, 2 and 4
+were `open` where the contract requires a terminal status with a reference. That
+is a violation of the two-phase rule this very artefact exists to enforce, and
+**nothing caught it**: the file sits outside the `*.findings.md` glob (§ 2.7, so
+the validator does not select it) and R2 runs `--advisory` during the Stage-A
+window, so neither layer looks at it. It is the exact gap the disposition-index
+work addresses — a terminal status recorded somewhere no machine reconciles.
+Logged here rather than silently corrected, because a quietly-fixed bookkeeping
+lie is the same class of defect as the steered review in § 5's case zero.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**68 / 182 steps done · 37%**
+**69 / 182 steps done · 38%**
 
 ```text
-███████████████░░░░░░░░░░░░░░░░░░░░░░░░░   37%
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░   38%
 ```
 
 ## Open roadmaps
@@ -24,7 +24,7 @@
 | 6 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 9 | [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md) | 4 | 25 | 25 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md) | 4 | 25 | 24 | 1 | 0 | 0 | 0 | ░░░░░░░░░░ 4% |
 | 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
@@ -160,11 +160,11 @@ _1 blocker resolved._
 
 ### [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md)
 
-**Plan-gate fence grammar — close the live fail-open, make dispositions machine-checkable** — 0 / 25 done (0%)
+**Plan-gate fence grammar — close the live fail-open, make dispositions machine-checkable** — 1 / 25 done (4%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Decide the grammar | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 1 | Decide the grammar | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
 | 2 | Implement and prove it | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 3 | Disposition index with stable ids | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
 | 4 | Projections + docs | ⬜ not started | 10 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 14 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
+> 15 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **10** open blockers
 
 ## Overall
 
-**68 / 157 steps done · 43%**
+**68 / 182 steps done · 37%**
 
 ```text
-█████████████████░░░░░░░░░░░░░░░░░░░░░░░   43%
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░   37%
 ```
 
 ## Open roadmaps
@@ -24,12 +24,13 @@
 | 6 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 9 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 10 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
-| 11 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 12 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 13 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
-| 14 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 9 | [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md) | 4 | 25 | 25 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
+| 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 14 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 15 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -156,6 +157,17 @@ _1 blocker resolved._
     the post-ADR-117 default (`subagents.auto: on`), then check
     `wc -l agents/runtime/state/audit/$(date +%Y-%m).jsonl`. Resume at ≥20.
   - **Resolved when:** the current-month audit log holds ≥20 orchestration lines.
+
+### [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md)
+
+**Plan-gate fence grammar — close the live fail-open, make dispositions machine-checkable** — 0 / 25 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Decide the grammar | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 2 | Implement and prove it | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 3 | Disposition index with stable ids | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 4 | Projections + docs | ⬜ not started | 10 | 0 | 0 | 0 | 0% |
 
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)
 

--- a/agents/roadmaps/road-to-plan-gate-fence-grammar.md
+++ b/agents/roadmaps/road-to-plan-gate-fence-grammar.md
@@ -67,11 +67,47 @@ complexity: structural
 - No retro-application to artefacts already merged — migration is explicit
   (Phase 1 Step 3), never silent.
 
+## Council verdict (2026-08-04)
+
+Deep-tier run, members anthropic/claude-sonnet-4-5 + openai/gpt-4o. **Convergent
+on Candidate B — the safety property moves into the data model and out of
+presentation parsing.** The three fence failures are read as symptoms of one
+mistake: treating markdown layout as a security boundary.
+
+**Accepted, with the load-bearing refinement:** rows are **live by default**; an
+illustrative row must be **explicitly marked**. This inverts the current default
+and is what makes it fail-closed — forgetting a marker blocks, it never passes.
+
+**Explicitly rejected — the pure structured-data-block variant** (findings move
+into a ```` ```findings-table ```` block, everything outside is ignored). One
+member killed it on a false-*negative*: an author who forgets the wrapper leaves
+a `| … | open | |` row sitting in prose, and the gate passes while the author
+believes a blocker was filed. "Manual review will notice" is the assumption that
+created the need for the gate. Structured data stays a long-term option to
+evaluate, not this change.
+
+**Also rejected:** blocking on a malformed table *inside* a declared block — an
+author adding a row would be blocked by someone else's older formatting glitch,
+with no indication which row or what the parser wanted. That is the confusing-
+block category the FP budget exists to prevent.
+
+**Migration:** version-marker based. The header already carries
+`completion-review: v1`, so `v2` is the discriminator; a transitional window
+accepts both and emits a deprecation warning for old-style illustrative content.
+Frozen records are never edited to comply.
+
+**What this sacrifices:** every existing illustrative row must be marked, the
+dispatcher's skeleton included; markdown authors gain one more piece of syntax to
+remember. Accepted because the alternative keeps a security property in a text
+layer that has now failed open four times.
+
 ## Phase 1: Decide the grammar
 
-- [ ] **Step 1:** Read the council convergence and record the verdict in this
+- [x] **Step 1:** Read the council convergence and record the verdict in this
       roadmap (accept / accept-with-modification / reject per finding), naming
       what the chosen direction sacrifices.
+      <!-- executed 2026-08-04 — verdict recorded above: Candidate B, rows live by default, explicit illustrative marker, v2 header discriminator; pure data-block and malformed-in-block blocking both rejected with the reason. -->
+
 - [ ] **Step 2:** Write the chosen rule into `docs/contracts/plan-review-gates.md`
       § 2.2 as a deterministic parser contract, covering explicitly: an
       undeclared labelled fence, an unterminated fence, nested fences

--- a/agents/roadmaps/road-to-plan-gate-fence-grammar.md
+++ b/agents/roadmaps/road-to-plan-gate-fence-grammar.md
@@ -1,0 +1,170 @@
+---
+complexity: structural
+---
+
+# Roadmap: Plan-gate fence grammar — close the live fail-open, make dispositions machine-checkable
+
+> Two open items the plan-governance work left on `main`, both carried here
+> because they were otherwise recorded only in a review artefact and two code
+> comments: **(F)** a confirmed `critical` fail-open in the R2 findings parser —
+> an `open` finding can be hidden from the gate — and **(D)** the absence of any
+> machine-checkable link between an archived round's `open` rows and the terminal
+> disposition recorded elsewhere. F is a live defect; D is why F's own
+> bookkeeping drifted unnoticed for a day.
+
+## Prerequisites
+
+- [ ] Read `docs/contracts/plan-review-gates.md` § 2.2 (fence rule + the
+      `KNOWN HOLE` note) and § 2.7 (superseded-round convention)
+- [ ] Read `agents/evidence/reviews/postmerge-blindpass-review.md` — findings
+      1, 2, 4 are the F items; its `### Correction` section is the D case study
+- [ ] Read the `KNOWN HOLE` characterization block in
+      `tests/scripts/check_completion_review.test.ts` — it pins current behaviour
+      and states what to do when it starts failing
+
+## Context
+
+- **F — the fail-open, reproduced.** A labelled fence opener is closed by the
+  first later **bare** fence anywhere in the artefact, including one the author
+  never meant as its closer. Lines between them are skipped, so a live
+  `| … | open | |` row disappears from the parsed rows; because the opener was
+  consumed, `strays` stays empty and no `unbalanced-fence` fires; an earlier
+  well-formed row keeps the neither-table-nor-honest-null fallback quiet. The
+  gate exits 0 on an unreviewed finding. The triggering arrangement is the one
+  `markdown-safe-codeblocks` itself prescribes (`~~~` outer wrapping ```` ``` ````
+  inner), and the remediation string the validator prints for
+  `unbalanced-fence` leads an author into it.
+- **Why it was not patched on discovery.** The obvious guard — "a
+  findings-shaped row inside a fenced region is a violation" — fires on every
+  artefact that legitimately quotes the six-column template, **including the
+  skeleton `dispatch_r2_reviewer` generates**, which ships an example row whose
+  Status is literally `open`. A guard that reds every future artefact would
+  repeat the failure class the plan-governance work exists to remove.
+- **Three prior attempts all failed open**, which is why this is a grammar
+  decision and not a fourth arithmetic patch: a single `inFence` toggle made
+  everything after an odd fence count invisible; positional pairing detected
+  parity but mis-paired; the current labelled-opener rule is defeated by a stray
+  bare fence.
+- **D — dispositions are not reconcilable.** Archived rounds are a frozen audit
+  trail (§ 2.7) and must not be edited in place, so their `open` rows stay
+  `open` while the terminal status lives in a closure commit or a follow-up
+  roadmap. The advisory bot parses the artefacts, sees the `open` rows, and
+  reports a contradiction that is not one. Round records also carry **no stable
+  identifiers** — rows are numbered per round, so `round3 #5` and `round4 #5`
+  collide, and any index must key on a composite or on real `R-NNN` ids (the
+  still-open advisory finding on stable ids called this out first).
+- **Direction for F was routed to the AI council** (2026-08-04) rather than
+  chosen unilaterally: candidate A = explicitly declared illustrative regions;
+  candidate B = move the safety property off fence pairing entirely (a row is
+  live unless explicitly neutralised). The convergence lands in Phase 1.
+
+## Non-goals
+
+- No change to the R2 advisory posture: Stage A stays `--advisory` until its
+  window closes on its own terms. This roadmap fixes correctness, not rollout.
+- No in-place edits to archived round records. They are the audit trail whose
+  immutability is the only detection floor § 5 has.
+- No retro-application to artefacts already merged — migration is explicit
+  (Phase 1 Step 3), never silent.
+
+## Phase 1: Decide the grammar
+
+- [ ] **Step 1:** Read the council convergence and record the verdict in this
+      roadmap (accept / accept-with-modification / reject per finding), naming
+      what the chosen direction sacrifices.
+- [ ] **Step 2:** Write the chosen rule into `docs/contracts/plan-review-gates.md`
+      § 2.2 as a deterministic parser contract, covering explicitly: an
+      undeclared labelled fence, an unterminated fence, nested fences
+      (```` ```` ```` wrapping ```` ``` ````), and a findings-shaped row whose
+      Status is an unknown token.
+- [ ] **Step 3:** Decide and document migration for artefacts authored under the
+      old grammar — the header already carries `completion-review: v1`, so a
+      `v2` marker is available as the discriminator. Grandfathering must not
+      require editing a frozen record.
+- [ ] **Step 4:** Remove the `KNOWN HOLE` notes (contract § 2.2 and the
+      `scanFences` JSDoc) in the same change that removes the hole — never
+      before.
+
+## Phase 2: Implement and prove it
+
+- [ ] **Step 1:** Implement the rule in `check_completion_review.ts`.
+- [ ] **Step 2:** Replace the `KNOWN HOLE` characterization block in
+      `tests/scripts/check_completion_review.test.ts` with the positive
+      assertion: the reproduction artefact (earlier terminal row, labelled
+      opener, live `open` row, later bare fence) now yields a blocking
+      violation. Deleting the block without that replacement is not allowed.
+- [ ] **Step 3:** Update `dispatch_r2_reviewer.ts` so its generated skeleton is
+      valid under the new grammar — the skeleton is the highest-traffic artefact
+      and a grammar that reds it is wrong by construction.
+- [ ] **Step 4:** Fix the `unbalanced-fence` remediation string so it cannot
+      describe the arrangement that produced finding 1.
+- [ ] **Step 5:** Verify: the four fail-open shapes from the § 2.2 history
+      (odd-count toggle, mis-paired positional, stray-closed labelled opener,
+      and the new grammar's own nearest miss) each have a fixture that blocks.
+
+## Phase 3: Disposition index with stable ids
+
+- [ ] **Step 1:** Choose the identifier scheme — composite `round<N>#<M>` or
+      real `R-NNN` ids minted per finding — and state why the other was rejected.
+      Rows are currently numbered per round and collide across rounds.
+- [ ] **Step 2:** Define the index artefact in the contract: one tracked file
+      keyed by finding id, carrying the terminal status plus its reference
+      (commit sha, reason, or carrier), and the rule that every `open` row in an
+      archived round MUST have an index entry.
+- [ ] **Step 3:** Implement the reconciliation in `check_completion_review.ts`:
+      an archived round's `open` row without a terminal index entry is a
+      violation; an index entry for an id no round contains is also a violation
+      (both directions, or the index rots).
+- [ ] **Step 4:** Backfill the index for the existing rounds 1–8 plus the
+      post-merge blind pass, from the closure commits already on `main`.
+- [ ] **Step 5:** Exempt archived rounds from the § 2.4 status-completeness rule
+      *only* where the index covers them, so "all terminal" becomes machine-
+      checkable instead of PR prose.
+- [ ] **Step 6:** Verify with fixtures: missing entry blocks, orphan entry
+      blocks, complete index passes, and the advisory bot's contradiction on
+      rounds 6/7/8 no longer reproduces.
+
+## Phase 4: Projections + docs
+
+- [ ] **Step 1:** `task sync` — regenerate `dist/agent-src/`.
+- [ ] **Step 2:** `task generate-tools` for any touched command/skill surface.
+- [ ] **Step 3:** Register any new validator entry point in
+      `src/config/gate-coverage.yml` with a real `min_scanned` floor, or state
+      why the existing entry covers it.
+
+## Acceptance Criteria
+
+- [ ] The reproduction artefact from the blind pass (earlier terminal row,
+      labelled opener, live `open` row, later bare fence) produces a **blocking**
+      violation; the characterization test is replaced by that positive
+      assertion, not deleted.
+- [ ] The dispatcher's generated skeleton passes the new grammar unchanged by a
+      human.
+- [ ] Every fail-open shape in the § 2.2 history has a fixture that blocks.
+- [ ] Both `KNOWN HOLE` notes are gone, removed in the same change as the hole.
+- [ ] Migration is explicit: an artefact authored under the old grammar either
+      passes by a documented discriminator or is named as requiring re-issue —
+      never silently red, never silently green, never edited in place.
+- [ ] An archived round's `open` row without a terminal index entry blocks; an
+      orphan index entry blocks; rounds 1–8 plus the blind pass are backfilled
+      and pass.
+- [ ] `check_completion_review` still emits `scanned: <N>` on every exit path
+      including exit 2, and the exit-code contract of § 6 is unchanged.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-04 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Fourth fail-open | implementation | A new grammar introduces its own hiding arrangement, as each of the three previous attempts did | Every historical fail-open shape gets a blocking fixture, plus a fixture for the new grammar's nearest miss | Phase 2 Step 5 |
+| 2 | Guard reds every artefact | product | The safety rule fires on legitimate template quoting, starting with the dispatcher's own skeleton | The skeleton is a first-class acceptance criterion, updated in the same change as the grammar | Phase 2 Step 3, Phase 1 Step 2 |
+| 3 | Frozen audit trail edited | implementation | Migration or backfill rewrites archived rounds in place, destroying the only detection floor § 5 has | Non-goal stated; migration keyed on a header version marker, backfill writes only the new index file | Phase 1 Step 3, Phase 3 Step 4 |
+| 4 | Index rots | implementation | The index drifts from the rounds it indexes and silently stops covering them | Reconciliation blocks in BOTH directions — missing entry and orphan entry | Phase 3 Step 3, Phase 3 Step 6 |
+| 5 | Hole outlives its note | product | The `KNOWN HOLE` notes are removed for tidiness before the hole is closed, or survive after | Removal is tied to the same change as the fix, and the characterization test fails loudly when behaviour changes | Phase 1 Step 4, Phase 2 Step 2 |
+| 6 | Id scheme churn | implementation | Stable ids are chosen without covering the cross-round collision, forcing a second renumbering | Scheme choice is an explicit step that must state why the alternative was rejected | Phase 3 Step 1 |
+
+## Notes
+
+- Full-pipeline CI stays off locally (`quality.local_auto_run: false`); the
+  targeted probes named in the steps run, remote CI on the PR is the gate.
+- Phase 3 was scoped as its own PR when the work was agreed; Phases 1–2 (the
+  live `critical`) may ship first and independently.


### PR DESCRIPTION
## What

Three things, all bookkeeping and decisions rather than gate behaviour — the
behaviour change they set up is deliberately **not** in this PR.

## 1. My own two-phase violation, corrected in the open

All five rows of `postmerge-blindpass-review.md` said `open` on `main`. Findings
3 and 5 were **fixed** in `16dace44b` and never updated; 1, 2 and 4 sat `open`
where the contract requires a terminal status with a reference. That is a
violation of the rule this artefact exists to enforce.

**Nothing caught it.** The file is outside the `*.findings.md` glob (§2.7, so the
validator never selects it) and R2 runs `--advisory` during Stage A — neither
layer looks. Now **2 fixed, 3 deferred, 0 open**, and the artefact carries a
`### Correction` section recording the slip instead of quietly repairing it: a
silently-fixed bookkeeping lie is the same class of defect as §5's steered
review.

## 2. A carrier, so a live critical is not held in code comments

Before this PR the only records of the confirmed `critical` fail-open on `main`
were one review artefact and two `KNOWN HOLE` comments. The follow-up roadmap on
`main` mentions none of it (0 hits for fence / blind-pass / disposition / stable
ids).

`road-to-plan-gate-fence-grammar.md` now carries both open items with a Risk
Register, acceptance criteria, and the non-goals that matter here (no in-place
edits to frozen round records; no change to the advisory posture).

## 3. The §2.2 grammar decision, made by council rather than by me

**Convergent on Candidate B:** the safety property moves into the data model and
out of presentation parsing. Rows are **live by default**; an illustrative row
must be **explicitly marked**. That inversion is the fail-closed part — forgetting
a marker blocks instead of passing.

Two variants were rejected, and both reasons are on the record:

- **Pure structured-data-block** (findings in a fenced data block, everything
  outside ignored) — killed on a false *negative*: an author who forgets the
  wrapper leaves an `open` row in prose and the gate passes while they believe a
  blocker was filed. "Manual review will notice" is the assumption that created
  the need for the gate.
- **Blocking on a malformed table inside a declared block** — a confusing-block
  generator: an author adding a row gets blocked by someone else's older
  formatting glitch, with no indication which row or what the parser wanted.

Migration is version-marker based (`completion-review: v1` → `v2`), with a
transitional window and a deprecation warning. Frozen records are never edited to
comply.

## Not in this PR, and why

**The parser change itself.** Implementing Candidate B touches the row grammar,
the `v2` discriminator, the migration path, the dispatcher's generated skeleton,
and the fixture set — in exactly the code where four fail-opens have now shipped
in sequence. It gets its own focused pass (roadmap Phases 1–2), not the tail of a
long session. The live hole stays pinned by the `KNOWN HOLE` characterization
test meanwhile.

**The disposition index — its premise did not survive contact.** The agreed design
assumed archived rounds carry `open` rows whose terminal disposition lives
elsewhere. Measured across every review artefact on `main`: **zero open rows.**
Rounds 6, 7 and 8 are terminal *in place*, each `deferred` row naming
`road-to-plan-gates-measurement.md` as its carrier with a real reason. So the gap
is not "dispositions live outside the rounds" — it is that **no validator reads
those files at all**, which is exactly how my own slip in item 1 survived.

That points at a smaller mechanism than an index with stable ids: apply
status-completeness to archived round records. It needs no new artefact, no id
scheme, and no backfill, and it would have caught item 1 directly. Stable ids and
a separate index only become necessary if dispositions must live outside the
rounds — which today they do not. Recorded as an open question in the roadmap
rather than built on the stale premise.

## Verification

- `task typecheck-ts` → exit 0
- `lint_plan_risk_register` → `scanned: 20`, exit 0 (new roadmap included, floor 12)
- `task sync` → counts in sync, no projection drift
- `roadmap:progress` regenerated · 15 roadmaps · 69/182 steps
