### PR TITLE
docs(testing-anti-patterns): the negative test that passes for the wrong reason

### DIFF
--- a/agents/evidence/reviews/negative-test-antipattern.findings.md
+++ b/agents/evidence/reviews/negative-test-antipattern.findings.md
@@ -1,10 +1,10 @@
 # Findings: negative-test-antipattern
-<!-- completion-review: v1 | reviewed: 2026-08-12 | scope: 6548639dcf593f55b8b6e07c2294f857210dab4072f16d67a947115775645032 | diff: 8bef27e8adae4e742350970323232981d8b499d0 | reviewer: r2-fresh-subagent-negative-test-antipattern | prompt_hash: 9fc1c44a83ee15f7019d358e8ee629f5fe0227e7001e1894a53883a3ca34287b -->
+<!-- completion-review: v1 | reviewed: 2026-08-12 | scope: 0dc952ac3b087f691d281b612528b06dbf0f58cfd1077ca4b84771ae8fd14170 | diff: 8bef27e8adae4e742350970323232981d8b499d0 | reviewer: r2-fresh-subagent-negative-test-antipattern | prompt_hash: 9fc1c44a83ee15f7019d358e8ee629f5fe0227e7001e1894a53883a3ca34287b -->
 
 <!-- context-manifest: v1
 inputs:
   diff_sha: 8bef27e8adae4e742350970323232981d8b499d0
-  scope_hash: 6548639dcf593f55b8b6e07c2294f857210dab4072f16d67a947115775645032
+  scope_hash: 0dc952ac3b087f691d281b612528b06dbf0f58cfd1077ca4b84771ae8fd14170
   roadmap: none
   roadmap_hash: none
   ac_hash: none
@@ -15,6 +15,6 @@ dispatched: 2026-08-12T01:04:10Z
 
 | # | Severity | File:Line | Finding | Status | Reason/Ref |
 |---|----------|-----------|---------|--------|------------|
-| 1 | medium | src/skills/testing-anti-patterns/SKILL.md:174 | The new Gate block tells the agent to delete or invert the control it claims to pin but contains no restore step; the only put-it-back instruction lives outside the block, in the prose at :180. Every other gate in this skill is self-contained, and gate blocks are the fragment agents lift verbatim, so the mutation can be applied to a production security guard and left in place. | open | |
-| 2 | medium | src/skills/testing-anti-patterns/SKILL.md:221 | The diff introduces a distinct, nameable failure mode but wires none of the skill dispatch surfaces: no bullet in `## Do NOT` (where all seven existing anti-patterns each have one) and no entry in `## Auto-trigger keywords`. The pattern is unreachable by keyword and absent from the closing checklist a reviewer scans. | open | |
-| 3 | low | src/skills/testing-anti-patterns/SKILL.md:177 | The unqualified delete instruction for an assertion that cannot fail sits ~20 lines above Anti-Pattern 7, which forbids deleting an assertion to obtain green. The two are mechanically compatible (a vacuous assertion is already green) but nothing distinguishes them, and cannot-fail-for-any-implementation is exactly the judgement an agent makes about an assertion it cannot get to pass. | open | |
+| 1 | medium | src/skills/testing-anti-patterns/SKILL.md:174 | The new Gate block tells the agent to delete or invert the control it claims to pin but contains no restore step; the only put-it-back instruction lives outside the block, in the prose at :180. Every other gate in this skill is self-contained, and gate blocks are the fragment agents lift verbatim, so the mutation can be applied to a production security guard and left in place. | fixed | 67b747e95 — restore step moved inside the gate block |
+| 2 | medium | src/skills/testing-anti-patterns/SKILL.md:221 | The diff introduces a distinct, nameable failure mode but wires none of the skill dispatch surfaces: no bullet in `## Do NOT` (where all seven existing anti-patterns each have one) and no entry in `## Auto-trigger keywords`. The pattern is unreachable by keyword and absent from the closing checklist a reviewer scans. | fixed | 67b747e95 — Do NOT bullet + three keywords; description left alone on purpose |
+| 3 | low | src/skills/testing-anti-patterns/SKILL.md:177 | The unqualified delete instruction for an assertion that cannot fail sits ~20 lines above Anti-Pattern 7, which forbids deleting an assertion to obtain green. The two are mechanically compatible (a vacuous assertion is already green) but nothing distinguishes them, and cannot-fail-for-any-implementation is exactly the judgement an agent makes about an assertion it cannot get to pass. | fixed | 67b747e95 — qualified and cross-referenced to Anti-Pattern 7 |

