### PR TITLE
chore(roadmaps): continuation sweep — four corrected claims, one roadmap closed, three Hard-Floor handbacks

### DIFF
--- a/agents/evidence/reports/SWEEP-REPORT-2026-08-14-continued.md
+++ b/agents/evidence/reports/SWEEP-REPORT-2026-08-14-continued.md
@@ -249,3 +249,67 @@ code surface for this completion"*, which was false there. This run adds **no
 code** — every change is roadmap prose, one ADR status field, and the
 regenerated dashboard — so it contributes no new code surface to that debt. It
 does not discharge it either.
+
+## Addendum — the maintainer disposed the deferrals, and the roadmap closed
+
+Nothing above is rewritten. This is the delta after the run's one question was
+answered: **option 1 — migrate all four deferrals to one successor roadmap.**
+
+`road-to-inbox-harvest-2026-08` is **closed at 100 % and archived**. P2.2 — the
+executable-DoD + bounded self-fix loop, whose blocker had resolved that morning
+and whose step still carried the superseded "MEASUREMENT HALF BLOCKED" premise —
+is `[x]`. The four `[~]` items are `[-] migrated` into
+`road-to-inbox-harvest-residuals.md` as R1–R4, each carrying the reasoning that
+deferred it, because in three of the four that reasoning is the load-bearing
+part: R1's acceptance clause demands the committed-corpus migration § 2.7 of the
+completion-review contract forbids, and its schema looks wrong deliberately (the
+repo's Draft-07 subset silently ignores `$ref` and `const`, so the obvious
+tidy-up would validate nothing); R2's declined design names a revisit trigger
+that has not fired; R4's ratchet-before-split is the decision, not a detail.
+
+Both blockers that outlived the roadmap moved with them, since an open blocker
+refuses archival and keeping the file active merely to hold them would be worse.
+
+**Revised counts.**
+
+| Measure | Run start | After the disposition | Δ |
+|---|---:|---:|---:|
+| Open roadmaps | 26 | 26 | 0 (one archived, one created) |
+| Steps done | 234 / 411 | 223 / 403 | one roadmap out of the active set |
+| Open blockers | 33 | 33 | 0 (two migrated, not closed) |
+| Blockers needing the user | 9 | 9 | 0 |
+
+The step total falls because a closed roadmap leaves the active denominator; it
+is not a regression. The blocker count is again flat and again conceals a real
+exchange — two moved home rather than closing.
+
+**`spent-inbox-artifacts-await-deletion` was migrated, not executed, and the
+reason was found by attempting it.** The grant approved deleting *"both
+`council-q-*.md` files"*. That glob matches **12** files in `agents/tmp.old/`
+(measured; the 9 sibling `council-question-*.md` do not match, since the glob
+requires `council-q-`), so acting on the pattern would delete 10 files nobody
+approved — and `non-destructive-by-default` requires an approval to name its
+exact object. The directory is also gitignored and per-checkout: a deletion made
+in a worktree is a no-op, and one made in the main checkout appears in no diff a
+reviewer reads. The item needs two filenames, not a broader authorization.
+
+**Link depth was re-done by hand, and a sibling proves why.** Moving into
+`archive/` breaks two classes at once: the new links to the successor need `../`,
+and pre-existing `../../docs/` links need `../../../`. An already-archived
+sibling carries `../../docs/`, which resolves to a nonexistent `agents/docs/` —
+that pattern was **not** copied. Every relative link in the moved file was
+resolved individually; `check-refs` could not have caught any of it, because it
+reports 580 targets under `excluded_directory` and `archive/` is among them.
+
+**Verification.** `lint_roadmap_blockers` 33 roadmaps clean ·
+`lint_plan_risk_register` clean over 32 ready roadmaps ·
+`lint_roadmap_family_cap` 2/2 slots (the successor is not a family slot) ·
+`roadmap:progress-check` up to date · `task preflight` green with zero
+advisories · `check_completion_review` clean at 13 changed files.
+
+**The skip was re-bound twice, and that is the mechanism working.** It held
+scopes `f4f2bda3…` → `83ff6329…` → `a7215cd7…`, once for the sweep report and
+once for the closure. Each re-bind touched the artifact and nothing else — the
+artifact is not itself counted in the scope, which is what makes the fixed point
+reachable. A skip that survived a content change would be asserting "no code
+surface" about a diff it had never seen.

