### PR TITLE
feat(gate): enforce the roadmap concurrency cap mechanically

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -146,6 +146,7 @@ tasks:
       - task: lint-empty-roadmaps
       - task: lint-roadmap-blockers
       - task: lint-roadmap-later-disposition
+      - task: lint-roadmap-family-cap
       - task: lint-plan-risk-register
       - task: check-completion-review
       - task: check-r2-manifest

--- a/docs/decisions/ADR-215-harvest-freeze-verification-arm-lift.md
+++ b/docs/decisions/ADR-215-harvest-freeze-verification-arm-lift.md
@@ -111,8 +111,23 @@ conformance (position 5).
 A guideline a single maintainer intends to honour drifts under urgency. The cap is
 enforced by a gate: a third concurrently-open `road-to-skill-ecosystem-*` roadmap
 outside `archive/` and `later/` fails the build with a pointer to this record.
-Implementation lands as a step in the gate-integrity roadmap rather than as a
-separate change, so the enforcement arrives with the work it bounds.
+
+> **Corrected 2026-08-05 — the claim now matches reality.** As first written this
+> clause asserted present-tense mechanical enforcement and then deferred the
+> implementation to "a step in the gate-integrity roadmap". **No such step
+> existed.** So the record claimed an enforcement that did not exist and pointed
+> at work that was never written — a claim-without-resolution in the one record
+> governing what is now the *only* surviving restraint mechanism, and a textbook
+> instance of the failure class this whole change set is about.
+>
+> The gate is `src/scripts/lint_roadmap_family_cap.ts`, registered as
+> `task lint-roadmap-family-cap` and wired into the CI aggregator. It carries the
+> scan-scope assertion (a dead roadmap root fails rather than passing green),
+> prints the scanned denominator on the green path, and ships six paired fixtures
+> including an over-cap failure and a dead-root failure — so it is demonstrably
+> able to fail. The family prefix and the cap are named constants: widening them
+> is a visible one-line diff that needs its own decision record, never a silent
+> threshold edit.
 
 ### D3 — ~~Capability stays frozen behind its own arm~~ — STRUCK by ADR-216
 

--- a/docs/decisions/ADR-216-restraint-reanchored-to-capacity.md
+++ b/docs/decisions/ADR-216-restraint-reanchored-to-capacity.md
@@ -126,6 +126,32 @@ The lesson for the sweep method: filtering a grep on words like "struck" or
 "superseded" hides live gates that happen to sit near an annotation. The second
 pass read every hit.
 