--- a/agents/evidence/reviews/negative-test-antipattern.findings.md
+++ b/agents/evidence/reviews/negative-test-antipattern.findings.md
@@ -1,0 +1,20 @@
+# Findings: negative-test-antipattern
+<!-- completion-review: v1 | reviewed: 2026-08-12 | scope: 6548639dcf593f55b8b6e07c2294f857210dab4072f16d67a947115775645032 | diff: 8bef27e8adae4e742350970323232981d8b499d0 | reviewer: r2-fresh-subagent-negative-test-antipattern | prompt_hash: 9fc1c44a83ee15f7019d358e8ee629f5fe0227e7001e1894a53883a3ca34287b -->
+
+<!-- context-manifest: v1
+inputs:
+  diff_sha: 8bef27e8adae4e742350970323232981d8b499d0
+  scope_hash: 6548639dcf593f55b8b6e07c2294f857210dab4072f16d67a947115775645032
+  roadmap: none
+  roadmap_hash: none
+  ac_hash: none
+excluded: [session-history, agents/runtime, implementation-context]
+tools: [git-diff-branch-scoped, file-read-branch-paths]
+dispatched: 2026-08-12T01:04:10Z
+-->
+
+| # | Severity | File:Line | Finding | Status | Reason/Ref |
+|---|----------|-----------|---------|--------|------------|
+| 1 | medium | src/skills/testing-anti-patterns/SKILL.md:174 | The new Gate block tells the agent to delete or invert the control it claims to pin but contains no restore step; the only put-it-back instruction lives outside the block, in the prose at :180. Every other gate in this skill is self-contained, and gate blocks are the fragment agents lift verbatim, so the mutation can be applied to a production security guard and left in place. | open | |
+| 2 | medium | src/skills/testing-anti-patterns/SKILL.md:221 | The diff introduces a distinct, nameable failure mode but wires none of the skill dispatch surfaces: no bullet in `## Do NOT` (where all seven existing anti-patterns each have one) and no entry in `## Auto-trigger keywords`. The pattern is unreachable by keyword and absent from the closing checklist a reviewer scans. | open | |
+| 3 | low | src/skills/testing-anti-patterns/SKILL.md:177 | The unqualified delete instruction for an assertion that cannot fail sits ~20 lines above Anti-Pattern 7, which forbids deleting an assertion to obtain green. The two are mechanically compatible (a vacuous assertion is already green) but nothing distinguishes them, and cannot-fail-for-any-implementation is exactly the judgement an agent makes about an assertion it cannot get to pass. | open | |

--- a/dist/agent-src/skills/testing-anti-patterns/SKILL.md
+++ b/dist/agent-src/skills/testing-anti-patterns/SKILL.md
@@ -173,11 +173,16 @@ Gate:
 ```
 BEFORE trusting a negative test:
   Delete or invert the control it claims to pin. Does it FAIL?
+  RESTORE THE CONTROL IMMEDIATELY — before any other edit, before any commit.
+    The mutation is a probe, never a change. A deleted guard left deleted is
+    a shipped vulnerability produced by a test-quality check.
   IF it still passes: it is pinning something else. Name what, then fix the test.
-  IF an assertion cannot fail for ANY implementation: delete it — it is decoration.
+  IF an assertion cannot fail for ANY implementation: delete THE ASSERTION —
+    it is decoration. Only after proving vacuity, and never to turn a red test
+    green — that is Anti-Pattern 7 below.
 ```
 
