### PR TITLE
fix(cli): routing commands dead through the shipped binary; assert skills reach the host

### DIFF
--- a/src/scripts/_cli/cmd_route_audit.ts
+++ b/src/scripts/_cli/cmd_route_audit.ts
@@ -36,8 +36,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { match_prompt, type Router } from '../_lib/router_match.js';
 import { load_agent_settings } from '../_lib/agent_settings.js';
 import { read_entries } from '../chat_history.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+// Marker-anchored, not hop-counted — see the sibling note in cmd_route_explain.ts.
+// Both routing commands were the last two `_cli` entries still counting hops.
+const REPO_ROOT = resolvePackageRoot(import.meta.url);
 const ROUTER_JSON = path.join(REPO_ROOT, 'dist', 'router.json');
 
 // cache-version: v1 — rebuildable audit log: delete-and-rerun rebuilds it from

--- a/src/scripts/_cli/cmd_route_explain.ts
+++ b/src/scripts/_cli/cmd_route_explain.ts
@@ -31,8 +31,16 @@ import {
 } from '../_lib/router_match.js';
 import { measure, method_note } from '../_lib/token_count.js';
 import { load_agent_settings } from '../_lib/agent_settings.js';
+import { resolvePackageRoot } from '../_lib/package_root.js';
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+// Marker-anchored, not hop-counted: this module runs from `src/scripts/_cli/`
+// (three levels down) AND from the precompiled `dist/cli-delegate/` (two), and
+// a fixed hop count is right in exactly one of them. Three hops from the bundle
+// landed on `<pkg>/..` — `node_modules/@event4u` for a scoped install — so
+// `route:explain` and `route:audit` reported dist/router.json as missing on
+// every invocation through the shipped binary while both worked under `tsx`.
+// The resolver exists precisely for this and 12 sibling commands already use it.
+const REPO_ROOT = resolvePackageRoot(import.meta.url);
 const ROUTER_JSON = path.join(REPO_ROOT, 'dist', 'router.json');
 const RULES_DIST_DIR = path.join(REPO_ROOT, 'dist', 'agent-src', 'rules');
 

--- a/src/scripts/check_host_loadability.ts
+++ b/src/scripts/check_host_loadability.ts
@@ -42,6 +42,51 @@ export function check_claude_skills(root: string, errors: string[]): number {
     return names.length;
 }
 
