### PR TITLE
feat(council)!: transport is resolved per machine, and the macOS Claude subscription is finally visible

### DIFF
--- a/agents/templates/.ai-council.yml.example
+++ b/agents/templates/.ai-council.yml.example
@@ -25,9 +25,13 @@
 # never at the raw secret. See docs/contracts/ai-council-config.md for
 # the full schema.
 #
-# Cost note: every consultation makes real, paid API calls. The
-# autonomy directive does NOT silently spend tokens — the /council
-# command always asks before invoking, even under autonomy: on.
+# Cost note: a consultation is billed only when it resolves to the metered
+# `api` rung. A vendor CLI under your subscription is preferred whenever one
+# resolves, so the common case costs nothing per token — run
+# `agent-config council status` to see the resolved transport and billing class
+# per member before invoking. The autonomy directive does NOT silently spend
+# tokens — the /council command always asks before invoking, even under
+# autonomy: on.
 
 # Master switch (true, false). REQUIRED — the loader has no default for it,
 # so this file's value is the only value.
@@ -44,51 +48,30 @@
 # "could work" and "may spend" is visible rather than mysterious.
 enabled: true
 
-# Per-invocation defaults. Each member may override `mode:` below.
+# Per-invocation defaults.
 defaults:
-  # Default transport mode for every member (overridable per-member
-  # below, and per-invocation via `/council mode:<x>`).
+  # There is NO transport-mode setting, deliberately.
   #
-  #   manual = copy & paste — the human transports prompt + reply
-  #            between the agent and an external chat surface. Free,
-  #            no key.
-  #   api    = SDK call against a stored key, per-token billing.
-  #   cli    = shell out to a locally-installed provider CLI under the
-  #            user's subscription auth (Claude Pro/Max, ChatGPT
-  #            Plus/Pro, Google Gemini, etc.). Spend is covered by the
-  #            flat-rate subscription, not per-token. `cost_budget.
-  #            max_total_usd` does NOT apply; use `cli_call_budget`
-  #            below to guard subscription quotas.
-  #   auto   = resolve per provider per invocation: the provider's CLI
-  #            binary resolves AND a credential is present -> cli; else a
-  #            key resolves -> api; else unavailable with a one-line
-  #            reason. `manual` is NEVER part of the auto chain (it would
-  #            always "succeed" and silently turn every call into a
-  #            copy-paste request) — it stays an explicit opt-in.
-  #            THE SHIPPED DEFAULT (road-to-always-on-orchestration
-  #            Phase 3.1 — CLI-first is the owner-set transport doctrine):
-  #            ride the vendor CLI under your subscription first, fall to
-  #            the metered API only where no CLI resolves. Pin `manual` /
-  #            `api` / `cli` here (or per-member below) to override it.
-  #            `cli_call_budget` below ships populated with a generous
-  #            per-provider guard so this default never runs your
-  #            subscription quota uncapped.
+  # Transport is resolved per machine per invocation — `cli → api →
+  # unavailable`, and an airgapped host forces the `api` rung. A vendor CLI
+  # under your subscription is preferred whenever one resolves with a
+  # credential, so the free transport wins without anybody configuring it.
   #
-  # Precedence: invocation flag > per-member mode > defaults.mode >
-  # built-in. Two DIFFERENT defaults sit at the bottom, and they are not
-  # the same thing:
-  #   · omit `defaults.mode` entirely and the loader fills "auto" (was
-  #     "api" before the Phase 3.1 flip) — that is what every real config
-  #     file observes.
-  #   · the resolver's built-in fallback, reached only when no layer at all
-  #     supplies a mode (a settings dict handed straight to the resolver,
-  #     no config file involved), is "manual" — free, no key. A caller who
-  #     named no transport has not asked to spend money. This did NOT flip
-  #     alongside the loader default: `auto` still resolves to a paying
-  #     rung when no CLI is usable, so flipping this too would let a
-  #     caller that bypassed the config file spend money on a preference
-  #     it never stated.
-  mode: auto
+  # It used to be `defaults.mode`, with a per-member override. The default was
+  # flipped to CLI-first, but a default only fires on an ABSENT key: every
+  # config that had spelled the key out — which this template did, and which
+  # the setup wizard wrote — kept its old `api` value and went on paying per
+  # token while a paid-for subscription CLI sat unused on the same machine.
+  # A knob whose stale value silently costs money is worse than no knob.
+  #
+  # A file that still carries `mode:` (here or under a member) loads fine; the
+  # key is ignored and `agent-config council status` lists it as ignored so you
+  # can delete it. To pin one transport for ONE run — including the free,
+  # key-free `manual` copy-paste loop — pass `--mode-override` on the
+  # invocation. That is a flag, not a setting: it cannot go stale.
+  #
+  # `agent-config council status` prints the resolved transport and the billing
+  # class per member, which is the only honest answer to "will this cost money".
 
   # Default number of debate rounds per /council invocation.
   #
@@ -264,7 +247,9 @@ quorum: majority
 #                 under ~/.event4u/agent-config/, legacy
 #                 ~/.config/agent-config/ read as a fallback) or an env
 #                 var (`env:<VAR>`). Raw keys here are a hard validation
-#                 error. Required for mode: api; optional for cli /
+#                 error. Optional: it is the credential for the metered `api`
+#                 fallback rung. Absent, that rung is simply unavailable and
+#                 the member needs a working CLI. Not needed for cli /
 #                 manual / auto (those may authenticate via the CLI).
 #   mode:         overrides defaults.mode for this member only.
 #   binary:       absolute path to the provider's CLI — only valid when
@@ -290,7 +275,6 @@ members:
     enabled: true
     model: claude-sonnet-4-5
     api_key_ref: file:anthropic.key
-    # mode: cli                          # use subscription auth (Claude Pro/Max) — free, see cli_call_budget above
     # binary: /usr/local/bin/claude      # only valid when mode == cli
     # Phase 7 — size-fit downgrade ladder (smallest → largest). The
     # active `model:` above must appear on this list. When the size
@@ -325,7 +309,6 @@ members:
     enabled: true
     model: gpt-4o
     api_key_ref: file:openai.key
