### PR TITLE
fix: repair the three dangling citations the rule migration left behind

### DIFF
--- a/agents/decisions/rule-migrations/README.md
+++ b/agents/decisions/rule-migrations/README.md
@@ -49,9 +49,19 @@ left a live citation pointing at content that no longer exists — a command fil
 still refers readers to `docker-commands` for a tool-detection branch that is
 gone, `laravel-translations` is cited as the home of a key-format mandate it no
 longer states, and two files name `reviewer-awareness` as the home of a reviewer
-vocabulary that exists nowhere. Those dangling pointers are recorded here rather
-than repaired: the ledger's job is that the loss is **visible**, and repairing
-them is a change with its own scope.
+vocabulary that exists nowhere. Those dangling pointers were recorded here
+rather than repaired: the ledger's job is that the loss is **visible**, and
+repairing them is a change with its own scope.
+
+**That repair has since landed, and the rows above did not change.** The three
+dropped sections were recovered from `d4fe80e1c^` and re-homed in their declared
+`migrated_to` targets — tooling detection in `skill:docker`, the flat
+dot-notation key format in `skill:laravel`, the seven-role vocabulary in
+`skill:review-routing`, with the citations that pointed at the rules repointed
+at the content. The `dropped` dispositions stay `dropped` **on purpose**: they
+record what the migration transform did, and a later repair does not retroact
+into that history. The gate agrees — it asserts a `dropped` row names no target
+and explicitly does not assert that a heading should have been carried.
 
 ## Retention policy
 

--- a/agents/evidence/reviews/dead-citations-after-rule-migration.findings.md
+++ b/agents/evidence/reviews/dead-citations-after-rule-migration.findings.md
@@ -1,0 +1,53 @@
+# Completion review — dead citations after the rule-body migration
+
+**Skipped:** no code surface for this completion — the diff is three skill bodies, one command file, one comment line in a shipped YAML example and the ledger README, plus their generated projections, and the gate itself measures zero code paths of eleven changed files, scope accfafd12f071276ddf7b1fd2816907565786407b1078a05fec7c4c0528e9d22, declared 2026-08-10
+
+## Why a skip rather than a review
+
+The change re-homes three prose sections that the rule-body migration dropped
+and re-aims the citations that pointed at them. It ships no executable surface:
+no script, no hook, no config, no test, and no frontmatter field.
+`check_completion_review` classifies the diff as zero code paths of eleven
+changed files, which is the condition this declaration covers.
+
+What replaces a code review here is the verification that produced the content,
+all of it re-runnable:
+
+- **Both halves of every claim were measured, not inherited.** The ledger names
+  three dangling citations; each was confirmed twice — the citing line exists
+  (`fix/ci/command.md:70`, `update-form-request-messages/command.md:132`, and
+  three files for the role vocabulary), and the cited content is absent
+  (`grep artisan src/skills/docker/SKILL.md` returned one unrelated line;
+  `dot-notation` returned zero in `skill:laravel`; the seven-role table returned
+  zero tree-wide).
+- **The ledger's own source pointer was wrong and is not followed blindly.**
+  `source_commit: d4fe80e1c` is the migration commit, which already carries the
+  stubs; the pre-migration bodies are in its parent. Recovered from
+  `d4fe80e1c^`, which `git log -S 'Tooling Detection'` independently confirms as
+  the last commit holding the heading.
+- **The ledger rows were deliberately left alone.** Flipping `dropped` to
+  `carried` would assert the migration did something it did not do. The gate
+  agrees in its own words — it asserts a dropped row names no target and
+  explicitly does not assert that a heading should have been carried — so
+  nothing here is a lint workaround.
+- **Two internal references inside `skill:review-routing` were already dead**
+  before this change and are repaired by the same edit: step 3 falls through
+  "to the generic-role fallback" and validation check 1 requires a role to be
+  "in the common vocabulary". Both now name a table in the same file.
+- `task preflight` is green, including `lint_regression` (no regressions),
+  `skill_linter --changed` (4 pass / 0 warn / 0 fail) and the kernel-rule bundle
+  check (no kernel rule touched).
+
+## Scope this does NOT cover
+
+The ledger records 15 dropped sections; this change repairs the three that left
+a live citation. The other twelve remain recorded losses with no dangling
+pointer — among them the four copy-pasteable in-container tool invocations and
+the blind-spot-reduction rationale. They are out of scope on purpose: no reader
+is currently sent to them.
+
+## Standing caveat
+
+A skip declaration is a statement about the diff's surface, not a claim that the
+prose is correct. Every claim above names the command or file that decides it,
+so a later reader can refute a row without trusting this artefact.

