### PR TITLE
fix(council): the spawned member answered the caller's hooks, and held tools it never needed

### DIFF
--- a/src/scripts/ai_council/clients.ts
+++ b/src/scripts/ai_council/clients.ts
@@ -42,6 +42,7 @@
 
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { hardenedSpawnEnv } from '../_lib/spawn_env.js';
@@ -1237,6 +1238,30 @@ export abstract class CliClient extends ExternalAIClient {
         const spawnOpts: Parameters<typeof spawnSync>[2] = {
             encoding: 'utf-8',
             timeout: Math.round(this.timeout_seconds * 1000),
+            // Neutral cwd, and this one is load-bearing rather than tidy.
+            //
+            // The spawn used to inherit the caller's directory, so a council
+            // invoked from inside a repository launched the vendor CLI THERE —
+            // and a vendor CLI in a project runs that project's hook chain.
+            // Measured 2026-08-12, three of three runs from a worktree with
+            // uncommitted changes: the member answered this repository's
+            // `end-review-nudge` instead of the question it was asked
+            // ("I see the end-review-nudge notification about 52 mutated
+            // lines…"). The same call from `/tmp` returned the answer.
+            //
+            // The trigger is why it stayed invisible: that nudge fires only on
+            // a session with modifications, so the contamination appears exactly
+            // when someone runs the council DURING work — the normal case — and
+            // disappears on the clean tree anyone would use to reproduce it.
+            //
+            // This does not contradict the worker-role marker below. That
+            // marker exists to make the spawned session load a THINNER chain;
+            // loading none is the limit of that direction, not a reversal of it.
+            // And a council member is the wrong audience for an operator nudge
+            // by construction: it is a neutral second opinion on a
+            // self-contained question, it holds no tools (see the Anthropic
+            // builder), and it has no working tree of its own to review.
+            cwd: os.tmpdir(),
             // Least-Agency: scrub code-execution-injection env vectors
             // (loader preload, git *_COMMAND, NODE_OPTIONS, …) so an
             // attacker-influenced parent env cannot RCE via the spawned CLI
@@ -1480,6 +1505,34 @@ export class AnthropicCliClient extends CliClient {
             'json',
             '--model',
             this.model,
+            // A council member is a text-in/text-out oracle: it reads a question
+            // and returns an opinion. It never edits, never runs a command,
+            // never fetches. `claude` is an AGENTIC CLI and grants its full
+            // built-in tool set by default, so the spawn was handing a
+            // read-write agent to a role that needs none of it — the over-broad
+            // grant `tool-safety` § Least Agency exists to refuse. `""` is the
+            // documented "disable all tools" value.
+            //
+            // It also repairs a live failure, which is how the grant was found
+            // rather than reasoned about. The spawn inherits the caller's cwd
+            // (`_runSubprocess` sets none, deliberately — the worker-role marker
+            // below depends on the vendor CLI loading this repo's hook chain),
+            // so invoking the council from inside a repository made the child
+            // load that project's own instructions AND every tool definition.
+            // In this package that overflowed the model's context window
+            // outright: `is_error: true`, `"the request is ~214331 tokens
+            // (limit 200000) … the rest is system prompt, tool definitions"`,
+            // exit 1, empty stderr — so the member reported as unavailable with
+            // no diagnosable cause. Measured 2026-08-12: identical call from
+            // `/tmp` exit 0, from the worktree exit 1, and adding this one flag
+            // returns the worktree call to exit 0.
+            //
+            // Dropping the tools rather than neutralising the cwd is the
+            // narrower fix of the two: it leaves the worker-role hook chain
+            // intact and removes only the capability the role never had a use
+            // for. The context saving is a consequence, not the justification.
+            '--tools',
+            '',
             '--append-system-prompt',
             system_prompt,
         ];

--- a/tests/scripts/ai_council/clients.test.ts
+++ b/tests/scripts/ai_council/clients.test.ts
@@ -524,13 +524,61 @@ describe('clients — CLI command construction', () => {
         });
         const r = client.ask('SYS', 'USER', 100);
         expect(calls[0]!.cmd).toEqual([
-            '/bin/echo', '--print', '--output-format', 'json', '--model', 'claude-sonnet-4-5', '--append-system-prompt', 'SYS',
+            '/bin/echo', '--print', '--output-format', 'json', '--model', 'claude-sonnet-4-5',
+            '--tools', '', '--append-system-prompt', 'SYS',
         ]);
         expect(calls[0]!.stdin).toBe('USER');
         expect(r.text).toBe('hi');
         expect(r.input_tokens).toBe(1);
         expect(r.output_tokens).toBe(2);
         expect(r.metadata.cli).toBe(true);
+    });
+
+    it('AnthropicCliClient grants the spawned agent NO tools, for every system prompt', () => {
+        // Asserted as a property rather than left to the argv literal above.
+        // The literal is the shape a refactor reorders or a "cleanup" drops, and
+        // the sibling openai defect survived precisely because its argv test
+        // pinned the broken command as expected — a test that transcribes the
+        // command cannot notice the command is wrong.
+        //
+        // `claude` is an agentic CLI: absent `--tools`, the spawned session gets
+        // the full built-in set. A council member reads a question and returns
+        // an opinion, so any tool at all is an over-broad grant
+        // (`tool-safety` § Least Agency).
+        for (const sys of ['', 'SYS', 'a'.repeat(5000)]) {
+            const { client, calls } = stubCli(AnthropicCliClient, { returncode: 0, stdout: '{}', stderr: '' });
+            client.ask(sys, 'USER', 100);
+            const cmd = calls[0]!.cmd;
+            const at = cmd.indexOf('--tools');
+            expect(at).toBeGreaterThan(-1);
+            expect(cmd[at + 1]).toBe('');
+        }
+    });
+
+    it('the CLI spawn runs OUTSIDE the caller repository, so no project hook chain reaches the member', () => {
+        // Exercised through the REAL `_runSubprocess` — the stub used elsewhere
+        // in this file replaces the spawn wholesale and would happily pass while
+        // the cwd option was missing, which is the "defined but not wired" shape
+        // this assertion exists to refuse. `/bin/pwd` prints the directory the
+        // child actually ran in, so the spawn option is what is measured rather
+        // than a constant that merely exists.
+        class PwdClient extends AnthropicCliClient {
+            protected override _build_command(): string[] {
+                return ['/bin/pwd'];
+            }
+            protected override _stdin_payload(): string | null {
+                return null;
+            }
+        }
+        const c = new PwdClient({ binary: '/bin/pwd' });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const where = ((c as any)._runSubprocess(['/bin/pwd'], null) as { stdout: string }).stdout.trim();
+        expect(where).not.toBe('');
+        // macOS reports /var/folders/… for a /private/var/folders/… tmpdir, so
+        // compare on the resolved real path rather than the string.
+        expect(fs.realpathSync(where)).toBe(fs.realpathSync(os.tmpdir()));
+        expect(fs.existsSync(path.join(where, 'CLAUDE.md'))).toBe(false);
+        expect(fs.existsSync(path.join(where, '.claude'))).toBe(false);
     });
 
     it('OpenAICliClient argv (prompt on stdin, no --system)', () => {


### PR DESCRIPTION
Two defects in one spawn. Both were found by *running* the council, not by reading it, and neither is visible on a clean checkout.

Follow-on to #1308, which fixed the two sibling defects in the same transport (the `codex exec --system` flag, and the run reporting itself as concluded). Verified those are in before writing anything here.

## 1. The member answered the wrong thing

`_runSubprocess` set no `cwd`, so the vendor CLI launched in **the caller's directory** — and a vendor CLI inside a project runs that project's hook chain.

Measured 2026-08-12, three of three runs from a worktree with uncommitted changes:

> `I see the end-review-nudge notification about 52 mutated lines, but since I only…`
> `I see the end-review-nudge hook detected modified lines, but those changes (\`src…`
> `I see the end-review reminder, but in this case it's not applicable - I only res…`

The question asked was *"Reply with exactly: PONG"*. The same call from `/tmp`, with the tree equally dirty, returned `PONG` twice out of twice.

**Why it survived until now:** that nudge fires only on a session with modifications. So the contamination appears exactly when someone runs the council *during* work — the normal case — and disappears on the clean tree anyone would use to reproduce it.

This does not contradict the worker-role marker on the same spawn. That marker exists to make the spawned session load a *thinner* chain; loading none is the limit of that direction, not a reversal of it. And a council member is the wrong audience for an operator nudge by construction: it is a neutral second opinion on a self-contained question, it holds no tools, and it has no working tree of its own to review.

## 2. The member held the full tool set

`claude` is an agentic CLI and grants its built-in tools by default, so the spawn handed a read-write agent to a role that reads a question and returns an opinion — the over-broad grant `tool-safety` § Least Agency exists to refuse.

It also had a live cost. Tool definitions were part of what overflowed the context window outright in this package:

    is_error: true
    "the request is ~214331 tokens (limit 200000) but this conversation is only
     ~5039 tokens — the rest is system prompt, tool definitions, and attachment content"

…surfacing as exit 1 with **empty stderr**, so the member reported as unavailable with no diagnosable cause. Adding `--tools ""` alone returns that call to exit 0. The context saving is a consequence; Least Agency is the justification.

## Scope

Defect-pattern search over every CLI client: the construct appears **once**. Gemini, xAI and Perplexity use plain prompt interfaces rather than an agentic mode. `codex exec` is agentic but exposes no equivalent single flag — noted, not blind-fixed.

## Why the tests are shaped this way

- The **cwd assertion runs through the real `_runSubprocess`** via `/bin/pwd`, not the stub the rest of the file uses. A stub replaces the spawn wholesale and would pass while the option was missing — the "defined but not wired" shape. Mutation-checked both ways: removing `cwd` reds it, restoring it greens it.
- The **tool assertion is a property** over three system prompts (empty, short, 5000 chars), not a line in the argv literal. #1308 recorded that its sibling defect survived because both argv tests pinned the broken command as expected; a test that transcribes the command cannot notice the command is wrong.

## Verification

- 87 tests pass in `clients.test.ts`
- mutation-proved in both directions on the cwd assertion
- end-to-end, dirty tree: from the repo 3/3 contaminated, from a neutral cwd 2/2 clean
- `task preflight` exit 0, no lint regressions vs `main`

## Not fixed here

The package's own daily call cap (`anthropic 78/50 · openai 80/50` at time of writing) is what blocks a live council run today. It is date-keyed and resets on the date rollover; raising it to get past a limit is a budget bypass, not a fix.