+/**
+ * Every authored skill must REACH the Claude tree, not merely be well-formed
+ * once there.
+ *
+ * The checker above validates whatever it finds, so a skill that never
+ * projects is indistinguishable from a skill that does not exist. Probed
+ * 2026-08-06 by deleting `.claude/skills/laravel`: this gate and
+ * `check_condensation` both stayed green, and the host would simply never see
+ * that skill. Loadability and completeness are different questions and only
+ * the first one was being asked.
+ *
+ * Scoped to `src/skills/*` deliberately. The tree also carries ~47 entries
+ * projected from `src/domains/<pack>/<cmd>/command.md`, whose directory name
+ * need not match the projected skill name (`domains/git/commit` →
+ * `git-commit`), so a naive directory comparison there would invent failures.
+ * The authored-skill set is the one with a 1:1 name contract.
+ *
+ * @returns how many authored skills were checked for arrival.
+ */
+export function check_claude_skill_completeness(root: string, errors: string[]): number {
+    const projected = path.join(root, '.claude', 'skills');
+    const authored = path.join(root, 'src', 'skills');
+    // An ungenerated projection is not an incomplete one — same stance as the
+    // checkers above. Nothing to compare against, so nothing to claim.
+    if (!fs.existsSync(projected) || !fs.existsSync(authored)) return 0;
+
+    const missing: string[] = [];
+    let checked = 0;
+    for (const entry of fs.readdirSync(authored, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        if (!fs.existsSync(path.join(authored, entry.name, 'SKILL.md'))) continue;
+        checked += 1;
+        if (!fs.existsSync(path.join(projected, entry.name, 'SKILL.md'))) missing.push(entry.name);
+    }
+    if (missing.length > 0) {
+        const shown = missing.slice(0, 10).join(', ');
+        const rest = missing.length > 10 ? ` … and ${String(missing.length - 10)} more` : '';
+        errors.push(
+            `.claude/skills: ${String(missing.length)} of ${String(checked)} authored skill(s) never reached the host tree — ` +
+                `${shown}${rest}. Regenerate with \`task generate-tools\`; if one is deliberately unprojected, the generator must say so.`,
+        );
+    }
+    return checked;
+}
+
 /** @returns how many `.mdc` rule files were examined. */
 export function check_cursor_rules(root: string, errors: string[]): number {
     const dir = path.join(root, '.cursor', 'rules');
@@ -74,7 +119,10 @@ export function run(root: string): string[] {
     // early when its tree is absent — so "no malformed artefacts" and "no
     // artefacts" are the same green. Thrown, not returned: `errors` names
     // malformed files, and an unprojected tree is not one.
+    // Completeness reads the same tree the first checker walks, so it adds no
+    // scanned units — counting it twice would inflate the published number.
     const scanned = check_claude_skills(root, errors) + check_cursor_rules(root, errors);
+    check_claude_skill_completeness(root, errors);
     assertScanned({
         gate: 'check_host_loadability',
         scanned,

--- a/tests/scripts/check_host_loadability.test.ts
+++ b/tests/scripts/check_host_loadability.test.ts
@@ -25,3 +25,40 @@ test('clean projection passes; malformed projection is caught (U4 verify criteri
     expect(errors.some((e) => e.includes("name 'other-name' != dir 'bad-skill'"))).toBe(true);
     expect(errors.some((e) => e.includes('broken.mdc'))).toBe(true);
 });
+
+// Loadability and completeness are different questions. Until 2026-08-06 only
+// the first was asked: deleting `.claude/skills/laravel` left this gate AND
+// check_condensation green, so a skill that never projected was
+// indistinguishable from one that does not exist. The host simply never saw it.
+test('an authored skill that never reached the Claude tree is a failure, not a silent absence', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'u4-complete-'));
+    // Two authored skills; only one is projected.
+    mk(root, 'src/skills/arrives/SKILL.md', '---\nname: arrives\ndescription: x\n---\nbody\n');
+    mk(root, 'src/skills/vanishes/SKILL.md', '---\nname: vanishes\ndescription: x\n---\nbody\n');
+    mk(root, '.claude/skills/arrives/SKILL.md', '---\nname: arrives\ndescription: x\n---\nbody\n');
+
+    const errors = run(root);
+    expect(errors.some((e) => e.includes('vanishes'))).toBe(true);
+    // The one that DID arrive must not be reported — a gate that names
+    // everything teaches the reader to skim past the real entry.
+    expect(errors.some((e) => e.includes('arrives'))).toBe(false);
+});
+
+test('a complete projection passes, and a domain-projected skill is not mistaken for missing', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'u4-complete-ok-'));
+    mk(root, 'src/skills/authored/SKILL.md', '---\nname: authored\ndescription: x\n---\nbody\n');
+    mk(root, '.claude/skills/authored/SKILL.md', '---\nname: authored\ndescription: x\n---\nbody\n');
+    // Projected from a domain command whose directory name differs — extra in
+    // the host tree, sourced nowhere under src/skills, and legitimately so.
+    mk(root, '.claude/skills/git-commit/SKILL.md', '---\nname: git-commit\ndescription: x\n---\nbody\n');
+
+    expect(run(root)).toEqual([]);
+});
+
+test('no authored tree yet — an ungenerated projection is not an incomplete one', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'u4-nogen-'));
+    mk(root, 'src/skills/authored/SKILL.md', '---\nname: authored\ndescription: x\n---\nbody\n');
+    mk(root, '.cursor/rules/ok.mdc', '---\ndescription: ok\n---\nbody\n');
+    // .claude/skills absent entirely: a fresh checkout, nothing to compare.
+    expect(run(root)).toEqual([]);
+});

