### PR TITLE
fix(release): self-heal stale hook bundle in preflight + race-safe tag push

### DIFF
--- a/src/scripts/check_hook_bundle_freshness.ts
+++ b/src/scripts/check_hook_bundle_freshness.ts
@@ -31,7 +31,10 @@
  * WHAT IT DOES NOT DO: it never builds. Building into a live hook path is a
  * documented hazard in this repo (an esbuild run that overwrites the
  * dispatcher a running hook is executing can wedge the tool loop), so the
- * remedy is printed for a human to run deliberately.
+ * remedy is printed for a human to run deliberately. The SAFE rebuild
+ * (build to .new → probe → atomic rename) lives in `rebuild_hook_bundle.ts`,
+ * which preflight runs right before this gate — so a red here means the heal
+ * itself failed or was bypassed, not merely that a merge landed.
  *
  * Exit codes: 0 = fresh, or no self-hosted bundle to check · 1 = stale.
  */

--- a/src/scripts/rebuild_hook_bundle.ts
+++ b/src/scripts/rebuild_hook_bundle.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env tsx
+/**
+ * Safe self-heal for the self-hosted hook bundle — the builder that
+ * `check_hook_bundle_freshness` deliberately is not.
+ *
+ * WHY THIS EXISTS — measured, not hypothetical.
+ *
+ * The freshness gate reds after ANY hook-source merge from main, because
+ * `dist/hooks/dispatch.js` is untracked and nothing in the local chain
+ * rebuilds it. On 2026-08-09 that turned `task release` (9.28.0) into a
+ * blocked push with a remedy the operator had to run by hand — a routine
+ * pre-push chore promoted to a release incident. The gate is right to never
+ * build (its documented hazard: esbuild overwriting the dispatcher a running
+ * hook is executing can wedge the tool loop). The hazard is in HOW a naive
+ * rebuild writes, not in rebuilding: this script builds to a sibling `.new`
+ * file, proves the result actually dispatches, and only then renames it into
+ * place — an atomic same-directory rename that a running hook holding an open
+ * file descriptor never observes mid-write.
+ *
+ * The `.new` file MUST live in `dist/hooks/` (not a temp dir): the bundle
+ * resolves `src/scripts/hook_manifest.yaml` relative to its OWN location via
+ * the `__AGENT_CONFIG_BUNDLE__` path-depth switch. Built anywhere else, every
+ * probe answers "manifest missing" with exit 0 and the smoke test proves
+ * nothing (measured 2026-08-08).
+ *
+ * The esbuild invocation is NOT duplicated here — it is read from
+ * `package.json`'s `build:hooks` script and only the `--outfile=` is
+ * rewritten, so the flag set (banner, defines, target) has exactly one home.
+ *
+ * Behaviour:
+ *   no self-hosted bundle → no-op (fresh checkout / CI — nothing is running
+ *                           stale code, and materialising a bundle here would
+ *                           change what other gates see)
+ *   bundle fresh          → no-op
+ *   bundle stale          → rebuild to `.new`, probe, rename into place
+ *   build or probe fails  → the `.new` file is removed and the OLD bundle
+ *                           keeps running (old-but-working beats broken);
+ *                           exit 1 so the freshness gate behind this still
+ *                           reds and the failure is loud.
+ *
+ * Exit codes: 0 = fresh / healed / nothing to heal · 1 = heal failed.
+ */
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { check } from "./check_hook_bundle_freshness.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..");
+const LIVE_REL = path.join("dist", "hooks", "dispatch.js");
+const NEW_REL = path.join("dist", "hooks", "dispatch.new.js");
+
+/**
+ * Rewrite the `--outfile=` of the canonical `build:hooks` script to the
+ * `.new` sibling. Returns null when the expected outfile token is absent —
+ * a changed `package.json` must fail loudly, never build to a guessed path.
+ */
+export function rewriteOutfile(script: string, newOutfile: string): string | null {
+  const token = `--outfile=${LIVE_REL}`;
+  if (!script.includes(token)) return null;
+  return script.replace(token, `--outfile=${newOutfile}`);
+}
+
+/**
+ * Verdict on a dispatcher probe. The probe contract is pinned against the
+ * real dry-run output: exit 0 AND parseable JSON AND a non-empty `concerns`
+ * array. Exit 0 alone is NOT enough — a bundle that cannot find its manifest
+ * answers "manifest missing" with exit 0 (measured 2026-08-08), which is
+ * exactly the broken dispatcher this probe exists to keep out of the live
+ * path. Returns null on pass, a human-readable reason on failure.
+ */
+export function probeVerdict(exitCode: number, stdout: string): string | null {
+  if (exitCode !== 0) return `probe exited ${String(exitCode)}`;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return `probe output is not JSON: ${stdout.slice(0, 120)}`;
+  }
+  const concerns = (parsed as { concerns?: unknown }).concerns;
+  if (!Array.isArray(concerns) || concerns.length === 0) {
+    return "probe JSON carries no concerns — the bundle dispatched nothing";
+  }
+  return null;
+}
+
+function cleanup(newAbs: string): void {
+  try {
+    fs.rmSync(newAbs, { force: true });
+  } catch {
+    // Best-effort: a leftover .new file is inert (nothing executes it).
+  }
+}
+
+export function main(): number {
+  const r = check(REPO_ROOT);
+
+  if (r.skipped) {
+    process.stdout.write(
+      `✅  OK  rebuild_hook_bundle: no self-hosted ${LIVE_REL} — nothing runs stale code, nothing to heal\n`,
+    );
+    return 0;
+  }
+  if (r.stale.length === 0) {
+    process.stdout.write("✅  OK  rebuild_hook_bundle: bundle already fresh — no rebuild needed\n");
+    return 0;
+  }
+
+  process.stdout.write(
+    `🔧  hook bundle stale (${String(r.stale.length)} newer source(s)) — rebuilding safely (build .new → probe → atomic rename)\n`,
+  );
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf-8")) as {
+    scripts?: Record<string, string>;
+  };
+  const buildScript = pkg.scripts?.["build:hooks"];
+  if (buildScript === undefined) {
+    console.error("❌  rebuild_hook_bundle: package.json has no build:hooks script");
+    return 1;
+  }
+  const cmd = rewriteOutfile(buildScript, NEW_REL);
+  if (cmd === null) {
+    console.error(
+      `❌  rebuild_hook_bundle: build:hooks no longer targets --outfile=${LIVE_REL} — ` +
+        "refusing to build to a guessed path; update this script alongside package.json",
+    );
+    return 1;
+  }
+
+  const newAbs = path.join(REPO_ROOT, NEW_REL);
+  const build = spawnSync("sh", ["-c", cmd], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    env: { ...process.env, PATH: `${path.join(REPO_ROOT, "node_modules", ".bin")}:${process.env["PATH"] ?? ""}` },
+  });
+  if (build.status !== 0) {
+    cleanup(newAbs);
+    console.error(`❌  rebuild_hook_bundle: esbuild failed (${String(build.status)}):`);
+    console.error((build.stderr || build.stdout || "").trim());
+    return 1;
+  }
+
+  const probe = spawnSync(
+    "node",
+    [newAbs, "--platform", "claude", "--event", "pre_tool_use", "--dry-run"],
+    { cwd: REPO_ROOT, encoding: "utf-8", input: "{}" },
+  );
+  const verdict = probeVerdict(probe.status ?? 1, probe.stdout ?? "");
+  if (verdict !== null) {
+    cleanup(newAbs);
+    console.error(`❌  rebuild_hook_bundle: new bundle failed its probe — ${verdict}`);
+    console.error("    The old bundle stays in place (old-but-working beats broken).");
+    return 1;
+  }
+
+  fs.renameSync(newAbs, path.join(REPO_ROOT, LIVE_REL));
+  process.stdout.write(
+    `✅  OK  rebuild_hook_bundle: rebuilt + probed + renamed into place (${String(r.checked)} bundled source(s))\n`,
+  );
+  return 0;
+}
+
+const invokedDirectly = ((): boolean => {
+  const entry = process.argv[1];
+  if (entry === undefined) return false;
+  try {
+    return fs.realpathSync(path.resolve(entry)) === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -1073,6 +1073,78 @@ function _tag_exists_remote(tag: string): boolean {
     return r.returncode === 0;
 }
 
+/**
+ * True when git rejected a tag push because the ref already exists on the
+ * remote. Wording pinned from the real failure (2026-08-09, 9.28.0 — two
+ * concurrent resume runs, the loser crashed):
+ *
+ *     ! [remote rejected]  9.28.0 -> 9.28.0 (cannot lock ref 'refs/tags/9.28.0': reference already exists)
+ *
+ * plus the `[rejected] … (already exists)` variant git emits when the local
+ * and remote tag objects differ.
+ */
+export function _is_tag_already_exists(stderr: string, stdout: string): boolean {
+    const text = `${stderr}\n${stdout}`;
+    return /\[(?:remote )?rejected\]/i.test(text) && /already exists/i.test(text);
+}
+
+/** Peeled commit the remote tag points at, or null when the tag is absent. */
+function _remote_tag_commit(tag: string): string | null {
+    const r = run(['git', 'ls-remote', REMOTE, `refs/tags/${tag}`, `refs/tags/${tag}^{}`], {
+        check: false,
+        capture: true,
+    });
+    if (r.returncode !== 0) return null;
+    const lines = r.stdout.trim().split('\n').filter(Boolean);
+    if (lines.length === 0) return null;
+    // An annotated tag lists the tag object AND the peeled `^{}` commit — the
+    // peeled line wins so the comparison is commit-vs-commit regardless of
+    // whether the two runs minted distinct tag objects for the same commit.
+    const peeled = lines.find((l) => l.trimEnd().endsWith('^{}'));
+    return (peeled ?? (lines[0] as string)).split('\t')[0] ?? null;
+}
+
+/**
+ * Push a tag, tolerating exactly ONE failure: the concurrent-release race.
+ * `_tag_exists_remote` in step 8 is a live check, but between it and this
+ * push a parallel `task release` run can land the same tag (measured
+ * 2026-08-09, 9.28.0). When the remote tag already points at the same commit
+ * as the local one, the repository IS in the desired state — continue. Any
+ * other rejection, and a same-name tag on a DIFFERENT commit, stays fatal
+ * with the push output as the error.
+ */
+function _push_tag(tag: string): void {
+    const first = run(['git', 'push', REMOTE, tag], { check: false, capture: true });
+    if (first.returncode === 0) {
+        process.stdout.write(first.stdout);
+        process.stderr.write(first.stderr);
+        return;
+    }
+    if (_is_tag_already_exists(first.stderr, first.stdout)) {
+        const remote = _remote_tag_commit(tag);
+        const local = git(['rev-list', '-n', '1', tag], { capture: true });
+        if (remote !== null && remote === local) {
+            process.stdout.write(
+                `↻  tag ${tag} already on ${REMOTE} at the same commit — a parallel run pushed it; continuing\n`,
+            );
+            return;
+        }
+        process.stdout.write(first.stdout);
+        process.stderr.write(first.stderr);
+        die(
+            `tag ${tag} exists on ${REMOTE} pointing at ${remote ?? '<unreadable>'} while the local tag ` +
+                `points at ${local} — refusing to overwrite a published tag; ` +
+                'delete the wrong one deliberately and re-run',
+        );
+    }
+    process.stdout.write(first.stdout);
+    process.stderr.write(first.stderr);
+    die(
+        `push of tag ${tag} failed (exit ${first.returncode}) — ` +
+            'the push output above is the real error (a pre-push gate, credentials, or protection)',
+    );
+}
+
 /** Most recent PR (any state) with `release/X.Y.Z` as head, or null. */
 function _pr_for_branch(branch: string): Record<string, unknown> | null {
     const r = run(
@@ -2029,7 +2101,7 @@ function execute(
             _step(8, total, `Tag ${plan.target} already on ${REMOTE} — skip`);
         } else {
             _step(8, total, `Tag ${plan.target} exists locally — push only`);
-            run(['git', 'push', REMOTE, plan.target]);
+            _push_tag(plan.target);
         }
     } else {
         // Sequencing is load-bearing (release-truth Phase 1, council
@@ -2047,7 +2119,7 @@ function execute(
             );
         }
         run(['git', 'tag', '-a', plan.target, '-m', tag_message_from_section(merged!.body, plan.target)]);
-        run(['git', 'push', REMOTE, plan.target]);
+        _push_tag(plan.target);
     }
 
     // ─── 9. GitHub Release ──────────────────────────────────────────────────

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -47,6 +47,14 @@ tasks:
       # four such fixes ran nowhere for a full session. Sub-second (38 stats).
       # In CI it declares a loud no-op — a fresh checkout has no bundle — rather
       # than passing silently on an invariant it never evaluated.
+      # The healer runs FIRST: the staleness the gate catches is a routine
+      # consequence of any hook-source merge (dist/ is untracked), and on
+      # 2026-08-09 it blocked the 9.28.0 release push. The healer rebuilds
+      # SAFELY (build to .new → probe the dispatcher → atomic rename), which
+      # removes the gate's documented never-build hazard; the gate behind it
+      # then verifies the fixpoint and still reds if the heal failed. In CI
+      # both are no-ops — a fresh checkout has no bundle.
+      - ./scripts-run src/scripts/rebuild_hook_bundle
       - ./scripts-run src/scripts/check_hook_bundle_freshness
       - ./scripts-run src/scripts/lint_regression
       # Same argv the CI `skill-lint` job runs. NOT chosen for speed — both

--- a/tests/scripts/rebuild_hook_bundle.test.ts
+++ b/tests/scripts/rebuild_hook_bundle.test.ts
@@ -1,0 +1,66 @@
+// The hook-bundle healer's two pure seams, pinned against real shapes.
+//
+// The build command is READ from package.json (single home for the esbuild
+// flag set) with only `--outfile=` rewritten — so the rewrite must work on
+// the real script string as committed, and must refuse loudly when the
+// expected token is gone. The probe contract exists because exit 0 alone is
+// NOT proof of a working dispatcher: a bundle that cannot resolve its
+// manifest answers "manifest missing" with exit 0 (measured 2026-08-08).
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { probeVerdict, rewriteOutfile } from '../../src/scripts/rebuild_hook_bundle.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('rewriteOutfile — the committed build:hooks script is the contract', () => {
+  it('rewrites the real package.json build:hooks outfile and nothing else', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(REPO, 'package.json'), 'utf-8')) as {
+      scripts: Record<string, string>;
+    };
+    const script = pkg.scripts['build:hooks'] as string;
+    const rewritten = rewriteOutfile(script, path.join('dist', 'hooks', 'dispatch.new.js'));
+    expect(rewritten).not.toBeNull();
+    expect(rewritten).toContain('--outfile=dist/hooks/dispatch.new.js');
+    expect(rewritten).not.toContain('--outfile=dist/hooks/dispatch.js');
+    // The banner and defines must survive untouched — they are the fix for
+    // the esbuild CLI-guard collision and the bundle path-depth switch.
+    expect(rewritten).toContain('--banner:js=');
+    expect(rewritten).toContain('--define:__AGENT_CONFIG_BUNDLE__=true');
+  });
+
+  it('returns null when the expected outfile token is absent (changed package.json fails loudly)', () => {
+    expect(rewriteOutfile('esbuild x.ts --outfile=somewhere/else.js', 'dist/hooks/dispatch.new.js')).toBeNull();
+  });
+});
+
+describe('probeVerdict — exit 0 alone is not a working dispatcher', () => {
+  it('passes the real dry-run shape: exit 0 + JSON with non-empty concerns', () => {
+    const stdout = JSON.stringify({
+      platform: 'claude',
+      event: 'pre_tool_use',
+      concerns: ['block-no-verify', 'rtk-wrap'],
+    });
+    expect(probeVerdict(0, stdout)).toBeNull();
+  });
+
+  it('fails a non-zero exit', () => {
+    expect(probeVerdict(1, '{}')).toMatch(/exited 1/);
+  });
+
+  it('fails the manifest-missing shape (exit 0, non-JSON prose) — the 2026-08-08 trap', () => {
+    expect(probeVerdict(0, 'dispatch_hook: manifest missing at /tmp/x/hook_manifest.yaml')).toMatch(
+      /not JSON/,
+    );
+  });
+
+  it('fails JSON that dispatched nothing (no concerns)', () => {
+    expect(probeVerdict(0, JSON.stringify({ platform: 'claude', concerns: [] }))).toMatch(
+      /no concerns/,
+    );
+    expect(probeVerdict(0, '{}')).toMatch(/no concerns/);
+  });
+});

