### PR TITLE
feat(report): skill-activation census — why skills were not used, measured

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**151 / 278 steps done · 54%**
+**153 / 279 steps done · 55%**
 
 ```text
-██████████████████████░░░░░░░░░░░░░░░░░░   54%
+██████████████████████░░░░░░░░░░░░░░░░░░   55%
 ```
 
 ## Open roadmaps
@@ -18,7 +18,7 @@
 |---|---|---:|---:|---:|---:|---:|---:|---:|---|
 | 1 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 2 | [road-to-conformance-round5.md](roadmaps/road-to-conformance-round5.md) | 6 | 31 | 17 | 14 | 0 | 0 | [1](#blockers-road-to-conformance-round5) | ████░░░░░░ 45% |
-| 3 | [road-to-conformance-round6.md](roadmaps/road-to-conformance-round6.md) | 6 | 29 | 28 | 1 | 0 | 0 | [2](#blockers-road-to-conformance-round6) | ░░░░░░░░░░ 3% |
+| 3 | [road-to-conformance-round6.md](roadmaps/road-to-conformance-round6.md) | 6 | 30 | 27 | 3 | 0 | 0 | [2](#blockers-road-to-conformance-round6) | █░░░░░░░░░ 10% |
 | 4 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
 | 5 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
 | 6 | [road-to-inbox-harvest-2026-08.md](roadmaps/road-to-inbox-harvest-2026-08.md) | 5 | 21 | 1 | 11 | 4 | 5 | [2](#blockers-road-to-inbox-harvest-2026-08) | █████████░ 92% |
@@ -73,16 +73,16 @@
 
 ### [road-to-conformance-round6.md](roadmaps/road-to-conformance-round6.md)
 
-**Road to conformance round 6 — the guard regress I shipped, the unmeasured half, and the therapy that has not started** — 1 / 29 done (3%)
+**Road to conformance round 6 — the guard regress I shipped, the unmeasured half, and the therapy that has not started** — 3 / 30 done (10%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Close the regress, then the standing hole | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
 | 2 | One trigger definition, both directions | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
-| 3 | Skills: the census IS the finding | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 3 | Skills: the census IS the finding | 🟡 in progress | 3 | 1 | 0 | 0 | 25% |
 | 4 | The volume question, answered differently than planned | 🟡 in progress | 4 | 1 | 0 | 0 | 20% |
 | 5 | Close round 5's own accounting | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
-| 6 | What this roadmap will not do | ⬜ not started | 10 | 0 | 0 | 0 | 0% |
+| 6 | What this roadmap will not do | 🟡 in progress | 10 | 1 | 0 | 0 | 9% |
 
 <a id="blockers-road-to-conformance-round6"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-conformance-round6.md
+++ b/agents/roadmaps/road-to-conformance-round6.md
@@ -235,23 +235,38 @@ specified, and matching `description:` prose instead is exactly the FC-8-shaped
 prose-matching the draft's own next step forbade — the contradiction sat two
 steps apart in one file, and no gate would have caught it.
 
-Second measurement, same pass: **8 of 288 skills** carry a deterministic
-`MUST`/`NEVER`/`ALWAYS` at line start. The draft pre-authorised the exit at a
-threshold of five, so 8 clears it — but it clears it while covering **2.8 %** of
-the corpus, which is not the same thing as a working instrument.
+Second measurement, same pass: **30 of 288 skills** (10.4 %) carry a
+deterministic `MUST`/`NEVER`/`ALWAYS`. The draft pre-authorised the exit at a
+threshold of five, so 30 clears it comfortably — but it clears it while covering
+a tenth of the corpus, which is not the same thing as a working instrument.
+
+**Corrected during execution, and the correction is the argument for the
+script.** This roadmap first reported **8**. That figure came from an ad-hoc grep
+anchored at line start with no list prefix, so every `- MUST` and `**NEVER**` was
+invisible to it. The census script counts them and reports 30. Both figures stay
+published per the instrument lock; the reason is mechanical and re-runnable,
+which is precisely why a one-off grep is not an instrument. Round 5 corrected
+three of its own numbers; this is the fourth in the series, and the first one
+where the replacement is a committed tool rather than a better command line.
 
 So the deliverable inverts. The honest answer to "are skills followed?" is not a
 rate; it is that today's frontmatter cannot support the question, and the census
 is what says so.
 
-- [ ] 3.1 Publish the census as the primary finding: 288 skills, **0** with
-  machine-readable triggers, **8** with a deterministic obligation. Skill
-  activation is not measurable against the shipped frontmatter, and no number
-  should be reported as if it were.
+- [x] 3.1 Publish the census as the primary finding — **shipped** as
+  `src/scripts/report_skill_activation.ts`, advisory, registered as a named task
+  and deliberately not wired into a pipeline (the convention `report_imperative_density`
+  set). Measured: 288 skills, **0** with a machine-matchable trigger key, **30**
+  with a deterministic obligation, and **31 invocations of 6 distinct skills**
+  across 59 sessions and 33 654 assistant turns in three stores. The script
+  prints an explicit unmeasurable verdict while no skill declares a trigger, and
+  a test pins that it never prints an activation rate — a rate would be exactly
+  the theatre the conformance scan's scope lock forbids, which is also why this
+  lives outside that scan.
 - [ ] 3.2 Build the one class that *is* buildable — **SK-2 loaded-but-violated**:
   a skill body is in context and a deterministic obligation stated in it is
   violated in a later assistant turn of the same session. Scope it explicitly to
-  the 8 skills, and name them, so the coverage is legible rather than implied.
+  the 30 named skills, so the coverage is legible rather than implied.
 - [ ] 3.3 Validate before believing any number: hand-read every flagged turn of
   the first run and publish precision. A detector that cannot state its
   false-positive rate ships as detection-only and this roadmap says so.
@@ -379,9 +394,10 @@ attributed rather than absorbed.
 - [ ] The hook-surface residue is settled by measurement, in either direction.
 - [ ] The re-measured language count is published beside 578 and 641 with the
   mechanical reason for the delta.
-- [ ] The skill census is published (288 / 0 with triggers / 8 with a
-  deterministic obligation), SK-2 publishes a count with a stated precision over
-  the named 8, and no activation number is reported at all.
+- [x] The skill census is published (288 / 0 with triggers / **30** with a
+  deterministic obligation, the 8 corrected with its reason), and no activation
+  rate is reported at all — pinned by a test.
+- [ ] SK-2 publishes a count with a stated precision over the named 30.
 - [ ] The volume hypothesis has a pre-registered threshold and a published
   result, null or not.
 - [ ] No enforcement claim in this roadmap's diff exceeds what a shipped

--- a/src/scripts/report_skill_activation.ts
+++ b/src/scripts/report_skill_activation.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env tsx
+/**
+ * report_skill_activation.ts — the census that answers "are the skills used?"
+ * by showing why the question cannot currently be answered as a rate.
+ *
+ * Executes round-6 Phase 3.1. Advisory: **it gates on nothing**, has no
+ * threshold, and must not acquire one — for the same reason
+ * `report_imperative_density` must not, plus one specific to this surface.
+ *
+ * WHY THIS IS NOT PART OF `conformance_scan`
+ * ------------------------------------------
+ * The conformance scan carries a binding constraint adopted verbatim from the
+ * round-1 council: it may measure ONLY classes that have a mechanism, because
+ * "a conformance scan that checks un-mechanised rules is theatre". Skill
+ * activation has no mechanism at all — there is no runtime router, and nothing
+ * observes whether a skill that should have fired did. Putting these numbers in
+ * the scan would read as enforcement. They belong in a census that says what it
+ * is.
+ *
+ * WHAT THE ROUND-6 PASS MEASURED, AND WHY THE SHAPE INVERTED
+ * ----------------------------------------------------------
+ * Usage, across 59 sessions and 33,618 assistant turns in three stores: **31
+ * Skill invocations, 6 distinct skills of 288 shipped (2.1%)**. Five of the six
+ * are slash-commands the human typed; one looks agent-initiated.
+ *
+ * The first draft of the round-6 phase planned a missed-activation detector
+ * keyed on "a skill's own frontmatter triggers". There are none: 0 of 288 skills
+ * carry a `triggers:` key. Matching the `description:` prose instead is the
+ * FC-8-shaped prose-matching the same phase forbids. So a rate is not available
+ * and the census is the finding — which is why this file prints counts and an
+ * explicit unmeasurable verdict rather than a percentage that would look like an
+ * answer.
+ *
+ * THE GAP THIS SCRIPT CANNOT CLOSE, STATED SO NOBODY READS IT AS COVERED
+ * ---------------------------------------------------------------------
+ * The strongest candidate cause is a delivery defect: in an observed session the
+ * host's injected skill catalogue carried descriptions for roughly the first
+ * forty entries and BARE NAMES thereafter, and a bare `- flux` carries no
+ * activation signal at all. That is a single-session observation, not a
+ * measurement, because the injected catalogue is **not persisted in the
+ * transcript** — grep for it across the store and it is absent. So this script
+ * prints the hypothesis and its falsifier instead of a number: capture the
+ * catalogue deliberately (a `session_start` concern logging the block once), then
+ * count descriptions against bare names. Until that runs, "most skills reach the
+ * model without a description" is a suspicion.
+ *
+ * Exit: 0 always, except a usage/IO error (1). Deliberate.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+export const SKILLS_ROOT = 'src/skills';
+
+/** A trigger key the host could match on without reading prose. */
+const TRIGGER_KEYS = ['triggers:', 'trigger_description:', 'file_pattern:', 'path_prefix:'];
+
+/**
+ * A deterministic obligation is one whose violation is observable without
+ * judgement — the line-start absolutes. Prose that merely urges ("prefer",
+ * "consider") is excluded on purpose: it is the FC-8 class, and counting it here
+ * would inflate the only number in this census that bounds what SK-2 can cover.
+ */
+const DETERMINISTIC_RE = /^\s*(?:[-*]\s*)?(?:\*\*)?(MUST|NEVER|ALWAYS)\b/m;
+
+export interface SkillCensus {
+  total: number;
+  withTriggerKey: string[];
+  withDeterministicObligation: string[];
+}
+
+export function censusSkills(root: string): SkillCensus {
+  const out: SkillCensus = { total: 0, withTriggerKey: [], withDeterministicObligation: [] };
+  if (!fs.existsSync(root)) {
+    return out;
+  }
+  for (const entry of fs.readdirSync(root, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const file = path.join(root, entry.name, 'SKILL.md');
+    if (!fs.existsSync(file)) {
+      continue;
+    }
+    out.total += 1;
+    const text = fs.readFileSync(file, 'utf8');
+    // Frontmatter is everything between the first two `---` fences; a trigger
+    // key anywhere else is prose about triggers, not a matchable declaration.
+    const fmEnd = text.startsWith('---') ? text.indexOf('\n---', 3) : -1;
+    const fm = fmEnd === -1 ? '' : text.slice(0, fmEnd);
+    if (TRIGGER_KEYS.some((k) => new RegExp(`^${k}`, 'm').test(fm))) {
+      out.withTriggerKey.push(entry.name);
+    }
+    const body = fmEnd === -1 ? text : text.slice(fmEnd + 4);
+    if (DETERMINISTIC_RE.test(body)) {
+      out.withDeterministicObligation.push(entry.name);
+    }
+  }
+  return out;
+}
+
+export interface UsageReport {
+  store: string;
+  sessions: number;
+  assistantTurns: number;
+  invocations: number;
+  bySkill: Record<string, number>;
+}
+
+/** Default store for the current working directory, mangled the way the host does. */
+export function defaultStore(cwd: string): string {
+  return path.join(os.homedir(), '.claude', 'projects', cwd.replace(/\//g, '-'));
+}
+
+export function measureUsage(store: string, limit: number): UsageReport {
+  const rep: UsageReport = { store, sessions: 0, assistantTurns: 0, invocations: 0, bySkill: {} };
+  if (!fs.existsSync(store)) {
+    return rep;
+  }
+  const files = fs
+    .readdirSync(store)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => path.join(store, f))
+    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs)
+    .slice(0, limit);
+  rep.sessions = files.length;
+  for (const file of files) {
+    for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+      if (!line.trim()) {
+        continue;
+      }
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (entry['type'] !== 'assistant') {
+        continue;
+      }
+      rep.assistantTurns += 1;
+      const msg = entry['message'];
+      const content = msg !== null && typeof msg === 'object' ? (msg as Record<string, unknown>)['content'] : null;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      for (const part of content) {
+        if (part === null || typeof part !== 'object') {
+          continue;
+        }
+        const p = part as Record<string, unknown>;
+        if (p['type'] !== 'tool_use' || p['name'] !== 'Skill') {
+          continue;
+        }
+        rep.invocations += 1;
+        const input = p['input'];
+        const name = input !== null && typeof input === 'object' ? (input as Record<string, unknown>)['skill'] : null;
+        const key = typeof name === 'string' && name !== '' ? name : '<unnamed>';
+        rep.bySkill[key] = (rep.bySkill[key] ?? 0) + 1;
+      }
+    }
+  }
+  return rep;
+}
+
+function _pct(n: number, d: number): string {
+  return d === 0 ? 'n/a' : `${((100 * n) / d).toFixed(1)}%`;
+}
+
+export function render(census: SkillCensus, usage: UsageReport[]): string {
+  const lines: string[] = [];
+  lines.push('skill activation census — advisory, gates on nothing');
+  lines.push('');
+  lines.push(`  skills shipped                         ${census.total}`);
+  lines.push(
+    `  with a machine-matchable trigger key   ${census.withTriggerKey.length} (${_pct(census.withTriggerKey.length, census.total)})`,
+  );
+  lines.push(
+    `  with a deterministic obligation        ${census.withDeterministicObligation.length} (${_pct(census.withDeterministicObligation.length, census.total)})`,
+  );
+  if (census.withDeterministicObligation.length > 0) {
+    lines.push(`      ${census.withDeterministicObligation.join(', ')}`);
+  }
+  lines.push('');
+  let totalInv = 0;
+  const distinct = new Set<string>();
+  for (const u of usage) {
+    for (const k of Object.keys(u.bySkill)) {
+      distinct.add(k);
+    }
+    totalInv += u.invocations;
+    lines.push(
+      `  ${path.basename(u.store).slice(-38).padEnd(38)} sessions=${String(u.sessions).padStart(3)} asst=${String(u.assistantTurns).padStart(6)} Skill calls=${String(u.invocations).padStart(3)}`,
+    );
+  }
+  lines.push('');
+  lines.push(`  invocations total                      ${totalInv}`);
+  lines.push(
+    `  distinct skills invoked                ${distinct.size} of ${census.total} (${_pct(distinct.size, census.total)})`,
+  );
+  if (distinct.size > 0) {
+    lines.push(`      ${[...distinct].sort().join(', ')}`);
+  }
+  lines.push('');
+  if (census.withTriggerKey.length === 0) {
+    lines.push('  VERDICT: activation is not measurable as a rate. No skill declares a');
+    lines.push('  machine-matchable trigger, so a missed-activation detector has nothing to');
+    lines.push('  match against, and matching the description prose is the class this suite');
+    lines.push('  excludes. The counts above are the finding, not an input to a percentage.');
+  }
+  lines.push('');
+  lines.push('  NOT MEASURED: whether each skill reached the model WITH its description.');
+  lines.push('  The host\'s injected catalogue is not persisted in the transcript, so the');
+  lines.push('  bare-name hypothesis is a single-session observation. Falsifier: log the');
+  lines.push('  catalogue once per session, then count descriptions against bare names.');
+  return lines.join('\n');
+}
+
+function main(argv: string[]): number {
+  let limit = 30;
+  const stores: string[] = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--limit' && argv[i + 1] !== undefined) {
+      limit = Number.parseInt(argv[i + 1] as string, 10);
+      i += 1;
+    } else if (a === '--store' && argv[i + 1] !== undefined) {
+      stores.push(argv[i + 1] as string);
+      i += 1;
+    } else if (a === '--help' || a === '-h') {
+      process.stdout.write('usage: report_skill_activation [--limit N] [--store PATH]...\n');
+      return 0;
+    }
+  }
+  if (!Number.isFinite(limit) || limit <= 0) {
+    process.stderr.write('report_skill_activation: --limit must be a positive integer\n');
+    return 1;
+  }
+  if (stores.length === 0) {
+    stores.push(defaultStore(REPO_ROOT));
+  }
+  const census = censusSkills(path.join(REPO_ROOT, SKILLS_ROOT));
+  const usage = stores.map((s) => measureUsage(s, limit));
+  process.stdout.write(`${render(census, usage)}\n`);
+  return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+export { main };

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -729,6 +729,11 @@ tasks:
     desc: Advisory imperative-density ratio over authored rules and skills — gates on nothing; direction unsettled per the sweep record § R2
     cmd: ./scripts-run src/scripts/report_imperative_density
 
+  report-skill-activation:
+    silent: true
+    desc: "Advisory skill-activation census (round-6 Phase 3.1) — shipped skills vs machine-matchable triggers vs actual invocations; gates on nothing and prints no rate, because none is available"
+    cmd: ./scripts-run src/scripts/report_skill_activation {{.CLI_ARGS}}
+
   lint-settings-classes:
     silent: true
     desc: Every settings-template leaf carries an A/B/C class in docs/contracts/settings-classes.md (road-to-zero-ceremony-settings Phase 1)

--- a/tests/scripts/report_skill_activation.test.ts
+++ b/tests/scripts/report_skill_activation.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The census exists because a rate is not available; these tests pin that the
+ * script keeps saying so rather than acquiring a threshold, and pin the two
+ * counting rules that a prior ad-hoc grep got wrong.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  censusSkills,
+  measureUsage,
+  render,
+  SKILLS_ROOT,
+  defaultStore,
+} from "../../src/scripts/report_skill_activation.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function mkSkill(root: string, name: string, frontmatter: string, body: string): void {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "SKILL.md"), `---\n${frontmatter}\n---\n\n${body}\n`, "utf8");
+}
+
+describe("censusSkills", () => {
+  it("counts a trigger key only when it is in frontmatter, not in prose about triggers", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "sa-census-"));
+    mkSkill(root, "declared", 'name: declared\ntriggers:\n  - keyword: "x"', "Body.");
+    mkSkill(root, "prose-only", "name: prose-only", "This skill discusses triggers:\n- keyword: x");
+    const c = censusSkills(root);
+    expect(c.total).toBe(2);
+    expect(c.withTriggerKey).toEqual(["declared"]);
+  });
+
+  // The round-6 roadmap first reported 8 skills with a deterministic obligation.
+  // That came from a grep anchored at line start with no list prefix, so every
+  // `- MUST` and `**MUST**` was missed. The real figure is higher; these cases
+  // are the shapes that were dropped.
+  it("counts a deterministic obligation behind a list marker or bold, not only bare", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "sa-det-"));
+    mkSkill(root, "bare", "name: bare", "MUST do the thing.");
+    mkSkill(root, "listed", "name: listed", "- MUST do the thing.");
+    mkSkill(root, "bolded", "name: bolded", "**NEVER** do the other thing.");
+    mkSkill(root, "soft", "name: soft", "Prefer the thing, and consider the alternative.");
+    const c = censusSkills(root);
+    expect(new Set(c.withDeterministicObligation)).toEqual(new Set(["bare", "listed", "bolded"]));
+    expect(c.withDeterministicObligation).not.toContain("soft");
+  });
+
+  it("ignores a trigger key that appears only in the body after the frontmatter fence", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "sa-fence-"));
+    mkSkill(root, "body-key", "name: body-key", "file_pattern: *.md\n\nProse.");
+    expect(censusSkills(root).withTriggerKey).toEqual([]);
+  });
+
+  it("returns an empty census for an absent root rather than throwing", () => {
+    const c = censusSkills(path.join(os.tmpdir(), "sa-does-not-exist-" + String(Date.now())));
+    expect(c.total).toBe(0);
+  });
+
+  it("the shipped corpus declares no machine-matchable trigger — the finding this script exists for", () => {
+    const c = censusSkills(path.join(REPO_ROOT, SKILLS_ROOT));
+    expect(c.total).toBeGreaterThan(200);
+    expect(c.withTriggerKey).toEqual([]);
+  });
+});
+
+describe("measureUsage", () => {
+  it("counts Skill tool invocations by name and ignores other tools", () => {
+    const store = fs.mkdtempSync(path.join(os.tmpdir(), "sa-store-"));
+    const rows = [
+      { type: "assistant", message: { content: [{ type: "tool_use", name: "Skill", input: { skill: "ai-council" } }] } },
+      { type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "ls" } }] } },
+      { type: "assistant", message: { content: [{ type: "tool_use", name: "Skill", input: { skill: "ai-council" } }] } },
+      { type: "user", message: { content: "hi" } },
+    ];
+    fs.writeFileSync(path.join(store, "s1.jsonl"), rows.map((r) => JSON.stringify(r)).join("\n"), "utf8");
+    const u = measureUsage(store, 30);
+    expect(u.sessions).toBe(1);
+    expect(u.assistantTurns).toBe(3);
+    expect(u.invocations).toBe(2);
+    expect(u.bySkill).toEqual({ "ai-council": 2 });
+  });
+
+  it("survives a malformed line instead of aborting the session", () => {
+    const store = fs.mkdtempSync(path.join(os.tmpdir(), "sa-bad-"));
+    fs.writeFileSync(
+      path.join(store, "s1.jsonl"),
+      ["{not json", JSON.stringify({ type: "assistant", message: { content: [] } })].join("\n"),
+      "utf8",
+    );
+    expect(measureUsage(store, 30).assistantTurns).toBe(1);
+  });
+
+  it("returns zeros for an absent store", () => {
+    const u = measureUsage(path.join(os.tmpdir(), "sa-absent-" + String(Date.now())), 30);
+    expect(u.sessions).toBe(0);
+    expect(u.invocations).toBe(0);
+  });
+
+  it("mangles a cwd into the host's store path", () => {
+    expect(defaultStore("/a/b")).toBe(path.join(os.homedir(), ".claude", "projects", "-a-b"));
+  });
+});
+
+describe("render", () => {
+  it("prints the unmeasurable verdict while no skill declares a trigger, and never a rate", () => {
+    const out = render(
+      { total: 288, withTriggerKey: [], withDeterministicObligation: ["a"] },
+      [{ store: "/x/store", sessions: 1, assistantTurns: 10, invocations: 1, bySkill: { a: 1 } }],
+    );
+    expect(out).toContain("not measurable as a rate");
+    expect(out).toContain("NOT MEASURED");
+    // The census must not present activation as a percentage of opportunities —
+    // that number does not exist and printing one would be the theatre the
+    // conformance scan's scope lock forbids.
+    expect(out).not.toMatch(/activation rate/i);
+  });
+
+  it("drops the verdict once triggers exist, because then a detector is buildable", () => {
+    const out = render(
+      { total: 2, withTriggerKey: ["a"], withDeterministicObligation: [] },
+      [{ store: "/x", sessions: 0, assistantTurns: 0, invocations: 0, bySkill: {} }],
+    );
+    expect(out).not.toContain("not measurable as a rate");
+  });
+});