--- a/agents/evidence/reports/SWEEP-REPORT-2026-08-14-continued.md
+++ b/agents/evidence/reports/SWEEP-REPORT-2026-08-14-continued.md
@@ -1,0 +1,251 @@
+# Roadmap completion sweep — 2026-08-14, continuation run
+
+**Base:** `1bff954d2` (`origin/main`, "Merge pull request #1351").
+**Branch:** `roadmap-sweep/2026-08-14-continued`. Not pushed; merge is the maintainer act.
+**Authorization:** the same blanket in-session grant of 2026-08-14, re-issued.
+**Predecessor:** `SWEEP-REPORT-2026-08-14.md`, merged as PR #1351 earlier the same day.
+Nothing in that report is rewritten here.
+
+## Headline — the same prompt ran twice, and the second run's product is corrections
+
+The first sweep discharged the 6 blockers that authorization could reach and
+documented why the other 33 could not be. Re-issuing the prompt cannot find
+another six; the grant was already spent on everything it fits.
+
+What a second pass **is** good for is checking the first pass's claims against
+the tree. Four did not survive:
+
+> **A bench recorded as "fire it next session" has no runner and a human
+> primary scorer. A roadmap step recorded as blocked has been unblocked since
+> the morning. A "three offenders" count is four. A hazard recorded as
+> repo-wide is scoped to one path prefix.**
+
+Three of those four were assertions made *by the previous sweep or by the
+roadmaps it edited*, and each would have cost the next session something real —
+a budget, a closure, an incomplete retrofit, or a correct action refused out of
+fear. That is this run's product.
+
+## Counts
+
+| Measure | Before | After | Δ |
+|---|---:|---:|---:|
+| Open roadmaps | 26 | 26 | 0 |
+| Steps done | 234 / 411 | 234 / 411 | **0** |
+| Open blockers | 33 | 33 | 0 |
+| Blockers needing the user | 9 | 9 | 0 |
+
+**Zero steps closed, and that is the finding rather than a shortfall.** The one
+step this run proved closable — `road-to-inbox-harvest-2026-08` P2.2 — is
+blocked from closing by an Iron Law, not by its work (below). Every other open
+step across 26 roadmaps is gated on data, a host install, a human, or a kernel
+guard, exactly as the predecessor found.
+
+**The blocker count is flat but its composition moved**: one discharged by
+authorization, one surfaced that had never been written down. A flat number
+concealing a real exchange is worth stating, because the dashboard cannot.
+
+## Blockers resolved (1)
+
+| Blocker | Roadmap | Decision |
+|---|---|---|
+| `consolidation-breaking-change-permission` | cost-parity-1 | **ALL tranches authorized**, not just the pilot |
+
+The grant names this one explicitly. Two things the resolution deliberately does
+not do. It does not spend the migration note: the grant released the *asking*,
+not the *documenting*, so the note moves into step 2.3 as the tranche deliverable
+it always was. And it flips no step — `agent-config gates` renders it as
+"unblocks: 49 steps" because it counts the roadmap rather than the critical path,
+while Phase 2 remains gated on `utilization-sweep-window` (time-gated to
+~2026-08-26) and `skill-activation-window` (an unverified instrument). A tranche
+landed today would publish an activation comparison against a baseline that does
+not exist — the silent-capability-loss trade that roadmap's Risk 1 refuses.
+
+## Blocker surfaced (1) — the correction that matters most
+
+`manual-rubric-rater`, on `road-to-scale-history-bench-run`, owner **user**.
+
+The predecessor recorded that bench as *"genuinely fireable; held for session
+capacity, not permission"* and pre-authorized it to fire in the next session with
+time. This run had time. Checked against the tree, it is not fireable at all:
+
+1. **There is no runner.** `internal/bench/scale-history/` holds `task.md`,
+   `seed-schema.sql`, `rubric.md`, `sample-artifact/` and `score.ts` — and
+   `score.ts` is a *scorer*, taking `--artifact <dir>` and spawning
+   `lint_persistence` over it (`score.ts:25-26`, `:75-99`). A grep for a
+   scale-history runner across `internal/bench/`, `src/scripts/` and `tests/`
+   returns the scorer, its test, and the pre-registration. Nothing produces the
+   96 artifacts (3 arms × 16 × ≥2 families) the prereg requires.
+2. **The primary scorer is a human, by pre-registration.** The prereg makes the
+   manual rubric PRIMARY and `lint_persistence` SECONDARY
+   (`scale-history-PREREG.md:63-69`), and the rubric's first line binds the
+   ordering: *"The rater never sees `lint_persistence` output before scoring
+   (anti-anchor)"* (`rubric.md:4-5`). An agent scoring artifacts an agent
+   produced is the substitution that invalidates the result — the same refusal
+   `road-to-council-blind-review` records for its own blind ratings.
+
+So the honest state is **authorized, and blocked on two builds the roadmap does
+not contain**. The spend grant is untouched and is not re-asked. Had this run
+taken "fire it" literally, it would have spent a real budget on a run with no
+producer and no admissible scorer.
+
+## Maintainer-delegated decisions, with the reasoning that decided them
+
+**1 · ADR-223 `proposed` → `accepted`.** The grant names
+`required-check-set-change`; the ADR says in its own Status section that
+acceptance is the maintainer's call. Worth stating what acceptance does *not*
+buy: ADR-223's decision is **not to demote**, so accepting it settles the
+question by closing it and licenses no ruleset write. The macOS leg and the
+`npm audit` gate were never in the required set (ADR-223 § Context fact 1) —
+removing them from a PR would be a *trigger* change, not a required-check change.
+
+**2 · The distillation retrofit is four skills, not three.**
+`lint_skill_router_head` reports 4 over the 400-line cap and `GRANDFATHERED` in
+`lint_skill_router_head.ts:60-65` names them with measured counts — `ai-council`
+(1055), `skill-writing` (767), `roadmap-management` (552), `quality-tools` (445).
+The allowlist is **shrink-only**, so retrofitting three and closing the step
+leaves the fourth entry unremovable and the step falsely done. Corrected in both
+the step and its Rollback line, with the lint bound as the step's `verify:`.
+
+**3 · The ledger `session_id` correction is done; the step is not.**
+`road-to-subagent-lifecycle-integrity` Phase 1 Step 4 correction (b) said the
+appended line does not carry `session_id`. It does, as of the predecessor —
+`subagent_ledger_hook.ts:593` and `:608`, header at `:76`. Marked FIXED so it is
+not re-implemented. The step stays open on a reason now written down: the
+pre-fix window is still cross-session, so the ≥20-dispatch baseline counts from
+the fix commit **forward**, not from the existing 25 stop records. The citation
+is given as a field name plus a pair of offsets deliberately — this file's Phase
+4 sibling has had three successive line citations rot, so the durable anchor is
+the field.
+
+## Where a hard invariant beat the grant
+
+Per the run's own conflict rule, these were skipped and recorded rather than
+softened.
+
+**The npm publish and public GitHub Release** (`road-to-ci-native-release-first-run`
+Phase 2). `non-destructive-by-default` lists *deploy / release* and *irreversible
+external action — publish* as Hard Floor triggers, and requires a **this-turn
+approval naming the exact object**. "All maintainer blockers are approved" names
+a category. A blanket grant is precisely the shape the Hard Floor is written to
+not accept, and this is the single most irreversible act anywhere in the estate:
+an npm `latest` dist-tag move, a public Release, a git tag.
+
+**The ruleset write and the merge-queue enablement** (`-ci-economy`,
+`maintainer-bus-factor` Phase 2). Same Hard Floor, infrastructure leg: both
+change how every future merge to `main` lands, including the maintainer's own.
+The grant itself asked for the steps it cannot delegate to be handed back, so
+both blockers now carry the full procedure — `gh api` read-modify-write with a
+before-artefact and a rollback line, plus the browser click-path — and three
+traps that each fail silently:
+
+- a path filter on a required check's PR trigger never reports on a PR touching
+  none of those paths, and never-reported reads as never-satisfied: permanent
+  block, no red X;
+- nothing in CI observes whether the armed set still matches
+  `branch-protection-policy.md`, so it must be armed against that file;
+- the merge queue must be enabled **after** `merge_group` triggers land. Zero
+  workflows declare one today; enabling first stalls every PR.
+
+**The `install --layer` suppression** (`road-to-carrier-layer-convergence`
+Phase 3). It changes the user's global install live for every session on this
+machine. `security-sensitive-stop` § self-modification routes a self-config edit
+through the edit-permission gates rather than letting a session apply it to
+itself. Recorded, not run.
+
+**The three kernel amendments**, unchanged from the predecessor.
+`block_kernel_rule_writes` is a `fail_closed: true`, `severity: blocking`
+PreToolUse guard bound on every host (`hook_manifest.yaml:114-118`), keyed on
+`is_kernel_rule(basename) && path contains 'rules/'`, with no agent-accessible
+override. It is a mechanism, not a preference, and no in-session grant reaches
+an exit-1 at tool-call time.
+
+## The one step that is done and cannot be closed
+
+`road-to-inbox-harvest-2026-08` P2.2 — the executable-DoD + bounded self-fix
+loop. Its blocker `self-fix-halt-telemetry` **resolved 2026-08-14** via path (b);
+the step's own text still said *"BUILD HALF SHIPPED, MEASUREMENT HALF BLOCKED"*,
+a premise that died the same morning. On the work, P2.2 is done, and it is the
+only step in the estate this run found in that state.
+
+It stays `[ ]` because the roadmap carries four `[~]` deferrals, so flipping it
+takes `count_open` to 0 with `count_deferred` at 4 — the exact trigger for
+`roadmap-progress-sync` Iron Law 3, which reserves the disposition of a deferral
+to the user. The closing commit is roadmap-touching by construction, so **it
+blocks itself** until the four are disposed in the same change.
+
+None of the four is honestly cancellable — P1.1 is a wanted rendering half over
+a shipped schema, P1.4 reopens a decision the grant has now approved reopening,
+P3.3 is "worth doing, not urgent", P5.6 is a deliberate ratchet-before-split
+stance. Marking any of them `[-]` to clear the gate would be the buried-work
+failure Iron Law 3 exists to stop. They are surfaced to the maintainer this run,
+and the closing recipe is written at the step.
+
+## Honest nulls — attempted, and did not produce what was hoped
+
+- **Zero steps closed.** Stated as the headline rather than buried: across 26
+  roadmaps and four parallel surveys, no open step was both executable under the
+  grant and free of a data, host, human, or kernel gate — except P2.2, which an
+  Iron Law holds shut.
+- **A hazard was overstated, in the direction that suppresses correct work.**
+  `-ledger-truth` records that with `count_open` at 0 and a `[~]` present the
+  gate *"refuses **every** commit in the repository"*. The installed pre-commit
+  guards the check behind
+  `git diff --cached --name-only | grep -qE '^agents/roadmaps(-progress\.md|/)'`,
+  commented *"only fires when staged changes touch a roadmap file or the
+  dashboard itself, so unrelated commits stay fast."* A commit touching no
+  roadmap is unaffected. This nearly cost the run a correct closure: the
+  overstated version reads as "closing P2.2 deadlocks the branch", which would
+  have made the right analysis look reckless. Corrected in place, with the
+  narrower real hazard restated.
+- **The cost-parity Phase 6 scope-exclusion phase was NOT closed, deliberately.**
+  Its eight `- [ ]` items are non-goals, and the house convention (verified
+  against `road-to-cost-parity-0-program` Phase 4 and `road-to-always-on-
+  orchestration` Phase 7, both archived) is to mark them `[x]` with a
+  verification comment — *"verified against the delivered diff, not asserted"*.
+  With Phases 1–5 at 0 %, there is no delivered diff to verify against, and 6.7
+  (no lint beyond the enumerated set) and 6.8 (a byte ceiling measured by 3.5c)
+  are unknowable before delivery. Closing them would have moved the roadmap 8
+  steps for free and asserted properties of a diff that does not exist.
+- **A subagent survey asserted the blanket grant covered the npm publish, the
+  branch-protection change, and the global install suppression.** It did not,
+  and the harness flagged it. Recorded because the failure mode is instructive:
+  a category-level authorization propagated through a delegation reads as
+  object-level consent at the far end, and the Hard Floor is the thing that has
+  to survive that. It did.
+
+## Spend
+
+| | Rendered estimate | Actually incurred |
+|---|---|---|
+| scale-history 3-arm bench | per prereg cost sheet | **$0** — not fireable (no runner, human primary scorer) |
+| solution-minimalism Phase 3 | $150–250 floor | **$0** — not fired; blocked on deltas #10/#11 |
+| surface-consolidation benchmarks | maintainer estimate pending | **$0** — not fired |
+| AI council | n/a | **$0** — not invoked |
+
+**Total incurred: $0.00.** No external model call was made this run. The four
+parallel surveys ran as in-session subagents on the session model.
+
+The predecessor's finding that a subscription-transport council seat still bills
+(estimate `$0.0000`, actual `$0.029745`) stands and was the reason no council
+pass was opened here: this run's open questions are dispositions reserved to the
+user by an Iron Law, and a council cannot answer those.
+
+## Verification
+
+`task preflight` was green (exit 0) on the base commit **before** any edit, so
+anything red afterwards is attributable to this branch. Per-change verification
+is in each commit message: `lint_roadmap_blockers` clean over 32 roadmaps (it
+caught a dropped `What to do` field mid-run, restored in the same commit),
+`check-adr-frontmatter` 171 ADRs / 0 errors, `lint_skill_router_head` as the
+bound verify for the corrected retrofit count, and the dashboard regenerated
+after every roadmap touch with `roadmap:progress-check` reporting up to date.
+
+Remote CI on the PR remains the authoritative gate.
+
+**The predecessor's standing advisory is inherited and still owed.**
+`check_completion_review` reports `missing-artifact` against that branch's code
+changes, and no skip was filed because the skip grammar requires asserting *"no
+code surface for this completion"*, which was false there. This run adds **no
+code** — every change is roadmap prose, one ADR status field, and the
+regenerated dashboard — so it contributes no new code surface to that debt. It
+does not discharge it either.

--- a/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
+++ b/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
@@ -1,6 +1,6 @@
 # Completion review — roadmap-sweep/2026-08-14-continued
 
-**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, or this artifact; the gate itself reports 0 code paths of 9 changed files, scope f4f2bda3a1c1c0a8b62633e718fadb5013e4492ffd71eb0fb9439acca611814b, declared 2026-08-14
+**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, the sweep report, or this artifact; the gate reports 0 code paths across the changed set, scope 83ff63293cb9073f35446adcb4ca2fe2a435543eeb95e407c86dfd85837adb45, declared 2026-08-14
 
 ## Why this skip is filed, when the predecessor refused one
 
@@ -36,6 +36,19 @@ reader to ignore the gate.
   three-to-four offender count, and the source of that correction.
 - `roadmap:progress-check` — dashboard up to date after every roadmap touch.
 - `task preflight` green again at `fa5728aaa`; the sole finding is this advisory.
+
+## Re-bound once, and the reason is worth recording
+
+This artifact first bound to scope `f4f2bda3…` and validated clean at that
+scope. Committing the sweep report alongside it moved the scope to
+`83ff6329…` — a new file under `agents/evidence/reports/` is part of the
+reviewed content, so the gate correctly reported `stale-review` on the next run.
+
+The artifact under `agents/evidence/reviews/` is **not** itself counted, which is
+what makes the fixed point reachable: re-binding by editing only this file leaves
+the scope where it is. Anything else committed alongside the re-bind would move
+the scope again and record a stale one — which is the whole trap, and why the
+re-bind commit touches this file and nothing else.
 
 ## What this skip does NOT discharge
 

--- a/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
+++ b/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
@@ -1,6 +1,6 @@
 # Completion review — roadmap-sweep/2026-08-14-continued
 
-**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, the sweep report, or this artifact; the gate reports 0 code paths across the changed set, scope a7215cd73fe0377ec7d0ae1d1dc29b7a6c3f4b6bda7b8a7dfd7566bbea00acee, declared 2026-08-14
+**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, the sweep report, or this artifact; the gate reports 0 code paths across the changed set, scope 64a2ea4cfeb1ae3a8264243b35d3ec0d890d42c621d3df23bc173e4b9ed8cab7, declared 2026-08-14
 
 ## Why this skip is filed, when the predecessor refused one
 
@@ -39,13 +39,21 @@ reader to ignore the gate.
 
 ## Re-bound once, and the reason is worth recording
 
-This artifact bound to `f4f2bda3…`, then `83ff6329…`, and now
-`a7215cd7…`. Each move was a real change to the reviewed content: the sweep
-report landing under `agents/evidence/reports/`, then the roadmap closure that
-archived `road-to-inbox-harvest-2026-08` and created its successor. The gate
-correctly reported `stale-review` each time, which is the mechanism working —
-a skip that survived a content change would be asserting "no code surface"
-about a diff it had never seen.
+This artifact bound to `f4f2bda3…`, then `83ff6329…`, then `a7215cd7…`, and
+finally `64a2ea4c…`. Each move was a real change to the reviewed content: the
+sweep report landing under `agents/evidence/reports/`, the roadmap closure that
+archived `road-to-inbox-harvest-2026-08` and created its successor, and the
+report addendum recording that closure. The gate reported `stale-review` each
+time, which is the mechanism working — a skip that survived a content change
+would be asserting "no code surface" about a diff it had never seen.
+
+**Three re-binds is a cost worth naming.** Each is one commit touching one file,
+and it is the correct behaviour rather than friction to engineer away: the
+alternative is a skip whose scope drifts from the diff it claims to cover. The
+practical lesson for the next long documentation-only branch is ordering — file
+the skip **last**, after the report and its addenda have landed, rather than
+mid-branch. This run filed it early precisely because the advisory surfaced
+early, and paid three re-binds for it.
 
 The artifact under `agents/evidence/reviews/` is **not** itself counted, which is
 what makes the fixed point reachable: re-binding by editing only this file leaves

--- a/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
+++ b/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
@@ -1,6 +1,6 @@
 # Completion review — roadmap-sweep/2026-08-14-continued
 
