### PR TITLE
fix(dispatch): refuse a cli-delegate bundle older than its sources

### DIFF
--- a/src/scripts/_dispatch.bash
+++ b/src/scripts/_dispatch.bash
@@ -447,6 +447,9 @@ require_tsx() {
 # command surface (`sync`, `doctor`, `validate`, `upgrade`, …) and its
 # basenames are unique, so the mapping is collision-free. Other exec_ts
 # callers (resolve_script results, the work engine, …) are unaffected.
+#
+# In a DEV tree the bundle is also suppressed when any `src/**/*.ts` is newer
+# than it — see cli_delegate_bundle_is_stale.
 cli_delegate_bundle() {
   local ts_abs="$1"
   case "$ts_abs" in
@@ -457,18 +460,52 @@ cli_delegate_bundle() {
   name="$(basename "${ts_abs%.ts}")"
   local bundle="$PACKAGE_ROOT/dist/cli-delegate/$name.js"
   if [[ -f "$bundle" ]] && command -v node >/dev/null 2>&1; then
+    cli_delegate_bundle_is_stale "$bundle" && return 0
     printf '%s' "$bundle"
   fi
+}
+
+# Is a `dist/cli-delegate/` bundle older than the sources it was built from?
+#
+# Only asked in a DEV tree — `$PACKAGE_ROOT/src` exists there and nowhere else.
+# A consumer install ships no `src/`, so it returns "not stale" without a single
+# stat and the ADR-204 fast path is untouched.
+#
+# The scan covers `src` WHOLE, not `src/scripts`: `_cli/*.ts` imports reach into
+# `src/shared`, `src/install`, `src/server`, `src/agent`, `src/config` and
+# `src/agent-src`, and the defect this guard exists for lived two hops away in
+# `src/scripts/_lib/cc_transcript.ts` — a scan narrowed to the entry point's own
+# directory would have missed it.
+#
+# Cost, measured 2026-08-14 on the local tree (1075 `.ts` files): 78 ms when the
+# bundle is current (the full walk) and ~12 ms when it is not (`-quit` exits at
+# the first newer file). The bundle saves ~290 ms against the tsx path, so the
+# worst case still leaves most of that — and buys the guarantee that a dev-tree
+# edit is never silently ignored in favour of a stale compile.
+cli_delegate_bundle_is_stale() {
+  local bundle="$1"
+  [[ -d "$PACKAGE_ROOT/src" ]] || return 1
+  local newer
+  newer="$(find "$PACKAGE_ROOT/src" -name '*.ts' -newer "$bundle" -print -quit 2>/dev/null)"
+  [[ -n "$newer" ]]
 }
 
 # Run an absolute script path. The argument is an absolute path that may carry
 # a `.py` (legacy) or `.ts` extension; we resolve the `.ts` twin.
 #
-# A precompiled `dist/cli-delegate/` bundle wins when present — the consumer
-# tree ships no tsx (see require_tsx), and the bundle is also ~5.7x faster
-# than the npx path it replaces (p50 56-71 ms vs 346-392 ms, measured
-# 2026-07-31; see docs/decisions/ADR-204). The tsx path stays as the dev-tree
-# route and as the fallback for every non-`_cli` caller.
+# A precompiled `dist/cli-delegate/` bundle wins when present AND not stale —
+# the consumer tree ships no tsx (see require_tsx), and the bundle is also
+# ~5.7x faster than the npx path it replaces (p50 56-71 ms vs 346-392 ms,
+# measured 2026-07-31; see docs/decisions/ADR-204). The tsx path stays as the
+# dev-tree route and as the fallback for every non-`_cli` caller.
+#
+# "Not stale" is the load-bearing qualifier, and it was added because the
+# unqualified version shipped a real failure: a dev-tree `dist/cli-delegate/`
+# built before a `projectStoreSlug` fix kept running the OLD slug, so
+# `agent-config handoff --list` reported "no recent sessions" in any worktree
+# whose path carried a `+`, while the fixed source right next to it listed ten.
+# A compiled copy that silently outranks the source it was built from turns
+# every edit into a coin flip — see cli_delegate_bundle_is_stale.
 #
 # Argv/stdin/stdout/stderr/exit-code pass through unchanged in both routes —
 # mirrors src/scripts/run.ts resolution.

--- a/tests/scripts/cli_delegate_bundle_freshness.test.ts
+++ b/tests/scripts/cli_delegate_bundle_freshness.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A `dist/cli-delegate/` bundle must not outrank the source it was built from.
+ *
+ * `exec_ts` prefers the precompiled bundle over the `.ts` entry (ADR-204, ~5.7x
+ * faster). That is right in a consumer install, which ships no `src/` and no
+ * tsx. In a DEV tree it is a trap: the compiled copy keeps running while the
+ * source next to it changes, so an edit is silently ignored and the developer
+ * tests a file nobody executes.
+ *
+ * Measured failure, 2026-08-14: a dev-tree bundle built before a
+ * `projectStoreSlug` fix carried the old character class (`/[/.]/g`, which
+ * leaves `+` intact) while the fixed source carried `/[^A-Za-z0-9-]/g`. In a
+ * worktree whose path contained a `+`, `agent-config handoff --list` reported
+ * "no recent sessions found for this repo" — the computed transcript-store slug
+ * named a directory that does not exist. The same enumeration, invoked through
+ * `tsx` against the very same sources, listed ten sessions. Nothing warned; the
+ * command simply answered as if the user had no history.
+ *
+ * `_dispatch.bash` ends by calling `main "$@"`, so it cannot be sourced. The
+ * two functions are therefore extracted from the real file and evaluated — the
+ * shipped definitions, not a paraphrase — and a separate assertion pins the
+ * call site, since an extracted function that nothing calls would pass happily.
+ */
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DISPATCH = path.join(REPO, 'src', 'scripts', '_dispatch.bash');
+
+/** Pull one top-level `name() { … }` block out of the real dispatcher. */
+function extractFunction(source: string, name: string): string {
+    const start = source.indexOf(`${name}() {`);
+    if (start < 0) throw new Error(`function ${name}() not found in _dispatch.bash`);
+    const end = source.indexOf('\n}\n', start);
+    if (end < 0) throw new Error(`function ${name}() has no closing brace`);
+    return source.slice(start, end + 3);
+}
+
+interface Fixture {
+    root: string;
+    bundle: string;
+    source: string;
+}
+
+/**
+ * A minimal tree with the two paths the guard reads: one `src/**\/*.ts` and one
+ * `dist/cli-delegate/<name>.js`. `devTree: false` omits `src/` entirely — that
+ * is what a consumer install looks like.
+ */
+function makeFixture(devTree: boolean): Fixture {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'delegate-freshness-'));
+    const bundleDir = path.join(root, 'dist', 'cli-delegate');
+    fs.mkdirSync(bundleDir, { recursive: true });
+    const bundle = path.join(bundleDir, 'cmd_probe.js');
+    fs.writeFileSync(bundle, '// bundle\n');
+
+    const source = path.join(root, 'src', 'scripts', '_lib', 'dep.ts');
+    if (devTree) {
+        fs.mkdirSync(path.dirname(source), { recursive: true });
+        fs.writeFileSync(source, '// source\n');
+    }
+    return { root, bundle, source };
+}
+
+/** Set both mtimes explicitly — `newer` decides which side wins. */
+function setOrder(fixture: Fixture, newer: 'bundle' | 'source'): void {
+    const older = new Date(Date.now() - 60_000);
+    const recent = new Date();
+    const bundleTime = newer === 'bundle' ? recent : older;
+    const sourceTime = newer === 'source' ? recent : older;
+    fs.utimesSync(fixture.bundle, bundleTime, bundleTime);
+    if (fs.existsSync(fixture.source)) fs.utimesSync(fixture.source, sourceTime, sourceTime);
+}
+
+/**
+ * Evaluate `cli_delegate_bundle` from the real file against a fixture root and
+ * return what it echoed — the bundle path, or '' meaning "use the tsx path".
+ */
+function resolveBundle(root: string): string {
+    const dispatch = fs.readFileSync(DISPATCH, 'utf-8');
+    const script = [
+        'set -euo pipefail',
+        `PACKAGE_ROOT=${JSON.stringify(root)}`,
+        extractFunction(dispatch, 'cli_delegate_bundle_is_stale'),
+        extractFunction(dispatch, 'cli_delegate_bundle'),
+        `cli_delegate_bundle "$PACKAGE_ROOT/src/scripts/_cli/cmd_probe.ts"`,
+    ].join('\n');
+    return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim();
+}
+
+describe('cli_delegate_bundle freshness guard', () => {
+    const fixtures: Fixture[] = [];
+    const track = (f: Fixture): Fixture => {
+        fixtures.push(f);
+        return f;
+    };
+
+    beforeAll(() => {
+        expect(fs.existsSync(DISPATCH)).toBe(true);
+    });
+
+    afterAll(() => {
+        for (const f of fixtures) fs.rmSync(f.root, { recursive: true, force: true });
+    });
+
+    it('uses the bundle when it is newer than the sources', () => {
+        const f = track(makeFixture(true));
+        setOrder(f, 'bundle');
+        expect(resolveBundle(f.root)).toBe(f.bundle);
+    });
+
+    it('falls back to tsx when a source is newer than the bundle', () => {
+        const f = track(makeFixture(true));
+        setOrder(f, 'source');
+        // The regression: this returned the stale bundle path, so the dispatcher
+        // ran month-old compiled logic against freshly edited sources.
+        expect(resolveBundle(f.root)).toBe('');
+    });
+
+    it('keeps the consumer fast path — no src/ means no staleness scan', () => {
+        const f = track(makeFixture(false));
+        setOrder(f, 'bundle');
+        expect(fs.existsSync(path.join(f.root, 'src'))).toBe(false);
+        expect(resolveBundle(f.root)).toBe(f.bundle);
+    });
+
+    it('scans src/ whole, not just the entry point directory', () => {
+        // The slug defect lived in src/scripts/_lib/, two hops from the _cli
+        // entry; a later narrowing of the scan would silently reopen it.
+        const f = track(makeFixture(true));
+        const outside = path.join(f.root, 'src', 'shared', 'far.ts');
+        fs.mkdirSync(path.dirname(outside), { recursive: true });
+        fs.writeFileSync(outside, '// far from _cli\n');
+        // Everything the narrow scan would have covered is OLDER than the
+        // bundle; only the far file is newer. `find -newer` is strict, so the
+        // two sides must not share a timestamp — hence explicit times here
+        // rather than setOrder's two-value scheme.
+        const old = new Date(Date.now() - 60_000);
+        fs.utimesSync(f.source, old, old);
+        fs.utimesSync(f.bundle, old, old);
+        const recent = new Date();
+        fs.utimesSync(outside, recent, recent);
+        expect(resolveBundle(f.root)).toBe('');
+    });
+
+    it('is actually wired into the bundle resolver', () => {
+        // An extracted function nothing calls would pass every test above.
+        const dispatch = fs.readFileSync(DISPATCH, 'utf-8');
+        const resolver = extractFunction(dispatch, 'cli_delegate_bundle');
+        expect(resolver).toContain('cli_delegate_bundle_is_stale');
+    });
+});


