### PR TITLE
chore(mcp): drop the agent-memory declaration ADR-094 left behind

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,20 +25,29 @@ so we can align on direction before code is written.
 
 If you are unsure whether a change is in scope: open a discussion first.
 
-## Dependency direction — no circular deps with `agent-memory`
+## Dependency direction — memory is file-first, with no external backend
 
-`agent-config` is the upstream, standalone package. It must **never**
-hard-depend on `@event4u/agent-memory`. The optional companion package
-is declared in `suggest` (Composer) / `optionalDependencies` or
-documentation only (npm) — never as a runtime or dev dependency that
-`composer install` / `npm install` would pull automatically.
+`agent-config` is the upstream, standalone package. Its memory layer is
+file-first and self-contained: curated YAML under `agents/memory/<type>/`
+plus agent-written JSONL under `agents/memory/intake/`, read by `retrieve()`
+in `src/scripts/memory_lookup.ts`. There is no external memory backend.
 
-Reasoning: `agent-memory` depends on `agent-config` for its skills and
-governance. Reversing that would create a circular dependency and break
-installs in consumer projects that only want the rule/skill layer.
+[ADR-094](docs/decisions/ADR-094-agent-memory-layer-removal.md) removed the
+`@event4u/agent-memory` binding — the provider seam, the package detection,
+and the MCP routing that used it "when present" — and explicitly rejected
+leaving the integration surface inert: *"a dormant integration surface
+advertising a capability the suite no longer has is misleading residue."*
 
-See [`agents/roadmaps/road-to-memory-self-consumption.md`](agents/roadmaps/road-to-memory-self-consumption.md)
-for the full conflict-resolution contract between the two packages.
+Two rules survive that removal, and both are unconditional:
+
+- **Never hard-depend on a package that depends on `agent-config`.** That was
+  the case for `agent-memory`, so the dependency could only ever run one way;
+  reversing it would create a cycle and break installs in consumer projects
+  that want the rule/skill layer alone.
+- **Adding any external memory backend is a Class-B decision** under
+  [ADR-124](docs/decisions/ADR-124-embedded-engine-doctrine.md) § 5 — its own
+  ADR, a named consumer demand signal, and a measured Class-A failure — never
+  a dependency bump or a config entry.
 
 ## Quick start for contributors
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,8 +1,3 @@
 {
-  "servers": {
-    "agent-memory": {
-      "command": "memory",
-      "args": ["mcp"]
-    }
-  }
+  "servers": {}
 }


### PR DESCRIPTION
## What

`mcp.json` still declared the `agent-memory` MCP server:

```json
{ "servers": { "agent-memory": { "command": "memory", "args": ["mcp"] } } }
```

ADR-094 removed that package's binding on 2026-06-14 — the provider seam, the
package detection in `memory_status`, and the MCP routing that used it "when
present". The declaration survived the removal. Nothing reads it for memory:
`retrieve()` is file-first and `src/scripts/memory_lookup.ts` states so in its
own header. What it did do is feed `task mcp:render`, which writes a
Cursor/Windsurf config pointing at a server the suite no longer endorses.

ADR-094 named this exact shape in its rejected alternatives:

> **Freeze Layer 2 (leave inert).** Rejected — a dormant integration surface
> advertising a capability the suite no longer has is misleading residue.

So this finishes an accepted decision rather than making a new one, and carries
no ADR of its own.

`CONTRIBUTING.md` § "Dependency direction" was the second half of the same drift:
present-tense "the optional companion package", a `suggest` /
`optionalDependencies` binding that no longer exists, and a link to
`agents/roadmaps/road-to-memory-self-consumption.md` — which lives under
`archive/`, so the link was broken. Rewritten to state the file-first position,
cite ADR-094 and ADR-124 § 5, and keep both rules that survive the removal:

- never hard-depend on a package that depends on `agent-config`;
- any external memory backend is a Class-B decision under ADR-124 § 5 — its own
  ADR, a named demand signal, a measured Class-A failure — not a config entry.

`mcp.json` keeps its `servers` key with an empty object rather than being
deleted: `mcp_render` requires the top-level key, and an empty map is the honest
statement that this repo declares no MCP servers.

## Why now

The question that surfaced it was the opposite one — whether the suite should
*add* a pointer to an external memory MCP server (a sibling product exposing
`memory_propose` / `memory_lookup` over stdio). Two independent external
reviewers rejected that, and the decisive argument is worth recording here
because it constrains any future proposal:

**The quarantine semantics do not match.** `retrieve()` reads
`agents/memory/intake/*.jsonl` immediately — agent-written, no human gate,
source weight 0.9. A propose-then-lookup server design gates visibility behind a
human decision, so an agent that writes and immediately reads **does not find its
own entry**. That is not friction; it is a different meaning of "memory". The
integration point for such a tool, if one is ever wanted, is the file contract
(`agents/memory/<type>/*.yaml`), not an MCP call.

The ADR-124 § 2 "orchestrator first" clause does not license it either: its
precedent is a consumer-shipped **index file** (Class A). A resident server is
Class B, and § 5's gate — named demand signal, measured Class-A failure — is
unmet.

## Verification

| Gate | Result |
|---|---|
| `lint_mcp_config_security` | pass (1 pre-existing MED warning in `src/templates/claude_desktop_config.json.template`, untouched) |
| `check_references` | pass — 1153 scanned, no broken references |
| `mcp.json` parses | yes |
| `task preflight`, `task lint-mcp-inventory` | **red on unmodified `main` in a fresh clone too** — generator drift needing `task generate-tools` / `audit_mcp_tools --write`. Verified by stashing the diff and re-running; not attributable to this change |

The full `task ci` was not run locally; remote CI on this PR is the authoritative
gate.

## Related residue found, deliberately not fixed here

`src/scripts/memory_lookup.ts:533` still reads *"The `present` path returns a
real score from agent-memory"* — two lines above a block stating this scorer is
"the primary, always-available scorer" per ADR-129. Same defect class, but the
line is mirrored in `src/agent-src/templates/` and `dist/agent-src/templates/`,
so fixing it pulls in a `task sync` projection pass. Left for a separate change
to keep this diff reviewable.

Everything else matching `agent-memory` in the tree is history and stays:
ADRs, changelogs, `agents/memory/*.yml` records, archived roadmaps, and the
`.gitignore` entry for the `.agent-memory/` sidecar directory.