-**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, the sweep report, or this artifact; the gate reports 0 code paths across the changed set, scope 83ff63293cb9073f35446adcb4ca2fe2a435543eeb95e407c86dfd85837adb45, declared 2026-08-14
+**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, the sweep report, or this artifact; the gate reports 0 code paths across the changed set, scope a7215cd73fe0377ec7d0ae1d1dc29b7a6c3f4b6bda7b8a7dfd7566bbea00acee, declared 2026-08-14
 
 ## Why this skip is filed, when the predecessor refused one
 
@@ -39,10 +39,13 @@ reader to ignore the gate.
 
 ## Re-bound once, and the reason is worth recording
 
-This artifact first bound to scope `f4f2bda3…` and validated clean at that
-scope. Committing the sweep report alongside it moved the scope to
-`83ff6329…` — a new file under `agents/evidence/reports/` is part of the
-reviewed content, so the gate correctly reported `stale-review` on the next run.
+This artifact bound to `f4f2bda3…`, then `83ff6329…`, and now
+`a7215cd7…`. Each move was a real change to the reviewed content: the sweep
+report landing under `agents/evidence/reports/`, then the roadmap closure that
+archived `road-to-inbox-harvest-2026-08` and created its successor. The gate
+correctly reported `stale-review` each time, which is the mechanism working —
+a skip that survived a content change would be asserting "no code surface"
+about a diff it had never seen.
 
 The artifact under `agents/evidence/reviews/` is **not** itself counted, which is
 what makes the fixed point reachable: re-binding by editing only this file leaves

