### PR TITLE
fix(release): stop treating "no checks reported" as a pass when checks ARE required

### DIFF
--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -700,13 +700,84 @@ export function _failed_checks_report(names: readonly string[]): string {
     return lines.join('\n');
 }
 
+/** Rounds of re-watching before an absent required check is called absent. */
+const _NO_CHECKS_ROUNDS = 10;
+/** Delay between those rounds — 10 × 60 s ≈ 10 minutes of tolerance. */
+const _NO_CHECKS_DELAY_MS = 60_000;
+
 /**
- * Watch PR checks and tolerate the 'no checks' case.
+ * Required status-check contexts for a branch, parsed from
+ * `gh api repos/{owner}/{repo}/rules/branches/{branch}`.
+ *
+ * That endpoint is the one that answers the question here: this repo protects
+ * `main` with a RULESET, and the classic `/branches/main/protection` API
+ * answers "Branch not protected" for it — so a check built on the classic
+ * endpoint would conclude "no required checks" and wave everything through.
+ *
+ * Any parse or shape surprise yields [] — the caller then behaves exactly as
+ * it did before this function existed.
+ */
+export function _required_contexts_from_rules(json: string): string[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(json);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(parsed)) return [];
+    const out: string[] = [];
+    for (const rule of parsed) {
+        const r = rule as { type?: unknown; parameters?: { required_status_checks?: unknown } };
+        if (r.type !== 'required_status_checks') continue;
+        const checks = r.parameters?.required_status_checks;
+        if (!Array.isArray(checks)) continue;
+        for (const c of checks) {
+            const ctx = (c as { context?: unknown }).context;
+            if (typeof ctx === 'string' && ctx !== '') out.push(ctx);
+        }
+    }
+    return out;
+}
+
+export type NoChecksAction = 'retry' | 'accept' | 'die';
+
+/**
+ * What to do when `gh pr checks` reports no checks at all.
+ *
+ * The old code had one answer — accept — for two situations it could not tell
+ * apart: a repo that configures no required checks (nothing will ever arrive,
+ * accepting is correct) and a repo whose checks have simply not been
+ * dispatched yet (accepting merges, tags and publishes unvalidated).
+ *
+ * The branch's own protection rules separate them. Required contexts declared
+ * ⇒ something IS expected, so absence means not-yet, and the answer is to wait
+ * and finally to refuse. None declared ⇒ the pre-existing tolerance stands.
+ */
+export function _no_checks_action(
+    required: readonly string[],
+    round: number,
+    maxRounds: number = _NO_CHECKS_ROUNDS,
+): NoChecksAction {
+    if (required.length === 0) return 'accept';
+    return round < maxRounds ? 'retry' : 'die';
+}
+
+/**
+ * Watch PR checks and tolerate the 'no checks' case ONLY where it is tolerable.
  *
  * `gh pr checks --watch` exits 1 both on real failures and when no checks are
- * reported at all (no workflow triggered, no required checks configured in
- * branch protection). The latter must not block the release — we warn and
- * continue. Real failures still die.
+ * reported at all. Real failures still die.
+ *
+ * Measured 2026-08-06/07: during a critical GitHub Actions incident
+ * (15:22–02:04 UTC, webhook triggers throttled from 20:34) `pull_request`
+ * events were delivered 15–30 minutes late. The five-second grace period below
+ * expires long before that, so the old unconditional accept would have tagged
+ * `main` and published to npm without a single check having run. It did not
+ * only because `main` happened to be independently green.
+ *
+ * So the tolerance is now conditional on the branch declaring no required
+ * checks. Where it declares some, absence is treated as latency: re-watch, and
+ * refuse rather than release blind.
  *
  * A short grace period gives GitHub time to register workflow runs on a
  * freshly-pushed branch.
@@ -721,41 +792,76 @@ function watch_pr_checks(branch: string): void {
             // busy-wait stand-in for time.sleep(5) without an event-loop yield.
         }
     }
-    // The branch is passed explicitly — `gh` inferring the PR from HEAD
-    // resolved to `main` mid-run once (2026-08-03, 9.16.0 resume) and the
-    // whole release died on "no pull requests found for branch main".
-    const proc = run(['gh', 'pr', 'checks', branch, '--watch'], {
-        check: false,
-        capture: true,
-    });
-    const output = ((proc.stdout || '') + (proc.stderr || '')).trim();
-    const returncode = proc.returncode;
-    if (returncode === 0) {
-        if (output) {
-            process.stdout.write(output + '\n');
+    // Rounds exist only for the no-checks-yet case below; every other outcome
+    // returns or dies on the first pass, exactly as before.
+    for (let round = 0; ; round++) {
+        // The branch is passed explicitly — `gh` inferring the PR from HEAD
+        // resolved to `main` mid-run once (2026-08-03, 9.16.0 resume) and the
+        // whole release died on "no pull requests found for branch main".
+        const proc = run(['gh', 'pr', 'checks', branch, '--watch'], {
+            check: false,
+            capture: true,
+        });
+        const output = ((proc.stdout || '') + (proc.stderr || '')).trim();
+        const returncode = proc.returncode;
+        if (returncode === 0) {
+            if (output) {
+                process.stdout.write(output + '\n');
+            }
+            return;
         }
-        return;
+        if (output.toLowerCase().includes('no checks reported')) {
+            const rules = run(
+                ['gh', 'api', `repos/{owner}/{repo}/rules/branches/${MAIN_BRANCH}`],
+                { check: false, capture: true },
+            );
+            const required = _required_contexts_from_rules(rules.stdout ?? '');
+            const action = _no_checks_action(required, round, _NO_CHECKS_ROUNDS);
+
+            if (action === 'accept') {
+                process.stdout.write(`⚠️  ${output}\n`);
+                process.stdout.write(
+                    '   Continuing without check validation — configure required ' +
+                        'checks in branch protection to enforce this gate.\n',
+                );
+                return;
+            }
+            if (action === 'retry') {
+                process.stdout.write(
+                    `⏳  no checks reported yet, but ${MAIN_BRANCH} requires ` +
+                        `${String(required.length)} (${required.join(', ')}) — ` +
+                        `waiting (${String(round + 1)}/${String(_NO_CHECKS_ROUNDS)})\n`,
+                );
+                if (_exec_override === null) {
+                    const until = Date.now() + _NO_CHECKS_DELAY_MS;
+                    while (Date.now() < until) {
+                        // blocking wait, same shape as the grace period above
+                    }
+                }
+                continue;
+            }
+            die(
+                `no checks reported for ${branch} after ` +
+                    `${String(_NO_CHECKS_ROUNDS)} rounds, but ${MAIN_BRANCH} requires ` +
+                    `${required.join(', ')}. Refusing to merge, tag and publish ` +
+                    'unvalidated — GitHub may be delaying event delivery (check ' +
+                    'githubstatus.com). Re-run with `task release -- --resume --yes` ' +
+                    'once the checks appear.',
+            );
+        }
+        if (output) {
+            process.stderr.write(output + '\n');
+        }
+        const summary = run(['gh', 'pr', 'checks', branch, '--json', 'name,bucket'], {
+            check: false,
+            capture: true,
+        });
+        const report = _failed_checks_report(_failed_check_names(summary.stdout ?? ''));
+        if (report) {
+            process.stderr.write(report + '\n');
+        }
+        die(`PR checks failed (exit ${returncode})`);
     }
-    if (output.toLowerCase().includes('no checks reported')) {
-        process.stdout.write(`⚠️  ${output}\n`);
-        process.stdout.write(
-            '   Continuing without check validation — configure required ' +
-                'checks in branch protection to enforce this gate.\n',
-        );
-        return;
-    }
-    if (output) {
-        process.stderr.write(output + '\n');
-    }
-    const summary = run(['gh', 'pr', 'checks', branch, '--json', 'name,bucket'], {
-        check: false,
-        capture: true,
-    });
-    const report = _failed_checks_report(_failed_check_names(summary.stdout ?? ''));
-    if (report) {
-        process.stderr.write(report + '\n');
-    }
-    die(`PR checks failed (exit ${returncode})`);
 }
 
 /**

--- a/tests/scripts/release_no_checks_tolerance.test.ts
+++ b/tests/scripts/release_no_checks_tolerance.test.ts
@@ -1,0 +1,90 @@
+// "No checks reported" means two different things. Only one of them is safe.
+//
+// `watch_pr_checks` accepted both: a repo that configures no required checks
+// (nothing will ever arrive — accepting is right) and a repo whose checks have
+// not been dispatched yet (accepting merges, tags and publishes unvalidated).
+//
+// Measured 2026-08-06/07: during a critical GitHub Actions incident
+// (15:22–02:04 UTC; webhook triggers throttled from 20:34) pull_request events
+// arrived 15–30 minutes late. The waiter's grace period is five seconds. The
+// 9.26.0 release therefore ran the whole way through — tag, GitHub Release,
+// npm publish — on a PR whose checks had not started. It was safe only because
+// `main` happened to be independently green at that commit, which is luck, not
+// a gate.
+//
+// The branch's own protection rules tell the two apart, so both halves are
+// pinned here: the parser that reads them, and the decision that follows.
+import { describe, expect, it } from 'vitest';
+
+import { _no_checks_action, _required_contexts_from_rules } from '../../src/scripts/release.js';
+
+describe('_required_contexts_from_rules — reads the ruleset, not the legacy API', () => {
+  it('extracts every required context from the effective-rules payload', () => {
+    const payload = JSON.stringify([
+      { type: 'deletion' },
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: [
+            { context: 'Sync + Generate Tools Consistency', integration_id: 15368 },
+            { context: 'Tests' },
+          ],
+        },
+      },
+    ]);
+    expect(_required_contexts_from_rules(payload)).toEqual([
+      'Sync + Generate Tools Consistency',
+      'Tests',
+    ]);
+  });
+
+  it('returns [] for a branch with rules but no required checks', () => {
+    expect(_required_contexts_from_rules(JSON.stringify([{ type: 'non_fast_forward' }]))).toEqual(
+      [],
+    );
+  });
+
+  it('degrades to [] on an error payload, unparseable text, or a non-array', () => {
+    // The classic protection endpoint answers this for a ruleset-protected
+    // branch — the exact shape that must not be read as "checks required".
+    expect(_required_contexts_from_rules('{"message":"Branch not protected"}')).toEqual([]);
+    expect(_required_contexts_from_rules('not json')).toEqual([]);
+    expect(_required_contexts_from_rules('')).toEqual([]);
+  });
+
+  it('skips malformed context entries rather than emitting empty strings', () => {
+    const payload = JSON.stringify([
+      {
+        type: 'required_status_checks',
+        parameters: { required_status_checks: [{ context: '' }, { nope: 1 }, { context: 'ok' }] },
+      },
+    ]);
+    expect(_required_contexts_from_rules(payload)).toEqual(['ok']);
+  });
+});
+
+describe('_no_checks_action — tolerance only where nothing is expected', () => {
+  it('accepts immediately when the branch requires no checks (pre-existing behaviour)', () => {
+    expect(_no_checks_action([], 0, 10)).toBe('accept');
+    expect(_no_checks_action([], 99, 10)).toBe('accept');
+  });
+
+  it('waits while required checks are declared but absent — the incident case', () => {
+    const required = ['Sync + Generate Tools Consistency'];
+    expect(_no_checks_action(required, 0, 10)).toBe('retry');
+    expect(_no_checks_action(required, 9, 10)).toBe('retry');
+  });
+
+  it('refuses rather than releasing blind once the budget is spent', () => {
+    expect(_no_checks_action(['Sync + Generate Tools Consistency'], 10, 10)).toBe('die');
+    expect(_no_checks_action(['a', 'b'], 11, 10)).toBe('die');
+  });
+
+  it('never answers accept while a required check is outstanding, at any round', () => {
+    // The property that matters: no round number may reproduce the old
+    // unconditional accept once something IS expected.
+    for (let round = 0; round < 25; round++) {
+      expect(_no_checks_action(['x'], round, 10)).not.toBe('accept');
+    }
+  });
+});


### PR DESCRIPTION
fix(release): stop treating "no checks reported" as a pass when checks ARE required

watch_pr_checks gave one answer — accept — to two situations it could not tell
apart: a repo that configures no required checks, where nothing will ever
arrive and accepting is correct, and a repo whose checks have not been
dispatched yet, where accepting merges, tags and publishes unvalidated.

Measured 2026-08-06/07. During a critical GitHub Actions incident
(15:22–02:04 UTC, webhook triggers throttled from 20:34) pull_request events
were delivered 15–30 minutes late. The waiter's grace period is five seconds.
The 9.26.0 release therefore ran the whole way through — merge, tag, GitHub
Release, npm publish — on a PR whose checks had not started. It was safe only
because main happened to be independently green at that commit, twice over.
That is luck, not a gate.

The branch's own protection rules separate the two cases, so the tolerance is
now conditional on them. Required contexts declared → absence means not-yet:
re-watch up to ten rounds a minute apart, then refuse with the resume command
and a pointer at githubstatus.com. None declared → the pre-existing accept
stands, unchanged.

The rules are read from repos/{owner}/{repo}/rules/branches/main, not from the
classic /branches/main/protection endpoint — this repo protects main with a
RULESET and the classic endpoint answers "Branch not protected" for it, so a
check built on that would have concluded "nothing required" and waved
everything through. That payload is pinned as a must-return-empty test case.

Nine tests: the parser (including the error payload, unparseable text and
malformed context entries) and the decision, with a property test asserting no
round number can reproduce the old unconditional accept while something is
outstanding. Mutation-checked — restoring the old `return 'accept'` reds three
of them.
