### PR TITLE
feat(discovery): estate lifecycle reporting — dormancy signal, zero-inbound traversal, graph observability

### DIFF
--- a/agents/evidence/analysis/discovery-graph-inbound-degree.md
+++ b/agents/evidence/analysis/discovery-graph-inbound-degree.md
@@ -1,0 +1,92 @@
+# Zero-inbound traversal — the first run, classified
+
+> Step 3.2 of `road-to-inbox-harvest-2026-08-b-estate-lifecycle`: *"Classify
+> every first-run hit before anything is wired … then decide whether the report
+> is worth publishing at all."*
+>
+> **Decision: not published as a list.** The traversal is correct; the edge set
+> it traverses cannot answer the question yet. What follows is the measurement
+> that settles it, and the defect it surfaced in two already-shipped commands.
+
+Measured 2026-08-11 against `origin/main` @ `91bee9f7e`, over
+`dist/discovery/discovery-manifest.json` built in the same worktree.
+
+## The first run
+
+```
+$ npx tsx src/scripts/discovery_graph.ts build --manifest dist/discovery/discovery-manifest.json
+discovery_graph.ts: graph — 759 nodes, 1624 edges
+  supersedes: 20
+  routes_to: 109
+  references_adr: 0
+  member_of_pack: 607
+  member_of_workspace: 888
+scanned: 759
+
+$ npx tsx src/scripts/discovery_graph.ts orphans --manifest …
+zero-inbound artefacts (595 of 759 nodes)
+```
+
+The 595 bucket by root:
+
+| Root | Hits | Total in tree |
+|---|---:|---:|
+| `src/skills` | 289 | 289 |
+| `src/domains` | 188 | — |
+| `src/rules` | 116 | 116 |
+| `src/subagents` | 1 | — |
+| `src/agent-src` | 1 | — |
+
+**Every skill and every rule is a hit.** A report whose hit rate is 100 % of two
+whole artefact classes is not reporting on the estate; it is reporting on
+itself.
+
+## Why — the targets are names, the nodes are paths
+
+`buildGraph` adds each artefact under its repo-relative path (`idOf` = `a.path`)
+and adds each edge target verbatim from the structured field. Those fields carry
+**logical names**:
+
+```
+routes_to targets: 109 | resolve to an artefact path: 0
+  sample: analyze-postmortem, analyze-premortem, analyze-decision, …
+replaces  targets:  10 | resolve to an artefact path: 0
+  sample: quality-fix, e2e-heal, commit, commit:in-chunks, …
+```
+
+0 of 119. So every EXTRACTED edge terminates on a **phantom node** that exists
+only as an edge target and never as an artefact, and no artefact ever receives
+an inbound EXTRACTED edge. The 595 is arithmetic, not evidence.
+
+`references_adr: 0` is the same defect seen from the other side: the pass tests
+its targets against a `docs/decisions/ADR-*` path regex, and a target that is a
+bare logical name can never match it. The pass has produced zero edges for as
+long as the field has carried names.
+
+## What this costs beyond the report
+
+`affected` and `explain` are shipped subcommands that traverse this edge set.
+With targets unresolved, `affected <rule>` cannot reach the skill that rule
+routes to — the hop exists, but it lands on a phantom rather than on the skill's
+own node, so the skill's own edges never continue the walk. The graph
+under-reports reachability for all 109 `routes_to` and 10 `replaces` relations.
+
+`build_discovery_manifest.ts` already carries a `resolve_logical` seam for
+exactly this name→path direction, so the fix has a home. It is **not made
+here**: changing how a shipped traversal resolves its targets is a behaviour
+change to `affected`/`explain`, a different subject from this roadmap's
+report-only phases, and it deserves its own diff and its own review.
+
+## The disposition
+
+1. `inboundZero` ships and is unit-tested — the traversal itself is right, and
+   it is the piece that is genuinely additive.
+2. The `orphans` subcommand **names the degraded state and prints no list**
+   while `dangling_targets > 0`. The count comes from the graph's own `stats`,
+   so the refusal is derived from the same run, not from this document.
+3. The list becomes meaningful the moment targets resolve. Nothing here needs to
+   be revisited to make that true — the guard clears itself.
+
+Publishing the 595 would have been a report that looks like evidence, on a
+question (`what does nothing point at?`) where a wrong answer invites deletion.
+The roadmap's own risk register ranks that #2. This is that mitigation firing.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**224 / 345 steps done · 65%**
+**232 / 345 steps done · 67%**
 
 ```text
-██████████████████████████░░░░░░░░░░░░░░   65%
+███████████████████████████░░░░░░░░░░░░░   67%
 ```
 
 ## Open roadmaps