### PR DESCRIPTION
## What this answers

Two questions have been asked three times across this series: **why were rules ignored, and why were skills not used?** The rule half has been measured for five rounds. The skill half never had an instrument — skills appeared in the conformance scan only as bodies to *exclude*. This ships the missing half and executes round-6 Phase 3.1.

## Why skills were not used — measured, not theorised

Across **59 sessions and 33,654 assistant turns** in three transcript stores:

| | |
|---|---:|
| Skill invocations, total | **31** |
| Distinct skills invoked | **6 of 288** (2.1 %) |
| …of which are slash-commands the human typed | 5 of the 6 |
| …of which look agent-initiated | **1** |

So skills are essentially never self-selected. The census over the authored corpus says why a rate cannot follow:

| | |
|---|---:|
| Skills shipped | 288 |
| With a machine-matchable trigger key | **0** (0.0 %) |
| With a deterministic obligation | **30** (10.4 %) |

There is no runtime router, so activation is the model's judgment over text in context. With **zero** declared triggers, a missed-activation detector has nothing to match against — and matching the `description:` prose instead is precisely the class this suite excludes. The script therefore prints an explicit *unmeasurable* verdict while that holds, and a test pins that it **never** prints an activation rate.

## Why this is a census and not part of `conformance_scan`

The scan carries a binding constraint adopted verbatim from the round-1 council: it may measure **only** classes that have a mechanism, because "a conformance scan that checks un-mechanised rules is theatre". Skill activation has no mechanism at all. Putting these numbers in the scan would read as enforcement; they belong in a census that says what it is. Registered as a named task and deliberately **not** wired into any pipeline — the convention `report_imperative_density` set for an advisory number.

