### PR TITLE
fix(session-register): anchor the record on the session checkout, not the chdir target

### DIFF
--- a/src/scripts/session_register_hook.ts
+++ b/src/scripts/session_register_hook.ts
@@ -50,7 +50,7 @@ import * as path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { current_branch } from './_lib/git_common_dir.js';
+import { current_branch, git_common_dir, git_dir } from './_lib/git_common_dir.js';
 import {
     HEARTBEAT_REACHABLE_PLATFORMS,
     type Collision,
@@ -258,11 +258,63 @@ export function claim_is_stale(
 }
 
 /**
+ * The checkout THIS session is actually working in — which is **not**
+ * `envelope.workspace_root` when the session runs in a worktree.
+ *
+ * Measured 2026-08-13, and it emptied the register of meaning: every one of four
+ * live records read `worktree: <main checkout>` / `branch: main` while the
+ * sessions writing them sat in four different worktrees on four different
+ * branches. The path is mechanical — the host hook line passes
+ * `--project-dir "$CLAUDE_PROJECT_DIR"`, `dispatch_hook.main` chdirs there, and
+ * `_build_envelope` sets `workspace_root: process.cwd()`. A host that keeps
+ * `CLAUDE_PROJECT_DIR` pointed at the ORIGINAL project for a worktree session
+ * therefore hands every concern the main checkout, and `current_branch` reads
+ * the main checkout's HEAD.
+ *
+ * The consequence was not cosmetic: with every record on one phantom branch,
+ * every pair of sessions collided, so the branch warning below fired in every
+ * session but the first and told the model to stop before doing any work.
+ *
+ * The session's own directory survives in `payload.cwd`, which every host in
+ * this suite's event-shape contract carries. It is trusted only under three
+ * conditions, because a wrong anchor is worse than the fallback:
+ *
+ * 1. it is an existing directory;
+ * 2. it is the ROOT of a checkout (`git_dir` looks for `<dir>/.git` and does not
+ *    walk up, so a session whose cwd is a subdirectory degrades to
+ *    `workspace_root` — today's behaviour, never something worse);
+ * 3. it belongs to the SAME repository — identical git common dir. A cwd in
+ *    another repo would otherwise write this repo's register with a foreign
+ *    branch, and the register is shared by every worktree here.
+ */
+export function session_checkout(
+    workspace_root: string,
+    payload_cwd: string | null | undefined,
+): string {
+    const cwd = String(payload_cwd ?? '').trim();
+    if (cwd === '') return workspace_root;
+    try {
+        if (!fs.statSync(cwd).isDirectory()) return workspace_root;
+    } catch {
+        return workspace_root;
+    }
+    if (git_dir(cwd) === null) return workspace_root;
+    const mine = git_common_dir(cwd);
+    const theirs = git_common_dir(workspace_root);
+    if (mine === null || theirs === null || mine !== theirs) return workspace_root;
+    return cwd;
+}
+
+/**
  * Build this session's record from live state.
  *
  * Branch and slug are **re-read on every beat**, never carried forward from
  * registration: a session checks out other branches mid-run, and the slug is
  * null at registration by construction because the roadmap is picked later.
+ *
+ * `workspace_root` here means **this session's checkout** — the caller resolves
+ * it through `session_checkout` first. Passing the envelope's value directly is
+ * the defect documented there.
  */
 export function build_record(
     workspace_root: string,
@@ -307,6 +359,10 @@ export function touch(
  * Spotlighted as DATA, never instructions: the worktree paths and branch names
  * in it come from other sessions, which are not a trusted instruction source
  * (`untrusted-input-defense`).
+ *
+ * `workspace_root` is **this session's checkout** (`session_checkout`), not the
+ * envelope's chdir target: every comparison below — the branch, the peer's
+ * worktree, the claim — is a statement about the tree this session works in.
  */
 export function foreign_sessions_block(
     workspace_root: string,
@@ -392,15 +448,40 @@ export function foreign_sessions_block(
         );
     }
 
+    // Same branch NAME is two different situations, and conflating them is what
+    // turned this warning into a work stop. In the SAME worktree two sessions
+    // edit one set of files and one index — worth a question before writing. In
+    // DIFFERENT worktrees they share a branch name and nothing else: separate
+    // files, separate index, separate HEAD. That is the normal shape here (this
+    // repo carries dozens of worktrees), and halting for it cost the user a
+    // commit per session.
+    //
+    // Distinguishing them only became possible once `worktree` was true — see
+    // `session_checkout`. Before that every record claimed the main checkout, so
+    // every collision looked like the dangerous one.
     if (branch_hit !== null) {
-        parts.push(
-            '',
-            `COLLISION: another live session already holds branch \`${here}\`.`,
-            'Ask the user ONCE, as numbered options, before doing any work on it:',
-            '  1. Join the same branch (coordinate manually — this register is advisory, not a lock)',
-            '  2. Spawn a separate worktree for this session',
-            'Never decide silently, in either direction.',
-        );
+        const peer_tree = path.resolve(branch_hit.record.worktree ?? '');
+        const same_tree = peer_tree !== '' && peer_tree === path.resolve(workspace_root);
+        if (same_tree) {
+            parts.push(
+                '',
+                `COLLISION: another live session is on branch \`${here}\` in THIS SAME worktree`,
+                `(${branch_hit.record.worktree}) — the same files and the same git index.`,
+                'Ask the user ONCE, as numbered options, before writing anything:',
+                '  1. Join anyway and coordinate manually (this register is advisory, not a lock)',
+                '  2. Spawn a separate worktree for this session',
+                'Never decide silently, in either direction.',
+            );
+        } else {
+            parts.push(
+                '',
+                `NOTE: another live session is on the same branch name \`${here}\` in a DIFFERENT`,
+                `worktree (${branch_hit.record.worktree}). Separate trees, separate index:`,
+                'this is the normal shape here. It is NOT a reason to stop, to ask, or to',
+                'withhold a commit — keep working. Say it in one line before a push, where the',
+                'two histories actually meet, so the user can intervene.',
+            );
+        }
     }
 
     parts.push(
@@ -427,7 +508,18 @@ export function main(): number {
     }
 
     const event = String(envelope['event'] ?? '');
-    const root = String(envelope['workspace_root'] ?? process.cwd());
+    const payload = envelope['payload'];
+    const payload_cwd =
+        payload !== null && typeof payload === 'object' && !Array.isArray(payload)
+            ? (payload as Record<string, unknown>)['cwd']
+            : null;
+    // `workspace_root` is the chdir'd project dir, which is the MAIN checkout for
+    // a worktree session on at least one host. Everything below is a statement
+    // about the session's own tree, so it anchors on the session's own cwd.
+    const root = session_checkout(
+        String(envelope['workspace_root'] ?? process.cwd()),
+        typeof payload_cwd === 'string' ? payload_cwd : null,
+    );
     const platform = String(envelope['platform'] ?? 'generic').trim().toLowerCase();
     const session_id = String(envelope['session_id'] ?? '').trim();
 

--- a/tests/scripts/session_register.test.ts
+++ b/tests/scripts/session_register.test.ts
@@ -38,9 +38,12 @@ import {
 } from '../../src/scripts/_lib/session_register.js';
 import {
     ROADMAP_CLAIM_REL,
+    build_record,
     claim_is_stale,
+    foreign_sessions_block,
     read_claimed_slug,
     roadmap_claim_rel,
+    session_checkout,
 } from '../../src/scripts/session_register_hook.js';
 import {
     branch_name_hits,
@@ -716,5 +719,86 @@ describe('the branch axis — what the register cannot see', () => {
             throw new Error('no git');
         }) as unknown as typeof spawnSync;
         expect(other_worktree_branches(main, thrower)).toEqual([]);
+    });
+});
+
+describe('the record describes THIS session checkout, not the chdir target', () => {
+    it('prefers the session cwd over workspace_root — the measured defect', () => {
+        const { main, wt } = make_repo();
+        // Exactly the shape hosts produce: the hook is chdir'd to the main
+        // checkout while the session works in a worktree.
+        expect(fs.realpathSync(session_checkout(main, wt))).toBe(fs.realpathSync(wt));
+        const record = build_record(session_checkout(main, wt), 'sess-wt', 'claude', iso_now());
+        expect(record.branch).toBe('feat/a');
+        expect(fs.realpathSync(record.worktree)).toBe(fs.realpathSync(wt));
+    });
+
+    it('without the fix the record claims the main checkout and its branch', () => {
+        const { main } = make_repo();
+        const wrong = build_record(main, 'sess-wt', 'claude', iso_now());
+        expect(wrong.branch).toBe('main');
+    });
+
+    it('falls back to workspace_root when the cwd is absent, empty, or not a directory', () => {
+        const { main } = make_repo();
+        expect(session_checkout(main, null)).toBe(main);
+        expect(session_checkout(main, '   ')).toBe(main);
+        expect(session_checkout(main, path.join(main, 'nope'))).toBe(main);
+        const file = path.join(main, 'a-file');
+        fs.writeFileSync(file, 'x');
+        expect(session_checkout(main, file)).toBe(main);
+    });
+
+    it('refuses a cwd that is not a checkout root — git_dir does not walk up', () => {
+        const { main, wt } = make_repo();
+        const sub = path.join(wt, 'src');
+        fs.mkdirSync(sub, { recursive: true });
+        expect(session_checkout(main, sub)).toBe(main);
+    });
+
+    it('refuses a cwd in a DIFFERENT repository — the register is shared per repo', () => {
+        const { main } = make_repo();
+        const other = path.join(tmp, 'other-repo');
+        fs.mkdirSync(other, { recursive: true });
+        git(other, 'init', '-q', '-b', 'main');
+        expect(session_checkout(main, other)).toBe(main);
+    });
+});
+
+describe('a shared branch NAME is only a collision inside one worktree', () => {
+    function register(dir: string, over: Partial<SessionRecord>): void {
+        fs.mkdirSync(dir, { recursive: true });
+        write_record(dir, rec(over));
+    }
+
+    it('same branch in a DIFFERENT worktree does not halt the session', () => {
+        const { main, wt } = make_repo();
+        const dir = register_dir(wt)!;
+        register(dir, { session_id: 'peer', branch: 'feat/a', worktree: main });
+        const block = foreign_sessions_block(wt, 'mine')!;
+        expect(block).toContain('DIFFERENT');
+        expect(block).not.toContain('COLLISION');
+        // The load-bearing half: nothing in it tells the model to stop or ask.
+        expect(block).not.toContain('Ask the user ONCE');
+        expect(block).toContain('withhold a commit');
+    });
+
+    it('same branch in the SAME worktree still asks before writing', () => {
+        const { wt } = make_repo();
+        const dir = register_dir(wt)!;
+        register(dir, { session_id: 'peer', branch: 'feat/a', worktree: wt });
+        const block = foreign_sessions_block(wt, 'mine')!;
+        expect(block).toContain('COLLISION');
+        expect(block).toContain('THIS SAME worktree');
+        expect(block).toContain('Ask the user ONCE');
+    });
+
+    it('a different branch in the same worktree is neither', () => {
+        const { wt } = make_repo();
+        const dir = register_dir(wt)!;
+        register(dir, { session_id: 'peer', branch: 'feat/other', worktree: wt });
+        const block = foreign_sessions_block(wt, 'mine')!;
+        expect(block).not.toContain('COLLISION');
+        expect(block).not.toContain('DIFFERENT');
     });
 });


### PR DESCRIPTION
## What was wrong

Measured 2026-08-13 on this repository: **all four live records in the session register read `worktree: <main checkout>` / `branch: main`**, while the sessions writing them sat in four different worktrees on four different branches.

The path is mechanical:

1. The host hook line passes `--project-dir "$CLAUDE_PROJECT_DIR"`.
2. `dispatch_hook.main()` chdirs there.
3. `_build_envelope` sets `workspace_root: process.cwd()`.

A host that keeps the project dir pointed at the **original** project for a worktree session therefore hands every concern the main checkout, and `current_branch()` reads the main checkout's HEAD.

The consequence was not cosmetic. With every record on one phantom branch, **every pair of sessions collided**, so the branch warning fired in every session but the first and told the model:

> `Ask the user ONCE, as numbered options, before doing any work on it` … `Never decide silently, in either direction.`

That is a hard stop before any work — in a block that calls itself `advisory only, not a lock` two paragraphs later. The observed symptom was sessions narrating a parallel-session collision and not committing.

The same wrong anchor also broke the roadmap claim: `sessions:claim` writes it into the worktree, the hook read it in the main checkout.

## The fix

**`session_checkout(workspace_root, payload_cwd)`** — the record now describes the checkout the session actually works in. `payload.cwd` (carried by every host in the event-shape contract) is trusted only when it is:

1. an existing directory,
2. a checkout **root** — `git_dir` does not walk up, so a cwd in a subdirectory degrades rather than misfires,
3. the **same repository** — identical git common dir; the register is shared per repo, and a cwd in another repo would write a foreign branch into it.

Anything else falls back to `workspace_root`, i.e. the previous behaviour. A wrong anchor is worse than the fallback.

**Collision split.** A shared branch *name* is two different situations, and conflating them is what turned a warning into a work stop:

- **same worktree** — same files, same index: keeps the question before writing.
- **different worktree** — separate trees, separate index: a note that explicitly does not stop work, ask, or withhold a commit.

Distinguishing them only became possible once the `worktree` field carried the truth.

## Evidence

| Check | Result |
|---|---|
| `vitest run tests/scripts/session_register.test.ts` | 74/74 |
| `vitest run tests/scripts/hooks` | 358/358, 24 files |
| `npm run typecheck` | clean |
| `eslint` on both changed files | clean |
| `condense.sh --changed` | every projection matches its source |

Eight new cases: the measured defect (a record built from `workspace_root` claims `main`), all four fallback paths, foreign-repo rejection, the subdirectory degradation, and the three collision shapes — including the assertion that the different-worktree block contains no `Ask the user ONCE`.

## Honest gap

Whether Claude sends the **worktree** in `payload.cwd` for a worktree session is inferred, not measured: the running hook is the `dist` bundle of the main checkout, and probing it would have disturbed three live sessions there. Indicators: the session scratchpad path is worktree-encoded, the memory directory is main-checkout-encoded, and the session cwd is the worktree. The three-condition fallback makes the worst case a no-op rather than a regression.

The measurement is one command after a rebuild: `agent-config sessions:list` from inside a worktree. If it shows the real branch, `payload.cwd` carries it.

## Rollout note

`dist/` is gitignored, so the fix takes effect in a checkout only after a build there. Existing records carry the phantom branch until their TTL (4 h for `claude`); deleting `<git-common-dir>/agent-sessions/*.json` releases them immediately.