+**The change set reproduced the defect it exists to fix — twice — and both
+instances are worth recording because they are the cheapest available evidence
+that the failure class is real rather than historical.**
+
+*First:* ADR-215 was authored earlier the same day with an external-adoption
+condition on its capability arm. It was written specifically to narrow an
+unreachable gate, and it carried that gate forward into its own text one file
+over. The commit history shows it plainly — the first three commits still title
+the work "freeze narrowed to verification arm", and the correction arrives only in
+the later commits. A record can inherit a premise from the record it amends
+without ever examining it.
+
+*Second:* ADR-215 § D2 declared the concurrency cap "mechanically enforced, not
+left to discipline" — the load-bearing sentence, since the cap became the only
+surviving restraint once the adoption gates were struck — and then deferred the
+implementation to a roadmap step that **did not exist**. So for the duration of
+this change set the sole remaining restraint ran on maintainer discipline while
+its own record asserted otherwise. Fixed by writing the gate rather than by
+softening the sentence: a written contract that describes an absent mechanism is
+the exact thing this package's own doctrine says loses to an enforced gate.
+
+Both are instances of the same shape the sweep found six sources converging on:
+**an assertion of coverage that nothing verifies.** Finding them inside the change
+that removes the class is not embarrassing, it is the method working — and it is
+why the enforcement obligation is discharged here rather than promised.
+
 **Two further adoption citations** were found in
 [ADR-123](ADR-123-runtime-security-scope-and-spawn-hardening.md) (three security
 items deferred, with the restraint's adoption clause cited as part of the
@@ -253,9 +279,15 @@ not do is gate work.
 pruning track, which is real work with a reachable end. That blocker is
 untouched.
 
+**Newly enforced rather than merely written:** the concurrency cap now has a gate
+(`src/scripts/lint_roadmap_family_cap.ts`, `task lint-roadmap-family-cap`) with
+paired fixtures proving it fails when the cap is exceeded and when its scan root
+is dead. Before this change the cap was the only surviving restraint and ran on
+discipline alone while its record claimed enforcement.
+
 **Not changed:** every safety floor, the Hard Floor, the evidence-direction
 requirement, the red-test door, the review cadence, the claims-pointer
-discipline, and the concurrency cap. This record removes an unreachable
+discipline, and the concurrency cap itself. This record removes an unreachable
 condition; it does not relax a standard.
 
 **Honest cost:** the project gives up the option of using adoption as a

--- a/src/scripts/lint_roadmap_family_cap.ts
+++ b/src/scripts/lint_roadmap_family_cap.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Hard-Gate linter: the skill-ecosystem roadmap family may not exceed its
+ * concurrency cap.
+ *
+ * ADR-215 § D2 states the cap is "mechanically enforced, not left to
+ * discipline", and gives the reason: a guideline a single maintainer intends to
+ * honour drifts under urgency. Until this file existed the record asserted an
+ * enforcement that did not exist and pointed at an implementation step that was
+ * never written — a claim-without-resolution in the one record governing the
+ * only surviving restraint mechanism. This gate makes the claim true.
+ *
+ * The cap counts roadmaps in the family that sit at the TOP LEVEL of
+ * `agents/roadmaps/` — i.e. active work. `archive/`, `later/`, `skipped/` and
+ * `stubs/` are by definition not concurrently open and are not counted.
+ *
+ * Widening the cap to cover more families (see ADR-216 § D3, which records the
+ * scope limitation honestly rather than pretending the cap manages total
+ * capacity) is a one-line change to FAMILY_PREFIX plus a new decision record —
+ * never a silent edit to CAP.
+ *
+ * CLI contract: exit 0 = at or under the cap, 1 = over the cap.
+ * `--quiet` suppresses the green line, matching the sibling roadmap gates.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { assertScanned, DeadScopeError } from './_lib/scan_scope.js';
+
+/** Mirror the sibling gates: bare argv membership, computed at import. */
+const QUIET = process.argv.slice(2).includes('--quiet');
+
+const ROADMAP_DIR = path.join('agents', 'roadmaps');
+
+/**
+ * The capped family and its ceiling, per ADR-215 § D2 as amended by ADR-216 § D3.
+ * Both are named constants so a future widening is a visible one-line diff
+ * accompanied by a decision record, not an unnoticed threshold edit.
+ */
+const FAMILY_PREFIX = 'road-to-skill-ecosystem-';
+const CAP = 2;
+
+const _HERE = path.resolve(fileURLToPath(import.meta.url));
+
+/** `Path.is_dir()` following symlinks, never throwing. */
+function _isDir(p: string): boolean {
+    try {
+        return fs.statSync(p).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+/** Walk up from CWD until a dir containing `agents/roadmaps` is found. */
+function _repo_root(): string {
+    let cur = process.cwd();
+    const chain = [cur];
+    for (;;) {
+        const parent = path.dirname(cur);
+        if (parent === cur) break;
+        chain.push(parent);
+        cur = parent;
+    }
+    for (const candidate of chain) {
+        if (_isDir(path.join(candidate, ROADMAP_DIR))) {
+            return candidate;
+        }
+    }
+    return process.cwd();
+}
+
+/**
+ * Every `*.md` directly under `agents/roadmaps/` — top level only, sorted.
+ * Subdirectories are deliberately NOT walked: a roadmap in `later/` or
+ * `archive/` is not concurrently open, which is the whole point of the cap.
+ */
+export function active_roadmaps(root: string): string[] {
+    const base = path.join(root, ROADMAP_DIR);
+    if (!_isDir(base)) {
+        return [];
+    }
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(base, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    return entries
+        .filter((e) => !e.isDirectory() && e.name.endsWith('.md'))
+        .map((e) => e.name)
+        .sort();
+}
+
+/** The subset of active roadmaps belonging to the capped family. */
+export function family_members(root: string): string[] {
+    return active_roadmaps(root).filter((n) => n.startsWith(FAMILY_PREFIX));
+}
+
+export function main(): number {
+    const root = _repo_root();
+
+    // Anti-vacuity: this gate reports an ABSENCE (no over-cap condition), so a
+    // dead scan root would print the same green line as a healthy tree. The
+    // scanned unit is every ACTIVE roadmap, not just the family — a repo whose
+    // top-level roadmap dir is empty or moved is a dead scope, not a pass.
+    // This is the invariant road-to-skill-ecosystem-gate-integrity generalises;
+    // the gate that enforces that roadmap's own cap had better honour it.
+    try {
+        assertScanned({
+            gate: 'lint_roadmap_family_cap',
+            scanned: active_roadmaps(root).length,
+            units: 'active roadmap file(s)',
+            roots: [ROADMAP_DIR],
+        });
+    } catch (exc) {
+        if (exc instanceof DeadScopeError) {
+            process.stderr.write(`❌  ${exc.message}\n`);
+            return 1;
+        }
+        throw exc;
+    }
+
+    const members = family_members(root);
+
+    if (members.length <= CAP) {
+        if (!QUIET) {
+            process.stdout.write(
+                `✅  lint-roadmap-family-cap: ${members.length}/${CAP} slot(s) used ` +
+                    `(scanned ${active_roadmaps(root).length} active roadmap file(s)).\n`,
+            );
+        }
+        return 0;
+    }
+
+    process.stdout.write(
+        `❌  lint-roadmap-family-cap: ${members.length} concurrently-open ` +
+            `\`${FAMILY_PREFIX}*\` roadmap(s), cap is ${CAP}:\n`,
+    );
+    for (const name of members) {
+        process.stdout.write(`      agents/roadmaps/${name}\n`);
+    }
+    process.stdout.write('\n');
+    process.stdout.write(
+        '   The cap is a capacity mechanism, not an adoption gate — one maintainer\n',
+    );
+    process.stdout.write(
+        '   cannot hold this many parallel workstreams (ADR-215 § D2, ADR-216 § D3).\n',
+    );
+    process.stdout.write('   To open another, free a slot first:\n');
+    process.stdout.write(
+        '     • archive a finished one — git mv it into agents/roadmaps/archive/, or\n',
+    );
+    process.stdout.write(
+        '     • park one — git mv it into agents/roadmaps/later/ with `status: later`\n',
+    );
+    process.stdout.write('       and a reachable resume condition, or\n');
+    process.stdout.write(
+        '     • widen the cap deliberately — edit CAP in this file AND record the\n',
+    );
+    process.stdout.write(
+        '       decision. A silent threshold edit is the failure this gate exists to stop.\n',
+    );
+    return 1;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) {
+        return false;
+    }
+    const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+    if (import.meta.url === argvUrl) {
+        return true;
+    }
+    // A symlinked invocation (installed projection, or macOS /var → /private/var
+    // temp dirs) makes the raw URLs differ: compare realpaths so the entry guard
+    // still fires instead of silently no-opping.
+    try {
+        const here = fs.realpathSync(fileURLToPath(import.meta.url));
+        const argv = fs.realpathSync(path.resolve(process.argv[1]));
+        return here === argv;
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry() || process.argv[1] === _HERE) {
+    process.exitCode = main();
+}
+
+export { CAP, FAMILY_PREFIX, QUIET };

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -699,6 +699,17 @@ tasks:
     desc: Reject empty (0-byte / whitespace-only) roadmap files under agents/roadmaps/ — backstop against auto-commit 0-byte stubs
     cmd: ./scripts-run src/scripts/lint_empty_roadmaps {{.QUIET_FLAG}}
 
+  lint-roadmap-family-cap:
+    silent: true
+    desc: |
+      Enforce the skill-ecosystem roadmap concurrency cap (ADR-215 § D2 as
+      amended by ADR-216 § D3). The cap is a capacity mechanism — one maintainer
+      cannot hold N parallel workstreams — and it is the only surviving restraint
+      after the adoption-anchored gates were struck, so it must be mechanical
+      rather than carried by discipline. Counts top-level roadmaps only;
+      archive/ later/ skipped/ stubs/ are not concurrently open.
+    cmd: ./scripts-run src/scripts/lint_roadmap_family_cap {{.QUIET_FLAG}}
+
   lint-plan-risk-register:
     silent: true
     desc: |

--- a/tests/scripts/lint_roadmap_family_cap.test.ts
+++ b/tests/scripts/lint_roadmap_family_cap.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `src/scripts/lint_roadmap_family_cap.ts`.
+ *
+ * Paired fixtures, per the discipline the gated roadmap itself introduces: a
+ * gate with no negative fixture cannot be shown to discriminate, and a gate
+ * that only ever passes is decorative. So this suite proves all four states:
+ *
+ *   1. the REAL repo tree is at or under the cap (exit 0, denominator printed),
+ *   2. an over-cap fixture FAILS (exit 1) and names every member,
+ *   3. subdirectories are not counted — the same family members parked in
+ *      `later/` / `archive/` do NOT trip the cap,
+ *   4. a dead scan root FAILS rather than passing green (anti-vacuity).
+ *
+ * State 4 is the one that matters most here: this gate reports an absence, so
+ * without the scan-scope assertion a moved or empty roadmap tree would print the
+ * same green line as a healthy one.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'lint_roadmap_family_cap.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+const FAMILY = 'road-to-skill-ecosystem-';
+
+function run(cwd: string, args: string[] = []) {
+    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd, encoding: 'utf8' });
+}
+
+/** Minimal roadmap body — content shape is irrelevant to this gate. */
+function writeRoadmap(dir: string, name: string): void {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+        path.join(dir, name),
+        '---\ncomplexity: lightweight\n---\n\n# Fixture\n\n## Phase 1: x\n\n- [ ] **Step 1:** x\n',
+        'utf8',
+    );
+}
+
+describe('lint_roadmap_family_cap', () => {
+    let tmp: string;
+
+    beforeEach(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'family-cap-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('real repo: at or under the cap, and prints the scanned denominator', () => {
+        const r = run(REPO_ROOT);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain('lint-roadmap-family-cap:');
+        // The denominator on the green path is the anti-vacuity affordance: a
+        // reader must be able to see coverage without waiting for a failure.
+        expect(r.stdout).toMatch(/scanned \d+ active roadmap file\(s\)/);
+    });
+
+    it('over the cap: exits 1 and names every family member', () => {
+        const rm = path.join(tmp, 'agents', 'roadmaps');
+        writeRoadmap(rm, `${FAMILY}alpha.md`);
+        writeRoadmap(rm, `${FAMILY}beta.md`);
+        writeRoadmap(rm, `${FAMILY}gamma.md`);
+        writeRoadmap(rm, 'road-to-something-unrelated.md');
+
+        const r = run(tmp);
+        expect(r.status).toBe(1);
+        expect(r.stdout).toContain('3 concurrently-open');
+        expect(r.stdout).toContain(`${FAMILY}alpha.md`);
+        expect(r.stdout).toContain(`${FAMILY}beta.md`);
+        expect(r.stdout).toContain(`${FAMILY}gamma.md`);
+        // An unrelated roadmap is scanned but must not be counted against the cap.
+        expect(r.stdout).not.toContain('road-to-something-unrelated.md');
+        // The remedy must be actionable, not a bare refusal.
+        expect(r.stdout).toContain('free a slot first');
+    });
+
+    it('exactly at the cap: passes', () => {
+        const rm = path.join(tmp, 'agents', 'roadmaps');
+        writeRoadmap(rm, `${FAMILY}alpha.md`);
+        writeRoadmap(rm, `${FAMILY}beta.md`);
+
+        const r = run(tmp);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain('2/2 slot(s) used');
+    });
+
+    it('parked and archived members are not concurrently open', () => {
+        const rm = path.join(tmp, 'agents', 'roadmaps');
+        writeRoadmap(rm, `${FAMILY}alpha.md`);
+        writeRoadmap(rm, `${FAMILY}beta.md`);
+        // Three more of the same family, but parked / archived. If the gate
+        // walked subdirectories these would push the count to five and fail.
+        writeRoadmap(path.join(rm, 'later'), `${FAMILY}gamma.md`);
+        writeRoadmap(path.join(rm, 'later'), `${FAMILY}delta.md`);
+        writeRoadmap(path.join(rm, 'archive'), `${FAMILY}epsilon.md`);
+
+        const r = run(tmp);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain('2/2 slot(s) used');
+    });
+
+    it('dead scan root: fails rather than passing green', () => {
+        // An empty roadmap dir means the gate inspected nothing. Zero findings
+        // and zero coverage must not look alike — that is the exact failure class
+        // this gate's own roadmap exists to generalise.
+        fs.mkdirSync(path.join(tmp, 'agents', 'roadmaps'), { recursive: true });
+
+        const r = run(tmp);
+        expect(r.status).toBe(1);
+        expect(r.stderr).toContain('lint_roadmap_family_cap');
+        expect(r.stdout).not.toContain('slot(s) used');
+    });
+
+    it('--quiet suppresses the green line but keeps the exit code', () => {
+        const rm = path.join(tmp, 'agents', 'roadmaps');
+        writeRoadmap(rm, `${FAMILY}alpha.md`);
+
+        const r = run(tmp, ['--quiet']);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toBe('');
+    });
+});