### PR DESCRIPTION
## What was broken

`/agent-handoff` was supposed to list recent sessions, let the user pick one, and
generate the handoff from that session. In a live session it did not: it produced
the old copy-paste summary instead, and `agent-config handoff --list` reported
**"no recent sessions found for this repo"** in a worktree that had 1201 lines of
transcript sitting on disk.

The source was fine. Running the very same enumeration through `tsx` over the
very same files listed ten sessions.

## Root cause

`exec_ts` prefers `dist/cli-delegate/<name>.js` over the `.ts` entry (ADR-204,
about 5.7x faster). That is correct for a consumer install, which ships neither
`src/` nor tsx. In a dev tree it means a compiled copy silently outranks the
source it was built from.

The dev-tree bundle had been built before a `projectStoreSlug` fix and still
carried the old character class:

| | slug logic |
|---|---|
| `src/scripts/_lib/cc_transcript.ts` (current) | `cwd.replace(/[^A-Za-z0-9-]/g, '-')` |
| `dist/cli-delegate/cmd_handoff.js` (stale) | `cwd.replace(/[/.]/g, "-")` |

The old expression leaves `+` intact. In a worktree whose path contained a `+`,
the computed transcript-store slug named a directory that does not exist, so the
enumeration returned zero and the command answered as if the user had no history.
Nothing warned. Any `_cli` command can fail this way, and the failure shape is
"wrong answer, exit 0".