--- a/dist/agent-src/commands/review/routing.md
+++ b/dist/agent-src/commands/review/routing.md
@@ -59,9 +59,8 @@ changed-file list. The skill:
 4. Computes overall severity (`high` wins).
 5. Returns the structured block.
 
-If neither data file exists, the skill returns the generic fallback
-from [`reviewer-awareness`](../../rules/reviewer-awareness.md). That is
-valid output — do not invent owners.
+If neither data file exists, the skill returns the generic fallback from
+its own common role vocabulary. That is valid output — do not invent owners.
 
 ### 3. Present the result
 
@@ -121,7 +120,7 @@ After the block, ask:
 ## See also
 
 - [`review-routing`](../../skills/review-routing/SKILL.md) — the resolver
-- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — role vocabulary + data-source rules
+- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — the rule that routes here: paths and risk over seniority, primary + secondary on medium/high
 - [`review-routing-data-format`](../../../docs/guidelines/agent-infra/review-routing-data-format.md)
   — YAML schemas
 - [`create-pr-description`](../../skills/create-pr:description-only/SKILL.md) —

--- a/dist/agent-src/skills/docker/SKILL.md
+++ b/dist/agent-src/skills/docker/SKILL.md
@@ -83,6 +83,17 @@ Read `docker-compose.yml` / `compose.yaml` to discover the actual service names.
 - Use `make console` for interactive shell access.
 - Use `make console-xdebug` for Xdebug container access.
 
+### Tooling detection
+
+Which test runner and quality commands exist depends on the project shape.
+Check for `artisan` in the project root before picking one:
+
+- **Laravel** (`artisan` present) — `php artisan test`, `vendor/bin/phpstan analyse`, `vendor/bin/rector process`
+- **Plain Composer** (no `artisan`) — `vendor/bin/phpunit`, `vendor/bin/phpstan analyse`, `vendor/bin/rector process`
+
+Either way the command runs inside the container:
+`docker compose exec -T <php-service> <command>`.
+
 ### Image building
 
 - Production images use `target: pro` — no dev dependencies.

--- a/dist/agent-src/skills/laravel/SKILL.md
+++ b/dist/agent-src/skills/laravel/SKILL.md
@@ -157,6 +157,17 @@ Then add these **Laravel-specific** checks:
 - Extract reusable UI pieces into components/partials when it matches project patterns.
 - Escape output by default and use raw output only when safe and intentional.
 
+## Translations and language files
+
+- **Flat dot-notation keys only** — `'type.daily_report' => 'Daily Report'`.
+  Nested arrays (`'type' => ['daily_report' => …]`) are forbidden: they break
+  key referencing and make a one-line addition a nested diff.
+- Reference with the helper and the same flat key —
+  `__('report.type.daily_report')`, `__('email.report.created.subject', ['number' => $number])`.
+- Every key exists in **every** shipped locale. Adding to `lang/en/` without
+  `lang/de/` is a bug, not a TODO — the app ships to both audiences.
+- Never hardcode a user-visible string in PHP.
+
 ## What NOT to do
 
 - Do not put business logic into controllers, models, or Blade templates.

--- a/dist/agent-src/skills/review-routing/SKILL.md
+++ b/dist/agent-src/skills/review-routing/SKILL.md
@@ -28,8 +28,8 @@ packs:
 
 Do NOT use when:
 
-- The diff is low-risk and no ownership map exists — fall back to
-  [`reviewer-awareness`](../../rules/reviewer-awareness.md) defaults.
+- The diff is low-risk and no ownership map exists — fall back to the
+  common role vocabulary below.
 - A full PR description is requested — route to
   [`create-pr-description`](../create-pr:description-only/SKILL.md) and let
   it call this skill for the routing block.
@@ -55,7 +55,7 @@ Check, in order:
 Parse each with YAML. Validate `version: 1` is present. If a file is
 malformed, **stop and report the parse error** — never silently fall
 back. If neither file exists, emit the generic role-based fallback
