### PR TITLE
docs: inbox harvest 2026-08-c — four roadmaps, twenty rejections, one measured defect

### DIFF
--- a/agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md
+++ b/agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md
@@ -1,0 +1,154 @@
+# Inbox harvest 2026-08-c — triage, verification, and the not-adopted register
+
+> **Produced by:** an `analyze:inbox` run over `agents/tmp/` on 2026-08-15,
+> against `main` @ `e44e87865` (release 12.0.0, tree identical to the tag).
+> **Inputs:** three dropped files, two of them external release reviews.
+> **Method:** seven parallel verification agents, one per review pass, each
+> required to label every repo claim against the current tree with a
+> `file:line` or a command output.
+
+This document exists so the *rejections* survive. Four roadmaps came out of this
+harvest; roughly thirty other recommendations did not, and without a written
+reason each of them returns in the next review cycle and is re-analysed from
+zero. The register at the end is the point of the document.
+
+## 1. Triage table
+
+| file | genre | lines | drafted-against | disposition |
+|---|---|---:|---|---|
+| `feedback-12.0.0.txt` | external-review, 5 independent passes | 8,643 | current `main` (self-declared, verified: `12.0.0...main` = `0 0`) | **deep-read, 3 roadmaps** |
+| `feedback-10.1.0.txt` | external-review, superseded generation | 6,419 | release 10.1.0, 434 commits behind | **spent** — see § 4 |
+| `road-to-viral-prompt-intake-hardening.md` | feature-spec / proposal roadmap | 177 | pinned `73ac7b8` (v11.0.0) | **adopt-narrowed, 1 roadmap** |
+
+The provenance line paid for itself twice. The viral-prompt proposal declared its
+drafting SHA, so the overtaken-vs-wrong split was mechanical: 57 commits landed
+since, `git diff --quiet 73ac7b8..HEAD` over every path it cites returns clean,
+and therefore **zero** of its claims could have been overtaken — a hard result,
+not an absence. The 12.0.0 review declared that it re-read current `main`, which
+`git rev-list --left-right --count 12.0.0...main` → `0 0` confirms.
+
+## 2. What the five passes converged on
+
+Five independent passes over one span is a convergence instrument, and the
+agreement is concentrated in four places:
+
+| theme | passes raising it | coverage before this harvest |
+|---|---|---|
+| release head does not tell the truth about its own span | **5 of 5** | none |
+| evidence binding churn / review-evidence growth | 3 of 5 | none |
+| workspace + worktree identity is fragmented | 2 of 5 | none |
+| one runtime-eligibility resolver over `runtime_requires` + host caps | 3 of 5 | partial |
+
+Everything else appears in one pass only, which is a weaker signal than the
+count suggests: the five passes are the same reviewer family reading the same
+diff, so a single-pass item is closer to "one reader's preference" than to
+"four readers missed it".
+
+## 3. The finding this harvest actually rests on
+
+Every pass raised the release head. Four of them asked for the same remedy —
+hard-block a release whose curated head still carries the derived marker — and
+**that remedy is a locked decision**: resolved 2026-08-13 on an AI-council 2/2
+convergence, recorded in `docs/contracts/CHANGELOG-conventions.md`, with the
+rejected branch and two pre-registered falsifiers written down. Re-proposing it
+without new evidence is relitigation, and the reviews supply none.
+
+What no pass had was the measurement underneath. The contract's own sentence is
+that a contradiction — a `_none_` curated field against a populated derived
+category — is *the sole blocking condition*. Measured on this branch, over the
+74-commit span `11.0.0..12.0.0`:
+
+- `Security and correctness` derives from `/secur/i` in the conventional scope
+  or the whole word `security` in the subject
+  (`src/scripts/_lib/release_highlights.ts:116`). Span hits: **0**.
+  `fix(...)`-scoped commits in the same span: **13**.
+- `Honest nulls` derives from a literal `honest[ -]null` in subject or body
+  (`release_highlights.ts:137`). Span hits: **0**, over a span containing a
+  commit whose subject records that a soak was waived rather than met.
+- Both fields shipped as `_none_` in the released head
+  (`CHANGELOG.md:367-368`).
+
+So the label reads *Security **and correctness*** while the classifier only ever
+looks for security, and the sole blocking condition is structurally unreachable
+for the half of that label the 12.0.0 span was actually full of. This is not the
+locked question. The lock chose retro-curation over hard-blocking *on the premise
+that the contradiction check still catches the false ones*; a derivation that
+cannot populate the category removes the premise rather than the decision.
+
+That is the one item in this harvest with five-way convergence, a measured cause,
+a small diff, and no coverage anywhere in 33 active or 42 parked roadmaps.
+
+## 4. `feedback-10.1.0.txt` — spent, with the reasoning kept
+
+Its recommendations resolve into three states and none of them is "live and
+lost":
+
+- **Implemented** — untrusted-content boundary and trust propagation
+  (`src/scripts/_lib/untrusted_content.ts` plus four ingress sites), the
+  confirmation threat model as executable invariants, the routing-metadata
+  consumer audit, completion evidence as a first-class record.
+- **Declined by a recorded decision** — the eight-kind split of
+  `runtime_requires` (the schema refuses a speculative vocabulary and ships four
+  kinds), the extended executable skill contract, and the release-highlight
+  blocking gate.
+- **Still open but restated more currently by the newer review** — the runtime
+  eligibility resolver, the release head, evidence retention, activation
+  integrity, machine-matchable triggers, the live eval runner.
+
+One caveat on the newer review's own scoreboard: its "what was implemented"
+table reads as if `runtime_requires` landed complete. The tree says the schema
+landed and the resolver did not — `runtime_requires` has exactly one consumer in
+the whole tree, `src/scripts/skill_linter.ts`. The review's own § 45 corrects
+this, so the table overstates rather than misleads.
+
+## 5. The not-adopted register
+
+Each row is a recommendation that survived at least one pass and was still not
+turned into a roadmap. The reason column is the point.
+
+| # | recommendation | why not adopted |
+|---|---|---|
+| 1 | Hard-block a release head carrying the derived marker | **Locked** 2026-08-13, council 2/2, with pre-registered falsifiers. Needs new evidence, not a re-ask. |
+| 2 | Canonical runtime event layer (`session.*`/`turn.*`/`tool.*`/`subagent.*`) | Real gap — no event-normalisation layer exists — but it is a platform, and four of the five passes explicitly ask for *no new subsystems* in the same breath. Re-propose only as a refactor of a concrete duplication that hurt. |
+| 3 | Unified `Action{actor,type,target,…}` authorization contract | Same shape as #2 and touches five safety guards at once; a kernel-adjacent rewrite is the worst possible first move in a package whose own reviews ask it to shrink. |
+| 4 | Unified runtime eligibility resolver | Genuinely uncovered and named P0 by three passes, but the capped `road-to-skill-ecosystem-*` family already holds its two slots, and the nearest member owns the `harness_compat` half. Fold there when a slot frees rather than opening a parallel track. |
+| 5 | R2 merge barrier for risk-classed diffs | Configuring a merge barrier is repo-admin, i.e. a maintainer act, and the predicate ("which diffs are risky") is exactly the judgement the reviews elsewhere warn against mechanising. |
+| 6 | `generated:doctor` freshness contract for every generated surface | Attractive, and the 12.0.0 `cli-delegate` staleness fix is one real instance — but the general form is a new subsystem over a class with two members. Revisit at the third instance. |
+| 7 | Blocker taxonomy (`decision`/`authorization`/`capability`/…) | The motivating figure ("39 open blockers, 6 solvable") does not re-derive from the roadmap tree: only four `owner: maintainer` occurrences exist. Re-measure before planning. |
+| 8 | `bench:doctor` preflight before paid runs | Sound, but it is a helper for a bench that is itself build-blocked; sequencing it first buys nothing. |
+| 9 | Split `design_system_import.ts` (987 lines) into six stages | Single-file chore, no defect attached. |
+| 10 | Modularise the scale-history bench runner | Its size claim (~1,034 lines) does not reproduce against any tracked file. |
+| 11 | Cut releases to smaller commit spans | A cadence preference with no defect behind it. |
+| 12 | Clear the two open skill-lint warnings | Two-file chore; belongs in the next patch, not in a plan. |
+| 13 | Reduce 200 commands to 40–60 host-visible entries | Public-surface removal — a breaking change needing explicit permission and a deprecation window, and `road-to-surface-consolidation` already owns the axis. |
+| 14 | Concern retirement (delete `ui-route-nudge`, `delegation-nudge`, …) | The retirement policy exists but the deletion candidates are exactly the carriers whose effect is *unmeasured*; deleting them now discards the instrument before the reading. Order: measure, then retire. |
+| 15 | Never label a council pass `concluded` when answered < configured | Would reverse a council-locked quorum decision (`ceil(n/2)` is deliberate, so one absent member cannot deadlock an n=2 gate). The labelling half already shipped. |
+| 16 | Ledger as sole source of truth for session-recycle / orchestration-explain / cost-tracking | Genuine and small, but it is the tail of a roadmap that already owns the ledger; add it there rather than opening a track for three call sites. |
+| 17 | Requirements traceability graph (REQ→AC→PLAN→…→EVIDENCE) | A governance layer over a governance layer, in a package whose reviews name roadmap-about-roadmap work as its dominant failure mode. |
+| 18 | Graphify the code-intelligence adapter | The reviewer deprioritises it themselves; the orchestrator-first stance is already recorded. |
+| 19 | Viral-prompt proposal Phase 2 (`evals.json` fixtures) | Rests on a parity claim the tree does not hold: 247 of 289 skills carry no `evals.json`, so "the only one without fixtures" describes an 86 % norm, not a defect. The eval harness is also stubbed, so the fixtures could not execute. |
+| 20 | Viral-prompt proposal Phase 4 (full-collection sweep) | Gated on an export from a source that already returned an honest null, and its own pre-registration expects "additional fixtures at most, zero template adoptions". That is a null worth publishing now, not a step worth parking. |
+
+## 6. Safety flags raised during the harvest
+
+- **Source confidentiality.** The viral-prompt proposal names its external source
+  by domain, author and handle. It cannot land in the tracked tree in that form;
+  the adopted roadmap carries the anonymised shape instead.
+- **Quoting floor.** The same proposal reproduces a ~45-word third-party prompt
+  verbatim and would have persisted it into a fixture. Not covered by the
+  user-owned-text carve-out — it is relayed third-party text.
+- **Language gate.** The proposal carries untagged German prose; anything derived
+  from it into `agents/` must be English.
+- **Consumer-default flip.** Any per-host skill-catalogue budget silently changes
+  what every existing install sees. The owning roadmap already carries a
+  user-owned blocker for exactly this and must keep "keep everything" as the
+  default.
+- **Kernel scope.** Rule/skill estate reduction reaches kernel rules in the
+  limit; kernel edits are slow-rollout gated and agent-impossible by the write
+  guard. Any estate work must exclude the kernel explicitly.
+
+## 7. What this harvest produced
+
+Four roadmaps: `road-to-inbox-harvest-2026-08-c-release-head-truth`,
+`-workspace-identity`, `-evidence-lifecycle`, `-prompt-deinflation`. Every other
+recommendation is in § 5 with its reason.