-    # mode: cli                          # use subscription auth (ChatGPT Plus/Pro via Codex CLI) — free
     # binary: /usr/local/bin/codex       # only valid when mode == cli
     # Phase 7 — size-fit downgrade ladder (smallest → largest). The
     # active `model:` above must appear on this list.
@@ -340,14 +323,12 @@ members:
     enabled: false
     model: gemini-2.5-pro
     api_key_ref: env:GEMINI_API_KEY
-    # mode: cli                          # use Google account (free-tier limits apply) — free
     # binary: /usr/local/bin/gemini      # only valid when mode == cli
 
   xai:
     enabled: false
     model: grok-4
     api_key_ref: env:XAI_API_KEY
-    # mode: cli                          # community `grok` CLI (Superagent) — ergonomic shortcut, NOT a billing change.
     # binary: /usr/local/bin/grok        # The CLI consumes XAI_API_KEY and remains billable=True;
     #                                    # cost_budget.max_total_usd STILL applies. Opt-in only.
 
@@ -355,7 +336,6 @@ members:
     enabled: false
     model: sonar-pro
     api_key_ref: env:PERPLEXITY_API_KEY
-    # mode: cli                          # community `perplexity` CLI — ergonomic shortcut, NOT a billing change.
     # binary: /usr/local/bin/perplexity  # The CLI consumes PERPLEXITY_API_KEY and remains billable=True;
     #                                    # cost_budget.max_total_usd STILL applies. Opt-in only.
 