-using [`reviewer-awareness`](../../rules/reviewer-awareness.md).
+using the common role vocabulary below.
 
 **Also** pull agent-written signals via the shared abstraction (see
 [`memory-access`](../../../docs/guidelines/agent-infra/memory-access.md)):
@@ -114,12 +114,29 @@ If `ownership-map.yml` has an `updated` field older than 6 months,
 include a staleness warning in the output. Still use the data — just
 flag it.
 
+## Common role vocabulary
+
+The fallback set when no ownership entry matches. Extend it per project, but
+keep these as the shared names — a role nobody else uses routes to nobody.
+
+| Role | Typical focus |
+|---|---|
+| `backend` | business logic, validation, side effects, data integrity |
+| `frontend` | UX, accessibility, client-side state, rendering |
+| `security` | authz, secrets, trust boundaries, data exposure |
+| `infra` / `ops` | rollout, migration safety, observability, retries |
+| `database` | schema changes, indexes, query plans, rollback realism |
+| `domain owner` | business invariants, policy intent, edge-case correctness |
+| `qa` | test coverage, regression scenarios, flake risk |
+
+Roles, never individuals: a package-shipped artifact names `security`, and the
+consumer's CODEOWNERS or ownership map maps that to a person.
+
 ## Validation
 
 Before returning:
 
-1. Every emitted role is either in the common vocabulary
-   ([`reviewer-awareness`](../../rules/reviewer-awareness.md)) or sourced
+1. Every emitted role is either in the common vocabulary above or sourced
    from an ownership entry — never invented.
 2. Every historical-pattern match cites its `id` and `required_test`
    verbatim.
@@ -191,7 +208,7 @@ Data source: <"ownership-map.yml + historical-bug-patterns.yml"
 
 ## See also
 
-- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — role vocabulary + data-source rules
+- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — the rule that routes here: anchor reviewer choice in paths and risk, never seniority
 - [`review-routing-data-format`](../../../docs/guidelines/agent-infra/review-routing-data-format.md)
 - [`create-pr-description`](../create-pr:description-only/SKILL.md)
 - [`judge-test-coverage`](../judge-test-coverage/SKILL.md) — consumes

--- a/dist/agent-src/templates/scripts/ownership-map.example.yml
+++ b/dist/agent-src/templates/scripts/ownership-map.example.yml
@@ -3,7 +3,7 @@
 # Copy this file to `.github/ownership-map.yml` (preferred) or
 # `agents/ownership-map.yml` and adapt the entries to your stack.
 # Omitting the file entirely is fine — routing falls back to the
-# generic role vocabulary from `reviewer-awareness`.
+# common role vocabulary in `skill:review-routing`.
 #
 # First match wins per file. List narrower globs before broader ones.
 

--- a/src/agent-src/templates/scripts/ownership-map.example.yml
+++ b/src/agent-src/templates/scripts/ownership-map.example.yml
@@ -3,7 +3,7 @@
 # Copy this file to `.github/ownership-map.yml` (preferred) or
 # `agents/ownership-map.yml` and adapt the entries to your stack.
 # Omitting the file entirely is fine — routing falls back to the
-# generic role vocabulary from `reviewer-awareness`.
+# common role vocabulary in `skill:review-routing`.
 #
 # First match wins per file. List narrower globs before broader ones.
 

--- a/src/domains/engineering-base/review/routing/command.md
+++ b/src/domains/engineering-base/review/routing/command.md
@@ -59,9 +59,8 @@ changed-file list. The skill:
 4. Computes overall severity (`high` wins).
 5. Returns the structured block.
 
-If neither data file exists, the skill returns the generic fallback
-from [`reviewer-awareness`](../../rules/reviewer-awareness.md). That is
-valid output — do not invent owners.
+If neither data file exists, the skill returns the generic fallback from
+its own common role vocabulary. That is valid output — do not invent owners.
 
 ### 3. Present the result
 
@@ -121,7 +120,7 @@ After the block, ask:
 ## See also
 
 - [`review-routing`](../../skills/review-routing/SKILL.md) — the resolver
-- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — role vocabulary + data-source rules
+- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — the rule that routes here: paths and risk over seniority, primary + secondary on medium/high
 - [`review-routing-data-format`](../../../docs/guidelines/agent-infra/review-routing-data-format.md)
   — YAML schemas
 - [`create-pr-description`](../../skills/create-pr:description-only/SKILL.md) —

