### PR TITLE
feat(bench): close the A/B harness integrity gaps before the paid run

### DIFF
--- a/agents/evidence/investigations/solution-minimalism-phase0-spikes.md
+++ b/agents/evidence/investigations/solution-minimalism-phase0-spikes.md
@@ -236,11 +236,11 @@ nothing to stop it.
 
 | # | Delta | Size |
 |---|---|---|
-| 1 | Per-trial injection audit — assert the arm's expected footprint from `tokens_breakdown` before it is discarded; persist an `activation` verdict; hard-fail on violation. Shape to copy: `bench_ab_tracka_run.ts:120-134` `integrity_check`. | small |
-| 2 | Preserve `tokens_breakdown` in the v2 record (one field). Unblocks #1 and #6. | small |
-| 3 | Model-id verification — read the model back from the CLI envelope, refuse on mismatch, reject bare aliases (`"sonnet"` appears in a stored report). | small |
-| 4 | Sweep-level `--max-usd` abort (pattern exists in `bench_quality_rerun.ts`). | small |
-| 5 | Record the errored-pair drop count per arm-pair and per `status_bucket` — attrition is not missing-at-random; budget caps fire preferentially on the arm doing more work. | small |
+| 1 | ~~Per-trial injection audit~~ — **DONE 2026-08-05.** `_lib/bench_ab_activation.ts`: `activation_verdict` (per-trial, both directions on the text channel) + `audit_activation` (the paired plugin direction, which one trial cannot see). Wired into `bench_ab_v2_run.main` as an **exit-2** gate; the report is still written so an invalid sweep stays inspectable. | small |
+| 2 | ~~Preserve `tokens_breakdown` in the v2 record~~ — **DONE 2026-08-05** via `integrity_fields`, on both the plain and the recursive arm. | small |
+| 3 | ~~Model-id verification~~ — **DONE 2026-08-05.** `bench_ab_task_runner.run_live` now records `models_seen` from the envelope's `modelUsage` keys unconditionally; `verify_model_id` compares it to the request (build-stamp-insensitive), and `main` refuses a bare alias with exit 2 **before** any spend. | small |
+| 4 | ~~Sweep-level `--max-usd` abort~~ — **DONE 2026-08-05.** `SweepBudget` prices the four buckets separately from `pricing.yaml` and aborts the sweep through a `collect_records` guard; completed runs are kept. An unpriceable model + `--max-usd` is refused rather than silently uncapped. | small |
+| 5 | ~~Record the errored-pair drop count~~ — **DONE 2026-08-05.** `bench_ab_v2_stats.compare` emits an `attrition` block (pairs seen / analysed / dropped, per-side split, signed asymmetry, per-`status_bucket` counts), rendered as Table 4 with the bias direction spelled out. | small |
 | 6 | Cost sheet — wire `load_pricing` into `bench_ab_v2_stats.ts`, price the four buckets separately, re-source the 2026-05-14 prices. | medium |
 | 7 | Preserve per-run workspaces + transcripts (key the work dir by `task\|arm\|seed`, not task alone) — prerequisite for offline re-scoring, and therefore for retro-fitting the complexity endpoint. | medium |
 | 8 | A real `--selftest` — today's `--mode dry-run` returns at `:844-851` before the CLI check, the fixtures, the scorer, and the report writer. The injectable seams (`:767`, `:534`) already exist. | medium |
@@ -252,6 +252,13 @@ nothing to stop it.
 and an unpublishable one — they land before any spend. #9 and #10 ship together
 (a harness pointed at a real repo with no oracles runs nothing). #11 is
 separable but the roadmap's metric-pair acceptance criterion depends on it.
+
+**Status 2026-08-05:** #1–#5 are landed (rows above, tests in
+`tests/scripts/_lib_bench_ab_activation.test.ts` plus the integrity block in
+`tests/scripts/bench_ab_v2_run.test.ts` and the attrition block in
+`tests/scripts/bench_ab_v2_stats.test.ts` — every gate asserted in both
+directions, so neither an always-firing nor a never-firing audit passes). #6–#11
+are untouched, and the two Phase-3 halt gates (spend grant; #9/#10/#11) stand.
 
 ### Consequence for Phase 3
 

--- a/agents/roadmaps/road-to-solution-minimalism.md
+++ b/agents/roadmaps/road-to-solution-minimalism.md
@@ -468,6 +468,11 @@ the standing model-id verification blocker.
 > from an undetected activation leak and today's code would not catch a
 > recurrence. Whatever else happens, they land before the first paid trial.
 >
+> **Deltas #1–#5 LANDED 2026-08-05** — see § Untracked prerequisite work below.
+> Both halt gates stand unchanged: the spend grant is still the user's, and
+> #9/#10/#11 are still missing. What changed is that the harness can no longer
+> produce the specific invalid null it produced before.
+>
 > Nothing from this phase is cancelled or reinterpreted; the steps stand as
 > written. Full evidence, delta table, and price inputs:
 > [`solution-minimalism-phase0-spikes § S0.3`](../evidence/investigations/solution-minimalism-phase0-spikes.md).
@@ -484,6 +489,12 @@ the standing model-id verification blocker.
       routed floors add over the naked principle; its safety-tier result is the
       exhibit for why the floors exist) · inert-prose placebo.
       *Verify:* per-trial injection audit in both directions for every arm.
+      <!-- OPEN 2026-08-05, but the VERIFY half now exists: the both-directions
+      audit shipped with delta #1 (`_lib/bench_ab_activation.activation_verdict`
+      + `audit_activation`, wired into `bench_ab_v2_run` as an exit-2 gate). What
+      remains is the STEP body — `ARMS` still lacks a `package + ladder` arm and
+      the bare-principle control, and those are arm definitions, not audit work. -->
+
 - [ ] **Endpoints:** added lines from `git diff`; tokens as the **sum** of
       input + cache + output (a metric mismatch here is the known reporting
       trap); cost; wall-clock; the existing discipline rubric; a **safety tier**
@@ -526,6 +537,36 @@ the standing model-id verification blocker.
       drops a guard has lost, not won (F6).
       *Verify:* the scoring code cannot rank an arm above another on size alone
       when its safety tier regressed.
+
+## Untracked prerequisite work (landed 2026-08-05)
+
+S0.3 deltas **#1–#5** landed ahead of any spend, exactly as the Phase-3 halt
+note requires. They close **zero checkboxes** — every open step above is gated
+on the spend grant or on deltas #9/#10/#11 — so the dashboard does not move.
+Recorded here rather than left invisible, and deliberately not spun off into a
+roadmap of its own: a meta-roadmap tracking untracked work is the recursive
+process debt this roadmap argues against.
+
+| # | What landed | Where |
+|---|---|---|
+| 1 | Per-trial injection audit + the paired cross-arm audit; violations fail the sweep with exit 2 | `_lib/bench_ab_activation.ts`, wired in `bench_ab_v2_run.ts` |
+| 2 | `tokens_breakdown` preserved on every trial record (unblocks #1 and #6) | `bench_ab_v2_run.integrity_fields` |
+| 3 | Model-id read back from the CLI envelope's `modelUsage`; bare aliases refused before spend | `bench_ab_task_runner.ts` (`models_seen`), `bench_ab_v2_run.ts` |
+| 4 | Sweep-level `--max-usd` abort, priced per bucket from `internal/bench/pricing.yaml` | `SweepBudget`, `collect_records` guard |
+| 5 | Errored-pair attrition per arm-pair and per `status_bucket`, with the drop asymmetry | `bench_ab_v2_stats.compare` → report Table 4 |
+
+**Why now, with the phase halted.** The harness has already produced one full
+set of invalid nulls from an undetected activation leak, and the only activation
+field on a record — `injected_chars` — is the length of a file the harness wrote
+itself and is `0` by construction for the `package` arm. A disabled or
+version-drifted plugin would have degraded every treatment run to `vanilla` and
+produced a report that looks identical to a real one. These five close that hole
+before the $150–250 grant is spent against it, not after.
+
+**What did NOT change.** Both Phase-3 halt gates stand: the spend grant is the
+user's to give, and #9 (pinned external repo), #10 (~30 oracles) and #11 (the
+cognitive-complexity endpoint) are still absent. No effect claim, no number, and
+no threshold was added anywhere.
 
 ## The principle-admission gate (this table is the scope boundary)
 