--- a/agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md
+++ b/agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md
@@ -125,7 +125,7 @@ turned into a roadmap. The reason column is the point.
 | 15 | Never label a council pass `concluded` when answered < configured | Would reverse a council-locked quorum decision (`ceil(n/2)` is deliberate, so one absent member cannot deadlock an n=2 gate). The labelling half already shipped. |
 | 16 | Ledger as sole source of truth for session-recycle / orchestration-explain / cost-tracking | Genuine and small, but it is the tail of a roadmap that already owns the ledger; add it there rather than opening a track for three call sites. |
 | 17 | Requirements traceability graph (REQ→AC→PLAN→…→EVIDENCE) | A governance layer over a governance layer, in a package whose reviews name roadmap-about-roadmap work as its dominant failure mode. |
-| 18 | Graphify the code-intelligence adapter | The reviewer deprioritises it themselves; the orchestrator-first stance is already recorded. |
+| 18 | Write a code-intelligence adapter for a named third-party graph service | The reviewer deprioritises it themselves; the orchestrator-first stance is already recorded, and the service is named in the source rather than here. |
 | 19 | Viral-prompt proposal Phase 2 (`evals.json` fixtures) | Rests on a parity claim the tree does not hold: 247 of 289 skills carry no `evals.json`, so "the only one without fixtures" describes an 86 % norm, not a defect. The eval harness is also stubbed, so the fixtures could not execute. |
 | 20 | Viral-prompt proposal Phase 4 (full-collection sweep) | Gated on an export from a source that already returned an honest null, and its own pre-registration expects "additional fixtures at most, zero template adoptions". That is a null worth publishing now, not a step worth parking. |
 

--- a/agents/evidence/reviews/inbox-harvest-2026-08-c.findings.md
+++ b/agents/evidence/reviews/inbox-harvest-2026-08-c.findings.md
@@ -1,0 +1,66 @@
+# Completion review — inbox harvest 2026-08-c
+
+**Skipped:** no code surface for this completion — the branch adds one evidence page, four roadmaps and the regenerated dashboard, and the gate itself measures zero code paths of six changed files, scope fc9a7ca955502c00433152050717895f62dbcdd3d02e3a5795e6e578bda406fa, declared 2026-08-15
+
+## Why a skip rather than a review
+
+The diff is `agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md`, four
+new files under `agents/roadmaps/`, and the regenerated
+`agents/roadmaps-progress.md`. No script, no hook, no schema, no test, no
+projection. `check_completion_review` classifies it as zero code paths of six
+changed files, which is exactly the condition this declaration covers.
+
+## What replaces a code review here
+
+The risk in a harvest is not a broken build, it is a plan built on a claim
+nobody checked. Every load-bearing number in the five files was re-derived on
+this branch rather than copied from the reviews that asserted it:
+
+- **The release-head finding.** `derive_category_hits` matches `/secur/i` in the
+  conventional scope or whole-word `security` in the subject
+  (`src/scripts/_lib/release_highlights.ts:116`). Over `11.0.0..12.0.0`, 74
+  commits: **0** matches, **13** `fix(...)`-scoped commits. `Honest nulls`
+  matches a literal `honest[ -]null` (`:137`): **0** matches over a span whose
+  subjects include a waived-soak record. Both shipped `_none_`
+  (`CHANGELOG.md:367-368`).
+- **The lock it does not touch.** `docs/contracts/CHANGELOG-conventions.md` was
+  read directly, not recalled: the hard-block branch is rejected, the cadence is
+  retro-curation, and the same section names the `_none_` contradiction as the
+  sole blocking condition. That sentence is what makes the derivation gap a
+  defect in the lock's own premise rather than an argument against the lock.
+- **The workspace-identity numbers.** 8 `--show-toplevel` call sites across 6
+  files; exactly one exported `repoRoot()`, in `src/scripts/migration_status.ts`;
+  `src/scripts/_lib/git_common_dir.ts` exports three functions with 4 consumers;
+  `git worktree list` reports 306.
+- **The evidence-binding mechanism.** The manifest writes three segments
+  (`dispatch_r2_reviewer.ts:417-419`), the currency check compares one
+  (`:331`), and `REVIEW_SCOPE_EXCLUDES` holds exactly two entries
+  (`:112-115`) — neither of them `agents/roadmaps`. The roadmap states this as a
+  verified mechanism with an unmeasured incidence, and makes measuring it Phase 1.
+- **The prompt-cluster gaps.** Both greps the outside proposal claimed were
+  re-run and reproduce empty. Its fixture phase was dropped on a re-derived
+  denominator: 247 of 289 skills carry no `evals.json`.
+
+Three claims from the reviews were **rejected** on re-derivation and are
+recorded in the triage page rather than planned: a bench-runner size figure that
+matches no tracked file, a "704 authored skills" count that is a host's merged
+catalogue view rather than this estate, and a blocker census (39 open, 6
+solvable) that does not reproduce from the roadmap tree.
+
+Gates green on this branch: `lint_plan_risk_register`, `lint_roadmap_blockers`,
+`check_roadmap_trackable`, `lint_roadmap_ci_steps`, `lint_empty_roadmaps`,
+`lint_roadmap_family_cap`, `lint_roadmap_complexity` (the four new files pass;
+the one failure is pre-existing on `main`), `check_references`,
+`check_no_roadmap_refs`, `check_no_external_sources`, `lint_output_slop`,
+`lint_hidden_unicode`, and `check_md_language` on all five new markdown files.
+
+## Standing caveat
+
+A skip declaration is a statement about the diff's surface, not a claim that the
+plans are right. The strongest objection to this branch is that a package whose
+own reviews name roadmap-about-roadmap work as its dominant failure mode has
+just gained four more roadmaps. The counter is the ratio: twenty recommendations
+were rejected with a written reason and four were kept, each anchored on a
+defect re-derived here rather than on a reviewer's assertion — and the register
+exists precisely so the twenty do not come back for re-analysis next cycle.
+Whether four was still one too many is a judgement the maintainer owns.

