### PR TITLE
fix(gates): a zero-tool checkout is an absent surface, not a dead scan scope

### DIFF
--- a/src/scripts/check_rule_projection_integrity.ts
+++ b/src/scripts/check_rule_projection_integrity.ts
@@ -74,7 +74,8 @@
  * and their `.md` entries, which is where the measured defect was.
  *
  * CLI: `--root <path>` (default: this repo) · `--quiet` suppresses the
- * per-target ledger line. Exit 0 = complete and fresh, 1 = any gap, any stale
+ * per-target ledger line. Exit 0 = complete and fresh, or no tool active at all
+ * (announced on stderr — see `auditRuleProjection`); 1 = any gap, any stale
  * entry, a ledger accounting error, or a dead scan scope.
  */
 import * as fs from 'node:fs';
@@ -137,16 +138,41 @@ export function auditRuleProjection(
         ledger.plan(rules.map((r) => `${tree}/${r}`));
     }
 
-    // The planned set is every (tree × rule) pair. Zero means either the emit
-    // plan is empty — no rule reached `dist/agent-src/rules/`, or every tool is
-    // deactivated — and in both cases this gate would print a green checkmark
-    // over an assertion it never evaluated. Thrown, not returned: `findings` is
-    // the drift channel and a dead scope is not drift.
+    // The planned set is every (tree × rule) pair, and zero has TWO causes that
+    // are not the same defect. `projected_rule_trees()` returns one key per
+    // ACTIVE tool dir, so the key count is the discriminator:
+    //
+    //   - keys > 0, rules == 0 → the rule corpus is dead. No rule reached
+    //     `dist/agent-src/rules/`, or every scope filter rejected every rule,
+    //     and a green checkmark here would cover an assertion never evaluated.
+    //     This still throws.
+    //   - keys == 0 → `agents/.agent-tools.yml` selects zero tools, which
+    //     `_active_tools()` honours by design. There is no projection surface
+    //     in this checkout, so there is nothing to be stale or missing. That is
+    //     an absent optional surface, not a moved root.
+    //
+    // Conflating the two made the gate unsatisfiable on a supported config: it
+    // runs FIRST in the pre-push `preflight` chain, so a maintainer who
+    // deactivates the per-tool trees (they duplicate a globally installed
+    // `~/.claude`) could not push at all, with no fix available short of the
+    // env escape hatch. A gate whose only compliant path is to change an
+    // unrelated setting is not a gate. `main()` prints the skip explicitly —
+    // the empty case must be LOUD, never a silent green.
+    const noActiveTree = Object.keys(expected).length === 0;
     assertScanned({
         gate: 'check_rule_projection_integrity',
         scanned: Object.values(expected).reduce((n, rules) => n + rules.length, 0),
         units: 'projected rule entries',
         roots: [DIST_RULES, ...Object.keys(expected)],
+        ...(noActiveTree
+            ? {
+                  allowEmpty:
+                      'OPTIONAL_INPUT: no host rule tree is active — agents/.agent-tools.yml ' +
+                      'selects zero tools, so the surface this gate audits does not exist in ' +
+                      'this checkout. With one or more active tools the emit plan carries the ' +
+                      'full rule set by construction, so a dead dist/agent-src/rules/ still fails here.',
+              }
+            : {}),
     });
 
     for (const [tree, rules] of Object.entries(expected)) {
@@ -266,6 +292,19 @@ export function main(argv?: readonly string[]): number {
             return 1;
         }
         throw exc;
+    }
+
+    // Zero active trees is a legitimate config (see `auditRuleProjection`), but
+    // it means this run audited nothing. Say so on its own line instead of
+    // letting the success line below report "0 entries across 0 trees", which
+    // reads as a pass to every human and every log scraper.
+    if (Object.keys(audit.treePresent).length === 0) {
+        process.stderr.write(
+            '⚠️  check_rule_projection_integrity: no host rule tree is active ' +
+                '(agents/.agent-tools.yml selects zero tools) — nothing to audit. This gate ' +
+                'has teeth only where a tool is active; CI activates all eight.\n',
+        );
+        return 0;
     }
 
     const lines = renderFindings(audit);