## The fix

`cli_delegate_bundle` now skips the bundle when any `src/**/*.ts` is newer than
it. The question is only asked when `PACKAGE_ROOT/src` exists, so a consumer
install performs no extra stat and the ADR-204 fast path is untouched.

The scan covers `src` whole rather than `src/scripts`: `_cli` entries import from
`src/shared`, `src/install`, `src/server`, `src/agent`, `src/config` and
`src/agent-src`, and this defect lived two hops from the entry point, in
`src/scripts/_lib/cc_transcript.ts`. A scan narrowed to the entry directory
would have missed it.

## Cost

Measured on the local tree, 1075 `.ts` files:

- **78 ms** when the bundle is current — the full walk.
- **~12 ms** when it is not — `find -quit` exits at the first newer file.

The bundle saves roughly 290 ms against the tsx path, so the worst case keeps
most of the win. Consumer installs pay nothing.

## Verification

End-to-end through the real `exec_ts` path, with a marker bundle:

- bundle newer than sources → marker printed, fast path intact
- sources newer than bundle → marker absent, tsx ran

Five tests in `tests/scripts/cli_delegate_bundle_freshness.test.ts` pin both
directions, the consumer fast path (no `src/`), the whole-`src` scope, and the
call site itself — an extracted helper that nothing calls would otherwise pass
every behavioural assertion.

Also green: `bash -n`, shellcheck on the changed file (one pre-existing SC2016
info at line 1045, untouched), eslint on the new test, `task typecheck-ts`.

## Not in this PR

The **stale generated `.claude/skills/` projection** in the main checkout, dated
5 July, which is why the live session loaded the pre-picker `/agent-handoff` body
in the first place. Same failure class — a gitignored generated artifact going
stale against its source with nothing detecting it — but a different mechanism
(`task generate-tools` output rather than the CLI bundle), so it wants its own
change rather than a widened diff here.