### PR DESCRIPTION
Follow-up to #1178, closing an enforcement gap that PR opened.

## The gap

ADR-215 § D2 declared the concurrency cap **"mechanically enforced, not left to discipline"** — and then deferred the implementation to "a step in the gate-integrity roadmap". **No such step existed.**

That matters more than a normal dangling reference, because #1178 struck the adoption-anchored gates and left this cap as the **only surviving restraint mechanism**. So for the duration of that change the sole remaining restraint ran on maintainer discipline while its own record asserted the opposite.

Fixed by writing the gate rather than by softening the sentence. A written contract describing an absent mechanism is exactly what this package's own doctrine says loses to an enforced gate.

## `src/scripts/lint_roadmap_family_cap.ts`

- Counts **top-level** `road-to-skill-ecosystem-*` roadmaps. `archive/`, `later/`, `skipped/` and `stubs/` are not concurrently open and are not counted.
- Carries the **scan-scope assertion**, so a dead or moved roadmap root fails instead of printing the same green line as a healthy tree. This gate reports an *absence*, which is precisely the shape that hides a dead scope — and it enforces the cap of the roadmap that generalises that invariant, so it had better honour it itself.
- Prints the **scanned denominator on the green path**, so coverage is auditable without waiting for a failure.
- Family prefix and cap are **named constants**: widening is a visible one-line diff that needs its own decision record, never a silent threshold edit. The failure output says so out loud.
- Failure output is **actionable** — archive one, park one, or widen deliberately — rather than a bare refusal.

