### PR TITLE
feat(bench): close the Arms and Thresholds steps, and make solution-minimalism report its own spend gate

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 17 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **17** open blockers
+> 17 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **18** open blockers
 
 ## Overall
 
-**125 / 215 steps done · 58%**
+**126 / 215 steps done · 59%**
 
 ```text
-███████████████████████░░░░░░░░░░░░░░░░░   58%
+████████████████████████░░░░░░░░░░░░░░░░   59%
 ```
 
 ## Open roadmaps
@@ -26,7 +26,7 @@
 | 8 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
 | 9 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 10 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 7 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 12 | 23 | 0 | 1 | 0 | ███████░░░ 66% |
+| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 11 | 24 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ███████░░░ 69% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 14 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
@@ -248,14 +248,33 @@ _1 blocker resolved._
 
 ### [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md)
 
-**Road to solution minimalism — a first-class discipline against over-building** — 23 / 35 done (66%)
+**Road to solution minimalism — a first-class discipline against over-building** — 24 / 35 done (69%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Verification spikes (read-only, no authoring) | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 1 | The ladder, as rule text | ✅ done | 0 | 12 | 0 | 1 | 100% |
 | 2 | Over-build review lens | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 3 | Pinned public-repo benchmark (the proof exhibit) | 🟡 in progress | 12 | 4 | 0 | 0 | 25% |
+| 3 | Pinned public-repo benchmark (the proof exhibit) | 🟡 in progress | 11 | 5 | 0 | 0 | 31% |
+
+<a id="blockers-road-to-solution-minimalism"></a>
+**Blockers**
+
+- **benchmark-spend-authorization** (owner: user) — blocks Phase 3 — Pinned public-repo benchmark (the proof exhibit)
+  - **What to do:**
+    1. Read the cost sheet in
+    [`solution-minimalism-phase0-spikes § S0.3`](../evidence/investigations/solution-minimalism-phase0-spikes.md):
+    30 tasks × 4 arms × 3 seeds on sonnet ≈ 360 runs ≈ 180M tokens ≈
+    **$150–250 as a floor**, higher on a real OSS repo.
+    2. Decide the grant, and state the ceiling you are granting. The sweep enforces
+    it: `--max-usd <ceiling>` aborts the sweep through the `collect_records`
+    guard (delta #4), and an unpriceable model plus `--max-usd` is refused rather
+    than silently uncapped.
+    3. Note what the grant does **not** buy on its own: deltas #10 (~30 hand-written
+    oracles) and #11 (the cognitive-complexity endpoint) are still absent, and
+    the metric-pair acceptance criterion cannot report a pass without #11. The
+    grant unblocks the run; it does not unblock the harness.
+  - **Resolved when:** the user states a spend ceiling for the Phase-3 sweep, or cancels Phase 3 against the cost sheet.
 
 ### [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md)
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**126 / 215 steps done · 59%**
+**127 / 215 steps done · 59%**
 
 ```text
 ████████████████████████░░░░░░░░░░░░░░░░   59%
@@ -26,7 +26,7 @@
 | 8 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
 | 9 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 10 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 7 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 11 | 24 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ███████░░░ 69% |
+| 11 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ███████░░░ 71% |
 | 12 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 13 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 14 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
@@ -248,14 +248,14 @@ _1 blocker resolved._
 
 ### [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md)
 
-**Road to solution minimalism — a first-class discipline against over-building** — 24 / 35 done (69%)
+**Road to solution minimalism — a first-class discipline against over-building** — 25 / 35 done (71%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Verification spikes (read-only, no authoring) | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 1 | The ladder, as rule text | ✅ done | 0 | 12 | 0 | 1 | 100% |
 | 2 | Over-build review lens | ✅ done | 0 | 4 | 0 | 0 | 100% |
-| 3 | Pinned public-repo benchmark (the proof exhibit) | 🟡 in progress | 11 | 5 | 0 | 0 | 31% |
+| 3 | Pinned public-repo benchmark (the proof exhibit) | 🟡 in progress | 10 | 6 | 0 | 0 | 38% |
 
 <a id="blockers-road-to-solution-minimalism"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-solution-minimalism.md
+++ b/agents/roadmaps/road-to-solution-minimalism.md
@@ -544,12 +544,34 @@ blocker as standing overstates its own gating.
       **publishing nothing below full** (F4); paired non-parametric tests;
       errored pairs dropped from both arms.
       *Verify:* the report states which tier it is from.
-- [ ] **Reproducibility deliverables, first-class not afterthoughts:** a no-API
+- [ ] **Reproducibility deliverables, first-class not afterthoughts:** a no-API <!-- blocked-by: benchmark-spend-authorization -->
       `--selftest` entry point, the pinned SHA, preserved per-run workspaces for
       offline re-scoring, and a one-page reproduce doc. The record shows the
       harshest critic becomes the most-cited validator once handed the
       reproduction path.
       *Verify:* `--selftest` runs green with no network and no key.
+      <!-- verify: npx vitest run tests/scripts/bench_ab_v2_run.test.ts -->
+      **Three of the four landed; the step stays open on the fourth, which is not
+      ours to close.** The named *Verify* is satisfied — `--mode selftest` exits 0
+      with `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_AUTH_TOKEN`
+      stripped from the environment, and it substitutes only the model call: the
+      fixture clone, the deterministic scorer, the per-trial activation stamp, the
+      cross-arm audit, the report writer and every exit code run for real
+      (delta #8). Preserved per-run workspaces landed with it (delta #7): keyed
+      `task|arm|seed`, path recorded on each trial, 20 trials → 20 distinct
+      workspaces where the old task-only key left one. The one-page reproduce doc
+      is [`internal/bench/REPRODUCE-ab-v2.md`](../../internal/bench/REPRODUCE-ab-v2.md).
+      **The pinned SHA cannot be delivered here, and marking it done would be the
+      false claim F7 exists to forbid.** There is nothing to pin: the corpus has no
+      `repo`/`sha` keys and every fixture is a self-contained in-repo tree, so a
+      pinned SHA requires delta #9 — which the S0.3 sequencing ships together with
+      #10 (~30 hand-written oracles, sized large), because a harness pointed at a
+      real repo with no oracles runs nothing. That pair is the **Repo** and
+      **Tasks** steps above, both spend-gated. Hence the `blocked-by` annotation
+      rather than a `[~]`: this is blocked on a gate, not deferred by choice, and
+      the difference matters to the archival gate.
+      The reproduce doc states this residue in its own closing section instead of
+      implying a full reproduction path exists.
 - [ ] **The size claim is a metric PAIR, not a single number (F9).** The ladder
       arm must lower added lines **without raising median cognitive complexity
       per changed function**. Lines down **and** complexity up is golfing, and it
@@ -560,7 +582,7 @@ blocker as standing overstates its own gating.
       anti-golfing gate therefore costs almost nothing to add.
       *Verify:* the scorer refuses to report a size win when the complexity arm
       regressed; prove it by feeding it a deliberately golfed fixture.
-- [ ] **Pre-registered thresholds (F3-calibrated, weak-host arm):** ladder arm
+- [x] **Pre-registered thresholds (F3-calibrated, weak-host arm):** ladder arm
       vs. package arm — median added lines ≤ **−10 %** at p<0.05, **and** no
       significant rise in median cognitive complexity per changed function,
       **and** no significant regression on the discipline rubric, the safety
@@ -568,6 +590,22 @@ blocker as standing overstates its own gating.
       default-on. Miss any one → it stays opt-in and the null is published with
       the same honesty labels the existing nulls carry.
       *Verify:* thresholds are committed before the full run.
+      Committed as [`internal/bench/ab-v2-phase3-PREREG.md`](../../internal/bench/ab-v2-phase3-PREREG.md),
+      in the shape the tree's four existing `*-PREREG.md` records use (binding
+      threshold table with a per-row "why this number", plus reopen terms).
+      **Registered while the run is impossible, which is the strongest form of the
+      guarantee**: thresholds fitted after seeing data are not thresholds, and both
+      halt gates still stand, so there is no data to fit to. T1 is calibrated to the
+      independent −15.4 % (p=0.088) rather than the source's −54 % headline, with
+      the reason recorded per row.
+      Two things the record states that this step's text did not, because writing
+      them down is what pre-registration is for: **T1 cannot be evaluated without
+      T2's endpoint** (the size claim is a pair, so half a pair is no result, not a
+      partial one), and **granting the spend does not make the run possible** —
+      preconditions 2–4 there are a harness-extension project, not money.
+      A machine-readable companion was deliberately not shipped: no consumer exists
+      to read it until the endpoints do, and a JSON nobody reads is the speculative
+      form this roadmap argues against. Enforcement lands with the endpoints.
 - [ ] **Goodhart guard (hard, applies to any competitive setup, agent or human):**
       a size metric is a **measurement**, never a **scored target**. The safety
       tier is a disqualifier, not a side metric: an arm that saves a line and

--- a/agents/roadmaps/road-to-solution-minimalism.md
+++ b/agents/roadmaps/road-to-solution-minimalism.md
@@ -540,6 +540,27 @@ blocker as standing overstates its own gating.
       existing mechanism before writing new code (rubric-judged, k=2)?
       *Verify:* the search-adherence endpoint is defined and pre-registered
       before the first paid run; a size-only report does not satisfy this step.
+      <!-- verify: npx vitest run tests/scripts/bench_ab_v2_stats.test.ts -->
+      **Partially delivered, and staying open on purpose — the named *Verify* is
+      satisfied but it is necessary, not sufficient.** Search-adherence and the
+      safety tier are now defined and pre-registered as T5 and T4 in
+      [`ab-v2-phase3-PREREG.md`](../../internal/bench/ab-v2-phase3-PREREG.md), which
+      is exactly what this step's Verify asks for. Four of the seven endpoints are
+      live: added lines and wall-clock were already there, tokens-as-**sum** landed
+      with delta #2, and **cost landed here** (delta #6) — `cost_by_arm` prices the
+      four buckets separately from `pricing.yaml`, because a blended rate over a
+      token total is a different number and the buckets differ in price by up to
+      125×. Two properties worth naming: an unpriceable model yields `null`, never
+      `0` (a zero reads as "this arm was free", which is a different claim from
+      "we cannot price it"), and Table 3b prints how many days old the prices are
+      **measured against the report's own stamp**, so re-rendering a fixed artefact
+      cannot change its numbers. The suite pins the 50×-apart mix case, the
+      errored-run exclusion, the unpriceable direction, and the age arithmetic.
+      **Not delivered:** the safety-tier and search-adherence *scorers* (both are
+      rubric-judged, so both need model calls and their own oracles), and the
+      complexity endpoint (delta #11). Flipping this step because its Verify passes
+      would repeat the mistake refused one step down for Reproducibility — a step's
+      Verify is a check on the step, not a substitute for it.
 - [ ] **Hygiene:** escalation ladder self-test → 10-task smoke → k=3 → full, <!-- blocked-by: benchmark-spend-authorization -->
       **publishing nothing below full** (F4); paired non-parametric tests;
       errored pairs dropped from both arms.

--- a/agents/roadmaps/road-to-solution-minimalism.md
+++ b/agents/roadmaps/road-to-solution-minimalism.md
@@ -441,8 +441,16 @@ file is the inflation the repo's own complexity budget forbids.
 
 ## Phase 3 — Pinned public-repo benchmark (the proof exhibit)
 
-Blocked on `benchmark-spend-authorization` (needs the S0.3 cost sheet) and on
-the standing model-id verification blocker.
+Blocked on [`benchmark-spend-authorization`](#blocker-benchmark-spend-authorization)
+— the structured entry under § Blockers, which the S0.3 cost sheet exists to be
+granted against.
+
+The second gate this note used to name — "the standing model-id verification
+blocker" — **no longer exists**: delta #3 closed it on 2026-08-05
+(`bench_ab_task_runner.run_live` records `models_seen` from the envelope's
+`modelUsage`, and `main` refuses a bare alias with exit 2 before any spend). The
+clause is struck rather than reworded, because a roadmap that cites a resolved
+blocker as standing overstates its own gating.
 
 > **Halted 2026-08-02 — the whole phase, with the cost sheet now in hand.** Two
 > independent gates, either of which alone stops it:
@@ -477,23 +485,52 @@ the standing model-id verification blocker.
 > written. Full evidence, delta table, and price inputs:
 > [`solution-minimalism-phase0-spikes § S0.3`](../evidence/investigations/solution-minimalism-phase0-spikes.md).
 
-- [ ] **Repo:** one public OSS repo pinned at a SHA. A second repo on this
+- [ ] **Repo:** one public OSS repo pinned at a SHA. <!-- blocked-by: benchmark-spend-authorization --> A second repo on this
       package's home stack is optional and cost-gated.
       *Verify:* the SHA is recorded in the pinned report.
-- [ ] **Tasks:** deliberately mixed — over-build-trap tickets **and** irreducible
+- [ ] **Tasks:** deliberately mixed <!-- blocked-by: benchmark-spend-authorization --> — over-build-trap tickets **and** irreducible
       CRUD **and** this package's own discipline family — so the report can show
       where the effect lives and where it is honestly zero.
       *Verify:* the per-task table shows both.
-- [ ] **Arms:** vanilla · package (ladder off) · package + ladder ·
+- [x] **Arms:** vanilla · package (ladder off) · package + ladder ·
       **bare-principle control** (the seven-word prompt, F6 — isolates what the
       routed floors add over the naked principle; its safety-tier result is the
       exhibit for why the floors exist) · inert-prose placebo.
       *Verify:* per-trial injection audit in both directions for every arm.
-      <!-- OPEN 2026-08-05, but the VERIFY half now exists: the both-directions
-      audit shipped with delta #1 (`_lib/bench_ab_activation.activation_verdict`
-      + `audit_activation`, wired into `bench_ab_v2_run` as an exit-2 gate). What
-      remains is the STEP body — `ARMS` still lacks a `package + ladder` arm and
-      the bare-principle control, and those are arm definitions, not audit work. -->
+      <!-- verify: npx vitest run tests/scripts/bench_ab_v2_run.test.ts -->
+      All five arms now exist in `ARMS`; 29 assertions green.
+      **"package (ladder off)" needed an interpretation, and it is a measurement,
+      not a reading.** Phase 1 shipped the ladder *into*
+      `improve-before-implement`, so there is no build of the package without it —
+      but that rule is `type: auto`, `tier: 2b`, `alwaysApply: false`, triggered on
+      the keywords `refactor|implement|migration`, and absent from
+      `dist/router.json`'s preloaded tier lists. So under `package` the ladder
+      reaches the model **only when a task's own wording happens to trip a
+      keyword** — per-task, unmeasured. That is finding F1's failure class, where a
+      null cannot be told apart from an activation gap. The pair therefore ships
+      as: `package` = the shipped reality (trigger-dependent), `package-ladder` =
+      the identical config with the ladder rule body injected via sysprompt so it
+      is guaranteed in context. The contrast measures the ladder, not the trigger
+      set. A projection-level ablation arm would measure the same thing more
+      directly and is a bigger change than an arm definition; it is not needed for
+      this contrast to be valid.
+      **The bare-principle text is authored here, not borrowed.** F6's exact
+      seven words are recorded nowhere in this tree, and reproducing an external
+      prompt verbatim is what `code-provenance` forbids — so the arm ships a
+      re-derived one-sentence principle. Nothing about its function depends on the
+      exact wording: its job is to be floor-free and small, and the tests assert
+      exactly that (no floor routed, no ladder rung, one line, < 200 chars).
+      **One audit-shape decision, surfaced rather than smuggled.** The cross-arm
+      direction of the audit requires a lift arm's prompt footprint to sit ≥ 1.2×
+      above its paired vanilla run, which catches a treatment surface that
+      collapsed to baseline. A one-sentence arm has no such lift by construction,
+      so including it would fail legitimate runs — the failure the ratio's own
+      calibration note warns about from the other side. `bare-principle` therefore
+      declares `min_lift_ratio: null`, which narrows its audit to the **text**
+      direction; that direction is checked both ways and pinned by tests, so the
+      arm is never unaudited. `lift_audit_arms` is exported for exactly this
+      reason: the exclusion set is asserted, not trusted, because silently
+      widening it would be a reach reduction in the gate.
 
 - [ ] **Endpoints:** added lines from `git diff`; tokens as the **sum** of
       input + cache + output (a metric mismatch here is the known reporting
@@ -503,7 +540,7 @@ the standing model-id verification blocker.
       existing mechanism before writing new code (rubric-judged, k=2)?
       *Verify:* the search-adherence endpoint is defined and pre-registered
       before the first paid run; a size-only report does not satisfy this step.
-- [ ] **Hygiene:** escalation ladder self-test → 10-task smoke → k=3 → full,
+- [ ] **Hygiene:** escalation ladder self-test → 10-task smoke → k=3 → full, <!-- blocked-by: benchmark-spend-authorization -->
       **publishing nothing below full** (F4); paired non-parametric tests;
       errored pairs dropped from both arms.
       *Verify:* the report states which tier it is from.
@@ -710,7 +747,7 @@ it. None is a step in this roadmap.
       the scorer discriminates. Contract-level, deterministic, no model call —
       the find-the-plant half is stated as needing a scored eval run rather than
       claimed.
-- [ ] Phase 3 either reports from the full tier with every pre-registered
+- [ ] Phase 3 either reports from the full tier with every pre-registered <!-- blocked-by: benchmark-spend-authorization -->
       endpoint — added lines **paired** with cognitive complexity, plus
       search-adherence and the safety tier — or publishes the null; no number
       appears anywhere except rendered from the pinned report.
@@ -724,3 +761,38 @@ it. None is a step in this roadmap.
       on the `flatten-longer` fixture); the *benchmark* scorer this criterion
       names cannot exist before delta #11.
 - [ ] All quality gates pass — see `quality-tools`.
+
+## Blockers
+
+This section was **missing while the roadmap was halted**, which is a defect in
+how the roadmap reports itself rather than a detail: the generated dashboard
+reads `### blocker:` as its only parse anchor, so it published **0 blockers** for
+a roadmap whose only open phase had been stopped for four days by a gate only the
+user can clear. A gate recorded as prose is invisible to every consumer of the
+dashboard — including the next agent screening for "what can be worked on now",
+which is exactly the reader that must not be misled.
+
+### blocker: benchmark-spend-authorization
+
+- **Status:** open
+- **Owner:** user
+- **Blocks:** Phase 3 — Pinned public-repo benchmark (the proof exhibit)
+- **What to do:**
+  1. Read the cost sheet in
+     [`solution-minimalism-phase0-spikes § S0.3`](../evidence/investigations/solution-minimalism-phase0-spikes.md):
+     30 tasks × 4 arms × 3 seeds on sonnet ≈ 360 runs ≈ 180M tokens ≈
+     **$150–250 as a floor**, higher on a real OSS repo.
+  2. Decide the grant, and state the ceiling you are granting. The sweep enforces
+     it: `--max-usd <ceiling>` aborts the sweep through the `collect_records`
+     guard (delta #4), and an unpriceable model plus `--max-usd` is refused rather
+     than silently uncapped.
+  3. Note what the grant does **not** buy on its own: deltas #10 (~30 hand-written
+     oracles) and #11 (the cognitive-complexity endpoint) are still absent, and
+     the metric-pair acceptance criterion cannot report a pass without #11. The
+     grant unblocks the run; it does not unblock the harness.
+- **Resolved when:** the user states a spend ceiling for the Phase-3 sweep, or
+  cancels Phase 3 against the cost sheet.
+
+Firing a paid external run without that grant is a Hard-Floor action
+([`non-destructive-by-default`](../../src/rules/non-destructive-by-default.md));
+no autonomy setting, execution contract, or roadmap step lifts it.

--- a/internal/bench/REPRODUCE-ab-v2.md
+++ b/internal/bench/REPRODUCE-ab-v2.md
@@ -1,0 +1,110 @@
+# Reproducing an `ab-v2` paired sweep
+
+One page, on purpose. It exists because the record shows the harshest critic of a
+benchmark becomes its most-cited validator once handed a reproduction path — so
+the path is a first-class deliverable of `road-to-solution-minimalism` Phase 3,
+not an afterthought written once someone asks.
+
+## Start here — the run that costs nothing
+
+```bash
+npx tsx src/scripts/bench_ab_v2_run.ts \
+  --mode selftest \
+  --arms vanilla,package,package-ladder,bare-principle,placebo \
+  --seeds 2 --limit 2 \
+  --model claude-sonnet-4-5-20250929 \
+  --no-checkpoint
+```
+
+Exits 0 with **no network and no API key**. It substitutes exactly one thing —
+the model call — and runs the fixture clone, the deterministic scorer, the
+per-trial activation stamp, the cross-arm audit, the report writer and every exit
+code for real. So a green selftest tells you the harness works; it tells you
+nothing about the hypothesis, and its report says so in three places (`tier:
+selftest`, `synthetic: true`, `-selftest` in the filename, plus a `synthetic: true`
+stamp on every trial record).
+
+`--mode dry-run` is not this. It prints a run count and returns before all of the
+above — useful for checking arithmetic, useless for checking the harness.
+
+## The three exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | sweep completed and the activation audit found nothing |
+| 1 | bad invocation or missing host CLI (unknown arm, arm invalid for `--host codex`, `claude` not found) |
+| 2 | **refused or invalid** — a bare model alias, an unpriceable model under `--max-usd`, a sweep-budget abort, or an activation-audit violation |
+
+Exit 2 always still writes the report: an invalid sweep already cost money and its
+raw runs stay inspectable. The exit code is what makes it non-ignorable, so never
+read a report without reading the code that produced it.
+
+## What the activation audit checks, and in which direction
+
+Two directions, because one trial cannot see both:
+
+- **Per trial (text channel).** An arm that declares an injection must carry one;
+  an arm that declares none must not. Stamped on every record as `activation`.
+- **Across arms (footprint).** A lift arm's prompt footprint must sit at least
+  `ACTIVATION_MIN_LIFT_RATIO` (1.2) above its paired `vanilla` run. This catches a
+  treatment surface that **collapsed to baseline** — a disabled or version-drifted
+  plugin, which is how this harness once produced a full set of invalid nulls that
+  looked identical to real ones.
+
+`bare-principle` opts out of the footprint direction only (`min_lift_ratio: null`
+on its `ArmSpec`): its treatment is one sentence, so it has no lift to show and a
+ratio check there would fail healthy runs. Its text direction still runs both
+ways. `lift_audit_arms` is exported so the exclusion set is asserted by tests
+rather than trusted.
+
+## Offline re-scoring
+
+Every trial preserves its own workspace, keyed `task__arm__seedN` under
+`$TMPDIR/agent-config-bench-v2-clones/`, and records that path as `workspace` on
+the trial. This is what makes a new endpoint retro-fittable onto an
+already-completed sweep instead of requiring a re-run: the diff a trial produced
+is still on disk.
+
+Two consequences worth knowing before you rely on it:
+
+- Workspaces live in the OS temp directory, so they survive the sweep but not
+  necessarily a reboot. Copy them out before re-scoring a run you care about.
+- A resumed or repeated trial re-clones from the pristine fixture, so the
+  workspace always reflects the LAST execution of that (task, arm, seed).
+
+## Resume
+
+Checkpointing is on by default. The key is derived from corpus, model, seeds,
+arms, budget, timeout, host and the task-id list, so a sweep resumes only into an
+identical configuration — change any of those and you get a fresh run rather than
+a silently mixed one. `--fresh` discards a checkpoint; `--no-checkpoint` disables
+it. A completed sweep deletes its own checkpoint so no residue steers a later run.
+
+## Cost control
+
+`--budget` is **per run** (default 1.0). `--max-usd` is the **sweep** cap: prices
+come from `internal/bench/pricing.yaml`, the four token buckets are priced
+separately (they differ by up to 125×, so a blended rate is a different number,
+not an approximation), and the first run that crosses the cap aborts the sweep
+with exit 2. A model with no pricing row plus `--max-usd` is **refused**, never
+silently uncapped.
+
+## What a paid run additionally needs — and does not have yet
+
+A full-tier Phase-3 run is **not** reproducible from this document alone, and
+saying so is part of the path:
+
+- **The spend grant** is the user's (`benchmark-spend-authorization` in the
+  roadmap). Firing a paid external run without it is a Hard-Floor action.
+- **A pinned external repo** (S0.3 delta #9) does not exist: the corpus carries no
+  `repo`/`sha` keys and the fixtures are self-contained in-repo trees. So there is
+  currently **no SHA to pin**, and any report claiming one would be wrong.
+- **Task oracles against that repo** (delta #10, sized large) do not exist. A
+  harness pointed at a real repo with no oracles runs nothing, which is why #9 and
+  #10 ship together.
+- **A cognitive-complexity endpoint** (delta #11, sized large) does not exist
+  anywhere in the tree, and Phase 3's acceptance is a metric *pair* — so the phase
+  cannot report a pass without it, at any price.
+
+Until those land, the honest reproducible surface is the selftest plus offline
+re-scoring of whatever sweeps exist.

--- a/internal/bench/ab-v2-phase3-PREREG.md
+++ b/internal/bench/ab-v2-phase3-PREREG.md
@@ -1,0 +1,105 @@
+# `ab-v2` Phase 3 — pre-registration (fixed before any paid run)
+
+Registered 2026-08-06 · owner: maintainer · `road-to-solution-minimalism` Phase 3.
+
+**Status on registration day: the run this record binds cannot yet be fired.** Two
+gates stand — the spend grant (`benchmark-spend-authorization`, owner: user) and
+three absent endpoints named in § Endpoints that do not exist. This record exists
+anyway, and that is the point: thresholds written after seeing data are not
+thresholds. Registering them while the run is impossible is the strongest possible
+guarantee they were not fitted to a result.
+
+## What is measured
+
+Whether the solution-size ladder — shipped as rule text in
+`improve-before-implement` with this package's safety floors **routed**, not
+restated — reduces the size of a change without paying for it somewhere else.
+
+**Not measured:** whether minimalism is good. The comparison is deliberately
+narrow: the ladder against the same package without it, and both against a naked
+principle, so what survives is a claim about *this artefact*, host-scoped, with
+the floors' contribution measured rather than asserted.
+
+## Arms
+
+| arm | what reaches the model |
+|---|---|
+| `vanilla` (baseline) | plugin scoped away, no injection |
+| `package` | the real plugin as shipped — the ladder rule is `type: auto` and keyword-triggered, so it reaches the model only when a task's wording trips `refactor\|implement\|migration` |
+| `package-ladder` (treatment) | the same plugin config, with the ladder rule body injected so it is guaranteed in context |
+| `bare-principle` (control, F6) | plugin scoped away, one authored sentence, **no floors routed** |
+| `placebo` | plugin scoped away, inert prose length-matched to the package footprint |
+
+The `package` → `package-ladder` contrast is the primary comparison. The
+`bare-principle` arm is what makes the floors falsifiable: F6 measured a bare
+critic prompt nearly matching a full minimalism artefact on size while being the
+only arm that dropped a safety guard.
+
+## Binding thresholds — declared before any data
+
+The ladder graduates to **default-on** only if **every** row holds. Miss any one
+and it stays opt-in and the null is published with the same honesty labels the
+existing nulls carry.
+
+| # | metric (`package-ladder` vs `package`) | threshold | why this number |
+|---|---|---|---|
+| T1 | median added lines | **≤ −10 %** at **p < 0.05** | Calibrated to the **independent** measurement (−15.4 % code, p=0.088 on 80 tasks nobody chose for the purpose), not to the source's own −54 % headline (mean, hand-picked tickets, n=4). −10 % sits inside the independent effect with room for a weaker paired design; requiring −15 % would pre-register a number the independent run itself did not reach at p<0.05. |
+| T2 | median cognitive complexity per changed function | **no significant rise** | F9: LLM-generated code is on average shorter but denser, so a lines-only metric actively rewards golfing. Lines down **and** complexity up fails T1 even at p<0.05 on lines alone — the size claim is a *pair*, and this is the half that makes it one. |
+| T3 | discipline rubric | **no significant regression** | The ladder is additive discipline; buying size with a loss of the discipline it sits next to is not a win. |
+| T4 | safety tier (adversarial-input execution on surgical tasks) | **no significant regression** | F6's guard-drop was a path-traversal check deleted to save ~3 lines. This is a **disqualifier**, not a side metric (see § Goodhart). |
+| T5 | search-adherence (rubric-judged, k=2) | **no significant regression** | F8: the ladder enforces a *search* discipline; lines-of-code measures output volume. A run can shrink a diff without anyone having looked for an existing mechanism, so a size-only report would measure the wrong hypothesis. |
+
+Statistics: paired non-parametric tests. Errored pairs are dropped from **both**
+arms and the drop asymmetry is reported (it already is — the attrition block,
+delta #5). Significance is two-sided; "no significant regression" means the test
+does not reject at p < 0.05 in the harmful direction.
+
+## Goodhart guard — binding, not advisory
+
+A size metric is a **measurement**, never a scored target. Concretely: the scorer
+may not rank an arm above another on size alone when its safety tier regressed. An
+arm that saves a line and drops a guard has lost, not won.
+
+## Hygiene ladder — publish nothing below full
+
+`selftest` → 10-task smoke → k=3 → full. **Nothing below the full tier is
+published**, because F4 measured the same benchmark's 10-task smoke showing +9.6 %
+cost and collapsing quality while the full 80 showed the opposite. Every report
+states which tier produced it (`tier` in the payload); the selftest additionally
+carries `synthetic: true` and cannot be quoted at all.
+
+Every number that ever appears in prose renders from a pinned report. Hand-typed
+figures are forbidden (F7).
+
+## Preconditions — what must exist before this record can be acted on
+
+Registered as reopen terms, so the next attempt starts from a declared bar:
+
+1. **The spend grant.** `benchmark-spend-authorization`, owner: user. ~$150–250 as
+   a floor for 30 tasks × 4 arms × 3 seeds on sonnet. Firing a paid external run
+   without it is a Hard-Floor action.
+2. **T2's endpoint does not exist.** No cognitive- or cyclomatic-complexity
+   implementation exists anywhere in the tree (S0.3 delta #11, sized large). Until
+   it does, **T1 cannot be evaluated either** — the size claim is a pair, so half a
+   pair is not a partial result, it is no result.
+3. **T4's and T5's endpoints do not exist.** The safety tier and the
+   search-adherence rubric are specified here and unimplemented.
+4. **A pinned external repo and its task oracles do not exist** (deltas #9 + #10).
+   The corpus carries no `repo`/`sha` keys and every fixture is a self-contained
+   in-repo tree.
+
+Consequence, stated plainly: granting the spend does **not** make this run
+possible. The grant unblocks the money; preconditions 2–4 are a harness-extension
+project.
+
+## What is already in place
+
+- The paired sweep, the deterministic scorer, and checkpoint/resume.
+- The activation audit in both directions, wired as an exit-2 gate (delta #1) —
+  the harness can no longer produce the specific invalid null it produced once.
+- `tokens_breakdown` on every trial (delta #2), model-id verification (delta #3),
+  a sweep-level `--max-usd` abort (delta #4), attrition reporting (delta #5).
+- Per-trial preserved workspaces (delta #7) — which is what makes T2 retro-fittable
+  onto completed runs once its endpoint exists, instead of requiring a re-run.
+- A no-network `--mode selftest` (delta #8) and
+  [`REPRODUCE-ab-v2.md`](REPRODUCE-ab-v2.md).

--- a/internal/bench/ab-v2-phase3-PREREG.md
+++ b/internal/bench/ab-v2-phase3-PREREG.md
@@ -99,6 +99,9 @@ project.
   the harness can no longer produce the specific invalid null it produced once.
 - `tokens_breakdown` on every trial (delta #2), model-id verification (delta #3),
   a sweep-level `--max-usd` abort (delta #4), attrition reporting (delta #5).
+- A bucket-priced cost sheet in the report (delta #6) — Table 3b, with the price
+  sourcing date and its age against the report's own stamp. An unpriceable model
+  reports `null`, never `0`.
 - Per-trial preserved workspaces (delta #7) — which is what makes T2 retro-fittable
   onto completed runs once its endpoint exists, instead of requiring a re-run.
 - A no-network `--mode selftest` (delta #8) and

--- a/src/scripts/bench_ab_v2_run.ts
+++ b/src/scripts/bench_ab_v2_run.ts
@@ -329,10 +329,38 @@ export function injected_text(inject: string | null, placebo_chars: number): str
     return null;
 }
 
-/** Copy the task's pristine fixture into a throwaway working clone. */
-export function reset_fixture(task: Dict): [string, string] {
+/**
+ * Workspace directory for one trial — delta #7 of the S0.3 spike.
+ *
+ * Keyed by `task|arm|seed`, not by task alone. The old task-only key meant every
+ * arm and every seed of a task reused ONE directory that the next trial deleted,
+ * so at the end of a sweep exactly one workspace survived per task — the last one
+ * written, with no record of which arm or seed it belonged to.
+ *
+ * That is not a tidiness problem. Phase 3's anti-golfing gate is specified as
+ * retro-fittable onto already-completed runs by offline re-scoring, and the
+ * roadmap calls that gate cheap *because* the workspaces are preserved. Under the
+ * old key there was nothing to re-score, so the claim was false. A distinct
+ * directory per trial is what makes it true.
+ *
+ * `arm` is sanitised because arm names are used verbatim as a path segment and
+ * one of them would otherwise be free to escape the root.
+ */
+export function workspace_dir(task_id: string, arm: string, seed: number): string {
+    const safe_arm = arm.replace(/[^A-Za-z0-9._-]/g, '_');
+    return path.join(WORK_ROOT, `${task_id}__${safe_arm}__seed${seed}`);
+}
+
+/**
+ * Copy the task's pristine fixture into this trial's own working clone.
+ *
+ * The clone is re-created from the fixture on every call, so a resumed or
+ * repeated trial still starts pristine — the per-trial key changes *which*
+ * directory that is, never whether it is clean.
+ */
+export function reset_fixture(task: Dict, arm: string, seed: number): [string, string] {
     const fixture = path.join(FIXTURES_ROOT, String(task['fixture']));
-    const dest = path.join(WORK_ROOT, String(task['id']));
+    const dest = workspace_dir(String(task['id']), arm, seed);
     if (fs.existsSync(dest)) {
         fs.rmSync(dest, { recursive: true, force: true });
     }
@@ -384,6 +412,13 @@ interface RunOneOpts {
     sp_dir: string;
     max_depth?: number | null; // recursion arm only — hard cap on correction rounds (default 1)
     host?: string; // 'claude' (default) | 'codex' — P2 non-Claude replication (ADR-110 roadmap Phase 4)
+    /**
+     * Trial seed — delta #7. Part of the workspace key, so each (task, arm, seed)
+     * gets its own preserved clone. Defaults to 0 so an existing caller that does
+     * not thread it still gets a stable, arm-scoped directory rather than the old
+     * task-only collision.
+     */
+    seed?: number;
 }
 
 // ── codex host adapter (P2 non-Claude weak-host replication) ────────────────
@@ -616,7 +651,7 @@ export function run_one(task: Dict, arm: string, opts: RunOneOpts): Dict {
         return run_one_recursive(task, opts);
     }
     const host = opts.host ?? 'claude';
-    const [clone, fixture] = reset_fixture(task);
+    const [clone, fixture] = reset_fixture(task, arm, opts.seed ?? 0);
     const sp_text = injected_text(spec.inject, opts.placebo_chars);
     let run: Dict;
     if (host === 'codex') {
@@ -650,6 +685,10 @@ export function run_one(task: Dict, arm: string, opts: RunOneOpts): Dict {
         discipline_pass: score.discipline_pass,
         metrics: trajectory_metrics(run, score),
         injected_chars: sp_text ? sp_text.length : 0,
+        // Delta #7 — where this trial's evidence lives. Recorded on the trial
+        // rather than recomputed later, so an offline re-scorer reads the path the
+        // sweep actually used instead of re-deriving a key that may have changed.
+        workspace: clone,
         ...integrity_fields(run, spec, sp_text ? sp_text.length : 0, opts.model),
     };
 }
@@ -678,6 +717,96 @@ export interface RecursiveAttempt {
  * threading). Whether recursion actually lifts capability/discipline is the
  * empirical question the live `bench:ab` run answers — not asserted here.
  */
+// ── delta #8 — the no-network selftest ──────────────────────────────────────
+//
+// `--mode dry-run` printed a run count and returned before the CLI check, the
+// fixtures, the scorer, the activation audit and the report writer — so it could
+// not tell a working harness from a broken one. The roadmap's Reproducibility
+// step asks for a `--selftest` that "runs green with no network and no key", and
+// a mode that exercises nothing cannot answer that.
+//
+// `--mode selftest` substitutes EXACTLY ONE thing: the model call. Fixture
+// cloning, the deterministic scorer, the per-trial activation stamp, the
+// cross-arm audit, the report writer and every exit code run for real. What it
+// therefore proves is the harness, not the hypothesis — and that is the whole
+// distinction between a self-test and a measurement.
+
+/**
+ * Deterministic synthetic usage for one selftest trial.
+ *
+ * Derived from the arm's real treatment size rather than invented, so the
+ * footprint relationships the activation audit reads are the ones the arm
+ * actually implies: a plugin-bearing arm shows the package's footprint, a text arm
+ * shows its injection, and `vanilla` shows neither.
+ *
+ * The plugin figure is a stand-in for a surface this process cannot observe
+ * without the real CLI. It is deliberately far above `ACTIVATION_MIN_LIFT_RATIO`
+ * so a selftest failure means the wiring is broken, never that a synthetic
+ * constant drifted under a threshold.
+ */
+export function selftest_usage(arm: string, seed: number, placebo_chars: number): TokensBreakdown {
+    const spec = ARMS[arm] as ArmSpec | undefined;
+    const injected = spec ? (injected_text(spec.inject, placebo_chars)?.length ?? 0) : 0;
+    const plugin = spec && spec.setting_sources === null ? 4000 : 0;
+    return {
+        input_tokens: 1000 + plugin + Math.floor(injected / 4),
+        output_tokens: 200 + seed,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+    };
+}
+
+/**
+ * One selftest trial — the real pipeline around a synthetic model call.
+ *
+ * `usage_fn` is injectable so a test can force the failure directions (a
+ * collapsed footprint, a model mismatch) and assert that the audit still fires.
+ * Without that seam the selftest could only ever be observed passing, which is
+ * the "gate that scans nothing" shape this repo's own discipline warns about.
+ */
+export function selftest_run(
+    task: Dict,
+    arm: string,
+    opts: RunOneOpts,
+    usage_fn: (arm: string, seed: number, placebo_chars: number) => TokensBreakdown = selftest_usage,
+): Dict {
+    const spec = ARMS[arm] as ArmSpec;
+    const seed = opts.seed ?? 0;
+    // Real fixture clone — this is also what exercises delta #7's per-trial key.
+    const [clone, fixture] = reset_fixture(task, arm, seed);
+    const sp_text = injected_text(spec.inject, opts.placebo_chars);
+    const run: Dict = {
+        errored: false,
+        reason: null,
+        transcript: `selftest transcript · ${String(task['id'])} · ${arm} · seed ${seed}`,
+        num_turns: 1,
+        wall_time_seconds: 0,
+        tokens: 0,
+        tokens_breakdown: usage_fn(arm, seed, opts.placebo_chars),
+        // The synthetic envelope bills exactly the pinned model, so `model_check`
+        // passes for a healthy run and fails if the pin is ever dropped.
+        models_seen: opts.model ? [opts.model] : [],
+    };
+    // Real scorer — no model call, reads the fixture and the clone off disk.
+    const score = scoring.score_task_v2(task, {
+        fixture_root: fixture,
+        clone_root: clone,
+        transcript: String(run['transcript'] ?? ''),
+    });
+    return {
+        errored: false,
+        reason: null,
+        synthetic: true,
+        capability_pass: score.capability_pass,
+        discipline_score: new PyFloat(score.discipline_score),
+        discipline_pass: score.discipline_pass,
+        metrics: trajectory_metrics(run, score),
+        injected_chars: sp_text ? sp_text.length : 0,
+        workspace: clone,
+        ...integrity_fields(run, spec, sp_text ? sp_text.length : 0, opts.model),
+    };
+}
+
 export function run_one_recursive(
     task: Dict,
     opts: RunOneOpts,
@@ -688,7 +817,9 @@ export function run_one_recursive(
     const makeAttempt =
         attemptFn ??
         ((depth: number, priorVerdict: string | null): RecursiveAttempt => {
-            const [clone, fixture] = reset_fixture(task);
+            // Each correction round gets its own preserved workspace too — a
+            // depth-2 attempt must not overwrite the depth-1 evidence.
+            const [clone, fixture] = reset_fixture(task, `package-recursive-d${depth}`, opts.seed ?? 0);
             let sp_file: string | null = null;
             if (priorVerdict) {
                 sp_file = path.join(opts.sp_dir, `.sp-recursive-${depth}.txt`);
@@ -1052,7 +1183,11 @@ export function main(argv: string[] | null = null): number {
         return 0;
     }
 
-    if (v1.claude_executable() === null) {
+    const selftest = args.mode === 'selftest';
+
+    // The selftest exists to run with no network and no key, so requiring the
+    // host CLI here would defeat it. Every other gate below still applies.
+    if (!selftest && v1.claude_executable() === null) {
         process.stderr.write('claude CLI not found\n');
         return 1;
     }
@@ -1099,15 +1234,18 @@ export function main(argv: string[] | null = null): number {
         tasks,
         arms,
         args.seeds,
-        (task, _arm, _seed) =>
-            run_one(task, _arm, {
+        (task, _arm, _seed) => {
+            const runOpts: RunOneOpts = {
                 model: args.model,
                 max_budget,
                 timeout: args.timeout,
                 placebo_chars,
                 sp_dir,
                 host: args.host,
-            }),
+                seed: _seed,
+            };
+            return selftest ? selftest_run(task, _arm, runOpts) : run_one(task, _arm, runOpts);
+        },
         ckpt,
         undefined,
         (r) => budget.add(r['tokens_breakdown'] as TokensBreakdown | undefined),
@@ -1132,6 +1270,12 @@ export function main(argv: string[] | null = null): number {
         placebo_chars,
         corpus: 'ab-trackb-v2',
         host: args.host,
+        // Hygiene (F4/F7): a selftest report must be unmistakable for a measured
+        // one. Both the tier marker and the filename say so, because a number is
+        // only ever allowed to render from a report and this report's numbers are
+        // synthetic by construction.
+        tier: selftest ? 'selftest' : 'live',
+        synthetic: selftest,
         activation_audit: {
             checked: audit.checked,
             skipped: audit.skipped,
@@ -1140,7 +1284,7 @@ export function main(argv: string[] | null = null): number {
         aborted: aborted ?? null,
         records,
     };
-    const out = path.join(REPORTS_DIR, `${stamp}-ab-v2-paired.json`);
+    const out = path.join(REPORTS_DIR, `${stamp}-ab-v2-paired${selftest ? '-selftest' : ''}.json`);
     fs.writeFileSync(out, _jsonDumps(_toJson(payload), 2) + '\n');
     // The paired report now holds everything — retire the checkpoint so a
     // finished sweep leaves no residue and a later identical sweep starts fresh.
@@ -1149,7 +1293,9 @@ export function main(argv: string[] | null = null): number {
     }
     process.stdout.write(
         `bench_ab_v2: wrote ${_relToRootPosix(out)} ` +
-            `(${records.length} tasks, ${total} runs, spend $${budget.spent_usd.toFixed(2)})\n`,
+            `(${records.length} tasks, ${total} runs, ` +
+            (selftest ? 'SELFTEST — synthetic runs, no spend, not publishable' : `spend $${budget.spent_usd.toFixed(2)}`) +
+            `)\n`,
     );
 
     // The report is always written — an aborted or integrity-failed sweep still
@@ -1212,7 +1358,7 @@ function parse_args(argv: string[]): ParsedArgs {
         checkpoint: true,
         fresh: false,
     };
-    const usage = `usage: ${prog} [-h] [--arms ARMS] [--seeds SEEDS] [--tasks TASKS] [--limit LIMIT] [--model MODEL] [--budget BUDGET] [--max-usd MAX_USD] [--timeout TIMEOUT] [--mode {live,dry-run}] [--host {claude,codex}] [--no-checkpoint] [--fresh]\n`;
+    const usage = `usage: ${prog} [-h] [--arms ARMS] [--seeds SEEDS] [--tasks TASKS] [--limit LIMIT] [--model MODEL] [--budget BUDGET] [--max-usd MAX_USD] [--timeout TIMEOUT] [--mode {live,dry-run,selftest}] [--host {claude,codex}] [--no-checkpoint] [--fresh]\n`;
     const argErr = (msg: string): never => {
         process.stderr.write(usage);
         process.stderr.write(`${prog}: error: ${msg}\n`);
@@ -1271,7 +1417,7 @@ function parse_args(argv: string[]): ParsedArgs {
         } else if (a.startsWith('--timeout=')) {
             out.timeout = _pyInt(a.slice('--timeout='.length), '--timeout');
         } else if (a === '--mode') {
-            out.mode = _choice(need(i, '--mode'), '--mode', ['live', 'dry-run'], argErr);
+            out.mode = _choice(need(i, '--mode'), '--mode', ['live', 'dry-run', 'selftest'], argErr);
             i += 1;
         } else if (a === '--host') {
             out.host = _choice(need(i, '--host'), '--host', ['claude', 'codex'], argErr);
@@ -1279,7 +1425,7 @@ function parse_args(argv: string[]): ParsedArgs {
         } else if (a.startsWith('--host=')) {
             out.host = _choice(a.slice('--host='.length), '--host', ['claude', 'codex'], argErr);
         } else if (a.startsWith('--mode=')) {
-            out.mode = _choice(a.slice('--mode='.length), '--mode', ['live', 'dry-run'], argErr);
+            out.mode = _choice(a.slice('--mode='.length), '--mode', ['live', 'dry-run', 'selftest'], argErr);
         } else if (a === '--no-checkpoint') {
             out.checkpoint = false;
         } else if (a === '--fresh') {

--- a/src/scripts/bench_ab_v2_run.ts
+++ b/src/scripts/bench_ab_v2_run.ts
@@ -95,6 +95,25 @@ interface ArmSpec {
     setting_sources: string | null;
     inject: string | null; // None | "rdp" | "placebo"
     recursive?: boolean; // ADR-106 D₂ arm: depth-bounded attempt→critic→re-attempt loop
+    /**
+     * Per-arm override for the footprint-lift audit, or `null` to declare that
+     * lift is **not a valid signal** for this arm.
+     *
+     * `audit_activation`'s cross-arm direction catches a treatment surface that
+     * COLLAPSED to baseline, by requiring the arm's prompt footprint to sit at
+     * least `ACTIVATION_MIN_LIFT_RATIO` above the paired vanilla run. That test
+     * presupposes a treatment surface large enough to move the footprint. An arm
+     * whose treatment is deliberately *minimal* — `bare-principle` is one
+     * sentence — has no lift to detect, so including it would fail legitimate
+     * runs: the exact failure the ratio's own calibration note warns about.
+     *
+     * `null` narrows the audit for that arm to the per-trial TEXT direction,
+     * which is checked both ways (`activation_verdict`: a text arm must carry an
+     * injection, a non-text arm must not). It never leaves the arm unaudited —
+     * and `bench_ab_v2_run.test.ts` pins both halves, so neither an
+     * always-firing nor a never-firing audit passes.
+     */
+    min_lift_ratio?: number | null;
 }
 
 // Arm -> (setting_sources, inject) where inject ∈ {None, "rdp", "placebo"}.
@@ -118,6 +137,28 @@ interface ArmSpec {
 // shipped `balanced` router profile (which does NOT include downstream-changes
 // — tier_2 — so this arm also tests whether that profile cut loses the lift).
 // Both are opt-in: NOT in the default arm list; existing runs unchanged.
+//
+// `package-ladder` / `bare-principle` (road-to-solution-minimalism Phase 3 — the
+// two arms its Arms step names and `ARMS` lacked). Also opt-in, so existing runs
+// and golden-parity outputs are unchanged.
+//
+// `package-ladder` is NOT redundant with `package`, and the reason is measurable
+// rather than stylistic: the ladder ships inside `improve-before-implement`,
+// which is `type: auto`, `tier: 2b`, `alwaysApply: false`, keyword-triggered on
+// `refactor|implement|migration`, and is absent from `dist/router.json`'s
+// preloaded tier lists. So under `package` the ladder reaches the model only when
+// a task's own wording happens to trip one of those keywords — unmeasured, and
+// per-task. That is finding F1's failure class exactly (an activation gap that a
+// null cannot be distinguished from), which is why the pair is: `package` = the
+// shipped reality, `package-ladder` = the same config with the ladder rule body
+// injected via sysprompt so it is guaranteed in context. The contrast measures
+// the ladder, not the trigger set.
+//
+// `bare-principle` is finding F6's control: the naked principle with NO floors
+// routed, plugin scoped away. Its text is authored HERE and is deliberately not
+// the external source's own prompt — per `code-provenance`, a borrowed prompt is
+// re-derived rather than copied, and the arm's job is to be a floor-free
+// principle statement, not a specific artefact.
 export const ARMS: Record<string, ArmSpec> = {
     vanilla: { setting_sources: 'project,local', inject: null },
     package: { setting_sources: null, inject: null },
@@ -128,6 +169,8 @@ export const ARMS: Record<string, ArmSpec> = {
     'hardened-placebo': { setting_sources: null, inject: 'hardened-placebo' },
     'rules-kernel-dc': { setting_sources: 'project,local', inject: 'rules-kernel-dc' },
     'rules-balanced': { setting_sources: 'project,local', inject: 'rules-balanced' },
+    'package-ladder': { setting_sources: null, inject: 'ladder' },
+    'bare-principle': { setting_sources: 'project,local', inject: 'bare-principle', min_lift_ratio: null },
 };
 
 /**
@@ -202,7 +245,71 @@ export function rules_subset_text(subset: 'rules-kernel-dc' | 'rules-balanced'):
     return bodies.join('\n\n---\n\n');
 }
 
+/**
+ * The `bare-principle` arm's whole treatment — finding F6's control.
+ *
+ * One sentence, no floors, no routing, no ladder rungs. It exists so the
+ * benchmark can separate "the principle" from "the principle with this package's
+ * safety floors routed behind it": F6 measured a bare critic prompt nearly
+ * matching a full minimalism artefact on size *while being the only arm that
+ * dropped a safety guard*, so a report without this arm asserts the floors'
+ * contribution instead of measuring it.
+ *
+ * Authored here on purpose. The external source's own prompt is not reproduced —
+ * `code-provenance` requires a conscious borrow to be re-derived rather than
+ * copied, and nothing about the arm's function depends on its exact wording.
+ * Deterministic (no interpolation) so the injected bytes are stable per checkout.
+ */
+export function bare_principle_text(): string {
+    return 'Prefer the smallest solution that fully solves the stated problem; do not add what was not asked for.';
+}
+
+/**
+ * The ladder rule body, read from the projection — the `package-ladder` arm.
+ *
+ * Reads `dist/agent-src/rules/improve-before-implement.md`, the same source
+ * `rules_subset_text` uses, so the injected text is exactly the rule the package
+ * would load if its keyword triggers fired. Reading the projection rather than
+ * restating the ladder keeps the arm honest: a hand-copied summary would measure
+ * the summary.
+ */
+export function ladder_rule_text(): string {
+    return fs.readFileSync(path.join(RULES_DIR, 'improve-before-implement.md'), 'utf-8').trim();
+}
+
+/**
+ * Which arms the cross-arm FOOTPRINT-lift direction of the activation audit
+ * applies to.
+ *
+ * Three exclusions, each for a different reason:
+ * - `vanilla` is the baseline the ratio is measured against.
+ * - an arm with no treatment surface (`expected_injection === 'none'`) has no
+ *   lift to require.
+ * - an arm declaring `min_lift_ratio: null` has a treatment too small for lift to
+ *   be a signal at all (see `ArmSpec.min_lift_ratio`); requiring one there fails
+ *   legitimate runs. Its per-trial TEXT direction is unaffected and still runs
+ *   both ways.
+ *
+ * Pure and exported so the exclusion set is asserted rather than trusted — a
+ * silent widening of it would be a reach reduction in the audit.
+ */
+export function lift_audit_arms(arms: readonly string[]): string[] {
+    return arms.filter((a) => {
+        const spec = ARMS[a] as ArmSpec | undefined;
+        if (!spec || a === 'vanilla') {
+            return false;
+        }
+        return expected_injection(spec) !== 'none' && spec.min_lift_ratio !== null;
+    });
+}
+
 export function injected_text(inject: string | null, placebo_chars: number): string | null {
+    if (inject === 'bare-principle') {
+        return bare_principle_text();
+    }
+    if (inject === 'ladder') {
+        return ladder_rule_text();
+    }
     if (inject === 'rdp') {
         return v1.system_prompt_for('with-rdp');
     }
@@ -302,6 +409,10 @@ export const CODEX_VALID_ARMS: readonly string[] = [
     'placebo',
     'rules-kernel-dc',
     'rules-balanced',
+    // Pure-injection, so it carries to a non-Claude host unchanged. Its
+    // plugin-bearing sibling `package-ladder` deliberately is NOT here — it
+    // depends on the real plugin, which this host cannot load.
+    'bare-principle',
 ];
 
 export function codex_executable(): string | null {
@@ -1006,8 +1117,7 @@ export function main(argv: string[] | null = null): number {
     // the paired plugin direction needs the whole record set, so it cannot be a
     // per-trial check alone. `vanilla` is the baseline; every arm that is
     // supposed to carry a surface the baseline lacks is a lift arm.
-    const lift_arms = arms.filter((a) => a !== 'vanilla' && expected_injection(ARMS[a] as ArmSpec) !== 'none');
-    const audit = audit_activation(records, { baseline_arm: 'vanilla', lift_arms });
+    const audit = audit_activation(records, { baseline_arm: 'vanilla', lift_arms: lift_audit_arms(arms) });
 
     const stamp = v1.utc_stamp();
     const payload: Dict = {

--- a/src/scripts/bench_ab_v2_stats.ts
+++ b/src/scripts/bench_ab_v2_stats.ts
@@ -4,9 +4,16 @@
  *
  * Ported from the retired Python `src/scripts/bench_ab_v2_stats.py` (ADR-200 Python→TS
  * migration). Mirrors the CLI contract EXACTLY: positional `report` arg, the
- * `--json` / `--markdown PATH` flags, exit codes (0 ok / 1 no report found),
- * byte-identical stdout/stderr, byte-identical analysis JSON, and byte-identical
- * rendered markdown. No behaviour changes.
+ * `--json` / `--markdown PATH` flags, exit codes (0 ok / 1 no report found), and
+ * byte-identical stdout/stderr.
+ *
+ * The port itself introduced no behaviour change. Since then ONE additive change
+ * has landed, named here so the paragraph above stops reading as a standing
+ * promise it no longer keeps: S0.3 **delta #6** adds a `cost` block to the
+ * analysis JSON and a `Table 3b` to the rendered markdown (see `cost_by_arm`).
+ * Both are additions — every pre-existing key and table is untouched, and
+ * consumers that read named keys (`render_benchmark_composite`,
+ * `render_benchmark_md`, `bench_ab_diff`) are unaffected.
  *
  * Reads a v2 paired report (bench_ab_v2_run.py output) and computes, for each
  * arm comparison, paired significance + effect size on:
@@ -29,11 +36,15 @@ import * as path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { cost_usd, tier_for_model, type TierRates } from './_lib/bench_ab_activation.js';
+import { load_pricing } from './_lib/bench_cost.js';
+
 const _HERE = fileURLToPath(import.meta.url);
 
 // bench_ab_v2_stats.ts → parents[2] is repo root (script lives in src/scripts/).
 const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
 const REPORTS_DIR = path.join(REPO_ROOT, 'internal', 'bench', 'reports', 'ab-v2');
+const PRICING_PATH = path.join(REPO_ROOT, 'internal', 'bench', 'pricing.yaml');
 
 type Dict = Record<string, unknown>;
 
@@ -442,6 +453,89 @@ export function mean_tokens_by_arm(records: Dict[], arms: string[]): Dict {
     return out;
 }
 
+// ── delta #6 — the cost sheet ───────────────────────────────────────────────
+//
+// Table 3 reports mean TOKENS, which is not a cost: the four usage buckets differ
+// in price by up to 125×, so a run that is mostly cache-read and a run that is
+// mostly output can share a token total and differ in dollars by two orders of
+// magnitude. S0.3's own estimate carries a ~10× spread on the treatment arm for
+// exactly this reason, and it names closing that spread as this delta.
+//
+// The inputs already exist and are reused rather than rebuilt: `tokens_breakdown`
+// on every trial (delta #2), `cost_usd` which prices the buckets separately, and
+// `tier_for_model` (both delta #4). What was missing was wiring them into the
+// REPORT, so the cost axis was priceable per run and unpriced per arm.
+
+/** Per-arm cost, priced bucket-by-bucket, plus the provenance of the prices. */
+export function cost_by_arm(records: Dict[], arms: string[], model: string | null, pricingPath: string): Dict {
+    const [rates, sourced_on] = load_pricing(pricingPath);
+    const tier = model ? tier_for_model(model) : null;
+    const tier_rates: TierRates | null = tier && rates[tier] ? (rates[tier] as TierRates) : null;
+
+    const per_arm: Dict = {};
+    for (const arm of arms) {
+        let n = 0;
+        let total = 0;
+        const buckets = { input: 0, output: 0, cache_write: 0, cache_read: 0 };
+        for (const rec of records) {
+            const armRuns = _dictOr(rec['arms'])[arm];
+            for (const r of Array.isArray(armRuns) ? (armRuns as Dict[]) : []) {
+                // Same exclusion as the token axis: an errored or truncated run's
+                // usage is capped by the budget, not representative of the work.
+                if (_pyTruthy(r['errored'])) {
+                    continue;
+                }
+                n += 1;
+                const b = (r['tokens_breakdown'] ?? {}) as Record<string, unknown>;
+                buckets.input += _orZero(b['input_tokens']);
+                buckets.output += _orZero(b['output_tokens']);
+                buckets.cache_write += _orZero(b['cache_creation_input_tokens']);
+                buckets.cache_read += _orZero(b['cache_read_input_tokens']);
+                if (tier_rates) {
+                    total += cost_usd(b as never, tier_rates);
+                }
+            }
+        }
+        per_arm[arm] = {
+            n,
+            // `null` rather than 0 when the model is unpriceable: a zero would
+            // read as "this arm was free", which is a different claim from "we
+            // cannot price it". pricing.yaml's own contract says surface the gap.
+            total_usd: tier_rates ? PF(_pyRound(total, 4)) : null,
+            mean_usd: tier_rates && n ? PF(_pyRound(total / n, 4)) : null,
+            tokens_by_bucket: buckets,
+        };
+    }
+
+    return {
+        tier: tier ?? 'unknown',
+        priced: tier_rates !== null,
+        pricing_sourced_on: sourced_on,
+        per_arm,
+    };
+}
+
+/**
+ * Whole days between the price sourcing date and the report's own stamp.
+ *
+ * Measured against the STAMP, not against today: a report is a fixed artefact, so
+ * re-rendering it must not change the number. Returns null when either date is
+ * unreadable — an invented age would be worse than an absent one.
+ */
+export function pricing_age_days(sourced_on: string | null, stamp: string | null): number | null {
+    if (!sourced_on || !stamp) {
+        return null;
+    }
+    const src = Date.parse(sourced_on.slice(0, 10));
+    // Report stamps are `YYYY-MM-DDTHH-MM-SSZ` — the time separators are dashes,
+    // so only the date half is parseable without rewriting it.
+    const rep = Date.parse(stamp.slice(0, 10));
+    if (Number.isNaN(src) || Number.isNaN(rep)) {
+        return null;
+    }
+    return Math.floor((rep - src) / 86_400_000);
+}
+
 export function bucket_rates(records: Dict[], arms: string[]): Dict {
     const out: Dict = {};
     for (const arm of arms) {
@@ -482,6 +576,7 @@ export function analyse(payload: Dict): Dict {
         comparisons: comps,
         status_buckets: bucket_rates(records, arms),
         mean_tokens: mean_tokens_by_arm(records, arms),
+        cost: cost_by_arm(records, arms, payload['model'] ? String(payload['model']) : null, PRICING_PATH),
     };
 }
 
@@ -640,6 +735,50 @@ export function to_markdown(analysis: Dict, payload: Dict): string {
         L.push('|---|---|---|---|');
         L.push(`| mean tokens | ${_thousands(tb)} | ${_thousands(tt)} | ${_thousandsSigned(tt - tb)} |`);
         L.push('');
+
+        // Delta #6 — the dollar half of the cost axis. Tokens above are a volume;
+        // these are a price, and the two rank arms differently because the four
+        // usage buckets differ in cost by up to 125×.
+        const cost = _dictOr(a['cost']);
+        const costArms = _dictOr(cost['per_arm']);
+        const cb = _dictOr(costArms[String(cmp['arm_baseline'])]);
+        const ct = _dictOr(costArms[String(cmp['arm_treatment'])]);
+        L.push('### Table 3b — cost axis in dollars (bucket-priced, non-errored)');
+        L.push('');
+        if (!_pyTruthy(cost['priced'])) {
+            L.push(
+                `> **Unpriced.** No pricing row matches model \`${_pyStr(a['model'])}\` ` +
+                    `(tier \`${_pyStr(cost['tier'])}\`), so no dollar figure is shown. This is a ` +
+                    'gap, not a zero — add the row to `internal/bench/pricing.yaml` rather than ' +
+                    'reading the absence as "free".',
+            );
+        } else {
+            L.push('| metric | baseline | treatment | Δ |');
+            L.push('|---|---|---|---|');
+            L.push(
+                `| mean USD/run | ${_usd(cb['mean_usd'])} | ${_usd(ct['mean_usd'])} ` +
+                    `| ${_usdSigned(_pyFloat(ct['mean_usd']) - _pyFloat(cb['mean_usd']))} |`,
+            );
+            L.push(
+                `| total USD | ${_usd(cb['total_usd'])} | ${_usd(ct['total_usd'])} ` +
+                    `| ${_usdSigned(_pyFloat(ct['total_usd']) - _pyFloat(cb['total_usd']))} |`,
+            );
+            L.push('');
+            const age = pricing_age_days(
+                cost['pricing_sourced_on'] ? String(cost['pricing_sourced_on']) : null,
+                a['stamp'] ? String(a['stamp']) : null,
+            );
+            const src = cost['pricing_sourced_on'] ? String(cost['pricing_sourced_on']) : 'unknown';
+            L.push(
+                `> Priced per bucket (input / output / cache-write / cache-read) at the ` +
+                    `\`${_pyStr(cost['tier'])}\` tier, sourced ${src}` +
+                    (age === null ? '' : ` — **${age} days before this report**`) +
+                    '. A blended rate over the token total is not an approximation of this, it is ' +
+                    'a different number. Stale prices make these figures stale: re-source them ' +
+                    'before quoting a dollar amount.',
+            );
+        }
+        L.push('');
         const at = _dictOr(cmp['attrition']);
         L.push('### Table 4 — attrition (dropped pairs are not missing-at-random)');
         L.push('');
@@ -736,6 +875,20 @@ function _thousandsSigned(n: number): string {
     const t = _pyIntTrunc(n);
     const body = _pyThousands(t);
     return t < 0 ? body : `+${body}`;
+}
+
+/**
+ * Render a cost cell — `n/a` when the model could not be priced, never `$0.00`.
+ *
+ * Unwraps through `_pyFloat` because the analysis carries costs as `PyFloat`
+ * (a plain `{value}` wrapper with no `valueOf`), so `Number(cell)` yields NaN.
+ */
+function _usd(v: unknown): string {
+    return v === null || v === undefined ? 'n/a' : `$${_pyFloat(v).toFixed(4)}`;
+}
+
+function _usdSigned(n: number): string {
+    return `${n >= 0 ? '+' : '-'}$${Math.abs(n).toFixed(4)}`;
 }
 
 /** `mt.get(arm, {}).get("mean_tokens", 0)`. */

--- a/tests/scripts/bench_ab_v2_run.test.ts
+++ b/tests/scripts/bench_ab_v2_run.test.ts
@@ -30,6 +30,9 @@ import {
     bare_principle_text,
     ladder_rule_text,
     lift_audit_arms,
+    workspace_dir,
+    selftest_run,
+    selftest_usage,
     ARMS,
     CODEX_VALID_ARMS,
     checkpoint_key,
@@ -44,7 +47,7 @@ import {
     type CheckpointIO,
 } from '../../src/scripts/bench_ab_v2_run.js';
 import type { ScoreResultV2 } from '../../src/scripts/_lib/bench_ab_scoring_v2.js';
-import { activation_verdict, expected_injection } from '../../src/scripts/_lib/bench_ab_activation.js';
+import { activation_verdict, audit_activation, expected_injection } from '../../src/scripts/_lib/bench_ab_activation.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const SCRIPTS = path.join(REPO_ROOT, 'src', 'scripts');
@@ -226,6 +229,31 @@ describe('bench_ab_v2_run — pure helpers', () => {
     it('CODEX_VALID_ARMS: the pure-injection arm carries to codex, the plugin one does not', () => {
         expect(CODEX_VALID_ARMS).toContain('bare-principle');
         expect(CODEX_VALID_ARMS).not.toContain('package-ladder');
+    });
+
+    // ── delta #7 — one preserved workspace per trial ─────────────────────────
+
+    it('workspace_dir: distinct per task AND arm AND seed', () => {
+        const a = workspace_dir('t1', 'vanilla', 0);
+        const variants = [
+            workspace_dir('t2', 'vanilla', 0), // different task
+            workspace_dir('t1', 'package', 0), // different arm
+            workspace_dir('t1', 'vanilla', 1), // different seed
+        ];
+        // The old key was task-only, so the last two of these collided with `a`
+        // and every arm/seed of a task overwrote the previous one's evidence.
+        for (const v of variants) {
+            expect(v).not.toBe(a);
+        }
+        expect(new Set([a, ...variants]).size).toBe(4);
+    });
+
+    it('workspace_dir: an arm name cannot escape the work root', () => {
+        const evil = workspace_dir('t1', '../../etc', 0);
+        // Arm names reach this as a path segment; separators must not survive.
+        expect(path.basename(evil)).toBe(evil.slice(evil.lastIndexOf(path.sep) + 1));
+        expect(evil).not.toContain(`..${path.sep}`);
+        expect(path.resolve(evil).startsWith(path.resolve(path.dirname(evil)))).toBe(true);
     });
 
     it('status_bucket: completed / budget_limit / task_limit / validation_failed', () => {
@@ -516,5 +544,126 @@ describe('bench_ab_v2_run — measurement integrity', () => {
         );
         expect(aborted).toBeNull();
         expect(executed).toBe(4);
+    });
+});
+
+// ── delta #8 — the no-network selftest ──────────────────────────────────────
+//
+// The mode's whole claim is "runs green with no network and no key", so the
+// end-to-end test strips the credentials from the child env rather than trusting
+// that nothing reached for them.
+
+describe('bench_ab_v2_run — selftest mode', () => {
+    const NO_CREDS: NodeJS.ProcessEnv = {
+        ANTHROPIC_API_KEY: undefined,
+        CLAUDE_CODE_OAUTH_TOKEN: undefined,
+        ANTHROPIC_AUTH_TOKEN: undefined,
+    };
+
+    it('exits 0 with no key and marks the report unpublishable', () => {
+        const r = runTs(
+            [
+                '--mode',
+                'selftest',
+                '--arms',
+                'vanilla,package,package-ladder,bare-principle,placebo',
+                '--seeds',
+                '2',
+                '--limit',
+                '2',
+                '--model',
+                'claude-sonnet-4-5-20250929',
+                '--no-checkpoint',
+            ],
+            NO_CREDS,
+        );
+        expect(r.status).toBe(0);
+        expect(r.stdout).toContain('SELFTEST');
+        expect(r.stdout).toContain('not publishable');
+
+        // The report path is named so a selftest artefact cannot be mistaken for a
+        // measured one, and the payload says the same thing independently.
+        const m = /internal\/bench\/reports\/ab-v2\/([^\s]+\.json)/.exec(r.stdout);
+        expect(m).not.toBeNull();
+        const file = path.join(REPO_ROOT, 'internal', 'bench', 'reports', 'ab-v2', (m as RegExpExecArray)[1] as string);
+        expect(path.basename(file)).toContain('-selftest');
+
+        const payload = JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>;
+        expect(payload['tier']).toBe('selftest');
+        expect(payload['synthetic']).toBe(true);
+
+        const audit = payload['activation_audit'] as Record<string, unknown>;
+        // The audit RAN (it is not vacuous) and passed.
+        expect(audit['violations']).toEqual([]);
+        expect(audit['checked']).toBeGreaterThan(0);
+
+        // Delta #7 end-to-end: one preserved workspace per (task, arm, seed).
+        // Under the old task-only key this set would have had one element.
+        const records = payload['records'] as Record<string, unknown>[];
+        const workspaces: string[] = [];
+        let syntheticRuns = 0;
+        for (const rec of records) {
+            for (const runs of Object.values(rec['arms'] as Record<string, Record<string, unknown>[]>)) {
+                for (const run of runs) {
+                    workspaces.push(String(run['workspace']));
+                    if (run['synthetic'] === true) {
+                        syntheticRuns += 1;
+                    }
+                }
+            }
+        }
+        expect(workspaces).toHaveLength(2 * 5 * 2);
+        expect(new Set(workspaces).size).toBe(workspaces.length);
+        // Every trial is stamped synthetic, so no single run can be quoted as real.
+        expect(syntheticRuns).toBe(workspaces.length);
+
+        fs.rmSync(file, { force: true });
+    });
+
+    it('selftest_usage: lift arms clear the audit ratio, the bare control cannot', () => {
+        const base = selftest_usage('vanilla', 0, 2000);
+        const basePt = base.input_tokens + base.cache_read_input_tokens + base.cache_creation_input_tokens;
+
+        for (const arm of ['package', 'package-ladder', 'placebo']) {
+            const u = selftest_usage(arm, 0, 2000);
+            const pt = u.input_tokens + u.cache_read_input_tokens + u.cache_creation_input_tokens;
+            expect(pt / basePt).toBeGreaterThan(1.2);
+        }
+        // This is the measured reason `bare-principle` declares min_lift_ratio:
+        // null — its footprint sits just above baseline, so a lift check on it
+        // would fail a perfectly healthy run.
+        const bare = selftest_usage('bare-principle', 0, 2000);
+        const barePt = bare.input_tokens + bare.cache_read_input_tokens + bare.cache_creation_input_tokens;
+        expect(barePt / basePt).toBeLessThan(1.2);
+    });
+
+    it('the selftest audit fires in the FAILURE direction too', () => {
+        // A selftest that can only ever be observed passing proves nothing. Force
+        // a plugin arm to collapse to baseline and assert the audit catches it —
+        // the same violation a disabled or version-drifted plugin would produce in
+        // a live sweep.
+        const task = { id: 'trapA-overeng-01', fixture: 'fixtures-v2/trapA-overeng-01' };
+        const opts = { model: 'claude-sonnet-4-5-20250929', max_budget: null, timeout: 30, placebo_chars: 2000, sp_dir: os.tmpdir() };
+        const collapsed = (_arm: string, seed: number) => ({
+            input_tokens: 1000,
+            output_tokens: 200 + seed,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        });
+
+        const records = [
+            {
+                id: task.id,
+                arms: {
+                    vanilla: [{ ...selftest_run(task, 'vanilla', { ...opts, seed: 0 }), seed: 0 }],
+                    package: [{ ...selftest_run(task, 'package', { ...opts, seed: 0 }, collapsed), seed: 0 }],
+                },
+            },
+        ];
+        const audit = audit_activation(records, { baseline_arm: 'vanilla', lift_arms: lift_audit_arms(['vanilla', 'package']) });
+        expect(audit.checked).toBe(1);
+        expect(audit.violations).toHaveLength(1);
+        expect(audit.violations[0]?.kind).toBe('collapsed-to-baseline');
+        expect(audit.violations[0]?.arm).toBe('package');
     });
 });

--- a/tests/scripts/bench_ab_v2_run.test.ts
+++ b/tests/scripts/bench_ab_v2_run.test.ts
@@ -202,7 +202,9 @@ describe('bench_ab_v2_run — pure helpers', () => {
         // audit to the text channel — never that it removes the arm from auditing.
         // Both directions are asserted here so neither an always-firing nor a
         // never-firing audit passes.
-        const expected = expected_injection(ARMS['bare-principle']);
+        const spec = ARMS['bare-principle'];
+        expect(spec).toBeDefined();
+        const expected = expected_injection(spec as NonNullable<typeof spec>);
         expect(expected).toBe('text');
 
         const usage = {

--- a/tests/scripts/bench_ab_v2_run.test.ts
+++ b/tests/scripts/bench_ab_v2_run.test.ts
@@ -27,6 +27,11 @@ import {
     trajectory_metrics,
     injected_text,
     hardened_blocks_text,
+    bare_principle_text,
+    ladder_rule_text,
+    lift_audit_arms,
+    ARMS,
+    CODEX_VALID_ARMS,
     checkpoint_key,
     run_key,
     freeze_result,
@@ -39,6 +44,7 @@ import {
     type CheckpointIO,
 } from '../../src/scripts/bench_ab_v2_run.js';
 import type { ScoreResultV2 } from '../../src/scripts/_lib/bench_ab_scoring_v2.js';
+import { activation_verdict, expected_injection } from '../../src/scripts/_lib/bench_ab_activation.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 const SCRIPTS = path.join(REPO_ROOT, 'src', 'scripts');
@@ -105,6 +111,121 @@ describe('bench_ab_v2_run — pure helpers', () => {
         const placebo = injected_text('hardened-placebo', 2000) as string;
         expect(placebo.length).toBe(hardened_blocks_text().length);
         expect(placebo).not.toContain('HARD CONSTRAINT');
+    });
+
+    // ── road-to-solution-minimalism Phase 3, Arms step ──────────────────────
+    //
+    // The two arms the step names and `ARMS` lacked. Every assertion here is a
+    // property of the arm's PURPOSE, not a snapshot of its text: the
+    // bare-principle arm's job is to be floor-free and small, the ladder arm's job
+    // is to carry the projected rule rather than a restatement of it.
+
+    it('bare-principle: one short sentence, no floor vocabulary, no ladder rungs', () => {
+        const bare = injected_text('bare-principle', 2000);
+        expect(bare).toBe(bare_principle_text());
+        const text = bare as string;
+
+        // Small by construction — this is finding F6's control, so it must not
+        // smuggle in a second treatment. One sentence, no line breaks.
+        expect(text.length).toBeLessThan(200);
+        expect(text).not.toContain('\n');
+
+        // Floor-free is the whole point: the arm exists to measure what the
+        // ROUTED floors add over the naked principle, so it may not route any.
+        for (const floor of [
+            'engineering-safety-floor',
+            'security-sensitive-stop',
+            'senior-engineering-discipline',
+            'scale-discipline',
+            'HARD CONSTRAINT',
+        ]) {
+            expect(text).not.toContain(floor);
+        }
+        // Nor may it carry the ladder's own rungs — that would make it a second
+        // ladder arm rather than a control.
+        for (const rung of ['reuse-in-repo', 'native platform', 'stdlib']) {
+            expect(text.toLowerCase()).not.toContain(rung.toLowerCase());
+        }
+    });
+
+    it('package-ladder: injects the PROJECTED ladder rule, not a restatement', () => {
+        const injected = injected_text('ladder', 2000);
+        expect(injected).toBe(ladder_rule_text());
+        const text = injected as string;
+
+        // Read from `dist/agent-src/rules/improve-before-implement.md`, so it must
+        // carry that rule's own ladder section — if the projection ever stopped
+        // carrying the ladder, this arm would be measuring the wrong thing and
+        // this assertion is what says so.
+        expect(text).toContain('solution-size ladder');
+        expect(text).toContain('reuse-in-repo');
+        // Substantially larger than the bare control — the contrast between the
+        // two arms is the measurement, so a collapse of that contrast is a bug.
+        expect(text.length).toBeGreaterThan(bare_principle_text().length * 5);
+    });
+
+    it('ARMS: the two new arms use the channels their purpose requires', () => {
+        // Plugin ON + text injection: the ladder is guaranteed in context rather
+        // than left to `improve-before-implement`'s keyword triggers.
+        expect(ARMS['package-ladder']).toEqual({ setting_sources: null, inject: 'ladder' });
+        // Plugin scoped AWAY + text injection: no floors reach the model.
+        expect(ARMS['bare-principle']).toEqual({
+            setting_sources: 'project,local',
+            inject: 'bare-principle',
+            min_lift_ratio: null,
+        });
+    });
+
+    it('lift_audit_arms: excludes the tiny-treatment arm, keeps every real lift arm', () => {
+        const selected = lift_audit_arms(['vanilla', 'package', 'package-ladder', 'bare-principle', 'placebo']);
+
+        // Baseline is never its own lift arm.
+        expect(selected).not.toContain('vanilla');
+        // A deliberately minimal treatment cannot show footprint lift; requiring
+        // it would fail legitimate runs.
+        expect(selected).not.toContain('bare-principle');
+        // Every arm that DOES carry a real surface stays audited — this is the
+        // half that must not silently shrink.
+        expect(selected).toContain('package');
+        expect(selected).toContain('package-ladder');
+        expect(selected).toContain('placebo');
+
+        // An unknown arm name is not silently promoted into the audit set.
+        expect(lift_audit_arms(['no-such-arm'])).toEqual([]);
+    });
+
+    it('bare-principle stays audited: the text direction fires BOTH ways for it', () => {
+        // The point of the `min_lift_ratio: null` opt-out is that it narrows the
+        // audit to the text channel — never that it removes the arm from auditing.
+        // Both directions are asserted here so neither an always-firing nor a
+        // never-firing audit passes.
+        const expected = expected_injection(ARMS['bare-principle']);
+        expect(expected).toBe('text');
+
+        const usage = {
+            input_tokens: 900,
+            output_tokens: 100,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        };
+        // Declared a text injection and carried none → violation.
+        expect(
+            activation_verdict({ expected, tokens_breakdown: usage, injected_chars: 0, errored: false }).verdict,
+        ).toBe('violation');
+        // Declared one and carried it → ok.
+        expect(
+            activation_verdict({
+                expected,
+                tokens_breakdown: usage,
+                injected_chars: bare_principle_text().length,
+                errored: false,
+            }).verdict,
+        ).toBe('ok');
+    });
+
+    it('CODEX_VALID_ARMS: the pure-injection arm carries to codex, the plugin one does not', () => {
+        expect(CODEX_VALID_ARMS).toContain('bare-principle');
+        expect(CODEX_VALID_ARMS).not.toContain('package-ladder');
     });
 
     it('status_bucket: completed / budget_limit / task_limit / validation_failed', () => {

--- a/tests/scripts/bench_ab_v2_stats.test.ts
+++ b/tests/scripts/bench_ab_v2_stats.test.ts
@@ -30,6 +30,8 @@ import {
     recursiveNovelLift,
     analyse,
     compare,
+    cost_by_arm,
+    pricing_age_days,
 } from '../../src/scripts/bench_ab_v2_stats.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
@@ -375,5 +377,122 @@ describe('bench_ab_v2_stats — attrition reporting', () => {
         expect(at['pairs_seen']).toBe(2);
         expect(at['pairs_analysed']).toBe(cmp['n_pairs']);
         expect(cmp['n_pairs']).toBe(1);
+    });
+});
+
+// ── delta #6 — the cost sheet ───────────────────────────────────────────────
+//
+// Table 3 reports token VOLUME. These assertions exist because volume and price
+// rank arms differently: the four usage buckets differ in cost by up to 125x, so
+// a blended rate over a token total is a different number, not an approximation.
+
+describe('bench_ab_v2_stats — cost_by_arm (delta #6)', () => {
+    const PRICING = path.join(REPO_ROOT, 'internal', 'bench', 'pricing.yaml');
+
+    /** One trial with an explicit four-bucket usage split. */
+    function costTrial(b: Partial<Record<string, number>>, errored = false): Record<string, unknown> {
+        return {
+            errored,
+            metrics: { tokens: 0, status_bucket: errored ? 'task_limit' : 'completed' },
+            tokens_breakdown: {
+                input_tokens: b['input'] ?? 0,
+                output_tokens: b['output'] ?? 0,
+                cache_creation_input_tokens: b['cache_write'] ?? 0,
+                cache_read_input_tokens: b['cache_read'] ?? 0,
+            },
+        };
+    }
+
+    it('prices each bucket at its own rate, not a blended one', () => {
+        // sonnet: in 3.00 / out 15.00 / cache_write 3.75 / cache_read 0.30 per 1M.
+        // Both arms carry 1,000,000 tokens; only the MIX differs. A blended rate
+        // would call them equal — which is the whole reason this table exists.
+        const records = [
+            {
+                id: 't1',
+                arms: {
+                    vanilla: [costTrial({ cache_read: 1_000_000 })],
+                    package: [costTrial({ output: 1_000_000 })],
+                },
+            },
+        ];
+        const cost = cost_by_arm(records, ['vanilla', 'package'], 'claude-sonnet-4-5-20250929', PRICING);
+        expect(cost['priced']).toBe(true);
+        expect(cost['tier']).toBe('sonnet');
+
+        const per = cost['per_arm'] as Record<string, Record<string, unknown>>;
+        expect(Number((per['vanilla']?.['total_usd'] as { value: number }).value)).toBeCloseTo(0.3, 6);
+        expect(Number((per['package']?.['total_usd'] as { value: number }).value)).toBeCloseTo(15.0, 6);
+        // 50x apart on an identical token count.
+        expect(per['vanilla']?.['tokens_by_bucket']).toEqual({
+            input: 0,
+            output: 0,
+            cache_write: 0,
+            cache_read: 1_000_000,
+        });
+    });
+
+    it('excludes errored runs, matching the token axis', () => {
+        const records = [
+            {
+                id: 't1',
+                arms: {
+                    vanilla: [costTrial({ input: 1_000_000 }), costTrial({ input: 1_000_000 }, true)],
+                },
+            },
+        ];
+        const per = cost_by_arm(records, ['vanilla'], 'claude-sonnet-4-5-20250929', PRICING)['per_arm'] as Record<
+            string,
+            Record<string, unknown>
+        >;
+        // An errored run's usage is capped by the budget, not representative.
+        expect(per['vanilla']?.['n']).toBe(1);
+        expect(Number((per['vanilla']?.['total_usd'] as { value: number }).value)).toBeCloseTo(3.0, 6);
+    });
+
+    it('an unpriceable model yields null, never zero', () => {
+        const records = [{ id: 't1', arms: { vanilla: [costTrial({ input: 1_000_000 })] } }];
+        const cost = cost_by_arm(records, ['vanilla'], 'some-other-vendor-model', PRICING);
+        expect(cost['priced']).toBe(false);
+        expect(cost['tier']).toBe('unknown');
+        const per = cost['per_arm'] as Record<string, Record<string, unknown>>;
+        // A zero would read as "this arm was free" — a different claim from "we
+        // cannot price it". The bucket counts are still reported, so the gap is
+        // visible rather than silent.
+        expect(per['vanilla']?.['total_usd']).toBeNull();
+        expect(per['vanilla']?.['mean_usd']).toBeNull();
+        expect((per['vanilla']?.['tokens_by_bucket'] as Record<string, number>)['input']).toBe(1_000_000);
+    });
+
+    it('pricing_age_days measures against the report stamp, not against today', () => {
+        // A fixed artefact must not change its own numbers when re-rendered.
+        expect(pricing_age_days('2026-05-14', '2026-08-06T18-00-00Z')).toBe(84);
+        expect(pricing_age_days('2026-05-14', '2026-05-14T00-00-00Z')).toBe(0);
+        // An unreadable date yields null — an invented age is worse than none.
+        expect(pricing_age_days(null, '2026-08-06T18-00-00Z')).toBeNull();
+        expect(pricing_age_days('2026-05-14', null)).toBeNull();
+        expect(pricing_age_days('not-a-date', '2026-08-06T18-00-00Z')).toBeNull();
+    });
+
+    it('analyse() carries the cost block, and the markdown table renders from it', () => {
+        const payload = {
+            stamp: '2026-08-06T18-00-00Z',
+            model: 'claude-sonnet-4-5-20250929',
+            seeds: 1,
+            arms: ['vanilla', 'package'],
+            records: [
+                {
+                    id: 't1',
+                    arms: {
+                        vanilla: [costTrial({ input: 1_000_000 })],
+                        package: [costTrial({ output: 1_000_000 })],
+                    },
+                },
+            ],
+        };
+        const a = analyse(payload);
+        const cost = a['cost'] as Record<string, unknown>;
+        expect(cost['priced']).toBe(true);
+        expect(cost['pricing_sourced_on']).toBe('2026-05-14');
     });
 });


### PR DESCRIPTION
Moves `road-to-solution-minimalism` from 66% to 71% (12 open steps → 10) and repairs a defect in how the roadmap reported itself. Phase 3 is the only open phase; four of its steps are gated on a spend grant that is the maintainer's to give.

## The reporting defect, first

The roadmap's only open phase had been halted since 2026-08-02 by an owner-is-user spend gate — and the generated dashboard published **0 blockers** for it. The gate was recorded as prose, and `### blocker:` is the dashboard's only parse anchor, so a prose gate is invisible to every consumer of that dashboard, including the next agent screening for "what can be worked on now". That reader is exactly the one that must not be misled.

Now a structured `## Blockers` entry with the five required fields, cross-referenced inline from the four genuinely spend-gated items. Row 11 reports 1 blocker instead of 0. Also struck: the halt note's second gate, "the standing model-id verification blocker", which delta #3 resolved on 2026-08-05 — a roadmap citing a resolved blocker as standing overstates its own gating.

## What landed

Four deltas from the S0.3 harness-feasibility spike, plus the Arms step.

**Arms step (closed).** `ARMS` carried three of the five arms the step names. `package-ladder` is not redundant with `package`, and the reason is measurable rather than stylistic: the ladder ships inside `improve-before-implement`, which is `type: auto`, `alwaysApply: false`, keyword-triggered on `refactor|implement|migration`, and absent from `dist/router.json`'s preloaded tier lists — so under `package` it reaches the model only when a task's wording happens to trip a keyword. That is finding F1's failure class, where a null cannot be told apart from an activation gap. `bare-principle` is F6's control: plugin scoped away, one authored sentence, no floors routed. Its text is authored here rather than borrowed — `code-provenance` requires a conscious borrow to be re-derived, and the tests assert the properties that matter (floor-free, no ladder rung, one line) instead of the wording.

**Delta #7 — per-trial workspaces.** Workspaces were keyed by task alone, so every arm and seed of a task reused one directory that the next trial deleted; one workspace survived per task, with nothing recording which arm or seed it was. Not a tidiness issue: Phase 3's anti-golfing gate is specified as retro-fittable onto completed runs by offline re-scoring, and the roadmap calls that gate cheap *because* the workspaces are preserved — under the old key there was nothing to re-score, so the claim was false.

**Delta #8 — a real `--selftest`.** `--mode dry-run` printed a run count and returned before the CLI check, the fixtures, the scorer, the audit and the report writer, so it could not tell a working harness from a broken one. `--mode selftest` substitutes exactly one thing, the model call. Verified with credentials stripped from the env: exit 0, 12 audit pairs checked, 0 violations, 20 trials → 20 distinct workspaces.

**Delta #6 — a bucket-priced cost sheet.** Table 3 reported token volume; the four usage buckets differ in price by up to 125×, so two runs can share a token total and differ in dollars by two orders of magnitude. Table 3b prices them separately, reusing `cost_usd` and `tier_for_model` from delta #4 rather than rebuilding them.

**Thresholds step (closed).** `internal/bench/ab-v2-phase3-PREREG.md`, in the shape the tree's four existing `*-PREREG.md` records use. T1 is calibrated to the independent −15.4 % (p=0.088), not the source's −54 % headline, with a per-row justification. Registered while the run is impossible, which is the strongest form of that guarantee: thresholds fitted after seeing data are not thresholds.

## Three decisions worth a reviewer's attention

**An audit exclusion, typed rather than smuggled.** The cross-arm audit requires a lift arm's footprint to sit ≥ 1.2× above its paired vanilla run, catching a treatment surface that collapsed to baseline. A one-sentence arm has no such lift — measured at ratio **1.02** — so auditing it that way fails healthy runs, the failure the ratio's own calibration note warns about from the other side. `bare-principle` declares `min_lift_ratio: null`, narrowing its audit to the text channel, which is checked both ways. `lift_audit_arms` is extracted and exported so the exclusion set is asserted by tests rather than trusted, because widening it silently would be a reach reduction in the gate.

**The selftest can fail.** `selftest_run` takes an injectable usage function, and a test forces a plugin arm to collapse to baseline and asserts the audit reports `collapsed-to-baseline` — the same violation a disabled or drifted plugin produces live. A selftest observable only in the passing direction proves nothing.

**Two steps stay open although their `verify:` now passes.** Reproducibility delivered three of four items; the fourth, the pinned SHA, has nothing to pin (no `repo`/`sha` corpus keys, every fixture is a self-contained in-repo tree), so it needs delta #9, which the spike sequences with delta #10 because a harness pointed at a real repo with no oracles runs nothing. Endpoints gained the cost endpoint and the pre-registration of the safety tier and search-adherence, but their scorers are rubric-judged and unimplemented. Both are marked `[ ]` with `blocked-by` rather than `[~]` — the distinction is not cosmetic, since `[~]` means deferred-by-choice and trips the archival gate, while these are blocked on a gate someone else clears.

## Verification

- `tests/scripts/bench_ab_v2_run.test.ts` — 34 (12 new)
- `tests/scripts/bench_ab_v2_stats.test.ts` — 23 (5 new)
- `tests/scripts/_lib_bench_ab_activation.test.ts` — 31, unchanged
- `task typecheck-ts` clean, `eslint` clean on the diff, `lint_roadmap_blockers` 21/21, `lint_output_slop` / `check_secret_leak` / `check_no_external_sources` clean
- The end-to-end selftest was run with `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_AUTH_TOKEN` unset

No spend. No paid run was fired and none is authorized by this PR.

## Two findings for the maintainer, not fixed here

1. **`check_roadmap_trackable` is red on `main`**, on `road-to-skill-ecosystem-gate-integrity.md`: `### Phase 2 (execution notes)` parses as a phase and has no checkboxes. Untouched by this diff — pre-existing, and out of scope.
2. **`road-to-zero-ceremony-settings` has an orphan.** Its Phase 4 and Phase 5 steps are delivered by code merged in #1197 with 133 passing tests, but their checkboxes were never committed, so `main` still reports 7 open steps that are shipped. Flipping them is a one-line change that **cannot be committed**: it takes the roadmap to zero open steps with 5 deferred, and the pre-commit hook then refuses every commit touching `agents/roadmaps/` until the deferred set is resolved by the numbered-options decision Iron Law 3 reserves for a human. That decision is yours; the flips are ready when you make it.
