### PR TITLE
docs(analyze-inbox): run in the checked-out branch; worktree only on request

### DIFF
--- a/dist/agent-src/commands/analyze/inbox.md
+++ b/dist/agent-src/commands/analyze/inbox.md
@@ -8,7 +8,7 @@ sub: inbox
 cluster: analyze
 skills: [learning-to-rule-or-skill, roadmap-writing, decision-review]
 description: Analyze a dropped inbox artifact (review, prompt, spec, transcript) against the current tree, verify every claim it makes, map what survives onto this suite's artefact types, emit a roadmap each.
-argument-hint: "[<file> | <dir>] [--triage-only] [--no-roadmap] [--keep-inbox]"
+argument-hint: "[<file> | <dir>] [--triage-only] [--no-roadmap] [--keep-inbox] [--worktree]"
 suggestion:
   eligible: false
   rationale: "Cluster sub-command — reached via its cluster head's routing or its explicit /analyze:inbox name; not independently suggested (surface-consolidation)."
@@ -40,7 +40,35 @@ still true.
 
 Flags: `--triage-only` stops after Phase 2 (no deep analysis, no roadmap) ·
 `--no-roadmap` analyses but emits findings instead of roadmaps ·
-`--keep-inbox` skips the `tmp.old/` move (default is to move — see Phase 6).
+`--keep-inbox` skips the `tmp.old/` move (default is to move — see Phase 6) ·
+`--worktree` opts into an isolated worktree (see below; off by default).
+
+## Where the work happens — the checked-out branch, unless asked otherwise
+
+```
+RUN IN THE CURRENT BRANCH. NEVER CREATE A BRANCH, A WORKTREE, OR A PR
+ON THIS COMMAND'S OWN AUTHORITY. A WORKTREE ONLY ON AN EXPLICIT ASK.
+```
+
+Default: the branch already checked out. The roadmaps, the findings, and the
+`agents/tmp.old/` move land there as ordinary uncommitted changes for the
+operator to review. This command authorizes **analysis and authoring** — not a
+git shape ([`scope-control`](../../../../rules/scope-control.md) § Git
+operations: branch and worktree creation are permission-gated, spike and
+throwaway branches included).
+
+An isolated worktree runs only when the invocation asks for one — `--worktree`,
+or the operator saying so in the prompt. Then follow
+[`using-git-worktrees`](../../../../skills/using-git-worktrees/SKILL.md),
+including its seeding allow/deny list.
+
+Why the current branch is the right default here: this command is read-heavy and
+its whole output is a few markdown files plus a rename. Nothing it writes is a
+generated tree, so there is no build to isolate — while a worktree costs a fresh
+`node_modules`, a copied `.augment`, and a family of stale-projection failures
+that only exist because the checkout is a second one. Isolation earns its price
+when a run churns generated output or must keep a large diff off the current
+branch; an inbox triage does neither.
 
 ## The Iron Law
 
@@ -188,3 +216,6 @@ each one is and why it is spent, and let the user remove it.
   execution authorization
   ([`scope-control`](../../../../rules/scope-control.md) § Authoring vs.
   implementation).
+- Spin up a branch, a worktree, or a PR because the run feels large. Scope is
+  the operator's call; without `--worktree` or an explicit ask, the work stays
+  in the checked-out branch.

--- a/src/domains/analysis-workbench/analyze/inbox/command.md
+++ b/src/domains/analysis-workbench/analyze/inbox/command.md
@@ -8,7 +8,7 @@ sub: inbox
 cluster: analyze
 skills: [learning-to-rule-or-skill, roadmap-writing, decision-review]
 description: Analyze a dropped inbox artifact (review, prompt, spec, transcript) against the current tree, verify every claim it makes, map what survives onto this suite's artefact types, emit a roadmap each.
-argument-hint: "[<file> | <dir>] [--triage-only] [--no-roadmap] [--keep-inbox]"
+argument-hint: "[<file> | <dir>] [--triage-only] [--no-roadmap] [--keep-inbox] [--worktree]"
 suggestion:
   eligible: false
   rationale: "Cluster sub-command — reached via its cluster head's routing or its explicit /analyze:inbox name; not independently suggested (surface-consolidation)."
@@ -40,7 +40,35 @@ still true.
 
 Flags: `--triage-only` stops after Phase 2 (no deep analysis, no roadmap) ·
 `--no-roadmap` analyses but emits findings instead of roadmaps ·
