### PR TITLE
chore(memory): drop three docblock claims about the removed agent-memory path

### DIFF
--- a/dist/agent-src/templates/scripts/memory_lookup.ts
+++ b/dist/agent-src/templates/scripts/memory_lookup.ts
@@ -388,8 +388,7 @@ function* _iter_knowledge_entries(): Generator<[string, Record<string, unknown>]
 /**
  * Naive relevance score: max over keys of (glob-match | substring).
  *
- * Good enough for the `absent` path where retrieval is best-effort.
- * The `present` path returns a real score from agent-memory.
+ * Retrieval is best-effort by design — this is the only scoring path.
  */
 export function _score(entry: Record<string, unknown>, keys: string[]): number {
     if (keys.length === 0) {

--- a/dist/agent-src/templates/scripts/memory_signal.ts
+++ b/dist/agent-src/templates/scripts/memory_signal.ts
@@ -214,10 +214,8 @@ export interface SignalRecord {
 /**
  * Append a signal entry. Returns the written record, or null when skipped.
  *
- * On `present` backend, routing to the package is a no-op here today —
- * the package adapter is wired in `road-to-agent-memory-integration.md`
- * Phase 3. For now, the file path is the single source of truth so
- * merge-safety is preserved in every mode.
+ * The file path is the single source of truth: there is no external backend
+ * to route to, so merge-safety holds in every mode.
  */
 export function emit(
     entry_type: string,

--- a/src/agent-src/templates/scripts/memory_lookup.ts
+++ b/src/agent-src/templates/scripts/memory_lookup.ts
@@ -388,8 +388,7 @@ function* _iter_knowledge_entries(): Generator<[string, Record<string, unknown>]
 /**
  * Naive relevance score: max over keys of (glob-match | substring).
  *
- * Good enough for the `absent` path where retrieval is best-effort.
- * The `present` path returns a real score from agent-memory.
+ * Retrieval is best-effort by design — this is the only scoring path.
  */
 export function _score(entry: Record<string, unknown>, keys: string[]): number {
     if (keys.length === 0) {

--- a/src/agent-src/templates/scripts/memory_signal.ts
+++ b/src/agent-src/templates/scripts/memory_signal.ts
@@ -214,10 +214,8 @@ export interface SignalRecord {
 /**
  * Append a signal entry. Returns the written record, or null when skipped.
  *
- * On `present` backend, routing to the package is a no-op here today —
- * the package adapter is wired in `road-to-agent-memory-integration.md`
- * Phase 3. For now, the file path is the single source of truth so
- * merge-safety is preserved in every mode.
+ * The file path is the single source of truth: there is no external backend
+ * to route to, so merge-safety holds in every mode.
  */
 export function emit(
     entry_type: string,

--- a/src/scripts/memory_lookup.ts
+++ b/src/scripts/memory_lookup.ts
@@ -529,8 +529,7 @@ function* _iter_knowledge_entries(): Generator<[string, Record<string, unknown>]
 /**
  * Naive relevance score: max over keys of (glob-match | substring).
  *
- * Good enough for the `absent` path where retrieval is best-effort.
- * The `present` path returns a real score from agent-memory.
+ * Retrieval is best-effort by design — this is the only scoring path.
  *
  * DOCUMENTED FALLBACK (road-to-reachable-code-memory Phase 6 / ADR-129):
  * this is the primary, always-available scorer. It has a known correctness


### PR DESCRIPTION
Follow-up to #1286, which named this residue and deliberately left it out to keep
that diff reviewable. The projection pass turned out to be two mirrored files, so
the whole thing is 5 files and 7+/14−.

## What

Three docblocks still described the routing ADR-094 removed.

**`_score` in `memory_lookup.ts`** (both the live script and the consumer template):

> Good enough for the `absent` path where retrieval is best-effort.
> The `present` path returns a real score from agent-memory.

Two lines below that, the same docblock states this scorer is *"the primary,
always-available scorer"* per ADR-129. The `present`/`absent` split was the
Layer-2 package routing; `agent-config` has one scoring path now. The vocabulary
appears nowhere else in the tree, so a reader chasing the `present` path finds
nothing at all — the comment sends them looking for code that does not exist.

**`memory_signal.ts`** (consumer template only — the live script is already
correct):

> On `present` backend, routing to the package is a no-op here today —
> the package adapter is wired in `road-to-agent-memory-integration.md`
> Phase 3.

That roadmap lives under `agents/roadmaps/archive/` and the adapter is not
coming. The live `src/scripts/memory_signal.ts` already says "file-backed (no
external backend)"; only the template lagged.

## Sibling search

The construct searched for was "a docblock asserting an agent-memory code path".
**Three sites, all in this diff.** Everything else matching `agent-memory` is
history that stays correct and is untouched: ADRs, changelogs,
`agents/memory/*.yml` records, archived roadmaps, `docs/adrs/memory/` (already
marked retired), and the `.gitignore` entry for the `.agent-memory/` sidecar
directory.

## Verification

| Gate | Result |
|---|---|
| `vitest tests/scripts/memory_lookup.test.ts tests/scripts/memory_signal.test.ts` | 25 passed |
| `check_condensation` | pass — 443 scanned, `dist/` byte-identical to the rewritten source |
| `check_references` | pass — 1153 scanned, no broken references |
| pre-push preflight (sync + consistency + generate-tools) | pass |

Comment-only; no behaviour change. `dist/` mirrors regenerated with `task sync`,
not hand-edited.
