### PR TITLE
docs(memory): say which repo the intake sharing-boundary line describes

### DIFF
--- a/docs/guidelines/agent-infra/memory-access.md
+++ b/docs/guidelines/agent-infra/memory-access.md
@@ -50,9 +50,20 @@ as provisional (best-effort, agent-written, not human-reviewed).
 
 **Sharing boundary.** Curated YAML (`agents/memory/<type>/*.yml`) is
 **committed** — it is the team-shared layer. Raw intake
-(`agents/memory/intake/*.jsonl`) is **gitignored, local scratch** — only
-entries promoted to curated get shared. `retrieve()` still reads local
-intake (low-confidence tier); it just never reaches the team repo unpromoted.
+(`agents/memory/intake/*.jsonl`) is **gitignored, local scratch** in a
+consumer project — only entries promoted to curated get shared. `retrieve()`
+still reads local intake (low-confidence tier); it just never reaches the team
+repo unpromoted.
+
+> **Which repo you are in changes this one line.** In a **consumer project**
+> intake is gitignored — the shipped block in `src/config/gitignore-block.txt`
+> lists `/agents/memory/intake/`. In **this package's own repo** it is
+> **tracked** and union-merged, because here intake is part of the corpus
+> under test; `agents/memory/intake/README.md` says so ("Local + tracked").
+> Both are correct in their own context, and the sentence above states the
+> consumer one. Read unconditionally, it makes a maintainer treat tracked
+> intake files as a mistake, and it makes a consumer who follows the
+> directory's README commit raw signals by accident.
 
 ## The status helper
 


### PR DESCRIPTION
One paragraph in `docs/guidelines/agent-infra/memory-access.md` states unconditionally that raw intake is gitignored. It is context-dependent, and the reader cannot tell which context is meant.

## Measured

| Source | Says |
|---|---|
| `src/config/gitignore-block.txt:63` | ships `/agents/memory/intake/` to consumers → **gitignored there** |
| this repo's root `.gitignore` | does not list it (only `knowledge/session/`, `.agent-learning.json`, `LESSONS.md`) → **tracked here** |
| `agents/memory/intake/README.md:3` | *"Local + tracked; union-merged"* → correct here, contradicts the guideline as written |
| `docs/guidelines/agent-infra/memory-access.md:53` | *"is **gitignored, local scratch**"* → correct for a consumer, stated unconditionally |

Every one of those is right in its own context. Only the guideline omits which context it means.

## Why it is worth a line

Two failure modes, in opposite directions:

- A maintainer reads the guideline in this repo and treats the tracked intake files as a mistake to clean up.
- A consumer follows the intake directory's own README ("Local + tracked") and commits raw signals by accident — the exact thing the sharing boundary exists to prevent.

## Scope

Documentation only. One paragraph, no code, no behaviour change, no new claim — it names the two contexts that already exist.

## What this PR deliberately does **not** fix

While checking the memory surface I also found the consumer template `src/agent-src/templates/scripts/memory_lookup.ts` describing itself in the present tense as the *"TypeScript twin of `…memory_lookup.py`"* and *"byte-identical to the dev-side `src/scripts/memory_lookup.py`"* — both `.py` files are gone, so that particular parity claim can no longer be checked against anything. The dev-side sibling already phrases it correctly ("Ported from the **retired** Python … (ADR-200)").

**I did not touch it, on purpose.** A sweep shows **940 `.py` references across 600 files** under `src/` — the memory ones are ~8 of those, and ADR-200 already covers the migration. Fixing eight instances of a 940-strong pattern would look like the defect was handled when it was not. If a repo-wide pass on those references is wanted, it deserves its own PR and its own decision about which references are legitimate historical provenance (`1:1 port of scripts/install.py:detect_scope`) and which are stale present-tense claims.