--- a/src/scripts/_lib/bench_ab_activation.ts
+++ b/src/scripts/_lib/bench_ab_activation.ts
@@ -1,0 +1,368 @@
+/**
+ * Measurement-integrity primitives for the bench:ab v2 paired sweep.
+ *
+ * Implements deltas #1–#4 of the S0.3 harness-feasibility spike
+ * (`agents/evidence/investigations/solution-minimalism-phase0-spikes.md`
+ * § "Deltas required before a paid run") — the four cheap ones the roadmap's
+ * Phase-3 halt note says "land before any spend".
+ *
+ * Why this exists at all: the sweep has ALREADY produced a full set of invalid
+ * nulls once. Clones lived inside the repo, so the `vanilla` arm inherited the
+ * package through project scope and every prior null was void
+ * (`bench_ab_v2_run.ts` § arm-isolation note). The fix at the time was a `/tmp`
+ * path constant with no runtime assertion behind it, and the only activation
+ * field on a trial record — `injected_chars` — is the `String.length` of a file
+ * the harness itself wrote. It proves nothing about the model, and it is `0` by
+ * construction for the `package` arm, which arrives through global settings.
+ * If the plugin were disabled or version-drifted mid-sweep, every treatment run
+ * would silently degrade to `vanilla` and the report would look identical.
+ *
+ * Everything here is pure and host-free so it can be unit-tested without a
+ * model call. The sweep wires it in `bench_ab_v2_run.ts`.
+ */
+
+/** Four-bucket usage split as reported by the Claude CLI JSON envelope. */
+export interface TokensBreakdown {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens: number;
+    cache_creation_input_tokens: number;
+}
+
+/** Per-1M-token rates for one pricing tier (mirrors `_lib/bench_cost.TierRates`). */
+export interface TierRates {
+    input: number;
+    output: number;
+    cache_write: number;
+    cache_read: number;
+}
+
+/**
+ * How an arm is supposed to reach the model.
+ *
+ * - `plugin` — the package rides global settings (`setting_sources: null`).
+ *   Invisible to `injected_chars`; only the prompt footprint can see it.
+ * - `text`   — an `--append-system-prompt-file` injection the harness wrote.
+ * - `none`   — the baseline: settings scoped away AND no text injection.
+ */
+export type ExpectedInjection = 'plugin' | 'text' | 'none';
+
+/**
+ * `unknown` is deliberately not a violation: an errored or budget-capped run
+ * carries a zeroed usage block, so its footprint says nothing. Attrition is
+ * reported separately (delta #5) rather than laundered into an integrity fail.
+ */
+export type ActivationVerdict = 'ok' | 'violation' | 'unknown';
+
+export interface Activation {
+    expected: ExpectedInjection;
+    prompt_tokens: number;
+    injected_chars: number;
+    verdict: ActivationVerdict;
+    reason: string;
+}
+
+export interface ActivationViolation {
+    task_id: string;
+    seed: number;
+    arm: string;
+    kind: 'text-injection-missing' | 'text-injection-unexpected' | 'collapsed-to-baseline' | 'model-mismatch';
+    detail: string;
+}
+
+export interface ActivationAudit {
+    checked: number;
+    skipped: number;
+    violations: ActivationViolation[];
+}
+
+/**
+ * Minimum prompt-footprint ratio a plugin-bearing arm must hold over the paired
+ * baseline run before the pair is believed.
+ *
+ * Calibrated DOWNWARD from the three stored sweeps in S0.3's cost sheet, whose
+ * observed treatment/vanilla total-token ratios were 4.68× (sonnet, `package`),
+ * 1.71× (haiku, `rules-kernel-dc`) and 6.79× (haiku, `package`). 1.2 sits below
+ * the smallest of those by a wide margin on purpose: this flags a COLLAPSE to
+ * baseline — a disabled or drifted plugin — never ordinary run-to-run variance.
+ * Raising it toward the observed values would start failing legitimate runs;
+ * lowering it toward 1.0 would stop catching the failure it exists for.
+ */
+export const ACTIVATION_MIN_LIFT_RATIO = 1.2;
+
+/**
+ * The footprint an injection actually moves: everything the model was fed.
+ *
+ * Output tokens are excluded — they measure how much the model wrote, which a
+ * bigger system prompt does not reliably change, so including them would blur
+ * the very signal this audit reads.
+ */
+export function prompt_tokens(b: TokensBreakdown | Record<string, never> | null | undefined): number {
+    if (!b) {
+        return 0;
+    }
+    const t = b as Partial<TokensBreakdown>;
+    return _int(t.input_tokens) + _int(t.cache_read_input_tokens) + _int(t.cache_creation_input_tokens);
+}
+
+/** Classify an arm spec into the injection channel it is supposed to use. */
+export function expected_injection(spec: { setting_sources: string | null; inject: string | null }): ExpectedInjection {
+    if (spec.inject) {
+        return 'text';
+    }
+    return spec.setting_sources === null ? 'plugin' : 'none';
+}
+
+/**
+ * Per-trial verdict — the direction that IS decidable from one run.
+ *
+ * A text injection is checked both ways: an arm that declares one must carry
+ * it, and an arm that declares none must not. The plugin direction needs the
+ * paired baseline and is handled by `audit_activation`.
+ */
+export function activation_verdict(args: {
+    expected: ExpectedInjection;
+    tokens_breakdown: TokensBreakdown | Record<string, never> | null | undefined;
+    injected_chars: number;
+    errored: boolean;
+}): Activation {
+    const pt = prompt_tokens(args.tokens_breakdown);
+    const base = { expected: args.expected, prompt_tokens: pt, injected_chars: args.injected_chars };
+    if (args.errored || pt === 0) {
+        return { ...base, verdict: 'unknown', reason: 'errored or zero usage — footprint unreadable' };
+    }
+    if (args.expected === 'text' && args.injected_chars <= 0) {
+        return { ...base, verdict: 'violation', reason: 'text arm carried no injection' };
+    }
+    if (args.expected !== 'text' && args.injected_chars > 0) {
+        return {
+            ...base,
+            verdict: 'violation',
+            reason: `${args.expected} arm carried a ${args.injected_chars}-char injection`,
+        };
+    }
+    return { ...base, verdict: 'ok', reason: 'expected channel present' };
+}
+
+/**
+ * Cross-arm audit over a finished (or partial) record set — the plugin
+ * direction plus every per-trial verdict already stamped on the records.
+ *
+ * A pair is only judged when BOTH sides are readable; unreadable pairs are
+ * counted as `skipped`, never silently passed.
+ */
+export function audit_activation(
+    records: readonly Record<string, unknown>[],
+    opts: { baseline_arm: string; lift_arms: readonly string[]; min_ratio?: number },
+): ActivationAudit {
+    const minRatio = opts.min_ratio ?? ACTIVATION_MIN_LIFT_RATIO;
+    const violations: ActivationViolation[] = [];
+    let checked = 0;
+    let skipped = 0;
+
+    for (const rec of records) {
+        const taskId = String(rec['id'] ?? '');
+        const arms = _dict(rec['arms']);
+
+        for (const [arm, runsRaw] of Object.entries(arms)) {
+            for (const run of _list(runsRaw)) {
+                const act = _dict(run['activation']);
+                if (act['verdict'] === 'violation') {
+                    const reason = String(act['reason'] ?? '');
+                    violations.push({
+                        task_id: taskId,
+                        seed: _int(run['seed']),
+                        arm,
+                        kind: reason.includes('no injection') ? 'text-injection-missing' : 'text-injection-unexpected',
+                        detail: reason,
+                    });
+                }
+                const mc = _dict(run['model_check']);
+                if ('ok' in mc && !_truthy(mc['ok'])) {
+                    violations.push({
+                        task_id: taskId,
+                        seed: _int(run['seed']),
+                        arm,
+                        kind: 'model-mismatch',
+                        detail: String(mc['reason'] ?? ''),
+                    });
+                }
+            }
+        }
+
+        const baseBySeed = new Map<number, number>();
+        for (const run of _list(arms[opts.baseline_arm])) {
+            const pt = _runPromptTokens(run);
+            if (!_truthy(run['errored']) && pt > 0) {
+                baseBySeed.set(_int(run['seed']), pt);
+            }
+        }
+
+        for (const arm of opts.lift_arms) {
+            for (const run of _list(arms[arm])) {
+                const seed = _int(run['seed']);
+                const basePt = baseBySeed.get(seed);
+                const armPt = _runPromptTokens(run);
+                if (_truthy(run['errored']) || basePt === undefined || armPt === 0) {
+                    skipped += 1;
+                    continue;
+                }
+                checked += 1;
+                if (armPt < basePt * minRatio) {
+                    violations.push({
+                        task_id: taskId,
+                        seed,
+                        arm,
+                        kind: 'collapsed-to-baseline',
+                        detail:
+                            `prompt footprint ${armPt} vs baseline ${basePt} ` +
+                            `(ratio ${(armPt / basePt).toFixed(2)} < ${minRatio}) — ` +
+                            'the treatment surface may not have reached the model',
+                    });
+                }
+            }
+        }
+    }
+
+    return { checked, skipped, violations };
+}
+
+// ── delta #3 — model-id verification ────────────────────────────────────────
+
+/**
+ * Aliases the Claude CLI resolves server-side to whatever is current.
+ *
+ * A stored report already contains the bare alias `"sonnet"`, which makes that
+ * report unreproducible: nothing in it records which model actually answered.
+ */
+export const BARE_MODEL_ALIASES: readonly string[] = ['default', 'haiku', 'opus', 'sonnet', 'sonnet[1m]'];
+
+/** True when `model` is an alias rather than a pinned, reproducible id. */
+export function is_bare_alias(model: string): boolean {
+    return BARE_MODEL_ALIASES.includes(model.trim().toLowerCase());
+}
+
+/** Drop a trailing `-YYYYMMDD` build stamp so `claude-x-1` == `claude-x-1-20250101`. */
+export function normalize_model_id(model: string): string {
+    return model.trim().toLowerCase().replace(/-\d{8}$/, '');
+}
+
+/**
+ * Compare the requested model against the ids the CLI actually billed.
+ *
+ * `models_seen` comes from the envelope's `modelUsage` keys — the only place
+ * the run states which model answered. An empty list is `ok`: some envelopes
+ * omit the block, and refusing there would fail runs for a reporting gap
+ * rather than a real mismatch.
+ */
+export function verify_model_id(requested: string, models_seen: readonly string[]): { ok: boolean; reason: string } {
+    if (is_bare_alias(requested)) {
+        return { ok: false, reason: `requested model "${requested}" is a bare alias — pin a full model id` };
+    }
+    if (models_seen.length === 0) {
+        return { ok: true, reason: 'envelope reported no model usage — nothing to contradict' };
+    }
+    const want = normalize_model_id(requested);
+    const seen = models_seen.map(normalize_model_id);
+    if (seen.every((s) => s === want)) {
+        return { ok: true, reason: `billed model matches ${requested}` };
+    }
+    return {
+        ok: false,
+        reason: `requested ${requested} but envelope billed ${[...new Set(models_seen)].sort().join(', ')}`,
+    };
+}
+
+// ── delta #4 — sweep-level cost ─────────────────────────────────────────────
+
+/** Map a full model id onto a `pricing.yaml` tier, or null when unrecognised. */
+export function tier_for_model(model: string): string | null {
+    const m = model.toLowerCase();
+    for (const tier of ['haiku', 'sonnet', 'opus']) {
+        if (m.includes(tier)) {
+            return tier;
+        }
+    }
+    return null;
+}
+
+/**
+ * Price one run's four buckets separately.
+ *
+ * The buckets differ in price by up to 125×, so a single blended rate over the
+ * summed total is not an approximation — it is a different number.
+ */
+export function cost_usd(b: TokensBreakdown | Record<string, never> | null | undefined, rates: TierRates): number {
+    if (!b) {
+        return 0;
+    }
+    const t = b as Partial<TokensBreakdown>;
+    return (
+        (_int(t.input_tokens) * rates.input +
+            _int(t.output_tokens) * rates.output +
+            _int(t.cache_creation_input_tokens) * rates.cache_write +
+            _int(t.cache_read_input_tokens) * rates.cache_read) /
+        1_000_000
+    );
+}
+
+/**
+ * Cumulative sweep spend with a hard cap.
+ *
+ * `--max-budget-usd` is per RUN (default 1.0), so a 30×4×3 sweep at `--budget
+ * 3.5` has a $1,260 ceiling with nothing to stop it. This is the sweep-level
+ * counterpart: the first run that pushes cumulative spend over the cap aborts
+ * the sweep instead of discovering the overrun on the invoice.
+ */
+export class SweepBudget {
+    private _spent = 0;
+
+    constructor(
+        readonly cap_usd: number | null,
+        private readonly rates: TierRates | null,
+    ) {}
+
+    get spent_usd(): number {
+        return this._spent;
+    }
+
+    /** Add one run's cost; return an abort reason when the cap is crossed. */
+    add(b: TokensBreakdown | Record<string, never> | null | undefined): string | null {
+        if (!this.rates) {
+            return null;
+        }
+        this._spent += cost_usd(b, this.rates);
+        if (this.cap_usd !== null && this._spent > this.cap_usd) {
+            return `sweep budget abort: cumulative $${this._spent.toFixed(2)} > cap $${this.cap_usd.toFixed(2)}`;
+        }
+        return null;
+    }
+}
+
+// ── internals ───────────────────────────────────────────────────────────────
+
+function _int(v: unknown): number {
+    return typeof v === 'number' && Number.isFinite(v) ? Math.trunc(v) : 0;
+}
+
+function _dict(v: unknown): Record<string, unknown> {
+    return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+function _list(v: unknown): Record<string, unknown>[] {
+    return Array.isArray(v) ? (v as Record<string, unknown>[]) : [];
+}
+
+function _truthy(v: unknown): boolean {
+    return Boolean(v);
+}
+
+/**
+ * Prompt footprint of one trial record — the stamped `activation` block when
+ * the sweep wrote one, else recomputed from the preserved breakdown (delta #2),
+ * so the audit also reads reports written before the stamp existed.
+ */
+function _runPromptTokens(run: Record<string, unknown>): number {
+    const stamped = _int(_dict(run['activation'])['prompt_tokens']);
+    return stamped > 0 ? stamped : prompt_tokens(run['tokens_breakdown'] as TokensBreakdown | undefined);
+}

--- a/src/scripts/bench_ab_task_runner.ts
+++ b/src/scripts/bench_ab_task_runner.ts
@@ -194,6 +194,12 @@ interface RunResult {
     tokens?: number;
     /** Empty object `{}` on dry-run (key absent in Python); breakdown otherwise. */
     tokens_breakdown?: TokensBreakdown | Record<string, never>;
+    /**
+     * Model ids the envelope actually billed (`modelUsage` keys) — the only
+     * place a run states which model answered it. Empty when the envelope
+     * omits the block. Feeds the delta-#3 model-id check.
+     */
+    models_seen?: string[];
     errored?: boolean;
     num_turns?: number;
     subtype?: string;
@@ -295,6 +301,7 @@ export function run_live(
     const returncode = result.status ?? -1;
     let transcript: string = stdout;
     let tokens = 0;
+    let modelsSeen: string[] = [];
     let isError = false;
     let errReason = 'ok';
     let numTurns = 0;
@@ -337,6 +344,16 @@ export function run_live(
             breakdown.output_tokens +
             breakdown.cache_read_input_tokens +
             breakdown.cache_creation_input_tokens;
+        // `modelUsage` is keyed by the model ids the run actually billed. Record
+        // them unconditionally: the delta-#3 check needs the id even on a run
+        // whose top-level `usage` was fine, and a mid-sweep model swap is exactly
+        // the case where the totals look ordinary.
+        modelsSeen = Object.keys(
+            (_isPlainObj(obj['modelUsage']) ? (obj['modelUsage'] as Record<string, unknown>) : {}) as Record<
+                string,
+                unknown
+            >,
+        );
         // The top-level `usage` block is zeroed on a budget-capped / errored run
         // (and unreliable even on some completions). `modelUsage` carries the
         // authoritative per-model counts — sum it as the fallback so token deltas
@@ -387,6 +404,7 @@ export function run_live(
         wall_time_seconds: _pyRound(duration, 3),
         tokens,
         tokens_breakdown: breakdown,
+        models_seen: modelsSeen,
         errored: isError || returncode !== 0,
         num_turns: numTurns,
         subtype,

--- a/src/scripts/bench_ab_v2_run.ts
+++ b/src/scripts/bench_ab_v2_run.ts
@@ -53,6 +53,18 @@ import { parse as parseYaml } from 'yaml';
 
 import * as v1 from './bench_ab_task_runner.js';
 import * as scoring from './_lib/bench_ab_scoring_v2.js';
+import {
+    SweepBudget,
+    activation_verdict,
+    audit_activation,
+    expected_injection,
+    is_bare_alias,
+    tier_for_model,
+    verify_model_id,
+    type TierRates,
+    type TokensBreakdown,
+} from './_lib/bench_ab_activation.js';
+import { load_pricing } from './_lib/bench_cost.js';
 
 const _HERE = fileURLToPath(import.meta.url);
 
@@ -66,6 +78,7 @@ const CORPUS_PATH = path.join(REPO_ROOT, 'internal', 'bench', 'corpora', 'ab-tra
 const FIXTURES_ROOT = path.join(REPO_ROOT, 'internal', 'bench', 'ab');
 const REPORTS_DIR = path.join(REPO_ROOT, 'internal', 'bench', 'reports', 'ab-v2');
 const CHECKPOINTS_DIR = path.join(REPORTS_DIR, 'checkpoints');
+const PRICING_PATH = path.join(REPO_ROOT, 'internal', 'bench', 'pricing.yaml');
 // CRITICAL (2026-06-15): clones MUST live OUTSIDE the agent-config repo. A clone
 // under the repo lets Claude discover the repo's own project surface (CLAUDE.md /
 // AGENTS.md / .claude/rules+skills) walking up from the cwd — so the `vanilla`
@@ -461,6 +474,31 @@ export function run_live_codex(
     };
 }
 
+/**
+ * Delta #1–#3 — stamp the measurement-integrity block onto a trial record.
+ *
+ * `tokens_breakdown` is preserved here (delta #2) because it is the ONLY
+ * observable that can see a plugin-arm collapse: `injected_chars` is the length
+ * of a file the harness wrote itself, and it is 0 for every arm that arrives
+ * through global settings. Discarding the breakdown made the audit
+ * unreconstructable even post-hoc.
+ */
+export function integrity_fields(run: Dict, spec: ArmSpec, injected_chars: number, model: string | null): Dict {
+    const breakdown = (run['tokens_breakdown'] ?? {}) as TokensBreakdown | Record<string, never>;
+    const models_seen = Array.isArray(run['models_seen']) ? (run['models_seen'] as string[]) : [];
+    return {
+        tokens_breakdown: breakdown,
+        models_seen,
+        activation: activation_verdict({
+            expected: expected_injection(spec),
+            tokens_breakdown: breakdown,
+            injected_chars,
+            errored: _pyBool(run['errored']),
+        }),
+        model_check: model ? verify_model_id(model, models_seen) : { ok: true, reason: 'no model pinned' },
+    };
+}
+
 export function run_one(task: Dict, arm: string, opts: RunOneOpts): Dict {
     const spec = ARMS[arm] as ArmSpec;
     if (spec.recursive) {
@@ -501,6 +539,7 @@ export function run_one(task: Dict, arm: string, opts: RunOneOpts): Dict {
         discipline_pass: score.discipline_pass,
         metrics: trajectory_metrics(run, score),
         injected_chars: sp_text ? sp_text.length : 0,
+        ...integrity_fields(run, spec, sp_text ? sp_text.length : 0, opts.model),
     };
 }
 
@@ -618,6 +657,10 @@ export function run_one_recursive(
         injected_chars: last_verdict_len,
         depth_reached: depth,
         stop_reason,
+        // `injected_chars` here counts the re-attempt VERDICT text, not an arm
+        // injection — the recursive arm's channel is the plugin. Pass 0 so the
+        // audit reads the arm's real channel instead of flagging the verdict.
+        ...integrity_fields(run, ARMS['package-recursive'] as ArmSpec, 0, opts.model),
     };
 }
 
@@ -767,17 +810,28 @@ export function collect_records(
     run_fn: (task: Dict, arm: string, seed: number) => Dict,
     ckpt: CheckpointIO | null = null,
     log: (msg: string) => void = (m) => process.stderr.write(m),
-): { records: Dict[]; executed: number; reused: number } {
+    /**
+     * Delta #4 — sweep-level spend guard. Called after each executed run with
+     * that run's record; a non-null return aborts the sweep. Records collected
+     * so far are still returned (and are already on the checkpoint), so an
+     * abort costs no completed work.
+     */
+    guard: ((record: Dict) => string | null) | null = null,
+): { records: Dict[]; executed: number; reused: number; aborted: string | null } {
     const total = tasks.length * arms.length * seeds;
     let done = 0;
     let executed = 0;
     let reused = 0;
+    let aborted: string | null = null;
     const records: Dict[] = [];
     for (const task of tasks) {
         const per_arm: Record<string, Dict[]> = {};
         for (const arm of arms) {
             const seed_runs: Dict[] = [];
             for (let seed = 0; seed < seeds; seed += 1) {
+                if (aborted) {
+                    break;
+                }
                 done += 1;
                 const key = run_key(String(task['id']), arm, seed);
                 const cached = ckpt?.completed.get(key);
@@ -794,6 +848,7 @@ export function collect_records(
                     append_checkpoint(ckpt.path, key, r);
                 }
                 seed_runs.push(r);
+                aborted = guard?.(r) ?? null;
             }
             per_arm[arm] = seed_runs;
         }
@@ -803,8 +858,11 @@ export function collect_records(
             rule: task['rule'],
             arms: per_arm,
         });
+        if (aborted) {
+            break;
+        }
     }
-    return { records, executed, reused };
+    return { records, executed, reused, aborted };
 }
 
 export function main(argv: string[] | null = null): number {
@@ -841,11 +899,23 @@ export function main(argv: string[] | null = null): number {
         }
     }
 
+    // Delta #3 — refuse a bare alias BEFORE any spend. An alias resolves
+    // server-side to whatever is current, so a report produced under one is
+    // unreproducible: nothing in it records which model actually answered.
+    if (is_bare_alias(args.model)) {
+        process.stderr.write(
+            `bench_ab_v2: refusing bare model alias "${args.model}" — pin a full id ` +
+                `(e.g. claude-sonnet-4-6). An alias makes the report unreproducible.\n`,
+        );
+        return 2;
+    }
+
     if (args.mode === 'dry-run') {
         process.stdout.write(
             `bench_ab_v2: DRY — ${tasks.length} tasks × ${arms.length} arms × ` +
                 `${args.seeds} seeds = ${tasks.length * arms.length * args.seeds} runs ` +
-                `(model=${args.model}, budget=${_pyNumStr(args.budget)}). No spend.\n`,
+                `(model=${args.model}, budget=${_pyNumStr(args.budget)}, ` +
+                `sweep cap=${args.max_usd === null ? 'none' : `$${_pyNumStr(args.max_usd)}`}). No spend.\n`,
         );
         return 0;
     }
@@ -891,7 +961,23 @@ export function main(argv: string[] | null = null): number {
         ckpt = { path: ckpt_path, completed };
     }
 
-    const { records } = collect_records(
+    // Delta #4 — sweep-level cap. `--max-budget-usd` is PER RUN, so 30×4×3 at
+    // --budget 3.5 has a $1,260 ceiling with nothing to stop it. Prices come
+    // from internal/bench/pricing.yaml; an unrecognised model tier leaves the
+    // guard inert rather than silently mispricing the sweep.
+    const [rates] = load_pricing(PRICING_PATH);
+    const tier = tier_for_model(args.model);
+    const tier_rates: TierRates | null = tier && rates[tier] ? (rates[tier] as TierRates) : null;
+    if (args.max_usd !== null && tier_rates === null) {
+        process.stderr.write(
+            `bench_ab_v2: --max-usd given but no pricing row matches model "${args.model}" ` +
+                `(${_relToRootPosix(PRICING_PATH)}) — the sweep cap cannot be enforced.\n`,
+        );
+        return 2;
+    }
+    const budget = new SweepBudget(args.max_usd, tier_rates);
+
+    const { records, aborted } = collect_records(
         tasks,
         arms,
         args.seeds,
@@ -905,7 +991,16 @@ export function main(argv: string[] | null = null): number {
                 host: args.host,
             }),
         ckpt,
+        undefined,
+        (r) => budget.add(r['tokens_breakdown'] as TokensBreakdown | undefined),
     );
+
+    // Delta #1 — the activation audit. Runs BEFORE the report is judged usable:
+    // the paired plugin direction needs the whole record set, so it cannot be a
+    // per-trial check alone. `vanilla` is the baseline; every arm that is
+    // supposed to carry a surface the baseline lacks is a lift arm.
+    const lift_arms = arms.filter((a) => a !== 'vanilla' && expected_injection(ARMS[a] as ArmSpec) !== 'none');
+    const audit = audit_activation(records, { baseline_arm: 'vanilla', lift_arms });
 
     const stamp = v1.utc_stamp();
     const payload: Dict = {
@@ -915,9 +1010,17 @@ export function main(argv: string[] | null = null): number {
         seeds: args.seeds,
         arms,
         budget_usd_per_run: args.budget,
+        sweep_cap_usd: args.max_usd,
+        sweep_spend_usd: new PyFloat(Number(budget.spent_usd.toFixed(4))),
         placebo_chars,
         corpus: 'ab-trackb-v2',
         host: args.host,
+        activation_audit: {
+            checked: audit.checked,
+            skipped: audit.skipped,
+            violations: audit.violations as unknown as Json,
+        },
+        aborted: aborted ?? null,
         records,
     };
     const out = path.join(REPORTS_DIR, `${stamp}-ab-v2-paired.json`);
@@ -928,8 +1031,31 @@ export function main(argv: string[] | null = null): number {
         fs.rmSync(ckpt.path);
     }
     process.stdout.write(
-        `bench_ab_v2: wrote ${_relToRootPosix(out)} ` + `(${records.length} tasks, ${total} runs)\n`,
+        `bench_ab_v2: wrote ${_relToRootPosix(out)} ` +
+            `(${records.length} tasks, ${total} runs, spend $${budget.spent_usd.toFixed(2)})\n`,
     );
+
+    // The report is always written — an aborted or integrity-failed sweep still
+    // cost money and its raw runs stay inspectable. The EXIT CODE is what makes
+    // the failure non-ignorable, so a caller cannot mistake an invalid sweep for
+    // a publishable one.
+    if (aborted) {
+        process.stderr.write(`bench_ab_v2: ${aborted}\n`);
+        return 2;
+    }
+    if (audit.violations.length > 0) {
+        process.stderr.write(
+            `bench_ab_v2: ACTIVATION AUDIT FAILED — ${audit.violations.length} violation(s) ` +
+                `over ${audit.checked} checked pair(s). This report is NOT publishable.\n`,
+        );
+        for (const v of audit.violations.slice(0, 20)) {
+            process.stderr.write(`  ${v.kind}: ${v.task_id} · ${v.arm} · seed ${v.seed} — ${v.detail}\n`);
+        }
+        if (audit.violations.length > 20) {
+            process.stderr.write(`  … ${audit.violations.length - 20} more (see the report)\n`);
+        }
+        return 2;
+    }
     return 0;
 }
 
@@ -942,6 +1068,8 @@ interface ParsedArgs {
     limit: number;
     model: string;
     budget: number;
+    /** Sweep-wide USD cap (delta #4); `null` = uncapped, the pre-existing behaviour. */
+    max_usd: number | null;
     timeout: number;
     mode: string;
     host: string;
@@ -960,13 +1088,14 @@ function parse_args(argv: string[]): ParsedArgs {
         limit: 0,
         model: 'claude-sonnet-4-6',
         budget: 1.0,
+        max_usd: null,
         timeout: 180,
         mode: 'live',
         host: 'claude',
         checkpoint: true,
         fresh: false,
     };
-    const usage = `usage: ${prog} [-h] [--arms ARMS] [--seeds SEEDS] [--tasks TASKS] [--limit LIMIT] [--model MODEL] [--budget BUDGET] [--timeout TIMEOUT] [--mode {live,dry-run}] [--host {claude,codex}] [--no-checkpoint] [--fresh]\n`;
+    const usage = `usage: ${prog} [-h] [--arms ARMS] [--seeds SEEDS] [--tasks TASKS] [--limit LIMIT] [--model MODEL] [--budget BUDGET] [--max-usd MAX_USD] [--timeout TIMEOUT] [--mode {live,dry-run}] [--host {claude,codex}] [--no-checkpoint] [--fresh]\n`;
     const argErr = (msg: string): never => {
         process.stderr.write(usage);
         process.stderr.write(`${prog}: error: ${msg}\n`);
@@ -1014,6 +1143,11 @@ function parse_args(argv: string[]): ParsedArgs {
             i += 1;
         } else if (a.startsWith('--budget=')) {
             out.budget = _pyFloatArg(a.slice('--budget='.length), '--budget');
+        } else if (a === '--max-usd') {
+            out.max_usd = _pyFloatArg(need(i, '--max-usd'), '--max-usd');
+            i += 1;
+        } else if (a.startsWith('--max-usd=')) {
+            out.max_usd = _pyFloatArg(a.slice('--max-usd='.length), '--max-usd');
         } else if (a === '--timeout') {
             out.timeout = _pyInt(need(i, '--timeout'), '--timeout');
             i += 1;

--- a/src/scripts/bench_ab_v2_run.ts
+++ b/src/scripts/bench_ab_v2_run.ts
@@ -910,6 +910,27 @@ export function main(argv: string[] | null = null): number {
         return 2;
     }
 
+    // Delta #4 — sweep-level cap. `--max-budget-usd` is PER RUN, so 30×4×3 at
+    // --budget 3.5 has a $1,260 ceiling with nothing to stop it. Prices come
+    // from internal/bench/pricing.yaml; an unrecognised model tier leaves the
+    // guard inert rather than silently mispricing the sweep.
+    //
+    // Resolved HERE, with the other argument validation, rather than next to
+    // its use below: a cap the harness cannot price is a bad argument, and a
+    // bad argument must be reported whether or not the host CLI is installed.
+    // Behind the CLI-presence check it was unreachable on any machine without
+    // `claude` — including CI.
+    const [rates] = load_pricing(PRICING_PATH);
+    const tier = tier_for_model(args.model);
+    const tier_rates: TierRates | null = tier && rates[tier] ? (rates[tier] as TierRates) : null;
+    if (args.max_usd !== null && tier_rates === null) {
+        process.stderr.write(
+            `bench_ab_v2: --max-usd given but no pricing row matches model "${args.model}" ` +
+                `(${_relToRootPosix(PRICING_PATH)}) — the sweep cap cannot be enforced.\n`,
+        );
+        return 2;
+    }
+
     if (args.mode === 'dry-run') {
         process.stdout.write(
             `bench_ab_v2: DRY — ${tasks.length} tasks × ${arms.length} arms × ` +
@@ -961,20 +982,6 @@ export function main(argv: string[] | null = null): number {
         ckpt = { path: ckpt_path, completed };
     }
 
-    // Delta #4 — sweep-level cap. `--max-budget-usd` is PER RUN, so 30×4×3 at
-    // --budget 3.5 has a $1,260 ceiling with nothing to stop it. Prices come
-    // from internal/bench/pricing.yaml; an unrecognised model tier leaves the
-    // guard inert rather than silently mispricing the sweep.
-    const [rates] = load_pricing(PRICING_PATH);
-    const tier = tier_for_model(args.model);
-    const tier_rates: TierRates | null = tier && rates[tier] ? (rates[tier] as TierRates) : null;
-    if (args.max_usd !== null && tier_rates === null) {
-        process.stderr.write(
-            `bench_ab_v2: --max-usd given but no pricing row matches model "${args.model}" ` +
-                `(${_relToRootPosix(PRICING_PATH)}) — the sweep cap cannot be enforced.\n`,
-        );
-        return 2;
-    }
     const budget = new SweepBudget(args.max_usd, tier_rates);
 
     const { records, aborted } = collect_records(

--- a/src/scripts/bench_ab_v2_stats.ts
+++ b/src/scripts/bench_ab_v2_stats.ts
@@ -291,8 +291,37 @@ export function compare(records: Dict[], arm_t: string, arm_b: string): Dict {
     let dis_t_sum = 0.0;
     let dis_b_sum = 0.0;
     let disn = 0.0;
+    // Delta #5 — attrition. A dropped pair is not missing-at-random: a budget
+    // cap or a timeout fires preferentially on the arm doing MORE work, so
+    // silently excluding those pairs biases the surviving sample toward the
+    // baseline. Report which side died and in which status bucket, so a reader
+    // can see whether the drops are balanced before trusting the estimate.
+    let pairs_seen = 0;
+    let dropped_treatment_only = 0;
+    let dropped_baseline_only = 0;
+    let dropped_both = 0;
+    const dropped_buckets: Record<string, number> = {};
     for (const { rt, rb } of _pairs(records, arm_t, arm_b)) {
-        if (!_pyTruthy(rt['errored']) && !_pyTruthy(rb['errored'])) {
+        pairs_seen += 1;
+        const t_err = _pyTruthy(rt['errored']);
+        const b_err = _pyTruthy(rb['errored']);
+        if (t_err || b_err) {
+            if (t_err && b_err) {
+                dropped_both += 1;
+            } else if (t_err) {
+                dropped_treatment_only += 1;
+            } else {
+                dropped_baseline_only += 1;
+            }
+            for (const r of [t_err ? rt : null, b_err ? rb : null]) {
+                if (r === null) {
+                    continue;
+                }
+                const bucket = _strOr(_dictOr(r['metrics'])['status_bucket'], 'unknown');
+                dropped_buckets[bucket] = (dropped_buckets[bucket] ?? 0) + 1;
+            }
+        }
+        if (!t_err && !b_err) {
             const t = _pyTruthy(rt['capability_pass']);
             const bb = _pyTruthy(rb['capability_pass']);
             capn += 1;
@@ -340,6 +369,18 @@ export function compare(records: Dict[], arm_t: string, arm_b: string): Dict {
             wilcoxon_p: PF(wil.p),
             rank_biserial: PF(wil.rank_biserial),
             n_nonzero: wil.n,
+        },
+        attrition: {
+            pairs_seen,
+            pairs_analysed: capn,
+            pairs_dropped: pairs_seen - capn,
+            dropped_treatment_only,
+            dropped_baseline_only,
+            dropped_both,
+            // Positive = the treatment arm died more often than the baseline,
+            // i.e. the surviving sample is biased toward the baseline.
+            drop_asymmetry: dropped_treatment_only - dropped_baseline_only,
+            dropped_by_status_bucket: dropped_buckets,
         },
     };
 }
@@ -509,7 +550,9 @@ export function to_markdown(analysis: Dict, payload: Dict): string {
     );
     L.push(
         '> 4. **Paired design**, errored runs excluded; McNemar (capability) + ' +
-            'Wilcoxon signed-rank (discipline) + effect sizes.',
+            'Wilcoxon signed-rank (discipline) + effect sizes. Exclusion is NOT ' +
+            'assumed harmless — see each comparison’s Table 4 for how many pairs ' +
+            'were dropped and whether the drops favour one arm.',
     );
     L.push(
         '> 5. **Not comparable to SWE-bench / GAIA / Fable scores** — a different ' +
@@ -597,6 +640,29 @@ export function to_markdown(analysis: Dict, payload: Dict): string {
         L.push('|---|---|---|---|');
         L.push(`| mean tokens | ${_thousands(tb)} | ${_thousands(tt)} | ${_thousandsSigned(tt - tb)} |`);
         L.push('');
+        const at = _dictOr(cmp['attrition']);
+        L.push('### Table 4 — attrition (dropped pairs are not missing-at-random)');
+        L.push('');
+        L.push('| pairs seen | analysed | dropped | treatment-only | baseline-only | both | asymmetry |');
+        L.push('|---|---|---|---|---|---|---|');
+        L.push(
+            `| ${_pyStr(at['pairs_seen'])} | ${_pyStr(at['pairs_analysed'])} | ${_pyStr(at['pairs_dropped'])} ` +
+                `| ${_pyStr(at['dropped_treatment_only'])} | ${_pyStr(at['dropped_baseline_only'])} ` +
+                `| ${_pyStr(at['dropped_both'])} | ${_fmtSignedInt(at['drop_asymmetry'])} |`,
+        );
+        const dropBuckets = Object.entries(_dictOr(at['dropped_by_status_bucket']))
+            .map(([k, v]) => `${k}:${_pyStr(v)}`)
+            .join(', ');
+        L.push('');
+        L.push(`Dropped runs by status bucket: ${dropBuckets || '_none_'}.`);
+        L.push('');
+        L.push(
+            '> A positive asymmetry means the treatment arm errored out more often than ' +
+                'the baseline. Budget caps and timeouts fire preferentially on the arm doing ' +
+                'more work, so the surviving sample is then biased TOWARD the baseline and the ' +
+                'measured lift is a floor, not an estimate.',
+        );
+        L.push('');
     }
     L.push('## Status buckets (trajectory)');
     L.push('');
@@ -653,6 +719,12 @@ function _fmt3(v: unknown): string {
 function _fmtSigned3(v: unknown): string {
     const body = _pyFixed(_pyFloat(v), 3);
     return body.startsWith('-') ? body : `+${body}`;
+}
+
+/** `f"{n:+d}"` over an int-ish JSON value (attrition asymmetry). */
+function _fmtSignedInt(v: unknown): string {
+    const n = _pyIntTrunc(_pyFloat(v));
+    return n < 0 ? String(n) : `+${n}`;
 }
 
 /** `f"{n:,}"` over `int(value)`. */

--- a/tests/scripts/_lib_bench_ab_activation.test.ts
+++ b/tests/scripts/_lib_bench_ab_activation.test.ts
@@ -1,0 +1,317 @@
+// Tests for src/scripts/_lib/bench_ab_activation.ts — deltas #1–#4 of the S0.3
+// harness-feasibility spike (road-to-solution-minimalism Phase 3 prerequisites).
+//
+// The whole point of this module is to catch a sweep that LOOKS fine, so every
+// positive case is paired with a negative one that must NOT fire. Without the
+// negatives these would be tautologies: an audit that flags everything and an
+// audit that flags nothing both "pass" a positive-only suite.
+import { describe, expect, it } from 'vitest';
+
+import {
+    ACTIVATION_MIN_LIFT_RATIO,
+    SweepBudget,
+    activation_verdict,
+    audit_activation,
+    cost_usd,
+    expected_injection,
+    is_bare_alias,
+    normalize_model_id,
+    prompt_tokens,
+    tier_for_model,
+    verify_model_id,
+    type TierRates,
+    type TokensBreakdown,
+} from '../../src/scripts/_lib/bench_ab_activation.js';
+
+const SONNET: TierRates = { input: 3.0, output: 15.0, cache_write: 3.75, cache_read: 0.3 };
+
+function tb(over: Partial<TokensBreakdown> = {}): TokensBreakdown {
+    return {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        ...over,
+    };
+}
+
+/** One trial record in the shape `collect_records` writes. */
+function run(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return { seed: 0, errored: false, tokens_breakdown: tb({ input_tokens: 1000 }), ...over };
+}
+
+function record(id: string, arms: Record<string, Record<string, unknown>[]>): Record<string, unknown> {
+    return { id, arms };
+}
+
+describe('prompt_tokens', () => {
+    it('sums the three prompt-side buckets', () => {
+        expect(
+            prompt_tokens(tb({ input_tokens: 10, cache_read_input_tokens: 20, cache_creation_input_tokens: 30 })),
+        ).toBe(60);
+    });
+
+    it('EXCLUDES output tokens — a bigger system prompt does not reliably change them', () => {
+        expect(prompt_tokens(tb({ input_tokens: 10, output_tokens: 9999 }))).toBe(10);
+    });
+
+    it('treats a missing or empty breakdown as zero rather than throwing', () => {
+        expect(prompt_tokens(undefined)).toBe(0);
+        expect(prompt_tokens({})).toBe(0);
+    });
+});
+
+describe('expected_injection', () => {
+    it('classifies the three real arm shapes', () => {
+        // vanilla: settings scoped away, no text → the baseline.
+        expect(expected_injection({ setting_sources: 'project,local', inject: null })).toBe('none');
+        // package: rides global settings — invisible to injected_chars.
+        expect(expected_injection({ setting_sources: null, inject: null })).toBe('plugin');
+        // placebo / rules-*: a file the harness wrote.
+        expect(expected_injection({ setting_sources: 'project,local', inject: 'placebo' })).toBe('text');
+    });
+
+    it('lets the text channel win when an arm carries both', () => {
+        expect(expected_injection({ setting_sources: null, inject: 'hardened' })).toBe('text');
+    });
+});
+
+describe('activation_verdict', () => {
+    it('passes a text arm that carried its injection', () => {
+        const v = activation_verdict({
+            expected: 'text',
+            tokens_breakdown: tb({ input_tokens: 5000 }),
+            injected_chars: 2000,
+            errored: false,
+        });
+        expect(v.verdict).toBe('ok');
+    });
+
+    it('flags a text arm that carried NO injection', () => {
+        const v = activation_verdict({
+            expected: 'text',
+            tokens_breakdown: tb({ input_tokens: 5000 }),
+            injected_chars: 0,
+            errored: false,
+        });
+        expect(v.verdict).toBe('violation');
+        expect(v.reason).toContain('no injection');
+    });
+
+    it('flags a baseline arm that unexpectedly carried one', () => {
+        const v = activation_verdict({
+            expected: 'none',
+            tokens_breakdown: tb({ input_tokens: 5000 }),
+            injected_chars: 2000,
+            errored: false,
+        });
+        expect(v.verdict).toBe('violation');
+        expect(v.reason).toContain('2000-char injection');
+    });
+
+    it('passes a plugin arm: injected_chars is 0 BY CONSTRUCTION there, not a fault', () => {
+        const v = activation_verdict({
+            expected: 'plugin',
+            tokens_breakdown: tb({ input_tokens: 90_000 }),
+            injected_chars: 0,
+            errored: false,
+        });
+        expect(v.verdict).toBe('ok');
+    });
+
+    it('returns unknown — never violation — for an errored run', () => {
+        const v = activation_verdict({
+            expected: 'text',
+            tokens_breakdown: tb({ input_tokens: 5000 }),
+            injected_chars: 0,
+            errored: true,
+        });
+        expect(v.verdict).toBe('unknown');
+    });
+
+    it('returns unknown when the usage block is zeroed (budget-capped run)', () => {
+        const v = activation_verdict({ expected: 'plugin', tokens_breakdown: tb(), injected_chars: 0, errored: false });
+        expect(v.verdict).toBe('unknown');
+    });
+});
+
+describe('audit_activation — the paired plugin direction', () => {
+    const healthy = [
+        record('t1', {
+            vanilla: [run({ tokens_breakdown: tb({ input_tokens: 10_000 }) })],
+            package: [run({ tokens_breakdown: tb({ input_tokens: 90_000 }) })],
+        }),
+    ];
+
+    it('passes a sweep where the treatment arm carries a real footprint lift', () => {
+        const a = audit_activation(healthy, { baseline_arm: 'vanilla', lift_arms: ['package'] });
+        expect(a.violations).toEqual([]);
+        expect(a.checked).toBe(1);
+    });
+
+    it('flags a treatment arm that COLLAPSED to the baseline footprint', () => {
+        // The canonical failure: the plugin is disabled or version-drifted, so
+        // every treatment run silently degrades to vanilla and the report looks
+        // identical to a real one.
+        const collapsed = [
+            record('t1', {
+                vanilla: [run({ tokens_breakdown: tb({ input_tokens: 10_000 }) })],
+                package: [run({ tokens_breakdown: tb({ input_tokens: 10_100 }) })],
+            }),
+        ];
+        const a = audit_activation(collapsed, { baseline_arm: 'vanilla', lift_arms: ['package'] });
+        expect(a.violations).toHaveLength(1);
+        expect(a.violations[0]!.kind).toBe('collapsed-to-baseline');
+        expect(a.violations[0]!.arm).toBe('package');
+    });
+
+    it('does NOT fire just above the threshold — ordinary variance is not a violation', () => {
+        const base = 10_000;
+        const justOver = Math.ceil(base * ACTIVATION_MIN_LIFT_RATIO) + 1;
+        const marginal = [
+            record('t1', {
+                vanilla: [run({ tokens_breakdown: tb({ input_tokens: base }) })],
+                package: [run({ tokens_breakdown: tb({ input_tokens: justOver }) })],
+            }),
+        ];
+        expect(audit_activation(marginal, { baseline_arm: 'vanilla', lift_arms: ['package'] }).violations).toEqual([]);
+    });
+
+    it('skips a pair whose baseline errored instead of judging it', () => {
+        const halfDead = [
+            record('t1', {
+                vanilla: [run({ errored: true })],
+                package: [run({ tokens_breakdown: tb({ input_tokens: 90_000 }) })],
+            }),
+        ];
+        const a = audit_activation(halfDead, { baseline_arm: 'vanilla', lift_arms: ['package'] });
+        expect(a.violations).toEqual([]);
+        expect(a.skipped).toBe(1);
+        expect(a.checked).toBe(0);
+    });
+
+    it('pairs by seed, never across seeds', () => {
+        const twoSeeds = [
+            record('t1', {
+                vanilla: [
+                    run({ seed: 0, tokens_breakdown: tb({ input_tokens: 10_000 }) }),
+                    run({ seed: 1, tokens_breakdown: tb({ input_tokens: 80_000 }) }),
+                ],
+                // seed 1 collapses against ITS OWN baseline (80k), even though it
+                // dwarfs seed 0's baseline.
+                package: [
+                    run({ seed: 0, tokens_breakdown: tb({ input_tokens: 90_000 }) }),
+                    run({ seed: 1, tokens_breakdown: tb({ input_tokens: 81_000 }) }),
+                ],
+            }),
+        ];
+        const a = audit_activation(twoSeeds, { baseline_arm: 'vanilla', lift_arms: ['package'] });
+        expect(a.violations).toHaveLength(1);
+        expect(a.violations[0]!.seed).toBe(1);
+    });
+
+    it('surfaces a stamped per-trial violation from the record', () => {
+        const stamped = [
+            record('t1', {
+                placebo: [run({ activation: { verdict: 'violation', reason: 'text arm carried no injection' } })],
+            }),
+        ];
+        const a = audit_activation(stamped, { baseline_arm: 'vanilla', lift_arms: [] });
+        expect(a.violations).toHaveLength(1);
+        expect(a.violations[0]!.kind).toBe('text-injection-missing');
+    });
+
+    it('surfaces a model mismatch stamped on the record', () => {
+        const stamped = [
+            record('t1', {
+                package: [run({ model_check: { ok: false, reason: 'requested X but envelope billed Y' } })],
+            }),
+        ];
+        const a = audit_activation(stamped, { baseline_arm: 'vanilla', lift_arms: [] });
+        expect(a.violations).toHaveLength(1);
+        expect(a.violations[0]!.kind).toBe('model-mismatch');
+    });
+
+    it('stays silent on a record whose model_check passed', () => {
+        const stamped = [record('t1', { package: [run({ model_check: { ok: true, reason: 'matches' } })] })];
+        expect(audit_activation(stamped, { baseline_arm: 'vanilla', lift_arms: [] }).violations).toEqual([]);
+    });
+});
+
+describe('model-id verification', () => {
+    it('recognises the bare aliases that make a report unreproducible', () => {
+        expect(is_bare_alias('sonnet')).toBe(true);
+        expect(is_bare_alias('SONNET')).toBe(true);
+        expect(is_bare_alias('opus')).toBe(true);
+        expect(is_bare_alias('claude-sonnet-4-6')).toBe(false);
+    });
+
+    it('normalises away a trailing build stamp', () => {
+        expect(normalize_model_id('claude-sonnet-4-5-20250929')).toBe('claude-sonnet-4-5');
+        expect(normalize_model_id('claude-sonnet-4-5')).toBe('claude-sonnet-4-5');
+    });
+
+    it('refuses a bare alias outright', () => {
+        expect(verify_model_id('sonnet', ['claude-sonnet-4-5']).ok).toBe(false);
+    });
+
+    it('accepts a dated id against its undated request', () => {
+        expect(verify_model_id('claude-sonnet-4-5', ['claude-sonnet-4-5-20250929']).ok).toBe(true);
+    });
+
+    it('refuses a genuine mid-sweep model swap', () => {
+        const v = verify_model_id('claude-sonnet-4-5', ['claude-opus-4-8']);
+        expect(v.ok).toBe(false);
+        expect(v.reason).toContain('claude-opus-4-8');
+    });
+
+    it('refuses when only SOME runs were billed to the requested model', () => {
+        expect(verify_model_id('claude-sonnet-4-5', ['claude-sonnet-4-5', 'claude-haiku-4-5']).ok).toBe(false);
+    });
+
+    it('accepts an envelope that reported no model usage — a reporting gap is not a mismatch', () => {
+        expect(verify_model_id('claude-sonnet-4-5', []).ok).toBe(true);
+    });
+});
+
+describe('cost', () => {
+    it('maps full model ids onto pricing tiers, and returns null for an unknown one', () => {
+        expect(tier_for_model('claude-sonnet-4-6')).toBe('sonnet');
+        expect(tier_for_model('claude-haiku-4-5-20251001')).toBe('haiku');
+        expect(tier_for_model('gpt-4o')).toBeNull();
+    });
+
+    it('prices the four buckets separately — a blended rate is a DIFFERENT number', () => {
+        const b = tb({ input_tokens: 1_000_000, cache_read_input_tokens: 1_000_000 });
+        // Per-bucket: 1M × $3.00 + 1M × $0.30 = $3.30.
+        expect(cost_usd(b, SONNET)).toBeCloseTo(3.3, 6);
+        // A blended input rate over the summed 2M would say $6.00 — 1.8× off.
+        expect(cost_usd(b, SONNET)).not.toBeCloseTo(6.0, 2);
+    });
+});
+
+describe('SweepBudget', () => {
+    it('aborts on the run that crosses the cap, not before', () => {
+        const budget = new SweepBudget(5.0, SONNET);
+        // $3.00 per 1M input tokens → two runs of 1M each = $6.00 total.
+        expect(budget.add(tb({ input_tokens: 1_000_000 }))).toBeNull();
+        expect(budget.spent_usd).toBeCloseTo(3.0, 6);
+        const abort = budget.add(tb({ input_tokens: 1_000_000 }));
+        expect(abort).toContain('sweep budget abort');
+        expect(abort).toContain('6.00');
+    });
+
+    it('never aborts without a cap — the pre-existing uncapped behaviour is preserved', () => {
+        const budget = new SweepBudget(null, SONNET);
+        for (let i = 0; i < 100; i += 1) {
+            expect(budget.add(tb({ input_tokens: 1_000_000 }))).toBeNull();
+        }
+        expect(budget.spent_usd).toBeCloseTo(300.0, 4);
+    });
+
+    it('stays inert when no pricing row matched the model', () => {
+        const budget = new SweepBudget(1.0, null);
+        expect(budget.add(tb({ input_tokens: 10_000_000 }))).toBeNull();
+        expect(budget.spent_usd).toBe(0);
+    });
+});

--- a/tests/scripts/bench_ab_v2_run.test.ts
+++ b/tests/scripts/bench_ab_v2_run.test.ts
@@ -315,9 +315,22 @@ describe('bench_ab_v2_run — measurement integrity', () => {
 
     it('refuses --max-usd when no pricing row matches the model', () => {
         // Enforcing a cap the harness cannot price would be a cap in name only.
-        const r = runTs(['--model', 'some-unpriced-model-9', '--max-usd', '10', '--limit', '1']);
+        // Asserted in dry-run so the check is proven on a host WITHOUT the claude
+        // CLI too — behind the CLI-presence check this was unreachable in CI.
+        const r = runTs(['--model', 'some-unpriced-model-9', '--max-usd', '10', '--limit', '1', '--mode', 'dry-run']);
         expect(r.status).toBe(2);
         expect(r.stderr).toContain('the sweep cap cannot be enforced');
+    });
+
+    it('accepts --max-usd on a priceable model', () => {
+        const r = runTs(['--model', 'claude-sonnet-4-6', '--max-usd', '10', '--limit', '1', '--mode', 'dry-run']);
+        expect(r.status).toBe(0);
+    });
+
+    it('leaves an unpriceable model alone when no cap was asked for', () => {
+        // The refusal is about an unenforceable CAP, not about the model.
+        const r = runTs(['--model', 'some-unpriced-model-9', '--limit', '1', '--mode', 'dry-run']);
+        expect(r.status).toBe(0);
     });
 
     it('reports the sweep cap in the dry-run line', () => {

--- a/tests/scripts/bench_ab_v2_run.test.ts
+++ b/tests/scripts/bench_ab_v2_run.test.ts
@@ -34,6 +34,7 @@ import {
     load_checkpoint,
     append_checkpoint,
     collect_records,
+    integrity_fields,
     PyFloat,
     type CheckpointIO,
 } from '../../src/scripts/bench_ab_v2_run.js';
@@ -292,5 +293,94 @@ describe('bench_ab_v2_run — checkpoint / resume', () => {
         expect(logs).toEqual(['[1/2] t1 · vanilla · seed 0\n', '[2/2] t1 · vanilla · seed 1\n']);
         const perArm = (records[0] as Record<string, unknown>)['arms'] as Record<string, unknown[]>;
         expect(perArm['vanilla']).toHaveLength(2);
+    });
+});
+
+// ── measurement integrity (S0.3 deltas #1–#4) ───────────────────────────────
+//
+// These guard the paid-run preconditions the roadmap's Phase-3 halt note says
+// must land before any spend. Each gate is asserted BOTH ways: it fires on the
+// bad input and stays quiet on the good one.
+describe('bench_ab_v2_run — measurement integrity', () => {
+    it('refuses a bare model alias before any spend', () => {
+        const r = runTs(['--model', 'sonnet', '--mode', 'dry-run']);
+        expect(r.status).toBe(2);
+        expect(r.stderr).toContain('refusing bare model alias');
+    });
+
+    it('accepts a pinned full model id', () => {
+        const r = runTs(['--model', 'claude-sonnet-4-6', '--mode', 'dry-run', '--limit', '1']);
+        expect(r.status).toBe(0);
+    });
+
+    it('refuses --max-usd when no pricing row matches the model', () => {
+        // Enforcing a cap the harness cannot price would be a cap in name only.
+        const r = runTs(['--model', 'some-unpriced-model-9', '--max-usd', '10', '--limit', '1']);
+        expect(r.status).toBe(2);
+        expect(r.stderr).toContain('the sweep cap cannot be enforced');
+    });
+
+    it('reports the sweep cap in the dry-run line', () => {
+        expect(runTs(['--mode', 'dry-run', '--limit', '1', '--max-usd', '25']).stdout).toContain('sweep cap=$25');
+        expect(runTs(['--mode', 'dry-run', '--limit', '1']).stdout).toContain('sweep cap=none');
+    });
+
+    it('integrity_fields stamps the activation block a plugin arm needs', () => {
+        const run = {
+            errored: false,
+            tokens_breakdown: { input_tokens: 90_000, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+            models_seen: ['claude-sonnet-4-6'],
+        };
+        const f = integrity_fields(run, { setting_sources: null, inject: null }, 0, 'claude-sonnet-4-6');
+        expect((f['activation'] as Record<string, unknown>)['expected']).toBe('plugin');
+        expect((f['activation'] as Record<string, unknown>)['verdict']).toBe('ok');
+        expect((f['activation'] as Record<string, unknown>)['prompt_tokens']).toBe(90_000);
+        // Delta #2: the breakdown survives onto the record instead of being discarded.
+        expect(f['tokens_breakdown']).toEqual(run.tokens_breakdown);
+        expect((f['model_check'] as Record<string, unknown>)['ok']).toBe(true);
+    });
+
+    it('integrity_fields records a model swap the totals would not reveal', () => {
+        const f = integrity_fields(
+            { errored: false, tokens_breakdown: {}, models_seen: ['claude-opus-4-8'] },
+            { setting_sources: null, inject: null },
+            0,
+            'claude-sonnet-4-6',
+        );
+        expect((f['model_check'] as Record<string, unknown>)['ok']).toBe(false);
+    });
+
+    it('collect_records stops the sweep when the guard aborts, keeping completed runs', () => {
+        const tasks = [{ id: 't1' }, { id: 't2' }];
+        let seen = 0;
+        const { records, executed, aborted } = collect_records(
+            tasks,
+            ['vanilla'],
+            2,
+            () => ({ errored: false }),
+            null,
+            () => {},
+            () => (++seen >= 2 ? 'sweep budget abort: test' : null),
+        );
+        expect(aborted).toContain('sweep budget abort');
+        expect(executed).toBe(2);
+        // The completed runs are still returned — an abort costs no finished work.
+        const perArm = (records[0] as Record<string, unknown>)['arms'] as Record<string, unknown[]>;
+        expect(perArm['vanilla']).toHaveLength(2);
+        expect(records).toHaveLength(1);
+    });
+
+    it('collect_records runs to completion when the guard never aborts', () => {
+        const { executed, aborted } = collect_records(
+            [{ id: 't1' }, { id: 't2' }],
+            ['vanilla'],
+            2,
+            () => ({ errored: false }),
+            null,
+            () => {},
+            () => null,
+        );
+        expect(aborted).toBeNull();
+        expect(executed).toBe(4);
     });
 });

--- a/tests/scripts/bench_ab_v2_stats.test.ts
+++ b/tests/scripts/bench_ab_v2_stats.test.ts
@@ -23,7 +23,14 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { mcnemar_exact, cohens_h, wilcoxon, recursiveNovelLift, analyse } from '../../src/scripts/bench_ab_v2_stats.js';
+import {
+    mcnemar_exact,
+    cohens_h,
+    wilcoxon,
+    recursiveNovelLift,
+    analyse,
+    compare,
+} from '../../src/scripts/bench_ab_v2_stats.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const SCRIPTS = path.join(REPO_ROOT, 'src', 'scripts');
@@ -287,5 +294,86 @@ describe('recursiveNovelLift (ADR-106 — D₂ − D₁, additive, golden-parity
         // Arm absent → arm-guard skips it; existing comparisons unaffected.
         const withoutArm = analyse({ records, arms: ['package', 'vanilla'] });
         expect(labelsOf(withoutArm)).not.toContain('recursion novel lift (D₂ − D₁)');
+    });
+});
+
+// ── attrition (S0.3 delta #5) ───────────────────────────────────────────────
+//
+// Dropped pairs are not missing-at-random: a budget cap or timeout fires
+// preferentially on the arm doing more work, so silent exclusion biases the
+// surviving sample toward the baseline. The count alone is not enough — WHICH
+// side died is the load-bearing number, so that is what these assert.
+describe('bench_ab_v2_stats — attrition reporting', () => {
+    function trial(over: Record<string, unknown> = {}): Record<string, unknown> {
+        return {
+            seed: 0,
+            errored: false,
+            capability_pass: true,
+            discipline_score: 0.5,
+            metrics: { status_bucket: 'completed' },
+            ...over,
+        };
+    }
+    function rec(t: Record<string, unknown>[], b: Record<string, unknown>[]): Record<string, unknown> {
+        return { id: 'task', arms: { package: t, vanilla: b } };
+    }
+
+    it('reports zero attrition on a clean sweep', () => {
+        const at = compare([rec([trial()], [trial()])], 'package', 'vanilla')['attrition'] as Record<string, unknown>;
+        expect(at['pairs_seen']).toBe(1);
+        expect(at['pairs_analysed']).toBe(1);
+        expect(at['pairs_dropped']).toBe(0);
+        expect(at['drop_asymmetry']).toBe(0);
+    });
+
+    it('attributes the drop to the side that actually errored', () => {
+        const records = [
+            rec(
+                [trial({ errored: true, metrics: { status_bucket: 'budget_exhausted' } })],
+                [trial()],
+            ),
+        ];
+        const at = compare(records, 'package', 'vanilla')['attrition'] as Record<string, unknown>;
+        expect(at['pairs_dropped']).toBe(1);
+        expect(at['dropped_treatment_only']).toBe(1);
+        expect(at['dropped_baseline_only']).toBe(0);
+        // Positive = the treatment arm died more → surviving sample favours the baseline.
+        expect(at['drop_asymmetry']).toBe(1);
+        expect(at['dropped_by_status_bucket']).toEqual({ budget_exhausted: 1 });
+    });
+
+    it('signs the asymmetry the other way when the BASELINE is the one dying', () => {
+        const records = [rec([trial()], [trial({ errored: true })])];
+        const at = compare(records, 'package', 'vanilla')['attrition'] as Record<string, unknown>;
+        expect(at['dropped_baseline_only']).toBe(1);
+        expect(at['drop_asymmetry']).toBe(-1);
+    });
+
+    it('counts a both-sides-dead pair once, and both its buckets', () => {
+        const records = [
+            rec(
+                [trial({ errored: true, metrics: { status_bucket: 'timeout' } })],
+                [trial({ errored: true, metrics: { status_bucket: 'budget_exhausted' } })],
+            ),
+        ];
+        const at = compare(records, 'package', 'vanilla')['attrition'] as Record<string, unknown>;
+        expect(at['dropped_both']).toBe(1);
+        expect(at['pairs_dropped']).toBe(1);
+        expect(at['drop_asymmetry']).toBe(0);
+        expect(at['dropped_by_status_bucket']).toEqual({ timeout: 1, budget_exhausted: 1 });
+    });
+
+    it('keeps pairs_analysed equal to the n the significance tests actually used', () => {
+        const records = [
+            rec(
+                [trial({ seed: 0 }), trial({ seed: 1, errored: true })],
+                [trial({ seed: 0 }), trial({ seed: 1 })],
+            ),
+        ];
+        const cmp = compare(records, 'package', 'vanilla');
+        const at = cmp['attrition'] as Record<string, unknown>;
+        expect(at['pairs_seen']).toBe(2);
+        expect(at['pairs_analysed']).toBe(cmp['n_pairs']);
+        expect(cmp['n_pairs']).toBe(1);
     });
 });


### PR DESCRIPTION
Lands S0.3 deltas #1–#5 of `road-to-solution-minimalism` — the measurement-integrity work its Phase-3 halt note says must land **before any spend**.

## Why now, with Phase 3 halted

The A/B harness has already produced one full set of invalid nulls: clones lived inside the repo, the `vanilla` arm inherited the package through project scope, and nothing noticed. The fix at the time was a `/tmp` path constant with no assertion behind it.

Today's code would not catch a recurrence. The only activation field on a trial record is `injected_chars` — the `String.length` of a file the harness wrote itself, and `0` by construction for the `package` arm, which arrives through global settings. A disabled or version-drifted plugin would silently degrade every treatment run to `vanilla` and produce a report that looks identical to a real one. `tokens_breakdown` was discarded, so the audit could not even be reconstructed post-hoc.

These five close that hole before the $150–250 grant is spent against it, not after.

## What landed

| # | Delta | Where |
|---|---|---|
| 1 | Per-trial injection audit (both directions on the text channel) + the paired cross-arm audit for the plugin channel; violations exit 2 | `_lib/bench_ab_activation.ts`, wired in `bench_ab_v2_run.ts` |
| 2 | `tokens_breakdown` preserved on every trial record — unblocks #1 and #6 | `bench_ab_v2_run.integrity_fields` |
| 3 | Model id read back from the envelope's `modelUsage`; bare aliases refused before the first call | `bench_ab_task_runner.ts`, `bench_ab_v2_run.ts` |
| 4 | Sweep-level `--max-usd` abort, priced per bucket | `SweepBudget` + a `collect_records` guard |
| 5 | Errored-pair attrition per arm-pair and per `status_bucket`, with the signed drop asymmetry | `bench_ab_v2_stats.compare` → report Table 4 |

Three design calls worth a reviewer's eye:

- **The report is still written on failure.** An invalid sweep already cost money and its raw runs stay inspectable; the **exit code** is what makes it non-ignorable.
- **`unknown` is not `violation`.** An errored or budget-capped run returns `unknown` — attrition is a separate question (#5) and laundering it into an integrity fail would hide it.
- **The lift threshold is calibrated downward.** `ACTIVATION_MIN_LIFT_RATIO = 1.2` sits well below the three stored sweeps' observed 1.71×–6.79×, so it flags a *collapse to baseline*, never ordinary variance.

## Scope — what this does NOT do

**It closes zero checkboxes.** Every open Phase-3 step is gated on the spend grant or on deltas #9/#10/#11 (pinned external repo · ~30 hand-written oracles · a cognitive-complexity endpoint that exists nowhere in the repo). The roadmap stays at 66% and both halt gates stand: the grant is the maintainer's to give, and the three large deltas are still absent.

That reporting gap is recorded in the roadmap's new `## Untracked prerequisite work` section rather than spun into a meta-roadmap tracking untracked work. No effect claim, no number, and no threshold was added to any published surface.

The `Arms` step gets an inline note because half of it moved: its `verify:` — the both-directions injection audit — now exists, while the step body still needs two arm definitions that do not.

## Verification

- `tests/scripts/_lib_bench_ab_activation.test.ts` — 31 new assertions. Every gate is asserted in **both** directions: a collapsed arm fires, an arm just above the threshold does not; a swapped model fires, a dated-vs-undated id does not; a capped run is `unknown`, not a violation. An always-firing and a never-firing audit both pass a positive-only suite, which is why the negatives are there.
- `bench_ab_v2_run.test.ts` +7, `bench_ab_v2_stats.test.ts` +5.
- 120 tests green across the 9 `bench_ab` suites; `task typecheck-ts` clean; eslint clean on the changed files; `check_references`, `check_md_language`, `lint_output_slop`, `sweep_dead_scan_roots`, and the `dist == rewrite(src)` projection check all green.

No behaviour change to any existing sweep that does not pass `--max-usd`: the new argument defaults to uncapped, and every added record field is additive.