@@ -25,7 +25,7 @@
 | 7 | [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 5 | 24 | 1 | 17 | 2 | 4 | [2](#blockers-road-to-inbox-harvest-2026-08-b-ci-economy) | █████████░ 94% |
 | 8 | [road-to-inbox-harvest-2026-08-b-council-integrity-followup.md](roadmaps/road-to-inbox-harvest-2026-08-b-council-integrity-followup.md) | 1 | 5 | 5 | 0 | 0 | 0 | [1](#blockers-road-to-inbox-harvest-2026-08-b-council-integrity-followup) | ░░░░░░░░░░ 0% |
 | 9 | [road-to-inbox-harvest-2026-08-b-dispatch-safety.md](roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md) | 4 | 21 | 13 | 1 | 1 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-dispatch-safety) | █░░░░░░░░░ 7% |
-| 10 | [road-to-inbox-harvest-2026-08-b-estate-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md) | 4 | 15 | 9 | 0 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-estate-lifecycle) | ░░░░░░░░░░ 0% |
+| 10 | [road-to-inbox-harvest-2026-08-b-estate-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md) | 4 | 15 | 1 | 8 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-estate-lifecycle) | █████████░ 89% |
 | 11 | [road-to-inbox-harvest-2026-08-b-install-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-install-lifecycle.md) | 2 | 13 | 1 | 6 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-install-lifecycle) | █████████░ 86% |
 | 12 | [road-to-inbox-harvest-2026-08-b-ledger-truth.md](roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md) | 3 | 19 | 1 | 12 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-ledger-truth) | █████████░ 92% |
 | 13 | [road-to-inbox-harvest-2026-08-b-release-integrity.md](roadmaps/road-to-inbox-harvest-2026-08-b-release-integrity.md) | 5 | 25 | 1 | 11 | 0 | 13 | [3](#blockers-road-to-inbox-harvest-2026-08-b-release-integrity) | █████████░ 92% |
@@ -268,14 +268,14 @@
 
 ### [road-to-inbox-harvest-2026-08-b-estate-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md)
 
-**Road to estate lifecycle reporting** — 0 / 9 done (0%)
+**Road to estate lifecycle reporting** — 8 / 9 done (89%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | The revisit offer | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
-| 2 | The dormancy signal governance already mandates | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 3 | Zero inbound references, on the graph that already exists | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 4 | The graph's own observability | ⬜ not started | 2 | 0 | 0 | 6 | 0% |
+| 2 | The dormancy signal governance already mandates | ✅ done | 0 | 3 | 0 | 0 | 100% |
+| 3 | Zero inbound references, on the graph that already exists | ✅ done | 0 | 3 | 0 | 0 | 100% |
+| 4 | The graph's own observability | ✅ done | 0 | 2 | 0 | 6 | 100% |
 
 <a id="blockers-road-to-inbox-harvest-2026-08-b-estate-lifecycle"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md
@@ -76,13 +76,29 @@ report-only by construction and moves no cap.
       parked roadmap, and do not reopen `governance.md:49-59` — the commit-based
       choice is the reason Phase 2 costs nothing.
 
+      **Surfaced 2026-08-11; the answer is outstanding, which is why this stays
+      open.** Put to the maintainer, unchanged, as the blocker words it:
+
+      > `later/road-to-cost-parity-1-rule-payload-diet.md:3` is `status: later`,
+      > parked `:17-30` on 2026-08-10 by council convergence + maintainer pick,
+      > with `:52` "do not relitigate". `docs/governance.md` § Skill lifecycle
+      > policy separately defers a `last_reviewed:` field "until a second
+      > maintainer exists". **Does the maintained-estate framing reopen now, or
+      > stay parked on its own resume conditions — and does the
+      > second-maintainer condition still hold?**
+
+      Neither lock was edited, and neither needed to be: Phases 2-4 shipped
+      report-only, added no frontmatter field and moved no cap, so nothing below
+      depends on the answer. What the answer unlocks is only what the blocker
+      already scopes — a removal list, a cap change, or a new estate field.
+
 ## Phase 2 — The dormancy signal governance already mandates
 
 `governance.md:52` names the exact command and calls the signal derivable. Nothing
 computes it, so an accepted policy has no instrument. This phase builds the
 instrument, not a new policy.
 
-- [ ] **2.1 Add a dormancy section to the existing discovery report family.**
+- [x] **2.1 Add a dormancy section to the existing discovery report family.**
       Compute per-artefact last-touch from `git log -1 --format=%cI -- <path>` over
       `iter_artefacts` and emit a section listing everything past the 6-month bar,
       alongside `_deprecation_report` (`build_discovery_manifest.ts:915-920`) and
@@ -92,13 +108,13 @@ instrument, not a new policy.
       commit dates, so the false-positive class is not empty and no argument makes
       it so.
       <!-- verify: task test -- --filter=build_discovery_manifest -->
-- [ ] **2.2 Publish the two-vocabulary finding and the coverage figures.** One
+- [x] **2.2 Publish the two-vocabulary finding and the coverage figures.** One
       paragraph in `docs/governance.md`: `lifecycle:` and skill `status:` are
       distinct fields with distinct enums, 15 of 289 and 66 of 289 declare them,
       and `lifecycle` defaults to `active` (`skill.schema.json:262`) so absent
       reads as active. Reconciling them is a separate decision; this only stops
       the two being read as one field.
-- [ ] **2.3 Record the sidecar-versus-frontmatter answer where the question is
+- [x] **2.3 Record the sidecar-versus-frontmatter answer where the question is
       asked.** `governance.md:58-59` defers the field; add the reasoning in one
       line — a review-date field across 405 artefacts is the diff noise the parked
       roadmap's own Phase 3 drift-lint contends with, and the only shipped
@@ -114,13 +130,13 @@ report is an **inverse traversal of `discovery_graph.ts`**, whose edge set is
 already deterministic and cached against the manifest checksum (`:143-154`). Not a
 new engine.
 
-- [ ] **3.1 Add an inbound-degree query to `discovery_graph.ts`.** `Edge` (`:45-50`)
+- [x] **3.1 Add an inbound-degree query to `discovery_graph.ts`.** `Edge` (`:45-50`)
       already carries `from`/`to`/`rel`/`confidence`; invert it once and report
       nodes with zero inbound `EXTRACTED` edges, excluding `member_of` (`INFERRED`
       at `:124,129`, which would make every artefact look reachable via its pack
       node). Additive alongside `affected` (`:195`) and `explain` (`:221`).
       <!-- verify: task test -- --filter=discovery_graph -->
-- [ ] **3.2 Classify every first-run hit before anything is wired.** The relation
+- [x] **3.2 Classify every first-run hit before anything is wired.** The relation
       set is narrow — `replaces`, `routes_to`, ADR path targets, `packs`,
       `workspaces` (`:10-14`) — so a prose-only cross-reference produces no edge and
       a reachable artefact reads as zero-inbound. Classify the hits, then decide
@@ -128,14 +144,14 @@ new engine.
       `check_references.ts` is the cross-reference gate and this traversal sees a
       strictly narrower graph, so the false-positive class is provably non-empty.
       <!-- verify: ./scripts-run src/scripts/check_references --format=text -->
-- [ ] **3.3 Point the report at review, not removal.** One line in the emitted
+- [x] **3.3 Point the report at review, not removal.** One line in the emitted
       section citing `governance.md:56-57` — sunset is explicit, recorded in the
       removing commit, no tombstone files — and `janitor.ts:10` as the
       archive-not-delete precedent.
 
 ## Phase 4 — The graph's own observability
 
-- [ ] **4.1 Add `stats` and per-source try-isolation to `discovery_graph.ts`.**
+- [x] **4.1 Add `stats` and per-source try-isolation to `discovery_graph.ts`.**
       `Graph` is exactly four fields (`:51-56`) with no `stats`, `buildGraph`
       (`:95`) runs one loop with no per-relation error containment, and the file has
       **zero** `reportScanned`/`assertScanned` calls. Add
@@ -146,11 +162,42 @@ new engine.
       just accepted". `schema_version` already exists (`:148`), so this is additive
       and **needs no ADR**.
       <!-- verify: task test -- --filter=discovery_graph -->
-- [ ] **4.2 Namespace non-artefact node ids.** `pack:` and `workspace:` are the only
+- [x] **4.2 Namespace non-artefact node ids.** `pack:` and `workspace:` are the only
       prefixes (`:123,128`); artefact nodes are bare paths (`idOf` at `:99`). A
       zero-inbound report over a mixed id space is ambiguous the first time a path
       collides with a synthetic node. One prefix constant, no format change.
       <!-- verify: task test -- --filter=discovery_graph -->
+
+## What landed — and the two findings that changed the shape
+
+Both report steps built their instrument and then **refused to publish a list**,
+in each case because a measurement said the list would not mean what a reader
+would take it to mean. Neither refusal was planned; both are recorded here
+rather than smoothed over.
+
+- **3.2 — the zero-inbound traversal is correct and its edge set is not.** First
+  run: 595 of 759 nodes, i.e. **every** skill (289/289) and **every** rule
+  (116/116). Cause, measured: all 119 `routes_to` / `replaces` targets are
+  *logical names* (`commit:in-chunks`) while node ids are repo-relative paths —
+  **0 of 119 resolve**, so no artefact ever carries an inbound EXTRACTED edge and
+  the 595 is arithmetic. `references_adr: 0` is the same defect from the other
+  side. `orphans` therefore names the degraded state and prints no list while
+  `stats.dangling_targets > 0`; the guard clears itself the moment targets
+  resolve. Evidence + the knock-on for the shipped `affected` / `explain`
+  traversals: [`discovery-graph-inbound-degree.md`](../evidence/analysis/discovery-graph-inbound-degree.md).
+  Fixing the resolution is a behaviour change to two shipped commands and is
+  deliberately **not** made here.
+- **2.1 — the dormancy window is longer than the available history.** This
+  checkout is a shallow clone (`git rev-parse --is-shallow-repository` → `true`)
+  whose oldest commit is 2026-05-18 — under three months against a six-month
+  bar, and CI clones are shallow by default. A truncated history is
+  indistinguishable from a dormant artefact, so the report names the missing
+  signal instead of emitting a list; the populated path is unit-tested rather
+  than left unexercised.
+
+The shared shape: an empty or maximal list is a *claim*, and neither report is
+allowed to make one it cannot support. Both follow the labelled-degraded-path
+precedent this roadmap's own Context cites (`check_standing_rule_delivery.ts:15-27`).
 
 ## Cancelled — each against a named citation
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -57,6 +57,38 @@ States: **active** · **dormant** · **sunset**. Slots beside the
   name the successor or the reason; no tombstone files.
 - A `last_reviewed:` / human-review field is **deferred until a second maintainer**
   exists (then human review, not commit activity, is the signal worth recording).
+  **If that condition ever fires, a sidecar is the precedent, not frontmatter.** A
+  review-date field spread across 405 artefacts is diff noise on every unrelated
+  edit, and the only review-metadata triple the tree actually ships
+  (`registered_at` / `owner` / `review_by` in
+  [`recycle-threshold-budget.json`](../src/config/recycle-threshold-budget.json))
+  is sidecar-shaped on a single config file.
+- **The signal has an instrument.** `build_discovery_manifest.ts` emits
+  `dist/discovery/dormancy-report.md` alongside the deprecation, trust and orphan
+  reports, from one bounded `git log --since` walk. It is report-only and never a
+  gate: a finished artefact and an abandoned one are indistinguishable from commit
+  dates, so the false-positive class is not empty. Where history is shorter than
+  the window — a shallow clone, which is the CI default — the report **names the
+  missing signal and publishes no list**, because an empty list would read as
+  "nothing is dormant", a different and false claim.
+
+### Two lifecycle vocabularies, and they are not one field
+
+`lifecycle:` and the skill-only `status:` are distinct fields with distinct
+enums, and reading either as the other is a mistake the schemas permit:
+
+| Field | Enum | Declared by |
+|---|---|---|
+| `lifecycle:` | `active · deprecated · experimental · archived` | 15 of 289 skills |
+| `status:` | `active · deprecated · superseded` | 66 of 289 skills |
+
+`lifecycle` carries `"default": "active"` (`skill.schema.json`), so **absent
+reads as active** — thin declared coverage is not evidence of an undeclared
+estate. Neither field is a runtime lifecycle: both are static declarations, and
+before the dormancy report above nothing computed dormancy at all. Reconciling
+the two enums is a separate decision and is not taken here; this entry exists so
+they stop being read as one field. Counts re-derived 2026-08-11 against
+`src/skills/` (289 skills, 116 rules).
 
 ## Deferred governance (council-decided, not dropped)
 

--- a/src/scripts/build_discovery_manifest.ts
+++ b/src/scripts/build_discovery_manifest.ts
@@ -38,6 +38,7 @@
  *
  * Schema: docs/contracts/discovery-manifest.schema.json
  */
+import * as child_process from 'node:child_process';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -83,6 +84,7 @@ interface ModuleConfig {
     DEFAULT_DEPRECATION_REPORT: string;
     DEFAULT_TRUST_REPORT: string;
     DEFAULT_ORPHAN_REPORT: string;
+    DEFAULT_DORMANCY_REPORT: string;
     DEFAULT_WORKSPACES_JSON: string;
     DEFAULT_PACKS_JSON: string;
     // Patchable seams (Python monkeypatches these module attributes).
@@ -101,6 +103,7 @@ function _deriveConfig(root: string): ModuleConfig {
         DEFAULT_DEPRECATION_REPORT: path.join(disc, 'deprecation-report.md'),
         DEFAULT_TRUST_REPORT: path.join(disc, 'trust-report.md'),
         DEFAULT_ORPHAN_REPORT: path.join(disc, 'orphan-report.md'),
+        DEFAULT_DORMANCY_REPORT: path.join(disc, 'dormancy-report.md'),
         DEFAULT_WORKSPACES_JSON: path.join(disc, 'workspaces.json'),
         DEFAULT_PACKS_JSON: path.join(disc, 'packs.json'),
         artefact_roots: _artefact_roots,
@@ -937,6 +940,156 @@ function _deprecation_report(manifest: JsonObject): string {
     return lines.join('\n') + '\n';
 }
 
+/** Dormancy window, in months. `docs/governance.md` § Skill lifecycle policy. */
+const _DORMANCY_MONTHS = 6;
+
+/**
+ * What the dormancy report could actually establish from git in this checkout.
+ *
+ * `ok: false` is a first-class outcome, not an error: a shallow clone or a
+ * repository younger than the window cannot distinguish "untouched for six
+ * months" from "history truncated three months ago", and CI clones are shallow
+ * by default. The report NAMES that instead of emitting a list built on it.
+ */
+export interface DormancyProbe {
+    ok: boolean;
+    /** Why the signal is unavailable — set iff `ok` is false. */
+    reason?: string;
+    /** Repo-relative paths with at least one commit inside the window. */
+    touched: Set<string>;
+}
+
+function _git(root: string, args: readonly string[]): string | null {
+    try {
+        return child_process.execFileSync('git', [...args], {
+            cwd: root,
+            encoding: 'utf-8',
+            maxBuffer: 64 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Probe git once for the whole estate: one bounded `--since` walk, exactly the
+ * command `governance.md` names, rather than one `git log` per artefact.
+ */
+function _dormancy_probe(root: string, now: Date = new Date()): DormancyProbe {
+    const since = `${String(_DORMANCY_MONTHS)} months ago`;
+    if (_git(root, ['rev-parse', '--git-dir']) === null) {
+        return { ok: false, reason: 'not a git checkout — commit history is unavailable', touched: new Set() };
+    }
+    if ((_git(root, ['rev-parse', '--is-shallow-repository']) ?? '').trim() === 'true') {
+        return {
+            ok: false,
+            reason:
+                'shallow clone — a truncated history is indistinguishable from a dormant artefact. ' +
+                'Re-run after `git fetch --unshallow`.',
+            touched: new Set(),
+        };
+    }
+    const oldest = (_git(root, ['log', '--reverse', '--format=%cI', '--max-count=1']) ?? '').trim();
+    if (oldest !== '') {
+        const cutoff = new Date(now);
+        cutoff.setMonth(cutoff.getMonth() - _DORMANCY_MONTHS);
+        if (new Date(oldest) > cutoff) {
+            return {
+                ok: false,
+                reason:
+                    `repository history starts ${oldest.slice(0, 10)}, inside the ` +
+                    `${String(_DORMANCY_MONTHS)}-month window — every artefact would read as dormant`,
+                touched: new Set(),
+            };
+        }
+    }
+    const out = _git(root, ['log', `--since=${since}`, '--name-only', '--format=']);
+    if (out === null) {
+        return { ok: false, reason: 'git log failed', touched: new Set() };
+    }
+    const touched = new Set(out.split('\n').map((l) => l.trim()).filter((l) => l !== ''));
+    return { ok: true, touched };
+}
+
+/**
+ * The unit dormancy is measured over. A skill is a directory (governance names
+ * `git log -- src/skills/<name>/`), so a commit touching its `reference.md`
+ * keeps the skill alive; every other artefact is its own file.
+ */
+function _dormancy_unit(artefactPath: string): string {
+    return path.basename(artefactPath) === 'SKILL.md' ? path.dirname(artefactPath) : artefactPath;
+}
+
+/**
+ * Artefacts with no commit inside the dormancy window.
+ *
+ * Report-only by construction: `governance.md` § Skill lifecycle policy says
+ * dormancy triggers review, never auto-deprecation — and a finished artefact is
+ * indistinguishable from an abandoned one from commit dates, so the
+ * false-positive class is not empty and no argument makes it so.
+ */
+function _dormant_artefacts(manifest: JsonObject, probe: DormancyProbe): JsonObject[] {
+    if (!probe.ok) {
+        return [];
+    }
+    const alive = new Set<string>();
+    for (const p of probe.touched) {
+        alive.add(p);
+        // A touched file keeps its containing directory-shaped artefact alive.
+        for (let d = path.dirname(p); d !== '.' && d !== path.sep; d = path.dirname(d)) {
+            alive.add(d);
+        }
+    }
+    const out: JsonObject[] = [];
+    for (const a of manifest['artefacts'] as JsonObject[]) {
+        const unit = _dormancy_unit(a['path'] as string);
+        if (!alive.has(unit)) {
+            out.push({ path: a['path'], unit, category: a['category'] });
+        }
+    }
+    out.sort((a, b) => _cmpStr(a['path'] as string, b['path'] as string));
+    return out;
+}
+
+/** The dormancy section of the discovery report family (governance.md § Skill lifecycle policy). */
+function _dormancy_report(manifest: JsonObject, probe: DormancyProbe): string {
+    const lines = ['# Discovery — Dormancy Report', ''];
+    lines.push(`- Generated: \`${String(manifest['generated_at'])}\``);
+    lines.push(`- Window: **${String(_DORMANCY_MONTHS)} months** without a commit`);
+    lines.push('');
+    lines.push('> Dormancy triggers **review, never auto-deprecation**');
+    lines.push('> (`docs/governance.md` § Skill lifecycle policy). A finished artefact and an');
+    lines.push('> abandoned one look identical from commit dates, so this is a prompt to ask');
+    lines.push('> "still earning its slot?" — never a removal list, and never a gate.');
+    lines.push('');
+    if (!probe.ok) {
+        lines.push('## Signal unavailable');
+        lines.push('');
+        lines.push(`**No dormancy list is published**: ${String(probe.reason)}`);
+        lines.push('');
+        lines.push('An empty section here would read as "nothing is dormant", which is a');
+        lines.push('different claim from "the signal could not be computed".');
+        lines.push('');
+        return lines.join('\n') + '\n';
+    }
+    const items = _dormant_artefacts(manifest, probe);
+    lines.push(`- Dormant artefacts: **${items.length}**`);
+    lines.push('');
+    if (items.length === 0) {
+        lines.push('_None. Every artefact was touched inside the window._');
+        lines.push('');
+        return lines.join('\n') + '\n';
+    }
+    lines.push('| Path | Unit | Category |');
+    lines.push('|---|---|---|');
+    for (const a of items) {
+        lines.push(`| \`${String(a['path'])}\` | \`${String(a['unit'])}\` | ${String(a['category'])} |`);
+    }
+    lines.push('');
+    return lines.join('\n') + '\n';
+}
+
 /** Trust-level breakdown by workspace + human-review sanity flag. Mirrors `_trust_report`. */
 function _trust_report(manifest: JsonObject): string {
     const byWs = new Map<string, JsonObject>();
@@ -1195,6 +1348,7 @@ interface ParsedArgs {
     deprecation_report: string;
     trust_report: string;
     orphan_report: string;
+    dormancy_report: string;
     workspaces_json: string;
     packs_json: string;
     strict: boolean;
@@ -1231,6 +1385,7 @@ function parse_args(argv: readonly string[]): ParsedArgs {
         deprecation_report: _config.DEFAULT_DEPRECATION_REPORT,
         trust_report: _config.DEFAULT_TRUST_REPORT,
         orphan_report: _config.DEFAULT_ORPHAN_REPORT,
+        dormancy_report: _config.DEFAULT_DORMANCY_REPORT,
         workspaces_json: _config.DEFAULT_WORKSPACES_JSON,
         packs_json: _config.DEFAULT_PACKS_JSON,
         strict: false,
@@ -1242,6 +1397,7 @@ function parse_args(argv: readonly string[]): ParsedArgs {
         '                                   [--deprecation-report DEPRECATION_REPORT]\n' +
         '                                   [--trust-report TRUST_REPORT]\n' +
         '                                   [--orphan-report ORPHAN_REPORT]\n' +
+        '                                   [--dormancy-report DORMANCY_REPORT]\n' +
         '                                   [--workspaces-json WORKSPACES_JSON]\n' +
         '                                   [--packs-json PACKS_JSON] [--strict]\n' +
         '                                   [--quiet]\n';
@@ -1252,6 +1408,7 @@ function parse_args(argv: readonly string[]): ParsedArgs {
         '--deprecation-report': 'deprecation_report',
         '--trust-report': 'trust_report',
         '--orphan-report': 'orphan_report',
+        '--dormancy-report': 'dormancy_report',
         '--workspaces-json': 'workspaces_json',
         '--packs-json': 'packs_json',
     };
@@ -1324,6 +1481,10 @@ function main(argv: readonly string[]): number {
         _writeFileMkdir(args.deprecation_report, _deprecation_report(manifest));
         _writeFileMkdir(args.trust_report, _trust_report(manifest));
         _writeFileMkdir(args.orphan_report, _orphan_report(manifest));
+        _writeFileMkdir(
+            args.dormancy_report,
+            _dormancy_report(manifest, _dormancy_probe(_config.ROOT)),
+        );
         // Phase 5 sub-views.
         _writeFileMkdir(
             args.workspaces_json,
@@ -1425,6 +1586,10 @@ export {
     _trust_report,
     _orphan_artefacts,
     _orphan_report,
+    _dormancy_probe,
+    _dormancy_unit,
+    _dormant_artefacts,
+    _dormancy_report,
     _workspaces_view,
     _packs_view,
     _summary,

--- a/src/scripts/discovery_graph.ts
+++ b/src/scripts/discovery_graph.ts
@@ -23,6 +23,18 @@
  *   build   [--manifest P] [--out P] [--force]     (re)build the graph cache
  *   affected <artefact> [--depth N] [--manifest P]  relation-filtered BFS
  *   explain  <concept>   [--budget N] [--manifest P] seed + 2-hop + budget-cut
+ *   orphans [--manifest P]                          zero-inbound artefact REPORT
+ *
+ * `orphans` is a **report, never a gate** (road-to-inbox-harvest-2026-08-b
+ * estate-lifecycle 3.2): the relation set above is five typed edges and sees a
+ * strictly narrower graph than `check_references.ts`, so a prose-only
+ * cross-reference produces no edge and a reachable artefact reads as
+ * zero-inbound. The false-positive class is provably non-empty, which is why
+ * the command exits 0 on hits and points at review rather than removal.
+ *
+ * Per-pass `stats` accompany the graph: each edge-extraction pass is wrapped in
+ * its own `try`, so one malformed field records `"error"` for that pass instead
+ * of failing the whole build silently or loudly.
  *
  * Exit codes: 0 ok, 1 not-found, 2 usage error, 3 internal error.
  */
@@ -33,13 +45,34 @@ import * as path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { reportScanned } from './_lib/scan_scope.js';
 import { scanCached } from './_lib/stat_index.js';
 
 const PROG = 'discovery_graph.ts';
 const _HERE = fileURLToPath(import.meta.url);
 export const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
 // discovery-graph-v<N>.json → version namespace in the path (versioned-cache B5b).
+// The FILE name stays v1 on purpose: `complexity_report.ts:234` reads this exact
+// path. `schema_version` inside the payload carries the shape version instead,
+// and `getGraph` forces a rebuild when a cached payload predates it.
 export const GRAPH_CACHE = path.join(REPO_ROOT, 'agents', 'runtime', 'state', 'discovery-graph-v1.json');
+
+/** Payload shape version. Bumped when `Graph` gains or changes a field. */
+export const GRAPH_SCHEMA_VERSION = 2;
+
+/**
+ * Prefixes that mark a node as SYNTHETIC — a pack or workspace container the
+ * graph invents, not an artefact on disk. Artefact ids are bare repo-relative
+ * paths (`idOf`), so the two live in one id space; anything reasoning over
+ * "artefacts" must exclude these explicitly rather than assume no path ever
+ * starts with `pack:`.
+ */
+export const SYNTHETIC_NODE_PREFIXES = ['pack:', 'workspace:'] as const;
+
+/** True when `id` names a pack/workspace container rather than an artefact. */
+export function isSyntheticNode(id: string): boolean {
+    return SYNTHETIC_NODE_PREFIXES.some((p) => id.startsWith(p));
+}
 
 export type EdgeConfidence = 'EXTRACTED' | 'INFERRED' | 'AMBIGUOUS';
 export interface Edge {
@@ -48,11 +81,14 @@ export interface Edge {
     rel: string;
     confidence: EdgeConfidence;
 }
+/** Per-pass edge counts; `"error"` marks a pass that threw and produced nothing. */
+export type GraphStats = Record<string, number | 'error'>;
 export interface Graph {
     schema_version: number;
     source_checksum: string;
     nodes: string[];
     edges: Edge[];
+    stats: GraphStats;
 }
 
 interface Artefact {
@@ -94,42 +130,91 @@ export function loadManifest(manifestPath: string | null): Manifest {
     return parsed;
 }
 
+/** The five independent edge-extraction passes, in stats-key order. */
+const _PASSES = ['supersedes', 'routes_to', 'references_adr', 'member_of_pack', 'member_of_workspace'] as const;
+type PassName = (typeof _PASSES)[number];
+
 /** Deterministic edge extraction from the manifest's structured fields. */
 export function buildGraph(manifest: Manifest): Graph {
     const nodeSet = new Set<string>();
     const edges: Edge[] = [];
     const idOf = (a: Artefact): string => a.path;
 
+    // Per-pass counters + error containment. One malformed field must not cost
+    // the other four passes: a pass that throws is recorded as `"error"` and
+    // contributes no edges, instead of aborting the build or — worse — being
+    // swallowed into a silently smaller graph nobody can distinguish from a
+    // correct one.
+    const counts = new Map<PassName, number>(_PASSES.map((p) => [p, 0]));
+    const failed = new Set<PassName>();
+    const run = (pass: PassName, fn: () => number): void => {
+        if (failed.has(pass)) return;
+        try {
+            counts.set(pass, (counts.get(pass) ?? 0) + fn());
+        } catch {
+            failed.add(pass);
+        }
+    };
+
     for (const a of manifest.artefacts) {
         const id = idOf(a);
         nodeSet.add(id);
-        for (const r of _asStrings(a.replaces)) {
-            edges.push({ from: id, to: r, rel: 'supersedes', confidence: 'EXTRACTED' });
-            edges.push({ from: r, to: id, rel: 'superseded_by', confidence: 'EXTRACTED' });
-            nodeSet.add(r);
-        }
-        for (const t of _asStrings(a.routes_to)) {
-            edges.push({ from: id, to: t, rel: 'routes_to', confidence: 'EXTRACTED' });
-            nodeSet.add(t);
-        }
-        // ADR references surfaced through any structured target field.
-        for (const t of [..._asStrings(a.replaces), ..._asStrings(a.routes_to)]) {
-            if (/(^|\/)docs\/(decisions|adr)\/ADR-/i.test(t) || /\bADR-\d+/.test(t)) {
-                edges.push({ from: id, to: t, rel: 'references_adr', confidence: 'EXTRACTED' });
-                nodeSet.add(t);
+        run('supersedes', () => {
+            let n = 0;
+            for (const r of _asStrings(a.replaces)) {
+                edges.push({ from: id, to: r, rel: 'supersedes', confidence: 'EXTRACTED' });
+                edges.push({ from: r, to: id, rel: 'superseded_by', confidence: 'EXTRACTED' });
+                nodeSet.add(r);
+                n += 2;
             }
-        }
-        for (const p of _asStrings(a.packs)) {
-            const node = `pack:${p}`;
-            edges.push({ from: id, to: node, rel: 'member_of', confidence: 'INFERRED' });
-            nodeSet.add(node);
-        }
-        for (const w of _asStrings(a.workspaces)) {
-            const node = `workspace:${w}`;
-            edges.push({ from: id, to: node, rel: 'member_of', confidence: 'INFERRED' });
-            nodeSet.add(node);
-        }
+            return n;
+        });
+        run('routes_to', () => {
+            let n = 0;
+            for (const t of _asStrings(a.routes_to)) {
+                edges.push({ from: id, to: t, rel: 'routes_to', confidence: 'EXTRACTED' });
+                nodeSet.add(t);
+                n += 1;
+            }
+            return n;
+        });
+        // ADR references surfaced through any structured target field.
+        run('references_adr', () => {
+            let n = 0;
+            for (const t of [..._asStrings(a.replaces), ..._asStrings(a.routes_to)]) {
+                if (/(^|\/)docs\/(decisions|adr)\/ADR-/i.test(t) || /\bADR-\d+/.test(t)) {
+                    edges.push({ from: id, to: t, rel: 'references_adr', confidence: 'EXTRACTED' });
+                    nodeSet.add(t);
+                    n += 1;
+                }
+            }
+            return n;
+        });
+        run('member_of_pack', () => {
+            let n = 0;
+            for (const p of _asStrings(a.packs)) {
+                const node = `pack:${p}`;
+                edges.push({ from: id, to: node, rel: 'member_of', confidence: 'INFERRED' });
+                nodeSet.add(node);
+                n += 1;
+            }
+            return n;
+        });
+        run('member_of_workspace', () => {
+            let n = 0;
+            for (const w of _asStrings(a.workspaces)) {
+                const node = `workspace:${w}`;
+                edges.push({ from: id, to: node, rel: 'member_of', confidence: 'INFERRED' });
+                nodeSet.add(node);
+                n += 1;
+            }
+            return n;
+        });
     }
+
+    const stats: GraphStats = {};
+    for (const p of _PASSES) stats[p] = failed.has(p) ? 'error' : (counts.get(p) ?? 0);
+    const artefactIds = new Set(manifest.artefacts.map(idOf));
 
     // Stable, de-duplicated ordering → byte-stable output.
     const seen = new Set<string>();
@@ -140,15 +225,28 @@ export function buildGraph(manifest: Manifest): Graph {
         return true;
     });
     uniq.sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to) || a.rel.localeCompare(b.rel));
+    // Distinct EXTRACTED targets that name no artefact in the manifest. The
+    // structured fields carry LOGICAL names (`commit:in-chunks`) while node ids
+    // are repo-relative paths, so a non-zero count here means inbound degree is
+    // systematically under-counted — the fact any inverse traversal has to know
+    // before it presents a list. Measured, not assumed: see
+    // `agents/evidence/analysis/discovery-graph-inbound-degree.md`.
+    const danglingTargets = new Set(
+        uniq.filter((e) => e.confidence === 'EXTRACTED' && !artefactIds.has(e.to)).map((e) => e.to),
+    );
+    stats['dangling_targets'] = danglingTargets.size;
     const checksum =
         typeof manifest.checksum === 'string' && manifest.checksum
             ? manifest.checksum
             : 'sha256:' + createHash('sha256').update(JSON.stringify(manifest.artefacts)).digest('hex');
     return {
-        schema_version: 1,
+        schema_version: GRAPH_SCHEMA_VERSION,
         source_checksum: checksum,
         nodes: [...nodeSet].sort(),
         edges: uniq,
+        // Counts are edges EXTRACTED per pass, before the de-duplication above —
+        // so they sum to ≥ `edges.length` and stay attributable to one pass.
+        stats,
     };
 }
 
@@ -188,7 +286,39 @@ export function getGraph(manifestPath: string | null, force: boolean): Graph {
     if (manifestPath !== null) {
         return buildGraph(loadManifest(manifestPath));
     }
-    return scanCached<Graph>(GRAPH_CACHE, _sourceFiles(), () => buildGraph(loadManifest(null)), force);
+    const files = _sourceFiles();
+    const graph = scanCached<Graph>(GRAPH_CACHE, files, () => buildGraph(loadManifest(null)), force);
+    // A cache written before the current payload shape is a stale shape, not a
+    // stale signature — `scanCached` compares signatures only, so the guard is
+    // here. One forced rebuild costs a manifest pass; serving a payload missing
+    // fields the caller's type promises costs a wrong answer.
+    if (graph.schema_version !== GRAPH_SCHEMA_VERSION) {
+        return scanCached<Graph>(GRAPH_CACHE, files, () => buildGraph(loadManifest(null)), true);
+    }
+    return graph;
+}
+
+/**
+ * Artefact nodes with zero inbound EXTRACTED edges — the estate's "nothing
+ * points at this" question, as an inverse traversal of the existing edge set.
+ *
+ * Two exclusions, both load-bearing:
+ *
+ * - `member_of` is INFERRED (`packs`/`workspaces`), and every packed artefact
+ *   has one. Counting it would make almost everything look reachable via its
+ *   own pack node and reduce the report to noise.
+ * - Synthetic pack/workspace nodes are not artefacts and are never the subject
+ *   of the question.
+ *
+ * The result is a REVIEW list, never a removal list — see the module header.
+ */
+export function inboundZero(graph: Graph): string[] {
+    const withInbound = new Set<string>();
+    for (const e of graph.edges) {
+        if (e.confidence !== 'EXTRACTED') continue;
+        withInbound.add(e.to);
+    }
+    return graph.nodes.filter((n) => !isSyntheticNode(n) && !withInbound.has(n)).sort();
 }
 
 /** Relation-filtered BFS from a start node. Returns reachable nodes + hop depth. */
@@ -247,6 +377,50 @@ export function main(argv: string[]): number {
         if (sub === 'build') {
             const graph = getGraph(manifestPath, rest.includes('--force'));
             process.stdout.write(`${PROG}: graph — ${graph.nodes.length} nodes, ${graph.edges.length} edges\n`);
+            for (const [pass, n] of Object.entries(graph.stats)) {
+                process.stdout.write(`  ${pass}: ${String(n)}\n`);
+            }
+            reportScanned({
+                gate: PROG,
+                scanned: graph.nodes.length,
+                units: 'node(s)',
+                roots: ['src', 'docs/decisions', 'docs/adr'],
+            });
+            return 0;
+        }
+        if (sub === 'orphans') {
+            const graph = getGraph(manifestPath, false);
+            const hits = inboundZero(graph);
+            const dangling = graph.stats['dangling_targets'];
+            // Degraded path, NAMED rather than papered over: while EXTRACTED
+            // targets do not resolve to artefact paths, inbound degree is
+            // under-counted for every artefact and the list below is the whole
+            // estate, not a finding. Printing it anyway would be a report that
+            // looks like evidence and is not.
+            if (typeof dangling === 'number' && dangling > 0) {
+                process.stdout.write(
+                    `${PROG}: inbound degree is DEGRADED — ${String(dangling)} EXTRACTED edge target(s)\n` +
+                        'name no artefact path in the manifest (the structured fields carry logical\n' +
+                        'names, node ids are repo-relative paths). Every artefact therefore reads as\n' +
+                        `zero-inbound (${String(hits.length)} of ${String(graph.nodes.length)} nodes), which is a\n` +
+                        'property of the edge set, not of the estate. No list is printed.\n' +
+                        'See `agents/evidence/analysis/discovery-graph-inbound-degree.md`.\n',
+                );
+                return 0;
+            }
+            process.stdout.write(`zero-inbound artefacts (${hits.length} of ${graph.nodes.length} nodes):\n`);
+            for (const h of hits) process.stdout.write(`  ${h}\n`);
+            // 3.3 — the disposition line travels WITH the list, so a reader who
+            // sees only the output still sees what it licenses.
+            process.stdout.write(
+                '\nThis is a review prompt, not a removal list. The graph sees five typed\n' +
+                    'edge kinds and no prose cross-references, so a referenced artefact can\n' +
+                    'appear here; `check_references.ts` is the cross-reference gate, not this.\n' +
+                    'Sunset stays explicit and recorded in the removing commit, with no\n' +
+                    'tombstone files (`docs/governance.md` § Skill lifecycle policy), and the\n' +
+                    'shipped precedent for stale artefacts is archive-not-delete\n' +
+                    '(`src/scripts/janitor.ts:10` — never auto-sweeps).\n',
+            );
             return 0;
         }
         if (sub === 'affected') {
@@ -279,7 +453,7 @@ export function main(argv: string[]): number {
             for (const n of nodes) process.stdout.write(`  [${n.depth}] ${n.node}  (via ${n.via})\n`);
             return 0;
         }
-        process.stderr.write(`usage: ${PROG} <build|affected|explain> [args]\n`);
+        process.stderr.write(`usage: ${PROG} <build|affected|explain|orphans> [args]\n`);
         return 2;
     } catch (exc) {
         process.stderr.write(`${PROG}: error: ${String(exc)}\n`);

--- a/tests/scripts/build_discovery_manifest.test.ts
+++ b/tests/scripts/build_discovery_manifest.test.ts
@@ -380,3 +380,79 @@ describe('build_discovery_manifest — builder contract (ported from pytest)', (
         expect(sortKeys(mod._packs_view(m1))).toBe(sortKeys(mod._packs_view(m2)));
     });
 });
+
+// --- Dormancy report (estate-lifecycle 2.1) --------------------------------
+
+describe('dormancy report', () => {
+    const manifest = {
+        generated_at: '2026-08-11T00:00:00Z',
+        artefacts: [
+            { path: 'src/skills/fresh/SKILL.md', category: 'skill' },
+            { path: 'src/skills/stale/SKILL.md', category: 'skill' },
+            { path: 'src/rules/fresh-rule.md', category: 'rule' },
+            { path: 'src/rules/stale-rule.md', category: 'rule' },
+        ],
+    };
+
+    it('measures a skill over its directory and every other artefact over its file', () => {
+        expect(mod._dormancy_unit('src/skills/foo/SKILL.md')).toBe(path.join('src', 'skills', 'foo'));
+        expect(mod._dormancy_unit('src/rules/bar.md')).toBe('src/rules/bar.md');
+    });
+
+    it('a commit on any file inside a skill keeps the whole skill alive', () => {
+        // Only a SIBLING of SKILL.md was touched — governance measures the
+        // directory, so the skill must not read as dormant.
+        const probe = { ok: true, touched: new Set(['src/skills/fresh/reference.md', 'src/rules/fresh-rule.md']) };
+        const dormant = mod._dormant_artefacts(manifest, probe).map((a) => a.path);
+        expect(dormant).not.toContain('src/skills/fresh/SKILL.md');
+        expect(dormant).not.toContain('src/rules/fresh-rule.md');
+        expect(dormant).toEqual(['src/rules/stale-rule.md', 'src/skills/stale/SKILL.md']);
+    });
+
+    it('publishes the list when the signal is available', () => {
+        const probe = { ok: true, touched: new Set(['src/skills/fresh/SKILL.md', 'src/rules/fresh-rule.md']) };
+        const report = mod._dormancy_report(manifest, probe);
+        expect(report).toContain('Dormant artefacts: **2**');
+        expect(report).toContain('`src/skills/stale/SKILL.md`');
+        expect(report).not.toContain('Signal unavailable');
+    });
+
+    it('says "none" rather than nothing when every artefact is fresh', () => {
+        const probe = { ok: true, touched: new Set(manifest.artefacts.map((a) => a.path)) };
+        const report = mod._dormancy_report(manifest, probe);
+        expect(report).toContain('Dormant artefacts: **0**');
+        expect(report).toContain('_None.');
+    });
+
+    it('NAMES an unavailable signal instead of emitting an empty list', () => {
+        const probe = { ok: false, reason: 'shallow clone — truncated history', touched: new Set<string>() };
+        const report = mod._dormancy_report(manifest, probe);
+        expect(report).toContain('Signal unavailable');
+        expect(report).toContain('shallow clone');
+        // The distinguishing property: an unavailable signal must NOT render as
+        // "0 dormant", which is the different — and false — claim.
+        expect(report).not.toContain('Dormant artefacts:');
+        expect(report).not.toContain('src/skills/stale/SKILL.md');
+    });
+
+    it('a dormant list is never produced from an unavailable probe', () => {
+        const probe = { ok: false, reason: 'not a git checkout', touched: new Set<string>() };
+        expect(mod._dormant_artefacts(manifest, probe)).toEqual([]);
+    });
+
+    it('probing a non-git directory reports unavailable, never "nothing dormant"', () => {
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dormancy-'));
+        try {
+            const probe = mod._dormancy_probe(tmp);
+            expect(probe.ok).toBe(false);
+            expect(String(probe.reason)).toMatch(/git/i);
+        } finally {
+            fs.rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    it('is deterministic across runs', () => {
+        const probe = { ok: true, touched: new Set(['src/rules/fresh-rule.md']) };
+        expect(mod._dormancy_report(manifest, probe)).toBe(mod._dormancy_report(manifest, probe));
+    });
+});

--- a/tests/scripts/build_discovery_manifest.test.ts
+++ b/tests/scripts/build_discovery_manifest.test.ts
@@ -2,12 +2,10 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import * as mod from '../../src/scripts/build_discovery_manifest.js';
 
-const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
 
 // --- Layer 1: ported builder contract (tmp-fixture) -------------------------
 
@@ -382,19 +380,3 @@ describe('build_discovery_manifest — builder contract (ported from pytest)', (
         expect(sortKeys(mod._packs_view(m1))).toBe(sortKeys(mod._packs_view(m2)));
     });
 });
-const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'build_discovery_manifest.ts');
-const VALIDATE_PY = path.join(REPO_ROOT, 'src', 'scripts', 'validate_discovery_manifest.py');
-const COMMITTED = path.join(REPO_ROOT, 'dist', 'discovery', 'discovery-manifest.json');
-const TSX_BIN = path.join(
-    REPO_ROOT,
-    'node_modules',
-    '.bin',
-    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
-);
-const big = { maxBuffer: 256 * 1024 * 1024, cwd: REPO_ROOT, encoding: 'utf8' as const };
-
-function normalizeGeneratedAt(jsonText: string): string {
-    const obj = JSON.parse(jsonText) as Record<string, unknown>;
-    obj.generated_at = '<normalised>';
-    return JSON.stringify(obj, Object.keys(obj).sort(), 2);
-}

--- a/tests/scripts/discovery_graph.test.ts
+++ b/tests/scripts/discovery_graph.test.ts
@@ -3,7 +3,14 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { affected, buildGraph, explain } from '../../src/scripts/discovery_graph.js';
+import {
+    GRAPH_SCHEMA_VERSION,
+    affected,
+    buildGraph,
+    explain,
+    inboundZero,
+    isSyntheticNode,
+} from '../../src/scripts/discovery_graph.js';
 
 const manifest = {
     checksum: 'sha256:test',
@@ -66,5 +73,111 @@ describe('explain — seed + 2-hop + budget-cut', () => {
     it('the budget hard-cuts the node set', () => {
         const { nodes } = explain(g, 'rule', 1);
         expect(nodes.length).toBe(1);
+    });
+});
+
+describe('stats — per-pass counts and error containment', () => {
+    it('carries a count for every extraction pass and stamps the payload version', () => {
+        const g = buildGraph(manifest);
+        expect(g.schema_version).toBe(GRAPH_SCHEMA_VERSION);
+        expect(Object.keys(g.stats).sort()).toEqual([
+            'dangling_targets',
+            'member_of_pack',
+            'member_of_workspace',
+            'references_adr',
+            'routes_to',
+            'supersedes',
+        ]);
+        // Derived from the fixture, not hardcoded to an observed run: every
+        // pass's count is the number of edges that pass is responsible for.
+        const perPass = (rel: string): number => manifest.artefacts.filter((a) => rel in a).length;
+        expect(g.stats['supersedes']).toBe(perPass('replaces') * 2);
+        expect(g.stats['routes_to']).toBe(perPass('routes_to'));
+        expect(g.stats['member_of_pack']).toBe(perPass('packs'));
+        expect(g.stats['member_of_workspace']).toBe(perPass('workspaces'));
+    });
+
+    it('a pass that throws is recorded as "error" and costs only itself', () => {
+        const hostile = {
+            checksum: 'sha256:hostile',
+            artefacts: [
+                {
+                    path: 'src/rules/hostile.md',
+                    get replaces(): string {
+                        throw new Error('malformed field');
+                    },
+                    routes_to: 'src/skills/foo/SKILL.md',
+                    packs: ['eng'],
+                },
+            ],
+        };
+        const g = buildGraph(hostile);
+        expect(g.stats['supersedes']).toBe('error');
+        // The other passes are unaffected — the whole point of the containment.
+        expect(g.stats['routes_to']).toBe(1);
+        expect(g.stats['member_of_pack']).toBe(1);
+        expect(g.edges.some((e) => e.rel === 'routes_to')).toBe(true);
+        expect(g.edges.some((e) => e.rel === 'supersedes')).toBe(false);
+    });
+
+    it('stays byte-stable with stats present', () => {
+        expect(JSON.stringify(buildGraph(manifest))).toBe(JSON.stringify(buildGraph(manifest)));
+    });
+
+    it('counts distinct EXTRACTED targets that name no artefact path', () => {
+        const g = buildGraph(manifest);
+        // Derived from the fixture: the ADR target is the only EXTRACTED target
+        // that is not itself an artefact entry.
+        const paths = new Set(manifest.artefacts.map((a) => a.path));
+        const expected = new Set(
+            g.edges.filter((e) => e.confidence === 'EXTRACTED' && !paths.has(e.to)).map((e) => e.to),
+        );
+        expect(g.stats['dangling_targets']).toBe(expected.size);
+        expect(expected).toContain('docs/decisions/ADR-042-thing.md');
+    });
+
+    it('reports zero dangling targets when every target resolves', () => {
+        const resolved = {
+            checksum: 'sha256:resolved',
+            artefacts: [
+                { path: 'a.md', routes_to: 'b.md' },
+                { path: 'b.md' },
+            ],
+        };
+        expect(buildGraph(resolved).stats['dangling_targets']).toBe(0);
+    });
+});
+
+describe('isSyntheticNode — the id-space discriminator', () => {
+    it('separates pack/workspace containers from artefact paths', () => {
+        expect(isSyntheticNode('pack:eng')).toBe(true);
+        expect(isSyntheticNode('workspace:design')).toBe(true);
+        expect(isSyntheticNode('src/rules/unrelated.md')).toBe(false);
+        expect(isSyntheticNode('docs/decisions/ADR-042-thing.md')).toBe(false);
+    });
+});
+
+describe('inboundZero — the zero-inbound review list', () => {
+    const g = buildGraph(manifest);
+    const hits = inboundZero(g);
+
+    it('lists exactly the artefacts no EXTRACTED edge points at', () => {
+        // Derived: an artefact is a hit iff it is the `to` of no EXTRACTED edge.
+        const pointedAt = new Set(g.edges.filter((e) => e.confidence === 'EXTRACTED').map((e) => e.to));
+        const expected = g.nodes.filter((n) => !isSyntheticNode(n) && !pointedAt.has(n));
+        expect(hits).toEqual(expected);
+        // And concretely, on this fixture, that is the one unreferenced rule.
+        expect(hits).toEqual(['src/rules/unrelated.md']);
+    });
+
+    it('never reports a pack or workspace container', () => {
+        expect(hits.some(isSyntheticNode)).toBe(false);
+    });
+
+    it('does not let INFERRED member_of edges mask an unreferenced artefact', () => {
+        // `src/rules/unrelated.md` HAS an outgoing member_of edge and is still a
+        // hit — counting INFERRED edges would empty the report of everything packed.
+        expect(g.edges.some((e) => e.from === 'src/rules/unrelated.md' && e.rel === 'member_of')).toBe(true);
+        expect(hits).toContain('src/rules/unrelated.md');
     });
 });


### PR DESCRIPTION
Closes 8 of 9 steps of `road-to-inbox-harvest-2026-08-b-estate-lifecycle` — Phases 2, 3 and 4 in full. Step 1.1 stays open on purpose: its answer is the maintainer's, and it is put to them in the step, dated, with both locks cited.

## What lands

| Step | Change |
|---|---|
| 2.1 | `dist/discovery/dormancy-report.md`, emitted beside the deprecation / trust / orphan reports, with a `--dormancy-report` flag |
| 2.2 / 2.3 | `docs/governance.md` — the two lifecycle vocabularies separated, coverage re-derived, and the deferred `last_reviewed:` field answered where the question is asked |
| 3.1 / 3.3 | `inboundZero()` + an `orphans` subcommand on `discovery_graph.ts`, with the review-not-removal disposition travelling inside the emitted output |
| 3.2 | The first run, classified — `agents/evidence/analysis/discovery-graph-inbound-degree.md` |
| 4.1 / 4.2 | Per-pass `stats`, per-pass `try` containment, `reportScanned` on the node count, and `SYNTHETIC_NODE_PREFIXES` as the id-space discriminator |

## The two findings that changed the shape

Both report steps built their instrument and then **declined to publish a list**, each because a measurement said the list would not mean what a reader would take it to mean. Neither refusal was planned.

**The zero-inbound traversal is correct and its edge set is not.** First run: 595 of 759 nodes — *every* skill (289/289) and *every* rule (116/116). Cause, measured: all 119 `routes_to` / `replaces` targets are logical names (`commit:in-chunks`) while node ids are repo-relative paths, so **0 of 119 resolve**, no artefact ever carries an inbound `EXTRACTED` edge, and the 595 is arithmetic. `references_adr: 0` is the same defect from the other side.

That also degrades two **already-shipped** commands: `affected` and `explain` under-report reachability for all 109 `routes_to` and 10 `replaces` relations, because each hop lands on a phantom node rather than on the target's own node. The fix has a home in the existing `resolve_logical` seam and is **deliberately not made here** — it is a behaviour change to shipped traversals and deserves its own diff and review.

**The dormancy window is longer than the available history.** This checkout is a shallow clone (`git rev-parse --is-shallow-repository` → `true`) whose oldest commit is 2026-05-18 — under three months against a six-month bar, and CI clones are shallow by default. A truncated history and a dormant artefact are indistinguishable, so the report names the missing signal and publishes no list. The populated path is unit-tested rather than left unexercised by the only environment that runs it.

The shared shape: an empty or maximal list is a **claim**. On a question that invites deletion, a wrong claim is expensive, so neither report is allowed to make one it cannot support. Both follow the labelled-degraded-path precedent the roadmap's own Context cites.

## Two things a reviewer should weigh

**A commit of unrelated cleanup, first in the series.** `chore(tests): drop the dead tail` removes six dead identifiers plus the two orphans they held alive. It is not this branch's work: `lint:ts` scopes to `src/**`, so findings under `tests/**` are CI-invisible, while the pre-push hook lints every *changed* `.ts` — so the debt detonates on whoever next edits the file, which is this branch. Scope is exactly the file the diff already touches. The same construct is live in **105 other test files (311 findings total)**, measured; that sweep needs its own change.

**No completion-review artifact.** The R2 gate is advisory and it is warning on this PR. The dispatcher assembled the package cleanly, but this session is configured not to spawn subagents, and committing an unfilled findings skeleton would be worse than none. To produce it:

```
npx tsx src/scripts/dispatch_r2_reviewer.ts --base origin/main \
  --roadmap agents/roadmaps/road-to-inbox-harvest-2026-08-b-estate-lifecycle.md \
  --slug estate-lifecycle
```
then dispatch a fresh subagent at the emitted input package.

## Verification

`task preflight` green (the R2 advisory above is the only warning). Typecheck clean on `tsconfig.scripts.json`; ESLint clean on all four changed `.ts` files. `discovery_graph` 18 tests, `build_discovery_manifest` 27 tests, both passing. `check_references`, `check_no_roadmap_refs`, `check_roadmap_trackable`, `check_md_language` and `roadmap:progress-check` all green.

Nothing here adds a frontmatter field, moves a cap, or gates anything — every new surface is report-only, which is why none of it depended on the open 1.1.
