### PR TITLE
fix(hooks): the round-2 fixes were never loaded — plus the sibling they missed

### DIFF
--- a/agents/reports/originality.json
+++ b/agents/reports/originality.json
@@ -1,12 +1,12 @@
 {
   "fail_threshold": 60,
   "warn_threshold": 40,
-  "artifacts_scanned": 513,
+  "artifacts_scanned": 514,
   "distribution": {
     "worst": 40,
     "p95": 0,
     "median": 0,
-    "comparisons": 60678
+    "comparisons": 60873
   },
   "pairs": [
     {

--- a/agents/reports/originality.md
+++ b/agents/reports/originality.md
@@ -1,13 +1,13 @@
 # Originality audit — entity-neutralized shingle overlap
 
-> Anti-reskin gate over 513 authored artifacts (skills · personas · commands), 
+> Anti-reskin gate over 514 authored artifacts (skills · personas · commands), 
 class-scoped, scaffold-subtracted, k=8. Thresholds: FAIL 60 / WARN 40. 
 This report blocks NOTHING on its own — `lint_originality --changed` is the CI gate.
 
 
-- Artifacts scanned: **513**
+- Artifacts scanned: **514**
 
-- Pairwise comparisons: **60678**
+- Pairwise comparisons: **60873**
 
 - Overlap distribution: worst **40%** · p95 **0%** · median **0%**
 

--- a/src/scripts/check_hook_bundle_freshness.ts
+++ b/src/scripts/check_hook_bundle_freshness.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env tsx
+/**
+ * Fail when the self-hosted hook bundle is older than the hook sources it
+ * bundles — i.e. when this repo's own agent is running a hook fix that has
+ * not been built.
+ *
+ * WHY THIS EXISTS — measured, not hypothetical.
+ *
+ * The Claude hook command resolves its dispatcher in two steps: the installed
+ * package copy (`node_modules/@event4u/agent-config/dist/hooks/dispatch.js`)
+ * if present, else this repo's OWN `dist/hooks/dispatch.js`. In the
+ * agent-config repo the second branch always wins — that is the dogfooding
+ * path, and it is the only place these hooks are exercised before release.
+ *
+ * `dist/hooks/dispatch.js` is UNTRACKED (a build artifact) and is produced
+ * only by `npm run build:hooks`, which no Taskfile target, no `task ci`
+ * target, and no workflow invokes. `prepack` runs the full build, so a
+ * PUBLISHED package is always fresh and consumers are unaffected. The gap is
+ * local and it is exactly where the testing happens.
+ *
+ * Consequence, observed on 2026-08-06: the conformance round-2 PR (#1195)
+ * merged four hook fixes — among them the language-mirror pin — while the
+ * running bundle was from 07:27 that morning, before any of them existed.
+ * Ten hook sources were newer than the bundle. In the very session that
+ * shipped the language fix, the scanner counted four German-prompt /
+ * English-reply violations: the fix was merged, correct, and not loaded.
+ *
+ * A hook fix that cannot reach the agent that wrote it is indistinguishable
+ * from no fix, and nothing said so. This gate says so.
+ *
+ * WHAT IT DOES NOT DO: it never builds. Building into a live hook path is a
+ * documented hazard in this repo (an esbuild run that overwrites the
+ * dispatcher a running hook is executing can wedge the tool loop), so the
+ * remedy is printed for a human to run deliberately.
+ *
+ * Exit codes: 0 = fresh, or no self-hosted bundle to check · 1 = stale.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parse as parseYaml } from "yaml";
+
+import { reportScanned } from "./_lib/scan_scope.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..");
+const BUNDLE = path.join("dist", "hooks", "dispatch.js");
+const MANIFEST = path.join("src", "scripts", "hook_manifest.yaml");
+const HOOK_DIR = path.join("src", "scripts", "hooks");
+const REMEDY = "npm run build:hooks";
+
+/** Every source whose edit changes the bundle's behaviour. */
+export function bundledSources(root: string): string[] {
+  const out = new Set<string>();
+
+  const manifestAbs = path.join(root, MANIFEST);
+  if (fs.existsSync(manifestAbs)) {
+    out.add(MANIFEST);
+    try {
+      const doc = parseYaml(fs.readFileSync(manifestAbs, "utf-8")) as {
+        concerns?: Record<string, { script?: string }>;
+      };
+      for (const def of Object.values(doc?.concerns ?? {})) {
+        const s = def?.script;
+        // A concern script is bundled wherever it lives, not only under hooks/.
+        if (typeof s === "string" && s.endsWith(".ts")) out.add(s);
+      }
+    } catch {
+      // A malformed manifest is another gate's problem; still check the dir.
+    }
+  }
+
+  const hookDirAbs = path.join(root, HOOK_DIR);
+  if (fs.existsSync(hookDirAbs)) {
+    for (const e of fs.readdirSync(hookDirAbs, { withFileTypes: true })) {
+      if (e.isFile() && e.name.endsWith(".ts")) out.add(path.join(HOOK_DIR, e.name));
+    }
+  }
+
+  return [...out].filter((rel) => fs.existsSync(path.join(root, rel))).sort();
+}
+
+export interface Result {
+  /** No self-hosted bundle → the installed package copy is authoritative. */
+  skipped: boolean;
+  bundleMtimeMs: number;
+  /** Sources strictly newer than the bundle, newest first. */
+  stale: { file: string; mtimeMs: number }[];
+  checked: number;
+}
+
+export function check(root: string): Result {
+  const bundleAbs = path.join(root, BUNDLE);
+  if (!fs.existsSync(bundleAbs)) {
+    return { skipped: true, bundleMtimeMs: 0, stale: [], checked: 0 };
+  }
+  const bundleMtimeMs = fs.statSync(bundleAbs).mtimeMs;
+  const sources = bundledSources(root);
+  const stale = sources
+    .map((file) => ({ file, mtimeMs: fs.statSync(path.join(root, file)).mtimeMs }))
+    .filter((s) => s.mtimeMs > bundleMtimeMs)
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return { skipped: false, bundleMtimeMs, stale, checked: sources.length };
+}
+
+function stamp(ms: number): string {
+  return new Date(ms).toISOString().replace("T", " ").slice(0, 16);
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+  const root = REPO_ROOT;
+  const quiet = argv.includes("--quiet");
+  const r = check(root);
+
+  // Scope hardening: publish the count and refuse a silent zero. The one
+  // legitimate zero is the absent self-hosted bundle — an optional input, and
+  // the reason survives the manifest's own test ("if the scan root were
+  // deleted, would this still make sense?"): with no bundle there is no stale
+  // dispatcher to catch, which is a correct verdict rather than blindness.
+  reportScanned({
+    gate: "check_hook_bundle_freshness",
+    scanned: r.checked,
+    units: "bundled hook source(s)",
+    roots: [BUNDLE, HOOK_DIR, MANIFEST],
+    ...(r.skipped
+      ? {
+          allowEmpty:
+            "OPTIONAL_INPUT: no self-hosted dist/hooks/dispatch.js — this repo is not " +
+            "running its own bundle (fresh checkout / CI), so there is nothing to compare against.",
+        }
+      : {}),
+  });
+
+  // A gate that scans nothing must SAY it scanned nothing — a silent green
+  // here is indistinguishable from a pass.
+  if (r.skipped) {
+    if (!quiet) {
+      console.log(
+        `✅  OK  hook bundle: no self-hosted ${BUNDLE} — the installed package copy is in use, nothing to check`,
+      );
+    }
+    return 0;
+  }
+
+  if (r.stale.length === 0) {
+    if (!quiet) {
+      console.log(
+        `✅  OK  hook bundle: fresh (built ${stamp(r.bundleMtimeMs)}, ${r.checked} bundled source(s) checked)`,
+      );
+    }
+    return 0;
+  }
+
+  console.error(
+    `❌  hook bundle is STALE — the running dispatcher predates ${r.stale.length} of ${r.checked} bundled source(s).`,
+  );
+  console.error(`    ${BUNDLE} built ${stamp(r.bundleMtimeMs)}; newer sources:`);
+  for (const s of r.stale.slice(0, 10)) {
+    console.error(`      ${stamp(s.mtimeMs)}  ${s.file}`);
+  }
+  if (r.stale.length > 10) console.error(`      … and ${r.stale.length - 10} more`);
+  console.error("");
+  console.error(`    Your hooks are running the OLD code. Rebuild:  ${REMEDY}`);
+  console.error(
+    "    (This gate never builds for you — writing into a live hook path can wedge the tool loop.)",
+  );
+  return 1;
+}
+
+const invokedDirectly = ((): boolean => {
+  const entry = process.argv[1];
+  if (entry === undefined) return false;
+  try {
+    return fs.realpathSync(path.resolve(entry)) === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/src/scripts/check_hook_bundle_freshness.ts
+++ b/src/scripts/check_hook_bundle_freshness.ts
@@ -136,8 +136,8 @@ export function main(argv: string[] = process.argv.slice(2)): number {
   // here is indistinguishable from a pass.
   if (r.skipped) {
     if (!quiet) {
-      console.log(
-        `✅  OK  hook bundle: no self-hosted ${BUNDLE} — the installed package copy is in use, nothing to check`,
+      process.stdout.write(
+        `✅  OK  hook bundle: no self-hosted ${BUNDLE} — the installed package copy is in use, nothing to check\n`,
       );
     }
     return 0;
@@ -145,8 +145,8 @@ export function main(argv: string[] = process.argv.slice(2)): number {
 
   if (r.stale.length === 0) {
     if (!quiet) {
-      console.log(
-        `✅  OK  hook bundle: fresh (built ${stamp(r.bundleMtimeMs)}, ${r.checked} bundled source(s) checked)`,
+      process.stdout.write(
+        `✅  OK  hook bundle: fresh (built ${stamp(r.bundleMtimeMs)}, ${String(r.checked)} bundled source(s) checked)\n`,
       );
     }
     return 0;

--- a/src/scripts/hooks/design_slop_hook.ts
+++ b/src/scripts/hooks/design_slop_hook.ts
@@ -71,8 +71,20 @@ function enabled(root: string): boolean {
   return false;
 }
 
+/**
+ * The dispatcher nests the host-shaped tool fields under `payload`; a bare host
+ * invocation puts them at the top level. Read both — this hook shipped reading
+ * only the top level, so under the dispatcher `extract` always returned null and
+ * the concern was silent on every write it was supposed to flag.
+ */
+function _unwrap(envelope: JsonObject): JsonObject {
+  const inner = envelope["payload"];
+  return isObject(inner) ? inner : envelope;
+}
+
 /** Best-effort: pull (toolName, filePath, proposedContent) from the PreToolUse envelope. */
-function extract(envelope: JsonObject): { file: string; content: string } | null {
+function extract(outer: JsonObject): { file: string; content: string } | null {
+  const envelope = _unwrap(outer);
   const ti = envelope["tool_input"] ?? envelope["toolInput"] ?? envelope["input"];
   if (!isObject(ti)) return null;
   const fileVal = ti["file_path"] ?? ti["path"] ?? ti["filePath"];

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -25,6 +25,13 @@ tasks:
       - ./scripts-run src/scripts/check_safety_floor_untouched
       - ./scripts-run src/scripts/check_no_new_legacy_path
       - ./scripts-run src/scripts/check_kernel_rule_bundle
+      # Catches the one failure that is invisible to CI AND to the test suite:
+      # a self-hosted hook bundle older than the hook sources it bundles, i.e.
+      # the agent running a merged hook fix that was never built. On 2026-08-06
+      # four such fixes ran nowhere for a full session. Sub-second (38 stats).
+      # In CI it declares a loud no-op — a fresh checkout has no bundle — rather
+      # than passing silently on an invariant it never evaluated.
+      - ./scripts-run src/scripts/check_hook_bundle_freshness
       - ./scripts-run src/scripts/lint_regression
       # Same argv the CI `skill-lint` job runs. NOT chosen for speed — both
       # forms are sub-second here (0.44s --changed / 0.52s --all, measured

--- a/tests/hooks/concern_envelope_nesting.test.ts
+++ b/tests/hooks/concern_envelope_nesting.test.ts
@@ -1,0 +1,97 @@
+// A concern must read the tool fields where the DISPATCHER puts them.
+//
+// Why this test exists, stated plainly because it is the second instance of
+// the same defect.
+//
+// `_build_envelope` (dispatch_hook.ts) hands every concern
+// `{schema_version, platform, event, native_event, session_id,
+//   workspace_root, payload, settings}` — the host-shaped tool fields live
+// under `payload`. A concern invoked bare by a host sees those same fields at
+// the TOP level. A concern that reads only the top level therefore works in
+// its own unit test, works when a human pipes a hand-written envelope into it,
+// and does nothing at all in production.
+//
+// Round 2 found and fixed exactly that in `pr_url_reminder` (it had never
+// fired). Round 3 ran the sibling search the fix should have triggered and
+// found one more, out of the 15 concerns bound to a tool event:
+// `design_slop` — proven silent by driving a real P1 side-stripe through both
+// envelope shapes (flat: exit 2 + reason; nested: exit 0, nothing).
+//
+// Scope, stated honestly: this pins the CONTRACT plus the two concerns that
+// have a cheap deterministic trigger. It is not a sweep over all 15 — the
+// others need per-concern fixtures, and a static "does the source mention
+// payload" check would pass `injection_scan` (which survives nesting only via
+// a whole-envelope JSON fallback) while proving nothing about the rest. A weak
+// gate that scans almost nothing is worse than a named gap.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { _build_envelope } from '../../src/scripts/hooks/dispatch_hook.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+
+describe('dispatcher envelope contract', () => {
+  it('nests the host payload under `payload` and never at the top level', () => {
+    const env = _build_envelope(
+      {
+        platform: 'claude',
+        event: 'pre_tool_use',
+        native_event: 'PreToolUse',
+      } as never,
+      JSON.stringify({ tool_name: 'Write', tool_input: { file_path: 'a.css', content: 'x' } }),
+    );
+
+    // The shape both sides of the boundary must code against.
+    expect(env['payload']).toMatchObject({ tool_name: 'Write' });
+    expect(env['tool_name']).toBeUndefined();
+    expect(env['tool_input']).toBeUndefined();
+    expect(env).toHaveProperty('workspace_root');
+  });
+});
+
+/** Run a concern with a raw stdin envelope; return its exit code + stdout. */
+function runConcern(script: string, envelope: unknown): { code: number; out: string } {
+  const r = spawnSync('npx', ['tsx', path.join(REPO, script)], {
+    input: JSON.stringify(envelope),
+    encoding: 'utf-8',
+    cwd: REPO,
+    timeout: 120_000,
+  });
+  return { code: r.status ?? -1, out: r.stdout ?? '' };
+}
+
+describe('a tool-bound concern behaves identically flat and nested', () => {
+  // A real P1 finding (slop-v1-side-stripe): a >1px coloured side border.
+  const SLOP = '.card { border-left: 4px solid #7c3aed; padding: 12px; }';
+
+  it('design_slop flags the same write whether the fields are nested or flat', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ds-envelope-'));
+    fs.writeFileSync(
+      path.join(root, '.agent-settings.yml'),
+      'hooks:\n  design_slop:\n    enabled: true\n',
+    );
+    const inner = {
+      tool_name: 'Write',
+      tool_input: { file_path: path.join(root, 'a.css'), content: SLOP },
+    };
+    const script = 'src/scripts/hooks/design_slop_hook.ts';
+
+    const flat = runConcern(script, { cwd: root, ...inner });
+    const nested = runConcern(script, { cwd: root, payload: inner });
+
+    // The flat shape is the pre-existing behaviour — assert it really fires,
+    // so a fixture that silently stops triggering cannot make this test vacuous.
+    expect(flat.code).toBe(2);
+    expect(flat.out).toContain('slop-v1-side-stripe');
+
+    // The regression: under the dispatcher's shape it used to exit 0, silent.
+    expect(nested.code).toBe(flat.code);
+    expect(nested.out).toContain('slop-v1-side-stripe');
+  }, 240_000);
+});

--- a/tests/scripts/check_hook_bundle_freshness.test.ts
+++ b/tests/scripts/check_hook_bundle_freshness.test.ts
@@ -1,0 +1,99 @@
+// The gate that catches a merged-but-unbuilt hook fix.
+//
+// The failure it encodes, measured 2026-08-06: PR #1195 merged four hook fixes
+// (language-mirror pin, git-authorization ledger, evidence-independence,
+// pr-url-reminder). The self-hosted `dist/hooks/dispatch.js` those hooks
+// actually execute from was built at 05:27 UTC the same morning — before any
+// of them existed. Ten hook sources were newer than the bundle, and in the
+// session that shipped the language fix the conformance scanner still counted
+// four German-prompt / English-reply violations. The fix was merged, correct,
+// and not loaded, and no gate, test, or workflow said so.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { bundledSources, check } from '../../src/scripts/check_hook_bundle_freshness.js';
+
+/** A minimal tree with the three inputs the gate reads. */
+function fixture(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hookfresh-'));
+  fs.mkdirSync(path.join(root, 'src', 'scripts', 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'dist', 'hooks'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'src', 'scripts', 'hook_manifest.yaml'),
+    'schema_version: 1\nconcerns:\n  demo:\n    script: src/scripts/demo_hook.ts\n',
+  );
+  fs.writeFileSync(path.join(root, 'src', 'scripts', 'demo_hook.ts'), '// concern\n');
+  fs.writeFileSync(path.join(root, 'src', 'scripts', 'hooks', 'a.ts'), '// hook\n');
+  return root;
+}
+
+function touch(file: string, whenMs: number): void {
+  fs.utimesSync(file, whenMs / 1000, whenMs / 1000);
+}
+
+describe('check_hook_bundle_freshness', () => {
+  it('counts a concern script outside hooks/ as bundled — the manifest decides, not the directory', () => {
+    const root = fixture();
+    const srcs = bundledSources(root);
+    expect(srcs).toContain('src/scripts/demo_hook.ts');
+    expect(srcs).toContain(path.join('src', 'scripts', 'hooks', 'a.ts'));
+    expect(srcs).toContain(path.join('src', 'scripts', 'hook_manifest.yaml'));
+  });
+
+  it('reports skipped — never stale — when the repo runs no self-hosted bundle', () => {
+    const root = fixture();
+    const r = check(root); // dist/hooks/dispatch.js deliberately not created
+    expect(r.skipped).toBe(true);
+    expect(r.stale).toEqual([]);
+    // A fresh checkout / CI must not be told to rebuild something it does not use.
+    expect(r.checked).toBe(0);
+  });
+
+  it('passes when the bundle is newer than every source it bundles', () => {
+    const root = fixture();
+    const bundle = path.join(root, 'dist', 'hooks', 'dispatch.js');
+    fs.writeFileSync(bundle, '// built\n');
+    const t = Date.now();
+    for (const rel of bundledSources(root)) touch(path.join(root, rel), t - 60_000);
+    touch(bundle, t);
+
+    const r = check(root);
+    expect(r.skipped).toBe(false);
+    expect(r.stale).toEqual([]);
+    expect(r.checked).toBeGreaterThan(0); // never a vacuous pass
+  });
+
+  it('names every source newer than the bundle — the round-2 situation', () => {
+    const root = fixture();
+    const bundle = path.join(root, 'dist', 'hooks', 'dispatch.js');
+    fs.writeFileSync(bundle, '// built\n');
+    const t = Date.now();
+    // Age everything behind the bundle first, so the assertion below is about
+    // the ONE edited file and not about fixture creation order.
+    for (const rel of bundledSources(root)) touch(path.join(root, rel), t - 120_000);
+    touch(bundle, t - 60_000);
+    // One edited hook is enough to invalidate the running dispatcher.
+    touch(path.join(root, 'src', 'scripts', 'hooks', 'a.ts'), t);
+
+    const r = check(root);
+    expect(r.stale.map((s) => s.file)).toEqual([path.join('src', 'scripts', 'hooks', 'a.ts')]);
+    // The untouched sources must NOT be reported — a gate that lists everything
+    // teaches the reader to ignore it.
+    expect(r.stale).toHaveLength(1);
+    expect(r.checked).toBeGreaterThan(1);
+  });
+
+  it('treats an equal mtime as fresh — only a strictly newer source is stale', () => {
+    const root = fixture();
+    const bundle = path.join(root, 'dist', 'hooks', 'dispatch.js');
+    fs.writeFileSync(bundle, '// built\n');
+    const t = Date.now();
+    for (const rel of bundledSources(root)) touch(path.join(root, rel), t);
+    touch(bundle, t);
+
+    expect(check(root).stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
Round 3 of the conformance audit. It re-ran the scan against the merged round-2
code and asked the one question round 2 could not answer about itself: **did any
of it actually take effect?**

For four of the five fixes, the answer was no — and not because they were wrong.

## The round-2 fixes were correct and not running

The Claude hook command resolves its dispatcher to the installed package copy if
present, else this repo's own `dist/hooks/dispatch.js`. In this repo the second
branch always wins — the dogfooding path, and the only place these hooks are
exercised before release.

That bundle is **untracked** and is produced only by `npm run build:hooks`, which
**no Taskfile target, no `task ci` target and no workflow invokes**. Measured
while writing this PR: the running bundle was built 05:27 UTC on 2026-08-06,
before any round-2 fix existed, and ten hook sources were newer than it. It
carried neither `invokedSegments` nor `_unwrap`.

The consequence is in the data. In session `0571cbc6` — the session that shipped
the language-mirror pin — the scanner counts **four German-prompt / English-reply
violations**. The pin was merged, correct, and never loaded.

`prepack` runs the full build, so a **published package is always fresh and
consumers were never affected**. The gap is local, and local is where the testing
happens.

**`check_hook_bundle_freshness`** (new, wired into `preflight`) compares the
bundle's mtime against every source it bundles — the `hooks/` directory, the
manifest, and each concern script the manifest names, wherever it lives. Only
strictly-newer files count and only those are listed, so an unrelated edit does
not produce noise a reader learns to skip. It **never builds**: writing into a
live hook path can wedge the running tool loop, so the remedy is printed for a
human. Where no self-hosted bundle exists (fresh checkout, CI) it declares a loud
no-op rather than passing silently on an invariant it never evaluated.

## The sibling round 2 never searched for

Round 2 fixed `pr_url_reminder`, which read `tool_name` / `tool_response` at the
envelope top level while the dispatcher nests them under `payload`. It did not
run the defect-pattern search that fix should have triggered.

Run here across all **15 concerns bound to a tool event**: exactly **one** more
match — `design_slop`. Proven by driving a real P1 finding (`slop-v1-side-stripe`)
through both envelope shapes: flat gave exit 2 and a reason, nested gave exit 0
and nothing. After the fix, end-to-end through the rebuilt dispatcher, the warning
arrives as `additionalContext`.

`injection_scan` looked like a third instance and is **not** — it survives nesting
via a whole-envelope JSON fallback. Verified by probe rather than assumed, because
the count is the point of a sibling search.

The new test pins the dispatcher's envelope contract plus the flat-vs-nested
equivalence, and was mutation-checked: reverting the unwrap turns it red.

## Verified clean

Also checked and found sound, so the audit is not only a list of defects: all 27
concerns are bound to at least one event; all five `blocking` concerns sit on
`pre_tool_use` on all three platforms, so none is structurally unable to refuse;
round 2's exit-parity test holds; the single `evidence-steering` hit in the whole
corpus is the historical 2026-08-04 fabrication event the rule was written for —
**no new occurrence**, including in round 2's own session.

## Findings NOT fixed here, stated rather than buried

- **`ratchet_base_ref` is red on `main`.** PR #1195 merged with `Node Tests
  (ubuntu-latest, shard 3/4)` failing on "renames are not growth". It is not in
  that PR's diff and passes locally — a CI-environment flake, but it merged red
  because branch protection requires exactly one check.
- **Two blocking concerns are not `fail_closed`** (`evidence-independence`,
  `block-config-weakening`) while the other three are. On a crash they fail open.
  That is a behaviour change on the crash path, so it is a maintainer decision,
  not something to flip inside an audit PR.
- **`conformance:behavior` silently accepts unknown flags** — `--help` runs a full
  scan instead of printing usage.
- **No generic per-concern nesting sweep.** The new test covers the contract plus
  the concerns with a cheap deterministic trigger. A static "does the source
  mention `payload`" check would pass `injection_scan` while proving nothing about
  the rest; a gate that scans almost nothing is worse than a named gap.

## Verification

`task typecheck-ts` EXIT=0 · `task preflight` EXIT=0 (including the new gate,
reporting fresh) · the two new suites 7/7 · `tests/hooks` + `tests/scripts`:
9,760 pass, the same 6 failures in the same 3 files as before this branch, all
outside the diff and each traced in #1195 (2 pre-existing on `main`, 1 worktree
path-depth, 3 an untracked local directory absent in CI).

Also refreshed the originality report, which round 2 left describing 513 artifacts
against a tree of 514.