## Six paired fixtures

Proving all four states plus two edges, because a gate with no negative fixture cannot be shown to discriminate:

| Fixture | Expected |
|---|---|
| Real repo tree | exit 0, denominator printed |
| Three family members at top level | **exit 1**, names every member, ignores unrelated roadmaps |
| Exactly at the cap | exit 0 |
| Family members in `later/` + `archive/` | exit 0 — subdirectories are not walked |
| **Empty roadmap root** | **exit 1** — dead scope, not a pass |
| `--quiet` | exit 0, no stdout |

## Verification

`task lint-roadmap-family-cap` registered and wired into the CI aggregator. Verified under **both argv forms** — bare and the CI-injected `--quiet` — since a wrongly-consumed flag has silently become a scan root in this repo before. Typecheck and ESLint clean on both new files. All 13 roadmap/reference/output gates green.

## Records corrected

ADR-215 § D2 and ADR-216 now describe what exists. ADR-216 additionally records that the #1178 change set **reproduced the defect it fixes, twice** — the adoption arm carried forward into ADR-215, and this enforcement gap — because that is the cheapest available evidence the failure class is live rather than historical. Finding both inside the change that removes the class is the method working, and it is why the obligation is discharged here rather than promised again.

Note: #1178 merged while this follow-up was in progress, so the branch was re-created and `main` merged back in before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