--- a/agents/evidence/reviews/inbox-harvest-2026-08-c.findings.md
+++ b/agents/evidence/reviews/inbox-harvest-2026-08-c.findings.md
@@ -1,6 +1,6 @@
 # Completion review — inbox harvest 2026-08-c
 
-**Skipped:** no code surface for this completion — the branch adds one evidence page, four roadmaps and the regenerated dashboard, and the gate itself measures zero code paths of six changed files, scope fc9a7ca955502c00433152050717895f62dbcdd3d02e3a5795e6e578bda406fa, declared 2026-08-15
+**Skipped:** no code surface for this completion — the branch adds one evidence page, four roadmaps and the regenerated dashboard, and the gate itself measures zero code paths of six changed files, scope b3b72e0fcd61c247a81bd361c196a5da6c876b0d7656444d056bce69c37a062e, declared 2026-08-15
 
 ## Why a skip rather than a review
 
@@ -53,6 +53,21 @@ Gates green on this branch: `lint_plan_risk_register`, `lint_roadmap_blockers`,
 the one failure is pre-existing on `main`), `check_references`,
 `check_no_roadmap_refs`, `check_no_external_sources`, `lint_output_slop`,
 `lint_hidden_unicode`, and `check_md_language` on all five new markdown files.
+
+## Re-bound once, and the cause is this branch's own subject
+
+The first binding went stale on a one-row wording fix in
+`agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md` — anonymising a
+vendor name that `check_no_external_sources` denylists. Nothing about the
+reviewed judgement changed; `agents/evidence/analysis` simply is not one of the
+two paths `REVIEW_SCOPE_EXCLUDES` holds, so the scope hash moved and the skip
+had to be re-bound in place.
+
+That is the mechanism `-evidence-lifecycle` describes, observed on the branch
+that describes it, and it is worth recording as one data point rather than as a
+vindication: one prose fix, one forced re-bind. It is exactly the shape that
+roadmap's Phase 1 has to count before Phase 2 is allowed to act — and a single
+instance is a sample, not the ratio.
 
 ## Standing caveat
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 27 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **34** open blockers, **10** need you → `agent-config gates`
+> 31 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **37** open blockers, **10** need you → `agent-config gates`
 
 ## Overall
 
-**223 / 426 steps done · 52%**
+**223 / 468 steps done · 48%**
 
 ```text
-█████████████████████░░░░░░░░░░░░░░░░░░░   52%
+███████████████████░░░░░░░░░░░░░░░░░░░░░   48%
 ```
 
 ## Open roadmaps