--- a/docs/contracts/ai-council-config.md
+++ b/docs/contracts/ai-council-config.md
@@ -73,7 +73,8 @@ breadcrumb there points at this contract.
 ```yaml
 enabled: <bool>                 # master switch, required
 defaults:                       # per-invocation defaults, required
-  mode: <"api" | "manual" | "cli" | "auto">   # "auto" is the SHIPPED default; see Transport modes
+  # NO transport-mode key — transport is resolved, not configured. A file that
+  # still carries one loads fine and reports it ignored. See Transport modes.
   min_rounds: <int >= 1>
   deep_min_rounds: <int >= min_rounds>
   max_output_tokens: <int >= 0>           # 0 widens to provider ceiling
@@ -94,8 +95,8 @@ members:                        # per-provider blocks, at least one enabled
   <provider>:
     enabled: <bool>
     model: <string>
-    api_key_ref: <string>                 # required for mode: api; optional for cli/manual
-    mode: <"api" | "manual" | "cli" | "auto">  # optional override of defaults.mode
+    api_key_ref: <string>                 # optional — the credential for the metered `api` fallback rung
+    # no per-member `mode:` either — same reason as `defaults`
     binary: <string>                      # optional; only valid when effective mode == "cli" or "auto"
 advisors:                       # Thinking-style replace-mode advisors
   <advisor-key>:
@@ -126,17 +127,33 @@ Supported `<provider>` keys: `anthropic`, `openai`, `gemini`, `xai`,
 
 ### Transport modes
 
-Three first-class transports on the `mode:` axis, plus `auto`, which selects
-one of them per provider per invocation. Resolution per member:
-`invocation flag > per-member mode > defaults.mode > built-in fallback` — and
-see [Two defaults, not one](#two-defaults-not-one) for what sits at the bottom.
+**There is no transport-mode setting.** Transport is resolved per member per
+machine per invocation, and the only layer above the resolver is a
+per-invocation `--mode-override` flag.
+
+It used to be configurable at two layers, `defaults.mode` and a per-member
+`mode:`. The default was flipped to CLI-first — but a default only fires on an
+ABSENT key, so every config that spelled the key out (the shipped template did,
+and the setup wizard wrote it on every run) kept its old `api` value and went on
+paying per token while a subscription CLI sat unused on the same machine. A knob
+whose stale value silently costs money is worse than no knob, so both layers were
+removed rather than re-defaulted a second time.
+
+A config still carrying either key **loads** — the key is ignored and listed in
+`CouncilConfig.ignored_transport_keys`, which `agent-config council status`
+prints so it can be deleted. Validating a key nobody reads would have turned
+every stale installation into a hard load failure, which is the breaking change
+the ignore-list exists to avoid.
+
+The three transports below are still the vocabulary of the resolver's output and
+of `--mode-override`; they are simply no longer things a file can pin.
 
 | Mode | Semantics | Billable | Auth | Cost gate |
 |---|---|---|---|---|
 | `manual` | Copy & paste — the human transports prompt + reply between the agent and an external chat surface. | No | None — human-in-the-loop | n/a |
 | `api` | SDK call against a stored key, per-token billing on the provider's API. | Yes | `api_key_ref` (env or 0600 file) | `cost_budget` (full) |
 | `cli` | Shell out to a locally-installed provider CLI. For `anthropic` / `openai` / `gemini` this runs under the user's subscription auth and is `billable=False`. For `xai` / `perplexity` (community wrappers) the CLI consumes the same API key as `mode: api` and remains `billable=True`. | Mixed — see below | CLI-managed OAuth (vendor) or API key in CLI env (community) | Vendor: `cli_call_budget.max_calls_per_day` only · Community: full `cost_budget` |
-| `auto` | Not a transport — a selection rule. Per provider per invocation: the CLI binary resolves AND a credential is present → `cli`; else a key resolves → `api`; else the member is unavailable with a one-line reason. `manual` is never in the chain. **The SHIPPED default** (road-to-always-on-orchestration Phase 3.1 — CLI-first is the owner-set transport doctrine). A pinned `manual` / `api` / `cli` on `defaults.mode` or a per-member `mode:` still overrides it. | Inherited from the selected rung's provider + credential — never from the fact that `auto` chose it | Whatever the selected rung needs | The selected rung's gate |
+| `auto` | Not a transport — a selection rule. Per provider per invocation: the CLI binary resolves AND a credential is present → `cli`; else a key resolves → `api`; else the member is unavailable with a one-line reason. `manual` is never in the chain. **The only mode the loader emits**, and therefore what every member resolves through unless a `--mode-override` flag names one transport for one run. | Inherited from the selected rung's provider + credential — never from the fact that `auto` chose it | Whatever the selected rung needs | The selected rung's gate |
 
 #### `auto` — the selection rule
 
@@ -174,7 +191,7 @@ different layers. They are now named separately:
 
 | Layer | When it applies | Value |
 |---|---|---|
-| **Loader default** for `defaults.mode` | The config file omits the key. `config.ts::_build_defaults` fills it, so every real config observes this. | `auto` (was `api` before road-to-always-on-orchestration Phase 3.1) |
+| **Loader value** | Unconditional — `config.ts::_build_defaults` no longer reads the file's `mode` at all, so this is what every config observes whether or not it carries the key. | `auto` |
 | **Built-in fallback** in the resolver | No layer supplies a mode at all — a settings dict handed straight to `resolve_mode`, no config file involved. | `manual` |
 
 The built-in fallback is the free transport by design: a caller who named no
@@ -183,9 +200,8 @@ transport has not asked to spend money (`modes.ts::DEFAULT_MODE`, pinned in
 loader default: `auto` still resolves to a paying rung (`api`) when no CLI is
 usable, so flipping the built-in fallback too would let a caller that bypassed
 the config loader entirely spend money on a preference it never stated — the
-exact violation the fallback exists to prevent. Every real, file-backed
-config always has `defaults.mode` populated (now `auto`), so this fallback is
-never reached on that path.
+exact violation the fallback exists to prevent. Every file-backed config now
+resolves `auto` unconditionally, so this fallback is never reached on that path.
 
 Both shapes of the global key resolve. `council_cli.ts` synthesizes the loaded
 config into a block whose global mode sits at the top level (`mode`), while a

--- a/src/scripts/_lib/environment_detector.ts
+++ b/src/scripts/_lib/environment_detector.ts
@@ -220,6 +220,50 @@ export interface DetectEnvironmentOptions {
      * hardened env and a 2s timeout; pass `() => null` to skip probing.
      */
     readonly probeVersion?: VersionProbe;
+    /**
+     * macOS Keychain presence probe for the Claude Code subscription
+     * credential. Omit to shell out to `security find-generic-password`;
+     * pass `() => false` to skip it entirely — every test that is not
+     * specifically about this probe should, so a developer machine's real
+     * Keychain never decides a test outcome.
+     */
+    readonly probeKeychain?: KeychainProbe;
+}
+
+/** `(service) => present?` — never returns the secret, only whether it exists. */
+export type KeychainProbe = (service: string) => boolean;
+
+/** Keychain service name Claude Code writes its subscription credential under. */
+export const CLAUDE_KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+/**
+ * Is the Claude Code subscription credential in the macOS login Keychain?
+ *
+ * Claude Code stores its OAuth credential in the Keychain on macOS and only
+ * falls back to `~/.claude/.credentials.json` elsewhere. Looking for the file
+ * alone therefore reports "no subscription" on the platform where the
+ * subscription is most likely to exist — which sent every macOS anthropic
+ * member down the metered `api` rung while a paid Claude subscription sat
+ * unused on the same machine. That is the defect this probe closes.
+ *
+ * `-w` is deliberately NOT passed: without it `security` prints attributes and
+ * never the password, so the secret cannot reach a log, a report, or a crash
+ * dump. Presence is read from the exit code alone.
+ */
+function defaultProbeKeychain(service: string): boolean {
+    if (process.platform !== 'darwin') return false;
+    try {
+        const res = spawnSync('security', ['find-generic-password', '-s', service], {
+            timeout: VERSION_PROBE_TIMEOUT_MS,
+            encoding: 'utf-8',
+            windowsHide: true,
+            env: hardenedSpawnEnv(),
+        });
+        if (res.error !== undefined || res.signal !== null) return false;
+        return res.status === 0;
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -298,12 +342,18 @@ function cliSubscriptionEvidence(
     home: string,
     env: EnvMap,
     claudeConfigDir: string,
+    probeKeychain: KeychainProbe,
 ): { source: AuthSource; evidence: string } | null {
     if (provider === 'anthropic') {
         const configDir = claudeConfigDir;
         for (const rel of ['.credentials.json', 'credentials.json']) {
             const p = path.join(configDir, rel);
             if (isFile(p)) return { source: 'cli-subscription', evidence: p };
+        }
+        // macOS keeps the credential in the Keychain instead of the file above.
+        // The evidence string is a locator, never the secret.
+        if (probeKeychain(CLAUDE_KEYCHAIN_SERVICE)) {
+            return { source: 'cli-subscription', evidence: `keychain:${CLAUDE_KEYCHAIN_SERVICE}` };
         }
         return null;
     }
@@ -359,11 +409,12 @@ function detectAuth(opts: DetectEnvironmentOptions): {
         opts.home === undefined && opts.env === undefined
             ? claude_config_dir()
             : ((env['CLAUDE_CONFIG_DIR'] ?? '').trim() || path.join(home, '.claude'));
+    const probeKeychain = opts.probeKeychain ?? defaultProbeKeychain;
     const auth: DetectedAuth[] = [];
     const keys: DetectedKey[] = [];
 
     for (const provider of knownProviders()) {
-        const cli = cliSubscriptionEvidence(provider, home, env, claudeConfigDir);
+        const cli = cliSubscriptionEvidence(provider, home, env, claudeConfigDir, probeKeychain);
         if (cli !== null) {
             auth.push({ provider, source: cli.source, evidence: cli.evidence });
         }

--- a/src/scripts/ai_council/config.ts
+++ b/src/scripts/ai_council/config.ts
@@ -639,6 +639,20 @@ export interface CouncilConfig {
     readonly low_impact: LowImpactConfig;
     readonly lens_overrides: LensOverridesConfig;
     readonly source_path: PathLike | null;
+    /**
+     * Transport keys the config file still carries and the loader deliberately
+     * IGNORED — dotted paths, e.g. `defaults.mode`, `members.anthropic.mode`.
+     *
+     * Transport is resolved per machine per invocation, never configured: the
+     * chain is `cli → api → unavailable`, and an airgapped host forces the
+     * `api` rung. Deleting the keys from the schema outright would have made
+     * every pre-existing installation fail to load, so a stale key is
+     * accepted, ignored, and reported once — the migration IS the ignore.
+     *
+     * Empty on a config that never carried one, which is the shape the current
+     * template ships.
+     */
+    readonly ignored_transport_keys: readonly string[];
 }
 
 // ── default factories (dataclass defaults) ─────────────────────────
@@ -796,7 +810,11 @@ export function _build_config(raw: Dict, source_path: PathLike): CouncilConfig {
         throw new CouncilConfigError('`enabled` must be a bool.');
     }
 
-    const defaults = _build_defaults(_asDict(_getOr(raw, 'defaults', {})));
+    const ignored_transport_keys: string[] = [];
+    const defaults = _build_defaults(
+        _asDict(_getOr(raw, 'defaults', {})),
+        ignored_transport_keys,
+    );
     const cost_budget = _build_cost_budget(
         _asDict(_getOr(raw, 'cost_budget', {})),
     );
@@ -809,7 +827,12 @@ export function _build_config(raw: Dict, source_path: PathLike): CouncilConfig {
     for (const [name, cfg] of Object.entries(members_raw)) {
         members.set(
             name,
-            _build_member(name, _asDict(_orEmpty(cfg)), defaults.mode),
+            _build_member(
+                name,
+                _asDict(_orEmpty(cfg)),
+                defaults.mode,
+                ignored_transport_keys,
+            ),
         );
     }
 
@@ -920,6 +943,7 @@ export function _build_config(raw: Dict, source_path: PathLike): CouncilConfig {
         low_impact,
         lens_overrides,
         source_path,
+        ignored_transport_keys,
     };
 }
 
@@ -1508,23 +1532,32 @@ function _build_consensus_scoring(d: Dict): ConsensusScoringConfig {
 
 const _VALID_MEMBER_MODES: ReadonlySet<string> = new Set(['cli', 'api']);
 
-function _build_defaults(d: Dict): DefaultsConfig {
+function _build_defaults(d: Dict, ignored: string[] = []): DefaultsConfig {
     if (!_isDict(d)) {
         throw new CouncilConfigError('`defaults` must be a mapping.');
     }
-    // road-to-always-on-orchestration Phase 3.1: CLI-first is the shipped
-    // default (was `api`) — see the module docstring rule 2. `manual` and a
-    // pinned `api`/`cli` remain valid overrides at every layer resolve_mode
-    // checks; this only changes what a config that never sets `mode` gets.
-    const mode = _get(d, 'mode', 'auto');
-    if (!(_isStr(mode) && _VALID_MODES.has(mode))) {
-        throw new CouncilConfigError(
-            `defaults.mode=${_pyRepr(mode)} not in ${_sortedListRepr(_VALID_MODES)}.`,
-        );
+    // Transport is RESOLVED, never configured.
+    //
+    // The CLI-first flip (road-to-always-on-orchestration Phase 3.1) changed
+    // only what a config that OMITS `mode` receives. Every installation that
+    // spelled the key out — which the wizard did, and which every pre-flip
+    // template shipped — kept its old `api` value forever, silently, and went
+    // on paying per token while a subscription CLI sat unused on the same
+    // machine. A default that only fires on an absent key does not migrate
+    // anybody; it just makes the docs read better than the behaviour.
+    //
+    // So the key is no longer read. `auto` is the only value this loader
+    // produces, and `transport_resolver` picks the concrete rung per machine
+    // per invocation (`cli → api → unavailable`, airgap forcing `api`). A file
+    // still carrying `mode:` loads fine and is reported via
+    // `ignored_transport_keys` — see `CouncilConfig`.
+    if (_get(d, 'mode', undefined) !== undefined) {
+        ignored.push('defaults.mode');
     }
+    const mode = 'auto';
     // `member_mode` (step-9 P8 · U1) — global preference for solo /
-    // CLI-mode invocations. Narrower set than `defaults.mode` because
-    // `manual` makes no sense as a per-member dispatch default.
+    // CLI-mode invocations. Narrower set than the retired `defaults.mode`
+    // because `manual` makes no sense as a per-member dispatch default.
     const member_mode = _get(d, 'member_mode', 'cli');
     if (!(_isStr(member_mode) && _VALID_MEMBER_MODES.has(member_mode))) {
         throw new CouncilConfigError(
@@ -1726,6 +1759,7 @@ function _build_member(
     // a future caller that omits the third argument observes the same
     // doctrine rather than silently reverting to the retired `api` default.
     default_mode = 'auto',
+    ignored: string[] = [],
 ): MemberConfig {
     if (!_VALID_PROVIDERS.has(name)) {
         throw new CouncilConfigError(
@@ -1738,15 +1772,15 @@ function _build_member(
     const model = _pyTruthy(modelVal) ? (modelVal as string) : '';
     const api_key_ref_raw = _get(cfg, 'api_key_ref', null);
     const api_key_ref = api_key_ref_raw === undefined ? null : api_key_ref_raw;
-    const member_mode_raw = _get(cfg, 'mode', null);
-    const member_mode = member_mode_raw === undefined ? null : member_mode_raw;
-    if (member_mode !== null && !(_isStr(member_mode) && _VALID_MODES.has(member_mode))) {
-        throw new CouncilConfigError(
-            `members.${name}.mode=${_pyRepr(member_mode)} not in ` +
-                `${_sortedListRepr(_VALID_MODES)}.`,
-        );
+    // Per-member transport is no longer configurable either — same reasoning
+    // as `_build_defaults`. A member that pinned `mode: api` would reintroduce
+    // exactly the silent-spend path the global key was removed for, one
+    // provider at a time. Recorded as ignored, never read.
+    if (_get(cfg, 'mode', undefined) !== undefined) {
+        ignored.push(`members.${name}.mode`);
     }
-    const effective_mode = member_mode !== null ? (member_mode as string) : default_mode;
+    const member_mode: string | null = null;
+    const effective_mode = default_mode;
     const binary_raw = _get(cfg, 'binary', null);
     const binary = binary_raw === undefined ? null : binary_raw;
     if (binary !== null) {

--- a/src/scripts/ai_council/config.ts
+++ b/src/scripts/ai_council/config.ts
@@ -1551,7 +1551,11 @@ function _build_defaults(d: Dict, ignored: string[] = []): DefaultsConfig {
     // per invocation (`cli → api → unavailable`, airgap forcing `api`). A file
     // still carrying `mode:` loads fine and is reported via
     // `ignored_transport_keys` — see `CouncilConfig`.
-    if (_get(d, 'mode', undefined) !== undefined) {
+    // `null` as the sentinel, not `undefined`: `_get`'s default parameter is
+    // typed `Json`, which excludes `undefined`. A config spelling `mode: null`
+    // is indistinguishable from an absent key here, and that is correct — a
+    // null transport is not a pin worth reporting.
+    if (_get(d, 'mode', null) !== null) {
         ignored.push('defaults.mode');
     }
     const mode = 'auto';
@@ -1776,7 +1780,7 @@ function _build_member(
     // as `_build_defaults`. A member that pinned `mode: api` would reintroduce
     // exactly the silent-spend path the global key was removed for, one
     // provider at a time. Recorded as ignored, never read.
-    if (_get(cfg, 'mode', undefined) !== undefined) {
+    if (_get(cfg, 'mode', null) !== null) {
         ignored.push(`members.${name}.mode`);
     }
     const member_mode: string | null = null;

--- a/src/scripts/council_cli.ts
+++ b/src/scripts/council_cli.ts
@@ -2328,6 +2328,31 @@ function _emit_shadow_slo_banner(): void {
  * leaves nothing to infer. Exit is always 0 — this reports a state, it does not
  * gate — and the verdict line is machine-greppable in both directions.
  */
+/**
+ * Resolve the concrete transport a member would use on THIS machine right now.
+ *
+ * `cmd_status` exists to answer "is the council reachable, and will it bill me".
+ * Since the transport-mode setting was removed, the second half is not a value
+ * anyone can look up in the config — it is a per-machine resolution. Printing a
+ * configured mode would be the same class of stale answer the removed setting
+ * produced. `mode` is pinned to `auto` because the loader no longer emits
+ * anything else.
+ */
+function _resolvedTransportFor(
+    name: string,
+    member: { readonly binary: string | null; readonly api_key_ref: string | null },
+    report?: EnvironmentReport,
+): ReturnType<typeof resolveMemberTransport> {
+    return resolveMemberTransport({
+        provider: name,
+        report: report ?? detectEnvironment(),
+        invocationMode: null,
+        memberSettings: null,
+        globalMode: 'auto',
+        binaryOverride: member.binary,
+    });
+}
+
 export function cmd_status(args: Args, opts: { env?: Record<string, string | undefined> } = {}): number {
     const env = opts.env ?? process.env;
     const override = env[COUNCIL_CONFIG_ENV];
@@ -2363,6 +2388,21 @@ export function cmd_status(args: Args, opts: { env?: Record<string, string | und
                 members_total: cfg === null ? null : cfg.members.size,
                 members_enabled: cfg === null ? null : enabledMembers.length,
                 member_names: enabledMembers.map(([n]) => n),
+                transports: Object.fromEntries(
+                    enabledMembers.map(([n, m]) => {
+                        const t = _resolvedTransportFor(n, m);
+                        return [
+                            n,
+                            {
+                                available: t.available,
+                                transport: t.available ? t.transport : null,
+                                billing: t.available ? t.billing : null,
+                                reason: t.reason,
+                            },
+                        ];
+                    }),
+                ),
+                ignored_transport_keys: cfg?.ignored_transport_keys ?? [],
                 parse_error,
                 project_tree_consulted: false,
             })}\n`,