--- a/src/skills/docker/SKILL.md
+++ b/src/skills/docker/SKILL.md
@@ -83,6 +83,17 @@ Read `docker-compose.yml` / `compose.yaml` to discover the actual service names.
 - Use `make console` for interactive shell access.
 - Use `make console-xdebug` for Xdebug container access.
 
+### Tooling detection
+
+Which test runner and quality commands exist depends on the project shape.
+Check for `artisan` in the project root before picking one:
+
+- **Laravel** (`artisan` present) — `php artisan test`, `vendor/bin/phpstan analyse`, `vendor/bin/rector process`
+- **Plain Composer** (no `artisan`) — `vendor/bin/phpunit`, `vendor/bin/phpstan analyse`, `vendor/bin/rector process`
+
+Either way the command runs inside the container:
+`docker compose exec -T <php-service> <command>`.
+
 ### Image building
 
 - Production images use `target: pro` — no dev dependencies.

--- a/src/skills/laravel/SKILL.md
+++ b/src/skills/laravel/SKILL.md
@@ -157,6 +157,17 @@ Then add these **Laravel-specific** checks:
 - Extract reusable UI pieces into components/partials when it matches project patterns.
 - Escape output by default and use raw output only when safe and intentional.
 
+## Translations and language files
+
+- **Flat dot-notation keys only** — `'type.daily_report' => 'Daily Report'`.
+  Nested arrays (`'type' => ['daily_report' => …]`) are forbidden: they break
+  key referencing and make a one-line addition a nested diff.
+- Reference with the helper and the same flat key —
+  `__('report.type.daily_report')`, `__('email.report.created.subject', ['number' => $number])`.
+- Every key exists in **every** shipped locale. Adding to `lang/en/` without
+  `lang/de/` is a bug, not a TODO — the app ships to both audiences.
+- Never hardcode a user-visible string in PHP.
+
 ## What NOT to do
 
 - Do not put business logic into controllers, models, or Blade templates.

--- a/src/skills/review-routing/SKILL.md
+++ b/src/skills/review-routing/SKILL.md
@@ -28,8 +28,8 @@ packs:
 
 Do NOT use when:
 
-- The diff is low-risk and no ownership map exists — fall back to
-  [`reviewer-awareness`](../../rules/reviewer-awareness.md) defaults.
+- The diff is low-risk and no ownership map exists — fall back to the
+  common role vocabulary below.
 - A full PR description is requested — route to
   [`create-pr-description`](../create-pr:description-only/SKILL.md) and let
   it call this skill for the routing block.
@@ -55,7 +55,7 @@ Check, in order:
 Parse each with YAML. Validate `version: 1` is present. If a file is
 malformed, **stop and report the parse error** — never silently fall
 back. If neither file exists, emit the generic role-based fallback
-using [`reviewer-awareness`](../../rules/reviewer-awareness.md).
+using the common role vocabulary below.
 
 **Also** pull agent-written signals via the shared abstraction (see
 [`memory-access`](../../../docs/guidelines/agent-infra/memory-access.md)):
@@ -114,12 +114,29 @@ If `ownership-map.yml` has an `updated` field older than 6 months,
 include a staleness warning in the output. Still use the data — just
 flag it.
 
+## Common role vocabulary
+
+The fallback set when no ownership entry matches. Extend it per project, but
+keep these as the shared names — a role nobody else uses routes to nobody.
+
+| Role | Typical focus |
+|---|---|
+| `backend` | business logic, validation, side effects, data integrity |
+| `frontend` | UX, accessibility, client-side state, rendering |
+| `security` | authz, secrets, trust boundaries, data exposure |
+| `infra` / `ops` | rollout, migration safety, observability, retries |
+| `database` | schema changes, indexes, query plans, rollback realism |
+| `domain owner` | business invariants, policy intent, edge-case correctness |
+| `qa` | test coverage, regression scenarios, flake risk |
+
+Roles, never individuals: a package-shipped artifact names `security`, and the
+consumer's CODEOWNERS or ownership map maps that to a person.
+
 ## Validation
 
 Before returning:
 
-1. Every emitted role is either in the common vocabulary
-   ([`reviewer-awareness`](../../rules/reviewer-awareness.md)) or sourced
+1. Every emitted role is either in the common vocabulary above or sourced
    from an ownership entry — never invented.
 2. Every historical-pattern match cites its `id` and `required_test`
    verbatim.
