### PR TITLE
fix(worktrees): the inventory judged location against the wrong worktree

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,11 +2,11 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 30 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **40** open blockers, **11** need you → `agent-config gates`
+> 29 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **39** open blockers, **10** need you → `agent-config gates`
 
 ## Overall
 
-**260 / 446 steps done · 58%**
+**253 / 437 steps done · 58%**
 
 ```text
 ███████████████████████░░░░░░░░░░░░░░░░░   58%
@@ -44,8 +44,7 @@
 | 26 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 27 | [road-to-tier-removal.md](roadmaps/road-to-tier-removal.md) | 4 | 8 | 1 | 7 | 0 | 0 | 0 | █████████░ 88% |
 | 28 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
-| 29 | [road-to-worktree-hygiene.md](roadmaps/road-to-worktree-hygiene.md) | 1 | 9 | 2 | 7 | 0 | 0 | [1](#blockers-road-to-worktree-hygiene) | ████████░░ 78% |
-| 30 | [road-to-zero-settings.md](roadmaps/road-to-zero-settings.md) | 4 | 15 | 1 | 14 | 0 | 0 | 0 | █████████░ 93% |
+| 29 | [road-to-zero-settings.md](roadmaps/road-to-zero-settings.md) | 4 | 15 | 1 | 14 | 0 | 0 | 0 | █████████░ 93% |
 
 ---
 
@@ -896,27 +895,6 @@ _1 blocker resolved._
     and chose the named blocker over a re-scope that changes a pre-registered
     input.
   - **Resolved when:** either a host-renderable framework lane exists (a build/serve step for the React lane, landed for its own reason) **or** a supported generic-lane override exists — at which point the re-scope is recorded as a dated amendment in `internal/bench/corpora/ui-track-integrity-PREREG.md` and Measurement B becomes executable.
-
-### [road-to-worktree-hygiene.md](roadmaps/road-to-worktree-hygiene.md)
-
-**Road to worktree hygiene — 249 worktrees, 40 GB, one prune that does nothing** — 7 / 9 done (78%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | inventory, classify, record | 🟡 in progress | 2 | 7 | 0 | 0 | 78% |
-
-<a id="blockers-road-to-worktree-hygiene"></a>
-**Blockers**
-
-- **safe-set-removal-approval** (owner: user) — blocks Phase 1 step 3, and the last acceptance criterion
-  - **What to do:**
-    review the prepared plan
-    (`./scripts-run src/scripts/worktree_cleanup_check inventory --plan`) and
-    approve, narrow, or decline the removal of the 143 safe worktrees and their
-    fully-merged branches. Bulk deletion is a Hard-Floor action
-    (`non-destructive-by-default`): an agent may prepare and surface it, never
-    perform it, and a single earlier approval never covers a bulk sweep.
-  - **Resolved when:** the maintainer has approved (or declined) the safe-set removal this turn, and — if approved — the post-removal count is recorded in `agents/evidence/reports/worktree-inventory.md`.
 
 ### [road-to-zero-settings.md](roadmaps/road-to-zero-settings.md)
 

--- a/agents/roadmaps/archive/road-to-worktree-hygiene.md
+++ b/agents/roadmaps/archive/road-to-worktree-hygiene.md
@@ -71,13 +71,15 @@ duty, not just a permission gate:
       (2) git reports worktree paths as realpaths, so a repo reached through a
       symlinked parent mis-classified conventional worktrees as non-standard;
       fixed by canonicalising the longest existing ancestor. -->
-- [ ] Present the safe set as a list and remove **only after explicit approval** —
+- [x] Present the safe set as a list and remove **only after explicit approval** —
       per `scope-control`, branch and worktree deletion is permission-gated, and
       a bulk sweep does not inherit a single earlier approval.
 
-      **Re-presented 2026-08-13 on maintainer instruction ("re-run the inventory
-      first, then remove"). Still NOT removed, and the three findings below are
-      why — none of them was knowable on 2026-08-05.**
+      **Re-presented and executed 2026-08-13 on maintainer instruction ("re-run
+      the inventory first, then remove"). The re-run produced three findings
+      first, none of them knowable on 2026-08-05, and they changed what "the safe
+      set" even refers to — which is why the removal that followed is two
+      worktrees rather than the 143 the earlier plan proposed.**
 
       **Finding 1 — the inventory misclassifies when run from inside a worktree,
       and the error is total.** Same binary, same repo, same minute:
@@ -110,11 +112,44 @@ duty, not just a permission gate:
       set would therefore be removal under a predicate the maintainer did not
       approve — the exact substitution the approval was written to prevent.
 
-      **What that leaves.** The removal needs either the tool taught the two
-      missing conditions, or an explicit approval of the 181-item set under the
-      predicate the tool actually implements. Both are maintainer calls, and the
-      second is a Hard-Floor bulk deletion that names its object. Nothing was
-      deleted.
+      **Resolved the same day by taking the first branch: the tool was taught
+      the two missing conditions.** `isStandardLocation` now takes the MAIN
+      worktree as its base (a one-line defect with a total effect), and
+      `inventory` gained `--min-age-days=N` and `--exclude-live-sessions`. The
+      second reads the session register — real records with a real `worktree`
+      path and a real TTL — rather than inferring occupancy from file mtime,
+      which this module's own header already rules out as a liveness signal. An
+      unreadable git-dir mtime disqualifies under an age floor rather than
+      passing it: absence of evidence must not read as "old enough". Pinned by a
+      regression test that judges one sibling worktree from inside another.
+
+      **Then the approved predicate ran, and its result is the finding.**
+
+      | Predicate | safe |
+      |---|---:|
+      | tool default (merged · clean · conventional root · 48 h) | 181 |
+      | **as approved** (+ >60 days · no live session) | **2** |
+
+      **275 of 304 worktrees had git activity inside 60 days.** The 40 GB is not
+      a residue of abandoned work — it is current work. So the condition set that
+      made the removal safe also made it nearly empty, and the two are the same
+      fact rather than a disappointment: at this rate of branching, "untouched
+      for 60 days" describes almost nothing. Executing the 181-item set would
+      have removed 179 worktrees that the approved predicate rejects.
+
+      **Executed 2026-08-13, both of them, named:**
+      `.claude/worktrees/perf-installer-e2e` (branch `fix/lint-report-warnings`)
+      and `.claude/worktrees/reaping-orphans` (branch
+      `fix/reaping-pre-inventory-orphans`). Registered count 304 → **302**;
+      re-run under the same predicate now reports safe **0**, so the approval is
+      fully spent.
+
+      **What the disk question still needs, and it is a different question.**
+      Reclaiming the 40 GB means deciding about worktrees that are *recent*, which
+      no age floor can authorise. The honest options are a cap on concurrent
+      worktrees, removal keyed on merged-and-branch-deleted regardless of age, or
+      accepting the disk cost. That is a policy call, not a predicate tweak, and
+      it is not made here.
       <!-- PRESENTED 2026-08-05, removal NOT run: `inventory --plan` emits the 143
       `git worktree remove` + `git branch -d` pairs (never `-D`, so git itself
       re-checks the merge). Running them is a Hard-Floor bulk deletion needing the
@@ -160,14 +195,21 @@ or a tool that walks worktrees — or simply when a maintainer wants the list.
       verdict does not change when it is run twice.
 - [x] The review set is recorded with a per-entry reason, untouched.
 - [x] The residual counts are recorded so growth can be told from residue.
-- [ ] The safe set has been removed after explicit maintainer approval, and the
+- [x] The safe set has been removed after explicit maintainer approval, and the
       post-removal count is recorded.
+      **2026-08-13 — met, and worth reading with the number beside it.** The safe
+      set *under the approved predicate* was **2**, both removed by name; the
+      registered count is recorded at 304 → **302**, and a re-run reports safe 0.
+      The approval is spent. What is NOT claimed: the 40 GB is untouched, because
+      275 of 304 worktrees are younger than the approved 60-day floor. This
+      criterion asked whether the approved set was removed and it was; it never
+      asked whether the disk problem was solved, and it is not.
 
 ## Blockers
 
 ### blocker: safe-set-removal-approval
 
-- **Status:** open
+- **Status:** resolved
 - **Owner:** user
 - **Blocks:** Phase 1 step 3, and the last acceptance criterion
 - **What to do:** review the prepared plan

--- a/src/scripts/worktree_cleanup_check.ts
+++ b/src/scripts/worktree_cleanup_check.ts
@@ -34,6 +34,7 @@ import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { read_live_records, register_dir } from './_lib/session_register.js';
 
 export interface CheckResult {
     allowed: boolean;
@@ -304,8 +305,20 @@ function isAncestor(repoPath: string, branch: string, trunk: string): boolean {
     }
 }
 
-export function isStandardLocation(repoPath: string, worktreePath: string): boolean {
-    const rel = path.relative(canonical(repoPath), canonical(worktreePath));
+/**
+ * `basePath` MUST be the main worktree, never the invoking repo path.
+ *
+ * Measured 2026-08-13, and the failure is total rather than partial: called with
+ * a linked worktree as the base, every sibling worktree resolves to `..` and the
+ * safe set collapses to empty. Same binary, same repo, same minute — from inside
+ * `.claude/worktrees/<branch>`: 304 registered, safe 0, 278 "non-standard"; from
+ * the main checkout: safe 181, 81 non-standard. A maintainer who ran the
+ * inventory from a worktree would read "nothing to clean" and conclude the
+ * estate was fine, which is the worst shape a cleanup tool can fail in — it
+ * fails silently, and toward inaction.
+ */
+export function isStandardLocation(basePath: string, worktreePath: string): boolean {
+    const rel = path.relative(canonical(basePath), canonical(worktreePath));
     if (rel.startsWith('..') || path.isAbsolute(rel)) return false;
     return STANDARD_WORKTREE_DIRS.some(
         (dir) => rel === dir || rel.startsWith(`${dir}${path.sep}`),
@@ -348,16 +361,70 @@ function lastGitActivity(worktreePath: string): Date | null {
  * Classify every worktree. `now` is injectable so the live-window boundary is
  * testable rather than wall-clock dependent.
  */
-export function buildInventory(repoPath: string, now: Date = new Date()): Inventory {
+/**
+ * Two conditions the `safe` predicate does NOT carry by default, both off unless
+ * asked for. They exist because an approval can be stricter than the tool, and
+ * silently removing under the looser predicate is the substitution such an
+ * approval is written to prevent.
+ *
+ * `minAgeDays` is a floor on git inactivity, layered ON TOP of the 48-hour live
+ * window rather than replacing it: 48h answers "is someone in it right now", a
+ * 60-day floor answers "is this abandoned". Different questions.
+ *
+ * `excludeLiveSessions` reads the session register — real records with a real
+ * `worktree` path and a real TTL — instead of inferring occupancy from file
+ * mtime, which this module's own header already rules out as a liveness signal.
+ */
+export interface InventoryOptions {
+    now?: Date;
+    minAgeDays?: number | null;
+    excludeLiveSessions?: boolean;
+}
+
+export function buildInventory(
+    repoPath: string,
+    nowOrOptions: Date | InventoryOptions = new Date(),
+): Inventory {
+    const opts: InventoryOptions =
+        nowOrOptions instanceof Date ? { now: nowOrOptions } : nowOrOptions;
+    const now = opts.now ?? new Date();
+    const minAgeDays = opts.minAgeDays ?? null;
+    const ageCutoff = minAgeDays === null ? null : now.getTime() - minAgeDays * 86400 * 1000;
+    return buildInventoryInner(repoPath, now, ageCutoff, minAgeDays, opts.excludeLiveSessions === true);
+}
+
+function buildInventoryInner(
+    repoPath: string,
+    nowArg: Date,
+    ageCutoff: number | null,
+    minAgeDays: number | null,
+    excludeLiveSessions: boolean,
+): Inventory {
+    const now = nowArg;
     const trunk = resolveTrunk(repoPath);
     const entries = listWorktrees(repoPath);
     const mainPath = canonical(entries.length > 0 ? entries[0]!.path : repoPath);
     const liveCutoff = now.getTime() - LIVE_WINDOW_HOURS * 3600 * 1000;
 
+    // Registered session worktrees, canonicalised so the comparison survives a
+    // symlinked checkout root the same way every other path here does. Empty set
+    // when the option is off, when no register directory exists (the normal
+    // state before any session registers), or when every record has expired.
+    const sessionPaths = new Set<string>();
+    if (excludeLiveSessions) {
+        const dir = register_dir(mainPath);
+        if (dir !== null) {
+            for (const rec of read_live_records(dir, { now })) {
+                sessionPaths.add(canonical(rec.worktree));
+            }
+        }
+    }
+
     const rows: InventoryRow[] = entries.map((e) => {
         const resolved = canonical(e.path);
         const isMain = resolved === mainPath;
-        const standardLocation = isMain ? true : isStandardLocation(repoPath, resolved);
+        // `mainPath`, NOT `repoPath` — see isStandardLocation's contract.
+        const standardLocation = isMain ? true : isStandardLocation(mainPath, resolved);
         const reasons: string[] = [];
 
         if (!fs.existsSync(resolved)) {
@@ -388,6 +455,20 @@ export function buildInventory(repoPath: string, now: Date = new Date()): Invent
         if (isMain) reasons.push('main worktree — cannot be removed');
         if (e.branch === null) {
             reasons.push('detached HEAD — no branch to judge reachability for');
+        }
+        if (sessionPaths.has(resolved)) {
+            reasons.push('a live agent session is registered in this worktree');
+        }
+        if (ageCutoff !== null && (activity === null || activity.getTime() >= ageCutoff)) {
+            // `activity === null` disqualifies rather than passes: an unreadable
+            // git-dir mtime is absence of evidence, and under an explicit
+            // minimum-age floor that has to read as "cannot show it is old
+            // enough", never as "old enough".
+            reasons.push(
+                activity === null
+                    ? `git activity unreadable — cannot prove ${minAgeDays}+ days of inactivity`
+                    : `git activity within the last ${minAgeDays} days`,
+            );
         }
         if (!standardLocation) {
             reasons.push('non-standard location — outside the conventional worktree roots');
@@ -465,7 +546,7 @@ export function removalPlan(inv: Inventory): string[] {
 function usage(): never {
     process.stderr.write(
         'usage: worktree_cleanup_check check <worktree-path> | scope-overlap [repo-path] | ' +
-            'inventory [repo-path] [--json|--plan]\n',
+            'inventory [repo-path] [--json|--plan] [--min-age-days=N] [--exclude-live-sessions]\n',
     );
     process.exit(2);
 }
@@ -509,9 +590,32 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
         const rest = argv.slice(1);
         const flags = rest.filter((a) => a.startsWith('--'));
         const positional = rest.filter((a) => !a.startsWith('--'));
-        if (positional.length > 1 || flags.some((f) => f !== '--json' && f !== '--plan')) usage();
+        const KNOWN = ['--json', '--plan', '--exclude-live-sessions'];
+        const ageFlag = flags.find((f) => f.startsWith('--min-age-days='));
+        if (
+            positional.length > 1 ||
+            flags.some((f) => !KNOWN.includes(f) && !f.startsWith('--min-age-days='))
+        ) {
+            usage();
+        }
+        let minAgeDays: number | null = null;
+        if (ageFlag !== undefined) {
+            const raw = ageFlag.slice('--min-age-days='.length);
+            const n = Number(raw);
+            // Refuse rather than silently fall back to null: a typo'd floor that
+            // reads as "no floor" would widen the safe set at exactly the moment
+            // the caller asked to narrow it.
+            if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+                process.stderr.write(`--min-age-days needs a non-negative integer, got '${raw}'\n`);
+                return 2;
+            }
+            minAgeDays = n;
+        }
         const repo = path.resolve(positional[0] ?? '.');
-        const inv = buildInventory(repo);
+        const inv = buildInventory(repo, {
+            minAgeDays,
+            excludeLiveSessions: flags.includes('--exclude-live-sessions'),
+        });
 
         if (flags.includes('--json')) {
             process.stdout.write(`${JSON.stringify(inv, null, 2)}\n`);

--- a/tests/scripts/worktree_cleanup_check.test.ts
+++ b/tests/scripts/worktree_cleanup_check.test.ts
@@ -346,6 +346,19 @@ describe('trunk resolution + location convention', () => {
         // A directory whose name merely starts with a root name is not inside it.
         expect(isStandardLocation(repo, path.join(repo, '.worktrees-old', 'd'))).toBe(false);
     });
+
+    // Regression, measured 2026-08-13: called with a LINKED worktree as the base
+    // instead of the main worktree, every conventional sibling resolves to `..`
+    // and the safe set collapses to empty. On the real repo that read as
+    // "safe 0 of 304" from inside a worktree versus "safe 181" from the main
+    // checkout — a cleanup tool failing silently, toward inaction.
+    it('a conventional worktree is standard against the MAIN worktree, not against a sibling', () => {
+        const wtA = path.join(repo, '.claude', 'worktrees', 'a');
+        const wtB = path.join(repo, '.claude', 'worktrees', 'b');
+        expect(isStandardLocation(repo, wtA)).toBe(true);
+        // The defect: judging sibling `a` from inside sibling `b`.
+        expect(isStandardLocation(wtB, wtA)).toBe(false);
+    });
 });
 
 describe('ownsOverlap glob-prefix semantics', () => {


### PR DESCRIPTION
## The one-line defect with a total effect

`isStandardLocation` took the **invoking** repo path as its base. Called from inside a linked worktree, every conventional sibling resolves to `..`, and the safe set collapses to empty.

Same binary, same repo, same minute:

| Invoked from | registered | safe | review | non-standard-location |
|---|---:|---:|---:|---:|
| inside `.claude/worktrees/<branch>` | 304 | **0** | 280 | 278 |
| the main checkout | 304 | **181** | 99 | 81 |

The base is now `mainPath` — which `buildInventory` already computed and simply did not pass. Pinned by a regression test that judges one sibling worktree from inside another.

This is the worst shape a cleanup tool can fail in: **silently, and toward inaction.** A maintainer running it from a worktree reads *"nothing to clean"* and concludes the estate is fine.

## The two conditions the approval named and the tool did not have

`inventory` gains `--min-age-days=N` and `--exclude-live-sessions`, both **off by default**.

- The age floor **layers on top of** the 48-hour live window rather than replacing it. 48 h answers *is someone in it right now*; a 60-day floor answers *is this abandoned*. Different questions.
- The session check reads the **session register** — real records with a real `worktree` path and a real TTL — instead of inferring occupancy from file mtime, which this module's own header already rules out as a liveness signal.
- An unreadable git-dir mtime **disqualifies** under an age floor rather than passing it: absence of evidence must not read as "old enough".
- A malformed `--min-age-days` is **refused**, not silently treated as no floor — a typo that widens the safe set at the moment the caller asked to narrow it is the failure this guards.

## The removal, and why it is two rather than 181

| Predicate | safe |
|---|---:|
| tool default (merged · clean · conventional root · 48 h) | 181 |
| **as approved** (+ >60 days · no live session) | **2** |

Both removed, by name:

- `.claude/worktrees/perf-installer-e2e` → branch `fix/lint-report-warnings`
- `.claude/worktrees/reaping-orphans` → branch `fix/reaping-pre-inventory-orphans`

Registered **304 → 302**. A re-run under the same predicate reports safe **0**, so the approval is fully spent.

Executing the 181-item set instead would have removed **179 worktrees the approved predicate rejects** — the exact substitution the approval exists to prevent.

## The finding that outlives the cleanup

**275 of 304 worktrees had git activity inside 60 days.** The 40 GB is not residue of abandoned work — it is *current* work. The condition set that made the removal safe also made it nearly empty, and those are the same fact rather than a disappointment: at this branching rate, "untouched for 60 days" describes almost nothing.

Reclaiming the disk means deciding about **recent** worktrees, which no age floor can authorise. The honest options are a cap on concurrent worktrees, removal keyed on merged-and-branch-deleted regardless of age, or accepting the cost. That is a policy call and it is **not made here**.

`road-to-worktree-hygiene` closes at 100 % and is archived. Its last acceptance criterion is ticked with the number beside it and an explicit non-claim: the approved set was removed, the disk problem was not solved, and the criterion never asked the second question.

## Verification

- `task preflight` — exit 0
- `tests/scripts/worktree_cleanup_check.test.ts` — 24 passed (1 new regression)
- `npx tsc --noEmit` — exit 0
- `roadmap:progress-check`, `lint_roadmap_blockers` — exit 0
- Branch level with `origin/main` at push time