--- a/tests/scripts/release_tag_race.test.ts
+++ b/tests/scripts/release_tag_race.test.ts
@@ -1,0 +1,59 @@
+// A tag push lost to a concurrent release run must not crash the release.
+//
+// Step 8's `_tag_exists_remote` is a live check, but it is a check-then-act:
+// between it and the push, a parallel `task release -- --resume` can land the
+// same tag. Measured 2026-08-09 on 9.28.0 — two resume runs raced, the loser
+// died with a raw CalledProcessError although the repository was already in
+// exactly the state the run wanted.
+//
+// The discriminator is pinned here against git's real wording, in both
+// directions: the already-exists rejection must be recognised, and every
+// other push failure (pre-push gate, credentials, moved branch) must NOT be,
+// so a real error is never silently absorbed as "raced".
+import { describe, expect, it } from 'vitest';
+
+import { _is_tag_already_exists } from '../../src/scripts/release.js';
+
+describe('_is_tag_already_exists — only the raced-tag case is tolerable', () => {
+  it('recognises the remote-rejected cannot-lock-ref wording (the 9.28.0 case, verbatim)', () => {
+    const stderr = [
+      'To github.com:event4u-app/agent-config.git',
+      " ! [remote rejected]     9.28.0 -> 9.28.0 (cannot lock ref 'refs/tags/9.28.0': reference already exists)",
+      "error: failed to push some refs to 'github.com:event4u-app/agent-config.git'",
+    ].join('\n');
+    expect(_is_tag_already_exists(stderr, '')).toBe(true);
+  });
+
+  it('recognises the plain rejected already-exists variant', () => {
+    const stderr = [
+      'To github.com:event4u-app/agent-config.git',
+      ' ! [rejected]        9.28.0 -> 9.28.0 (already exists)',
+      'hint: Updates were rejected because the tag already exists in the remote.',
+    ].join('\n');
+    expect(_is_tag_already_exists(stderr, '')).toBe(true);
+  });
+
+  it('does NOT treat a pre-push hook rejection as a raced tag', () => {
+    const stderr = [
+      '❌  Preflight failed. These gates run in CI too, so pushing now buys a',
+      '    red run and a fixup re-push.',
+      "error: failed to push some refs to 'github.com:event4u-app/agent-config.git'",
+    ].join('\n');
+    expect(_is_tag_already_exists(stderr, '')).toBe(false);
+  });
+
+  it('does NOT treat credentials or protection failures as a raced tag', () => {
+    expect(_is_tag_already_exists('remote: Permission to event4u-app/x.git denied', '')).toBe(false);
+    expect(
+      _is_tag_already_exists('remote: error: GH006: Protected branch update failed', ''),
+    ).toBe(false);
+  });
+
+  it('does NOT treat a moved branch (non-fast-forward) as a raced tag', () => {
+    const stderr = [
+      ' ! [rejected]        main -> main (fetch first)',
+      'hint: Updates were rejected because the remote contains work that you do not',
+    ].join('\n');
+    expect(_is_tag_already_exists(stderr, '')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The 9.28.0 release run died twice, for two independent reasons:

1. **Stale hook bundle blocked the push.** `check_hook_bundle_freshness` reds after any hook-source merge, because `dist/hooks/dispatch.js` is untracked and nothing in the local chain rebuilds it. The gate deliberately never builds (documented wedge hazard), so a routine chore escalated into a blocked release with a manual remedy.
2. **Concurrent tag push crashed the loser.** Step 8's `_tag_exists_remote` is check-then-act: a parallel `task release -- --resume` landed the tag between the check and the push, and the losing run died with a raw `CalledProcessError` on `cannot lock ref 'refs/tags/9.28.0': reference already exists` — although the repository was already in exactly the desired state.

## Fix

**Commit 1 — `rebuild_hook_bundle` heals before the gate verifies.** New preflight step directly before the freshness gate. It reads the esbuild command from `package.json`'s `build:hooks` (single home for the flag set), rewrites only `--outfile=` to `dist/hooks/dispatch.new.js`, probes the new bundle (exit 0 **and** JSON with non-empty `concerns` — exit 0 alone is the measured manifest-missing trap), then renames it atomically into place. A running hook holding an open fd never observes a partial write, which removes the gate's documented never-build hazard. Failed heal → `.new` removed, old bundle keeps running, exit 1 so the gate behind it still reds. Fresh checkout / CI → loud no-op, so CI parity holds without a manifest exemption.

**Commit 2 — `_push_tag` tolerates exactly the raced-tag case.** `_is_tag_already_exists` is pinned against git's real wording (both the `[remote rejected] … cannot lock ref` and `[rejected] … (already exists)` variants). The race is only absorbed when the remote tag's **peeled commit** equals the local one; a same-name tag on a different commit and every other rejection (pre-push gate, credentials, protection) stay fatal with the push output as the error — the same discriminator discipline as `_is_non_fast_forward` for branch pushes.

## Verification

- 17 new/adjacent unit tests green (`release_tag_race`, `rebuild_hook_bundle`, `release_push_failure_masking`); full `release.test.ts` (91) + `release_drill.test.ts` (8) green.
- Healer exercised live on the real stale path: touch a hook source → heal (build → probe → rename) → gate green → second run no-op → live dispatcher still answers the dry-run probe.
- `check_ci_local_parity` green (261 CI / 236 local, no new declaration needed — CI reaches the healer via `task preflight`, where it no-ops).
- `task typecheck-ts` + eslint on the changed files green.

Tests: 17 new assertions across 2 new test files.