@@ -2382,6 +2422,25 @@ export function cmd_status(args: Args, opts: { env?: Record<string, string | und
         _stdout(`  members          ${enabledMembers.length} enabled of ${cfg.members.size}\n`);
         if (enabledMembers.length > 0) {
             _stdout(`                   ${enabledMembers.map(([n]) => n).join(', ')}\n`);
+        }
+        // Transport is resolved per machine, so the only honest way to answer
+        // "will this cost money" is to resolve it here rather than print a
+        // configured value. The billing class comes from the detected auth
+        // source, never from the transport name — a community CLI wrapper
+        // shells out to the same paid API and stays metered.
+        for (const [name, member] of enabledMembers) {
+            const t = _resolvedTransportFor(name, member);
+            const billing = t.available ? ` · ${t.billing}` : '';
+            const detail = t.available ? t.transport : `unavailable — ${t.reason ?? 'no usable transport'}`;
+            _stdout(`  transport        ${name}: ${detail}${billing}\n`);
+        }
+        if (cfg.ignored_transport_keys.length > 0) {
+            _stdout('\n');
+            _stdout('  Ignored transport keys — transport is resolved, not configured:\n');
+            for (const key of cfg.ignored_transport_keys) {
+                _stdout(`    ${key}\n`);
+            }
+            _stdout('  Safe to delete from the config file; they change nothing.\n');
         }
     }
     _stdout('\n');

--- a/src/server/routes/wizard.ts
+++ b/src/server/routes/wizard.ts
@@ -355,7 +355,11 @@ function extractCouncilConfig(body: string): CouncilConfigView {
     return {
         enabled: doc['enabled'] === true,
         defaults: {
-            mode: typeof defaults['mode'] === 'string' ? defaults['mode'] as string : 'api',
+            // Always `auto`: transport is resolved per machine, not configured,
+            // and the loader emits nothing else. The old fallback here was
+            // `'api'`, which reported a paid transport for a config that had
+            // never asked for one.
+            mode: 'auto',
             min_rounds: typeof defaults['min_rounds'] === 'number' ? defaults['min_rounds'] as number : 2,
         },
         cost_budget: {
@@ -670,7 +674,15 @@ const modulesConfigSchema = z.object({
 // model_ladder, …) are intentionally NOT writable here — hand-edit only.
 const aiCouncilPayloadSchema = z.object({
     enabled: z.boolean().optional(),
-    defaultMode: z.enum(['manual', 'api', 'cli']).optional(),
+    /**
+     * Accepted and IGNORED — kept in the schema on purpose.
+     *
+     * `.strict()` rejects unknown keys, so dropping the field outright would
+     * make an older SPA build's POST fail wholesale and take the rest of the
+     * council settings down with it. Transport is resolved, never persisted;
+     * the value is discarded rather than written.
+     */
+    defaultMode: z.enum(['manual', 'api', 'cli', 'auto']).optional(),
     minRounds: z.number().int().min(1).optional(),
     maxTotalUsd: z.number().min(0).optional(),
     members: z.record(z.object({
@@ -876,7 +888,15 @@ export function wizardRoute(opts: WizardRouteOptions & { packageRoot: string }):
                     if (value !== undefined) body = replaceScalar(body, path, value);
                 };
                 set(['enabled'], p.enabled);
-                set(['defaults', 'mode'], p.defaultMode);
+                // `defaults.mode` is deliberately NOT written any more.
+                //
+                // This write is how the defect shipped: the wizard materialised
+                // the key on every run, so the later CLI-first default — which
+                // only fires on an ABSENT key — could never reach a machine the
+                // wizard had touched. Those installations kept paying per token
+                // with a subscription CLI sitting available. Transport is
+                // resolved now (`cli → api → unavailable`, airgap forcing
+                // `api`), so there is nothing left to persist.
                 set(['defaults', 'min_rounds'], p.minRounds);
                 set(['cost_budget', 'max_total_usd'], p.maxTotalUsd);
                 for (const provider of AI_COUNCIL_PROVIDERS) {

--- a/tests/scripts/_lib/environment_detector.test.ts
+++ b/tests/scripts/_lib/environment_detector.test.ts
@@ -3,8 +3,11 @@
  *
  * Five synthetic machines (bare · cli-only · keys-only · mixed ·
  * unreadable-credential-file), the static no-network property, and the
- * version-shape table. Every case injects `home` / `pathEnv` / `env` and a
- * stub version probe, so nothing here touches the developer's real machine.
+ * version-shape table, plus the macOS Keychain rung for the anthropic
+ * subscription. Every case injects `home` / `pathEnv` / `env`, a stub version
+ * probe AND a stub Keychain probe, so nothing here touches the developer's real
+ * machine — the Keychain probe in particular defaults to shelling out to
+ * `security`, which would otherwise let a subscribed laptop decide outcomes.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -64,6 +67,12 @@ function machine(extraEnv: Record<string, string> = {}): DetectEnvironmentOption
             ...extraEnv,
         },
         probeVersion: () => 'stub 1.2.3\n',
+        // This suite's whole contract is that no case touches the developer's
+        // real machine. The Keychain probe defaults to shelling out to
+        // `security`, so a macOS machine holding a Claude subscription would
+        // otherwise inject a `cli-subscription` auth into the `bare` and
+        // `keys-only` fixtures and make their outcome depend on who ran them.
+        probeKeychain: () => false,
     };
 }
 
@@ -358,13 +367,27 @@ describe('static property: read-only and spend-free', () => {
         expect(violations).toEqual(['node:https']);
     });
 
-    it('never calls fetch and spawns only a --version probe', () => {
+    it('never calls fetch, and every spawn site is a read-only probe', () => {
         const src = fs.readFileSync(DETECTOR_SRC, 'utf-8');
         expect(src).not.toMatch(/\bfetch\s*\(/);
         expect(src).not.toMatch(/\bexecSync\s*\(/);
-        // One spawn call site, and its argv is the version flag.
-        expect(src.match(/spawnSync\(/g)).toHaveLength(1);
+        // TWO spawn call sites, both read-only: the version probe and the
+        // macOS Keychain presence probe. The count is pinned deliberately —
+        // a third one appearing should force a reviewer to justify it here.
+        expect(src.match(/spawnSync\(/g)).toHaveLength(2);
         expect(src).toContain("['--version']");
+        expect(src).toContain("'find-generic-password'");
+    });
+
+    it('the Keychain probe never asks for the secret itself', () => {
+        const src = fs.readFileSync(DETECTOR_SRC, 'utf-8');
+        // `security find-generic-password -w` PRINTS the password to stdout.
+        // Without `-w` it prints attributes only, so presence is read from the
+        // exit code and the credential cannot reach a log, a detection report,
+        // or a crash dump. This is the security property of the probe, so it
+        // gets its own witness rather than riding along in the argv check.
+        expect(src).not.toMatch(/'find-generic-password',\s*'-w'/);
+        expect(src).not.toMatch(/'-w',\s*'-s'/);
     });
 });
 
@@ -437,5 +460,40 @@ describe('per-process cache', () => {
         const first = detectEnvironment();
         resetEnvironmentCache();
         expect(detectEnvironment()).not.toBe(first);
+    });
+});
+
+// === the macOS Keychain rung for the anthropic subscription ===============
+
+describe('anthropic cli-subscription — Keychain vs credential file', () => {
+    it('a Keychain hit is a cli-subscription, and its evidence is a locator not a secret', () => {
+        const report = detectEnvironment({ ...machine(), probeKeychain: () => true });
+        expect(sourcesFor(report, 'anthropic')).toEqual(['cli-subscription']);
+        const strongest = strongestAuth(report, 'anthropic');
+        expect(strongest?.evidence).toBe('keychain:Claude Code-credentials');
+        // The whole point of the rung: this member costs the subscription, not
+        // per-token billing.
+        expect(classifyBilling('anthropic', strongest?.source ?? null)).toBe('subscription');
+    });
+
+    it('the Keychain outranks a stored API key — otherwise the paid rung wins on a subscribed machine', () => {
+        put(path.join('.event4u', 'agent-config', 'anthropic.key'), 'sk-ant-x');
+        const report = detectEnvironment({ ...machine(), probeKeychain: () => true });
+        expect(strongestAuth(report, 'anthropic')?.source).toBe('cli-subscription');
+    });
+
+    it('no Keychain and no credential file leaves the key file as the only auth', () => {
+        put(path.join('.event4u', 'agent-config', 'anthropic.key'), 'sk-ant-x');
+        const report = detectEnvironment({ ...machine(), probeKeychain: () => false });
+        expect(sourcesFor(report, 'anthropic')).toEqual(['key-file']);
+        expect(classifyBilling('anthropic', 'key-file')).toBe('per-token');
+    });
+
+    it('the credential FILE still wins when present — the Keychain is an additional rung, not a replacement', () => {
+        put(path.join('.claude', '.credentials.json'));
+        const report = detectEnvironment({ ...machine(), probeKeychain: () => true });
+        const strongest = strongestAuth(report, 'anthropic');
+        expect(strongest?.source).toBe('cli-subscription');
+        expect(strongest?.evidence).toContain('.credentials.json');
     });
 });

--- a/tests/scripts/ai_council/config.test.ts
+++ b/tests/scripts/ai_council/config.test.ts
@@ -71,7 +71,8 @@ describe('load_council_config — happy path', () => {
         const tmp = make_tmp();
         const c = cfg.load_council_config(write_yaml(tmp, MINIMAL_VALID));
         expect(c.enabled).toBe(true);
-        expect(c.defaults.mode).toBe('api');
+        // `auto` is the ONLY value this loader emits — see `_build_defaults`.
+        expect(c.defaults.mode).toBe('auto');
         expect(c.cost_budget.max_total_usd).toBe(20.0);
         const member = c.members.get('anthropic');
         expect(member).toBeDefined();
@@ -252,9 +253,12 @@ members:
     model: gpt-x
 `;
         const c = cfg.load_council_config(write_yaml(tmp, payload));
-        expect(c.members.get('anthropic')!.mode).toBe('api');
-        // openai inherits defaults.mode (manual) → no api_key_ref required.
+        // Transport is resolved per machine, never configured — a member that
+        // still spells `mode:` out is loaded, ignored, and reported. Reading it
+        // is what let a pre-flip config keep paying per token forever.
+        expect(c.members.get('anthropic')!.mode).toBeNull();
         expect(c.members.get('openai')!.mode).toBeNull();
+        expect(c.ignored_transport_keys).toContain('members.anthropic.mode');
     });
 
     it('disabled member allows omitted key and model', () => {
@@ -292,19 +296,32 @@ describe('load_council_config — validation errors', () => {
         expect(() => cfg.load_council_config(p)).toThrow(/enabled.*bool/);
     });
 
-    it('unknown default mode is rejected', () => {
+    it('a bogus default mode no longer fails the load — the key is not read at all', () => {
         const tmp = make_tmp();
         const p = write_yaml(tmp, 'enabled: false\ndefaults:\n  mode: bogus\n');
-        expect(() => cfg.load_council_config(p)).toThrow(/defaults\.mode/);
+        // Validating a key nobody reads would turn every stale config into a
+        // hard load failure, which is the breaking change the ignore-list
+        // exists to avoid. Accept, ignore, report.
+        const c = cfg.load_council_config(p);
+        expect(c.defaults.mode).toBe('auto');
+        expect(c.ignored_transport_keys).toContain('defaults.mode');
     });
 
-    it('unknown member mode is rejected', () => {
+    it('a bogus member mode is likewise ignored rather than rejected', () => {
         const tmp = make_tmp();
         const p = write_yaml(
             tmp,
             'enabled: false\nmembers:\n  anthropic:\n    enabled: false\n    mode: weird\n',
         );
-        expect(() => cfg.load_council_config(p)).toThrow(/members\.anthropic\.mode/);
+        const c = cfg.load_council_config(p);
+        expect(c.members.get('anthropic')!.mode).toBeNull();
+        expect(c.ignored_transport_keys).toContain('members.anthropic.mode');
+    });
+
+    it('a config that never carried a transport key reports none ignored', () => {
+        const tmp = make_tmp();
+        const p = write_yaml(tmp, 'enabled: false\nmembers:\n  anthropic:\n    enabled: false\n');
+        expect(cfg.load_council_config(p).ignored_transport_keys).toEqual([]);
     });
 
     it('unknown provider is rejected', () => {
@@ -319,19 +336,20 @@ describe('load_council_config — validation errors', () => {
         expect(() => cfg.load_council_config(p)).toThrow(/non-empty `model`/);
     });
 
-    it('enabled api-mode member without api_key_ref fails', () => {
+    it('an enabled member without api_key_ref loads — the key is a fallback credential, not a requirement', () => {
         const tmp = make_tmp();
-        // Explicit `mode: api` — road-to-always-on-orchestration Phase 3.1
-        // flipped the implicit `defaults.mode` default to `auto`, under
-        // which a missing `api_key_ref` is not fatal (the auto chain may
-        // still resolve to the key-free `cli` rung). This test targets the
-        // api-mode-specific rule, so it pins the mode it means to exercise
-        // rather than relying on the (now different) default.
+        // Every member now resolves through the auto chain, whose first rung is
+        // the key-free `cli` transport. Demanding an API key up front would
+        // refuse to load exactly the subscription-only machine this change
+        // exists to serve; a missing key simply makes the `api` fallback rung
+        // unavailable, which `resolveTransport` reports at call time.
         const p = write_yaml(
             tmp,
             'enabled: false\nmembers:\n  anthropic:\n    enabled: true\n    model: m\n    mode: api\n',
         );
-        expect(() => cfg.load_council_config(p)).toThrow(/api_key_ref/);
+        const c = cfg.load_council_config(p);
+        expect(c.members.get('anthropic')!.api_key_ref).toBeNull();
+        expect(c.ignored_transport_keys).toContain('members.anthropic.mode');
     });
 
     it('api_key_ref must use a known prefix', () => {
@@ -650,7 +668,7 @@ describe('cost_budget.daily_limit_usd — the rolling 24h cap (and the ledger sw
 
 // === road-to-always-on-orchestration Phase 3.1 — CLI-first shipped default ===
 
-describe('defaults.mode — CLI-first is the shipped default (Phase 3.1)', () => {
+describe('transport is resolved, not configured — the mode key is ignored', () => {
     it('defaults to auto when the config omits `defaults` entirely', () => {
         const tmp = make_tmp();
         const payload = 'enabled: true\nmembers:\n  anthropic:\n    enabled: false\n';
@@ -679,20 +697,34 @@ describe('defaults.mode — CLI-first is the shipped default (Phase 3.1)', () =>
         expect(() => cfg.load_council_config(write_yaml(tmp, payload))).not.toThrow();
     });
 
-    it('a pinned `mode: api` member still requires api_key_ref — the flip never relaxes an explicit pin', () => {
+    it('a pinned `mode: api` no longer survives — a per-member pin was the last silent-spend path', () => {
         const tmp = make_tmp();
         const payload =
             'enabled: true\nmembers:\n  anthropic:\n    enabled: true\n    model: claude-x\n    mode: api\n';
-        expect(() => cfg.load_council_config(write_yaml(tmp, payload))).toThrow(/api_key_ref/);
+        const c = cfg.load_council_config(write_yaml(tmp, payload));
+        expect(c.members.get('anthropic')!.mode).toBeNull();
+        expect(c.ignored_transport_keys).toEqual(['members.anthropic.mode']);
     });
 
-    it('a pinned `mode: manual` or `mode: cli` member is unaffected by the default flip', () => {
-        const tmp = make_tmp();
+    it('a pinned `mode: manual` / `mode: cli` is ignored too — one rule for every value, no exceptions', () => {
         for (const mode of ['manual', 'cli']) {
+            const tmp = make_tmp();
             const payload = `enabled: true\nmembers:\n  anthropic:\n    enabled: true\n    model: claude-x\n    mode: ${mode}\n`;
             const c = cfg.load_council_config(write_yaml(tmp, payload));
-            expect(c.members.get('anthropic')!.mode).toBe(mode);
+            // Ignoring only the paid value would leave `mode:` half-alive and
+            // reintroduce the two-defaults confusion this change removes.
+            // `manual` stays reachable per invocation via `--mode-override`.
+            expect(c.members.get('anthropic')!.mode).toBeNull();
+            expect(c.ignored_transport_keys).toEqual(['members.anthropic.mode']);
         }
+    });
+
+    it('both layers are reported when both carry a stale key', () => {
+        const tmp = make_tmp();
+        const payload =
+            'enabled: true\ndefaults:\n  mode: api\nmembers:\n  anthropic:\n    enabled: true\n    model: claude-x\n    mode: api\n';
+        const c = cfg.load_council_config(write_yaml(tmp, payload));
+        expect(c.ignored_transport_keys).toEqual(['defaults.mode', 'members.anthropic.mode']);
     });
 });
 

--- a/tests/scripts/council_cli.test.ts
+++ b/tests/scripts/council_cli.test.ts
@@ -289,10 +289,17 @@ describe('council_cli CLI — argparse intent', () => {
 // ── quota / shadow-report (read-only, no member construction) ───────
 
 describe('council_cli quota + shadow-report — intent', () => {
-    it('quota (no configured caps in user-global config) → exit 0', () => {
+    it('quota → exit 0 and one council:quota report, whatever this machine has configured', () => {
         const ts = runTs(['quota']);
         expect(ts.status).toBe(0);
-        expect(ts.stdout).toContain('council:quota · no providers have a configured cli_call_budget.max_calls_per_day cap.');
+        // Deliberately NOT pinning which of the two shapes appears. The old
+        // assertion demanded the "no configured caps" line, and it held only
+        // because the developer's real user-global config pinned `mode: api`,
+        // which took every member out of the CLI call budget. Now that
+        // transport is resolved rather than configured, every member is `auto`
+        // and the caps apply wherever a config exists — so the old expectation
+        // was asserting a property of one machine, not of the verb.
+        expect(ts.stdout).toMatch(/^council:quota · /);
     });
 
     it('quota --reset openai without --confirm → exit 2', () => {


### PR DESCRIPTION
A council run billed $0.44 while a paid Claude subscription and an authenticated codex CLI both sat available on the same machine. Two independent defects had to line up for that, and both are here.

## Defect 1 — a default that migrated nobody

The transport default was flipped to CLI-first. But a default only fires on an **absent** key: the shipped template spelled `defaults.mode` out, and the setup wizard wrote it on **every** run. So no installation that had ever been set up could reach the new default — those configs kept `api` forever, silently, and went on paying per token.

Re-defaulting a second time would repeat the same mistake, so the layers are gone instead. `defaults.mode` and the per-member `mode:` are no longer read; transport is resolved per member per machine per invocation (`cli → api → unavailable`, airgap forcing `api`).

- **A stale key does not break the load.** It is ignored and reported via `CouncilConfig.ignored_transport_keys`, which `council status` prints so it can be deleted. Rejecting it was the obvious alternative and is worse — it turns every pre-existing installation into a hard load failure.
- **Both values are ignored, not just the paid one.** Leaving `manual`/`cli` readable would keep the key half-alive. `manual` stays reachable per invocation via `--mode-override`, which is a flag and cannot go stale.
- **`api_key_ref` stops being conditionally required.** Every member resolves through a chain whose first rung is key-free; demanding a key up front refused to load exactly the subscription-only machine this serves. A missing key now just makes the metered fallback unavailable, reported at call time.
- The wizard stops writing the key, and its read fallback stops being `api`. `defaultMode` stays in the POST schema, accepted and discarded — the schema is `.strict()`, so removing the field would make an older SPA build fail the whole request.

## Defect 2 — the Claude subscription was invisible on macOS

Even under the resolver, `anthropic` still resolved to `api · per-token`. Claude Code stores its OAuth credential in the **login Keychain** on macOS and only falls back to `~/.claude/.credentials.json` elsewhere. The detector looked for that file alone, so on the platform where a Claude subscription is most likely to exist it reported "no subscription" and fell through to the stored API key.

The probe passes no `-w`, so `security` prints attributes and never the password; presence comes from the exit code and the evidence string is a locator (`keychain:Claude Code-credentials`), never the secret. It is injectable and `darwin`-guarded, and the fixture suite stubs it to `false` everywhere — that suite promises no case touches the real machine, and a subscribed laptop would otherwise decide the `bare` and `keys-only` outcomes.

## Verified on the config that billed

Against the same user-global config, before → after:

```
transport   anthropic: api · per-token      →  anthropic: cli · subscription
transport   openai:    cli · subscription   →  openai:    cli · subscription
```

`council status` now prints the resolved transport and billing class per member, because after this change no file holds the answer to "will this cost money".

## What is deliberately NOT here

- **No spend guard.** Its condition can no longer occur: the metered rung is reached only when no CLI resolved, which is exactly the case a guard would have to allow. A check that can never fire is not protection.
- **No `ai_team` change.** It has no transport setting at all — it is codex-CLI-only by construction, so the CLI-first ask was already satisfied there.
- **`binary:` stays.** It is a path hint for the CLI rung, never a transport pin.

## Verification

`npm run typecheck`, ESLint on the changed files, `check_references`, `check_md_language`, `lint_hidden_unicode`, and `task preflight` green. Council + detector + wizard-adjacent suites: 1638 passed. Six `installedPacks` failures in `tests/server` are **pre-existing** — the same five fail on an unrelated branch with no council or wizard changes.

The spawn-site property test previously pinned exactly one `spawnSync`; it now pins two, asserts both argv shapes are read-only, and carries the no-`-w` invariant as its own witness.