## A figure this branch corrects in its own roadmap

The roadmap said **8** skills carry a deterministic obligation. That came from a grep anchored at line start with no list prefix, so every `- MUST` and `**NEVER**` was invisible to it. The real count is **30**. Both stay published per the instrument lock, and the correction is the argument for the script: a one-off command line is not an instrument. This is the fourth self-correction in the series and the first where the replacement is a committed tool rather than a better command line.

## What the census cannot close, said in the header rather than implied

The strongest candidate cause for 2.1 % is a **delivery** defect, parallel to the rule-projection staleness round 5 found: in an observed session the host's injected skill catalogue carried descriptions for roughly the first forty entries and **bare names** thereafter — and a bare `- flux` carries no activation signal at all.

That is a single-session observation, **not** a measurement, because the injected catalogue is not persisted in the transcript (grep the store and it is absent). So the header prints the hypothesis with its falsifier instead of a number: capture the catalogue deliberately once per session, then count descriptions against bare names. Until that runs, "most skills reach the model without a description" is a suspicion and is labelled as one.

## Verification

`task report-skill-activation` runs and produces the figures above. 11 tests green, including the two counting rules the prior grep got wrong (list-prefixed and bolded obligations), the frontmatter-vs-prose trigger distinction, and the two render invariants. `check_ci_local_parity` clean (259 CI / 234 local / 26 declared CI-only / 1 local-only), `check_gate_paths` clean, ESLint exit 0, `task typecheck-ts` exit 0, blocker contract and Risk Register clean, `check_md_language` clean.
