### PR TITLE
feat(worktree): classify every worktree in one pass, promote the hygiene roadmap on its fired trigger

### DIFF
--- a/agents/evidence/reports/worktree-inventory.md
+++ b/agents/evidence/reports/worktree-inventory.md
@@ -1,0 +1,82 @@
+# Worktree inventory — baseline pass
+
+> Produced by `worktree_cleanup_check inventory` (the `road-to-worktree-hygiene`
+> roadmap's Phase 1). Recorded so a later pass can tell **growth** from
+> **residue** rather than re-deriving the same numbers. Nothing was removed:
+> bulk worktree + branch deletion is a Hard-Floor action
+> (`non-destructive-by-default`) and needs the maintainer's explicit
+> this-turn approval.
+
+## Why the roadmap's promotion trigger fired
+
+The draft's own trigger: *"Promote when the count materially affects clone size,
+disk, or a tool that walks worktrees — or simply when a maintainer wants the
+list."*
+
+| Signal | At filing | This pass (2026-08-05) |
+|---|---:|---:|
+| Registered worktrees | 209 | **249** |
+| Disk under `.claude/worktrees/` | not measured | **40 GB** |
+| Local branches | not measured | **692** |
+| Registrations `git worktree prune` would clear | — | **0** |
+
+Disk is the leg that fired: 40 GB is material, and the count grew by 40 in the
+five days between filing and this pass. `prune` clearing nothing confirms the
+roadmap's premise — every registration points at a real directory, so there is
+no cheap cleanup path.
+
+## Classification
+
+Repo: this checkout · trunk: `refs/remotes/origin/main` · 249 registered.
+
+| Class | Count |
+|---|---:|
+| safe | 143 |
+| review | 78 |
+| live | 28 |
+
+`safe` requires **all** of: on a branch · merged into the trunk · clean
+(including untracked) · inside a conventional worktree root · no git activity
+for 48 h.
+
+### Review set, by primary disqualifier
+
+| Count | Reason |
+|---:|---|
+| 63 | non-standard location — outside the conventional worktree roots |
+| 9 | unsaved work (7 × 1 path, 1 × 2 paths, 1 × 6 paths) |
+| 4 | branch is not an ancestor of `refs/remotes/origin/main` — unmerged work |
+| 2 | detached HEAD — no branch to judge reachability for |
+
+The 63 non-standard-location entries are the largest single finding and are
+**deliberately excluded from the safe set**: they sit beside the repo in the
+parent package directory, where a worktree can be mistaken for a sibling
+package. Removing them is a judgement call about the layout convention, not a
+mechanical cleanup, so they stay for the maintainer.
+
+The 4 unmerged branches are exactly the case the roadmap warns about — a
+cherry-pick gives the same content a different SHA, so `rev-list --count` alone
+proves nothing. The inventory does not guess: it reports them as review and
+leaves the content check to a human.
+
+## Honest limits of these numbers
+
+- **The `live` count is transient and partly self-inflicted.** Liveness is read
+  from per-worktree git-dir mtime. Two inventory runs made during this session's
+  development — before the `--no-optional-locks` fix landed — refreshed the
+  index in worktrees they touched, moving 10 of them from `safe` to `live`
+  (151/80/18 → 143/78/28). The classification is stable across runs now, and
+  the inflation decays on its own once the 48 h window passes. The **structural**
+  figures (total, location, merge status, dirty, detached) are unaffected.
+- **Liveness is a heuristic, not a lock.** A session that has a worktree open but
+  has run no git command in 48 h reads as quiet. That is why the safe set is a
+  proposal for review, never an automatic action.
+- **Disk is measured for one root only** (`.claude/worktrees/`), not for the 63
+  entries outside it, so 40 GB is a floor.
+
+## Next pass
+
+Re-run `worktree_cleanup_check inventory` and compare against the table above:
+a rising **total** with a flat review set is growth; a flat total with the same
+review reasons is residue. The review set should shrink as its named reasons are
+resolved, so the next pass starts from a shorter list rather than the same 249.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 13 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **12** open blockers
+> 14 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **13** open blockers
 
 ## Overall
 
-**68 / 144 steps done · 47%**
+**75 / 153 steps done · 49%**
 
 ```text
-███████████████████░░░░░░░░░░░░░░░░░░░░░   47%
+████████████████████░░░░░░░░░░░░░░░░░░░░   49%
 ```
 
 ## Open roadmaps
@@ -29,6 +29,7 @@
 | 11 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [3](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 12 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
 | 13 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
+| 14 | [road-to-worktree-hygiene.md](roadmaps/road-to-worktree-hygiene.md) | 1 | 9 | 2 | 7 | 0 | 0 | [1](#blockers-road-to-worktree-hygiene) | ████████░░ 78% |
 
 ---
 
@@ -307,6 +308,26 @@ _1 blocker resolved._
     and chose the named blocker over a re-scope that changes a pre-registered
     input.
   - **Resolved when:** either a host-renderable framework lane exists (a build/serve step for the React lane, landed for its own reason) **or** a supported generic-lane override exists — at which point the re-scope is recorded as a dated amendment in `internal/bench/corpora/ui-track-integrity-PREREG.md` and Measurement B becomes executable.
+
+### [road-to-worktree-hygiene.md](roadmaps/road-to-worktree-hygiene.md)
+
+**Road to worktree hygiene — 249 worktrees, 40 GB, one prune that does nothing** — 7 / 9 done (78%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | inventory, classify, record | 🟡 in progress | 2 | 7 | 0 | 0 | 78% |
+
+<a id="blockers-road-to-worktree-hygiene"></a>
+**Blockers**
+
+- **safe-set-removal-approval** (owner: user) — blocks Phase 1 step 3, and the last acceptance criterion
+  - **What to do:**
+    (`./scripts-run src/scripts/worktree_cleanup_check inventory --plan`) and
+    approve, narrow, or decline the removal of the 143 safe worktrees and their
+    fully-merged branches. Bulk deletion is a Hard-Floor action
+    (`non-destructive-by-default`): an agent may prepare and surface it, never
+    perform it, and a single earlier approval never covers a bulk sweep.
+  - **Resolved when:** the maintainer has approved (or declined) the safe-set removal this turn, and — if approved — the post-removal count is recorded in `agents/evidence/reports/worktree-inventory.md`.
 
 ---
 

--- a/agents/roadmaps/road-to-worktree-hygiene.md
+++ b/agents/roadmaps/road-to-worktree-hygiene.md
@@ -1,26 +1,37 @@
 ---
 complexity: lightweight
-status: draft
+status: ready
 ---
 
-# Road to worktree hygiene — 209 worktrees, one prune, no inventory
+# Road to worktree hygiene — 249 worktrees, 40 GB, one prune that does nothing
 
 > Planned, not scheduled, and deliberately kept out of the session that found it.
 > A bulk branch/worktree sweep is exactly the kind of work that must not ride
 > along on an unrelated change.
+>
+> **Promoted draft → ready 2026-08-05.** The `Why draft` trigger below
+> ("materially affects clone size, disk, or a tool that walks worktrees") fired
+> on the **disk** leg: 40 GB under one worktree root, with the count up 209 → 249
+> in five days. AI council 2026-08-05 (2 members, $0.05) converged 2/2 on
+> adopting the roadmap now and on extending the existing gate script rather than
+> adding a parallel one. Its decisive point: the maintainer currently has **no
+> list at all**, so the removal decision already exists and is merely
+> un-actionable — a classified safe set turns an unbounded chore into one
+> reviewable approval.
 
 ## The finding
 
-`git worktree list` reports **209** entries in this checkout. They accumulate one
-per feature branch and are never removed on merge; `git worktree prune` only
-clears registrations whose directory is already gone, so it does nothing for the
-real ones. Disk cost aside, the practical cost is that a stale worktree is a
-second copy of the repo that can hold an old `.agent-settings.yml`, a stale
-`node_modules` symlink, or a branch that looks alive in `git branch` long after
-its PR merged.
+`git worktree list` reports **249** entries in this checkout (filed at 209).
+They accumulate one per feature branch and are never removed on merge;
+`git worktree prune` only clears registrations whose directory is already gone —
+measured this pass that is **0 of 249**, so here it does nothing at all. Disk is
+**40 GB** under `.claude/worktrees/` alone, beside **692** local branches. On top
+of disk, a stale worktree is a second copy of the repo that can hold an old
+`.agent-settings.yml`, a stale `node_modules` symlink, or a branch that looks
+alive in `git branch` long after its PR merged.
 
-Nothing here is broken. This is hygiene, and it is filed so the number does not
-quietly become 400.
+Nothing here is broken. This is hygiene, and it was filed so the number did not
+quietly become 400. It reached 249 instead — hence `ready`.
 
 ## Why it is not a one-liner
 
@@ -36,27 +47,103 @@ duty, not just a permission gate:
 - Some worktrees belong to concurrent sessions. A sweep run while another agent
   or terminal is working in one destroys live state.
 
-## What a pass would do
+## Phase 1 — inventory, classify, record
 
-- [ ] Inventory: per worktree — path, branch, dirty?, commits not on `main`,
+- [x] Inventory: per worktree — path, branch, dirty?, commits not on `main`,
       whether that content is reachable on `main` anyway, PR state if any.
-- [ ] Classify: **safe** (clean, merged, content on `main`) · **review**
+      <!-- done 2026-08-05: `inventory` mode on the EXISTING
+      src/scripts/worktree_cleanup_check.ts (council Decision 2, option 1 — reuse
+      the already-tested per-worktree gate rather than a parallel script). Reports
+      path, branch, trunk-ancestry, dirty count, detached HEAD, location
+      convention, and liveness. PR state is deliberately NOT fetched: it needs a
+      network call per worktree and trunk-ancestry already answers the question
+      the PR state was a proxy for. -->
+- [x] Classify: **safe** (clean, merged, content on `main`) · **review**
       (unique commits or dirty) · **live** (another session's).
+      <!-- done 2026-08-05: `safe` requires ALL of — on a branch, merged into the
+      trunk, clean incl. untracked, inside a conventional worktree root, and no
+      git activity for 48 h. Result: 143 safe / 78 review / 28 live of 249.
+      Two real defects were found and fixed while building it, both pinned by
+      regression tests: (1) plain `git status` refreshes the on-disk index, so the
+      check bumped the very mtime it reads as the liveness signal — two runs moved
+      10 worktrees safe → live (151/80/18 → 143/78/28); fixed with
+      `--no-optional-locks`, classification now stable across consecutive runs.
+      (2) git reports worktree paths as realpaths, so a repo reached through a
+      symlinked parent mis-classified conventional worktrees as non-standard;
+      fixed by canonicalising the longest existing ancestor. -->
 - [ ] Present the safe set as a list and remove **only after explicit approval** —
       per `scope-control`, branch and worktree deletion is permission-gated, and
       a bulk sweep does not inherit a single earlier approval.
-- [ ] Leave the review set untouched with its reason recorded, so the next pass
+      <!-- PRESENTED 2026-08-05, removal NOT run: `inventory --plan` emits the 143
+      `git worktree remove` + `git branch -d` pairs (never `-D`, so git itself
+      re-checks the merge). Running them is a Hard-Floor bulk deletion needing the
+      maintainer's explicit this-turn approval — see blocker
+      `safe-set-removal-approval`. This step stays open by design: the roadmap
+      cannot close without a human, and that is the correct shape, not a gap. -->
+- [x] Leave the review set untouched with its reason recorded, so the next pass
       starts from a shorter list rather than the same 209.
-- [ ] Record whatever count remains, so a later pass can tell growth from
+      <!-- done 2026-08-05: nothing in the review set was touched. Reasons recorded
+      in agents/evidence/reports/worktree-inventory.md — 63 non-standard location,
+      9 unsaved work, 4 unmerged, 2 detached HEAD. The 63 are excluded from the
+      safe set deliberately: beside the repo they can be mistaken for sibling
+      packages, so the layout call is the maintainer's, not mechanical. -->
+- [x] Record whatever count remains, so a later pass can tell growth from
       residue.
+      <!-- done 2026-08-05: agents/evidence/reports/worktree-inventory.md carries
+      the baseline table (249 / 40 GB / 692 branches / 0 prunable) plus the
+      growth-vs-residue read for the next pass. It also states the honest limit:
+      the `live` figure is inflated by this session's own pre-fix runs and decays
+      once the 48 h window passes; the structural figures are unaffected. -->
 
 ## Non-goals
 
 - **No automatic pruning on merge.** A hook that deletes worktrees is exactly the
   wrong place for irreversible cleanup; the sweep stays deliberate and reviewed.
 - **Not a git-hygiene framework.** One inventory script and a reviewed list.
+- **No creation-side quota or convention enforcement.** One council member
+  suggested guarding future growth at creation time. Out of scope here and
+  deliberately not filed: this roadmap measures and cleans, and a mechanism to
+  prevent growth needs its own evidence that the convention is what fails —
+  `worktree-lifecycle` already documents the conventional roots.
 
-## Why `draft`
+## Why `draft` (superseded — kept for the trail)
 
 Nothing is failing. Promote when the count materially affects clone size, disk,
 or a tool that walks worktrees — or simply when a maintainer wants the list.
+
+*Fired 2026-08-05 on the disk leg (40 GB) — see the promotion note at the top.*
+
+## Acceptance criteria
+
+- [x] A repeatable inventory exists that classifies every worktree and whose
+      verdict does not change when it is run twice.
+- [x] The review set is recorded with a per-entry reason, untouched.
+- [x] The residual counts are recorded so growth can be told from residue.
+- [ ] The safe set has been removed after explicit maintainer approval, and the
+      post-removal count is recorded.
+
+## Blockers
+
+### blocker: safe-set-removal-approval
+
+- **Status:** open
+- **Owner:** user
+- **Blocks:** Phase 1 step 3, and the last acceptance criterion
+- **What to do:** review the prepared plan
+  (`./scripts-run src/scripts/worktree_cleanup_check inventory --plan`) and
+  approve, narrow, or decline the removal of the 143 safe worktrees and their
+  fully-merged branches. Bulk deletion is a Hard-Floor action
+  (`non-destructive-by-default`): an agent may prepare and surface it, never
+  perform it, and a single earlier approval never covers a bulk sweep.
+- **Resolved when:** the maintainer has approved (or declined) the safe-set
+  removal this turn, and — if approved — the post-removal count is recorded in
+  `agents/evidence/reports/worktree-inventory.md`.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-05 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Removing a worktree that holds the only copy of some work | implementation | A branch may carry commits reachable from no other ref, or uncommitted files; a wrong removal destroys work with no undo | `safe` requires trunk-ancestry AND a clean tree; unmerged branches additionally run the existing unique-commit gate; the plan uses `git branch -d`, never `-D`, so git re-checks the merge at execution time | Phase 1 — inventory, classify, record |
+| 2 | Sweeping a worktree another session is using | implementation | A concurrent agent or terminal loses live state mid-task | Liveness (git-dir mtime within 48 h) excludes the worktree from the safe set; the report states plainly that liveness is a heuristic, not a lock, which is why the safe set is a proposal for review | Phase 1 — inventory, classify, record |
+| 3 | The measurement corrupts its own signal | implementation | The check reads git-dir mtime as liveness while `git status` rewrites the index — a self-poisoning report that silently reclassifies on every run | Found and fixed during this pass (`--no-optional-locks`); pinned by a regression test asserting two consecutive runs agree | Phase 1 — inventory, classify, record |
+| 4 | The prepared plan is never approved | product | The tooling's payoff is contingent on a human acting on a 143-item deletion; if that never happens, the 40 GB persists and the mechanism was built for nothing | Accepted, and named by the council as the strongest argument against adopting this roadmap: the inventory itself has standalone value (the maintainer now knows 143/249 are safe, 63 are in non-standard locations, 4 are unmerged), and the residual counts make a later decision cheaper than this one | blocker: safe-set-removal-approval |

--- a/dist/agent-src/commands/worktree/cleanup.md
+++ b/dist/agent-src/commands/worktree/cleanup.md
@@ -31,6 +31,23 @@ never force-removes.
 `git worktree list --porcelain` — target the worktree(s) named by the
 user, or every non-main worktree when asked to "clean up".
 
+For a whole-checkout sweep, get the classified set in one pass instead of
+running the per-worktree gate by hand:
+
+```bash
+./scripts-run src/scripts/worktree_cleanup_check inventory        # counts + review reasons
+./scripts-run src/scripts/worktree_cleanup_check inventory --plan # commands for the safe set
+```
+
+`safe` = on a branch, merged into the trunk, clean, in a conventional
+worktree root, and no git activity for 48 h. `review` carries its
+disqualifying reason; `live` means another session may hold it. The mode
+reports only — running the plan is a bulk deletion needing the user's
+explicit this-turn approval per
+[`non-destructive-by-default`](../../../rules/non-destructive-by-default.md).
+Present the safe set as a list and wait; a bulk sweep never inherits a
+single earlier approval.
+
 ### 2. Per candidate, run the gates IN ORDER
 
 Run the deterministic gate helper (edge-case-tested: detached HEAD,

--- a/dist/agent-src/commands/worktree/status.md
+++ b/dist/agent-src/commands/worktree/status.md
@@ -29,6 +29,12 @@ git worktree list --porcelain
 ```
 
 One report block per worktree (skip the main working tree unless asked).
+Above roughly a dozen worktrees a per-worktree block stops being readable —
+lead with the aggregate instead, then block only what the user asks about:
+
+```bash
+./scripts-run src/scripts/worktree_cleanup_check inventory
+```
 
 ### 2. Per worktree, gather
 

--- a/dist/agent-src/skills/worktree-lifecycle/SKILL.md
+++ b/dist/agent-src/skills/worktree-lifecycle/SKILL.md
@@ -128,6 +128,28 @@ step (`scope-control`); never force-delete (`-D`) as part of cleanup.
 Cross-worktree scope-lock overlaps are scanned via
 `worktree_cleanup_check scope-overlap` (surfaced by `/worktree status`).
 
+**Whole-checkout sweeps.** Worktrees accumulate one per branch and are never
+removed on merge; `git worktree prune` only clears registrations whose
+directory is already gone, so it does nothing for the live ones. Classify the
+whole set in one pass rather than gate-checking by hand:
+
+```bash
+npx tsx node_modules/@event4u/agent-config/src/scripts/worktree_cleanup_check.ts inventory [repo] [--json|--plan]
+```
+
+`safe` requires all of: on a branch, merged into the trunk, clean, inside a
+conventional worktree root (`.claude/worktrees/` or `.worktrees/`), and no git
+activity for 48 h. `review` keeps its disqualifying reason so the next sweep
+starts from a shorter list; `live` means another session may hold it. A
+worktree outside the conventional roots is never `safe` — sitting beside the
+repo it can be mistaken for a sibling package, so its removal stays a
+judgement call.
+
+The mode reports only. `--plan` prints `git worktree remove` plus
+`git branch -d` (never `-D`) for the safe set; **running it is a bulk deletion
+needing the user's explicit this-turn approval**
+(`non-destructive-by-default`), which a single earlier approval never covers.
+
 ## Host-native mapping
 
 | Host capability | Use |

--- a/src/domains/engineering-base/worktree/cleanup/command.md
+++ b/src/domains/engineering-base/worktree/cleanup/command.md
@@ -31,6 +31,23 @@ never force-removes.
 `git worktree list --porcelain` — target the worktree(s) named by the
 user, or every non-main worktree when asked to "clean up".
 
+For a whole-checkout sweep, get the classified set in one pass instead of
+running the per-worktree gate by hand:
+
+```bash
+./scripts-run src/scripts/worktree_cleanup_check inventory        # counts + review reasons
+./scripts-run src/scripts/worktree_cleanup_check inventory --plan # commands for the safe set
+```
+
+`safe` = on a branch, merged into the trunk, clean, in a conventional
+worktree root, and no git activity for 48 h. `review` carries its
+disqualifying reason; `live` means another session may hold it. The mode
+reports only — running the plan is a bulk deletion needing the user's
+explicit this-turn approval per
+[`non-destructive-by-default`](../../../rules/non-destructive-by-default.md).
+Present the safe set as a list and wait; a bulk sweep never inherits a
+single earlier approval.
+
 ### 2. Per candidate, run the gates IN ORDER
 
 Run the deterministic gate helper (edge-case-tested: detached HEAD,

--- a/src/domains/engineering-base/worktree/status/command.md
+++ b/src/domains/engineering-base/worktree/status/command.md
@@ -29,6 +29,12 @@ git worktree list --porcelain
 ```
 
 One report block per worktree (skip the main working tree unless asked).
+Above roughly a dozen worktrees a per-worktree block stops being readable —
+lead with the aggregate instead, then block only what the user asks about:
+
+```bash
+./scripts-run src/scripts/worktree_cleanup_check inventory
+```
 
 ### 2. Per worktree, gather
 

--- a/src/scripts/worktree_cleanup_check.ts
+++ b/src/scripts/worktree_cleanup_check.ts
@@ -16,11 +16,18 @@
  *   scope-overlap           Scan every worktree's .worktree-scope.md and
  *                           report pairwise `owns:` overlaps (the hazard
  *                           /worktree status + verify must surface).
+ *   inventory               Classify EVERY worktree safe / review / live and
+ *                           report the counts, the review reasons, and a
+ *                           prepared removal plan for the safe set. Reporting
+ *                           only — it never removes anything, because bulk
+ *                           worktree + branch deletion is a Hard-Floor action
+ *                           (`non-destructive-by-default`) that needs the
+ *                           user's explicit this-turn approval.
  *
  * Reachability counts ALL other refs — local branches, remotes, AND tags
  * (a branch whose only other ref is a tag is still reachable elsewhere).
- * Exit codes: 0 = allowed / no overlap, 1 = refused / overlap found,
- * 2 = usage error, 3 = internal error.
+ * Exit codes: 0 = allowed / no overlap / inventory reported, 1 = refused /
+ * overlap found, 2 = usage error, 3 = internal error.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -53,6 +60,17 @@ function tryGit(cwd: string, args: string[]): string | null {
     }
 }
 
+/**
+ * `git status` with the index left alone. Plain `git status` refreshes the
+ * on-disk index, which bumps its mtime — and the inventory mode reads that
+ * mtime as the "another session is working here" signal. Without
+ * `--no-optional-locks` the check corrupts the very signal it is measured
+ * against: two consecutive inventory runs moved 10 worktrees from safe to live.
+ */
+function statusPorcelain(cwd: string): string {
+    return git(cwd, ['--no-optional-locks', 'status', '--porcelain']);
+}
+
 /** Refs (heads + remotes + tags) EXCLUDING the given branch's own head ref. */
 function otherRefs(cwd: string, branch: string): string[] {
     const out = git(cwd, ['for-each-ref', '--format=%(refname)']);
@@ -77,7 +95,7 @@ export function checkWorktree(worktreePath: string): CheckResult {
     }
     const branch = headRef.trim().replace(/^refs\/heads\//, '');
 
-    const status = git(worktreePath, ['status', '--porcelain']);
+    const status = statusPorcelain(worktreePath);
     if (status.trim().length > 0) {
         const files = status
             .trimEnd()
@@ -194,9 +212,260 @@ export function findScopeOverlaps(repoPath: string): ScopeOverlap[] {
     return overlaps;
 }
 
+/**
+ * A worktree is "live" when another session may be working in it. Git touches
+ * the per-worktree index on almost every command, so its mtime is the cheapest
+ * available activity signal.
+ */
+export const LIVE_WINDOW_HOURS = 48;
+
+/**
+ * The two conventional worktree roots, relative to the repo. Anything else is
+ * a non-standard location: it is not wrong, but it is excluded from the safe
+ * set on purpose — worktrees that sit beside the repo can be mistaken for
+ * sibling packages, so their removal is a judgement the maintainer makes.
+ */
+export const STANDARD_WORKTREE_DIRS = ['.claude/worktrees', '.worktrees'] as const;
+
+/**
+ * Symlink-resolved absolute path, falling back to a plain resolve when the
+ * path is gone. Git reports worktree paths as realpaths, so a repo reached
+ * through a symlinked parent (`/tmp` → `/private/tmp` on macOS, or any
+ * symlinked checkout root) would otherwise fail every path comparison and
+ * mis-report conventional worktrees as non-standard.
+ */
+function canonical(p: string): string {
+    const abs = path.resolve(p);
+    const tail: string[] = [];
+    let head = abs;
+    for (;;) {
+        try {
+            // Resolve the longest existing ancestor, then re-append the rest —
+            // a registration pointing at an already-deleted directory still has
+            // to classify its location correctly.
+            const real = fs.realpathSync(head);
+            return tail.length === 0 ? real : path.join(real, ...tail);
+        } catch {
+            const parent = path.dirname(head);
+            if (parent === head) return abs;
+            tail.unshift(path.basename(head));
+            head = parent;
+        }
+    }
+}
+
+export type Classification = 'safe' | 'review' | 'live';
+
+export interface InventoryRow {
+    path: string;
+    branch: string | null;
+    classification: Classification;
+    /** Why it is not safe. Empty exactly when `classification === 'safe'`. */
+    reasons: string[];
+    /** The branch is an ancestor of the trunk, so `git branch -d` is safe. */
+    mergedIntoTrunk: boolean;
+    standardLocation: boolean;
+    /** Main worktree — never removable, and never counted as residue. */
+    isMain: boolean;
+}
+
+export interface Inventory {
+    trunk: string;
+    rows: InventoryRow[];
+    counts: {
+        total: number;
+        safe: number;
+        review: number;
+        live: number;
+        /** Review rows grouped by reason, highest first. */
+        reviewReasons: Record<string, number>;
+    };
+}
+
+/** First existing trunk ref, preferring the remote (the merge authority). */
+export function resolveTrunk(repoPath: string): string {
+    for (const ref of [
+        'refs/remotes/origin/main',
+        'refs/remotes/origin/master',
+        'refs/heads/main',
+        'refs/heads/master',
+    ]) {
+        if (tryGit(repoPath, ['rev-parse', '--verify', '--quiet', ref]) !== null) return ref;
+    }
+    return 'HEAD';
+}
+
+function isAncestor(repoPath: string, branch: string, trunk: string): boolean {
+    try {
+        git(repoPath, ['merge-base', '--is-ancestor', branch, trunk]);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export function isStandardLocation(repoPath: string, worktreePath: string): boolean {
+    const rel = path.relative(canonical(repoPath), canonical(worktreePath));
+    if (rel.startsWith('..') || path.isAbsolute(rel)) return false;
+    return STANDARD_WORKTREE_DIRS.some(
+        (dir) => rel === dir || rel.startsWith(`${dir}${path.sep}`),
+    );
+}
+
+/**
+ * Per-worktree git-dir mtime, or null when it cannot be read. A linked
+ * worktree's `.git` is a file holding `gitdir: <path>`; the main worktree's is
+ * a directory.
+ */
+function lastGitActivity(worktreePath: string): Date | null {
+    const dotGit = path.join(worktreePath, '.git');
+    let gitDir: string;
+    try {
+        const st = fs.statSync(dotGit);
+        if (st.isDirectory()) {
+            gitDir = dotGit;
+        } else {
+            const m = fs.readFileSync(dotGit, 'utf-8').match(/^gitdir:\s*(.+)$/m);
+            if (!m) return null;
+            gitDir = path.resolve(worktreePath, m[1]!.trim());
+        }
+    } catch {
+        return null;
+    }
+    let newest: number | null = null;
+    for (const name of ['index', 'HEAD']) {
+        try {
+            const t = fs.statSync(path.join(gitDir, name)).mtimeMs;
+            if (newest === null || t > newest) newest = t;
+        } catch {
+            /* absent is not an error — the other candidate may still exist */
+        }
+    }
+    return newest === null ? null : new Date(newest);
+}
+
+/**
+ * Classify every worktree. `now` is injectable so the live-window boundary is
+ * testable rather than wall-clock dependent.
+ */
+export function buildInventory(repoPath: string, now: Date = new Date()): Inventory {
+    const trunk = resolveTrunk(repoPath);
+    const entries = listWorktrees(repoPath);
+    const mainPath = canonical(entries.length > 0 ? entries[0]!.path : repoPath);
+    const liveCutoff = now.getTime() - LIVE_WINDOW_HOURS * 3600 * 1000;
+
+    const rows: InventoryRow[] = entries.map((e) => {
+        const resolved = canonical(e.path);
+        const isMain = resolved === mainPath;
+        const standardLocation = isMain ? true : isStandardLocation(repoPath, resolved);
+        const reasons: string[] = [];
+
+        if (!fs.existsSync(resolved)) {
+            return {
+                path: e.path,
+                branch: e.branch,
+                classification: 'review',
+                reasons: ['registration points at a missing directory — `git worktree prune` clears it'],
+                mergedIntoTrunk: false,
+                standardLocation,
+                isMain,
+            };
+        }
+
+        const activity = lastGitActivity(resolved);
+        if (activity !== null && activity.getTime() >= liveCutoff) {
+            return {
+                path: e.path,
+                branch: e.branch,
+                classification: 'live',
+                reasons: [`git activity within the last ${LIVE_WINDOW_HOURS}h — another session may hold it`],
+                mergedIntoTrunk: e.branch !== null && isAncestor(resolved, e.branch, trunk),
+                standardLocation,
+                isMain,
+            };
+        }
+
+        if (isMain) reasons.push('main worktree — cannot be removed');
+        if (e.branch === null) {
+            reasons.push('detached HEAD — no branch to judge reachability for');
+        }
+        if (!standardLocation) {
+            reasons.push('non-standard location — outside the conventional worktree roots');
+        }
+
+        const mergedIntoTrunk = e.branch !== null && isAncestor(resolved, e.branch, trunk);
+
+        // A branch that is an ancestor of the trunk has every commit reachable
+        // from the trunk ref, so the expensive rev-list gate cannot find a
+        // unique commit. Only run it for the branches that are NOT merged —
+        // that is where it can actually refuse.
+        if (e.branch !== null && !mergedIntoTrunk) {
+            reasons.push(`branch is not an ancestor of ${trunk} — unmerged work`);
+            const gate = checkWorktree(resolved);
+            if (!gate.allowed) reasons.push(...gate.reasons);
+        } else if (e.branch !== null) {
+            const status = statusPorcelain(resolved);
+            if (status.trim().length > 0) {
+                const n = status.trimEnd().split('\n').length;
+                reasons.push(`unsaved work — ${n} dirty or untracked path(s)`);
+            }
+        }
+
+        return {
+            path: e.path,
+            branch: e.branch,
+            classification: reasons.length === 0 ? 'safe' : 'review',
+            reasons,
+            mergedIntoTrunk,
+            standardLocation,
+            isMain,
+        };
+    });
+
+    const reviewReasons: Record<string, number> = {};
+    for (const r of rows) {
+        if (r.classification !== 'review') continue;
+        // Group by the first reason: it is the primary disqualifier, and the
+        // per-row reasons stay available in --json for the full picture.
+        const key = (r.reasons[0] ?? 'unknown').split('\n')[0]!;
+        reviewReasons[key] = (reviewReasons[key] ?? 0) + 1;
+    }
+
+    return {
+        trunk,
+        rows,
+        counts: {
+            total: rows.length,
+            safe: rows.filter((r) => r.classification === 'safe').length,
+            review: rows.filter((r) => r.classification === 'review').length,
+            live: rows.filter((r) => r.classification === 'live').length,
+            reviewReasons: Object.fromEntries(
+                Object.entries(reviewReasons).sort((a, b) => b[1] - a[1]),
+            ),
+        },
+    };
+}
+
+/**
+ * The removal commands for the safe set — printed for a human to review and
+ * run, never executed here. `git branch -d` (never `-D`) so git itself
+ * re-checks the merge before the branch goes.
+ */
+export function removalPlan(inv: Inventory): string[] {
+    return inv.rows
+        .filter((r) => r.classification === 'safe')
+        .map((r) => {
+            const remove = `git worktree remove ${JSON.stringify(r.path)}`;
+            return r.branch !== null && r.mergedIntoTrunk
+                ? `${remove} && git branch -d ${JSON.stringify(r.branch)}`
+                : remove;
+        });
+}
+
 function usage(): never {
     process.stderr.write(
-        'usage: worktree_cleanup_check check <worktree-path> | scope-overlap [repo-path]\n',
+        'usage: worktree_cleanup_check check <worktree-path> | scope-overlap [repo-path] | ' +
+            'inventory [repo-path] [--json|--plan]\n',
     );
     process.exit(2);
 }
@@ -235,6 +504,52 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
             );
         }
         return 1;
+    }
+    if (mode === 'inventory') {
+        const rest = argv.slice(1);
+        const flags = rest.filter((a) => a.startsWith('--'));
+        const positional = rest.filter((a) => !a.startsWith('--'));
+        if (positional.length > 1 || flags.some((f) => f !== '--json' && f !== '--plan')) usage();
+        const repo = path.resolve(positional[0] ?? '.');
+        const inv = buildInventory(repo);
+
+        if (flags.includes('--json')) {
+            process.stdout.write(`${JSON.stringify(inv, null, 2)}\n`);
+            return 0;
+        }
+        if (flags.includes('--plan')) {
+            const plan = removalPlan(inv);
+            if (plan.length === 0) {
+                process.stdout.write('# no safe worktrees — nothing to propose.\n');
+                return 0;
+            }
+            process.stdout.write(
+                `# Prepared removal plan for ${plan.length} safe worktree(s).\n` +
+                    '# NOT executed: bulk worktree + branch deletion is a Hard-Floor action that\n' +
+                    '# needs the maintainer\'s explicit approval. Review, then run deliberately.\n',
+            );
+            process.stdout.write(`${plan.join('\n')}\n`);
+            return 0;
+        }
+
+        const c = inv.counts;
+        process.stdout.write(
+            `worktree inventory · ${c.total} registered · trunk ${inv.trunk}\n` +
+                `  safe    ${c.safe}\n` +
+                `  review  ${c.review}\n` +
+                `  live    ${c.live}\n`,
+        );
+        if (c.review > 0) {
+            process.stdout.write('\nreview reasons (primary disqualifier):\n');
+            for (const [reason, n] of Object.entries(c.reviewReasons)) {
+                process.stdout.write(`  ${String(n).padStart(4)}  ${reason}\n`);
+            }
+        }
+        process.stdout.write(
+            '\nThis mode reports only. `--plan` prints the removal commands for the safe set;\n' +
+                'running them is a Hard-Floor action needing the maintainer\'s explicit approval.\n',
+        );
+        return 0;
     }
     usage();
 }

--- a/src/skills/worktree-lifecycle/SKILL.md
+++ b/src/skills/worktree-lifecycle/SKILL.md
@@ -128,6 +128,28 @@ step (`scope-control`); never force-delete (`-D`) as part of cleanup.
 Cross-worktree scope-lock overlaps are scanned via
 `worktree_cleanup_check scope-overlap` (surfaced by `/worktree status`).
 
+**Whole-checkout sweeps.** Worktrees accumulate one per branch and are never
+removed on merge; `git worktree prune` only clears registrations whose
+directory is already gone, so it does nothing for the live ones. Classify the
+whole set in one pass rather than gate-checking by hand:
+
+```bash
+npx tsx node_modules/@event4u/agent-config/src/scripts/worktree_cleanup_check.ts inventory [repo] [--json|--plan]
+```
+
+`safe` requires all of: on a branch, merged into the trunk, clean, inside a
+conventional worktree root (`.claude/worktrees/` or `.worktrees/`), and no git
+activity for 48 h. `review` keeps its disqualifying reason so the next sweep
+starts from a shorter list; `live` means another session may hold it. A
+worktree outside the conventional roots is never `safe` — sitting beside the
+repo it can be mistaken for a sibling package, so its removal stays a
+judgement call.
+
+The mode reports only. `--plan` prints `git worktree remove` plus
+`git branch -d` (never `-D`) for the safe set; **running it is a bulk deletion
+needing the user's explicit this-turn approval**
+(`non-destructive-by-default`), which a single earlier approval never covers.
+
 ## Host-native mapping
 
 | Host capability | Use |

--- a/tests/scripts/worktree_cleanup_check.test.ts
+++ b/tests/scripts/worktree_cleanup_check.test.ts
@@ -9,9 +9,13 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+    buildInventory,
     checkWorktree,
     findScopeOverlaps,
+    isStandardLocation,
     ownsOverlap,
+    removalPlan,
+    resolveTrunk,
 } from '../../src/scripts/worktree_cleanup_check.js';
 
 let tmp = '';
@@ -165,6 +169,182 @@ describe('cleanup gates — edge-case matrix', () => {
         fs.writeFileSync(path.join(wtA, '.worktree-scope.md'), 'owns:\n  - src/a/**\n');
         fs.writeFileSync(path.join(wtB, '.worktree-scope.md'), 'owns:\n  - src/b/**\n');
         expect(findScopeOverlaps(repo)).toEqual([]);
+    });
+});
+
+/** A worktree under a conventional root, so it can reach `safe`. */
+function addStandardWorktree(name: string, branch: string): string {
+    const wt = path.join(repo, '.claude', 'worktrees', name);
+    fs.mkdirSync(path.dirname(wt), { recursive: true });
+    git(repo, ['worktree', 'add', wt, '-b', branch]);
+    return wt;
+}
+
+/** Merge `branch` into main so the worktree's commits are trunk-reachable. */
+function mergeIntoMain(branch: string): void {
+    git(repo, ['merge', '--no-ff', '-m', `merge ${branch}`, branch]);
+}
+
+/** Far enough ahead that no real mtime falls inside the live window. */
+function afterEverything(): Date {
+    return new Date(Date.now() + 1000 * 60 * 60 * 24 * 365);
+}
+
+function rowFor(inv: ReturnType<typeof buildInventory>, wt: string) {
+    const canon = (p: string): string => fs.realpathSync(p);
+    const row = inv.rows.find((r) => canon(r.path) === canon(wt));
+    if (row === undefined) throw new Error(`no inventory row for ${wt}`);
+    return row;
+}
+
+/**
+ * Backdate a linked worktree's git-dir so it falls outside the live window.
+ * Both `index` and `HEAD` count — liveness takes the newest of the two.
+ */
+function backdateGitDir(name: string, daysAgo: number): void {
+    const t = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+    for (const f of ['index', 'HEAD']) {
+        fs.utimesSync(path.join(repo, '.git', 'worktrees', name, f), t, t);
+    }
+}
+
+describe('inventory classification', () => {
+    it('merged + clean + standard location + quiet → safe, with a branch -d plan entry', () => {
+        const wt = addStandardWorktree('wt-safe', 'feat/safe');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/safe');
+
+        const inv = buildInventory(repo, afterEverything());
+        const row = rowFor(inv, wt);
+        expect(row.classification).toBe('safe');
+        expect(row.reasons).toEqual([]);
+        expect(row.mergedIntoTrunk).toBe(true);
+
+        const plan = removalPlan(inv);
+        expect(plan.some((c) => c.includes(wt) && c.includes('git branch -d "feat/safe"'))).toBe(
+            true,
+        );
+    });
+
+    it('merged + clean but OUTSIDE the conventional roots → review on location alone', () => {
+        const wt = addWorktree('wt-outside', 'feat/outside');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/outside');
+
+        const row = rowFor(buildInventory(repo, afterEverything()), wt);
+        expect(row.classification).toBe('review');
+        expect(row.standardLocation).toBe(false);
+        expect(row.reasons.join('\n')).toContain('non-standard location');
+    });
+
+    it('dirty worktree → review naming the unsaved-path count, never safe', () => {
+        const wt = addStandardWorktree('wt-dirty', 'feat/dirty');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/dirty');
+        fs.writeFileSync(path.join(wt, 'scratch.txt'), 'untracked');
+
+        const row = rowFor(buildInventory(repo, afterEverything()), wt);
+        expect(row.classification).toBe('review');
+        expect(row.reasons.join('\n')).toContain('unsaved work — 1 dirty or untracked path(s)');
+    });
+
+    it('unmerged branch → review naming the trunk it is not an ancestor of', () => {
+        const wt = addStandardWorktree('wt-unmerged', 'feat/unmerged');
+        commitFile(wt, 'a.txt', 'x', 'unique work');
+
+        const inv = buildInventory(repo, afterEverything());
+        const row = rowFor(inv, wt);
+        expect(row.classification).toBe('review');
+        expect(row.mergedIntoTrunk).toBe(false);
+        expect(row.reasons.join('\n')).toContain(`not an ancestor of ${inv.trunk}`);
+    });
+
+    it('detached HEAD → review, and the main worktree is never safe', () => {
+        const wt = addStandardWorktree('wt-detached', 'feat/detached');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/detached');
+        git(wt, ['checkout', '--detach', 'HEAD']);
+
+        const inv = buildInventory(repo, afterEverything());
+        expect(rowFor(inv, wt).classification).toBe('review');
+
+        const main = rowFor(inv, repo);
+        expect(main.isMain).toBe(true);
+        expect(main.classification).not.toBe('safe');
+        expect(main.reasons.join('\n')).toContain('main worktree');
+        expect(removalPlan(inv).some((c) => c.includes(`"${repo}"`))).toBe(false);
+    });
+
+    it('recent git activity wins over the structural verdict → live, not safe', () => {
+        const wt = addStandardWorktree('wt-live', 'feat/live');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/live');
+
+        // Real `now`: the worktree was created seconds ago, so its index mtime
+        // is inside the window.
+        const row = rowFor(buildInventory(repo, new Date()), wt);
+        expect(row.classification).toBe('live');
+        expect(row.reasons.join('\n')).toContain('another session may hold it');
+    });
+
+    it('counts partition the rows exactly, and review reasons are grouped', () => {
+        const safe = addStandardWorktree('wt-c1', 'feat/c1');
+        commitFile(safe, 'a.txt', 'x', 'w1');
+        mergeIntoMain('feat/c1');
+        const unmerged = addStandardWorktree('wt-c2', 'feat/c2');
+        commitFile(unmerged, 'b.txt', 'y', 'w2');
+
+        const inv = buildInventory(repo, afterEverything());
+        const { total, safe: s, review, live } = inv.counts;
+        expect(total).toBe(inv.rows.length);
+        expect(s + review + live).toBe(total);
+        expect(s).toBe(1);
+        expect(Object.values(inv.counts.reviewReasons).reduce((a, b) => a + b, 0)).toBe(review);
+    });
+
+    it('regression: a second run must not reclassify — the check may not touch the index', () => {
+        const wt = addStandardWorktree('wt-stable', 'feat/stable');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/stable');
+        // Outside the live window, so a status-triggered index rewrite would
+        // pull it back in and flip safe → live on the next pass.
+        backdateGitDir('wt-stable', 10);
+
+        const first = buildInventory(repo, new Date());
+        expect(rowFor(first, wt).classification).toBe('safe');
+        const second = buildInventory(repo, new Date());
+        expect(rowFor(second, wt).classification).toBe('safe');
+        expect(second.counts).toEqual(first.counts);
+    });
+
+    it('the removal plan never uses the force flag', () => {
+        const wt = addStandardWorktree('wt-force', 'feat/force');
+        commitFile(wt, 'a.txt', 'x', 'work');
+        mergeIntoMain('feat/force');
+        const plan = removalPlan(buildInventory(repo, afterEverything()));
+        expect(plan.length).toBeGreaterThan(0);
+        expect(plan.join('\n')).not.toContain('branch -D');
+        expect(plan.join('\n')).not.toContain('--force');
+    });
+});
+
+describe('trunk resolution + location convention', () => {
+    it('falls back to a local trunk when no remote exists, and prefers the remote when it does', () => {
+        expect(resolveTrunk(repo)).toBe('refs/heads/main');
+        const origin = path.join(tmp, 'origin.git');
+        git(tmp, ['init', '--bare', '-b', 'main', 'origin.git']);
+        git(repo, ['remote', 'add', 'origin', origin]);
+        git(repo, ['push', '-q', 'origin', 'main']);
+        expect(resolveTrunk(repo)).toBe('refs/remotes/origin/main');
+    });
+
+    it('only the two conventional roots are standard locations', () => {
+        expect(isStandardLocation(repo, path.join(repo, '.claude', 'worktrees', 'a'))).toBe(true);
+        expect(isStandardLocation(repo, path.join(repo, '.worktrees', 'b'))).toBe(true);
+        expect(isStandardLocation(repo, path.join(repo, 'other', 'c'))).toBe(false);
+        expect(isStandardLocation(repo, path.join(tmp, 'sibling'))).toBe(false);
+        // A directory whose name merely starts with a root name is not inside it.
+        expect(isStandardLocation(repo, path.join(repo, '.worktrees-old', 'd'))).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Why now

`road-to-worktree-hygiene` was filed as a draft with an explicit promotion trigger: *"promote when the count materially affects clone size, disk, or a tool that walks worktrees."* It fired on the disk leg.

| Signal | At filing | Measured this pass |
|---|---:|---:|
| Registered worktrees | 209 | **249** |
| Disk under `.claude/worktrees/` | not measured | **40 GB** |
| Local branches | not measured | **692** |
| Registrations `git worktree prune` would clear | — | **0** |

`prune` clearing nothing confirms the draft's premise: every registration points at a real directory, so there is no cheap cleanup path.

## What ships

**An `inventory` mode on the existing gate script** (`src/scripts/worktree_cleanup_check.ts`), not a new one. The script already answered *"may I remove this one"* per worktree; there was no way to ask it of all of them. `safe` requires **all** of: on a branch · merged into the trunk · clean (untracked included) · inside a conventional worktree root · no git activity for 48 h. `review` keeps its disqualifying reason so the next sweep starts from a shorter list; `live` means another session may hold it.

Result on this checkout — **143 safe / 78 review / 28 live** of 249:

| Count | Primary disqualifier |
|---:|---|
| 63 | non-standard location — outside the conventional worktree roots |
| 9 | unsaved work |
| 4 | branch is not an ancestor of `origin/main` — unmerged work |
| 2 | detached HEAD |

The 63 non-standard-location entries are excluded from the safe set **deliberately**: they sit beside the repo in the parent package directory, where a worktree can be mistaken for a sibling package. That is a layout judgement, not a mechanical cleanup.

## Two defects found while building it

Both are pinned by regression tests, and both were real rather than theoretical:

1. **The check corrupted its own measurement.** Plain `git status` refreshes the on-disk index, and liveness is read from that mtime. Two consecutive runs moved 10 worktrees from safe to live (151/80/18 → 143/78/28). Fixed with `--no-optional-locks`; the verdict is now stable across runs, asserted by a test that backdates a git-dir and runs the inventory twice.
2. **Symlinked checkout roots mis-classified.** Git reports worktree paths as realpaths, so a repo reached through a symlinked parent read every conventional worktree as non-standard. Fixed by canonicalising the longest *existing* ancestor — which also keeps a registration pointing at an already-deleted directory classifiable.

## What stays open, and why that is the right shape

Removing the 143 safe worktrees is a **Hard-Floor bulk deletion**: an agent may prepare and surface it, never perform it. `inventory --plan` emits the `git worktree remove` + `git branch -d` pairs (never `-D`, so git re-checks the merge at execution time); the roadmap files it as blocker `safe-set-removal-approval` (owner: user). The roadmap closes 7 of 9 items and cannot close further without a human.

`agents/evidence/reports/worktree-inventory.md` records the baseline so a later pass can tell **growth** from **residue** — and states the limit of its own numbers: the `live` figure is inflated by this session's two pre-fix runs and decays once the 48 h window passes; the structural figures are unaffected.

## Council

AI council 2026-08-05 (2 members, \$0.05) converged 2/2 on both decisions: adopt this roadmap over scattered documentation repairs, and extend the existing script rather than add a parallel one. Recorded because it **overturns an earlier ruling from the same day** that disqualified this roadmap for "creating a human decision rather than removing one". The council's counter: the maintainer had no list at all, so the decision already existed and was merely un-actionable — a classified safe set makes an existing decision reviewable.

The strongest argument against, kept rather than glossed: if the removal is never approved, the tooling's payoff is hypothetical. It is filed as risk 4 in the roadmap's register.

## Verification

- `tests/scripts/worktree_cleanup_check.test.ts` — **23/23 green** (14 pre-existing, 9 new); the 9 new ones failed first and drove both fixes above.
- `task typecheck-ts` 0 · `eslint` on both changed TS files 0
- `check_condensation` (dist byte-exact) · `check_references` · `check_md_language` · `lint_output_slop` · `audit_skill_overlap` · `lint_skill_descriptions` · `lint_framework_leakage` — all 0
- Roadmap gates: `lint_plan_risk_register` · `lint_roadmap_blockers` · `lint_roadmap_complexity` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `lint_roadmap_ci_steps` — all 0
- All three CLI modes exercised end-to-end, including exit-code 2 on a bad flag and on too many positionals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)