-No mutation-testing rig required: comment the guard out, run that one spec, put it back. A negative test nobody has ever watched fail is a claim, not evidence.
+No mutation-testing rig required: comment the control out, run that one spec, put it back. A negative test nobody has ever watched fail is a claim, not evidence.
 
 ### Anti-Pattern 7 — Gaming the green (test-integrity)
 
@@ -227,6 +232,7 @@ This is the test-surface instance of the `autonomous-execution` N=3 / allowlist-
 - Do NOT mark a story complete until at least one test was watched failing first.
 - Do NOT hardcode an expected value the code will emit, or pin a regex to an incidental fixed date/id — derive from inputs and seeded data, and vary the input across cases.
 - Do NOT skip / `xfail` / delete a failing test, or rewrite its `expected` to the code's current output, to get a green run — fix the code, or state a real spec change in the diff.
+- Do NOT trust a negative test you have never watched fail — delete the control it pins, confirm the test goes red, restore the control immediately.
 
 ## Auto-trigger keywords
 
@@ -241,6 +247,9 @@ This is the test-surface instance of the `autonomous-execution` N=3 / allowlist-
 - gaming the green
 - skip failing test
 - test integrity
+- negative test
+- vacuous assertion
+- abuse-case test
 
 ## Provenance
 

--- a/dist/agent-src/skills/testing-anti-patterns/SKILL.md
+++ b/dist/agent-src/skills/testing-anti-patterns/SKILL.md
@@ -163,6 +163,22 @@ expect([403, 404]).toContain((await api.get(`/users/${otherTenantUser.id}`)).sta
 
 Deriving from seeded data is necessary but **not sufficient** — a test that only reads back the exact fields it seeded is still overfit (a mutation in the code survives it). A real test also exercises boundary (empty / null / max / Unicode), error (missing / invalid), and, on security-sensitive paths, an abuse case (IDOR, injection string, XSS payload). Coverage of *cases*, not just lines.
 
+**The adversarial variant, and it is the one that looks safest.** A *negative* test — the abuse case just named — fails the same way, but nothing about it reads as weak: it names an attack, it asserts a refusal, it goes green. It passes because **something other than the control under test** produced that refusal. Two shapes, both from one real review:
+
+- **The hostile value sits only in the argument.** A guard rejecting a path-traversing `token` was pinned by planting a fixture whose own `token` field held the *legitimate* value while `'../outside'` was passed as the argument. Downstream, an ordinary token comparison mismatched and returned exactly the expected refusal — delete the guard and the test still passes. The hostile value belongs in the **field under test**, not only in the call.
+- **The assertion cannot fail.** The same test asserted the planted file still existed after a rejected claim. The two directories were siblings, so both `../x.json` joins resolved to one path and the rename could never have moved it — a green no implementation could turn red.
+
+Gate:
+
+```
+BEFORE trusting a negative test:
+  Delete or invert the control it claims to pin. Does it FAIL?
+  IF it still passes: it is pinning something else. Name what, then fix the test.
+  IF an assertion cannot fail for ANY implementation: delete it — it is decoration.
+```
+
+No mutation-testing rig required: comment the guard out, run that one spec, put it back. A negative test nobody has ever watched fail is a claim, not evidence.
+
 ### Anti-Pattern 7 — Gaming the green (test-integrity)
 
 Symptom: a test fails, and the "fix" edits the *test* instead of the code — `.skip` / `it.skip` / `xfail` / `@Disabled` on the failing case, deleting the failing assertion, loosening `toBe(x)` to `toBeTruthy()`, or rewriting the `expected` value to whatever the (possibly buggy) code now emits. The suite goes green while the behavior stays broken — the worst outcome, because green now *hides* the bug. This is the automation-bias trap: under pressure to finish, the agent optimizes the signal (green) instead of the target (correct behavior).

--- a/src/scripts/lint_framework_leakage_allowlist.json
+++ b/src/scripts/lint_framework_leakage_allowlist.json
@@ -113,7 +113,7 @@
       "lines": [
         87,
         124,
-        201
+        206
       ],
       "reason": "Multi-ecosystem capture-tools line and skip-marker grep spanning pytest/PHPUnit/JS in one pattern — documentation across stacks."
     },

