### PR TITLE
docs(roadmap): split the 2026-08-10 harvest into eight executable roadmaps

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 22 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **31** open blockers, **10** need you → `agent-config gates`
+> 29 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **38** open blockers, **9** need you → `agent-config gates`
 
 ## Overall
 
-**177 / 301 steps done · 59%**
+**178 / 365 steps done · 49%**
 
 ```text
-████████████████████████░░░░░░░░░░░░░░░░   59%
+████████████████████░░░░░░░░░░░░░░░░░░░░   49%
 ```
 
 ## Open roadmaps
@@ -20,24 +20,31 @@
 | 2 | [road-to-capability-answerability.md](roadmaps/road-to-capability-answerability.md) | 4 | 19 | 1 | 18 | 0 | 0 | [1](#blockers-road-to-capability-answerability) | ██████████ 95% |
 | 3 | [road-to-carrier-layer-convergence.md](roadmaps/road-to-carrier-layer-convergence.md) | 3 | 8 | 2 | 3 | 0 | 3 | [1](#blockers-road-to-carrier-layer-convergence) | ██████░░░░ 60% |
 | 4 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 5 | [road-to-cost-parity-0-program.md](roadmaps/road-to-cost-parity-0-program.md) | 4 | 23 | 23 | 0 | 0 | 0 | [2](#blockers-road-to-cost-parity-0-program) | ░░░░░░░░░░ 0% |
-| 6 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
-| 7 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 8 | [road-to-inbox-harvest-2026-08-b.md](roadmaps/road-to-inbox-harvest-2026-08-b.md) | 4 | 26 | 12 | 2 | 1 | 11 | [3](#blockers-road-to-inbox-harvest-2026-08-b) | █░░░░░░░░░ 14% |
-| 9 | [road-to-inbox-harvest-2026-08.md](roadmaps/road-to-inbox-harvest-2026-08.md) | 5 | 21 | 1 | 11 | 4 | 5 | [3](#blockers-road-to-inbox-harvest-2026-08) | █████████░ 92% |
-| 10 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 11 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
-| 12 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 13 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
-| 14 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 15 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
-| 16 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 7 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 17 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ███████░░░ 71% |
-| 18 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 19 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 20 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
-| 21 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
-| 22 | [road-to-worktree-hygiene.md](roadmaps/road-to-worktree-hygiene.md) | 1 | 9 | 2 | 7 | 0 | 0 | [1](#blockers-road-to-worktree-hygiene) | ████████░░ 78% |
+| 5 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | 0 | ██████░░░░ 60% |
+| 6 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
+| 7 | [road-to-inbox-harvest-2026-08-b-authoring-contract.md](roadmaps/road-to-inbox-harvest-2026-08-b-authoring-contract.md) | 6 | 25 | 15 | 0 | 1 | 9 | [1](#blockers-road-to-inbox-harvest-2026-08-b-authoring-contract) | ░░░░░░░░░░ 0% |
+| 8 | [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 5 | 24 | 21 | 0 | 2 | 1 | [2](#blockers-road-to-inbox-harvest-2026-08-b-ci-economy) | ░░░░░░░░░░ 0% |
+| 9 | [road-to-inbox-harvest-2026-08-b-council-integrity.md](roadmaps/road-to-inbox-harvest-2026-08-b-council-integrity.md) | 3 | 16 | 7 | 1 | 1 | 7 | [1](#blockers-road-to-inbox-harvest-2026-08-b-council-integrity) | █░░░░░░░░░ 12% |
+| 10 | [road-to-inbox-harvest-2026-08-b-dispatch-safety.md](roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md) | 4 | 21 | 14 | 0 | 1 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-dispatch-safety) | ░░░░░░░░░░ 0% |
+| 11 | [road-to-inbox-harvest-2026-08-b-estate-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md) | 4 | 15 | 9 | 0 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-estate-lifecycle) | ░░░░░░░░░░ 0% |
+| 12 | [road-to-inbox-harvest-2026-08-b-install-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-install-lifecycle.md) | 2 | 13 | 7 | 0 | 1 | 5 | [1](#blockers-road-to-inbox-harvest-2026-08-b-install-lifecycle) | ░░░░░░░░░░ 0% |
+| 13 | [road-to-inbox-harvest-2026-08-b-ledger-truth.md](roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md) | 3 | 19 | 12 | 0 | 1 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-ledger-truth) | ░░░░░░░░░░ 0% |
+| 14 | [road-to-inbox-harvest-2026-08-b-release-integrity.md](roadmaps/road-to-inbox-harvest-2026-08-b-release-integrity.md) | 5 | 25 | 12 | 0 | 1 | 12 | [3](#blockers-road-to-inbox-harvest-2026-08-b-release-integrity) | ░░░░░░░░░░ 0% |
+| 15 | [road-to-inbox-harvest-2026-08-b.md](roadmaps/road-to-inbox-harvest-2026-08-b.md) | 3 | 6 | 1 | 2 | 0 | 3 | [1](#blockers-road-to-inbox-harvest-2026-08-b) | ███████░░░ 67% |
+| 16 | [road-to-inbox-harvest-2026-08.md](roadmaps/road-to-inbox-harvest-2026-08.md) | 5 | 21 | 1 | 11 | 4 | 5 | [3](#blockers-road-to-inbox-harvest-2026-08) | █████████░ 92% |
+| 17 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 12 | 5 | 7 | 0 | 0 | [1](#blockers-road-to-maintainer-bus-factor) | ██████░░░░ 58% |
+| 19 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 20 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
+| 21 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 22 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
+| 23 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
+| 24 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ███████░░░ 71% |
+| 25 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 26 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 27 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 2 | 6 | 0 | 0 | [1](#blockers-road-to-tier-removal) | ████████░░ 75% |
+| 28 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
+| 29 | [road-to-worktree-hygiene.md](roadmaps/road-to-worktree-hygiene.md) | 1 | 9 | 2 | 7 | 0 | 0 | [1](#blockers-road-to-worktree-hygiene) | ████████░░ 78% |
 
 ---
 
@@ -188,46 +195,233 @@
     `yt-dlp` and a JavaScript runtime are installed **by a human** on the machine that runs this. Execution starts when the condition clears. The package never auto-installs — that is a contract (`missing-tool-handling`), not a limitation to work around.
   - **Resolved when:** condition described above clears
 
-### [road-to-inbox-harvest-2026-08-b.md](roadmaps/road-to-inbox-harvest-2026-08-b.md)
+### [road-to-inbox-harvest-2026-08-b-authoring-contract.md](roadmaps/road-to-inbox-harvest-2026-08-b-authoring-contract.md)
 
-**Road to inbox harvest 2026-08-b** — 2 / 14 done (14%)
+**Road to an enforced authoring contract** — 0 / 15 done (0%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | The quorum-attendance defect | ⬜ not started | 4 | 0 | 1 | 0 | 0% |
-| 2 | Landed in this PR | ✅ done | 0 | 2 | 0 | 0 | 100% |
-| 3 | Single-artefact extensions | ⬜ not started | 8 | 0 | 0 | 0 | 0% |
-| 4 | Cancelled against a lock | ⏭️ skipped | 0 | 0 | 0 | 11 | 0% |
+| 1 | Enforce the one required section whose population is decidable | ⬜ not started | 3 | 0 | 1 | 0 | 0% |
+| 2 | Extend the skill-writing pattern registry | ⬜ not started | 4 | 0 | 0 | 4 | 0% |
+| 3 | Failure signatures: a stable code, and a drill per row | ⬜ not started | 3 | 0 | 0 | 1 | 0% |
+| 4 | Bind the external research citations to the ledger | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 5 | Hedge-word lint, diff-scoped, with a declared escalation stage | ⬜ not started | 2 | 0 | 0 | 1 | 0% |
+| 6 | Cancelled with citation | ⏭️ skipped | 0 | 0 | 0 | 3 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-authoring-contract"></a>
+**Blockers**
+
+- **conditional-section-population-key** (owner: maintainer) — blocks step 1.4 only. Phase 1 steps 1.1-1.3 (the script-bearing section and its gate), and all of Phases 2-7, proceed independently.
+  - **What to do:**
+    Decide between two options for
+    `## Rationalizations to reject` (`src/skills/skill-writing/SKILL.md:533`) and
+    `## Non-negotiable deliverable` (`:556`), whose populations are not decidable
+    from the tree. (1) Add a declarative skill-frontmatter key naming the pattern
+    a skill opts into — a schema change under
+    `src/scripts/schemas/skill.schema.json:8` `additionalProperties: false`, plus
+    the frontmatter validator and every generator reading skill frontmatter.
+    (2) Drop `required` from both headings so the label matches the enforcement
+    that exists, leaving them optional patterns like `:505` and `:592`.
+  - **Resolved when:** The maintainer records option 1 or option 2 in this blocker, and step 1.4 is rewritten as the concrete steps that option needs.
+
+### [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md)
+
+**Road to CI Economy — cut the redundant full builds and re-anchor the cost artefacts to CI-recorded data** — 0 / 21 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Re-anchor the two existing cost artefacts to CI-recorded data | ⬜ not started | 4 | 0 | 0 | 1 | 0% |
+| 1 | Free hygiene: dead filters, missing concurrency, stale comments, caches | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
+| 2 | The build fan-out: stop rebuilding the same 6 targets 13 times | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 3 | The subprocess lever: extend in-process running, do not add a skill | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 4 | Required-check-set changes (authored here, applied by the maintainer) | ⬜ not started | 1 | 0 | 2 | 0 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-ci-economy"></a>
+**Blockers**
+
+- **required-check-set-change** (owner: maintainer) — blocks step 4.2 only. Phases 0-3 and step 4.1 are not blocked — they change no required check, and ADR-222 is a proposal, not an enforcement change.
+  - **What to do:**
+    decide whether the macOS leg and the `npm audit` PR gate stay in
+    the required set, then apply the ruleset edit. Ruleset `17749383` currently
+    requires exactly one check, `Sync + Generate Tools Consistency`
+    (`docs/contracts/branch-protection-policy.md:59`); the write path is documented
+    at `branch-protection-policy.md:158`.
+  - **Resolved when:** ADR-222 is accepted and the ruleset's `required_status_checks` list matches the matrix in `branch-protection-policy.md`, with `ci-green-floor.md` and `release-pr-gating.md` updated in the same change.
+- **merge-queue-enablement** (owner: maintainer) — blocks step 4.3 only. Nothing else here depends on a merge queue.
+  - **What to do:**
+    decide whether to enable a GitHub merge queue for `main` — a
+    repo-admin setting that cannot be turned on from the tree.
+  - **Resolved when:** the merge queue is enabled on `main` and at least one workflow declares a `merge_group` trigger (currently zero across `.github/`).
+
+### [road-to-inbox-harvest-2026-08-b-council-integrity.md](roadmaps/road-to-inbox-harvest-2026-08-b-council-integrity.md)
+
+**Road to council-pass integrity** — 1 / 8 done (12%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Attendance becomes machine-readable | ⬜ not started | 5 | 0 | 1 | 0 | 0% |
+| 2 | A verdict that disagrees with its own tally | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 3 | One duplicated defence, honestly scoped | 🟡 in progress | 1 | 1 | 0 | 7 | 50% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-council-integrity"></a>
+**Blockers**
+
+- **quorum-solo-floor** (owner: maintainer) — blocks 1.6 only. Phases 1.1–1.5, 2 and 3 ship and are useful without it.
+  - **What to do:**
+    the solo-conclusion rate is a rate over real passes, and no
+    event exists yet to accumulate it — which is why this is a blocker and not a
+    step. After 1.1 lands, pick between three pre-registered outcomes: (a) add a
+    third CLI member — `gemini` is already in `ai_council/cli_hints.ts:40-43` and
+    `ai_council/config.ts:78`, and `_lib/environment_detector.ts:138` records it as
+    `['gemini', false]` where the boolean is the community-wrapper flag documented
+    at `:127-133` (`false` = vendor-official CLI running under the user's own
+    subscription), so this option is spend-free on a host that has the binary;
+    (b) scope a `min_present: 2` floor to gate-class passes only; or (c) publish a
+    null if the rate is under 5 %. Tightening `ceil(n/2)` itself is out of scope —
+    `quorum.ts:13-19` records that divergence as a decision.
+  - **Resolved when:** one of the three outcomes is chosen against real attendance data, or 1.6 is cancelled against the published null.
+
+### [road-to-inbox-harvest-2026-08-b-dispatch-safety.md](roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md)
+
+**Road to inbox harvest 2026-08-b — dispatch safety** — 0 / 14 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Scoped tool grants | ⬜ not started | 4 | 0 | 0 | 2 | 0% |
+| 2 | A confirmation primitive for staged irreversible actions | ⬜ not started | 3 | 0 | 1 | 0 | 0% |
+| 3 | Checkable handoff-envelope fields | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
+| 4 | Roles, lifecycles, and the two residues | ⬜ not started | 3 | 0 | 0 | 4 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-dispatch-safety"></a>
+**Blockers**
+
+- **confirmation-degraded-host-semantics** (owner: maintainer) — blocks step 2.4 only. Steps 2.1-2.3 are unblocked and land default-unbound; Phases 1, 3 and 4 are not blocked at all.
+  - **What to do:**
+    decide what a host without a `pre_tool_use` slot gets when a
+    `requires_confirmation` action is staged — a model-carried obligation stated as such,
+    or a refusal to stage at all — and whether the primitive is default-on or default-off
+    where the slot does exist.
+  - **Resolved when:** the decision is recorded (an ADR, or the ADR-109 amendment note from 1.4) and names both the degraded-host behaviour and the default.
+
+### [road-to-inbox-harvest-2026-08-b-estate-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md)
+
+**Road to estate lifecycle reporting** — 0 / 9 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | The revisit offer | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 2 | The dormancy signal governance already mandates | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Zero inbound references, on the graph that already exists | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 4 | The graph's own observability | ⬜ not started | 2 | 0 | 0 | 6 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-estate-lifecycle"></a>
+**Blockers**
+
+- **estate-lifecycle-revisit-answer** (owner: maintainer) — blocks any step that would act on a report — a removal list, a cap change, or a new estate metadata field. Phases 2, 3 and 4 are NOT blocked: every step there is report-only, adds no frontmatter field, and moves no cap.
+  - **What to do:**
+    answer whether the maintained-estate framing in
+    `later/road-to-cost-parity-1-rule-payload-diet.md` reopens now, or stays parked
+    on its own resume conditions (`:24-30`). Separately: `governance.md:58-59` defers
+    a `last_reviewed:` field until a second maintainer exists — confirm that
+    condition still holds, since it is what makes Phase 2 derive rather than store.
+  - **Resolved when:** the answer is written into 1.1 with its date, and either the parked roadmap moves out of `later/` or 1.1 records that it stays.
+
+### [road-to-inbox-harvest-2026-08-b-install-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-install-lifecycle.md)
+
+**Road to install lifecycle — every write recorded, org packs decided** — 0 / 7 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | record the three writes uninstall cannot undo | ⬜ not started | 5 | 0 | 0 | 1 | 0% |
+| 2 | put the org-pack question to the maintainer | ⬜ not started | 2 | 0 | 1 | 4 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-install-lifecycle"></a>
+**Blockers**
+
+- **org-pack-reopening** (owner: maintainer) — blocks step 2.3 only. Steps 2.1 and 2.2 are authoring and verification and are not blocked; all of Phase 1 is independent of the pack question entirely.
+  - **What to do:**
+    read the 2.1 brief and either decline (ADR-011 stands, 2.3 closes as
+    `- [-]`) or reopen by commissioning an ADR that answers the four ADR-088 § 3 questions
+    and reconciles the `agents/overrides/` `replace` mode.
+  - **Resolved when:** either 2.3 is marked `- [-]` citing a decline, or a new ADR exists with `status: accepted` amending ADR-011 and ADR-013 § packs.
+
+### [road-to-inbox-harvest-2026-08-b-ledger-truth.md](roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md)
+
+**Road to cost-ledger truth** — 0 / 12 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Served-model truth | ⬜ not started | 5 | 0 | 0 | 0 | 0% |
+| 2 | The rate tables cannot disagree | ⬜ not started | 4 | 0 | 1 | 0 | 0% |
+| 3 | Two aggregation lines and a cache signature | ⬜ not started | 3 | 0 | 0 | 6 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-ledger-truth"></a>
+**Blockers**
+
+- **unknown-model-row-never-observed** (owner: maintainer) — blocks step 2.5 only. Steps 2.1-2.4 are unblocked — 2.4 is what makes an unknown-model row detectable in the first place, and Phases 1 and 3 do not touch this path.
+  - **What to do:**
+    after 2.4 ships, wait for the first `rate_missing` row in
+    `agents/cost-tracking/sessions.jsonl` and record its actual shape.
+  - **Resolved when:** at least one real `rate_missing` row exists and its field set is written down, so a backfill pass can be built against an observed shape rather than a guessed one.
+
+### [road-to-inbox-harvest-2026-08-b-release-integrity.md](roadmaps/road-to-inbox-harvest-2026-08-b-release-integrity.md)
+
+**Road to release-surface integrity** — 0 / 12 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | The release head cannot ship its own placeholder | ⬜ not started | 3 | 0 | 1 | 0 | 0% |
+| 2 | The carrier remainder, with its premise corrected | ⬜ not started | 1 | 0 | 0 | 2 | 0% |
+| 3 | Four flags over data that already exists | ⬜ not started | 4 | 0 | 0 | 1 | 0% |
+| 4 | Two real contract gaps | ⬜ not started | 2 | 0 | 0 | 2 | 0% |
+| 5 | Records, and the asks that need no work | ⬜ not started | 2 | 0 | 0 | 7 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-b-release-integrity"></a>
+**Blockers**
+
+- **release-head-cadence-decision** (owner: maintainer) — blocks step 1.4 only. Steps 1.1-1.3 proceed either way.
+  - **What to do:**
+    Pick exactly one — (a) hard-block the placeholder string in the
+    final release head, or (b) rewrite the head comment in
+    `docs/contracts/CHANGELOG-conventions.md` to document retro-curation as the real
+    cadence. Mutually exclusive, and hard-block was already CUT to a maintainer
+    decision at `archive/road-to-feedback-9-29.md:77`.
+  - **Resolved when:** (a) or (b) is named here and 1.2 records it in the contract.
+- **carrier-install-paths-decision** (owner: maintainer) — blocks the fix for the 24 `paths:` disagreements, which lives in `road-to-carrier-layer-convergence.md` Phase 3. Nothing here is blocked — 2.3 proceeds regardless.
+  - **What to do:**
+    Decide whether `install.ts` should emit `paths:` — consumer-
+    visible install behaviour and a default flip, so an ADR candidate and
+    maintainer-only. That roadmap explicitly declines to decide it (`:35`).
+  - **Resolved when:** An ADR records the decision and that roadmap's Phase 3 cites it.
+- **adr-221-acceptance** (owner: maintainer) — blocks nothing here. Named because four of the five reviews already treat host-native-first as settled doctrine while the record is not.
+  - **What to do:**
+    Accept or reject
+    `docs/decisions/ADR-221-host-native-first-ladder.md`, `status: proposed` at `:3`.
+    No code either way — the cheapest survivor in the source file.
+  - **Resolved when:** `status` is `accepted` or `rejected` and the index is regenerated.
+
+### [road-to-inbox-harvest-2026-08-b.md](roadmaps/road-to-inbox-harvest-2026-08-b.md)
+
+**Road to inbox harvest 2026-08-b** — 2 / 3 done (67%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Landed in this PR | ✅ done | 0 | 2 | 0 | 0 | 100% |
+| 2 | The family | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 3 | Cancelled at batch level | ⏭️ skipped | 0 | 0 | 0 | 3 | 0% |
 
 <a id="blockers-road-to-inbox-harvest-2026-08-b"></a>
 **Blockers**
 
-- **quorum-solo-floor** (owner: maintainer) — blocks 1.5 only — 1.1–1.4 ship and are useful without it.
+- **harvest-b-execution-order** (owner: maintainer) — blocks 2.1 only. Every child roadmap is independently readable and independently executable; none waits on this.
   - **What to do:**
-    the solo-conclusion rate is a rate over real passes, and no
-    quorum event exists yet to accumulate it. After 1.1 lands, pick between three
-    pre-registered outcomes: add a third CLI member (`gemini` is already in
-    `cli_hints.ts:40-43` and `environment_detector.ts:138` marks it
-    **non-metered** — vendor-official CLI under the user's own subscription, so
-    this option is spend-free on a host with the binary); scope `min_present: 2`
-    to gate-class passes only; or publish a null under 5 %. Tightening `ceil(n/2)`
-    itself is out of scope — the ceil-vs-floor divergence is a recorded decision.
-  - **Resolved when:** one of the three outcomes is chosen against real attendance data, or 1.5 is cancelled against the null.
-- **release-head-cadence-decision** (owner: maintainer) — blocks 3.3
-  - **What to do:**
-    two mutually exclusive fixes. Either the final release head may
-    never carry the generator's placeholder (flip
-    `check_release_highlights.ts:205` to blocking), or the head comment is rewritten
-    to document retro-curation as the real cadence and the placeholder is legitimate
-    until then. The recurrence is verified — v9.32.0 carries it, v9.31.0 does not —
-    so doing neither leaves a known-recurring defect advisory.
-  - **Resolved when:** one of the two is chosen and the other recorded as rejected.
-- **adr-221-acceptance** (owner: maintainer) — blocks nothing in this roadmap; recorded because it was the cheapest survivor the release review surfaced and it needs no code.
-  - **What to do:**
-    `ADR-221-host-native-first-ladder.md:3` is `status: proposed`.
-    Four of five reviews treat host-native-first as settled doctrine. Accepting or
-    rejecting it is an owner decision, not an agent edit.
-  - **Resolved when:** the status field is `accepted` or `rejected`.
+    decide which of the eight siblings open now and which wait.
+    `-ledger-truth` Phase 1 and `-release-integrity` Phase 5 are the two cheapest
+    unblocked items in the batch. `-estate-lifecycle` and `-install-lifecycle` Phase 2
+    each open with a decision-revisit offer against an accepted or council-parked lock,
+    so they need an answer before any code. `-ci-economy` is the largest and its
+    Phase 0 spends CI minutes recording a baseline.
+  - **Resolved when:** the chosen order is written into 2.1 and the unchosen siblings are moved to `agents/roadmaps/later/` with a resume condition, per `lint_roadmap_later_disposition`.
 
 ### [road-to-inbox-harvest-2026-08.md](roadmaps/road-to-inbox-harvest-2026-08.md)
 

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-authoring-contract.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-authoring-contract.md
@@ -1,0 +1,280 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to an enforced authoring contract
+
+> Take the three sections `skill-writing` labels **required** from 0-of-3
+> enforced and 0-of-4 complied to 1-of-3 enforced with its population at 100%,
+> and the other 2 explicitly reclassified with a citation — plus bind the
+> estate's 14 external research ids into the claims ledger, from 0 bound today.
+
+> Source (consumed inbox): `agents/tmp.old/ac-skill-template`,
+> `agents/tmp.old/ac-failure-signatures`, `agents/tmp.old/ac-doctrine-cited-briefs`,
+> `agents/tmp.old/ac-positional-doctrine` — part of the 2026-08-10 batch triaged
+> by [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+Measured in this worktree at HEAD, not asserted:
+
+- **Three sections are labelled required and enforced by nothing.**
+  `src/skills/skill-writing/SKILL.md:533` (`## Rationalizations-to-reject
+  section (required, security-stop-routed skills)`), `:556`
+  (`## Non-negotiable-deliverable section (required, adjacent-technology
+  clusters)`), `:619` (`## Security-constraints section (required pattern,
+  script-bearing skills)`). `grep -rlE 'Rationalizations-to-reject|Non-negotiable-deliverable|Security constraints' src/scripts/*.ts`
+  returns nothing.
+- **The enforcement pattern already exists.**
+  `src/scripts/skill_linter.ts:98` `REQUIRED_SKILL_SECTIONS = ['When to use',
+  'Gotcha', 'Procedure', 'Output format', 'Do NOT']`, aliased at `:100-105`
+  (`Do NOT` → `Anti-patterns`), emitting `error/missing_section` at `:1356-1359`.
+  Budget is ample: `skill_linter --all` scans **437 artefacts in 0.56 s**.
+- **Compliance with all three is zero.** 4 skills ship a `scripts/` directory
+  (`corpus-grounding`, `design-tokens`, `react-shadcn-ui`, `tailwind-engineer`)
+  and **none** carries `## Security constraints`. Exactly one file matches
+  `^## Rationalizations` and one matches `^## Non-negotiable` — both are
+  `skill-writing/SKILL.md` itself, describing the pattern, not an instance.
+- **Only one of the three has a filesystem-decidable population.**
+  "script-bearing" is `test -d src/skills/<n>/scripts`. "security-stop-routed"
+  and "adjacent-technology cluster" are judgement calls; `security-sensitive-stop.md:72-75`
+  names 4 analysis skills and the `*-routing.md` rules name 4 cluster heads, but
+  neither list is a declared skill property. `src/scripts/schemas/skill.schema.json:8`
+  sets `additionalProperties: false`, so a declarative key is a schema change.
+- **The claims ledger has the format and zero usage for external cites.**
+  `docs/CLAIMS.md:46` already defines `https://… (YYYY-MM-DD)` as pointer
+  grammar #3 of 4; 43 backed / 10 unbacked / 5 resolved-null entries exist and
+  **no `- evidence:` line carries an http or arXiv pointer**. The tree cites
+  **14 distinct arXiv ids across 49 lines in 33 tracked files**. Ledger entries
+  render into `docs/proof.md` via `src/scripts/build_proof.ts`, drift-checked by
+  `task build-proof-check` (`Taskfile.yml:293`).
+- **Hedge words are measured, never linted.** `src/scripts/bench_honesty_score.ts:528`
+  `HEDGE_WORDS`, `:593` `countHedgeWords`, `:606-621` `hedge_count` /
+  `hedge_per_100_words` — all scoring agent *output*, not artefact prose. No
+  `src/scripts/*hedge*` lint exists.
+- **`## Known pitfalls` is at 4 of 289 skills** and its content is already
+  governed by `src/rules/size-enforcement.md:29` ("never a new skill per
+  pitfall", cap 5 sourced entries). No work is planned on it here — an optional
+  pattern with low uptake is not a defect.
+
+Estate: **116 rules, 289 skills, 437 linted artefacts.** Every step below names
+the existing artefact it extends; nothing here adds a rule or a skill.
+
+## Phase 1 — Enforce the one required section whose population is decidable
+
+- [ ] **1.1 Write `## Security constraints` into the four script-bearing skills.**
+      `src/skills/{corpus-grounding,design-tokens,react-shadcn-ui,tailwind-engineer}/SKILL.md`
+      each ship a `scripts/` directory and none carries the section. Use the
+      four-bullet shape already specified at `src/skills/skill-writing/SKILL.md:629-643`
+      — what it may touch, what it must never do, default-invocation behaviour
+      (read-only or mutating, and the gating flag if any), what it sends
+      outbound. Must land **before** 1.2 or the gate reds four shipped skills.
+      <!-- verify: grep -lc '^## Security constraints' src/skills/corpus-grounding/SKILL.md src/skills/design-tokens/SKILL.md src/skills/react-shadcn-ui/SKILL.md src/skills/tailwind-engineer/SKILL.md -->
+- [ ] **1.2 Add a conditional required-section check to `skill_linter.ts`, keyed on
+      `scripts/` directory existence.** Extend the `REQUIRED_SKILL_SECTIONS` loop
+      at `src/scripts/skill_linter.ts:1356-1359` with a conditional tier that
+      emits `error/missing_conditional_section` when a skill directory contains
+      `scripts/` and the body has no `## Security constraints`. **The
+      false-positive class is empty by construction**: the predicate is a
+      filesystem existence test on the skill's own directory, not a heuristic
+      over prose — a skill either ships a script or it does not. After 1.1 the
+      violation set is 0, so the check ships as `error` on day one rather than
+      advisory (the stage-vs-hedge argument in
+      `src/scripts/check_suppression_hygiene.ts:38-42`).
+      <!-- verify: ./scripts-run src/scripts/skill_linter --all -->
+- [ ] **1.3 Pin the new check in the linter's own test file.** Add cases to
+      `tests/scripts/skill_linter.test.ts`: a fixture skill with `scripts/` and
+      no section → one `missing_conditional_section` error; the same fixture with
+      the section → clean; a skill with no `scripts/` and no section → clean (the
+      discrimination case, without which the check is indistinguishable from an
+      unconditional one).
+      <!-- verify: npx vitest run tests/scripts/skill_linter.test.ts -->
+- [~] **1.4 Resolve the other two sections: declared key, or reclassified as
+      documentation-only.** Blocked on `blocker: conditional-section-population-key`.
+      Neither "security-stop-routed" nor "adjacent-technology cluster" is
+      decidable from the tree. Either a schema key lands (a real surface —
+      `src/scripts/schemas/skill.schema.json:8` is `additionalProperties: false`),
+      or the two headings at `src/skills/skill-writing/SKILL.md:533` and `:556`
+      drop the word `required` and read `(recommended pattern, …)` to match the
+      enforcement that exists. Silently leaving `required` unbacked is the one
+      option that is not honest.
+
+## Phase 2 — Extend the skill-writing pattern registry
+
+`src/skills/skill-writing/SKILL.md:482-645` already **is** a conditional
+section-pattern registry (Self-QA loop, Known-pitfalls, Rationalizations-to-reject,
+Non-negotiable-deliverable, Upstream-version-notes, Security-constraints). Every
+step below extends that registry. No new artefact; no new skill against 289.
+
+- [ ] **2.1 Add a mechanism-teaching pattern.** One screen, mechanisms only — the
+      currently-unnamed sibling of the existing patterns. No section pattern and
+      no linter signal exists for it (`grep -n '^## ' src/skills/skill-writing/SKILL.md`
+      lists all 20 headings; none covers it). Land it as an *optional* pattern:
+      "teaches a mechanism" is a prose judgement, so it gets no gate — see the
+      Risk Register row on FP classes.
+- [ ] **2.2 Add an illustrative-not-verbatim marker pattern for reference code.**
+      `grep -c illustrative` over both `src/skills/skill-writing/SKILL.md` and
+      `src/scripts/skill_linter.ts` returns **0**; the nearest existing guidance
+      is `skill-writing/SKILL.md:265` "### 4. Add safe/unsafe example". Specify a
+      one-line marker above a reference block so a reader can tell shape-teaching
+      code from copy-me code.
+- [ ] **2.3 Add a headline-metric-plus-closing-report pattern for optimization
+      skills.** `grep -rn 'headline metric' src/ docs/` returns exactly one
+      unrelated hit (`src/scripts/measure_projection_bytes.ts:11`). Specify: name
+      the single number the skill moves, and the closing report shape that states
+      it before and after.
+- [-] **2.4 Read-only reconnaissance as a new pattern — already shipped.**
+      `src/scripts/skill_linter.ts:704-708` `_INSPECT_VERB_PATTERN` /
+      `hasInspectStep`, enforced at `:1515`; the authored counterpart is
+      `src/skills/skill-writing/SKILL.md:111` "### 0. Inspect, then run the
+      Drafting Protocol".
+- [-] **2.5 Negative knowledge as a new pattern — already mandatory.** `Do NOT`
+      is in `REQUIRED_SKILL_SECTIONS` (`src/scripts/skill_linter.ts:98`) with
+      `Anti-patterns` aliased at `:103`, so all 289 skills already carry it.
+- [-] **2.6 The validation half of verification — already shipped.**
+      `src/scripts/skill_linter.ts:670-705` `hasValidationStep`, enforced at
+      `:1508` against both the procedure block and the full body.
+- [ ] **2.7 Name the contrastive-example slot in `skill-writing` and
+      `rule-writing`.** The practice is already house style with six live corpora
+      — `docs/guidelines/agent-infra/{direct-answers-demos,asking-and-brevity-examples,language-and-tone-examples}.md`
+      and `src/agent-src/contexts/execution/{autonomy-examples,interrupt-examples,cheap-question-mechanics}.md`
+      — but neither authoring skill names the slot, so it does not propagate.
+      `src/skills/rule-writing/SKILL.md:349-357` has an `## Examples` section that
+      shows good-vs-bad for descriptions only. Point at the existing exemplars;
+      do not invent a format.
+- [-] **2.8 A new rule for contrastive examples — cancelled.** 116 rules already
+      ship; this is a template slot in two existing skills, not a behaviour
+      constraint needing its own always-loaded file.
+
+## Phase 3 — Failure signatures: a stable code, and a drill per row
+
+`docs/guidelines/agent-infra/failure-signatures.md` already exists (35 lines,
+10-row table, read by `src/skills/systematic-debugging/SKILL.md:224-228`). Its
+own header records the file-first council decision of 2026-06-15.
+
+- [ ] **3.1 Give each row a stable identifier.** The first column is headed
+      `Signature (what you see)` (`failure-signatures.md:15`) but holds prose, so
+      nothing can be cited by name. Add a short kebab code per row and point the
+      gate/guard/coercion rows at the identifiers the tooling already emits —
+      `skill_linter.ts:1358` emits `missing_section`, `:1255`
+      `invalid_execution_handler`, and the whole `Issue` code set is stable
+      strings a signature row can name verbatim.
+- [ ] **3.2 Add a discrimination drill per row.** A row's "first check" is only
+      worth following if the documented signature is what actually appears. For
+      each row, state the one-line drill that produces it (break the named layer,
+      assert the documented signature). Doc-only step; the drills are text a
+      human runs, not a CI gate.
+- [ ] **3.3 Add one row: stale capability self-claim.** Signature — budget
+      exhausted plus repeated attempts at a tool that is not available. Likely
+      cause — a capability the session claimed for itself rather than resolved.
+      First check — `agent-config hooks:status` and `agent-config routing:doctor`,
+      both live verbs (`src/cli/registry.ts:82` and `:84`), the latter printing
+      per-field provenance.
+- [-] **3.4 Per-subsystem `TROUBLESHOOTING.md` files — cancelled.** Reverses the
+      file-first decision recorded in the guideline's own header
+      (`docs/guidelines/agent-infra/failure-signatures.md:9-11`, council
+      2026-06-15): one table the skill reads, deliberately not scattered.
+
+## Phase 4 — Bind the external research citations to the ledger
+
+- [ ] **4.1 Inventory the citations.** 14 distinct arXiv ids across 49 lines in
+      33 tracked files, and **zero** are bound: no `- evidence:` line in
+      `docs/CLAIMS.md` carries an http or arXiv pointer, against 43 backed
+      entries. Produce the id → citing-file:line list as the input to 4.2.
+      <!-- verify: grep -rhoiE 'arxiv[:/ ]*(abs/)?[0-9]{4}\.[0-9]{4,5}' $(git ls-files) | grep -oE '[0-9]{4}\.[0-9]{4,5}' | sort -u | wc -l -->
+- [ ] **4.2 Bind the load-bearing cites using pointer grammar #3.** Use the
+      already-specified `https://… (YYYY-MM-DD)` form (`docs/CLAIMS.md:46`) —
+      **do not invent a dossier format**; a second source of truth is exactly
+      what `src/scripts/generate_subagent_floor.ts` exists to prevent. Bind only
+      cites that a public or normative sentence rests on; a citation that decorates
+      prose needs no ledger row. Re-run `build_proof` after editing the ledger
+      (`docs/CLAIMS.md` renders into `docs/proof.md` per
+      `src/scripts/build_proof.ts:8`).
+      <!-- verify: ./scripts-run src/scripts/check_claims -->
+- [ ] **4.3 Add a successor pointer to retired claims.** The retire-never-delete
+      lifecycle already ships as `status: resolved-null` (`docs/CLAIMS.md:23-31`).
+      What it lacks is a forward link when a closed question is later reopened by
+      a different mechanism. One optional field, schema-documented at
+      `docs/CLAIMS.md:37-44`.
+      <!-- verify: npx vitest run tests/scripts/check_claims.test.ts -->
+
+## Phase 5 — Hedge-word lint, diff-scoped, with a declared escalation stage
+
+- [ ] **5.1 Add a diff-scoped hedge-word check reusing the existing lexicon.**
+      Export and reuse `HEDGE_WORDS` from `src/scripts/bench_honesty_score.ts:528`
+      rather than restating a list. Diff-scoped, not corpus-wide: ADR-218:93 states
+      the preference outright — "one that watches diffs, not one that counts the
+      corpus". Adjacent precedent for a vocabulary floor over prose is
+      `src/scripts/lint_provenance_vocabulary.ts:14-17` (a phrase banned "anywhere,
+      even hedged", with a quote-the-ban carve-out this check needs too).
+      <!-- verify: ./scripts-run src/scripts/lint_hedge_words -->
+- [ ] **5.2 Ship it with a declared escalation stage, not open-ended warn-only.**
+      The FP class here is **not** empty: hedging is legitimate in this tree's own
+      honesty prose (every "may", "typically", "in doubt" in a rule body). So the
+      check needs a measured FP rate over the current diff surface plus a written
+      trigger for advisory → error. `src/scripts/check_suppression_hygiene.ts:38-42`
+      is the shape to copy: state which stage it ships in and why, because
+      "shipping it advisory would have been a hedge rather than a stage".
+- [-] **5.3 Estate-wide hedge count as the gate — cancelled.** ADR-218:93 already
+      settled the diff-vs-corpus question for prose-shape tooling; a corpus count
+      over 116 rules and 289 skills produces a number nobody can act on.
+
+## Phase 6 — Cancelled with citation
+
+- [-] **6.1 Per-turn doctrine-recency cue (inject 3-6 kernel constraints at the
+      payload tail every turn) — cancelled, hard-blocked three ways.** (a)
+      `docs/decisions/ADR-054-rule-adherence-decay-triggered-restate.md:3` is
+      `status: rejected` and is this exact proposal. (b)
+      `agents/settings/contexts/reminder-injection-verdict.md:54` records the
+      pilot at **Δ = 0 pp on both hosts**, with the hook, manifest wiring and
+      settings flag "removed in the same branch that built it" (`:75-77`) per a
+      pre-committed teardown at `<5 pp` (`:28`). (c) The premise itself failed a
+      pre-registered search: `agents/evidence/analysis/activation-red-baseline.md:15`
+      swept **1,158 sessions** and `:25-27` records qualifying rows spanning
+      **9,464 to 727,537 tokens** against a 3,000-token bar — "distance was never
+      the limiting factor". And the one carrier that does fire per turn on this
+      exact surface is measured at **24 of 29 misses** with the honesty clause
+      firing **0** times (`src/rules/session-canary.md:105-106`), whose own
+      conclusion is that a reminder in context is not a mechanism for this
+      obligation.
+- [-] **6.2 The 97-of-111 absoluta point estimate — cancelled, re-derive instead.**
+      `./scripts-run src/scripts/measure_rule_absoluta` at HEAD reports **116
+      rules scanned, 84 strict (72.4%), 102 case-insensitive (87.9%), 99 carrying
+      an Iron Law (85.3%), 287 strict occurrences**. `docs/decisions/ADR-218-absoluta-census-is-a-closed-decision-input.md:43`
+      and `:88` require citing the range and the structural figure, never a point
+      estimate.
+- [-] **6.3 "Positional doctrine is new" — cancelled, already shipped.**
+      `src/rules/token-budget-discipline.md:117` ships `## Rich artifacts lead
+      with a non-negotiable band`, and `src/scripts/check_iron_law_prominence.ts:14-19`
+      enforces both halves: no Iron-Law heading at H3 or deeper, and at least one
+      Iron-Law H2 among the file's first two H2 headings.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Gate lands before its population complies | implementation | 1.2 turns a missing `## Security constraints` into `error/missing_conditional_section`, and all 4 script-bearing skills are non-compliant today — wiring it first reds four shipped artefacts and the fix looks like a linter regression | 1.1 strictly precedes 1.2 in the same change; 1.3's third case pins that a script-free skill stays clean | Phase 1 — Enforce the one required section whose population is decidable |
+| 2 | Hedge-word lint has a live false-positive class | product | Hedges are legitimate in this tree's own honesty prose; a check over rule bodies will flag "may", "typically", "in doubt" in the very rules that teach calibrated language | Diff-scoped per ADR-218:93; measured FP rate plus a written advisory→error trigger before it can fail a build; quote-the-ban carve-out modelled on `lint_provenance_vocabulary.ts:14-17` | Phase 5 — Hedge-word lint, diff-scoped, with a declared escalation stage |
+| 3 | A declarative frontmatter key is a wider surface than it looks | implementation | `skill.schema.json:8` is `additionalProperties: false`, so keying the other two sections on a declared property touches the schema, the frontmatter validator, and every generator that reads skill frontmatter | Held behind `blocker: conditional-section-population-key`; the reclassification alternative (drop `required` from the two headings) needs no schema change at all | Phase 1 — Enforce the one required section whose population is decidable |
+| 4 | A bound external cite can rot silently | implementation | Pointer grammar #3 is an existence-and-date check — `docs/CLAIMS.md:46` says plainly "not fetched in CI" — so a bound arXiv row stays green after the paper is withdrawn or renumbered | Bind only cites a normative sentence rests on (4.2), carry the dated stamp the grammar requires, and leave decorative citations unbound rather than manufacturing ledger rows | Phase 4 — Bind the external research citations to the ledger |
+| 5 | skill-writing outgrows its budget | product | `src/skills/skill-writing/SKILL.md` is 661 lines and already carries 20 H2 sections; three more patterns plus a contrastive slot push it further against `size-enforcement` | Keep each new pattern to the ~15-line shape the existing patterns use (`:505-532` is the model); if the file crosses its budget, the pattern registry splits out rather than the patterns being dropped | Phase 2 — Extend the skill-writing pattern registry |
+
+## Blockers
+
+### blocker: conditional-section-population-key
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 1.4 only. Phase 1 steps 1.1-1.3 (the script-bearing section
+  and its gate), and all of Phases 2-7, proceed independently.
+- **What to do:** Decide between two options for
+  `## Rationalizations to reject` (`src/skills/skill-writing/SKILL.md:533`) and
+  `## Non-negotiable deliverable` (`:556`), whose populations are not decidable
+  from the tree. (1) Add a declarative skill-frontmatter key naming the pattern
+  a skill opts into — a schema change under
+  `src/scripts/schemas/skill.schema.json:8` `additionalProperties: false`, plus
+  the frontmatter validator and every generator reading skill frontmatter.
+  (2) Drop `required` from both headings so the label matches the enforcement
+  that exists, leaving them optional patterns like `:505` and `:592`.
+- **Resolved when:** The maintainer records option 1 or option 2 in this
+  blocker, and step 1.4 is rewritten as the concrete steps that option needs.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
@@ -1,0 +1,255 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to CI Economy — cut the redundant full builds and re-anchor the cost artefacts to CI-recorded data
+
+> Cut the number of matrix-expanded `tests.yml` jobs that each run the full
+> 6-target `npm run build` on a `src/**` PR from 13 to at most 5, and replace
+> every stale row in `docs/contracts/ci-cost-budget.md` with a figure recorded
+> from a CI run — with no required check removed.
+
+> Source (consumed inbox): `agents/tmp.old/test-economy.txt` — part of the
+> 2026-08-10 batch triaged by [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+Re-derived in this worktree at `c073d5732` (v9.32.0):
+
+- `tests.yml` declares **6 job keys** (`:55`, `:99`, `:173`, `:246`, `:348`, `:386`)
+  which matrix-expand to **23 jobs**: `install-tests` 4 shards x 2 OS (`:76-78`),
+  `install-aux-tests` 2 OS (`:111-112`), `node-tests` 2 OS x 4 shards (`:203-204`),
+  `static-checks` 1 (`:246`, no matrix), `golden-tests` 2 OS (`:363-364`),
+  `workspace-tests` 2 OS (`:398-399`).
+- Four `npm run build --silent` steps (`:231`, `:286`, `:381`, `:415`) sit in
+  `node-tests`, `static-checks`, `golden-tests`, `workspace-tests` — so
+  **13 matrix-expanded jobs** each run the full build (8 + 1 + 2 + 2). The inbox
+  file said 12; 13 is the measured number.
+- `npm run build` is **6 targets** (`package.json:78`). Two workflow comments still
+  claim it is `build:cli && build:ui` (`tests.yml:183`, `:229`) — stale.
+- **1041** test files reach the vitest include set (`vitest.config.ts:16`, minus the
+  `tests/golden/sandbox/repo/**` exclude at `:21`); **191** of them spawn a
+  subprocess, which is what makes a `--changed`-style selection blind to that
+  slice. **43** files already use `tests/_lib/run_in_process.ts` — the lever exists.
+- `consistency.yml` is 1 job (`:94`) with **48** `- name:` steps. `scripts-run`
+  invocations total **99** across workflows, of which `rule-backstops.yml` = **23**
+  and `consistency.yml` = **21**. The inbox file targeted `consistency.yml`; the
+  larger surface is `rule-backstops.yml`.
+- **The artefact the inbox file proposes to create already exists.**
+  `docs/contracts/ci-cost-budget.md` carries the per-job wall-clock table
+  (`:24-36`), the 5-min ceiling (`:70-84`) and a quarterly review checklist
+  (`:86-100`, next due 2026-08-26). It is **stale**: rows for `python-tests`,
+  `windows-lockfile-export` and `migration-dry-run.yml` describe jobs and workflows
+  that no longer exist (`ls` on all three: absent; no `python-tests:` key anywhere
+  in `.github/workflows/`); `node-tests` is listed as "2 OS" when it is 2 OS x 4
+  shards; no rows for `golden-tests`, `workspace-tests` or `static-checks`.
+- `src/scripts/ci_time_ratio.ts` already samples `gh run list` (`:16`), classifies
+  commits by touched path and writes a JSON report (`:262`). Two defects: its
+  docstring names `agents/runtime/reports/` (`:23`) while `DEFAULT_OUT` (`:37`)
+  writes `agents/reports/`, and only the latter exists; and it is registered in no
+  `Taskfile.yml` / `taskfiles/*` / `src/cli/registry.ts` target.
+- **The baseline must come from CI, not from this laptop.**
+  `docs/hook-latency.json:2` records the exact failure: "a locally recorded darwin
+  baseline made the 20% regression window measure the environment offset instead of
+  real regressions." The inbox file's local 15s/19s timings plus a guessed "2-4x on
+  hosted runners" are that class and are not carried here.
+- Predecessor programme, read first:
+  `agents/roadmaps/archive/road-to-optimized-ci-and-release-gates.md` — Phase A
+  shipped the `release/*` skip guard, Phase C split the over-broad Windows and
+  Python legs out, and Phase C Step 3 authored `ci-cost-budget.md` itself (`:55`).
+  None of that is re-planned here.
+- Only **one** required check exists at the enforcement layer:
+  `Sync + Generate Tools Consistency` (`docs/contracts/branch-protection-policy.md:59`),
+  in ruleset `17749383`. Changing the required set is a maintainer action.
+
+## Phase 0 — Re-anchor the two existing cost artefacts to CI-recorded data
+
+- [-] **0.1 Create a `ci-timings.json` under `docs/`.** <!-- ref-ignore -->
+      Cancelled: already satisfied by `docs/contracts/ci-cost-budget.md` (table
+      `:24-36`, ceiling `:70-84`, review cadence `:86-100`). Extend that file; do not
+      add a second one. The path is named without a link on purpose — it must stay
+      absent, so a resolvable reference to it would be the defect.
+- [ ] **0.2 Fix the `ci_time_ratio` output-path drift.** Docstring `:23` names
+      `agents/runtime/reports/ci-time-ratio.json`; `DEFAULT_OUT` `:37` writes
+      `agents/reports/ci-time-ratio.json`; only the latter directory exists.
+      <!-- verify: grep -n 'runtime/reports' src/scripts/ci_time_ratio.ts -->
+- [ ] **0.3 Register `ci_time_ratio` behind a named target.** Zero hits today in
+      `Taskfile.yml`, `taskfiles/*.yml`, `src/cli/registry.ts`. Add it beside the
+      sibling CI helper in `taskfiles/ci-fast.yml`, which already hosts
+      `ci:required-checks` (`branch-protection-policy.md:101`).
+      <!-- verify: grep -rn 'ci_time_ratio' taskfiles/ -->
+- [ ] **0.4 Replace the stale `ci-cost-budget.md` baseline rows with CI figures.**
+      Drop `python-tests`, `windows-lockfile-export`, `migration-dry-run.yml` (all
+      gone); correct `node-tests` to 2 OS x 4 shards (`tests.yml:203-204`); add
+      `static-checks`, `golden-tests`, `workspace-tests`. Figures from `gh run list
+      --branch main --limit 50` as the file's own checklist specifies (`:90-91`) —
+      never a local run, per `docs/hook-latency.json:2`.
+      <!-- verify: grep -n 'python-tests\|windows-lockfile-export\|migration-dry-run' docs/contracts/ci-cost-budget.md -->
+- [ ] **0.5 State the measurement-only kill criterion in the file.** The inbox file
+      bound every kill criterion to `escaped_regressions`, which needs a human to
+      attribute a post-merge failure to a demoted check and is not mechanically
+      decidable. Phase 0 changes no job, so its criterion is "the refreshed table
+      names every job that exists and none that does not" — decidable by 0.4.
+
+## Phase 1 — Free hygiene: dead filters, missing concurrency, stale comments, caches
+
+- [ ] **1.1 Delete the dead `.agent-src.uncondensed/**` path filters.** The tree is
+      absent yet 10 filter entries reference it: `skill-lint.yml:7,29`,
+      `consistency.yml:13,52`, `smoke.yml:17,19`, `tests.yml:20,21,39,40`. Classify
+      each before removal — a filter naming a not-yet-created path is legitimate; a
+      filter naming a removed tree is not.
+      <!-- verify: grep -rn 'agent-src.uncondensed' .github/workflows/ -->
+- [ ] **1.2 Delete the three other dead filter entries.** `smoke.yml:20`
+      (`router.json` — root file absent; the live artefact `dist/router.json` is
+      already correctly filtered at `rule-backstops.yml:37,55`),
+      `smoke-public-install.yml:42` (`src/scripts/install.py` — absent) and `:50`
+      (`templates/**` — no `templates/` at repo root).
+      <!-- verify: grep -rn "'src/scripts/install.py'" .github/workflows/ -->
+- [ ] **1.3 Add a report-only dead-filter sweep.** Walk every `paths:` entry in
+      `.github/workflows/` and report entries matching nothing. **Report-only, not a
+      gate:** the false-positive class is non-empty by construction — a filter may
+      legitimately name a path a future PR adds — so failing CI on it would block a
+      legal shape. Revisit as a gate only with a measured FP rate over its output.
+      <!-- verify: grep -rn 'paths:' .github/workflows/tests.yml -->
+- [ ] **1.4 Add `concurrency:` to the five workflows without it.** 23 of 28 carry
+      it; `rule-backstops.yml`, `self-review-gate.yml`, `adoption-snapshot.yml`,
+      `cross-model-canary.yml`, `release-adjacent-health.yml` do not.
+      `rule-backstops.yml` (`:24` PR, `:40` push) and `self-review-gate.yml` (`:19`
+      PR, two PR jobs at `:27`, `:41`) are the two that actually stack. Scope
+      `cancel-in-progress` to `pull_request` refs only — a cancelled push-to-main
+      backstop run loses the only signal for that commit.
+      <!-- verify: grep -c 'concurrency:' .github/workflows/rule-backstops.yml -->
+- [ ] **1.5 Correct the three stale workflow comments.** `tests.yml:183` and `:229`
+      claim `build` = `build:cli && build:ui`; it is 6 targets (`package.json:78`).
+      `tests.yml:238` points at a `heavy-tests` job that does not exist — the real
+      jobs are `golden-tests` (`:348`) and `workspace-tests` (`:386`).
+      `tests.yml:349` says "29 scenarios"; `tests/golden/baseline/` holds 30.
+      <!-- verify: grep -n 'build:cli && build:ui\|heavy-tests\|29 scenario' .github/workflows/tests.yml -->
+- [ ] **1.6 Turn on the two absent toolchain caches.** No `incremental` or
+      `tsBuildInfoFile` in `tsconfig.json`, `tsconfig.scripts.json`,
+      `tsconfig.test.json`, `tsconfig.ui.json`; `lint:ts` is bare
+      `eslint 'src/**/*.ts'` (`package.json:80`) with no `--cache`. Both are
+      correctness-neutral and both feed `static-checks`.
+      <!-- verify: grep -n 'incremental' tsconfig.json -->
+- [ ] **1.7 Add `--no-audit --no-fund --prefer-offline` to the bare `npm ci` calls.**
+      13 workflows already pass the first two; 10 still carry at least one bare
+      `run: npm ci`, including all six in `tests.yml` (`:94`, `:125`, `:214`,
+      `:263`, `:374`, `:409`). `--prefer-offline` appears zero times anywhere, while
+      `setup-node` already populates the npm cache.
+      <!-- verify: grep -nE '^\s*-?\s*run:\s*npm ci\s*$' .github/workflows/tests.yml -->
+
+## Phase 2 — The build fan-out: stop rebuilding the same 6 targets 13 times
+
+- [ ] **2.1 Record the per-build cost before changing anything.** Add the
+      `npm run build --silent` step duration for `node-tests`, `static-checks`,
+      `golden-tests`, `workspace-tests` to the Phase 0.4 table, from a CI run.
+      Without that row the fan-out saving is asserted, not measured.
+      <!-- verify: grep -c 'npm run build --silent' .github/workflows/tests.yml -->
+- [ ] **2.2 Build once, share the artefact.** One producer job runs the full build
+      and uploads `dist/`; the other three families download it instead of
+      rebuilding. Both primitives are already in-tree — `upload-artifact@v7` in 8
+      workflows (e.g. `consistency.yml:470`) and `actions/cache@v6` in
+      `release-validation.yml:391` — so this adds no new dependency.
+      <!-- verify: grep -c 'npm run build --silent' .github/workflows/tests.yml -->
+- [ ] **2.3 Keep the drift gate on the producer.** The freshness check at
+      `tests.yml:303-312` is what makes a shared artefact safe: it asserts
+      `dist/install/` still derives from `src/install/` via `git status
+      --porcelain`. It stays on the job that actually builds, and consumers assert
+      the artefact they received rather than silently rebuilding on cache miss.
+      <!-- verify: grep -n 'Committed build output is fresh' .github/workflows/tests.yml -->
+- [ ] **2.4 Split the build where a consumer needs fewer than six targets.**
+      `build:cli-delegate` (`package.json:71`) is the in-repo precedent for an
+      independently buildable esbuild target. `static-checks` runs ESLint + tsc +
+      prepack and never spawns `./agent-config`, so it does not need `build:ui`;
+      `golden-tests` and `workspace-tests` spawn the CLI and do. Record per job
+      which targets are actually required.
+      <!-- verify: grep -n 'build:cli-delegate' package.json -->
+- [ ] **2.5 Record the deliberate non-adoption of a remote build cache.** Rejected
+      on cost and dependency grounds: a third-party cache service adds an external
+      dependency and a spend line for a saving 2.2 gets from primitives already in
+      the repo. **Not** an ADR-088 consequence —
+      `ADR-088-no-external-runtime-federation.md` is a category boundary about
+      driving external agent runtimes and does not reach build caching. The inbox
+      file cited it incorrectly.
+
+## Phase 3 — The subprocess lever: extend in-process running, do not add a skill
+
+- [ ] **3.1 Inventory the 191 spawning test files against the 43 adopters.**
+      `tests/_lib/run_in_process.ts` already exports `runInProc` / `runInProcAsync`
+      (`:149`, `:48`) and models process exit as a throwable (`ProcessExit`, `:41`).
+      Produce the candidate list: files whose spawn is a plain `./scripts-run` or
+      `./agent-config` invocation with no real process-boundary assertion.
+      <!-- verify: grep -rl 'run_in_process' tests/ | wc -l -->
+- [ ] **3.2 Migrate the mechanical candidates in batches, keeping one spawning test
+      per CLI entry point.** The process boundary is the thing under test for argv
+      handling, exit codes and stdio; converting every last one deletes that
+      coverage.
+      <!-- verify: grep -rl 'run_in_process' tests/ | wc -l -->
+- [ ] **3.3 Document the in-process pattern in the existing
+      `src/skills/test-performance/SKILL.md`.** No new skill: the estate is 116
+      rules / 289 skills and this is the subject that skill already owns. Note
+      honestly that the skill is currently single-stack — its whole "Optimization
+      strategies" section (`:68-147`) is database / migration / seeder work. Adding
+      the node-vitest subprocess-vs-in-process axis gives it a second stack peer,
+      which also moves it toward the multi-stack shape
+      `framework-neutrality-in-generic-skills` asks of a generically named artefact.
+- [ ] **3.4 Retire the `heavy-tests` framing if the clumping cause is gone.**
+      `golden-tests` and `workspace-tests` exist as dedicated runners because
+      subprocess-heavy files hash-clump into one over-budget vitest shard
+      (`tests.yml:349-357`, `:387-392`). If 3.2 removes enough spawns that the clump
+      disappears, both fold back into the shard matrix — decidable from the shard
+      durations in the Phase 0.4 table, not from a guess.
+      <!-- verify: grep -n 'hash-clump' .github/workflows/tests.yml -->
+
+## Phase 4 — Required-check-set changes (authored here, applied by the maintainer)
+
+- [ ] **4.1 Draft ADR-222 for any required-check demotion, after 0.4 has numbers.**
+      Next free number is 222 (`docs/decisions/` ends at
+      `ADR-221-host-native-first-ladder.md`). The ADR states what regression class
+      the demoted check was catching and what still catches it. It is a proposal in
+      `docs/decisions/` and changes no enforcement by itself.
+      <!-- verify: ls docs/decisions/ | tail -3 -->
+- [~] **4.2 Demote the macOS leg and/or the `npm audit` PR gate.** Deferred behind
+      `blocker: required-check-set-change`. Touches ruleset `17749383` plus
+      `docs/contracts/branch-protection-policy.md`, `ci-green-floor.md` and
+      `release-pr-gating.md` in the same change.
+- [~] **4.3 Enable a GitHub merge queue.** Deferred behind
+      `blocker: merge-queue-enablement`. `merge_group` appears zero times in
+      `.github/`, so nothing in-tree is wired for it either way.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Shared build artefact hides per-job drift | implementation | Four independent builds today each re-derive `dist/`; one shared artefact means a drift only the producer would notice. | Keep the `tests.yml:303-312` freshness gate on the producer; consumers assert the artefact rather than rebuilding on cache miss (2.3). | Phase 2 — The build fan-out |
+| 2 | Baseline recorded from too few runs | implementation | A figure from one PR run measures runner variance; a later regression window would then flag noise. | Use the 50-run average the file's own checklist specifies (`ci-cost-budget.md:90-91`), recorded from CI, never locally (`hook-latency.json:2`). | Phase 0 — Re-anchor the two existing cost artefacts |
+| 3 | In-process migration deletes real coverage | implementation | Converting a spawn to an in-process call removes the argv / exit-code / stdio boundary some tests exist to prove. | Keep one spawning test per CLI entry point (3.2); `ProcessExit` (`run_in_process.ts:41`) preserves exit semantics for the rest. | Phase 3 — The subprocess lever |
+| 4 | A filter is dead by typo, not by removal | product | Deleting a path-filter entry that was meant to match something narrows a trigger surface silently. | Classify every entry before deleting (1.1, 1.2), each removal citing its absence check; the sweep in 1.3 stays report-only. | Phase 1 — Free hygiene |
+| 5 | `cancel-in-progress` drops a backstop signal | product | On `push: main`, `rule-backstops.yml` is the only run for that commit; cancelling it loses the signal entirely. | Scope `cancel-in-progress` to `pull_request` refs only (1.4). | Phase 1 — Free hygiene |
+
+## Blockers
+
+### blocker: required-check-set-change
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 4.2 only. Phases 0-3 and step 4.1 are not blocked — they change
+  no required check, and ADR-222 is a proposal, not an enforcement change.
+- **What to do:** decide whether the macOS leg and the `npm audit` PR gate stay in
+  the required set, then apply the ruleset edit. Ruleset `17749383` currently
+  requires exactly one check, `Sync + Generate Tools Consistency`
+  (`docs/contracts/branch-protection-policy.md:59`); the write path is documented
+  at `branch-protection-policy.md:158`.
+- **Resolved when:** ADR-222 is accepted and the ruleset's
+  `required_status_checks` list matches the matrix in
+  `branch-protection-policy.md`, with `ci-green-floor.md` and
+  `release-pr-gating.md` updated in the same change.
+
+### blocker: merge-queue-enablement
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 4.3 only. Nothing else here depends on a merge queue.
+- **What to do:** decide whether to enable a GitHub merge queue for `main` — a
+  repo-admin setting that cannot be turned on from the tree.
+- **Resolved when:** the merge queue is enabled on `main` and at least one workflow
+  declares a `merge_group` trigger (currently zero across `.github/`).

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-council-integrity.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-council-integrity.md
@@ -1,0 +1,235 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to council-pass integrity
+
+> Make a solo-concluded council pass distinguishable from a full-attendance one
+> in the machine-readable event log, and make a synthesis verdict checkable
+> against its own stance tally — so an attendance claim and a verdict claim both
+> have a downstream signal behind them.
+
+> Source (consumed inbox): `agents/tmp.old/subagents-optimization-2.txt` and
+> `agents/tmp.old/ac-council-hardening` — part of the 2026-08-10 batch triaged by
+> [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+One inbox file out of twenty-two survived verification intact — eleven of eleven
+checkable repo claims held, one exact to the line number. This roadmap is that
+file, expanded, plus the one surviving sub-mechanism from the council-hardening
+bundle.
+
+**The defect.** `agents/roadmaps/road-to-always-on-orchestration.md:395` (Risk 6)
+claimed as its mitigation that *"attendance telemetry makes absent members
+visible rather than silent"*, while `src/scripts/ai_council/events_log.ts:30`
+carries `EventAction = 'proceed' | 'skip_necessity' | 'block_quota'` and the file
+contains **zero** occurrences of `quorum`. That roadmap is `status: ready`
+(active), so an active risk register asserted a mitigation the code did not
+deliver. A solo-concluded pass is downstream-identical to a full-attendance one.
+
+**What visibility actually exists, and where it stops.** Artifact and manifest
+visibility are real: `ai_council/orchestrator.ts:1973,1977` push
+`_render_quorum_line` / `_render_absent_members` (defined `:1983`, `:1992`), and
+`ai_council/session.ts:109` holds `quorum: QuorumResult | null`, serialised at
+`:550`. Nothing reaches the event log. So the honest description of the shipped
+state is **artifact-visible only** — which is what the Risk-6 row now says.
+
+**What is already registered, and what is not.**
+`road-to-always-on-orchestration.md:273` marks 6.1 `[x]`; its registered list
+(dispatch rate per delegable verdict, ladder precision, council fire rate +
+unactioned-verdict rate, per-session quota burn, metered-fallback spend) omits
+attendance rate, solo-conclusion rate, and absent-reason distribution.
+
+**The insertion point is validated, not free-form.** `appendEvent`
+(`events_log.ts:153`) throws when `action` is not in `_VALID_ACTIONS`
+(`:32-36`, `:162-166`) — a literal set parallel to the `EventAction` type, so a
+new action must land in both. Non-reserved diagnostic fields already pass
+through (`:196-200`), so the payload does not need a reserved-field change; the
+action does. Byte-parity with the retired port is a stated invariant of the
+module (`:18-21`), which is where the `SCHEMA_VERSION` (`:28`) discipline comes
+from.
+
+## Phase 1 — Attendance becomes machine-readable
+
+- [ ] **1.1 Add a `quorum_result` event.** Extend `EventAction`
+      (`ai_council/events_log.ts:30`) **and** `_VALID_ACTIONS` (`:32-36`) — both,
+      or `appendEvent` throws at `:162`. Payload: `status`, `threshold`, `total`,
+      `present`, `absent[{member, reason}]`; these ride the non-reserved
+      pass-through at `:196-200`. Emit at both `evaluateQuorum` call sites —
+      `src/scripts/council_cli.ts:668` and `:937` (verified: exactly two; note
+      the caller is `src/scripts/council_cli.ts`, **not** a file under
+      `ai_council/`). Follow the two shipped `appendEvent` emitters
+      (`council_cli.ts:1940`, `ai_council/clients.ts:1274`) — both wrap the call
+      in a `try`, which is the fail-open shape. Bump `SCHEMA_VERSION` (`:28`) per
+      the module's own byte-parity convention (`:18-21`).
+      <!-- verify: task test -- --filter=events_log -->
+- [ ] **1.2 Use the tree's real absent-reason vocabulary.** The source file drafted
+      `(binary_missing, quota, timeout, error)`; three of four tokens are wrong.
+      The real set is `AbsentReason = 'no_binary' | 'no_auth' | 'timeout' |
+      'quota'` (`ai_council/transport_resolver.ts:65`), plus the runtime fallback
+      `'unavailable'` (`council_cli.ts:664`, `:834`) and the literal
+      `'binary_missing'` at `council_cli.ts:910`. The event records what the
+      caller already computed; it introduces no sixth token.
+      <!-- verify: task test -- --filter=transport_resolver -->
+- [ ] **1.3 Add `isSoloConcluded(q)` as a derived predicate** in
+      `ai_council/quorum.ts`, beside `evaluateQuorum` (`:75`). Deliberately **not**
+      a third `QuorumStatus`: the two-state enum (`:29`) and `ceil(n/2)` (`:63`)
+      stay untouched, because the ceil-vs-floor divergence is a recorded decision
+      in that module's own docstring (`:13-19`) — 1-of-2 is called "the deliberate
+      choice, not an off-by-one". Advisory derivation only; no gate behaviour
+      changes. <!-- verify: task test -- --filter=quorum -->
+- [ ] **1.4 Render a solo marker** in `ai_council/orchestrator.ts:1983`
+      `_render_quorum_line`, consuming 1.3. `:1992 _render_absent_members` and
+      `session.ts:109`/`:550` already carry the artifact and manifest halves, so
+      this is one line in an existing renderer, not a new surface.
+      <!-- verify: task test -- --filter=orchestrator -->
+- [ ] **1.5 Register the three omitted metrics in a budget JSON, not roadmap
+      prose** — attendance rate, solo-conclusion rate, absent-reason
+      distribution. The schema and the honest-gap convention both already exist:
+      `src/config/hook-token-budget.json` carries
+      `definition` / `instrument` / `threshold` plus declared `HONEST GAP` text
+      (`:44`, `:53-62`), and `src/config/recycle-threshold-budget.json` carries
+      `registered_at` / `owner` / `review_by` / `honest_null_consequence`
+      (`:4-6`, `:11`). Registration precedes data; no threshold is committed here.
+- [~] **1.6 Solo-attendance floor.** Deferred behind `blocker: quorum-solo-floor`
+      below — the rate cannot be read before 1.1 accumulates it. 1.1–1.5 ship and
+      are useful without it.
+
+**Exit conditions — both required.**
+
+1. A solo-concluded pass is distinguishable from a full-attendance one by reading
+   `agents/runtime/council/events.log` alone.
+2. **No `member_slot` vocabulary is introduced.** `grep -rn
+   'member_slot\|memberSlot\|slot_index' src/scripts/ai_council/` returns **zero**
+   today, and `agents/roadmaps/road-to-council-blind-review.md` is `status: ready`
+   with open work in Phase 2 (`:145`) and Phase 3 (`:179`); its anonymisation seam
+   is `ai_council/orchestrator.ts:1430-1433` and `:1589` (`Response-A` labels for
+   the peer-review pass). 1.1 records `member` as the already-public name the
+   absent-list at `council_cli.ts:662-666` already carries, or it waits for that
+   roadmap's seam. A parallel anonymisation vocabulary is drift this repo has paid
+   for before.
+
+## Phase 2 — A verdict that disagrees with its own tally
+
+- [ ] **2.1 Check synthesis prose against the stance tally.**
+      `ai_council/prompts.ts:467 assert_synthesis_sections` validates that
+      `### Kill criteria` and `### Concrete next step` are present and non-empty
+      (`REQUIRED_SYNTHESIS_SECTIONS`, `:456`) — a *shape* check. It does not
+      compare the recommendation prose to the counted stances, so a synthesis can
+      report agreement over a tally that recorded dissent.
+      `ai_council/stance_tally.ts` owns the controlled vocabulary
+      (`ABSTAIN_LABEL` `:27`, `abstain_count` `:53`, `needs_repair` `:61`), and
+      `tests/scripts/ai_council/synthesis_check.test.ts` is the existing seam —
+      extend that function and that test, do not add a script. The analogous check
+      already ships on the release surface as `check_finding_dispositions.ts` —
+      built for the recorded 9.14.0 failure where the release head read "Security
+      and correctness: none" over a critical finding (`:1-28`), i.e. exactly this
+      defect class on a different artifact.
+      <!-- verify: task test -- --filter=synthesis_check -->
+
+**Exit:** a synthesis naming agreement while the tally records dissent throws
+`SynthesisRenderError` on the emit path, the same way a missing section does.
+
+## Phase 3 — One duplicated defence, honestly scoped
+
+- [ ] **3.1 Consolidate the two byte-identical truthy-string guards.** The
+      `'false'`-is-a-truthy-string defence is written out twice, byte-for-byte:
+      `ai_council/events_log.ts:129-133` and `ai_team/review_gate.ts:172-176` —
+      `diff` over the two blocks is empty, and no shared helper exists
+      (`ls src/scripts/_lib/ | grep -i 'coerce\|bool'` → nothing). Extract one
+      `src/scripts/_lib/` helper and migrate exactly those two call sites. This is
+      a **refactor**, not a new capability: no behaviour changes, and the win is
+      that the next env kill-switch has somewhere to come from.
+      <!-- verify: task test -- --filter=events_log -->
+
+**Scope correction, recorded because the source over-claimed it.** The inbox item
+asserted "≥5 sites" of the same defence. Measured: `grep -rn "=== 'false'"
+src/scripts/` returns **10** hits, but only the two above share one predicate.
+`orchestration_record.ts:91` is a CLI-flag coercion whose invalid-string
+fall-through is deliberate and documented (`:85-86`);
+`turn_end_gate_hook.ts:562-564` accepts `yes`/`on`;
+`validate_frontmatter.ts:236` is a YAML scalar parser. Folding those into one
+helper would change three behaviours to remove three lines. They stay.
+
+## Already landed on this branch
+
+- [x] **Risk-6 row corrected** — `road-to-always-on-orchestration.md:395` now
+      states absent members are **artifact-visible only**, names
+      `_render_quorum_line` / `_render_absent_members` and the `session.ts`
+      serialisation, records that `events_log.ts` carries no quorum event, and
+      says the row "claims no telemetry mitigation" until Phase 1 lands
+      (`e1f271e6b`). Correct either way: if Phase 1 is rejected, the row still
+      must not assert a mechanism that does not exist.
+
+## Cancelled against evidence
+
+- [-] **A citation gate against a per-dispatch "shown set", and an isolation
+      smoke test.** There is nothing to gate against.
+      `ai_council/project_context.ts:1-23` gives members only manifest fields and
+      README prose under a stated "Iron law of neutrality", capped at
+      `REPO_PURPOSE_MAX_CHARS = 400` (`:23`); no dossier layer and no projection
+      manifest exists. Members are separate providers in separate calls, so
+      divergence is structural rather than something a test establishes.
+- [-] **An `unsourced` verdict flag.** Already shipped under two names:
+      `stance_tally.needs_repair` (`:61`, populated `:150-154`, counted in the
+      denominator `:176`) and `ABSTAIN_LABEL` (`:27`, special-cased `:182`,
+      counted `:212-213`) — and the abstain path is documented as one that
+      "raises the bar" (`:231`), not one that penalises.
+- [-] **Voice dedupe across chairman candidates.** `ai_council/chairman.ts:51`
+      already builds `new Set(candidates.map((c) => c.name))` and rejects a
+      chairman not in it.
+- [-] **A budget check before the call.** `ai_council/orchestrator.ts:719`
+      already calls the imported `would_exceed` (`:27`) against
+      `budget.daily_limit_usd` before dispatching.
+- [-] **Tolerant quorum / a non-downgradable inconclusive.** Both are the shipped
+      decision: `ai_council/quorum.ts:7-8` records that an inconclusive pass
+      "HOLDS the gate for a human — it is NEVER silently downgraded to advisory
+      (council-verified, 2026-08-09)".
+- [-] **Recalibrating the decline criteria.** `ai_council/necessity.ts:9-14`
+      already states the calibration doctrine in the intended direction ("False
+      positives are preferable to false negatives on the `necessary` side"), and
+      `check_detector_corpus.ts:1-24` already gates every detector on all three
+      fixture classes including `must-not-fire`.
+- [-] **Unicode normalisation before id matching.** No observed failure. A
+      mechanism must match an observed failure mode; this one matches a
+      hypothetical.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Phase 1 invents a second anonymisation vocabulary | implementation | The obvious implementation adds a `member_slot` field to `events_log.ts`, while `road-to-council-blind-review` still has open work in Phases 2 and 3 and owns the anonymisation seam — producing two vocabularies for one property, in a module whose byte-parity invariant makes a later rename expensive | Stated as exit condition 2 of Phase 1, not a footnote: the seam is named (`orchestrator.ts:1430-1433`, `:1589`), and 1.1 records the already-public member name the absent-list carries or waits for that roadmap | Phase 1 — Attendance becomes machine-readable |
+| 2 | Adding an action breaks the events log for existing callers | implementation | `appendEvent` validates `action` against a literal set parallel to the type, and the module holds a byte-parity invariant with a retired port, so a half-edit throws at runtime rather than at compile time | 1.1 names both edit sites (`:30` and `:32-36`) and the throw site (`:162`); the payload rides the documented non-reserved pass-through so no reserved-field change is needed; the verify command is the module's own test file | Phase 1 — Attendance becomes machine-readable |
+| 3 | 2.1 turns a taste judgement into a build failure | product | "The prose disagrees with the tally" is a semantic claim, and a check that guesses wrong reds a legitimate synthesis | The comparison is bounded to `stance_tally`'s controlled label vocabulary (`ABSTAIN_LABEL`, `needs_repair`, counted stances) — never free-text sentiment — so the compared values are generator-produced; it extends an existing shape check on an existing test seam rather than adding a scanner | Phase 2 — A verdict that disagrees with its own tally |
+| 4 | 1.5 registers metrics that are never read | product | Three registered metrics with no threshold can sit in a budget file indefinitely and become decoration | The two precedent budget files both carry `review_by` and an `honest_null_consequence` clause; 1.5 inherits both, so a metric that produces nothing publishes a null at its review date instead of expiring quietly | Phase 1 — Attendance becomes machine-readable |
+| 5 | A cancelled item is re-adopted from the source file | product | Seven items are cancelled because the mechanism already ships, and the source files argue for them persuasively and outlive this roadmap in `tmp.old/` | Every cancellation carries the shipped mechanism's `file:line` inline, so a re-reader meets the code before the argument | Cancelled against evidence |
+
+## Blockers
+
+### blocker: quorum-solo-floor
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 1.6 only. Phases 1.1–1.5, 2 and 3 ship and are useful without it.
+- **What to do:** the solo-conclusion rate is a rate over real passes, and no
+  event exists yet to accumulate it — which is why this is a blocker and not a
+  step. After 1.1 lands, pick between three pre-registered outcomes: (a) add a
+  third CLI member — `gemini` is already in `ai_council/cli_hints.ts:40-43` and
+  `ai_council/config.ts:78`, and `_lib/environment_detector.ts:138` records it as
+  `['gemini', false]` where the boolean is the community-wrapper flag documented
+  at `:127-133` (`false` = vendor-official CLI running under the user's own
+  subscription), so this option is spend-free on a host that has the binary;
+  (b) scope a `min_present: 2` floor to gate-class passes only; or (c) publish a
+  null if the rate is under 5 %. Tightening `ceil(n/2)` itself is out of scope —
+  `quorum.ts:13-19` records that divergence as a decision.
+- **Resolved when:** one of the three outcomes is chosen against real attendance
+  data, or 1.6 is cancelled against the published null.
+
+**This ask is its third occurrence.** It was already deferred once as
+`blocker: b-quorum-n2` in `agents/roadmaps/archive/road-to-feedback-9-29.md:365-373`,
+whose "Resolved when: attendance data exists" is the same unpaid precondition,
+and whose "watch council attendance telemetry" presumed the telemetry Phase 1
+builds. It is not a new idea; it is an unpaid one — which is the argument for
+1.1 rather than for another deferral.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md
@@ -1,0 +1,233 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to inbox harvest 2026-08-b — dispatch safety
+
+> Close four checkable gaps on the dispatch surface: a scoped `Bash(<prefix>:*)` grant
+> becomes expressible and the one shipped subagent stops holding a full shell; a staged
+> irreversible action gets a registry-level confirmation flag with exactly-once
+> execution; the handoff envelope gains two validated fields plus one shape lint; and
+> self-repair complaint creation gains a per-source rate cap. Zero new rules, zero new
+> skills.
+
+> Source (consumed inbox): `agents/tmp.old/ac-host-flag-compilation`,
+> `agents/tmp.old/ac-orchestration-deltas`, `agents/tmp.old/better-handoff.txt`,
+> `agents/tmp.old/ac-role-catalog`, `agents/tmp.old/ac-factory-mechanics` — part of the
+> 2026-08-10 batch triaged by
+> [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+**The tool grant is a build-time schema question, not a hook question.** The bundles
+proposed a PreToolUse layer for per-agent tool scope; that layering is inverted.
+`src/scripts/schemas/subagent.schema.json:46-55` enum-validates `tools` at build time
+and `src/scripts/condense.ts:2045-2060` projects `{name, description, tools, model}`
+verbatim into `.claude/agents/<name>.md`, so the host already enforces it. What is
+broken is the enum — line 52 admits only the bare token `Bash`, making
+`Bash(npm run:*)` inexpressible, while `src/rules/tool-safety.md:40` prescribes the
+opposite ("Prefer scoped-grant syntax over bare tool names"). The one shipped subagent
+therefore holds a shell: `.claude/agents/production-validator.md:4` reads
+`tools: Read, Grep, Glob, Bash`. Precedent for both halves sits in the sibling schema —
+`skill.schema.json:211-217` carries the scoped-grant guidance, `:218-224` carries
+`disallowed_tools`. **The rule needs no edit**; ADR-109 gets an amendment note, not a
+new record. And the detector that would catch this cannot see the file:
+`src/scripts/lint_skill_frontmatter_safety.ts:39` carries a `_BARE_BASH` regex and
+reports a bare grant as HIGH (`:220`), but its roots at `:261` are `src/skills`,
+`src/agent-src`, `src/domains` — `src/subagents` is absent — and the key it reads is
+`allowed_tools` / `allowed-tools` (`:48`, `:201`), not the subagent `tools:` key.
+
+**The confirmation policy is complete; only the mechanism is missing.**
+`src/rules/non-destructive-by-default.md` already states "Never act while asking", the
+strictly-sequential ordering, and that the approval names the exact object.
+`requires_confirmation` returns **0 hits** across `src/` and `docs/`, and no
+exactly-once machinery exists. Extendable precedents: the `ask` / `ask_timeout` path in
+`src/agent-src/templates/scripts/work_engine/hooks/builtin/decision_gate.ts:100-109`,
+and `skill.schema.json:218` as the registry-flag shape. Host coverage bounds any guard:
+`src/scripts/hook_manifest.yaml` binds `pre_tool_use` on 3 of 8 platform rows — augment
+`:531`, claude `:539`, cowork `:578`; `agent-config hooks:status` is the per-install
+check.
+
+**The handoff test is presence, not effect.**
+`agents/roadmaps/archive/road-to-cost-parity-3-handoff-envelope.md:229-231` (blocker
+`handoff-content-adjudication`, resolved 2026-08-10): "A field whose presence is
+checkable survives where a doctrine whose effect is unmeasured did not, and that is the
+whole distinction." Against that bar: `do_not_touch` returns 0 hits in `src/`, nearest
+is `constraints?` at `src/scripts/_lib/subagent_capsule.ts:238`; and while
+`reversibility` appears 36 times in `src/` as prose, it appears **0 times** across the
+four handoff surfaces (`_lib/subagent_capsule.ts`, `_cli/handoff_generate.ts`,
+`_lib/envelope_grounding.ts`, `lint_handoffs.ts`) — the gap is field-absence, not
+word-absence. `lint_handoffs.ts:342-360` validates required *headings* only.
+
+**The turn-end primitive already ships, default OFF** —
+`turn_end_gate_hook.ts:107` declares `DetectorId = 'promissory' | 'language'`,
+`hook_manifest.yaml:445-449` carries `fail_closed: false`, and
+`src/config/agent-settings.template.yml:1216-1219` keeps the master switch
+`enabled: false` with both detectors on inside it, so the mechanism soaks before it
+binds. Only a third detector is missing, and the soak stays.
+
+## Phase 1 — Scoped tool grants
+
+- [ ] **1.1 Widen the subagent `tools` enum to admit a scoped grant.** Replace the
+      bare-token-only `enum` at `subagent.schema.json:52` with a constraint that also
+      accepts `Bash(<prefix>:*)`, keeping every existing token valid.
+      `tests/scripts/subagent_contract.test.ts:59-61` pins that `curl` is rejected —
+      that assertion must still hold.
+      <!-- verify: task test -- --filter=subagent_contract -->
+- [ ] **1.2 Narrow `production-validator` to the prefixes it needs.** Edit
+      `src/subagents/production-validator.md` so the shell grant becomes the command
+      families the audit runs, then regenerate so
+      `.claude/agents/production-validator.md:4` no longer carries a bare `Bash`.
+      <!-- verify: grep -n 'tools:' .claude/agents/production-validator.md -->
+- [ ] **1.3 Extend the existing safety linter to the subagent corpus and key.** Add
+      `src/subagents` to the roots at `lint_skill_frontmatter_safety.ts:261` and teach
+      `_scan` the subagent `tools:` key so the `_BARE_BASH` finding at `:220` reaches it.
+      The false-positive class is empty by construction: the key can only hold values
+      the 1.1 schema admits, and a bare `Bash` is what `tool-safety.md:40` names as
+      over-broad.
+      <!-- verify: ./scripts-run src/scripts/lint_skill_frontmatter_safety -->
+- [ ] **1.4 Record the contract change as an ADR-109 amendment note** — one paragraph in
+      `docs/decisions/ADR-109-subagent-v1-contract.md` stating that the enum now admits
+      scoped grants and why that is additive. Doc-only.
+- [-] **1.5 Host-flag compiler (`--allowedTools` / `--max-turns` / `--model`) and an
+      NDJSON `stream-json` driver — cancelled, no call site.**
+      `src/scripts/_lib/subagent_spawn.ts:1-12` is declared "Pure, no-I/O" brief
+      composition and the host spawns; the only `claude` subprocess is the council text
+      client (`src/scripts/ai_council/clients.ts:1416,1447`,
+      `--print --output-format json`, non-streaming). `stream-json`: 0 hits in `src/`.
+- [-] **1.6 Spawn-env allowlist — cancelled, contradicts an accepted record.**
+      `docs/decisions/ADR-123-runtime-security-scope-and-spawn-hardening.md:120-121`
+      lists "Env allowlist instead of deny-by-family" as a **rejected** alternative and
+      `:164-166` reaffirms "Deny-by-family stands unchanged";
+      `src/scripts/_lib/spawn_env.ts:28-33` gives the reason. The proposed six-variable
+      set omits the `ANTHROPIC_*` variants and config paths the council transport needs.
+
+## Phase 2 — A confirmation primitive for staged irreversible actions
+
+- [ ] **2.1 Add `requires_confirmation` as a registry-level flag.** Shape it on
+      `skill.schema.json:218-224` (optional, additive, schema-backed) so a command or
+      skill can declare that its action stages rather than executes. Schema plus fixture
+      only — no binding yet.
+      <!-- verify: ./scripts-run src/scripts/validate_frontmatter -->
+- [ ] **2.2 Implement exactly-once confirmed execution.** A staged action carries a
+      token; a double-approve executes once. Extend the `ask` / `ask_timeout` branch at
+      `decision_gate.ts:100-109` rather than adding a second prompt path, and keep the
+      non-interactive fallback it defines.
+      <!-- verify: task test -- --filter=hooks_builtin_decision_gate -->
+- [ ] **2.3 Make pending confirmations enumerable through an existing verb** — a flag,
+      never a new command; the enumeration precedent is `self-repair:status`
+      (`src/cli/registry.ts:118`, `src/scripts/self_repair_cli.ts:403-418`).
+      <!-- verify: grep -rn 'requires_confirmation' src/cli/registry.ts -->
+- [~] **2.4 Decide whether the primitive binds, and what the other five hosts get.**
+      Deferred behind `blocker: confirmation-degraded-host-semantics` — a host without a
+      `pre_tool_use` slot (5 of 8, per `hook_manifest.yaml:531,539,578`) can only carry
+      the obligation in prose, and shipping a mechanism that claims enforcement it does
+      not have is the failure `src/rules/ui-audit-gate.md` already names.
+
+## Phase 3 — Checkable handoff-envelope fields
+
+- [ ] **3.1 Add a validated `do_not_touch` envelope field.** Add to
+      `RECYCLE_ENVELOPE_KEYS` (`subagent_capsule.ts:447-460`, beside `constraints` at
+      `:459`), a `checkList` line beside `:522`, the interface entry beside `:238`, and
+      the heading to `HANDOFF_ARTIFACT_REQUIRED` (`lint_handoffs.ts:342-349`), with a
+      fixture pin.
+      <!-- verify: task test -- --filter=_lib_subagent_capsule -->
+- [ ] **3.2 Add `reversibility` to each decision line** — a one-line shape extension on
+      `decisions` (`subagent_capsule.ts:236`) plus the writer's contract at
+      `src/domains/meta/agent-handoff/command.md:169,227`. No claim is made that it
+      improves resumption; that stays the registered, unmeasured
+      `envelope_resume_success` metric.
+      <!-- verify: task test -- --filter=lint_handoffs -->
+- [ ] **3.3 Lint the Open-questions shape, not just the heading.**
+      `validate_handoff_artifact` (`lint_handoffs.ts:351-360`) only tests that each
+      required `##` heading exists; require at least one `?`-terminated line under
+      `Open questions`. Roughly five deterministic lines, and the false-positive class is
+      empty by construction — a section with no question in it is the defect.
+      <!-- verify: task test -- --filter=lint_handoffs_artifact -->
+- [ ] **3.4 Warn on a write against a `do_not_touch` path.** Sequenced strictly after
+      3.1 — the field must exist before a guard can read it. Model on
+      `block-kernel-rule-writes` (`hook_manifest.yaml:110`) and `reread-guard` (`:480`),
+      register in `src/scripts/hooks/concern_registry.ts:98-108`, advisory and
+      `fail_closed: false`. The `pre_tool_use` chain already runs nine concerns
+      (`hook_manifest.yaml:531`) — a tenth pays latency on every tool call.
+      <!-- verify: grep -rn 'do_not_touch' src/scripts/hooks/concern_registry.ts -->
+
+## Phase 4 — Roles, lifecycles, and the two residues
+
+- [ ] **4.1 Rate-cap self-repair complaint creation per source.** `upsertFinding`
+      (`src/scripts/_lib/self_repair_store.ts:84-89`) folds on fingerprint (`:85`), but
+      the only cap in the module pair is `MAX_EVIDENCE = 160`
+      (`src/scripts/_lib/self_repair.ts:94`) — a cap on evidence *length*, not on record
+      creation. Roughly ten lines. Note: the bundle calls this function `openOrMerge`,
+      which does not exist; the exports are at `:18-110`.
+      <!-- verify: task test -- --filter=self_repair -->
+- [ ] **4.2 Quarantine a stale findings artefact before a revision re-dispatch.**
+      `src/scripts/dispatch_r2_reviewer.ts:298-307` already owns the single review-scope
+      hash both dispatcher and validator bind to (contract §2.1, cited at `:32`); reuse
+      that hash as the staleness signal instead of adding a second definition, and read
+      `docs/contracts/plan-review-gates.md` §5 for the artefact-then-fix ordering the
+      re-dispatch must not break.
+      <!-- verify: task test -- --filter=dispatch_r2_reviewer -->
+- [ ] **4.3 Add an edit-without-fresh-verification detector to the turn-end gate.** A
+      third `DetectorId` beside `'promissory' | 'language'`
+      (`turn_end_gate_hook.ts:107`), inside the existing two-layer re-entrancy guard, and
+      **the default-off soak stays** — `agent-settings.template.yml:1216-1219` is not
+      flipped here. Before relying on a structured-error shape, re-confirm the severity
+      mapping on this host: `dispatch_hook.ts:76-78,803-804` defines `EXIT_WARN = 2`
+      alongside `EXIT_BLOCK = 1`, and an advisory finding delivered on the wrong exit
+      code becomes a hard deny. Treat that as a probe, not an assumption.
+      <!-- verify: task test -- --filter=turn_end_gate -->
+- [-] **4.4 Role-contract budget fields and an eight-role catalog behind a flag —
+      cancelled by record.** `ADR-109-subagent-v1-contract.md:75-76` lists
+      `max_iterations` / `anomaly_caps` / per-role budget as "Banned fields (would imply
+      runtime we do not have)"; Gate A (`:152-155`) ships a unit only if its eval beats
+      both baselines, and no such eval result is recorded in the tree today — a unit
+      without one "stays in `src/` as a documented honest-null". Seven of the eight
+      proposed roles already exist as skills (`src/skills/judge-*`, 7 directories).
+- [-] **4.5 `role@version` in every dispatch trace, plus PreToolUse per-role tool scope —
+      cancelled, precondition unpassable.** A resolved live probe
+      (`archive/road-to-token-economy-dispatch.md:435-455`) established that a subagent's
+      env is indistinguishable from the parent's (`CLAUDE_CODE_SESSION_ID` carries the
+      parent id) and that upstream marked per-spawn identity NOT_PLANNED;
+      `src/scripts/_lib/session_role.ts:20-26` fails open to `orchestrator` by contract.
+      `reviewer` is already enum-reserved at `:33-36` and already scheduled as Phase 3.2
+      of `later/road-to-token-economy-dispatch-followup.md:53-57` — unpark that rather
+      than re-author it.
+- [-] **4.6 Typed lifecycle state machines, a per-role-branch lint, and an asyncio
+      in-flight lint — cancelled.** There is one two-state runtime store
+      (`src/scripts/_lib/self_repair.ts:71`, `'open' | 'released'`); the other three
+      claimed lifecycles are static frontmatter enums and a grep for `transition` over
+      `src/scripts/` returns only CSS rule text. A per-role-branch lint would fire on the
+      dispatcher's own deliberate fail-open branch at
+      `src/scripts/hooks/dispatch_hook.ts:315-322` on day one. An asyncio lint would scan
+      nothing — zero authored Python remains under `src/` (`find src -name '*.py'`
+      returns 0) — and the doctrine already ships at
+      `src/skills/async-python-patterns/SKILL.md:63-65`.
+- [-] **4.7 Programmatic tool calling (executing model-authored scripts against a tool
+      RPC) — cancelled.** The largest novel mechanism in the batch and the wrong shape
+      here: ADR-123 holds behavioural enforcement out of scope, and the gate-equivalence
+      precondition presumes guards that bind on 3 of 8 hosts.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Confirmation primitive claims enforcement it lacks | product | On 5 of 8 hosts there is no `pre_tool_use` slot, so a staged-action guard degrades to prose while the flag reads like a control. | 2.4 stays deferred behind the blocker; the flag ships unbound until the degraded semantics are decided. | Phase 2 — A confirmation primitive for staged irreversible actions |
+| 2 | Narrowing the shipped subagent weakens its audit | implementation | `production-validator` uses the shell for real probes; a too-narrow prefix set makes the audit quietly weaker rather than failing loudly. | 1.2 lands after 1.1 and is verified by regenerating and reading the projected frontmatter, not by inspecting the source. | Phase 1 — Scoped tool grants |
+| 3 | Envelope-field additions inflate the payload | implementation | Two new fields plus a heading push against `RECYCLE_ENVELOPE_MAX_BYTES = 6144` (`_lib/recycle_envelope_paths.ts:35`, enforced at `_cli/cmd_session_recycle.ts:162`) and the required-heading list existing fixtures pin. | Both fields are single lines under the existing `MAX_LINE_CHARS = 240` limit (`subagent_capsule.ts:51`); fixture pins are part of 3.1 and 3.2. | Phase 3 — Checkable handoff-envelope fields |
+| 4 | The third turn-end detector lands on the wrong exit code | implementation | `EXIT_WARN = 2` sits beside `EXIT_BLOCK = 1` (`dispatch_hook.ts:76-78`), so an advisory finding delivered on the wrong path becomes a hard deny. | 4.3 re-confirms the mapping as a probe and leaves the master switch off, so a mistake soaks before it binds. | Phase 4 — Roles, lifecycles, and the two residues |
+
+## Blockers
+
+### blocker: confirmation-degraded-host-semantics
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 2.4 only. Steps 2.1-2.3 are unblocked and land default-unbound;
+  Phases 1, 3 and 4 are not blocked at all.
+- **What to do:** decide what a host without a `pre_tool_use` slot gets when a
+  `requires_confirmation` action is staged — a model-carried obligation stated as such,
+  or a refusal to stage at all — and whether the primitive is default-on or default-off
+  where the slot does exist.
+- **Resolved when:** the decision is recorded (an ADR, or the ADR-109 amendment note
+  from 1.4) and names both the degraded-host behaviour and the default.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md
@@ -1,0 +1,221 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to estate lifecycle reporting
+
+> Answer the estate's two unanswered questions — which artefacts nothing has
+> touched in six months, and which nothing points at — as two sections of reports
+> the tree already generates, adding zero frontmatter fields and moving no cap.
+
+> Source (consumed inbox): `agents/tmp.old/ac-hermes-harvest`,
+> `agents/tmp.old/chief-of-staff.txt`, `agents/tmp.old/ac-truthful-introspection`,
+> `agents/tmp.old/agent-config-fremon-harvest` — part of the 2026-08-10 batch
+> triaged by [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+**This roadmap opens as a decision-revisit offer against a same-day lock, not as
+fresh work.** The shrink mandate for the maintained estate is owned by
+[`later/road-to-cost-parity-1-rule-payload-diet.md`](later/road-to-cost-parity-1-rule-payload-diet.md) —
+`:8` "the maintained estate shrinks where nothing else owns it", `:10` "289 skills
+and 116 rules must all stay true, **reviewed** and non-contradictory". It is
+`status: later` (`:3`), parked `:17-30` "**2026-08-10 — AI-council convergence,
+maintainer pick**", and its Context is headed `:52` "verified against the tree
+2026-08-10, **do not relitigate**". Its Phase 5.1 already contemplates the
+semantics this subject would need: `:286-289` "A pack marked `maintained: false`
+is best-effort: **no review dates, excluded from estate caps**". Per
+[`decision-revisit-gate`](../../src/rules/decision-revisit-gate.md), the offer is
+surfaced (Phase 1), never planned around silently.
+
+**A second lock the inbox never found, and it decides the flagship item outright.**
+[`docs/governance.md`](../../docs/governance.md) § Skill lifecycle policy (`:44`)
+already declares the states `active · dormant · sunset` (`:46`) and already chose
+the mechanism: `:49-53` "**Dormancy is commit-based, not review-date-based.** A
+solo maintainer does not hand-maintain `last_reviewed:` timestamps (busywork that
+drifts). Dormancy signal = no commits touching a skill's files in 6 months
+(`git log --since='6 months ago' -- src/skills/<name>/`). Derivable — so it is
+*not* stored in the spine". `:54-55` "Dormancy triggers review, never
+auto-deprecation." `:58-59` a `last_reviewed:` field is "**deferred until a second
+maintainer** exists". So the sidecar-versus-frontmatter question the source asks is
+already answered as **neither**: derive it, store nothing.
+
+Re-derived estate: **116 rules** (`ls src/rules/*.md`), **289 skills**
+(`ls -d src/skills/*/`). Two lifecycle vocabularies are live and disagree:
+`lifecycle:` is `active|deprecated|experimental|archived`
+(`build_discovery_manifest.ts:152`, `schemas/rule.schema.json:143`,
+`command.schema.json:231`, `subagent.schema.json:80`, `skill.schema.json:254-263`
+with `"default": "active"`), while skills also carry a separate `status:` enum
+`active|deprecated|superseded` (`skill.schema.json:64-71`). Coverage is thin —
+**15 of 289** skills declare `lifecycle:`, **66 of 289** declare `status:` — and
+neither is a runtime lifecycle: both are static declarations, and nothing computes
+dormancy.
+
+Shipped precedents every step extends rather than replaces:
+`src/scripts/janitor.ts:1-16` (TTL sweep, `:10` "NEVER auto-sweeps `agents/tmp/`" —
+the archive-not-delete precedent); `src/config/recycle-threshold-budget.json:4-6`
+(`registered_at`/`owner`/`review_by` — the review-metadata triple, already
+sidecar-shaped); `src/scripts/hook_manifest.yaml:213,223` (`profile-staleness`,
+`wrapper-freshness`, both `severity: advisory` + `fail_closed: false` — the
+soft-warn shape); `src/scripts/discovery_graph.ts` (the artefact relation graph:
+content-addressed to the manifest checksum, version-namespaced cache, atomic write,
+`:10-14` typed relations, `:23-25` `build`/`affected`/`explain` with `--out`);
+`build_discovery_manifest.ts:103` (`DEFAULT_ORPHAN_REPORT`) and `:915-920`
+(`_deprecation_report`). Standing staleness gates: `sweep_dead_scan_roots.ts`,
+`check_corpus_staleness.ts`, `lint_one_off_age.ts`, `check_reach_staleness.ts`.
+
+Nothing below is gated on the revisit answer except a removal list: every report is
+report-only by construction and moves no cap.
+
+## Phase 1 — The revisit offer
+
+- [ ] **1.1 Surface the offer to the maintainer, and stop.** State the two locks
+      above with their `file:line`, state that Phases 2-4 are report-only and need
+      no reopening, and ask the one question the blocker names. Do not edit the
+      parked roadmap, and do not reopen `governance.md:49-59` — the commit-based
+      choice is the reason Phase 2 costs nothing.
+
+## Phase 2 — The dormancy signal governance already mandates
+
+`governance.md:52` names the exact command and calls the signal derivable. Nothing
+computes it, so an accepted policy has no instrument. This phase builds the
+instrument, not a new policy.
+
+- [ ] **2.1 Add a dormancy section to the existing discovery report family.**
+      Compute per-artefact last-touch from `git log -1 --format=%cI -- <path>` over
+      `iter_artefacts` and emit a section listing everything past the 6-month bar,
+      alongside `_deprecation_report` (`build_discovery_manifest.ts:915-920`) and
+      `_orphan_artefacts` (`:999-1022`). Report-only: `governance.md:54-55` says
+      dormancy triggers review, never auto-deprecation, and a gate would be wrong
+      anyway — a finished artefact is indistinguishable from an abandoned one from
+      commit dates, so the false-positive class is not empty and no argument makes
+      it so.
+      <!-- verify: task test -- --filter=build_discovery_manifest -->
+- [ ] **2.2 Publish the two-vocabulary finding and the coverage figures.** One
+      paragraph in `docs/governance.md`: `lifecycle:` and skill `status:` are
+      distinct fields with distinct enums, 15 of 289 and 66 of 289 declare them,
+      and `lifecycle` defaults to `active` (`skill.schema.json:262`) so absent
+      reads as active. Reconciling them is a separate decision; this only stops
+      the two being read as one field.
+- [ ] **2.3 Record the sidecar-versus-frontmatter answer where the question is
+      asked.** `governance.md:58-59` defers the field; add the reasoning in one
+      line — a review-date field across 405 artefacts is the diff noise the parked
+      roadmap's own Phase 3 drift-lint contends with, and the only shipped
+      review-metadata triple (`recycle-threshold-budget.json:4-6`) is
+      sidecar-shaped on a single config file. If the second-maintainer condition
+      ever fires, sidecar is the precedent, not frontmatter.
+
+## Phase 3 — Zero inbound references, on the graph that already exists
+
+`_orphan_artefacts` (`build_discovery_manifest.ts:999-1022`) means "sole declared
+member of its pack" — a typo detector, not a reachability one. A zero-inbound
+report is an **inverse traversal of `discovery_graph.ts`**, whose edge set is
+already deterministic and cached against the manifest checksum (`:143-154`). Not a
+new engine.
+
+- [ ] **3.1 Add an inbound-degree query to `discovery_graph.ts`.** `Edge` (`:45-50`)
+      already carries `from`/`to`/`rel`/`confidence`; invert it once and report
+      nodes with zero inbound `EXTRACTED` edges, excluding `member_of` (`INFERRED`
+      at `:124,129`, which would make every artefact look reachable via its pack
+      node). Additive alongside `affected` (`:195`) and `explain` (`:221`).
+      <!-- verify: task test -- --filter=discovery_graph -->
+- [ ] **3.2 Classify every first-run hit before anything is wired.** The relation
+      set is narrow — `replaces`, `routes_to`, ADR path targets, `packs`,
+      `workspaces` (`:10-14`) — so a prose-only cross-reference produces no edge and
+      a reachable artefact reads as zero-inbound. Classify the hits, then decide
+      whether the report is worth publishing at all. **Report, never a gate**:
+      `check_references.ts` is the cross-reference gate and this traversal sees a
+      strictly narrower graph, so the false-positive class is provably non-empty.
+      <!-- verify: ./scripts-run src/scripts/check_references --format=text -->
+- [ ] **3.3 Point the report at review, not removal.** One line in the emitted
+      section citing `governance.md:56-57` — sunset is explicit, recorded in the
+      removing commit, no tombstone files — and `janitor.ts:10` as the
+      archive-not-delete precedent.
+
+## Phase 4 — The graph's own observability
+
+- [ ] **4.1 Add `stats` and per-source try-isolation to `discovery_graph.ts`.**
+      `Graph` is exactly four fields (`:51-56`) with no `stats`, `buildGraph`
+      (`:95`) runs one loop with no per-relation error containment, and the file has
+      **zero** `reportScanned`/`assertScanned` calls. Add
+      `stats: Record<string, number | "error">`, wrap each edge-extraction pass in
+      its own `try` recording `"error"` for the pass that threw, and emit the count
+      via `_lib/scan_scope.reportScanned`, whose contract (`scan_scope.ts:98-120`)
+      is that "the emitted number is, by construction, the number the assertion
+      just accepted". `schema_version` already exists (`:148`), so this is additive
+      and **needs no ADR**.
+      <!-- verify: task test -- --filter=discovery_graph -->
+- [ ] **4.2 Namespace non-artefact node ids.** `pack:` and `workspace:` are the only
+      prefixes (`:123,128`); artefact nodes are bare paths (`idOf` at `:99`). A
+      zero-inbound report over a mixed id space is ambiguous the first time a path
+      collides with a synthetic node. One prefix constant, no format change.
+      <!-- verify: task test -- --filter=discovery_graph -->
+
+## Cancelled — each against a named citation
+
+- [-] **A `SELF.md` / generated self-knowledge doc family.** Closed in
+      [`road-to-capability-answerability.md`](road-to-capability-answerability.md)
+      (`status: ready` `:3`; **18 of 19** steps closed) plus
+      [`capability-answerability`](../../docs/contracts/capability-answerability.md),
+      whose `:24-30` table decides carry-vs-name per capability and whose `:40-44`
+      sets an **empirical revisit bar** — "Flip a `name` to a `carry` when the same
+      wrong guess is observed twice." A successor clears that bar first. The
+      AUTO-block-in-a-hand-written-doc mechanism also ships exactly once already, as
+      `src/scripts/generate_subagent_floor.ts`, which **derives** its content from
+      `_lib/kernel_rules.ts` `:15` "so a second source of truth cannot appear" and is
+      `:19` drift-gated.
+- [-] **A truthful-reporting doctrine as new prose.** All four clauses are already
+      enforced mechanisms: `check_claims.ts:7-15` (a marker must resolve to a
+      `status: backed` ledger entry with a resolving evidence pointer);
+      `_lib/scan_scope.ts:98-120`; `assertScanned`/`DeadScopeError` with the recorded
+      14-gate incident in
+      [`gates-that-cannot-fail`](../settings/contexts/gates-that-cannot-fail.md); and
+      labelled degraded paths in `check_standing_rule_delivery.ts:15-27` ("always
+      NAMES which input it used") and `lint_token_budget_discipline.ts:14-18` ("the
+      gate says which"). `ADR-215:170-178` § D5 adopts "structural enforcement or
+      deletion, not a **louder restatement**".
+- [-] **A usage-count ship bar** ("fewer than two citing decisions per quarter →
+      demote the generator"). `ADR-216:14-16` strikes adoption as a gate condition
+      outright — "adoption is not a project goal and therefore not a valid gate".
+- [-] **A per-skill hard-fail `requires:` field.** Already shipped as
+      `requires_skills:` (`skill.schema.json:265-267`; 5 skills declare it) with
+      `src/scripts/check_skill_requires.ts:1-13` as its gate — referential integrity
+      plus cross-pack co-availability, `assertScanned`-guarded, exit 1 on violations.
+      The source's estate claim about it was never counted and is not counted here.
+- [-] **Per-skill `last_used` usage timestamps.** No `last_used` exists anywhere, but
+      the utilization question is owned and blocked:
+      [`road-to-surface-consolidation.md`](road-to-surface-consolidation.md)`:144-155`
+      Phase 3 is the KEEP/MERGE/DEMOTE/REMOVE sweep, time-gated to ~2026-08-26, with
+      `:313-315` blocking "utilization-driven MERGE/DEMOTE/HIDE/REMOVE of artefacts
+      (needs loaded-vs-fired usage over the window)". A second instrument competes.
+- [-] **Extending the `code-graph` engine instead.** Different subject, permanent
+      lock: `ADR-124:221-229` published the honest null — recall **0.365 vs
+      disciplined grep 0.797**, Δ **−43.2 pp** — and set `code_graph.enabled: false`
+      permanently, deprecation at the next major. `discovery_graph.ts` is the
+      **artefact** relation graph and is unaffected; do not conflate them.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The revisit offer is read as the lock being lifted | product | Two accepted decisions sit under this subject, one parked the same day by council convergence and one live in `governance.md`; a roadmap that opens by offering to revisit them is one step from a session treating the offer as the answer and adding estate metadata nobody approved | 1.1 is the only step in Phase 1 and it ends the turn; every other step is report-only and cites why it needs no reopening; the blocker names what is NOT blocked | Phase 1 — The revisit offer |
+| 2 | A zero-inbound report is trusted as a removal list | product | The manifest's relation set is five typed edges and misses prose cross-references entirely, so a reachable artefact can read as unreferenced and get deleted on a report's word | 3.2 classifies every first-run hit before the report is published and states it is never a gate; 3.3 puts the sunset-is-explicit and archive-not-delete citations inside the emitted section | Phase 3 — Zero inbound references |
+| 3 | Dormancy dates are read as abandonment | product | A finished, correct artefact and an abandoned one look identical from commit dates, and `governance.md` chose commit-based dormancy precisely as a review prompt | 2.1 emits report-only and quotes `governance.md:54-55` in the step; the false-positive class is stated as non-empty rather than argued away, so the step never becomes a gate | Phase 2 — The dormancy signal |
+| 4 | The graph delta changes a cached artefact's shape | implementation | `discovery_graph.ts` is content-addressed with a version-namespaced cache; adding `stats` and an id prefix touches what consumers read | `schema_version` already exists at `:148` so the change is additive by the file's own contract; both 4.1 and 4.2 verify against the existing `discovery_graph` test | Phase 4 — The graph's own observability |
+
+## Blockers
+
+### blocker: estate-lifecycle-revisit-answer
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** any step that would act on a report — a removal list, a cap change, or
+  a new estate metadata field. Phases 2, 3 and 4 are NOT blocked: every step there
+  is report-only, adds no frontmatter field, and moves no cap.
+- **What to do:** answer whether the maintained-estate framing in
+  `later/road-to-cost-parity-1-rule-payload-diet.md` reopens now, or stays parked
+  on its own resume conditions (`:24-30`). Separately: `governance.md:58-59` defers
+  a `last_reviewed:` field until a second maintainer exists — confirm that
+  condition still holds, since it is what makes Phase 2 derive rather than store.
+- **Resolved when:** the answer is written into 1.1 with its date, and either the
+  parked roadmap moves out of `later/` or 1.1 records that it stays.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-install-lifecycle.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-install-lifecycle.md
@@ -1,0 +1,170 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to install lifecycle — every write recorded, org packs decided
+
+> Close the three writes an install performs that its own uninstall cannot undo, so
+> `agent-config uninstall` leaves zero unrecorded artefacts; and put the org-pack
+> question in front of the maintainer as a named reopening of ADR-011 rather than a
+> silent park.
+
+> Source (consumed inbox): `agents/tmp.old/plugin-system.txt` — part of the
+> 2026-08-10 batch triaged by [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+The source proposed an org-level plugin system. Two things are true about it, and both
+change the plan.
+
+**The removal path already ships.** The source's headline gap — no clean removal — is
+overtaken. `uninstall` (874 lines, `src/scripts/_cli/cmd_uninstall.ts`), `prune` (629
+lines, `src/scripts/_cli/cmd_prune.ts`) and a read-only drift report `doctor`
+(`src/scripts/_cli/cmd_doctor.ts`, orphan check at `:1528`) are all registered
+(`src/cli/registry.ts:39,40,41`). Provenance is specified and implemented: per-tool
+`files[]` with `kind` ∈ `{deployed, bridge, marker}` plus `sha256`, `merged_keys[]`
+with RFC-6901 pointers, and a two-phase `status: uninstalling` resume
+(`docs/contracts/install-layout.md:177-191`; `--resume-uninstall` at
+`cmd_prune.ts:478-479`, sha256 drift-skip documented at `cmd_prune.ts:31-33`).
+Searching `src/scripts/install.ts` alone for "uninstall" returns one comment at `:3682`
+— that is a fact about that file, not about the repo.
+
+**What is genuinely open is narrower and sharper.** The layout contract freezes three
+writes as known gaps and states plainly that "fixing them is an additive change
+(recording a previously-untracked write), never a breaking one"
+(`docs/contracts/install-layout.md`, § Untracked surfaces). All three are the same
+construct — a recorded-write channel that exists and is not used — and the population
+is countable, not open-ended:
+
+- `install.ts:984` is **the only one of 11** `merge_json_file(` call sites in
+  `install.ts` that discards the returned merged keys; the other 10 capture them. It
+  writes `.vscode/settings.json` `chat.pluginLocations`. `ensure_vscode_bridge`
+  (`:978`) is typed `: void`, unlike the five bridge writers that return
+  `Record<string, unknown>[]`.
+- `install.ts:3858` calls `_update_installed_tools_manifest(...)` with five arguments,
+  omitting the sixth parameter `merged_keys_by_tool` declared at `:2504`. The project
+  path at `:5138-5145` passes all six. So user-scope JSON merges are unrecorded.
+- `install.ts:1038-1050` (`_remove_legacy_augment_trampolines`) swallows the failure in
+  a bare `catch { /* OSError → ignore */ }`, leaving a stale file with no manifest entry.
+
+Finally, `docs/CLAIMS.md:94-99` carries `claim: surgical-uninstall` with
+`status: backed` and `evidence: docs/contracts/install-layout.md#JSON-pointer` — a
+behavioural claim whose only evidence is the document specifying it, while executable
+tests for that behaviour exist (`tests/scripts/_cli/cmd_uninstall.test.ts`,
+`tests/lib/installed_tools.test.ts`).
+
+## Phase 1 — record the three writes uninstall cannot undo
+
+- [ ] **1.1 Return and record the `.vscode/settings.json` merge.** Make
+      `ensure_vscode_bridge` (`src/scripts/install.ts:978-989`) return the
+      `merge_json_file` result like its nine sibling call sites, and thread it into
+      `merged_keys_by_tool` at the project call site (`:5138-5145`). Extend the
+      existing manifest writer; add no new module.
+      <!-- verify: task test -- --filter=cmd_uninstall -->
+- [ ] **1.2 Pass `merged_keys_by_tool` on the global install path.** `install.ts:3858`
+      omits the sixth parameter declared at `:2504`, so merges into
+      `~/.augment/settings.json`, `~/.cursor/hooks.json` and their siblings
+      (`:5106-5118`) never reach the lockfile. Pass the map the project path already
+      builds.
+      <!-- verify: task test -- --filter=installed_tools -->
+- [ ] **1.3 Stop discarding legacy-trampoline removal failures.** Replace the bare
+      `catch` in `_remove_legacy_augment_trampolines` (`install.ts:1038-1050`) with a
+      surfaced non-fatal warning naming the path, so a failed removal is visible rather
+      than a silent stale file. Do not change removal semantics.
+      <!-- verify: task test -- --filter=cmd_prune -->
+- [ ] **1.4 Re-point the `surgical-uninstall` claim at executable evidence.** In
+      `docs/CLAIMS.md:94-99` the claim is `backed` by the contract that specifies it.
+      Retarget `evidence` to the tests that exercise the behaviour and re-stamp
+      `last_verified`.
+      <!-- verify: rg -n 'claim: surgical-uninstall' -A5 docs/CLAIMS.md -->
+- [ ] **1.5 Shrink the frozen-gaps list to what remains.** Update § Untracked surfaces
+      in `docs/contracts/install-layout.md` so each closed item is struck with its
+      commit, and anything still untracked (user-scope *files* such as the Cline
+      trampoline at `install.ts:1247-1262`) is named as still-frozen.
+- [-] **1.6 Add provenance markers, a marked-content-only removal path, and an
+      orphan report.** Cancelled — all three ship: `files[]`/`merged_keys[]`/`sha256`
+      (`docs/contracts/install-layout.md:177-191`), `uninstall` + `prune`
+      (`src/cli/registry.ts:39,40`), orphan reporting (`cmd_doctor.ts:1528`,
+      `cmd_prune.ts:24-33`).
+
+## Phase 2 — put the org-pack question to the maintainer
+
+- [ ] **2.1 Write the reopening brief, not the implementation.** One artefact stating:
+      (a) the governing lock — `docs/decisions/ADR-011-domain-pack-readiness.md`,
+      `status: accepted` (`:3`), holding that future domains ship as in-repo capability
+      bundles "not as separately-installable packs, until at least two independent"
+      domains with overlapping surfaces exist (`:66-67`), triggers unmet, with
+      `agents/roadmaps/domain-pack-extraction-when-triggered.md` (`status: draft`) as
+      the parked sibling; (b) why it is surfaceable under
+      [`decision-revisit-gate`](../../src/rules/decision-revisit-gate.md) — the
+      **mechanism differs**, ADR-011 governs extracting core domains *out* while the
+      source proposes pulling org content *in*; (c) the bar any reopening clears, per
+      `docs/decisions/ADR-088-no-external-runtime-federation.md:93-102` § 3 —
+      identity, generic design, the maintenance model for N bridges, and the trust
+      contract naming who validates external output and how the safety floors are
+      enforced across the boundary. State honestly that ADR-088 does **not** forbid
+      this proposal — it scopes to driving an external agent *runtime* — so it is cited
+      as the bar, never as a prohibition; (d) the unresolved contradiction below.
+      Do not route around the lock and do not pre-commit the answer.
+- [ ] **2.2 Record the overrides contradiction as a precondition.** The source's claim
+      that manual duplication is the only option today is false:
+      `agents/overrides/` is the shipped project-local extension layer and
+      `src/skills/override-management/SKILL.md:50-51` defines **`extend` and
+      `replace`** modes. The source's own non-goal "no override semantics" therefore
+      contradicts a shipped, documented mechanism. Any reopening must reconcile the two
+      first or they contradict at runtime.
+      <!-- verify: rg -n 'extend|replace' src/skills/override-management/SKILL.md | head -5 -->
+- [~] **2.3 Decide whether an external pack source root opens.** Deferred behind
+      `blocker: org-pack-reopening`. Note that `src/config/discovery/packs.yml:1-4` is a
+      **closed** id vocabulary whose amendment "require[s] an ADR-013 amendment in the
+      same PR", so an open vocabulary is a direct contract change, not an additive
+      feature.
+- [-] **2.4 Build the pack system.** Cancelled — it ships: `packs:` is a schema'd
+      frontmatter key (`src/scripts/schemas/skill.schema.json:244-253`) carried by all
+      **289** skills; **12** in-repo packs at `src/domains/*/pack.yaml`;
+      `packs:active` at `src/cli/registry.ts:54`; pack-scoped projection via
+      `projection.mode: scoped` + a `runtime.active_packs` overlay
+      (`src/scripts/install.ts:3475-3478`), installer flags `--packs` / `--core-only`
+      (`:3981`, `:4016`), rule scoping via `rule_in_scope`
+      (`src/install/ruleInScope.ts:107`).
+- [-] **2.5 Add a `templates/pack/` scaffold.** Cancelled — `templates/` does not
+      exist at repo root, and a stale `templates/**` path filter already sits at
+      `.github/workflows/smoke-public-install.yml:50`.
+- [-] **2.6 Ship a plugin-marketplace export channel.** Cancelled —
+      `.claude-plugin/marketplace.json:8` describes itself as "DEPRECATED as a content
+      channel", shipping only dispatcher hooks plus one pointer skill. Reviving it needs
+      its own decision.
+- [-] **2.7 Build per-pack token accounting.** Cancelled as new work — the measurement
+      apparatus exists (`src/scripts/check_always_budget.ts`, `measure_rule_budget.ts`,
+      `check_token_regression.ts`, `lint_token_budget_discipline.ts`); only per-pack
+      attribution is absent, and it is downstream of 2.3.
+
+**Capacity frame for 2.1.** The estate measures **116 rules** (`src/rules/*.md`) and
+**289 skills** (`src/skills/*/`). A pack system is a capacity multiplier on the surface
+furthest from its own budget, and
+`docs/decisions/ADR-216-restraint-reanchored-to-capacity.md` re-anchors every restraint
+gate to maintainer capacity — with external adoption explicitly struck as a valid
+condition (`:10-17`). That is the frame the decision is taken in.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Recording a write changes what uninstall deletes | implementation | A `.vscode/settings.json` or `~/.cursor/hooks.json` key that previously survived removal now gets removed, on trees installed before the change. | The layout contract already classifies this as additive, never breaking; `cmd_prune.ts:31-33` hashes recorded content and skips removal on drift, so a consumer edit is preserved. | Phase 1 — record the three writes uninstall cannot undo |
+| 2 | The brief reads as advocacy | product | A reopening brief that argues for org packs pre-commits the maintainer to the answer the source wanted, defeating the point of surfacing the lock. | 2.1 fixes the brief's shape to lock, mechanism distinction, bar, contradiction — no recommendation; the decision stays a maintainer-owned blocker. | Phase 2 — put the org-pack question to the maintainer |
+| 3 | Surfacing removal failures adds output noise | implementation | Turning a swallowed `OSError` into a warning may fire on ordinary permission conditions and read as a broken install. | Non-fatal, path-named, single line; removal semantics unchanged, so no exit-code shift. | Phase 1 — record the three writes uninstall cannot undo |
+| 4 | Residual scope smaller than the phase implies | product | If a closed gap turns out already recorded elsewhere, Phase 1 collapses toward doc-only and the roadmap outlives its content. | Each step cites the exact omitted argument or discarded return value; a step whose premise fails is marked `- [-]` with the citation rather than reinterpreted. | Phase 1 — record the three writes uninstall cannot undo |
+
+## Blockers
+
+### blocker: org-pack-reopening
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 2.3 only. Steps 2.1 and 2.2 are authoring and verification and are
+  not blocked; all of Phase 1 is independent of the pack question entirely.
+- **What to do:** read the 2.1 brief and either decline (ADR-011 stands, 2.3 closes as
+  `- [-]`) or reopen by commissioning an ADR that answers the four ADR-088 § 3 questions
+  and reconciles the `agents/overrides/` `replace` mode.
+- **Resolved when:** either 2.3 is marked `- [-]` citing a decline, or a new ADR exists
+  with `status: accepted` amending ADR-011 and ADR-013 § packs.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md
@@ -1,0 +1,190 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to cost-ledger truth
+
+> Make every recorded spend row attribute to the model the provider actually
+> served, and priced from a table that cannot silently disagree with its sibling.
+
+> Source (consumed inbox): `agents/tmp.old/ac-cost-ledger-mechanics` and
+> `agents/tmp.old/ac-cache-breakpoints` — part of the 2026-08-10 batch triaged by
+> [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+The ledger itself is not missing — it ships under other names
+(`agents/cost-tracking/sessions.jsonl`, `src/scripts/cost/track.mjs`,
+`src/scripts/cost_summary.ts`, [`cost-summary-schema`](../../docs/contracts/cost-summary-schema.md),
+`/cost:report`, `src/scripts/cost/budget.mjs`, `src/config/budget-routing.json`).
+What is missing is **truthfulness at two joints**: the model an entry claims, and
+the rate it was priced at. Both are live defects with in-tree citations, both are
+single-file fixes, and neither needs an ADR. Six proposals are cancelled against a
+named citation in `## Cancelled` — the cache half of the batch turned out to be
+already-shipped, which is why it contributes one signature step, not a phase.
+
+## Phase 1 — Served-model truth
+
+The single highest-value item in the batch. `grep -rn 'model_served\|model_requested' src/`
+returns **0 hits**: nothing anywhere distinguishes the model that was asked for
+from the model that answered.
+
+- [ ] **1.1 Read the served model off the API response.**
+      `src/scripts/ai_council/clients.ts` stores `model: this.model` — the
+      **requested** id — at every one of its 22 `new CouncilResponse` sites
+      (:545, :577, :586, :618, :704, :721, :780, :787, :798 among them), while the
+      Anthropic response object's own `model` field is read nowhere in the file.
+      Extract it beside the existing `_getattr(response, 'content')` read (:594).
+      <!-- verify: task test -- --filter=clients -->
+- [ ] **1.2 Carry it as a distinct `CouncilResponse` field.** The class is
+      declared at `clients.ts:199-213` with `model: string` at :201 and an
+      optional-with-default constructor at :215-230 — the same additive shape
+      `cache_read_input_tokens` used. Add the served id as a new optional field;
+      do **not** overwrite `model`, because the requested id is what the tier
+      decision was made against and both are needed to detect a substitution.
+      <!-- verify: task test -- --filter=clients -->
+- [ ] **1.3 Extend the cost-summary contract additively.**
+      [`cost-summary-schema`](../../docs/contracts/cost-summary-schema.md):60-62
+      states its own rule — new fields are "a **v1 additive extension**", rows
+      written before them read "like a row missing `input_tokens` — no version
+      bump". Follow that rule exactly; no version bump, no required field.
+- [ ] **1.4 Assert it at the consumer that silently mis-attributes today.**
+      `src/scripts/_lib/orchestration_record.ts:48-71` reads the requested tier
+      for `tier_chosen`, `tier_source`, `session_tier` and the downshift
+      cost-percentage — so on any alias or provider substitution the recorded
+      downshift saving is attributed to a model that never ran. Add the
+      served-vs-requested divergence as a recorded field, not a thrown error —
+      `buildOrchestrationLine` collects into an `errors: string[]` (:183-184)
+      rather than throwing, and this stays inside that contract.
+      <!-- verify: task test -- --filter=_lib_orchestration_record -->
+- [ ] **1.5 State in the change that no ADR is needed.**
+      [`ADR-035`](../../docs/decisions/ADR-035-model-capability-tiers.md) is not
+      amended — its tier mapping is unchanged; this phase makes the ADR's
+      attribution honest rather than re-deciding it. Say so, so a later reader does
+      not go looking for a missing record.
+
+## Phase 2 — The rate tables cannot disagree
+
+A finding the inbox subjects did not contain. Two independent price tables exist,
+they are never cross-checked, and **they match model ids by different strategies**
+— so a dated model suffix can miss in one and match in the other:
+
+| Table | Rates | Matching |
+|---|---|---|
+| `src/scripts/ai_council/pricing.ts` | `CACHE_READ_MULTIPLIER = 0.1`, `_5M = 1.25`, `_1H = 2.0` (:111-113) — multipliers off a base rate | `lookup()` :52-54, **exact key only** |
+| `src/scripts/cost/track.mjs` | `PRICING` :42-46 — absolute per-tier USD | `modelTier()` :48-55, **substring** (`m.includes('sonnet')` :52) |
+
+- [ ] **2.1 Add a deterministic parity gate over the two tables.** Assert every
+      tier `track.mjs` can name resolves in `pricing.ts`, and that the derived
+      cache rates agree with the absolute ones within a stated epsilon. **The
+      false-positive class is empty by construction** — both tables are committed
+      constants, so the gate reads fixed inputs with no sampling, no prose parsing
+      and no host dependency; a disagreement it reports is a real one. Register in
+      `src/config/gate-coverage.yml`; report its scan via `reportScanned`
+      (`src/scripts/_lib/scan_scope.ts:117`).
+      <!-- verify: ./scripts-run src/scripts/lint_price_table_parity -->
+- [ ] **2.2 Respect the byte-frozen row format.** `pricing.ts:109` records why the
+      multipliers are constants and not columns: the `.agent-prices.md` row format
+      "is byte-frozen (see the file header) and downstream tests pin it". Any new
+      value this phase needs is a **constant**, never a new column.
+      <!-- verify: task test -- --filter=pricing -->
+- [ ] **2.3 Make `lookup()` longest-prefix instead of exact-key.**
+      `pricing.ts:52-54` is a bare `table.prices.get(priceKey(provider, model))`,
+      so `claude-sonnet-4-5-20260101` misses a `claude-sonnet-4-5` row and prices
+      at nothing. Fall back to the longest matching key prefix, keeping exact
+      match as the first hit so no currently-priced call changes.
+      <!-- verify: task test -- --filter=pricing -->
+- [ ] **2.4 Flag the silent zero instead of returning it.** `track.mjs:64` is
+      `if (!p || !u) return 0;`, reached whenever `modelTier()` returns
+      `'unknown'` (:49, :54) — an unknown model is priced at **zero, with no
+      warning and no flag**; `grep -rn rate_missing src/` returns 0 hits. Emit a
+      `rate_missing` marker on the row and one stderr warning per run. Rows keep
+      their token counts, so a later backfill stays possible.
+- [~] **2.5 Backfill machinery for `rate_missing` rows.** Deferred behind
+      `unknown-model-row-never-observed` — see `## Blockers`. Writing a
+      re-pricing pass before a single real unknown-model row exists would be
+      built against a shape nobody has seen.
+
+## Phase 3 — Two aggregation lines and a cache signature
+
+- [ ] **3.1 Add a cache-savings line to the cost summary.** `grep -rni saving`
+      over `src/scripts/cost*` returns 0 hits — the summary reports spend but never
+      what caching bought. Both inputs exist: the totals block carries
+      `cache_read_input_tokens` / `cache_creation_input_tokens`
+      ([`cost-summary-schema`](../../docs/contracts/cost-summary-schema.md):46-47,
+      :58) and `pricing.ts:111-113` holds the multipliers to price the
+      counterfactual. Additive per the schema's own rule (:60-62).
+      <!-- verify: task test -- --filter=cost_summary -->
+- [ ] **3.2 Add a day-by-day breakdown.** `grep -rn by_date src/ docs/` returns 0
+      hits, yet every row already carries `startedAt` / `endedAt`
+      (`track.mjs:214`, from the per-message timestamps at :175-177). One derived
+      grouping, no new capture. Additive, same rule.
+      <!-- verify: task test -- --filter=cost_summary -->
+- [ ] **3.3 Add a write-share signature to the existing cache report.** Extend
+      `src/scripts/cache_realization_report.ts`, which already parses the
+      read/write split and computes `median_first_call_written_or_uncached` /
+      `mean_first_call_written_or_uncached` (:85-86) beside
+      `first_call_cache_read_share` and `cold_start_share_of_write_volume` (:88-90,
+      computed :130-140). Do **not** write a new script.
+      <!-- verify: task test -- --filter=cache_realization_report -->
+
+## Cancelled — each against a named citation
+
+- [-] **Chokepoint doctrine (instrument the call site, stream the cost).** Never
+      true by architecture: this repo does not own the call sites it costs —
+      `src/scripts/cost/track.mjs:1-20` reconstructs spend from
+      `~/.claude/projects/**/*.jsonl` after the fact — and nothing streams
+      (`clients.ts` non-streaming `messages.create`; CLI clients use
+      `--print --output-format json`). Both halves have no call site.
+- [-] **Statusline "API" tag, 60s aggregation cache, month-over-month delta.** No
+      statusline surface exists here to tag: `src/scripts/hooks/session_eol_hook.ts:18-26`
+      writes `agents/runtime/state/context-fill.json` as "display substrate for an
+      **external** statusline".
+- [-] **Spend caps and an alert ladder.** Shipped, and a separate surface:
+      `src/scripts/cost/budget.mjs`, `src/config/budget-routing.json`,
+      [`budget-routing`](../../docs/contracts/budget-routing.md), 50/75/90/100%
+      ladder at [`/cost:report`](../../src/domains/meta/cost/report/command.md):67-71.
+      [`ADR-133`](../../docs/decisions/ADR-133-subsystem-freeze-unblock-list.md):26
+      rejected a standing WIP cap as "accounting theater for a solo maintainer".
+- [-] **Recycling x caching interaction test.**
+      [`ai-council-config`](../../docs/contracts/ai-council-config.md):1042-1044 —
+      "**Host subagents are unaffected.** This key governs ONLY the council's own
+      Anthropic API calls." Recycling lives in `cmd_session_recycle.ts`, **0**
+      case-insensitive `cache` hits: no shared path, so the flagged blow-up has no
+      call site to test.
+- [-] **Cache-TTL extension and pre-warming.**
+      [`archive/road-to-cache-economy.md`](archive/road-to-cache-economy.md):53
+      measured blanket 1h at **+8.6% (worse)**, head-1h/tail-5m at +1.3% (worse);
+      :57 records "98% of cache reuse happens within ~34 seconds". `'5m'` is a
+      permanent default with a published falsification condition.
+- [-] **Cache-breakpoint placement compiler.** Both breakpoints ship —
+      `clients.ts:541-570` puts `cache_control` on the system block and the stable
+      user prefix, volatile suffix after it ("The volatile suffix NEVER carries
+      cache_control"); :530 "Two breakpoints (≤ the 4 allowed)"; :528-530 records
+      the min-cacheable-prefix reasoning. The per-call opt-out is already stronger
+      than proposed: `enable_prompt_cache` defaults **false** (:459, rationale
+      :445-448).
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Prefix fallback re-prices a call that priced correctly before | implementation | Making `lookup()` longest-prefix can newly match a key the exact-match path deliberately missed, changing a live billed figure | Keep exact match as the first hit so no currently-resolving call changes path; pin the new fallback with a dated-suffix case in `pricing.test.ts` | Phase 2 — The rate tables cannot disagree |
+| 2 | Parity gate lands red on the tree as it stands | implementation | The two tables have never been cross-checked, so the gate may report a real pre-existing disagreement on its first run | Classify every first-run finding before wiring the gate into CI; a genuine disagreement is a Phase 2 fix, not a gate to loosen | Phase 2 — The rate tables cannot disagree |
+| 3 | Served-model field read as authoritative for tier decisions | product | A second model id in the record invites a consumer to route on the served id, when the requested id is what the tier decision was made against | Keep `model` as the requested id and document the served field as attribution-only in the schema extension | Phase 1 — Served-model truth |
+| 4 | Additive schema fields drift past the additive rule | implementation | Three separate additive extensions (1.3, 3.1, 3.2) touch one contract; one required field or version bump breaks older rows | Cite `cost-summary-schema`:60-62 in each change; all new fields optional with a documented absent-reading | Phase 3 — Two aggregation lines and a cache signature |
+
+## Blockers
+
+### blocker: unknown-model-row-never-observed
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 2.5 only. Steps 2.1-2.4 are unblocked — 2.4 is what makes an
+  unknown-model row detectable in the first place, and Phases 1 and 3 do not
+  touch this path.
+- **What to do:** after 2.4 ships, wait for the first `rate_missing` row in
+  `agents/cost-tracking/sessions.jsonl` and record its actual shape.
+- **Resolved when:** at least one real `rate_missing` row exists and its field set
+  is written down, so a backfill pass can be built against an observed shape
+  rather than a guessed one.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-release-integrity.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-release-integrity.md
@@ -1,0 +1,234 @@
+---
+complexity: lightweight
+parent_roadmap: road-to-inbox-harvest-2026-08-b.md
+---
+
+# Road to release-surface integrity
+
+> Reduce the release surface's unbacked-claim count to zero on the one flow that
+> ships them: the curated CHANGELOG head, the carrier-divergence figure, and the
+> four report gaps five independent reviews asked for.
+
+> Source (consumed inbox): `agents/tmp.old/feedback-9.30.0-1.txt` — part of the
+> 2026-08-10 batch triaged by [`road-to-inbox-harvest-2026-08-b.md`](road-to-inbox-harvest-2026-08-b.md).
+
+## Context / What is verified
+
+Five independent reviews plus one scorecard over the identical commit; the scores
+disagree with each other (taste, not signal). ~400 assertions reduce to 44
+checkable claims. What survived verification at HEAD `9e999d64e`:
+
+- **The recurring defect is real.** `CHANGELOG.md:329` (v9.32.0) still reads
+  `_auto-derived, rewrite before merge:_` in its Behaviour-changes head line;
+  v9.31.0's head is clean (`CHANGELOG.md:379-384`), and
+  `src/scripts/check_release_highlights.ts:205` prints `— advisory, not blocking.`
+- **The loudest P0 rests on a false premise, and the real number is 78% smaller.**
+  "109 divergent carrier pairs, binding undefined" is wrong:
+  `road-to-carrier-layer-convergence.md:24-42` records all 109 as
+  **byte-identical prose** — the whole difference is frontmatter — leaving **24**
+  rules whose copies disagree on `paths:`, where the global copy **un-scopes** a
+  project-scoped rule. Over-delivery only, never a missing obligation. The
+  instrument bug behind the original figure was fixed in `c48b6c88c`.
+- **Two cited figures are withdrawn by our own tree.** "87,677 of 230,556 tokens
+  = a measured ~15% lever" is a **38.0% reduction against a pre-registered 15%
+  bar** (a bar is not a lever), recorded unreachable for production installs,
+  "the recipient set is empty" (`docs/proof.md:82`, `docs/CLAIMS.md:350`). The
+  language-detector rates were withdrawn by `313e66535`, then moved twice more
+  under their own corrections; best-founded reading A 2.7% / B 25.4% over 30
+  sessions, 185 turns, 2252 entries, still provisional
+  (`archive/road-to-conformance-round5.md:427-435`).
+- **The command surface is at 196** (`docs/proof.md:51`), so every new capability
+  below is a **flag** on an existing verb, never a 197th command.
+
+## Phase 1 — The release head cannot ship its own placeholder
+
+The exclusive alternative to a hard block is rewriting the head comment to document
+retro-curation as the real cadence, making the placeholder legitimate until
+curation. Both cannot be done, and the script argues against the flip itself:
+`check_release_highlights.ts:196-200` keeps the exit code owned solely by the
+`_none_` check because "a warning that reds the build is the guaranteed-red failure
+mode this whole change exists to remove". So the flip is a decision revisit, not a
+fix.
+
+- [ ] **1.1 Rewrite the shipped placeholder line by hand.** `CHANGELOG.md:329` is
+      wrong today whichever cadence wins — the release is out and the line still
+      says rewrite-before-merge. Curate it from `1f01490`, `e05de77`.
+- [ ] **1.2 State the cadence question in the contract, both branches.** Neither
+      `docs/contracts/release-pr-gating.md` nor
+      `docs/contracts/CHANGELOG-conventions.md` says whether the curated head is a
+      merge precondition or a retro-curation surface. Record both readings and the
+      one the blocker picks — no behaviour change.
+- [ ] **1.3 Pin the current advisory behaviour with a fixture.** Extend
+      `tests/scripts/check_release_highlights.test.ts` so a placeholder head
+      produces exit 0 plus the advisory line, making the decision a one-line diff
+      either way.
+      <!-- verify: task test -- --filter=check_release_highlights -->
+- [~] **1.4 Flip the placeholder check to blocking for the final release head.**
+      Deferred behind `release-head-cadence-decision`. The gate is constructible
+      despite *a measurement is not a gate*: the placeholder string is emitted by
+      our own generator into our own file, so the false-positive class is **empty
+      by construction** — no third party can produce that byte sequence in a
+      curated head. The argument holds; wanting the gate is the maintainer's call.
+
+## Phase 2 — The carrier remainder, with its premise corrected
+
+- [-] **2.1 Cancelled: re-planning the carrier fix.** Already
+      [`road-to-carrier-layer-convergence.md`](road-to-carrier-layer-convergence.md)
+      Phase 3 (`:152`), 2 open steps, blocked on `b-convergence-machine` (`:178`).
+- [-] **2.2 Cancelled: making the 24-of-109 split visible in the report.** Shipped:
+      `src/scripts/report_carrier_divergence.ts:320` prints the `paths:` subset as
+      ACTIONABLE under the frontmatter-only count, and
+      `tests/scripts/report_carrier_divergence.test.ts` pins `pathsScopeDiff`.
+- [ ] **2.3 Promote the corrected premise to a stable context.** It lives only in a
+      roadmap (transient) and in
+      `agents/evidence/analysis/carrier-layer-divergence-classification.md`. Per
+      `no-roadmap-references`, promote the durable conclusion (109 prose-identical,
+      24 actionable on `paths:`, over-delivery) into a context under
+      `agents/settings/contexts/` — 70 exist, and contexts are that rule's
+      sanctioned promote-target — and cite it from the report's header. Five reviews
+      re-cited 109 because the correction had no stable surface.
+      <!-- verify: ./scripts-run src/scripts/check_context_paths -->
+
+## Phase 3 — Four flags over data that already exists
+
+- [ ] **3.1 `doctor --anatomy`.** Render the injection anatomy from
+      `src/scripts/preamble_byte_census.ts` and
+      `src/scripts/dispatch_economy_report.ts`; `doctor` is already registered
+      (`src/cli/registry.ts:41`). No new measurement.
+      <!-- verify: task test -- --filter=preamble_byte_census -->
+- [ ] **3.2 `conformance:why <id>`.** A flag on the existing `explain`
+      (`src/cli/registry.ts:58`) and `conformance:behavior`
+      (`src/cli/registry.ts:44`) verbs — trace why one conformance id fired.
+      <!-- verify: task test -- --filter=runtime_registry -->
+- [ ] **3.3 `recycle:verify` plus envelope mutation tests.** A flag on
+      `session:recycle` (`src/cli/registry.ts:71`).
+      `src/scripts/_lib/subagent_capsule.ts` already does the version check
+      (`:495`), unknown-key rejection (`:489`) and a staleness guard (`:223`); the
+      gap is a mutation suite proving each rejection fires.
+      <!-- verify: task test -- --filter=_lib_subagent_capsule -->
+- [ ] **3.4 `surface prune` as a report flag.** Over census data already computed
+      in `docs/SKILL_CENSUS.md` and `docs/artefact-census.md`; a flag beats a 197th
+      command against a 196-command surface.
+      <!-- verify: ./scripts-run src/scripts/check_references -->
+- [-] **3.5 Cancelled: the surface-reduction targets themselves.** Owned by
+      `road-to-surface-consolidation.md` (92%, 1 open),
+      `road-to-solution-minimalism.md` (10 open) and `road-to-tier-removal.md`
+      (2 open), bounded by `agents/settings/contexts/surface-consolidation-restraint.md`.
+
+## Phase 4 — Two real contract gaps
+
+- [ ] **4.1 Write the model-ceiling escalation contract.** Genuine gap: a
+      case-insensitive `ceiling` grep returns 0 for both
+      `docs/contracts/subagent-boundary.md` and `src/rules/delegation-policy.md`,
+      so nothing states what a worker does when the ceiling cannot carry the task.
+      Extend both: the worker **escalates, never silently degrades**.
+      `subagents.model_ceiling` is class C, default `""`
+      (`src/config/agent-settings.template.yml:795`,
+      `docs/contracts/settings-classes.md:284`) — nothing is capped today.
+- [ ] **4.2 Add the funnel's missing Opportunity stage.**
+      `src/scripts/report_conformance_funnel.ts` joins delivery to activation to
+      compliance (`:128`), prints `NO DATA` honestly (`:187`, `:219`), and carries
+      zero hits for `outcome` or `opportunity`. Derive Opportunity from the
+      existing transcript store; keep it report-only, as its own header says.
+      <!-- verify: task test -- --filter=report_conformance_funnel -->
+- [-] **4.3 Cancelled: per-task-class and dollar caps on the ceiling.** No
+      over-spend observed and nothing is capped today (4.1), so a cap would be a
+      mechanism without a matched failure mode.
+- [-] **4.4 Cancelled: outcome-lift and rule A/B on golden tasks.** Collides with
+      the terminal activation-red-baseline and thin-projection honest nulls;
+      re-running them is relitigation without new evidence.
+
+## Phase 5 — Records, and the asks that need no work
+
+- [ ] **5.1 Decide Continuation Protocol v1 as a record first.** Is one schema
+      right, or are the variants correct? The capsule is already
+      variant-discriminated at `CAPSULE_SCHEMA_VERSION = 3`
+      (`src/scripts/_lib/subagent_capsule.ts:112`, 2 to 3 in #1255). A decision
+      record, never a fourth format — the source file's own negative instruction.
+- [ ] **5.2 Record the runtime transition graph and loop detector as deferred,
+      with a named revisit trigger.** The loop feared is already bounded: the
+      turn-end gate refuses at most once per turn per key
+      (`src/scripts/hooks/turn_end_gate_hook.ts:442-446`, "costs at most one extra
+      refusal") and `session-eol` is `severity: advisory`, `fail_closed: false`,
+      and cannot inject `/clear` (`src/scripts/hook_manifest.yaml:501-505`).
+      Trigger: a transcript showing a real block, repair, recycle, same-block cycle.
+- [-] **5.3 Cancelled: Runtime Event Model / canonical event bus.** The reviewer's
+      own condition was "only if it replaces hooks"; the target is already a single
+      in-process dispatcher and the item is recorded as CUT to a maintainer
+      decision (`archive/road-to-feedback-9-29.md:77`).
+- [-] **5.4 Already shipped: hook fusion plus a latency budget.**
+      `src/config/hook-latency-budget.json`, `src/scripts/bench_hook_latency.ts`,
+      one in-process dispatcher at ~84 ms p95
+      (`src/scripts/hooks/dispatch_hook.ts:272-275`, `:617`).
+- [-] **5.5 Already shipped: skill-invocation attestation.**
+      `docs/decisions/ADR-220-skill-invocation-attestation.md:3` is
+      `status: accepted`, dated 2026-08-09 — before the release under review.
+- [-] **5.6 Already satisfied: the re-read-guard staleness caution.**
+      `src/scripts/hooks/reread_guard_hook.ts:9,24,111,186-191` keys on an
+      `{mtime, size}` ledger and fires only on unchanged paths.
+- [-] **5.7 Already pre-registered: worker-recycling automation.**
+      `worker-capsule-trigger-arm` in
+      `later/road-to-worker-generation-recycling.md`, blocked on 30 shadow capsules.
+- [-] **5.8 Cancelled: a compaction-survival obligation class.** Gated on a prior
+      unknown — the `pre_compact` re-emit is claude-only, "the sole verified
+      platform" (`src/scripts/hook_manifest.yaml:541-547`), and whether it lands
+      after a real compaction is stated open. Generalising an unverified re-emit is
+      the wrong order.
+- [-] **5.9 Cancelled: a numeric stop-concern budget.** The premise is wrong: the
+      claude `stop` slot carries **9** concerns, not 8
+      (`src/scripts/hook_manifest.yaml:537`), and no numeric budget exists in
+      `src/scripts/lint_hook_manifest.ts` to hold a ninth entry against.
+
+## Safety — named, not planned
+
+Found in the source file, deliberately not carried into a step: posting the launch
+drafts or obtaining an external session before 26.08 — two of five reviews make it
+their single P0 — which is irreversible external publication, and `ADR-216:14-16`
+strikes adoption as a valid gate while `ADR-134` already governs it as an accepted,
+dated, human-owned decision; flipping the turn-end gate default-on (consumer-facing
+default flip); posting a mechanical review-summary comment on the release PR
+(conflicts with `no-pr-progress-comments`, `pr_progress_comments: false` at
+`src/config/agent-settings.template.yml:307`).
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Flipping the highlights check to blocking | implementation | The script's own header argues the flip re-creates the guaranteed-red failure mode it was written to remove, and the item is already recorded as CUT to a maintainer decision — an agent-side flip would relitigate a lock | The flip is `[~]` behind `release-head-cadence-decision`; 1.3 pins today's behaviour first so the decision is a one-line diff either way | Phase 1 — The release head cannot ship its own placeholder |
+| 2 | Acting on the 109-pair figure | product | Four of the five reviews treat 109 divergent pairs as the biggest technical debt; suppressing 109 copies on that premise would drop governed text to fix a defect that is 24 rules wide and over-delivering, not missing | 2.1 and 2.2 mark the work cancelled with citations and 2.3 gives the correction a stable surface, so the next reader does not re-derive 109 | Phase 2 — The carrier remainder, with its premise corrected |
+| 3 | Four flags becoming four commands | implementation | The surface is at 196 commands and every one of these renders data another script already computes; adding verbs would grow the surface the same reviews asked to shrink | Each step in Phase 3 names its host verb and its registry line; 3.5 points surface reduction at the three roadmaps that own it | Phase 3 — Four flags over data that already exists |
+| 4 | The funnel Opportunity stage drifting into a gate | implementation | A joined funnel with a denominator invites a threshold, and the activation-red-baseline null is terminal — a gate here would fail on absent data rather than on a real defect | 4.2 keeps it report-only and 4.4 cancels the A/B arm outright, both citing the nulls | Phase 4 — Two real contract gaps |
+
+## Blockers
+
+### blocker: release-head-cadence-decision
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** step 1.4 only. Steps 1.1-1.3 proceed either way.
+- **What to do:** Pick exactly one — (a) hard-block the placeholder string in the
+  final release head, or (b) rewrite the head comment in
+  `docs/contracts/CHANGELOG-conventions.md` to document retro-curation as the real
+  cadence. Mutually exclusive, and hard-block was already CUT to a maintainer
+  decision at `archive/road-to-feedback-9-29.md:77`.
+- **Resolved when:** (a) or (b) is named here and 1.2 records it in the contract.
+
+### blocker: carrier-install-paths-decision
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** the fix for the 24 `paths:` disagreements, which lives in
+  `road-to-carrier-layer-convergence.md` Phase 3. Nothing here is blocked — 2.3
+  proceeds regardless.
+- **What to do:** Decide whether `install.ts` should emit `paths:` — consumer-
+  visible install behaviour and a default flip, so an ADR candidate and
+  maintainer-only. That roadmap explicitly declines to decide it (`:35`).
+- **Resolved when:** An ADR records the decision and that roadmap's Phase 3 cites it.
+
+### blocker: adr-221-acceptance
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing here. Named because four of the five reviews already treat
+  host-native-first as settled doctrine while the record is not.
+- **What to do:** Accept or reject
+  `docs/decisions/ADR-221-host-native-first-ladder.md`, `status: proposed` at `:3`.
+  No code either way — the cheapest survivor in the source file.
+- **Resolved when:** `status` is `accepted` or `rejected` and the index is regenerated.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b.md
@@ -166,7 +166,7 @@ for them persuasively and will outlive this file in `tmp.old/`.
       or the structural reading.
 
 ## Risk Register
-<!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
+<!-- risk-review: v1 | reviewed: 2026-08-11 | reviewer: claude/host -->
 
 | Rank | Item | Risk type | Description | Mitigation | Anchored under |
 |------|------|-----------|-------------|------------|----------------|

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b.md
@@ -4,20 +4,16 @@ complexity: lightweight
 
 # Road to inbox harvest 2026-08-b
 
-> Twenty-two inbox artifacts triaged against the tree at `c073d5732` (v9.32.0):
-> six chat/review transcripts and a sixteen-bundle harvest set dropped
-> 2026-08-10. **One file survived verification intact. The set did not.** The
-> sixteen bundles share one byte-identical context dossier whose "current
-> programme" section is wrong in every load-bearing line, and the item-ID
-> namespace they cross-reference exists nowhere in this repo. Net: one small
-> roadmap phase, two corrections landed here, eight single-artefact extensions,
-> and eleven items cancelled against a named lock.
+> Index and triage record for the 2026-08-10 inbox batch — 22 artifacts, verified
+> against the tree at `c073d5732` (v9.32.0). The surviving work ships as **eight
+> sibling roadmaps** under this file's prefix; this file carries the verification
+> that decided what went into them, and what did not.
 
 > Source (consumed inbox): the 2026-08-10 batch under
-> [`agents/tmp.old/`](../tmp.old/) — six `*.txt` transcripts plus sixteen
-> harvest bundles. Two bundles are external-source parents, referenced below as
-> **Source A** and **Source B** per [`source-confidentiality`](../../src/rules/source-confidentiality.md);
-> the other fourteen are named by subject.
+> [`agents/tmp.old/`](../tmp.old/) — six `*.txt` transcripts plus sixteen harvest
+> bundles. Two bundles are external-source parents, referenced as **Source A** and
+> **Source B** per [`source-confidentiality`](../../src/rules/source-confidentiality.md);
+> the other fourteen are named by subject slug.
 > Produced by [`/analyze:inbox`](../../src/domains/analysis-workbench/analyze/inbox/command.md).
 
 ## Iron Law of this harvest
@@ -32,335 +28,190 @@ VERIFY THE ROOT BEFORE THE LEAF. NEVER PLAN WORK OFF AN UNADOPTED SIBLING.
 
 | Class | Count | Shape |
 |---|---|---|
-| Harvest bundles | 16 | `00-source-analysis` + shared dossier + a drafted `20-road-to-*` + a frozen `30-benchmark-preregistration` |
-| Release review | 1 | five independent reviews + one scorecard of v9.30.0, ~400 assertions |
+| Harvest bundles | 16 | source analysis + shared dossier + a drafted `20-road-to-*` + a frozen `30-benchmark-preregistration` |
+| Release review | 1 | five independent reviews plus one scorecard of v9.30.0, ~400 assertions |
 | Feature specs | 2 | CI/test economy; an org-level plugin/pack system |
 | Prompts / installs | 2 | a third-party handoff prompt; a third-party skill install |
 | Verified transcript | 1 | a self-checked quorum-telemetry plan |
 
-The sixteen bundles pre-register **38 benchmarks** (`B-01`…`B-93`). Eight require
-live spend; one (`B-131`) proposes disabling a live enforcement gate as a control.
-None is authorised here.
+The bundles pre-register **38 benchmarks** (`B-01`…`B-93`). Eight need live spend;
+one (`B-131`) proposes disabling a live enforcement gate as a control. None is
+authorised — they are parked below rather than planned.
 
-## The four findings that prevent the most work
+## The four findings that decided the split
 
-**1. The item-ID namespace is fictional.** Every `RC-*`, `H-AC-*`, `H-HM-*`,
-`FM-*`, `TI-*`, `CN-*`, `FS-*`, `ST-*`, `DB-*`, `SK-*`, `PD-*`, `CB-*`, `CL-*`,
-`OD-*`, `HC-*` and `B-nn` id resolves to **zero** files outside `agents/tmp/`.
-The bundles cite each other: leaves extend roots, and no root was ever adopted.
-Every "composes with X" is a claim about a sibling proposal.
+**1. The item-ID namespace is fictional.** Every `RC-*`, `H-AC-*`, `H-HM-*`, `FM-*`,
+`TI-*`, `CN-*`, `FS-*`, `ST-*`, `DB-*`, `SK-*`, `PD-*`, `CB-*`, `CL-*`, `OD-*`,
+`HC-*` and `B-nn` id resolves to **zero** files outside `agents/tmp/`. The bundles
+cite each other, so leaves extend roots nothing ever adopted. This is why an item's
+survival had to be re-derived from the tree rather than read off its own
+dependency list.
 
-**2. The shared dossier is the dominant defect source.** It is byte-identical
-across all sixteen bundles (`md5` of `10-project-context.md`: one hash), so each
-error propagates sixteen times:
+**2. One shared dossier, byte-identical across all sixteen bundles** — so each of
+its errors propagates sixteen times:
 
-| Dossier claim | Reality |
+| Dossier claim | Verified reality |
 |---|---|
-| Six *active* roadmaps named | **5 of 6 exist nowhere** — and four were themselves inbox drafts triaged 2026-08-10, recorded at `road-to-cost-parity-0-program.md:36-42` as "87 % already shipped", "premise refuted", "central premise false". Cited in 15–17 bundle files each. |
-| `ADR-054` = honest-null discipline | `status: **rejected**`; subject is decay-triggered rule re-statement — the applicant the doctrine killed. Both `30-*` pre-registrations register "per ADR-054 discipline" against it. |
-| ≤50 rules / ~130 skills | **116 rules / 289 skills**; neither figure appears anywhere in tracked prose. |
-| arXiv **2607.21656** | Phantom. Real citation: **arXiv:2404.13076** (`road-to-council-blind-review.md:72`). |
+| Six *active* roadmaps named | **5 of 6 exist nowhere.** Four were themselves inbox drafts triaged the same day, recorded at `archive/road-to-cost-parity-0-program.md:36-42` as "87 % already shipped", "premise refuted", "central premise false" — that programme was itself closed and archived on 2026-08-10, after this batch was written. Cited in 15–17 bundle files each. |
+| `ADR-054` = honest-null discipline | `status: **rejected**`; its subject is decay-triggered rule re-statement — the applicant that doctrine killed. Both `30-*` files pre-register "per ADR-054 discipline" against it. |
+| ≤50 rules / ~130 skills | **116 rules / 289 skills** measured; neither target figure appears anywhere in tracked prose. |
+| arXiv `2607.21656` | Phantom. The real citation is `arXiv:2404.13076` (`road-to-council-blind-review.md:72`). |
 | 12-dimension release matrix as `B-01`'s corpus | "could not be located anywhere" (`archive/road-to-judgment-and-forensic-evidence.md:59`), re-confirmed dropped. |
-| ADR-124 code graph "can power reference resolution" | ADR-124:210-225 is a **published null** — recall 0.365 vs grep 0.797, Δ −43.2 pp; `code_graph.enabled: false` permanently. |
+| ADR-124 code graph "can power reference resolution" | `ADR-124:210-225` is a **published null** — recall 0.365 vs disciplined grep 0.797, Δ −43.2 pp; `code_graph.enabled: false` permanently. |
 | 34.8 % scoped-rule saving | Self-refuted in-tree **the same day**: the figure conflated frontmatter deletion (−81,016 B) with scoping (−64,841 B). Real: **19.2 %** (`agents/evidence/analysis/scoped-rule-absence-preregistration.md:15-30`). |
-| ~163k always-loaded | **29,466 / 49,000 chars across 9 rules (60.1 %)** per `check_always_budget` — off by ~10×. |
+| ~163k always-loaded | **29,466 / 49,000 chars across 9 rules (60.1 %)** per `check_always_budget` — off by roughly tenfold. |
 
-**3. The batch is additive, and additive is the shape the harvest gate refuses.**
+**3. The batch is additive, which is the shape the harvest gate refuses.**
 [`ADR-211`](../../docs/decisions/ADR-211-harvest-freeze-resume-conditions.md)
 Amendments C and D admit a borrow only when it closes a failure finding that
 **pre-dates** the proposal with commit/timestamp provenance, or lands a red test
-committed before the borrow. Every bundle item is shaped "the source has X, we
-lack X". The 2026-08-03 precedent found **zero** candidates under that bar.
+committed before the borrow. Nearly every bundle item is shaped "the source has X,
+we lack X". Where a survivor below clears that bar it does so on a *tree-verified*
+defect, not on the bundle's argument — and each child roadmap names its own.
 
-**4. Six hours.** Source A's designated do-first item was the handoff picker
-offering the caller its own empty session. It was fixed at **2026-08-10 20:34**
-(`b72f772a0`, six fixtures, threshold derived over 217 sessions). The bundle was
-prepared at **14:51**.
+**4. Six hours.** Source A's designated do-first item — the handoff picker offering
+the caller its own empty session — was fixed at **2026-08-10 20:34** (`b72f772a0`,
+six fixtures, threshold derived over 217 sessions). The bundle was prepared at
+**14:51**.
 
 ## Triage result
 
-| Source | Genre | Disposition | Surviving |
-|---|---|---|---|
-| `subagents-optimization-2.txt` | verified transcript | **roadmap — Phase 1** | 11 of 11 claims held, one exact to the line |
-| `feedback-9.30.0-1.txt` | 5 reviews + scorecard | **Phase 2 + folded** | 27 of 44 claims still-true; 2 of 3 consensus P0s were false-premise or already shipped |
-| `test-economy.txt` | CI economy spec | **fold — extend, not create** | every figure re-derived accurate; the artefact it proposes already exists, stale |
-| `plugin-system.txt` | pack-system spec | **parked behind ADR-011** | 4 real deltas of ~20 proposals |
-| `better-handoff.txt` | third-party prompt | **fold (3 fields)** | 13 of 21 repo claims already-fixed or never-true |
-| `chief-of-staff.txt` | third-party install | **refused + 2 checkboxes** | install declined; 7 of 11 adopts unfalsifiable by the author's own admission |
-| Source A, Source B (parents) | harvest bundles | **fold (4 residues)** | ~2 of 8 and ~1/3 of items, no flagship |
-| 14 `ac-*` subject bundles | harvest bundles | **fold or cancel** | ~10–30 % each; six map onto the two parents at finer grain |
+| Source | Genre | Where the survivors went |
+|---|---|---|
+| `subagents-optimization-2.txt` | verified transcript, 11 of 11 claims held | `-council-integrity` |
+| `feedback-9.30.0-1.txt` | 5 reviews + scorecard, 27 of 44 claims still-true | `-release-integrity` |
+| `test-economy.txt` | CI spec, every figure re-derived accurate | `-ci-economy` |
+| `plugin-system.txt` | pack spec, 4 real deltas of ~20 proposals | `-install-lifecycle` |
+| `better-handoff.txt` | third-party prompt, 13 of 21 claims already-fixed | `-dispatch-safety` |
+| `chief-of-staff.txt` | third-party install — install itself refused | `-estate-lifecycle` |
+| Source A, Source B (parents) | harvest bundles, no flagship survived | `-council-integrity`, `-estate-lifecycle`, `-authoring-contract` |
+| `ac-cost-ledger-mechanics`, `ac-cache-breakpoints` | bundles | `-ledger-truth` |
+| `ac-skill-template`, `ac-failure-signatures`, `ac-doctrine-cited-briefs`, `ac-positional-doctrine` | bundles | `-authoring-contract` |
+| `ac-host-flag-compilation`, `ac-orchestration-deltas`, `ac-role-catalog`, `ac-factory-mechanics` | bundles | `-dispatch-safety` |
+| `ac-truthful-introspection`, `ac-self-knowledge-mechanics` | bundles | `-estate-lifecycle` |
+| `ac-council-hardening` | bundle | `-council-integrity` |
 
-## Phase 1 — The quorum-attendance defect
+Every one of the 22 is accounted for above.
 
-The one file that survived verification intact names a real, self-documenting
-defect: an **active** roadmap's risk register asserts a mitigation the code does
-not deliver.
+## Phase 1 — Landed in this PR
 
-`road-to-always-on-orchestration.md:395`, Risk 6, mitigation text: *"…attendance
-telemetry makes absent members visible rather than silent"*. Verified against the
-tree: `src/scripts/ai_council/events_log.ts:30` carries
-`EventAction = 'proceed' | 'skip_necessity' | 'block_quota'` and **zero**
-occurrences of `quorum`. A solo-concluded pass is downstream-identical to a
-full-attendance one.
+- [x] **1.1 Risk-6 row corrected** in `road-to-always-on-orchestration.md:395`.
+      It claimed *"attendance telemetry makes absent members visible rather than
+      silent"* as its mitigation while `events_log.ts` carries no quorum event, so a
+      solo-concluded pass is downstream-identical to a full-attendance one. The row
+      now states what the code delivers — artifact-visible only, via
+      `_render_quorum_line` / `_render_absent_members` and the serialised quorum in
+      `session.ts` — and claims no telemetry mitigation until one lands. Correct
+      either way: if `-council-integrity` Phase 1 is rejected, the row still must not
+      assert a mechanism that does not exist.
+- [x] **1.2 Stale harvest-slot line corrected** in
+      `road-to-inbox-harvest-2026-08.md:42`. It read "Both harvest slots occupied";
+      `lint_roadmap_family_cap.ts:41-42` scopes the cap to
+      `FAMILY_PREFIX = 'road-to-skill-ecosystem-'` with `CAP = 2` at occupancy
+      **1 of 2**. Nothing mechanically blocked this batch — and nothing mechanically
+      counted it either. The park still stands on maintainer capacity and
+      `source-confidentiality`, which are the reasons that hold.
 
-- [ ] **1.1 `quorum_result` event.** Extend `events_log.ts` with `status`,
-      `threshold`, `total`, `present`, `absent[]`. Emit at both `evaluateQuorum`
-      call sites — `src/scripts/council_cli.ts:668` and `:937` (verified: exactly
-      two, no third). Follow the two existing `appendEvent` emitters; bump
-      `SCHEMA_VERSION` per that module's port-parity convention; fail-open.
-      <!-- verify: task test -- --filter=events_log -->
-- [ ] **1.2 Use the real absent-reason vocabulary.** The draft writes
-      `(binary_missing, quota, timeout, error)`; the tree has
-      `AbsentReason = 'no_binary' | 'no_auth' | 'timeout' | 'quota'`
-      (`transport_resolver.ts:65`) plus the runtime fallbacks `'unavailable'` and
-      the literal `'binary_missing'`. Three of four drafted tokens are wrong.
-      <!-- verify: task test -- --filter=transport_resolver -->
-- [ ] **1.3 `isSoloConcluded` as a derived predicate** in `quorum.ts` beside
-      `evaluateQuorum` — deliberately **not** a third `QuorumStatus`; the two-state
-      enum and `ceil(n/2)` stay untouched (the ceil-vs-floor divergence is a
-      recorded decision at `quorum.ts:13-15`). Advisory render only; no gate
-      behaviour change. <!-- verify: task test -- --filter=quorum -->
-- [ ] **1.4 Register the three omitted metrics** — attendance rate,
-      solo-conclusion rate, absent-reason distribution — in a **budget JSON**, not
-      roadmap prose. `hook-token-budget.json` (definition / instrument / threshold
-      / declared honest gap) and `recycle-threshold-budget.json` (`owner`,
-      `registered_at`, `review_by`, `honest_null_consequence`) already carry the
-      schema and the honest-gap convention.
-- [~] **1.5 Solo-attendance floor.** Deferred to the blocker below: the three
-      candidate outcomes (a third CLI member · gate-scoped `min_present: 2` · a
-      null under 5 %) cannot be chosen before the 1.1 telemetry accumulates.
+## Phase 2 — The family
 
-**Exit:** a solo-concluded council pass is distinguishable from a
-full-attendance one in the event log, and the Risk-6 row describes what the code
-actually does.
+Eight sibling roadmaps carry the surviving work. Each one names the existing artefact
+every step extends, carries its own risk register and blockers, and records its own
+cancellations with the lock cited inline.
 
-**Sequencing constraint.** 1.1 must **not** invent a `member_slot` vocabulary.
-`grep member_slot|memberSlot|slot_index` over `src/scripts/ai_council/` returns
-zero, and `road-to-council-blind-review.md` is `status: ready` with Phase 2.145
-and all of Phase 3 open — its de-anonymisation seam sits at
-`orchestrator.ts:1431,:1591`. Share that seam or sequence after it; a parallel
-anonymisation vocabulary is the drift this repo has paid for before.
+| Roadmap | Carries | Shape |
+|---|---|---|
+| [`-ci-economy`](road-to-inbox-harvest-2026-08-b-ci-economy.md) | the CI/test economy — 36–43 jobs per broad PR, 12 redundant full builds, 191 subprocess-spawning tests, dead path filters | largest; baseline must be recorded **from CI** |
+| [`-ledger-truth`](road-to-inbox-harvest-2026-08-b-ledger-truth.md) | `model_served` vs `model_requested` (0 hits), two un-cross-checked rate tables with different matching strategies, silent zero-costing | highest-value single item in the batch |
+| [`-council-integrity`](road-to-inbox-harvest-2026-08-b-council-integrity.md) | the quorum-attendance defect, shared model-field coercion, synthesis prose-vs-tally | the one fully-surviving source |
+| [`-authoring-contract`](road-to-inbox-harvest-2026-08-b-authoring-contract.md) | three sections labelled *required* and enforced by nothing; failure-signature drills; 20 unbound research citations | sharpest finding the bundles missed |
+| [`-estate-lifecycle`](road-to-inbox-harvest-2026-08-b-estate-lifecycle.md) | staleness metadata, archive-not-delete, zero-inbound report | **opens with a decision-revisit offer** against a same-day lock |
+| [`-install-lifecycle`](road-to-inbox-harvest-2026-08-b-install-lifecycle.md) | there is no uninstall path in `install.ts` at all; plus the org-pack decision | the uninstall half needs no pack system |
+| [`-dispatch-safety`](road-to-inbox-harvest-2026-08-b-dispatch-safety.md) | scoped-Bash expressibility, a confirmation primitive, checkable handoff fields | a live schema-vs-rule contradiction |
+| [`-release-integrity`](road-to-inbox-harvest-2026-08-b-release-integrity.md) | the recurring release-head placeholder, the carrier remainder, four flags over existing data | most survivors of any single source |
 
-## Phase 2 — Landed in this PR
+- [ ] **2.1 Record the execution order the maintainer picks.** Eight roadmaps opened
+      in one pass is a capacity question, not a throughput one — `ADR-216` re-anchors
+      restraint to maintainer capacity, and nothing here is urgent. Two are
+      independently cheap and unblocked (`-ledger-truth` Phase 1,
+      `-release-integrity` Phase 5); two open with a maintainer decision before any
+      code (`-estate-lifecycle`, `-install-lifecycle` Phase 2). Write the chosen
+      order into this step and strike the rest until they are reached.
 
-- [x] **2.1 Risk-6 row corrected** to what the code delivers —
-      *artifact-visible only* (`orchestrator.ts:1983,:1992` do render
-      `_render_quorum_line` / `_render_absent_members`, and `session.ts:109`
-      serialises the quorum) — with the telemetry claim removed until 1.1 lands.
-      Correct either way: if Phase 1 is rejected, the row still must not assert a
-      mechanism that does not exist.
-- [x] **2.2 Stale harvest-slot line corrected** in
-      `road-to-inbox-harvest-2026-08.md:42`. It reads "Both harvest slots
-      occupied"; `lint_roadmap_family_cap.ts:41-42` scopes the cap to
-      `FAMILY_PREFIX = 'road-to-skill-ecosystem-'` with `CAP = 2`, and the live
-      reading is **1 of 2**. Nothing mechanically blocked this batch — and
-      nothing mechanically counted it either.
+## Phase 3 — Cancelled at batch level
 
-## Phase 3 — Single-artefact extensions
+Each child roadmap records the cancellations specific to its own subject. These three
+apply to the batch as a whole, and are recorded here because the source files argue
+for them persuasively and will outlive this file in `tmp.old/`.
 
-Each item extends one existing file. None warrants a roadmap; none is a new rule
-or skill (the estate is at 116 / 289).
-
-- [ ] **3.1 `model_served` vs `model_requested`.** `grep` → **0 hits** tree-wide.
-      `ai_council/clients.ts` records the *requested* model at ~10 construction
-      sites; the API response's own `model` field is read nowhere. ADR-035 tier
-      attribution and `orchestration_record.ts:48-71`'s downshift cost-% both read
-      the requested tier, so an alias or provider substitution corrupts both
-      silently. Additive schema extension; ADR-035 is not changed, it is made
-      honest. <!-- verify: task test -- --filter=clients -->
-- [ ] **3.2 Cache-rate table parity gate.** Two independent, un-cross-checked
-      tables — `ai_council/pricing.ts:111-119` (multipliers) and
-      `cost/track.mjs:42-46` (absolute per-tier USD) — with **different**
-      model-matching strategies: exact-key vs substring. Neither package found
-      this. A deterministic parity check; note `pricing.ts:113-116` byte-freezes
-      the prices row format, so constants are the sanctioned extension point.
-      <!-- verify: task test -- --filter=pricing -->
-- [ ] **3.3 Release-head placeholder becomes blocking.** `CHANGELOG.md:329`
-      (v9.32.0) still carries `_auto-derived, rewrite before merge:_`; v9.31.0's
-      head is clean. `check_release_highlights.ts:205` prints it "advisory, not
-      blocking". This is legitimately gateable despite *a measurement is not a
-      gate*: the placeholder string is emitted by our own generator, so the
-      false-positive class is empty. The alternative — rewriting the head comment
-      to document retro-curation as the real cadence — is exclusive with this and
-      is a maintainer call. <!-- verify: ./scripts-run src/scripts/check_release_highlights -->
-- [ ] **3.4 Bind the external research citations.** **20** distinct arXiv ids
-      across **47** lines in **32** tracked files; **0** bound to
-      `docs/CLAIMS.md`, which carries **0** `https` evidence pointers of any kind.
-      The ledger mechanism already exists with four pointer grammars; the gap is
-      usage, not format. Ledger entries flow into `docs/proof.md` automatically.
-      <!-- verify: ./scripts-run src/scripts/check_claims -->
-- [ ] **3.5 Scoped-Bash expressibility.** `subagent.schema.json:46-53` admits only
-      the bare token `Bash`, so `Bash(npm run:*)` is inexpressible and the one
-      shipped subagent holds a full shell — while `tool-safety` prescribes
-      "prefer scoped-grant syntax over bare tool names" and
-      `skill.schema.json:218` already carries `disallowed_tools`. A live
-      schema-vs-rule contradiction. Enforcement home:
-      `lint_skill_frontmatter_safety.ts`; the rule needs no edit.
-      <!-- verify: ./scripts-run src/scripts/validate_frontmatter -->
-- [ ] **3.6 Enforce the three already-required conditional sections.**
-      `skill-writing/SKILL.md:533,556,619` label `Rationalizations-to-reject`,
-      `Non-negotiable-deliverable` and `Security-constraints` **required** —
-      and `grep` over `src/scripts/*.ts` finds **no enforcement of any of the
-      three**. A documented obligation with zero backing, which outranks adding
-      checks for sections nothing declares yet. `skill_linter.ts --all` runs in
-      0.70 s over 437 artefacts, so the budget is there.
-      <!-- verify: ./scripts-run src/scripts/skill_linter --all -->
-- [ ] **3.7 Per-skill usage timestamps + archive-not-delete.** No `last_used`
-      field exists anywhere. `janitor.ts:1-14` is the never-delete precedent
-      (including its "NEVER auto-sweeps `agents/tmp/`" invariant), and
-      `profile-staleness` / `wrapper-freshness` are the advisory-hook shape.
-      Metadata goes in a **sidecar**, not frontmatter: frontmatter across 405
-      artefacts is the diff noise the payload-diet roadmap already contends with,
-      and the budget-file precedent is sidecar-shaped.
-- [ ] **3.8 Dead CI path filters.** Live `paths:` entries that match nothing:
-      `.agent-src.uncondensed/**` (tree removed) in `tests.yml:20-21`,
-      `consistency.yml`, `skill-lint.yml:7`, `smoke.yml:17,19`; plus
-      `router.json` (`smoke.yml:20`), `templates/**`
-      (`smoke-public-install.yml:50`), `src/scripts/install.py` (`:42`). Also a
-      stale `heavy-tests` job reference at `tests.yml:237` and a "29 scenarios"
-      comment against 30 baselines. The source spec found a subset of this.
-      <!-- verify: ./scripts-run src/scripts/lint_workflow_paths -->
-
-## Phase 4 — Cancelled against a lock
-
-Recorded with the lock cited inline, because each source file argues its case
-persuasively and will outlive this roadmap in `tmp.old/`.
-
-- [-] **Doctrine recency cue** (per-turn kernel-constraint injection at the
-      payload tail). Three independent locks: `ADR-054` is `status: rejected` and
-      *is* this proposal; `agents/settings/contexts/reminder-injection-verdict.md`
-      records the pilot at **Δ = 0 pp on both hosts**, torn down in the branch
-      that built it per a pre-committed threshold; and the premise was searched
-      across **1,158 sessions** under a bar registered in its own commit before
-      the data was read — **0 of 67** confirmed, at distances up to 240× the
-      threshold (`activation-red-baseline.md`). The one carrier that does fire
-      per turn on that surface was measured at **24 of 29 misses**
-      (`session-canary` § enforcement). The next mechanism must be able to
-      **refuse**, not remind.
-- [-] **Spawn-env allowlist.** `ADR-123:120` records "env allowlist instead of
-      deny-by-family" as an explicitly rejected alternative and `:164` reaffirms
-      "deny-by-family stands unchanged". The proposed six-variable set omits the
-      `ANTHROPIC_*` variants and config paths the council transport needs.
-- [-] **Role-contract budget fields** (`max_iterations`, `anomaly_caps`,
-      per-role budget). ADR-109 § 2 bans them by name as "fields that would imply
-      runtime we do not have".
-- [-] **An eight-role catalog behind a flag.** ADR-109's Gate A governs shipping:
-      each unit needs an eval beating both baselines. The one completed eval is an
-      honest null. Seven of the eight proposed roles already exist as skills.
-- [-] **`role@version` in every dispatch trace** and PreToolUse-enforced
-      per-role tool scope. A resolved host probe
-      (`archive/road-to-token-economy-dispatch.md:435-455`) established that an
-      Agent-tool subagent's env is indistinguishable from the parent's and
-      upstream marked it NOT_PLANNED — so the bundle's own declared hard
-      precondition is unpassable.
-- [-] **Recycling × caching interaction test.** `ai-council-config.md:1042-1044`:
-      "Host subagents are unaffected. This key governs ONLY the council's own
-      Anthropic API calls." The two share no code path; the flagged blow-up has no
-      call site. Caching is also already opt-in, default **off**.
-- [-] **Cost-tracking chokepoint doctrine.** This repo does not own the LLM call
-      sites it costs — `cost/track.mjs` reconstructs spend from host transcripts
-      after the fact — and nothing streams. Both halves are inapplicable.
-- [-] **A host-flag compiler and an NDJSON subprocess driver.**
-      `subagent_spawn.ts:1-12` is "pure, no-I/O" brief composition; the host
-      spawns. No call site exists for either.
-- [-] **TTL extension / cache pre-warm.** `'5m'` is a permanent default with a
-      published falsification condition; blanket 1h measured **+8.6 % worse**, and
-      98 % of cache reuse happens within ~34 s.
-- [-] **Pre-commit gate softened to refresh-and-stage.** Weakens a blocking gate
-      that enforces `roadmap-progress-sync` Iron Law 3; `engineering-safety-floor`
-      lists "disabling tests / quality gates to ship faster" as forbidden, and a
-      hook that stages its own generated diff is the tree-mutating-gate trap.
-- [-] **A usage-count ship bar** ("fewer than two citing decisions per quarter →
-      demote"). ADR-216 strikes adoption as a gate condition outright.
+- [-] **The per-turn doctrine-recency cue** — the batch's flagship, blocked three
+      independent ways. `ADR-054` is `status: rejected` and *is* this proposal;
+      `agents/settings/contexts/reminder-injection-verdict.md` records the pilot at
+      **Δ = 0 pp on both hosts**, torn down in the branch that built it per a
+      pre-committed threshold; and the premise was searched across **1,158 sessions**
+      under a bar registered in its own commit before the data was read, confirming
+      **0 of 67** at distances up to 240× the threshold
+      (`agents/evidence/analysis/activation-red-baseline.md`). The one carrier that
+      does fire per turn on that surface was measured at **24 of 29 misses**
+      (`session-canary` § enforcement), whose own conclusion is that the next
+      mechanism must be able to **refuse**, not remind.
+- [-] **All 38 pre-registered benchmarks, as written.** `B-01`'s corpus does not
+      exist; `B-16` pre-registers an interaction against a phantom paper; `B-42`
+      needs ignore-data that measured 0 of 67; `B-131` would disable a live gate as
+      a control; eight need live spend. Any that is ever run re-homes into
+      `docs/CLAIMS.md` with an `exec:` pointer, where the exit code is the verdict.
+- [-] **The `97/111` absoluta point estimate**, wherever the bundles cite it.
+      Re-derived at HEAD: **116 rules · 84 strict (72.4 %) · 102 case-insensitive
+      (87.9 %) · 99 carry an Iron Law (85.3 %)**. `ADR-218` (accepted) states that no
+      artefact cites a point estimate for absoluta prevalence — cite the 71–87 % band
+      or the structural reading.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-10 | reviewer: claude/host -->
 
 | Rank | Item | Risk type | Description | Mitigation | Anchored under |
 |------|------|-----------|-------------|------------|----------------|
-| 1 | A cancelled item is re-adopted from the source file | product | Eleven items are cancelled against locks, but sixteen bundles argue for them with drafted roadmaps and frozen pre-registrations, and they outlive this file in `tmp.old/` | Every cancellation names the lock and its file:line inline, so a re-reader meets the evidence before the argument; the four dossier-level defects are stated once at the top rather than per item | Phase 4 — Cancelled against a lock |
-| 2 | Phase 1 invents a second anonymisation vocabulary | implementation | The obvious implementation adds `member_slot` to `events_log.ts`, while `road-to-council-blind-review` has Phase 3 open and owns the de-anonymisation seam — producing two vocabularies for one property | 1.1 names the seam (`orchestrator.ts:1431,:1591`) and the sequencing constraint is stated as an exit condition, not a footnote | Phase 1 — The quorum-attendance defect |
-| 3 | 3.3 flips a gate to blocking and reds an unrelated release | implementation | A blocking release-head check fires on any release whose head was not curated, including one already in flight | The placeholder string is generator-emitted so the false-positive class is empty; the item is scoped to the **final** release head only, and the exclusive alternative is named for the maintainer | Phase 3 — Single-artefact extensions |
-| 4 | 3.1 is read as a tier-policy change | product | Recording the served model looks like a licence to re-tier work, when it only makes existing attribution honest | The step states that ADR-035 is unchanged and the extension is additive; the consumer assertion lands in the same change | Phase 3 — Single-artefact extensions |
-| 5 | The batch is re-triaged from scratch by a later session | product | Sixteen bundles with plausible drafted roadmaps invite a second full pass costing what this one cost | The four prevention findings are stated as reusable facts (fictional ID namespace, shared-dossier defects, ADR-211 additive shape) rather than per-item verdicts | The four findings that prevent the most work |
+| 1 | Eight roadmaps open at once exceed maintainer capacity | product | The batch's surviving work is real, but opening eight tracks in one pass is exactly the concurrency ADR-216 re-anchored to capacity; the likely failure is eight stalled roadmaps rather than two finished ones | 2.1 makes the execution order an explicit recorded decision rather than an implicit "all of it", and names which two are cheap-and-unblocked versus which two need a decision first | Phase 2 — The family |
+| 2 | A cancelled item is re-adopted from the source file | product | Sixteen bundles ship drafted roadmaps and frozen pre-registrations arguing for cancelled items, and they outlive this file in `tmp.old/` | Every cancellation names the lock and its `file:line` inline, here and in each child; the four dossier-level defects are stated once at the top so a re-reader meets the evidence before the argument | Phase 3 — Cancelled at batch level |
+| 3 | The family's cross-references rot as children are archived | implementation | Eight siblings plus an index is nine files of mutual links; archiving one on completion breaks the index and the `parent_roadmap` chain | `check_references` and `check_no_roadmap_refs` both gate this and were run green on this change; the index table is the single place a child is named, so an archival edit has one site | Phase 2 — The family |
+| 4 | The index is mistaken for the plan | product | A reader who opens only this file sees analysis and two done items, and may conclude the batch produced no work | Phase 2's table is the first thing after the landed work, and every child carries the same `Source:` provenance line back to the batch | Phase 2 — The family |
 
 ## Blockers
 
-### blocker: quorum-solo-floor
+### blocker: harvest-b-execution-order
 - **Status:** open
 - **Owner:** maintainer
-- **Blocks:** 1.5 only — 1.1–1.4 ship and are useful without it.
-- **What to do:** the solo-conclusion rate is a rate over real passes, and no
-  quorum event exists yet to accumulate it. After 1.1 lands, pick between three
-  pre-registered outcomes: add a third CLI member (`gemini` is already in
-  `cli_hints.ts:40-43` and `environment_detector.ts:138` marks it
-  **non-metered** — vendor-official CLI under the user's own subscription, so
-  this option is spend-free on a host with the binary); scope `min_present: 2`
-  to gate-class passes only; or publish a null under 5 %. Tightening `ceil(n/2)`
-  itself is out of scope — the ceil-vs-floor divergence is a recorded decision.
-- **Resolved when:** one of the three outcomes is chosen against real
-  attendance data, or 1.5 is cancelled against the null.
-
-### blocker: release-head-cadence-decision
-- **Status:** open
-- **Owner:** maintainer
-- **Blocks:** 3.3
-- **What to do:** two mutually exclusive fixes. Either the final release head may
-  never carry the generator's placeholder (flip
-  `check_release_highlights.ts:205` to blocking), or the head comment is rewritten
-  to document retro-curation as the real cadence and the placeholder is legitimate
-  until then. The recurrence is verified — v9.32.0 carries it, v9.31.0 does not —
-  so doing neither leaves a known-recurring defect advisory.
-- **Resolved when:** one of the two is chosen and the other recorded as rejected.
-
-### blocker: adr-221-acceptance
-- **Status:** open
-- **Owner:** maintainer
-- **Blocks:** nothing in this roadmap; recorded because it was the cheapest
-  survivor the release review surfaced and it needs no code.
-- **What to do:** `ADR-221-host-native-first-ladder.md:3` is `status: proposed`.
-  Four of five reviews treat host-native-first as settled doctrine. Accepting or
-  rejecting it is an owner decision, not an agent edit.
-- **Resolved when:** the status field is `accepted` or `rejected`.
+- **Blocks:** 2.1 only. Every child roadmap is independently readable and
+  independently executable; none waits on this.
+- **What to do:** decide which of the eight siblings open now and which wait.
+  `-ledger-truth` Phase 1 and `-release-integrity` Phase 5 are the two cheapest
+  unblocked items in the batch. `-estate-lifecycle` and `-install-lifecycle` Phase 2
+  each open with a decision-revisit offer against an accepted or council-parked lock,
+  so they need an answer before any code. `-ci-economy` is the largest and its
+  Phase 0 spends CI minutes recording a baseline.
+- **Resolved when:** the chosen order is written into 2.1 and the unchosen siblings
+  are moved to `agents/roadmaps/later/` with a resume condition, per
+  `lint_roadmap_later_disposition`.
 
 ## Explicitly parked
 
-- **The org pack / plugin system** (`plugin-system.txt`). Blocked on
-  [`ADR-011`](../../docs/decisions/ADR-011-domain-pack-readiness.md) (accepted):
-  the platform ships future domains as in-repo capability bundles, **not**
-  separately-installable packs, until at least two independent domains with
-  overlapping execution surfaces exist. Three named triggers, none met. The
-  spec never mentions it. Most of what it proposes already ships —
-  `packs:` frontmatter on all 289 skills, twelve `src/domains/*/pack.yaml`,
-  a closed id vocabulary, `packs:active`, scoped projection with `--packs` /
-  `--core-only`. Its own non-goal "no override semantics" contradicts the shipped
-  `agents/overrides/` layer, which has an `extend` **and** a `replace` mode.
-  Unparks only if ADR-011 is reopened. **One real gap is independently
-  shippable and does not need the pack system:** there is no uninstall path in
-  `install.ts` at all (only a `surgical-uninstall` comment at `:3682`), so
-  removal leaves ghost artefacts in every projected host tree.
 - **The third-party skill install** (`chief-of-staff.txt`). Downloading and
   installing third-party code into a global skills directory is a safety-floor
   action, and it would be a 290th skill with no retire candidate. Its highest-value
-  pattern — staleness metadata on rules and skills — is already contemplated in
-  Phase 5.1 of `later/road-to-cost-parity-1-rule-payload-diet.md`, parked
-  2026-08-10 by council convergence under a "do not relitigate" header. Taking it
-  is a **decision-revisit offer against a same-day lock**, not fresh work. Note
-  the lock is not ADR-088: that record scopes to an external multi-agent runtime,
-  and citing it here would be a lock invoked out of scope.
-- **A `SELF.md` / self-knowledge doc family.** Its governing problem — an agent
-  that cannot tell what capabilities it has — was measured across twelve
-  instances and closed four phases deep in `road-to-capability-answerability`
-  (merged in-window): eleven probe verbs, a per-capability carry-vs-name contract
-  with an empirical revisit bar, and per-field provenance so `false` reads as
-  "nobody answered". Any future proposal must clear that contract's own revisit
-  bar — the same wrong guess observed twice.
-- **Programmatic tool calling** (model-authored scripts against a tool RPC). The
-  largest novel mechanism in the batch, and the wrong shape here: ADR-123 holds
-  behavioural enforcement out of scope, and its gate-equivalence precondition
+  pattern — staleness metadata — is carried by `-estate-lifecycle` as a revisit
+  offer. Note the lock is **not** ADR-088: that record scopes to driving an external
+  agent *runtime*, and citing it here would be a lock invoked out of scope.
+- **A `SELF.md` / generated self-knowledge doc family.** Its governing problem is
+  owned by `road-to-capability-answerability.md` — **`status: ready`, active, 18 of 19
+  steps closed** (an earlier draft of this index called it merged in-window; it is
+  not) — which ships a family of self-describing probe verbs, a per-capability
+  carry-vs-name contract table (`docs/contracts/capability-answerability.md:24-30`),
+  and per-field provenance so `false` reads as "nobody answered" rather than "the host
+  cannot". Any future proposal must clear that contract's own empirical revisit bar at
+  `:40-44` — the same wrong guess observed twice.
+- **Programmatic tool calling** (executing model-authored scripts against a tool
+  RPC). The largest novel mechanism in the batch and the wrong shape here: `ADR-123`
+  holds behavioural enforcement out of scope, and the gate-equivalence precondition
   presumes PreToolUse guards that bind on three of eight hosts.
-- **All 38 pre-registered benchmarks.** Eight need live spend; `B-01`'s corpus
-  does not exist; `B-16` pre-registers an interaction against a phantom paper;
-  `B-42` needs ignore-data that measured 0 of 67; `B-131` would disable a live
-  gate as a control. Any that is ever run re-homes into `docs/CLAIMS.md` with an
-  `exec:` pointer, where the exit code is the verdict.
+- **A runtime event bus.** Already recorded as CUT to a maintainer decision
+  (`archive/road-to-feedback-9-29.md:77`); the replacement target is already a single
+  in-process dispatcher. Re-proposing it is relitigation without new evidence.


### PR DESCRIPTION
Follow-up to #1259, which merged while this was being written. That PR verified the 2026-08-10 inbox batch correctly and **packaged it wrong**: eight verified extensions became one-line bullets in a single collector phase, and three substantial programmes — CI economy, ledger attribution, estate lifecycle — were reduced to a sentence each. That buries work instead of planning it.

This splits the surviving material into **eight sibling roadmaps** under the index prefix.

**98 open steps across eight files, against 12 in one before.** Docs only.

## The family

| Roadmap | Open | Carries |
|---|---:|---|
| `-ci-economy` | 21 | 36–43 jobs per broad `src/**` PR; **13** jobs each rebuild the full 6-target build; 191 subprocess-spawning tests blind to `vitest --changed`; 10 dead `paths:` entries across 4 workflows |
| `-authoring-contract` | 15 | three sections `skill-writing` labels *required* and **nothing enforces**; failure-signature drills; the unbound research citations |
| `-dispatch-safety` | 14 | scoped-Bash inexpressible in `subagent.schema.json`; a confirmation primitive; three checkable handoff fields |
| `-ledger-truth` | 12 | `model_served` vs `model_requested` (**0 hits**, 22 construction sites); two un-cross-checked rate tables with *different* matching strategies |
| `-release-integrity` | 12 | the recurring release-head placeholder; the carrier remainder; four flags over data that already exists |
| `-estate-lifecycle` | 9 | staleness instrument, archive-not-delete, zero-inbound report |
| `-council-integrity` | 7 | the quorum-attendance defect — an active risk register asserting a mitigation the code does not deliver |
| `-install-lifecycle` | 7 | three verified `install.ts` defects; plus the org-pack decision |

Two open with a **decision-revisit offer** rather than a plan, because a lock blocking real benefit gets surfaced, not silently obeyed: `-estate-lifecycle` against the council-parked payload-diet roadmap *and* the governance skill-lifecycle policy; `-install-lifecycle` against accepted ADR-011.

## What stays cancelled, and why that is not packaging

**55 items** remain cancelled with the lock cited inline. The batch's flagship — a per-turn doctrine-recency cue — is blocked three independent ways: `ADR-054` is `status: rejected` and *is* that proposal; the reminder-injection pilot ran at **Δ = 0 pp on both hosts** and was torn down in the branch that built it per a pre-committed threshold; and its premise was searched across **1,158 sessions** under a bar registered in its own commit before the data was read, confirming **0 of 67**. Those are measurements, not preferences.

## The eight authors corrected the brief — including things #1259 published

Each author got the earlier verification dossier and was told to re-check it. They returned roughly **thirty corrections**, and several land on claims #1259 stated as fact. Recording them here rather than quietly shipping the fixed versions:

| #1259 said | Verified |
|---|---|
| "no uninstall path in `install.ts`" — called it the one real standalone gap | **False as a repo claim.** `cmd_uninstall.ts` is 874 lines, `cmd_prune.ts` 629 with `--resume-uninstall`, plus a drift `doctor` — `registry.ts:39,40,41`. Provenance markers and an orphan report already exist. Phase 1 was rebuilt on three residual defects verified at line level instead |
| `road-to-capability-answerability` "merged in-window" | `status: ready`, **still active**, 18 of 19 steps closed |
| "eleven probe verbs" | the contract table carries **7** rows |
| 20 arXiv ids / 47 lines / 32 files, 0 `https` pointers | **14 / 49 / 33**; and `CLAIMS.md` carries exactly one `https` — the line that *defines* the grammar. What is zero is `- evidence:` lines using it |
| "12 jobs rebuild the full build" | **13** (`tests.yml:231,286,381,415`) |
| language-detector "A 9.3% · B 15.1%" | the **second of three** readings, superseded in the same file; best-founded is **A 2.7% · B 25.4%**, still provisional |
| a hook `warn` exits 2 and this host reads BLOCK | **not in the tree at all.** The constants exist (`dispatch_hook.ts:76-78`); the mapping is unsourced. The step now instructs a probe instead of asserting it |
| `openOrMerge` as the self-repair entry point | the export is **`upsertFinding`** (`_lib/self_repair_store.ts:84`) — the brief sent them to grep a phantom |
| "sidecar, not frontmatter" for staleness metadata | **neither.** `docs/governance.md:44-59` already decided it: dormancy is commit-based and derivable, "so it is *not* stored in the spine", with a `last_reviewed:` field deferred until a second maintainer exists |

Every roadmap carries the corrected figure **with the command that re-derives it**, so the next reader does not have to trust this table.

## One finding no source bundle had

`lint_skill_frontmatter_safety.ts` already ships a `_BARE_BASH` detector reporting HIGH (`:39`, `:213`) — but its scan roots at `:261` are `['src/skills','src/agent-src','src/domains']`, **`src/subagents` is absent**, and it reads `allowed_tools` (10 hits) rather than the subagent `tools:` key (**0 hits**). So the check has never seen `src/subagents/production-validator.md:14`, the one artefact in the tree that grants a bare shell. Verified independently, twice.

## Rebase note

#1259 merged mid-work and **fifteen** commits landed after it, including the archival of the cost-parity programme these roadmaps cite and a fix for the trackable-phase gate that two authors had flagged as pre-existing. This branch is cut fresh from `353ce56f9`, and the stale citations were followed to their new paths.

## Gates run locally

`lint_plan_risk_register` (via `task`, which is the only invocation that catches `stale_review`) · `lint_roadmap_blockers` · `lint_roadmap_complexity` · `lint_empty_roadmaps` · `lint_roadmap_ci_steps` · `lint_roadmap_later_disposition` · `lint_roadmap_family_cap` · `check_no_external_sources` · `check_no_roadmap_refs` · `check_roadmap_trackable` · `check_references` · `check_md_language` · `check_branch_freshness` — all green. Remote CI is the authoritative gate.