--- a/tests/scripts/cli_root_resolution.test.ts
+++ b/tests/scripts/cli_root_resolution.test.ts
@@ -1,0 +1,144 @@
+// A `_cli` command must find the package root from the layout it SHIPS in.
+//
+// The defect, measured 2026-08-06 on a clean `main`:
+//
+//     $ ./agent-config route:explain "commit this and push to main"
+//     route:explain: cannot read …/event4u/dist/router.json: ENOENT
+//
+// Both routing commands — the two the operator uses to inspect what the router
+// does — were dead through the shipped binary while working perfectly under
+// `npx tsx`. `cmd_route_explain.ts` and `cmd_route_audit.ts` derived the root
+// with three hard-coded parent hops. That is correct from
+// `src/scripts/_cli/` (three levels down) and wrong from the precompiled
+// `dist/cli-delegate/` (two): three hops from the bundle lands on `<pkg>/..`,
+// which for a scoped install is `node_modules/@event4u`.
+//
+// This repo had already paid for that lesson once: `_lib/package_root.ts`
+// exists because the same hop arithmetic turned a 9.11.0 release PR's tarball
+// E2E red on both Node majors, and 12 sibling commands were migrated to it.
+// These two were left behind, and nothing noticed for one reason — the existing
+// `cmd_route_explain.test.ts` imports `build_report` and `render_text`
+// directly. Pure functions cannot observe the module-level constant that broke,
+// so the suite was green the whole time.
+//
+// Three layers below, deliberately: a class gate that needs no build, a layout
+// assertion that pins the two-vs-three hop asymmetry, and an end-to-end run of
+// the real binary.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parse as parseYaml } from 'yaml';
+import { describe, expect, it } from 'vitest';
+
+import { PACKAGE_NAME, resolvePackageRoot } from '../../src/scripts/_lib/package_root.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const CLI_DIR = path.join(REPO, 'src', 'scripts', '_cli');
+const BINARY = path.join(REPO, 'dist', 'cli', 'agent-config.js');
+
+/** The exact wrong construct: a root derived by counting `..` from this module. */
+const HOP_COUNTED_ROOT =
+  /path\.resolve\(\s*(?:path\.dirname\()?fileURLToPath\(import\.meta\.url\)\)?\s*,\s*(?:'\.\.'\s*,?\s*)+\)/;
+
+describe('no _cli command counts hops to the package root', () => {
+  it('every module that derives a root uses the marker-anchored resolver', () => {
+    const offenders: string[] = [];
+    for (const name of fs.readdirSync(CLI_DIR).sort()) {
+      if (!name.endsWith('.ts')) continue;
+      const src = fs.readFileSync(path.join(CLI_DIR, name), 'utf8');
+      if (HOP_COUNTED_ROOT.test(src) && !src.includes('resolvePackageRoot')) {
+        offenders.push(name);
+      }
+    }
+    // Named rather than counted: a bare number invites someone to bump it.
+    expect(offenders).toEqual([]);
+  });
+
+  it('scans a non-empty population — the gate must not pass by finding nothing', () => {
+    const modules = fs.readdirSync(CLI_DIR).filter((f) => f.endsWith('.ts'));
+    expect(modules.length).toBeGreaterThan(5);
+  });
+});
+
+describe('resolvePackageRoot is layout-independent', () => {
+  /** A package tree with the marker manifest and both call-site layouts. */
+  function pkg(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pkgroot-'));
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: PACKAGE_NAME }));
+    fs.mkdirSync(path.join(root, 'src', 'scripts', '_cli'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'dist', 'cli-delegate'), { recursive: true });
+    return root;
+  }
+
+  it('resolves from the source layout (three levels down)', () => {
+    const root = pkg();
+    const from = path.join(root, 'src', 'scripts', '_cli', 'cmd_x.ts');
+    expect(fs.realpathSync(resolvePackageRoot(from))).toBe(fs.realpathSync(root));
+  });
+
+  it('resolves from the precompiled delegate layout (two levels down) — the case hops got wrong', () => {
+    const root = pkg();
+    const from = path.join(root, 'dist', 'cli-delegate', 'cmd_x.js');
+    expect(fs.realpathSync(resolvePackageRoot(from))).toBe(fs.realpathSync(root));
+  });
+
+  it('skips a consumer package.json on the way up', () => {
+    const outer = fs.mkdtempSync(path.join(os.tmpdir(), 'consumer-'));
+    fs.writeFileSync(path.join(outer, 'package.json'), JSON.stringify({ name: 'some-app' }));
+    const root = path.join(outer, 'node_modules', '@event4u', 'agent-config');
+    fs.mkdirSync(path.join(root, 'dist', 'cli-delegate'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name: PACKAGE_NAME }));
+    const from = path.join(root, 'dist', 'cli-delegate', 'cmd_x.js');
+    expect(fs.realpathSync(resolvePackageRoot(from))).toBe(fs.realpathSync(root));
+  });
+});
+
+describe('the shipped binary can actually route', () => {
+  const built = fs.existsSync(BINARY);
+
+  it.skipIf(!built)('route:explain reads router.json and reports matches', () => {
+    const r = spawnSync('node', [BINARY, 'route:explain', 'commit this and push to main'], {
+      encoding: 'utf-8',
+      cwd: REPO,
+      timeout: 120_000,
+    });
+    const out = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+    // The exact failure this test exists for.
+    expect(out).not.toMatch(/cannot read .*router\.json/);
+    expect(out).toContain('kernel (always active');
+    expect(r.status).toBe(0);
+  }, 180_000);
+
+  it.skipIf(!built)('route:audit reads router.json too', () => {
+    const r = spawnSync('node', [BINARY, 'route:audit'], {
+      encoding: 'utf-8',
+      cwd: REPO,
+      timeout: 120_000,
+    });
+    expect(`${r.stdout ?? ''}${r.stderr ?? ''}`).not.toMatch(/cannot read .*router\.json/);
+  }, 180_000);
+
+  // The two cases above skip on an unbuilt checkout, so on its own this
+  // end-to-end layer could go dark exactly the way the defect did. This is the
+  // guard on the guard: CI must still build before it runs vitest, or the only
+  // coverage that drives the real binary silently stops existing.
+  it('CI builds the CLI before the vitest job, so the E2E above is never skipped there', () => {
+    const wf = parseYaml(
+      fs.readFileSync(path.join(REPO, '.github', 'workflows', 'tests.yml'), 'utf8'),
+    ) as { jobs: Record<string, { name?: string; steps?: { run?: string }[] }> };
+
+    const nodeTests = Object.values(wf.jobs).find((j) => (j.name ?? '').startsWith('Node Tests'));
+    expect(nodeTests, 'a job named "Node Tests …" must exist in tests.yml').toBeDefined();
+
+    const runs = (nodeTests?.steps ?? []).map((s) => s.run ?? '');
+    const buildAt = runs.findIndex((c) => /npm run build\b/.test(c));
+    // The job invokes the suite through the npm script, not the binary name.
+    const vitestAt = runs.findIndex((c) => /\bvitest\b|npm run test:ts\b/.test(c));
+    expect(buildAt, 'Node Tests must run `npm run build`').toBeGreaterThanOrEqual(0);
+    expect(vitestAt, 'Node Tests must run the vitest suite').toBeGreaterThanOrEqual(0);
+    expect(buildAt).toBeLessThan(vitestAt);
+  });
+});