--- a/src/scripts/lint_framework_leakage_allowlist.json
+++ b/src/scripts/lint_framework_leakage_allowlist.json
@@ -113,7 +113,7 @@
       "lines": [
         87,
         124,
-        185
+        201
       ],
       "reason": "Multi-ecosystem capture-tools line and skip-marker grep spanning pytest/PHPUnit/JS in one pattern — documentation across stacks."
     },

--- a/src/skills/testing-anti-patterns/SKILL.md
+++ b/src/skills/testing-anti-patterns/SKILL.md
@@ -173,11 +173,16 @@ Gate:
 ```
 BEFORE trusting a negative test:
   Delete or invert the control it claims to pin. Does it FAIL?
+  RESTORE THE CONTROL IMMEDIATELY — before any other edit, before any commit.
+    The mutation is a probe, never a change. A deleted guard left deleted is
+    a shipped vulnerability produced by a test-quality check.
   IF it still passes: it is pinning something else. Name what, then fix the test.
-  IF an assertion cannot fail for ANY implementation: delete it — it is decoration.
+  IF an assertion cannot fail for ANY implementation: delete THE ASSERTION —
+    it is decoration. Only after proving vacuity, and never to turn a red test
+    green — that is Anti-Pattern 7 below.
 ```
 
-No mutation-testing rig required: comment the guard out, run that one spec, put it back. A negative test nobody has ever watched fail is a claim, not evidence.
+No mutation-testing rig required: comment the control out, run that one spec, put it back. A negative test nobody has ever watched fail is a claim, not evidence.
 
 ### Anti-Pattern 7 — Gaming the green (test-integrity)
 
@@ -227,6 +232,7 @@ This is the test-surface instance of the `autonomous-execution` N=3 / allowlist-
 - Do NOT mark a story complete until at least one test was watched failing first.
 - Do NOT hardcode an expected value the code will emit, or pin a regex to an incidental fixed date/id — derive from inputs and seeded data, and vary the input across cases.
 - Do NOT skip / `xfail` / delete a failing test, or rewrite its `expected` to the code's current output, to get a green run — fix the code, or state a real spec change in the diff.
+- Do NOT trust a negative test you have never watched fail — delete the control it pins, confirm the test goes red, restore the control immediately.
 
 ## Auto-trigger keywords
 
@@ -241,6 +247,9 @@ This is the test-surface instance of the `autonomous-execution` N=3 / allowlist-
 - gaming the green
 - skip failing test
 - test integrity
+- negative test
+- vacuous assertion
+- abuse-case test
 
 ## Provenance
 