-`--keep-inbox` skips the `tmp.old/` move (default is to move — see Phase 6).
+`--keep-inbox` skips the `tmp.old/` move (default is to move — see Phase 6) ·
+`--worktree` opts into an isolated worktree (see below; off by default).
+
+## Where the work happens — the checked-out branch, unless asked otherwise
+
+```
+RUN IN THE CURRENT BRANCH. NEVER CREATE A BRANCH, A WORKTREE, OR A PR
+ON THIS COMMAND'S OWN AUTHORITY. A WORKTREE ONLY ON AN EXPLICIT ASK.
+```
+
+Default: the branch already checked out. The roadmaps, the findings, and the
+`agents/tmp.old/` move land there as ordinary uncommitted changes for the
+operator to review. This command authorizes **analysis and authoring** — not a
+git shape ([`scope-control`](../../../../rules/scope-control.md) § Git
+operations: branch and worktree creation are permission-gated, spike and
+throwaway branches included).
+
+An isolated worktree runs only when the invocation asks for one — `--worktree`,
+or the operator saying so in the prompt. Then follow
+[`using-git-worktrees`](../../../../skills/using-git-worktrees/SKILL.md),
+including its seeding allow/deny list.
+
+Why the current branch is the right default here: this command is read-heavy and
+its whole output is a few markdown files plus a rename. Nothing it writes is a
+generated tree, so there is no build to isolate — while a worktree costs a fresh
+`node_modules`, a copied `.augment`, and a family of stale-projection failures
+that only exist because the checkout is a second one. Isolation earns its price
+when a run churns generated output or must keep a large diff off the current
+branch; an inbox triage does neither.
 
 ## The Iron Law
 
@@ -188,3 +216,6 @@ each one is and why it is spent, and let the user remove it.
   execution authorization
   ([`scope-control`](../../../../rules/scope-control.md) § Authoring vs.
   implementation).
+- Spin up a branch, a worktree, or a PR because the run feels large. Scope is
+  the operator's call; without `--worktree` or an explicit ask, the work stays
+  in the checked-out branch.


### PR DESCRIPTION
`/analyze:inbox` shipped without saying where it runs. On its first real run the agent created a worktree — because the invoking prompt asked for one, not because the command did. A command whose git shape depends on how the request happened to be phrased has no contract, so this gives it one.

## The change

**Default: the checked-out branch.** Roadmaps, findings, and the `agents/tmp.old/` move land there as ordinary uncommitted changes for the operator to review. Branch, worktree, and PR creation are named explicitly as outside what invoking the command authorizes, pointing at [`scope-control` § Git operations](../blob/main/src/rules/scope-control.md) where those are already permission-gated — spike and throwaway branches included.

**Worktree on explicit ask only** — the new `--worktree` flag, or the operator saying so in the prompt. That path then follows [`using-git-worktrees`](../blob/main/src/skills/using-git-worktrees/SKILL.md), including its seeding allow/deny list.

An Iron Law block carries it, so the obligation survives a partial read:

```
RUN IN THE CURRENT BRANCH. NEVER CREATE A BRANCH, A WORKTREE, OR A PR
ON THIS COMMAND'S OWN AUTHORITY. A WORKTREE ONLY ON AN EXPLICIT ASK.
```

## Why this default, stated in the file

The rationale ships with the rule so it does not read as arbitrary: this command is read-heavy and its entire output is a few markdown files plus a rename. **Nothing it writes is a generated tree**, so there is no build to isolate — while a second checkout costs a fresh `node_modules`, a copied `.augment`, and a family of stale-projection failures that exist *only because the checkout is a second one*. Isolation earns its price when a run churns generated output or must keep a large diff off the current branch. An inbox triage does neither.

## Also

- A `Do NOT` entry against reaching for a worktree because a run *feels* large — scope is the operator's call.
- `--worktree` wired into `argument-hint` alongside the existing flags.

## Verification

Branch was created off a local `main` that was 15 commits stale; `origin/main` merged in first, projections regenerated, then gates re-run — not run once before the merge and assumed to hold after it.

`task sync-check` · `task check-index` · `task check-condensation` · `skill_linter --changed` · `check_references` — all pass. The `dist` projection carries the new section (`check-condensation` asserts `dist == rewrite(src)` byte-for-byte). 0 commits behind `origin/main` at push time.