@@ -191,7 +208,7 @@ Data source: <"ownership-map.yml + historical-bug-patterns.yml"
 
 ## See also
 
-- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — role vocabulary + data-source rules
+- [`reviewer-awareness`](../../rules/reviewer-awareness.md) — the rule that routes here: anchor reviewer choice in paths and risk, never seniority
 - [`review-routing-data-format`](../../../docs/guidelines/agent-infra/review-routing-data-format.md)
 - [`create-pr-description`](../create-pr:description-only/SKILL.md)
 - [`judge-test-coverage`](../judge-test-coverage/SKILL.md) — consumes

--- a/tests/scripts/cli/python/workspace_inbox.test.ts
+++ b/tests/scripts/cli/python/workspace_inbox.test.ts
@@ -253,6 +253,17 @@ describe('workspace_inbox — write + read + list + forget', () => {
           - Use \`make console\` for interactive shell access.
           - Use \`make console-xdebug\` for Xdebug container access.
 
+          ### Tooling detection
+
+          Which test runner and quality commands exist depends on the project shape.
+          Check for \`artisan\` in the project root before picking one:
+
+          - **Laravel** (\`artisan\` present) — \`php artisan test\`, \`vendor/bin/phpstan analyse\`, \`vendor/bin/rector process\`
+          - **Plain Composer** (no \`artisan\`) — \`vendor/bin/phpunit\`, \`vendor/bin/phpstan analyse\`, \`vendor/bin/rector process\`
+
+          Either way the command runs inside the container:
+          \`docker compose exec -T <php-service> <command>\`.
+
           ### Image building
 
           - Production images use \`target: pro\` — no dev dependencies.


### PR DESCRIPTION
The rule-migration ledger records 15 sections the body-migration transform
dropped, and notes that three of them left **a live citation pointing at content
that no longer exists**. It recorded them rather than repairing them, because
"repairing them is a change with its own scope". This is that change.

## What was dangling

| Citation | Pointed at | Reality |
|---|---|---|
| `fix/ci/command.md:70` — "if `artisan` exists → Laravel, otherwise → Composer (see `rules/docker-commands.md`)" | the tooling-detection branch | the rule is a routing stub; `skill:docker` had one unrelated `artisan` mention and no detection |
| `update-form-request-messages/command.md:132` — "the flat dot-notation format from `laravel-translations`" | the key-format mandate | the rule states only mirror-keys-across-locales; `skill:laravel` carried no translation content at all |
| `skill:review-routing` see-also, the routing command's see-also, and the shipped `ownership-map.example.yml` — all naming `reviewer-awareness` as the home of the role vocabulary | the seven-role table | the table exists nowhere in the tree |

The third had two further pointers nobody had counted, **inside the skill
itself**: step 3 falls through "to the generic-role fallback" and validation
check 1 requires every emitted role to be "in the common vocabulary". Neither
resolved to anything.

## What landed

The three sections were recovered and re-homed in the targets the ledger already
declares — tooling detection in `skill:docker`, the flat dot-notation key format
in `skill:laravel`, the role table in `skill:review-routing`. Citations that
pointed at the rules for that content are repointed; citations that name a rule
for what it still says are untouched.

## Two decisions worth reviewing

**The ledger rows stay `dropped`.** Flipping them to `carried` would assert the
migration did something it did not do. The gate is built the same way: it asserts
a `dropped` row names no target and states outright that it does not assert a
heading should have been carried. Only the README's live-state paragraph moved,
because it claimed the pointers were unrepaired.

**The ledger's own source pointer is wrong, and was not followed.**
`source_commit: d4fe80e1c` is the *migration* commit and already carries the
stubs; the pre-migration bodies are in its parent. Recovered from `d4fe80e1c^`,
independently confirmed by `git log -S 'Tooling Detection'`. Worth knowing for
the next of the 44 ledgers someone reads — and worth noting that these commits
are not ancestors of HEAD, so a remote branch prune destroys them.

## Scope

The other twelve dropped sections stay recorded losses: no reader is currently
sent to them. Named explicitly in the review artefact so the boundary is
auditable rather than implied.

`task preflight` green — `lint_regression` clean, `skill_linter --changed`
4 pass / 0 warn / 0 fail, kernel-rule bundle untouched, completion review clean
(zero code paths across eleven changed files, skip declared).
