### PR TITLE
docs(roadmap): pin-then-migrate ordering, and a round-record check instead of the disposition index

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**69 / 182 steps done · 38%**
+**69 / 183 steps done · 38%**
 
 ```text
 ███████████████░░░░░░░░░░░░░░░░░░░░░░░░░   38%
@@ -24,7 +24,7 @@
 | 6 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 7 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
 | 8 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 9 | [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md) | 4 | 25 | 24 | 1 | 0 | 0 | 0 | ░░░░░░░░░░ 4% |
+| 9 | [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md) | 4 | 26 | 25 | 1 | 0 | 0 | 0 | ░░░░░░░░░░ 4% |
 | 10 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
@@ -160,13 +160,13 @@ _1 blocker resolved._
 
 ### [road-to-plan-gate-fence-grammar.md](roadmaps/road-to-plan-gate-fence-grammar.md)
 
-**Plan-gate fence grammar — close the live fail-open, make dispositions machine-checkable** — 1 / 25 done (4%)
+**Plan-gate fence grammar — close the live fail-open, make archived dispositions machine-checked** — 1 / 26 done (4%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Decide the grammar | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
-| 2 | Implement and prove it | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
-| 3 | Disposition index with stable ids | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 1 | Decide the grammar | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
+| 2 | Pin the IS-behaviour FIRST, then migrate | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+| 3 | Status-completeness on archived round records | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
 | 4 | Projections + docs | ⬜ not started | 10 | 0 | 0 | 0 | 0% |
 
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)

--- a/agents/roadmaps/road-to-plan-gate-fence-grammar.md
+++ b/agents/roadmaps/road-to-plan-gate-fence-grammar.md
@@ -2,15 +2,15 @@
 complexity: structural
 ---
 
-# Roadmap: Plan-gate fence grammar — close the live fail-open, make dispositions machine-checkable
+# Roadmap: Plan-gate fence grammar — close the live fail-open, make archived dispositions machine-checked
 
 > Two open items the plan-governance work left on `main`, both carried here
 > because they were otherwise recorded only in a review artefact and two code
 > comments: **(F)** a confirmed `critical` fail-open in the R2 findings parser —
-> an `open` finding can be hidden from the gate — and **(D)** the absence of any
-> machine-checkable link between an archived round's `open` rows and the terminal
-> disposition recorded elsewhere. F is a live defect; D is why F's own
-> bookkeeping drifted unnoticed for a day.
+> an `open` finding can be hidden from the gate — and **(D)** the fact that **no validator reads
+> archived round records at all** — they sit outside the `*.findings.md` glob, so
+> a finding recorded `open` after being fixed is caught by nothing. F is a live
+> defect; D is why F's own bookkeeping drifted unnoticed for a day.
 
 ## Prerequisites
 
@@ -45,14 +45,21 @@ complexity: structural
   everything after an odd fence count invisible; positional pairing detected
   parity but mis-paired; the current labelled-opener rule is defeated by a stray
   bare fence.
-- **D — dispositions are not reconcilable.** Archived rounds are a frozen audit
-  trail (§ 2.7) and must not be edited in place, so their `open` rows stay
-  `open` while the terminal status lives in a closure commit or a follow-up
-  roadmap. The advisory bot parses the artefacts, sees the `open` rows, and
-  reports a contradiction that is not one. Round records also carry **no stable
-  identifiers** — rows are numbered per round, so `round3 #5` and `round4 #5`
-  collide, and any index must key on a composite or on real `R-NNN` ids (the
-  still-open advisory finding on stable ids called this out first).
+- **D — archived round records are read by nothing.** They sit outside the
+  `*.findings.md` glob (§ 2.7), so the validator never selects them, and R2 runs
+  `--advisory` during Stage A. A row left `open` after its finding was fixed is
+  therefore caught by no layer — which is exactly what happened to the blind-pass
+  artefact for a day (see its `### Correction`).
+
+  **The originally-assumed cause was measured and refuted.** The plan assumed
+  archived rounds *carry* `open` rows whose terminal disposition lives elsewhere
+  (a closure commit, a follow-up roadmap), and that reconciling them needed a
+  stable-id index because rows are numbered per round and `round3 #5` collides
+  with `round4 #5`. Measured across every review artefact on `main`: **zero open
+  rows.** Rounds 6, 7 and 8 are terminal *in place*, each `deferred` row naming
+  `road-to-plan-gates-measurement.md` with a real reason. So the collision
+  problem is real but not yet load-bearing, and the index it would justify is not
+  built — see the Phase 3 decision.
 - **Direction for F was routed to the AI council** (2026-08-04) rather than
   chosen unilaterally: candidate A = explicitly declared illustrative regions;
   candidate B = move the safety property off fence pairing entirely (a row is
@@ -117,48 +124,104 @@ layer that has now failed open four times.
       old grammar — the header already carries `completion-review: v1`, so a
       `v2` marker is available as the discriminator. Grandfathering must not
       require editing a frozen record.
-- [ ] **Step 4:** Remove the `KNOWN HOLE` notes (contract § 2.2 and the
-      `scanFences` JSDoc) in the same change that removes the hole — never
-      before.
 
-## Phase 2: Implement and prove it
+## Phase 2: Pin the IS-behaviour FIRST, then migrate
 
-- [ ] **Step 1:** Implement the rule in `check_completion_review.ts`.
-- [ ] **Step 2:** Replace the `KNOWN HOLE` characterization block in
-      `tests/scripts/check_completion_review.test.ts` with the positive
-      assertion: the reproduction artefact (earlier terminal row, labelled
-      opener, live `open` row, later bare fence) now yields a blocking
-      violation. Deleting the block without that replacement is not allowed.
-- [ ] **Step 3:** Update `dispatch_r2_reviewer.ts` so its generated skeleton is
+> **Sequencing requirement (maintainer, 2026-08-04) — not negotiable.** This
+> change touches the exact code that has shipped four fail-opens in a row, so the
+> fixtures and the characterization assertions land **before** the row-grammar
+> edit, in an earlier commit. Pinning first makes the behaviour change visible as
+> a test diff instead of invisible; a grammar edit that arrives before its
+> fixtures proves nothing about what it changed. The original ordering here had
+> Step 1 implementing the rule and Step 5 adding fixtures — that is the inversion
+> this section corrects.
+
+- [ ] **Step 1 (pin — its own commit, no production edit):** Extend the fixture
+      set to cover **every** fail-open shape in the § 2.2 history, each asserting
+      CURRENT behaviour so the suite is green before anything migrates:
+      the odd-count `inFence` toggle, the mis-paired positional pairing, the
+      stray-closed labelled opener (the live reproduction), and the nearest miss
+      of the incoming grammar. Alongside them, a non-regression fixture per
+      legitimate shape that must KEEP working: a properly-closed labelled block,
+      a nested ```` ```` ````-wrapped fence, and the dispatcher's generated
+      skeleton verbatim.
+- [ ] **Step 2:** Implement the Candidate-B rule in `check_completion_review.ts`
+      (rows live by default, explicit illustrative marker, `v2` discriminator).
+- [ ] **Step 3:** In the SAME commit as Step 2, flip the pinned assertions from
+      Step 1 to their post-change expectations. The diff of that commit is then
+      the exact, reviewable list of behaviours that changed — and any fixture
+      that flips unexpectedly is a defect found before merge, not after.
+- [ ] **Step 4:** Update `dispatch_r2_reviewer.ts` so its generated skeleton is
       valid under the new grammar — the skeleton is the highest-traffic artefact
-      and a grammar that reds it is wrong by construction.
-- [ ] **Step 4:** Fix the `unbalanced-fence` remediation string so it cannot
+      and a grammar that reds it is wrong by construction. Its verbatim fixture
+      from Step 1 must stay green.
+- [ ] **Step 5:** Fix the `unbalanced-fence` remediation string so it cannot
       describe the arrangement that produced finding 1.
-- [ ] **Step 5:** Verify: the four fail-open shapes from the § 2.2 history
-      (odd-count toggle, mis-paired positional, stray-closed labelled opener,
-      and the new grammar's own nearest miss) each have a fixture that blocks.
+- [ ] **Step 6:** Remove the `KNOWN HOLE` notes (contract § 2.2 and the
+      `scanFences` JSDoc) — in the same change that removes the hole, never
+      before, and never while any Step-1 fixture still asserts the old
+      behaviour. (Moved here from Phase 1: the notes describe a hole Phase 2
+      closes, so removing them in Phase 1 would have documented a fix that did
+      not exist yet.)
 
-## Phase 3: Disposition index with stable ids
+## Phase 3: Status-completeness on archived round records
 
-- [ ] **Step 1:** Choose the identifier scheme — composite `round<N>#<M>` or
-      real `R-NNN` ids minted per finding — and state why the other was rejected.
-      Rows are currently numbered per round and collide across rounds.
-- [ ] **Step 2:** Define the index artefact in the contract: one tracked file
-      keyed by finding id, carrying the terminal status plus its reference
-      (commit sha, reason, or carrier), and the rule that every `open` row in an
-      archived round MUST have an index entry.
-- [ ] **Step 3:** Implement the reconciliation in `check_completion_review.ts`:
-      an archived round's `open` row without a terminal index entry is a
-      violation; an index entry for an id no round contains is also a violation
-      (both directions, or the index rots).
-- [ ] **Step 4:** Backfill the index for the existing rounds 1–8 plus the
-      post-merge blind pass, from the closure commits already on `main`.
-- [ ] **Step 5:** Exempt archived rounds from the § 2.4 status-completeness rule
-      *only* where the index covers them, so "all terminal" becomes machine-
-      checkable instead of PR prose.
-- [ ] **Step 6:** Verify with fixtures: missing entry blocks, orphan entry
-      blocks, complete index passes, and the advisory bot's contradiction on
-      rounds 6/7/8 no longer reproduces.
+> **Decision (maintainer, 2026-08-04): the disposition index with stable ids is
+> NOT built. Archived round records get a status-completeness check instead.**
+>
+> The premise the index rested on did not survive measurement. It assumed
+> archived rounds carry `open` rows whose terminal disposition lives elsewhere.
+> Measured across every review artefact on `main`: **zero open rows.** Rounds 6,
+> 7 and 8 are terminal *in place*, each `deferred` row naming
+> `road-to-plan-gates-measurement.md` with a real reason.
+>
+> The maintainer's argument, recorded because it is the reusable part: the only
+> failure mode actually observed — the agent's own bookkeeping slip, two `fixed`
+> findings left recorded `open` for a day — **would have been caught by a
+> status-completeness check on the round records.** The index protects against a
+> mode that has not occurred (dispositions needing reference from outside the
+> rounds). Until that happens the index is backdoor debt in waiting: a second
+> artefact that must be kept in sync with the rounds, and therefore itself a new
+> drift source. It can still be built later if dispositions genuinely migrate out
+> of the rounds; the reverse rollback would cost more.
+>
+> Root cause restated: the gap was never "dispositions live outside the rounds",
+> it was that **no validator reads those files at all** — they sit outside the
+> `*.findings.md` glob (§ 2.7) so nothing selects them.
+
+- [ ] **Step 1:** Define the rule in the contract: every findings-shaped row in
+      an archived round record (`*-review.md` outside the `*.findings.md` glob)
+      MUST carry a terminal status, and each status its required reference —
+      `fixed` a commit-ish, `accepted-risk` a reason, `deferred` a carrier. An
+      `open` row in an archived record is a violation by definition: archiving is
+      what asserts the round is closed.
+- [ ] **Step 2:** Implement it as its own validator
+      (`check_review_dispositions.ts`) rather than inside
+      `check_completion_review`. Keeping it separate preserves § 2.6's
+      scope-selection — folding a corpus-wide sweep into the scope-selecting
+      validator is exactly the directory-wide coupling § 2.6 removed — and gives
+      the new check its own `scanned:` floor.
+- [ ] **Step 3:** Reference-shape validation, deliberately narrow: a `fixed` ref
+      must resolve via `rev-parse`, a `deferred` ref must name an existing file.
+      No prose grading. Getting stricter than "the reference resolves" invites
+      the confusing-block failure the council named.
+- [ ] **Step 4:** Run it against the existing corpus (rounds 1–8 plus the blind
+      pass) and fix whatever it legitimately flags. Expect it to pass on the
+      first run — the corpus is already terminal — so a failure here is a
+      finding about the checker, not the corpus.
+- [ ] **Step 5:** Register in `src/config/gate-coverage.yml` with a real
+      `min_scanned` floor derived from the current record count, and wire into
+      `task preflight` + CI with the § 6 exit-code contract (exit 2 →
+      warn-and-allow, dead scan scope → exit 1).
+- [ ] **Step 6:** Verify with fixtures: an `open` row in an archived record
+      blocks; `fixed` without a resolvable ref blocks; `deferred` without a
+      carrier blocks; `accepted-risk` without a reason blocks; the real corpus
+      passes. Plus the regression that motivated this phase — the exact shape of
+      the blind-pass slip (a `fixed` finding still recorded `open`) must block.
+- [ ] **Step 7:** Note in the contract that the stable-id index remains an
+      option, with the trigger that would justify it: a disposition that cannot
+      be recorded in the round record itself. Recording the trigger prevents both
+      re-litigating the decision and forgetting it was conditional.
 
 ## Phase 4: Projections + docs
 
@@ -194,9 +257,9 @@ layer that has now failed open four times.
 | 1 | Fourth fail-open | implementation | A new grammar introduces its own hiding arrangement, as each of the three previous attempts did | Every historical fail-open shape gets a blocking fixture, plus a fixture for the new grammar's nearest miss | Phase 2 Step 5 |
 | 2 | Guard reds every artefact | product | The safety rule fires on legitimate template quoting, starting with the dispatcher's own skeleton | The skeleton is a first-class acceptance criterion, updated in the same change as the grammar | Phase 2 Step 3, Phase 1 Step 2 |
 | 3 | Frozen audit trail edited | implementation | Migration or backfill rewrites archived rounds in place, destroying the only detection floor § 5 has | Non-goal stated; migration keyed on a header version marker, backfill writes only the new index file | Phase 1 Step 3, Phase 3 Step 4 |
-| 4 | Index rots | implementation | The index drifts from the rounds it indexes and silently stops covering them | Reconciliation blocks in BOTH directions — missing entry and orphan entry | Phase 3 Step 3, Phase 3 Step 6 |
+| 4 | Ref-shape check too strict | product | Reference validation grows past "the ref resolves" into grading prose, producing the confusing blocks the council warned about | Scope fixed in the step itself: `fixed` resolves via rev-parse, `deferred` names an existing file, nothing more | Phase 3 Step 3 |
 | 5 | Hole outlives its note | product | The `KNOWN HOLE` notes are removed for tidiness before the hole is closed, or survive after | Removal is tied to the same change as the fix, and the characterization test fails loudly when behaviour changes | Phase 1 Step 4, Phase 2 Step 2 |
-| 6 | Id scheme churn | implementation | Stable ids are chosen without covering the cross-round collision, forcing a second renumbering | Scheme choice is an explicit step that must state why the alternative was rejected | Phase 3 Step 1 |
+| 6 | Corpus-wide sweep re-couples the gate | implementation | Folding the archived-record check into `check_completion_review` re-introduces the directory-wide coupling § 2.6 removed | Shipped as its own validator with its own scanned floor, never inside the scope-selecting one | Phase 3 Step 2 |
 
 ## Notes
 
@@ -204,3 +267,6 @@ layer that has now failed open four times.
   targeted probes named in the steps run, remote CI on the PR is the gate.
 - Phase 3 was scoped as its own PR when the work was agreed; Phases 1–2 (the
   live `critical`) may ship first and independently.
+- Phase 2's pin-then-migrate ordering is a maintainer requirement, not a
+  preference: fixtures land in an earlier commit than the grammar edit, so the
+  behaviour change is reviewable as a test diff.


### PR DESCRIPTION
## What

Two maintainer decisions on the fence-grammar roadmap, recorded with their
arguments rather than as bare outcomes. Roadmap-only — no gate behaviour changes.

## 1. Phase 2 ordering was inverted, and is corrected

The roadmap had **Step 1 implementing the grammar** and **Step 5 adding
fixtures**. That is backwards for a change touching the exact code that has
shipped four fail-opens in sequence.

Corrected to **pin-then-migrate**:

- **Step 1 (own commit, no production edit):** fixtures for *every* fail-open
  shape in the §2.2 history — the odd-count `inFence` toggle, the mis-paired
  positional pairing, the stray-closed labelled opener (the live reproduction),
  and the incoming grammar's nearest miss — each asserting **current** behaviour
  so the suite is green before anything moves. Plus non-regression fixtures for
  the shapes that must keep working, including **the dispatcher's generated
  skeleton verbatim**.
- **Step 2:** implement Candidate B.
- **Step 3:** flip the pinned assertions in the *same commit* as Step 2 — so that
  commit's diff is the exact, reviewable list of behaviours that changed, and any
  fixture flipping unexpectedly is a defect found before merge.

`KNOWN HOLE` note removal moved from Phase 1 to the end of Phase 2: the notes
describe a hole Phase 2 closes, so removing them in Phase 1 would have documented
a fix that did not exist yet.

## 2. The disposition index is not built — a round-record check replaces it

Its premise was measured and refuted. The design assumed archived rounds carry
`open` rows whose terminal disposition lives elsewhere. Across every review
artefact on `main`: **zero open rows** — rounds 6/7/8 are terminal *in place*,
each `deferred` row naming a carrier with a real reason.

The decisive argument, recorded because it is the reusable part: the **only
observed** failure mode — two `fixed` findings left recorded `open` for a day —
would have been caught by status-completeness on the round records. The index
guards a mode that **has not occurred** (dispositions needing reference from
outside the rounds). Until it does, the index is a second artefact that must be
kept in sync with the rounds, and therefore a new drift source of its own. It can
still be built if dispositions genuinely migrate out; the reverse rollback costs
more.

Root cause restated: the gap was never "dispositions live outside the rounds" —
it is that **no validator reads those files at all**. They sit outside the
`*.findings.md` glob (§2.7), so nothing selects them, and R2 is `--advisory`
during Stage A.

Phase 3 now specifies that check, with three constraints worth naming:

- **Its own validator** (`check_review_dispositions.ts`), not folded into
  `check_completion_review` — a corpus-wide sweep there would re-introduce the
  directory-wide coupling §2.6 removed, and this way it gets its own `scanned:`
  floor.
- **Reference validation stays narrow** — `fixed` resolves via `rev-parse`,
  `deferred` names an existing file. No prose grading; going stricter invites the
  confusing-block failure the council warned about.
- **The index stays available with its trigger recorded** (Step 7): a disposition
  that cannot be recorded in the round record itself. That keeps the decision
  conditional rather than something to re-litigate or forget was conditional.

## Consistency pass on my own document

The context bullet still carried the refuted premise while the phase below it
said the opposite — the doc-vs-code drift this roadmap exists to stop. Title,
context bullet D, two risk rows (index-rots and id-scheme-churn replaced by the
risks the chosen mechanism actually carries) and the notes are reconciled.

## Verification

- `lint_plan_risk_register` → `scanned: 20`, exit 0
- `check_references` → 1066 scanned, none broken
- `roadmap:progress` regenerated · 15 roadmaps · 69/183 steps
- Branch merged up to date with `main`