--- a/tests/scripts/check_rule_projection_integrity.test.ts
+++ b/tests/scripts/check_rule_projection_integrity.test.ts
@@ -29,9 +29,9 @@ import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { projected_rule_trees } from '../../src/scripts/condense.js';
+import { _resetStateForTest, projected_rule_trees } from '../../src/scripts/condense.js';
 import { DeadScopeError } from '../../src/scripts/_lib/scan_scope.js';
-import { auditRuleProjection, renderFindings } from '../../src/scripts/check_rule_projection_integrity.js';
+import { auditRuleProjection, main, renderFindings } from '../../src/scripts/check_rule_projection_integrity.js';
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const TREE = '.claude/rules';
@@ -124,20 +124,75 @@ describe('an empty scan root does not silently pass', () => {
         expect(() => auditRuleProjection(root, { [TREE]: [] })).toThrow(DeadScopeError);
     });
 
-    it('throws when the expected map itself is empty (every tool deactivated)', () => {
+    it('still throws when a tree IS active but plans no rule', () => {
+        // The discriminator, from the failing side: an active tool whose emit
+        // plan is empty means the rule corpus died, and that must stay fatal.
+        // If the zero-tool carve-out below were keyed on the rule count instead
+        // of the tree count, this case would be silenced with it.
         const root = makeRoot(['alpha.md']);
-        expect(() => auditRuleProjection(root, {})).toThrow(DeadScopeError);
+        expect(() => auditRuleProjection(root, { [TREE]: [], '.clinerules': [] })).toThrow(DeadScopeError);
+    });
+});
+
+describe('a checkout with every tool deactivated is skipped, not failed', () => {
+    // `agents/.agent-tools.yml` may legitimately select zero tools — the
+    // maintainer config that avoids duplicating a globally installed `~/.claude`.
+    // `projected_rule_trees()` then returns `{}`, and this gate runs FIRST in the
+    // pre-push chain: treating that as a dead scope made `git push` impossible on
+    // a supported config, which is the defect this pair pins.
+    it('does not throw when the expected map is empty (no active tool)', () => {
+        const root = makeRoot(['alpha.md']);
+        const audit = auditRuleProjection(root, {});
+        expect(audit.findings).toEqual([]);
+        expect(audit.treePresent).toEqual({});
+        expect(audit.ledger.finalize().planned).toBe(0);
+    });
+
+    it('exits 0 through the CLI and announces the skip on stderr', () => {
+        // Silence would be indistinguishable from a real pass — the false-green
+        // class `_lib/scan_scope.ts` exists to prevent — so the announcement is
+        // part of the contract. Driven end-to-end through `main()` because the
+        // exit code is what the pre-push chain reads.
+        const root = makeRoot(['alpha.md'], []);
+        fs.mkdirSync(path.join(root, 'agents'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'agents', '.agent-tools.yml'), 'tools: []\n', 'utf-8');
+
+        const chunks: string[] = [];
+        const original = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((c: string | Uint8Array) => {
+            chunks.push(String(c));
+            return true;
+        }) as typeof process.stderr.write;
+        let code: number;
+        try {
+            code = main(['--root', root, '--quiet']);
+        } finally {
+            process.stderr.write = original;
+            // `main` repoints condense's MODULE_STATE at `--root`; leaving it
+            // there would make the repo-corpus tests below audit a tmp dir.
+            _resetStateForTest();
+        }
+        expect(code).toBe(0);
+        expect(chunks.join('')).toContain('no host rule tree is active');
     });
 });
 
 describe('the expected set comes from the generator, not from dist/ verbatim', () => {
     const distRules = path.join(REPO_ROOT, 'dist', 'agent-src', 'rules');
 
+    // These two read the REAL repo's emit plan, which is empty when
+    // `agents/.agent-tools.yml` selects zero tools — a supported local config
+    // (it avoids duplicating a globally installed `~/.claude`). Asserting
+    // `size > 50` there fails on the config rather than on a defect. CI commits
+    // all eight tools, so both keep their teeth where the corpus exists; a
+    // change that empties the committed list is a visible one-line diff.
+    const planEmpty = Object.keys(projected_rule_trees()).length === 0;
+
     function isManual(rule: string): boolean {
         return /^type:\s*["']?manual["']?\s*$/m.test(fs.readFileSync(path.join(distRules, rule), 'utf-8'));
     }
 
-    it('omits every ADR-004 `type: manual` rule and includes every other one', () => {
+    it.skipIf(planEmpty)('omits every ADR-004 `type: manual` rule and includes every other one', () => {
         const plan = projected_rule_trees();
         const projected = new Set(plan[TREE] ?? []);
         expect(projected.size).toBeGreaterThan(50);
@@ -151,7 +206,7 @@ describe('the expected set comes from the generator, not from dist/ verbatim', (
         expect(missing, 'every non-manual dist rule belongs to the emit plan').toEqual([]);
     });
 
-    it('plans the same rule set for every active host rule tree', () => {
+    it.skipIf(planEmpty)('plans the same rule set for every active host rule tree', () => {
         const plan = projected_rule_trees();
         const trees = Object.keys(plan);
         expect(trees).toContain(TREE);


### PR DESCRIPTION
## What broke

`task release` for 9.27.0 aborted before the release branch was ever pushed:

```
❌  check_rule_projection_integrity: scanned 0 projected rule entries under
    dist/agent-src/rules — the scan scope is dead or the root moved.
```

Nothing was dead. `agents/.agent-tools.yml` is `skip-worktree`-masked locally to
`tools: []` — the maintainer config that avoids duplicating a globally installed
`~/.claude`. `_active_tools()` honours an empty list by design, so
`_filter_tool_dirs()` returns `{}`, `projected_rule_trees()` returns `{}`, and the
gate read that as a moved root.

The gate runs **first** in the pre-push `preflight` chain, deliberately, so it sees
staleness before `check_bridge_derivation` regenerates and erases the evidence. The
consequence of the conflation was that `git push` became impossible on a supported
config, with no remedy short of `AGENT_CONFIG_SKIP_PREPUSH_PREFLIGHT=1`. A gate whose
only compliant path is to change an unrelated setting is not a gate.

## The discriminator

`projected_rule_trees()` returns one key per **active** tool dir, so the key count
separates the two causes of an empty plan:

| keys | rules | meaning | verdict |
|---|---|---|---|
| > 0 | 0 | no rule reached `dist/agent-src/rules/`, or every scope filter rejected every rule | **still throws** `DeadScopeError` |
| 0 | 0 | zero tools selected — the audited surface does not exist in this checkout | skip, announced |

Zero keys now carries a justified `OPTIONAL_INPUT:` `allowEmpty` reason, and `main()`
returns 0 **after writing the skip to stderr**:

```
⚠️  check_rule_projection_integrity: no host rule tree is active
    (agents/.agent-tools.yml selects zero tools) — nothing to audit.
    This gate has teeth only where a tool is active; CI activates all eight.
```

The announcement is part of the contract, not decoration: silence here would be
indistinguishable from a real pass, which is the false-green class
`_lib/scan_scope.ts` exists to prevent.

## The same defect on the test side

Two cases in `check_rule_projection_integrity.test.ts` assert against the **real**
repo's emit plan and were red locally for the same reason — on the config, not on a
defect:

```
AssertionError: expected 0 to be greater than 50    (line 143)
AssertionError: expected [] to include '.claude/rules'    (line 157)
```

They now `skipIf` an empty plan. CI commits all eight tools, so both keep full teeth
there; emptying the committed list would be a visible one-line diff.

## Coverage

- new: zero active trees → no throw, empty ledger, `treePresent == {}`
- new: `main()` end-to-end on a tmp root with `tools: []` → exit 0 **and** the stderr
  announcement (state repointed back in `finally`, so the repo-corpus cases below do
  not audit a tmp dir)
- new: **two** active trees planning zero rules → still `DeadScopeError`. This is the
  case that fails if the carve-out is ever re-keyed on the rule count instead of the
  tree count.
- unchanged: missing entry named, tree-absent, stale-via-`lstat`, non-vacuous-link

## Verification

```
task typecheck-ts                                  exit 0
npx vitest run tests/scripts/check_rule_projection_integrity.test.ts
                                                   9 passed | 2 skipped
./scripts-run src/scripts/check_rule_projection_integrity
                                                   exit 0, skip announced
task preflight                                     exit 0
```

`task preflight` also required rebuilding the local hook bundle (`dist/hooks/` is
gitignored, so that is not in this diff): it predated 7 of 39 sources on `main`. Built
to `dist/hooks/dispatch.new.js`, smoke-tested allow/block/dry-run/post, then moved into
place — never built straight to the live hook path.