### PR DESCRIPTION
Round 4 of the conformance audit, with the scope the maintainer asked for: stop
looking only at hooks and establish what is actually **provable** about rule
routing and skill loading.

The answer is uneven, and the uneven part was broken.

## Rule routing: the engine was fine, the commands were dead

```
$ ./agent-config route:explain "commit this and push to main"
route:explain: cannot read …/event4u/dist/router.json: ENOENT
```

`route:explain` and `route:audit` — the two commands an operator uses to inspect
what the router does — derived the package root with three hard-coded parent
hops. Correct from `src/scripts/_cli/` (three levels down), wrong from the
precompiled `dist/cli-delegate/` (two): three hops from the bundle lands on
`<pkg>/..`, which for a scoped install is `node_modules/@event4u`. Under
`npx tsx` both worked perfectly, which is why nothing noticed.

This repo had already paid for that lesson. `_lib/package_root.ts` exists because
the same arithmetic turned a 9.11.0 release PR's tarball E2E red on both Node
majors, and 12 sibling `_cli` commands were migrated to the marker-anchored
resolver. A defect-pattern search over `src/scripts/_cli/` finds **exactly 2 of
14** still counting hops — and both are the routing commands.

Why the suite stayed green: `cmd_route_explain.test.ts` imports `build_report`
and `render_text` directly. Pure functions cannot observe the module-level
constant that broke — the same shape as round 2's blocking concerns, whose unit
tests asserted a constant against itself.