--- a/src/skills/testing-anti-patterns/SKILL.md
+++ b/src/skills/testing-anti-patterns/SKILL.md
@@ -163,6 +163,22 @@ expect([403, 404]).toContain((await api.get(`/users/${otherTenantUser.id}`)).sta
 
 Deriving from seeded data is necessary but **not sufficient** — a test that only reads back the exact fields it seeded is still overfit (a mutation in the code survives it). A real test also exercises boundary (empty / null / max / Unicode), error (missing / invalid), and, on security-sensitive paths, an abuse case (IDOR, injection string, XSS payload). Coverage of *cases*, not just lines.
 
+**The adversarial variant, and it is the one that looks safest.** A *negative* test — the abuse case just named — fails the same way, but nothing about it reads as weak: it names an attack, it asserts a refusal, it goes green. It passes because **something other than the control under test** produced that refusal. Two shapes, both from one real review:
+
+- **The hostile value sits only in the argument.** A guard rejecting a path-traversing `token` was pinned by planting a fixture whose own `token` field held the *legitimate* value while `'../outside'` was passed as the argument. Downstream, an ordinary token comparison mismatched and returned exactly the expected refusal — delete the guard and the test still passes. The hostile value belongs in the **field under test**, not only in the call.
+- **The assertion cannot fail.** The same test asserted the planted file still existed after a rejected claim. The two directories were siblings, so both `../x.json` joins resolved to one path and the rename could never have moved it — a green no implementation could turn red.
+
+Gate:
+
+```
+BEFORE trusting a negative test:
+  Delete or invert the control it claims to pin. Does it FAIL?
+  IF it still passes: it is pinning something else. Name what, then fix the test.
+  IF an assertion cannot fail for ANY implementation: delete it — it is decoration.
+```
+
+No mutation-testing rig required: comment the guard out, run that one spec, put it back. A negative test nobody has ever watched fail is a claim, not evidence.
+
 ### Anti-Pattern 7 — Gaming the green (test-integrity)
 
 Symptom: a test fails, and the "fix" edits the *test* instead of the code — `.skip` / `it.skip` / `xfail` / `@Disabled` on the failing case, deleting the failing assertion, loosening `toBe(x)` to `toBeTruthy()`, or rewriting the `expected` value to whatever the (possibly buggy) code now emits. The suite goes green while the behavior stays broken — the worst outcome, because green now *hides* the bug. This is the automation-bias trap: under pressure to finish, the agent optimizes the signal (green) instead of the target (correct behavior).


### PR DESCRIPTION
One paragraph in `testing-anti-patterns`, from a failure this repo produced twice in one night.

## The pattern

Anti-Pattern 6 covers assertions too weak to catch a bug. It did not cover the adversarial variant, which is the one that **looks safest**: a *negative* test that names an attack, asserts a refusal, and goes green because **something other than the control under test** produced that refusal.

Both shapes are from a real review of PR #1280, not invented:

- **The hostile value sits only in the argument.** A guard rejecting a path-traversing `token` was pinned by a fixture whose own `token` field held the *legitimate* value while `'../outside'` was passed as the argument. Downstream, an ordinary token comparison mismatched and returned exactly the expected refusal — delete the guard and the test still passes.
- **The assertion cannot fail.** The same test asserted the planted file still existed after a rejected claim. The two directories were siblings, so both `../x.json` joins resolved to one path and the rename could never have moved it — a green no implementation could turn red.

The gate is a delete-the-control-and-rerun check, not a mutation-testing rig, because that is what a reviewer will actually do.

## What the review of this PR changed

A fresh reviewer returned three findings and the first one matters more than the paragraph:

- **The gate block carried the mutation step and not the restore step.** The put-it-back sentence sat in the surrounding prose, and gate blocks are the fragment agents lift verbatim — so a test-quality check could delete a production guard and leave it deleted. The restore is now inside the block, as the step that comes before any other edit.
- **The pattern wired none of the dispatch surfaces.** Each of the seven existing anti-patterns carries a `Do NOT` bullet and keywords; this one carried neither, so it was unreachable by keyword and absent from the closing checklist. Both added. The frontmatter description is deliberately left alone — 200-char cap, four regenerations, and the two surfaces above already deliver the reach.
- **`delete it` sat unqualified twenty lines above Anti-Pattern 7**, which forbids deleting an assertion to obtain green. Mechanically compatible, textually indistinguishable, and "cannot fail for any implementation" is exactly the judgement an agent makes about an assertion it cannot get to pass. Qualified and cross-referenced.

## An observation, not a fix

`lint_framework_leakage_allowlist.json` is keyed by **absolute line number**. Inserting a paragraph moved a pre-existing `pytest` mention out from under its own exemption and reddened the gate for a reason unrelated to the paragraph — **twice in this PR** (185 → 201 → 206), the second time caused by the review fixes themselves. Re-anchoring is a one-line edit each time; redesigning the keying is not this PR, and is recorded here rather than silently absorbed.

## Verification

`skill_linter` PASS on the changed skill · `lint_framework_leakage` 0 hits · `task preflight` green · `check_completion_review` clean, artefact committed before the fix pass and re-bound in place after.