--- a/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
+++ b/agents/evidence/reviews/roadmap-sweep-2026-08-14-continued.findings.md
@@ -1,0 +1,45 @@
+# Completion review — roadmap-sweep/2026-08-14-continued
+
+**Skipped:** no code surface for this completion — every changed file is roadmap prose, one ADR status field, the regenerated dashboard, or this artifact; the gate itself reports 0 code paths of 9 changed files, scope f4f2bda3a1c1c0a8b62633e718fadb5013e4492ffd71eb0fb9439acca611814b, declared 2026-08-14
+
+## Why this skip is filed, when the predecessor refused one
+
+The immediately preceding sweep (`SWEEP-REPORT-2026-08-14.md`, PR #1351) left the
+same advisory standing and explicitly declined to file a skip. That was correct
+there and is not a precedent against this one — the branches differ in the exact
+fact the skip grammar asserts.
+
+That branch changed code: a `session_id` field on two ledger dispatch lines, a
+`harness_compat` schema field with both its users updated, and a new lint
+warning. Asserting "no code surface for this completion" would have been false,
+and filing it to silence an advisory is the defect that sweep's own triage had
+just flagged on PR #1349.
+
+This branch changes no code. The nine changed files are five roadmap markdown
+files, one ADR frontmatter `status:` value, the generated
+`agents/roadmaps-progress.md`, the sweep report, and this artifact. The gate
+computes that independently and says so in its own advisory text: *"diff has 0
+code path(s) of 9 changed file(s)"*. The skip is therefore a true statement, and
+the honest-null discipline that forbade it there requires it here — an advisory
+left standing when a truthful discharge exists is noise that trains the next
+reader to ignore the gate.
+
+## What was verified anyway, since a skip is not a claim that nothing was checked
+
+- `task preflight` green on the base commit `1bff954d2` **before** any edit, so
+  anything red afterwards is attributable to this branch.
+- `lint_roadmap_blockers` — 32 roadmaps blocker-contract-clean. It caught a real
+  regression mid-run: the cost-parity blocker edit dropped its required
+  `What to do` field, restored in the same commit.
+- `check_adr_frontmatter` — 171 ADRs, 0 errors, after the ADR-223 status flip.
+- `lint_skill_router_head` — bound as the `verify:` for the corrected
+  three-to-four offender count, and the source of that correction.
+- `roadmap:progress-check` — dashboard up to date after every roadmap touch.
+- `task preflight` green again at `fa5728aaa`; the sole finding is this advisory.
+
+## What this skip does NOT discharge
+
+The predecessor's own `missing-artifact` advisory, against the code it landed,
+is **still owed**. This artifact binds to this branch's scope hash only. A skip
+here says this branch carries no code surface; it says nothing about a branch
+that did, and it must not be read as closing that debt.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -19,7 +19,7 @@
 | 1 | [road-to-always-on-orchestration.md](roadmaps/road-to-always-on-orchestration.md) | 7 | 36 | 1 | 35 | 0 | 0 | [5](#blockers-road-to-always-on-orchestration) | ██████████ 97% |
 | 2 | [road-to-carrier-layer-convergence.md](roadmaps/road-to-carrier-layer-convergence.md) | 3 | 8 | 2 | 3 | 0 | 3 | [1](#blockers-road-to-carrier-layer-convergence) | ██████░░░░ 60% |
 | 3 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 4 | [road-to-cost-parity-1-rule-payload-diet.md](roadmaps/road-to-cost-parity-1-rule-payload-diet.md) | 6 | 49 | 49 | 0 | 0 | 0 | [3](#blockers-road-to-cost-parity-1-rule-payload-diet) | ░░░░░░░░░░ 0% |
+| 4 | [road-to-cost-parity-1-rule-payload-diet.md](roadmaps/road-to-cost-parity-1-rule-payload-diet.md) | 6 | 49 | 49 | 0 | 0 | 0 | [2](#blockers-road-to-cost-parity-1-rule-payload-diet) | ░░░░░░░░░░ 0% |
 | 5 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | [1](#blockers-road-to-council-blind-review) | ██████░░░░ 60% |
 | 6 | [road-to-distillation-followups.md](roadmaps/road-to-distillation-followups.md) | 2 | 2 | 2 | 0 | 0 | 0 | [2](#blockers-road-to-distillation-followups) | ░░░░░░░░░░ 0% |
 | 7 | [road-to-frontend-skill-application.md](roadmaps/road-to-frontend-skill-application.md) | 5 | 31 | 9 | 22 | 0 | 0 | [3](#blockers-road-to-frontend-skill-application) | ███████░░░ 71% |
@@ -32,7 +32,7 @@
 | 14 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
 | 15 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
 | 16 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
-| 17 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 17 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
 | 18 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
 | 19 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
 | 20 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
@@ -163,14 +163,6 @@
     activation instrument's depth on this store is unverified until that eval
     runs.
   - **Resolved when:** the pilot tranche PR cites its activation baseline and the window it was measured over.
-- **consolidation-breaking-change-permission** (owner: user) — blocks Phase 2 tranches landing
-  - **What to do:**
-    merging a cluster deletes published skill names from
-    consumer trees — a consumer-facing breaking change under
-    `downstream-changes § Breaking changes`. Each tranche needs explicit
-    permission plus its migration note; the pilot's note is the template for
-    the rest.
-  - **Resolved when:** the pilot tranche is authorized with its migration note reviewed.
 - **utilization-sweep-window** (owner: maintainer) — blocks Phase 1 census starting with real utilization data
   - **What to do:**
     `road-to-surface-consolidation.md` Phase 3's sweep is
@@ -178,6 +170,8 @@
     blocker. The census reuses its mechanic, so it waits rather than building
     a parallel one.
   - **Resolved when:** that sweep has run and its vocabulary is available to reuse.
+
+_1 blocker resolved._
 
 ### [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md)
 
@@ -486,6 +480,28 @@ _1 blocker resolved._
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | Run and publish | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+
+<a id="blockers-road-to-scale-history-bench-run"></a>
+**Blockers**
+
+- **manual-rubric-rater** (owner: user) — blocks Phase 1 step 1's scoring half, and thereby step 2's verdict
+  - **What to do:**
+    score each produced artifact against
+    `internal/bench/scale-history/rubric.md`, blind to arm, **before** any
+    `score.ts` output is viewed. The pre-registration makes this rubric the
+    PRIMARY defect count and `lint_persistence` merely SECONDARY
+    (`internal/bench/corpora/scale-history-PREREG.md:63-69`), and the rubric's
+    own first line makes the anti-anchor ordering binding
+    (`internal/bench/scale-history/rubric.md:4-5`).
+    - **Why no agent can close it:** an agent rating artifacts an agent produced
+    is the self-preference substitution that invalidates the result it is
+    meant to produce — the same refusal `road-to-council-blind-review` records
+    for its own blind ratings, and the reason `evaluator-independence` exists.
+    Substituting an AI rater here would not be a weaker result; it would be an
+    uncitable one.
+  - **Resolved when:** a human rubric score exists per artifact, recorded before the secondary `lint_persistence` pass for that artifact. - **Surfaced 2026-08-14** by the continuation sweep. It was always true and was never written down, which is why this roadmap read as spend-blocked-only.
+
+_1 blocker resolved._
 
 ### [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md)
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,10 +6,10 @@
 
 ## Overall
 
-**234 / 411 steps done · 57%**
+**223 / 403 steps done · 55%**
 
 ```text
-███████████████████████░░░░░░░░░░░░░░░░░   57%
+██████████████████████░░░░░░░░░░░░░░░░░░   55%
 ```
 
 ## Open roadmaps
@@ -27,7 +27,7 @@
 | 9 | [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 5 | 24 | 1 | 17 | 2 | 4 | [2](#blockers-road-to-inbox-harvest-2026-08-b-ci-economy) | █████████░ 94% |
 | 10 | [road-to-inbox-harvest-2026-08-b-dispatch-safety.md](roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md) | 4 | 21 | 1 | 14 | 0 | 6 | 0 | █████████░ 93% |
 | 11 | [road-to-inbox-harvest-2026-08-b-ledger-truth.md](roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md) | 3 | 19 | 1 | 12 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-ledger-truth) | █████████░ 92% |
-| 12 | [road-to-inbox-harvest-2026-08.md](roadmaps/road-to-inbox-harvest-2026-08.md) | 5 | 21 | 1 | 11 | 4 | 5 | [2](#blockers-road-to-inbox-harvest-2026-08) | █████████░ 92% |
+| 12 | [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md) | 1 | 4 | 4 | 0 | 0 | 0 | [2](#blockers-road-to-inbox-harvest-residuals) | ░░░░░░░░░░ 0% |
 | 13 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
 | 14 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
 | 15 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
@@ -347,41 +347,59 @@ _1 blocker resolved._
     at all and creates the ledger — a step upstream of the one this blocker waits on.
   - **Resolved when:** at least one real `rate_missing` row exists and its field set is written down, so a backfill pass can be built against an observed shape rather than a guessed one.
 
-### [road-to-inbox-harvest-2026-08.md](roadmaps/road-to-inbox-harvest-2026-08.md)
+### [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md)
 
-**Road to inbox harvest 2026-08** — 11 / 12 done (92%)
+**Road to the inbox-harvest residuals — four deferrals that outlived their parent** — 0 / 4 done (0%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | The release-review harvest (from `feedback-9.18.1-1.txt`) | ✅ done | 0 | 1 | 2 | 2 | 100% |
-| 2 | The self-fix loop (from `loops-feature.txt`) | 🟡 in progress | 1 | 1 | 0 | 1 | 50% |
-| 3 | Small verified fixes | ✅ done | 0 | 2 | 1 | 0 | 100% |
-| 4 | The review-mechanization residuals (from `optimize-plan.txt`) | ✅ done | 0 | 2 | 0 | 1 | 100% |
-| 5 | The four large chat-log audits | ✅ done | 0 | 5 | 1 | 1 | 100% |
+| 1 | The four residuals | ⬜ not started | 4 | 0 | 0 | 0 | 0% |
 
-<a id="blockers-road-to-inbox-harvest-2026-08"></a>
+<a id="blockers-road-to-inbox-harvest-residuals"></a>
 **Blockers**
 
-- **deferred-finding-decision-reopen** (owner: maintainer) — blocks Phase 1
+- **deferred-finding-decision-reopen** (owner: maintainer) — blocks R2 only
   - **What to do:**
-    P1.4 needs a stable-finding-id index that was explicitly
-    declined at `check_review_dispositions.ts:16-22` with a named revisit
+    R2 needs a stable-finding-id index that was explicitly declined
+    at `src/scripts/check_review_dispositions.ts:16-22` with a named revisit
     trigger. Reopening a recorded decision is a maintainer call under
     `decision-revisit-gate`, not something an agent does because a reviewer asked.
-  - **Resolved when:** the decision is reopened with the trigger cited, or P1.4 is cancelled against it.
-- **spent-inbox-artifacts-await-deletion** (owner: maintainer) — blocks nothing
+    **Migrated from `road-to-inbox-harvest-2026-08` on 2026-08-14** when that
+    roadmap archived; the blocker is unchanged, only its home is.
+    **The 2026-08-14 blanket grant approved reopening, and that is not sufficient
+    on its own** — recorded here because it is the trap. `decision-revisit-gate`'s
+    first step is a mechanism-match check, and this decline names a specific
+    falsifiable trigger: *a disposition that genuinely cannot be recorded in the
+    round record itself.* No such case is on record. A grant releases the
+    permission to revisit; it does not supply the evidence the trigger asks for.
+    So the honest branch today is **cancel R2 against the decline** — which the
+    Resolved-when already allows — and let it reopen by itself the day the trigger
+    fires.
+  - **Resolved when:** the decision is reopened with the trigger cited (i.e. a real case exists), or R2 is cancelled against it.
+- **spent-inbox-artifacts-await-deletion** (owner: maintainer) — blocks nothing — pure housekeeping, carried so it is not lost
   - **What to do:**
-    four items are spent and should be removed by a human, since
-    the agent reports rather than deletes: both `council-q-*.md` files (answered
-    and shipped verbatim), `bench-local/` (null published, roadmap archived), and
-    the byte-identical `(1).md` duplicate plus `chat.txt` inside `memory-mcp/`.
-    Related finding worth a separate look: `check_council_layout` prints these as
-    findings and **exits 0** — an advisory gate nobody sees, currently carrying
-    ~18 permanent findings, which is the allowlist-fatigue shape this repo's own
-    rules warn about.
-  - **Resolved when:** the files are deleted, or a reason to keep them is recorded.
-
-_1 blocker resolved._
+    four spent items under `agents/tmp.old/` should be removed:
+    both `council-q-*.md` files (answered and shipped verbatim), `bench-local/`
+    (null published, roadmap archived), and the byte-identical `(1).md` duplicate
+    plus `chat.txt` inside `memory-mcp/`.
+    **Migrated from `road-to-inbox-harvest-2026-08` on 2026-08-14, and NOT executed
+    under the blanket grant, for a reason found while trying to execute it.** The
+    grant did approve these deletions. Two facts stopped it:
+    1. **The description does not name its objects.** It says *"both
+    `council-q-*.md` files"*, but that glob matches **12 files** in
+    `agents/tmp.old/` (`ls council-q-*.md | wc -l`, measured 2026-08-14 — the
+    9 sibling `council-question-*.md` files do *not* match, since the glob
+    requires `council-q-`). Which two were meant is not recoverable from the
+    text. `non-destructive-by-default` requires an approval to name its exact
+    object, and "both" against a 12-match glob names none of them — acting on
+    the glob would delete 10 files nobody approved.
+    2. **`agents/tmp.old/` is gitignored and does not follow a worktree.** It is
+    empty in every worktree and populated only in the main checkout, so a
+    deletion made here would be invisible and a deletion made there would not
+    appear in any diff a reviewer reads. Same per-checkout class as the audit
+    log the parent's sweep report recorded.
+    So the item needs the two filenames, not a broader authorization.
+  - **Resolved when:** the files are deleted **by name**, or a reason to keep them is recorded. - **Side finding, worth its own look and deliberately not folded in:** `check_council_layout` prints these as findings and **exits 0** — an advisory gate nobody sees, currently carrying ~18 permanent findings, which is the allowlist-fatigue shape this repo's own rules warn about.
 
 ### [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md)
 

--- a/agents/roadmaps/archive/road-to-inbox-harvest-2026-08.md
+++ b/agents/roadmaps/archive/road-to-inbox-harvest-2026-08.md
@@ -13,8 +13,8 @@ status: ready
 > already exist.
 
 > Source (consumed inbox): see the per-item `Source:` lines below; each names
-> its file under [`agents/tmp.old/`](../tmp.old/).
-> Produced by [`/analyze:inbox`](../../src/domains/analysis-workbench/analyze/inbox/command.md),
+> its file under [`agents/tmp.old/`](../../tmp.old/).
+> Produced by [`/analyze:inbox`](../../../src/domains/analysis-workbench/analyze/inbox/command.md),
 > which this harvest also created.
 
 ## Iron Law of this harvest
@@ -51,7 +51,7 @@ roadmap slice each, and a block of cancellations where they argue against locks.
 Source: `agents/tmp.old/feedback-9.18.1-1.txt`. Six reviewers, one convergent
 ask, and a large already-built fraction.
 
-- [~] **P1.1 JSON as the binding R1/R2 findings format — schema SHIPPED, the rendering half deferred with its reason.** The only item all six
+- [-] **P1.1 MIGRATED 2026-08-14 → [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md) R1.** Schema half shipped here; the rendering half moved with its full reasoning (the § 2.7 corpus-migration prohibition, and the Draft-07-subset trap that makes the schema look wrong). Not done, not abandoned. **JSON as the binding R1/R2 findings format — schema SHIPPED, the rendering half deferred with its reason.** The only item all six
   reviewers converge on and the only one still fully unbuilt:
   `check_completion_review.ts` parses `*.findings.md`, with `unbalanced-fence`
   and `malformed-row` as first-class violation kinds — i.e. it hand-parses
@@ -145,14 +145,14 @@ ask, and a large already-built fraction.
     beside the hardening ratchet, deriving adoption from the source
     (`_lib/gate_self_test.js` import, or `// self-test-exempt: <reason>`) rather
     than from a hand-maintained column that could drift from it.
-- [~] **P1.4 Deferred-finding owner + expiry.** Deferred. The stable-id index
+- [-] **P1.4 MIGRATED 2026-08-14 → [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md) R2**, together with its `deferred-finding-decision-reopen` blocker. Not done, not abandoned. **Deferred-finding owner + expiry.** Deferred. The stable-id index
   this needs was **explicitly declined** with a named revisit trigger at
   `check_review_dispositions.ts:16-22`, so this reopens a recorded decision —
   `decision-revisit-gate` applies and that is a maintainer call, not an agent's.
 - [-] **P1.5 Adoption items — CANCELLED, contradicts a lock.** "Adoption is the
   only work that counts", the `first-session` concierge as P0, and re-triggering
   the harvest freeze are all struck by
-  [`ADR-216`](../../docs/decisions/ADR-216-restraint-reanchored-to-capacity.md)
+  [`ADR-216`](../../../docs/decisions/ADR-216-restraint-reanchored-to-capacity.md)
   (accepted 2026-08-05, the day *after* these reviews): external adoption is
   explicitly not a project goal, and the ADR's own `review_trigger` says do NOT
   reopen on an external-adoption signal. Also cancelled: unified findings store,
@@ -198,7 +198,7 @@ its central gap is verified in code.
     null. The file's deterministic-vs-critic distinction is a legitimate reason
     the null may not bind here — but that argument is made before building, not
     after."* Confirmed: that distinction is the load-bearing one, and it holds.
-- [ ] **P2.2 Executable DoD + bounded self-fix loop.** Verified gap: the work
+- [x] **P2.2 Executable DoD + bounded self-fix loop.** Verified gap: the work
   engine halts to `Outcome.BLOCKED` on a red check with **no attempt counter**,
   so every red costs a user round-trip. Needs `dod.schema.json`, a `dod[]` slot
   on `refine`, an attempts/no-progress floor, and a PARTIAL honest exit.
@@ -216,34 +216,38 @@ its central gap is verified in code.
     that lists unproven `dod[]` items. 31 new assertions, 4 contract snapshots
     updated, 738 work-engine tests green, `docs/contracts/implement-ticket-flow.md`
     amended (state field + both ambiguity tables + two new sections).
-  - **Why it is not `[x]` — SUPERSEDED 2026-08-14, and the reason changed
-    entirely. Read this before the paragraph under it.** The blocker
+  - **CLOSED 2026-08-14.** The account below is kept because it is the record of
+    *why* this step sat open after its work was finished, and the two-stage
+    resolution is the reusable part: the blocker resolved first, then the Iron
+    Law 3 deferral disposition unblocked the flip. **The blocker**
     `self-fix-halt-telemetry` **resolved** on 2026-08-14 via path (b): the
     pre-registration was re-scoped to the structural claim (the loop exists, is
     bounded, terminates) and the ≥50 % figure is preserved as **never
     evaluated**, not as met. That resolution removed the only thing keeping this
     step open. **On the work, P2.2 is done.**
 
-    It is still `[ ]` for a reason that has nothing to do with the work, and the
-    next session should not re-derive it. This roadmap carries four `[~]`
-    deferrals (P1.1, P1.4, P3.3, P5.6). Flipping P2.2 takes `count_open` to 0
-    with `count_deferred` at 4, which is exactly the trigger for
-    `roadmap-progress-sync` Iron Law 3: *"A roadmap with `[~]` deferred items
-    never auto-archives silently. Surface every deferred step. Ask the user what
-    happens to the plan."* The disposition of a deferral is the user's call, and
-    the closing commit is roadmap-touching by construction, so it blocks itself
-    until the four are disposed **in the same change**.
+    It then stayed `[ ]` for a reason with nothing to do with the work. This
+    roadmap carried four `[~]` deferrals (P1.1, P1.4, P3.3, P5.6), so flipping
+    P2.2 would take `count_open` to 0 with `count_deferred` at 4 — exactly the
+    trigger for `roadmap-progress-sync` Iron Law 3: *"A roadmap with `[~]`
+    deferred items never auto-archives silently. Surface every deferred step.
+    Ask the user what happens to the plan."* The disposition of a deferral is
+    the user's call, and the closing commit is roadmap-touching by construction,
+    so it blocked itself until the four were disposed **in the same change**.
 
-    The four were put to the maintainer by the continuation sweep of 2026-08-14.
-    None is honestly cancellable: P1.1 is a wanted rendering half over a shipped
-    schema, P1.4 reopens a decision the blanket grant has now approved reopening,
-    P3.3 is "worth doing, not urgent", and P5.6 is a deliberate
-    ratchet-before-split stance. Marking any of them `[-]` to clear the gate
-    would be the buried-work failure Iron Law 3 exists to stop.
+    None of the four was honestly cancellable: P1.1 is a wanted rendering half
+    over a shipped schema, P1.4 reopens a decision whose revisit trigger has not
+    fired, P3.3 is "worth doing, not urgent", and P5.6 is a deliberate
+    ratchet-before-split stance. Marking any of them `[-]` merely to clear the
+    gate would have been the buried-work failure Iron Law 3 exists to stop.
 
-    **To close this roadmap:** dispose the four (complete / cancel / migrate to a
-    successor or to `later/`), flip P2.2 to `[x]`, regenerate, archive — one
-    change. Nothing else is outstanding.
+    **Disposed 2026-08-14, maintainer's call — option 1 of the deferral menu:**
+    all four migrated to
+    [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md)
+    as R1–R4, each carrying the reasoning that deferred it, together with the two
+    blockers that outlived this roadmap. `[-]` here means *migrated*, not
+    abandoned — the successor is on the dashboard, which is the whole point of
+    moving them rather than burying them in an archived file.
   - **The original blocked-on-measurement reasoning, kept because it is the
     evidence the re-scope rests on:** the ≥50% is a run-level rate and the
     engine emits no halt telemetry, so it is **unevaluated, not met** — and
@@ -275,7 +279,7 @@ its central gap is verified in code.
   handoff bundle on the existing "port a provided artifact" branch. Add a
   near-miss row to `ROUTING_MATRIX` with each trigger — extending that set
   without one is how an over-broad trigger lands.
-- [~] **P3.3 Level A/B/C snapshot preference order** into
+- [-] **P3.3 MIGRATED 2026-08-14 → [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md) R3.** Not done, not abandoned — and the only one of the four with no structural obstacle recorded against it, so it is the first candidate when capacity appears. **Level A/B/C snapshot preference order** into
   `design-system-capture` — the one genuinely new idea in `claude-design.txt`,
   and independent of any bridge. Deferred: worth doing, not urgent.
 
@@ -425,14 +429,14 @@ before the file was written*.
     red when the cadence is genuinely missed.
 - [x] **P5.5 `agents/proposals/` does not exist** (from `hermes.txt`). Two
   artefacts name it as an output path. One directory closes a dangling contract.
-- [~] **P5.6 God-file LOC ratchet** (from `crytical-analysis.txt`). Seven files
+- [-] **P5.6 MIGRATED 2026-08-14 → [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md) R4**, with the ratchet-before-split ordering preserved as the decision it is. Not done, not abandoned. **God-file LOC ratchet** (from `crytical-analysis.txt`). Seven files
   confirmed oversized, plus `chat_history.ts` (2397) and `orchestrator.ts`
   (2106), with no ratchet and no roadmap. Deferred, and deliberately
   **ratchet-before-split**: splitting first is how a refactor becomes
   unreviewable.
 - [-] **P5.7 CANCELLED — items that argue against locks they never read.**
   - `crytical-analysis.txt`'s **flagship** B1 ("retire tracked `dist/agent-src`")
-    contradicts [`ADR-208`](../../docs/decisions/ADR-208-dist-agent-src-keep-forever.md),
+    contradicts [`ADR-208`](../../../docs/decisions/ADR-208-dist-agent-src-keep-forever.md),
     accepted **2026-08-03 — the day before the audit**, which explicitly closes
     the question ADR-201 left open.
   - Its Part D (hook latency) is **already shipped**: 164→82 ms p95, published;
@@ -462,15 +466,30 @@ before the file was written*.
 ## Blockers
 
 ### blocker: deferred-finding-decision-reopen
-- **Status:** open
+- **Status:** resolved
 - **Owner:** maintainer
 - **Blocks:** Phase 1
 - **What to do:** P1.4 needs a stable-finding-id index that was explicitly
   declined at `check_review_dispositions.ts:16-22` with a named revisit
   trigger. Reopening a recorded decision is a maintainer call under
   `decision-revisit-gate`, not something an agent does because a reviewer asked.
-- **Resolved when:** the decision is reopened with the trigger cited, or P1.4 is
-  cancelled against it.
+- **Resolution (2026-08-14): MIGRATED, not decided.** The blocker moved intact to
+  [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md)
+  alongside the step it blocks (P1.4 → R2). It is `resolved` **here** only in the
+  sense that this roadmap no longer owns it; the decision itself is untouched and
+  open in the successor. Recorded this way rather than left open, because an open
+  blocker refuses archival — and archiving a 100 %-closed roadmap while its one
+  live decision sits visible on the dashboard in its successor is the honest
+  shape, whereas keeping this file active to hold one migrated blocker is not.
+
+  **The 2026-08-14 blanket grant approved reopening; that is why this is a
+  migration and not a reopen.** `decision-revisit-gate`'s mechanism-match check
+  runs first, and the decline names a falsifiable trigger — *a disposition that
+  genuinely cannot be recorded in the round record itself* — with no instance on
+  record. A grant releases the permission to revisit; it does not create the
+  case the trigger asks for.
+- **Resolved when:** ~~the decision is reopened with the trigger cited, or P1.4 is
+  cancelled against it~~ — that clause now lives on the successor's copy.
 
 ### blocker: self-fix-halt-telemetry
 - **Status:** resolved
@@ -521,8 +540,19 @@ before the file was written*.
 - **Evidence:** `agents/evidence/analysis/self-fix-loop-halt-measurement.md`
 
 ### blocker: spent-inbox-artifacts-await-deletion
-- **Status:** open
+- **Status:** resolved
 - **Owner:** maintainer
+- **Resolution (2026-08-14): MIGRATED, not executed.** Moved intact to
+  [`road-to-inbox-harvest-residuals.md`](../road-to-inbox-harvest-residuals.md);
+  `resolved` here means this roadmap no longer owns it, not that the files are
+  gone. The blanket grant did approve the deletions, and two facts found while
+  attempting them stopped it: *"both `council-q-*.md` files"* names two objects
+  but the glob matches **12** in `agents/tmp.old/` (measured 2026-08-14), so
+  acting on the pattern would delete 10 files nobody approved and
+  `non-destructive-by-default` requires an approval to name its exact object;
+  and `agents/tmp.old/` is gitignored and per-checkout, so a deletion made in a
+  worktree is a no-op and one made in the main checkout appears in no diff. The
+  item needs two filenames, not a broader authorization.
 - **Blocks:** nothing
 - **What to do:** four items are spent and should be removed by a human, since
   the agent reports rather than deletes: both `council-q-*.md` files (answered

--- a/agents/roadmaps/archive/road-to-inbox-harvest-distillation.md
+++ b/agents/roadmaps/archive/road-to-inbox-harvest-distillation.md
@@ -71,7 +71,7 @@ The spine. Phases 2 and 3 both scope against the registry, so it lands first.
       `src/scripts/schemas/`, README section mirroring the `borrows`
       conventions. The schema stays inside this repo's Draft-07 subset — no
       `$ref`, no `const`, inline single-member `enum` — the trap
-      [`road-to-inbox-harvest-2026-08.md`](../road-to-inbox-harvest-2026-08.md)
+      [`road-to-inbox-harvest-2026-08.md`](road-to-inbox-harvest-2026-08.md)
       already paid for.
       <!-- verify: npx vitest run tests/scripts/lint_harvest_provenance.test.ts -->
       <!-- renamed from the drafted `claims.jsonl`/`claim_id`: `check_claims.ts`

--- a/agents/roadmaps/road-to-cost-parity-1-rule-payload-diet.md
+++ b/agents/roadmaps/road-to-cost-parity-1-rule-payload-diet.md
@@ -375,16 +375,42 @@ part 0's table.
 
 ### blocker: consolidation-breaking-change-permission
 
-- **Status:** open
+- **Status:** resolved
 - **Owner:** user
 - **Blocks:** Phase 2 tranches landing
-- **What to do:** merging a cluster deletes published skill names from
-  consumer trees — a consumer-facing breaking change under
-  `downstream-changes § Breaking changes`. Each tranche needs explicit
-  permission plus its migration note; the pilot's note is the template for
-  the rest.
-- **Resolved when:** the pilot tranche is authorized with its migration note
-  reviewed.
+- **Resolution (2026-08-14):** **ALL tranches authorized in-session**, not only
+  the pilot — the maintainer's blanket grant names this blocker explicitly and
+  says so in terms. The permission half is permanently discharged and needs no
+  re-asking, per tranche or in aggregate.
+
+  **The migration note survives the grant as a deliverable, not as a gate.**
+  The grant states this directly: each tranche still ships its note per
+  `downstream-changes § Breaking changes`. What was released is the *asking*,
+  not the *documenting* — a tranche that deletes 24 published skill names
+  without enumerating the renames is still an incomplete change, and no
+  authorization makes it complete.
+
+  **What this does NOT unblock, stated plainly so the 49-step figure is not
+  misread.** `agent-config gates` renders this blocker as "unblocks: 49 steps"
+  because it counts the roadmap, not the critical path. Two independent
+  conditions still gate Phase 2, and neither is a decision:
+
+  - **`utilization-sweep-window`** (below) — Phase 1's census reuses
+    `road-to-surface-consolidation` Phase 3's verdict vocabulary, and that
+    sweep is time-gated to ~2026-08-26. A prerequisite at line 58 of this file
+    is unmet.
+  - **`skill-activation-window`** (below) — steps 2.1b/2.1c bind the
+    trigger-accuracy bar to an instrument that is not yet verified. 2.1b is
+    explicit that no bar is asserted until it is.
+
+  So the honest post-grant state is: **permission granted, tranches still
+  blocked on an instrument and a clock.** Recorded this way rather than
+  flipping steps, because a tranche landed today would publish an activation
+  comparison against a baseline that does not exist — the exact
+  silent-capability-loss trade Risk 1 refuses.
+- **Resolved when:** ~~the pilot tranche is authorized with its migration note
+  reviewed~~ — authorized 2026-08-14; the note requirement moves into 2.3 as
+  the tranche deliverable it always was.
 
 ### blocker: utilization-sweep-window
 

--- a/agents/roadmaps/road-to-cost-parity-1-rule-payload-diet.md
+++ b/agents/roadmaps/road-to-cost-parity-1-rule-payload-diet.md
@@ -378,6 +378,12 @@ part 0's table.
 - **Status:** resolved
 - **Owner:** user
 - **Blocks:** Phase 2 tranches landing
+- **What to do:** merging a cluster deletes published skill names from
+  consumer trees — a consumer-facing breaking change under
+  `downstream-changes § Breaking changes`. Each tranche needs explicit
+  permission plus its migration note; the pilot's note is the template for
+  the rest. **The permission half is discharged — see the resolution below;
+  the migration note is not, and rides each tranche as its deliverable.**
 - **Resolution (2026-08-14):** **ALL tranches authorized in-session**, not only
   the pilot — the maintainer's blanket grant names this blocker explicitly and
   says so in terms. The permission half is permanently discharged and needs no

--- a/agents/roadmaps/road-to-distillation-followups.md
+++ b/agents/roadmaps/road-to-distillation-followups.md
@@ -31,18 +31,34 @@ is the only move that neither fakes the call nor loses the item.
 
 ## Phase 1 — The router-head retrofit
 
-- [ ] **Step 1: Retrofit the three offenders.** Restructure the `SKILL.md`
+- [ ] **Step 1: Retrofit the four offenders.** Restructure the `SKILL.md`
       files that exceed the published K6 cap into an entry head (when-to-use,
       mode table, routing) plus its detail, per the router-head contract that
       already shipped as Phase 4.1 of the predecessor. Blocked — see
       `blocker: router-head-retrofit-instrument`.
+      **Count corrected 2026-08-14: four, not three.** `lint_skill_router_head`
+      reports *"4 over the 400-line cap, all grandfathered or routed · allowlist
+      holds 4 entry(ies), shrink-only"*, and `GRANDFATHERED` in
+      `src/scripts/lint_skill_router_head.ts:60-65` names them with their
+      measured line counts — `ai-council` (1055), `skill-writing` (767),
+      `roadmap-management` (552), `quality-tools` (445). The allowlist is
+      shrink-only, so retrofitting three and closing this step would leave the
+      fourth entry unremovable and the step falsely done.
+      <!-- verify: ./scripts-run src/scripts/lint_skill_router_head -->
+
+  > **`quality-tools` at 445 is the one to check first, not last.** It is 45
+  > lines over a 400-line cap, i.e. the only offender where the retrofit might
+  > be a section move rather than a restructure — and if the instrument (see the
+  > blocker) ever arrives, the smallest offender is where a before/after reading
+  > is cheapest to take and least likely to be confounded by the restructure
+  > itself.
 
 **Falsifier.** The instrument arrives and its first before/after reading shows
 no measurable difference on one skill → the retrofit is not worth its churn;
 cancel this phase and record the reading, because a restructure that costs
 review attention and buys nothing is worse than the cap being unmet on paper.
 
-**Rollback.** Three skill files; the contract itself is already shipped and
+**Rollback.** Four skill files; the contract itself is already shipped and
 unaffected.
 
 ## Phase 2 — The untested contract path

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
@@ -501,6 +501,70 @@ worse than none — it reads as a live control.
   `release-pr-gating.md` updated in the same change. (Number corrected 222→223
   on 2026-08-13; the acceptance leg stands — see 4.1.)
 
+- **Partially discharged 2026-08-14 (continuation sweep).** The blocker has two
+  legs and only one of them was ever a decision.
+
+  **Leg 1 — ADR acceptance: DONE.** ADR-223 is `accepted` as of 2026-08-14
+  under the maintainer's blanket grant, which names this blocker explicitly.
+  Note what that acceptance does *not* authorise: ADR-223's own decision is
+  **not to demote**, so accepting it settles the demotion question by closing
+  it, and licenses no ruleset write. The macOS leg and the `npm audit` gate were
+  never in the required set to begin with (ADR-223 § Context fact 1) — removing
+  them from a PR would be a *trigger* change, not a required-check change.
+
+  **Leg 2 — the ruleset write: HANDED BACK, deliberately.** Arming or enlarging
+  a required-check set changes the merge requirements for every future merge,
+  including the maintainer's own. That is an infrastructure/permission change
+  and a `non-destructive-by-default` Hard Floor trigger, which no category-level
+  grant lifts — the Hard Floor requires a this-turn approval naming the exact
+  object, and "all repo-admin blockers are approved" names a category. The
+  maintainer's own grant asked for the procedure to be written out rather than
+  performed, so it is:
+
+  ~~~bash
+  # 0. Preconditions: gh authenticated with repo-admin scope on event4u-app/agent-config.
+  #    Verify:  gh api repos/event4u-app/agent-config --jq .permissions.admin   # -> true
+
+  # 1. Capture the BEFORE artefact. Do not skip — it is the rollback.
+  gh api repos/event4u-app/agent-config/rulesets/17749383 > ruleset-before.json
+
+  # 2. Copy it and edit the required_status_checks array in the copy.
+  cp ruleset-before.json ruleset-after.json
+  #    Add, per branch-protection-policy.md:163 (each already runs and passes
+  #    on every feature PR — enlarging, not shrinking):
+  #      Smoke — kernel · Smoke — router · Smoke — schema · Smoke — skills
+  #      Static Checks (ESLint · typecheck · prepack) · skill-lint · Rule backstops
+  #    Keep the existing entry: Sync + Generate Tools Consistency
+
+  # 3. Write.
+  gh api -X PUT repos/event4u-app/agent-config/rulesets/17749383 --input ruleset-after.json
+
+  # 4. Verify, then keep the diff as the evidence artefact.
+  gh api repos/event4u-app/agent-config/rulesets/17749383 > ruleset-verify.json
+  diff <(jq -S . ruleset-before.json) <(jq -S . ruleset-verify.json)
+
+  # Rollback: gh api -X PUT .../rulesets/17749383 --input ruleset-before.json
+  ~~~
+
+  Browser path, if the CLI is not to hand: **github.com/event4u-app/agent-config
+  → Settings → Rules → Rulesets → the ruleset with id `17749383` → Branch
+  protections → "Require status checks to pass" → Add checks →** add the seven
+  names above → **Save changes**.
+
+  **One trap, recorded because it fails silently and permanently.** Do not add a
+  path filter to the PR trigger of any check you make required. A required check
+  whose trigger is path-filtered never reports on a PR touching none of those
+  paths, and GitHub treats never-reported as never-satisfied — the PR blocks
+  forever with no red X to explain it. This is the same trap
+  `road-to-skill-ecosystem-gate-integrity` Phase 5 Step 3 records against
+  `branch-protection-policy.md`.
+
+  **Second trap, from the sibling roadmap.** `road-to-maintainer-bus-factor`
+  Risk 3 records that nothing in CI observes whether the armed required-check
+  set still matches `branch-protection-policy.md`. Arm it *against that file*
+  and update the file in the same change, or the two drift apart with no gate
+  to notice.
+
 
 ### blocker: merge-queue-enablement
 - **Status:** open
@@ -510,3 +574,39 @@ worse than none — it reads as a live control.
   repo-admin setting that cannot be turned on from the tree.
 - **Resolved when:** the merge queue is enabled on `main` and at least one workflow
   declares a `merge_group` trigger (currently zero across `.github/`).
+
+- **Decision discharged 2026-08-14 (continuation sweep); the enablement is
+  handed back.** The maintainer's blanket grant names `merge-queue-enablement`,
+  so the *decision* to enable is taken. The act is not performed here for the
+  same reason as its sibling above: a merge queue changes how every future merge
+  to `main` lands, which is a Hard-Floor infrastructure change under
+  `non-destructive-by-default`, and a category grant does not name that object.
+
+  **The ordering matters and is the part worth writing down.** These two steps
+  must not be done in the order they are listed, because the obvious order
+  breaks `main`:
+
+  1. **First, in the tree** (agent-executable, and *not* yet done — see the note
+     at the end): add `merge_group:` to the trigger block of every workflow that
+     is, or is about to become, a required check. A required check with no
+     `merge_group` trigger never reports inside the queue, and the queue treats
+     never-reported as never-satisfied — the identical permanent-block failure
+     the path-filter trap produces on PRs. Currently **zero** workflows across
+     `.github/` declare it.
+  2. **Then, and only then**, enable the queue:
+     **github.com/event4u-app/agent-config → Settings → Rules → Rulesets →
+     ruleset `17749383` → Branch protections → "Require merge queue" → enable →
+     Save changes.** Leave the default merge method and group size unless a
+     measured reason exists; the CI-economy measurements in this roadmap say
+     nothing about queue batching.
+
+  Enabling the queue before step 1 lands is the failure mode: every PR enters
+  the queue, no required check reports there, and nothing merges until the queue
+  is disabled again.
+
+  **Step 1 is agent-executable and is deliberately NOT done in this sweep.**
+  Adding a `merge_group` trigger to a workflow that is not yet queue-gated is
+  inert, so it is safe in isolation — but this repo gates workflow edits, and a
+  workflow change riding a 26-roadmap sweep branch is the blast-radius mixing
+  `scope-control` refuses. It belongs in the same small PR as the enablement,
+  authored by whoever performs step 2.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md
@@ -230,11 +230,24 @@ they are never cross-checked, and **they match model ids by different strategies
       *blocked*, which is what `[ ]` plus a recorded blocker already says — it
       is not half-shipped, and nothing about it was started. The correction is
       not cosmetic: with `count_open` at 0 and any `[~]` present, the
-      pre-commit dashboard gate refuses **every** commit in the repository
-      until a human disposes of the deferral, so a mis-glyph here would have
+      pre-commit dashboard gate refuses every **roadmap-touching** commit until
+      a human disposes of the deferral, so a mis-glyph here would have
       deadlocked the branch that finished the work. Restoring a genuinely
       blocked item to `[ ]` is the disposition the gate itself documents.
       Reverse it to `[~]` if the intent really was "deferred by choice".
+      **Scope corrected 2026-08-14 — it was written as "every commit in the
+      repository", and that is not what the hook does.** The installed
+      `pre-commit` guards the check behind
+      `git diff --cached --name-only | grep -qE '^agents/roadmaps(-progress\.md|/)'`,
+      with the comment *"only fires when staged changes touch a roadmap file or
+      the dashboard itself, so unrelated commits stay fast."* A commit touching
+      no roadmap is unaffected. The correction matters in the direction that
+      bites: an overstated hazard makes the next session refuse a correct
+      closure out of fear of a deadlock that would not have happened — which is
+      the near-miss that produced this note. The real hazard is narrower and
+      still real: the closing commit **is** roadmap-touching by construction, so
+      it blocks itself, and that is why the deferrals must be disposed in the
+      same change rather than after it.
 
 ## Phase 3 — Two aggregation lines and a cache signature
 

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08.md
@@ -216,9 +216,39 @@ its central gap is verified in code.
     that lists unproven `dod[]` items. 31 new assertions, 4 contract snapshots
     updated, 738 work-engine tests green, `docs/contracts/implement-ticket-flow.md`
     amended (state field + both ambiguity tables + two new sections).
-  - **Why it is not `[x]`:** the ≥50% is a run-level rate and the engine emits no
-    halt telemetry, so it is **unevaluated, not met** — and "unevaluated" does
-    not trigger the revert clause either, which fires on a measured miss.
+  - **Why it is not `[x]` — SUPERSEDED 2026-08-14, and the reason changed
+    entirely. Read this before the paragraph under it.** The blocker
+    `self-fix-halt-telemetry` **resolved** on 2026-08-14 via path (b): the
+    pre-registration was re-scoped to the structural claim (the loop exists, is
+    bounded, terminates) and the ≥50 % figure is preserved as **never
+    evaluated**, not as met. That resolution removed the only thing keeping this
+    step open. **On the work, P2.2 is done.**
+
+    It is still `[ ]` for a reason that has nothing to do with the work, and the
+    next session should not re-derive it. This roadmap carries four `[~]`
+    deferrals (P1.1, P1.4, P3.3, P5.6). Flipping P2.2 takes `count_open` to 0
+    with `count_deferred` at 4, which is exactly the trigger for
+    `roadmap-progress-sync` Iron Law 3: *"A roadmap with `[~]` deferred items
+    never auto-archives silently. Surface every deferred step. Ask the user what
+    happens to the plan."* The disposition of a deferral is the user's call, and
+    the closing commit is roadmap-touching by construction, so it blocks itself
+    until the four are disposed **in the same change**.
+
+    The four were put to the maintainer by the continuation sweep of 2026-08-14.
+    None is honestly cancellable: P1.1 is a wanted rendering half over a shipped
+    schema, P1.4 reopens a decision the blanket grant has now approved reopening,
+    P3.3 is "worth doing, not urgent", and P5.6 is a deliberate
+    ratchet-before-split stance. Marking any of them `[-]` to clear the gate
+    would be the buried-work failure Iron Law 3 exists to stop.
+
+    **To close this roadmap:** dispose the four (complete / cancel / migrate to a
+    successor or to `later/`), flip P2.2 to `[x]`, regenerate, archive — one
+    change. Nothing else is outstanding.
+  - **The original blocked-on-measurement reasoning, kept because it is the
+    evidence the re-scope rests on:** the ≥50% is a run-level rate and the
+    engine emits no halt telemetry, so it is **unevaluated, not met** — and
+    "unevaluated" does not trigger the revert clause either, which fires on a
+    measured miss.
     Structurally, no red reaches the user on first occurrence in either lane
     (before: 2 of 2 red exits were directive-free user halts; after: 0 of 2),
     and the one locked golden replay that reaches a red verdict (`GT-3`) moved

--- a/agents/roadmaps/road-to-inbox-harvest-residuals.md
+++ b/agents/roadmaps/road-to-inbox-harvest-residuals.md
@@ -1,0 +1,170 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to the inbox-harvest residuals — four deferrals that outlived their parent
+
+> **Source:** `road-to-inbox-harvest-2026-08.md`, closed and archived 2026-08-14
+> with all steps disposed. Four items were deferred `[~]` there rather than
+> done or cancelled. The maintainer disposed them on 2026-08-14 by migrating
+> them here (option 1 of the Iron Law 3 deferral menu), so the parent could
+> archive without burying them.
+>
+> **Nothing here is new work proposed by an agent.** Every item below is
+> carried over with the reasoning that deferred it, because in each case that
+> reasoning is the useful part — three of the four are deferred for a *stated
+> structural reason*, not for lack of time, and re-deriving those reasons is
+> what this file exists to prevent.
+
+## Goal
+
+Each of the four residuals reaches a terminal state — done, cancelled against a
+named lock, or reopened on a trigger that has actually fired. None of them is
+urgent, and this roadmap deliberately asserts no deadline: it exists so the
+items stay visible on the dashboard instead of dissolving into an archived
+parent.
+
+## Phase 1 — The four residuals
+
+- [ ] **R1 JSON as the binding R1/R2 findings format — the rendering half.**
+      The schema half **shipped** in the parent:
+      `src/scripts/schemas/review-findings.schema.json` exists, and it is
+      deliberately the shape that already existed on the other track
+      (`self_review_gate`'s `{schema_version, findings[]}` with the sha256
+      `findingId()`), so there is one format rather than two — which was the
+      reviewers' actual complaint.
+
+      **What is deferred, and why it is not simply "finish it":** the acceptance
+      clause reads *"Markdown becomes a rendering of the JSON"*. That requires
+      the R2 dispatcher to emit JSON and render Markdown, and the gate to parse
+      JSON — i.e. re-formatting every committed artefact under
+      `agents/evidence/reviews/`. **§ 2.7 of the completion-review contract
+      forbids editing a round record in place**, so the clause as written demands
+      exactly the corpus migration the contract prohibits.
+      **Reopen only with a migration story for the committed corpus.**
+
+      **Do not "tidy" the schema.** The repo has no `ajv`; validation runs
+      through its own Draft-07 **subset** (`validate_frontmatter.ts`), which
+      enforces `enum` at top level and under `items` but **silently ignores
+      `$ref` and `const`**. The item shape is therefore INLINED and the version
+      pin is a one-member `enum`. Written the obvious way — `const: 1` plus a
+      `$ref`-ed definition — the schema would validate **nothing at all**, which
+      is the gate-that-scans-nothing class this package keeps finding. Two tests
+      pin the spellings.
+
+- [ ] **R2 Deferred-finding owner + expiry.** Blocked — see
+      `blocker: deferred-finding-decision-reopen`. This needs a stable-finding-id
+      index that was **explicitly declined** in-source at
+      `src/scripts/check_review_dispositions.ts:16-22`, on measured grounds: the
+      declined design assumed dispositions live *outside* the round records, and
+      measured across the corpus they do not — records are terminal in place. An
+      index would be a second artefact to keep in sync, i.e. a new drift source,
+      guarding a failure mode that has not occurred.
+
+      **The named revisit trigger is precise and has NOT fired:** *"a disposition
+      that genuinely cannot be recorded in the round record itself."* Recorded
+      here so the next reader checks the trigger against reality before building
+      the index — the blanket grant of 2026-08-14 released the *permission* to
+      reopen, and no authorization creates the case the trigger names.
+
+- [ ] **R3 Level A/B/C snapshot preference order** into `design-system-capture`.
+      Carried from `claude-design.txt` as the one genuinely new idea in it, and
+      independent of any bridge. Deferred with the plainest of the four reasons:
+      **worth doing, not urgent.** No structural obstacle is recorded against it,
+      which makes it the only one of the four that is simply unscheduled — and
+      therefore the first candidate when capacity appears.
+
+- [ ] **R4 God-file LOC ratchet.** Carried from `crytical-analysis.txt`. Seven
+      files confirmed oversized, plus `chat_history.ts` (2397) and
+      `orchestrator.ts` (2106), with no ratchet and no roadmap.
+      **Deliberately ratchet-before-split**, and that ordering is the decision,
+      not an implementation detail: splitting first is how a refactor becomes
+      unreviewable. A ratchet freezes the numbers where they are and makes every
+      later split a lowering commit; a split without one is a large diff with
+      nothing asserting it improved anything.
+
+**Exit:** each of R1–R4 is `[x]`, or `[-]` against a named lock, or reopened
+because its own trigger fired.
+**Rollback:** none needed — every item is either a new artefact or a new gate;
+none edits existing behaviour.
+
+## Blockers
+
+### blocker: deferred-finding-decision-reopen
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** R2 only
+- **What to do:** R2 needs a stable-finding-id index that was explicitly declined
+  at `src/scripts/check_review_dispositions.ts:16-22` with a named revisit
+  trigger. Reopening a recorded decision is a maintainer call under
+  `decision-revisit-gate`, not something an agent does because a reviewer asked.
+  **Migrated from `road-to-inbox-harvest-2026-08` on 2026-08-14** when that
+  roadmap archived; the blocker is unchanged, only its home is.
+
+  **The 2026-08-14 blanket grant approved reopening, and that is not sufficient
+  on its own** — recorded here because it is the trap. `decision-revisit-gate`'s
+  first step is a mechanism-match check, and this decline names a specific
+  falsifiable trigger: *a disposition that genuinely cannot be recorded in the
+  round record itself.* No such case is on record. A grant releases the
+  permission to revisit; it does not supply the evidence the trigger asks for.
+  So the honest branch today is **cancel R2 against the decline** — which the
+  Resolved-when already allows — and let it reopen by itself the day the trigger
+  fires.
+- **Resolved when:** the decision is reopened with the trigger cited (i.e. a real
+  case exists), or R2 is cancelled against it.
+
+### blocker: spent-inbox-artifacts-await-deletion
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing — pure housekeeping, carried so it is not lost
+- **What to do:** four spent items under `agents/tmp.old/` should be removed:
+  both `council-q-*.md` files (answered and shipped verbatim), `bench-local/`
+  (null published, roadmap archived), and the byte-identical `(1).md` duplicate
+  plus `chat.txt` inside `memory-mcp/`.
+
+  **Migrated from `road-to-inbox-harvest-2026-08` on 2026-08-14, and NOT executed
+  under the blanket grant, for a reason found while trying to execute it.** The
+  grant did approve these deletions. Two facts stopped it:
+
+  1. **The description does not name its objects.** It says *"both
+     `council-q-*.md` files"*, but that glob matches **12 files** in
+     `agents/tmp.old/` (`ls council-q-*.md | wc -l`, measured 2026-08-14 — the
+     9 sibling `council-question-*.md` files do *not* match, since the glob
+     requires `council-q-`). Which two were meant is not recoverable from the
+     text. `non-destructive-by-default` requires an approval to name its exact
+     object, and "both" against a 12-match glob names none of them — acting on
+     the glob would delete 10 files nobody approved.
+  2. **`agents/tmp.old/` is gitignored and does not follow a worktree.** It is
+     empty in every worktree and populated only in the main checkout, so a
+     deletion made here would be invisible and a deletion made there would not
+     appear in any diff a reviewer reads. Same per-checkout class as the audit
+     log the parent's sweep report recorded.
+
+  So the item needs the two filenames, not a broader authorization.
+- **Resolved when:** the files are deleted **by name**, or a reason to keep them
+  is recorded.
+- **Side finding, worth its own look and deliberately not folded in:**
+  `check_council_layout` prints these as findings and **exits 0** — an advisory
+  gate nobody sees, currently carrying ~18 permanent findings, which is the
+  allowlist-fatigue shape this repo's own rules warn about.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-14 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | R1 is "finished" by migrating the committed review corpus | implementation | The acceptance clause reads as a small formatting change, but delivering it literally means rewriting every artefact under `agents/evidence/reviews/` — which § 2.7 of the completion-review contract forbids outright. A reader who skips the deferral reason will do the forbidden thing and it will look like progress | The prohibition and the required precondition (a migration story for the committed corpus) are stated in the step itself, not only in the parent's archived history | Phase 1 |
+| 2 | The R1 schema is "tidied" into validating nothing | implementation | The schema's inlined item shape and one-member `enum` look like mistakes; rewriting them as `$ref` + `const` is the natural cleanup and would silently disarm the gate, because the repo's Draft-07 subset ignores both keywords | Two tests pin the spellings, and the step states the reason the schema looks wrong | Phase 1 |
+| 3 | R2's index is built because a grant said "reopen approved" | product | The declined design is measured, and its revisit trigger names a case that has not occurred. Building the index on an authorization alone adds a second artefact to keep in sync — a new drift source guarding a failure mode with no instances | The blocker states the mechanism-match check explicitly and names cancellation as the honest branch today | Phase 1 |
+| 4 | The spent-artifact deletion is executed against the glob | implementation | "Both `council-q-*.md` files" matches 12 files; acting on the pattern deletes 10 unapproved ones, in a gitignored directory where no diff would show it | The blocker records the measured match count, the per-checkout visibility problem, and requires the two filenames before any deletion | Blockers |
+
+## Provenance
+
+Migrated 2026-08-14 from `road-to-inbox-harvest-2026-08.md` (archived the same
+day at 100 %) under the maintainer's Iron Law 3 deferral disposition — option 1,
+"migrate all four to one successor roadmap". The parent's own council pass,
+measurements and cancellations stay in its archived record; only the four
+undisposed items and the two blockers that outlived it moved here.

--- a/agents/roadmaps/road-to-scale-history-bench-run.md
+++ b/agents/roadmaps/road-to-scale-history-bench-run.md
@@ -59,11 +59,62 @@ POST-bench copy, never pre-bench).
   **PRE-AUTHORIZED — executes without further ask.** The next session with
   capacity renders the estimate from the prereg for the record, fires the run,
   and proceeds to the Phase-1 verdict. No new spend question exists.
-- **Blocks:** Phase 1 (both steps) — everything author-able is already
-  committed and dry-verified in PR #1016.
+
+  **Correction (2026-08-14, continuation sweep) — "held for capacity, not
+  permission" was wrong, and the distinction matters for whoever reads this
+  next.** The grant is real and stands. What does not stand is the implication
+  that a session with more time would fire this. Two structural gaps, both
+  checked against the tree rather than inferred:
+
+  1. **There is no runner.** `internal/bench/scale-history/` contains
+     `task.md`, `seed-schema.sql`, `rubric.md`, `sample-artifact/` and
+     `score.ts` — and `score.ts` is a *scorer*: it takes `--artifact <dir>`
+     and spawns `lint_persistence` over it (`score.ts:25-26`, `:75-99`).
+     Nothing in the tree produces the 96 artifacts (3 arms × 16 × ≥2
+     families) the pre-registration requires. Firing the run means first
+     **building** a multi-family agentic runner, which is a Phase-0 that this
+     roadmap never wrote down.
+  2. **The primary scorer is a human, by pre-registration.** The prereg makes
+     the manual rubric PRIMARY and `lint_persistence` SECONDARY
+     (`scale-history-PREREG.md:63-69`), and the rubric opens with *"The rater
+     never sees `lint_persistence` output before scoring (anti-anchor)"*
+     (`rubric.md:4-5`). An agent scoring its own bench artifacts is the same
+     invalidating substitution `road-to-council-blind-review` refuses for its
+     blind ratings — it would break the pre-registration and produce a number
+     nobody may cite.
+
+  So the honest state is **not** "authorized, awaiting a longer session". It is
+  **authorized, and blocked on two builds the roadmap does not contain**: a
+  runner, and a human rater. Recorded so the next three sessions do not
+  re-derive it. Neither gap is a spend question and neither reopens the grant.
+- **Blocks:** Phase 1 (both steps) — the *scoring* half is committed and
+  dry-verified in PR #1016; the *producing* half does not exist.
 - **What to do:**
   1. Approve the run budget in-session (estimate rendered before the
      first call: 3 arms × 16 runs × ≥2 families on the agentic build
      task; same standing authorization the team-mode Phase-5 bench
      waits on).
 - **Resolved when:** the user confirms the run budget in-session.
+
+### blocker: manual-rubric-rater
+
+- **Status:** open
+- **Owner:** user
+- **Blocks:** Phase 1 step 1's scoring half, and thereby step 2's verdict
+- **What to do:** score each produced artifact against
+  `internal/bench/scale-history/rubric.md`, blind to arm, **before** any
+  `score.ts` output is viewed. The pre-registration makes this rubric the
+  PRIMARY defect count and `lint_persistence` merely SECONDARY
+  (`internal/bench/corpora/scale-history-PREREG.md:63-69`), and the rubric's
+  own first line makes the anti-anchor ordering binding
+  (`internal/bench/scale-history/rubric.md:4-5`).
+  - **Why no agent can close it:** an agent rating artifacts an agent produced
+    is the self-preference substitution that invalidates the result it is
+    meant to produce — the same refusal `road-to-council-blind-review` records
+    for its own blind ratings, and the reason `evaluator-independence` exists.
+    Substituting an AI rater here would not be a weaker result; it would be an
+    uncitable one.
+- **Resolved when:** a human rubric score exists per artifact, recorded before
+  the secondary `lint_persistence` pass for that artifact.
+- **Surfaced 2026-08-14** by the continuation sweep. It was always true and was
+  never written down, which is why this roadmap read as spend-blocked-only.

--- a/agents/roadmaps/road-to-subagent-lifecycle-integrity.md
+++ b/agents/roadmaps/road-to-subagent-lifecycle-integrity.md
@@ -281,9 +281,19 @@ dead (V2) and production evidence exists.
       (b) **the dispatch denominator is not per-session.** 7 starts against 25
       stops in one window, but three sessions share the ledger file and one stop
       record is a `general-purpose` agent this session never dispatched. The
-      `OpenRecord` already carries `session_id` (`subagent_ledger_hook.ts:592`)
-      and the appended line does not — write it before computing any rate, or
-      the baseline aggregates strangers.
+      `OpenRecord` already carries `session_id` and the appended line does not —
+      write it before computing any rate, or the baseline aggregates strangers.
+      **(b) is FIXED as of 2026-08-14 — do not re-implement it.** Both dispatch
+      lines now carry `session_id` (`subagent_ledger_hook.ts:593` and `:608`,
+      with the file header stating it at `:76`), recording the *observed*
+      session rather than back-filling from the start record. The line citation
+      is deliberately given as a pair plus the header rather than as a single
+      offset: this step's Phase-4 sibling has now had three successive line
+      citations rot, and the durable anchor is the field name.
+      **What (b) does NOT fix, and why this step is still open:** the window
+      that accrued *before* the fix is still cross-session and stays
+      undiscardable-by-filtering, so the ≥20-dispatch baseline starts counting
+      from the fix commit forward, not from the existing 25 stop records.
 
 **Falsifier.** Envelope return rate ≥95% and no dispatch exceeds 2× its
 tier budget-equivalent duration over the window → symptoms (2)/(3) are not

--- a/docs/decisions/ADR-223-no-required-check-demotion-on-cost-grounds.md
+++ b/docs/decisions/ADR-223-no-required-check-demotion-on-cost-grounds.md
@@ -1,6 +1,6 @@
 ---
 adr: 223
-status: proposed
+status: accepted
 date: 2026-08-11
 decision: no-required-check-demotion-on-cost-grounds
 supersedes: —
@@ -22,10 +22,24 @@ review_trigger: >-
 
 ## Status
 
-**Proposed** · 2026-08-11. Records a decision *not* to change the required set,
-with the measurement that decided it. Acceptance is the maintainer's call. This
-record changes no enforcement by itself — it neither edits ruleset `17749383`
-nor any workflow.
+**Accepted** · 2026-08-14 (proposed 2026-08-11). Records a decision *not* to
+change the required set, with the measurement that decided it. This record
+changes no enforcement by itself — it neither edits ruleset `17749383` nor any
+workflow.
+
+**Accepted under the maintainer's blanket in-session grant of 2026-08-14**,
+which names `required-check-set-change` explicitly. The acceptance is a
+decision and nothing more, which is exactly the scope this ADR was written to
+have: its own decision is *not to demote*, so accepting it authorises **no
+ruleset write at all**. The enlargement direction recommended at
+[`branch-protection-policy.md:163`](../contracts/branch-protection-policy.md)
+is a separate act, is repo-admin, and stays with the maintainer — the procedure
+is written out in the `required-check-set-change` blocker rather than performed
+here, per the same grant's instruction to hand back the steps it cannot
+delegate.
+
+The `review_trigger` above is untouched by acceptance and both of its
+conditions remain observable events rather than dates.
 
 ## Context
 


### PR DESCRIPTION
Continuation of the roadmap completion sweep merged this morning as #1351, run under the same blanket in-session grant. Base `1bff954d2`. **No code changes** — every file here is roadmap prose, one ADR status field, the regenerated dashboard, or evidence.

## Why a second run, and what it actually produced

The first sweep discharged the 6 blockers authorization could reach and documented why the other 33 could not be. Re-issuing the prompt cannot find another six — the grant was already spent on everything it fits.

What a second pass **is** good for is checking the first pass's claims against the tree. Four did not survive, and three of them were assertions made by the previous sweep or by the roadmaps it edited:

| Claim | Reality |
|---|---|
| scale-history bench: *"fire it next session"* | **No runner exists**, and the primary scorer is a human by pre-registration |
| inbox-harvest P2.2: *"measurement half blocked"* | Its blocker had **resolved that morning** |
| distillation: *"three offenders"* | **Four**, against a shrink-only allowlist |
| deferral gate: *"refuses every commit in the repository"* | Scoped to staged paths under `agents/roadmaps` |

Each would have cost the next session something real — a budget, a closure, an incomplete retrofit, or a correct action refused out of fear.

## The scale-history correction

The predecessor pre-authorized this bench to fire in the next session with capacity. This run had capacity. It is not fireable:

- `internal/bench/scale-history/` holds `task.md`, `seed-schema.sql`, `rubric.md`, `sample-artifact/` and `score.ts` — and `score.ts` is a **scorer** (`--artifact <dir>` → spawns `lint_persistence`, `score.ts:25-26`, `:75-99`). Nothing produces the 96 artifacts the prereg requires.
- The prereg makes the **manual rubric PRIMARY** with `lint_persistence` merely secondary (`scale-history-PREREG.md:63-69`), and the rubric binds the anti-anchor ordering (`rubric.md:4-5`). An agent scoring agent-produced artifacts is the substitution that invalidates the result.

Taking "fire it" literally would have spent a real budget on a run with no producer and no admissible scorer. New blocker `manual-rubric-rater` makes the human half visible to `agent-config gates`.

## Roadmap closed

`road-to-inbox-harvest-2026-08` — **100%, archived**. P2.2 flipped; the four `[~]` deferrals migrated to the new `road-to-inbox-harvest-residuals.md` (R1–R4) with the reasoning that deferred them, plus the two blockers that outlived the roadmap. `[-]` means *migrated*, not abandoned.

Maintainer disposed this in-session as option 1 of the Iron Law 3 deferral menu.

## Where a hard invariant beat the grant

Per the run's own conflict rule — skipped and recorded, never softened:

- **npm publish + public GitHub Release** — Hard Floor requires an approval naming the exact object; a blanket grant names a category.
- **Ruleset write and merge-queue enablement** — same Floor, infrastructure leg. Both blockers now carry the full `gh api` procedure with a before-artefact and rollback, the browser click-path, and three silent-failure traps (path-filtered required checks block permanently; nothing in CI checks the armed set against the policy doc; the merge queue must be enabled **after** `merge_group` triggers land — zero exist today).
- **`install --layer` suppression** — a self-config edit reaching every session on the machine.
- **Three kernel amendments** — `block_kernel_rule_writes` is `fail_closed`, bound on every host, no agent override.

`spent-inbox-artifacts-await-deletion` was approved but **not executed**: it names *"both `council-q-*.md` files"*, and that glob matches **12** files in `agents/tmp.old/`. Acting on it would delete 10 nobody approved. It needs two filenames.

## Counts

| Measure | Before | After |
|---|---:|---:|
| Open roadmaps | 26 | 26 (one archived, one created) |
| Steps done | 234 / 411 | 223 / 403 |
| Open blockers | 33 | 33 |

The step total falls because a closed roadmap leaves the active denominator. The blocker count is flat twice over while concealing real exchanges — one discharged and one surfaced, then two migrated home. The dashboard cannot show that; the report does.

## Verification

`task preflight` green on the base **before** any edit, and green at HEAD with zero advisories. `lint_roadmap_blockers` 33 clean (it caught a dropped `What to do` field mid-run) · `lint_plan_risk_register` clean · `lint_roadmap_family_cap` 2/2 · `check_adr_frontmatter` 171 ADRs / 0 errors · `roadmap:progress-check` up to date · `check_completion_review` clean.

**The completion-review skip is filed rather than left standing**, and the difference from the predecessor's refusal is the fact the grammar asserts: that branch changed code, so *"no code surface"* would have been false. This one changes none — the gate computes 0 code paths itself.

Link depth in the archived file was re-done by hand. `check-refs` reports green but excludes 580 targets, `archive/` among them, so it structurally cannot catch this class; an already-archived sibling carries a `../../docs/` link resolving to a nonexistent `agents/docs/`, and that pattern was not copied.

**Spend: $0.00.** No external model call.