## What is now testable about routing — three layers, plus a guard on the guard

- **Class gate, no build required.** No `_cli` module may derive a root by
  counting `..` hops. It also asserts the population it scanned is non-empty, so
  it cannot pass by finding nothing.
- **Layout assertion.** `resolvePackageRoot` resolves from the source layout,
  from the two-level delegate layout, and from a nested consumer install where a
  foreign `package.json` sits on the way up.
- **End-to-end on the real binary.** Spawns `dist/cli/agent-config.js` and
  asserts `route:explain` prints a routing report and never the ENOENT.
- **Guard on the guard.** The E2E skips on an unbuilt checkout, so a further test
  asserts the Node Tests job still runs `npm run build` **before** vitest. If that
  ordering changes, the only layer driving the real binary would go dark exactly
  the way this defect did.

Mutation-checked: reverting the fix reds the class gate and the E2E independently.

## Skill loading: loadable was asserted, complete was not

`check_host_loadability` validated whatever it found in `.claude/skills`, so a
skill that never projected was indistinguishable from one that does not exist.
Probed by deleting `.claude/skills/laravel`: that gate **and**
`check_condensation` both stayed green.

The gate now also asserts arrival: every `src/skills/*` must reach the Claude
tree. Scoped to authored skills deliberately — the tree also carries 46 entries
projected from `src/domains/<pack>/<cmd>/command.md` whose directory name need
not match the projected name (`domains/git/commit` → `git-commit`), so a naive
comparison would invent failures. An ungenerated projection stays green, matching
the gate's existing stance that an unprojected tree is not a malformed one.

## What was checked and found genuinely sound

Reported because an audit that only lists defects cannot be distinguished from
one that stopped looking:

- **Router pointers resolve.** `conformance` reports 108 rule ids + 96
  `routes_to` targets resolving; an independent probe over `dist/router.json`
  confirms 0 missing rule files.
- **The `.claude` skill tree regenerates deterministically.** Deleted and
  regenerated: 335 before, 335 after, no leftovers. `git-commit` looked like an
  orphan with no source until `src/domains/git/commit/command.md` turned up
  declaring that name — so it is projected, not stale.
- **Round 3's gates hold.** `check_hook_bundle_freshness` correctly reports the
  main checkout still running a 07:27 bundle, which is the round-3 finding still
  awaiting its one-command remedy, surfaced instead of silent.

## Still open, named rather than buried

- **The round-3 remedy has not been run.** The live hook bundle in the main
  checkout is still from 07:27, so the language-mirror pin and the other
  round-2/3 hook fixes remain unloaded in the maintainer's own session. The gate
  now says so on every `preflight`; running `npm run build:hooks` is a human
  action by design.
- **The combined suite does not have a stable failing set — measured, and worth
  its own look.** Running the full `tests/hooks` + `tests/scripts` set twice:

  | run | failing files |
  |---|---|
  | this branch | `check_artefact_count_messaging`, `explain_run`, `reach_doctor`, `sweep_dead_scan_roots`, `tool_probe` |
  | `main` | `build_mcp_registry_manifest`, `code_graph_refresh`, `explain_run`, `manual_rule_projection` |

  The sets are almost disjoint — one file in common — and **every** file in both
  lists passes when run in isolation, on both branches. That is the signature of
  cross-test interference and load sensitivity, not of a regression: suites that
  regenerate the tree race suites that read it, and `tool_probe` is
  deadline-based. None of the eight files appears in this diff. It also means a
  green combined run is not currently evidence of much, which is the honest
  caveat on every "suite green" claim this PR could otherwise make.
- **No consumer-install assertion for skill arrival.** Completeness is checked in
  this repo's projection. Whether an installed consumer tree receives the same
  set is covered only indirectly by the install suites.

## Verification

`task typecheck-ts` EXIT=0 · `task preflight` EXIT=0 · the new and extended
suites 12/12 · `route:explain` and `route:audit` verified through the shipped
binary, not just the module.