@@ -27,22 +27,26 @@
 | 9 | [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 5 | 24 | 1 | 17 | 2 | 4 | [2](#blockers-road-to-inbox-harvest-2026-08-b-ci-economy) | █████████░ 94% |
 | 10 | [road-to-inbox-harvest-2026-08-b-dispatch-safety.md](roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md) | 4 | 21 | 1 | 14 | 0 | 6 | 0 | █████████░ 93% |
 | 11 | [road-to-inbox-harvest-2026-08-b-ledger-truth.md](roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md) | 3 | 19 | 1 | 12 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-ledger-truth) | █████████░ 92% |
-| 12 | [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md) | 1 | 4 | 4 | 0 | 0 | 0 | [2](#blockers-road-to-inbox-harvest-residuals) | ░░░░░░░░░░ 0% |
-| 13 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 14 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
-| 15 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 16 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
-| 17 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 18 | [road-to-skill-catalogue-budget.md](roadmaps/road-to-skill-catalogue-budget.md) | 4 | 23 | 23 | 0 | 0 | 0 | [1](#blockers-road-to-skill-catalogue-budget) | ░░░░░░░░░░ 0% |
-| 19 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
-| 20 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
-| 21 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 22 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | 0 | ███████░░░ 71% |
-| 23 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 8 | 9 | 1 | 0 | 0 | █████░░░░░ 53% |
-| 24 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
-| 25 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 26 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 27 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
+| 12 | [road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md) | 3 | 13 | 12 | 0 | 1 | 0 | [1](#blockers-road-to-inbox-harvest-2026-08-c-evidence-lifecycle) | ░░░░░░░░░░ 0% |
+| 13 | [road-to-inbox-harvest-2026-08-c-prompt-deinflation.md](roadmaps/road-to-inbox-harvest-2026-08-c-prompt-deinflation.md) | 2 | 9 | 9 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 14 | [road-to-inbox-harvest-2026-08-c-release-head-truth.md](roadmaps/road-to-inbox-harvest-2026-08-c-release-head-truth.md) | 3 | 11 | 10 | 0 | 1 | 0 | [1](#blockers-road-to-inbox-harvest-2026-08-c-release-head-truth) | ░░░░░░░░░░ 0% |
+| 15 | [road-to-inbox-harvest-2026-08-c-workspace-identity.md](roadmaps/road-to-inbox-harvest-2026-08-c-workspace-identity.md) | 3 | 12 | 11 | 0 | 1 | 0 | [1](#blockers-road-to-inbox-harvest-2026-08-c-workspace-identity) | ░░░░░░░░░░ 0% |
+| 16 | [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md) | 1 | 4 | 4 | 0 | 0 | 0 | [2](#blockers-road-to-inbox-harvest-residuals) | ░░░░░░░░░░ 0% |
+| 17 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
+| 19 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 20 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
+| 21 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 22 | [road-to-skill-catalogue-budget.md](roadmaps/road-to-skill-catalogue-budget.md) | 4 | 23 | 23 | 0 | 0 | 0 | [1](#blockers-road-to-skill-catalogue-budget) | ░░░░░░░░░░ 0% |
+| 23 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
+| 24 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
+| 25 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
+| 26 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | 0 | ███████░░░ 71% |
+| 27 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 8 | 9 | 1 | 0 | 0 | █████░░░░░ 53% |
+| 28 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
+| 29 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 30 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 31 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -347,6 +351,84 @@ _1 blocker resolved._
     The precondition for observing a flagged row is therefore that `track.mjs` runs
     at all and creates the ledger — a step upstream of the one this blocker waits on.
   - **Resolved when:** at least one real `rate_missing` row exists and its field set is written down, so a backfill pass can be built against an observed shape rather than a guessed one.
+
+### [road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md)
+
+**Road to a review binding that survives a checkbox** — 0 / 12 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Measure which segment actually moves | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Make the verdict segment-aware, only if Phase 1 earns it | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Give the evidence a retention shape | ⬜ not started | 6 | 0 | 1 | 0 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-c-evidence-lifecycle"></a>
+**Blockers**
+
+- **evidence-compaction-approval** (owner: maintainer - **Question:** may provably-reproducible `diff.patch` bodies be dropped in favour of their recorded base/head revisions? Phase 3 produces the list and the proof of reproducibility; the removal itself is a bulk deletion of committed evidence and is not an agent's call.) — blocks step 3.3 only. Phases 1 and 2 and the classification in 3.1–3.2 proceed either way.
+  - **What to do:**
+    pick exactly one — (a) no compaction: the tiering and the
+    reproducibility verdict are the whole deliverable, and step 3.3 is marked
+    `[-]` cancelled; or (b) compact at a named tier boundary, dropping only
+    directories Phase 3 proved reproducible and leaving every irreproducible one
+    intact. Mutually exclusive. (b) requires the boundary to be stated in this
+    blocker, not chosen at execution time.
+  - **Resolved when:** the maintainer records yes with a tier boundary, or no.
+
+### [road-to-inbox-harvest-2026-08-c-prompt-deinflation.md](roadmaps/road-to-inbox-harvest-2026-08-c-prompt-deinflation.md)
+
+**Road to a prompt optimizer that deflates before it polishes** — 0 / 9 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | A de-inflation step in Diagnose | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Provenance, recorded either way | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
+
+### [road-to-inbox-harvest-2026-08-c-release-head-truth.md](roadmaps/road-to-inbox-harvest-2026-08-c-release-head-truth.md)
+
+**Road to a release head that can be contradicted** — 0 / 10 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Measure the derivation's recall before changing it | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Widen the two derivations, conservatively | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Decide whether the publish side gets the invariant | ⬜ not started | 4 | 0 | 1 | 0 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-c-release-head-truth"></a>
+**Blockers**
+
+- **publish-side-marker-invariant** (owner: maintainer - **Question:** may an unresolved derived marker block *publishing* (tag + npm), given that blocking it at *merge* was rejected on 2026-08-11/13? The two are distinct: at merge the marker is present by construction on every substantiated release, so blocking is a guaranteed first-run red; at publish the maintainer has already had the whole review window to curate, so the marker's survival carries different information.) — blocks step 3.2 only. Phases 1 and 2 proceed either way.
+  - **What to do:**
+    pick exactly one — (a) add the unresolved-marker invariant to
+    `check_release_published.ts`, so a tag or npm publish carrying an unrewritten
+    derived head fails; or (b) leave the publish side untouched and mark step 3.2
+    `[-]` cancelled, citing this blocker. Mutually exclusive. Either answer
+    closes the blocker; (b) is the answer consistent with the 2026-08-13 lock and
+    should be preferred absent a reason to differ.
+  - **Resolved when:** the maintainer records a yes or a no in this blocker.
+
+### [road-to-inbox-harvest-2026-08-c-workspace-identity.md](roadmaps/road-to-inbox-harvest-2026-08-c-workspace-identity.md)
+
+**Road to one answer for "where am I"** — 0 / 11 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Census the question and its wrong answers | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | One resolver, in the module that already owns the hazard | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Read the state, do not act on it | ⬜ not started | 5 | 0 | 1 | 0 | 0% |
+
+<a id="blockers-road-to-inbox-harvest-2026-08-c-workspace-identity"></a>
+**Blockers**
+
+- **worktree-disposal-policy** (owner: maintainer - **Question:** what may be disposed of automatically, if anything? The pressure read makes the population legible for the first time, but every disposal is a bulk deletion and therefore Hard-Floor. The plausible answers range from "nothing, ever — the report is the whole deliverable" to "merged, commit-free and session-free entries are proposed for deletion in one confirmable batch".) — blocks step 3.3 only. Phases 1 and 2 and the read in 3.1–3.2 proceed either way.
+  - **What to do:**
+    pick exactly one — (a) report-only forever: the pressure read
+    is the whole deliverable, and step 3.3 is marked `[-]` cancelled; or
+    (b) propose a disposal batch from the read, listing merged, commit-free and
+    session-free entries for one confirmable deletion under the Hard Floor.
+    Mutually exclusive; (a) needs no further work, (b) reopens 3.3 with the tier
+    boundary written into it.
+  - **Resolved when:** the maintainer records which of those the policy is.
 
 ### [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md)
 

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md
@@ -1,0 +1,139 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to a review binding that survives a checkbox
+
+**Goal.** Stop a code review from being invalidated by an edit that did not
+touch code, and give the review evidence a retention shape — without weakening
+what the binding proves.
+
+**Source:** `agents/tmp.old/feedback-12.0.0.txt`, raised by three of its five
+passes as the largest remaining structural cost. Triage:
+`agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md`.
+
+## Context
+
+The R2 completion-review manifest already carries **three** hash segments —
+`scope_hash`, `roadmap_hash`, `ac_hash`
+(`src/scripts/dispatch_r2_reviewer.ts:417-419`). The reviews asked for that
+segmentation to be built; it exists. The defect is one layer down, and it is
+sharper than the reviews stated:
+
+- The staleness verdict compares **only** `scope_hash`
+  (`dispatch_r2_reviewer.ts:331`). The other two segments are written, parsed,
+  and never consulted for currency.
+- `scope_hash` is `sha256` of `git diff <base>...HEAD` with exactly **two**
+  exclusions: `agents/evidence/reviews` and `agents/evidence/metrics`
+  (`dispatch_r2_reviewer.ts:112-115`).
+- `agents/roadmaps/` is therefore **inside** the code scope. Flipping one
+  checkbox changes `scope_hash` and invalidates the binding — and because the
+  dashboard regenerates on every roadmap touch, a single checkbox produces two
+  in-scope file changes.
+
+So the segment that exists to hold roadmap content does not protect the review
+from roadmap content. That is a mechanism, not yet an incidence: how often the
+churn is *actually* caused by a roadmap-only change is Phase 1's job, because a
+mechanism that fires rarely does not justify touching an integrity gate.
+
+The cost side is measured: **28** `*.review-input/` directories carrying **28**
+`diff.patch` files totalling **45,598** lines, **50** `*.findings.md`,
+**5.7 MB** under `agents/evidence`, and **4** re-bind entries in the 12.0.0
+changelog era alone.
+
+## Non-goals
+
+- Weakening what a binding proves. A review that no longer notices a code change
+  is worse than one that re-binds too often; `evaluator-independence` and the R2
+  contract are the floor, not the negotiable part.
+- Deleting review evidence. Retention here means tiering and a regeneration
+  guarantee; any actual removal is a separate, confirmable act.
+- Changing who may dispatch or adopt a review.
+
+## Phase 1 — Measure which segment actually moves
+
+- [ ] For every tracked binding under `agents/evidence/reviews/`, recompute the
+      three segments at the recorded revision and at the branch tip, and record
+      which segments differ. Write it to
+      `agents/evidence/analysis/review-binding-drift.md`.
+      *verify:* the file has one row per binding with three per-segment verdicts.
+- [ ] Split the differing rows into "code changed" and "only non-code paths
+      changed" (roadmaps, dashboard, docs), and report the ratio. That ratio is
+      the whole case for Phase 2.
+      *verify:* the analysis states both counts and the ratio.
+- [ ] Record what each of the four 12.0.0-era re-binds was actually caused by,
+      from the same data.
+      *verify:* the analysis names a cause per re-bind, or says the data cannot
+      attribute it.
+
+## Phase 2 — Make the verdict segment-aware, only if Phase 1 earns it
+
+- [ ] Decide from the Phase 1 ratio whether to act, and write the decision into
+      the analysis file either way. A ratio that shows code changes dominate is
+      a legitimate stop: the churn would then be reviews correctly noticing
+      code, and nothing here should ship.
+      *verify:* the analysis carries an explicit proceed or stop with the ratio
+      that decided it.
+- [ ] If proceeding: make the currency verdict consult all three segments, so a
+      binding whose `scope_hash` moved solely through roadmap content is
+      reported as `roadmap-drifted` rather than `stale` — a distinct verdict,
+      not a pass.
+      *verify:* a test constructs both cases and asserts the two verdicts differ
+      and that a real code change still reports `stale`.
+- [ ] Pin the negative case: a diff that touches code **and** a roadmap in the
+      same range must still report `stale`. The failure mode of a segmented
+      verdict is exactly a code change hiding behind a roadmap edit.
+      *verify:* that test exists and fails when the segment check is inverted.
+
+## Phase 3 — Give the evidence a retention shape
+
+- [ ] Classify the 28 `review-input/` directories as active (binding current),
+      recent, or archived (the reviewed content is merged and the binding is
+      historical), and record the tier plus its byte cost per directory.
+      *verify:* every one of the 28 carries a tier in the analysis file.
+- [ ] State the regeneration guarantee per tier: for which tiers a stored
+      `diff.patch` can be re-derived from the recorded revisions, and for which
+      it cannot (a force-push or a rewritten history makes it irreproducible, in
+      which case the patch is the only copy and stays).
+      *verify:* the analysis names the irreproducible directories explicitly.
+- [~] Compact the tiers that are provably reproducible. Deferred behind
+      the blocker below — it removes committed evidence.
+
+## Blockers
+
+### blocker: evidence-compaction-approval
+- **Status:** open
+- **Owner:** maintainer
+- **Question:** may provably-reproducible `diff.patch` bodies be dropped in
+  favour of their recorded base/head revisions? Phase 3 produces the list and
+  the proof of reproducibility; the removal itself is a bulk deletion of
+  committed evidence and is not an agent's call.
+- **Resolved when:** the maintainer records yes with a tier boundary, or no.
+- **Blocks:** step 3.3 only. Phases 1 and 2 and the classification in 3.1–3.2
+  proceed either way.
+- **What to do:** pick exactly one — (a) no compaction: the tiering and the
+  reproducibility verdict are the whole deliverable, and step 3.3 is marked
+  `[-]` cancelled; or (b) compact at a named tier boundary, dropping only
+  directories Phase 3 proved reproducible and leaving every irreproducible one
+  intact. Mutually exclusive. (b) requires the boundary to be stated in this
+  blocker, not chosen at execution time.
+
+## Acceptance criteria
+
+- [ ] The per-binding segment-drift table exists and states the
+      code-vs-non-code ratio.
+- [ ] Phase 2 carries an explicit proceed or stop decision citing that ratio.
+- [ ] If Phase 2 proceeded: a test asserts that a code change accompanied by a
+      roadmap edit still reports `stale`.
+- [ ] Every `review-input/` directory carries a retention tier and a
+      reproducible-or-not verdict.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-15 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A segment-aware verdict becomes an escape hatch | product | The whole value of the binding is that it notices when the reviewed content moved; a verdict that forgives one segment is one careless predicate away from forgiving a code change that rode along with a roadmap edit | Step 2.3 pins the mixed case as a required failing test before the relaxation lands, and the new verdict is a distinct label rather than a pass | Phase 2 — Make the verdict segment-aware, only if Phase 1 earns it |
+| 2 | The mechanism is real and the incidence is nil | implementation | The roadmap-inside-scope mechanism is verified from source, but "verified mechanism" and "this is what has been costing us" are different claims, and building on the first while assuming the second is the premise error this package has recorded repeatedly | Phase 1 measures the ratio before any code moves, and step 2.1 makes a stop the documented outcome rather than a failure | Phase 1 — Measure which segment actually moves |
+| 3 | Compaction destroys the only copy | implementation | A patch is reproducible only while both recorded revisions remain reachable; a force-push or a pruned branch silently converts a reproducible directory into the sole record, and the loss is discovered when someone needs it | 3.2 requires the irreproducible set to be named before anything is dropped, and 3.3 is `[~]` behind a maintainer blocker | Phase 3 — Give the evidence a retention shape |
+| 4 | Excluding roadmaps from the scope diff is chosen as the shortcut | implementation | The cheapest fix is adding `agents/roadmaps` to the exclusion list, which also hides genuine roadmap changes from every review that should have read them | The plan routes through the verdict rather than the scope: the segments already exist, so the fix is to consult them, and the exclusion list stays at its two entries | Context |

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-c-prompt-deinflation.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-c-prompt-deinflation.md
@@ -1,0 +1,102 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to a prompt optimizer that deflates before it polishes
+
+**Goal.** Teach `prompt-optimizer` to strip the inflation patterns of viral
+prompt collections — grandiose persona, presupposed canon, scope stuffing —
+before it improves anything, so the optimizer stops polishing a premise the
+target model will confabulate around.
+
+**Source:** an external, German-language viral-prompt collection, harvested into
+a proposal roadmap that arrived in the inbox. The source is referenced
+anonymously per `source-confidentiality`; the raw proposal, with its links and
+its verbatim specimen, stays local-only at
+`agents/tmp.old/road-to-viral-prompt-intake-hardening.md`. Triage and the
+reasons two of its four phases were dropped:
+`agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md`.
+
+## Context
+
+The proposal declared its drafting revision, which made verification mechanical:
+57 commits landed since, and `git diff --quiet <drafted-SHA>..HEAD` over every
+path it cites returns clean. Nothing it claims could have been overtaken, and
+nothing was. Two of its greps reproduce as **empty** against the current tree:
+
+- `grep -rin "anti-pattern"` over `src/skills/prompt-optimizer/` and
+  `src/skills/refine-prompt/` → **0 hits**. Neither skill names a single input
+  pattern as one to strip.
+- `grep -in "debug|iterate|failure"` over
+  `src/skills/prompt-optimizer/SKILL.md` → **0 hits**. The skill has a Deliver
+  step (`:104`) and no notion of a delivered prompt coming back unsatisfactory.
+
+The behavioural gap is what those two absences produce together. Fed a
+specimen of the genre, the optimizer improves the slots — clearer role,
+tighter constraints, better output format — while preserving a presupposition
+the prompt smuggles in, so the target model invents a canon to satisfy it. The
+Diagnose step (`:88`) has nothing that says *remove* rather than *sharpen*.
+
+No roadmap owns the prompt cluster: a grep for the five prompt skills and the
+template guideline across all 33 active and 42 parked roadmaps returns nothing.
+
+## What was dropped from the proposal, and why
+
+- **Its eval-fixture phase.** It rests on the claim that `prompt-optimizer` is
+  the only cluster member without `evals/`. Literally true, and misleading: 247
+  of 289 skills carry no `evals.json`, so the absence is an 86 % norm rather
+  than a defect. The eval runner is also stubbed, so the fixtures could not
+  execute. If the fixtures are wanted they belong to the roadmap that owns the
+  eval harness, as corpus — not to a second owner.
+- **Its full-collection sweep phase.** Gated on an export from a source that
+  already returned an honest null, and its own pre-registration expects
+  "additional fixtures at most, zero template adoptions". That is a null worth
+  publishing now, not a step worth parking in a 42-deep queue.
+
+## Phase 1 — A de-inflation step in Diagnose
+
+- [ ] Add a de-inflation sub-step to `### 3. Inspect + Diagnose` in
+      `src/skills/prompt-optimizer/SKILL.md`, naming the three patterns to strip
+      and, for each, what it costs: a grandiose persona spends tokens without
+      changing behaviour; a presupposed canon invites confabulation; scope
+      stuffing produces an answer to a question nobody asked.
+      *verify:* `grep -c "de-inflat" src/skills/prompt-optimizer/SKILL.md`
+      returns non-zero and the skill linter reports the file clean.
+- [ ] Add the matching entries to the skill's `## Gotcha` section (`:115`), so
+      the failure is visible to a reader who skips the procedure.
+      *verify:* the Gotcha section names all three patterns.
+- [ ] Add a "viral-prompt anti-patterns" subsection to
+      `docs/guidelines/prompt-templates.md`, so the 12-template catalogue says
+      what it deliberately does not contain.
+      *verify:* the subsection exists and the guideline stays under its size
+      budget.
+
+## Phase 2 — Provenance, recorded either way
+
+- [ ] Decide whether `prompt-optimizer` gets an entry in
+      `agents/settings/contexts/skills-provenance.yml`, which today carries one
+      prompt-cluster entry (`:114`). Record the decision and its reason in the
+      file or in this roadmap — an explicit no is a complete answer, since the
+      de-inflation content is own analysis rather than adopted material.
+      *verify:* the decision is written down somewhere a reader will find it.
+- [ ] Check the upstream attribution already present in the tracked skill body
+      against `source-confidentiality`'s recommending-versus-deriving split, and
+      either leave it with a one-line reason or route it through the encrypted
+      form.
+      *verify:* `check_no_external_sources` passes and the disposition is stated.
+
+## Acceptance criteria
+
+- [ ] Diagnose names the three inflation patterns and what each one costs.
+- [ ] The template guideline states what the catalogue deliberately omits.
+- [ ] The provenance question has a recorded answer, yes or no.
+- [ ] No new skill, no new template, no new command.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-15 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | De-inflation becomes a licence to discard the author's intent | product | Stripping a persona is one step from stripping a constraint the author meant, and an optimizer that quietly removes requirements is worse than one that polishes noise | The step names exactly three patterns and states the cost of each rather than granting a general mandate to shorten; anything outside those three stays | Phase 1 — A de-inflation step in Diagnose |
+| 2 | The source leaks into the tracked tree | implementation | The proposal names its source by domain, author and handle, and reproduces a third-party prompt verbatim well past the quoting floor; copying its framing across would carry both into a tracked artefact | The source is referenced anonymously here, the specimen is not reproduced, and the raw file stays in the gitignored inbox archive | Context |
+| 3 | Prose lands with no way to tell whether it helped | implementation | The change is guidance, and guidance that nobody measures is exactly the surface these reviews ask the package to stop growing | The scope is deliberately two files and no new artefact, and the eval-fixture phase was dropped rather than kept as a fig leaf of measurement it could not deliver | What was dropped from the proposal, and why |

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-c-release-head-truth.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-c-release-head-truth.md
@@ -1,0 +1,136 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to a release head that can be contradicted
+
+**Goal.** Make the release head's *sole blocking condition* reachable for the
+two labels where it currently cannot fire, so the curated head stops shipping
+`_none_` over evidence the span actually carries.
+
+**Source:** `agents/tmp.old/feedback-12.0.0.txt` — five independent external
+review passes over the `10.1.0 → 12.0.0` span, all five raising the release
+head. Triage and the not-adopted register:
+`agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md`.
+
+## Context
+
+`docs/contracts/CHANGELOG-conventions.md` settled the curated-head cadence on
+2026-08-13: **retro-curation**, an AI-council 2/2 convergence, with the
+hard-block branch explicitly rejected and two falsifiers pre-registered. The
+argument for that choice rests on one sentence in the same contract — a
+contradiction, meaning a `_none_` curated field against a populated derived
+category, remains the sole blocking condition. A marked line is a prose gap; a
+contradiction is a lie, and only the lie blocks.
+
+Measured on this branch over the 74-commit span `11.0.0..12.0.0`, that premise
+does not hold for two of the five labels:
+
+| label | derivation | span hits | curated value shipped |
+|---|---|---:|---|
+| `Security and correctness` | `/secur/i` in the conventional scope, or whole-word `security` in the subject — `src/scripts/_lib/release_highlights.ts:116` | **0** | `_none_` (`CHANGELOG.md:367`) |
+| `Honest nulls` | literal `honest[ -]null` in subject or body — `release_highlights.ts:137` | **0** | `_none_` (`CHANGELOG.md:368`) |
+
+The same span carries **13** `fix(...)`-scoped commits, and one commit whose
+subject records that a soak was waived rather than met. The label reads
+*Security **and correctness*** while the classifier only ever looks for
+security; nothing in the tree derives the correctness half, so the field cannot
+be contradicted and `_none_` ships uncontested.
+
+**This is not the locked question.** The lock chose retro-curation over
+hard-blocking; this roadmap changes neither. It repairs the check the lock
+depends on. Widening a *derivation* makes contradictions detectable; it does not
+make an unrewritten marker block, which stays exactly as decided.
+
+## Non-goals
+
+- Flipping `check_release_highlights` from advisory to blocking on a surviving
+  derived marker. Decided against, recorded, and not reopened here.
+- Rewriting historical release heads. The contract already permits in-place
+  repair of a shipped head; that is curation, not this plan.
+- Adding a new label to `HEAD_LABELS`. The five are a contract surface.
+
+## Phase 1 — Measure the derivation's recall before changing it
+
+- [ ] Run `derive_category_hits` over the last six released spans and record,
+      per label, how many commits it caught against how many a hand pass calls
+      in-category. Write the table to
+      `agents/evidence/analysis/release-head-derivation-recall.md`.
+      *verify:* the file exists and carries one row per label per span.
+- [ ] From that table, state which labels are under-derived and by how much. A
+      label whose recall is already high is out of scope for Phase 2 — the
+      widening must be aimed, not general.
+      *verify:* the analysis names the in-scope labels explicitly.
+- [ ] Record the false-positive cost of the current conservative stance in the
+      same file: how many of the six spans would have gone red under a naive
+      "any `fix(` counts" rule. The derivation's own comment argues a false red
+      is worse than a miss; that trade-off needs a number before it is moved.
+      *verify:* the file carries the naive-rule count per span.
+
+## Phase 2 — Widen the two derivations, conservatively
+
+- [ ] Extend the `Security and correctness` derivation so the correctness half
+      of its own label is derivable, using a signal Phase 1 showed is precise
+      over the six spans — not a bare `fix(` match if Phase 1 measured that as
+      noisy.
+      *verify:* `tests/scripts/release_highlights.test.ts` gains a case that is
+      caught by the new rule and was missed by the old one, and the
+      false-positive fixture from Phase 1 stays uncaught.
+- [ ] Extend the `Honest nulls` derivation beyond the literal marker to the
+      recorded forms Phase 1 found in real subjects (a waived condition, an
+      unmet soak, a published null).
+      *verify:* a test asserts the 12.0.0-era waived-soak subject now derives.
+- [ ] Re-run the gate against the `11.0.0..12.0.0` span and record what it now
+      says about the shipped head, in the Phase 1 analysis file.
+      *verify:* the file states the gate's verdict on that span, before and
+      after.
+
+## Phase 3 — Decide whether the publish side gets the invariant
+
+- [ ] Record, in `docs/contracts/CHANGELOG-conventions.md`, that the derivation
+      is the load-bearing half of the retro-curation decision, so the next
+      reader does not re-derive why widening it is not a reversal.
+      *verify:* the contract's rejected-branch paragraph cites the derivation.
+- [~] Add an unresolved-marker invariant to `check_release_published.ts`
+      (tag/npm side, not the merge side). Deferred behind the blocker below —
+      it changes when a release can be published, which is a maintainer call
+      even though it is a different mechanism from the rejected merge block.
+
+## Blockers
+
+### blocker: publish-side-marker-invariant
+- **Status:** open
+- **Owner:** maintainer
+- **Question:** may an unresolved derived marker block *publishing* (tag + npm),
+  given that blocking it at *merge* was rejected on 2026-08-11/13? The two are
+  distinct: at merge the marker is present by construction on every
+  substantiated release, so blocking is a guaranteed first-run red; at publish
+  the maintainer has already had the whole review window to curate, so the
+  marker's survival carries different information.
+- **Resolved when:** the maintainer records a yes or a no in this blocker.
+- **Blocks:** step 3.2 only. Phases 1 and 2 proceed either way.
+- **What to do:** pick exactly one — (a) add the unresolved-marker invariant to
+  `check_release_published.ts`, so a tag or npm publish carrying an unrewritten
+  derived head fails; or (b) leave the publish side untouched and mark step 3.2
+  `[-]` cancelled, citing this blocker. Mutually exclusive. Either answer
+  closes the blocker; (b) is the answer consistent with the 2026-08-13 lock and
+  should be preferred absent a reason to differ.
+
+## Acceptance criteria
+
+- [ ] A recall table for all five labels over six released spans exists and is
+      cited from this roadmap.
+- [ ] The `11.0.0..12.0.0` span, replayed through the widened derivation,
+      populates `Security and correctness`.
+- [ ] No previously-green released span turns red under the widened derivation
+      (measured, not asserted).
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-15 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Widening reads as reopening the lock | product | The recorded decision rejected hard-blocking; a change to the same file family can be mistaken for a reversal, and the next reader relitigates a settled question | The Non-goals section states the boundary, and step 3.1 writes it into the contract next to the rejected branch, so the distinction lives where the decision lives | Non-goals |
+| 2 | A wider derivation makes every release red | implementation | The current derivation is conservative by an explicit argument in its own source: a false red makes every release annoying, a miss only returns the head to its pre-gate state | Phase 1 measures the false-positive cost over six real spans before any rule moves, and the acceptance criteria require that no previously-green span turns red | Phase 1 — Measure the derivation's recall before changing it |
+| 3 | The correctness signal is judgement, not pattern | implementation | "Correctness" has no conventional-commit scope of its own, so any regex is a proxy and may encode the author's habits rather than the category | Phase 1 forces the signal to be chosen from measured precision over six spans rather than picked first and justified after; a label with no precise signal is a legitimate Phase 1 outcome | Phase 2 — Widen the two derivations, conservatively |
+| 4 | The publish-side invariant drifts into the rejected merge block | product | Both are "a marker blocks something", and the difference is only the moment; a careless implementation would restore the guaranteed first-run red under a new name | The step is `[~]` behind a maintainer blocker that states the distinction in its own question, and it names the publish script explicitly rather than the merge gate | Phase 3 — Decide whether the publish side gets the invariant |

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-c-workspace-identity.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-c-workspace-identity.md
@@ -1,0 +1,138 @@
+---
+complexity: lightweight
+status: ready
+---
+
+# Road to one answer for "where am I"
+
+**Goal.** Give the tree a single resolver for workspace identity — repo root,
+main worktree, current worktree, branch, PR base — and put the worktree
+inventory on top of it, so the recurring "misclassifies from inside a worktree"
+defect class has one place to be fixed instead of eight.
+
+**Source:** `agents/tmp.old/feedback-12.0.0.txt`, raised as a P0 by two of its
+five passes. Triage:
+`agents/evidence/analysis/inbox-harvest-2026-08-c-triage.md`.
+
+## Context
+
+Measured on this branch:
+
+- **8** call sites run `git rev-parse --show-toplevel` themselves, spread over
+  **6** files (`update_roadmap_progress.ts`, `archive_completed_roadmaps.ts`,
+  `roadmap_gates.ts`, `evidence_report.ts`, `lint_plan_risk_register.ts`,
+  `migration_status.ts`).
+- Exactly **one** exported `repoRoot()` exists, and it lives in
+  `src/scripts/migration_status.ts:160` — a report script, which is why nothing
+  imports it.
+- A worktree-aware primitive already exists and is the right foundation:
+  `src/scripts/_lib/git_common_dir.ts` exports `git_dir`, `current_branch` and
+  `git_common_dir`, with the inherited-`GIT_DIR` hazard documented in its own
+  header. It has **4** consumers and no notion of repo root, main worktree, or
+  PR base.
+- `git worktree list` currently reports **306** entries. Age-based cleanup was
+  measured against roughly the same population and addressed two of them.
+
+The defect class this produces is already in the release history: the 12.0.0
+span carries `fix(worktrees): the inventory misclassifies from inside a worktree,
+totally` and `fix(worktrees): judge location against the main worktree, and
+teach the two missing conditions`. Both are the same bug wearing different
+call sites.
+
+This roadmap **extends the existing primitive**. It does not add a subsystem —
+the reviews that raised it also ask, in the same breath, for no new platforms.
+
+## Non-goals
+
+- Deleting worktrees. Bulk deletion is a Hard-Floor action; everything here is
+  report-only, and the disposal question is a blocker, not a step.
+- A session/claim redesign. `session_register` keeps its semantics; it becomes
+  a consumer of the identity resolver rather than a co-owner of the question.
+- Any change to how branches or PRs are created.
+
+## Phase 1 — Census the question and its wrong answers
+
+- [ ] List every site that answers a workspace-identity question for itself
+      (repo root, main worktree, current worktree, branch, PR base) and record
+      which primitive each uses, in
+      `agents/evidence/analysis/workspace-identity-census.md`.
+      *verify:* the file has one row per call site with a `file:line`.
+- [ ] For each of the two shipped worktree misclassification fixes in the
+      12.0.0 span, record which identity question was answered wrongly and by
+      which primitive. A third instance found in the census counts as a row.
+      *verify:* the census names the primitive per defect.
+- [ ] State which of the five identity fields `git_common_dir.ts` already
+      answers correctly under an inherited `GIT_DIR`, and which it does not.
+      *verify:* the census carries a five-row support table.
+
+## Phase 2 — One resolver, in the module that already owns the hazard
+
+- [ ] Extend `src/scripts/_lib/git_common_dir.ts` with a `workspaceIdentity()`
+      returning repo root, main worktree, current worktree, branch and PR base,
+      each field carrying whether it was resolved or unresolvable — never a
+      silently wrong default.
+      *verify:* a test asserts every field is either a value or an explicit
+      unresolved marker, from inside a worktree and from the main checkout.
+- [ ] Migrate the census's call sites to it, one commit per file, leaving
+      behaviour identical where the site was already correct.
+      *verify:* the census file records, per row, migrated or deliberately not,
+      with a reason for each not.
+- [ ] Pin the two shipped misclassification defects as regression tests against
+      the new resolver.
+      *verify:* both tests fail against the pre-migration primitive and pass
+      after.
+
+## Phase 3 — Read the state, do not act on it
+
+- [ ] Add a read-only `workspace doctor` report: repo root, main worktree,
+      current worktree, branch, PR base, session claim, conflicting session
+      records, stale records, path containment — every field with its
+      provenance, in the shape `routing:doctor` already uses.
+      *verify:* the command exits 0 in a clean checkout and in a worktree, and
+      its output names the provenance of each field.
+- [ ] Add a worktree pressure read to the same report: total registered,
+      how many are fully merged into the trunk, how many carry commits that are
+      not, how many have a live session record.
+      *verify:* the counts sum to the `git worktree list` total.
+- [~] Propose a disposal policy from the pressure read (merged and
+      session-free is eligible; unmerged is preserved). Deferred behind the
+      blocker below.
+
+## Blockers
+
+### blocker: worktree-disposal-policy
+- **Status:** open
+- **Owner:** maintainer
+- **Question:** what may be disposed of automatically, if anything? The pressure
+  read makes the population legible for the first time, but every disposal is a
+  bulk deletion and therefore Hard-Floor. The plausible answers range from
+  "nothing, ever — the report is the whole deliverable" to "merged, commit-free
+  and session-free entries are proposed for deletion in one confirmable batch".
+- **Resolved when:** the maintainer records which of those the policy is.
+- **Blocks:** step 3.3 only. Phases 1 and 2 and the read in 3.1–3.2 proceed
+  either way.
+- **What to do:** pick exactly one — (a) report-only forever: the pressure read
+  is the whole deliverable, and step 3.3 is marked `[-]` cancelled; or
+  (b) propose a disposal batch from the read, listing merged, commit-free and
+  session-free entries for one confirmable deletion under the Hard Floor.
+  Mutually exclusive; (a) needs no further work, (b) reopens 3.3 with the tier
+  boundary written into it.
+
+## Acceptance criteria
+
+- [ ] Every census row is either migrated to the shared resolver or carries a
+      written reason it is not.
+- [ ] Both shipped worktree misclassification defects have a regression test
+      that fails against the pre-migration primitive.
+- [ ] `workspace doctor` reports the same repo root and main worktree from
+      inside a worktree as from the main checkout, and says so under an
+      inherited `GIT_DIR`.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-15 | reviewer: claude/host -->
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The migration silently changes a gate's scope | implementation | Several call sites are gate scripts that resolve a root and then scan it; a resolver that returns a different root turns a green gate red or, worse, makes it scan nothing and exit green | Phase 2 migrates one file per commit and the census records behaviour-identical per row, so a scope change is visible in a single diff rather than buried in a sweep | Phase 2 — One resolver, in the module that already owns the hazard |
+| 2 | A new field is added that nothing consumes | product | `prBase` and `sessionId` are the two fields most likely to be declared because the review named them rather than because a call site needs them, which is the metadata-without-a-consumer failure this package has already recorded twice | Phase 1 derives the field list from the census rather than from the review, and a field with zero census rows is not added | Phase 1 — Census the question and its wrong answers |
+| 3 | The pressure read becomes a disposal path by accident | product | A report that classifies entries as eligible is one small step from a command that removes them, and that step crosses a Hard Floor | 3.3 is `[~]` behind a maintainer blocker whose own question names "nothing, ever" as a legitimate answer, and the Non-goals section states deletion is out of scope | Phase 3 — Read the state, do not act on it |
+| 4 | The inherited-`GIT_DIR` hazard is re-introduced | implementation | The existing module documents that hooks export `GIT_DIR` and that discovery must not trust it; a new function added beside it can easily forget, and the failure is silent and environment-dependent | The resolver lands in that same module rather than a new one, so the hazard note is adjacent to the code, and the acceptance criteria require the inherited-`GIT_DIR` case to be asserted | Phase 2 — One resolver, in the module that already owns the hazard |


### PR DESCRIPTION
Runs `analyze:inbox` over `agents/tmp/`. Three files arrived: two external release reviews and one proposal roadmap drafted outside the repo. Docs-only — six markdown files, zero code paths.

## The finding this rests on

All five review passes raise the release head. Four ask for the same remedy — hard-block a head carrying the derived marker — and that is a **locked decision** (2026-08-13, council 2/2, retro-curation, falsifiers pre-registered). It is not reopened here.

What none of them had is the measurement underneath. The contract calls a `_none_` curated field against a populated derived category *the sole blocking condition*. Measured over `11.0.0..12.0.0`, 74 commits:

| label | derivation | span hits | shipped |
|---|---|---:|---|
| `Security and correctness` | `/secur/i` only (`release_highlights.ts:116`) | **0** | `_none_` |
| `Honest nulls` | literal `honest[ -]null` (`:137`) | **0** | `_none_` |

Same span: **13** `fix(...)`-scoped commits, and one recording a waived soak. The label reads *Security **and correctness*** while the classifier only ever looks for security — so the sole blocking condition is structurally unreachable for the half the span was full of. That repairs the check the lock depends on; it does not touch the lock.

## What landed

- `road-to-...-c-release-head-truth` — measure the derivation's recall, then widen it conservatively. Publish-side invariant is `[~]` behind a maintainer blocker.
- `road-to-...-c-workspace-identity` — 8 `--show-toplevel` call sites over 6 files, one exported `repoRoot()` living in a report script, 306 worktrees, two shipped fixes for the same misclassification. Extends `_lib/git_common_dir.ts` rather than adding a module.
- `road-to-...-c-evidence-lifecycle` — the R2 manifest already writes three hash segments and the currency check reads one; `agents/roadmaps` sits inside the reviewed scope. Mechanism verified from source, incidence explicitly not — Phase 1 measures it and a stop is a documented outcome.
- `road-to-...-c-prompt-deinflation` — the narrowed half of the outside proposal; its two motivating greps reproduce empty, its fixture phase was dropped on a re-derived denominator (247 of 289 skills carry no `evals.json`), source referenced anonymously.
- `inbox-harvest-2026-08-c-triage.md` — the triage, the convergence table, and **twenty rejected recommendations with the reason each was not planned**. That register is the point: without it the same thirty items are re-analysed from zero next cycle.

## Three claims that did not survive re-derivation

A bench-runner size figure matching no tracked file; a "704 authored skills" count that is a host's merged catalogue view, not this estate; a blocker census (39 open, 6 solvable) that does not reproduce from the roadmap tree. All recorded, none planned.

`feedback-10.1.0.txt` is reported **spent** — implemented, declined by a recorded decision, or restated more currently by the newer review. No roadmap was authored from it.

## Notes for review

- The completion review is a **skip declaration** (zero code paths of six changed files). It had to be re-bound once, on a one-row wording fix — which is exactly the mechanism `-evidence-lifecycle` describes, observed on the branch describing it. Recorded there as one sample, not as a ratio.
- Four new roadmaps against a 33-active backlog is the obvious objection. The counter is the ratio — twenty rejected, four kept, each anchored on a defect re-derived here. Whether four was still one too many is yours.